### PR TITLE
Fix header guards using reserved identifiers

### DIFF
--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef _BITCOIN_CUCKOOCACHE_H_
-#define _BITCOIN_CUCKOOCACHE_H_
+#ifndef BITCOIN_CUCKOOCACHE_H
+#define BITCOIN_CUCKOOCACHE_H
 
 #include <array>
 #include <algorithm>
@@ -478,4 +478,4 @@ public:
 };
 } // namespace CuckooCache
 
-#endif
+#endif // BITCOIN_CUCKOOCACHE_H

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef _BITCOIN_PREVECTOR_H_
-#define _BITCOIN_PREVECTOR_H_
+#ifndef BITCOIN_PREVECTOR_H
+#define BITCOIN_PREVECTOR_H
 
 #include <assert.h>
 #include <stdlib.h>
@@ -514,4 +514,4 @@ public:
 };
 #pragma pack(pop)
 
-#endif
+#endif // BITCOIN_PREVECTOR_H


### PR DESCRIPTION
Identifiers beginning with an underscore followed immediately by an uppercase letter are reserved.