### PR TITLE
RPC: Restore backward compatibility, in multiwallet mode

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -45,7 +45,7 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
         }
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
     }
-    return ::vpwallets.size() == 1 || (request.fHelp && ::vpwallets.size() > 0) ? ::vpwallets[0] : nullptr;
+    return vpwallets.empty() ? nullptr : vpwallets[0];
 }
 
 std::string HelpRequiringPassphrase(CWallet * const pwallet)

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -41,16 +41,13 @@ class MultiWalletTest(BitcoinTestFramework):
         # accessing invalid wallet fails
         assert_raises_jsonrpc(-18, "Requested wallet does not exist or is not loaded", (self.nodes[0] / "wallet/bad").getwalletinfo)
 
-        # accessing wallet RPC without using wallet endpoint fails
-        assert_raises_jsonrpc(-19, "Wallet file not specified", self.nodes[0].getwalletinfo)
-
         # check w1 wallet balance
         w1_info = w1.getwalletinfo()
         assert_equal(w1_info['immature_balance'], 50)
         w1_name = w1_info['walletname']
         assert_equal(w1_name, "w1")
 
-        # check w1 wallet balance
+        # check w2 wallet balance
         w2 = self.nodes[0] / "wallet/w2"
         w2_info = w2.getwalletinfo()
         assert_equal(w2_info['immature_balance'], 0)
@@ -62,6 +59,9 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(w3_name, "w3")
 
         assert_equal({"w1", "w2", "w3"}, {w1_name, w2_name, w3_name})
+
+        # accessing wallet RPC without using wallet endpoint accesses w1
+        assert_equal(self.nodes[0].getwalletinfo()['walletname'], 'w1')
 
         w1.generate(101)
         assert_equal(w1.getbalance(), 100)


### PR DESCRIPTION
Appears to have been broken by #10849 