### PR TITLE
[wallet] Clarify wallet initialization / destruction interface

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1567,7 +1567,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET
-    if (!InitLoadWallet())
+    if (!OpenWallets())
         return false;
 #else
     LogPrintf("No wallet support compiled in!\n");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -189,9 +189,7 @@ void Shutdown()
     StopRPC();
     StopHTTPServer();
 #ifdef ENABLE_WALLET
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->Flush(false);
-    }
+    FlushWallets(false);
 #endif
     MapPort(false);
     UnregisterValidationInterface(peerLogic.get());
@@ -246,9 +244,7 @@ void Shutdown()
         pblocktree = nullptr;
     }
 #ifdef ENABLE_WALLET
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->Flush(true);
-    }
+    FlushWallets(true);
 #endif
 
 #if ENABLE_ZMQ

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1246,7 +1246,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // ********************************************************* Step 5: verify wallet database integrity
 #ifdef ENABLE_WALLET
-    if (!WalletVerify())
+    if (!VerifyWallets())
         return false;
 #endif
     // ********************************************************* Step 6: network initialization

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -44,7 +44,6 @@
 #include "validationinterface.h"
 #ifdef ENABLE_WALLET
 #include "wallet/init.h"
-#include "wallet/wallet.h"
 #endif
 #include "warnings.h"
 #include <stdint.h>
@@ -1691,9 +1690,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->postInitProcess(scheduler);
-    }
+    StartWallets(scheduler);
 #endif
 
     return !fRequestShutdown;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -265,10 +265,7 @@ void Shutdown()
     UnregisterAllValidationInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
 #ifdef ENABLE_WALLET
-    for (CWalletRef pwallet : vpwallets) {
-        delete pwallet;
-    }
-    vpwallets.clear();
+    CloseWallets();
 #endif
     globalVerifyHandle.reset();
     ECC_Stop();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1017,7 +1017,7 @@ bool AppInitParameterInteraction()
 
     RegisterAllCoreRPCCommands(tableRPC);
 #ifdef ENABLE_WALLET
-    RegisterWalletRPCCommands(tableRPC);
+    RegisterWalletRPC(tableRPC);
 #endif
 
     nConnectTimeout = gArgs.GetArg("-timeout", DEFAULT_CONNECT_TIMEOUT);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -189,7 +189,7 @@ void Shutdown()
     StopRPC();
     StopHTTPServer();
 #ifdef ENABLE_WALLET
-    FlushWallets(false);
+    FlushWallets();
 #endif
     MapPort(false);
     UnregisterValidationInterface(peerLogic.get());
@@ -244,7 +244,7 @@ void Shutdown()
         pblocktree = nullptr;
     }
 #ifdef ENABLE_WALLET
-    FlushWallets(true);
+    StopWallets();
 #endif
 
 #if ENABLE_ZMQ

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -245,3 +245,9 @@ bool OpenWallets()
 
     return true;
 }
+
+void FlushWallets(bool shutdown) {
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->Flush(shutdown);
+    }
+}

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -171,7 +171,7 @@ bool WalletParameterInteraction()
     return true;
 }
 
-bool WalletVerify()
+bool VerifyWallets()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
         return true;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -228,7 +228,7 @@ bool WalletVerify()
     return true;
 }
 
-bool InitLoadWallet()
+bool OpenWallets()
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         LogPrintf("Wallet disabled!\n");

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -254,6 +254,12 @@ bool OpenWallets()
     return true;
 }
 
+void StartWallets(CScheduler& scheduler) {
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->postInitProcess(scheduler);
+    }
+}
+
 void FlushWallets() {
     for (CWalletRef pwallet : vpwallets) {
         pwallet->Flush(false);

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -257,3 +257,10 @@ void StopWallets() {
         pwallet->Flush(true);
     }
 }
+
+void CloseWallets() {
+    for (CWalletRef pwallet : vpwallets) {
+        delete pwallet;
+    }
+    vpwallets.clear();
+}

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -246,8 +246,14 @@ bool OpenWallets()
     return true;
 }
 
-void FlushWallets(bool shutdown) {
+void FlushWallets() {
     for (CWalletRef pwallet : vpwallets) {
-        pwallet->Flush(shutdown);
+        pwallet->Flush(false);
+    }
+}
+
+void StopWallets() {
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->Flush(true);
     }
 }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -10,6 +10,7 @@
 #include "utilmoneystr.h"
 #include "validation.h"
 #include "wallet/wallet.h"
