### PR TITLE
Use prefix instead of postfix increment/decrement for non-trivial typ…

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -313,32 +313,32 @@ public:
         s << nUBuckets;
         std::map<int, int> mapUnkIds;
         int nIds = 0;
-        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
+        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); ++it) {
             mapUnkIds[(*it).first] = nIds;
             const CAddrInfo &info = (*it).second;
             if (info.nRefCount) {
                 assert(nIds != nNew); // this means nNew was wrong, oh ow
                 s << info;
-                nIds++;
+                ++nIds;
             }
         }
         nIds = 0;
-        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); it++) {
+        for (std::map<int, CAddrInfo>::const_iterator it = mapInfo.begin(); it != mapInfo.end(); ++it) {
             const CAddrInfo &info = (*it).second;
             if (info.fInTried) {
                 assert(nIds != nTried); // this means nTried was wrong, oh ow
                 s << info;
-                nIds++;
+                ++nIds;
             }
         }
-        for (int bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
+        for (int bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; ++bucket) {
             int nSize = 0;
-            for (int i = 0; i < ADDRMAN_BUCKET_SIZE; i++) {
+            for (int i = 0; i < ADDRMAN_BUCKET_SIZE; ++i) {
                 if (vvNew[bucket][i] != -1)
-                    nSize++;
+                    ++nSize;
             }
             s << nSize;
-            for (int i = 0; i < ADDRMAN_BUCKET_SIZE; i++) {
+            for (int i = 0; i < ADDRMAN_BUCKET_SIZE; ++i) {
                 if (vvNew[bucket][i] != -1) {
                     int nIndex = mapUnkIds[vvNew[bucket][i]];
                     s << nIndex;
@@ -377,7 +377,7 @@ public:
         }
 
         // Deserialize entries from the new table.
-        for (int n = 0; n < nNew; n++) {
+        for (int n = 0; n < nNew; ++n) {
             CAddrInfo &info = mapInfo[n];
             s >> info;
             mapAddr[info] = n;
@@ -390,7 +390,7 @@ public:
                 int nUBucketPos = info.GetBucketPosition(nKey, true, nUBucket);
                 if (vvNew[nUBucket][nUBucketPos] == -1) {
                     vvNew[nUBucket][nUBucketPos] = n;
-                    info.nRefCount++;
+                    ++info.nRefCount;
                 }
             }
         }
@@ -398,7 +398,7 @@ public:
 
         // Deserialize entries from the tried table.
         int nLost = 0;
-        for (int n = 0; n < nTried; n++) {
+        for (int n = 0; n < nTried; ++n) {
             CAddrInfo info;
             s >> info;
             int nKBucket = info.GetTriedBucket(nKey);
@@ -410,25 +410,25 @@ public:
                 mapInfo[nIdCount] = info;
                 mapAddr[info] = nIdCount;
                 vvTried[nKBucket][nKBucketPos] = nIdCount;
-                nIdCount++;
+                ++nIdCount;
             } else {
-                nLost++;
+                ++nLost;
             }
         }
         nTried -= nLost;
 
         // Deserialize positions in the new table (if possible).
-        for (int bucket = 0; bucket < nUBuckets; bucket++) {
+        for (int bucket = 0; bucket < nUBuckets; ++bucket) {
             int nSize = 0;
             s >> nSize;
-            for (int n = 0; n < nSize; n++) {
+            for (int n = 0; n < nSize; ++n) {
                 int nIndex = 0;
                 s >> nIndex;
                 if (nIndex >= 0 && nIndex < nNew) {
                     CAddrInfo &info = mapInfo[nIndex];
                     int nUBucketPos = info.GetBucketPosition(nKey, true, bucket);
                     if (nVersion == 1 && nUBuckets == ADDRMAN_NEW_BUCKET_COUNT && vvNew[bucket][nUBucketPos] == -1 && info.nRefCount < ADDRMAN_NEW_BUCKETS_PER_ADDRESS) {
-                        info.nRefCount++;
+                        ++info.nRefCount;
                         vvNew[bucket][nUBucketPos] = nIndex;
                     }
                 }
@@ -441,9 +441,9 @@ public:
             if (it->second.fInTried == false && it->second.nRefCount == 0) {
                 std::map<int, CAddrInfo>::const_iterator itCopy = it++;
                 Delete(itCopy->first);
-                nLostUnk++;
+                ++nLostUnk;
             } else {
-                it++;
+                ++it;
             }
         }
         if (nLost + nLostUnk > 0) {
@@ -457,13 +457,13 @@ public:
     {
         std::vector<int>().swap(vRandom);
         nKey = GetRandHash();
-        for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
-            for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; entry++) {
+        for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; ++bucket) {
+            for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; ++entry) {
                 vvNew[bucket][entry] = -1;
             }
         }
-        for (size_t bucket = 0; bucket < ADDRMAN_TRIED_BUCKET_COUNT; bucket++) {
-            for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; entry++) {
+        for (size_t bucket = 0; bucket < ADDRMAN_TRIED_BUCKET_COUNT; ++bucket) {
+            for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; ++entry) {
                 vvTried[bucket][entry] = -1;
             }
         }
@@ -524,7 +524,7 @@ public:
         LOCK(cs);
         int nAdd = 0;
         Check();
-        for (std::vector<CAddress>::const_iterator it = vAddr.begin(); it != vAddr.end(); it++)
+        for (std::vector<CAddress>::const_iterator it = vAddr.begin(); it != vAddr.end(); ++it)
             nAdd += Add_(*it, source, nTimePenalty) ? 1 : 0;
         Check();
         if (nAdd) {

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -33,7 +33,7 @@ public:
     {
         static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
 
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             pn[i] = 0;
     }
 
@@ -41,13 +41,13 @@ public:
     {
         static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
 
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             pn[i] = b.pn[i];
     }
 
     base_uint& operator=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             pn[i] = b.pn[i];
         return *this;
     }
@@ -58,7 +58,7 @@ public:
 
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
+        for (int i = 2; i < WIDTH; ++i)
             pn[i] = 0;
     }
 
@@ -66,7 +66,7 @@ public:
 
     bool operator!() const
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             if (pn[i] != 0)
                 return false;
         return true;
@@ -75,7 +75,7 @@ public:
     const base_uint operator~() const
     {
         base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             ret.pn[i] = ~pn[i];
         return ret;
     }
@@ -83,9 +83,9 @@ public:
     const base_uint operator-() const
     {
         base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             ret.pn[i] = ~pn[i];
-        ret++;
+        ++ret;
         return ret;
     }
 
@@ -95,28 +95,28 @@ public:
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
+        for (int i = 2; i < WIDTH; ++i)
             pn[i] = 0;
         return *this;
     }
 
     base_uint& operator^=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             pn[i] ^= b.pn[i];
         return *this;
     }
 
     base_uint& operator&=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             pn[i] &= b.pn[i];
         return *this;
     }
 
     base_uint& operator|=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
             pn[i] |= b.pn[i];
         return *this;
     }
@@ -141,7 +141,7 @@ public:
     base_uint& operator+=(const base_uint& b)
     {
         uint64_t carry = 0;
-        for (int i = 0; i < WIDTH; i++)
+        for (int i = 0; i < WIDTH; ++i)
         {
             uint64_t n = carry + pn[i] + b.pn[i];
             pn[i] = n & 0xffffffff;
@@ -181,7 +181,7 @@ public:
         // prefix operator
         int i = 0;
         while (i < WIDTH && ++pn[i] == 0)
-            i++;
+            ++i;
         return *this;
     }
 
@@ -198,7 +198,7 @@ public:
         // prefix operator
         int i = 0;
         while (i < WIDTH && --pn[i] == (uint32_t)-1)
-            i++;
+            ++i;
         return *this;
     }
 

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -22,13 +22,13 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
 {
     // Skip leading spaces.
     while (*psz && isspace(*psz))
-        psz++;
+        ++psz;
     // Skip and count leading '1's.
     int zeroes = 0;
     int length = 0;
     while (*psz == '1') {
-        zeroes++;
-        psz++;
+        ++zeroes;
+        ++psz;
     }
     // Allocate enough space in big-endian base256 representation.
     int size = strlen(psz) * 733 /1000 + 1; // log(58) / log(256), rounded up.
@@ -49,17 +49,17 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
         }
         assert(carry == 0);
         length = i;
-        psz++;
+        ++psz;
     }
     // Skip trailing spaces.
     while (isspace(*psz))
-        psz++;
+        ++psz;
     if (*psz != 0)
         return false;
     // Skip leading zeroes in b256.
     std::vector<unsigned char>::iterator it = b256.begin() + (size - length);
     while (it != b256.end() && *it == 0)
-        it++;
+        ++it;
     // Copy result into output vector.
     vch.reserve(zeroes + (b256.end() - it));
     vch.assign(zeroes, 0x00);
@@ -74,8 +74,8 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
     int zeroes = 0;
     int length = 0;
     while (pbegin != pend && *pbegin == 0) {
-        pbegin++;
-        zeroes++;
+        ++pbegin;
+        ++zeroes;
     }
     // Allocate enough space in big-endian base58 representation.
     int size = (pend - pbegin) * 138 / 100 + 1; // log(256) / log(58), rounded up.
@@ -85,7 +85,7 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
         int carry = *pbegin;
         int i = 0;
         // Apply "b58 = b58 * 256 + ch".
-        for (std::vector<unsigned char>::reverse_iterator it = b58.rbegin(); (carry != 0 || i < length) && (it != b58.rend()); it++, i++) {
+        for (std::vector<unsigned char>::reverse_iterator it = b58.rbegin(); (carry != 0 || i < length) && (it != b58.rend()); ++it, ++i) {
             carry += 256 * (*it);
             *it = carry % 58;
             carry /= 58;
@@ -93,12 +93,12 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
 
         assert(carry == 0);
         length = i;
-        pbegin++;
+        ++pbegin;
     }
     // Skip leading zeroes in base58 result.
     std::vector<unsigned char>::iterator it = b58.begin() + (size - length);
     while (it != b58.end() && *it == 0)
-        it++;
+        ++it;
     // Translate the result into a string.
     std::string str;
     str.reserve(zeroes + (b58.end() - it));

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -59,7 +59,7 @@ void CBloomFilter::insert(const std::vector<unsigned char>& vKey)
 {
     if (isFull)
         return;
-    for (unsigned int i = 0; i < nHashFuncs; i++)
+    for (unsigned int i = 0; i < nHashFuncs; ++i)
     {
         unsigned int nIndex = Hash(i, vKey);
         // Sets bit nIndex of vData
@@ -88,7 +88,7 @@ bool CBloomFilter::contains(const std::vector<unsigned char>& vKey) const
         return true;
     if (isEmpty)
         return false;
-    for (unsigned int i = 0; i < nHashFuncs; i++)
+    for (unsigned int i = 0; i < nHashFuncs; ++i)
     {
         unsigned int nIndex = Hash(i, vKey);
         // Checks bit nIndex of vData
@@ -143,7 +143,7 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)
     if (contains(hash))
         fFound = true;
 
-    for (unsigned int i = 0; i < tx.vout.size(); i++)
+    for (unsigned int i = 0; i < tx.vout.size(); ++i)
     {
         const CTxOut& txout = tx.vout[i];
         // Match if the filter contains any arbitrary script data element in any scriptPubKey in tx
@@ -204,7 +204,7 @@ void CBloomFilter::UpdateEmptyFull()
 {
     bool full = true;
     bool empty = true;
-    for (unsigned int i = 0; i < vData.size(); i++)
+    for (unsigned int i = 0; i < vData.size(); ++i)
     {
         full &= vData[i] == 0xff;
         empty &= vData[i] == 0;
@@ -249,7 +249,7 @@ void CRollingBloomFilter::insert(const std::vector<unsigned char>& vKey)
 {
     if (nEntriesThisGeneration == nEntriesPerGeneration) {
         nEntriesThisGeneration = 0;
-        nGeneration++;
+        ++nGeneration;
         if (nGeneration == 4) {
             nGeneration = 1;
         }
@@ -263,9 +263,9 @@ void CRollingBloomFilter::insert(const std::vector<unsigned char>& vKey)
             data[p + 1] = p2 & mask;
         }
     }
-    nEntriesThisGeneration++;
+    ++nEntriesThisGeneration;
 
-    for (int n = 0; n < nHashFuncs; n++) {
+    for (int n = 0; n < nHashFuncs; ++n) {
         uint32_t h = RollingBloomHash(n, nTweak, vKey);
         int bit = h & 0x3F;
         uint32_t pos = (h >> 6) % data.size();
@@ -283,7 +283,7 @@ void CRollingBloomFilter::insert(const uint256& hash)
 
 bool CRollingBloomFilter::contains(const std::vector<unsigned char>& vKey) const
 {
-    for (int n = 0; n < nHashFuncs; n++) {
+    for (int n = 0; n < nHashFuncs; ++n) {
         uint32_t h = RollingBloomHash(n, nTweak, vKey);
         int bit = h & 0x3F;
         uint32_t pos = (h >> 6) % data.size();
@@ -306,7 +306,7 @@ void CRollingBloomFilter::reset()
     nTweak = GetRand(std::numeric_limits<unsigned int>::max());
     nEntriesThisGeneration = 0;
     nGeneration = 1;
-    for (std::vector<uint64_t>::iterator it = data.begin(); it != data.end(); it++) {
+    for (std::vector<uint64_t>::iterator it = data.begin(); it != data.end(); ++it) {
         *it = 0;
     }
 }

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -19,7 +19,7 @@ static inline size_t RecursiveDynamicUsage(const COutPoint& out) {
 
 static inline size_t RecursiveDynamicUsage(const CTxIn& in) {
     size_t mem = RecursiveDynamicUsage(in.scriptSig) + RecursiveDynamicUsage(in.prevout) + memusage::DynamicUsage(in.scriptWitness.stack);
-    for (std::vector<std::vector<unsigned char> >::const_iterator it = in.scriptWitness.stack.begin(); it != in.scriptWitness.stack.end(); it++) {
+    for (std::vector<std::vector<unsigned char> >::const_iterator it = in.scriptWitness.stack.begin(); it != in.scriptWitness.stack.end(); ++it) {
          mem += memusage::DynamicUsage(*it);
     }
     return mem;
@@ -31,10 +31,10 @@ static inline size_t RecursiveDynamicUsage(const CTxOut& out) {
 
 static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     size_t mem = memusage::DynamicUsage(tx.vin) + memusage::DynamicUsage(tx.vout);
-    for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
+    for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); ++it) {
         mem += RecursiveDynamicUsage(*it);
     }
-    for (std::vector<CTxOut>::const_iterator it = tx.vout.begin(); it != tx.vout.end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = tx.vout.begin(); it != tx.vout.end(); ++it) {
         mem += RecursiveDynamicUsage(*it);
     }
     return mem;
@@ -42,10 +42,10 @@ static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
 
 static inline size_t RecursiveDynamicUsage(const CMutableTransaction& tx) {
     size_t mem = memusage::DynamicUsage(tx.vin) + memusage::DynamicUsage(tx.vout);
-    for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
+    for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); ++it) {
         mem += RecursiveDynamicUsage(*it);
     }
-    for (std::vector<CTxOut>::const_iterator it = tx.vout.begin(); it != tx.vout.end(); it++) {
+    for (std::vector<CTxOut>::const_iterator it = tx.vout.begin(); it != tx.vout.end(); ++it) {
         mem += RecursiveDynamicUsage(*it);
     }
     return mem;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -80,7 +80,7 @@ public:
             while (mi != mapKeys.end())
             {
                 setAddress.insert((*mi).first);
-                mi++;
+                ++mi;
             }
         }
     }

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -219,7 +219,7 @@ void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
             testSet.erase(iit++);
         }
         else {
-            iit++;
+            ++iit;
         }
     }
 }

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -55,7 +55,7 @@ public:
 #if QT_VERSION >= 0x040700
         cachedBanlist.reserve(banMap.size());
 #endif
-        for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); it++)
+        for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); ++it)
         {
             CCombinedBan banEntry;
             banEntry.subnet = (*it).first;

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -569,7 +569,7 @@ UniValue listbanned(const JSONRPCRequest& request)
     g_connman->GetBanned(banMap);
 
     UniValue bannedAddresses(UniValue::VARR);
-    for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); it++)
+    for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); ++it)
     {
         CBanEntry banEntry = (*it).second;
         UniValue rec(UniValue::VOBJ);
@@ -641,6 +641,6 @@ static const CRPCCommand commands[] =
 
 void RegisterNetRPCCommands(CRPCTable &t)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
+    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); ++vcidx)
         t.appendCommand(commands[vcidx].name, &commands[vcidx]);
 }

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -81,7 +81,7 @@ public:
         // Manually recompute the dynamic usage of the whole data, and compare it.
         size_t ret = memusage::DynamicUsage(cacheCoins);
         size_t count = 0;
-        for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); it++) {
+        for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); ++it) {
             ret += it->second.coin.DynamicMemoryUsage();
             ++count;
         }
