### PR TITLE
Move local include to before system includes

### DIFF
--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -9,9 +9,9 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include <stdint.h>
-
 #include "compat/byteswap.h"
+
+#include <stdint.h>
 
 #if defined(HAVE_ENDIAN_H)
 #include <endian.h>


### PR DESCRIPTION
Prevents accidental missing includes and hidden dependencies in the local file.