### PR TITLE
Add attribute [[noreturn]] (C++11) to functions that will not return

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -39,10 +39,10 @@
 #include <openssl/err.h>
 #include <openssl/rand.h>
 
-static void RandFailure()
+[[noreturn]] static void RandFailure()
 {
     LogPrintf("Failed to read randomness, aborting\n");
-    abort();
+    std::abort();
 }
 
 static inline int64_t GetPerformanceCounter()

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -10,14 +10,14 @@
 
 std::unique_ptr<CConnman> g_connman;
 
-void Shutdown(void* parg)
+[[noreturn]] void Shutdown(void* parg)
 {
-  exit(EXIT_SUCCESS);
+  std::exit(EXIT_SUCCESS);
 }
 
-void StartShutdown()
+[[noreturn]] void StartShutdown()
 {
-  exit(EXIT_SUCCESS);
+  std::exit(EXIT_SUCCESS);
 }
 
 bool ShutdownRequested()


### PR DESCRIPTION
Add attribute `[[noreturn]]` (C++11) to functions that will not return.

Rationale:
* Reduce the number of false positives/false negatives from static analyzers with regards to things such as unused or unreachable code
* Potentially enable additional compiler optimizations