### PR TITLE
Serialization improvements

### DIFF
--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -49,15 +49,7 @@ public:
         banReason = ban_reason_in;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(this->nVersion);
-        READWRITE(nCreateTime);
-        READWRITE(nBanUntil);
-        READWRITE(banReason);
-    }
+    SERIALIZE_METHODS(CBanEntry, obj) { READWRITE(obj.nVersion, obj.nCreateTime, obj.nBanUntil, obj.banReason); }
 
     void SetNull()
     {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -53,14 +53,10 @@ private:
 
 public:
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CAddress, *this);
-        READWRITE(source);
-        READWRITE(nLastSuccess);
-        READWRITE(nAttempts);
+    SERIALIZE_METHODS(CAddrInfo, obj)
+    {
+        READWRITEAS(CAddress, obj);
+        READWRITE(obj.source, obj.nLastSuccess, obj.nAttempts);
     }
 
     CAddrInfo(const CAddress &addrIn, const CNetAddr &addrSource) : CAddress(addrIn), source(addrSource)
@@ -294,7 +290,7 @@ public:
      * This format is more complex, but significantly smaller (at most 1.5 MiB), and supports
      * changes to the ADDRMAN_ parameters without breaking the on-disk structure.
      *
-     * We don't use ADD_SERIALIZE_METHODS since the serialization and deserialization code has
+     * We don't use SERIALIZE_METHODS since the serialization and deserialization code has
      * very little in common.
      */
     template<typename Stream>

--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -20,9 +20,7 @@
 struct nontrivial_t {
     int x;
     nontrivial_t() :x(-1) {}
-    ADD_SERIALIZE_METHODS
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {READWRITE(x);}
+    SERIALIZE_METHODS(nontrivial_t, obj) { READWRITE(obj.x); }
 };
 static_assert(!IS_TRIVIALLY_CONSTRUCTIBLE<nontrivial_t>::value,
               "expected nontrivial_t to not be trivially constructible");

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -83,7 +83,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     for (size_t i = 0; i < cmpctblock.shorttxids.size(); i++) {
         while (txn_available[i + index_offset])
             index_offset++;
-        shorttxids[cmpctblock.shorttxids[i]] = i + index_offset;
+        shorttxids[cmpctblock.shorttxids[i]] = uint16_t(i + index_offset);
         // To determine the chance that the number of entries in a bucket exceeds N,
         // we use the fact that the number of elements in a single bucket is
         // binomially distributed (with n = the number of shorttxids S, and p =

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -66,15 +66,7 @@ public:
     CBloomFilter(const unsigned int nElements, const double nFPRate, const unsigned int nTweak, unsigned char nFlagsIn);
     CBloomFilter() : isFull(true), isEmpty(false), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(vData);
-        READWRITE(nHashFuncs);
-        READWRITE(nTweak);
-        READWRITE(nFlags);
-    }
+    SERIALIZE_METHODS(CBloomFilter, obj) { READWRITE(obj.vData, obj.nHashFuncs, obj.nTweak, obj.nFlags); }
 
     void insert(const std::vector<unsigned char>& vKey);
     void insert(const COutPoint& outpoint);

--- a/src/chain.h
+++ b/src/chain.h
@@ -48,17 +48,15 @@ public:
     uint64_t nTimeFirst;       //!< earliest time of block in file
     uint64_t nTimeLast;        //!< latest time of block in file
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(nBlocks));
-        READWRITE(VARINT(nSize));
-        READWRITE(VARINT(nUndoSize));
-        READWRITE(VARINT(nHeightFirst));
-        READWRITE(VARINT(nHeightLast));
-        READWRITE(VARINT(nTimeFirst));
-        READWRITE(VARINT(nTimeLast));
+    SERIALIZE_METHODS(CBlockFileInfo, obj)
+    {
+        READWRITE(VARINT(obj.nBlocks));
+        READWRITE(VARINT(obj.nSize));
+        READWRITE(VARINT(obj.nUndoSize));
+        READWRITE(VARINT(obj.nHeightFirst));
+        READWRITE(VARINT(obj.nHeightLast));
+        READWRITE(VARINT(obj.nTimeFirst));
+        READWRITE(VARINT(obj.nTimeLast));
     }
 
      void SetNull() {
@@ -332,31 +330,29 @@ public:
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    SERIALIZE_METHODS(CDiskBlockIndex, obj)
+    {
         int _nVersion = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH))
             READWRITE(VARINT(_nVersion, VarIntMode::NONNEGATIVE_SIGNED));
 
