### PR TITLE
test: Move variable `state` down where it is used

### DIFF
--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -196,8 +196,8 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
     // Test that invalidity under a set of flags doesn't preclude validity
     // under other (eg consensus) flags.
     // spend_tx is invalid according to DERSIG
-    CValidationState state;
     {
+        CValidationState state;
         PrecomputedTransactionData ptd_spend_tx(spend_tx);
 
         BOOST_CHECK(!CheckInputs(spend_tx, state, pcoinsTip, true, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_DERSIG, true, true, ptd_spend_tx, nullptr));


### PR DESCRIPTION
Tests added in #10192 emit few shadowing warnings:

```
test/txvalidationcache_tests.cpp:268:26: warning: declaration shadows a local variable [-Wshadow]
test/txvalidationcache_tests.cpp:296:26: warning: declaration shadows a local variable [-Wshadow]
test/txvalidationcache_tests.cpp:357:26: warning: declaration shadows a local variable [-Wshadow]
```

Remove shadowing declarations and reuse the upper local declaration as in other already present test cases.
