### PR TITLE
[wallet] Change bumpfee totalFee option to feeRate option

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -667,7 +667,7 @@ bool WalletModel::bumpFee(uint256 hash)
     std::unique_ptr<CFeeBumper> feeBump;
     {
         LOCK2(cs_main, wallet->cs_wallet);
-        feeBump.reset(new CFeeBumper(wallet, hash, nTxConfirmTarget, false, 0, true));
+        feeBump.reset(new CFeeBumper(wallet, hash, nTxConfirmTarget, false, CFeeRate(0), true));
     }
     if (feeBump->getResult() != BumpFeeResult::OK)
     {

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_FEEBUMPER_H
 
 #include <primitives/transaction.h>
+#include "policy/fees.h"
 
 class CWallet;
 class CWalletTx;
@@ -24,7 +25,7 @@ enum class BumpFeeResult
 class CFeeBumper
 {
 public:
-    CFeeBumper(const CWallet *pWalletIn, const uint256 txidIn, int newConfirmTarget, bool ignoreGlobalPayTxFee, CAmount totalFee, bool newTxReplaceable);
+    CFeeBumper(const CWallet *pWalletIn, const uint256 txidIn, int newConfirmTarget, bool ignoreGlobalPayTxFee, CFeeRate feeRate, bool newTxReplaceable);
     BumpFeeResult getResult() const { return currentResult; }
     const std::vector<std::string>& getErrors() const { return vErrors; }
     CAmount getOldFee() const { return nOldFee; }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2902,7 +2902,12 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry& acentry, CWalletDB *pwa
 
 CAmount CWallet::GetRequiredFee(unsigned int nTxBytes)
 {
-    return std::max(minTxFee.GetFee(nTxBytes), ::minRelayTxFee.GetFee(nTxBytes));
+    return GetRequiredFeeRate().GetFee(nTxBytes);
+}
+
+CFeeRate CWallet::GetRequiredFeeRate()
+{
+    return std::max(minTxFee, ::minRelayTxFee);
 }
 
 CAmount CWallet::GetMinimumFee(unsigned int nTxBytes, unsigned int nConfirmTarget, const CTxMemPool& pool, const CBlockPolicyEstimator& estimator, FeeCalculation *feeCalc, bool ignoreGlobalPayTxFee)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -969,6 +969,11 @@ public:
      * floating relay fee and user set minimum transaction fee
      */
     static CAmount GetRequiredFee(unsigned int nTxBytes);
+    /**
+     * Return the minimum required feerate taking into account the
+     * floating relay fee and user set minimum transaction fee
+     */
+    static CFeeRate GetRequiredFeeRate();
 
     bool NewKeyPool();
     size_t KeypoolCountExternalKeys();


### PR DESCRIPTION
Using a total fee argument is of dubious utility and also makes further improvements where you are changing inputs/outputs difficult. To use the previous argument successfully the user must do additional math, rather than taking any fee estimate desired and plugging it in

Did satoshis/byte since `totalFee` was satoshis.