### PR TITLE
Improve shutdown process

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -481,6 +481,8 @@ void StopHTTPServer()
     }
     if (eventBase) {
         LogPrint(BCLog::HTTP, "Waiting for HTTP event thread to exit\n");
+        // Exit the event loop as soon as there are no active events.
+        event_base_loopexit(eventBase, nullptr);
         // Give event loop a few seconds to exit (to send back last RPC responses), then break it
         // Before this was solved with event_base_loopexit, but that didn't work as expected in
         // at least libevent 2.0.21 and always introduced a delay. In libevent


### PR DESCRIPTION
Improve the shutdown time by not having to wait up to 2 seconds.

Here is a comparison running `wallet.py` function tests before this PR:
```
2017-08-08 03:25:20.881000 TestFramework (INFO): Initializing test directory /var/folders/1v/8_69hby54nj2k3n6fywt44x80000gn/T/testq_ramjjr
2017-08-08 03:25:23.853000 TestFramework (INFO): Mining blocks...
2017-08-08 03:25:24.132000 TestFramework (INFO): test getmemoryinfo
2017-08-08 03:25:24.559000 TestFramework (INFO): test gettxout
2017-08-08 03:25:59.858000 TestFramework (INFO): check -rescan
2017-08-08 03:26:07.735000 TestFramework (INFO): check -reindex
2017-08-08 03:26:15.751000 TestFramework (INFO): check -zapwallettxes=1
2017-08-08 03:26:24.105000 TestFramework (INFO): check -zapwallettxes=2
2017-08-08 03:26:36.694000 TestFramework (INFO): Stopping nodes
2017-08-08 03:26:43.599000 TestFramework (INFO): Cleaning up
2017-08-08 03:26:43.612000 TestFramework (INFO): Tests successful
```
After:
```
2017-08-08 03:24:04.319000 TestFramework (INFO): Initializing test directory /var/folders/1v/8_69hby54nj2k3n6fywt44x80000gn/T/testoqeyi50_
2017-08-08 03:24:07.035000 TestFramework (INFO): Mining blocks...
2017-08-08 03:24:07.317000 TestFramework (INFO): test getmemoryinfo
2017-08-08 03:24:07.763000 TestFramework (INFO): test gettxout
2017-08-08 03:24:25.715000 TestFramework (INFO): check -rescan
2017-08-08 03:24:27.792000 TestFramework (INFO): check -reindex
2017-08-08 03:24:29.797000 TestFramework (INFO): check -zapwallettxes=1
2017-08-08 03:24:32.207000 TestFramework (INFO): check -zapwallettxes=2
2017-08-08 03:24:36.812000 TestFramework (INFO): Stopping nodes
2017-08-08 03:24:37.915000 TestFramework (INFO): Cleaning up
2017-08-08 03:24:37.927000 TestFramework (INFO): Tests successful
```
This largely improves the time spent in Travis (under evaluation).