### PR TITLE
Docs: Syntax highlight shell commands in the building notes

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -41,7 +41,7 @@ Do not use `pkg_add boost`! The boost version installed thus is compiled using t
 
 This makes it necessary to build boost, or at least the parts used by Bitcoin Core, manually:
 
-```
+```bash
 # Pick some path to install boost to, here we create a directory within the bitcoin directory
 BITCOIN_ROOT=$(pwd)
 BOOST_PREFIX="${BITCOIN_ROOT}/boost"

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -57,22 +57,28 @@ Bitcoin Core is now available at `./src/bitcoind`
 
 Before running, it's recommended you create an RPC configuration file.
 
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+```bash
+echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 
-    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+```
 
 The first time you run bitcoind, it will start downloading the blockchain. This process could take several hours.
 
 You can monitor the download process by looking at the debug.log file:
 
-    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
+```bash
+tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
+```
 
 Other commands:
 -------
 
-    ./src/bitcoind -daemon # Starts the bitcoin daemon.
-    ./src/bitcoin-cli --help # Outputs a list of command-line options.
-    ./src/bitcoin-cli help # Outputs a list of RPC commands when the daemon is running.
+```bash
+./src/bitcoind -daemon    # Starts the bitcoin daemon.
+./src/bitcoin-cli --help  # Outputs a list of command-line options.
+./src/bitcoin-cli help    # Outputs a list of RPC commands when the daemon is running.
+```
 
 Using Qt Creator as IDE
 ------------------------

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -9,7 +9,9 @@ Note
 Always use absolute paths to configure and compile bitcoin and the dependencies,
 for example, when specifying the path of the dependency:
 
-	../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+```bash
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+```
 
 Here BDB_PREFIX must be an absolute path - it is defined using $(pwd) which ensures
 the usage of the absolute path.
@@ -58,8 +60,9 @@ C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
 memory available when compiling Bitcoin Core. On systems with less, gcc can be
 tuned to conserve memory with additional CXXFLAGS:
 
-
-    ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+```bash
+./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
+```
 
 Dependency Build Instructions: Ubuntu & Debian
 ----------------------------------------------
@@ -198,7 +201,7 @@ Boost
 -----
 If you need to build Boost yourself:
 
-	sudo su
+	sudo -i
 	./bootstrap.sh
 	./bjam install
 
@@ -303,11 +306,13 @@ Then, install the toolchain and curl:
 
 To build executables for ARM:
 
-    cd depends
-    make HOST=arm-linux-gnueabihf NO_QT=1
-    cd ..
-    ./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
-    make
+```bash
+cd depends
+make HOST=arm-linux-gnueabihf NO_QT=1
+cd ..
+./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
+make
+```
 
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
@@ -338,9 +343,11 @@ with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above
 
 Then build using:
 
-    ./autogen.sh
-    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
-    gmake
+```bash
+./autogen.sh
+./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
+gmake
+```
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
 It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and


### PR DESCRIPTION
This is a trivial change that adds syntax highlighting to all of the shell commands that use strings/variables/comments from the build docs (i.e. all of the shell commands that actually can be highlighted). I also made one minor change to one of the commands, encouraging the use of `sudo -i` instead of `sudo su` (the two are functionally equivalent).