### PR TITLE
Add option to avoid warning on certain network upgrades

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -5,6 +5,7 @@
 
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <versionbits.h>
 
 #include <tinyformat.h>
 #include <util.h>
@@ -171,6 +172,8 @@ public:
                         //   (the tx=... number in the SetBestChain debug.log lines)
             3.1         // * estimated number of transactions per second after that timestamp
         };
+
+        vIgnoreBits.clear();
     }
 };
 
@@ -261,6 +264,12 @@ public:
             0.15
         };
 
+        vIgnoreBits.clear();
+        vIgnoreBits.emplace_back(
+            28,         // BIP 109 by Bitcoin Classic
+            1453334400, // 2016-01-21 00:00:00 +0000
+            1514764800  // 2018-01-01 00:00:00 +0000
+            );
     }
 };
 
@@ -330,6 +339,8 @@ public:
             0,
             0
         };
+
+        vIgnoreBits.clear();
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -10,6 +10,7 @@
 #include <consensus/params.h>
 #include <primitives/block.h>
 #include <protocol.h>
+#include <versionbits.h>
 
 #include <memory>
 #include <vector>
@@ -77,6 +78,7 @@ public:
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
+    const std::vector<IgnoreVersionBits>& IgnoreBits() const { return vIgnoreBits; }
     void UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout);
 protected:
     CChainParams() {}
@@ -96,6 +98,7 @@ protected:
     bool fMineBlocksOnDemand;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