-        READWRITE(VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(nStatus));
-        READWRITE(VARINT(nTx));
-        if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
-            READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        if (nStatus & BLOCK_HAVE_DATA)
-            READWRITE(VARINT(nDataPos));
-        if (nStatus & BLOCK_HAVE_UNDO)
-            READWRITE(VARINT(nUndoPos));
+        READWRITE(VARINT(obj.nHeight, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT(obj.nStatus));
+        READWRITE(VARINT(obj.nTx));
+        if (obj.nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
+            READWRITE(VARINT(obj.nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        if (obj.nStatus & BLOCK_HAVE_DATA)
+            READWRITE(VARINT(obj.nDataPos));
+        if (obj.nStatus & BLOCK_HAVE_UNDO)
+            READWRITE(VARINT(obj.nUndoPos));
 
         // block header
-        READWRITE(this->nVersion);
-        READWRITE(hashPrev);
-        READWRITE(hashMerkleRoot);
-        READWRITE(nTime);
-        READWRITE(nBits);
-        READWRITE(nNonce);
+        READWRITE(obj.nVersion);
+        READWRITE(obj.hashPrev);
+        READWRITE(obj.hashMerkleRoot);
+        READWRITE(obj.nTime);
+        READWRITE(obj.nBits);
+        READWRITE(obj.nNonce);
     }
 
     uint256 GetBlockHash() const

--- a/src/chain.h
+++ b/src/chain.h
@@ -333,26 +333,15 @@ public:
     SERIALIZE_METHODS(CDiskBlockIndex, obj)
     {
         int _nVersion = s.GetVersion();
-        if (!(s.GetType() & SER_GETHASH))
-            READWRITE(VARINT(_nVersion, VarIntMode::NONNEGATIVE_SIGNED));
+        if (!(s.GetType() & SER_GETHASH)) READWRITE(VARINT(_nVersion, VarIntMode::NONNEGATIVE_SIGNED));
 
-        READWRITE(VARINT(obj.nHeight, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(obj.nStatus));
-        READWRITE(VARINT(obj.nTx));
-        if (obj.nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
-            READWRITE(VARINT(obj.nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        if (obj.nStatus & BLOCK_HAVE_DATA)
-            READWRITE(VARINT(obj.nDataPos));
-        if (obj.nStatus & BLOCK_HAVE_UNDO)
-            READWRITE(VARINT(obj.nUndoPos));
+        READWRITE(VARINT(obj.nHeight, VarIntMode::NONNEGATIVE_SIGNED), VARINT(obj.nStatus), VARINT(obj.nTx));
+        if (obj.nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO)) READWRITE(VARINT(obj.nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        if (obj.nStatus & BLOCK_HAVE_DATA) READWRITE(VARINT(obj.nDataPos));
+        if (obj.nStatus & BLOCK_HAVE_UNDO) READWRITE(VARINT(obj.nUndoPos));
 
         // block header
-        READWRITE(obj.nVersion);
-        READWRITE(obj.hashPrev);
-        READWRITE(obj.hashMerkleRoot);
-        READWRITE(obj.nTime);
-        READWRITE(obj.nBits);
-        READWRITE(obj.nNonce);
+        READWRITE(obj.nVersion, obj.hashPrev, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
     }
 
     uint256 GetBlockHash() const

--- a/src/coins.h
+++ b/src/coins.h
@@ -25,7 +25,7 @@
  *
  * Serialized format:
  * - VARINT((coinbase ? 1 : 0) | (height << 1))
- * - the non-spent CTxOut (via CTxOutCompressor)
+ * - the non-spent CTxOut (via TxOutCompress)
  */
 class Coin
 {
@@ -61,7 +61,7 @@ public:
         assert(!IsSpent());
         uint32_t code = nHeight * 2 + fCoinBase;
         ::Serialize(s, VARINT(code));
-        ::Serialize(s, CTxOutCompressor(REF(out)));
+        ::Serialize(s, Wrap<TxOutCompression>(out));
     }
 
     template<typename Stream>
@@ -70,7 +70,7 @@ public:
         ::Unserialize(s, VARINT(code));
         nHeight = code >> 1;
         fCoinBase = code & 1;
-        ::Unserialize(s, CTxOutCompressor(out));
+        ::Unserialize(s, Wrap<TxOutCompression>(out));
     }
 
     bool IsSpent() const {

--- a/src/coins.h
+++ b/src/coins.h
@@ -61,7 +61,7 @@ public:
         assert(!IsSpent());
         uint32_t code = nHeight * 2 + fCoinBase;
         ::Serialize(s, VARINT(code));
-        ::Serialize(s, Wrap<TxOutCompression>(out));
+        ::Serialize(s, Using<TxOutCompression>(out));
     }
 
     template<typename Stream>
@@ -70,7 +70,7 @@ public:
         ::Unserialize(s, VARINT(code));
         nHeight = code >> 1;
         fCoinBase = code & 1;
-        ::Unserialize(s, Wrap<TxOutCompression>(out));
+        ::Unserialize(s, Using<TxOutCompression>(out));
     }
 
     bool IsSpent() const {

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -16,12 +16,10 @@ struct FlatFilePos
     int nFile;
     unsigned int nPos;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(nPos));
+    SERIALIZE_METHODS(FlatFilePos, obj)
+    {
+        READWRITE(VARINT(obj.nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT(obj.nPos));
     }
 
     FlatFilePos() : nFile(-1), nPos(0) {}

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -39,14 +39,7 @@ struct DBVal {
     uint256 header;
     FlatFilePos pos;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(hash);
-        READWRITE(header);
-        READWRITE(pos);
-    }
+    SERIALIZE_METHODS(DBVal, obj) { READWRITE(obj.hash, obj.header, obj.pos); }
 };
 
 struct DBHeightKey {
@@ -78,17 +71,14 @@ struct DBHashKey {
 
     explicit DBHashKey(const uint256& hash_in) : hash(hash_in) {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    SERIALIZE_METHODS(DBHashKey, obj) {
         char prefix = DB_BLOCK_HASH;
         READWRITE(prefix);
         if (prefix != DB_BLOCK_HASH) {
             throw std::ios_base::failure("Invalid format for block filter index DB hash key");
         }
 
-        READWRITE(hash);
+        READWRITE(obj.hash);
     }
 };
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -21,12 +21,10 @@ struct CDiskTxPos : public FlatFilePos
 {
     unsigned int nTxOffset; // after header
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(FlatFilePos, *this);
-        READWRITE(VARINT(nTxOffset));
+    SERIALIZE_METHODS(CDiskTxPos, obj)
+    {
+        READWRITEAS(FlatFilePos, obj);
+        READWRITE(VARINT(obj.nTxOffset));
     }
 
     CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -88,12 +88,7 @@ class CNetAddr
         friend bool operator!=(const CNetAddr& a, const CNetAddr& b) { return !(a == b); }
         friend bool operator<(const CNetAddr& a, const CNetAddr& b);
 
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action) {
-            READWRITE(ip);
-        }
+        SERIALIZE_METHODS(CNetAddr, obj) { READWRITE(obj.ip); }
 
         friend class CSubNet;
 };
@@ -125,13 +120,11 @@ class CSubNet
         friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
         friend bool operator<(const CSubNet& a, const CSubNet& b);
 
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action) {
-            READWRITE(network);
-            READWRITE(netmask);
-            READWRITE(valid);
+        SERIALIZE_METHODS(CSubNet, obj)
+        {
+            READWRITE(obj.network);
+            READWRITE(obj.netmask);
+            READWRITE(obj.valid);
         }
 };
 
@@ -160,13 +153,7 @@ class CService : public CNetAddr
         CService(const struct in6_addr& ipv6Addr, unsigned short port);
         explicit CService(const struct sockaddr_in6& addr);
 
-        ADD_SERIALIZE_METHODS;
-
-        template <typename Stream, typename Operation>
-        inline void SerializationOp(Stream& s, Operation ser_action) {
-            READWRITE(ip);
-            READWRITE(Wrap<BigEndian>(port));
-        }
+        SERIALIZE_METHODS(CService, obj) { READWRITE(obj.ip, Wrap<BigEndian>(obj.port)); }
 };
 
 #endif // BITCOIN_NETADDRESS_H

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -165,7 +165,7 @@ class CService : public CNetAddr
         template <typename Stream, typename Operation>
         inline void SerializationOp(Stream& s, Operation ser_action) {
             READWRITE(ip);
-            READWRITE(WrapBigEndian(port));
+            READWRITE(Wrap<BigEndian>(port));
         }
 };
 

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -153,7 +153,7 @@ class CService : public CNetAddr
         CService(const struct in6_addr& ipv6Addr, unsigned short port);
         explicit CService(const struct sockaddr_in6& addr);
 
-        SERIALIZE_METHODS(CService, obj) { READWRITE(obj.ip, Wrap<BigEndian>(obj.port)); }
+        SERIALIZE_METHODS(CService, obj) { READWRITE(obj.ip, Using<BigEndian>(obj.port)); }
 };
 
 #endif // BITCOIN_NETADDRESS_H

--- a/src/node/utxo_snapshot.h
+++ b/src/node/utxo_snapshot.h
@@ -35,14 +35,11 @@ public:
             m_coins_count(coins_count),
             m_nchaintx(nchaintx) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(SnapshotMetadata, obj)
     {
-        READWRITE(m_base_blockhash);
-        READWRITE(m_coins_count);
-        READWRITE(m_nchaintx);
+        READWRITE(obj.m_base_blockhash);
+        READWRITE(obj.m_coins_count);
+        READWRITE(obj.m_nchaintx);
     }
 
 };

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -48,12 +48,7 @@ public:
     CFeeRate& operator+=(const CFeeRate& a) { nSatoshisPerK += a.nSatoshisPerK; return *this; }
     std::string ToString() const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nSatoshisPerK);
-    }
+    SERIALIZE_METHODS(CFeeRate, obj) { READWRITE(obj.nSatoshisPerK); }
 };
 
 #endif //  BITCOIN_POLICY_FEERATE_H

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -33,16 +33,9 @@ public:
         SetNull();
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(this->nVersion);
-        READWRITE(hashPrevBlock);
-        READWRITE(hashMerkleRoot);
-        READWRITE(nTime);
-        READWRITE(nBits);
-        READWRITE(nNonce);
+    SERIALIZE_METHODS(CBlockHeader, obj)
+    {
+        READWRITE(obj.nVersion, obj.hashPrevBlock, obj.hashMerkleRoot, obj.nTime, obj.nBits, obj.nNonce);
     }
 
     void SetNull()
