### PR TITLE
Use quoted form when including primitives/transaction.h and wallet/wallet.h

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -25,7 +25,7 @@
 
 #ifdef ENABLE_WALLET
 #include <db_cxx.h>
-#include <wallet/wallet.h>
+#include "wallet/wallet.h"
 #endif
 
 #include <QKeyEvent>

--- a/src/wallet/feebumper.h
+++ b/src/wallet/feebumper.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_WALLET_FEEBUMPER_H
 #define BITCOIN_WALLET_FEEBUMPER_H
 
-#include <primitives/transaction.h>
+#include "primitives/transaction.h"
 
 class CWallet;
 class CWalletTx;


### PR DESCRIPTION
Nit: We expect to find `primitives/transaction.h` locally in `src/`.