### PR TITLE
Docs: Run windows build in a clean path

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -68,7 +68,7 @@ To build executables for Windows 64-bit, install the following dependencies:
 Then build using:
 
     cd depends
-    make HOST=x86_64-w64-mingw32
+    make HOST=x86_64-w64-mingw32 PATH=$(getconf PATH)
     cd ..
     ./autogen.sh # not required when building from tarball
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/


### PR DESCRIPTION
Fixes the error described in https://github.com/bitcoin/bitcoin/issues/10856

In Windows Subsystem for Linux the entire windows path is now part of the $PATH variable and it interferes with the `make` command.

```
bmcmichael@DESKTOP-I6V4RLU:~$ echo $PATH
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/mnt/c/ProgramData/Oracle/Java/javapath_target_209286125:
/mnt/c/Windows/System32:/mnt/c/Windows:/mnt/c/Windows/System32/wbem:/mnt/c/Windows/System32/WindowsPowerShell/v1.0:
/mnt/c/Program Files (x86)/Skype/Phone:/mnt/c/Program Files/Microsoft SQL Server/130/Tools/Binn:
/mnt/c/Program Files (x86)/Windows Kits/10/Windows Performance Toolkit:/mnt/c/Program Files/Git/cmd:/mnt/c/Program Files/Microsoft DNX/Dnvm:
/mnt/c/Program Files/Microsoft SQL Server/120/Tools/Binn:/mnt/c/Program Files (x86)/NVIDIA Corporation/PhysX/Common:
/mnt/c/Users/brian/AppData/Local/Microsoft/WindowsApps:/mnt/c/Program Files (x86)/Microsoft VS Code/bin:/home/bmcmichael/.fzf/bin
```

```
bmcmichael@DESKTOP-I6V4RLU:~$ echo $(getconf PATH)
/bin:/usr/bin
```

Adding `PATH=$(getconf PATH)` to the `make` command runs the process in a clean environment (ex. `PATH=/bin:/usr/bin`) and allows the build to proceed.

I haven't tested whether the Windows 32-bit build is affected by this so I haven't updated that command.
