### PR TITLE
Avoid unnecessary work in SetNetworkActive

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2182,16 +2182,18 @@ void CConnman::SetNetworkActive(bool active)
 {
     LogPrint(BCLog::NET, "SetNetworkActive: %s\n", active);
 
-    if (!active) {
-        fNetworkActive = false;
+    if (fNetworkActive == active) {
+        return;
+    }
 
+    fNetworkActive = active;
+
+    if (!fNetworkActive) {
         LOCK(cs_vNodes);
         // Close sockets to all nodes
         for (CNode* pnode : vNodes) {
             pnode->CloseSocketDisconnect();
         }
-    } else {
-        fNetworkActive = true;
     }
 
     uiInterface.NotifyNetworkActiveChanged(fNetworkActive);


### PR DESCRIPTION
This PR adds an early return to avoid unnecessary notifications when the status doesn't change.