### PR TITLE
Bugfix: Use testnet RequireStandard for -acceptnonstdtxn default

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -479,7 +479,7 @@ std::string HelpMessage(HelpMessageMode mode)
 
     strUsage += HelpMessageGroup(_("Node relay options:"));
     if (showDebug) {
-        strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", defaultChainParams->RequireStandard()));
+        strUsage += HelpMessageOpt("-acceptnonstdtxn", strprintf("Relay and mine \"non-standard\" transactions (%sdefault: %u)", "testnet/regtest only; ", !testnetChainParams->RequireStandard()));
         strUsage += HelpMessageOpt("-incrementalrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to define cost of relay, used for mempool limiting and BIP 125 replacement. (default: %s)", CURRENCY_UNIT, FormatMoney(DEFAULT_INCREMENTAL_RELAY_FEE)));
         strUsage += HelpMessageOpt("-dustrelayfee=<amt>", strprintf("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost more than its value in fees at this fee rate to spend it. (default: %s)", CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)));
     }


### PR DESCRIPTION
Fixes a bug introduced in #8855

`-acceptnonstdtxn` is a valid option only for testnet/regtest (in Core), and the help message reflects that. Currently, however, it is buggy in two ways:

1. It uses mainnet to get the default value, which doesn't make sense since the option is never available for mainnet, and the only time the option is available, is when the default is the opposite.
2. It uses the value of "require standard" directly as the default for "accept non-standard transactions", but these concepts are opposites: a negation must be performed to transform one to the other.

Note the combination of these bugs results in the correct boolean output, but the logic to get there is completely wrong.