### PR TITLE
[Qt] Terminate string *pszExePath after readlink and without using memset

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -743,9 +743,10 @@ bool SetStartOnSystemStartup(bool fAutoStart)
     else
     {
         char pszExePath[MAX_PATH+1];
-        memset(pszExePath, 0, sizeof(pszExePath));
-        if (readlink("/proc/self/exe", pszExePath, sizeof(pszExePath)-1) == -1)
+        ssize_t r = readlink("/proc/self/exe", pszExePath, sizeof(pszExePath) - 1);
+        if (r == -1)
             return false;
+        pszExePath[r] = '\0';
 
         fs::create_directories(GetAutostartDir());
 


### PR DESCRIPTION
Terminate string `*pszExePath` after `readlink` and before passing to operator `<<`.

* `ssize_t readlink(const char *pathname, char *buf, size_t bufsiz)` does not append a null byte to `buf`.
* Operator `<<` expects a null-terminated string.