### PR TITLE
TestNode tidyups

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -24,8 +24,8 @@ don't have test cases for.
 - Use a module-level docstring to describe what the test is testing, and how it
   is testing it.
 - When subclassing the BitcoinTestFramwork, place overrides for the
-  `__init__()`, and `setup_xxxx()` methods at the top of the subclass, then
-  locally-defined helper methods, then the `run_test()` method.
+  `set_test_params()`, `add_options()` and `setup_xxxx()` methods at the top of
+  the subclass, then locally-defined helper methods, then the `run_test()` method.
 
 #### General test-writing advice
 
@@ -36,7 +36,7 @@ don't have test cases for.
 - Avoid stop-starting the nodes multiple times during the test if possible. A
   stop-start takes several seconds, so doing it several times blows up the
   runtime of the test.
-- Set the `self.setup_clean_chain` variable in `__init__()` to control whether
+- Set the `self.setup_clean_chain` variable in `set_test_params()` to control whether
   or not to use the cached data directories. The cached data directories
   contain a 200-block pre-mined blockchain and wallets for four nodes. Each node
   has 25 mature blocks (25x50=1250 BTC) in its wallet.

--- a/test/functional/abandonconflict.py
+++ b/test/functional/abandonconflict.py
@@ -74,7 +74,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         # Restart the node with a higher min relay fee so the parent tx is no longer in mempool
         # TODO: redo with eviction
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.0001"])
+        self.start_node(0, extra_args=["-minrelaytxfee=0.0001"])
 
         # Verify txs no longer in either node's mempool
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
@@ -101,7 +101,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # Verify that even with a low min relay fee, the tx is not reaccepted from wallet on startup once abandoned
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.00001"])
+        self.start_node(0, extra_args=["-minrelaytxfee=0.00001"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         assert_equal(self.nodes[0].getbalance(), balance)
 
@@ -121,7 +121,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # Remove using high relay fee again
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-minrelaytxfee=0.0001"])
+        self.start_node(0, extra_args=["-minrelaytxfee=0.0001"])
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
         newbalance = self.nodes[0].getbalance()
         assert_equal(newbalance, balance - Decimal("24.9996"))

--- a/test/functional/abandonconflict.py
+++ b/test/functional/abandonconflict.py
@@ -14,10 +14,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class AbandonConflictTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
         self.extra_args = [["-minrelaytxfee=0.00001"], []]
 
     def run_test(self):

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -54,8 +54,7 @@ class BaseNode(NodeConnCB):
         self.send_message(headers_message)
 
 class AssumeValidTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
 

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -60,10 +60,11 @@ class AssumeValidTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self):
+        self.add_nodes(3, self.options.tmpdir)
         # Start node0. We don't start the other nodes yet since
         # we need to pre-mine a block with an invalid transaction
         # signature so we can pass in the block hash as assumevalid.
-        self.nodes = [self.start_node(0, self.options.tmpdir)]
+        self.start_node(0)
 
     def send_blocks_until_disconnected(self, node):
         """Keep sending blocks to the node until we're disconnected."""
@@ -162,15 +163,13 @@ class AssumeValidTest(BitcoinTestFramework):
             height += 1
 
         # Start node1 and node2 with assumevalid so they accept a block with a bad signature.
-        self.nodes.append(self.start_node(1, self.options.tmpdir,
-                                     ["-assumevalid=" + hex(block102.sha256)]))
+        self.start_node(1, extra_args=["-assumevalid=" + hex(block102.sha256)])
         node1 = BaseNode()  # connects to node1
         connections.append(NodeConn('127.0.0.1', p2p_port(1), self.nodes[1], node1))
         node1.add_connection(connections[1])
         node1.wait_for_verack()
 
-        self.nodes.append(self.start_node(2, self.options.tmpdir,
-                                     ["-assumevalid=" + hex(block102.sha256)]))
+        self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256)])
         node2 = BaseNode()  # connects to node2
         connections.append(NodeConn('127.0.0.1', p2p_port(2), self.nodes[2], node2))
         node2.add_connection(connections[2])

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -60,7 +60,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.num_nodes = 3
 
     def setup_network(self):
-        self.add_nodes(3, self.options.tmpdir)
+        self.add_nodes(3)
         # Start node0. We don't start the other nodes yet since
         # we need to pre-mine a block with an invalid transaction
         # signature so we can pass in the block hash as assumevalid.

