### PR TITLE
Update to latest Bitcoin patches for LevelDB

### DIFF
--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -101,7 +101,7 @@ void MemTable::Add(SequenceNumber s, ValueType type,
   p += 8;
   p = EncodeVarint32(p, val_size);
   memcpy(p, value.data(), val_size);
-  assert((p + val_size) - buf == encoded_len);
+  assert(p + val_size == buf + encoded_len);
   table_.Insert(buf);
 }
 

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -20,7 +20,7 @@
 
 namespace leveldb {
 
-static int TargetFileSize(const Options* options) {
+static size_t TargetFileSize(const Options* options) {
   return options->max_file_size;
 }
 

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -376,7 +376,7 @@ class Compaction {
   // Each compaction reads inputs from "level_" and "level_+1"
   std::vector<FileMetaData*> inputs_[2];      // The two sets of inputs
 
-  // State used to check for number of of overlapping grandparent files
+  // State used to check for number of overlapping grandparent files
   // (parent == level_ + 1, grandparent == level_ + 2)
   std::vector<FileMetaData*> grandparents_;
   size_t grandparent_index_;  // Index in grandparent_starts_

--- a/port/atomic_pointer.h
+++ b/port/atomic_pointer.h
@@ -46,6 +46,30 @@
 namespace leveldb {
 namespace port {
 
+// AtomicPointer based on <cstdatomic> if available
+#if defined(LEVELDB_ATOMIC_PRESENT)
+class AtomicPointer {
+ private:
+  std::atomic<void*> rep_;
+ public:
+  AtomicPointer() { }
+  explicit AtomicPointer(void* v) : rep_(v) { }
+  inline void* Acquire_Load() const {
+    return rep_.load(std::memory_order_acquire);
+  }
+  inline void Release_Store(void* v) {
+    rep_.store(v, std::memory_order_release);
+  }
+  inline void* NoBarrier_Load() const {
+    return rep_.load(std::memory_order_relaxed);
+  }
+  inline void NoBarrier_Store(void* v) {
+    rep_.store(v, std::memory_order_relaxed);
+  }
+};
+
+#else
+
 // Define MemoryBarrier() if available
 // Windows on x86
 #if defined(OS_WIN) && defined(COMPILER_MSVC) && defined(ARCH_CPU_X86_FAMILY)
@@ -142,28 +166,6 @@ class AtomicPointer {
   }
 };
 
-// AtomicPointer based on <cstdatomic>
-#elif defined(LEVELDB_ATOMIC_PRESENT)
-class AtomicPointer {
- private:
-  std::atomic<void*> rep_;
- public:
-  AtomicPointer() { }
-  explicit AtomicPointer(void* v) : rep_(v) { }
-  inline void* Acquire_Load() const {
-    return rep_.load(std::memory_order_acquire);
-  }
-  inline void Release_Store(void* v) {
-    rep_.store(v, std::memory_order_release);
-  }
-  inline void* NoBarrier_Load() const {
-    return rep_.load(std::memory_order_relaxed);
-  }
-  inline void NoBarrier_Store(void* v) {
-    rep_.store(v, std::memory_order_relaxed);
-  }
-};
-
 // Atomic pointer based on sparc memory barriers
 #elif defined(__sparcv9) && defined(__GNUC__)
 class AtomicPointer {
@@ -228,6 +230,7 @@ class AtomicPointer {
 #else
 #error Please implement AtomicPointer for this platform.
 
+#endif
 #endif
 
 #undef LEVELDB_HAVE_MEMORY_BARRIER

--- a/port/port_example.h
+++ b/port/port_example.h
@@ -129,6 +129,10 @@ extern bool Snappy_Uncompress(const char* input_data, size_t input_length,
 // The concatenation of all "data[0,n-1]" fragments is the heap profile.
 extern bool GetHeapProfile(void (*func)(void*, const char*, int), void* arg);
 
+// Determine whether a working accelerated crc32 implementation exists
+// Returns true if AcceleratedCRC32C is safe to call
+bool HasAcceleratedCRC32C();
+
 // Extend the CRC to include the first n bytes of buf.
 //
 // Returns zero if the CRC cannot be extended using acceleration, else returns

--- a/port/port_posix.cc
+++ b/port/port_posix.cc
@@ -8,6 +8,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GNUC__)
+#include <cpuid.h>
+#endif
+
 namespace leveldb {
 namespace port {
 
@@ -47,6 +51,16 @@ void CondVar::SignalAll() {
 
 void InitOnce(OnceType* once, void (*initializer)()) {
   PthreadCall("once", pthread_once(once, initializer));
+}
+
+bool HasAcceleratedCRC32C() {
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__GNUC__)
+  unsigned int eax, ebx, ecx, edx;
+  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
+  return (ecx & (1 << 20)) != 0;
+#else
+  return false;
+#endif
 }
 
 }  // namespace port

--- a/port/port_posix.h
+++ b/port/port_posix.h
@@ -152,6 +152,7 @@ inline bool GetHeapProfile(void (*func)(void*, const char*, int), void* arg) {
   return false;
 }
 
+bool HasAcceleratedCRC32C();
 uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size);
 
 } // namespace port

--- a/port/port_posix_sse.cc
+++ b/port/port_posix_sse.cc
@@ -19,7 +19,6 @@
 #include <intrin.h>
 #elif defined(__GNUC__) && defined(__SSE4_2__)
 #include <nmmintrin.h>
-#include <cpuid.h>
 #endif
 
 #endif  // defined(LEVELDB_PLATFORM_POSIX_SSE)
@@ -48,20 +47,6 @@ static inline uint64_t LE_LOAD64(const uint8_t *p) {
 
 #endif  // defined(_M_X64) || defined(__x86_64__)
 
-static inline bool HaveSSE42() {
-#if defined(_MSC_VER)
-  int cpu_info[4];
-  __cpuid(cpu_info, 1);
-  return (cpu_info[2] & (1 << 20)) != 0;
-#elif defined(__GNUC__)
-  unsigned int eax, ebx, ecx, edx;
-  __get_cpuid(1, &eax, &ebx, &ecx, &edx);
-  return (ecx & (1 << 20)) != 0;
-#else
-  return false;
-#endif
-}
-
 #endif  // defined(LEVELDB_PLATFORM_POSIX_SSE)
 
 // For further improvements see Intel publication at:
@@ -70,10 +55,6 @@ uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size) {
 #if !defined(LEVELDB_PLATFORM_POSIX_SSE)
   return 0;
 #else
-  static bool have = HaveSSE42();
-  if (!have) {
-    return 0;
-  }
 
   const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
   const uint8_t *e = p + size;

--- a/port/port_win.cc
+++ b/port/port_win.cc
@@ -32,6 +32,7 @@
 
 #include <windows.h>
 #include <cassert>
+#include <intrin.h>
 
 namespace leveldb {
 namespace port {
@@ -141,6 +142,16 @@ void* AtomicPointer::NoBarrier_Load() const {
 
 void AtomicPointer::NoBarrier_Store(void* v) {
   rep_ = v;
+}
+
+bool HasAcceleratedCRC32C() {
+#if defined(__x86_64__) || defined(__i386__)
+  int cpu_info[4];
+  __cpuid(cpu_info, 1);
+  return (cpu_info[2] & (1 << 20)) != 0;
+#else
+  return false;
+#endif
 }
 
 }

--- a/port/port_win.h
+++ b/port/port_win.h
@@ -168,6 +168,7 @@ inline bool GetHeapProfile(void (*func)(void*, const char*, int), void* arg) {
   return false;
 }
 
+bool HasAcceleratedCRC32C();
 uint32_t AcceleratedCRC32C(uint32_t crc, const char* buf, size_t size);
 
 }

--- a/util/crc32c.cc
+++ b/util/crc32c.cc
@@ -288,6 +288,10 @@ static inline uint32_t LE_LOAD32(const uint8_t *p) {
 // Determine if the CPU running this program can accelerate the CRC32C
 // calculation.
 static bool CanAccelerateCRC32C() {
+  if (!port::HasAcceleratedCRC32C())
+    return false;
+
+  // Double-check that the accelerated implementation functions correctly.
   // port::AcceleretedCRC32C returns zero when unable to accelerate.
   static const char kTestCRCBuffer[] = "TestCRCBuffer";
   static const char kBufSize = sizeof(kTestCRCBuffer) - 1;

--- a/util/logging.cc
+++ b/util/logging.cc
@@ -49,7 +49,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
   uint64_t v = 0;
   int digits = 0;
   while (!in->empty()) {
-    char c = (*in)[0];
+    unsigned char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
       const int delta = (c - '0');


### PR DESCRIPTION
Includes:
* https://github.com/bitcoin-core/leveldb/pull/2: Prefer std::atomic over MemoryBarrier (Pieter Wuille)
* https://github.com/bitcoin-core/leveldb/pull/5: Move helper functions out of sse4.2 object (Cory Fields)
* https://github.com/bitcoin-core/leveldb/pull/6: Fixes typo (Dimitris Tsapakidis)
* https://github.com/bitcoin-core/leveldb/pull/10: Clean up compile-time warnings (gcc 7.1) (Matt Corallo)
* https://github.com/bitcoin-core/leveldb/pull/11: fixup define checks. Cleans up some oopses from #5 (Cory Fields)

