### PR TITLE
Fix incorrect Doxygen tag (@ince → @since). Doxygen parameter name matching.

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -117,7 +117,7 @@ public:
      * Create new TxConfirmStats. This is called by BlockPolicyEstimator's
      * constructor with default values.
      * @param defaultBuckets contains the upper limits for the bucket boundaries
-     * @param maxConfirms max number of confirms to track
+     * @param maxPeriods max number of periods to track
      * @param decay how much to decay the historical moving average per block
      */
     TxConfirmStats(const std::vector<double>& defaultBuckets, const std::map<double, unsigned int>& defaultBucketMap,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -163,7 +163,7 @@ extern const char *PONG;
 /**
  * The notfound message is a reply to a getdata message which requested an
  * object the receiving node does not have available for relay.
- * @ince protocol version 70001.
+ * @since protocol version 70001.
  * @see https://bitcoin.org/en/developer-reference#notfound
  */
 extern const char *NOTFOUND;

--- a/src/util.h
+++ b/src/util.h
@@ -215,7 +215,7 @@ public:
      * Return string argument or default value
      *
      * @param strArg Argument to get (e.g. "-foo")
-     * @param default (e.g. "1")
+     * @param strDefault (e.g. "1")
      * @return command-line argument or default value
      */
     std::string GetArg(const std::string& strArg, const std::string& strDefault);
@@ -224,7 +224,7 @@ public:
      * Return integer argument or default value
      *
      * @param strArg Argument to get (e.g. "-foo")
-     * @param default (e.g. 1)
+     * @param nDefault (e.g. 1)
      * @return command-line argument (0 if invalid number) or default value
      */
     int64_t GetArg(const std::string& strArg, int64_t nDefault);
@@ -233,7 +233,7 @@ public:
      * Return boolean argument or default value
      *
      * @param strArg Argument to get (e.g. "-foo")
-     * @param default (true or false)
+     * @param fDefault (true or false)
      * @return command-line argument or default value
      */
     bool GetBoolArg(const std::string& strArg, bool fDefault);

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -16,7 +16,7 @@ void RegisterWalletRPCCommands(CRPCTable &t);
  * @param[in] request JSONRPCRequest that wishes to access a wallet
  * @return NULL if no wallet should be used, or a pointer to the CWallet
  */
-CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest&);
+CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
 std::string HelpRequiringPassphrase(CWallet *);
 void EnsureWalletIsUnlocked(CWallet *);


### PR DESCRIPTION
Doxygen fixes:
* Fix incorrect Doxygen tag (`@ince` → `@since`).
* Make Doxygen parameter names match actual parameter names.