### PR TITLE
[QA] Avoid running multiwallet.py twice

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -63,7 +63,6 @@ BASE_SCRIPTS= [
     'segwit.py',
     # vv Tests less than 2m vv
     'wallet.py',
-    'multiwallet.py',
     'wallet-accounts.py',
     'p2p-segwit.py',
     'wallet-dump.py',


### PR DESCRIPTION
It's already on L92.

Second script execution was introduced in #10604 3707fcd94e6251384235d16faafc975853d49e3d (probably rebase issue)

Reported by @MarcoFalke 