+#include "wallet/rpcwallet.h"
 
 std::string GetWalletHelpString(bool showDebug)
 {
@@ -169,6 +170,13 @@ bool WalletParameterInteraction()
     fWalletRbf = gArgs.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
 
     return true;
+}
+
+void RegisterWalletRPC(CRPCTable &t)
+{
+    if (gArgs.GetBoolArg("-disablewallet", false)) return;
+
+    RegisterWalletRPCCommands(t);
 }
 
 bool VerifyWallets()

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -20,6 +20,6 @@ bool WalletParameterInteraction();
 bool WalletVerify();
 
 //! Load wallet databases.
-bool InitLoadWallet();
+bool OpenWallets();
 
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -22,4 +22,7 @@ bool VerifyWallets();
 //! Load wallet databases.
 bool OpenWallets();
 
+//! Flush all wallets in preparation for shutdown.
+//! Call with shutdown = true to actually shutdown the wallet.
+void FlushWallets(bool shutdown);
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -17,7 +17,7 @@ bool WalletParameterInteraction();
 //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
 //  This function will perform salvage on the wallet if requested, as long as only one wallet is
 //  being loaded (CWallet::ParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
-bool WalletVerify();
+bool VerifyWallets();
 
 //! Load wallet databases.
 bool OpenWallets();

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -23,6 +23,8 @@ bool VerifyWallets();
 bool OpenWallets();
 
 //! Flush all wallets in preparation for shutdown.
-//! Call with shutdown = true to actually shutdown the wallet.
-void FlushWallets(bool shutdown);
+void FlushWallets();
+
+//! Stop all wallets. Wallets will be flushed first.
+void StopWallets();
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -27,4 +27,8 @@ void FlushWallets();
 
 //! Stop all wallets. Wallets will be flushed first.
 void StopWallets();
+
+//! Close all wallets.
+void CloseWallets();
+
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -9,6 +9,7 @@
 #include <string>
 
 class CRPCTable;
+class CScheduler;
 
 //! Return the wallets help message.
 std::string GetWalletHelpString(bool showDebug);
@@ -26,6 +27,9 @@ bool VerifyWallets();
 
 //! Load wallet databases.
 bool OpenWallets();
+
+//! Complete startup of wallets.
+void StartWallets(CScheduler& scheduler);
 
 //! Flush all wallets in preparation for shutdown.
 void FlushWallets();

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -22,7 +22,7 @@ void RegisterWalletRPC(CRPCTable &tableRPC);
 
 //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
 //  This function will perform salvage on the wallet if requested, as long as only one wallet is
-//  being loaded (CWallet::ParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
+//  being loaded (WalletParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
 bool VerifyWallets();
 
 //! Load wallet databases.

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -8,11 +8,16 @@
 
 #include <string>
 
+class CRPCTable;
+
 //! Return the wallets help message.
 std::string GetWalletHelpString(bool showDebug);
 
 //! Wallets parameter interaction
 bool WalletParameterInteraction();
+
+//! Register wallet RPCs.
+void RegisterWalletRPC(CRPCTable &tableRPC);
 
 //! Responsible for reading and validating the -wallet arguments and verifying the wallet database.
 //  This function will perform salvage on the wallet if requested, as long as only one wallet is

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3217,9 +3217,6 @@ static const CRPCCommand commands[] =
 
 void RegisterWalletRPCCommands(CRPCTable &t)
 {
-    if (gArgs.GetBoolArg("-disablewallet", false))
-        return;
-
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         t.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -5,7 +5,10 @@
 #ifndef BITCOIN_WALLET_RPCWALLET_H
 #define BITCOIN_WALLET_RPCWALLET_H
 
+#include <string>
+
 class CRPCTable;
+class CWallet;
 class JSONRPCRequest;
 
 void RegisterWalletRPCCommands(CRPCTable &t);


### PR DESCRIPTION
Apologies for the mostly code move only PR. This is a pre-req for both #10740 and #10762 

All wallet component initialization/destruction functions are now in their own `wallet/init.cpp` translation unit and are no longer static functions on the CWallet class. The bitcoin_server also no longer has any knowledge that there are multiple wallets in vpwallet.

There should be no changes in behavior from this PR.