### PR TITLE
net: drop custom CNode refcounting in favor of smart pointers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,7 @@ BITCOIN_CORE_H = \
   script/standard.h \
   script/ismine.h \
   streams.h \
+  strong_ptr.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
   support/cleanse.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -71,6 +71,7 @@ BITCOIN_TESTS =\
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/streams_tests.cpp \
+  test/strong_ptr.cpp \
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
   test/test_bitcoin_main.cpp \

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2484,9 +2484,11 @@ size_t CConnman::GetNodeCount(NumConnections flags)
         return vNodes.size();
 
     int nNum = 0;
-    for(std::vector<CNode*>::const_iterator it = vNodes.begin(); it != vNodes.end(); ++it)
-        if (flags & ((*it)->fInbound ? CONNECTIONS_IN : CONNECTIONS_OUT))
+    for (const auto& pnode : vNodes) {
+        if (flags & (pnode->fInbound ? CONNECTIONS_IN : CONNECTIONS_OUT)) {
             nNum++;
+        }
+    }
 
     return nNum;
 }
@@ -2496,8 +2498,7 @@ void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats)
     vstats.clear();
     LOCK(cs_vNodes);
     vstats.reserve(vNodes.size());
-    for(std::vector<CNode*>::iterator it = vNodes.begin(); it != vNodes.end(); ++it) {
-        CNode* pnode = *it;
+    for (auto& pnode : vNodes) {
         vstats.emplace_back();
         pnode->copyStats(vstats.back());
     }

--- a/src/net.h
+++ b/src/net.h
@@ -166,8 +166,8 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                func(node);
+            if (NodeFullyConnected(node.get()))
+                func(node.get());
         }
     };
 
@@ -176,8 +176,8 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                func(node);
+            if (NodeFullyConnected(node.get()))
+                func(node.get());
         }
     };
 
@@ -186,8 +186,8 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                pre(node);
+            if (NodeFullyConnected(node.get()))
+                pre(node.get());
         }
         post();
     };
@@ -197,8 +197,8 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                pre(node);
+            if (NodeFullyConnected(node.get()))
+                pre(node.get());
         }
         post();
     };
@@ -303,10 +303,10 @@ private:
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
     bool AttemptToEvictConnection();
-    CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure);
+    std::shared_ptr<CNode> ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure);
     bool IsWhitelistedRange(const CNetAddr &addr);
 
-    void DeleteNode(CNode* pnode);
+    void DeleteNode(std::shared_ptr<CNode>&& pnode);
 
     NodeId GetNewNodeId();
 
@@ -329,11 +329,11 @@ private:
     static bool NodeFullyConnected(const CNode* pnode);
 
     template <typename Callable>
-    CNode* FindNode(Callable&& func)
+    std::shared_ptr<CNode> FindNode(Callable&& func)
     {
         LOCK(cs_vNodes);
         for (auto& node : vNodes) {
-            if(func(node)) {
+            if(func(node.get())) {
                 return node;
             }
         }
@@ -371,8 +371,8 @@ private:
     CCriticalSection cs_vOneShots;
     std::vector<std::string> vAddedNodes;
     CCriticalSection cs_vAddedNodes;
-    std::vector<CNode*> vNodes;
-    std::list<CNode*> vNodesDisconnected;
+    std::vector<std::shared_ptr<CNode>> vNodes;
+    std::list<std::shared_ptr<CNode>> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;
     std::atomic<NodeId> nLastNodeId;
 

--- a/src/net.h
+++ b/src/net.h
@@ -302,11 +302,6 @@ private:
 
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
-    CNode* FindNode(const CNetAddr& ip);
-    CNode* FindNode(const CSubNet& subNet);
-    CNode* FindNode(const std::string& addrName);
-    CNode* FindNode(const CService& addr);
-
     bool AttemptToEvictConnection();
     CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure);
     bool IsWhitelistedRange(const CNetAddr &addr);
@@ -332,6 +327,19 @@ private:
 
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);
+
+    template <typename Callable>
+    CNode* FindNode(Callable&& func)
+    {
+        LOCK(cs_vNodes);
+        for (auto& node : vNodes) {
+            if(func(node)) {
+                return node;
+            }
+        }
+        return nullptr;
+    }
+
 
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;

