### PR TITLE
[wallet] Remove Wallet dependencies from init.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -161,6 +161,7 @@ BITCOIN_CORE_H = \
   validation.h \
   validationinterface.h \
   versionbits.h \
+  walletinitinterface.h \
   wallet/coincontrol.h \
   wallet/crypter.h \
   wallet/db.h \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -18,6 +18,10 @@
 #include <httpserver.h>
 #include <httprpc.h>
 #include <utilstrencodings.h>
+#if ENABLE_WALLET
+#include <wallet/init.h>
+#include <walletinitinterface.h>
+#endif
 
 #include <boost/thread.hpp>
 
@@ -58,6 +62,10 @@ void WaitForShutdown()
 bool AppInit(int argc, char* argv[])
 {
     bool fRet = false;
+
+#if ENABLE_WALLET
+    g_wallet_init_interface.reset(new WalletInit);
+#endif
 
     //
     // Parameters

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -20,8 +20,8 @@
 #include <utilstrencodings.h>
 #if ENABLE_WALLET
 #include <wallet/init.h>
-#include <walletinitinterface.h>
 #endif
+#include <walletinitinterface.h>
 
 #include <boost/thread.hpp>
 
@@ -65,6 +65,8 @@ bool AppInit(int argc, char* argv[])
 
 #if ENABLE_WALLET
     g_wallet_init_interface.reset(new WalletInit);
+#else
+    g_wallet_init_interface.reset(new DummyWalletInit);
 #endif
 
     //

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -190,7 +190,7 @@ void Shutdown()
     StopRPC();
     StopHTTPServer();
 #ifdef ENABLE_WALLET
-    FlushWallets();
+    WalletInit::Flush();
 #endif
     StopMapPort();
 
@@ -250,7 +250,7 @@ void Shutdown()
         pblocktree.reset();
     }
 #ifdef ENABLE_WALLET
-    StopWallets();
+    WalletInit::Stop();
 #endif
 
 #if ENABLE_ZMQ
@@ -272,7 +272,7 @@ void Shutdown()
     GetMainSignals().UnregisterBackgroundSignalScheduler();
     GetMainSignals().UnregisterWithMempoolSignals(mempool);
 #ifdef ENABLE_WALLET
-    CloseWallets();
+    WalletInit::Close();
 #endif
     globalVerifyHandle.reset();
     ECC_Stop();
@@ -416,7 +416,7 @@ std::string HelpMessage(HelpMessageMode mode)
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
 
 #ifdef ENABLE_WALLET
-    strUsage += GetWalletHelpString(showDebug);
+    strUsage += WalletInit::GetHelpString(showDebug);
 #endif
 
 #if ENABLE_ZMQ
@@ -1092,8 +1092,7 @@ bool AppInitParameterInteraction()
     nBytesPerSigOp = gArgs.GetArg("-bytespersigop", nBytesPerSigOp);
 
 #ifdef ENABLE_WALLET
-    if (!WalletParameterInteraction())
-        return false;
+    if (!WalletInit::ParameterInteraction()) return false;
 #endif
 
     fIsBareMultisigStd = gArgs.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
@@ -1258,7 +1257,7 @@ bool AppInitMain()
      */
     RegisterAllCoreRPCCommands(tableRPC);
 #ifdef ENABLE_WALLET
