### PR TITLE
Building Environment: Set ARFLAGS to cr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,12 @@ BITCOIN_GUI_NAME=bitcoin-qt
 BITCOIN_CLI_NAME=bitcoin-cli
 BITCOIN_TX_NAME=bitcoin-tx
 
+dnl Unless the user specified ARFLAGS, force it to be cr
+AC_ARG_VAR(ARFLAGS, [Flags for the archiver, defaults to <cr> if not set])
+if test "x${ARFLAGS+set}" != "xset"; then
+  ARFLAGS="cr"
+fi
+
 AC_CANONICAL_HOST
 
 AH_TOP([#ifndef BITCOIN_CONFIG_H])
@@ -1262,4 +1268,5 @@ echo "  CPPFLAGS      = $CPPFLAGS"
 echo "  CXX           = $CXX"
 echo "  CXXFLAGS      = $CXXFLAGS"
 echo "  LDFLAGS       = $LDFLAGS"
+echo "  ARFLAGS       = $ARFLAGS"
 echo 


### PR DESCRIPTION
Override the default of ARFLAGS of `cru` to `cr`.

When building, ar produces a warning for each archive, for example
```
  AR       libbitcoin_server.a
/usr/bin/ar: `u' modifier ignored since `D' is the default (see `U')

```
Since `u` is the default anyway, it cannot hurt to remove it.