### PR TITLE
[script] Return early if no valid opcodes found in CountWitnessSigOps(...)

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1557,9 +1557,15 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
     if (scriptPubKey.IsPayToScriptHash() && scriptSig.IsPushOnly()) {
         CScript::const_iterator pc = scriptSig.begin();
         std::vector<unsigned char> data;
+        bool hasValidOp = false;
         while (pc < scriptSig.end()) {
             opcodetype opcode;
-            scriptSig.GetOp(pc, opcode, data);
+            if (scriptSig.GetOp(pc, opcode, data)) {
+                hasValidOp = true;
+            }
+        }
+        if (!hasValidOp) {
+            return 0;
         }
         CScript subscript(data.begin(), data.end());
         if (subscript.IsWitnessProgram(witnessversion, witnessprogram)) {


### PR DESCRIPTION
Return early if no valid opcodes found in `CountWitnessSigOps(...)`.

Prior to this commit this was the only place in the codebase where `GetOp(...)` was called without checking the return value.