### PR TITLE
RPC: Also serve txo from gettxout (not just utxo and mempool)

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -93,6 +93,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "fundrawtransaction", 1, "options" },
     { "gettxout", 1, "n" },
     { "gettxout", 2, "include_mempool" },
+    { "gettxout", 3, "include_spent" },
     { "gettxoutproof", 0, "txids" },
     { "lockunspent", 0, "unlock" },
     { "lockunspent", 1, "transactions" },

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -900,18 +900,11 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
 }
 
 /** Return transaction in txOut, and if it was found inside a block, its hash is placed in hashBlock */
-bool GetTransaction(const uint256 &hash, CTransactionRef &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
+bool GetBlockchainTx(const uint256 &hash, CTransactionRef &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
 {
     CBlockIndex *pindexSlow = NULL;
 
     LOCK(cs_main);
-
-    CTransactionRef ptx = mempool.get(hash);
-    if (ptx)
-    {
-        txOut = ptx;
-        return true;
-    }
 
     if (fTxIndex) {
         CDiskTxPos postx;
@@ -953,6 +946,23 @@ bool GetTransaction(const uint256 &hash, CTransactionRef &txOut, const Consensus
     }
 
     return false;
+}
+
+/**
+ * Return transaction in txOut, and if it was found inside a block,
+ * its hash is placed in hashBlock. Look in the mempool first.
+*/
+bool GetTransaction(const uint256 &hash, CTransactionRef &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow)
+{
+    LOCK(cs_main);
+
+    CTransactionRef ptx = mempool.get(hash);
+    if (ptx)
+    {
+        txOut = ptx;
+        return true;
+    }
+    return GetBlockchainTx(hash, txOut, consensusParams, hashBlock, fAllowSlow);
 }
 
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -276,6 +276,8 @@ bool IsInitialBlockDownload();
  * This function only returns the highest priority warning of the set selected by strFor.
  */
 std::string GetWarnings(const std::string& strFor);
+/** Retrieve a transaction (from disk (not mempool), if possible) */
+bool GetBlockchainTx(const uint256 &hash, CTransactionRef &txOut, const Consensus::Params& consensusParams, uint256 &hashBlock, bool fAllowSlow);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransactionRef &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */


### PR DESCRIPTION
Expand gettxout to also serve spent txo if pruning or lack of -txindex don't get in the way.

If the output is spent, it will be slower to load, but there's no reason not to serve this if the data is there.

TODO (functional tests):

- [x] Test success (ideally more than one example)
- [x] Test error no txid
- [x] Test error no n for this txid
- [x] Test spent/unspent
- [x] Test txindex error
- [ ] Test prunning error
