### PR TITLE
Add simple light-client mode (RPC only)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -340,7 +340,8 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-?", _("Print this help message and exit"));
     strUsage += HelpMessageOpt("-version", _("Print version and exit"));
     strUsage += HelpMessageOpt("-alertnotify=<cmd>", _("Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)"));
-    strUsage +=HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)"), defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex()));
+    strUsage += HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)"), defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex()));
+    strUsage += HelpMessageOpt("-autorequestblocks", strprintf(_("Automatic block request, if disabled, blocks will not be requested automatically (default: %u)"), DEFAULT_AUTOMATIC_BLOCK_REQUESTS));
     strUsage += HelpMessageOpt("-blocksdir=<dir>", _("Specify blocks directory (default: <datadir>/blocks)"));
     strUsage += HelpMessageOpt("-blocknotify=<cmd>", _("Execute command when the best block changes (%s in cmd is replaced by block hash)"));
     strUsage += HelpMessageOpt("-blockreconstructionextratxn=<n>", strprintf(_("Extra transactions to keep in memory for compact block reconstructions (default: %u)"), DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN));
@@ -1004,6 +1005,7 @@ bool AppInitParameterInteraction()
     }
     fCheckBlockIndex = gArgs.GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = gArgs.GetBoolArg("-checkpoints", DEFAULT_CHECKPOINTS_ENABLED);
+    SetAutoRequestBlocks(gArgs.GetBoolArg("-autorequestblocks", DEFAULT_AUTOMATIC_BLOCK_REQUESTS));
 
     hashAssumeValid = uint256S(gArgs.GetArg("-assumevalid", chainparams.GetConsensus().defaultAssumeValid.GetHex()));
     if (!hashAssumeValid.IsNull())

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2715,6 +2715,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
         bool fNewBlock = false;
         ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock, !result.fPriorityRequest);
+        if (result.fPriorityRequest) {
+            ProcessPriorityRequests(pblock);
+        }
         if (fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
         } else {
@@ -3765,6 +3768,46 @@ void AddPriorityDownload(const std::vector<const CBlockIndex*>& blocksToDownload
     for (const CBlockIndex* pindex: blocksToDownload) {
         // we add blocks regardless of duplicates
         blocksToDownloadFirst.push_back({pindex, false});
+    }
+}
+
+void ProcessPriorityRequests(const std::shared_ptr<CBlock> blockRef) {
+    LOCK(cs_main);
+    if (blocksToDownloadFirst.empty()) {
+        return;
+    }
+    auto it = std::begin(blocksToDownloadFirst);
+    while (it != std::end(blocksToDownloadFirst)) {
+        std::shared_ptr<const CBlock> currentBlock;
+        const PriorityBlockRequest &r = *it;
+        // make sure we process blocks in order
+        if (!r.downloaded) {
+            break;
+        }
+        if (r.pindex && blockRef && blockRef->GetHash() == r.pindex->GetBlockHash()) {
+            // the passed in block, no need to load again from disk
+            currentBlock = blockRef;
+        }
+        else if (r.pindex->nStatus & BLOCK_HAVE_DATA) {
+            CBlock loadBlock;
+            if (!ReadBlockFromDisk(loadBlock, r.pindex, Params().GetConsensus())) {
+                throw std::runtime_error(std::string(__func__) + "Can't read block from disk");
+            }
+            currentBlock = std::make_shared<const CBlock>(loadBlock);
+        }
+        else {
+            // stop in case we have no block data for this request
+            break;
+        }
+
+        // allow processing through signal
+        GetMainSignals().ProcessPriorityRequest(currentBlock, r.pindex);
+        LogPrint(BCLog::NET, "processed priority block request (%s) height=%d\n", r.pindex->GetBlockHash().ToString(), r.pindex->nHeight);
+
+        // remove processed block from queue
+        it = blocksToDownloadFirst.erase(std::remove_if(blocksToDownloadFirst.begin(), blocksToDownloadFirst.end(), [&r](const PriorityBlockRequest &rB) {
+                                        return rB.pindex == r.pindex;
+                                    }), blocksToDownloadFirst.end());
     }
 }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2701,19 +2701,20 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         LogPrint(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->GetId());
 
         bool forceProcessing = false;
+        MarkBlockAsReceivedResult result;
         const uint256 hash(pblock->GetHash());
         {
             LOCK(cs_main);
             // Also always process if we requested the block explicitly, as we may
             // need it even though it is not a candidate for a new best tip.
-            MarkBlockAsReceivedResult result = MarkBlockAsReceived(hash);
+            result = MarkBlockAsReceived(hash);
             forceProcessing |= result.fRequested;
             // mapBlockSource is only used for sending reject messages and DoS scores,
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         bool fNewBlock = false;
-        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock, !result.fPriorityRequest);
         if (fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
         } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3821,6 +3821,18 @@ void ProcessPriorityRequests(const std::shared_ptr<CBlock> blockRef) {
     }
 }
 
