### PR TITLE
Fix uninitialized atomic variables

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -563,7 +563,7 @@ static bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDe
     // do socks negotiation
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
-        static std::atomic_int counter;
+        static std::atomic_int counter(0);
         random_auth.username = random_auth.password = strprintf("%i", counter++);
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -95,13 +95,13 @@ class CWalletDBWrapper
     friend class CDB;
 public:
     /** Create dummy DB handle */
-    CWalletDBWrapper() : nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(nullptr)
+    CWalletDBWrapper() : nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(nullptr)
     {
     }
 
     /** Create DB handle to real database */
     CWalletDBWrapper(CDBEnv *env_in, const std::string &strFile_in) :
-        nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(env_in), strFile(strFile_in)
+        nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(env_in), strFile(strFile_in)
     {
     }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -747,7 +747,7 @@ DBErrors CWalletDB::ZapWalletTx(std::vector<CWalletTx>& vWtx)
 
 void MaybeCompactWalletDB()
 {
-    static std::atomic<bool> fOneThread;
+    static std::atomic<bool> fOneThread(false);
     if (fOneThread.exchange(true)) {
         return;
     }


### PR DESCRIPTION
This PR fixes uninitialized atomic variables that caused some errors when running with valgrind:

```
==30439== Thread 5 bitcoin-scheduler:
==30439== Conditional jump or move depends on uninitialised value(s)
==30439==    at 0x6C8E0F: MaybeCompactWalletDB() (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x1863F3: std::_Function_handler<void (), void (*)()>::_M_invoke(std::_Any_data const&) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x187D38: std::function<void ()>::operator()() const (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x5BEC84: Repeat(CScheduler*, std::function<void ()>, long) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x5C3683: void boost::_bi::list3<boost::_bi::value<CScheduler*>, boost::_bi::value<std::function<void ()> >, boost::_bi::value<long> >::operator()<void (*)(CScheduler*, std::function<void ()>, long), boost::_bi::list0>(boost::_bi::type<void>, void (*&)(CScheduler*, std::function<void ()>, long), boost::_bi::list0&, int) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x5C2ACF: boost::_bi::bind_t<void, void (*)(CScheduler*, std::function<void ()>, long), boost::_bi::list3<boost::_bi::value<CScheduler*>, boost::_bi::value<std::function<void ()> >, boost::_bi::value<long> > >::operator()() (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x5C1AAE: std::_Function_handler<void (), boost::_bi::bind_t<void, void (*)(CScheduler*, std::function<void ()>, long), boost::_bi::list3<boost::_bi::value<CScheduler*>, boost::_bi::value<std::function<void ()> >, boost::_bi::value<long> > > >::_M_invoke(std::_Any_data const&) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x187D38: std::function<void ()>::operator()() const (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x5BE914: CScheduler::serviceQueue() (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x1A2239: boost::_mfi::mf0<void, CScheduler>::operator()(CScheduler*) const (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x19A233: void boost::_bi::list1<boost::_bi::value<CScheduler*> >::operator()<boost::_mfi::mf0<void, CScheduler>, boost::_bi::list0>(boost::_bi::type<void>, boost::_mfi::mf0<void, CScheduler>&, boost::_bi::list0&, int) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x1907EB: boost::_bi::bind_t<void, boost::_mfi::mf0<void, CScheduler>, boost::_bi::list1<boost::_bi::value<CScheduler*> > >::operator()() (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==  Uninitialised value was created by a heap allocation
==30439==    at 0x4C2E19F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==30439==    by 0x664514: CWallet::CreateWalletFromFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x6673A5: CWallet::InitLoadWallet() (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x170E83: AppInitMain(boost::thread_group&, CScheduler&) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x13E005: AppInit(int, char**) (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439==    by 0x13E6B6: main (in /home/joao/Projects/bitcoin/src/bitcoind)
==30439== 

==30439== HEAP SUMMARY:
==30439==     in use at exit: 2,384 bytes in 11 blocks
==30439==   total heap usage: 101,957 allocs, 101,946 frees, 69,306,991 bytes allocated
==30439== 
==30439== LEAK SUMMARY:
==30439==    definitely lost: 160 bytes in 1 blocks
==30439==    indirectly lost: 0 bytes in 0 blocks
==30439==      possibly lost: 0 bytes in 0 blocks
==30439==    still reachable: 2,224 bytes in 10 blocks
==30439==         suppressed: 0 bytes in 0 blocks
==30439== Rerun with --leak-check=full to see details of leaked memory
==30439== 
==30439== For counts of detected and suppressed errors, rerun with: -v
==30439== ERROR SUMMARY: 7 errors from 1 contexts (suppressed: 0 from 0)
```