-    RegisterWalletRPC(tableRPC);
+    WalletInit::RegisterRPC(tableRPC);
 #endif
 
     /* Start the RPC server already.  It will be started in "warmup" mode
@@ -1277,8 +1276,7 @@ bool AppInitMain()
 
     // ********************************************************* Step 5: verify wallet database integrity
 #ifdef ENABLE_WALLET
-    if (!VerifyWallets())
-        return false;
+    if (!WalletInit::Verify()) return false;
 #endif
     // ********************************************************* Step 6: network initialization
     // Note that we absolutely cannot open any actual connections
@@ -1598,8 +1596,7 @@ bool AppInitMain()
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET
-    if (!OpenWallets())
-        return false;
+    if (!WalletInit::Open()) return false;
 #else
     LogPrintf("No wallet support compiled in!\n");
 #endif
@@ -1749,7 +1746,7 @@ bool AppInitMain()
     uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET
-    StartWallets(scheduler);
+    WalletInit::Start(scheduler);
 #endif
 
     return true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -43,10 +43,8 @@
 #include <util.h>
 #include <utilmoneystr.h>
 #include <validationinterface.h>
-#ifdef ENABLE_WALLET
-#include <wallet/init.h>
-#endif
 #include <warnings.h>
+#include <walletinitinterface.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <memory>
@@ -74,6 +72,7 @@ static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 
 std::unique_ptr<CConnman> g_connman;
 std::unique_ptr<PeerLogicValidation> peerLogic;
+std::unique_ptr<WalletInitInterface> g_wallet_init_interface;
 
 #if ENABLE_ZMQ
 static CZMQNotificationInterface* pzmqNotificationInterface = nullptr;
@@ -189,9 +188,9 @@ void Shutdown()
     StopREST();
     StopRPC();
     StopHTTPServer();
-#ifdef ENABLE_WALLET
-    WalletInit::Flush();
-#endif
+    if (g_wallet_init_interface) {
+        g_wallet_init_interface->Flush();
+    }
     StopMapPort();
 
     // Because these depend on each-other, we make sure that neither can be
@@ -249,9 +248,9 @@ void Shutdown()
         pcoinsdbview.reset();
         pblocktree.reset();
     }
-#ifdef ENABLE_WALLET
-    WalletInit::Stop();
-#endif
+    if (g_wallet_init_interface) {
+        g_wallet_init_interface->Stop();
+    }
 
 #if ENABLE_ZMQ
     if (pzmqNotificationInterface) {
@@ -271,9 +270,10 @@ void Shutdown()
     UnregisterAllValidationInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
     GetMainSignals().UnregisterWithMempoolSignals(mempool);
-#ifdef ENABLE_WALLET
-    WalletInit::Close();
-#endif
+    if (g_wallet_init_interface) {
+        g_wallet_init_interface->Close();
+    }
+    g_wallet_init_interface.reset();
     globalVerifyHandle.reset();
     ECC_Stop();
     LogPrintf("%s: done\n", __func__);
@@ -415,9 +415,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-whitelist=<IP address or network>", _("Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.") +
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
 
-#ifdef ENABLE_WALLET
-    strUsage += WalletInit::GetHelpString(showDebug);
-#endif
+    if (g_wallet_init_interface) {
+        strUsage += g_wallet_init_interface->GetHelpString(showDebug);
+    }
 
 #if ENABLE_ZMQ
     strUsage += HelpMessageGroup(_("ZeroMQ notification options:"));
@@ -1091,9 +1091,7 @@ bool AppInitParameterInteraction()
         return InitError(strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
     nBytesPerSigOp = gArgs.GetArg("-bytespersigop", nBytesPerSigOp);
 
-#ifdef ENABLE_WALLET
-    if (!WalletInit::ParameterInteraction()) return false;
-#endif
+    if (g_wallet_init_interface && !g_wallet_init_interface->ParameterInteraction()) return false;
 
     fIsBareMultisigStd = gArgs.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = gArgs.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
@@ -1256,9 +1254,9 @@ bool AppInitMain()
      * available in the GUI RPC console even if external calls are disabled.
      */
     RegisterAllCoreRPCCommands(tableRPC);
-#ifdef ENABLE_WALLET
-    WalletInit::RegisterRPC(tableRPC);
-#endif
+    if (g_wallet_init_interface) {
+        g_wallet_init_interface->RegisterRPC(tableRPC);
+    }
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections
@@ -1275,9 +1273,8 @@ bool AppInitMain()
     int64_t nStart;
 
     // ********************************************************* Step 5: verify wallet database integrity
-#ifdef ENABLE_WALLET
-    if (!WalletInit::Verify()) return false;
-#endif
+    if (g_wallet_init_interface && !g_wallet_init_interface->Verify()) return false;
+
     // ********************************************************* Step 6: network initialization
     // Note that we absolutely cannot open any actual connections
     // until the very end ("start node") as the UTXO/block state
@@ -1595,11 +1592,7 @@ bool AppInitMain()
     fFeeEstimatesInitialized = true;
 
     // ********************************************************* Step 8: load wallet
-#ifdef ENABLE_WALLET
-    if (!WalletInit::Open()) return false;
-#else
-    LogPrintf("No wallet support compiled in!\n");
-#endif
+    if (g_wallet_init_interface && !g_wallet_init_interface->Open()) return false;
 
     // ********************************************************* Step 9: data directory maintenance
 