+bool FlushPriorityDownloads() {
+    LOCK(cs_main);
+    bool ret = blocksToDownloadFirst.empty();
+    blocksToDownloadFirst.clear();
+    return !ret;
+}
+
+size_t CountPriorityDownloads() {
+    LOCK(cs_main);
+    return blocksToDownloadFirst.size();
+}
+
 void SetAutoRequestBlocks(bool state) {
     fAutoRequestBlocks = state;
 }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -103,5 +103,6 @@ void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
  * Downloaded blocks will not trigger ActivateBestChain
  */
 void AddPriorityDownload(const std::vector<const CBlockIndex*>& blocksToDownload);
+void ProcessPriorityRequests(const std::shared_ptr<CBlock> block);
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -106,6 +106,8 @@ void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
  */
 void AddPriorityDownload(const std::vector<const CBlockIndex*>& blocksToDownload);
 void ProcessPriorityRequests(const std::shared_ptr<CBlock> block);
+bool FlushPriorityDownloads();
+size_t CountPriorityDownloads();
 
 void SetAutoRequestBlocks(bool state);
 bool isAutoRequestingBlocks();

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -97,4 +97,11 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */
 void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
 
+/**
+ * Prioritize a block for downloading
+ * Blocks requested with priority will be downloaded and processed first
+ * Downloaded blocks will not trigger ActivateBestChain
+ */
+void AddPriorityDownload(const std::vector<const CBlockIndex*>& blocksToDownload);
+
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -34,6 +34,8 @@ static constexpr int64_t STALE_CHECK_INTERVAL = 10 * 60; // 10 minutes
 static constexpr int64_t EXTRA_PEER_CHECK_INTERVAL = 45;
 /** Minimum time an outbound-peer-eviction candidate must be connected for, in order to evict, in seconds */
 static constexpr int64_t MINIMUM_CONNECT_TIME = 30;
+/** if disabled, blocks will not be requested automatically, useful for low-resources-available mode */
+static const bool DEFAULT_AUTOMATIC_BLOCK_REQUESTS = true;
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
@@ -104,5 +106,8 @@ void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
  */
 void AddPriorityDownload(const std::vector<const CBlockIndex*>& blocksToDownload);
 void ProcessPriorityRequests(const std::shared_ptr<CBlock> block);
+
+void SetAutoRequestBlocks(bool state);
+bool isAutoRequestingBlocks();
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -140,6 +140,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
     { "addwitnessaddress", 1, "p2sh" },
+    { "requestblocks", 1, "blockhashes" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -155,7 +155,7 @@ public:
     bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock);
 
     bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex);
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock, bool checkFarAhead = true);
 
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view);
@@ -3389,7 +3389,7 @@ static CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CCh
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock, bool checkFarAhead)
 {
     const CBlock& block = *pblock;
 
@@ -3425,7 +3425,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     if (!fRequested) {  // If we didn't ask for it:
         if (pindex->nTx != 0) return true;    // This is a previously-processed block that was pruned
         if (!fHasMoreOrSameWork) return true; // Don't process less-work chains
-        if (fTooFarAhead) return true;        // Block height is too high
+        if (checkFarAhead && fTooFarAhead) return true;      // Block height is too high
 
         // Protect against DoS attacks from low-work chains.
         // If our tip is behind, a peer could try to send us
@@ -3484,8 +3484,8 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         LOCK(cs_main);
 
         if (ret) {
-            // Store to disk
-            ret = g_chainstate.AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
+            // Store to disk, skip toFarAway check if we are not planing to activate the best chain
+            ret = g_chainstate.AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock, activateBestChain);
         }
         if (!ret) {
             GetMainSignals().BlockChecked(*pblock, state);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3469,7 +3469,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock, bool activateBestChain)
 {
     AssertLockNotHeld(cs_main);
 
@@ -3496,7 +3496,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
     NotifyHeaderTip();
 
     CValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!g_chainstate.ActivateBestChain(state, chainparams, pblock))
+    if (activateBestChain && !g_chainstate.ActivateBestChain(state, chainparams, pblock))
         return error("%s: ActivateBestChain failed", __func__);
 
     return true;

--- a/src/validation.h
+++ b/src/validation.h
@@ -238,10 +238,11 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  *
  * @param[in]   pblock  The block we want to process.
  * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
+ * @param[in]   activateBestChain will allow to bypass the activate best chain logic (for priority block downloads)
  * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock, bool activateBestChain = true);
 
 /**
  * Process incoming block headers.

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -30,6 +30,7 @@ struct MainSignalsInstance {
     boost::signals2::signal<void (int64_t nBestBlockTime, CConnman* connman)> Broadcast;
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
     boost::signals2::signal<void (const CBlockIndex *, const std::shared_ptr<const CBlock>&)> NewPoWValidBlock;
+    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex)> ProcessPriorityRequest;
 
     // We are not allowed to assume the scheduler only runs in one thread,
     // but must ensure all callbacks happen in-order, so we end up creating
@@ -85,9 +86,12 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
     g_signals.m_internals->BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.m_internals->NewPoWValidBlock.connect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.m_internals->ProcessPriorityRequest.connect(boost::bind(&CValidationInterface::ProcessPriorityRequest, pwalletIn, _1, _2));
+
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
+    g_signals.m_internals->ProcessPriorityRequest.disconnect(boost::bind(&CValidationInterface::ProcessPriorityRequest, pwalletIn, _1, _2));
     g_signals.m_internals->BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.m_internals->Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
     g_signals.m_internals->Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -104,6 +108,7 @@ void UnregisterAllValidationInterfaces() {
     if (!g_signals.m_internals) {
         return;
     }
+    g_signals.m_internals->ProcessPriorityRequest.disconnect_all_slots();
     g_signals.m_internals->BlockChecked.disconnect_all_slots();
     g_signals.m_internals->Broadcast.disconnect_all_slots();
     g_signals.m_internals->Inventory.disconnect_all_slots();
@@ -188,4 +193,8 @@ void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& sta
 
 void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {
     m_internals->NewPoWValidBlock(pindex, block);
+}
+
+void CMainSignals::ProcessPriorityRequest(const std::shared_ptr<const CBlock> &pblock, const CBlockIndex *pindex) {
+    m_internals->ProcessPriorityRequest(pblock, pindex);
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -121,6 +121,10 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    /**
+     * Notifies listeners of that a new priorit block request is ready to process
+     */
+    virtual void ProcessPriorityRequest(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -162,6 +166,7 @@ public:
     void Broadcast(int64_t nBestBlockTime, CConnman* connman);
     void BlockChecked(const CBlock&, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void ProcessPriorityRequest(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
 };
 
 CMainSignals& GetMainSignals();

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -173,6 +173,14 @@ void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBloc
     }
 }
 
