### PR TITLE
Avoid printing incorrect block indexing time due to uninitialized variable

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1496,7 +1496,9 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         LogPrintf("Shutdown requested. Exiting.\n");
         return false;
     }
-    LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
+    if (fLoaded) {
+        LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
+    }
 
     fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fsbridge::fopen(est_path, "rb"), SER_DISK, CLIENT_VERSION);


### PR DESCRIPTION
Avoid printing incorrect block indexing time due to uninitialized variable.

Fixes:

```
init.cpp: In function ‘bool AppInitMain(boost::thread_group&, CScheduler&)’:
init.cpp:1499:56: warning: ‘nStart’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
                                                        ^
```

In this fix I've assumed that block indexing time is only relevant to print in case of `fLoaded`. Let me know if that assumption is incorrect.