### PR TITLE
[rpc] Verbose flags for chaining and scripting

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -96,6 +96,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signrawtransaction", 2, "privkeys" },
     { "signrawtransactionwithkey", 1, "privkeys" },
     { "signrawtransactionwithkey", 2, "prevtxs" },
+    { "signrawtransactionwithkey", 4, "verbose" },
     { "signrawtransactionwithwallet", 1, "prevtxs" },
     { "signrawtransactionwithwallet", 3, "verbose" },
     { "sendrawtransaction", 1, "allowhighfees" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -97,6 +97,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "signrawtransactionwithkey", 1, "privkeys" },
     { "signrawtransactionwithkey", 2, "prevtxs" },
     { "signrawtransactionwithwallet", 1, "prevtxs" },
+    { "signrawtransactionwithwallet", 3, "verbose" },
     { "sendrawtransaction", 1, "allowhighfees" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -101,6 +101,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },
     { "fundrawtransaction", 2, "iswitness" },
+    { "fundrawtransaction", 3, "verbose" },
     { "gettxout", 1, "n" },
     { "gettxout", 2, "include_mempool" },
     { "gettxoutproof", 0, "txids" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -672,7 +672,7 @@ UniValue combinerawtransaction(const JSONRPCRequest& request)
     return EncodeHexTx(mergedTx);
 }
 
-UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival, CBasicKeyStore *keystore, bool is_temp_keystore, const UniValue& hashType)
+UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival, CBasicKeyStore *keystore, bool is_temp_keystore, const UniValue& hashType, bool verbose_mode)
 {
     // Fetch previous transactions (inputs):
     CCoinsView viewDummy;
@@ -815,6 +815,11 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
             }
         }
     }
+
+    if (!verbose_mode) {
+        return EncodeHexTx(mtx);
+    }
+
     bool fComplete = vErrors.empty();
 
     UniValue result(UniValue::VOBJ);

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -10,6 +10,6 @@ struct CMutableTransaction;
 class UniValue;
 
 /** Sign a transaction with the given keystore and previous transactions */
-UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxs, CBasicKeyStore *keystore, bool tempKeystore, const UniValue& hashType);
+UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxs, CBasicKeyStore *keystore, bool tempKeystore, const UniValue& hashType, bool verbose_mode = true);
 
 #endif // BITCOIN_RPC_RAWTRANSACTION_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3262,9 +3262,9 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
         throw std::runtime_error(
-            "signrawtransactionwithwallet \"hexstring\" ( [{\"txid\":\"id\",\"vout\":n,\"scriptPubKey\":\"hex\",\"redeemScript\":\"hex\"},...] sighashtype )\n"
+            "signrawtransactionwithwallet \"hexstring\" ( [{\"txid\":\"id\",\"vout\":n,\"scriptPubKey\":\"hex\",\"redeemScript\":\"hex\"},...] sighashtype verbose )\n"
             "\nSign inputs for raw transaction (serialized, hex-encoded).\n"
             "The second optional argument (may be null) is an array of previous transaction outputs that\n"
             "this transaction depends on but may not yet be in the block chain.\n"
@@ -3290,8 +3290,9 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
             "       \"ALL|ANYONECANPAY\"\n"
             "       \"NONE|ANYONECANPAY\"\n"
             "       \"SINGLE|ANYONECANPAY\"\n"
+            "4. \"verbose\"                        (boolean, optional, default=true) Whether to return verbose information or not\n"
 
-            "\nResult:\n"
+            "\nResult (default, verbose=true):\n"
             "{\n"
             "  \"hex\" : \"value\",                  (string) The hex-encoded raw transaction with signature(s)\n"
             "  \"complete\" : true|false,          (boolean) If the transaction has a complete set of signatures\n"
@@ -3307,12 +3308,17 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
             "  ]\n"
             "}\n"
 
+            "\nResult (verbose=false):\n"
+            "tx                                  (hex string) Resulting transaction\n"
+
             "\nExamples:\n"
             + HelpExampleCli("signrawtransactionwithwallet", "\"myhex\"")
             + HelpExampleRpc("signrawtransactionwithwallet", "\"myhex\"")
         );
 
-    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR, UniValue::VSTR}, true);
+    RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VARR, UniValue::VSTR, UniValue::VBOOL}, true);
+
+    bool verbose_mode = request.params[3].isNull() || request.params[3].get_bool();
 
     CMutableTransaction mtx;
     if (!DecodeHexTx(mtx, request.params[0].get_str(), true)) {
@@ -3321,7 +3327,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
 
     // Sign the transaction
     LOCK2(cs_main, pwallet->cs_wallet);
-    return SignTransaction(mtx, request.params[1], pwallet, false, request.params[2]);
+    return SignTransaction(mtx, request.params[1], pwallet, false, request.params[2], verbose_mode);
 }
 
 UniValue bumpfee(const JSONRPCRequest& request)
