### PR TITLE
Fix multi_rpc test for hosts that dont default to utf8

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -236,7 +236,7 @@ def get_auth_cookie(datadir, n):
     user = None
     password = None
     if os.path.isfile(os.path.join(datadir, "bitcoin.conf")):
-        with open(os.path.join(datadir, "bitcoin.conf"), 'r') as f:
+        with open(os.path.join(datadir, "bitcoin.conf"), 'r', encoding='utf8') as f:
             for line in f:
                 if line.startswith("rpcuser="):
                     assert user is None  # Ensure that there is only one rpcuser line


### PR DESCRIPTION
Otherwise the utf8 written to bitcoin.conf throws an exception when
read from get_auth_cookie