### PR TITLE
fees: optimize decay

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -231,13 +231,25 @@ void TxConfirmStats::Record(int blocksToConfirm, double val)
 
 void TxConfirmStats::UpdateMovingAverages()
 {
-    for (unsigned int j = 0; j < buckets.size(); j++) {
-        for (unsigned int i = 0; i < confAvg.size(); i++)
-            confAvg[i][j] = confAvg[i][j] * decay;
-        for (unsigned int i = 0; i < failAvg.size(); i++)
-            failAvg[i][j] = failAvg[i][j] * decay;
-        avg[j] = avg[j] * decay;
-        txCtAvg[j] = txCtAvg[j] * decay;
+    for (auto& elem : confAvg) {
+        assert(elem.size() == buckets.size());
+        for (auto& bucket : elem) {
+            bucket *= decay;
+        }
+    }
+    for (auto& elem : failAvg) {
+        assert(elem.size() == buckets.size());
+        for (auto& bucket : elem) {
+            bucket *= decay;
+        }
+    }
+    assert(avg.size() == buckets.size());
+    for (auto& bucket : avg) {
+        bucket *= decay;
+    }
+    assert(txCtAvg.size() == buckets.size());
+    for (auto& bucket : txCtAvg) {
+        bucket *= decay;
     }
 }
 


### PR DESCRIPTION
As discussed briefly last week with @morcos and @sdaftuar.
Rather than jumping around, visit elements in-order. This produces a noticeable speedup.

I added the assertions because it's not entirely clear from the existing code if the bucket size is allowed to differ from the individual sizes. I can't imagine that that could be the case, so I'll remove them if preferred.

Additionally, I assume we could skip UpdateMovingAverages() altogether if no entries have ever been added, but it's not obvious to me how to do that without breaking something.