### PR TITLE
[bench] Restore format state of cout after printing with std::fixed/setprecision

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -100,6 +100,7 @@ bool benchmark::State::KeepRunning()
     int64_t averageCycles = (nowCycles-beginCycles)/count;
     std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << minTime << "," << maxTime << "," << average << ","
               << minCycles << "," << maxCycles << "," << averageCycles << "\n";
+    std::cout.copyfmt(std::ios(nullptr));
 
     return false;
 }


### PR DESCRIPTION
Restore default format state of `std::cout` after printing with `std::fixed`/`std::setprecision`.