### PR TITLE
Allow only a single -usewallet argument

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -300,8 +300,12 @@ int CommandLineRPC(int argc, char *argv[])
             while (std::getline(std::cin,line))
                 args.push_back(line);
         }
-        if (args.size() < 1)
+        if (args.size() < 1) {
             throw std::runtime_error("too few parameters (need at least command)");
+        }
+        if (gArgs.GetArgs("-usewallet").size() > 1) {
+            throw std::runtime_error("Only one -usewallet arguments is allowed");
+        }
         std::string strMethod = args[0];
         args.erase(args.begin()); // Remove trailing method name from arguments vector
 


### PR DESCRIPTION
Currently, one can specify multiple `-usewallet` arguments in bitcoin-cli (Including `bitcoin.conf`) where the last passed-in `-usewallet` will be used. This can result in executing critical actions on the wrong wallet.

This PR halts bitcoin-cli if multiple `-usewallet`-arguments where passed-in.

Tagged for 0.15 (in case we consider this a bug-fix).

Reported by @morcos (https://github.com/bitcoin/bitcoin/pull/10849#issuecomment-316065717)