### PR TITLE
Add per-network config file network.conf

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -107,7 +107,7 @@ static int AppInitRPC(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     try {
-        gArgs.ReadConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+        gArgs.ReadConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME), false);
     } catch (const std::exception& e) {
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return EXIT_FAILURE;
@@ -326,8 +326,7 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
         if (!GetAuthCookie(&strRPCUserColonPass)) {
             throw std::runtime_error(strprintf(
                 _("Could not locate RPC credentials. No authentication cookie could be found, and RPC password is not set.  See -rpcpassword and -stdinrpcpass.  Configuration file: (%s)"),
-                    GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string().c_str()));
-
+                    GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME), false).string().c_str()));
         }
     } else {
         strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -36,6 +36,7 @@ std::string HelpMessageCli()
     strUsage += HelpMessageGroup(_("Options:"));
     strUsage += HelpMessageOpt("-?", _("This help message"));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
+    strUsage += HelpMessageOpt("-netconf=<file>", strprintf(_("Specify network-specific configuration file (default: %s)"), BITCOIN_NETCONF_FILENAME));
     strUsage += HelpMessageOpt("-datadir=<dir>", _("Specify data directory"));
     strUsage += HelpMessageOpt("-getinfo", _("Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)"));
     AppendParamsHelpMessages(strUsage);
@@ -118,6 +119,14 @@ static int AppInitRPC(int argc, char* argv[])
         fprintf(stderr, "Error: %s\n", e.what());
         return EXIT_FAILURE;
     }
+
+    try {
+        gArgs.ReadConfigFile(gArgs.GetArg("-netconf", BITCOIN_NETCONF_FILENAME), true);
+    } catch (const std::exception& e) {
+        fprintf(stderr, "Error reading network configuration file: %s\n", e.what());
+        return EXIT_FAILURE;
+    }
+
     if (gArgs.GetBoolArg("-rpcssl", false))
     {
         fprintf(stderr, "Error: SSL mode for RPC (-rpcssl) is no longer supported.\n");

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -116,6 +116,13 @@ bool AppInit(int argc, char* argv[])
             return false;
         }
 
+        try {
+            gArgs.ReadConfigFile(gArgs.GetArg("-netconf", BITCOIN_NETCONF_FILENAME), true);
+        } catch (const std::exception& e) {
+            fprintf(stderr, "Error reading network configuration file: %s\n", e.what());
+            return false;
+        }
+
         // Error out when loose non-argument tokens are encountered on command line
         for (int i = 1; i < argc; i++) {
             if (!IsSwitchChar(argv[i][0])) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -103,7 +103,7 @@ bool AppInit(int argc, char* argv[])
         }
         try
         {
-            gArgs.ReadConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+            gArgs.ReadConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME), false);
         } catch (const std::exception& e) {
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1221,7 +1221,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
-    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
+    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME), false).string());
     LogPrintf("Using network config file %s\n", GetConfigFile(gArgs.GetArg("-netconf", BITCOIN_NETCONF_FILENAME), true).string());
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -328,6 +328,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-blocksonly", strprintf(_("Whether to operate in a blocks only mode (default: %u)"), DEFAULT_BLOCKSONLY));
     strUsage +=HelpMessageOpt("-assumevalid=<hex>", strprintf(_("If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all, default: %s, testnet: %s)"), defaultChainParams->GetConsensus().defaultAssumeValid.GetHex(), testnetChainParams->GetConsensus().defaultAssumeValid.GetHex()));
     strUsage += HelpMessageOpt("-conf=<file>", strprintf(_("Specify configuration file (default: %s)"), BITCOIN_CONF_FILENAME));
