### PR TITLE
coincontrol can filter for segwit inputs, expose fundraw option

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -236,6 +236,7 @@ endif
 libbitcoin_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
+  wallet/coincontrol.cpp \
   wallet/crypter.cpp \
   wallet/db.cpp \
   wallet/feebumper.cpp \

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2011-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "coincontrol.h"
+
+bool InputTypeFromString(const std::string& input_string, InputType& input_type) {
+    static const std::map<std::string, InputType> input_types = {
+        {"LEGACY", InputType::LEGACY},
+        {"SEGWIT", InputType::SEGWIT},
+        {"ALL", InputType::ALL},
+    };
+    auto it = input_types.find(input_string);
+    if (it == input_types.end()) return false;
+    input_type = it->second;
+    return true;
+}

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -12,6 +12,14 @@
 
 #include <boost/optional.hpp>
 
+enum class InputType {
+    LEGACY, //! Only use non-segwit inputs
+    SEGWIT, //! Only use segwit inputs
+    ALL,    //! Use all input types
+};
+
+bool InputTypeFromString(const std::string& input_string, InputType& input_type);
+
 /** Coin Control Features. */
 class CCoinControl
 {
@@ -31,6 +39,7 @@ public:
     bool signalRbf;
     //! Fee estimation mode to control arguments to estimateSmartFee
     FeeEstimateMode m_fee_mode;
+    InputType m_input_type;
 
     CCoinControl()
     {
@@ -48,6 +57,7 @@ public:
         m_confirm_target.reset();
         signalRbf = fWalletRbf;
         m_fee_mode = FeeEstimateMode::UNSET;
+        m_input_type = InputType::ALL;
     }
 
     bool HasSelected() const

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -6,6 +6,7 @@
 #include "amount.h"
 #include "base58.h"
 #include "chain.h"
+#include "coincontrol.h"
 #include "consensus/validation.h"
 #include "core_io.h"
 #include "init.h"
@@ -2811,6 +2812,10 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
                             "         \"UNSET\"\n"
                             "         \"ECONOMICAL\"\n"
                             "         \"CONSERVATIVE\"\n"
+                            "     \"input_type\"             (string, optional, default=ALL) The type of inputs used to fund the transaction, must be one of:\n"
+                            "         \"ALL\"                Only use non-segwit inputs\n"
+                            "         \"LEGACY\"             Only use segwit inputs\n"
+                            "         \"SEGWIT\"             Use all input types\n"
                             "   }\n"
                             "                         for backward compatibility: passing in a true instead of an object will result in {\"includeWatching\":true}\n"
                             "\nResult:\n"
@@ -2860,6 +2865,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
                 {"replaceable", UniValueType(UniValue::VBOOL)},
                 {"conf_target", UniValueType(UniValue::VNUM)},
                 {"estimate_mode", UniValueType(UniValue::VSTR)},
+                {"input_type", UniValueType(UniValue::VSTR)},
             },
             true, true);
 
@@ -2905,6 +2911,11 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
             }
             if (!FeeModeFromString(options["estimate_mode"].get_str(), coinControl.m_fee_mode)) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid estimate_mode parameter");
+            }
+        }
+        if (options.exists("input_type")) {
+            if (!InputTypeFromString(options["input_type"].get_str(), coinControl.m_input_type)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid input_type parameter");
             }
         }
       }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2215,6 +2215,25 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                     continue;
                 }
 
+
+                if (coinControl && coinControl->m_input_type != InputType::ALL) {
+                    std::vector<std::vector<unsigned char> > vSolutions;
+                    txnouttype whichType = TX_NONSTANDARD;
+                    if (Solver(pcoin->tx->vout[i].scriptPubKey, whichType, vSolutions) && whichType == TX_SCRIPTHASH) {
+                        CScriptID scriptID = CScriptID(uint160(vSolutions[0]));
+                        CScript subscript;
+                        if (!GetCScript(scriptID, subscript) || !Solver(subscript, whichType, vSolutions)) {
+                            continue;
+                        }
+                    }
+                    if (coinControl->m_input_type == InputType::LEGACY && (whichType == TX_WITNESS_V0_SCRIPTHASH || whichType == TX_WITNESS_V0_KEYHASH)) {
+                        continue;
+                    }
+                    if (coinControl->m_input_type == InputType::SEGWIT && (whichType != TX_WITNESS_V0_SCRIPTHASH && whichType != TX_WITNESS_V0_KEYHASH)) {
+                        continue;
+                    }
+                }
+
                 bool fSpendableIn = ((mine & ISMINE_SPENDABLE) != ISMINE_NO) || (coinControl && coinControl->fAllowWatchOnly && (mine & ISMINE_WATCH_SOLVABLE) != ISMINE_NO);
                 bool fSolvableIn = (mine & (ISMINE_SPENDABLE | ISMINE_WATCH_SOLVABLE)) != ISMINE_NO;
 
@@ -4337,3 +4356,4 @@ bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& 
 {
     return ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, nullptr, false, nAbsurdFee);
 }
+

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -7,7 +7,6 @@
 from test_framework.test_framework import BitcoinTestFramework, BITCOIND_PROC_WAIT_TIMEOUT
 from test_framework.util import *
 
-
 def get_unspent(listunspent, amount):
     for utx in listunspent:
         if utx['amount'] == amount:
@@ -719,6 +718,44 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # the total subtracted from the outputs is equal to the fee
         assert_equal(share[0] + share[2] + share[3], result[0]['fee'])
+
+        ##########################
+        # Test input_type option #
+        ##########################
+
+        # Activate segwit
+        self.nodes[0].generate(300)
+
+        # Get a segwit address to fund later
+        addr = self.nodes[0].getnewaddress()
+        witaddr = self.nodes[0].addwitnessaddress(addr)
+        rawtx = self.nodes[0].createrawtransaction([], {witaddr:1})
+
+        # Test fund attempts with no segwit funds
+        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[0].fundrawtransaction, rawtx, {"input_type":"SEGWIT"})
+
+        # Fund the witness address using ALL and LEGACY
+        funded = self.nodes[0].fundrawtransaction(rawtx, {"input_type":"LEGACY"})
+        signed = self.nodes[0].signrawtransaction(funded["hex"])
+        self.nodes[0].sendrawtransaction(signed["hex"])
+
+        funded = self.nodes[0].fundrawtransaction(rawtx, {"input_type":"ALL"})
+        signed = self.nodes[0].signrawtransaction(funded["hex"])
+        self.nodes[0].sendrawtransaction(signed["hex"])
+
+        # Now fund using segwit funds only, sending to legacy address
+        rawtx = self.nodes[0].createrawtransaction([], {addr:2})
+        funded = self.nodes[0].fundrawtransaction(rawtx, {"input_type":"SEGWIT", "subtractFeeFromOutputs":[0]})
+        signed = self.nodes[0].signrawtransaction(funded["hex"])
+        self.nodes[0].sendrawtransaction(signed["hex"])
+
+        # No more segwit funds available again
+        assert_raises_jsonrpc(-4, "Insufficient funds", self.nodes[0].fundrawtransaction, rawtx, {"input_type":"SEGWIT"})
+
+        # Invalid funding type
+        assert_raises_jsonrpc(-8, "Invalid input_type parameter", self.nodes[0].fundrawtransaction, rawtx, {"input_type":"NONE"})
+
+
 
 if __name__ == '__main__':
     RawTransactionsTest().main()


### PR DESCRIPTION
This is useful for external signers such as Ledger where only one type of input is allowed for any given transaction to be signed ~~or in the case where you want to explicitly make a non-malleable transaction.~~