### PR TITLE
Avoid redundant redeclaration of GetWarnings(const string&)

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -18,6 +18,7 @@
 #include "txmempool.h"
 #include "ui_interface.h"
 #include "util.h"
+#include "warnings.h"
 
 #include <stdint.h>
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -24,6 +24,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "warnings.h"
 
 #include <memory>
 #include <stdint.h>

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -21,6 +21,7 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 #endif
+#include "warnings.h"
 
 #include <stdint.h>
 #ifdef HAVE_MALLOC_INFO

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -18,7 +18,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"
-
+#include "warnings.h"
 
 #include <univalue.h>
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -268,14 +268,6 @@ void UnloadBlockIndex();
 void ThreadScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
-/** Format a string that describes several potential problems detected by the core.
- * strFor can have three values:
- * - "rpc": get critical warnings, which should put the client in safe mode if non-empty
- * - "statusbar": get all warnings
- * - "gui": get all warnings, translated (where possible) for GUI
- * This function only returns the highest priority warning of the set selected by strFor.
- */
-std::string GetWarnings(const std::string& strFor);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
 bool GetTransaction(const uint256 &hash, CTransactionRef &tx, const Consensus::Params& params, uint256 &hashBlock, bool fAllowSlow = false);
 /** Find the best known block, and make it the tip of the block chain */

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -14,6 +14,13 @@ void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);
 bool GetfLargeWorkInvalidChainFound();
+/** Format a string that describes several potential problems detected by the core.
+ * strFor can have three values:
+ * - "rpc": get critical warnings, which should put the client in safe mode if non-empty
+ * - "statusbar": get all warnings
+ * - "gui": get all warnings, translated (where possible) for GUI
+ * This function only returns the highest priority warning of the set selected by strFor.
+ */
 std::string GetWarnings(const std::string& strFor);
 
 static const bool DEFAULT_TESTSAFEMODE = false;


### PR DESCRIPTION
Avoid redundant redeclaration of `GetWarnings(const string&)`.

`std::string GetWarnings(const std::string& strFor)` is declared in `warnings.h` and defined in `warnings.cpp`.