### PR TITLE
Add histunspent RPC

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -77,6 +77,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "addmultisigaddress", 1, "keys" },
     { "createmultisig", 0, "nrequired" },
     { "createmultisig", 1, "keys" },
+    { "histunspent", 0, "ranges" },
     { "listunspent", 0, "minconf" },
     { "listunspent", 1, "maxconf" },
     { "listunspent", 2, "addresses" },

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -74,11 +74,17 @@ void RPCTypeCheck(const UniValue& params,
     }
 }
 
-void RPCTypeCheckArgument(const UniValue& value, UniValue::VType typeExpected)
+bool RPCTypeCheckArgument(const UniValue& value, UniValue::VType typeExpected)
 {
+    if (value.isNull()) {
+        return false;
+    }
+
     if (value.type() != typeExpected) {
         throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Expected type %s, got %s", uvTypeName(typeExpected), uvTypeName(value.type())));
     }
+
+    return true;
 }
 
 void RPCTypeCheckObj(const UniValue& o,

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -75,7 +75,7 @@ void RPCTypeCheck(const UniValue& params,
 /**
  * Type-check one argument; throws JSONRPCError if wrong type given.
  */
-void RPCTypeCheckArgument(const UniValue& value, UniValue::VType typeExpected);
+bool RPCTypeCheckArgument(const UniValue& value, UniValue::VType typeExpected);
 
 /*
   Check for expected keys/value types in an Object.


### PR DESCRIPTION
This PR introduces `histunspent` RPC. It calculates an histogram for the current unspent transaction output amounts.

This allows to have a better perspective of how the total balance is distributed. This also avoids transmitting the whole UTXO to create the histogram on client side, specially when it has thousands of unspents.

For the moment, the histogram bins are defined with an array of amounts. Later there can be other constructors to define the bins.

Example:
```
./bitcoin-cli -regtest  listunspent | grep amount
    "amount": 50.00000000,
    "amount": 50.00000000,
    "amount": 4.00000000,
    "amount": 45.99996160,
    "amount": 50.00000000,
    "amount": 50.00000000,
    "amount": 36.99996160,
    "amount": 13.00000000,
    "amount": 50.00000000,

./bitcoin-cli -regtest  histunspent '[0,1,5,10,15,100]'
{
  "bins": [
    0, 
    1, 
    0, 
    1, 
    7
  ],
  "ranges": [
    0.00000000, 
    1.00000000, 
    5.00000000, 
    10.00000000, 
    15.00000000, 
    100.00000000
  ]
}
```

Note for reviewers, WIP and missing tests.