### PR TITLE
New file-partition.md doc describing how to partition files to ensure fast initial blockchain synchronization..

### DIFF
--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -45,7 +45,7 @@ Finally, set up soft links to restore the original folder structure:
       
           ln -s /Users/coinadm/local/bitcoin/index /Volumes/WD-Passport-Mac/bitcoin/blocks/index 
 
-6) Replace the original index folder location with a soft link:
+6) Replace the original blocks folder location with a soft link:
       
           ln -s /Volumes/WD-Passport-Mac/bitcoin/blocks /Users/coinadm/local/bitcoin/data/blocks
 

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -4,14 +4,14 @@ Since the blockchain is around ~140GB, storage of large files on an external dri
 | Original Location       | New Location | Capacity Needs | i/o Frequency  |
 | ----------------------- | ------------ | -------------- | -------------- |
 | ${datadir}/blocks/index | ${datadir}   | low            | high           |
-| ${datadir}/blocks       | ${EXTERAL}   | high           | low            |
+| ${datadir}/blocks       | ${EXTERNAL}  | high           | low            |
 | ${datadir}/chainstate   | n/a          | low            | high           |
 
 Note: the chainstate folder will not move if these instructions are followed closely.  Like the index folder, chainstate contains very high frequency LevelDB files and must remain on a fast (internal) disk if reasonable syncronization time is to be expected.
 
 Change "coinadm" in the following as appropriate for your Bitcoin administrative account.
 
-1) Start bitcoind with --datadir pointing to your internal drive:
+1) Start bitcoind with -datadir pointing to your internal drive:
 
         bitcoind -daemon -conf=macos-bitcoin.conf -datadir=/Users/coinadm/local/bitcoin/data
 
@@ -25,7 +25,7 @@ Let it run for a few minutes, or long enough that it has started syncho-
 
        bitcoin-cli stop
 
-3) Move the "index" folder up one level (so that it may remain on the internal drive). Like the 
+3) Move the "index" folder up one level, so that it may remain on the internal drive: 
       
           mv -f /Users/coinadm/local/bitcoin/data/blocks/index /Users/coinadm/local/bitcoin/data/
 
@@ -39,7 +39,7 @@ Finally, set up soft links to restore the original folder structure:
 | Folder Name              | Link Name           |
 | ------------------------ | ------------------- |
 | ${EXTERNAL}/blocks/index | ${datadir}/../index |
-| ${datadir}/blocks        | ${EXTERAL}/blocks   |
+| ${datadir}/blocks        | ${EXTERNAL}/blocks  |
 
 5) Replace the original index folder location with a soft link:
       

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -1,8 +1,12 @@
-Since the blockchain is around 130GB many developers may find it 
-convenient to store the blockchain on an external drive.  This
-document describes how to partitioning of datadir files between 
-the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. 
-Examples are given for macOS, but Linux / Windows should be similar. 
+# File Partition:
+Since the blockchain is around 130GB, storage of large files on an external drive is convenient.  
+If this is not done properly though, the external drive will also contain high i/o-frequency LevelDB index
+files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
+
+| Original Location       | New Location | Capacity Needs | IO Frequency        |
+| ----------------------- | ------------ | -------------- | ------------------- |
+| ${datadir}/blocks/index | ${datadir}   | low            | high                |
+| ${datadir}/blocks       | ${EXTERAL}   | high           | low                 |
 
 Change "username" in the follows as appropriate for your macOS Bitcoin
 administrative account ("coinadm" in this example conf file).
@@ -18,32 +22,25 @@ administrative account ("coinadm" in this example conf file).
 2) Stop bitcoind, so that we can rearrange some datadir folders:
 
        kill -QUIT `cat /Volumes/WD-Passport-Mac/bitcoin/data/bitcoind.pid`
-3) Rearrange the datadir folders as follows:
 