@@ -132,11 +132,11 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
     // Use a limited set of random transaction ids, so we do test overwriting entries.
     std::vector<uint256> txids;
     txids.resize(NUM_SIMULATION_ITERATIONS / 8);
-    for (unsigned int i = 0; i < txids.size(); i++) {
+    for (unsigned int i = 0; i < txids.size(); ++i) {
         txids[i] = InsecureRand256();
     }
 
-    for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; i++) {
+    for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; ++i) {
         // Do a random modification.
         {
             uint256 txid = txids[InsecureRandRange(txids.size())]; // txid we're going to modify in this iteration.
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
 
         // Once every 1000 iterations and at the end, verify the full cache.
         if (InsecureRandRange(1000) == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
-            for (auto it = result.begin(); it != result.end(); it++) {
+            for (auto it = result.begin(); it != result.end(); ++it) {
                 bool have = stack.back()->HaveCoin(it->first);
                 const Coin& coin = stack.back()->AccessCoin(it->first);
                 BOOST_CHECK(have == !coin.IsSpent());
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
     std::set<COutPoint> duplicate_coins;
     std::set<COutPoint> utxoset;
 
-    for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; i++) {
+    for (unsigned int i = 0; i < NUM_SIMULATION_ITERATIONS; ++i) {
         uint32_t randiter = InsecureRand32();
 
         // 19/20 txs add a new transaction
@@ -420,7 +420,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 
         // Once every 1000 iterations and at the end, verify the full cache.
         if (InsecureRandRange(1000) == 1 || i == NUM_SIMULATION_ITERATIONS - 1) {
-            for (auto it = result.begin(); it != result.end(); it++) {
+            for (auto it = result.begin(); it != result.end(); ++it) {
                 bool have = stack.back()->HaveCoin(it->first);
                 const Coin& coin = stack.back()->AccessCoin(it->first);
                 BOOST_CHECK(have == !coin.IsSpent());

--- a/src/test/limitedmap_tests.cpp
+++ b/src/test/limitedmap_tests.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     BOOST_CHECK(map.count(-1) == 1);
 
     // insert 10 new items
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; ++i) {
         map.insert(std::pair<int, int>(i, i + 1));
     }
 
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
 
     // iterate over the map, both with an index and an iterator
     limitedmap<int, int>::const_iterator it = map.begin();
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; ++i) {
         // make sure the item is present
         BOOST_CHECK(map.count(i) == 1);
 
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
         map.update(it, i + 2);
         BOOST_CHECK(map.find(i)->second == i + 2);
 
-        it++;
+        ++it;
     }
 
     // check that we've exhausted the iterator
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
 
     // check that items less than 5 have been discarded
     // and items greater than 5 are retained
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; ++i) {
         if (i < 5) {
             BOOST_CHECK(map.count(i) == 0);
         } else {
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(limitedmap_test)
     BOOST_CHECK(map.size() == 5);
 
     // erase the remaining elements
-    for (int i = 5; i < 10; i++) {
+    for (int i = 5; i < 10; ++i) {
         map.erase(i);
     }
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -85,7 +85,7 @@ std::string FormatScriptFlags(unsigned int flags)
         if (flags & it->second) {
             ret += it->first + ",";
         }
-        it++;
+        ++it;
     }
     return ret.substr(0, ret.size() - 1);
 }
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
     UniValue tests = read_json(std::string(json_tests::tx_valid, json_tests::tx_valid + sizeof(json_tests::tx_valid)));
 
     ScriptError err;
-    for (unsigned int idx = 0; idx < tests.size(); idx++) {
+    for (unsigned int idx = 0; idx < tests.size(); ++idx) {
         UniValue test = tests[idx];
         std::string strTest = test.write();
         if (test[0].isArray())
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             std::map<COutPoint, int64_t> mapprevOutValues;
             UniValue inputs = test[0].get_array();
             bool fValid = true;
-	    for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
+	    for (unsigned int inpIdx = 0; inpIdx < inputs.size(); ++inpIdx) {
 	        const UniValue& input = inputs[inpIdx];
                 if (!input.isArray())
                 {
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             BOOST_CHECK(state.IsValid());
 
             PrecomputedTransactionData txdata(tx);
-            for (unsigned int i = 0; i < tx.vin.size(); i++)
+            for (unsigned int i = 0; i < tx.vin.size(); ++i)
             {
                 if (!mapprevOutScriptPubKeys.count(tx.vin[i].prevout))
                 {
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
     // Initialize to SCRIPT_ERR_OK. The tests expect err to be changed to a
     // value other than SCRIPT_ERR_OK.
     ScriptError err = SCRIPT_ERR_OK;
-    for (unsigned int idx = 0; idx < tests.size(); idx++) {
+    for (unsigned int idx = 0; idx < tests.size(); ++idx) {
         UniValue test = tests[idx];
         std::string strTest = test.write();
         if (test[0].isArray())
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             std::map<COutPoint, int64_t> mapprevOutValues;
             UniValue inputs = test[0].get_array();
             bool fValid = true;
-	    for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
+	    for (unsigned int inpIdx = 0; inpIdx < inputs.size(); ++inpIdx) {
 	        const UniValue& input = inputs[inpIdx];
                 if (!input.isArray())
                 {
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             fValid = CheckTransaction(tx, state) && state.IsValid();
 
             PrecomputedTransactionData txdata(tx);
-            for (unsigned int i = 0; i < tx.vin.size() && fValid; i++)
+            for (unsigned int i = 0; i < tx.vin.size() && fValid; ++i)
             {
                 if (!mapprevOutScriptPubKeys.count(tx.vin[i].prevout))
                 {
@@ -293,7 +293,7 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
 
     // Add some keys to the keystore:
     CKey key[4];
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 4; ++i)
     {
         key[i].MakeNewKey(i % 2);
         keystoreRet.AddKey(key[i]);
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     sigHashes.push_back(SIGHASH_ALL);
 
     // create a big transaction of 4500 inputs signed by the same key
-    for(uint32_t ij = 0; ij < 4500; ij++) {
+    for(uint32_t ij = 0; ij < 4500; ++ij) {
         uint32_t i = mtx.vin.size();
         uint256 prevId;
         prevId.SetHex("0000000000000000000000000000000000000000000000000000000000000100");
@@ -449,7 +449,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     }
 
     // sign all inputs
-    for(uint32_t i = 0; i < mtx.vin.size(); i++) {
+    for(uint32_t i = 0; i < mtx.vin.size(); ++i) {
         bool hashSigned = SignSignature(keystore, scriptPubKey, mtx, i, 1000, sigHashes.at(i % sigHashes.size()));
         assert(hashSigned);
     }
@@ -465,11 +465,11 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     CCheckQueue<CScriptCheck> scriptcheckqueue(128);
     CCheckQueueControl<CScriptCheck> control(&scriptcheckqueue);
 
-    for (int i=0; i<20; i++)
+    for (int i=0; i<20; ++i)
         threadGroup.create_thread(boost::bind(&CCheckQueue<CScriptCheck>::Thread, boost::ref(scriptcheckqueue)));
 
     std::vector<Coin> coins;
-    for(uint32_t i = 0; i < mtx.vin.size(); i++) {
+    for(uint32_t i = 0; i < mtx.vin.size(); ++i) {
         Coin coin;
         coin.nHeight = 1;
         coin.fCoinBase = false;
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
         coins.emplace_back(std::move(coin));
     }
 
-    for(uint32_t i = 0; i < mtx.vin.size(); i++) {
+    for(uint32_t i = 0; i < mtx.vin.size(); ++i) {
         std::vector<CScriptCheck> vChecks;
         const CTxOut& output = coins[tx.vin[i].prevout.n].out;
         CScriptCheck check(output.scriptPubKey, output.nValue, tx, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -113,9 +113,9 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
                 batch.Erase(entry);
             else
                 batch.Write(entry, it->second.coin);
-            changed++;
+            ++changed;
         }
-        count++;
+        ++count;
         CCoinsMap::iterator itOld = it++;
         mapCoins.erase(itOld);
         if (batch.SizeEstimate() > batch_size) {
@@ -226,11 +226,11 @@ void CCoinsViewDBCursor::Next()
 
 bool CBlockTreeDB::WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo*> >& fileInfo, int nLastFile, const std::vector<const CBlockIndex*>& blockinfo) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); it++) {
+    for (std::vector<std::pair<int, const CBlockFileInfo*> >::const_iterator it=fileInfo.begin(); it != fileInfo.end(); ++it) {
         batch.Write(std::make_pair(DB_BLOCK_FILES, it->first), *it->second);
     }
     batch.Write(DB_LAST_BLOCK, nLastFile);
-    for (std::vector<const CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); it++) {
+    for (std::vector<const CBlockIndex*>::const_iterator it=blockinfo.begin(); it != blockinfo.end(); ++it) {
         batch.Write(std::make_pair(DB_BLOCK_INDEX, (*it)->GetBlockHash()), CDiskBlockIndex(*it));
     }
     return WriteBatch(batch, true);
@@ -242,7 +242,7 @@ bool CBlockTreeDB::ReadTxIndex(const uint256 &txid, CDiskTxPos &pos) {
 
 bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> >&vect) {
     CDBBatch batch(*this);
-    for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); it++)
+    for (std::vector<std::pair<uint256,CDiskTxPos> >::const_iterator it=vect.begin(); it!=vect.end(); ++it)
         batch.Write(std::make_pair(DB_TXINDEX, it->first), it->second);
     return WriteBatch(batch);
 }
@@ -337,16 +337,16 @@ public:
         while (nMaskCode > 0) {
             unsigned char chAvail = 0;
             ::Unserialize(s, chAvail);
-            for (unsigned int p = 0; p < 8; p++) {
+            for (unsigned int p = 0; p < 8; ++p) {
                 bool f = (chAvail & (1 << p)) != 0;
                 vAvail.push_back(f);
             }
             if (chAvail != 0)
-                nMaskCode--;
+                --nMaskCode;
         }
         // txouts themself
         vout.assign(vAvail.size(), CTxOut());
-        for (unsigned int i = 0; i < vAvail.size(); i++) {
+        for (unsigned int i = 0; i < vAvail.size(); ++i) {
             if (vAvail[i])
                 ::Unserialize(s, REF(CTxOutCompressor(vout[i])));
         }

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -182,7 +182,7 @@ public:
         while (mi != mapCryptedKeys.end())
         {
             setAddress.insert((*mi).first);
-            mi++;
+            ++mi;
         }
     }
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -587,7 +587,7 @@ void CDBEnv::Flush(bool fShutdown)
                 LogPrint(BCLog::DB, "CDBEnv::Flush: %s closed\n", strFile);
                 mapFileUseCount.erase(mi++);
             } else
-                mi++;
+                ++mi;
         }
         LogPrint(BCLog::DB, "CDBEnv::Flush: Flush(%s)%s took %15dms\n", fShutdown ? "true" : "false", fDbEnvInit ? "" : " database not started", GetTimeMillis() - nStart);
         if (fShutdown) {
@@ -619,7 +619,7 @@ bool CDB::PeriodicFlush(CWalletDBWrapper& dbw)
         while (mit != env->mapFileUseCount.end())
         {
             nRefCount += (*mit).second;
-            mit++;
+            ++mit;
         }
 
         if (nRefCount == 0)

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -58,7 +58,7 @@ std::string static EncodeDumpString(const std::string &str) {
 
 std::string DecodeDumpString(const std::string &str) {
     std::stringstream ret;
-    for (unsigned int pos = 0; pos < str.length(); pos++) {
+    for (unsigned int pos = 0; pos < str.length(); ++pos) {
         unsigned char c = str[pos];
         if (c == '%' && pos+2 < str.length()) {
             c = (((str[pos+1]>>6)*9+((str[pos+1]-'0')&15)) << 4) | 
@@ -510,7 +510,7 @@ UniValue importwallet(const JSONRPCRequest& request)
         int64_t nTime = DecodeDumpTime(vstr[1]);
         std::string strLabel;
         bool fLabel = true;
-        for (unsigned int nStr = 2; nStr < vstr.size(); nStr++) {
+        for (unsigned int nStr = 2; nStr < vstr.size(); ++nStr) {
             if (boost::algorithm::starts_with(vstr[nStr], "#"))
                 break;
             if (vstr[nStr] == "change=1")
@@ -654,7 +654,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             file << "# extended private masterkey: " << b58extkey.ToString() << "\n\n";
         }
     }
-    for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
+    for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); ++it) {
         const CKeyID &keyid = it->second;
         std::string strTime = EncodeDumpTime(it->first);
         std::string strAddr = CBitcoinAddress(keyid).ToString();
@@ -798,7 +798,7 @@ UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int6
 
             // Import private keys.
             if (keys.size()) {
-                for (size_t i = 0; i < keys.size(); i++) {
+                for (size_t i = 0; i < keys.size(); ++i) {
                     const std::string& privkey = keys[i].get_str();
 
                     CBitcoinSecret vchSecret;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -188,12 +188,12 @@ void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKe
         if (internal) {
             chainChildKey.Derive(childKey, hdChain.nInternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
             metadata.hdKeypath = "m/0'/1'/" + std::to_string(hdChain.nInternalChainCounter) + "'";
-            hdChain.nInternalChainCounter++;
+            ++hdChain.nInternalChainCounter;
         }
         else {
             chainChildKey.Derive(childKey, hdChain.nExternalChainCounter | BIP32_HARDENED_KEY_LIMIT);
             metadata.hdKeypath = "m/0'/0'/" + std::to_string(hdChain.nExternalChainCounter) + "'";
-            hdChain.nExternalChainCounter++;
+            ++hdChain.nExternalChainCounter;
         }
     } while (HaveKey(childKey.key.GetPubKey().GetID()));
     secret = childKey.key;
@@ -1047,7 +1047,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, const CBlockI
                         LogPrintf("Transaction %s (in block %s) conflicts with wallet transaction %s (both spend %s:%i)\n", tx.GetHash().ToString(), pIndex->GetBlockHash().ToString(), range.first->second.ToString(), range.first->first.hash.ToString(), range.first->first.n);
                         MarkConflicted(pIndex->GetBlockHash(), range.first->second);
                     }
-                    range.first++;
+                    ++range.first;
                 }
             }
         }
@@ -1143,7 +1143,7 @@ bool CWallet::AbandonTransaction(const uint256& hashTx)
                 if (!done.count(iter->second)) {
                     todo.insert(iter->second);
                 }
-                iter++;
+                ++iter;
             }
             // If a transaction changes 'conflicted' state, that changes the balance
             // available of the outputs it spends. So force those to be recomputed
@@ -1207,7 +1207,7 @@ void CWallet::MarkConflicted(const uint256& hashBlock, const uint256& hashTx)
                  if (!done.count(iter->second)) {
                      todo.insert(iter->second);
                  }
-                 iter++;
+                 ++iter;
             }
             // If a transaction changes 'conflicted' state, that changes the balance
             // available of the outputs it spends. So force those to be recomputed
@@ -1256,7 +1256,7 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
     }
-    for (size_t i = 0; i < pblock->vtx.size(); i++) {
+    for (size_t i = 0; i < pblock->vtx.size(); ++i) {
         SyncTransaction(pblock->vtx[i], pindex, i);
     }
 }
@@ -1815,7 +1815,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
 
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();
-    for (unsigned int i = 0; i < tx->vout.size(); i++)
+    for (unsigned int i = 0; i < tx->vout.size(); ++i)
     {
         if (!pwallet->IsSpent(hashTx, i))
         {
@@ -1858,7 +1858,7 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const
         return nAvailableWatchCreditCached;
 
     CAmount nCredit = 0;
-    for (unsigned int i = 0; i < tx->vout.size(); i++)
+    for (unsigned int i = 0; i < tx->vout.size(); ++i)
     {
         if (!pwallet->IsSpent(GetHash(), i))
         {
@@ -2205,7 +2205,7 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
             if (nDepth < nMinDepth || nDepth > nMaxDepth)
                 continue;
 
-            for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++) {
+            for (unsigned int i = 0; i < pcoin->tx->vout.size(); ++i) {
                 if (pcoin->tx->vout[i].nValue < nMinimumAmount || pcoin->tx->vout[i].nValue > nMaximumAmount)
                     continue;
 
@@ -2320,14 +2320,14 @@ static void ApproximateBestSubset(const std::vector<CInputCoin>& vValue, const C
 
     FastRandomContext insecure_rand;
 
-    for (int nRep = 0; nRep < iterations && nBest != nTargetValue; nRep++)
+    for (int nRep = 0; nRep < iterations && nBest != nTargetValue; ++nRep)
     {
         vfIncluded.assign(vValue.size(), false);
         CAmount nTotal = 0;
         bool fReachedTarget = false;
-        for (int nPass = 0; nPass < 2 && !fReachedTarget; nPass++)
+        for (int nPass = 0; nPass < 2 && !fReachedTarget; ++nPass)
         {
-            for (unsigned int i = 0; i < vValue.size(); i++)
+            for (unsigned int i = 0; i < vValue.size(); ++i)
             {
                 //The solver here uses a randomized algorithm,
                 //the randomness serves no real security purpose but is just
@@ -2441,7 +2441,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
         nValueRet += coinLowestLarger->txout.nValue;
     }
     else {
-        for (unsigned int i = 0; i < vValue.size(); i++)
+        for (unsigned int i = 0; i < vValue.size(); ++i)
             if (vfBest[i])
             {
                 setCoinsRet.insert(vValue[i]);
@@ -2450,7 +2450,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const int nConfMin
 
         if (LogAcceptCategory(BCLog::SELECTCOINS)) {
             LogPrint(BCLog::SELECTCOINS, "SelectCoins() best subset: ");
-            for (unsigned int i = 0; i < vValue.size(); i++) {
+            for (unsigned int i = 0; i < vValue.size(); ++i) {
                 if (vfBest[i]) {
                     LogPrint(BCLog::SELECTCOINS, "%s ", FormatMoney(vValue[i].txout.nValue));
                 }
@@ -2550,7 +2550,7 @@ bool CWallet::SignTransaction(CMutableTransaction &tx)
             return false;
         }
         UpdateTransaction(tx, nIn, sigdata);
-        nIn++;
+        ++nIn;
     }
     return true;
 }
@@ -2560,7 +2560,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
     std::vector<CRecipient> vecSend;
 
     // Turn the txout set into a CRecipient vector
-    for (size_t idx = 0; idx < tx.vout.size(); idx++)
+    for (size_t idx = 0; idx < tx.vout.size(); ++idx)
     {
         const CTxOut& txOut = tx.vout[idx];
         CRecipient recipient = {txOut.scriptPubKey, txOut.nValue, setSubtractFeeFromOutputs.count(idx) == 1};
@@ -2586,7 +2586,7 @@ bool CWallet::FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nC
     }
 
     // Copy output sizes from new transaction; they may have had the fee subtracted from them
-    for (unsigned int idx = 0; idx < tx.vout.size(); idx++)
+    for (unsigned int idx = 0; idx < tx.vout.size(); ++idx)
         tx.vout[idx].nValue = wtx.tx->vout[idx].nValue;
 
     // Add new txins (keeping original txin scriptSig/order)
@@ -2635,7 +2635,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
         nValue += recipient.nAmount;
 
         if (recipient.fSubtractFeeFromAmount)
-            nSubtractFeeFromAmount++;
+            ++nSubtractFeeFromAmount;
     }
     if (vecSend.empty())
     {
@@ -2931,7 +2931,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     UpdateTransaction(txNew, nIn, sigdata);
                 }
 
-                nIn++;
+                ++nIn;
             }
         }
 
@@ -3480,7 +3480,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
             if (nDepth < (pcoin->IsFromMe(ISMINE_ALL) ? 0 : 1))
                 continue;
 
-            for (unsigned int i = 0; i < pcoin->tx->vout.size(); i++)
+            for (unsigned int i = 0; i < pcoin->tx->vout.size(); ++i)
             {
                 CTxDestination addr;
                 if (!IsMine(pcoin->tx->vout[i]))
@@ -3706,7 +3706,7 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const
 {
     AssertLockHeld(cs_wallet); // setLockedCoins
     for (std::set<COutPoint>::iterator it = setLockedCoins.begin();
-         it != setLockedCoins.end(); it++) {
+         it != setLockedCoins.end(); ++it) {
         COutPoint outpt = (*it);
         vOutpts.push_back(outpt);
     }
@@ -3742,7 +3742,7 @@ void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) c
 
     // find first block that affects those keys, if there are any left
     std::vector<CKeyID> vAffected;
-    for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); it++) {
+    for (std::map<uint256, CWalletTx>::const_iterator it = mapWallet.begin(); it != mapWallet.end(); ++it) {
         // iterate over all wallet transactions...
         const CWalletTx &wtx = (*it).second;
         BlockMap::const_iterator blit = mapBlockIndex.find(wtx.hashBlock);
@@ -3764,7 +3764,7 @@ void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) c
     }
 
     // Extract block timestamps for those keys
-    for (std::map<CKeyID, CBlockIndex*>::const_iterator it = mapKeyFirstBlock.begin(); it != mapKeyFirstBlock.end(); it++)
+    for (std::map<CKeyID, CBlockIndex*>::const_iterator it = mapKeyFirstBlock.begin(); it != mapKeyFirstBlock.end(); ++it)
         mapKeyBirth[it->first] = it->second->GetBlockTime() - TIMESTAMP_WINDOW; // block times can be 2h off
 }
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -316,7 +316,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         }
         else if (strType == "watchs")
         {
-            wss.nWatchKeys++;
+            ++wss.nWatchKeys;
             CScript script;
             ssKey >> script;
             char fYes;
@@ -339,7 +339,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
 
             if (strType == "key")
             {
-                wss.nKeys++;
+                ++wss.nKeys;
                 ssValue >> pkey;
             } else {
                 CWalletKey wkey;
@@ -414,7 +414,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
             std::vector<unsigned char> vchPrivKey;
             ssValue >> vchPrivKey;
-            wss.nCKeys++;
+            ++wss.nCKeys;
 
             if (!pwallet->LoadCryptedKey(vchPubKey, vchPrivKey))
             {
@@ -441,7 +441,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
 
             CKeyMetadata keyMeta;
             ssValue >> keyMeta;
-            wss.nKeyMeta++;
+            ++wss.nKeyMeta;
 
             pwallet->LoadKeyMetadata(keyID, keyMeta);
         }
@@ -709,7 +709,7 @@ DBErrors CWalletDB::ZapSelectTx(std::vector<uint256>& vTxHashIn, std::vector<uin
     std::vector<uint256>::iterator it = vTxHashIn.begin();
     for (uint256 hash : vTxHash) {
         while (it < vTxHashIn.end() && (*it) < hash) {
-            it++;
+            ++it;
         }
         if (it == vTxHashIn.end()) {
             break;

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -134,7 +134,7 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, co
         CZMQAbstractNotifier *notifier = *i;
         if (notifier->NotifyBlock(pindexNew))
         {
-            i++;
+            ++i;
         }
         else
         {
@@ -155,7 +155,7 @@ void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef&
         CZMQAbstractNotifier *notifier = *i;
         if (notifier->NotifyTransaction(tx))
         {
-            i++;
+            ++i;
         }
         else
         {


### PR DESCRIPTION
…es where the result isn't used (and for trivial types as well in the changed files, for consistency).

Follow Scott Meyers' advice in his More Effective C++ book, as well as cppcheck's performance messages, and use prefix instead of postfix increment/decrement for objects of non-trivial type, whenever the result of the increment isn't used, to avoid possible extra copies and maximize performance.

All the modified files fix this for some objects of non-trivial type. Increments/decrements of trivial types in these files were also converted to prefix instead of postfix (wherever the result isn't used) for consistency.