### PR TITLE
[wallet] getbalance: Add option to include non-mempool UTXOs

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -56,6 +56,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 1, "minconf" },
     { "getbalance", 2, "include_watchonly" },
     { "getblockhash", 0, "height" },
+    { "getunconfirmedbalance", 0, "include_unavailable" },
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },
     { "waitforblock", 1, "timeout" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -832,41 +832,63 @@ static UniValue getbalance(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || (request.params.size() > 3 && IsDeprecatedRPCEnabled("accounts")) || (request.params.size() != 0 && !IsDeprecatedRPCEnabled("accounts")))
-        throw std::runtime_error(
-            "getbalance ( \"account\" minconf include_watchonly )\n"
-            "\nIf account is not specified, returns the server's total available balance.\n"
-            "The available balance is what the wallet considers currently spendable, and is\n"
-            "thus affected by options which limit spendability such as -spendzeroconfchange.\n"
-            "If account is specified (DEPRECATED), returns the balance in the account.\n"
-            "Note that the account \"\" is not the same as leaving the parameter out.\n"
-            "The server total may be different to the balance in the default \"\" account.\n"
-            "\nArguments:\n"
-            "1. \"account\"         (string, optional) DEPRECATED. This argument will be removed in V0.18. \n"
-            "                     To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. The account string may be given as a\n"
-            "                     specific account name to find the balance associated with wallet keys in\n"
-            "                     a named account, or as the empty string (\"\") to find the balance\n"
-            "                     associated with wallet keys not in any named account, or as \"*\" to find\n"
-            "                     the balance associated with all wallet keys regardless of account.\n"
-            "                     When this option is specified, it calculates the balance in a different\n"
-            "                     way than when it is not specified, and which can count spends twice when\n"
-            "                     there are conflicting pending transactions (such as those created by\n"
-            "                     the bumpfee command), temporarily resulting in low or even negative\n"
-            "                     balances. In general, account balance calculation is not considered\n"
-            "                     reliable and has resulted in confusing outcomes, so it is recommended to\n"
-            "                     avoid passing this argument.\n"
-            "2. minconf           (numeric, optional, default=1) DEPRECATED. Only valid when an account is specified. This argument will be removed in V0.18. To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. Only include transactions confirmed at least this many times.\n"
-            "3. include_watchonly (bool, optional, default=false) DEPRECATED. Only valid when an account is specified. This argument will be removed in V0.18. To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. Also include balance in watch-only addresses (see 'importaddress')\n"
-            "\nResult:\n"
-            "amount              (numeric) The total amount in " + CURRENCY_UNIT + " received for this account.\n"
-            "\nExamples:\n"
-            "\nThe total amount in the wallet with 1 or more confirmations\n"
-            + HelpExampleCli("getbalance", "") +
-            "\nThe total amount in the wallet at least 6 blocks confirmed\n"
-            + HelpExampleCli("getbalance", "\"*\" 6") +
-            "\nAs a json rpc call\n"
-            + HelpExampleRpc("getbalance", "\"*\", 6")
-        );
+    if (request.fHelp || (request.params.size() > 3 && IsDeprecatedRPCEnabled("accounts")) || (request.params.size() > 1 && !IsDeprecatedRPCEnabled("accounts"))) {
+        if (IsDeprecatedRPCEnabled("accounts")) {
+            throw std::runtime_error(
+                "getbalance ( \"account\" minconf include_watchonly )\n"
+                "\nIf account is not specified, returns the server's total available balance.\n"
+                "The available balance is what the wallet considers currently spendable, and is\n"
+                "thus affected by options which limit spendability such as -spendzeroconfchange.\n"
+                "If account is specified (DEPRECATED), returns the balance in the account.\n"
+                "Note that the account \"\" is not the same as leaving the parameter out.\n"
+                "The server total may be different to the balance in the default \"\" account.\n"
+                "\nArguments:\n"
+                "1. \"account\"         (string, optional) DEPRECATED. This argument will be removed in V0.18. \n"
+                "                     To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. The account string may be given as a\n"
+                "                     specific account name to find the balance associated with wallet keys in\n"
+                "                     a named account, or as the empty string (\"\") to find the balance\n"
+                "                     associated with wallet keys not in any named account, or as \"*\" to find\n"
+                "                     the balance associated with all wallet keys regardless of account.\n"
+                "                     When this option is specified, it calculates the balance in a different\n"
+                "                     way than when it is not specified, and which can count spends twice when\n"
+                "                     there are conflicting pending transactions (such as those created by\n"
+                "                     the bumpfee command), temporarily resulting in low or even negative\n"
+                "                     balances. In general, account balance calculation is not considered\n"
+                "                     reliable and has resulted in confusing outcomes, so it is recommended to\n"
+                "                     avoid passing this argument.\n"
+                "2. minconf           (numeric, optional, default=1) DEPRECATED. Only valid when an account is specified. This argument will be removed in V0.18. To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. Only include transactions confirmed at least this many times.\n"
+                "3. include_watchonly (bool, optional, default=false) DEPRECATED. Only valid when an account is specified. This argument will be removed in V0.18. To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. Also include balance in watch-only addresses (see 'importaddress')\n"
+                "\nResult:\n"
+                "amount              (numeric) The total amount in " + CURRENCY_UNIT + " received for this account.\n"
+                "\nExamples:\n"
+                "\nThe total amount in the wallet with 1 or more confirmations\n"
+                + HelpExampleCli("getbalance", "") +
+                "\nThe total amount in the wallet at least 6 blocks confirmed\n"
+                + HelpExampleCli("getbalance", "\"*\" 6") +
+                "\nAs a json rpc call\n"
+                + HelpExampleRpc("getbalance", "\"*\", 6")
+            );
+        } else {
+            throw std::runtime_error(
+                "getbalance ( include_unavailable )\n"
+                "\nReturns the wallet's total available balance.\n"
+                "The available balance is what the wallet considers currently spendable, and is\n"
+                "thus affected by options which limit spendability such as -spendzeroconfchange.\n"
+                "\nArguments:\n"
+                "1. include_unavailable (bool, optional, default=false) Also include balance for UTXOs which are currently not (but possibly in the future)\n"
+                "                                                       spendable.\n"
+                "\nResult:\n"
+                "amount              (numeric) The total amount in " + CURRENCY_UNIT + " received.\n"
+                "\nExamples:\n"
+                "\nThe total amount in the wallet\n"
+                + HelpExampleCli("getbalance", "") +
+                "\nThe total amount in the wallet, including currently unspendable UTXO:s\n"
+                + HelpExampleCli("getbalance", "true") +
+                "\nAs a json rpc call\n"
+                + HelpExampleRpc("getbalance", "true")
+            );
+        }
+    }
 
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
@@ -905,7 +927,16 @@ static UniValue getbalance(const JSONRPCRequest& request)
         return ValueFromAmount(pwallet->GetLegacyBalance(filter, nMinDepth, account));
     }
 
