### PR TITLE
[test] Qt: Use _putenv_s instead of setenv on Windows builds

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -59,7 +59,11 @@ int main(int argc, char *argv[])
     // Prefer the "minimal" platform for the test instead of the normal default
     // platform ("xcb", "windows", or "cocoa") so tests can't unintentially
     // interfere with any background GUIs and don't require extra resources.
-    setenv("QT_QPA_PLATFORM", "minimal", 0);
+    #if defined(WIN32)
+        _putenv_s("QT_QPA_PLATFORM", "minimal");
+    #else
+        setenv("QT_QPA_PLATFORM", "minimal", 0);
+    #endif
 
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/10836

Error message I would get on `make`:
```
...
  CXXLD    bench/bench_bitcoin.exe
  OBJCXXLD qt/bitcoin-qt.exe
qt/test/test_main.cpp: In function ‘int main(int, char**)’:
qt/test/test_main.cpp:64:43: error: ‘setenv’ was not declared in this scope
     setenv("QT_QPA_PLATFORM", "minimal", 0);
                                           ^
make[2]: *** [qt/test/qt_test_test_bitcoin_qt-test_main.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory `/home/bmcmichael/Projects/bcoin/src'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/bmcmichael/Projects/bcoin/src'
make: *** [all-recursive] Error 1
```

`setenv` function is not available from the Microsoft runtime library. Need to use `_putenv_s` instead.

This solution tells the compiler to use `_putenv_s` on `WIN32` compilation (Note: this also works on 64-bit Windows instances.) and `setenv` everywhere else.

I've tested builds on Windows 10 x64 and Ubuntu 16.04 with this code.