### PR TITLE
[WIP] [mempool] Mempool snapshots to avoid lots of locking

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3138,7 +3138,7 @@ bool SendMessages(CNode* pto, CConnman& connman, const std::atomic<bool>& interr
                     filterrate = pto->minFeeFilter;
                 }
                 // Make a mempool snapshot to avoid a high number of locks
-                TxMemPoolSnapshot mps = mempool.snapshot(std::set<uint256>(vInvTx.begin(), vInvTx.end()));
+                TxMemPoolSnapshot mps = mempool.snapshot(vInvTx);
                 // Topologically and fee-rate sort the inventory we send for privacy and priority reasons.
                 // A heap is used so that not all items need sorting if only a few are being sent.
                 CompareInvMempoolOrder compareInvMempoolOrder(&mps);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1067,7 +1067,7 @@ bool CTxMemPool::TransactionWithinChainLimit(const uint256& txid, size_t chainLi
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
 
-TxMemPoolSnapshot CTxMemPool::snapshot(const std::set<uint256> hashes) const
+TxMemPoolSnapshot CTxMemPool::snapshot(const std::vector<uint256>& hashes) const
 {
     indexed_transaction_set mapTxOut;
     {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1067,13 +1067,13 @@ bool CTxMemPool::TransactionWithinChainLimit(const uint256& txid, size_t chainLi
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
 
-TxMemPoolSnapshot CTxMemPool::snapshot(const std::vector<uint256>& hashes) const
+TxMemPoolSnapshot CTxMemPool::snapshot(const std::vector<std::set<uint256>::iterator>& hashes) const
 {
     indexed_transaction_set mapTxOut;
     {
         LOCK(cs);
-        for (const uint256& hash : hashes) {
-            auto it = mapTx.find(hash);
+        for (const auto& hit : hashes) {
+            auto it = mapTx.find(*hit);
             if (it != mapTx.end()) {
                 mapTxOut.insert(*it);
             }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -429,7 +429,6 @@ private:
     void trackPackageRemoved(const CFeeRate& rate);
 
 public:
-
     static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
 
     typedef boost::multi_index_container<
@@ -479,6 +478,7 @@ public:
 
     const setEntries & GetMemPoolParents(txiter entry) const;
     const setEntries & GetMemPoolChildren(txiter entry) const;
+
 private:
     typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
 
@@ -542,7 +542,6 @@ public:
     void ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const;
     void ClearPrioritisation(const uint256 hash);
 
-public:
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must
      *  also be in the set, unless this transaction is being removed for being

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -618,7 +618,7 @@ public:
         return (mapTx.count(hash) != 0);
     }
 
-    TxMemPoolSnapshot snapshot(const std::set<uint256> hashes) const;
+    TxMemPoolSnapshot snapshot(const std::vector<uint256>& hashes) const;
 
     CTransactionRef get(const uint256& hash) const;
     TxMempoolInfo info(const uint256& hash) const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -618,7 +618,7 @@ public:
         return (mapTx.count(hash) != 0);
     }
 
-    TxMemPoolSnapshot snapshot(const std::vector<uint256>& hashes) const;
+    TxMemPoolSnapshot snapshot(const std::vector<std::set<uint256>::iterator>& hashes) const;
 
     CTransactionRef get(const uint256& hash) const;
     TxMempoolInfo info(const uint256& hash) const;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -294,6 +294,7 @@ struct mining_score {};
 struct ancestor_score {};
 
 class CBlockPolicyEstimator;
+class TxMemPoolSnapshot;
 
 /**
  * Information about a mempool transaction.
@@ -617,6 +618,8 @@ public:
         return (mapTx.count(hash) != 0);
     }
 
+    TxMemPoolSnapshot snapshot(const std::set<uint256> hashes) const;
+
     CTransactionRef get(const uint256& hash) const;
     TxMempoolInfo info(const uint256& hash) const;
     std::vector<TxMempoolInfo> infoAll() const;
@@ -684,6 +687,17 @@ protected:
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+};
+
+class TxMemPoolSnapshot
+{
+protected:
+    CTxMemPool::indexed_transaction_set mapTx;
+
+public:
+    TxMemPoolSnapshot(CTxMemPool::indexed_transaction_set mapTxIn) : mapTx(mapTxIn) {};
+    bool compareDepthAndScore(const uint256& hasha, const uint256& hashb);
+    TxMempoolInfo info(const uint256& hash) const;
 };
 
 /**


### PR DESCRIPTION
This PR addresses the tx relay trickle case specifically, but the snapshot feature can be used in other places as well, where a known set of mempool transactions are being juggled around.

A new class `TxMemPoolSnapshot` is introduced (63e7997) which is instantiated from `CTxMemPool` via the `snapshot()` method. This generates a minimalized, no-locks mempool which can be queried and discarded at will. It is obviously not thread safe.

In 499f14f, this is used for the tx trickle code in `SendMessages`. This code is executed roughly 5-6 times per second. The number of LOCK(cs) inside the mempool are proportional to the number of entries in `vInvTx` (because of the sorting part using `CompareInvMempoolOrder`), which ranges in size from 0 to over 4000.

I began investigating this after seeing 131703419 occurrences of `LOCK(cs)` in the mempool caused by 504302 entries into the tx relay trickle code path (that's ~250 locks per entry). This was after less than 24 hours of running.