### PR TITLE
Avoid static analyzer warnings regarding uninitialized arguments

### DIFF
--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -7,34 +7,37 @@
 #include "validation.h"
 #include "base58.h"
 
+#include <array>
 #include <vector>
 #include <string>
 
 
 static void Base58Encode(benchmark::State& state)
 {
-    unsigned char buff[32] = {
-        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
-        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
-        200, 24
+    static const std::array<unsigned char, 32> buff = {
+        {
+            17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24
+        }
     };
-    unsigned char* b = buff;
     while (state.KeepRunning()) {
-        EncodeBase58(b, b + 32);
+        EncodeBase58(buff.begin(), buff.end());
     }
 }
 
 
 static void Base58CheckEncode(benchmark::State& state)
 {
-    unsigned char buff[32] = {
-        17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
-        227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
-        200, 24
+    static const std::array<unsigned char, 32> buff = {
+        {
+            17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24
+        }
     };
-    unsigned char* b = buff;
     std::vector<unsigned char> vch;
-    vch.assign(b, b + 32);
+    vch.assign(buff.begin(), buff.end());
     while (state.KeepRunning()) {
         EncodeBase58Check(vch);
     }

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -11,6 +11,8 @@
 #include "script/sign.h"
 #include "streams.h"
 
+#include <array>
+
 // FIXME: Dedup with BuildCreditingTransaction in test/script_tests.cpp.
 static CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey)
 {
@@ -55,8 +57,12 @@ static void VerifyScriptBench(benchmark::State& state)
 
     // Keypair.
     CKey key;
-    const unsigned char vchKey[32] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    key.Set(vchKey, vchKey + 32, false);
+    static const std::array<unsigned char, 32> vchKey = {
+        {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+        }
+    };
+    key.Set(vchKey.begin(), vchKey.end(), false);
     CPubKey pubkey = key.GetPubKey();
     uint160 pubkeyHash;
     CHash160().Write(pubkey.begin(), pubkey.size()).Finalize(pubkeyHash.begin());


### PR DESCRIPTION
Avoid static analyzer warnings regarding _"Function call argument is a pointer to uninitialized value"_ in cases where we are intentionally using such arguments.

This is achieved by using `f(b.begin(), b.end())` (`std::array<char, N>`) instead of `f(b, b + N)` (`char b[N]`).

Rationale:
* Reduce false positives by guiding static analyzers regarding our intentions.

Before this commit:

```shell
$ clang-tidy-3.5 -checks=* src/bench/base58.cpp
bench/base58.cpp:23:9: warning: Function call argument is a pointer to uninitialized value [clang-analyzer-core.CallAndMessage]
        EncodeBase58(b, b + 32);
        ^
$ clang-tidy-3.5 -checks=* src/bench/verify_script.cpp
bench/verify_script.cpp:59:5: warning: Function call argument is a pointer to uninitialized value [clang-analyzer-core.CallAndMessage]
    key.Set(vchKey, vchKey + 32, false);
    ^
$
```

After this commit:

```shell
$ clang-tidy-3.5 -checks=* src/bench/base58.cpp
$ clang-tidy-3.5 -checks=* src/bench/verify_script.cpp
$
```