### PR TITLE
Consensus: add const to temp int in base58.cpp

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -31,7 +31,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
         psz++;
     }
     // Allocate enough space in big-endian base256 representation.
-    int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
+    const int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
     std::vector<unsigned char> b256(size);
     // Process the characters.
     while (*psz && !isspace(*psz)) {


### PR DESCRIPTION
Just caught my eye when looking over some code. Could be a const instead of a non-const.