-| Original Location       | New Location | Capacity Needs | IO Frequency        |
-| ----------------------- | ------------ | -------------- | ------------------- |
-| ${datadir}/blocks/index | ${datadir}   | low            | high                |
-| ${datadir}/blocks       | ${EXTERAL}   | high           | low                 |
-
-   a) Move the Bitcoin LevelDB index folder up one level (so that it may
-      remain on the internal drive).
+3) Move the Bitcoin LevelDB index folder up one level (so that it may remain on the internal drive).
       
           mv -f /Users/coinadm/local/bitcoin/data/blocks/index /Users/coinadm/local/bitcoin/data/
-   b) Next, move the Bitcoin blockchain blocks folder off the internal drive:
+4) Next, move the Bitcoin blockchain blocks folder off the internal drive:
    
           mkdir /Volumes/WD-Passport-Mac/bitcoin 
           mv -f /Users/coinadm/local/bitcoin/data/blocks /Volumes/WD-Passport-Mac/bitcoin 
-   Finally, set up soft links to restore the original folder structure:
+Finally, set up soft links to restore the original folder structure:
    
 | Folder Name              | Link Name           |
 | ------------------------ | ------------------- |
 | ${EXTERNAL}/blocks/index | ${datadir}/../index |
 | ${datadir}/blocks        | ${EXTERAL}/blocks   |
 
-    c) Replace the original index folder location with a soft link:
+5) Replace the original index folder location with a soft link:
       
           ln -s /Users/coinadm/local/bitcoin/index /Volumes/WD-Passport-Mac/bitcoin/blocks/index 
-    d) Replace the original index folder location with a soft link:
+6) Replace the original index folder location with a soft link:
       
           ln -s /Volumes/WD-Passport-Mac/bitcoin/blocks /Users/coinadm/local/bitcoin/data/blocks
 

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -1,7 +1,5 @@
 # File Partition:
-Since the blockchain is around ~140GB, storage of large files on an external drive is convenient.  
-If this is not done properly, the external drive will also contain high i/o-frequency LevelDB index
-files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
+Since the blockchain is around ~140GB, storage of large files on an external drive is convenient.  If this is not done properly, the external drive will also contain high i/o-frequency LevelDB index files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
 
 | Original Location       | New Location | Capacity Needs | i/o Frequency  |
 | ----------------------- | ------------ | -------------- | -------------- |

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -1,5 +1,5 @@
 # File Partition:
-Since the blockchain is around 130GB, storage of large files on an external drive is convenient.  
+Since the blockchain is around 140GB, storage of large files on an external drive is convenient.  
 If this is not done properly though, the external drive will also contain high i/o-frequency LevelDB index
 files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
 
@@ -45,4 +45,4 @@ Finally, set up soft links to restore the original folder structure:
           ln -s /Volumes/WD-Passport-Mac/bitcoin/blocks /Users/coinadm/local/bitcoin/data/blocks
 
  注意 - Nota - Note - ध्यान दें - ﻢﻠﺣﻮﻇﺓ - метка 
-These instructions are confusing due to the way the index folder is nested within the blocks folder.
+These instructions are confusing due to the way the LevelDB "index" folder is nested within the blockchain "blocks" folder by default.

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -23,7 +23,7 @@ Let it run for a few minutes, or long enough that it has started syncho-
 
 2) Stop bitcoind, so that we can rearrange some datadir folders:
 
-       kill -QUIT `cat /Volumes/WD-Passport-Mac/bitcoin/data/bitcoind.pid`
+       bitcoin-cli stop
 
 3) Move the "index" folder up one level (so that it may remain on the internal drive). Like the 
       

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -8,6 +8,7 @@ files, protracting time for initial blockchain synchronization. This document de
 | ${datadir}/blocks/index | ${datadir}   | low            | high           |
 | ${datadir}/blocks       | ${EXTERAL}   | high           | low            |
 | ${datadir}/chainstate   | n/a          | low            | high           |
+
 Note: the chainstate folder will not move if these instructions are followed closely.  Like the index folder, chainstate contains very high frequency LevelDB files and must remain on a fast (internal) disk if reasonable syncronization time is to be expected.
 
 Change "coinadm" in the following as appropriate for your Bitcoin administrative account.

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -1,5 +1,5 @@
 # File Partition:
