### PR TITLE
Avoid some new gcc warnings in 15

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -27,7 +27,7 @@ CScript ParseScript(const std::string& s)
 
     if (mapOpNames.empty())
     {
-        for (int op = 0; op <= MAX_OPCODE; op++)
+        for (unsigned int op = 0; op <= MAX_OPCODE; op++)
         {
             // Allow OP_RESERVED to get into mapOpNames
             if (op < OP_NOP && op != OP_RESERVED)

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -220,7 +220,7 @@ public:
         }
     }
 
-    prevector() : _size(0) {}
+    prevector() : _size(0), _union{{}} {}
 
     explicit prevector(size_type n) : _size(0) {
         resize(n);


### PR DESCRIPTION
This, plus #10714 avoids adding new compile-time warnings in 15.

Fixes a warning added in #10792.