### PR TITLE
[RPC] trivial: gettxout no longer shows version of tx

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -962,7 +962,6 @@ UniValue gettxout(const JSONRPCRequest& request)
             "        ,...\n"
             "     ]\n"
             "  },\n"
-            "  \"version\" : n,            (numeric) The version\n"
             "  \"coinbase\" : true|false   (boolean) Coinbase or not\n"
             "}\n"
 


### PR DESCRIPTION
Since the switch to a per-txout chainstate db in #10195, the tx version information is no longer stored. Updated `gettxout` rpc help text accordingly.