### PR TITLE
Optimize compact reconstruction somewhat

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -124,6 +124,7 @@ BITCOIN_CORE_H = \
   netbase.h \
   netmessagemaker.h \
   noui.h \
+  open_hash_set.h \
   policy/feerate.h \
   policy/fees.h \
   policy/policy.h \

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -101,6 +101,10 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     }
     prefilled_count = cmpctblock.prefilledtxn.size();
 
+    if (cmpctblock.shorttxids.empty()) {
+        return READ_STATUS_OK;
+    }
+
     // Calculate map of txids -> positions and check mempool to see what we have (or don't)
     // Because well-formed cmpctblock messages will have a (relatively) uniform distribution
     // of short IDs, any highly-uneven distribution of elements can be safely treated as a

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -166,7 +166,7 @@ public:
         if (ser_action.ForRead()) {
             size_t i = 0;
             while (shorttxids.size() < shorttxids_size) {
-                shorttxids.resize(std::min((uint64_t)(1000 + shorttxids.size()), shorttxids_size));
+                shorttxids.resize(std::min((uint64_t)(5000 + shorttxids.size()), shorttxids_size));
                 for (; i < shorttxids.size(); i++) {
                     uint32_t lsb = 0; uint16_t msb = 0;
                     READWRITE(lsb);

--- a/src/open_hash_set.h
+++ b/src/open_hash_set.h
@@ -40,10 +40,9 @@ private:
     std::vector<value_type> m_table;
     size_type m_count = 0, m_scan_max;
 
-    inline size_t hash_pos(uint64_t hash, size_t i) {
-        uint64_t input = hash * (i + 1);
-        uint32_t value = (input & 0xffffffffffLLU) ^ ((input & 0xffff00000000LLU) >> 16) ^ ((input & 0xffff000000000000LLU) >> 32);
-        return value & ((size_type(1) << m_bits)-1);
+    /* Hash should be uniform already. */
+    inline size_t hash_base(uint64_t hash) {
+        return hash & ((size_type(1) << m_bits)-1);
     }
 
     // Power of 2 which keeps us under 25 full.
@@ -63,12 +62,12 @@ public:
     {}
 
     std::pair<iterator, bool> insert(const value_type& value) {
-        size_t pos;
+        size_t pos = hash_base(m_hash_instance(value));
         size_t i = 0;
         while (i < m_scan_max) {
-            pos = hash_pos(m_hash_instance(value), i);
             if (m_null_instance(m_table[pos])) break;
             if (m_equal_instance(m_table[pos], value)) break;
+            pos = (pos + 1)  & ((size_type(1) << m_bits)-1);
             i++;
         }
 
@@ -86,12 +85,12 @@ public:
     }
 
     iterator find(const value_type& value) {
-        size_t pos;
+        size_t pos = hash_base(m_hash_instance(value));
         size_t i = 0;
         while (i < m_scan_max) {
-            pos = hash_pos(m_hash_instance(value), i);
             if (m_null_instance(m_table[pos])) break;
             if (m_equal_instance(m_table[pos], value)) break;
+            pos = (pos + 1)  & ((size_type(1) << m_bits)-1);
             i++;
         }
 

--- a/src/open_hash_set.h
+++ b/src/open_hash_set.h
@@ -44,7 +44,7 @@ private:
     size_type m_count = 0;
 
     /* Hash should be uniform already. */
-    inline size_t hash_base(uint64_t hash) {
+    inline size_t hash_base(uint64_t hash) const {
         return hash & ((size_type(1) << m_bits)-1);
     }
 
@@ -86,16 +86,16 @@ public:
         return std::make_pair(iterator(&m_table[pos]), true);
     }
 
-    iterator find(const value_type& value) {
+    const value_type *find_fast(const value_type& value) const {
         size_t pos = hash_base(m_hash_instance(value));
         while (!m_equal_instance(m_table[pos], value)) {
             if (m_null_instance(m_table[pos])) {
-                return end();
+                return nullptr;
             }
             pos = (pos + 1)  & ((size_type(1) << m_bits)-1);
         }
 
-        return iterator(&m_table[pos]);
+        return &m_table[pos];
     }
 
     iterator end() {

--- a/src/open_hash_set.h
+++ b/src/open_hash_set.h
@@ -1,0 +1,101 @@
+#ifndef BITCOIN_OPEN_HASH_SET_H
+#define BITCOIN_OPEN_HASH_SET_H
+
+#include <functional>
+#include <utility>
+#include <vector>
+
+/** Implements an open hash set.
+ */
+template<class Key, class IsKeyNull, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+class open_hash_set
+{
+public:
+    typedef Key key_type;
+    typedef Key value_type;
+    typedef size_t size_type;
+    typedef Hash hasher;
+    typedef KeyEqual key_equal;
+
+    class iterator
+    {
+        value_type* ptr;
+    public:
+        iterator(value_type* ptr_) : ptr(ptr_) {}
+        value_type& operator*() const { return *ptr; }
+        value_type* operator->() const { return ptr; }
+        bool operator==(iterator x) const { return ptr == x.ptr; }
+        bool operator!=(iterator x) const { return ptr != x.ptr; }
+        bool operator>=(iterator x) const { return ptr >= x.ptr; }
+        bool operator<=(iterator x) const { return ptr <= x.ptr; }
+        bool operator>(iterator x) const { return ptr > x.ptr; }
+        bool operator<(iterator x) const { return ptr < x.ptr; }
+    };
+
+private:
+    hasher m_hash_instance;
+    key_equal m_equal_instance;
+    IsKeyNull m_null_instance;
+    std::vector<value_type> m_table;
+    size_type m_count = 0, m_scan_max;
+
+    inline size_t hash_pos(uint64_t hash, size_t i) {
+        uint64_t input = hash * (i + 1);
+        uint32_t value = (input & 0xffffffffffLLU) ^ ((input & 0xffff00000000LLU) >> 16) ^ ((input & 0xffff000000000000LLU) >> 32);
+        return (value * uint64_t(m_table.size())) >> 32;
+    }
+
+public:
+    open_hash_set(size_type entry_count=1000) :
+        m_table(std::max(128*1024/sizeof(value_type), entry_count*3)), // max(1/2 of L2, 3*entries)
+        m_scan_max(m_table.size() / 2)
+    {}
+
+    std::pair<iterator, bool> insert(const value_type& value) {
+        size_t pos;
+        size_t i = 0;
+        while (i < m_scan_max) {
+            pos = hash_pos(m_hash_instance(value), i);
+            if (m_null_instance(m_table[pos])) break;
+            if (m_equal_instance(m_table[pos], value)) break;
+            i++;
+        }
+
+        if (i == m_scan_max) {
+            return std::make_pair(end(), false);
+        }
+
+        if (m_equal_instance(m_table[pos], value)) {
+            return std::make_pair(iterator(&m_table[pos]), false);
+        }
+
+        m_table[pos] = value;
+        m_count++;
+        return std::make_pair(iterator(&m_table[pos]), true);
+    }
+
+    iterator find(const value_type& value) {
+        size_t pos;
+        size_t i = 0;
+        while (i < m_scan_max) {
+            pos = hash_pos(m_hash_instance(value), i);
+            if (m_null_instance(m_table[pos])) break;
+            if (m_equal_instance(m_table[pos], value)) break;
+            i++;
+        }
+
+        if (i == m_scan_max || m_null_instance(m_table[pos]) || !m_equal_instance(m_table[pos], value)) {
+            return end();
+        }
+        return iterator(&m_table[pos]);
+    }
+
+    iterator end() {
+        value_type* ptr = &m_table[m_table.size() - 1];
+        return iterator(ptr + 1);
+    }
+
+    size_type size() const { return m_count; }
+};
+
+#endif // BITCOIN_OPEN_HASH_SET_H

--- a/src/open_hash_set.h
+++ b/src/open_hash_set.h
@@ -88,17 +88,13 @@ public:
 
     iterator find(const value_type& value) {
         size_t pos = hash_base(m_hash_instance(value));
-        size_t i = 0;
-        while (i < scan_max) {
-            if (m_null_instance(m_table[pos])) break;
-            if (m_equal_instance(m_table[pos], value)) break;
+        while (!m_equal_instance(m_table[pos], value)) {
+            if (m_null_instance(m_table[pos])) {
+                return end();
+            }
             pos = (pos + 1)  & ((size_type(1) << m_bits)-1);
-            i++;
         }
 
-        if (i == scan_max || m_null_instance(m_table[pos]) || !m_equal_instance(m_table[pos], value)) {
-            return end();
-        }
         return iterator(&m_table[pos]);
     }
 


### PR DESCRIPTION
This is some stuff I did for FIBRE a while back (that @rustyrussell cleaned up a lot, thanks!) and figured could get upstreamed. It saves some milliseconds when reconstructing, but for upstream its not all that critical.