### PR TITLE
Assert that CWallet::SyncMetaData finds oldest transaction.

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -569,6 +569,9 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
             copyFrom = &mapWallet[hash];
         }
     }
+
+    assert(copyFrom);
+
     // Now copy data from copyFrom to rest:
     for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {


### PR DESCRIPTION
Without this assert, the Clang static analyzer warns about subsequent dereferencing of copyFrom, because it can't be sure that it's not nullptr. See #9573.