--- a/src/net.h
+++ b/src/net.h
@@ -165,7 +165,6 @@ public:
     template<typename Callable>
     void ForEachNode(Callable&& func)
     {
-        LOCK(cs_vNodes);
         for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 func(node.get());
@@ -175,7 +174,6 @@ public:
     template<typename Callable>
     void ForEachNode(Callable&& func) const
     {
-        LOCK(cs_vNodes);
         for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 func(node.get());
@@ -185,7 +183,6 @@ public:
     template<typename Callable, typename CallableAfter>
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post)
     {
-        LOCK(cs_vNodes);
         for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 pre(node.get());
@@ -196,7 +193,6 @@ public:
     template<typename Callable, typename CallableAfter>
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post) const
     {
-        LOCK(cs_vNodes);
         for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 pre(node.get());

--- a/src/net.h
+++ b/src/net.h
@@ -18,6 +18,7 @@
 #include "protocol.h"
 #include "random.h"
 #include "streams.h"
+#include "strong_ptr.h"
 #include "sync.h"
 #include "uint256.h"
 #include "threadinterrupt.h"
@@ -303,10 +304,10 @@ private:
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
     bool AttemptToEvictConnection();
-    std::shared_ptr<CNode> ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure);
+    strong_ptr<CNode> ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure);
     bool IsWhitelistedRange(const CNetAddr &addr);
 
-    void DeleteNode(std::shared_ptr<CNode>&& pnode);
+    void DeleteNode(decay_ptr<CNode>&& pnode);
 
     NodeId GetNewNodeId();
 
@@ -334,7 +335,7 @@ private:
         LOCK(cs_vNodes);
         for (auto& node : vNodes) {
             if(func(node.get())) {
-                return node;
+                return node.get_shared();
             }
         }
         return nullptr;
@@ -371,8 +372,8 @@ private:
     CCriticalSection cs_vOneShots;
     std::vector<std::string> vAddedNodes;
     CCriticalSection cs_vAddedNodes;
-    std::vector<std::shared_ptr<CNode>> vNodes;
-    std::list<std::shared_ptr<CNode>> vNodesDisconnected;
+    std::vector<strong_ptr<CNode>> vNodes;
+    std::list<decay_ptr<CNode>> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;
     std::atomic<NodeId> nLastNodeId;
 

--- a/src/net.h
+++ b/src/net.h
@@ -166,7 +166,7 @@ public:
     void ForEachNode(Callable&& func)
     {
         LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
+        for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 func(node.get());
         }
@@ -176,7 +176,7 @@ public:
     void ForEachNode(Callable&& func) const
     {
         LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
+        for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 func(node.get());
         }
@@ -186,7 +186,7 @@ public:
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post)
     {
         LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
+        for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 pre(node.get());
         }
