### PR TITLE
[qt] Fix potential memory leak in newPossibleKey(ChangeCWallet *wallet)

### DIFF
--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -10,7 +10,6 @@
 WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &_recipients) :
     recipients(_recipients),
     walletTransaction(0),
-    keyChange(0),
     fee(0)
 {
     walletTransaction = new CWalletTx();
@@ -18,7 +17,6 @@ WalletModelTransaction::WalletModelTransaction(const QList<SendCoinsRecipient> &
 
 WalletModelTransaction::~WalletModelTransaction()
 {
-    delete keyChange;
     delete walletTransaction;
 }
 
@@ -91,10 +89,10 @@ CAmount WalletModelTransaction::getTotalTransactionAmount()
 
 void WalletModelTransaction::newPossibleKeyChange(CWallet *wallet)
 {
-    keyChange = new CReserveKey(wallet);
+    keyChange.reset(new CReserveKey(wallet));
 }
 
 CReserveKey *WalletModelTransaction::getPossibleKeyChange()
 {
-    return keyChange;
+    return keyChange.get();
 }

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -40,7 +40,7 @@ public:
 private:
     QList<SendCoinsRecipient> recipients;
     CWalletTx *walletTransaction;
-    CReserveKey *keyChange;
+    std::unique_ptr<CReserveKey> keyChange;
     CAmount fee;
 };
 


### PR DESCRIPTION
Fix potential memory leak in `newPossibleKey(ChangeCWallet *wallet)`.