### PR TITLE
qt: Increase BLOCK_CHAIN_SIZE constants

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -22,9 +22,9 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 120;
+static const uint64_t BLOCK_CHAIN_SIZE = 150;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
-static const uint64_t CHAIN_STATE_SIZE = 2;
+static const uint64_t CHAIN_STATE_SIZE = 3;
 /* Total required space (in GB) depending on user choice (prune, not prune) */
 static uint64_t requiredSpace;
 


### PR DESCRIPTION
- Increase `BLOCK_CHAIN_SIZE` from 120GB to 150GB
- Increase `CHAIN_STATE_SIZE` from 2GB to 4GB

I took the local sizes of the blocks and chainstate directory, and added a bit extra to accomodate the near future (15GB for the chain and 1GB for the chainstate).