### PR TITLE
Enable disablesafemode by default.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -69,7 +69,7 @@
 bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
-static const bool DEFAULT_DISABLE_SAFEMODE = false;
+static const bool DEFAULT_DISABLE_SAFEMODE = true;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 
 std::unique_ptr<CConnman> g_connman;


### PR DESCRIPTION
Safemode is almost useless as is-- it only triggers in limited
 cases most of which aren't even concerning. There have been
 several proposals to remove it. But as a simpler, safer, and
 more flexible first case, simply deactivate it by default.

Anyone who wants it can re-enable and know what they've signed up for.