### PR TITLE
Add configuration files for a Docker-based development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# A base Docker image running Python 3.6.2 and Debian 8 "Jessie"
+# See: https://github.com/docker-library/python/blob/master/3.6/jessie/Dockerfile
+FROM python:3.6.2-jessie
+
+RUN apt-get update && \
+    apt-get install -y \
+    libboost-system-dev libboost-filesystem-dev libboost-chrono-dev \
+    libboost-program-options-dev libboost-test-dev libboost-thread-dev \
+    build-essential libtool autotools-dev automake pkg-config libssl-dev \
+    libevent-dev bsdmainutils \
+    libzmq3 miniupnpc \
+    # Install clang for potential use over g++.
+    clang
+
+# The Bitcoin source code will be located at /code and mounted by 
+# docker-compose.
+ENV HOME /code
+WORKDIR /code
+
+# Install Berkeley DB 4.8 for use with wallet functionality.
+ENV BDB_PREFIX /db4
+ENV BDB_VERSION db-4.8.30.NC
+RUN mkdir -p $BDB_PREFIX && \
+    wget --no-check-certificate \
+        "https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz" \
+        -O ${BDB_VERSION}.tar.gz && \
+    echo "12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  ${BDB_VERSION}.tar.gz" \
+        | sha256sum -c && \
+    tar -xzvf ${BDB_VERSION}.tar.gz -C $BDB_PREFIX && \
+    rm ${BDB_VERSION}.tar.gz && \
+    ${BDB_PREFIX}/${BDB_VERSION}/dist/configure \
+        --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX && \
+    make install
+
+ENTRYPOINT ["./bin/docker_entrypoint.sh"]

--- a/bin/docker_entrypoint.sh
+++ b/bin/docker_entrypoint.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -e
+
+#
+# Docker entrypoint 
+#   (see: https://docs.docker.com/engine/reference/builder/#entrypoint)
+#
+# This script is for use with the Docker container built by `../Dockerfile`
+# and run with `docker-compose` (see `docker-compose.yml`).
+#
+# Recognized arguments:
+#
+#   - `test`: Run all tests. 
+#      E.g. `docker-compose run --rm bitcoind test`.
+#
+#   - `test-cpp`: Run all C++-based tests. 
+#      E.g. `docker-compose run --rm bitcoind test-cpp`.
+#
+#   - `test-python`: Run all Python-based tests. 
+#      E.g. `docker-compose run --rm bitcoind test-python --coverage`.
+#
+#   - `[no args]`: Start bitcoind.
+#      E.g. `docker-compose up bitcoind`.
+#
+# Any arguments that aren't the above are executed in the container image as
+# normal.
+
+[ -z "${MAKE_JOBS}" ] && MAKE_JOBS=$(nproc)
+[ -z "${CC}" ] && export CC=/usr/bin/clang
+if [ -z "${CXX}" ]; then
+  export CXX=/usr/bin/clang++
+  export CXXFLAGS="-std=c++11 ${CXXFLAGS}"
+fi
+ 
+run_make() {
+  make -j $MAKE_JOBS "$@"
+}
+ 
+# If we haven't run libtool, do so.
+[ ! -f "configure" ] && ./autogen.sh
+
+# Configure Bitcoin Core to use our own-built instance of BDB.
+[ ! -f "config.status" ] && ./configure \
+  LDFLAGS="-L${BDB_PREFIX}/lib/" \
+  CPPFLAGS="-I${BDB_PREFIX}/include/" \
+  CXXFLAGS="${CXXFLAGS}"
+[ ! -f "src/bitcoind" ] && run_make
+
+test_cpp() { 
+  run_make check "$@" 
+}
+
+test_python() { 
+  ./test/functional/test_runner.py "$@" 
+}
+
+case "${1}" in
+  "test")
+    shift;
+    run_make
+    test_cpp
+    test_python --coverage
+    ;;
+
+  "test-cpp")
+    shift;
+    run_make
+    test_cpp $EXTRA_ARGS
+    ;;
+
+  "test-python")
+    shift;
+    run_make
+    [ -z "${EXTRA_ARGS}" ] && EXTRA_ARGS='--coverage'
+    test_python $EXTRA_ARGS
+    ;;
+
+  *)
+    exec "$@"
+    ;;
+esac

