### PR TITLE
Improve readability of DecodeBase58Check(...)

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -136,7 +136,7 @@ bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet)
     }
     // re-calculate the checksum, ensure it matches the included 4-byte checksum
     uint256 hash = Hash(vchRet.begin(), vchRet.end() - 4);
-    if (memcmp(&hash, &vchRet.end()[-4], 4) != 0) {
+    if (memcmp(&hash, &vchRet[vchRet.size() - 4], 4) != 0) {
         vchRet.clear();
         return false;
     }


### PR DESCRIPTION
Use the more readable form ...

```c++
&vchRet[vchRet.size() - 4]
```

... instead of ...

```c++
&v.end()[-n]
```

Has the added benefit of eliminating a spurious static analyzer warning about improper use of negative values.