### PR TITLE
Docs: Hash in ZMQ hash is raw bytes, not hex

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -72,7 +72,7 @@ For instance:
 Each PUB notification has a topic and body, where the header
 corresponds to the notification type. For instance, for the
 notification `-zmqpubhashtx` the topic is `hashtx` (no null
-terminator) and the body is the hexadecimal transaction hash (32
+terminator) and the body is the transaction hash (32
 bytes).
 
 These options can also be provided in bitcoin.conf.


### PR DESCRIPTION
Transaction hex cannot be in hexadecimal, that would be 64 bytes. In reality it's just raw bytes.