@@ -89,12 +82,10 @@ public:
         *(static_cast<CBlockHeader*>(this)) = header;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CBlockHeader, *this);
-        READWRITE(vtx);
+    SERIALIZE_METHODS(CBlock, obj)
+    {
+        READWRITEAS(CBlockHeader, obj);
+        READWRITE(obj.vtx);
     }
 
     void SetNull()
@@ -131,14 +122,12 @@ struct CBlockLocator
 
     explicit CBlockLocator(const std::vector<uint256>& vHaveIn) : vHave(vHaveIn) {}
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    SERIALIZE_METHODS(CBlockLocator, obj)
+    {
         int nVersion = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH))
             READWRITE(nVersion);
-        READWRITE(vHave);
+        READWRITE(obj.vHave);
     }
 
     void SetNull()

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -26,13 +26,7 @@ public:
     COutPoint(): n(NULL_INDEX) { }
     COutPoint(const uint256& hashIn, uint32_t nIn): hash(hashIn), n(nIn) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(hash);
-        READWRITE(n);
-    }
+    SERIALIZE_METHODS(COutPoint, obj) { READWRITE(obj.hash, obj.n); }
 
     void SetNull() { hash.SetNull(); n = NULL_INDEX; }
     bool IsNull() const { return (hash.IsNull() && n == NULL_INDEX); }
@@ -103,14 +97,7 @@ public:
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
     CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(prevout);
-        READWRITE(scriptSig);
-        READWRITE(nSequence);
-    }
+    SERIALIZE_METHODS(CTxIn, obj) { READWRITE(obj.prevout, obj.scriptSig, obj.nSequence); }
 
     friend bool operator==(const CTxIn& a, const CTxIn& b)
     {
@@ -143,13 +130,7 @@ public:
 
     CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(nValue);
-        READWRITE(scriptPubKey);
-    }
+    SERIALIZE_METHODS(CTxOut, obj) { READWRITE(obj.nValue, obj.scriptPubKey); }
 
     void SetNull()
     {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -336,9 +336,7 @@ public:
         if ((s.GetType() & SER_DISK) ||
             (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH)))
             READWRITE(nTime);
-        uint64_t nServicesInt = nServices;
-        READWRITE(nServicesInt);
-        nServices = static_cast<ServiceFlags>(nServicesInt);
+        READWRITE(Wrap<Convert<uint64_t>>(nServices));
         READWRITEAS(CService, *this);
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -42,15 +42,9 @@ public:
     std::string GetCommand() const;
     bool IsValid(const MessageStartChars& messageStart) const;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CMessageHeader, obj)
     {
-        READWRITE(pchMessageStart);
-        READWRITE(pchCommand);
-        READWRITE(nMessageSize);
-        READWRITE(pchChecksum);
+        READWRITE(obj.pchMessageStart, obj.pchCommand, obj.nMessageSize, obj.pchChecksum);
     }
 
     char pchMessageStart[MESSAGE_START_SIZE];
@@ -323,21 +317,18 @@ public:
 
     void Init();
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(Caddress, obj)
     {
-        if (ser_action.ForRead())
-            Init();
         int nVersion = s.GetVersion();
-        if (s.GetType() & SER_DISK)
+        if (s.GetType() & SER_DISK) {
             READWRITE(nVersion);
+        }
         if ((s.GetType() & SER_DISK) ||
-            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH)))
-            READWRITE(nTime);
-        READWRITE(Wrap<Convert<uint64_t>>(nServices));
-        READWRITEAS(CService, *this);
+            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH))) {
+            READWRITE(obj.nTime);
+        }
+        READWRITE(Wrap<Convert<uint64_t>>(obj.nServices));
+        READWRITEAS(CService, obj);
     }
 
     // TODO: make private (improves encapsulation)
@@ -376,14 +367,7 @@ public:
     CInv();
     CInv(int typeIn, const uint256& hashIn);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(type);
-        READWRITE(hash);
-    }
+    SERIALIZE_METHODS(CInv, obj) { READWRITE(obj.type, obj.hash); }
 
     friend bool operator<(const CInv& a, const CInv& b);
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -327,7 +327,7 @@ public:
             (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH))) {
             READWRITE(obj.nTime);
         }
-        READWRITE(Wrap<Convert<uint64_t>>(obj.nServices));
+        READWRITE(Using<Convert<uint64_t>>(obj.nServices));
         READWRITEAS(CService, obj);
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -317,7 +317,7 @@ public:
 
     void Init();
 
