### PR TITLE
Trivial: Fix outdated comment

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -152,7 +152,7 @@ enum
 #define READWRITEMANY(...)      (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 
 /** 
- * Implement three methods for serializable objects. These are actually wrappers over
+ * Implement two methods for serializable objects. These are actually wrappers over
  * "SerializationOp" template, which implements the body of each class' serialization
  * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers to be
  * added as members. 


### PR DESCRIPTION
Only two methods are now implemented for serializable objects. The comment which says there are three is wrong (was not updated properly in commit 657e05ab2e87ff725723fe8a375fc3f8aad02126)