-    return ValueFromAmount(pwallet->GetBalance());
+    // params[0] is not converted from JSON until account stuff is removed, so we need to manually convert it here
+    // TODO: add param[0] to clients.cpp for getbalance and switch to get_bool() here, once account stuff is removed
+    if (!request.params[0].isNull() && request.params[0].get_str() != "true" && request.params[0].get_str() != "false") {
+        throw JSONRPCError(RPC_INVALID_PARAMETER,
+            "include_unavailable may only be true or false");
+    }
+
+    const bool include_unavailable = !request.params[0].isNull() && request.params[0].get_str() == "true";
+
+    return ValueFromAmount(pwallet->GetBalance(include_unavailable));
 }
 
 static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
@@ -915,10 +946,16 @@ static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() > 0)
+    if (request.fHelp || request.params.size() > 1)
         throw std::runtime_error(
-                "getunconfirmedbalance\n"
-                "Returns the server's total unconfirmed balance\n");
+                "getunconfirmedbalance ( include_unavailable )\n"
+                "\nReturns the server's total unconfirmed balance.\n"
+                "\nArguments:\n"
+                "1. include_unavailable (bool, optional, default=false) Also include balance for UTXOs which are\n"
+                "                                                       currently not (but possibly in the future)\n"
+                "                                                       spendable."
+                "\nResult:\n"
+                "amount                 (numeric)                       The total balance in " + CURRENCY_UNIT + ".\n");
 
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now
@@ -926,7 +963,8 @@ static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    return ValueFromAmount(pwallet->GetUnconfirmedBalance());
+    bool include_unavailable = !request.params[0].isNull() && request.params[0].get_bool();
+    return ValueFromAmount(pwallet->GetUnconfirmedBalance(include_unavailable));
 }
 
 
