### PR TITLE
[wallet] Abandon transactions that fail to go into the mempool

### DIFF
--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -266,7 +266,6 @@ Result CommitTransaction(CWallet* wallet, const uint256& txid, CMutableTransacti
     wtxBumped.fFromMe = true;
     CValidationState state;
     if (!wallet->CommitTransaction(wtxBumped, reservekey, g_connman.get(), state)) {
-        // NOTE: CommitTransaction never returns false, so this should never happen.
         errors.push_back(strprintf("The transaction was rejected: %s", state.GetRejectReason()));
         return Result::WALLET_ERROR;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3036,7 +3036,8 @@ bool CWallet::CommitTransaction(CWalletTx& wtxNew, CReserveKey& reservekey, CCon
             // Broadcast
             if (!wtx.AcceptToMemoryPool(maxTxFee, state)) {
                 LogPrintf("CommitTransaction(): Transaction cannot be broadcast immediately, %s\n", state.GetRejectReason());
-                // TODO: if we expect the failure to be long term or permanent, instead delete wtx from the wallet and return failure.
+                AbandonTransaction(wtxNew.GetHash());
+                return false;
             } else {
                 wtx.RelayWalletTransaction(connman);
             }

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -128,6 +128,7 @@ BASE_SCRIPTS= [
     'uacomment.py',
     'p2p-acceptblock.py',
     'feature_logging.py',
+    'wallet-longchain.py',
 ]
 
 EXTENDED_SCRIPTS = [

--- a/test/functional/wallet-longchain.py
+++ b/test/functional/wallet-longchain.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test long chained transactions in the wallet code."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (connect_nodes_bi,
+                                 assert_equal,
+                                )
+
+class WalletTestLongchain(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 4
+
+    def setup_network(self):
+        self.add_nodes(3)
+        self.start_node(0)
+        self.start_node(1)
+        self.start_node(2)
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,0,2)
+        self.sync_all([self.nodes[0:3]])
+
+    def run_test(self):
+
+        # Check that there's no UTXO on any of the nodes
+        assert_equal(len(self.nodes[0].listunspent()), 0)
+        assert_equal(len(self.nodes[1].listunspent()), 0)
+
+        self.log.info("Mining blocks...")
+
+        self.nodes[0].generate(101)
+
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_equal(walletinfo['immature_balance'], 5000)
+        assert_equal(walletinfo['balance'], 50)
+
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance(), 50)
+        assert_equal(self.nodes[1].getbalance(), 0)
+
+        # Check that only first node has UTXOs
+        utxos = self.nodes[0].listunspent()
+        assert_equal(len(utxos), 1)
+        assert_equal(len(self.nodes[1].listunspent()), 0)
+
+        # Send 0.1 BTC 100 times (=10 BTC) to node 2; we will eventually hit the mempool chain limit
+        for i in range(100):
+            try:
+                self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
+            except:
+                break
+        # After failure, we should have at least ~39 BTC left, as we would have at most sent 10*0.1
+        # (plus 100 tx fees)
+        assert(self.nodes[0].getbalance() > 25)
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.sync_all()
+        # After generating, we should be able to send again
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 39)
+
+if __name__ == '__main__':
+    WalletTestLongchain().main()

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -412,12 +412,9 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getmempoolinfo()['size'], chainlimit*2)
         assert_equal(len(txid_list), chainlimit*2)
 
-        # Without walletrejectlongchains, we will still generate a txid
-        # The tx will be stored in the wallet but not accepted to the mempool
-        extra_txid = self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001'))
-        assert(extra_txid not in self.nodes[0].getrawmempool())
-        assert(extra_txid in [tx["txid"] for tx in self.nodes[0].listtransactions()])
-        self.nodes[0].abandontransaction(extra_txid)
+        # Even without walletrejectlongchains, if a txid we make has a too long
+        # chain to go into the mempool, it will raise a JSON RPC error
+        assert_raises_rpc_error(-4, "too-long-mempool-chain", self.nodes[0].sendtoaddress, sending_addr, Decimal('0.0001'))
         total_txs = len(self.nodes[0].listtransactions("*",99999))
 
         # Try with walletrejectlongchains


### PR DESCRIPTION
This PR addresses the case where a wallet transaction fails to be accepted to the mempool when committed. This would keep the transaction in the wallet, to be rebroadcast at some undetermined time in the future, with the consequence that the change output would be cloaked. Even adding the mempool transactions into a new block will not immediately resolve the problem, due to the wallet not rebroadcasting the transaction immediately (even to itself) for (I think) privacy reasons.

Although there is a `walletrejectlongchain` option, the behavior when this is turned off is confusing and unpredictable, as noted above, and the `CommitTransaction` code will do the exact same thing for other mempool add failures, whichever those may be.

Edit: ~~~open question and currently investigating: will the coin selection algorithm inadvertently pick UTXOs that would result in a rejection of the transaction even if the user has other UTXOs available that wouldn't result in a too long chain? I have tried to trigger this case but the coin select is always picking the "right" UTXO that won't result in failure.~~~

Edit 2: In https://github.com/bitcoin/bitcoin/blame/master/src/wallet/wallet.cpp#L2457 the very last attempt to select coins increases the ancestor cap to num max, so above concern about coin select sometimes inadvertently picking an unspendable-due-to-chain-length tx is not a problem.