### PR TITLE
Add blocknotify and walletnotify functional tests

### DIFF
--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -4,9 +4,9 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the -alertnotify option."""
 import os
-import time
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, wait_until
 
 class ForkNotifyTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -14,46 +14,30 @@ class ForkNotifyTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
-        with open(self.alert_filename, 'w', encoding='utf8'):
-            pass  # Just open then close to create zero-length file
-        self.extra_args = [["-blockversion=2", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""],
+        self.extra_args = [["-alertnotify=echo %%s >> %s" % self.alert_filename],
                            ["-blockversion=211"]]
         super().setup_network()
 
     def run_test(self):
-        # Mine 51 up-version blocks
+        # Mine 51 up-version blocks. -alertnotify should trigger on the 51st.
         self.nodes[1].generate(51)
-        self.sync_all()
-        # -alertnotify should trigger on the 51'st,
-        # but mine and sync another to give
-        # -alertnotify time to write
-        self.nodes[1].generate(1)
         self.sync_all()
 
         # Give bitcoind 10 seconds to write the alert notification
-        timeout = 10.0
-        while timeout > 0:
-            if os.path.exists(self.alert_filename) and os.path.getsize(self.alert_filename):
-                break
-            time.sleep(0.1)
-            timeout -= 0.1
-        else:
-            assert False, "-alertnotify did not warn of up-version blocks"
+        wait_until(lambda: os.path.isfile(self.alert_filename) and os.path.getsize(self.alert_filename), timeout=10)
 
         with open(self.alert_filename, 'r', encoding='utf8') as f:
             alert_text = f.read()
 
         # Mine more up-version blocks, should not get more alerts:
-        self.nodes[1].generate(1)
-        self.sync_all()
-        self.nodes[1].generate(1)
+        self.nodes[1].generate(2)
         self.sync_all()
 
         with open(self.alert_filename, 'r', encoding='utf8') as f:
             alert_text2 = f.read()
 
-        if alert_text != alert_text2:
-            raise AssertionError("-alertnotify excessive warning of up-version blocks")
+        self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
+        assert_equal(alert_text, alert_text2)
 
 if __name__ == '__main__':
     ForkNotifyTest().main()

--- a/test/functional/notifications.py
+++ b/test/functional/notifications.py
@@ -2,23 +2,29 @@
 # Copyright (c) 2014-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the -alertnotify and -blocknotify options."""
+"""Test the -alertnotify, -blocknotify and -walletnotify options."""
 import os
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, wait_until
+from test_framework.util import assert_equal, wait_until, connect_nodes_bi
 
 class NotificationsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.setup_clean_chain = True
 
     def setup_network(self):
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
-        self.block_filename = os.path.join(self.options.tmpdir, 'blocks.txt')
+        self.block_filename = os.path.join(self.options.tmpdir, "blocks.txt")
+        self.tx_filename = os.path.join(self.options.tmpdir, "transactions.txt")
+
+        # -alertnotify and -blocknotify on node0, walletnotify on node1
         self.extra_args = [["-blockversion=2",
                             "-alertnotify=echo %%s >> %s" % self.alert_filename,
                             "-blocknotify=echo %%s >> %s" % self.block_filename],
-                           ["-blockversion=211"]]
+                           ["-blockversion=211",
+                            "-rescan",
+                            "-walletnotify=echo %%s >> %s" % self.tx_filename]]
         super().setup_network()
 
     def run_test(self):
@@ -32,6 +38,28 @@ class NotificationsTest(BitcoinTestFramework):
         # file content should equal the generated blocks hashes
         with open(self.block_filename, 'r') as f:
             assert_equal(sorted(blocks), sorted(f.read().splitlines()))
+
+        self.log.info("test -walletnotify")
+        # wait at most 10 seconds for expected file size before reading the content
+        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+
+        # file content should equal the generated transaction hashes
+        txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
+        with open(self.tx_filename, 'r') as f:
+            assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
+        os.remove(self.tx_filename)
+
+        self.log.info("test -walletnotify after rescan")
+        # restart node to rescan to force wallet notifications
+        self.restart_node(1)
+        connect_nodes_bi(self.nodes, 0, 1)
+
+        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+
+        # file content should equal the generated transaction hashes
+        txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
+        with open(self.tx_filename, 'r') as f:
+            assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
 
         # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
         self.log.info("test -alertnotify")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -148,7 +148,7 @@ EXTENDED_SCRIPTS = [
     'example_test.py',
     'txn_doublespend.py',
     'txn_clone.py --mineblock',
-    'forknotify.py',
+    'notifications.py',
     'invalidateblock.py',
     'p2p-acceptblock.py',
     'replace-by-fee.py',


### PR DESCRIPTION
This patch adds the missing functional tests for `-blocknotify` and `-walletnotify` notifications. The `-alertnotify` test file `forknotify.py` is renamed to `notifications.py` to accommodate the new tests. Credits to @jnewbery for this cleanup and unification.