### PR TITLE
[GUI] Make tabs toolbar no longer have a context menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -454,6 +454,7 @@ void BitcoinGUI::createToolBars()
     if(walletFrame)
     {
         QToolBar *toolbar = addToolBar(tr("Tabs toolbar"));
+        toolbar->setContextMenuPolicy(Qt::PreventContextMenu);
         toolbar->setMovable(false);
         toolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
         toolbar->addAction(overviewAction);


### PR DESCRIPTION
Adds a contextMenuPolicy of Qt::PreventContextMenu to prevent the tabs toolbar from showing a context menu that allows it to be hidden.

Fixes #11168