### PR TITLE
[rpc] fix verbose argument for getblock in bitcoin-cli

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -79,6 +79,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listunspent", 3, "include_unsafe" },
     { "listunspent", 4, "query_options" },
     { "getblock", 1, "verbosity" },
+    { "getblock", 1, "verbose" },
     { "getblockheader", 1, "verbose" },
     { "getchaintxstats", 0, "nblocks" },
     { "gettransaction", 1, "include_watchonly" },


### PR DESCRIPTION
Using the `verbose` option with `getblock` in bitcoin-cli has been broken since #8704:

```
→ bitcoin-cli -named getblock blockhash=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206 verbose=true
error code: -1
error message:
JSON value is not a boolean as expected

→ bitcoin-cli -named getblock blockhash=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206 verbosity=true
{
  "hash": "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
...
```

In general, I think that adding aliases because some people find argument names distasteful is a bad idea since it leads to subtle bugs like this.

However, that functionality has already been merged in so I'm not going to try to undo it. This is the simplest fix for restoring the previous behavior.

@achow101 @luke-jr 