### PR TITLE
No longer ever reuse keypool indexes

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3211,21 +3211,17 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
                 internal = true;
             }
 
-            if (!setInternalKeyPool.empty()) {
-                nEnd = *(setInternalKeyPool.rbegin()) + 1;
-            }
-            if (!setExternalKeyPool.empty()) {
-                nEnd = std::max(nEnd, *(setExternalKeyPool.rbegin()) + 1);
-            }
+            assert(m_max_keypool_index < std::numeric_limits<int64_t>::max()); // How in the hell did you use so many keys?
+            int64_t index = ++m_max_keypool_index;
 
-            if (!walletdb.WritePool(nEnd, CKeyPool(GenerateNewKey(walletdb, internal), internal))) {
+            if (!walletdb.WritePool(index, CKeyPool(GenerateNewKey(walletdb, internal), internal))) {
                 throw std::runtime_error(std::string(__func__) + ": writing generated key failed");
             }
 
             if (internal) {
-                setInternalKeyPool.insert(nEnd);
+                setInternalKeyPool.insert(index);
             } else {
-                setExternalKeyPool.insert(nEnd);
+                setExternalKeyPool.insert(index);
             }
         }
         if (missingInternal + missingExternal > 0) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -701,6 +701,7 @@ private:
 
     std::set<int64_t> setInternalKeyPool;
     std::set<int64_t> setExternalKeyPool;
+    int64_t m_max_keypool_index;
 
     int64_t nTimeFirstKey;
 
@@ -743,13 +744,14 @@ public:
         }
     }
 
-    void LoadKeyPool(int nIndex, const CKeyPool &keypool)
+    void LoadKeyPool(int64_t nIndex, const CKeyPool &keypool)
     {
         if (keypool.fInternal) {
             setInternalKeyPool.insert(nIndex);
         } else {
             setExternalKeyPool.insert(nIndex);
         }
+        m_max_keypool_index = std::max(m_max_keypool_index, nIndex);
 
         // If no metadata exists yet, create a default with the pool key's
         // creation time. Note that this may be overwritten by actually
@@ -795,6 +797,7 @@ public:
         nAccountingEntryNumber = 0;
         nNextResend = 0;
         nLastResend = 0;
+        m_max_keypool_index = 0;
         nTimeFirstKey = 0;
         fBroadcastTransactions = false;
         nRelockTime = 0;


### PR DESCRIPTION
This fixes an issue where you could reserve a keypool entry, then
top up the keypool, writing out a new key at the given index, then
return they key from the pool. This isnt likely to cause issues,
but given there is no reason to ever re-use keypool indexes
(they're 64 bits...), best to avoid it alltogether.

Builds on #10235, should probably get a 15 tag.