### PR TITLE
Compat: Simplify bswap_16 implementation

### DIFF
--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -35,7 +35,7 @@
 #if HAVE_DECL_BSWAP_16 == 0
 inline uint16_t bswap_16(uint16_t x)
 {
-    return (x >> 8) | ((x & 0x00ff) << 8);
+    return (x >> 8) | (x << 8);
 }
 #endif // HAVE_DECL_BSWAP16
 


### PR DESCRIPTION
Simplify bswap_16 implementation on platforms which don't already have it defined.
This has no effect on the generated assembly; it just simplifies the source code.