### PR TITLE
getwalletinfo: return path for wallet file

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2400,6 +2400,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"unlocked_until\": ttt,           (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,              (numeric) the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB\n"
             "  \"hdmasterkeyid\": \"<hash160>\"     (string) the Hash160 of the HD master pubkey\n"
+            "  \"wallet_path\": \"<path>\"          (string) the file path of the wallet\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getwalletinfo", "")
@@ -2428,6 +2429,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
     if (!masterKeyID.IsNull())
          obj.push_back(Pair("hdmasterkeyid", masterKeyID.GetHex()));
+    obj.push_back(Pair("wallet_path", pwallet->GetName()));
     return obj;
 }
 

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -42,6 +42,9 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(walletinfo['immature_balance'], 50)
         assert_equal(walletinfo['balance'], 0)
 
+        # Check wallet path
+        assert_equal(walletinfo['wallet_path'], "wallet.dat")
+
         self.sync_all()
         self.nodes[1].generate(101)
         self.sync_all()


### PR DESCRIPTION
Makes handling multiwallet a bit easier in case user forgets which wallet is loaded.