### PR TITLE
[rpc] Give users one final warning before removing getinfo

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-checkmempool=<n>", strprintf("Run checks every <n> transactions (default: %u)", defaultChainParams->DefaultConsistencyChecks()));
         strUsage += HelpMessageOpt("-checkpoints", strprintf("Disable expensive verification for known chain history (default: %u)", DEFAULT_CHECKPOINTS_ENABLED));
         strUsage += HelpMessageOpt("-disablesafemode", strprintf("Disable safemode, override a real safe mode event (default: %u)", DEFAULT_DISABLE_SAFEMODE));
+        strUsage += HelpMessageOpt("-enablegetinfo", strprintf("Enable the getinfo RPC. Only applicable for v0.15. getinfo will be fully removed in v0.16"));
         strUsage += HelpMessageOpt("-testsafemode", strprintf("Force safe mode (default: %u)", DEFAULT_TESTSAFEMODE));
         strUsage += HelpMessageOpt("-dropmessagestest=<n>", "Randomly drop 1 of every <n> network messages");
         strUsage += HelpMessageOpt("-fuzzmessagestest=<n>", "Randomly fuzz 1 of every <n> network messages");

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -72,6 +72,10 @@ UniValue getinfo(const JSONRPCRequest& request)
             + HelpExampleRpc("getinfo", "")
         );
 
+    if (!GetBoolArg("-enablegetinfo", false)) {
+        return "getinfo is deprecated and will be fully removed in v0.16. To use getinfo in v0.15, restart bitcoind with -enablegetinfo.\n"
+           "Projects should transition to using getblockchaininfo, getnetworkinfo and getwalletinfo before upgrading to v0.16";
+    }
 #ifdef ENABLE_WALLET
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
 

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -88,7 +88,6 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         self.nodes[0].generate(VB_PERIOD - VB_THRESHOLD + 1)
         # Check that we're not getting any versionbit-related errors in
         # get*info()
-        assert(not VB_PATTERN.match(self.nodes[0].getinfo()["errors"]))
         assert(not VB_PATTERN.match(self.nodes[0].getmininginfo()["errors"]))
         assert(not VB_PATTERN.match(self.nodes[0].getnetworkinfo()["warnings"]))
 
@@ -100,7 +99,6 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # have gotten a different alert due to more than 51/100 blocks
         # being of unexpected version.
         # Check that get*info() shows some kind of error.
-        assert(WARN_UNKNOWN_RULES_MINED in self.nodes[0].getinfo()["errors"])
         assert(WARN_UNKNOWN_RULES_MINED in self.nodes[0].getmininginfo()["errors"])
         assert(WARN_UNKNOWN_RULES_MINED in self.nodes[0].getnetworkinfo()["warnings"])
 
@@ -116,7 +114,6 @@ class VersionBitsWarningTest(BitcoinTestFramework):
 
         # Connecting one block should be enough to generate an error.
         self.nodes[0].generate(1)
-        assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getinfo()["errors"])
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getmininginfo()["errors"])
         assert(WARN_UNKNOWN_RULES_ACTIVE in self.nodes[0].getnetworkinfo()["warnings"])
         self.stop_nodes()

--- a/test/functional/rpcnamedargs.py
+++ b/test/functional/rpcnamedargs.py
@@ -23,10 +23,10 @@ class NamedArgumentTest(BitcoinTestFramework):
 
     def run_test(self):
         node = self.nodes[0]
-        h = node.help(command='getinfo')
-        assert(h.startswith('getinfo\n'))
+        h = node.help(command='getmininginfo')
+        assert(h.startswith('getmininginfo\n'))
 
-        assert_raises_jsonrpc(-8, 'Unknown named parameter', node.help, random='getinfo')
+        assert_raises_jsonrpc(-8, 'Unknown named parameter', node.help, random='getmininginfo')
 
         h = node.getblockhash(height=0)
         node.getblock(blockhash=h)


### PR DESCRIPTION
Alternative to #10838 

This PR disables `getinfo` by default in v0.15.0. `getinfo` will return a string informing the user that `getinfo` is deprecated, but can be enabled in v0.15.0 by running with `-enablegetinfo`. v0.15.1 will remove `getinfo` entirely.

Should address @achow101's objection to #10838 by giving clients a final warning before removing the RPC in v0.15.1.

Draws a final line in the sand. `getinfo` **will** be gone in v0.15.1

@TheBlueMatt 