### PR TITLE
[tests] fix replace_by_fee.py

### DIFF
--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -531,8 +531,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         assert_equal(json1["vin"][0]["sequence"], 4294967295)
 
         rawtx2 = self.nodes[0].createrawtransaction([], outs)
-        frawtx2a = self.nodes[0].fundrawtransaction(rawtx2, {"optIntoRbf": True})
-        frawtx2b = self.nodes[0].fundrawtransaction(rawtx2, {"optIntoRbf": False})
+        frawtx2a = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": True})
+        frawtx2b = self.nodes[0].fundrawtransaction(rawtx2, {"replaceable": False})
 
         json0  = self.nodes[0].decoderawtransaction(frawtx2a['hex'])
         json1  = self.nodes[0].decoderawtransaction(frawtx2b['hex'])


### PR DESCRIPTION
fb915d5b183adb915c72bb11c6f3b418841e3512 changed the optIntoRbf field in
fundrawtransaction to replaceable. This commit fixes up
replace-by-fee.py to use the new option name.