### PR TITLE
Wrap EvalScript in a ScriptExecution class

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -279,7 +279,7 @@ int FindAndDelete(CScript& script, const CScript& b)
 }
 
 ScriptExecution::ScriptExecution(StackType& stack_in, const CScript& script_in, unsigned int flags_in, const BaseSignatureChecker& checker_in, SigVersion sigversion_in) :
-    script(script_in), stack(stack_in), flags(flags_in), checker(checker_in), sigversion(sigversion_in)
+    script(script_in), stack(stack_in), flags(flags_in), checker(checker_in), sigversion(sigversion_in), pc(script.begin()), pbegincodehash(script.begin()), nOpCount(0)
 {
 }
 
@@ -293,17 +293,12 @@ bool ScriptExecution::Eval(ScriptError* serror)
     // static const valtype vchZero(0);
     static const valtype vchTrue(1, 1);
 
-    CScript::const_iterator pc = script.begin();
-    CScript::const_iterator pend = script.end();
-    CScript::const_iterator pbegincodehash = script.begin();
+    const CScript::const_iterator pend = script.end();
     opcodetype opcode;
     valtype vchPushValue;
-    std::vector<bool> vfExec;
-    std::vector<valtype> altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     if (script.size() > MAX_SCRIPT_SIZE)
         return set_error(serror, SCRIPT_ERR_SCRIPT_SIZE);
-    int nOpCount = 0;
     bool fRequireMinimal = (flags & SCRIPT_VERIFY_MINIMALDATA) != 0;
 
     try

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -278,7 +278,12 @@ int FindAndDelete(CScript& script, const CScript& b)
     return nFound;
 }
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
+ScriptExecution::ScriptExecution(StackType& stack_in, const CScript& script_in, unsigned int flags_in, const BaseSignatureChecker& checker_in, SigVersion sigversion_in) :
+    script(script_in), stack(stack_in), flags(flags_in), checker(checker_in), sigversion(sigversion_in)
+{
+}
+
+bool ScriptExecution::Eval(ScriptError* serror)
 {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -185,7 +185,27 @@ public:
 using TransactionSignatureChecker = GenericTransactionSignatureChecker<CTransaction>;
 using MutableTransactionSignatureChecker = GenericTransactionSignatureChecker<CMutableTransaction>;
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
+class ScriptExecution {
+public:
+    typedef std::vector<unsigned char> StackElementType;
+    typedef std::vector<StackElementType> StackType;
+
+    const CScript& script;
+    StackType& stack;
+    unsigned int flags;
+    const BaseSignatureChecker& checker;
+    SigVersion sigversion;
+
+    ScriptExecution(StackType& stack, const CScript&, unsigned int flags, const BaseSignatureChecker&, SigVersion);
+
+    bool Eval(ScriptError* error = nullptr);
+};
+
+inline bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr)
+{
+    return ScriptExecution(stack, script, flags, checker, sigversion).Eval(error);
+}
+
 bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
 
 size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -196,6 +196,13 @@ public:
     const BaseSignatureChecker& checker;
     SigVersion sigversion;
 
+    CScript::const_iterator pc;
+    CScript::const_iterator pbegincodehash;
+
+    std::vector<bool> vfExec;
+    StackType altstack;
+    int nOpCount;
+
     ScriptExecution(StackType& stack, const CScript&, unsigned int flags, const BaseSignatureChecker&, SigVersion);
 
     bool Eval(ScriptError* error = nullptr);


### PR DESCRIPTION
When we last discussed making scripts debuggable (sometime after #3901), the plan was to instead trace execution rather than single-step through it.

This is the first step toward that goal. The full implementation can be found on my `script_debugger` branch.