### PR TITLE
[contrib] Add Valgrind suppressions file

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -1,0 +1,43 @@
+# Valgrind suppressions file for Bitcoin.
+#
+# Includes known Valgrind warnings in our dependencies that cannot be fixed
+# in-tree.
+#
+# Example use:
+# $ valgrind --suppressions=contrib/valgrind.supp src/test/test_bitcoin
+# $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
+#       --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite
+{
+   Suppress libstdc++ warning - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   obj:*/libstdc++.*
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   obj:*/ld-*.so
+}
+{
+   Suppress libdb warning - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=662917
+   Memcheck:Cond
+   obj:*/libdb_cxx-*.so
+   fun:__log_put
+   obj:*/libdb_cxx-*.so
+   fun:__log_put_record
+}
+{
+   Suppress leveldb warning (leveldb::InitModule()) - https://github.com/google/leveldb/issues/113
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN7leveldbL10InitModuleEv
+}
+{
+   Suppress leveldb warning (leveldb::Env::Default()) - https://github.com/google/leveldb/issues/113
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   ...
+   fun:_ZN7leveldbL14InitDefaultEnvEv
+}

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -165,6 +165,21 @@ can be very difficult to track down. Compiling with -DDEBUG_LOCKORDER (configure
 CXXFLAGS="-DDEBUG_LOCKORDER -g") inserts run-time checks to keep track of which locks
 are held, and adds warnings to the debug.log file if inconsistencies are detected.
 
+**Valgrind suppressions file**
+
+Valgrind is a programming tool for memory debugging, memory leak detection, and
+profiling. The repo contains a Valgrind suppressions file
+([`valgrind.supp`](https://github.com/bitcoin/bitcoin/blob/master/contrib/valgrind.supp))
+which includes known Valgrind warnings in our dependencies that cannot be fixed
+in-tree. Example use:
+
+```shell
+$ valgrind --suppressions=contrib/valgrind.supp src/test/test_bitcoin
+$ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
+      --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite
+$ valgrind -v --leak-check=full src/bitcoind -printtoconsole
+```
+
 Locking/mutex usage notes
 -------------------------
 


### PR DESCRIPTION
Includes known Valgrind warnings in our dependencies that cannot be fixed in-tree.

Example use:

```
$ valgrind --suppressions=contrib/valgrind.supp src/test/test_bitcoin
$ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
      --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite
```

Running with the suppressions file under Ubuntu 16.04:

```
$ valgrind --suppressions=contrib/valgrind.supp --leak-check=full --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite --run_test=wallet_crypto
…
==10769== LEAK SUMMARY:
==10769==    definitely lost: 0 bytes in 0 blocks
==10769==    indirectly lost: 0 bytes in 0 blocks
==10769==      possibly lost: 0 bytes in 0 blocks
==10769==    still reachable: 0 bytes in 0 blocks
==10769==         suppressed: 72,704 bytes in 1 blocks
```

Running without the suppressions file under Ubuntu 16.04:

```
$ valgrind --leak-check=full --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite --run_test=wallet_crypto
…
==10724== 72,704 bytes in 1 blocks are still reachable in loss record 1 of 1
==10724==    at 0x4C2DBF6: malloc (vg_replace_malloc.c:299)
==10724==    by 0x6F74EFF: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.21)
==10724==    by 0x40106B9: call_init.part.0 (dl-init.c:72)
==10724==    by 0x40107CA: call_init (dl-init.c:30)
==10724==    by 0x40107CA: _dl_init (dl-init.c:120)
==10724==    by 0x4000C69: ??? (in /lib/x86_64-linux-gnu/ld-2.23.so)
==10724==    by 0x2: ???
==10724==    by 0x1FFF0006D2: ???
==10724==    by 0x1FFF0006E8: ???
==10724==    by 0x1FFF0006FF: ???
==10724==
==10724== LEAK SUMMARY:
==10724==    definitely lost: 0 bytes in 0 blocks
==10724==    indirectly lost: 0 bytes in 0 blocks
==10724==      possibly lost: 0 bytes in 0 blocks
==10724==    still reachable: 72,704 bytes in 1 blocks
==10724==         suppressed: 0 bytes in 0 blocks
```