### PR TITLE
[developer-notes] By default, declare single-argument constructors "explicit"

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -332,6 +332,12 @@ C++ data structures
   - *Rationale*: Ensure determinism by avoiding accidental use of uninitialized
     values. Also, static analyzers balk about this.
 
+- By default, declare single-argument constructors `explicit`.
+
+  - *Rationale*: This is a precaution to avoid unintended conversions that might
+    arise when single-argument constructors are used as implicit conversion
+    functions.
+
 - Use explicitly signed or unsigned `char`s, or even better `uint8_t` and
   `int8_t`. Do not use bare `char` unless it is to pass to a third-party API.
   This type can be signed or unsigned depending on the architecture, which can

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -15,7 +15,7 @@ class CAddrManTest : public CAddrMan
     uint64_t state;
 
 public:
-    CAddrManTest(bool makeDeterministic = true)
+    explicit CAddrManTest(bool makeDeterministic = true)
     {
         state = 1;
 


### PR DESCRIPTION
This is a follow-up to the now merged #10969.

Add recommendation:

> By default, declare single-argument constructors `explicit`.
> 
> - *Rationale*: This is a precaution to avoid unintended conversions that might arise when single-argument constructors are used as implicit conversion functions.
> 