-    SERIALIZE_METHODS(Caddress, obj)
+    SERIALIZE_METHODS(CAddress, obj)
     {
         int nVersion = s.GetVersion();
         if (s.GetType() & SER_DISK) {

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -13,28 +13,16 @@
 
 class WalletModel;
 
-//! Wrapper class to serialize QDateTime objects as 32-bit time_t.
+//! Formatter class to serialize QDateTime objects as 32-bit time_t.
 struct AsTimeT
 {
-    template<typename Q>
-    class Wrapper
+    template<typename Stream> static void Ser(Stream& s, const QDateTime& q) { s << (uint32_t)q.toTime_t(); }
+    template<typename Stream> static void Unser(Stream& s, QDateTime& q)
     {
-    private:
-        Q& m_qdatetime;
-    public:
-        Wrapper(Q& qdatetime) : m_qdatetime(qdatetime) {}
-
-        template<typename Stream>
-        void Serialize(Stream& s) const { s << (uint32_t)m_qdatetime.toTime_t(); }
-
-        template<typename Stream>
-        void Unserialize(Stream& s)
-        {
-            uint32_t timeval;
-            s >> timeval;
-            m_qdatetime = QDateTime::fromTime_t(timeval);
-        }
-    };
+        uint32_t timeval;
+        s >> timeval;
+        q = QDateTime::fromTime_t(timeval);
+    }
 };
 
 class RecentRequestEntry
@@ -50,7 +38,7 @@ public:
 
     SERIALIZE_METHODS(RecentRequestEntry, obj)
     {
-        READWRITE(obj.nVersion, obj.id, Wrap<AsTimeT>(obj.date), obj.recipient);
+        READWRITE(obj.nVersion, obj.id, Using<AsTimeT>(obj.date), obj.recipient);
     }
 };
 

--- a/src/qt/sendcoinsrecipient.h
+++ b/src/qt/sendcoinsrecipient.h
@@ -16,28 +16,16 @@
 
 #include <QString>
 
-//! Wrapper class to serialize QString objects as std::strings.
+//! Formatter class to serialize QString objects as std::strings.
 struct AsStdString
 {
-    template<typename Q>
-    class Wrapper
+    template<typename Stream> static void Ser(Stream& s, const QString& q) { s << q.toStdString(); }
+    template<typename Stream> static void Unser(Stream& s, QString& q)
     {
-    private:
-        Q& m_qstring;
-    public:
-        Wrapper(Q& qstring) : m_qstring(qstring) {}
-
-        template<typename Stream>
-        void Serialize(Stream& s) const { s << m_qstring.toStdString(); }
-
-        template<typename Stream>
-        void Unserialize(Stream& s)
-        {
-            std::string str;
-            s >> str;
-            m_qstring = QString::fromStdString(std::move(str));
-        }
-    };
+        std::string str;
+        s >> str;
+        q = QString::fromStdString(std::move(str));
+    }
 };
 
 class SendCoinsRecipient
@@ -71,12 +59,12 @@ public:
     SERIALIZE_METHODS(SendCoinsRecipient, obj)
     {
         READWRITE(obj.nVersion);
-        READWRITE(Wrap<AsStdString>(obj.address));
-        READWRITE(Wrap<AsStdString>(obj.label));
+        READWRITE(Using<AsStdString>(obj.address));
+        READWRITE(Using<AsStdString>(obj.label));
         READWRITE(obj.amount);
-        READWRITE(Wrap<AsStdString>(obj.message));
+        READWRITE(Using<AsStdString>(obj.message));
         READWRITE(obj.sPaymentRequest);
-        READWRITE(Wrap<AsStdString>(obj.authenticatedMerchant));
+        READWRITE(Using<AsStdString>(obj.authenticatedMerchant));
     }
 };
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -49,18 +49,13 @@ struct CCoin {
     uint32_t nHeight;
     CTxOut out;
 
-    ADD_SERIALIZE_METHODS;
-
     CCoin() : nHeight(0) {}
     explicit CCoin(Coin&& in) : nHeight(in.nHeight), out(std::move(in.out)) {}
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+    SERIALIZE_METHODS(CCoin, obj)
     {
         uint32_t nTxVerDummy = 0;
-        READWRITE(nTxVerDummy);
-        READWRITE(nHeight);
-        READWRITE(out);
+        READWRITE(nTxVerDummy, obj.nHeight, obj.out);
     }
 };
 

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -18,13 +18,7 @@ struct KeyOriginInfo
         return std::equal(std::begin(a.fingerprint), std::end(a.fingerprint), std::begin(b.fingerprint)) && a.path == b.path;
     }
 
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
-    {
-        READWRITE(fingerprint);
-        READWRITE(path);
-    }
+    SERIALIZE_METHODS(KeyOriginInfo, obj) { READWRITE(obj.fingerprint, obj.path); }
 
     void clear()
     {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -412,12 +412,7 @@ public:
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CScriptBase, *this);
-    }
+    SERIALIZE_METHODS(CScript, obj) { READWRITEAS(CScriptBase, obj); }
 
     CScript& operator+=(const CScript& b)
     {

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -199,6 +199,30 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
         SerializationOp(s, CSerActionUnserialize());                  \
     }
 
+/**
+ * Implement the Serialize and Unserialize methods by delegating to a single templated
+ * static method that takes the to-be-(de)serialized object as a parameter. This approach
+ * has the advantage that the constness of the object becomes a template parameter, and
+ * thus allows a single implementation that sees the object as const for serializing
+ * and non-const for deserializing, without casts.
+ */
+#define SERIALIZE_METHODS(cls, obj)                                                 \
+    template<typename Stream>                                                       \
+    void Serialize(Stream& s) const                                                 \
+    {                                                                               \
+        static_assert(std::is_same<const cls&, decltype(*this)>::value, "Serialize type mismatch"); \
+        SerializationOps(*this, s, CSerActionSerialize());                          \
+    }                                                                               \
+    template<typename Stream>                                                       \
+    void Unserialize(Stream& s)                                                     \
+    {                                                                               \
+        static_assert(std::is_same<cls&, decltype(*this)>::value, "Unserialize type mismatch"); \
+        SerializationOps(*this, s, CSerActionUnserialize());                        \
+    }                                                                               \
+    template<typename Stream, typename Type, typename Operation>                    \
+    static inline void SerializationOps(Type& obj, Stream& s, Operation ser_action) \
+
+
 #ifndef CHAR_EQUALS_INT8
 template<typename Stream> inline void Serialize(Stream& s, char a    ) { ser_writedata8(s, a); } // TODO Get rid of bare char
 #endif

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -25,6 +25,9 @@
 
 static const unsigned int MAX_SIZE = 0x02000000;
 
