### PR TITLE
Reject invalid wallets

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -473,21 +473,21 @@ bool CWallet::Verify()
 
     for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
         if (boost::filesystem::path(walletFile).filename() != walletFile) {
-            return InitError(_("-wallet parameter must only specify a filename (not a path)"));
+            return InitError(strprintf(_("Error loading wallet %s. -wallet parameter must only specify a filename (not a path)."), walletFile));
         }
 
         if (SanitizeString(walletFile, SAFE_CHARS_FILENAME) != walletFile) {
-            return InitError(_("Invalid characters in -wallet filename"));
+            return InitError(strprintf(_("Error loading wallet %s. Invalid characters in -wallet filename."), walletFile));
         }
 
         fs::path wallet_path = fs::absolute(walletFile, GetDataDir());
 
         if (fs::exists(wallet_path) && (!fs::is_regular_file(wallet_path) || fs::is_symlink(wallet_path))) {
-            return InitError(_("Invalid -wallet file"));
+            return InitError(strprintf(_("Error loading wallet %s. -wallet filename must be a regular file."), walletFile));
         }
 
         if (!wallet_paths.insert(wallet_path).second) {
-            return InitError(_("Duplicate -wallet filename"));
+            return InitError(strprintf(_("Error loading wallet %s. Duplicate -wallet filename specified."), walletFile));
         }
 
         std::string strError;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -482,6 +482,10 @@ bool CWallet::Verify()
 
         fs::path wallet_path = fs::absolute(walletFile, GetDataDir());
 
+        if (fs::exists(wallet_path) && (!fs::is_regular_file(wallet_path) || fs::is_symlink(wallet_path))) {
+            return InitError(_("Invalid -wallet file"));
+        }
+
         if (!wallet_paths.insert(wallet_path).second) {
             return InitError(_("Duplicate -wallet filename"));
         }

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -18,6 +18,13 @@ class MultiWalletTest(BitcoinTestFramework):
         self.extra_args = [['-wallet=w1', '-wallet=w2', '-wallet=w3']]
 
     def run_test(self):
+        self.stop_node(0)
+
+        # should not initialize if there are duplicate wallets
+        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w1', '-wallet=w1'], 'Duplicate -wallet filename')
+
+        self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
+
         w1 = self.nodes[0] / "wallet/w1"
         w1.generate(1)
 

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -6,6 +6,8 @@
 
 Verify that a bitcoind node can load multiple wallet files
 """
+import os
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_jsonrpc
 
@@ -22,6 +24,14 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # should not initialize if there are duplicate wallets
         self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w1', '-wallet=w1'], 'Duplicate -wallet filename')
+
+        # should not initialize if wallet file is a directory
+        os.mkdir(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w11'))
+        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w11'], 'Invalid -wallet file')
+
+        # should not initialize if wallet file is a symlink
+        os.symlink(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w1'), os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w12'))
+        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w12'], 'Invalid -wallet file')
 
         self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
 

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -23,15 +23,15 @@ class MultiWalletTest(BitcoinTestFramework):
         self.stop_node(0)
 
         # should not initialize if there are duplicate wallets
-        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w1', '-wallet=w1'], 'Duplicate -wallet filename')
+        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w1', '-wallet=w1'], 'Error loading wallet w1. Duplicate -wallet filename specified.')
 
         # should not initialize if wallet file is a directory
         os.mkdir(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w11'))
-        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w11'], 'Invalid -wallet file')
+        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
 
         # should not initialize if wallet file is a symlink
         os.symlink(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w1'), os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w12'))
-        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w12'], 'Invalid -wallet file')
+        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
 
         self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
 


### PR DESCRIPTION
This PR prevents loading the same wallet more than once in a multi wallet scenario. It also prevents loading with invalid files: non regular files or symlinks.