### PR TITLE
[Trivial] Improve end-of-namespace comment consistency

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -450,11 +450,13 @@ Source code organization
   should be placed on the same line as the brace closing the namespace, e.g.
 
 ```c++
-namespace mynamespace {
+namespace mynamespace
+{
     ...
 } // namespace mynamespace
 
-namespace {
+namespace
+{
     ...
 } // namespace
 ```

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -15,7 +15,8 @@
 #include "tinyformat.h"
 #include "util.h"
 
-namespace {
+namespace
+{
 
 template <typename Stream, typename Data>
 bool SerializeDB(Stream& stream, const Data& data)
@@ -103,7 +104,7 @@ bool DeserializeFileDB(const fs::path& path, Data& data)
     return DeserializeDB(filein, data);
 }
 
-}
+}  // namespace
 
 CBanDB::CBanDB()
 {

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -35,7 +35,8 @@ BENCHMARK(CODE_TO_TIME);
 
  */
  
-namespace benchmark {
+namespace benchmark
+{
 
     class State {
         std::string name;
@@ -72,7 +73,7 @@ namespace benchmark {
 
         static void RunAll(double elapsedTimeForOne=1.0);
     };
-}
+}  // namespace benchmark
 
 // BENCHMARK(foo) expands to:  benchmark::BenchRunner bench_11foo("foo", foo);
 #define BENCHMARK(n) \

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -9,7 +9,8 @@
 #include "streams.h"
 #include "consensus/validation.h"
 
-namespace block_bench {
+namespace block_bench
+{
 #include "bench/data/block413567.raw.h"
 } // namespace block_bench
 

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -13,7 +13,8 @@
 #include <stdint.h>
 
 
-namespace Checkpoints {
+namespace Checkpoints
+{
 
     CBlockIndex* GetLastCheckpoint(const CCheckpointData& data)
     {

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -10,7 +10,8 @@
 #include <map>
 #include <string>
 
-namespace Consensus {
+namespace Consensus
+{
 
 enum DeploymentPos
 {

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -18,7 +18,8 @@ class CValidationState;
 /** Context-independent validity checks */
 bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true);
 
-namespace Consensus {
+namespace Consensus
+{
 /**
  * Check whether all inputs of this transaction are valid (no double spends and amounts)
  * This does not modify the UTXO set. This does not check scripts and sigs.

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -194,7 +194,8 @@ bool CDBIterator::Valid() const { return piter->Valid(); }
 void CDBIterator::SeekToFirst() { piter->SeekToFirst(); }
 void CDBIterator::Next() { piter->Next(); }
 
-namespace dbwrapper_private {
+namespace dbwrapper_private
+{
 
 void HandleError(const leveldb::Status& status)
 {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -29,7 +29,8 @@ class CDBWrapper;
 
 /** These should be considered an implementation detail of the specific database.
  */
-namespace dbwrapper_private {
+namespace dbwrapper_private
+{
 
 /** Handle database error by throwing dbwrapper_error exception.
  */
@@ -41,7 +42,7 @@ void HandleError(const leveldb::Status& status);
  */
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w);
 
-};
+}  // namespace dbwrapper_private
 
 /** Batch of changes queued to be written to a CDBWrapper */
 class CDBBatch

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -1,6 +1,7 @@
 #include "fs.h"
 
-namespace fsbridge {
+namespace fsbridge
+{
 
 FILE *fopen(const fs::path& p, const char *mode)
 {
@@ -12,4 +13,4 @@ FILE *freopen(const fs::path& p, const char *mode, FILE *stream)
     return ::freopen(p.string().c_str(), mode, stream);
 }
 
-} // fsbridge
+} // namespace fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -16,9 +16,10 @@
 namespace fs = boost::filesystem;
 
 /** Bridge operations to C stdio */
-namespace fsbridge {
+namespace fsbridge
+{
     FILE *fopen(const fs::path& p, const char *mode);
     FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
-};
+} // namespace fsbridge
 
 #endif // BITCOIN_FS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -811,7 +811,8 @@ void InitLogging()
     LogPrintf("Bitcoin version %s\n", FormatFullVersion());
 }
 
-namespace { // Variables internal to initialization process only
+namespace // Variables internal to initialization process only
+{
 
 ServiceFlags nRelevantServices = NODE_NETWORK;
 int nMaxConnections;

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -164,6 +164,6 @@ static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
     return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }
 
-}
+}  // namespace memusage
 
 #endif // BITCOIN_MEMUSAGE_H

--- a/src/net.h
+++ b/src/net.h
@@ -37,7 +37,8 @@
 class CScheduler;
 class CNode;
 
-namespace boost {
+namespace boost
+{
     class thread_group;
 } // namespace boost
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -62,7 +62,8 @@ static std::vector<std::pair<uint256, CTransactionRef>> vExtraTxnForCompact GUAR
 static const uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL; // SHA256("main address relay")[0:8]
 
 // Internal stuff
-namespace {
+namespace
+{
     /** Number of nodes with fSyncStarted. */
     int nSyncStarted = 0;
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -12,7 +12,8 @@
 # include <arpa/inet.h>
 #endif
 
-namespace NetMsgType {
+namespace NetMsgType
+{
 const char *VERSION="version";
 const char *VERACK="verack";
 const char *ADDR="addr";

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -66,7 +66,8 @@ public:
  * Bitcoin protocol message types. When adding new message types, don't forget
  * to update allNetMessageTypes in protocol.cpp.
  */
-namespace NetMsgType {
+namespace NetMsgType
+{
 
 /**
  * The version message provides information about the transmitting node to the
@@ -240,7 +241,7 @@ extern const char *GETBLOCKTXN;
  * @since protocol version 70014 as described by BIP 152
  */
 extern const char *BLOCKTXN;
-};
+}  // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
 const std::vector<std::string> &getAllNetMessageTypes();

--- a/src/qt/addressbookpage.h
+++ b/src/qt/addressbookpage.h
@@ -10,7 +10,8 @@
 class AddressTableModel;
 class PlatformStyle;
 
-namespace Ui {
+namespace Ui
+{
     class AddressBookPage;
 }
 

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -9,7 +9,8 @@
 
 class WalletModel;
 
-namespace Ui {
+namespace Ui
+{
     class AskPassphraseDialog;
 }
 

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -21,7 +21,8 @@ class WalletModel;
 
 class CCoinControl;
 
-namespace Ui {
+namespace Ui
+{
     class CoinControlDialog;
 }
 

--- a/src/qt/editaddressdialog.h
+++ b/src/qt/editaddressdialog.h
@@ -9,7 +9,8 @@
 
 class AddressTableModel;
 
-namespace Ui {
+namespace Ui
+{
     class EditAddressDialog;
 }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -75,7 +75,8 @@ extern double NSAppKitVersionNumber;
 #endif
 #endif
 
-namespace GUIUtil {
+namespace GUIUtil
+{
 
 QString dateTimeStr(const QDateTime &date)
 {

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -13,7 +13,8 @@ static const bool DEFAULT_CHOOSE_DATADIR = false;
 
 class FreespaceChecker;
 
-namespace Ui {
+namespace Ui
+{
     class Intro;
 }
 

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -11,7 +11,8 @@
 //! The required delta of headers to the estimated number of available headers until we show the IBD progress
 static constexpr int HEADER_HEIGHT_DELTA_SYNC = 24;
 
-namespace Ui {
+namespace Ui
+{
     class ModalOverlay;
 }
 

--- a/src/qt/openuridialog.h
+++ b/src/qt/openuridialog.h
@@ -7,7 +7,8 @@
 
 #include <QDialog>
 
-namespace Ui {
+namespace Ui
+{
     class OpenURIDialog;
 }
 

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -15,7 +15,8 @@ QT_BEGIN_NAMESPACE
 class QDataWidgetMapper;
 QT_END_NAMESPACE
 
-namespace Ui {
+namespace Ui
+{
 class OptionsDialog;
 }
 

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -16,7 +16,8 @@ class TxViewDelegate;
 class PlatformStyle;
 class WalletModel;
 
-namespace Ui {
+namespace Ui
+{
     class OverviewPage;
 }
 

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -66,7 +66,7 @@ struct X509Deleter {
       void operator()(X509* b) { X509_free(b); }
 };
 
-namespace // Anon namespace
+namespace
 {
     std::unique_ptr<X509_STORE, X509StoreDeleter> certStore;
 }

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -29,7 +29,8 @@ static const struct {
 };
 static const unsigned platform_styles_count = sizeof(platform_styles)/sizeof(*platform_styles);
 
-namespace {
+namespace
+{
 /* Local functions for colorizing single-color images */
 
 void MakeSingleColorImage(QImage& img, const QColor& colorbase)
@@ -69,7 +70,7 @@ QIcon ColorizeIcon(const QString& filename, const QColor& colorbase)
     return QIcon(QPixmap::fromImage(ColorizeImage(filename, colorbase)));
 }
 
-}
+}  // namespace
 
 
 PlatformStyle::PlatformStyle(const QString &_name, bool _imagesOnButtons, bool _colorizeIcons, bool _useExtraSpacing):

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -18,7 +18,8 @@
 class PlatformStyle;
 class WalletModel;
 
-namespace Ui {
+namespace Ui
+{
     class ReceiveCoinsDialog;
 }
 

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -14,7 +14,8 @@
 
 class OptionsModel;
 
-namespace Ui {
+namespace Ui
+{
     class ReceiveRequestDialog;
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -63,7 +63,8 @@ const struct {
     {nullptr, nullptr}
 };
 
-namespace {
+namespace
+{
 
 // don't add private key handling cmd's to the history
 const QStringList historyFilter = QStringList()
@@ -75,7 +76,7 @@ const QStringList historyFilter = QStringList()
     << "walletpassphrasechange"
     << "encryptwallet";
 
-}
+}  // namespace
 
 /* Object for executing console RPC commands in a separate thread.
 */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -18,7 +18,8 @@ class ClientModel;
 class PlatformStyle;
 class RPCTimerInterface;
 
-namespace Ui {
+namespace Ui
+{
     class RPCConsole;
 }
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -17,7 +17,8 @@ class PlatformStyle;
 class SendCoinsEntry;
 class SendCoinsRecipient;
 
-namespace Ui {
+namespace Ui
+{
     class SendCoinsDialog;
 }
 

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -12,7 +12,8 @@
 class WalletModel;
 class PlatformStyle;
 
-namespace Ui {
+namespace Ui
+{
     class SendCoinsEntry;
 }
 

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -10,7 +10,8 @@
 class PlatformStyle;
 class WalletModel;
 
-namespace Ui {
+namespace Ui
+{
     class SignVerifyMessageDialog;
 }
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -188,7 +188,7 @@ void TestSendCoins()
     bitdb.Reset();
 }
 
-}
+}  // namespace
 
 void WalletTests::walletTests()
 {

--- a/src/qt/transactiondescdialog.h
+++ b/src/qt/transactiondescdialog.h
@@ -7,7 +7,8 @@
 
 #include <QDialog>
 
-namespace Ui {
+namespace Ui
+{
     class TransactionDescDialog;
 }
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -10,7 +10,8 @@
 
 class BitcoinGUI;
 
-namespace Ui {
+namespace Ui
+{
     class HelpMessageDialog;
 }
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -25,7 +25,7 @@ namespace RPCServer
 {
     void OnStarted(std::function<void ()> slot);
     void OnStopped(std::function<void ()> slot);
-}
+}  // namespace RPCServer
 
 /** Wrapper for UniValue::VType, which includes typeAny:
  * Used to denote don't care type. Only used by RPCTypeCheckObj */

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -10,7 +10,8 @@
 #include "script/interpreter.h"
 #include "version.h"
 
-namespace {
+namespace
+{
 
 /** A class that deserializes a single CTransaction one time. */
 class TxInputStream

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -15,7 +15,8 @@
 
 typedef std::vector<unsigned char> valtype;
 
-namespace {
+namespace
+{
 
 inline bool set_success(ScriptError* ret)
 {
@@ -1043,7 +1044,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
     return set_success(serror);
 }
 
-namespace {
+namespace
+{
 
 /**
  * Wrapper that serializes like CTransaction, but with the modifications

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -14,7 +14,8 @@
 #include "cuckoocache.h"
 #include <boost/thread.hpp>
 
-namespace {
+namespace
+{
 /**
  * Valid signature cache, to avoid doing expensive ECDSA signature checking
  * twice for every transaction (once when accepted into memory pool, and

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -299,7 +299,7 @@ struct Stacks
         return result;
     }
 };
-}
+}  // namespace
 
 static Stacks CombineSignatures(const CScript& scriptPubKey, const BaseSignatureChecker& checker,
                                  const txnouttype txType, const std::vector<valtype>& vSolutions,
@@ -385,7 +385,8 @@ SignatureData CombineSignatures(const CScript& scriptPubKey, const BaseSignature
     return CombineSignatures(scriptPubKey, checker, txType, vSolutions, Stacks(scriptSig1), Stacks(scriptSig2), SIGVERSION_BASE).Output();
 }
 
-namespace {
+namespace
+{
 /** Dummy signature checker which accepts all signatures. */
 class DummySignatureChecker : public BaseSignatureChecker
 {

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -162,7 +162,8 @@ namespace tfm = tinyformat;
 #   define TINYFORMAT_HIDDEN
 #endif
 
-namespace tinyformat {
+namespace tinyformat
+{
 
 class format_error: public std::runtime_error
 {
@@ -172,7 +173,8 @@ public:
 };
 
 //------------------------------------------------------------------------------
-namespace detail {
+namespace detail
+{
 
 // Test whether type T1 is convertible to type T2
 template <typename T1, typename T2>
@@ -486,7 +488,8 @@ cog.outl('#define TINYFORMAT_FOREACH_ARGNUM(m) \\\n    ' +
 
 
 
-namespace detail {
+namespace detail
+{
 
 // Type-opaque holder for an argument to format(), with associated actions on
 // the type held as explicit function pointers.  This allows FormatArg's for
@@ -858,7 +861,8 @@ class FormatList
 typedef const FormatList& FormatListRef;
 
 
-namespace detail {
+namespace detail
+{
 
 // Format list subclass with fixed storage to avoid dynamic allocation
 template<int N>

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -30,7 +30,8 @@ static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
 
-namespace {
+namespace
+{
 
 struct CoinEntry {
     COutPoint* outpoint;
@@ -52,7 +53,7 @@ struct CoinEntry {
     }
 };
 
-}
+}  // namespace
 
 CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe) : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true) 
 {
@@ -302,7 +303,8 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
     return true;
 }
 
-namespace {
+namespace
+{
 
 //! Legacy class to deserialize pre-pertxout database entries without reindex.
 class CCoins
@@ -355,7 +357,7 @@ public:
     }
 };
 
-}
+}  // namespace
 
 /** Upgrade the database from older formats.
  *

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -751,7 +751,8 @@ bool CTxMemPool::CompareDepthAndScore(const uint256& hasha, const uint256& hashb
     return counta < countb;
 }
 
-namespace {
+namespace
+{
 class DepthAndScoreComparator
 {
 public:

--- a/src/util.h
+++ b/src/util.h
@@ -77,7 +77,8 @@ struct CLogCategoryActive
     bool active;
 };
 
-namespace BCLog {
+namespace BCLog
+{
     enum LogFlags : uint32_t {
         NONE        = 0,
         NET         = (1 <<  0),
@@ -103,7 +104,8 @@ namespace BCLog {
         LEVELDB     = (1 << 20),
         ALL         = ~(uint32_t)0,
     };
-}
+}  // namespace BCLog
+
 /** Return true if log accepts specified category */
 static inline bool LogAcceptCategory(uint32_t category)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -99,7 +99,8 @@ CScript COINBASE_FLAGS;
 const std::string strMessageMagic = "Bitcoin Signed Message:\n";
 
 // Internal stuff
-namespace {
+namespace
+{
 
     struct CBlockIndexWorkComparator
     {
@@ -161,7 +162,7 @@ namespace {
 
     /** Dirty block file entries. */
     std::set<int> setDirtyFileInfo;
-} // anon namespace
+} // namespace
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {
@@ -1328,7 +1329,8 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
     return true;
 }
 
-namespace {
+namespace
+{
 
 bool UndoWriteToDisk(const CBlockUndo& blockundo, CDiskBlockPos& pos, const uint256& hashBlock, const CMessageHeader::MessageStartChars& messageStart)
 {


### PR DESCRIPTION
Continuing on from #9544 this just makes the end-of-namespace comments consistent across all files

While purely style changes are not normally acceptable, this one should cause very few merge conflicts just because namespaces aren't usually touched often, and because of the nature of namespace indentation, I believe its quite a readability improvement to keep track of what the closing braces belong to.