+/** Maximum amount of memory to allocate at once when deserializing vectors. */
+static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
+
 /**
  * Dummy data type to identify deserializing constructors.
  *
@@ -761,7 +764,7 @@ void Unserialize_impl(Stream& is, prevector<N, T>& v, const V&)
     unsigned int nMid = 0;
     while (nMid < nSize)
     {
-        nMid += 5000000 / sizeof(T);
+        nMid += MAX_VECTOR_ALLOCATE / sizeof(T);
         if (nMid > nSize)
             nMid = nSize;
         v.resize_uninitialized(nMid);
@@ -841,7 +844,7 @@ void Unserialize_impl(Stream& is, std::vector<T, A>& v, const V&)
     unsigned int nMid = 0;
     while (nMid < nSize)
     {
-        nMid += 5000000 / sizeof(T);
+        nMid += MAX_VECTOR_ALLOCATE / sizeof(T);
         if (nMid > nSize)
             nMid = nSize;
         v.resize(nMid);

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -578,6 +578,32 @@ struct LimitedString
     };
 };
 
+template<typename F> struct Convert
+{
+    template<typename T> class Wrapper
+    {
+    protected:
+        T& m_val;
+    public:
+        explicit Wrapper(T& val) : m_val(val) {}
+
+        template<typename Stream>
+        void Serialize(Stream& s) const
+        {
+            F tmp(m_val);
+            s << tmp;
+        }
+
+        template<typename Stream>
+        void Unserialize(Stream& s)
+        {
+            F tmp;
+            s >> tmp;
+            m_val = T(tmp);
+        }
+    };
+};
+
 /**
  * Forward declarations
  */

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -442,6 +442,10 @@ I ReadVarInt(Stream& is)
     }
 }
 
+/** Wrap a serializable object with a serialization wrapper. */
+template<typename W, typename T>
+static inline typename W::template Wrapper<typename std::remove_reference<T>::type> Wrap(T&& t) { return typename W::template Wrapper<typename std::remove_reference<T>::type>(t); }
+
 #define VARINT(obj, ...) WrapVarInt<__VA_ARGS__>(REF(obj))
 #define COMPACTSIZE(obj) CCompactSize(REF(obj))
 #define LIMITED_STRING(obj,n) LimitedString< n >(REF(obj))

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -485,29 +485,31 @@ struct VarIntFormat
  *
  * Only 16-bit types are supported for now.
  */
-template<typename I>
-class BigEndian
+struct BigEndian
 {
-protected:
-    I& m_val;
-public:
-    explicit BigEndian(I& val) : m_val(val)
+    template<typename I> class Wrapper
     {
-        static_assert(std::is_unsigned<I>::value, "BigEndian type must be unsigned integer");
-        static_assert(sizeof(I) == 2 && std::numeric_limits<I>::min() == 0 && std::numeric_limits<I>::max() == std::numeric_limits<uint16_t>::max(), "Unsupported BigEndian size");
-    }
+    protected:
+        I& m_val;
+    public:
+        explicit Wrapper(I& val) : m_val(val)
+        {
+            static_assert(std::is_unsigned<I>::value, "BigEndian type must be unsigned integer");
+            static_assert(sizeof(I) == 2 && std::numeric_limits<I>::min() == 0 && std::numeric_limits<I>::max() == std::numeric_limits<uint16_t>::max(), "Unsupported BigEndian size");
+        }
 
-    template<typename Stream>
-    void Serialize(Stream& s) const
-    {
-        ser_writedata16be(s, m_val);
-    }
+        template<typename Stream>
+        void Serialize(Stream& s) const
+        {
+            ser_writedata16be(s, m_val);
+        }
 
-    template<typename Stream>
-    void Unserialize(Stream& s)
-    {
-        m_val = ser_readdata16be(s);
-    }
+        template<typename Stream>
+        void Unserialize(Stream& s)
+        {
+            m_val = ser_readdata16be(s);
+        }
+    };
 };
 
 /** Serialization wrapper class for integers in CompactSize format. */
@@ -575,9 +577,6 @@ struct LimitedString
         }
     };
 };
-
-template<typename I>
-BigEndian<I> WrapBigEndian(I& n) { return BigEndian<I>(n); }
 
 /**
  * Forward declarations

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -42,26 +42,6 @@ static const unsigned int MAX_VECTOR_ALLOCATE = 5000000;
 struct deserialize_type {};
 constexpr deserialize_type deserialize {};
 
-/**
- * Used to bypass the rule against non-const reference to temporary
- * where it makes sense with wrappers.
- */
-template<typename T>
-inline T& REF(const T& val)
-{
-    return const_cast<T&>(val);
-}
-
-/**
- * Used to acquire a non-const pointer "this" to generate bodies
- * of const serialization operations from a template
- */
-template<typename T>
-inline T* NCONST_PTR(const T* val)
-{
-    return const_cast<T*>(val);
-}
-
 //! Safely convert odd char pointer types to standard ones.
 inline char* CharCast(char* c) { return c; }
 inline char* CharCast(unsigned char* c) { return (char*)c; }
@@ -185,22 +165,6 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
 
 #define READWRITE(...) (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 #define READWRITEAS(type, obj) (::SerReadWriteMany(s, ser_action, ReadWriteAsHelper<type>(obj)))
-
-/**
- * Implement three methods for serializable objects. These are actually wrappers over
- * "SerializationOp" template, which implements the body of each class' serialization
- * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers to be
- * added as members.
- */
-#define ADD_SERIALIZE_METHODS                                         \
-    template<typename Stream>                                         \
-    void Serialize(Stream& s) const {                                 \
-        NCONST_PTR(this)->SerializationOp(s, CSerActionSerialize());  \
-    }                                                                 \
-    template<typename Stream>                                         \
-    void Unserialize(Stream& s) {                                     \
-        SerializationOp(s, CSerActionUnserialize());                  \
-    }
 
 /**
  * Implement the Serialize and Unserialize methods by delegating to a single templated
@@ -1028,7 +992,7 @@ void Unserialize(Stream& is, std::shared_ptr<const T>& p)
 
 
 /**
- * Support for ADD_SERIALIZE_METHODS and READWRITE macro
+ * Support for SERIALIZE_METHODS and READWRITE macro.
  */
 struct CSerActionSerialize
 {

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -132,23 +132,9 @@ public:
         return base.GetShortID(txhash);
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(header);
-        READWRITE(nonce);
-        size_t shorttxids_size = shorttxids.size();
-        READWRITE(VARINT(shorttxids_size));
-        shorttxids.resize(shorttxids_size);
-        for (size_t i = 0; i < shorttxids.size(); i++) {
-            uint32_t lsb = shorttxids[i] & 0xffffffff;
-            uint16_t msb = (shorttxids[i] >> 32) & 0xffff;
-            READWRITE(lsb);
-            READWRITE(msb);
-            shorttxids[i] = (uint64_t(msb) << 32) | uint64_t(lsb);
-        }
-        READWRITE(prefilledtxn);
+    SERIALIZE_METHODS(TestHeaderAndShortIDs, obj)
+    {
+        READWRITE(obj.header, obj.nonce, Wrap<VectorApply<Uint48>>(obj.shorttxids), obj.prefilledtxn);
     }
 };
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -134,7 +134,7 @@ public:
 
     SERIALIZE_METHODS(TestHeaderAndShortIDs, obj)
     {
-        READWRITE(obj.header, obj.nonce, Wrap<VectorApply<Uint48>>(obj.shorttxids), obj.prefilledtxn);
+        READWRITE(obj.header, obj.nonce, Using<VectorUsing<Uint48>>(obj.shorttxids), obj.prefilledtxn);
     }
 };
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -331,24 +331,26 @@ struct StringContentsSerializer {
     }
     StringContentsSerializer& operator+=(const StringContentsSerializer& s) { return *this += s.str; }
 
