### PR TITLE
Add length check for CExtKey deserialization (jonasschnelli, guidovranken)

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -172,6 +172,8 @@ struct CExtKey {
     {
         unsigned int len = ::ReadCompactSize(s);
         unsigned char code[BIP32_EXTKEY_SIZE];
+        if (len != BIP32_EXTKEY_SIZE)
+            throw std::runtime_error("Invalid extended key size\n");
         s.read((char *)&code[0], len);
         Decode(code);
     }


### PR DESCRIPTION
Fix a potential overwrite or uninitialised data issue.
That code part is currently unused (at least in Bitcoin Core).
We already do the same check `CExtPubKey`.

Reported by @guidovranken