### PR TITLE
Simplify "!foo || (foo && bar)" as "!foo || bar"

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1141,7 +1141,7 @@ static void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     // or a chain that is entirely longer than ours and invalid (note that this should be detected by both)
     // We define it this way because it allows us to only store the highest fork tip (+ base) which meets
     // the 7-block condition and from this always have the most-likely-to-cause-warning fork
-    if (pfork && (!pindexBestForkTip || (pindexBestForkTip && pindexNewForkTip->nHeight > pindexBestForkTip->nHeight)) &&
+    if (pfork && (!pindexBestForkTip || pindexNewForkTip->nHeight > pindexBestForkTip->nHeight) &&
             pindexNewForkTip->nChainWork - pfork->nChainWork > (GetBlockProof(*pfork) * 7) &&
             chainActive.Height() - pindexNewForkTip->nHeight < 72)
     {


### PR DESCRIPTION
Simplify `!foo || (foo && bar)` as `!foo || bar`.

Rationale:
* Improve readability by removing redundant condition.
