### PR TITLE
Support for SegWit Addresses in RPC  calls and change addresses

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -453,6 +453,7 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-limitdescendantcount=<n>", strprintf("Do not accept transactions if any ancestor would have <n> or more in-mempool descendants (default: %u)", DEFAULT_DESCENDANT_LIMIT));
         strUsage += HelpMessageOpt("-limitdescendantsize=<n>", strprintf("Do not accept transactions if any ancestor would have more than <n> kilobytes of in-mempool descendants (default: %u).", DEFAULT_DESCENDANT_SIZE_LIMIT));
         strUsage += HelpMessageOpt("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)");
+        strUsage += HelpMessageOpt("-defaultwitnessaddress", "Return witness addresses by default in RPC calls (default: false)");
     }
     strUsage += HelpMessageOpt("-debug=<category>", strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
         _("If <category> is not supplied or if <category> = 1, output all debugging information.") + " " + _("<category> can be:") + " " + ListLogCategories() + ".");

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -120,6 +120,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },
     { "prioritisetransaction", 2, "fee_delta" },
+    { "getnewaddress", 1, "witness" },
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },
     { "setnetworkactive", 0, "state" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -120,6 +120,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },
     { "prioritisetransaction", 2, "fee_delta" },
+    { "getaccountaddress", 1, "witness" },
     { "getnewaddress", 1, "witness" },
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1233,14 +1233,15 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 1)
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
     {
-        std::string msg = "addwitnessaddress \"address\"\n"
+        std::string msg = "addwitnessaddress \"address\" \"label\"\n"
             "\nAdd a witness address for a script (with pubkey or redeemscript known).\n"
             "It returns the witness script.\n"
 
             "\nArguments:\n"
             "1. \"address\"       (string, required) An address known to the wallet\n"
+            "2. \"label\"         (string, optional) A comment for the address if any\n"
 
             "\nResult:\n"
             "\"witnessaddress\",  (string) The value of the new address (P2SH of witness script).\n"
@@ -1260,16 +1261,15 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
 
-    Witnessifier w(pwallet);
-    CTxDestination dest = address.Get();
-    bool ret = boost::apply_visitor(w, dest);
-    if (!ret) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet, or the key is uncompressed");
-    }
+	CScriptID wresult = GetWitnessScriptFromAddress(pwallet, address);
 
-    pwallet->SetAddressBook(w.result, "", "receive");
+    std::string strLabel;
+    if (request.params.size() >= 2)
+		strLabel = request.params[1].get_str();
 
-    return CBitcoinAddress(w.result).ToString();
+    pwallet->SetAddressBook(wresult, strLabel, "receive");
+
+    return CBitcoinAddress(wresult).ToString();
 }
 
 struct tallyitem
@@ -3206,7 +3206,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "abandontransaction",       &abandontransaction,       false,  {"txid"} },
     { "wallet",             "abortrescan",              &abortrescan,              false,  {} },
     { "wallet",             "addmultisigaddress",       &addmultisigaddress,       true,   {"nrequired","keys","account"} },
-    { "wallet",             "addwitnessaddress",        &addwitnessaddress,        true,   {"address"} },
+    { "wallet",             "addwitnessaddress",        &addwitnessaddress,        true,   {"address", "label"} },
     { "wallet",             "backupwallet",             &backupwallet,             true,   {"destination"} },
     { "wallet",             "bumpfee",                  &bumpfee,                  true,   {"txid", "options"} },
     { "wallet",             "dumpprivkey",              &dumpprivkey,              true,   {"address"}  },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -104,6 +104,23 @@ public:
     }
 };
 
+CScriptID GetWitnessScriptFromAddress(CWallet * const pwallet, CBitcoinAddress addr)
+{
+        Witnessifier w(pwallet);
+        CTxDestination dest = addr.Get();
+        if (!boost::apply_visitor(w, dest)) 
+			throw JSONRPCError(RPC_WALLET_ERROR, "Public key or redeemscript not known to wallet, or the key is uncompressed");
+        return w.result;
+}
+
+CBitcoinAddress WitnessifyBitcoinAddress(CWallet* const pwallet, std::string strAccount, CBitcoinAddress addr)
+{
+        Witnessifier w(pwallet);
+        CScriptID wscript = GetWitnessScriptFromAddress(pwallet, addr);
+        pwallet->SetAddressBook(wscript, strAccount, "receive");
+        return CBitcoinAddress(wscript);
+}
+
 std::string HelpRequiringPassphrase(CWallet * const pwallet)
 {
     return pwallet && pwallet->IsCrypted()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -804,11 +804,12 @@ bool CWallet::GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bFo
         else {
             // Check if the current key has been used
             CScript scriptPubKey = GetScriptForDestination(account.vchPubKey.GetID());
+            CScript scriptWitness = GetScriptForDestination(GetScriptForWitness(scriptPubKey));
             for (std::map<uint256, CWalletTx>::iterator it = mapWallet.begin();
                  it != mapWallet.end() && account.vchPubKey.IsValid();
                  ++it)
                 for (const CTxOut& txout : (*it).second.tx->vout)
-                    if (txout.scriptPubKey == scriptPubKey) {
+                    if (txout.scriptPubKey == scriptPubKey || txout.scriptPubKey == scriptWitness) {
                         bForceNew = true;
                         break;
                     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2649,6 +2649,11 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
 
                 scriptChange = GetScriptForDestination(vchPubKey.GetID());
+                if (gArgs.GetBoolArg("-defaultwitnessaddress", false)) {
+                    scriptChange = GetScriptForWitness(scriptChange);
+                    this->AddCScript(scriptChange);
+                    scriptChange = GetScriptForDestination(scriptChange);
+                }
             }
             CTxOut change_prototype_txout(0, scriptChange);
             size_t change_prototype_size = GetSerializeSize(change_prototype_txout, SER_DISK, 0);


### PR DESCRIPTION
This is the approach I've taken to enabling segwit addresses for rpc calls on some bitcoin nodes I run.

* **-defaultwitnessaddress** startup parameters has been added to return segwitaddresses by defaults
* **Witnessifier** visitor has been moved to the top of the file for use in getaccountaddress/getnewaddress

* **getaccountaddress** has been added the optional witness flag which will return Witnessified addresses
* **getnewaddress** has been added the optional witness flag which will return Witnessified addresses
* **addwitnessaddress** has been added an optional label parameter
* Added check for witness used destination scripts in GetAccountPubkey 


* Change addresses default to P2SH wrapped segwit addresses when **-defaultwitnessaddress** is used