### PR TITLE
[Wallet] Bare segwit scriptPubKey should not considered change by the wallet

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -222,6 +222,8 @@ public:
 
     bool operator()(const CKeyID& id) const { return addr->Set(id); }
     bool operator()(const CScriptID& id) const { return addr->Set(id); }
+    bool operator()(const CWitKeyID& id) const { return false; }
+    bool operator()(const CWitScriptID& id) const { return false; }
     bool operator()(const CNoDestination& no) const { return false; }
 };
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -202,6 +202,16 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
         addressRet = CScriptID(uint160(vSolutions[0]));
         return true;
     }
+    else if (whichType == TX_WITNESS_V0_SCRIPTHASH)
+    {
+        addressRet = CWitScriptID(uint256(vSolutions[0]));
+        return true;
+    }
+    else if (whichType == TX_WITNESS_V0_KEYHASH)
+    {
+        addressRet = CWitKeyID(uint160(vSolutions[0]));
+        return true;
+    }
     // Multisig txns have more than one address...
     return false;
 }
@@ -263,6 +273,18 @@ public:
     bool operator()(const CKeyID &keyID) const {
         script->clear();
         *script << OP_DUP << OP_HASH160 << ToByteVector(keyID) << OP_EQUALVERIFY << OP_CHECKSIG;
+        return true;
+    }
+
+    bool operator()(const CWitKeyID &keyID) const {
+        script->clear();
+        *script << OP_0 << ToByteVector(keyID);
+        return true;
+    }
+
+    bool operator()(const CWitScriptID &scriptID) const {
+        script->clear();
+        *script << OP_0 << ToByteVector(scriptID);
         return true;
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1156,6 +1156,16 @@ public:
         }
         return false;
     }
+
+    /* We can't witnessify what is already witnessified */
+    bool operator()(const CWitScriptID &scriptID) {
+        return false;
+    }
+
+    /* We can't witnessify what is already witnessified */
+    bool operator()(const CWitKeyID &keyId) {
+        return false;
+    }
 };
 
 UniValue addwitnessaddress(const JSONRPCRequest& request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3637,9 +3637,17 @@ public:
             vKeys.push_back(keyId);
     }
 
+    void operator()(const CWitKeyID &keyId) {}
+
     void operator()(const CScriptID &scriptId) {
         CScript script;
         if (keystore.GetCScript(scriptId, script))
+            Process(script);
+    }
+
+    void operator()(const CWitScriptID &scriptId) {
+        CScript script;
+        if (keystore.GetCScript(scriptId.ToP2SH(), script))
             Process(script);
     }
 

--- a/test/functional/segwit2.py
+++ b/test/functional/segwit2.py
@@ -23,7 +23,7 @@ class SegWitTest2(BitcoinTestFramework):
         self.nodes[0].generate(101)
         sync_blocks(self.nodes)
 
-        use_p2wsh = False
+        use_p2wsh = True
 
         transaction = ""
         scriptPubKey = ""

--- a/test/functional/segwit2.py
+++ b/test/functional/segwit2.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) 2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the SegWit changeover logic."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import sha256, CTransaction, CTxIn, COutPoint, CTxOut, COIN, ToHex, FromHex
+from test_framework.address import script_to_p2sh, key_to_p2pkh
+from test_framework.script import CScript, OP_HASH160, OP_CHECKSIG, OP_0, hash160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_1, OP_2, OP_CHECKMULTISIG, OP_TRUE
+from io import BytesIO
+
+class SegWitTest2(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-walletprematurewitness", "-prematurewitness"]]
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+        sync_blocks(self.nodes)
+
+        use_p2wsh = False
+
+        transaction = ""
+        scriptPubKey = ""
+
+        if use_p2wsh:
+            scriptPubKey = "00203a59f3f56b713fdcf5d1a57357f02c44342cbf306ffe0c4741046837bf90561a"
+            transaction = "01000000000100e1f505000000002200203a59f3f56b713fdcf5d1a57357f02c44342cbf306ffe0c4741046837bf90561a00000000"
+        else:
+            scriptPubKey = "a9142f8c469c2f0084c48e11f998ffbe7efa7549f26d87"
+            transaction = "01000000000100e1f5050000000017a9142f8c469c2f0084c48e11f998ffbe7efa7549f26d8700000000"
+            
+        self.nodes[0].importaddress(scriptPubKey, "", False)
+        rawtxfund = self.nodes[0].fundrawtransaction(transaction)['hex']
+
+        rawtxfund = self.nodes[0].signrawtransaction(rawtxfund)["hex"]
+        txid = self.nodes[0].decoderawtransaction(rawtxfund)["txid"]
+
+        self.nodes[0].sendrawtransaction(rawtxfund)
+
+        assert(self.nodes[0].gettransaction(txid, True)["txid"]  == txid)
+        assert(self.nodes[0].listtransactions("*", 1, 0, True)[0]["txid"]  == txid)
+        
+        # Assert it is properly saved
+        self.stop_nodes()
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+
+        assert(self.nodes[0].gettransaction(txid, True)["txid"]  == txid)
+        assert(self.nodes[0].listtransactions("*", 1, 0, True)[0]["txid"]  == txid)
+
+if __name__ == '__main__':
+    SegWitTest2().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -116,6 +116,7 @@ BASE_SCRIPTS= [
     'p2p-leaktests.py',
     'wallet-encryption.py',
     'uptime.py',
+    'segwit2.py'
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
As the test describe, segwit scriptPubKey are considered as change. It means that if you import the scriptPubKey, then send money to it, and call `listtransactions`, you will not see it. (contrary to p2sh scriptPubKey)

This PR makes it possible to use watchonly on segwit scriptPubKey.

