### PR TITLE
Changing -txindex requires -reindex, not -reindex-chainstate

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1428,7 +1428,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 // Check for changed -txindex state
                 if (fTxIndex != gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
-                    strLoadError = _("You need to rebuild the database using -reindex-chainstate to change -txindex");
+                    strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
                     break;
                 }
 


### PR DESCRIPTION
If there's an 0.15.0rc3, this should go in it.