### PR TITLE
Rename member field according to the style guide

### DIFF
--- a/src/reverse_iterator.h
+++ b/src/reverse_iterator.h
@@ -1,7 +1,7 @@
 // Taken from https://gist.github.com/arvidsson/7231973
 
-#ifndef BITCOIN_REVERSE_ITERATOR_HPP
-#define BITCOIN_REVERSE_ITERATOR_HPP
+#ifndef BITCOIN_REVERSE_ITERATOR_H
+#define BITCOIN_REVERSE_ITERATOR_H
 
 /**
  * Template used for reverse iteration in C++11 range-based for loops.
@@ -14,19 +14,19 @@
 template <typename T>
 class reverse_range
 {
-    T &x;
+    T &m_x;
     
 public:
-    reverse_range(T &x) : x(x) {}
+    reverse_range(T &x) : m_x(x) {}
     
-    auto begin() const -> decltype(this->x.rbegin())
+    auto begin() const -> decltype(this->m_x.rbegin())
     {
-        return x.rbegin();
+        return m_x.rbegin();
     }
     
-    auto end() const -> decltype(this->x.rend())
+    auto end() const -> decltype(this->m_x.rend())
     {
-        return x.rend();
+        return m_x.rend();
     }
 };
  
@@ -36,4 +36,4 @@ reverse_range<T> reverse_iterate(T &x)
     return reverse_range<T>(x);
 }
 
-#endif // BITCOIN_REVERSE_ITERATOR_HPP
+#endif // BITCOIN_REVERSE_ITERATOR_H


### PR DESCRIPTION
After #10193, approx. five instances of this warning are printed when compiling with `-Wshadow`:

```
In file included from txmempool.cpp:14:
./reverse_iterator.h:20:22: warning: declaration shadows a field of 'reverse_range<T>' [-Wshadow]
    reverse_range(T &x) : x(x) {}
                     ^
./reverse_iterator.h:17:8: note: previous declaration is here
    T &x;
       ^
1 warning generated.
```
