### PR TITLE
Fix resource leak on error in GetDevURandom

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -191,6 +191,7 @@ void GetDevURandom(unsigned char *ent32)
     do {
         ssize_t n = read(f, ent32 + have, NUM_OS_RANDOM_BYTES - have);
         if (n <= 0 || n + have > NUM_OS_RANDOM_BYTES) {
+            close(f);
             RandFailure();
         }
         have += n;


### PR DESCRIPTION
Fixes a potential file handle leak when size of entropy is invalid