### PR TITLE
Trivial: Improve #endif comments

### DIFF
--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -37,7 +37,7 @@ inline uint16_t bswap_16(uint16_t x)
 {
     return (x >> 8) | ((x & 0x00ff) << 8);
 }
-#endif // HAVE_DECL_BSWAP16
+#endif // HAVE_DECL_BSWAP16 == 0
 
 #if HAVE_DECL_BSWAP_32 == 0
 inline uint32_t bswap_32(uint32_t x)
@@ -45,7 +45,7 @@ inline uint32_t bswap_32(uint32_t x)
     return (((x & 0xff000000U) >> 24) | ((x & 0x00ff0000U) >>  8) |
             ((x & 0x0000ff00U) <<  8) | ((x & 0x000000ffU) << 24));
 }
-#endif // HAVE_DECL_BSWAP32
+#endif // HAVE_DECL_BSWAP32 == 0
 
 #if HAVE_DECL_BSWAP_64 == 0
 inline uint64_t bswap_64(uint64_t x)
@@ -59,7 +59,7 @@ inline uint64_t bswap_64(uint64_t x)
           | ((x & 0x000000000000ff00ull) << 40)
           | ((x & 0x00000000000000ffull) << 56));
 }
-#endif // HAVE_DECL_BSWAP64
+#endif // HAVE_DECL_BSWAP64 == 0
 
 #endif // defined(__APPLE__)
 


### PR DESCRIPTION
Improve the #endif comments for the '#if HAVE_DECL_BSWAP_XX == 0' preprocessor conditions, so each shows the full condition which it closes.