### PR TITLE
Enable devirtualization opportunities by using the final specifier (C++11)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -133,7 +133,7 @@ bool ShutdownRequested()
  * chainstate, while keeping user interface out of the common library, which is shared
  * between bitcoind, and bitcoin-qt and non-server tools.
 */
-class CCoinsViewErrorCatcher : public CCoinsViewBacked
+class CCoinsViewErrorCatcher final : public CCoinsViewBacked
 {
 public:
     CCoinsViewErrorCatcher(CCoinsView* view) : CCoinsViewBacked(view) {}

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1134,7 +1134,7 @@ public:
 };
 
 /** A key allocated from the key pool. */
-class CReserveKey : public CReserveScript
+class CReserveKey final : public CReserveScript
 {
 protected:
     CWallet* pwallet;


### PR DESCRIPTION
Enable devirtualization opportunities by using the `final` specifier (C++11).

* Declaring `CCoinsViewErrorCatcher` final enables devirtualization of two calls
* Declaring `CReserveKey` final enables devirtualization of one call