@@ -197,7 +197,7 @@ public:
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post) const
     {
         LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
+        for (auto&& node : GetNodesCopy()) {
             if (NodeFullyConnected(node.get()))
                 pre(node.get());
         }
@@ -328,6 +328,19 @@ private:
 
     // Whether the node should be passed out in ForEach* callbacks
     static bool NodeFullyConnected(const CNode* pnode);
+
+    std::vector<std::shared_ptr<CNode>> GetNodesCopy() const
+    {
+        std::vector<std::shared_ptr<CNode>> nodes_copy;
+        {
+            LOCK(cs_vNodes);
+            nodes_copy.reserve(vNodes.size());
+            for (auto&& node : vNodes) {
+                nodes_copy.push_back(node.get_shared());
+            }
+        }
+        return nodes_copy;
+    }
 
     template <typename Callable>
     std::shared_ptr<CNode> FindNode(Callable&& func)

--- a/src/net.h
+++ b/src/net.h
@@ -751,19 +751,6 @@ public:
     //! May not be called more than once
     void SetAddrLocal(const CService& addrLocalIn);
 
-    CNode* AddRef()
-    {
-        nRefCount++;
-        return this;
-    }
-
-    void Release()
-    {
-        nRefCount--;
-    }
-
-
-
     void AddAddressKnown(const CAddress& _addr)
     {
         addrKnown.insert(_addr.GetKey());

--- a/src/strong_ptr.h
+++ b/src/strong_ptr.h
@@ -1,0 +1,317 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_STRONGPTR_H
+#define BITCOIN_STRONGPTR_H
+
+#include <memory>
+
+/*
+    strong_ptr and decay_ptr create a safe use pattern for moving shared_ptrs
+    to a unique_ptr.
+
+    While any such pattern would usually make no sense, it can be made to work
+    with a new type that holds an extra reference (strong_ptr), and one that
+    observes the lifetime of extra references (decay_ptr).
+
+    The process is:
+        1. Create a strong_ptr like any typical smart pointer. It cannot be
+            copied, but it can "loan out" shared_ptrs using
+            strong_ptr::get_shared().
+        2. Use the "loaned" shared_ptrs as usual, and use the strong_ptr as
+            though it were a unique_ptr.
+        3. When it's time to coalesce, move the strong_ptr into a decay_ptr.
+        4. Query the status with decay_ptr::decayed().
+
+    Once moved into a decay_ptr, the original strong_ptr is reset, and the
+    decay_ptr is unable to loan out any new shared_ptrs. Once the decay_ptr has
+    decayed, it behaves just like a unique_ptr.
+
+    If a loaned shared_ptr outlives the strong_ptr that owns it, the lifetime
+    is extended until the last copy is deleted. This is accomplished by
+    creating a shared_ptr to represent the lifetime of the strong_ptr, and
+    storing a copy of it in the loaned shared_ptr's deleter.
+
+    Thus, strong_ptr and decay_ptr ensure that allocated memory is always freed.
+
+    Here's a quick example of their use:
+
+        void func(std::shared_ptr<int>)
+        {
+            // Some long-lived operation
+        }
+
+        int main()
+        {
+            strong_ptr<int> str(make_strong<int>(100));
+            std::thread(func, str.get_shared());
+            decay_ptr<int> dec(std::move(strong));
+            // The original strong_ptr is now reset
+            while (!dec.decayed()) {
+                // wait here
+                continue;
+            }
+            // dec is guaranteed to be unique here. Its memory will be freed
+            // when it goes out of scope.
+            return 0;
+        }
+*/
+
+template <typename T>
+class decay_ptr;
+
+template <typename T>
+class strong_ptr
+{
+    struct shared_deleter {
+        void operator()(T* /* unused */) const {}
+        const std::shared_ptr<void> m_data;
+    };
+
+    friend class decay_ptr<T>;
+
+    template <typename U, typename... Args>
+    friend strong_ptr<U> make_strong(Args&&... args);
+
+    template <typename U>
+    explicit strong_ptr(std::shared_ptr<U>&& rhs) : m_data{std::move(rhs)}
+    {
+    }
+
+public:
+    using element_type = T;
+
+    constexpr strong_ptr() : strong_ptr(nullptr) {}
+
+    constexpr strong_ptr(std::nullptr_t) : m_shared{nullptr} {}
+
+    template <typename U>
+    explicit strong_ptr(U* ptr) : m_data(ptr)
+    {
+    }
+
+    template <typename Deleter>
+    strong_ptr(std::nullptr_t ptr, Deleter deleter) : m_data{ptr, std::move(deleter)}
+    {
+    }
+
+    template <typename U, typename Deleter>
+    strong_ptr(U* ptr, Deleter deleter) : m_data{ptr, std::move(deleter)}
+    {
+    }
+
+    template <typename U, typename Deleter>
+    strong_ptr(std::unique_ptr<U, Deleter>&& rhs) : m_data{std::move(rhs)}
+    {
+    }
+
+    template <typename U>
+    strong_ptr(strong_ptr<U>&& rhs) : m_data{std::move(rhs.m_data)}, m_shared{std::move(rhs.m_shared)}
+    {
+    }
+
+    strong_ptr(strong_ptr&& rhs) noexcept : m_data{std::move(rhs.m_data)}, m_shared{std::move(rhs.m_shared)} {}
+
+    ~strong_ptr() = default;
+
+    strong_ptr(const strong_ptr& rhs) = delete;
+    strong_ptr& operator=(const strong_ptr& rhs) = delete;
+
+    strong_ptr& operator=(strong_ptr&& rhs) noexcept
+    {
+        m_data = std::move(rhs.m_data);
+        m_shared = std::move(rhs.m_shared);
+        return *this;
+    }
+
+    template <typename U>
+    strong_ptr& operator=(strong_ptr<U>&& rhs)
+    {
+        m_data = std::move(rhs.m_data);
+        m_shared = std::move(rhs.m_shared);
+        return *this;
+    }
+
+    template <typename U>
+    strong_ptr& operator=(U* rhs)
+    {
+        reset(rhs);
+        return *this;
+    }
+
+    template <typename U, typename Deleter>
+    strong_ptr& operator=(std::unique_ptr<U, Deleter>&& rhs)
+    {
+        m_data = std::move(rhs);
+        m_shared.reset(nullptr, shared_deleter{m_data});
+        return *this;
+    }
+
+    void reset()
+    {
+        m_data.reset();
+        m_shared.reset();
+    }
+    void reset(std::nullptr_t)
+    {
+        reset();
+    }
+    template <typename U>
+    void reset(U* ptr)
+    {
+        m_data.reset(ptr);
+        m_shared.reset(nullptr, shared_deleter{m_data});
+    }
+    template <typename U, typename Deleter>
+    void reset(U* ptr, Deleter deleter)
+    {
+        m_data.reset(ptr, std::move(deleter));
+        m_shared.reset(nullptr, shared_deleter{m_data});
+    }
+    std::shared_ptr<T> get_shared() const
+    {
+        return std::shared_ptr<T>(m_shared, m_data.get());
+    }
+    T* operator*()
+    {
+        return m_data.operator*();
+    }
+    const T* operator*() const
+    {
+        return m_data.operator*();
+    }
+    T* operator->()
+    {
+        return m_data.operator->();
+    }
+    const T* operator->() const
+    {
+        return m_data.operator->();
+    }
+    const T* get() const
+    {
+        return m_data.get();
+    }
+    T* get()
+    {
+        return m_data.get();
+    }
+    explicit operator bool() const
+    {
+        return m_data.operator bool();
+    }
+
+private:
+    std::shared_ptr<T> m_data;
+    std::shared_ptr<void> m_shared{nullptr, shared_deleter{m_data}};
+};
+
+template <typename T>
+class decay_ptr
+{
+public:
+    constexpr decay_ptr() = default;
+    constexpr decay_ptr(std::nullptr_t) : decay_ptr{} {}
+    decay_ptr(decay_ptr&& rhs) noexcept : m_data{std::move(rhs.m_data)}, m_decaying{rhs.m_decaying}
+    {
+        // NOTE: Until c++14, weak_ptr lacked a move ctor
+        rhs.m_decaying.reset();
+    }
+
+    template <typename U>
+    decay_ptr(decay_ptr<U>&& rhs) : m_data{std::move(rhs.m_data)}, m_decaying{rhs.m_decaying}
+    {
+        // NOTE: Until c++14, weak_ptr lacked a move ctor
+        rhs.m_decaying.reset();
+    }
+
+    decay_ptr(const decay_ptr&) = delete;
+    decay_ptr& operator=(const decay_ptr&) = delete;
+
+    template <typename U>
+    decay_ptr(strong_ptr<U>&& ptr) : m_data{std::move(ptr.m_data)}, m_decaying{ptr.m_shared}
+    {
+        // NOTE: Until c++14, weak_ptr lacked a ctor which accepts an rvalue shared_ptr.
+        ptr.m_shared.reset();
+    }
+
+    ~decay_ptr() = default;
+
+    template <typename U>
+    decay_ptr& operator=(decay_ptr<U>&& rhs)
+    {
+        // NOTE: Until c++14, weak_ptr lacked a move operator
+        m_data = std::move(rhs.m_data);
+        m_decaying = rhs.m_decaying;
+        rhs.m_decaying.reset();
+        return *this;
+    }
+    decay_ptr& operator=(decay_ptr&& rhs) noexcept
+    {
+        // NOTE: Until c++14, weak_ptr lacked a move operator
+        m_data = std::move(rhs.m_data);
+        m_decaying = rhs.m_decaying;
+        rhs.m_decaying.reset();
+        return *this;
+    }
+    template <typename U>
+    decay_ptr& operator=(strong_ptr<U>&& rhs)
+    {
+        // NOTE: Until c++14, weak_ptr lacked a move operator which accepts an rvalue shared_ptr.
+        m_data = std::move(rhs.m_data);
+        m_decaying = rhs.m_shared;
+        rhs.m_shared.reset();
+        return *this;
+    }
+    bool decayed() const
+    {
+        return m_decaying.expired();
+    }
+    void reset()
+    {
+        m_decaying.reset();
+        m_data.reset();
+    }
+    T* operator*()
+    {
+        return m_data.operator*();
+    }
+    const T* operator*() const
+    {
+        return m_data.operator*();
+    }
+    T* operator->()
+    {
+        return m_data.operator->();
+    }
+    const T* operator->() const
+    {
+        return m_data.operator->();
+    }
+    const T* get() const
+    {
+        return m_data.get();
+    }
+    T* get()
+    {
+        return m_data.get();
+    }
+    explicit operator bool() const
+    {
+        return m_data.operator bool();
+    }
+
+private:
+    std::shared_ptr<T> m_data;
+    std::weak_ptr<void> m_decaying;
+};
+
+template <typename T, typename... Args>
+inline strong_ptr<T> make_strong(Args&&... args)
+{
+    return strong_ptr<T>(std::make_shared<T>(std::forward<Args>(args)...));
+}
+
+
+#endif // BITCOIN_STRONGPTR_H

--- a/src/test/strong_ptr.cpp
+++ b/src/test/strong_ptr.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "strong_ptr.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+class my_struct
+{
+public:
+    my_struct(int){}
+    my_struct() = default;
+    ~my_struct()
+    {
+        m_valid = false;
+    }
+    bool valid() const
+    {
+        return m_valid;
+    }
+private:
+    bool m_valid = true;
+};
+
+class Deleter
+{
+public:
+    explicit Deleter(bool& deleted) : m_deleted{deleted}{}
+
+    void operator()(std::nullptr_t)
+    {
+        m_deleted = true;
+    }
+    template <typename T>
+    void operator()(T* ptr)
+    {
+        delete ptr;
+        m_deleted = true;
+    }
+private:
+    bool& m_deleted;
+};
+
+BOOST_FIXTURE_TEST_SUITE(strong_ptr_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(construction)
+{
+    // typical construction
+    strong_ptr<my_struct> strong(new my_struct());
+    BOOST_CHECK(strong);
+    BOOST_CHECK(strong->valid());
+    decay_ptr<my_struct> degraded(std::move(strong));
+    BOOST_CHECK(!strong);
+    BOOST_CHECK(degraded);
+    BOOST_CHECK(degraded.decayed());
+    BOOST_CHECK(degraded->valid());
+}
+
+BOOST_AUTO_TEST_CASE(deletion)
+{
+    // test typical deletion
+    {
+        bool deleted = false;
+        {
+            strong_ptr<my_struct> strong(new my_struct(), Deleter(deleted));
+        }
+        BOOST_CHECK(deleted);
+    }
+    {
+        bool deleted = false;
+        strong_ptr<my_struct> strong(new my_struct(), Deleter(deleted));
+        strong.reset();
+        BOOST_CHECK(deleted);
+    }
+    {
+        bool deleted = false;
+        strong_ptr<my_struct> strong(new my_struct(), Deleter(deleted));
+        decay_ptr<my_struct> degraded(std::move(strong));
+        BOOST_CHECK(!deleted);
+        degraded.reset();
+        BOOST_CHECK(deleted);
+    }
+    {
+        bool deleted = false;
+        strong_ptr<my_struct> strong(new my_struct(), Deleter(deleted));
+        {
+            auto shared = strong.get_shared();
+        }
+        decay_ptr<my_struct> degraded(std::move(strong));
+        BOOST_CHECK(!deleted);
+        degraded.reset();
+        BOOST_CHECK(deleted);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(shared_outlives_strong)
+{
+    {
+        bool deleted = false;
+        strong_ptr<my_struct> strong(new my_struct(), Deleter(deleted));
+        auto shared = strong.get_shared();
+        {
+            decay_ptr<my_struct> degraded(std::move(strong));
+            BOOST_CHECK(!degraded.decayed());
+        }
+        BOOST_CHECK(!deleted);
+        shared.reset();
+        BOOST_CHECK(deleted);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(use_count)
+{
+        strong_ptr<my_struct> strong(new my_struct());
+        auto shared = strong.get_shared();
+        BOOST_CHECK(shared.use_count() == 2);
+        auto strong2(std::move(strong));
+        BOOST_CHECK(shared.use_count() == 2);
+        BOOST_CHECK(strong2);
+        BOOST_CHECK(!strong);
+        strong = std::move(strong2);
+        BOOST_CHECK(shared.use_count() == 2);
+        BOOST_CHECK(strong);
+        BOOST_CHECK(!strong2);
+        decay_ptr<my_struct> degraded(std::move(strong));
+        BOOST_CHECK(shared.use_count() == 1);
+        BOOST_CHECK(!strong);
+        BOOST_CHECK(!degraded.decayed());
+        shared.reset();
+        BOOST_CHECK(degraded.decayed());
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a more involved version of #10697, which instead completely gets rid of our nasty AddRef() and Release() in favor of automatic lifetime management.

Special care must be taken, though, to only delete CNodes from a single thread, and to control which thread that is. Eventually, this should move to the message processing thread, so that it's not possible to hit cs_main from the main network thread.

In order to do this safely, this PR introduces 2 new generic smart pointer types: strong_ptr and decay_ptr. They provide a functionality that I've wanted for a long time: the ability to safely decay a shared_ptr to a unique_ptr. That sounds somewhat nonsensical at first, but it's useful to be able to make copies of a pointer for a while, stop, wait until only one remains, then delete with guaranteed safety.

Please read shared_ptr.h and check out the tests before groaning. I think this is a very cool (and completely safe) pattern.

This functionality could potentially be accomplished with a shared_ptr and polling ptr.unique(), but that's inherently racy because a new copy could be created simultaneously. Even moving to a local instance and calling .unique() on that one is not safe, as a weak_ptr could be upgraded simultaneously.

Instead, a strong_ptr is created which acts like a unique_ptr but allows shared_ptrs to be "loaned" out. Once a strong_ptr is moved into a decay_ptr, the strong_ptr is reset and no new loans may be created. The decay_ptr tracks the lifetime of the loaned copies, and knows whether or not they have all expired. This can be queried, with no race concerns, with decay_ptr::decay().

Additionally, if the loaned shared_ptrs for some reason outlive the strong_ptr/decay_ptr, they are safely deleted once the last loaned shared_ptr expires. So there is no risk of leaks.

In order to make review easier, these changes were made in a few stages:
1. Where possible, make functions agnostic to the type of pointer being used
2. Switch to shared_ptr but keep existing refcounting on top
3. Switch to strong_ptr
4. Drop existing refcounting and now-unnecessary locking.