### PR TITLE
Use AC_ARG_VAR to set ARFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,12 @@ BITCOIN_GUI_NAME=bitcoin-qt
 BITCOIN_CLI_NAME=bitcoin-cli
 BITCOIN_TX_NAME=bitcoin-tx
 
+dnl Unless the user specified ARFLAGS, force it to be cr
+AC_ARG_VAR(ARFLAGS, [Flags for the archiver, defaults to <cr> if not set])
+if test "x${ARFLAGS}" != "xset"; then
+  ARFLAGS="cr"
+fi
+
 AC_CANONICAL_HOST
 
 AH_TOP([#ifndef BITCOIN_CONFIG_H])
@@ -1262,4 +1268,5 @@ echo "  CPPFLAGS      = $CPPFLAGS"
 echo "  CXX           = $CXX"
 echo "  CXXFLAGS      = $CXXFLAGS"
 echo "  LDFLAGS       = $LDFLAGS"
+echo "  ARFLAGS       = $ARFLAGS"
 echo 


### PR DESCRIPTION
Improvement for pull request [10766](https://github.com/bitcoin/bitcoin/pull/10766) as suggested by _theoni_: the archiver flags `cr` are not hardcoded, but can be specified with `./configure`.