### PR TITLE
[RPC][mempool]: Add savemempool RPC

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1532,6 +1532,25 @@ UniValue getchaintxstats(const JSONRPCRequest& request)
     return ret;
 }
 
+UniValue savemempool(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0) {
+        throw std::runtime_error(
+            "savemempool\n"
+            "\nDumps the mempool to disk.\n"
+            "\nExamples:\n"
+            + HelpExampleCli("savemempool", "")
+            + HelpExampleRpc("savemempool", "")
+        );
+    }
+
+    if (!DumpMempool()) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Unable to dump mempool to disk");
+    }
+
+    return NullUniValue;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
@@ -1552,6 +1571,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxout",               &gettxout,               {"txid","n","include_mempool"} },
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        {} },
     { "blockchain",         "pruneblockchain",        &pruneblockchain,        {"height"} },
+    { "blockchain",         "savemempool",            &savemempool,            {} },
     { "blockchain",         "verifychain",            &verifychain,            {"checklevel","nblocks"} },
 
     { "blockchain",         "preciousblock",          &preciousblock,          {"blockhash"} },

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4332,7 +4332,7 @@ bool LoadMempool(void)
     return true;
 }
 
-void DumpMempool(void)
+bool DumpMempool(void)
 {
     int64_t start = GetTimeMicros();
 
@@ -4352,7 +4352,7 @@ void DumpMempool(void)
     try {
         FILE* filestr = fsbridge::fopen(GetDataDir() / "mempool.dat.new", "wb");
         if (!filestr) {
-            return;
+            return false;
         }
 
         CAutoFile file(filestr, SER_DISK, CLIENT_VERSION);
@@ -4376,7 +4376,9 @@ void DumpMempool(void)
         LogPrintf("Dumped mempool: %gs to copy, %gs to dump\n", (mid-start)*MICRO, (last-mid)*MICRO);
     } catch (const std::exception& e) {
         LogPrintf("Failed to dump mempool: %s. Continuing anyway.\n", e.what());
+        return false;
     }
+    return true;
 }
 
 //! Guess how far we are in the verification process at the given block index

--- a/src/validation.h
+++ b/src/validation.h
@@ -475,7 +475,7 @@ static const unsigned int REJECT_HIGHFEE = 0x100;
 CBlockFileInfo* GetBlockFileInfo(size_t n);
 
 /** Dump the mempool to disk. */
-void DumpMempool();
+bool DumpMempool();
 
 /** Load the mempool from disk. */
 bool LoadMempool();

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -28,8 +28,14 @@ Test is as follows:
   - Restart node0 with -persistmempool. Verify that it has 5
     transactions in its mempool. This tests that -persistmempool=0
     does not overwrite a previously valid mempool stored on disk.
+  - Remove node0 mempool.dat and verify savemempool RPC recreates it
+    and verify that node1 can load it and has 5 transaction in its
+    mempool.
+  - Verify that savemempool throws when the RPC is called if
+    node1 can't write to disk.
 
 """
+import os
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -77,6 +83,28 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.stop_nodes()
         self.start_node(0)
         wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
+
+        mempooldat0 = os.path.join(self.options.tmpdir, 'node0', 'regtest', 'mempool.dat')
+        mempooldat1 = os.path.join(self.options.tmpdir, 'node1', 'regtest', 'mempool.dat')
+        self.log.debug("Remove the mempool.dat file. Verify that savemempool to disk via RPC re-creates it")
+        os.remove(mempooldat0)
+        self.nodes[0].savemempool()
+        assert os.path.isfile(mempooldat0)
+
+        self.log.debug("Stop nodes, make node1 use mempool.dat from node0. Verify it has 5 transactions")
+        os.rename(mempooldat0, mempooldat1)
+        self.stop_nodes()
+        self.start_node(1, extra_args=[])
+        wait_until(lambda: len(self.nodes[1].getrawmempool()) == 5)
+
+        self.log.debug("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")
+        # to test the exception we are setting bad permissions on a tmp file called mempool.dat.new
+        # which is an implementation detail that could change and break this test
+        mempooldotnew1 = mempooldat1 + '.new'
+        with os.fdopen(os.open(mempooldotnew1, os.O_CREAT, 0o000), 'w'):
+            pass
+        assert_raises_jsonrpc(-1, "Unable to dump mempool to disk", self.nodes[1].savemempool)
+        os.remove(mempooldotnew1)
 
 if __name__ == '__main__':
     MempoolPersistTest().main()


### PR DESCRIPTION
Adds a simple parameterless rpc command to dump the mempool.

Rationale:

Sometimes there can be a crash for whatever reason (bug, power loss, etc) causing the mempool.dat file to not be saved.

This change allows to script/cron the rpc call to have more regular saves to the file as well as cli/ad-hoc.

This should solve issue https://github.com/bitcoin/bitcoin/issues/11086