### PR TITLE
doc: Update build-openbsd for 6.1

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,6 +1,6 @@
 OpenBSD build guide
 ======================
-(updated for OpenBSD 6.0)
+(updated for OpenBSD 6.1)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
@@ -48,13 +48,13 @@ BOOST_PREFIX="${BITCOIN_ROOT}/boost"
 mkdir -p $BOOST_PREFIX
 
 # Fetch the source and verify that it is not tampered with
-curl -o boost_1_61_0.tar.bz2 http://heanet.dl.sourceforge.net/project/boost/boost/1.61.0/boost_1_61_0.tar.bz2
-echo 'a547bd06c2fd9a71ba1d169d9cf0339da7ebf4753849a8f7d6fdb8feee99b640  boost_1_61_0.tar.bz2' | sha256 -c
-# MUST output: (SHA256) boost_1_61_0.tar.bz2: OK
-tar -xjf boost_1_61_0.tar.bz2
+curl -o boost_1_64_0.tar.bz2 https://netcologne.dl.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2
+echo '7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332 boost_1_64_0.tar.bz2' | sha256 -c
+# MUST output: (SHA256) boost_1_64_0.tar.bz2: OK
+tar -xjf boost_1_64_0.tar.bz2
 
-# Boost 1.61 needs one small patch for OpenBSD
-cd boost_1_61_0
+# Boost 1.64 needs one small patch for OpenBSD
+cd boost_1_64_0
 # Also here: https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
 patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp
 


### PR DESCRIPTION
- Bump "updated for"
- Fix link to boost (haenet mirror is broken)
- Upgrade boost version to 1.64

Ref: closes #10796