### PR TITLE
Move CloseSocket out of SetSocketNonBlocking and pass socket as const reference

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -76,7 +76,7 @@ typedef unsigned int SOCKET;
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN
 
-bool static inline IsSelectableSocket(SOCKET s) {
+bool static inline IsSelectableSocket(const SOCKET& s) {
 #ifdef WIN32
     return true;
 #else

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2076,6 +2076,7 @@ bool CConnman::BindListenPort(const CService &addrBind, std::string& strError, b
 
     // Set to non-blocking, incoming connections will also inherit this
     if (!SetSocketNonBlocking(hListenSocket, true)) {
+        CloseSocket(hListenSocket);
         strError = strprintf("BindListenPort: Setting listening socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
         LogPrintf("%s\n", strError);
         return false;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -57,9 +57,9 @@ std::string NetworkErrorString(int err);
 /** Close socket and set hSocket to INVALID_SOCKET */
 bool CloseSocket(SOCKET& hSocket);
 /** Disable or enable blocking-mode for a socket */
-bool SetSocketNonBlocking(SOCKET& hSocket, bool fNonBlocking);
+bool SetSocketNonBlocking(const SOCKET& hSocket, bool fNonBlocking);
 /** Set the TCP_NODELAY flag on a socket */
-bool SetSocketNoDelay(SOCKET& hSocket);
+bool SetSocketNoDelay(const SOCKET& hSocket);
 /**
  * Convert milliseconds to a struct timeval for e.g. select.
  */


### PR DESCRIPTION
Rationale:

Readability, SetSocketNonBlocking does what it says on the tin.

Consistency, More consistent with the rest of the API in this unit.

Reusability, SetSocketNonBlocking can also be used by clients that may not want to close the socket on failure.

This also moves the responsibility of closing the socket back to the caller that opened it, which in general should know better how and when to close it.