### PR TITLE
Avoid returning a BIP9Stats object with uninitialized values

### DIFF
--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -107,7 +107,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
 // return the numerical statistics of blocks signalling the specified BIP9 condition in this current period
 BIP9Stats AbstractThresholdConditionChecker::GetStateStatisticsFor(const CBlockIndex* pindex, const Consensus::Params& params) const
 {
-    BIP9Stats stats;
+    BIP9Stats stats = {};
 
     stats.period = Period(params);
     stats.threshold = Threshold(params);


### PR DESCRIPTION
Uninitialized data potentially used in `rpc/blockchain.cpp`:

```
static UniValue BIP9SoftForkDesc(const Consensus::Params& consensusParams, Consensus::DeploymentPos id)
{
    ...
    const ThresholdState thresholdState = VersionBitsTipState(consensusParams, id);
    ...
    if (THRESHOLD_STARTED == thresholdState)
    {
        UniValue statsUV(UniValue::VOBJ);
        BIP9Stats statsStruct = VersionBitsTipStatistics(consensusParams, id);
        statsUV.push_back(Pair("period", statsStruct.period));
        statsUV.push_back(Pair("threshold", statsStruct.threshold));
        statsUV.push_back(Pair("elapsed", statsStruct.elapsed));
        statsUV.push_back(Pair("count", statsStruct.count));
        statsUV.push_back(Pair("possible", statsStruct.possible));
        rv.push_back(Pair("statistics", statsUV));
    }
    ...
    return rv;
}
```

Friendly ping @pinheadmz :-)