### PR TITLE
Remove -usewallet

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -482,7 +482,13 @@ void ArgsManager::ForceSetArg(const std::string& strArg, const std::string& strV
     mapMultiArgs[strArg].push_back(strValue);
 }
 
-
+bool ArgsManager::ClearArg(const std::string& strArg)
+{
+    LOCK(cs_args);
+    return mapArgs.erase(strArg) | mapMultiArgs.erase(strArg);
+    // bitwise or is deliberate. erase() returns number of items erased. We don't want
+    // to short-circuit the mapMultiArgs erase().
+}
 
 static const int screenWidth = 79;
 static const int optIndent = 2;

--- a/src/util.h
+++ b/src/util.h
@@ -259,6 +259,14 @@ public:
     // Forces an arg setting. Called by SoftSetArg() if the arg hasn't already
     // been set. Also called directly in testing.
     void ForceSetArg(const std::string& strArg, const std::string& strValue);
+
+    /**
+     * Clears an argument if it is already set
+     *
+     * @param strArg Argument to set (e.g. "-foo")
+     * @return true if argument gets cleared, false if there was no argument
+     */
+    bool ClearArg(const std::string& strArg);
 };
 
 extern ArgsManager gArgs;


### PR DESCRIPTION
For merge after v0.15 (**or perhaps as a bugfix for v0.15**)

1. Adds better validation of bitcoin-cli wallet argument to make sure it is only specified once, and that is only ever picked up from the command line, not from a config file (which could have bad results if someone was writing a script and forgot a command line argument).
2. Renames -usewallet to -wallet

If there is zero or one `-wallet` argument in bitcoin.conf (ie single wallet mode), **there is no change from pre-0.15 behaviour**. No `-wallet` argument is required for bitcoin.cli.

If there is more than one `-wallet` argument in bitcoin.conf (ie multiwallet), then a single command-line `-wallet` argument must be provided to bitcoin.cli.

It is always an error to specify more than one `-wallet` command line argument, and the request will be rejected by bitcoin.cli on the client side.