### PR TITLE
Remove declaration of unused method: void UpdatedTransaction(const uint256 &)

### DIFF
--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -86,7 +86,6 @@ public:
     void TransactionAddedToMempool(const CTransactionRef &);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef> &);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &);
-    void UpdatedTransaction(const uint256 &);
     void SetBestChain(const CBlockLocator &);
     void Inventory(const uint256 &);
     void Broadcast(int64_t nBestBlockTime, CConnman* connman);


### PR DESCRIPTION
Remove declaration of unused method: `void UpdatedTransaction(const uint256 &)`

Removed in 9fececb2cbabc52cc375b84bf840fac018cc8121.