@@ -1745,9 +1738,9 @@ bool AppInitMain()
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));
 
-#ifdef ENABLE_WALLET
-    WalletInit::Start(scheduler);
-#endif
+    if (g_wallet_init_interface) {
+        g_wallet_init_interface->Start(scheduler);
+    }
 
     return true;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -188,9 +188,7 @@ void Shutdown()
     StopREST();
     StopRPC();
     StopHTTPServer();
-    if (g_wallet_init_interface) {
-        g_wallet_init_interface->Flush();
-    }
+    g_wallet_init_interface->Flush();
     StopMapPort();
 
     // Because these depend on each-other, we make sure that neither can be
@@ -248,9 +246,7 @@ void Shutdown()
         pcoinsdbview.reset();
         pblocktree.reset();
     }
-    if (g_wallet_init_interface) {
-        g_wallet_init_interface->Stop();
-    }
+    g_wallet_init_interface->Stop();
 
 #if ENABLE_ZMQ
     if (pzmqNotificationInterface) {
@@ -270,9 +266,7 @@ void Shutdown()
     UnregisterAllValidationInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
     GetMainSignals().UnregisterWithMempoolSignals(mempool);
-    if (g_wallet_init_interface) {
-        g_wallet_init_interface->Close();
-    }
+    g_wallet_init_interface->Close();
     g_wallet_init_interface.reset();
     globalVerifyHandle.reset();
     ECC_Stop();
@@ -415,9 +409,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-whitelist=<IP address or network>", _("Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times.") +
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
 
-    if (g_wallet_init_interface) {
-        strUsage += g_wallet_init_interface->GetHelpString(showDebug);
-    }
+    strUsage += g_wallet_init_interface->GetHelpString(showDebug);
 
 #if ENABLE_ZMQ
     strUsage += HelpMessageGroup(_("ZeroMQ notification options:"));
@@ -1091,7 +1083,7 @@ bool AppInitParameterInteraction()
         return InitError(strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
     nBytesPerSigOp = gArgs.GetArg("-bytespersigop", nBytesPerSigOp);
 
-    if (g_wallet_init_interface && !g_wallet_init_interface->ParameterInteraction()) return false;
+    if (!g_wallet_init_interface->ParameterInteraction()) return false;
 
     fIsBareMultisigStd = gArgs.GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = gArgs.GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
@@ -1254,9 +1246,7 @@ bool AppInitMain()
      * available in the GUI RPC console even if external calls are disabled.
      */
     RegisterAllCoreRPCCommands(tableRPC);
-    if (g_wallet_init_interface) {
-        g_wallet_init_interface->RegisterRPC(tableRPC);
-    }
+    g_wallet_init_interface->RegisterRPC(tableRPC);
 
     /* Start the RPC server already.  It will be started in "warmup" mode
      * and not really process calls already (but it will signify connections
@@ -1273,7 +1263,7 @@ bool AppInitMain()
     int64_t nStart;
 
     // ********************************************************* Step 5: verify wallet database integrity
-    if (g_wallet_init_interface && !g_wallet_init_interface->Verify()) return false;
+    if (!g_wallet_init_interface->Verify()) return false;
 
     // ********************************************************* Step 6: network initialization
     // Note that we absolutely cannot open any actual connections
@@ -1592,7 +1582,7 @@ bool AppInitMain()
     fFeeEstimatesInitialized = true;
 
     // ********************************************************* Step 8: load wallet
-    if (g_wallet_init_interface && !g_wallet_init_interface->Open()) return false;
+    if (!g_wallet_init_interface->Open()) return false;
 
     // ********************************************************* Step 9: data directory maintenance
 
@@ -1738,9 +1728,7 @@ bool AppInitMain()
     SetRPCWarmupFinished();
     uiInterface.InitMessage(_("Done loading"));
 
-    if (g_wallet_init_interface) {
-        g_wallet_init_interface->Start(scheduler);
-    }
+    g_wallet_init_interface->Start(scheduler);
 
     return true;
 }

--- a/src/init.h
+++ b/src/init.h
@@ -6,10 +6,14 @@
 #ifndef BITCOIN_INIT_H
 #define BITCOIN_INIT_H
 
+#include <memory>
 #include <string>
 
 class CScheduler;
 class CWallet;
+
+class WalletInitInterface;
+extern std::unique_ptr<WalletInitInterface> g_wallet_init_interface;
 
 namespace boost
 {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -35,8 +35,8 @@
 #ifdef ENABLE_WALLET
 #include <wallet/init.h>
 #include <wallet/wallet.h>
-#include <walletinitinterface.h>
 #endif
+#include <walletinitinterface.h>
 
 #include <stdint.h>
 
@@ -674,6 +674,8 @@ int main(int argc, char *argv[])
 
     // Hook up the wallet init interface
     g_wallet_init_interface.reset(new WalletInit);
+#else
+    g_wallet_init_interface.reset(new DummyWalletInit);
 #endif
 
     /// 9. Main GUI initialization

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -33,7 +33,9 @@
 #include <warnings.h>
 
 #ifdef ENABLE_WALLET
+#include <wallet/init.h>
 #include <wallet/wallet.h>
+#include <walletinitinterface.h>
 #endif
 
 #include <stdint.h>
@@ -669,6 +671,9 @@ int main(int argc, char *argv[])
     // Start up the payment server early, too, so impatient users that click on
     // bitcoin: links repeatedly have their payment requests routed to this process:
     app.createPaymentServer();
+
+    // Hook up the wallet init interface
+    g_wallet_init_interface.reset(new WalletInit);
 #endif
 
     /// 9. Main GUI initialization

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -13,7 +13,7 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-std::string GetWalletHelpString(bool showDebug)
+std::string WalletInit::GetHelpString(bool showDebug)
 {
     std::string strUsage = HelpMessageGroup(_("Wallet options:"));
     strUsage += HelpMessageOpt("-addresstype", strprintf("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")", FormatOutputType(OUTPUT_TYPE_DEFAULT)));
@@ -55,7 +55,7 @@ std::string GetWalletHelpString(bool showDebug)
     return strUsage;
 }
 
-bool WalletParameterInteraction()
+bool WalletInit::ParameterInteraction()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         for (const std::string& wallet : gArgs.GetArgs("-wallet")) {
@@ -192,7 +192,7 @@ bool WalletParameterInteraction()
     return true;
 }
 
-void RegisterWalletRPC(CRPCTable &t)
+void WalletInit::RegisterRPC(CRPCTable &t)
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         return;
@@ -201,7 +201,7 @@ void RegisterWalletRPC(CRPCTable &t)
     RegisterWalletRPCCommands(t);
 }
 
-bool VerifyWallets()
+bool WalletInit::Verify()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         return true;
@@ -272,7 +272,7 @@ bool VerifyWallets()
     return true;
 }
 
-bool OpenWallets()
+bool WalletInit::Open()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         LogPrintf("Wallet disabled!\n");
@@ -290,25 +290,29 @@ bool OpenWallets()
     return true;
 }
 
-void StartWallets(CScheduler& scheduler) {
+void WalletInit::Start(CScheduler& scheduler)
+{
     for (CWalletRef pwallet : vpwallets) {
         pwallet->postInitProcess(scheduler);
     }
 }
 
-void FlushWallets() {
+void WalletInit::Flush()
+{
     for (CWalletRef pwallet : vpwallets) {
         pwallet->Flush(false);
     }
 }
 
-void StopWallets() {
+void WalletInit::Stop()
+{
     for (CWalletRef pwallet : vpwallets) {
         pwallet->Flush(true);
     }
 }
 
-void CloseWallets() {
+void WalletInit::Close()
+{
     for (CWalletRef pwallet : vpwallets) {
         delete pwallet;
     }

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -11,33 +11,37 @@
 class CRPCTable;
 class CScheduler;
 
-//! Return the wallets help message.
-std::string GetWalletHelpString(bool showDebug);
+class WalletInit {
+public:
 
-//! Wallets parameter interaction
-bool WalletParameterInteraction();
+    //! Return the wallets help message.
+    static std::string GetHelpString(bool showDebug);
 
-//! Register wallet RPCs.
-void RegisterWalletRPC(CRPCTable &tableRPC);
+    //! Wallets parameter interaction
+    static bool ParameterInteraction();
 
-//! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
-//  This function will perform salvage on the wallet if requested, as long as only one wallet is
-//  being loaded (WalletParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
-bool VerifyWallets();
+    //! Register wallet RPCs.
+    static void RegisterRPC(CRPCTable &tableRPC);
 
-//! Load wallet databases.
-bool OpenWallets();
+    //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
+    //  This function will perform salvage on the wallet if requested, as long as only one wallet is
+    //  being loaded (WalletParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
+    static bool Verify();
 
-//! Complete startup of wallets.
-void StartWallets(CScheduler& scheduler);
+    //! Load wallet databases.
+    static bool Open();
 
-//! Flush all wallets in preparation for shutdown.
-void FlushWallets();
+    //! Complete startup of wallets.
+    static void Start(CScheduler& scheduler);
 
-//! Stop all wallets. Wallets will be flushed first.
-void StopWallets();
+    //! Flush all wallets in preparation for shutdown.
+    static void Flush();
 
-//! Close all wallets.
-void CloseWallets();
+    //! Stop all wallets. Wallets will be flushed first.
+    static void Stop();
+
+    //! Close all wallets.
+    static void Close();
+};
 
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -6,42 +6,43 @@
 #ifndef BITCOIN_WALLET_INIT_H
 #define BITCOIN_WALLET_INIT_H
 
+#include <walletinitinterface.h>
 #include <string>
 
 class CRPCTable;
 class CScheduler;
 
-class WalletInit {
+class WalletInit : public WalletInitInterface {
 public:
 
     //! Return the wallets help message.
-    static std::string GetHelpString(bool showDebug);
+    std::string GetHelpString(bool showDebug) override;
 
     //! Wallets parameter interaction
-    static bool ParameterInteraction();
+    bool ParameterInteraction() override;
 
     //! Register wallet RPCs.
-    static void RegisterRPC(CRPCTable &tableRPC);
+    void RegisterRPC(CRPCTable &tableRPC) override;
 
     //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
     //  This function will perform salvage on the wallet if requested, as long as only one wallet is
     //  being loaded (WalletParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
-    static bool Verify();
+    bool Verify() override;
 
     //! Load wallet databases.
-    static bool Open();
+    bool Open() override;
 
     //! Complete startup of wallets.
-    static void Start(CScheduler& scheduler);
+    void Start(CScheduler& scheduler) override;
 
     //! Flush all wallets in preparation for shutdown.
-    static void Flush();
+    void Flush() override;
 
     //! Stop all wallets. Wallets will be flushed first.
-    static void Stop();
+    void Stop() override;
 
     //! Close all wallets.
-    static void Close();
+    void Close() override;
 };
 
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef WALLETINITINTERFACE_H
+#define WALLETINITINTERFACE_H
+
+#include <string>
+
+class CScheduler;
+class CRPCTable;
+
+class WalletInitInterface {
+public:
+    /** Get wallet help string */
+    virtual std::string GetHelpString(bool showDebug) = 0;
+    /** Check wallet parameter interaction */
+    virtual bool ParameterInteraction() = 0;
+    /** Register wallet RPC*/
+    virtual void RegisterRPC(CRPCTable &) = 0;
+    /** Verify wallets */
+    virtual bool Verify() = 0;
+    /** Open wallets*/
+    virtual bool Open() = 0;
+    /** Start wallets*/
+    virtual void Start(CScheduler& scheduler) = 0;
+    /** Flush Wallets*/
+    virtual void Flush() = 0;
+    /** Stop Wallets*/
+    virtual void Stop() = 0;
+    /** Close wallets */
+    virtual void Close() = 0;
+
+    virtual ~WalletInitInterface() {}
+};
+
+#endif // WALLETINITINTERFACE_H

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -34,4 +34,18 @@ public:
     virtual ~WalletInitInterface() {}
 };
 
+class DummyWalletInit : public WalletInitInterface {
+public:
+
+    std::string GetHelpString(bool showDebug) override {return std::string{};}
+    bool ParameterInteraction() override {return true;}
+    void RegisterRPC(CRPCTable &) override {}
+    bool Verify() override {return true;}
+    bool Open() override {return true;}
+    void Start(CScheduler& scheduler) override {}
+    void Flush() override {}
+    void Stop() override {}
+    void Close() override {}
+};
+
 #endif // WALLETINITINTERFACE_H


### PR DESCRIPTION
This continues the work of #7965. This PR, along with several others, would remove the remaining dependencies from libbitcoin_server.a on libbitcoin_wallet.a.

To create the interface, I've just translated all the old init.cpp wallet function calls into an interface class. I've not done any thinking about whether it makes sense to change that interface by combining/splitting those calls. This is a purely internal interface, so there's no problem in changing it later.