-    ADD_SERIALIZE_METHODS;
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        for (size_t i = 0; i < str.size(); i++) {
+            s << str[i];
+        }
+    }
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        if (ser_action.ForRead()) {
-            str.clear();
-            char c = 0;
-            while (true) {
-                try {
-                    READWRITE(c);
-                    str.push_back(c);
-                } catch (const std::ios_base::failure&) {
-                    break;
-                }
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        str.clear();
+        char c = 0;
+        while (true) {
+            try {
+                s >> c;
+                str.push_back(c);
+            } catch (const std::ios_base::failure&) {
+                break;
             }
-        } else {
-            for (size_t i = 0; i < str.size(); i++)
-                READWRITE(str[i]);
         }
     }
 };

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -206,7 +206,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         DeserializeFromFuzzingInput(buffer, dbi);
 #elif TXOUTCOMPRESSOR_DESERIALIZE
         CTxOut to;
-        auto toc = Wrap<TxOutCompression>(to);
+        auto toc = Using<TxOutCompression>(to);
         DeserializeFromFuzzingInput(buffer, toc);
 #elif BLOCKTRANSACTIONS_DESERIALIZE
         BlockTransactions bt;

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -206,7 +206,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         DeserializeFromFuzzingInput(buffer, dbi);
 #elif TXOUTCOMPRESSOR_DESERIALIZE
         CTxOut to;
-        CTxOutCompressor toc(to);
+        auto toc = Wrap<TxOutCompression>(to);
         DeserializeFromFuzzingInput(buffer, toc);
 #elif BLOCKTRANSACTIONS_DESERIALIZE
         BlockTransactions bt;

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -29,15 +29,13 @@ public:
         memcpy(charstrval, charstrvalin, sizeof(charstrval));
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(intval);
-        READWRITE(boolval);
-        READWRITE(stringval);
-        READWRITE(charstrval);
-        READWRITE(txval);
+    SERIALIZE_METHODS(CSerializeMethodsTestSingle, obj)
+    {
+        READWRITE(obj.intval);
+        READWRITE(obj.boolval);
+        READWRITE(obj.stringval);
+        READWRITE(obj.charstrval);
+        READWRITE(obj.txval);
     }
 
     bool operator==(const CSerializeMethodsTestSingle& rhs)
@@ -54,11 +52,10 @@ class CSerializeMethodsTestMany : public CSerializeMethodsTestSingle
 {
 public:
     using CSerializeMethodsTestSingle::CSerializeMethodsTestSingle;
-    ADD_SERIALIZE_METHODS;
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(intval, boolval, stringval, charstrval, txval);
+    SERIALIZE_METHODS(CSerializeMethodsTestMany, obj)
+    {
+        READWRITE(obj.intval, obj.boolval, obj.stringval, obj.charstrval, obj.txval);
     }
 };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -36,19 +36,7 @@ struct CoinEntry {
     char key;
     explicit CoinEntry(const COutPoint* ptr) : outpoint(const_cast<COutPoint*>(ptr)), key(DB_COIN)  {}
 
-    template<typename Stream>
-    void Serialize(Stream &s) const {
-        s << key;
-        s << outpoint->hash;
-        s << VARINT(outpoint->n);
-    }
-
-    template<typename Stream>
-    void Unserialize(Stream& s) {
-        s >> key;
-        s >> outpoint->hash;
-        s >> VARINT(outpoint->n);
-    }
+    SERIALIZE_METHODS(CoinEntry, obj) { READWRITE(obj.key, obj.outpoint->hash, VARINT(obj.outpoint->n)); }
 };
 
 }
@@ -336,7 +324,7 @@ public:
         vout.assign(vAvail.size(), CTxOut());
         for (unsigned int i = 0; i < vAvail.size(); i++) {
             if (vAvail[i])
-                ::Unserialize(s, CTxOutCompressor(vout[i]));
+                ::Unserialize(s, Wrap<TxOutCompression>(vout[i]));
         }
         // coinbase height
         ::Unserialize(s, VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -324,7 +324,7 @@ public:
         vout.assign(vAvail.size(), CTxOut());
         for (unsigned int i = 0; i < vAvail.size(); i++) {
             if (vAvail[i])
-                ::Unserialize(s, Wrap<TxOutCompression>(vout[i]));
+                ::Unserialize(s, Using<TxOutCompression>(vout[i]));
         }
         // coinbase height
         ::Unserialize(s, VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));

--- a/src/undo.h
+++ b/src/undo.h
@@ -13,7 +13,7 @@
 #include <serialize.h>
 #include <version.h>
 
