### PR TITLE
[RPC] Make ImportAddress works with segwit scriptPubKey

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -202,6 +202,16 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = CScriptID(uint160(vSolutions[0]));
         return true;
     }
+    else if (whichType == TX_WITNESS_V0_SCRIPTHASH)
+    {
+        addressRet = CScriptID(CScript() << OP_0 << vSolutions[0]);
+        return true;
+    }
+    else if (whichType == TX_WITNESS_V0_KEYHASH)
+    {
+        addressRet = CScriptID(CScript() << OP_0 << vSolutions[0]);
+        return true;
+    }
     // Multisig txns have more than one address...
     return false;
 }


### PR DESCRIPTION
`ImportAddress` rpc functions does not work for segwit `scirptPubKey`. Worst, it fails without error.

Reason is https://github.com/bitcoin/bitcoin/blob/041dad94b047313a17edb0324742cf80cfd550f1/src/wallet/rpcdump.cpp#L202 , if `ExtractDestination` fails, nothing is done.