### PR TITLE
[qt] Fix typo and access key in optionsdialog.ui

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -199,10 +199,10 @@
        <item>
         <widget class="QCheckBox" name="allowIncoming">
          <property name="toolTip">
-          <string>Accept connections from outside</string>
+          <string>Accept connections from outside.</string>
          </property>
          <property name="text">
-          <string>Allow incoming connections</string>
+          <string>Allow incomin&amp;g connections</string>
          </property>
         </widget>
        </item>
@@ -399,7 +399,7 @@
           <string>Connect to the Bitcoin network through a separate SOCKS5 proxy for Tor hidden services.</string>
          </property>
          <property name="text">
-          <string>Use separate SOCKS5 proxy to reach peers via Tor hidden services:</string>
+          <string>Use separate SOCKS&amp;5 proxy to reach peers via Tor hidden services:</string>
          </property>
         </widget>
        </item>
@@ -507,10 +507,10 @@
        <item>
         <widget class="QCheckBox" name="hideTrayIcon">
          <property name="toolTip">
-          <string>&amp;Hide the icon from the system tray.</string>
+          <string>Hide the icon from the system tray.</string>
          </property>
          <property name="text">
-          <string>Hide tray icon</string>
+          <string>&amp;Hide tray icon</string>
          </property>
         </widget>
        </item>
@@ -610,7 +610,7 @@
             <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
            </property>
            <property name="text">
-            <string>Third party transaction URLs</string>
+            <string>&amp;Third party transaction URLs</string>
            </property>
            <property name="buddy">
             <cstring>thirdPartyTxUrls</cstring>


### PR DESCRIPTION
Tooltip displayed ampersand incorrectly, &amp; should be in text property rather than tooltip so that access key is correctly displayed for accessibility.