### PR TITLE
Add chainwork to getchaintxstats

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1528,6 +1528,7 @@ UniValue getchaintxstats(const JSONRPCRequest& request)
     ret.push_back(Pair("time", (int64_t)pindex->nTime));
     ret.push_back(Pair("txcount", (int64_t)pindex->nChainTx));
     ret.push_back(Pair("txrate", ((double)nTxDiff) / nTimeDiff));
+    ret.push_back(Pair("chainwork", ArithToUint256(pindex->nChainWork).ToString()));
 
     return ret;
 }


### PR DESCRIPTION
This makes it easier to create and verify the `nMinimumChainWork` data in chain parameters.