### PR TITLE
trivial: fix various pyflakes/vulture warnings

### DIFF
--- a/test/functional/bip68-sequence.py
+++ b/test/functional/bip68-sequence.py
@@ -387,7 +387,7 @@ class BIP68Test(BitcoinTestFramework):
         tx = FromHex(CTransaction(), rawtxfund)
         tx.nVersion = 2
         tx_signed = self.nodes[1].signrawtransaction(ToHex(tx))["hex"]
-        tx_id = self.nodes[1].sendrawtransaction(tx_signed)
+        self.nodes[1].sendrawtransaction(tx_signed)
 
 if __name__ == '__main__':
     BIP68Test().main()

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -168,7 +168,7 @@ def test_bumpfee_with_descendant_fails(rbf_node, rbf_node_address, dest_address)
     parent_id = spend_one_input(rbf_node, rbf_node_address)
     tx = rbf_node.createrawtransaction([{"txid": parent_id, "vout": 0}], {dest_address: 0.00020000})
     tx = rbf_node.signrawtransaction(tx)
-    txid = rbf_node.sendrawtransaction(tx["hex"])
+    rbf_node.sendrawtransaction(tx["hex"])
     assert_raises_jsonrpc(-8, "Transaction has descendants in the wallet", rbf_node.bumpfee, parent_id)
 
 

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -312,7 +312,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         ##############################################
         # test a fundrawtransaction with invalid vin #
         ##############################################
-        listunspent = self.nodes[2].listunspent()
         inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
         outputs = { self.nodes[0].getnewaddress() : 1.0}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -161,7 +161,6 @@ class ImportRescanTest(BitcoinTestFramework):
                 variant.check()
 
         # Create new transactions sending to each address.
-        fee = self.nodes[0].getnetworkinfo()["relayfee"]
         for i, variant in enumerate(IMPORT_VARIANTS):
             variant.sent_amount = 10 - (2 * i + 1) / 8.0
             variant.sent_txid = self.nodes[0].sendtoaddress(variant.address["address"], variant.sent_amount)

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -21,16 +21,9 @@ class ImportMultiTest (BitcoinTestFramework):
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
 
-        # keyword definition
-        PRIV_KEY = 'privkey'
-        PUB_KEY = 'pubkey'
-        ADDRESS_KEY = 'address'
-        SCRIPT_KEY = 'script'
-
-
         node0_address1 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
-        node0_address2 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
-        node0_address3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
+        self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
 
         #Check only one address
         assert_equal(node0_address1['ismine'], True)
