### PR TITLE
Remove dead store in ecdsa_signature_parse_der_lax.

### DIFF
--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -126,7 +126,6 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1
         return 0;
     }
     spos = pos;
-    pos += slen;
 
     /* Ignore leading zeroes in R */
     while (rlen > 0 && input[rpos] == 0) {


### PR DESCRIPTION
This was one of the issues found by Clang's static analyzer (#9573).