### PR TITLE
Increase DEFAULT_ANCESTOR_LIMIT and DEFAULT_DESCENDANT_LIMIT to 100

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -58,11 +58,11 @@ static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
-static const unsigned int DEFAULT_ANCESTOR_LIMIT = 25;
+static const unsigned int DEFAULT_ANCESTOR_LIMIT = 100;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */
 static const unsigned int DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
 /** Default for -limitdescendantcount, max number of in-mempool descendants */
-static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
+static const unsigned int DEFAULT_DESCENDANT_LIMIT = 100;
 /** Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
@@ -215,7 +215,7 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
@@ -226,7 +226,7 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  *
  * Note that we guarantee that either the proof-of-work is valid on pblock, or
  * (and possibly also) BlockChecked will have been called.
- * 
+ *
  * Call without cs_main held.
  *
  * @param[in]   pblock  The block we want to process.
@@ -350,7 +350,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = null
 
 /**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -8,8 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 from test_framework.mininode import COIN
 
-MAX_ANCESTORS = 25
-MAX_DESCENDANTS = 25
+MAX_ANCESTORS = 100
+MAX_DESCENDANTS = 100
 
 class MempoolPackagesTest(BitcoinTestFramework):
     def __init__(self):
@@ -102,7 +102,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for x in chain:
             ancestor_fees += mempool[x]['fee']
             assert_equal(mempool[x]['ancestorfees'], ancestor_fees * COIN + 1000)
-        
+
         # Undo the prioritisetransaction for later tests
         self.nodes[0].prioritisetransaction(txid=chain[0], fee_delta=-1000)
 
@@ -234,7 +234,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         signedtx = self.nodes[0].signrawtransaction(rawtx)
         txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
         sync_mempools(self.nodes)
-        
+
         # Now try to disconnect the tip on each node...
         self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())


### PR DESCRIPTION
I have intentionally avoided touching DEFAULT_ANCESTOR_SIZE_LIMIT to err on the site of caution, but this is something I'd like to see lifted again.

Due to the ridiculous transaction fees required these days, it's not really economically sane to rely on bitcoin core's wallet for processing deposits and withdrawals. So I have been helping a company come up with a pretty low-tech solution, and have a simple structure:

* Deposits go into a wallet A
* They are periodically swept to wallet B, with an extremely low fee
* Withdrawals are processed from wallet C. When extra funds are needed, they are immediately sent from wallet B.


However continually sending payments from wallet C, this structure results in very long transaction chains. Even when being responsible and batching in 1 minute sends, it'll very often hit against the current limits which is fun for no one.

For a background of why the limit was previously lowered from 100 to 25:

https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-October/011401.html