### PR TITLE
[Qt] Check return value of addr.GetKeyID(keyid) on custom change address change

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -790,8 +790,8 @@ void SendCoinsDialog::coinControlChangeEdited(const QString& text)
         else // Valid address
         {
             CKeyID keyid;
-            addr.GetKeyID(keyid);
-            if (!model->havePrivKey(keyid)) // Unknown change address
+            bool valid = addr.GetKeyID(keyid);
+            if (!valid || !model->havePrivKey(keyid)) // Unknown change address
             {
                 ui->labelCoinControlChangeLabel->setText(tr("Warning: Unknown change address"));
 


### PR DESCRIPTION
Check return value of `addr.GetKeyID(keyid)` on custom change address change. Prior to this commit this was the only place where the return value of `GetKeyID(…)` was unchecked.

Clarify our assumption of `addr.GetKeyID(keyid)` being `true` in this context via an assertion.

(**Note to reviewers:** Let me know if this assumption is not being made. If the assumption is not made then the case of `!addr.GetKeyID(keyid)` should obviously be handled more gracefully than with an `assert` :-))