### PR TITLE
Remove unused variable int64_t nEnd. Fix typo: "conditon" → "condition".

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -840,7 +840,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
 
     // Return failure if trying to analyze a target we're not tracking
     if (confTarget <= 0 || (unsigned int)confTarget > longStats->GetMaxConfirms()) {
-        return CFeeRate(0);  // error conditon
+        return CFeeRate(0);  // error condition
     }
 
     // It's not possible to get reasonable estimates for confTarget of 1
@@ -852,7 +852,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
     }
     if (feeCalc) feeCalc->returnedTarget = confTarget;
 
-    if (confTarget <= 1) return CFeeRate(0); // error conditon
+    if (confTarget <= 1) return CFeeRate(0); // error condition
 
     assert(confTarget > 0); //estimateCombinedFee and estimateConservativeFee take unsigned ints
     /** true is passed to estimateCombined fee for target/2 and target so
@@ -899,7 +899,7 @@ CFeeRate CBlockPolicyEstimator::estimateSmartFee(int confTarget, FeeCalculation 
         }
     }
 
-    if (median < 0) return CFeeRate(0); // error conditon
+    if (median < 0) return CFeeRate(0); // error condition
 
     return CFeeRate(median);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3206,7 +3206,6 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
         CWalletDB walletdb(*dbw);
         for (int64_t i = missingInternal + missingExternal; i--;)
         {
-            int64_t nEnd = 1;
             if (i < missingInternal) {
                 internal = true;
             }


### PR DESCRIPTION
* Remove unused variable `int64_t nEnd`. Last use of `nEnd` removed in commit 1fc8c3d.
* Fix typo: "conditon" → "condition". Typo introduced in commit 439c4e8.



