### PR TITLE
Build: Fix Automake warnings when running autogen.sh

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ SUBDIRS += doc/man
 endif
 .PHONY: deploy FORCE
 
-GZIP_ENV="-9n"
+override GZIP_ENV = "-9n"
 export PYTHONPATH
 
 if BUILD_BITCOIN_LIBS

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -494,10 +494,6 @@ clean-local:
 	## FIXME: How to get the appropriate modulename_CPPFLAGS in here?
 	$(AM_V_GEN) $(WINDRES) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(CPPFLAGS) -DWINDRES_PREPROC -i $< -o $@
 
-.mm.o:
-	$(AM_V_CXX) $(OBJCXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
-	  $(CPPFLAGS) $(AM_CXXFLAGS) $(QT_INCLUDES) $(AM_CXXFLAGS) $(PIE_FLAGS) $(CXXFLAGS) -c -o $@ $<
-
 check-symbols: $(bin_PROGRAMS)
 if GLIBC_BACK_COMPAT
 	@echo "Checking glibc back compat..."


### PR DESCRIPTION
This fixes some harmless (but annoying) automake warnings when invokes `autogen.sh`. The warnings I'm referring to are the ones printed at the very end of running `autogen.sh`, on my system they look like:

```
Makefile.am:12: warning: user variable 'GZIP_ENV' defined here ...
/usr/share/automake-1.15/am/distdir.am: ... overrides Automake variable 'GZIP_ENV' defined here
src/Makefile.am: installing 'build-aux/depcomp'
src/Makefile.am:497: warning: user target '.mm.o' defined here ...
/usr/share/automake-1.15/am/depend2.am: ... overrides Automake target '.mm.o' defined here
```

 I did some research on both of these, and here's what I found:
 * Automake has been setting `GZIP_ENV` since 1998. They set it to `--best`, we set it to `-9n`. I'm not sure if the `-n` is really necessary, but using the `override` directive suppresses the warning.
 * Automake has had a rule for `.mm.o` targets (used for Objective C++) built in since Automake 1.12.1, which appears to have been released in 2012. Trusty (used by Travis and Gitian) is on Automake 1.14.1. I don't know if it's strictly correct to update this rule, as it has some stuff about `QT_INCLUDES` and `PIE_FLAGS`, but the Travis build for Darwin passed on my branch even after removing this rule. If this seems too scary to change maybe we can leave it in.

It looks like both of these rules were added by @theuni when he did the initial autotools conversion in 2013. These warnings are harmless, but there's no reason not to fix them. While researching these I accidentally stumbled across a few forum posts and GitHub comments from end users who thought the errors meant their Bitcoin build was broken, so that's another reason to fix them.