### PR TITLE
nCheckDepth chain height fix

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3577,10 +3577,8 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         return true;
 
     // Verify blocks in the best chain
-    if (nCheckDepth <= 0)
-        nCheckDepth = 1000000000; // suffices until the year 19000
-    if (nCheckDepth > chainActive.Height())
-        nCheckDepth = chainActive.Height();
+    if (nCheckDepth <= 0 || nCheckDepth > chainActive.Heigh())
+        nCheckDepth = chainActive.Heigh()
     nCheckLevel = std::max(0, std::min(4, nCheckLevel));
     LogPrintf("Verifying last %i blocks at level %i\n", nCheckDepth, nCheckLevel);
     CCoinsViewCache coins(coinsview);


### PR DESCRIPTION
````
if (nCheckDepth <= 0)
    nCheckDepth = 1000000000; // suffices until the year 19000
if (nCheckDepth > chainActive.Height())
    nCheckDepth = chainActive.Height();
````

These lines confuse me.
Correct me if I am wrong, but we can't check any more blocks than we have right? 
If someone requests <= 0 it get set it into some huge number and then immediately limit it to the chain height in the following statement.
````
if (nCheckDepth > chainActive.Height())
    nCheckDepth = chainActive.Height();
````
when using ````--checkblocks=Z```` When Z is ````0```` or any other negative number, it will check all blocks.

I think it should be changed to this maybe.
````
if (nCheckDepth <= 0 || nCheckDepth > chainActive.Height())
    nCheckDepth = chainActive.Height()
```` 
Which gets rid of that huge number which is confusing for any other altcoins that have a different block time.  