@@ -4215,7 +4253,7 @@ extern UniValue rescanblockchain(const JSONRPCRequest& request);
 
 static const CRPCCommand commands[] =
 { //  category              name                                actor (function)                argNames
-    //  --------------------- ------------------------          -----------------------         ----------
+  //  --------------------- ------------------------            -----------------------         ----------
     { "rawtransactions",    "fundrawtransaction",               &fundrawtransaction,            {"hexstring","options","iswitness"} },
     { "hidden",             "resendwallettransactions",         &resendwallettransactions,      {} },
     { "wallet",             "abandontransaction",               &abandontransaction,            {"txid"} },
@@ -4228,12 +4266,12 @@ static const CRPCCommand commands[] =
     { "wallet",             "dumpwallet",                       &dumpwallet,                    {"filename"} },
     { "wallet",             "encryptwallet",                    &encryptwallet,                 {"passphrase"} },
     { "wallet",             "getaddressinfo",                   &getaddressinfo,                {"address"} },
-    { "wallet",             "getbalance",                       &getbalance,                    {"account","minconf","include_watchonly"} },
+    { "wallet",             "getbalance",                       &getbalance,                    {"account|include_unavailable","minconf","include_watchonly"} },
     { "wallet",             "getnewaddress",                    &getnewaddress,                 {"label|account","address_type"} },
     { "wallet",             "getrawchangeaddress",              &getrawchangeaddress,           {"address_type"} },
     { "wallet",             "getreceivedbyaddress",             &getreceivedbyaddress,          {"address","minconf"} },
     { "wallet",             "gettransaction",                   &gettransaction,                {"txid","include_watchonly"} },
-    { "wallet",             "getunconfirmedbalance",            &getunconfirmedbalance,         {} },
+    { "wallet",             "getunconfirmedbalance",            &getunconfirmedbalance,         {"include_unavailable"} },
     { "wallet",             "getwalletinfo",                    &getwalletinfo,                 {} },
     { "wallet",             "importmulti",                      &importmulti,                   {"requests","options"} },
     { "wallet",             "importprivkey",                    &importprivkey,                 {"privkey","label","rescan"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2042,7 +2042,7 @@ bool CWalletTx::InMempool() const
     return fInMempool;
 }
 
-bool CWalletTx::IsTrusted() const
+bool CWalletTx::IsTrusted(bool trust_unavailable) const
 {
     // Quick answer in most cases
     if (!CheckFinalTx(*tx))
@@ -2055,8 +2055,9 @@ bool CWalletTx::IsTrusted() const
     if (!pwallet->m_spend_zero_conf_change || !IsFromMe(ISMINE_ALL)) // using wtx's cached debit
         return false;
 
-    // Don't trust unconfirmed transactions from us unless they are in the mempool.
-    if (!InMempool())
+    // Don't consider unconfirmed transactions from us as trusted unless we want to
+    // trust unavailable UTXOs, or they are in the mempool
+    if (!trust_unavailable && !InMempool())
         return false;
 
     // Trusted if all inputs are from us and are in the mempool:
@@ -2141,7 +2142,7 @@ void CWallet::ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman
  */
 
 
-CAmount CWallet::GetBalance() const
+CAmount CWallet::GetBalance(bool include_unavailable) const
 {
     CAmount nTotal = 0;
     {
@@ -2149,7 +2150,7 @@ CAmount CWallet::GetBalance() const
         for (const auto& entry : mapWallet)
         {
             const CWalletTx* pcoin = &entry.second;
-            if (pcoin->IsTrusted())
+            if (pcoin->IsTrusted(include_unavailable))
                 nTotal += pcoin->GetAvailableCredit();
         }
     }
@@ -2157,7 +2158,7 @@ CAmount CWallet::GetBalance() const
     return nTotal;
 }
 
-CAmount CWallet::GetUnconfirmedBalance() const
+CAmount CWallet::GetUnconfirmedBalance(bool include_unavailable) const
 {
     CAmount nTotal = 0;
     {
@@ -2165,7 +2166,7 @@ CAmount CWallet::GetUnconfirmedBalance() const
         for (const auto& entry : mapWallet)
         {
             const CWalletTx* pcoin = &entry.second;
-            if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 && pcoin->InMempool())
+            if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 && (include_unavailable || pcoin->InMempool()))
                 nTotal += pcoin->GetAvailableCredit();
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -482,7 +482,7 @@ public:
     bool IsEquivalentTo(const CWalletTx& tx) const;
 
     bool InMempool() const;
-    bool IsTrusted() const;
+    bool IsTrusted(bool trust_unavailable = false) const;
 
     int64_t GetTxTime() const;
     int GetRequestCount() const;
@@ -941,8 +941,8 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
-    CAmount GetBalance() const;
-    CAmount GetUnconfirmedBalance() const;
+    CAmount GetBalance(bool include_unavailable = false) const;
+    CAmount GetUnconfirmedBalance(bool include_unavailable = false) const;
     CAmount GetImmatureBalance() const;
     CAmount GetWatchOnlyBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -430,6 +430,10 @@ class WalletTest(BitcoinTestFramework):
         extra_txid = self.nodes[0].sendtoaddress(sending_addr, Decimal('0.0001'))
         assert(extra_txid not in self.nodes[0].getrawmempool())
         assert(extra_txid in [tx["txid"] for tx in self.nodes[0].listtransactions()])
+        # The change output for extra_txid should be in the balance if we include unspendable
+        assert(self.nodes[0].getbalance() < self.nodes[0].getbalance(include_unavailable="true"))
+        # This should be reflected in getunconfirmedbalance as well
+        assert(self.nodes[0].getunconfirmedbalance() < self.nodes[0].getunconfirmedbalance(include_unavailable=True))
         self.nodes[0].abandontransaction(extra_txid)
         total_txs = len(self.nodes[0].listtransactions("*", 99999))
 


### PR DESCRIPTION
Currently, if the wallet generates a transaction that cannot currently go into the mempool (e.g. due to too-long-mempool-chain), the wallet UTXOs related to this will vanish from `getbalance`, giving the appearance that the user has less funds than they actually do.

From a "get spendable balance" perspective, this is perfectly valid, but users may sometimes want to see their actual balance, regardless of whether they can spend it or not at that time.

This PR adds an `include_unspendable` option (default=false) to `getbalance` which, when `true`, will consider non-mempool transactions as trusted, and thus display these in the tally.

Note: this flag does nothing when a user specifies an account (i.e. `GetLegacyBalance`), and the legacy balance in fact already does what `include_unspendable=true` does, given the right arguments.