-/** Undo information for a CTxIn
+/** Formatter for undo information for a CTxIn
  *
  *  Contains the prevout's CTxOut being spent, and its metadata as well
  *  (coinbase or not, height). The serialization contains a dummy value of
@@ -22,40 +22,31 @@
  */
 struct TxInUndo
 {
-    template<typename C>
-    class Wrapper
-    {
-        C& txout;
-
-    public:
-        template<typename Stream>
-        void Serialize(Stream &s) const {
-            ::Serialize(s, VARINT(txout.nHeight * 2 + (txout.fCoinBase ? 1u : 0u)));
-            if (txout.nHeight > 0) {
-                // Required to maintain compatibility with older undo format.
-                ::Serialize(s, (unsigned char)0);
-            }
-            ::Serialize(s, Wrap<TxOutCompression>(txout.out));
+    template<typename Stream>
+    void Ser(Stream &s, const Coin& txout) {
+        ::Serialize(s, VARINT(txout.nHeight * 2 + (txout.fCoinBase ? 1u : 0u)));
+        if (txout.nHeight > 0) {
+            // Required to maintain compatibility with older undo format.
+            ::Serialize(s, (unsigned char)0);
         }
+        ::Serialize(s, Using<TxOutCompression>(txout.out));
+    }
 
-        template<typename Stream>
-        void Unserialize(Stream &s) {
-            unsigned int nCode = 0;
-            ::Unserialize(s, VARINT(nCode));
-            txout.nHeight = nCode / 2;
-            txout.fCoinBase = nCode & 1;
-            if (txout.nHeight > 0) {
-                // Old versions stored the version number for the last spend of
-                // a transaction's outputs. Non-final spends were indicated with
-                // height = 0.
-                unsigned int nVersionDummy;
-                ::Unserialize(s, VARINT(nVersionDummy));
-            }
-            ::Unserialize(s, Wrap<TxOutCompression>(txout.out));
+    template<typename Stream>
+    void Unser(Stream &s, Coin& txout) {
+        unsigned int nCode = 0;
+        ::Unserialize(s, VARINT(nCode));
+        txout.nHeight = nCode / 2;
+        txout.fCoinBase = nCode & 1;
+        if (txout.nHeight > 0) {
+            // Old versions stored the version number for the last spend of
+            // a transaction's outputs. Non-final spends were indicated with
+            // height = 0.
+            unsigned int nVersionDummy;
+            ::Unserialize(s, VARINT(nVersionDummy));
         }
-
-        explicit Wrapper(C& coin) : txout(coin) {}
-    };
+        ::Unserialize(s, Using<TxOutCompression>(txout.out));
+    }
 };
 
 /** Undo information for a CTransaction */
@@ -65,7 +56,7 @@ public:
     // undo information for all txins
     std::vector<Coin> vprevout;
 
-    SERIALIZE_METHODS(CTxUndo, obj) { READWRITE(Wrap<VectorApply<TxInUndo>>(obj.vprevout)); }
+    SERIALIZE_METHODS(CTxUndo, obj) { READWRITE(Using<VectorUsing<TxInUndo>>(obj.vprevout)); }
 };
 
 /** Undo information for a CBlock */

--- a/src/undo.h
+++ b/src/undo.h
@@ -20,50 +20,43 @@
  *  zero. This is compatible with older versions which expect to see
  *  the transaction version there.
  */
-class TxInUndoSerializer
+struct TxInUndo
 {
-    const Coin* txout;
+    template<typename C>
+    class Wrapper
+    {
+        C& txout;
 
-public:
-    template<typename Stream>
-    void Serialize(Stream &s) const {
-        ::Serialize(s, VARINT(txout->nHeight * 2 + (txout->fCoinBase ? 1u : 0u)));
-        if (txout->nHeight > 0) {
-            // Required to maintain compatibility with older undo format.
-            ::Serialize(s, (unsigned char)0);
+    public:
+        template<typename Stream>
+        void Serialize(Stream &s) const {
+            ::Serialize(s, VARINT(txout.nHeight * 2 + (txout.fCoinBase ? 1u : 0u)));
+            if (txout.nHeight > 0) {
+                // Required to maintain compatibility with older undo format.
+                ::Serialize(s, (unsigned char)0);
+            }
+            ::Serialize(s, Wrap<TxOutCompression>(txout.out));
         }
-        ::Serialize(s, CTxOutCompressor(REF(txout->out)));
-    }
 
-    explicit TxInUndoSerializer(const Coin* coin) : txout(coin) {}
-};
-
-class TxInUndoDeserializer
-{
-    Coin* txout;
-
-public:
-    template<typename Stream>
-    void Unserialize(Stream &s) {
-        unsigned int nCode = 0;
-        ::Unserialize(s, VARINT(nCode));
-        txout->nHeight = nCode / 2;
-        txout->fCoinBase = nCode & 1;
-        if (txout->nHeight > 0) {
-            // Old versions stored the version number for the last spend of
-            // a transaction's outputs. Non-final spends were indicated with
-            // height = 0.
-            unsigned int nVersionDummy;
-            ::Unserialize(s, VARINT(nVersionDummy));
+        template<typename Stream>
+        void Unserialize(Stream &s) {
+            unsigned int nCode = 0;
+            ::Unserialize(s, VARINT(nCode));
+            txout.nHeight = nCode / 2;
+            txout.fCoinBase = nCode & 1;
+            if (txout.nHeight > 0) {
+                // Old versions stored the version number for the last spend of
+                // a transaction's outputs. Non-final spends were indicated with
+                // height = 0.
+                unsigned int nVersionDummy;
+                ::Unserialize(s, VARINT(nVersionDummy));
+            }
+            ::Unserialize(s, Wrap<TxOutCompression>(txout.out));
         }
-        ::Unserialize(s, CTxOutCompressor(REF(txout->out)));
-    }
 
-    explicit TxInUndoDeserializer(Coin* coin) : txout(coin) {}
+        explicit Wrapper(C& coin) : txout(coin) {}
+    };
 };
-
-static const size_t MIN_TRANSACTION_INPUT_WEIGHT = WITNESS_SCALE_FACTOR * ::GetSerializeSize(CTxIn(), PROTOCOL_VERSION);
-static const size_t MAX_INPUTS_PER_BLOCK = MAX_BLOCK_WEIGHT / MIN_TRANSACTION_INPUT_WEIGHT;
 
 /** Undo information for a CTransaction */
 class CTxUndo
@@ -72,29 +65,7 @@ public:
     // undo information for all txins
     std::vector<Coin> vprevout;
 
-    template <typename Stream>
-    void Serialize(Stream& s) const {
-        // TODO: avoid reimplementing vector serializer
-        uint64_t count = vprevout.size();
-        ::Serialize(s, COMPACTSIZE(REF(count)));
-        for (const auto& prevout : vprevout) {
-            ::Serialize(s, TxInUndoSerializer(&prevout));
-        }
-    }
-
-    template <typename Stream>
-    void Unserialize(Stream& s) {
-        // TODO: avoid reimplementing vector deserializer
-        uint64_t count = 0;
-        ::Unserialize(s, COMPACTSIZE(count));
-        if (count > MAX_INPUTS_PER_BLOCK) {
-            throw std::ios_base::failure("Too many input undo records");
-        }
-        vprevout.resize(count);
-        for (auto& prevout : vprevout) {
-            ::Unserialize(s, TxInUndoDeserializer(&prevout));
-        }
-    }
+    SERIALIZE_METHODS(CTxUndo, obj) { READWRITE(Wrap<VectorApply<TxInUndo>>(obj.vprevout)); }
 };
 
 /** Undo information for a CBlock */
@@ -103,12 +74,7 @@ class CBlockUndo
 public:
     std::vector<CTxUndo> vtxundo; // for all but the coinbase
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(vtxundo);
-    }
+    SERIALIZE_METHODS(CBlockUndo, obj) { READWRITE(obj.vtxundo); }
 };
 
 #endif // BITCOIN_UNDO_H

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -43,15 +43,9 @@ public:
     //! such as the various parameters to scrypt
     std::vector<unsigned char> vchOtherDerivationParameters;
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(vchCryptedKey);
-        READWRITE(vchSalt);
-        READWRITE(nDerivationMethod);
-        READWRITE(nDeriveIterations);
-        READWRITE(vchOtherDerivationParameters);
+    SERIALIZE_METHODS(CMasterKey, obj)
+    {
+        READWRITE(obj.vchCryptedKey, obj.vchSalt, obj.nDerivationMethod, obj.nDeriveIterations, obj.vchOtherDerivationParameters);
     }
 
     CMasterKey()

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -100,36 +100,37 @@ public:
     CKeyPool();
     CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn);
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
         int nVersion = s.GetVersion();