--- a/test/functional/bip65-cltv-p2p.py
+++ b/test/functional/bip65-cltv-p2p.py
@@ -60,9 +60,7 @@ def create_transaction(node, coinbase, to_address, amount):
     return tx
 
 class BIP65Test(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [['-promiscuousmempoolflags=1', '-whitelist=127.0.0.1']]
         self.setup_clean_chain = True

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -92,9 +92,9 @@ def all_rlt_txs(txarray):
     return txs
 
 class BIP68_112_113Test(ComparisonTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
+        self.setup_clean_chain = True
         self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=4']]
 
     def run_test(self):

--- a/test/functional/bip68-sequence.py
+++ b/test/functional/bip68-sequence.py
@@ -17,10 +17,8 @@ SEQUENCE_LOCKTIME_MASK = 0x0000ffff
 NOT_FINAL_ERROR = "64: non-BIP68-final"
 
 class BIP68Test(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
         self.extra_args = [[], ["-acceptnonstdtxn=0"]]
 
     def run_test(self):

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -28,11 +28,10 @@ from test_framework.comptool import TestInstance, TestManager
 from test_framework.script import CScript, OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP
 
 class BIP9SoftForksTest(ComparisonTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [['-whitelist=127.0.0.1']]
+        self.setup_clean_chain = True
 
     def run_test(self):
         self.test = TestManager(self, self.options.tmpdir)

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -241,6 +241,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         # Restart all
         self.test.clear_all_connections()
         self.stop_nodes()
+        self.nodes = []
         shutil.rmtree(self.options.tmpdir + "/node0")
         self.setup_chain()
         self.setup_network()

--- a/test/functional/bipdersig-p2p.py
+++ b/test/functional/bipdersig-p2p.py
@@ -48,9 +48,7 @@ def create_transaction(node, coinbase, to_address, amount):
     return tx
 
 class BIP66Test(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [['-promiscuousmempoolflags=1', '-whitelist=127.0.0.1']]
         self.setup_clean_chain = True

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -30,12 +30,8 @@ from test_framework.util import (
     assert_is_hash_string,
 )
 
-
 class BlockchainTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        self.setup_clean_chain = False
+    def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [['-stopatheight=207']]
 

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -146,7 +146,7 @@ class BlockchainTest(BitcoinTestFramework):
             pass  # The node already shut down before response
         self.log.debug('Node should stop at this height...')
         self.nodes[0].process.wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir)
+        self.start_node(0)
         assert_equal(self.nodes[0].getblockcount(), 207)
 
 

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -34,21 +34,18 @@ class BumpFeeTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 2
         self.setup_clean_chain = True
+        self.extra_args = [["-prematurewitness", "-walletprematurewitness", "-walletrbf={}".format(i)]
+                           for i in range(self.num_nodes)]
 
-    def setup_network(self, split=False):
-        extra_args = [["-prematurewitness", "-walletprematurewitness", "-walletrbf={}".format(i)]
-                      for i in range(self.num_nodes)]
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
-
+    def run_test(self):
         # Encrypt wallet for test_locked_wallet_fails test
         self.nodes[1].node_encrypt_wallet(WALLET_PASSPHRASE)
-        self.nodes[1] = self.start_node(1, self.options.tmpdir, extra_args[1])
+        self.start_node(1)
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_all()
 
-    def run_test(self):
         peer_node, rbf_node = self.nodes
         rbf_node_address = rbf_node.getnewaddress()
 

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -30,8 +30,7 @@ WALLET_PASSPHRASE_TIMEOUT = 3600
 
 
 class BumpFeeTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
         self.extra_args = [["-prematurewitness", "-walletprematurewitness", "-walletrbf={}".format(i)]

--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -12,11 +12,9 @@ tests are being run in parallel.
 from test_framework.test_framework import BitcoinTestFramework
 
 class CreateCache(BitcoinTestFramework):
+    # Test network and test nodes are not required:
 
-    def __init__(self):
-        super().__init__()
-
-        # Test network and test nodes are not required:
+    def set_test_params(self):
         self.num_nodes = 0
 
     def setup_network(self):

--- a/test/functional/create_cache.py
+++ b/test/functional/create_cache.py
@@ -18,7 +18,6 @@ class CreateCache(BitcoinTestFramework):
 
         # Test network and test nodes are not required:
         self.num_nodes = 0
-        self.nodes = []
 
     def setup_network(self):
         pass

--- a/test/functional/dbcrash.py
+++ b/test/functional/dbcrash.py
@@ -65,7 +65,8 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Need a bit of extra time for the nodes to start up for this test
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=90)
+        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=90)
+        self.start_nodes()
         # Leave them unconnected, we'll use submitblock directly in this test
 
     def restart_node(self, node_index, expected_tip):
@@ -78,7 +79,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         while time.time() - time_start < 120:
             try:
                 # Any of these RPC calls could throw due to node crash
-                self.nodes[node_index] = self.start_node(node_index, self.options.tmpdir, self.extra_args[node_index], timewait=90)
+                self.start_node(node_index)
                 self.nodes[node_index].waitforblock(expected_tip)
                 utxo_hash = self.nodes[node_index].gettxoutsetinfo()['hash_serialized_2']
                 return utxo_hash

--- a/test/functional/dbcrash.py
+++ b/test/functional/dbcrash.py
@@ -43,8 +43,7 @@ except AttributeError:
     pass
 
 class ChainstateWriteCrashTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 4
         self.setup_clean_chain = False
 

--- a/test/functional/dbcrash.py
+++ b/test/functional/dbcrash.py
@@ -65,7 +65,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Need a bit of extra time for the nodes to start up for this test
-        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=90)
+        self.add_nodes(self.num_nodes, timewait=90)
         self.start_nodes()
         # Leave them unconnected, we'll use submitblock directly in this test
 

--- a/test/functional/decodescript.py
+++ b/test/functional/decodescript.py
@@ -10,9 +10,7 @@ from test_framework.mininode import *
 from io import BytesIO
 
 class DecodeScriptTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/disablewallet.py
+++ b/test/functional/disablewallet.py
@@ -11,11 +11,8 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-
 class DisableWalletTest (BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [["-disablewallet"]]

--- a/test/functional/disconnect_ban.py
+++ b/test/functional/disconnect_ban.py
@@ -14,11 +14,8 @@ from test_framework.util import (
 )
 
 class DisconnectBanTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
 
     def run_test(self):
         self.log.info("Test setban and listbanned RPCs")

--- a/test/functional/disconnect_ban.py
+++ b/test/functional/disconnect_ban.py
@@ -68,8 +68,8 @@ class DisconnectBanTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listbanned()), 3)
 
         self.stop_node(1)
+        self.start_node(1)
 
-        self.nodes[1] = self.start_node(1, self.options.tmpdir)
         listAfterShutdown = self.nodes[1].listbanned()
         assert_equal("127.0.0.0/24", listAfterShutdown[0]['address'])
         assert_equal("127.0.0.0/32", listAfterShutdown[1]['address'])

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -73,15 +73,11 @@ def custom_function():
 class ExampleTest(BitcoinTestFramework):
     # Each functional test is a subclass of the BitcoinTestFramework class.
 
-    # Override the __init__(), add_options(), setup_chain(), setup_network()
+    # Override the set_test_params(), add_options(), setup_chain(), setup_network()
     # and setup_nodes() methods to customize the test setup as required.
 
-    def __init__(self):
-        """Initialize the test
-
-        Call super().__init__() first, and then override any test parameters
-        for your individual test."""
-        super().__init__()
+    def set_test_params(self):
+        """Override any test parameters for your individual test."""
         self.setup_clean_chain = True
         self.num_nodes = 3
         # Use self.extra_args to change command-line arguments for the nodes

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -77,7 +77,9 @@ class ExampleTest(BitcoinTestFramework):
     # and setup_nodes() methods to customize the test setup as required.
 
     def set_test_params(self):
-        """Override any test parameters for your individual test."""
+        """Override test parameters for your individual test.
+
+        This method must be overridden and num_nodes must be exlicitly set."""
         self.setup_clean_chain = True
         self.num_nodes = 3
         # Use self.extra_args to change command-line arguments for the nodes

--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -7,7 +7,6 @@ import os
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
 
 class ForkNotifyTest(BitcoinTestFramework):
 
@@ -17,18 +16,12 @@ class ForkNotifyTest(BitcoinTestFramework):
         self.setup_clean_chain = False
 
     def setup_network(self):
-        self.nodes = []
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
         with open(self.alert_filename, 'w', encoding='utf8'):
             pass  # Just open then close to create zero-length file
-        self.nodes.append(self.start_node(0, self.options.tmpdir,
-                            ["-blockversion=2", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""]))
-        # Node1 mines block.version=211 blocks
-        self.nodes.append(self.start_node(1, self.options.tmpdir,
-                                ["-blockversion=211"]))
-        connect_nodes(self.nodes[1], 0)
-
-        self.sync_all()
+        self.extra_args = [["-blockversion=2", "-alertnotify=echo %s >> \"" + self.alert_filename + "\""],
+                           ["-blockversion=211"]]
+        super().setup_network()
 
     def run_test(self):
         # Mine 51 up-version blocks

--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -9,11 +9,8 @@ import time
 from test_framework.test_framework import BitcoinTestFramework
 
 class ForkNotifyTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
 
     def setup_network(self):
         self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -14,13 +14,9 @@ def get_unspent(listunspent, amount):
             return utx
     raise AssertionError('Could not find unspent with amount={}'.format(amount))
 
-
 class RawTransactionsTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 4
 
     def setup_network(self, split=False):
         self.setup_nodes()

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -449,11 +449,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         # locked wallet test
         self.stop_node(0)
+        self.nodes[1].node_encrypt_wallet("test")
         self.stop_node(2)
         self.stop_node(3)
-        self.nodes[1].node_encrypt_wallet("test")
 
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
+        self.start_nodes()
         # This test is not meant to test fee estimation and we'd like
         # to be sure all txs are sent at a consistent desired feerate
         for node in self.nodes:

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -16,6 +16,7 @@ def get_unspent(listunspent, amount):
 
 class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 4
         self.setup_clean_chain = True
 
     def setup_network(self, split=False):

--- a/test/functional/getblocktemplate_longpoll.py
+++ b/test/functional/getblocktemplate_longpoll.py
@@ -23,6 +23,9 @@ class LongpollThread(threading.Thread):
         self.node.getblocktemplate({'longpollid':self.longpollid})
 
 class GetBlockTemplateLPTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)

--- a/test/functional/getblocktemplate_longpoll.py
+++ b/test/functional/getblocktemplate_longpoll.py
@@ -23,11 +23,6 @@ class LongpollThread(threading.Thread):
         self.node.getblocktemplate({'longpollid':self.longpollid})
 
 class GetBlockTemplateLPTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
-
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)

