### PR TITLE
Fix upgrade cancel warnings

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -422,5 +422,5 @@ bool CCoinsViewDB::Upgrade() {
     db.CompactRange({DB_COINS, uint256()}, key);
     uiInterface.SetProgressBreakAction(std::function<void(void)>());
     LogPrintf("[%s].\n", ShutdownRequested() ? "CANCELLED" : "DONE");
-    return true;
+    return !ShutdownRequested();
 }


### PR DESCRIPTION
Based on #10919.
Without this, if you cancel upgrade, you get a needless error:
ERROR: VerifyDB(): *** irrecoverable inconsistency in block data at