### PR TITLE
[tests] skip zapwallettxes.py

### DIFF
--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -28,6 +28,10 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         connect_nodes_bi(self.nodes,0,2)
 
     def run_test (self):
+        # TODO this test currently fails because wallet transactions remain in the mempool between restarts (since 3f78562d...)
+        # There is a fix in github PR #10330. Until that is merged, just skip this test.
+        return
+
         self.log.info("Mining blocks...")
         self.nodes[0].generate(1)
         self.sync_all()
@@ -69,7 +73,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         #restart bitcoind with zapwallettxes
         self.nodes[0] = self.start_node(0,self.options.tmpdir, ["-zapwallettxes=1"])
         
-        assert_raises(JSONRPCException, self.nodes[0].gettransaction, [txid3])
+        assert_raises_jsonrpc(-5, 'Invalid or non-wallet transaction id', self.nodes[0].gettransaction, txid3)
         #there must be an exception because the unconfirmed wallettx0 must be gone by now
 
         tx0 = self.nodes[0].gettransaction(txid0)


### PR DESCRIPTION
Temporary fix for #10678 

zapwallettxes.py doesn't test anything due to a syntax error.

Fixing the syntax error causes the test to fail because of bad interaction between zapwallettxes and persistent mempool. There is a fix for that in #10330 

Until #10330 is merged we should disable this test. There's no point in running a test that doesn't actually test anything, and which occasionally causes spurious Travis failures.