--- a/doc/README.md
+++ b/doc/README.md
@@ -39,6 +39,7 @@ The following are developer notes on how to build Bitcoin on your native platfor
 
 - [OS X Build Notes](build-osx.md)
 - [Unix Build Notes](build-unix.md)
+- [Docker Build Notes](build-docker.md)
 - [Windows Build Notes](build-windows.md)
 - [OpenBSD Build Notes](build-openbsd.md)
 - [Gitian Building Guide](gitian-building.md)

--- a/doc/build-docker.md
+++ b/doc/build-docker.md
@@ -1,0 +1,64 @@
+# Docker Build Instructions and Notes
+
+Bitcoind can be easily built on any platform which hosts a 
+[Docker](https://en.wikipedia.org/wiki/Docker_(software)) daemon. This is
+likely the lowest-effort way to get a bitcoin development environment on your
+machine.
+
+The Docker development environment does not facilitate development of the
+GUI.
+
+## Preparation
+
+1. [Install Docker](https://www.docker.com/community-edition#/download).
+2. If on Linux, install Docker Compose with `pip install docker-compose`.
+3. Change directory to the root of this repository.
+4. Run `docker-compose run bitcoind` to compile bitcoin.
+
+Bitcoin's source tree will be
+[mounted](https://docs.docker.com/compose/compose-file/compose-file-v2/#volumes-volume_driver) 
+into the Docker container, so any changes you make to the source tree on
+your host computer will be immediately reflected within the Docker container.
+
+## Commands
+
+### Run all tests
+
+```sh
+docker-compose run --rm bitcoind test
+```
+
+### Run C++ tests
+
+```sh
+docker-compose run --rm bitcoind test-cpp [args ...]
+```
+
+### Run Python tests
+
+```sh
+docker-compose run --rm bitcoind test-python [args ...]
+```
+  
+### Run bitcoind
+
+In the foreground
+
+```sh
+docker-compose up bitcoind
+```
+
+or in the background
+
+```sh
+docker-compose up -d bitcoind
+```
+ 
+### Other commands
+
+Any command can be run within the container image by passing it as additional
+arguments:
+ 
+```sh
+docker-compose run --rm bitcoind [cmd ...]
+```             

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '2'
+
+services:
+  bitcoind:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: bitcoind
+    # By default, run the bitcoind daemon. This can be overridden with
+    # additional arguments to `docker-compose run bitcoind`.
+    command: "src/bitcoind -printtoconsole"
+    volumes:
+      # Mount `pwd` into the container to support immediate code updates.
+      - .:/code
+      # Persist bash history in the web container.
+      - .docker_bash_history:/root/.bash_history
+    ports:
+      - "8333:8333"
+    environment:
+      CC:
+      CXX:
+      CXX_FLAGS:


### PR DESCRIPTION
This PR introduces a number of configuration files which facilitate use of a Docker environment for local development and bitcoind execution. I've found this method to be an easy way to quickly setup a local dev environment; the use of a container also allows us to prevent polluting the host system with Bitcoin-specific dependencies.

The base image that I reference in the Dockerfile is maintained by Docker [in an "official" image repository](https://hub.docker.com/_/python/). It's based on Debian 8 "Jessie" and comes with Python 3.6.2 for running the tests.

After obtaining the Docker dependencies (as described in `docs/build-docker.md`), building and testing bitcoin from scratch can be done in a single command:
```
docker-compose run bitcoind test
```

During the docker image build (`docker-compose build bitcoind`), system dependencies are installed per `docs/build-unix.md` (including all non-GUI optional dependencies) but Bitcoin itself isn't compiled. This is because `docker-compose` attaches the source tree to the container as a mounted volume after build, which allows changes we make to the source on the host machine to propagate immediately to a running container. The entrypoint script (`./bin/docker_entrypoint.sh`) is responsible for handling bitcoind compilation as well as providing the `test*` commands. Clang is installed and used as the default compiler.

You'll notice that a few files (`Dockerfile`, `bin/`, `docker-compose.yaml`) are introduced to the top-level of the directory structure. I wasn't eager to do this -- I started out in `contrib/`, but in order for `docker-compose` to mount the entire source tree, commands have to be executed from the project root.

This is a modest suggestion and I'm happy to help incorporate feedback.