+    strUsage += HelpMessageOpt("-netconf=<file>", strprintf(_("Specify network-specific configuration file (default: %s)"), BITCOIN_NETCONF_FILENAME));
     if (mode == HMM_BITCOIND)
     {
 #if HAVE_DECL_DAEMON
@@ -1221,6 +1222,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
     LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
+    LogPrintf("Using network config file %s\n", GetConfigFile(gArgs.GetArg("-netconf", BITCOIN_NETCONF_FILENAME), true).string());
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     InitSignatureCache();

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -659,6 +659,14 @@ int main(int argc, char *argv[])
     // Re-initialize translations after changing application name (language in network-specific settings can be different)
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
 
+    try {
+        gArgs.ReadConfigFile(gArgs.GetArg("-netconf", BITCOIN_NETCONF_FILENAME), true);
+    } catch (const std::exception& e) {
+        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
+            QObject::tr("Error: Cannot parse network configuration file: %1. Only use key=value syntax.").arg(e.what()));
+        return EXIT_FAILURE;
+    }
+
 #ifdef ENABLE_WALLET
     /// 8. URI IPC sending
     // - Do this early as we don't want to bother initializing if we are just calling IPC

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -627,7 +627,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
     try {
-        gArgs.ReadConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+        gArgs.ReadConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME), false);
     } catch (const std::exception& e) {
         QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
                               QObject::tr("Error: Cannot parse configuration file: %1. Only use key=value syntax.").arg(e.what()));

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -418,7 +418,7 @@ void openDebugLogfile()
 
 bool openBitcoinConf()
 {
-    boost::filesystem::path pathConfig = GetConfigFile(BITCOIN_CONF_FILENAME);
+    boost::filesystem::path pathConfig = GetConfigFile(BITCOIN_CONF_FILENAME, false);
 
     /* Create the file */
     boost::filesystem::ofstream configFile(pathConfig, std::ios_base::app);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -88,6 +88,7 @@
 const int64_t nStartupTime = GetTime();
 
 const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
+const char * const BITCOIN_NETCONF_FILENAME = "network.conf";
 const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
@@ -606,18 +607,18 @@ void ClearDatadirCache()
     pathCachedNetSpecific = fs::path();
 }
 
-fs::path GetConfigFile(const std::string& confPath)
+fs::path GetConfigFile(const std::string& confPath, bool fNetSpecific)
 {
     fs::path pathConfigFile(confPath);
     if (!pathConfigFile.is_complete())
-        pathConfigFile = GetDataDir(false) / pathConfigFile;
+        pathConfigFile = GetDataDir(fNetSpecific) / pathConfigFile;
 
     return pathConfigFile;
 }
 