-Since the blockchain is around 140GB, storage of large files on an external drive is convenient.  
+Since the blockchain is around ~140GB, storage of large files on an external drive is convenient.  
 If this is not done properly though, the external drive will also contain high i/o-frequency LevelDB index
 files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
 

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -1,0 +1,51 @@
+Since the blockchain is around 130GB many developers may find it 
+convenient to store the blockchain on an external drive.  This
+document describes how to partitioning of datadir files between 
+the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. 
+Examples are given for macOS, but Linux / Windows should be similar. 
+
+Change "username" in the follows as appropriate for your macOS Bitcoin
+administrative account ("coinadm" in this example conf file).
+
+1) Start bitcoind with datadir pointing to your internal drive:
+
+        bitcoind -daemon -conf=macos-bitcoin.conf -datadir=/Users/coinadm/local/bitcoin/data
+   Let it run for a few minutes, or long enough that it has started syncho-
+   nizing.  Either tail the debug.log, or watch the blocks folder:
+   
+        ls -l /Users/coinadm/local/bitcoin/data/blocks/blk00000.dat
+        -rw-------  1 coinadm  staff  134191893 Jul 27 11:31 /Users/coinadm/local/data/blocks/blk00000.dat
+2) Stop bitcoind, so that we can rearrange some datadir folders:
+
+       kill -QUIT `cat /Volumes/WD-Passport-Mac/bitcoin/data/bitcoind.pid`
+3) Rearrange the datadir folders as follows:
+
+| Original Location       | New Location | Capacity Needs | IO Frequency        |
+| ----------------------- | ------------ | -------------- | ------------------- |
+| ${datadir}/blocks/index | ${datadir}   | low            | high                |
+| ${datadir}/blocks       | ${EXTERAL}   | high           | low                 |
+
+   a) Move the Bitcoin LevelDB index folder up one level (so that it may
+      remain on the internal drive).
+      
+          mv -f /Users/coinadm/local/bitcoin/data/blocks/index /Users/coinadm/local/bitcoin/data/
+   b) Next, move the Bitcoin blockchain blocks folder off the internal drive:
+   
+          mkdir /Volumes/WD-Passport-Mac/bitcoin 
+          mv -f /Users/coinadm/local/bitcoin/data/blocks /Volumes/WD-Passport-Mac/bitcoin 
+   Finally, set up soft links to restore the original folder structure:
+   
+| Folder Name              | Link Name           |
+| ------------------------ | ------------------- |
+| ${EXTERNAL}/blocks/index | ${datadir}/../index |
+| ${datadir}/blocks        | ${EXTERAL}/blocks   |
+
+    c) Replace the original index folder location with a soft link:
+      
+          ln -s /Users/coinadm/local/bitcoin/index /Volumes/WD-Passport-Mac/bitcoin/blocks/index 
+    d) Replace the original index folder location with a soft link:
+      
+          ln -s /Volumes/WD-Passport-Mac/bitcoin/blocks /Users/coinadm/local/bitcoin/data/blocks
+
+ 注意 - Nota - Note - ध्यान दें - ﻢﻠﺣﻮﻇﺓ - метка 
+These instructions are confusing due to the way the index folder is nested within the blocks folder.

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -3,7 +3,7 @@ Since the blockchain is around ~140GB, storage of large files on an external dri
 If this is not done properly though, the external drive will also contain high i/o-frequency LevelDB index
 files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
 
-| Original Location       | New Location | Capacity Needs | IO Frequency        |
+| Original Location       | New Location | Capacity Needs | i/o Frequency        |
 | ----------------------- | ------------ | -------------- | ------------------- |
 | ${datadir}/blocks/index | ${datadir}   | low            | high                |
 | ${datadir}/blocks       | ${EXTERAL}   | high           | low                 |

--- a/doc/file-partition.md
+++ b/doc/file-partition.md
@@ -1,35 +1,40 @@
 # File Partition:
 Since the blockchain is around ~140GB, storage of large files on an external drive is convenient.  