+    std::vector<IgnoreVersionBits> vIgnoreBits;
 };
 
 /**

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -71,6 +71,7 @@ bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
+static const bool DEFAULT_VB_IGNORE_DEFAULTS = true;
 
 std::unique_ptr<CConnman> g_connman;
 std::unique_ptr<PeerLogicValidation> peerLogic;
@@ -440,6 +441,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)");
         strUsage += HelpMessageOpt("-vbignore=bit:start:end", "Ignore use of given version bit between given start/end times");
+        strUsage += HelpMessageOpt("-vbignoredefaults=<n>", strprintf("Ignore version bits per chain defaults (default: %u).", DEFAULT_VB_IGNORE_DEFAULTS));
     }
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + " " + _("<category> can be:") + " " + ListLogCategories() + ".");
@@ -1109,6 +1111,12 @@ bool AppInitParameterInteraction()
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
     }
 
+    if (gArgs.GetBoolArg("-vbignoredefaults", DEFAULT_VB_IGNORE_DEFAULTS)) {
+        for (const IgnoreVersionBits& ivb : chainparams.IgnoreBits()) {
+            LogPrintf("Ignoring version bit %d from start=%ld, end=%ld (default)\n", ivb.bit, ivb.beginTime, ivb.endTime);
+            ignorebits.push_back(ivb);
+        }
+    }
     if (gArgs.IsArgSet("-vbignore")) {
         // Allow ignoring version bit parameters for forks that you will not enforce
         for (const std::string& strIgnoreVersionBits : gArgs.GetArgs("-vbignore")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -439,6 +439,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)");
+        strUsage += HelpMessageOpt("-vbignore=bit:start:end", "Ignore use of given version bit between given start/end times");
     }
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + " " + _("<category> can be:") + " " + ListLogCategories() + ".");
@@ -1106,6 +1107,30 @@ bool AppInitParameterInteraction()
         std::vector<std::string> vstrReplacementModes;
         boost::split(vstrReplacementModes, strReplacementModeList, boost::is_any_of(","));
         fEnableReplacement = (std::find(vstrReplacementModes.begin(), vstrReplacementModes.end(), "fee") != vstrReplacementModes.end());
+    }
+
+    if (gArgs.IsArgSet("-vbignore")) {
+        // Allow ignoring version bit parameters for forks that you will not enforce
+        for (const std::string& strIgnoreVersionBits : gArgs.GetArgs("-vbignore")) {
+            std::vector<std::string> vIgnore;
+            boost::split(vIgnore, strIgnoreVersionBits, boost::is_any_of(":"));
+            if (vIgnore.size() != 3) {
+                return InitError("Version bits ignore instruction malformed, expecting bit:start:end");
+            }
+            int64_t nBeginTime, nEndTime;
+            int32_t nBit;
+            if (!ParseInt32(vIgnore[0], &nBit) || nBit < 0 || nBit > 28) {
+                return InitError(strprintf("Invalid version bit (%s)", vIgnore[0]));
+            }
+            if (!ParseInt64(vIgnore[1], &nBeginTime)) {
+                return InitError(strprintf("Invalid start time (%s)", vIgnore[1]));
+            }
+            if (!ParseInt64(vIgnore[2], &nEndTime)) {
+                return InitError(strprintf("Invalid end time (%s)", vIgnore[2]));
+            }
+            LogPrintf("Ignoring version bit %d from start=%ld, end=%ld\n", nBit, nBeginTime, nEndTime);
+            ignorebits.emplace_back(nBit, nBeginTime, nEndTime);
+        }
     }
 
     if (gArgs.IsArgSet("-vbparams")) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;
 
-    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
+    pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), IgnoreBitsMode::ibmFALSE);
     // -regtest only: allow overriding block.nVersion with
     // -blockversion=N to test forking scenarios
     if (chainparams.MineBlocksOnDemand())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1565,8 +1565,9 @@ void ThreadScriptCheck() {
 
 // Protected by cs_main
 VersionBitsCache versionbitscache;
+std::vector<IgnoreVersionBits> ignorebits;
 
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, IgnoreBitsMode use_ignorebits)
 {
     LOCK(cs_main);
     int32_t nVersion = VERSIONBITS_TOP_BITS;
@@ -1575,6 +1576,14 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
         ThresholdState state = VersionBitsState(pindexPrev, params, (Consensus::DeploymentPos)i, versionbitscache);
         if (state == THRESHOLD_LOCKED_IN || state == THRESHOLD_STARTED) {
             nVersion |= VersionBitsMask(params, (Consensus::DeploymentPos)i);
+        }
+    }
+    if (use_ignorebits == IgnoreBitsMode::ibmTRUE) {
+        int64_t mtp = (pindexPrev == nullptr ? 0 : pindexPrev->GetMedianTimePast());
+        for (const auto& ib : ignorebits) {
+            if (ib.beginTime <= mtp && mtp < ib.endTime) {
+                nVersion |= (((uint32_t)1) << ib.bit);
+            }
         }
     }
 
@@ -1601,7 +1610,7 @@ public:
     {
         return ((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) &&
                ((pindex->nVersion >> bit) & 1) != 0 &&
-               ((ComputeBlockVersion(pindex->pprev, params) >> bit) & 1) == 0;
+               ((ComputeBlockVersion(pindex->pprev, params, IgnoreBitsMode::ibmTRUE) >> bit) & 1) == 0;
     }
 };
 
@@ -2058,7 +2067,7 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
         // Check the version of the last 100 blocks to see if we need to upgrade:
         for (int i = 0; i < 100 && pindex != nullptr; i++)
         {
-            int32_t nExpectedVersion = ComputeBlockVersion(pindex->pprev, chainParams.GetConsensus());
+            int32_t nExpectedVersion = ComputeBlockVersion(pindex->pprev, chainParams.GetConsensus(), IgnoreBitsMode::ibmTRUE);
             if (pindex->nVersion > VERSIONBITS_LAST_OLD_BLOCK_VERSION && (pindex->nVersion & ~nExpectedVersion) != 0)
                 ++nUpgraded;
             pindex = pindex->pprev;

--- a/src/validation.h
+++ b/src/validation.h
@@ -462,9 +462,19 @@ int GetSpendHeight(const CCoinsViewCache& inputs);
 extern VersionBitsCache versionbitscache;
 
 /**
+ * Ignorable version bits
+ */
+extern std::vector<IgnoreVersionBits> ignorebits;
+enum class IgnoreBitsMode {
+  ibmFALSE = 0,
+  ibmTRUE = 1,
+};
+
+/**
  * Determine what nVersion a new block should use.
  */
-int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+
+int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, IgnoreBitsMode use_ignorebits = IgnoreBitsMode::ibmFALSE);
 
 /** Reject codes greater or equal to this can be returned by AcceptToMemPool
  * for transactions, to signal internal conditions. They cannot and should not

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -72,6 +72,18 @@ struct VersionBitsCache
     void Clear();
 };
 
+struct IgnoreVersionBits {
+    int bit;
+    int64_t beginTime;
+    int64_t endTime;
+
+    IgnoreVersionBits(int _bit, int64_t _begin, int64_t _end)
+        : bit(_bit), beginTime(_begin), endTime(_end)
+    {
+    }
+};
+
+
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 BIP9Stats VersionBitsStatistics(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos);
 int VersionBitsStateSinceHeight(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);


### PR DESCRIPTION
The "-vbignore=bit:start:end" option can be used to prevent bitcoin
from alerting the user of known but uninteresting proposed upgrades
that are being signalled via the version field.

This hopefully provides the feature requested in issue #8266, allow version bits to have an "ignore button". It requires specifying start and end times rather than a final block height, which should map better to BIP 9 implementations. It also allows multiple deployments on a single bit to be ignored independently -- if the bit is used in between any deployments, it will still generate warnings.

This setting will also avoid the bit from triggering the "Unknown block versions being mined" warning during the set period.