### PR TITLE
[net] Ignore getheaders requests for very old side blocks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -61,6 +61,14 @@ static std::vector<std::pair<uint256, CTransactionRef>> vExtraTxnForCompact GUAR
 
 static const uint64_t RANDOMIZER_ID_ADDRESS_RELAY = 0x3cac0035b5866b90ULL; // SHA256("main address relay")[0:8]
 
+/// Age after which a stale block will no longer be served if requested as
+/// protection against fingerprinting. Set to one month, denominated in seconds.
+static const int STALE_RELAY_AGE_LIMIT = 30 * 24 * 60 * 60;
+
+/// Age after which a block is considered historical for purposes of rate
+/// limiting block relay. Set to one week, denominated in seconds.
+static const int HISTORICAL_BLOCK_AGE = 7 * 24 * 60 * 60;
+
 // Internal stuff
 namespace {
     /** Number of nodes with fSyncStarted. */
@@ -706,6 +714,17 @@ void Misbehaving(NodeId pnode, int howmuch)
 // blockchain -> download logic notification
 //
 
+// To prevent fingerprinting attacks, only send blocks/headers outside of the
+// active chain if they are no more than a month older (both in time, and in
+// best equivalent proof of work) than the best header chain we know about.
+static bool StaleBlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+{
+    AssertLockHeld(cs_main);
+    return (pindexBestHeader != nullptr) &&
+        (pindexBestHeader->GetBlockTime() - pindex->GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
+        (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, consensusParams) < STALE_RELAY_AGE_LIMIT);
+}
+
 PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn) : connman(connmanIn) {
     // Initialize global variables that cannot be constructed at startup.
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
@@ -983,13 +1002,8 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                     if (chainActive.Contains(mi->second)) {
                         send = true;
                     } else {
-                        static const int nOneMonth = 30 * 24 * 60 * 60;
-                        // To prevent fingerprinting attacks, only send blocks outside of the active
-                        // chain if they are valid, and no more than a month older (both in time, and in
-                        // best equivalent proof of work) than the best header chain we know about.
-                        send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != nullptr) &&
-                            (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() < nOneMonth) &&
-                            (GetBlockProofEquivalentTime(*pindexBestHeader, *mi->second, *pindexBestHeader, consensusParams) < nOneMonth);
+                        send = mi->second->IsValid(BLOCK_VALID_SCRIPTS) &&
+                            StaleBlockRequestAllowed(mi->second, consensusParams);
                         if (!send) {
                             LogPrintf("%s: ignoring request from peer=%i for old block that isn't in the main chain\n", __func__, pfrom->GetId());
                         }
@@ -997,8 +1011,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                 }
                 // disconnect node in case we have reached the outbound limit for serving historical blocks
                 // never disconnect whitelisted nodes
