### PR TITLE
Disconnect network service bits 6 and 8 until Aug 1, 2018

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1260,6 +1260,17 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             return false;
         }
 
+        if (nServices & ((1 << 7) | (1 << 5))) {
+            if (GetTime() < 1533096000) {
+                // Immediately disconnect peers that use service bits 6 or 8 until August 1st, 2018
+                // These bits have been used as a flag to indicate that a node is running incompatible
+                // consensus rules instead of changing the network magic, so we're stuck disconnecting
+                // based on these service bits, at least for a while.
+                pfrom->fDisconnect = true;
+                return false;
+            }
+        }
+
         if (nVersion < MIN_PEER_PROTO_VERSION)
         {
             // disconnect from peers older than this proto version


### PR DESCRIPTION
Immediately disconnect peers that use service bits 6 and 8 until August 1st, 2018
These bits have been used as a flag to indicate that a node is running incompatible
consensus rules instead of changing the network magic, so we're stuck disconnecting
based on the service bits, at least for a while.

Staying connected to nodes on other networks only prevents both sides from reaching consensus quickly, wastes network resources on both sides, etc.

Didn't add constants to protocol.h as the code there notes that "service bits should be allocated via the BIP process".