### PR TITLE
Better API for estimatesmartfee RPC 

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -839,20 +839,20 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
     EstimationResult tempResult;
 
     // Return failure if trying to analyze a target we're not tracking
-    if (confTarget <= 0 || (unsigned int)confTarget > longStats->GetMaxConfirms())
-        return CFeeRate(0);
+    if (confTarget <= 0 || (unsigned int)confTarget > longStats->GetMaxConfirms()) {
+        return CFeeRate(0);  // error conditon
+    }
 
     // It's not possible to get reasonable estimates for confTarget of 1
-    if (confTarget == 1)
-        confTarget = 2;
+    if (confTarget == 1) confTarget = 2;
 
     unsigned int maxUsableEstimate = MaxUsableEstimate();
-    if (maxUsableEstimate <= 1)
-        return CFeeRate(0);
-
     if ((unsigned int)confTarget > maxUsableEstimate) {
         confTarget = maxUsableEstimate;
     }
+    if (feeCalc) feeCalc->returnedTarget = confTarget;
+
+    if (confTarget <= 1) return CFeeRate(0); // error conditon
 
     assert(confTarget > 0); //estimateCombinedFee and estimateConservativeFee take unsigned ints
     /** true is passed to estimateCombined fee for target/2 and target so
@@ -899,10 +899,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
         }
     }
 
-    if (feeCalc) feeCalc->returnedTarget = confTarget;
-
-    if (median < 0)
-        return CFeeRate(0);
+    if (median < 0) return CFeeRate(0); // error conditon
 
     return CFeeRate(median);
 }

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -114,7 +114,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getrawmempool", 0, "verbose" },
     { "estimatefee", 0, "nblocks" },
     { "estimatesmartfee", 0, "nblocks" },
-    { "estimatesmartfee", 1, "conservative" },
     { "estimaterawfee", 0, "nblocks" },
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },


### PR DESCRIPTION
Through 0.14 branch, the estimatesmartfee API was tagged "WARNING: This interface is unstable and may disappear or change!" and this warning is removed for 0.15, so any wanted API updates should happen now.

The changes here are to make the additional parameter for conservative estimates a more general estimate_mode string , to omit the feerate and include an error string instead of returning -1 on error, and to do better parameter checking initially.

~It is only the last 2 commits, but it's built on #10706 and #10543~.

See https://github.com/bitcoin/bitcoin/pull/10707#issuecomment-314869251 for renaming of nblocks argument to conf_target.  Will need to be included before string freeze.

PR description edited for clarity