### PR TITLE
Eliminate fee overpaying edge case when subtracting fee from recipients

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2774,10 +2774,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     // selected to meet nFeeNeeded result in a transaction that
                     // requires less fee than the prior iteration.
 
-                    // TODO: The case where nSubtractFeeFromAmount > 0 remains
-                    // to be addressed because it requires returning the fee to
-                    // the payees and not the change output.
-
                     // If we have no change and a big enough excess fee, then
                     // try to construct transaction again only without picking
                     // new inputs. We now know we only need the smaller fee
@@ -2804,6 +2800,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 else if (!pick_new_inputs) {
                     // This shouldn't happen, we should have had enough excess
                     // fee to pay for the new output and still meet nFeeNeeded
+                    // Or we should have just subtracted fee from recipients and
+                    // nFeeNeeded should not have changed
                     strFailReason = _("Transaction fee and change calculation failed");
                     return false;
                 }
@@ -2818,6 +2816,12 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                         nFeeRet += additionalFeeNeeded;
                         break; // Done, able to increase fee from change
                     }
+                }
+
+                // If subtracting fee from recipients, we now know what fee we
+                // need to subtract, we have no reason to reselect inputs
+                if (nSubtractFeeFromAmount > 0) {
+                    pick_new_inputs = false;
                 }
 
                 // Include more fee and try again.


### PR DESCRIPTION
I'm not sure if this is the cause of the issue in #10034 , but this was a known edge case.  I just didn't realize how simple the fix is.  

Could use a couple more eyes to make sure nothing silly can go wrong here, but if we all agree it's this simple, we can add this as another 0.15 bug fix.