-If this is not done properly though, the external drive will also contain high i/o-frequency LevelDB index
+If this is not done properly, the external drive will also contain high i/o-frequency LevelDB index
 files, protracting time for initial blockchain synchronization. This document describes how partition datadir files between the high-frequency/low-capacity "index" files and the low-frequency/high-capacity "blocks" files. Examples are given for macOS, but Linux / Windows should be similar. These instructions result in the following physical folder rearrangement:
 
-| Original Location       | New Location | Capacity Needs | i/o Frequency        |
-| ----------------------- | ------------ | -------------- | ------------------- |
-| ${datadir}/blocks/index | ${datadir}   | low            | high                |
-| ${datadir}/blocks       | ${EXTERAL}   | high           | low                 |
+| Original Location       | New Location | Capacity Needs | i/o Frequency  |
+| ----------------------- | ------------ | -------------- | -------------- |
+| ${datadir}/blocks/index | ${datadir}   | low            | high           |
+| ${datadir}/blocks       | ${EXTERAL}   | high           | low            |
+| ${datadir}/chainstate   | n/a          | low            | high           |
+Note: the chainstate folder will not move if these instructions are followed closely.  Like the index folder, chainstate contains very high frequency LevelDB files and must remain on a fast (internal) disk if reasonable syncronization time is to be expected.
 
-Change "username" in the follows as appropriate for your macOS Bitcoin
-administrative account ("coinadm" in this example conf file).
+Change "coinadm" in the following as appropriate for your Bitcoin administrative account.
 
-1) Start bitcoind with datadir pointing to your internal drive:
+1) Start bitcoind with --datadir pointing to your internal drive:
 
         bitcoind -daemon -conf=macos-bitcoin.conf -datadir=/Users/coinadm/local/bitcoin/data
-   Let it run for a few minutes, or long enough that it has started syncho-
+
+Let it run for a few minutes, or long enough that it has started syncho-
    nizing.  Either tail the debug.log, or watch the blocks folder:
    
         ls -l /Users/coinadm/local/bitcoin/data/blocks/blk00000.dat
         -rw-------  1 coinadm  staff  134191893 Jul 27 11:31 /Users/coinadm/local/data/blocks/blk00000.dat
+
 2) Stop bitcoind, so that we can rearrange some datadir folders:
 
        kill -QUIT `cat /Volumes/WD-Passport-Mac/bitcoin/data/bitcoind.pid`
 
-3) Move the Bitcoin LevelDB index folder up one level (so that it may remain on the internal drive).
+3) Move the "index" folder up one level (so that it may remain on the internal drive). Like the 
       
           mv -f /Users/coinadm/local/bitcoin/data/blocks/index /Users/coinadm/local/bitcoin/data/
+
 4) Next, move the Bitcoin blockchain blocks folder off the internal drive:
    
           mkdir /Volumes/WD-Passport-Mac/bitcoin 
           mv -f /Users/coinadm/local/bitcoin/data/blocks /Volumes/WD-Passport-Mac/bitcoin 
+
 Finally, set up soft links to restore the original folder structure:
    
 | Folder Name              | Link Name           |
@@ -40,6 +45,7 @@ Finally, set up soft links to restore the original folder structure:
 5) Replace the original index folder location with a soft link:
       
           ln -s /Users/coinadm/local/bitcoin/index /Volumes/WD-Passport-Mac/bitcoin/blocks/index 
+
 6) Replace the original index folder location with a soft link:
       
           ln -s /Volumes/WD-Passport-Mac/bitcoin/blocks /Users/coinadm/local/bitcoin/data/blocks


### PR DESCRIPTION
After native build from source on Mac OS, my initial attempts to synchronize the blockchain were very very slow.  Upon finding [Issue Sync Taking Too Long](https://github.com/bitcoin/bitcoin/issues/10647), I found discussion by all and comments by @sipa in particular to be very useful, and reorganized $datadir folders on my local macOS build/install and summarized steps taken in file-partition.md doc.  These comments might find their audience more appropriately elsewhere, please feel free to suggest, thank you very much.
-jimhash
Note: This looks to be logged as issue: https://github.com/bitcoin/bitcoin/issues/10736