### PR TITLE
[Qt] Use wallet 0 in rpc console if running with multiple wallets

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -25,6 +25,7 @@
 
 #ifdef ENABLE_WALLET
 #include <db_cxx.h>
+#include <wallet/wallet.h>
 #endif
 
 #include <QKeyEvent>
@@ -301,6 +302,14 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                             JSONRPCRequest req;
                             req.params = RPCConvertValues(stack.back()[0], std::vector<std::string>(stack.back().begin() + 1, stack.back().end()));
                             req.strMethod = stack.back()[0];
+#ifdef ENABLE_WALLET
+                            // TODO: Move this logic to WalletModel
+                            if (!vpwallets.empty()) {
+                                // in Qt, use always the wallet with index 0 when running with multiple wallets
+                                QByteArray encodedName = QUrl::toPercentEncoding(QString::fromStdString(vpwallets[0]->GetName()));
+                                req.URI = "/wallet/"+std::string(encodedName.constData(), encodedName.length());
+                            }
+#endif
                             lastResult = tableRPC.execute(req);
                         }
 


### PR DESCRIPTION
Current master with multiwallet results in accessing wallet 0 in QT (send / receive / tx history / etc.), **but** the RPC console cannot access that wallet (only non-wallet commands work).

This is a quick solution to re-allow accessing the same wallet (Index 0) via RPC console in multiwallet.

The solutions design is not "state of the art" (should go over WalletModel). Ideally we work on an overall multiwallet support for the GUI (which then would remove this change).

I think we should consider this as a bugfix.