### PR TITLE
[Do not merge] Stop advancing best block and shutdown node if keypool drops below critical threshold

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -369,17 +369,14 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
     {
         // Generate a new address to associate with given label
         CPubKey newKey;
-        if(!wallet->GetKeyFromPool(newKey))
-        {
+        if (!wallet->GetKeyFromPool(newKey, false, true)) {
             WalletModel::UnlockContext ctx(walletModel->requestUnlock());
-            if(!ctx.isValid())
-            {
+            if(!ctx.isValid()) {
                 // Unlock wallet failed or was cancelled
                 editStatus = WALLET_UNLOCK_FAILURE;
                 return QString();
             }
-            if(!wallet->GetKeyFromPool(newKey))
-            {
+            if (!wallet->GetKeyFromPool(newKey, false, true)) {
                 editStatus = KEY_GENERATION_FAILURE;
                 return QString();
             }

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -648,7 +648,7 @@ void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipien
     }
     else {
         CPubKey newKey;
-        if (wallet->GetKeyFromPool(newKey)) {
+        if (wallet->GetKeyFromPool(newKey, false, true)) {
             CKeyID keyID = newKey.GetID();
             wallet->SetAddressBook(keyID, strAccount, "refund");
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -161,8 +161,8 @@ UniValue getnewaddress(const JSONRPCRequest& request)
 
     // Generate a new key that is added to wallet
     CPubKey newKey;
-    if (!pwallet->GetKeyFromPool(newKey)) {
-        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool ran out, please call keypoolrefill first");
+    if (!pwallet->GetKeyFromPool(newKey, false, true)) {
+        throw JSONRPCError(RPC_WALLET_KEYPOOL_RAN_OUT, "Error: Keypool is at critical level or has run out, please call keypoolrefill first");
     }
     CKeyID keyID = newKey.GetID();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -885,8 +885,9 @@ bool CWallet::GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bFo
 
     // Generate a new key
     if (bForceNew) {
-        if (!GetKeyFromPool(account.vchPubKey, false))
+        if (!GetKeyFromPool(account.vchPubKey, false, true)) {
             return false;
+        }
 
         SetAddressBook(account.vchPubKey.GetID(), strAccount, "receive");
         walletdb.WriteAccount(strAccount, account);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -419,8 +419,14 @@ void CWallet::SetBestChain(const CBlockLocator& loc)
 {
     LOCK(cs_wallet); //nWalletMaxVersion
     unsigned int keypool_min = GetArg("-keypoolmin", DEFAULT_KEYPOOL_MIN);
-    if (IsHDEnabled() && !HasUnusedKeys(keypool_min)) {
+    if (IsHDEnabled() && (!m_update_best_block || !HasUnusedKeys(keypool_min))) {
         // If the keypool has dropped below -keypoolmin, then don't update the bestblock height. We can rescan later once the wallet is unlocked.
+
+        if (m_update_best_block) {
+            LogPrintf("Keypool has fallen below keypool_min (%s). Wallet will no longer watch for new transactions and best block height will not be advanced.\n", keypool_min);
+            LogPrintf("Unlock wallet, top up keypool and rescan to resume watching for new transactions.\n");
+            m_update_best_block = false;
+        }
         return;
     }
     CWalletDB walletdb(*dbw);
@@ -1649,6 +1655,23 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, bool f
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
 
         fScanningWallet = false;
+    }
+
+    // Update m_update_best_block if we've scanned from before the previous best block and keypool level is still above Keypool_min
+    CWalletDB walletdb(*dbw);
+    CBlockLocator loc;
+    walletdb.ReadBestBlock(loc);
+    CBlockIndex* pindexBestBlock = FindForkInGlobalIndex(chainActive, loc);
+    if (IsHDEnabled() && pindexStart && pindexStart->nHeight <= pindexBestBlock->nHeight) {
+        m_update_best_block = HasUnusedKeys(GetArg("-keypoolmin", DEFAULT_KEYPOOL_MIN));
+    }
+
+    // If the keypool has dropped below -keypoolmin, then stop updating the bestblock height. We can rescan later once the wallet is unlocked.
+    unsigned int keypool_min = GetArg("-keypoolmin", DEFAULT_KEYPOOL_MIN);
+    if (IsHDEnabled() && !HasUnusedKeys(keypool_min) && m_update_best_block) {
+        LogPrintf("Keypool has fallen below keypool_min (%s). Wallet will no longer watch for new transactions and best block height will not be advanced.\n", keypool_min);
+        LogPrintf("Unlock wallet, top up keypool and rescan to resume watching for new transactions.\n");
+        m_update_best_block = false;
     }
 
     // Check that we haven't dropped below the keypool_critical threshold.
@@ -4082,6 +4105,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         }
 
     }
+
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -40,7 +40,13 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fWalletRbf;
 
+//! Default size for the keypool. Always try to top up the keypool to have this
+//  many keys. For an HD split wallet, have this many keys in each of the
+//  internal/external chains
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+//! Don't update wallet's best block if keypool falls below this size (to avoid
+//  not detecting transactions)
+static const unsigned int DEFAULT_KEYPOOL_MIN = 500;
 //! Shut down if the keypool falls below this size
 static const unsigned int DEFAULT_KEYPOOL_CRITICAL = 500;
 //! -paytxfee default

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -665,6 +665,7 @@ private:
     static std::atomic<bool> fFlushScheduled;
     std::atomic<bool> fAbortRescan;
     std::atomic<bool> fScanningWallet;
+    bool m_update_best_block;
 
     /**
      * Select a set of coins such that nValueRet >= nTargetValue and at least
@@ -800,6 +801,7 @@ public:
         nRelockTime = 0;
         fAbortRescan = false;
         fScanningWallet = false;
+        m_update_best_block = true;
     }
 
     std::map<uint256, CWalletTx> mapWallet;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -987,7 +987,7 @@ public:
     void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fRequestedInternal);
     void KeepKey(int64_t nIndex);
     void ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey);
-    bool GetKeyFromPool(CPubKey &key, bool internal = false);
+    bool GetKeyFromPool(CPubKey &key, bool internal = false, bool fail_on_critical = false);
     int64_t GetOldestKeyPoolTime();
     void ShutdownIfKeypoolCritical();
     /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -41,6 +41,8 @@ extern bool bSpendZeroConfChange;
 extern bool fWalletRbf;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
+//! Shut down if the keypool falls below this size
+static const unsigned int DEFAULT_KEYPOOL_CRITICAL = 500;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default
@@ -979,6 +981,7 @@ public:
     void ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey);
     bool GetKeyFromPool(CPubKey &key, bool internal = false);
     int64_t GetOldestKeyPoolTime();
+    void ShutdownIfKeypoolCritical();
     /**
      * Marks all keys in the keypool up to and including reserve_key as used.
      */

--- a/test/functional/keypool-topup.py
+++ b/test/functional/keypool-topup.py
@@ -6,15 +6,23 @@
 
 Two nodes. Node1 is under test. Node0 is providing transactions and generating blocks.
 
+Repeat test twice, once with encrypted wallet and once with unencrypted wallet:
+
 - Start node1, shutdown and backup wallet.
 - Generate 110 keys (enough to drain the keypool). Store key 90 (in the initial keypool) and key 110 (beyond the initial keypool). Send funds to key 90 and key 110.
 - Stop node1, clear the datadir, move wallet file back into the datadir and restart node1.
-- connect node1 to node0. Verify that they sync and node1 receives its funds."""
+- if wallet is unencrypted:
+    - connect node1 to node0. Verify that they sync and node1 receives its funds.
+- else wallet is encrypted:
+    - connect node1 to node0. Verify that node1 shuts down to avoid loss of funds.
+"""
+import os
 import shutil
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import BitcoinTestFramework, BITCOIND_PROC_WAIT_TIMEOUT
 from test_framework.util import (
     assert_equal,
+    assert_raises_jsonrpc,
     connect_nodes_bi,
     sync_blocks,
 )
@@ -24,15 +32,27 @@ class KeypoolRestoreTest(BitcoinTestFramework):
         super().__init__()
         self.setup_clean_chain = True
         self.num_nodes = 2
-        self.extra_args = [['-usehd=0'], ['-usehd=1', '-keypool=100', '-keypoolmin=20']]
+        self.extra_args = [['-usehd=0'], ['-usehd=1', '-keypool=100', '-keypoolmin=20', '-keypoolcritical=20']]
 
     def run_test(self):
         self.tmpdir = self.options.tmpdir
         self.nodes[0].generate(101)
 
+        self.log.info("Test keypool restore (encrypted wallet)")
+        self._test_restore(encrypted=True)
+
+        self.log.info("Test keypool restore (unencrypted wallet)")
+        self._test_restore(encrypted=False)
+
+    def _test_restore(self, encrypted):
+
         self.log.info("Make backup of wallet")
 
-        self.stop_node(1)
+        if encrypted:
+            self.nodes[1].encryptwallet('test')
+            self.bitcoind_processes[1].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
+        else:
+            self.stop_node(1)
 
         shutil.copyfile(self.tmpdir + "/node1/regtest/wallet.dat", self.tmpdir + "/wallet.bak")
         self.nodes[1] = self.start_node(1, self.tmpdir, self.extra_args[1])
@@ -40,7 +60,13 @@ class KeypoolRestoreTest(BitcoinTestFramework):
 
         self.log.info("Generate keys for wallet")
 
-        for _ in range(90):
+        for _ in range(80):
+            self.nodes[1].getnewaddress()
+        if encrypted:
+            # Keypool can't top up because the wallet is encrypted
+            assert_raises_jsonrpc(-12, "Keypool is at critical level or has run out, please call keypoolrefill first", self.nodes[1].getnewaddress)
+            self.nodes[1].walletpassphrase("test", 10)
+        for _ in range(10):
             addr_oldpool = self.nodes[1].getnewaddress()
         for _ in range(20):
             addr_extpool = self.nodes[1].getnewaddress()
@@ -59,17 +85,28 @@ class KeypoolRestoreTest(BitcoinTestFramework):
 
         shutil.copyfile(self.tmpdir + "/wallet.bak", self.tmpdir + "/node1/regtest/wallet.dat")
 
-        self.log.info("Verify keypool is restored and balance is correct")
+        if encrypted:
+            self.log.info("Encrypted wallet - verify node shuts down to avoid loss of funds")
 
-        self.nodes[1] = self.start_node(1, self.tmpdir, self.extra_args[1])
-        connect_nodes_bi(self.nodes, 0, 1)
-        self.sync_all()
+            self.assert_start_raises_init_error(1, self.tmpdir, self.extra_args[1], expected_msg="Number of keys in keypool is below critical minimum and the wallet is encrypted. Bitcoin will now shutdown to avoid loss of funds.")
 
-        assert_equal(self.nodes[1].getbalance(), 15)
-        assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
+            shutil.rmtree(self.tmpdir + "/node1/regtest/chainstate")
+            shutil.rmtree(self.tmpdir + "/node1/regtest/blocks")
+            os.remove(self.tmpdir + "/node1/regtest/wallet.dat")
+            self.nodes[1] = self.start_node(1, self.tmpdir, self.extra_args[1])
 
-        # Check that we have marked all keys up to the used keypool key as used
-        assert_equal(self.nodes[1].validateaddress(self.nodes[1].getnewaddress())['hdkeypath'], "m/0'/0'/111'")
+        else:
+            self.log.info("Unencrypted wallet - verify keypool is restored and balance is correct")
+
+            self.nodes[1] = self.start_node(1, self.tmpdir, self.extra_args[1])
+            connect_nodes_bi(self.nodes, 0, 1)
+            self.sync_all()
+
+            assert_equal(self.nodes[1].getbalance(), 15)
+            assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
+
+            # Check that we have marked all keys up to the used keypool key as used
+            assert_equal(self.nodes[1].validateaddress(self.nodes[1].getnewaddress())['hdkeypath'], "m/0'/0'/111'")
 
 if __name__ == '__main__':
     KeypoolRestoreTest().main()

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -27,7 +27,7 @@ class KeyPoolTest(BitcoinTestFramework):
         wallet_info = nodes[0].getwalletinfo()
         assert(addr_before_encrypting_data['hdmasterkeyid'] != wallet_info['hdmasterkeyid'])
         assert(addr_data['hdmasterkeyid'] == wallet_info['hdmasterkeyid'])
-        assert_raises_jsonrpc(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
+        assert_raises_jsonrpc(-12, "Keypool is at critical level or has run out, please call keypoolrefill first", nodes[0].getnewaddress)
 
         # put six (plus 2) new keys in the keypool (100% external-, +100% internal-keys, 1 in min)
         nodes[0].walletpassphrase('test', 12000)
@@ -57,7 +57,7 @@ class KeyPoolTest(BitcoinTestFramework):
         addr.add(nodes[0].getnewaddress())
         assert(len(addr) == 6)
         # the next one should fail
-        assert_raises_jsonrpc(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
+        assert_raises_jsonrpc(-12, "Keypool is at critical level or has run out, please call keypoolrefill first", nodes[0].getnewaddress)
 
         # refill keypool with three new addresses
         nodes[0].walletpassphrase('test', 1)

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -44,19 +44,10 @@ class KeyPoolTest(BitcoinTestFramework):
         nodes[0].getrawchangeaddress()
         nodes[0].getrawchangeaddress()
         nodes[0].getrawchangeaddress()
-        addr = set()
         # the next one should fail
         assert_raises_jsonrpc(-12, "Keypool ran out", nodes[0].getrawchangeaddress)
 
-        # drain the external keys
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        assert(len(addr) == 6)
-        # the next one should fail
+        # getting an external key should also fail now
         assert_raises_jsonrpc(-12, "Keypool is at critical level or has run out, please call keypoolrefill first", nodes[0].getnewaddress)
 
         # refill keypool with three new addresses
@@ -68,9 +59,8 @@ class KeyPoolTest(BitcoinTestFramework):
         assert_equal(nodes[0].getwalletinfo()["unlocked_until"], 0)
 
         # drain them by mining
-        nodes[0].generate(1)
-        nodes[0].generate(1)
-        nodes[0].generate(1)
+        for _ in range(6):
+            nodes[0].generate(1)
         assert_raises_jsonrpc(-12, "Keypool ran out", nodes[0].generate, 1)
 
         nodes[0].walletpassphrase('test', 100)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -216,7 +216,7 @@ class BitcoinTestFramework(object):
         datadir = os.path.join(dirname, "node" + str(i))
         if binary is None:
             binary = os.getenv("BITCOIND", "bitcoind")
-        args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(self.mocktime), "-uacomment=testnode%d" % i]
+        args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-keypoolcritical=0", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(self.mocktime), "-uacomment=testnode%d" % i]
         if extra_args is not None:
             args.extend(extra_args)
         self.bitcoind_processes[i] = subprocess.Popen(args, stderr=stderr)
@@ -386,7 +386,7 @@ class BitcoinTestFramework(object):
             # Create cache directories, run bitcoinds:
             for i in range(MAX_NODES):
                 datadir = initialize_datadir(cachedir, i)
-                args = [os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir=" + datadir, "-discover=0"]
+                args = [os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-keypoolcritical=0", "-datadir=" + datadir, "-discover=0"]
                 if i > 0:
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
                 self.bitcoind_processes[i] = subprocess.Popen(args)


### PR DESCRIPTION
- Add `keypool_critical` (configurable). If the number of keys in the keypool drops below this limit while the wallet is rescanning, shutdown the node. Do not shutdown the node if the wallet is 'current', ie it is receiving `BlockConnected` calls from the node.
- Add `keypool_min` (configurable). If the number of keys in the keypool drops below this limit, stop advancing the wallet's best block. This forces the wallet to rescan from the point that it dropped below the limit the next time that it starts up. This is a toggle controlled by `m_update_best_block`, which doesn't get unset until the wallet has rescanned with the keypool above keypool_min.
- Add `bypasskeypoolcritical` (command line argument). This disables the keypool_critical behavior, so the user has a chance to top up their keypool.
- don't allow user actions like `getnewaddress` to cause the keypool to drop below the critical limit (return an error telling the user to unlock and topup their keypool).

This is a simpler version of #10830 , which caused the node to stop sync'ing if the keypool dropped below a certain limit. It is built on top of #11022 which does the following:

- if a key in the keypool is used, mark all keys in the keypool up to that key as used
- try to top up the keypool when keys from the keypool are used.

This PR couldn't be merged for v0.15 because there are some edge cases that make this dangerous and could result in users not being able to start up the node without onerous recovery steps.