@@ -3868,7 +3874,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "setaccount",                       &setaccount,                    {"address","account"} },
     { "wallet",             "settxfee",                         &settxfee,                      {"amount"} },
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },
-    { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype"} },
+    { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype","verbose"} },
     { "wallet",             "walletlock",                       &walletlock,                    {} },
     { "wallet",             "walletpassphrasechange",           &walletpassphrasechange,        {"oldpassphrase","newpassphrase"} },
     { "wallet",             "walletpassphrase",                 &walletpassphrase,              {"passphrase","timeout"} },

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -77,6 +77,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert(len(dec_tx['vin']) > 0) #test that we have enough inputs
+        assert(len(
+            self.nodes[2].decoderawtransaction(
+                self.nodes[2].fundrawtransaction(hexstring=rawtx, verbose=False)
+            )
+        ) > 0)
 
         ##############################
         # simple test with two coins #
@@ -90,6 +95,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert(len(dec_tx['vin']) > 0) #test if we have enough inputs
+        assert(len(
+            self.nodes[2].decoderawtransaction(
+                self.nodes[2].fundrawtransaction(hexstring=rawtx, verbose=False)
+            )
+        ))
 
         ##############################
         # simple test with two coins #
@@ -104,7 +114,12 @@ class RawTransactionsTest(BitcoinTestFramework):
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert(len(dec_tx['vin']) > 0)
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
-
+        assert_equal(
+            '',
+            self.nodes[2].decoderawtransaction(
+                self.nodes[2].fundrawtransaction(hexstring=rawtx, verbose=False)
+            )['vin'][0]['scriptSig']['hex']
+        )
 
         ################################
         # simple test with two outputs #
@@ -123,6 +138,12 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert(len(dec_tx['vin']) > 0)
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
+        assert_equal(
+            '',
+            self.nodes[2].decoderawtransaction(
+                self.nodes[2].fundrawtransaction(hexstring=rawtx, verbose=False)
+            )['vin'][0]['scriptSig']['hex']
+        )
 
 
         #########################################################################

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -46,6 +46,10 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         rawTxSigned2 = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys)
         assert_equal(rawTxSigned, rawTxSigned2)
 
+        # Try with verbose=false
+        rawTxSigned3 = self.nodes[0].signrawtransactionwithkey(rawTx, privKeys, inputs, None, False)
+        assert_equal(rawTxSigned3, rawTxSigned['hex'])
+
     def script_verification_error_test(self):
         """Create and sign a raw transaction with valid (vin 0), invalid (vin 1) and one missing (vin 2) input script.
 
@@ -143,6 +147,10 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         # Perform same test with signrawtransaction
         rawTxSigned2 = self.nodes[0].signrawtransaction(p2wpkh_raw_tx)
         assert_equal(rawTxSigned, rawTxSigned2)
+
+        # Try with verbose=false
+        rawTxSigned3 = self.nodes[0].signrawtransactionwithwallet(hexstring=p2wpkh_raw_tx, verbose=False)
+        assert_equal(rawTxSigned3, rawTxSigned['hex'])
 
     def run_test(self):
         self.successful_signing_test()


### PR DESCRIPTION
[Reviewer hint: use [?w=1](https://github.com/bitcoin/bitcoin/pull/10877/files?w=1) to avoid seeing a bunch of indentation changes.]

Right now, some RPC commands return JSON data along with transaction hex strings, which means scripting and/or chaining needs to do JSON processing before being able to use the resulting transaction data. For use cases where you don't need the extra info, this PR adds a verbose=false mode (default true) which returns only the transaction hex string.

This means you can now do things like this:
```Bash
./bitcoin-cli -regtest -named signrawtransactionwithwallet hexstring=$(
    ./bitcoin-cli -regtest -named fundrawtransaction hexstring=$(
        ./bitcoin-cli -regtest createrawtransaction "[]" "{\"$(
            ./bitcoin-cli -regtest getnewaddress)\": 10.0}") verbose=false) verbose=false
```

This is also useful in scripts, where you perform some operation on a transaction and store the tx itself in a variable. Before you would need e.g. `jq` or some other tool to do this.

Edit: `signrawtransaction` has been deprecated; I chose to add verbose to the new commands `withkey`/`withwallet` but not to `signrawtransaction`.