-                static const int nOneWeek = 7 * 24 * 60 * 60; // assume > 1 week = historical
-                if (send && connman->OutboundTargetReached(true) && ( ((pindexBestHeader != nullptr) && (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > nOneWeek)) || inv.type == MSG_FILTERED_BLOCK) && !pfrom->fWhitelisted)
+                if (send && connman->OutboundTargetReached(true) && ( ((pindexBestHeader != nullptr) && (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > HISTORICAL_BLOCK_AGE)) || inv.type == MSG_FILTERED_BLOCK) && !pfrom->fWhitelisted)
                 {
                     LogPrint(BCLog::NET, "historical block serving limit reached, disconnect peer=%d\n", pfrom->GetId());
 
@@ -1723,6 +1736,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             if (mi == mapBlockIndex.end())
                 return true;
             pindex = (*mi).second;
+
+            if (!chainActive.Contains(pindex) &&
+                !StaleBlockRequestAllowed(pindex, chainparams.GetConsensus())) {
+                LogPrintf("%s: ignoring request from peer=%i for old block header that isn't in the main chain\n", __func__, pfrom->GetId());
+                return true;
+            }
         }
         else
         {

--- a/test/functional/p2p-fingerprint.py
+++ b/test/functional/p2p-fingerprint.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test various fingerprinting protections.
+
+If an stale block more than a month old or its header are requested by a peer,
+the node should pretend that it does not have it to avoid fingerprinting.
+"""
+
+import time
+
+from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.mininode import (
+    CInv,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_headers,
+    msg_block,
+    msg_getdata,
+    msg_getheaders,
+    wait_until,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    p2p_port,
+)
+
+class P2PFingerprintTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    # Build a chain of blocks on top of given one
+    def build_chain(self, nblocks, prev_hash, prev_height, prev_median_time):
+        blocks = []
+        for _ in range(nblocks):
+            coinbase = create_coinbase(prev_height + 1)
+            block_time = prev_median_time + 1
+            block = create_block(int(prev_hash, 16), coinbase, block_time)
+            block.solve()
+
+            blocks.append(block)
+            prev_hash = block.hash
+            prev_height += 1
+            prev_median_time = block_time
+        return blocks
+
+    # Send a getdata request for a given block hash
+    def send_block_request(self, block_hash, node):
+        msg = msg_getdata()
+        msg.inv.append(CInv(2, block_hash))  # 2 == "Block"
+        node.send_message(msg)
+
+    # Send a getheaders request for a given single block hash
+    def send_header_request(self, block_hash, node):
+        msg = msg_getheaders()
+        msg.hashstop = block_hash
+        node.send_message(msg)
+
+    # Check whether last block received from node has a given hash
+    def last_block_equals(self, expected_hash, node):
+        block_msg = node.last_message.get("block")
+        return block_msg and block_msg.block.rehash() == expected_hash
+
+    # Check whether last block header received from node has a given hash
+    def last_header_equals(self, expected_hash, node):
+        headers_msg = node.last_message.get("headers")
+        return (headers_msg and
+                headers_msg.headers and
+                headers_msg.headers[0].rehash() == expected_hash)
+
+    # Checks that stale blocks timestamped more than a month ago are not served
+    # by the node while recent stale blocks and old active chain blocks are.
+    # This does not currently test that stale blocks timestamped within the
+    # last month but that have over a month's worth of work are also withheld.
+    def run_test(self):
+        node0 = NodeConnCB()
+
+        connections = []
+        connections.append(NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], node0))
+        node0.add_connection(connections[0])
+
+        NetworkThread().start()
+        node0.wait_for_verack()
+
+        # Set node time to 60 days ago
+        self.nodes[0].setmocktime(int(time.time()) - 60 * 24 * 60 * 60)
+
+        # Generating a chain of 10 blocks
+        block_hashes = self.nodes[0].generate(nblocks=10)
+
+        # Create longer chain starting 2 blocks before current tip
+        height = len(block_hashes) - 2
+        block_hash = block_hashes[height - 1]
+        block_time = self.nodes[0].getblockheader(block_hash)["mediantime"] + 1
+        new_blocks = self.build_chain(5, block_hash, height, block_time)
+
+        # Force reorg to a longer chain
+        node0.send_message(msg_headers(new_blocks))
+        node0.wait_for_getdata()
+        for block in new_blocks:
+            node0.send_and_ping(msg_block(block))
+
+        # Check that reorg succeeded
+        assert_equal(self.nodes[0].getblockcount(), 13)
+
+        stale_hash = int(block_hashes[-1], 16)
+
+        # Check that getdata request for stale block succeeds
+        self.send_block_request(stale_hash, node0)
+        test_function = lambda: self.last_block_equals(stale_hash, node0)
+        wait_until(test_function, timeout=3)
+
+        # Check that getheader request for stale block header succeeds
+        self.send_header_request(stale_hash, node0)
+        test_function = lambda: self.last_header_equals(stale_hash, node0)
+        wait_until(test_function, timeout=3)
+
+        # Longest chain is extended so stale is much older than chain tip
+        self.nodes[0].setmocktime(0)
+        tip = self.nodes[0].generate(nblocks=1)[0]
+        assert_equal(self.nodes[0].getblockcount(), 14)
+
+        # Send getdata & getheaders to refresh last received getheader message
+        block_hash = int(tip, 16)
+        self.send_block_request(block_hash, node0)
+        self.send_header_request(block_hash, node0)
+        node0.sync_with_ping()
+
+        # Request for very old stale block should now fail
+        self.send_block_request(stale_hash, node0)
+        time.sleep(3)
+        assert not self.last_block_equals(stale_hash, node0)
+
+        # Request for very old stale block header should now fail
+        self.send_header_request(stale_hash, node0)
+        time.sleep(3)
+        assert not self.last_header_equals(stale_hash, node0)
+
+        # Verify we can fetch very old blocks and headers on the active chain
+        block_hash = int(block_hashes[2], 16)
+        self.send_block_request(block_hash, node0)
+        self.send_header_request(block_hash, node0)
+        node0.sync_with_ping()
+
+        self.send_block_request(block_hash, node0)
+        test_function = lambda: self.last_block_equals(block_hash, node0)
+        wait_until(test_function, timeout=3)
+
+        self.send_header_request(block_hash, node0)
+        test_function = lambda: self.last_header_equals(block_hash, node0)
+        wait_until(test_function, timeout=3)
+
+if __name__ == '__main__':
+    P2PFingerprintTest().main()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1310,8 +1310,8 @@ class msg_getheaders(object):
 class msg_headers(object):
     command = b"headers"
 
-    def __init__(self):
-        self.headers = []
+    def __init__(self, headers=None):
+        self.headers = headers if headers is not None else []
 
     def deserialize(self, f):
         # comment in bitcoind indicates these should be deserialized as blocks

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -123,6 +123,7 @@ BASE_SCRIPTS= [
     'uptime.py',
     'resendwallettransactions.py',
     'minchainwork.py',
+    'p2p-fingerprint.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
Sending a getheaders message with an empty locator and a stop hash is a request for a single header by hash. The node will respond with headers for blocks not in the main chain as well as those in the main chain. To avoid fingerprinting, the node should, however, ignore requests for headers on side branches that are too old. This replicates the logic that currently exists for `getdata` requests for blocks.