### PR TITLE
Add missing lock in CScheduler::AreThreadsServicingQueue()

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -141,6 +141,7 @@ size_t CScheduler::getQueueInfo(boost::chrono::system_clock::time_point &first,
 }
 
 bool CScheduler::AreThreadsServicingQueue() const {
+    boost::unique_lock<boost::mutex> lock(newTaskMutex);
     return nThreadsServicingQueue;
 }
 


### PR DESCRIPTION
Not an actual bug as this is only used in asserts right now, but
nice to not have a missing lock.