### PR TITLE
scripted-diff: Prefer x.empty() over x.size() == 0 and x.length() == 0

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -448,9 +448,9 @@ int CAddrMan::Check_()
         }
     }
 
-    if (setTried.size())
+    if (!setTried.empty())
         return -13;
-    if (mapNew.size())
+    if (!mapNew.empty())
         return -15;
     if (nKey.IsNull())
         return -16;

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -491,6 +491,11 @@ public:
         return vRandom.size();
     }
 
+    bool empty() const
+    {
+        return size() == 0;
+    }
+
     //! Consistency check
     void Check()
     {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -525,7 +525,7 @@ static void MutateTxSign(CMutableTransaction& tx, const std::string& flagStr)
 {
     int nHashType = SIGHASH_ALL;
 
-    if (flagStr.size() > 0)
+    if (!flagStr.empty())
         if (!findSighashFlags(nHashType, flagStr))
             throw std::runtime_error("unknown sighash flag/sign option");
 

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -45,7 +45,7 @@
 /* This implements a constant-space merkle root/path calculator, limited to 2^32 leaves. */
 static void MerkleComputation(const std::vector<uint256>& leaves, uint256* proot, bool* pmutated, uint32_t branchpos, std::vector<uint256>* pbranch) {
     if (pbranch) pbranch->clear();
-    if (leaves.size() == 0) {
+    if (leaves.empty()) {
         if (pmutated) *pmutated = false;
         if (proot) *proot = uint256();
         return;

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -39,10 +39,10 @@ std::string FormatScript(const CScript& script)
                     continue;
                 }
             }
-            if (vch.size() > 0) {
-                ret += strprintf("0x%x 0x%x ", HexStr(it2, it - vch.size()), HexStr(it - vch.size(), it));
-            } else {
+            if (vch.empty()) {
                 ret += strprintf("0x%x ", HexStr(it2, it));
+            } else {
+                ret += strprintf("0x%x 0x%x ", HexStr(it2, it - vch.size()), HexStr(it - vch.size(), it));
             }
             continue;
         }

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -17,7 +17,7 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
 {
     // The following is MurmurHash3 (x86_32), see http://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
     uint32_t h1 = nHashSeed;
-    if (vDataToHash.size() > 0)
+    if (!vDataToHash.empty())
     {
         const uint32_t c1 = 0xcc9e2d51;
         const uint32_t c2 = 0x1b873593;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1714,7 +1714,7 @@ void CConnman::ThreadOpenConnections()
             return;
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
-        if (addrman.size() == 0 && (GetTime() - nStart > 60)) {
+        if (addrman.empty() && (GetTime() - nStart > 60)) {
             static bool done = false;
             if (!done) {
                 LogPrintf("Adding fixed seed nodes as DNS doesn't seem to be available.\n");

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1574,7 +1574,7 @@ void CConnman::ThreadDNSAddressSeed()
     // Avoiding DNS seeds when we don't need them improves user privacy by
     //  creating fewer identifying DNS requests, reduces trust by giving seeds
     //  less influence on the network topology, and reduces traffic to the seeds.
-    if ((addrman.size() > 0) &&
+    if (!addrman.empty() &&
         (!GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED))) {
         if (!interruptNet.sleep_for(std::chrono::seconds(11)))
             return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -750,7 +750,7 @@ void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pb
     }
 
     // Erase orphan transactions include or precluded by this block
-    if (vOrphanErase.size()) {
+    if (!vOrphanErase.empty()) {
         int nErased = 0;
         for (uint256 &orphanHash : vOrphanErase) {
             nErased += EraseOrphanTx(orphanHash);
@@ -1589,7 +1589,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         LogPrint(BCLog::NET, "received getdata (%u invsz) peer=%d\n", vInv.size(), pfrom->GetId());
 
-        if (vInv.size() > 0) {
+        if (!vInv.empty()) {
             LogPrint(BCLog::NET, "received getdata for: %s peer=%d\n", vInv[0].ToString(), pfrom->GetId());
         }
 
@@ -2353,7 +2353,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     LogPrint(BCLog::NET, "Downloading blocks toward %s (%d) via headers direct fetch\n",
                             pindexLast->GetBlockHash().ToString(), pindexLast->nHeight);
                 }
-                if (vGetData.size() > 0) {
+                if (!vGetData.empty()) {
                     if (nodestate->fSupportsDesiredCmpctVersion && vGetData.size() == 1 && mapBlocksInFlight.size() == 1 && pindexLast->pprev->IsValid(BLOCK_VALID_CHAIN)) {
                         // In any case, we want to download using a compact block, not a regular one
                         vGetData[0] = CInv(MSG_CMPCT_BLOCK, vGetData[0].hash);
@@ -3180,7 +3180,7 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
         // We compensate for other peers to prevent killing off peers due to our own downstream link
         // being saturated. We only count validated in-flight blocks so peers can't advertise non-existing block hashes
         // to unreasonably increase our timeout.
-        if (state.vBlocksInFlight.size() > 0) {
+        if (!state.vBlocksInFlight.empty()) {
             QueuedBlock &queuedBlock = state.vBlocksInFlight.front();
             int nOtherPeersWithValidatedDownloads = nPeersWithValidatedDownloads - (state.nBlocksInFlightValidHeaders > 0);
             if (nNow > state.nDownloadingSince + consensusParams.nPowTargetSpacing * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads)) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -522,7 +522,7 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<con
                 // The block is not already downloaded, and not yet in flight.
                 if (pindex->nHeight > nWindowEnd) {
                     // We reached the end of the window.
-                    if (vBlocks.size() == 0 && waitingfor != nodeid) {
+                    if (vBlocks.empty() && waitingfor != nodeid) {
                         // We aren't able to fetch anything, but we would be if the download window was one larger.
                         nodeStaller = waitingfor;
                     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -131,7 +131,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
 
     freeaddrinfo(aiRes);
 
-    return (vIP.size() > 0);
+    return !vIP.empty();
 }
 
 bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup)
@@ -603,7 +603,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 
     std::vector<CService> addrResolved;
     if (Lookup(strDest.c_str(), addrResolved, port, fNameLookup && !HaveNameProxy(), 256)) {
-        if (addrResolved.size() > 0) {
+        if (!addrResolved.empty()) {
             addr = addrResolved[GetRand(addrResolved.size())];
             return ConnectSocket(addr, hSocketRet, nTimeout);
         }

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -204,7 +204,7 @@ inline void UnserializeTransaction(TxType& tx, Stream& s) {
     tx.vout.clear();
     /* Try to read the vin. In case the dummy is there, this will be read as an empty vector. */
     s >> tx.vin;
-    if (tx.vin.size() == 0 && fAllowWitness) {
+    if (tx.vin.empty() && fAllowWitness) {
         /* We read a dummy or an empty vin. */
         s >> flags;
         if (flags != 0) {

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -172,7 +172,7 @@ bool CPubKey::Verify(const uint256 &hash, const std::vector<unsigned char>& vchS
     if (!secp256k1_ec_pubkey_parse(secp256k1_context_verify, &pubkey, &(*this)[0], size())) {
         return false;
     }
-    if (vchSig.size() == 0) {
+    if (vchSig.empty()) {
         return false;
     }
     if (!ecdsa_signature_parse_der_lax(secp256k1_context_verify, &sig, &vchSig[0], vchSig.size())) {

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -407,12 +407,15 @@ void CoinControlDialog::updateLabelLocked()
 {
     std::vector<COutPoint> vOutpts;
     model->listLockedCoins(vOutpts);
-    if (vOutpts.size() > 0)
+    if (vOutpts.empty())
+    {
+       ui->labelLocked->setVisible(false);
+    }
+    else
     {
        ui->labelLocked->setText(tr("(%1 locked)").arg(vOutpts.size()));
        ui->labelLocked->setVisible(true);
     }
-    else ui->labelLocked->setVisible(false);
 }
 
 void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -936,10 +936,9 @@ QString formatServicesStr(quint64 mask)
         }
     }
 
-    if (strList.size())
-        return strList.join(" & ");
-    else
+    if (strList.empty())
         return QObject::tr("None");
+    return strList.join(" & ");
 }
 
 QString formatPingTime(double dPingTime)

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -249,12 +249,12 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                             curarg = lastResult.write(2);
 
                         // if we have a non empty result, use it as stack argument otherwise as general result
-                        if (curarg.size())
+                        if (!curarg.empty())
                         {
-                            if (stack.size())
-                                add_to_current_stack(curarg);
-                            else
+                            if (stack.empty())
                                 strResult = curarg;
+                            else
+                                add_to_current_stack(curarg);
                         }
                         curarg.clear();
                         // assume eating space state

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -23,7 +23,7 @@
 X509 *parse_b64der_cert(const char* cert_data)
 {
     std::vector<unsigned char> data = DecodeBase64(cert_data);
-    assert(data.size() > 0);
+    assert(!data.empty());
     const unsigned char* dptr = &data[0];
     X509 *cert = d2i_X509(NULL, &dptr, data.size());
     assert(cert);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -425,7 +425,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     // parse/deserialize input
     // input-format = output-format, rest/getutxos/bin requires binary input, gives binary output, ...
 
-    if (uriParts.size() > 0)
+    if (!uriParts.empty())
     {
 
         //inputs is sent over URI scheme (/rest/getutxos/checkmempool/txid1-n/txid2-n/...)
@@ -446,10 +446,9 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
             vOutPoints.push_back(COutPoint(txid, (uint32_t)nOutput));
         }
 
-        if (vOutPoints.size() > 0)
-            fInputParsed = true;
-        else
+        if (vOutPoints.empty())
             return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
+        fInputParsed = true;
     }
 
     switch (rf) {
@@ -462,7 +461,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     case RF_BINARY: {
         try {
             //deserialize only if user sent a request
-            if (strRequestMutable.size() > 0)
+            if (!strRequestMutable.empty())
             {
                 if (fInputParsed) //don't allow sending input over URI and HTTP RAW DATA
                     return RESTERR(req, HTTP_BAD_REQUEST, "Combination of URI scheme inputs and raw post data is not allowed");

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -415,7 +415,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
 
     // throw exception in case of an empty request
     std::string strRequestMutable = req->ReadBody();
-    if (strRequestMutable.length() == 0 && uriParts.size() == 0)
+    if (strRequestMutable.length() == 0 && uriParts.empty())
         return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
 
     bool fInputParsed = false;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -415,7 +415,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
 
     // throw exception in case of an empty request
     std::string strRequestMutable = req->ReadBody();
-    if (strRequestMutable.length() == 0 && uriParts.empty())
+    if (strRequestMutable.empty() && uriParts.empty())
         return RESTERR(req, HTTP_BAD_REQUEST, "Error: empty request");
 
     bool fInputParsed = false;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -210,7 +210,7 @@ UniValue waitfornewblock(const JSONRPCRequest& request)
             + HelpExampleRpc("waitfornewblock", "1000")
         );
     int timeout = 0;
-    if (request.params.size() > 0)
+    if (!request.params.empty())
         timeout = request.params[0].get_int();
 
     CUpdatedBlock block;
@@ -434,7 +434,7 @@ UniValue getrawmempool(const JSONRPCRequest& request)
         );
 
     bool fVerbose = false;
-    if (request.params.size() > 0)
+    if (!request.params.size())
         fVerbose = request.params[0].get_bool();
 
     return mempoolToJSON(fVerbose);
@@ -1037,7 +1037,7 @@ UniValue verifychain(const JSONRPCRequest& request)
 
     LOCK(cs_main);
 
-    if (request.params.size() > 0)
+    if (!request.params.empty())
         nCheckLevel = request.params[0].get_int();
     if (request.params.size() > 1)
         nCheckDepth = request.params[1].get_int();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -91,7 +91,7 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
        );
 
     LOCK(cs_main);
-    return GetNetworkHashPS(request.params.size() > 0 ? request.params[0].get_int() : 120, request.params.size() > 1 ? request.params[1].get_int() : -1);
+    return GetNetworkHashPS((!request.params.empty()) ? request.params[0].get_int() : 120, request.params.size() > 1 ? request.params[1].get_int() : -1);
 }
 
 UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript)
@@ -363,7 +363,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     UniValue lpval = NullUniValue;
     std::set<std::string> setClientRules;
     int64_t nMaxVersionPreVB = -1;
-    if (request.params.size() > 0)
+    if (!request.params.empty())
     {
         const UniValue& oparam = request.params[0].get_obj();
         const UniValue& modeval = find_value(oparam, "mode");

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -237,7 +237,7 @@ UniValue addnode(const JSONRPCRequest& request)
 
 UniValue disconnectnode(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() == 0 || request.params.size() >= 3)
+    if (request.fHelp || request.params.empty() || request.params.size() >= 3)
         throw std::runtime_error(
             "disconnectnode \"[address]\" [nodeid]\n"
             "\nImmediately disconnects from the specified peer node.\n"

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -238,7 +238,7 @@ UniValue help(const JSONRPCRequest& jsonRequest)
         );
 
     std::string strCommand;
-    if (jsonRequest.params.size() > 0)
+    if (!jsonRequest.params.empty())
         strCommand = jsonRequest.params[0].get_str();
 
     return tableRPC.help(strCommand, jsonRequest);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -182,7 +182,7 @@ bool static IsLowDERSignature(const valtype &vchSig, ScriptError* serror) {
 }
 
 bool static IsDefinedHashtypeSignature(const valtype &vchSig) {
-    if (vchSig.size() == 0) {
+    if (vchSig.empty()) {
         return false;
     }
     unsigned char nHashType = vchSig[vchSig.size() - 1] & (~(SIGHASH_ANYONECANPAY));
@@ -195,7 +195,7 @@ bool static IsDefinedHashtypeSignature(const valtype &vchSig) {
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror) {
     // Empty signature. Not strictly DER encoded, but allowed to provide a
     // compact way to provide an invalid signature for use with CHECK(MULTI)SIG
-    if (vchSig.size() == 0) {
+    if (vchSig.empty()) {
         return true;
     }
     if ((flags & (SCRIPT_VERIFY_DERSIG | SCRIPT_VERIFY_LOW_S | SCRIPT_VERIFY_STRICTENC)) != 0 && !IsValidSignatureEncoding(vchSig)) {
@@ -221,7 +221,7 @@ bool static CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, co
 }
 
 bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
-    if (data.size() == 0) {
+    if (data.empty()) {
         // Could have used OP_0.
         return opcode == OP_0;
     } else if (data.size() == 1 && data[0] >= 1 && data[0] <= 16) {
@@ -1359,7 +1359,7 @@ static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, 
     if (witversion == 0) {
         if (program.size() == 32) {
             // Version 0 segregated witness program: SHA256(CScript) inside the program, CScript + inputs in witness
-            if (witness.stack.size() == 0) {
+            if (witness.stack.empty()) {
                 return set_error(serror, SCRIPT_ERR_WITNESS_PROGRAM_WITNESS_EMPTY);
             }
             scriptPubKey = CScript(witness.stack.back().begin(), witness.stack.back().end());

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -127,7 +127,7 @@ static CScript PushAll(const std::vector<valtype>& values)
 {
     CScript result;
     for (const valtype& v : values) {
-        if (v.size() == 0) {
+        if (v.empty()) {
             result << OP_0;
         } else if (v.size() == 1 && v[0] >= 1 && v[0] <= 16) {
             result << CScript::EncodeOP_N(v[0]);

--- a/src/streams.h
+++ b/src/streams.h
@@ -420,7 +420,7 @@ public:
      */
     void Xor(const std::vector<unsigned char>& key)
     {
-        if (key.size() == 0) {
+        if (key.empty()) {
             return;
         }
 

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -112,7 +112,7 @@ public:
     }
     bool operator()(const CNoDestination &no) const
     {
-        return exp_payload.size() == 0;
+        return exp_payload.empty();
     }
 };
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -215,7 +215,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
         }
         if (InsecureRandRange(100) == 0) {
             // Every 100 iterations, change the cache stack.
-            if (stack.size() > 0 && InsecureRandBool() == 0) {
+            if (!stack.empty() && InsecureRandBool() == 0) {
                 //Remove the top cache
                 stack.back()->Flush();
                 delete stack.back();
@@ -224,10 +224,10 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             if (stack.empty() || (stack.size() < 4 && InsecureRandBool())) {
                 //Add a new cache
                 CCoinsView* tip = &base;
-                if (stack.size() > 0) {
-                    tip = stack.back();
-                } else {
+                if (stack.empty()) {
                     removed_all_caches = true;
+                } else {
+                    tip = stack.back();
                 }
                 stack.push_back(new CCoinsViewCacheTest(tip));
                 if (stack.size() == 4) {
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
     }
 
     // Clean up the stack.
-    while (stack.size() > 0) {
+    while (!stack.empty()) {
         delete stack.back();
         stack.pop_back();
     }
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 
             // Track this tx and undo info to use later
             utxoData.emplace(outpoint, std::make_tuple(tx,undo,old_coin));
-        } else if (utxoset.size()) {
+        } else if (!utxoset.empty()) {
             //1/20 times undo a previous transaction
             auto utxod = FindRandomFrom(utxoset);
 
@@ -448,14 +448,14 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
         }
         if (InsecureRandRange(100) == 0) {
             // Every 100 iterations, change the cache stack.
-            if (stack.size() > 0 && InsecureRandBool() == 0) {
+            if (!stack.empty() && InsecureRandBool() == 0) {
                 stack.back()->Flush();
                 delete stack.back();
                 stack.pop_back();
             }
             if (stack.empty() || (stack.size() < 4 && InsecureRandBool())) {
                 CCoinsView* tip = &base;
-                if (stack.size() > 0) {
+                if (!stack.empty()) {
                     tip = stack.back();
                 }
                 stack.push_back(new CCoinsViewCacheTest(tip));
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
     }
 
     // Clean up the stack.
-    while (stack.size() > 0) {
+    while (!stack.empty()) {
         delete stack.back();
         stack.pop_back();
     }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
                 delete stack.back();
                 stack.pop_back();
             }
-            if (stack.size() == 0 || (stack.size() < 4 && InsecureRandBool())) {
+            if (stack.empty() || (stack.size() < 4 && InsecureRandBool())) {
                 //Add a new cache
                 CCoinsView* tip = &base;
                 if (stack.size() > 0) {
@@ -453,7 +453,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
                 delete stack.back();
                 stack.pop_back();
             }
-            if (stack.size() == 0 || (stack.size() < 4 && InsecureRandBool())) {
+            if (stack.empty() || (stack.size() < 4 && InsecureRandBool())) {
                 CCoinsView* tip = &base;
                 if (stack.size() > 0) {
                     tip = stack.back();

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -17,7 +17,7 @@ BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 static void ResetArgs(const std::string& strArg)
 {
     std::vector<std::string> vecArg;
-    if (strArg.size())
+    if (!strArg.empty())
       boost::split(vecArg, strArg, boost::is_space(), boost::token_compress_on);
 
     // Insert dummy executable name:

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -19,7 +19,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     BOOST_CHECK(map.max_size() == 10);
 
     // check that it's empty
-    BOOST_CHECK(map.size() == 0);
+    BOOST_CHECK(map.empty());
 
     // insert (-1, -1)
     map.insert(std::pair<int, int>(-1, -1));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         txCoinbase.vout.resize(1); // Ignore the (optional) segwit commitment added by CreateNewBlock (as the hardcoded nonces don't account for this)
         txCoinbase.vout[0].scriptPubKey = CScript();
         pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
-        if (txFirst.size() == 0)
+        if (txFirst.empty())
             baseheight = chainActive.Height();
         if (txFirst.size() < 4)
             txFirst.push_back(pblock->vtx[0]);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     bool exceptionThrown = false;
     CAddrMan addrman1;
 
-    BOOST_CHECK(addrman1.size() == 0);
+    BOOST_CHECK(addrman1.empty());
     try {
         unsigned char pchMsgTmp[4];
         ssPeers1 >> FLATDATA(pchMsgTmp);
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
 
     CAddrMan addrman2;
     CAddrDB adb;
-    BOOST_CHECK(addrman2.size() == 0);
+    BOOST_CHECK(addrman2.empty());
     adb.Read(addrman2, ssPeers2);
     BOOST_CHECK(addrman2.size() == 3);
 }
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
     CDataStream ssPeers1 = AddrmanToStream(addrmanCorrupted);
     bool exceptionThrown = false;
     CAddrMan addrman1;
-    BOOST_CHECK(addrman1.size() == 0);
+    BOOST_CHECK(addrman1.empty());
     try {
         unsigned char pchMsgTmp[4];
         ssPeers1 >> FLATDATA(pchMsgTmp);
@@ -156,9 +156,9 @@ BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
 
     CAddrMan addrman2;
     CAddrDB adb;
-    BOOST_CHECK(addrman2.size() == 0);
+    BOOST_CHECK(addrman2.empty());
     adb.Read(addrman2, ssPeers2);
-    BOOST_CHECK(addrman2.size() == 0);
+    BOOST_CHECK(addrman2.empty());
 }
 
 BOOST_AUTO_TEST_CASE(cnode_simple_test)

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -151,8 +151,12 @@ public:
         pre_vector.assign(n, value);
     }
 
-    Size size() {
+    Size size() const {
         return real_vector.size();
+    }
+
+    bool empty() const {
+        return size() == 0;
     }
 
     Size capacity() {

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (InsecureRandBits(2) == 0) {
                 test.insert(InsecureRandRange(test.size() + 1), InsecureRand32());
             }
-            if (test.size() > 0 && InsecureRandBits(2) == 1) {
+            if (!test.empty() && InsecureRandBits(2) == 1) {
                 test.erase(InsecureRandRange(test.size()));
             }
             if (InsecureRandBits(3) == 2) {
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (InsecureRandBits(4) == 5) {
                 test.push_back(InsecureRand32());
             }
-            if (test.size() > 0 && InsecureRandBits(4) == 6) {
+            if (!test.empty() && InsecureRandBits(4) == 6) {
                 test.pop_back();
             }
             if (InsecureRandBits(5) == 7) {
@@ -245,7 +245,7 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             if (InsecureRandBits(6) == 10) {
                 test.shrink_to_fit();
             }
-            if (test.size() > 0) {
+            if (!test.empty()) {
                 test.update(InsecureRandRange(test.size()), InsecureRand32());
             }
             if (InsecureRandBits(10) == 11) {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -394,7 +394,7 @@ static CScript PushAll(const std::vector<valtype>& values)
 {
     CScript result;
     for (const valtype& v : values) {
-        if (v.size() == 0) {
+        if (v.empty()) {
             result << OP_0;
         } else if (v.size() == 1 && v[0] >= 1 && v[0] <= 16) {
             result << CScript::EncodeOP_N(v[0]);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -409,7 +409,7 @@ void ReplaceRedeemScript(CScript& script, const CScript& redeemScript)
 {
     std::vector<valtype> stack;
     EvalScript(stack, script, SCRIPT_VERIFY_STRICTENC, BaseSignatureChecker(), SIGVERSION_BASE);
-    assert(stack.size() > 0);
+    assert(!stack.empty());
     stack.back() = std::vector<unsigned char>(redeemScript.begin(), redeemScript.end());
     script = PushAll(stack);
 }

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -228,7 +228,7 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
 std::string DecodeBase64(const std::string& str)
 {
     std::vector<unsigned char> vchRet = DecodeBase64(str.c_str());
-    return (vchRet.size() == 0) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
+    return (vchRet.empty()) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
 }
 
 std::string EncodeBase32(const unsigned char* pch, size_t len)
@@ -415,7 +415,7 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
 std::string DecodeBase32(const std::string& str)
 {
     std::vector<unsigned char> vchRet = DecodeBase32(str.c_str());
-    return (vchRet.size() == 0) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
+    return (vchRet.empty()) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
 }
 
 static bool ParsePrechecks(const std::string& str)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -228,7 +228,7 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pfInvalid)
 std::string DecodeBase64(const std::string& str)
 {
     std::vector<unsigned char> vchRet = DecodeBase64(str.c_str());
-    return (vchRet.empty()) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
+    return vchRet.empty() ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
 }
 
 std::string EncodeBase32(const unsigned char* pch, size_t len)
@@ -415,7 +415,7 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pfInvalid)
 std::string DecodeBase32(const std::string& str)
 {
     std::vector<unsigned char> vchRet = DecodeBase32(str.c_str());
-    return (vchRet.empty()) ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
+    return vchRet.empty() ? std::string() : std::string((const char*)&vchRet[0], vchRet.size());
 }
 
 static bool ParsePrechecks(const std::string& str)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -62,7 +62,7 @@ bool IsHex(const std::string& str)
         if (HexDigit(*it) < 0)
             return false;
     }
-    return (str.size() > 0) && (str.size()%2 == 0);
+    return !str.empty() && str.size() % 2 == 0;
 }
 
 std::vector<unsigned char> ParseHex(const char* psz)

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -128,7 +128,7 @@ std::string FormatParagraph(const std::string& in, size_t width = 79, size_t ind
 template <typename T>
 bool TimingResistantEqual(const T& a, const T& b)
 {
-    if (b.size() == 0) return a.size() == 0;
+    if (b.empty()) return a.empty();
     size_t accumulator = a.size() ^ b.size();
     for (size_t i = 0; i < a.size(); i++)
         accumulator |= a[i] ^ b[i%b.size()];

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -46,7 +46,7 @@ public:
 
     bool HasSelected() const
     {
-        return (setSelected.size() > 0);
+        return !setSelected.empty();
     }
 
     bool IsSelected(const COutPoint& output) const

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -799,7 +799,7 @@ UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int6
             }
 
             // Import private keys.
-            if (keys.size()) {
+            if (!keys.empty()) {
                 for (size_t i = 0; i < keys.size(); i++) {
                     const std::string& privkey = keys[i].get_str();
 
@@ -840,7 +840,7 @@ UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int6
             success = true;
         } else {
             // Import public keys.
-            if (pubKeys.size() && keys.empty()) {
+            if (!pubKeys.empty() && keys.empty()) {
                 const std::string& strPubKey = pubKeys[0].get_str();
 
                 if (!IsHex(strPubKey)) {
@@ -908,7 +908,7 @@ UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int6
             }
 
             // Import private keys.
-            if (keys.size()) {
+            if (!keys.empty()) {
                 const std::string& strPrivkey = keys[0].get_str();
 
                 // Checks.

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -840,7 +840,7 @@ UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int6
             success = true;
         } else {
             // Import public keys.
-            if (pubKeys.size() && keys.size() == 0) {
+            if (pubKeys.size() && keys.empty()) {
                 const std::string& strPubKey = pubKeys[0].get_str();
 
                 if (!IsHex(strPubKey)) {
@@ -967,7 +967,7 @@ UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int6
             }
 
             // Import scriptPubKey only.
-            if (pubKeys.size() == 0 && keys.size() == 0) {
+            if (pubKeys.empty() && keys.empty()) {
                 if (::IsMine(*pwallet, script) == ISMINE_SPENDABLE) {
                     throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
                 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -727,7 +727,7 @@ UniValue getbalance(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    if (request.params.size() == 0)
+    if (request.params.empty())
         return  ValueFromAmount(pwallet->GetBalance());
 
     const std::string& account_param = request.params[0].get_str();
@@ -2753,7 +2753,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
     if (!DecodeHexTx(tx, request.params[0].get_str(), true))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
 
-    if (tx.vout.size() == 0)
+    if (tx.vout.empty())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "TX must have at least one output");
 
     if (changePosition != -1 && (changePosition < 0 || (unsigned int)changePosition > tx.vout.size()))

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -134,7 +134,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
 
     // Parse the account first so we don't generate a key if there's an error
     std::string strAccount;
-    if (request.params.size() > 0)
+    if (!request.params.empty())
         strAccount = AccountFromValue(request.params[0]);
 
     if (!pwallet->IsLocked()) {
@@ -751,7 +751,7 @@ UniValue getunconfirmedbalance(const JSONRPCRequest &request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() > 0)
+    if (request.fHelp || !request.params.empty())
         throw std::runtime_error(
                 "getunconfirmedbalance\n"
                 "Returns the server's total unconfirmed balance\n");
@@ -1165,7 +1165,7 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByA
 {
     // Minimum confirmations
     int nMinDepth = 1;
-    if (params.size() > 0)
+    if (!params.empty())
         nMinDepth = params[0].get_int();
 
     // Whether to include empty accounts
@@ -1536,7 +1536,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     std::string strAccount = "*";
-    if (request.params.size() > 0)
+    if (!request.params.empty())
         strAccount = request.params[0].get_str();
     int nCount = 10;
     if (request.params.size() > 1)
@@ -1629,7 +1629,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     int nMinDepth = 1;
-    if (request.params.size() > 0)
+    if (!request.params.empty())
         nMinDepth = request.params[0].get_int();
     isminefilter includeWatchonly = ISMINE_SPENDABLE;
     if(request.params.size() > 1)
@@ -1732,7 +1732,7 @@ UniValue listsinceblock(const JSONRPCRequest& request)
     int target_confirms = 1;
     isminefilter filter = ISMINE_SPENDABLE;
 
-    if (request.params.size() > 0)
+    if (!request.params.empty())
     {
         uint256 blockId;
 
@@ -1965,7 +1965,7 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
 
     // 0 is interpreted by TopUpKeyPool() as the default keypool size given by -keypool
     unsigned int kpSize = 0;
-    if (request.params.size() > 0) {
+    if (!request.params.empty()) {
         if (request.params[0].get_int() < 0)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid parameter, expected valid size.");
         kpSize = (unsigned int)request.params[0].get_int();

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -148,7 +148,7 @@ static void TestDecrypt(const CCrypter& crypt, const std::vector<unsigned char>&
 
     BOOST_CHECK_MESSAGE(vchDecrypted1 == vchDecrypted2, HexStr(vchDecrypted1.begin(), vchDecrypted1.end()) + " != " + HexStr(vchDecrypted2.begin(), vchDecrypted2.end()));
 
-    if (vchPlaintext.size())
+    if (!vchPlaintext.empty())
         BOOST_CHECK(CKeyingMaterial(vchPlaintext.begin(), vchPlaintext.end()) == vchDecrypted2);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3356,7 +3356,7 @@ std::set< std::set<CTxDestination> > CWallet::GetAddressGroupings()
                        grouping.insert(txoutAddr);
                    }
             }
-            if (grouping.size() > 0)
+            if (!grouping.empty())
             {
                 groupings.insert(grouping);
                 grouping.clear();


### PR DESCRIPTION
Changes:
* Prefer `x.empty()` over `x.size() == 0` and `x.length() == 0`
* Prefer `!x.empty()` over `bool(x.size())`
* Prefer `!x.empty()` over `x.size() > 0`

Rationale:
* Improve readability.
* Avoid nongeneric code - see ["T.143: Don't write unintentionally nongeneric code"](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#t143-dont-write-unintentionally-nongeneric-code) in the C++ Core Guidelines (Stroustrup & Sutter): *"Emptiness works for more containers than size(), because some containers don't know their size or are conceptually of unbounded size."*