### PR TITLE
Tests: Add a lint check for trailing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ before_script:
     - if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/commit-script-check.sh $TRAVIS_COMMIT_RANGE; fi
     - unset CC; unset CXX
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
+    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/lint-all.sh; fi
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi

--- a/contrib/devtools/lint-all.sh
+++ b/contrib/devtools/lint-all.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs all contrib/devtools/lint-*.sh files, and fails if any exit
+# with a non-zero status code.
+
+set -u
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+LINTALL=$(basename "${BASH_SOURCE[0]}")
+
+for f in "${SCRIPTDIR}"/lint-*.sh; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    if ! "$f"; then
+      echo "^---- failure generated from $f"
+      exit 1
+    fi
+  fi
+done

--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for new lines in diff that introduce trailing whitespace.
+
+# We can't run this check unless we know the commit range for the PR.
+if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
+  exit 0
+fi
+
+showdiff() {
+  if ! git diff "${TRAVIS_COMMIT_RANGE}" --; then
+    echo "Failed to get a diff"
+    exit 1
+  fi
+}
+
+# Do a first pass, and if no trailing whitespace was found then exit early.
+if ! showdiff | egrep -q '^\+.*\s+$'; then
+  exit
+fi
+
+echo "This diff appears to have added new lines with trailing whitespace."
+echo "The following changes were suspected:"
+
+FILENAME=""
+SEEN=0
+
+while read -r line; do
+  if [[ "$line" =~ ^diff ]]; then
+    FILENAME="$line"
+    SEEN=0
+  else
+    if [ "$SEEN" -eq 0 ]; then
+      # The first time a file is seen with trailing whitespace, we print the
+      # filename (preceded by a newline).
+      echo
+      echo "$FILENAME"
+      SEEN=1
+    fi
+    echo "$line"
+  fi
+done < <(showdiff | egrep '^(diff --git |\+.*\s+$)')
+exit 1

--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -12,14 +12,14 @@ if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
 fi
 
 showdiff() {
-  if ! git diff "${TRAVIS_COMMIT_RANGE}" --; then
+  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" --; then
     echo "Failed to get a diff"
     exit 1
   fi
 }
 
 # Do a first pass, and if no trailing whitespace was found then exit early.
-if ! showdiff | egrep -q '^\+.*\s+$'; then
+if ! showdiff | grep -E -q '^\+.*\s+$'; then
   exit
 fi
 
@@ -43,5 +43,5 @@ while read -r line; do
     fi
     echo "$line"
   fi
-done < <(showdiff | egrep '^(diff --git |\+.*\s+$)')
+done < <(showdiff | grep -E '^(diff --git |\+.*\s+$)')
 exit 1


### PR DESCRIPTION
This adds a new CHECK_DOC check that looks for newly introduced trailing
whitespace. Existing trailing whitespace (of which there is plenty!)
will not trigger an error.

This is written in a generic way so that new lint-*.sh scripts can be
added to contrib/devtools/, as I'd like to contribute additional lint
checks in the future.

Example of what a lint failure looks like in Travis: https://travis-ci.org/eklitzke/bitcoin/jobs/262052953