### PR TITLE
Document the preference of nullptr over NULL or (void*)0

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -37,6 +37,7 @@ code.
 
 - **Miscellaneous**
   - `++i` is preferred over `i++`.
+  - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
 
 Block style example:
@@ -276,7 +277,7 @@ Wallet
 
   - *Rationale*: In RPC code that conditionally uses the wallet (such as
     `validateaddress`) it is easy to forget that global pointer `pwalletMain`
-    can be NULL. See `test/functional/disablewallet.py` for functional tests
+    can be nullptr. See `test/functional/disablewallet.py` for functional tests
     exercising the API with `-disablewallet`
 
 - Include `db_cxx.h` (BerkeleyDB header) only when `ENABLE_WALLET` is set

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -18,7 +18,7 @@
 extern void qt_mac_set_dock_menu(QMenu *);
 #endif
 
-static MacDockIconHandler *s_instance = NULL;
+static MacDockIconHandler *s_instance = nullptr;
 
 bool dockClickHandler(id self,SEL _cmd,...) {
     Q_UNUSED(self)
@@ -34,7 +34,7 @@ void setupDockClickHandler() {
     Class cls = objc_getClass("NSApplication");
     id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
     
-    if (appInst != NULL) {
+    if (appInst != nullptr) {
         id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
         Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
         SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
@@ -53,7 +53,7 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     setupDockClickHandler();
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
-    this->setMainWindow(NULL);
+    this->setMainWindow(nullptr);
 #if QT_VERSION < 0x050000
     qt_mac_set_dock_menu(this->m_dockMenu);
 #elif QT_VERSION >= 0x050200
@@ -69,7 +69,7 @@ void MacDockIconHandler::setMainWindow(QMainWindow *window) {
 MacDockIconHandler::~MacDockIconHandler()
 {
     delete this->m_dummyWidget;
-    this->setMainWindow(NULL);
+    this->setMainWindow(nullptr);
 }
 
 QMenu *MacDockIconHandler::dockMenu()

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -75,7 +75,7 @@ bool MacNotificationHandler::hasUserNotificationCenterSupport(void)
 
 MacNotificationHandler *MacNotificationHandler::instance()
 {
-    static MacNotificationHandler *s_instance = NULL;
+    static MacNotificationHandler *s_instance = nullptr;
     if (!s_instance) {
         s_instance = new MacNotificationHandler();
         

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -242,7 +242,7 @@ void GetOSRand(unsigned char *ent32)
     }
 #elif defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
     // We need a fallback for OSX < 10.12
-    if (&getentropy != NULL) {
+    if (&getentropy != nullptr) {
         if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
             RandFailure();
         }


### PR DESCRIPTION
Document the preference of `nullptr` over `NULL` or `(void*)0`.

After this commit:

```
$ git grep "[^A-Za-z_]NULL[^A-Za-z_]" | grep -vE '(leveldb|univalue|secp256k1|torcontrol|NULL certificates|ctaes|release-notes|patches|configure.ac|developer-notes)'
$
```

Some context:
* `NULL → nullptr` was handled in the recently merged PR #10483
* `0 → nullptr` was handled in the recently merged PR #10645 

