### PR TITLE
[tests] fix timeout issues from TestNode

### DIFF
--- a/test/functional/dbcrash.py
+++ b/test/functional/dbcrash.py
@@ -64,7 +64,8 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         self.extra_args = [self.node0_args, self.node1_args, self.node2_args, self.node3_args]
 
     def setup_network(self):
-        self.setup_nodes()
+        # Need a bit of extra time for the nodes to start up for this test
+        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=90)
         # Leave them unconnected, we'll use submitblock directly in this test
 
     def restart_node(self, node_index, expected_tip):
@@ -74,10 +75,10 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         after 60 seconds. Returns the utxo hash of the given node."""
 
         time_start = time.time()
-        while time.time() - time_start < 60:
+        while time.time() - time_start < 120:
             try:
                 # Any of these RPC calls could throw due to node crash
-                self.nodes[node_index] = self.start_node(node_index, self.options.tmpdir, self.extra_args[node_index])
+                self.nodes[node_index] = self.start_node(node_index, self.options.tmpdir, self.extra_args[node_index], timewait=90)
                 self.nodes[node_index].waitforblock(expected_tip)
                 utxo_hash = self.nodes[node_index].gettxoutsetinfo()['hash_serialized_2']
                 return utxo_hash

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -34,7 +34,11 @@ class TestNode():
         self.index = i
         self.datadir = os.path.join(dirname, "node" + str(i))
         self.rpchost = rpchost
-        self.rpc_timeout = timewait
+        if timewait:
+            self.rpc_timeout = timewait
+        else:
+            # Wait for up to 60 seconds for the RPC server to respond
+            self.rpc_timeout = 60
         if binary is None:
             self.binary = os.getenv("BITCOIND", "bitcoind")
         else:
@@ -65,10 +69,10 @@ class TestNode():
 
     def wait_for_rpc_connection(self):
         """Sets up an RPC connection to the bitcoind process. Returns False if unable to connect."""
-        timeout_s = 60 # Wait for up to 60 seconds for the RPC server to respond
-        poll_per_s = 4 # Poll at a rate of four times per second
-        for _ in range(timeout_s*poll_per_s):
-            assert not self.process.poll(), "bitcoind exited with status %i during initialization" % self.process.returncode
+        # Poll at a rate of four times per second
+        poll_per_s = 4
+        for _ in range(poll_per_s * self.rpc_timeout):
+            assert self.process.poll() is None, "bitcoind exited with status %i during initialization" % self.process.returncode
             try:
                 self.rpc = get_rpc_proxy(rpc_url(self.datadir, self.index, self.rpchost), self.index, coveragedir=self.coverage_dir)
                 self.rpc.getblockcount()


### PR DESCRIPTION
Fixes a couple of bugs from the introduction of TestNode:

- test scripts were no longer able to specify a custom timeout for
starting a node. Therefore tests with nodes that take a long time to
start up (eg pruning.py) would fail.
- the test for whether a node has failed on start up was broken
by changing 'assert x is None' to 'assert not x'. Since
subprocess.poll() can return None (indicating the node is still running)
or 0 (indicating the node exited with return code 0), this was a
regression.