### PR TITLE
[test] don't run dbcrash.py on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ script:
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning"; fi
+    - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning,dbcrash"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --coverage --quiet ${extended}; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
dbcrash.db is disk intensive (it's stop-starting nodes and flushing to disk many times). Travis performs badly with heavy disk load and even with the fixes in #10704 the test still fails with timeouts in individual calls.

Even if none of the individual calls timeout, the test takes far too long on Travis. Here's an example of the test timing out the 20 minute max for an individual functional test: https://travis-ci.org/bitcoin/bitcoin/jobs/250016845. Note that the test was only about half way through when it was killed, so without the timeout in test_runner this would have taken ~40 minutes and travis would have killed the job.

For now I think we should just exclude dbcrash.py from Travis in the same way as pruning.py. It doesn't make sense to run disk-heavy tests on Travis.