-void ArgsManager::ReadConfigFile(const std::string& confPath)
+void ArgsManager::ReadConfigFile(const std::string& confPath, bool fNetSpecific)
 {
-    fs::ifstream streamConfig(GetConfigFile(confPath));
+    fs::ifstream streamConfig(GetConfigFile(confPath, fNetSpecific));
     if (!streamConfig.good())
         return; // No bitcoin.conf file is OK
 

--- a/src/util.h
+++ b/src/util.h
@@ -174,7 +174,7 @@ bool TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
-fs::path GetConfigFile(const std::string& confPath, bool fNetSpecific = false);
+fs::path GetConfigFile(const std::string& confPath, bool fNetSpecific);
 #ifndef WIN32
 fs::path GetPidFile();
 void CreatePidFile(const fs::path &path, pid_t pid);
@@ -204,7 +204,7 @@ protected:
     std::map<std::string, std::vector<std::string>> mapMultiArgs;
 public:
     void ParseParameters(int argc, const char*const argv[]);
-    void ReadConfigFile(const std::string& confPath, bool fNetSpecific = false);
+    void ReadConfigFile(const std::string& confPath, bool fNetSpecific);
 
     /**
      * Return a vector of strings of the given argument

--- a/src/util.h
+++ b/src/util.h
@@ -56,6 +56,7 @@ extern std::atomic<bool> fReopenDebugLog;
 extern CTranslationInterface translationInterface;
 
 extern const char * const BITCOIN_CONF_FILENAME;
+extern const char * const BITCOIN_NETCONF_FILENAME;
 extern const char * const BITCOIN_PID_FILENAME;
 
 extern std::atomic<uint32_t> logCategories;
@@ -173,7 +174,7 @@ bool TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
-fs::path GetConfigFile(const std::string& confPath);
+fs::path GetConfigFile(const std::string& confPath, bool fNetSpecific = false);
 #ifndef WIN32
 fs::path GetPidFile();
 void CreatePidFile(const fs::path &path, pid_t pid);
@@ -203,7 +204,7 @@ protected:
     std::map<std::string, std::vector<std::string>> mapMultiArgs;
 public:
     void ParseParameters(int argc, const char*const argv[]);
-    void ReadConfigFile(const std::string& confPath);
+    void ReadConfigFile(const std::string& confPath, bool fNetSpecific = false);
 
     /**
      * Return a vector of strings of the given argument

--- a/test/functional/feature_netconf.py
+++ b/test/functional/feature_netconf.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests the network-specific config file."""
+
+import os
+from test_framework.test_framework import BitcoinTestFramework
+
+class NetConfTest(BitcoinTestFramework):
+    def setup_chain(self):
+        super().setup_chain()
+
+        with open(os.path.join(self.options.tmpdir, "node0", "regtest", "network.conf"), "w", encoding="utf8") as f:
+            f.write("uacomment=net\n")
+            f.write("maxmempool=111\n")
+
+        with open(os.path.join(self.options.tmpdir, "node0", "regtest", "alt-network.conf"), "w", encoding="utf8") as f:
+            f.write("uacomment=altnet\n")
+            f.write("uacomment=extra\n")
+            f.write("maxmempool=222\n")
+
+        with open(os.path.join(self.options.tmpdir, "node0", "bitcoin-altnet.conf"), 'a', encoding='utf8') as f:
+            for l in open(os.path.join(self.options.tmpdir, "node0", "bitcoin.conf")):
+                f.write(l)
+            f.write("uacomment=mainalt\n")
+            f.write("netconf=alt-network.conf\n")
+            f.write("maxmempool=333\n")
+
+        with open(os.path.join(self.options.tmpdir, "node0", "bitcoin.conf"), 'a', encoding='utf8') as f:
+            f.write("uacomment=main\n")
+
+    def set_test_params(self):
+         self.setup_clean_chain = False
+         self.num_nodes = 1
+
+    def check_maxmempool(self, expected):
+        mpinfo = self.nodes[0].getmempoolinfo()
+        maxmem = mpinfo["maxmempool"]
+        assert maxmem == expected*1000000, "Max mempool is %s M not %s M" % (maxmem/1000000, expected)
+
+    def check_subversion(self, *expected):
+        nwinfo = self.nodes[0].getnetworkinfo()
+        subversion = nwinfo["subversion"]
+        want = "(testnode0; " + "; ".join(expected) + ")/"
+        assert subversion.endswith(want), "Subversion %s does not end with %s" % (subversion, want)
+
+    def run_test(self):
+        # expected behaviour:
+        #   single option arguments should adopt the first seen value,
+        #   in order of command line, bitcoin.conf, network.conf.
+        #   tested using maxmempool setting.
+        #
+        #   multi option arguments should see all values, in the same
+        #   order (command line, bitcoin.conf, network.conf). tested
+        #   using uacomment sub-version.
+
+        # by default, loads bitcoin.conf and network.conf
+        self.check_subversion("main", "net")
+        self.check_maxmempool(111)
+
+        # if bitcoin.conf specifies a network conf, that gets loaded
+        self.restart_node(0, ["-conf=bitcoin-altnet.conf"])
+        self.check_subversion("mainalt", "altnet", "extra")
+        self.check_maxmempool(333)
+
+        # netconf on command line works
+        self.restart_node(0, ["-netconf=alt-network.conf"])
+        self.check_subversion("main", "altnet", "extra")
+        self.check_maxmempool(222)
+
+        # netconf on command line overrides specification in bitcoin.conf
+        self.restart_node(0, ["-conf=bitcoin-altnet.conf", "-netconf=network.conf"])
+        self.check_subversion("mainalt", "net")
+        self.check_maxmempool(333)
+
+        # if file doesn't exist, everything is fine
+        self.restart_node(0, ["-netconf=no-network.conf"])
+        self.check_subversion("main")
+        self.check_maxmempool(300)
+
+if __name__ == '__main__':
+    NetConfTest().main()
+

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -128,6 +128,7 @@ BASE_SCRIPTS= [
     'uacomment.py',
     'p2p-acceptblock.py',
     'feature_logging.py',
+    'feature_netconf.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
Adds a per-net network.conf as per #9374 ; this is pretty much the same as #9402 which was closed for lack of interest.

It's somewhat interesting in the context of #10994 because it provides somewhere to stick the network-specific vbignore settings. Unless I'm missing something, I don't think #10267 provides an easy way of doing per-network config files, so wouldn't work well for that particular use case.

This patch doesn't include any tests, so is marked as WIP. There's some test code in #10267 that would presumably be able to be adapted pretty easily.