### PR TITLE
Change type of op to agree with type of MAX_OPCODE.

### DIFF
--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -27,7 +27,7 @@ CScript ParseScript(const std::string& s)
 
     if (mapOpNames.empty())
     {
-        for (int op = 0; op <= MAX_OPCODE; op++)
+        for (unsigned int op = 0; op <= MAX_OPCODE; op++)
         {
             // Allow OP_RESERVED to get into mapOpNames
             if (op < OP_NOP && op != OP_RESERVED)


### PR DESCRIPTION
MAX_OPCODE is defined 'unsigned int' in script/script.h.
Changing the variable op's type from int to unsigned int eliminates
a compiler warning.