### PR TITLE
Update .gitignore to ignore more test files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ src/qt/test/moc*.cpp
 .libs
 .*.swp
 *.*~*
+*.backup
 *.bak
 *.rej
 *.orig
@@ -97,9 +98,11 @@ total.coverage/
 coverage_percent.txt
 
 #build tests
+qa/
 linux-coverage-build
 linux-build
 win32-build
+src/test/buildenv.py
 test/config.ini
 test/cache/*
 


### PR DESCRIPTION
Without this change, after building bitcoin master and testing it, I see the following untracked files:

```
$ git status
On branch master
Your branch is up-to-date with 'origin/master'.
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	qa/
	src/test/buildenv.py
	src/wallet.backup
```

I've tried to keep the `.gitignore` lines in the appropriate sections of the file.