+void CZMQNotificationInterface::ProcessPriorityRequest(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected)
+{
+    for (const CTransactionRef& ptx : pblock->vtx) {
+        // Do a normal notify for each transaction added in the block
+        TransactionAddedToMempool(ptx);
+    }
+}
+
 void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -27,6 +27,7 @@ protected:
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void ProcessPriorityRequest(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -215,6 +215,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(header['hash'], besthash)
         assert_equal(header['height'], 200)
         assert_equal(header['confirmations'], 1)
+        assert_equal(header['validated'], True)
         assert_equal(header['previousblockhash'], secondbesthash)
         assert_is_hex_string(header['chainwork'])
         assert_is_hash_string(header['hash'])

--- a/test/functional/rpc_requestblocks.py
+++ b/test/functional/rpc_requestblocks.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class RequestBlockRequestTest (BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.extra_args = [[], ['-autorequestblocks=0']]
+
+    def run_test(self):
+        self.nodes[0].generate(50)
+        timeout = 20
+        ctps = self.nodes[1].getchaintips()
+        while timeout > 0:
+            ctps = self.nodes[1].getchaintips()
+            headerHeightReached = False
+            for ct in ctps:
+                if ct['status'] == "headers-only":
+                    if ct['height'] == 50:
+                        headerHeightReached = True
+                if ct['status'] == "active":
+                    assert(ct['height'] == 0)
+            time.sleep(1)
+            timeout-=1
+            if headerHeightReached == True:
+                break
+        assert(timeout>0)
+
+        node0bbhash = self.nodes[0].getbestblockhash()
+        # best block should not be validated, header must be available
+        bh = self.nodes[1].getblockheader(node0bbhash, True)
+
+        assert_equal(bh['validated'], False)
+        # block must not be available
+        assert_raises_rpc_error(-1, "Block not found on disk", self.nodes[1].getblock, node0bbhash)
+
+        # request best block (auxiliary)
+        self.nodes[1].requestblocks("add", [node0bbhash])
+        timeout = 20
+        while timeout > 0:
+            if self.nodes[1].requestblocks("status")['count'] == 0:
+                break
+            time.sleep(1)
+            timeout-=1
+        assert(timeout>0)
+
+        # block must now be available
+        block = self.nodes[1].getblock(node0bbhash, True)
+        assert_equal(block['hash'], node0bbhash)
+        assert_equal(block['validated'], False)
+
+        #prevblock must not be available
+        assert_raises_rpc_error(-1, "Block not found on disk", self.nodes[1].getblock, block['previousblockhash'])
+
+if __name__ == '__main__':
+    RequestBlockRequestTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -128,6 +128,7 @@ BASE_SCRIPTS = [
     'wallet_encryption.py',
     'feature_dersig.py',
     'feature_cltv.py',
+    'rpc_requestblocks.py',
     'rpc_uptime.py',
     'wallet_resendwallettransactions.py',
     'wallet_fallbackfee.py',


### PR DESCRIPTION
This adds a simple light client mode (RPC only, no wallet support).

With this PR, It is possible to disable auto-request-blocks by passing in `-autorequestblocks=0`.
In that mode, one can request out-of-band blocks by calling `requestblock add ["<blockhash>", ...]`.
Those blocks will then be requested/downloaded and can be loaded via `getblock` (and they will also be passed through ZMQ).

This allows a very simple light-client mode ideally when you already have a validated peer in your trusted network.

This is also a reviewable step towards light client mode for the wallet (which will ultimately allow process separation o the wallet).