### PR TITLE
test: Make sure wallet.backup is created in temp path

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -469,7 +469,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back("wallet.backup");
+        request.params.push_back((pathTemp / "wallet.backup").string());
         vpwallets.insert(vpwallets.begin(), &wallet);
         ::dumpwallet(request);
     }
@@ -481,7 +481,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back("wallet.backup");
+        request.params.push_back((pathTemp / "wallet.backup").string());
         vpwallets[0] = &wallet;
         ::importwallet(request);
 


### PR DESCRIPTION
This assures that we don't overwrite a random file called `wallet.backup` that happens to be in the current directory. It also assures that the temporary file will be cleaned up.

Noticed by Evan Klitzke, came up in discussion here: https://github.com/bitcoin/bitcoin/pull/10880#discussion_r128460722