--- a/test/functional/getchaintips.py
+++ b/test/functional/getchaintips.py
@@ -14,13 +14,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 class GetChainTipsTest (BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
-
     def run_test (self):
-
         tips = self.nodes[0].getchaintips ()
         assert_equal (len (tips), 1)
         assert_equal (tips[0]['branchlen'], 0)

--- a/test/functional/getchaintips.py
+++ b/test/functional/getchaintips.py
@@ -14,6 +14,9 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 class GetChainTipsTest (BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 4
+
     def run_test (self):
         tips = self.nodes[0].getchaintips ()
         assert_equal (len (tips), 1)

--- a/test/functional/httpbasics.py
+++ b/test/functional/httpbasics.py
@@ -11,10 +11,8 @@ import http.client
 import urllib.parse
 
 class HTTPBasicsTest (BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 3
-        self.setup_clean_chain = False
 
     def setup_network(self):
         self.setup_nodes()

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -121,7 +121,7 @@ class ImportRescanTest(BitcoinTestFramework):
             if import_node.prune:
                 extra_args[i] += ["-prune=1"]
 
-        self.add_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.add_nodes(self.num_nodes, extra_args)
         self.start_nodes()
         for i in range(1, self.num_nodes):
             connect_nodes(self.nodes[i], 0)

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -111,8 +111,7 @@ TIMESTAMP_WINDOW = 2 * 60 * 60
 
 
 class ImportRescanTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2 + len(IMPORT_NODES)
 
     def setup_network(self):

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -121,7 +121,8 @@ class ImportRescanTest(BitcoinTestFramework):
             if import_node.prune:
                 extra_args[i] += ["-prune=1"]
 
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.add_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.start_nodes()
         for i in range(1, self.num_nodes):
             connect_nodes(self.nodes[i], 0)
 

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -7,8 +7,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class ImportMultiTest (BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
 

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -429,7 +429,7 @@ class ImportMultiTest (BitcoinTestFramework):
 
         # restart nodes to check for proper serialization/deserialization of watch only address
         self.stop_nodes()
-        self.nodes = self.start_nodes(2, self.options.tmpdir)
+        self.start_nodes()
         address_assert = self.nodes[1].validateaddress(watchonly_address)
         assert_equal(address_assert['iswatchonly'], True)
         assert_equal(address_assert['ismine'], False)

--- a/test/functional/importprunedfunds.py
+++ b/test/functional/importprunedfunds.py
@@ -6,11 +6,8 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-
 class ImportPrunedFundsTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
 

--- a/test/functional/invalidateblock.py
+++ b/test/functional/invalidateblock.py
@@ -8,9 +8,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class InvalidateTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
 

--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -23,9 +23,9 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
 
     ''' Can either run this test as 1 node with expected answers, or two and compare them. 
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
+        self.setup_clean_chain = True
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -19,9 +19,9 @@ class InvalidTxRequestTest(ComparisonTestFramework):
 
     ''' Can either run this test as 1 node with expected answers, or two and compare them. 
         Change the "outcome" variable from each TestInstance object to only do the comparison. '''
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
+        self.setup_clean_chain = True
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)

--- a/test/functional/keypool-topup.py
+++ b/test/functional/keypool-topup.py
@@ -35,7 +35,7 @@ class KeypoolRestoreTest(BitcoinTestFramework):
         self.stop_node(1)
 
         shutil.copyfile(self.tmpdir + "/node1/regtest/wallet.dat", self.tmpdir + "/wallet.bak")
-        self.nodes[1] = self.start_node(1, self.tmpdir, self.extra_args[1])
+        self.start_node(1, self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
 
         self.log.info("Generate keys for wallet")
@@ -61,7 +61,7 @@ class KeypoolRestoreTest(BitcoinTestFramework):
 
         self.log.info("Verify keypool is restored and balance is correct")
 
-        self.nodes[1] = self.start_node(1, self.tmpdir, self.extra_args[1])
+        self.start_node(1, self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_all()
 

--- a/test/functional/keypool-topup.py
+++ b/test/functional/keypool-topup.py
@@ -20,8 +20,7 @@ from test_framework.util import (
 )
 
 class KeypoolRestoreTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [['-usehd=0'], ['-usehd=1', '-keypool=100', '-keypoolmin=20']]

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -19,7 +19,7 @@ class KeyPoolTest(BitcoinTestFramework):
         # Encrypt wallet and wait to terminate
         nodes[0].node_encrypt_wallet('test')
         # Restart node 0
-        nodes[0] = self.start_node(0, self.options.tmpdir)
+        self.start_node(0)
         # Keep creating keys
         addr = nodes[0].getnewaddress()
         addr_data = nodes[0].validateaddress(addr)

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -8,6 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class KeyPoolTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
 
     def run_test(self):
         nodes = self.nodes
@@ -77,11 +79,6 @@ class KeyPoolTest(BitcoinTestFramework):
         wi = nodes[0].getwalletinfo()
         assert_equal(wi['keypoolsize_hd_internal'], 100)
         assert_equal(wi['keypoolsize'], 100)
-
-    def __init__(self):
-        super().__init__()
-        self.setup_clean_chain = False
-        self.num_nodes = 1
 
 if __name__ == '__main__':
     KeyPoolTest().main()

--- a/test/functional/listsinceblock.py
+++ b/test/functional/listsinceblock.py
@@ -9,6 +9,7 @@ from test_framework.util import assert_equal
 
 class ListSinceBlockTest (BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 4
         self.setup_clean_chain = True
 
     def run_test(self):

--- a/test/functional/listsinceblock.py
+++ b/test/functional/listsinceblock.py
@@ -8,11 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 class ListSinceBlockTest (BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 4
 
     def run_test(self):
         self.nodes[2].generate(101)

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -16,10 +16,7 @@ def txFromHex(hexstring):
     return tx
 
 class ListTransactionsTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
+    def set_test_params(self):
         self.enable_mocktime()
 
     def run_test(self):

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -20,11 +20,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 4
         self.setup_clean_chain = False
-
-    def setup_nodes(self):
-        #This test requires mocktime
         self.enable_mocktime()
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         # Simple send, 0 to 1:

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -17,6 +17,7 @@ def txFromHex(hexstring):
 
 class ListTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 2
         self.enable_mocktime()
 
     def run_test(self):

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -31,8 +31,7 @@ class TestNode(NodeConnCB):
 
 class MaxUploadTest(BitcoinTestFramework):
  
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [["-maxuploadtarget=800", "-blockmaxsize=999000"]]

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -147,7 +147,7 @@ class MaxUploadTest(BitcoinTestFramework):
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
         self.log.info("Restarting nodes with -whitelist=127.0.0.1")
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
+        self.start_node(0, ["-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
 
         #recreate/reconnect a test node
         test_nodes = [TestNode()]

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -8,9 +8,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class MempoolLimitTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [["-maxmempool=5", "-spendzeroconfchange=0"]]

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -12,10 +12,8 @@ MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
 
 class MempoolPackagesTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
         self.extra_args = [["-maxorphantx=1000"], ["-maxorphantx=1000", "-limitancestorcount=5"]]
 
     # Build a transaction that spends parent_txid:vout

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -63,9 +63,8 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         self.log.debug("Stop-start node0 and node1. Verify that node0 has the transactions in its mempool and node1 does not.")
         self.stop_nodes()
-        self.nodes = []
-        self.nodes.append(self.start_node(0, self.options.tmpdir))
-        self.nodes.append(self.start_node(1, self.options.tmpdir))
+        self.start_node(0)
+        self.start_node(1)
         # Give bitcoind a second to reload the mempool
         time.sleep(1)
         wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
@@ -73,16 +72,14 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         self.log.debug("Stop-start node0 with -persistmempool=0. Verify that it doesn't load its mempool.dat file.")
         self.stop_nodes()
-        self.nodes = []
-        self.nodes.append(self.start_node(0, self.options.tmpdir, ["-persistmempool=0"]))
+        self.start_node(0, extra_args=["-persistmempool=0"])
         # Give bitcoind a second to reload the mempool
         time.sleep(1)
         assert_equal(len(self.nodes[0].getrawmempool()), 0)
 
         self.log.debug("Stop-start node0. Verify that it has the transactions in its mempool.")
         self.stop_nodes()
-        self.nodes = []
-        self.nodes.append(self.start_node(0, self.options.tmpdir))
+        self.start_node(0)
         wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
 
 if __name__ == '__main__':

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -36,12 +36,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class MempoolPersistTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        # We need 3 nodes for this test. Node1 does not have a persistent mempool.
+    def set_test_params(self):
         self.num_nodes = 3
-        self.setup_clean_chain = False
         self.extra_args = [[], ["-persistmempool=0"], []]
 
     def run_test(self):

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -13,10 +13,8 @@ from test_framework.util import *
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
         self.extra_args = [["-checkmempool"]] * 2
 
     alert_filename = None  # Set by setup_network

--- a/test/functional/mempool_resurrect_test.py
+++ b/test/functional/mempool_resurrect_test.py
@@ -9,12 +9,8 @@ from test_framework.util import *
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = False
-        # Just need one node for this test
         self.extra_args = [["-checkmempool"]]
 
     def run_test(self):

--- a/test/functional/mempool_spendcoinbase.py
+++ b/test/functional/mempool_spendcoinbase.py
@@ -17,11 +17,8 @@ from test_framework.util import *
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = False
         self.extra_args = [["-checkmempool"]]
 
     def run_test(self):

--- a/test/functional/merkle_blocks.py
+++ b/test/functional/merkle_blocks.py
@@ -9,6 +9,7 @@ from test_framework.util import *
 
 class MerkleBlockTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 4
         self.setup_clean_chain = True
         # Nodes 0/1 are "wallet" nodes, Nodes 2/3 are used for testing
         self.extra_args = [[], [], [], ["-txindex"]]

--- a/test/functional/merkle_blocks.py
+++ b/test/functional/merkle_blocks.py
@@ -8,11 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class MerkleBlockTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 4
         # Nodes 0/1 are "wallet" nodes, Nodes 2/3 are used for testing
         self.extra_args = [[], [], [], ["-txindex"]]
 

--- a/test/functional/mining.py
+++ b/test/functional/mining.py
@@ -25,9 +25,7 @@ def assert_template(node, block, expect, rehash=True):
     assert_equal(rsp, expect)
 
 class MiningTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = False
 

--- a/test/functional/multi_rpc.py
+++ b/test/functional/multi_rpc.py
@@ -12,10 +12,7 @@ import http.client
 import urllib.parse
 
 class HTTPBasicsTest (BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        self.setup_clean_chain = False
+    def set_test_params(self):
         self.num_nodes = 2
 
     def setup_chain(self):

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -23,17 +23,17 @@ class MultiWalletTest(BitcoinTestFramework):
         self.stop_node(0)
 
         # should not initialize if there are duplicate wallets
-        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w1', '-wallet=w1'], 'Error loading wallet w1. Duplicate -wallet filename specified.')
+        self.assert_start_raises_init_error(0, ['-wallet=w1', '-wallet=w1'], 'Error loading wallet w1. Duplicate -wallet filename specified.')
 
         # should not initialize if wallet file is a directory
         os.mkdir(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w11'))
-        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
+        self.assert_start_raises_init_error(0, ['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
 
         # should not initialize if wallet file is a symlink
         os.symlink(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w1'), os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w12'))
-        self.assert_start_raises_init_error(0, self.options.tmpdir, ['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
+        self.assert_start_raises_init_error(0, ['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
 
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
+        self.start_node(0, self.extra_args[0])
 
         w1 = self.nodes[0].get_wallet_rpc("w1")
         w2 = self.nodes[0].get_wallet_rpc("w2")

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -12,9 +12,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class MultiWalletTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [['-wallet=w1', '-wallet=w2', '-wallet=w3']]

--- a/test/functional/net.py
+++ b/test/functional/net.py
@@ -17,10 +17,8 @@ from test_framework.util import (
     p2p_port,
 )
 
-
 class NetTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
 

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -37,8 +37,7 @@ def trueDummy(tx):
 
 class NULLDUMMYTest(BitcoinTestFramework):
 
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
         self.extra_args = [['-whitelist=127.0.0.1', '-walletprematurewitness']]

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -60,8 +60,7 @@ class AcceptBlockTest(BitcoinTestFramework):
                           default=os.getenv("BITCOIND", "bitcoind"),
                           help="bitcoind binary to test")
 
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [[], ["-whitelist=127.0.0.1"]]

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -89,8 +89,7 @@ class TestNode(NodeConnCB):
         wait_until(lambda: not self.connected, timeout=timeout, lock=mininode_lock)
 
 class CompactBlocksTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         # Node0 = pre-segwit, node1 = segwit-aware
         self.num_nodes = 2

--- a/test/functional/p2p-feefilter.py
+++ b/test/functional/p2p-feefilter.py
@@ -37,11 +37,8 @@ class TestNode(NodeConnCB):
             self.txinvs = []
 
 class FeeFilterTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = False
 
     def run_test(self):
         node1 = self.nodes[1]

--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -49,12 +49,11 @@ class CBrokenBlock(CBlock):
         return r
 
 class FullBlockTest(ComparisonTestFramework):
-
     # Can either run this test as 1 node with expected answers, or two and compare them.
     # Change the "outcome" variable from each TestInstance object to only do the comparison.
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
+        self.setup_clean_chain = True
         self.block_heights = {}
         self.coinbase_key = CECKey()
         self.coinbase_key.set_secretbytes(b"horsebattery")

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -92,8 +92,7 @@ class CNodeNoVerackIdle(CLazyNode):
         conn.send_message(msg_getaddr())
 
 class P2PLeakTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [['-banscore='+str(banscore)]]
 

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -13,9 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class P2PMempoolTests(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [["-peerbloomfilters=0"]]

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -34,6 +34,7 @@ def get_virtual_size(witness_block):
 
 class TestNode(NodeConnCB):
     def set_test_params(self):
+        self.num_nodes = 3
         self.getdataset = set()
 
     def on_getdata(self, conn, message):

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -33,8 +33,7 @@ def get_virtual_size(witness_block):
     return vsize
 
 class TestNode(NodeConnCB):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.getdataset = set()
 
     def on_getdata(self, conn, message):
@@ -109,9 +108,7 @@ def sign_P2PK_witness_input(script, txTo, inIdx, hashtype, value, key):
 
 
 class SegWitTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
         self.extra_args = [["-whitelist=127.0.0.1"], ["-whitelist=127.0.0.1", "-acceptnonstdtxn=0"], ["-whitelist=127.0.0.1", "-vbparams=segwit:0:0"]]

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -1496,7 +1496,7 @@ class SegWitTest(BitcoinTestFramework):
 
         # Restart with the new binary
         self.stop_node(node_id)
-        self.nodes[node_id] = self.start_node(node_id, self.options.tmpdir)
+        self.start_node(node_id, extra_args=[])
         connect_nodes(self.nodes[0], node_id)
 
         sync_blocks(self.nodes)

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -33,8 +33,7 @@ class TestNode(NodeConnCB):
         pass
 
 class TimeoutsTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -28,8 +28,7 @@ class TestNode(NodeConnCB):
         pass
 
 class VersionBitsWarningTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -112,7 +112,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         # Empty out the alert file
         with open(self.alert_filename, 'w', encoding='utf8') as _:
             pass
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.start_nodes()
 
         # Connecting one block should be enough to generate an error.
         self.nodes[0].generate(1)
@@ -123,7 +123,7 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         self.test_versionbits_in_alert_file()
 
         # Test framework expects the node to still be running...
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.start_nodes()
 
 if __name__ == '__main__':
     VersionBitsWarningTest().main()

--- a/test/functional/preciousblock.py
+++ b/test/functional/preciousblock.py
@@ -35,8 +35,7 @@ def node_sync_via_rpc(nodes):
             unidirectional_node_sync_via_rpc(node_src, node_dest)
 
 class PreciousTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
 

--- a/test/functional/prioritise_transaction.py
+++ b/test/functional/prioritise_transaction.py
@@ -9,9 +9,7 @@ from test_framework.util import *
 from test_framework.mininode import COIN, MAX_BLOCK_BASE_SIZE
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [["-printpriority=1"], ["-printpriority=1"]]

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -42,6 +42,9 @@ from test_framework.netutil import test_ipv6_local
 RANGE_BEGIN = PORT_MIN + 2 * PORT_RANGE  # Start after p2p and rpc ports
 
 class ProxyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 4
+
     def setup_nodes(self):
         self.have_ipv6 = test_ipv6_local()
         # Create two proxies on different ports

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -89,7 +89,7 @@ class ProxyTest(BitcoinTestFramework):
             ]
         if self.have_ipv6:
             args[3] = ['-listen', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
-        self.add_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
+        self.add_nodes(self.num_nodes, extra_args=args)
         self.start_nodes()
 
     def node_test(self, node, proxies, auth, test_onion=True):

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -89,7 +89,8 @@ class ProxyTest(BitcoinTestFramework):
             ]
         if self.have_ipv6:
             args[3] = ['-listen', '-proxy=[%s]:%i' % (self.conf3.addr),'-proxyrandomize=0', '-noonion']
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
+        self.add_nodes(self.num_nodes, self.options.tmpdir, extra_args=args)
+        self.start_nodes()
 
     def node_test(self, node, proxies, auth, test_onion=True):
         rv = []

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -41,13 +41,7 @@ from test_framework.netutil import test_ipv6_local
 
 RANGE_BEGIN = PORT_MIN + 2 * PORT_RANGE  # Start after p2p and rpc ports
 
-
 class ProxyTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
-
     def setup_nodes(self):
         self.have_ipv6 = test_ipv6_local()
         # Create two proxies on different ports

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -57,7 +57,7 @@ class PruneTest(BitcoinTestFramework):
         sync_blocks(self.nodes[0:5])
 
     def setup_nodes(self):
-        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=900)
+        self.add_nodes(self.num_nodes, self.extra_args, timewait=900)
         self.start_nodes()
 
     def create_big_chain(self):

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -56,6 +56,10 @@ class PruneTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 4)
         sync_blocks(self.nodes[0:5])
 
+    def setup_nodes(self):
+        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=900)
+        self.start_nodes()
+
     def create_big_chain(self):
         # Start by creating some coinbases we can spend later
         self.nodes[1].generate(200)
@@ -98,7 +102,7 @@ class PruneTest(BitcoinTestFramework):
             # Node 2 stays connected, so it hears about the stale blocks and then reorg's when node0 reconnects
             # Stopping node 0 also clears its mempool, so it doesn't have node1's transactions to accidentally mine
             self.stop_node(0)
-            self.nodes[0]=self.start_node(0, self.options.tmpdir, self.full_node_default_args, timewait=900)
+            self.start_node(0, extra_args=self.full_node_default_args)
             # Mine 24 blocks in node 1
             for i in range(24):
                 if j == 0:
@@ -126,7 +130,7 @@ class PruneTest(BitcoinTestFramework):
         # Reboot node 1 to clear its mempool (hopefully make the invalidate faster)
         # Lower the block max size so we don't keep mining all our big mempool transactions (from disconnected blocks)
         self.stop_node(1)
-        self.nodes[1] = self.start_node(1, self.options.tmpdir, ["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
+        self.start_node(1, extra_args=["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"])
 
         height = self.nodes[1].getblockcount()
         self.log.info("Current block height: %d" % height)
@@ -149,7 +153,7 @@ class PruneTest(BitcoinTestFramework):
 
         # Reboot node1 to clear those giant tx's from mempool
         self.stop_node(1)
-        self.nodes[1] = self.start_node(1, self.options.tmpdir, ["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"], timewait=900)
+        self.start_node(1, extra_args=["-maxreceivebuffer=20000","-blockmaxsize=5000", "-checkblocks=5", "-disablesafemode"])
 
         self.log.info("Generating new longer chain of 300 more blocks")
         self.nodes[1].generate(300)
@@ -227,13 +231,15 @@ class PruneTest(BitcoinTestFramework):
 
     def manual_test(self, node_number, use_timestamp):
         # at this point, node has 995 blocks and has not yet run in prune mode
-        node = self.nodes[node_number] = self.start_node(node_number, self.options.tmpdir, timewait=900)
+        self.start_node(node_number)
+        node = self.nodes[node_number]
         assert_equal(node.getblockcount(), 995)
         assert_raises_jsonrpc(-1, "not in prune mode", node.pruneblockchain, 500)
-        self.stop_node(node_number)
 
         # now re-start in manual pruning mode
-        node = self.nodes[node_number] = self.start_node(node_number, self.options.tmpdir, ["-prune=1"], timewait=900)
+        self.stop_node(node_number)
+        self.start_node(node_number, extra_args=["-prune=1"])
+        node = self.nodes[node_number]
         assert_equal(node.getblockcount(), 995)
 
         def height(index):
@@ -307,7 +313,7 @@ class PruneTest(BitcoinTestFramework):
 
         # stop node, start back up with auto-prune at 550MB, make sure still runs
         self.stop_node(node_number)
-        self.nodes[node_number] = self.start_node(node_number, self.options.tmpdir, ["-prune=550"], timewait=900)
+        self.start_node(node_number, extra_args=["-prune=550"])
 
         self.log.info("Success")
 
@@ -315,7 +321,7 @@ class PruneTest(BitcoinTestFramework):
         # check that the pruning node's wallet is still in good shape
         self.log.info("Stop and start pruning node to trigger wallet rescan")
         self.stop_node(2)
-        self.nodes[2] = self.start_node(2, self.options.tmpdir, ["-prune=550"])
+        self.start_node(2, extra_args=["-prune=550"])
         self.log.info("Success")
 
         # check that wallet loads successfully when restarting a pruned node after IBD.
@@ -325,7 +331,7 @@ class PruneTest(BitcoinTestFramework):
         nds = [self.nodes[0], self.nodes[5]]
         sync_blocks(nds, wait=5, timeout=300)
         self.stop_node(5) #stop and start to trigger rescan
-        self.nodes[5] = self.start_node(5, self.options.tmpdir, ["-prune=550"])
+        self.start_node(5, extra_args=["-prune=550"])
         self.log.info("Success")
 
     def run_test(self):

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -26,9 +26,7 @@ def calc_usage(blockdir):
     return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f)) / (1024. * 1024.)
 
 class PruneTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 6
 

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -17,9 +17,7 @@ from test_framework.util import *
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
 

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -23,11 +23,7 @@ def get_sub_array_from_array(object_array, to_match):
     return []
 
 class ReceivedByTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
+    def set_test_params(self):
         self.enable_mocktime()
 
     def run_test(self):

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -24,6 +24,7 @@ def get_sub_array_from_array(object_array, to_match):
 
 class ReceivedByTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 2
         self.enable_mocktime()
 
     def run_test(self):

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -28,11 +28,7 @@ class ReceivedByTest(BitcoinTestFramework):
         super().__init__()
         self.num_nodes = 4
         self.setup_clean_chain = False
-
-    def setup_nodes(self):
-        #This test requires mocktime
         self.enable_mocktime()
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir)
 
     def run_test(self):
         '''

--- a/test/functional/reindex.py
+++ b/test/functional/reindex.py
@@ -15,8 +15,7 @@ import time
 
 class ReindexTest(BitcoinTestFramework):
 
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/reindex.py
+++ b/test/functional/reindex.py
@@ -25,7 +25,7 @@ class ReindexTest(BitcoinTestFramework):
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
         extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.start_nodes(extra_args)
         while self.nodes[0].getblockcount() < blockcount:
             time.sleep(0.1)
         assert_equal(self.nodes[0].getblockcount(), blockcount)

--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -61,10 +61,8 @@ def make_utxo(node, amount, confirmed=True, scriptPubKey=CScript([1])):
 
 class ReplaceByFeeTest(BitcoinTestFramework):
 
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = False
         self.extra_args= [["-maxorphantx=1000",
                            "-whitelist=127.0.0.1",
                            "-limitancestorcount=50",

--- a/test/functional/resendwallettransactions.py
+++ b/test/functional/resendwallettransactions.py
@@ -20,7 +20,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
 
         # Should return an empty array if there aren't unconfirmed wallet transactions.
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir)
+        self.start_node(0, extra_args=[])
         assert_equal(self.nodes[0].resendwallettransactions(), [])
 
         # Should return an array with the unconfirmed wallet transaction.

--- a/test/functional/resendwallettransactions.py
+++ b/test/functional/resendwallettransactions.py
@@ -8,11 +8,9 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class ResendWalletTransactionsTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        self.extra_args = [['--walletbroadcast=false']]
+    def set_test_params(self):
         self.num_nodes = 1
+        self.extra_args = [['--walletbroadcast=false']]
 
     def run_test(self):
         # Should raise RPC_WALLET_ERROR (-4) if walletbroadcast is disabled.

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -43,8 +43,7 @@ def http_post_call(host, port, path, requestdata = '', response_object = 0):
 class RESTTest (BitcoinTestFramework):
     FORMAT_SEPARATOR = "."
 
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
 

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -11,11 +11,8 @@ from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.util import *
 from test_framework.netutil import *
 
-
 class RPCBindTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -20,7 +20,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.num_nodes = 1
 
     def setup_network(self):
-        self.add_nodes(self.num_nodes, self.options.tmpdir, None)
+        self.add_nodes(self.num_nodes, None)
 
     def run_bind_test(self, allow_ips, connect_to, addresses, expected):
         '''

--- a/test/functional/rpcnamedargs.py
+++ b/test/functional/rpcnamedargs.py
@@ -10,15 +10,8 @@ from test_framework.util import (
     assert_raises_jsonrpc,
 )
 
-
 class NamedArgumentTest(BitcoinTestFramework):
-    """
-    Test named arguments on RPC calls.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.setup_clean_chain = False
+    def set_test_params(self):
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -75,9 +75,7 @@ def find_unspent(node, min_value):
             return utxo
 
 class SegWitTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
         self.extra_args = [["-walletprematurewitness", "-rpcserialversion=0"],

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -174,8 +174,7 @@ class TestNode(NodeConnCB):
         self.send_message(getblocks_message)
 
 class SendHeadersTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
 

--- a/test/functional/signmessages.py
+++ b/test/functional/signmessages.py
@@ -7,9 +7,7 @@
 from test_framework.test_framework import BitcoinTestFramework
 
 class SignMessagesTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/signrawtransactions.py
+++ b/test/functional/signrawtransactions.py
@@ -9,8 +9,7 @@ from test_framework.util import *
 
 
 class SignRawTransactionsTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -153,9 +153,9 @@ class EstimateFeeTest(BitcoinTestFramework):
         But first we need to use one node to create a lot of outputs
         which we will use to generate our transactions.
         """
-        self.add_nodes(3, self.options.tmpdir, extra_args=[["-maxorphantx=1000", "-whitelist=127.0.0.1"],
-                                                           ["-blockmaxsize=17000", "-maxorphantx=1000"],
-                                                           ["-blockmaxsize=8000", "-maxorphantx=1000"]])
+        self.add_nodes(3, extra_args=[["-maxorphantx=1000", "-whitelist=127.0.0.1"],
+                                      ["-blockmaxsize=17000", "-maxorphantx=1000"],
+                                      ["-blockmaxsize=8000", "-maxorphantx=1000"]])
         # Use node0 to mine blocks for input splitting
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -141,11 +141,8 @@ def check_estimates(node, fees_seen, max_invalid, print_estimates = True):
 
 
 class EstimateFeeTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 3
-        self.setup_clean_chain = False
 
     def setup_network(self):
         """

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -153,57 +153,16 @@ class EstimateFeeTest(BitcoinTestFramework):
         But first we need to use one node to create a lot of outputs
         which we will use to generate our transactions.
         """
-        self.nodes = []
+        self.add_nodes(3, self.options.tmpdir, extra_args=[["-maxorphantx=1000", "-whitelist=127.0.0.1"],
+                                                           ["-blockmaxsize=17000", "-maxorphantx=1000"],
+                                                           ["-blockmaxsize=8000", "-maxorphantx=1000"]])
         # Use node0 to mine blocks for input splitting
-        self.nodes.append(self.start_node(0, self.options.tmpdir, ["-maxorphantx=1000",
-                                                              "-whitelist=127.0.0.1"]))
-
-        self.log.info("This test is time consuming, please be patient")
-        self.log.info("Splitting inputs so we can generate tx's")
-        self.txouts = []
-        self.txouts2 = []
-        # Split a coinbase into two transaction puzzle outputs
-        split_inputs(self.nodes[0], self.nodes[0].listunspent(0), self.txouts, True)
-
-        # Mine
-        while (len(self.nodes[0].getrawmempool()) > 0):
-            self.nodes[0].generate(1)
-
-        # Repeatedly split those 2 outputs, doubling twice for each rep
-        # Use txouts to monitor the available utxo, since these won't be tracked in wallet
-        reps = 0
-        while (reps < 5):
-            #Double txouts to txouts2
-            while (len(self.txouts)>0):
-                split_inputs(self.nodes[0], self.txouts, self.txouts2)
-            while (len(self.nodes[0].getrawmempool()) > 0):
-                self.nodes[0].generate(1)
-            #Double txouts2 to txouts
-            while (len(self.txouts2)>0):
-                split_inputs(self.nodes[0], self.txouts2, self.txouts)
-            while (len(self.nodes[0].getrawmempool()) > 0):
-                self.nodes[0].generate(1)
-            reps += 1
-        self.log.info("Finished splitting")
-
-        # Now we can connect the other nodes, didn't want to connect them earlier
-        # so the estimates would not be affected by the splitting transactions
         # Node1 mines small blocks but that are bigger than the expected transaction rate.
         # NOTE: the CreateNewBlock code starts counting block size at 1,000 bytes,
         # (17k is room enough for 110 or so transactions)
-        self.nodes.append(self.start_node(1, self.options.tmpdir,
-                                     ["-blockmaxsize=17000", "-maxorphantx=1000"]))
-        connect_nodes(self.nodes[1], 0)
-
         # Node2 is a stingy miner, that
         # produces too small blocks (room for only 55 or so transactions)
-        node2args = ["-blockmaxsize=8000", "-maxorphantx=1000"]
 
-        self.nodes.append(self.start_node(2, self.options.tmpdir, node2args))
-        connect_nodes(self.nodes[0], 2)
-        connect_nodes(self.nodes[2], 1)
-
-        self.sync_all()
 
     def transact_and_mine(self, numblocks, mining_node):
         min_fee = Decimal("0.00001")
@@ -232,9 +191,51 @@ class EstimateFeeTest(BitcoinTestFramework):
             self.memutxo = newmem
 
     def run_test(self):
+        self.log.info("This test is time consuming, please be patient")
+        self.log.info("Splitting inputs so we can generate tx's")
+
         # Make log handler available to helper functions
         global log
         log = self.log
+
+        # Start node0
+        self.start_node(0)
+        self.txouts = []
+        self.txouts2 = []
+        # Split a coinbase into two transaction puzzle outputs
+        split_inputs(self.nodes[0], self.nodes[0].listunspent(0), self.txouts, True)
+
+        # Mine
+        while (len(self.nodes[0].getrawmempool()) > 0):
+            self.nodes[0].generate(1)
+
+        # Repeatedly split those 2 outputs, doubling twice for each rep
+        # Use txouts to monitor the available utxo, since these won't be tracked in wallet
+        reps = 0
+        while (reps < 5):
+            #Double txouts to txouts2
+            while (len(self.txouts)>0):
+                split_inputs(self.nodes[0], self.txouts, self.txouts2)
+            while (len(self.nodes[0].getrawmempool()) > 0):
+                self.nodes[0].generate(1)
+            #Double txouts2 to txouts
+            while (len(self.txouts2)>0):
+                split_inputs(self.nodes[0], self.txouts2, self.txouts)
+            while (len(self.nodes[0].getrawmempool()) > 0):
+                self.nodes[0].generate(1)
+            reps += 1
+        self.log.info("Finished splitting")
+
+        # Now we can connect the other nodes, didn't want to connect them earlier
+        # so the estimates would not be affected by the splitting transactions
+        self.start_node(1)
+        self.start_node(2)
+        connect_nodes(self.nodes[1], 0)
+        connect_nodes(self.nodes[0], 2)
+        connect_nodes(self.nodes[2], 1)
+
+        self.sync_all()
+
         self.fees_per_kb = []
         self.memutxo = []
         self.confutxo = self.txouts # Start with the set of confirmed txouts after splitting

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -48,11 +48,10 @@ BITCOIND_PROC_WAIT_TIMEOUT = 60
 class BitcoinTestFramework(object):
     """Base class for a bitcoin test script.
 
-    Individual bitcoin test scripts should subclass this class and override the run_test() method.
+    Individual bitcoin test scripts should subclass this class and override the set_test_params() and run_test() methods.
 
     Individual tests can also override the following methods to customize the test setup:
 
-    - set_test_params()
     - add_options()
     - setup_chain()
     - setup_network()
@@ -64,11 +63,12 @@ class BitcoinTestFramework(object):
 
     def __init__(self):
         """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
-        self.num_nodes = 4
         self.setup_clean_chain = False
         self.nodes = []
         self.mocktime = 0
         self.set_test_params()
+
+        assert hasattr(self, "num_nodes"), "Test must set self.num_nodes in set_test_params()"
 
     def main(self):
         """Main function. This should not be overridden by the subclass test scripts."""
@@ -177,8 +177,8 @@ class BitcoinTestFramework(object):
 
     # Methods to override in subclass test scripts.
     def set_test_params(self):
-        """Override this method to change default values for number of nodes, topology, etc"""
-        pass
+        """Tests must this method to change default values for number of nodes, topology, etc"""
+        raise NotImplementedError
 
     def add_options(self, parser):
         """Override this method to add command-line options to the test"""
@@ -212,7 +212,7 @@ class BitcoinTestFramework(object):
         self.start_nodes()
 
     def run_test(self):
-        """Override this method to define test logic"""
+        """Tests must override this method to define test logic"""
         raise NotImplementedError
 
     # Public helper methods. These can be accessed by the subclass test scripts.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -74,7 +74,7 @@ class TestNode():
         for _ in range(poll_per_s * self.rpc_timeout):
             assert self.process.poll() is None, "bitcoind exited with status %i during initialization" % self.process.returncode
             try:
-                self.rpc = get_rpc_proxy(rpc_url(self.datadir, self.index, self.rpchost), self.index, coveragedir=self.coverage_dir)
+                self.rpc = get_rpc_proxy(rpc_url(self.datadir, self.index, self.rpchost), self.index, timeout=self.rpc_timeout, coveragedir=self.coverage_dir)
                 self.rpc.getblockcount()
                 # If the call to getblockcount() succeeds then the RPC connection is up
                 self.rpc_connected = True

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -61,9 +61,13 @@ class TestNode():
         assert self.rpc_connected and self.rpc is not None, "Error: no RPC connection"
         return self.rpc.__getattr__(*args, **kwargs)
 
-    def start(self):
+    def start(self, extra_args=None, stderr=None):
         """Start the node."""
-        self.process = subprocess.Popen(self.args + self.extra_args, stderr=self.stderr)
+        if extra_args is None:
+            extra_args = self.extra_args
+        if stderr is None:
+            stderr = self.stderr
+        self.process = subprocess.Popen(self.args + extra_args, stderr=stderr)
         self.running = True
         self.log.debug("bitcoind started, waiting for RPC to come up")
 

--- a/test/functional/txn_clone.py
+++ b/test/functional/txn_clone.py
@@ -8,6 +8,9 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class TxnMallTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 4
+
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")

--- a/test/functional/txn_clone.py
+++ b/test/functional/txn_clone.py
@@ -8,12 +8,6 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class TxnMallTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
-
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")

--- a/test/functional/txn_doublespend.py
+++ b/test/functional/txn_doublespend.py
@@ -8,6 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class TxnMallTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 4
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",

--- a/test/functional/txn_doublespend.py
+++ b/test/functional/txn_doublespend.py
@@ -9,11 +9,6 @@ from test_framework.util import *
 
 class TxnMallTest(BitcoinTestFramework):
 
-    def __init__(self):
-        super().__init__()
-        self.num_nodes = 4
-        self.setup_clean_chain = False
-
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
                           help="Test double-spend of 1-confirmed transaction")

--- a/test/functional/uptime.py
+++ b/test/functional/uptime.py
@@ -13,9 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework
 
 
 class UptimeTest(BitcoinTestFramework):
-    def __init__(self):
-        super().__init__()
-
+    def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
 

--- a/test/functional/wallet-accounts.py
+++ b/test/functional/wallet-accounts.py
@@ -17,9 +17,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
 class WalletAccountsTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
         self.extra_args = [[]]

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -68,7 +68,8 @@ class WalletDumpTest(BitcoinTestFramework):
         # longer than the default 30 seconds due to an expensive
         # CWallet::TopUpKeyPool call, and the encryptwallet RPC made later in
         # the test often takes even longer.
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=60)
+        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=60)
+        self.start_nodes()
 
     def run_test (self):
         tmpdir = self.options.tmpdir
@@ -95,7 +96,7 @@ class WalletDumpTest(BitcoinTestFramework):
 
         #encrypt wallet, restart, unlock and dump
         self.nodes[0].node_encrypt_wallet('test')
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, self.extra_args[0])
+        self.start_node(0)
         self.nodes[0].walletpassphrase('test', 10)
         # Should be a no-op:
         self.nodes[0].keypoolrefill()

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -56,10 +56,7 @@ def read_dump(file_name, addrs, hd_master_addr_old):
 
 
 class WalletDumpTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
-        self.setup_clean_chain = False
+    def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [["-keypool=90"]]
 

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -68,7 +68,7 @@ class WalletDumpTest(BitcoinTestFramework):
         # longer than the default 30 seconds due to an expensive
         # CWallet::TopUpKeyPool call, and the encryptwallet RPC made later in
         # the test often takes even longer.
-        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args, timewait=60)
+        self.add_nodes(self.num_nodes, self.extra_args, timewait=60)
         self.start_nodes()
 
     def run_test (self):

--- a/test/functional/wallet-encryption.py
+++ b/test/functional/wallet-encryption.py
@@ -31,7 +31,7 @@ class WalletEncryptionTest(BitcoinTestFramework):
 
         # Encrypt the wallet
         self.nodes[0].node_encrypt_wallet(passphrase)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir)
+        self.start_node(0)
 
         # Test that the wallet is encrypted
         assert_raises_jsonrpc(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)

--- a/test/functional/wallet-encryption.py
+++ b/test/functional/wallet-encryption.py
@@ -13,9 +13,7 @@ from test_framework.util import (
 )
 
 class WalletEncryptionTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
 

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -25,8 +25,8 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
-        self.assert_start_raises_init_error(1, self.options.tmpdir, ['-usehd=0'], 'already existing HD wallet')
-        self.nodes[1] = self.start_node(1, self.options.tmpdir, self.extra_args[1])
+        self.assert_start_raises_init_error(1, ['-usehd=0'], 'already existing HD wallet')
+        self.start_node(1)
         connect_nodes_bi(self.nodes, 0, 1)
 
         # Make sure we use hd, keep masterkeyid
@@ -76,7 +76,7 @@ class WalletHDTest(BitcoinTestFramework):
         shutil.rmtree(tmpdir + "/node1/regtest/blocks")
         shutil.rmtree(tmpdir + "/node1/regtest/chainstate")
         shutil.copyfile(tmpdir + "/hd.bak", tmpdir + "/node1/regtest/wallet.dat")
-        self.nodes[1] = self.start_node(1, self.options.tmpdir, self.extra_args[1])
+        self.start_node(1)
 
         # Assert that derivation is deterministic
         hd_add_2 = None
@@ -91,7 +91,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Needs rescan
         self.stop_node(1)
-        self.nodes[1] = self.start_node(1, self.options.tmpdir, self.extra_args[1] + ['-rescan'])
+        self.start_node(1, extra_args=self.extra_args[1] + ['-rescan'])
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 
         # send a tx and make sure its using the internal chain for the changeoutput

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -11,11 +11,8 @@ from test_framework.util import (
 )
 import shutil
 
-
 class WalletHDTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
         self.extra_args = [['-usehd=0'], ['-usehd=1', '-keypool=0']]

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -21,11 +21,14 @@ class WalletTest(BitcoinTestFramework):
         self.extra_args = [['-usehd={:d}'.format(i%2==0)] for i in range(4)]
 
     def setup_network(self):
-        self.nodes = self.start_nodes(3, self.options.tmpdir, self.extra_args[:3])
+        self.add_nodes(4, self.options.tmpdir, self.extra_args)
+        self.start_node(0)
+        self.start_node(1)
+        self.start_node(2)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
     def run_test(self):
 
@@ -42,9 +45,9 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(walletinfo['immature_balance'], 50)
         assert_equal(walletinfo['balance'], 0)
 
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         self.nodes[1].generate(101)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         assert_equal(self.nodes[0].getbalance(), 50)
         assert_equal(self.nodes[1].getbalance(), 50)
@@ -88,7 +91,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Have node0 mine a block, thus it will collect its own fee.
         self.nodes[0].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         # Exercise locking of unspent outputs
         unspent_0 = self.nodes[2].listunspent()[0]
@@ -101,7 +104,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Have node1 generate 100 blocks (so node0 can recover the fee)
         self.nodes[1].generate(100)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         # node0 should end up with 100 btc in block rewards plus fees, but
         # minus the 21 plus fees sent to node2
@@ -130,7 +133,7 @@ class WalletTest(BitcoinTestFramework):
 
         # Have node1 mine a block to confirm transactions:
         self.nodes[1].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         assert_equal(self.nodes[0].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 94)
@@ -142,14 +145,14 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[2].settxfee(fee_per_byte * 1000)
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", False)
         self.nodes[2].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), Decimal('84'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
         assert_equal(self.nodes[0].getbalance(), Decimal('10'))
 
         # Send 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendtoaddress(address, 10, "", "", True)
         self.nodes[2].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         node_2_bal -= Decimal('10')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
         node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), Decimal('20'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
@@ -157,7 +160,7 @@ class WalletTest(BitcoinTestFramework):
         # Sendmany 10 BTC
         txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [])
         self.nodes[2].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         node_0_bal += Decimal('10')
         node_2_bal = self.check_fee_amount(self.nodes[2].getbalance(), node_2_bal - Decimal('10'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
@@ -165,7 +168,7 @@ class WalletTest(BitcoinTestFramework):
         # Sendmany 10 BTC with subtract fee from amount
         txid = self.nodes[2].sendmany('from1', {address: 10}, 0, "", [address])
         self.nodes[2].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         node_2_bal -= Decimal('10')
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
         node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, count_bytes(self.nodes[2].getrawtransaction(txid)))
@@ -176,9 +179,9 @@ class WalletTest(BitcoinTestFramework):
         # EXPECT: nodes[3] should have those transactions in its mempool.
         txid1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         txid2 = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-        sync_mempools(self.nodes)
+        sync_mempools(self.nodes[0:2])
 
-        self.nodes.append(self.start_node(3, self.options.tmpdir, self.extra_args[3]))
+        self.start_node(3)
         connect_nodes_bi(self.nodes, 0, 3)
         sync_blocks(self.nodes)
 
@@ -222,22 +225,24 @@ class WalletTest(BitcoinTestFramework):
 
         #do some -walletbroadcast tests
         self.stop_nodes()
-        self.nodes = self.start_nodes(3, self.options.tmpdir, [["-walletbroadcast=0"],["-walletbroadcast=0"],["-walletbroadcast=0"]])
+        self.start_node(0, ["-walletbroadcast=0"])
+        self.start_node(1, ["-walletbroadcast=0"])
+        self.start_node(2, ["-walletbroadcast=0"])
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         txIdNotBroadcasted  = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 2)
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         self.nodes[1].generate(1) #mine a block, tx should not be in there
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         assert_equal(self.nodes[2].getbalance(), node_2_bal) #should not be changed because tx was not broadcasted
 
         #now broadcast from another node, mine a block, sync, and check the balance
         self.nodes[1].sendrawtransaction(txObjNotBroadcasted['hex'])
         self.nodes[1].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         node_2_bal += 2
         txObjNotBroadcasted = self.nodes[0].gettransaction(txIdNotBroadcasted)
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
@@ -247,14 +252,16 @@ class WalletTest(BitcoinTestFramework):
 
         #restart the nodes with -walletbroadcast=1
         self.stop_nodes()
-        self.nodes = self.start_nodes(3, self.options.tmpdir)
+        self.start_node(0)
+        self.start_node(1)
+        self.start_node(2)
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,0,2)
-        sync_blocks(self.nodes)
+        sync_blocks(self.nodes[0:3])
 
         self.nodes[0].generate(1)
-        sync_blocks(self.nodes)
+        sync_blocks(self.nodes[0:3])
         node_2_bal += 2
 
         #tx should be added to balance because after restarting the nodes tx should be broadcastet
@@ -285,7 +292,7 @@ class WalletTest(BitcoinTestFramework):
         address_to_import = self.nodes[2].getnewaddress()
         txid = self.nodes[0].sendtoaddress(address_to_import, 1)
         self.nodes[0].generate(1)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         # 2. Import address from node2 to node1
         self.nodes[1].importaddress(address_to_import)
@@ -311,15 +318,15 @@ class WalletTest(BitcoinTestFramework):
         cbAddr = self.nodes[1].getnewaddress()
         blkHash = self.nodes[0].generatetoaddress(1, cbAddr)[0]
         cbTxId = self.nodes[0].getblock(blkHash)['tx'][0]
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
 
         # Check that the txid and balance is found by node1
         self.nodes[1].gettransaction(cbTxId)
 
         # check if wallet or blockchain maintenance changes the balance
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         blocks = self.nodes[0].generate(2)
-        self.sync_all()
+        self.sync_all([self.nodes[0:3]])
         balance_nodes = [self.nodes[i].getbalance() for i in range(3)]
         block_count = self.nodes[0].getblockcount()
 
@@ -350,7 +357,9 @@ class WalletTest(BitcoinTestFramework):
             self.log.info("check " + m)
             self.stop_nodes()
             # set lower ancestor limit for later
-            self.nodes = self.start_nodes(3, self.options.tmpdir, [[m, "-limitancestorcount="+str(chainlimit)]] * 3)
+            self.start_node(0, [m, "-limitancestorcount="+str(chainlimit)])
+            self.start_node(1, [m, "-limitancestorcount="+str(chainlimit)])
+            self.start_node(2, [m, "-limitancestorcount="+str(chainlimit)])
             while m == '-reindex' and [block_count] * 3 != [self.nodes[i].getblockcount() for i in range(3)]:
                 # reindex will leave rpc warm up "early"; Wait for it to finish
                 time.sleep(0.1)
@@ -398,7 +407,7 @@ class WalletTest(BitcoinTestFramework):
         # Try with walletrejectlongchains
         # Double chain limit but require combining inputs, so we pass SelectCoinsMinConf
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-walletrejectlongchains", "-limitancestorcount="+str(2*chainlimit)])
+        self.start_node(0, extra_args=["-walletrejectlongchains", "-limitancestorcount="+str(2*chainlimit)])
 
         # wait for loadmempool
         timeout = 10

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -7,17 +7,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class WalletTest(BitcoinTestFramework):
-
-    def check_fee_amount(self, curr_balance, balance_with_fee, fee_per_byte, tx_size):
-        """Return curr_balance after asserting the fee was in range"""
-        fee = balance_with_fee - curr_balance
-        assert_fee_amount(fee, tx_size, fee_per_byte * 1000)
-        return curr_balance
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 4
         self.extra_args = [['-usehd={:d}'.format(i%2==0)] for i in range(4)]
 
     def setup_network(self):
@@ -30,8 +21,13 @@ class WalletTest(BitcoinTestFramework):
         connect_nodes_bi(self.nodes,0,2)
         self.sync_all([self.nodes[0:3]])
 
-    def run_test(self):
+    def check_fee_amount(self, curr_balance, balance_with_fee, fee_per_byte, tx_size):
+        """Return curr_balance after asserting the fee was in range"""
+        fee = balance_with_fee - curr_balance
+        assert_fee_amount(fee, tx_size, fee_per_byte * 1000)
+        return curr_balance
 
+    def run_test(self):
         # Check that there's no UTXO on none of the nodes
         assert_equal(len(self.nodes[0].listunspent()), 0)
         assert_equal(len(self.nodes[1].listunspent()), 0)

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -21,7 +21,7 @@ class WalletTest(BitcoinTestFramework):
         self.extra_args = [['-usehd={:d}'.format(i%2==0)] for i in range(4)]
 
     def setup_network(self):
-        self.add_nodes(4, self.options.tmpdir, self.extra_args)
+        self.add_nodes(4, self.extra_args)
         self.start_node(0)
         self.start_node(1)
         self.start_node(2)

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -8,6 +8,7 @@ from test_framework.util import *
 
 class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 4
         self.setup_clean_chain = True
         self.extra_args = [['-usehd={:d}'.format(i%2==0)] for i in range(4)]
 

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -37,11 +37,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
 class WalletBackupTest(BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 4
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         self.extra_args = [["-keypool=100"], ["-keypool=100"], ["-keypool=100"], []]
 

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -38,6 +38,7 @@ from test_framework.util import *
 
 class WalletBackupTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.num_nodes = 4
         self.setup_clean_chain = True
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         self.extra_args = [["-keypool=100"], ["-keypool=100"], ["-keypool=100"], []]

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -78,9 +78,9 @@ class WalletBackupTest(BitcoinTestFramework):
 
     # As above, this mirrors the original bash test.
     def start_three(self):
-        self.nodes[0] = self.start_node(0, self.options.tmpdir)
-        self.nodes[1] = self.start_node(1, self.options.tmpdir)
-        self.nodes[2] = self.start_node(2, self.options.tmpdir)
+        self.start_node(0)
+        self.start_node(1)
+        self.start_node(2)
         connect_nodes(self.nodes[0], 3)
         connect_nodes(self.nodes[1], 3)
         connect_nodes(self.nodes[2], 3)

--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -20,9 +20,7 @@ from test_framework.util import (assert_equal,
                                  )
 
 class ZapWalletTXesTest (BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
 

--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -48,7 +48,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
 
         # Stop-start node0. Both confirmed and unconfirmed transactions remain in the wallet.
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir)
+        self.start_node(0)
 
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
@@ -56,7 +56,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         # Stop node0 and restart with zapwallettxes and persistmempool. The unconfirmed
         # transaction is zapped from the wallet, but is re-added when the mempool is reloaded.
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-persistmempool=1", "-zapwallettxes=2"])
+        self.start_node(0, ["-persistmempool=1", "-zapwallettxes=2"])
 
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)
@@ -64,7 +64,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         # Stop node0 and restart with zapwallettxes, but not persistmempool.
         # The unconfirmed transaction is zapped and is no longer in the wallet.
         self.stop_node(0)
-        self.nodes[0] = self.start_node(0, self.options.tmpdir, ["-zapwallettxes=2"])
+        self.start_node(0, ["-zapwallettxes=2"])
 
         # tx1 is still be available because it was confirmed
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -13,9 +13,7 @@ from test_framework.util import (assert_equal,
                                  )
 
 class ZMQTest (BitcoinTestFramework):
-
-    def __init__(self):
-        super().__init__()
+    def set_test_params(self):
         self.num_nodes = 2
 
     def setup_nodes(self):

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -41,8 +41,9 @@ class ZMQTest (BitcoinTestFramework):
         self.zmqSubSocket.setsockopt(zmq.SUBSCRIBE, b"hashtx")
         ip_address = "tcp://127.0.0.1:28332"
         self.zmqSubSocket.connect(ip_address)
-        extra_args = [['-zmqpubhashtx=%s' % ip_address, '-zmqpubhashblock=%s' % ip_address], []]
-        self.nodes = self.start_nodes(self.num_nodes, self.options.tmpdir, extra_args)
+        self.extra_args = [['-zmqpubhashtx=%s' % ip_address, '-zmqpubhashblock=%s' % ip_address], []]
+        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.start_nodes()
 
     def run_test(self):
         try:

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -42,7 +42,7 @@ class ZMQTest (BitcoinTestFramework):
         ip_address = "tcp://127.0.0.1:28332"
         self.zmqSubSocket.connect(ip_address)
         self.extra_args = [['-zmqpubhashtx=%s' % ip_address, '-zmqpubhashblock=%s' % ip_address], []]
-        self.add_nodes(self.num_nodes, self.options.tmpdir, self.extra_args)
+        self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
 
     def run_test(self):


### PR DESCRIPTION
Some additional tidyups after the introduction of TestNode:

- commit 1 makes TestNode use the correct rpc timeout. This should have been included in #11077
- commit 2 separates `add_node()` from `start_node()` as originally discussed here: https://github.com/bitcoin/bitcoin/pull/10556#discussion_r121161453 with @kallewoof . The test writer no longer needs to assign to `self.nodes` when starting/stopping nodes.
- commit 3 adds a `set_test_params()` method, so individual tests don't need to override `__init__()` and call `super().__init__()`