### PR TITLE
[wallet] return correct error code from resendwallettransaction

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2599,7 +2599,7 @@ UniValue resendwallettransactions(const JSONRPCRequest& request)
     LOCK2(cs_main, pwallet->cs_wallet);
 
     if (!pwallet->GetBroadcastTransactions()) {
-        throw JSONRPCError(RPC_INVALID_REQUEST, "Error: Wallet transaction broadcasting is disabled with -walletbroadcast");
+        throw JSONRPCError(RPC_WALLET_ERROR, "Error: Wallet transaction broadcasting is disabled with -walletbroadcast");
     }
 
     std::vector<uint256> txids = pwallet->ResendWalletTransactionsBefore(GetTime(), g_connman.get());


### PR DESCRIPTION
New code in #10995 uses `RPC_INVALID_REQUEST`. According to the comment in rpc/protocol.h:
```
// RPC_INVALID_REQUEST is internally mapped to HTTP_BAD_REQUEST (400).
// It should not be used for application-layer errors.
```
Change the returned error code to `RPC_WALLET_ERROR`

#11000 will need to be updated to test for the correct error code.