### PR TITLE
Pass SendCoinsRecipient (208 bytes) by reference

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -620,7 +620,7 @@ void PaymentServer::fetchRequest(const QUrl& url)
     netManager->get(netRequest);
 }
 
-void PaymentServer::fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction)
+void PaymentServer::fetchPaymentACK(CWallet* wallet, const SendCoinsRecipient& recipient, QByteArray transaction)
 {
     const payments::PaymentDetails& details = recipient.paymentRequest.getDetails();
     if (!details.has_payment_url())

--- a/src/qt/paymentserver.h
+++ b/src/qt/paymentserver.h
@@ -113,7 +113,7 @@ public Q_SLOTS:
     void uiReady();
 
     // Submit Payment message to a merchant, get back PaymentACK:
-    void fetchPaymentACK(CWallet* wallet, SendCoinsRecipient recipient, QByteArray transaction);
+    void fetchPaymentACK(CWallet* wallet, const SendCoinsRecipient& recipient, QByteArray transaction);
 
     // Handle an incoming URI, URI with local file scheme or file
     void handleURIOrFile(const QString& s);

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -205,7 +205,7 @@ void PaymentServerTests::paymentServerTests()
     delete server;
 }
 
-void RecipientCatcher::getRecipient(SendCoinsRecipient r)
+void RecipientCatcher::getRecipient(const SendCoinsRecipient& r)
 {
     recipient = r;
 }

--- a/src/qt/test/paymentservertests.h
+++ b/src/qt/test/paymentservertests.h
@@ -26,7 +26,7 @@ class RecipientCatcher : public QObject
     Q_OBJECT
 
 public Q_SLOTS:
-    void getRecipient(SendCoinsRecipient r);
+    void getRecipient(const SendCoinsRecipient& r);
 
 public:
     SendCoinsRecipient recipient;


### PR DESCRIPTION
Pass `SendCoinsRecipient` (208 bytes) by reference.

Avoid passing big parameters by value.