### PR TITLE
Use a condition variable for shutdown notifications

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -42,13 +42,7 @@
 
 void WaitForShutdown(boost::thread_group* threadGroup)
 {
-    bool fShutdown = ShutdownRequested();
-    // Tell the main threads to shutdown.
-    while (!fShutdown)
-    {
-        MilliSleep(200);
-        fShutdown = ShutdownRequested();
-    }
+    WaitForShutdownNotify();
     if (threadGroup)
     {
         Interrupt(*threadGroup);

--- a/src/init.h
+++ b/src/init.h
@@ -18,6 +18,7 @@ class thread_group;
 
 void StartShutdown();
 bool ShutdownRequested();
+void WaitForShutdownNotify();
 /** Interrupt threads */
 void Interrupt(boost::thread_group& threadGroup);
 void Shutdown();


### PR DESCRIPTION
Currently bitcoind polls every 200ms to see if a shutdown has been requested. This causes the process to wake up frequently and unnecessarily when the network is idle. The change here adds a condition variable so that the main bitcoind thread can do a blocking wait on the condition variable, rather than polling. Without this patch (i.e. in master) if you strace bitcoind you will see a lot of nanosleep() calls, with this patch the process does just a blocking wait on a futex(). The motivation here is that I want the CPU to be able to stay powered down more on my local bitcoin node.

I elected to keep `fRequestShutdown` as an atomic variable, even though a new mutex is added for the condition variable, just to minimize code churn. I think there's a case to be made that it should be turned into a regular bool and then `ShutdownRequested()` should use the mutex, but I don't have a strong preference. To make it non-atomic and use the mutex would make the diff a little bigger, as there are a few places that read the atomic variable directly.

This is my first Bitcoin diff. I have read the contributions doc, but please let me know if I made any errors related to code style, contributing, etc.