@@ -227,10 +220,9 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
-        transaction = self.nodes[1].gettransaction(transactionid)
 
         self.log.info("Should import a p2sh")
         result = self.nodes[1].importmulti([{
@@ -255,10 +247,9 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
-        transaction = self.nodes[1].gettransaction(transactionid)
 
         self.log.info("Should import a p2sh with respective redeem script")
         result = self.nodes[1].importmulti([{
@@ -283,10 +274,9 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
-        transaction = self.nodes[1].gettransaction(transactionid)
 
         self.log.info("Should import a p2sh with respective redeem script and private keys")
         result = self.nodes[1].importmulti([{
@@ -311,10 +301,9 @@ class ImportMultiTest (BitcoinTestFramework):
         sig_address_3 = self.nodes[0].validateaddress(self.nodes[0].getnewaddress())
         multi_sig_script = self.nodes[0].createmultisig(2, [sig_address_1['address'], sig_address_2['address'], sig_address_3['pubkey']])
         self.nodes[1].generate(100)
-        transactionid = self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
+        self.nodes[1].sendtoaddress(multi_sig_script['address'], 10.00)
         self.nodes[1].generate(1)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
-        transaction = self.nodes[1].gettransaction(transactionid)
 
         self.log.info("Should import a p2sh with respective redeem script and private keys")
         result = self.nodes[1].importmulti([{

--- a/test/functional/importprunedfunds.py
+++ b/test/functional/importprunedfunds.py
@@ -19,12 +19,12 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.nodes[0].generate(101)
 
         self.sync_all()
-        
+
         # address
         address1 = self.nodes[0].getnewaddress()
         # pubkey
         address2 = self.nodes[0].getnewaddress()
-        address2_pubkey = self.nodes[0].validateaddress(address2)['pubkey']                 # Using pubkey
+        self.nodes[0].validateaddress(address2)['pubkey']                 # Using pubkey
         # privkey
         address3 = self.nodes[0].getnewaddress()
         address3_privkey = self.nodes[0].dumpprivkey(address3)                              # Using privkey
@@ -77,13 +77,13 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
         #Import with affiliated address with no rescan
         self.nodes[1].importaddress(address2, "add2", False)
-        result2 = self.nodes[1].importprunedfunds(rawtxn2, proof2)
+        self.nodes[1].importprunedfunds(rawtxn2, proof2)
         balance2 = self.nodes[1].getbalance("add2", 0, True)
         assert_equal(balance2, Decimal('0.05'))
 
         #Import with private key with no rescan
         self.nodes[1].importprivkey(address3_privkey, "add3", False)
-        result3 = self.nodes[1].importprunedfunds(rawtxn3, proof3)
+        self.nodes[1].importprunedfunds(rawtxn3, proof3)
         balance3 = self.nodes[1].getbalance("add3", 0, False)
         assert_equal(balance3, Decimal('0.025'))
         balance3 = self.nodes[1].getbalance("*", 0, True)

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -36,7 +36,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
     def setup_network(self):
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
         # Open and close to create zero-length file
-        with open(self.alert_filename, 'w', encoding='utf8') as _:
+        with open(self.alert_filename, 'w', encoding='utf8'):
             pass
         self.extra_args = [["-alertnotify=echo %s >> \"" + self.alert_filename + "\""]]
         self.setup_nodes()
@@ -110,7 +110,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         self.nodes[0].generate(VB_PERIOD)
         self.stop_nodes()
         # Empty out the alert file
-        with open(self.alert_filename, 'w', encoding='utf8') as _:
+        with open(self.alert_filename, 'w', encoding='utf8'):
             pass
         self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
 

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -63,7 +63,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         addr2Obj = self.nodes[2].validateaddress(addr2)
 
         mSigObj = self.nodes[2].addmultisigaddress(2, [addr1Obj['pubkey'], addr2Obj['pubkey']])
-        mSigObjValid = self.nodes[2].validateaddress(mSigObj)
+        assert self.nodes[2].validateaddress(mSigObj)
 
         #use balance deltas instead of absolute values
         bal = self.nodes[2].getbalance()
@@ -87,7 +87,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         addr3Obj = self.nodes[2].validateaddress(addr3)
 
         mSigObj = self.nodes[2].addmultisigaddress(2, [addr1Obj['pubkey'], addr2Obj['pubkey'], addr3Obj['pubkey']])
-        mSigObjValid = self.nodes[2].validateaddress(mSigObj)
+        assert self.nodes[2].validateaddress(mSigObj)
 
         txId = self.nodes[0].sendtoaddress(mSigObj, 2.2)
         decTx = self.nodes[0].gettransaction(txId)

--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -270,7 +270,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         tx1a.vout = [CTxOut(1*COIN, CScript([b'a']))]
         tx1a_hex = txToHex(tx1a)
-        tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, True)
+        self.nodes[0].sendrawtransaction(tx1a_hex, True)
 
         # Higher fee, but the fee per KB is much lower, so the replacement is
         # rejected.
@@ -331,7 +331,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1.vin = [CTxIn(confirmed_utxo)]
         tx1.vout = [CTxOut(1*COIN, CScript([b'a']))]
         tx1_hex = txToHex(tx1)
-        tx1_txid = self.nodes[0].sendrawtransaction(tx1_hex, True)
+        self.nodes[0].sendrawtransaction(tx1_hex, True)
 
         tx2 = CTransaction()
         tx2.vin = [CTxIn(confirmed_utxo), CTxIn(unconfirmed_utxo)]
@@ -499,7 +499,7 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2a.vin = [CTxIn(tx1_outpoint, nSequence=0)]
         tx2a.vout = [CTxOut(1*COIN, CScript([b'a']))]
         tx2a_hex = txToHex(tx2a)
-        tx2a_txid = self.nodes[0].sendrawtransaction(tx2a_hex, True)
+        self.nodes[0].sendrawtransaction(tx2a_hex, True)
 
         # Lower fee, but we'll prioritise it
         tx2b = CTransaction()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -71,9 +71,6 @@ mininode_lock = RLock()
 def sha256(s):
     return hashlib.new('sha256', s).digest()
 
-def ripemd160(s):
-    return hashlib.new('ripemd160', s).digest()
-
 def hash256(s):
     return sha256(sha256(s))
 

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -14,8 +14,7 @@ import hashlib
 import sys
 bchr = chr
 bord = ord
-if sys.version > '3':
-    long = int
+if sys.version_info.major == 3:
     bchr = lambda x: bytes([x])
     bord = lambda x: x
 

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -141,7 +141,7 @@ class Socks5Server(object):
                 thread = threading.Thread(None, conn.handle)
                 thread.daemon = True
                 thread.start()
-    
+
     def start(self):
         assert(not self.running)
         self.running = True
@@ -156,4 +156,3 @@ class Socks5Server(object):
         s.connect(self.conf.addr)
         s.close()
         self.thread.join()
-

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -206,7 +206,7 @@ class WalletTest(BitcoinTestFramework):
         signedRawTx = self.nodes[1].signrawtransaction(rawTx)
         decRawTx = self.nodes[1].decoderawtransaction(signedRawTx['hex'])
         zeroValueTxid= decRawTx['txid']
-        sendResp = self.nodes[1].sendrawtransaction(signedRawTx['hex'])
+        self.nodes[1].sendrawtransaction(signedRawTx['hex'])
 
         self.sync_all()
         self.nodes[1].generate(1) #mine a block


### PR DESCRIPTION
I am trying to learn my way around the Bitcoin code, and I decided to try to fix some minor errors reported by pyflakes/vulture. Most of these are just getting rid of unused variables.