-        if (!(s.GetType() & SER_GETHASH))
-            READWRITE(nVersion);
-        READWRITE(nTime);
-        READWRITE(vchPubKey);
-        if (ser_action.ForRead()) {
-            try {
-                READWRITE(fInternal);
-            }
-            catch (std::ios_base::failure&) {
-                /* flag as external address if we can't read the internal boolean
-                   (this will be the case for any wallet before the HD chain split version) */
-                fInternal = false;
-            }
-            try {
-                READWRITE(m_pre_split);
-            }
-            catch (std::ios_base::failure&) {
-                /* flag as postsplit address if we can't read the m_pre_split boolean
-                   (this will be the case for any wallet that upgrades to HD chain split)*/
-                m_pre_split = false;
-            }
+        if (!(s.GetType() & SER_GETHASH)) {
+            s << nVersion;
         }
-        else {
-            READWRITE(fInternal);
-            READWRITE(m_pre_split);
+        s << nTime << vchPubKey << fInternal << m_pre_split;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        int nVersion;
+        if (!(s.GetType() & SER_GETHASH)) {
+            s >> nVersion;
+        }
+        s >> nTime >> vchPubKey;
+        try {
+            s >> fInternal;
+        } catch (std::ios_base::failure&) {
+            /* flag as external address if we can't read the internal boolean
+               (this will be the case for any wallet before the HD chain split version) */
+            fInternal = false;
+        }
+        try {
+            s >> m_pre_split;
+        } catch (std::ios_base::failure&) {
+            /* flag as external address if we can't read the internal boolean
+               (this will be the case for any wallet before the HD chain split version) */
+            m_pre_split = false;
         }
     }
 };

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -228,15 +228,13 @@ struct COutputEntry
 class CMerkleTx
 {
 public:
-    template<typename Stream>
-    void Unserialize(Stream& s)
+    SERIALIZE_METHODS(CMerkleTx, obj)
     {
         CTransactionRef tx;
         uint256 hashBlock;
-        std::vector<uint256> vMerkleBranch;
+        std::vector<uint256> vMerkleBranch; // For compatibility with older versions.
         int nIndex;
-
-        s >> tx >> hashBlock >> vMerkleBranch >> nIndex;
+        READWRITE(tx, hashBlock, vMerkleBranch, nIndex);
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -92,15 +92,13 @@ public:
     int nVersion;
 
     CHDChain() { SetNull(); }
-    ADD_SERIALIZE_METHODS;
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action)
+
+    SERIALIZE_METHODS(CHDChain, obj)
     {
-        READWRITE(this->nVersion);
-        READWRITE(nExternalChainCounter);
-        READWRITE(seed_id);
-        if (this->nVersion >= VERSION_HD_CHAIN_SPLIT)
-            READWRITE(nInternalChainCounter);
+        READWRITE(obj.nVersion, obj.nExternalChainCounter, obj.seed_id);
+        if (obj.nVersion >= VERSION_HD_CHAIN_SPLIT) {
+            READWRITE(obj.nInternalChainCounter);
+        }
     }
 
     void SetNull()
@@ -136,21 +134,16 @@ public:
         nCreateTime = nCreateTime_;
     }
 
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(this->nVersion);
-        READWRITE(nCreateTime);
-        if (this->nVersion >= VERSION_WITH_HDDATA)
-        {
-            READWRITE(hdKeypath);
-            READWRITE(hd_seed_id);
+    SERIALIZE_METHODS(CKeyMetadata, obj)
+    {
+        READWRITE(obj.nVersion, obj.nCreateTime);
+        if (obj.nVersion >= VERSION_WITH_HDDATA) {
+            READWRITE(obj.hdKeypath, obj.hd_seed_id);
         }
-        if (this->nVersion >= VERSION_WITH_KEY_ORIGIN)
+        if (obj.nVersion >= VERSION_WITH_KEY_ORIGIN)
         {
-            READWRITE(key_origin);
-            READWRITE(has_key_origin);
+            READWRITE(obj.key_origin);
+            READWRITE(obj.has_key_origin);
         }
     }
 


### PR DESCRIPTION
This PR improves correctness (removing potentially unsafe `const_cast`s) and flexibility of the serialization code.

The main issue is that use of the current `ADD_SERIALIZE_METHODS` macro (which is the only way to not duplicate serialization and deserialization code) only expands to a single class method, and thus can only be qualified as either const or non-const - not both. In many cases, serialization needs to work on const objects however, and preferably that is done without casts that could hide const-correctness bugs.

To deal with that, this PR introduces a new approach that includes a `SERIALIZE_METHODS(obj)` macro, where `obj` is a variable name. It expands to some boilerplate and a static method to which the object itself is an argument. The advantage is that its type can be templated, and be `const` when serializing.

Another issue is the various serialization-wrapping macros (`VARINT`, `COMPACTSIZE`, `FLATDATA` and `LIMITED_STRING`). They all `const_cast` their argument in order to construct a wrapper object, which supports both serialization and deserialization. This PR makes them templated in the underlying data type (for example, `CompactSizeWrapper<uint64_t>`). This has the advantage that we can make the template type `const` when invoked on a `const` variable (so it would be `CompactSizeWrapper<const uint64_t>` in that case).

A last issue is the persistent use of the `REF` macro to deal with temporary expressions being passed in. Since C++11, this is not needed anymore as temporaries are explicitly represented as rvalue references. Thus we can remove `REF` invocations and instead just make the various classes and helper functions deal correctly with references.

The above changes permit a fully const-correct version of all serialization code. However, it is cumbersome. Any existing `ADD_SERIALIZE_METHODS` instances in the code that do more than just (conditionally) serializing/deserializing some fields (in particular, it contains branches that assign to some of the variables) need to be split up into an explicit `Serialize` and `Unserialize` method instead. In some cases this is inevitable (wallet serializers do some crazy transformations while serializing!), but in many cases it is just annoying duplication.

To improve upon this, a few more primitives that are currently inlined are turned into serialization wrappers:
* `BigEndianWrapper`: Serializes/deserializes an integer as big endian rather than little endian (only for 16-bit). This permits the CService serialization to become a oneliner.
* `Uint48Wrapper`: Serializes/deserializes only the lower 48 bits of an integer (used in BIP152 code).
* `VectorApplyWrapper`: Serializes/deserializes a vector while using a custom serializer for its elements. This simplifies the undo and blockencoding serializers a lot.

Best of all, it removes 147 lines of while code adding a bunch of comments (though the increased use of vararg `READWRITE` is probably cheating a bit).

The commits are ordered into 3 sections:
* First, introduce new classes that permit const-correct serialization.
* Then one by one transform the various files to use the new serializers.
* Finally, remove the old serializers.

This may be too much to go in at once. I'm happy to split things up as needed.