### PR TITLE
Add CChain object for headers-only chain

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1279,6 +1279,7 @@ UniValue getchaintips(const JSONRPCRequest& request)
 
     // Always report the currently active tip.
     setTips.insert(chainActive.Tip());
+    setTips.insert(headersChainActive.Tip());
 
     /* Construct the output array.  */
     UniValue res(UniValue::VARR);
@@ -1300,7 +1301,7 @@ UniValue getchaintips(const JSONRPCRequest& request)
             status = "invalid";
         } else if (block->nChainTx == 0) {
             // This block cannot be connected because full block data for it or one of its parents is missing.
-            status = "headers-only";
+            status = headersChainActive.Contains(block) ? "headers-only-fork" : "headers-only";
         } else if (block->IsValid(BLOCK_VALID_SCRIPTS)) {
             // This block is fully validated, but no longer part of the active chain. It was probably the active block once, but was reorganized.
             status = "valid-fork";

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -60,6 +60,7 @@ CCriticalSection cs_main;
 
 BlockMap mapBlockIndex;
 CChain chainActive;
+CChain headersChainActive;
 CBlockIndex *pindexBestHeader = NULL;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
@@ -2613,7 +2614,10 @@ static CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
     pindexNew->nChainWork = (pindexNew->pprev ? pindexNew->pprev->nChainWork : 0) + GetBlockProof(*pindexNew);
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == NULL || pindexBestHeader->nChainWork < pindexNew->nChainWork)
+    {
         pindexBestHeader = pindexNew;
+        headersChainActive.SetTip(pindexNew);
+    }
 
     setDirtyBlockIndex.insert(pindexNew);
 
@@ -3483,7 +3487,10 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
         if (pindex->pprev)
             pindex->BuildSkip();
         if (pindex->IsValid(BLOCK_VALID_TREE) && (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
+        {
             pindexBestHeader = pindex;
+            headersChainActive.SetTip(pindex);
+        }
     }
 
     // Load block file info
@@ -3838,6 +3845,7 @@ void UnloadBlockIndex()
     LOCK(cs_main);
     setBlockIndexCandidates.clear();
     chainActive.SetTip(NULL);
+    headersChainActive.SetTip(NULL);
     pindexBestInvalid = NULL;
     pindexBestHeader = NULL;
     mempool.clear();

--- a/src/validation.h
+++ b/src/validation.h
@@ -439,6 +439,9 @@ bool ResetBlockFailureFlags(CBlockIndex *pindex);
 /** The currently-connected chain of blocks (protected by cs_main). */
 extern CChain chainActive;
 
+/** The currently-connected chain of PoW validated headers (protected by cs_main). */
+extern CChain headersChainActive;
+
 /** Global variable that points to the coins database (protected by cs_main) */
 extern CCoinsViewDB *pcoinsdbview;
 

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -674,7 +674,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         found = False
         for x in tips:
             if x["hash"] == block.hash:
-                assert_equal(x["status"], "headers-only")
+                assert( (x["status"] == "headers-only" or x["status"] == "headers-only-fork") )
                 found = True
                 break
         assert(found)


### PR DESCRIPTION
This PR introduces a `CChain` object for the headers chain. It allows to better inspect the headers chain (things like reorg detection). It would simplify a lot of things for a possible light client (SPV) mode.

Slightly improves the headers-chain fork reporting in `getchaintips`.
 