### PR TITLE
[tests] Fix incorrect memory_cleanse(…) call in crypto_tests.cpp

### DIFF
--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -26,8 +26,8 @@ bool OldSetKeyFromPassphrase(const SecureString& strKeyData, const std::vector<u
 
     if (i != (int)WALLET_CRYPTO_KEY_SIZE)
     {
-        memory_cleanse(chKey, sizeof(chKey));
-        memory_cleanse(chIV, sizeof(chIV));
+        memory_cleanse(chKey, WALLET_CRYPTO_KEY_SIZE);
+        memory_cleanse(chIV, WALLET_CRYPTO_IV_SIZE);
         return false;
     }
     return true;


### PR DESCRIPTION
`chKey` and `chIV` are pointers, not arrays :-)

Probably the result of copy-pasting of old code where the code was operating on arrays instead of pointers.

If I'm reading the code correctly the absence/presence of these `memory_cleanse(…)` calls won't alter the outcome of the test in question (`TestPassphraseSingle`) even if fixed. Therefore removing.

