### PR TITLE
Sync module: Use std locking primitives instead of boost ones

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -26,6 +26,7 @@
 #include "validationinterface.h"
 #include "warnings.h"
 
+#include <chrono>
 #include <memory>
 #include <stdint.h>
 
@@ -451,7 +452,9 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     {
         // Wait to respond until either the best block changes, OR a minute has passed and there are more transactions
         uint256 hashWatchedChain;
-        boost::system_time checktxtime;
+        // TODO: Change checktxtime type to std::chrono::steady_clock::time_point so it can never go back in time due to
+        // modifying the time in the OS.
+        std::chrono::system_clock::time_point checktxtime;
         unsigned int nTransactionsUpdatedLastLP;
 
         if (lpval.isStr())
@@ -472,17 +475,19 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         // Release the wallet and main lock while waiting
         LEAVE_CRITICAL_SECTION(cs_main);
         {
-            checktxtime = boost::get_system_time() + boost::posix_time::minutes(1);
+            // TODO: Change std::chrono::system_clock::now() to std::chrono::steady_clock::now()
+            // (see comment at checktxtime definition).
+            checktxtime = std::chrono::system_clock::now() + std::chrono::minutes(1);
 
-            boost::unique_lock<boost::mutex> lock(csBestBlock);
+            std::unique_lock<std::mutex> lock(csBestBlock);
             while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning())
             {
-                if (!cvBlockChange.timed_wait(lock, checktxtime))
+                if (cvBlockChange.wait_until(lock, checktxtime) == std::cv_status::timeout)
                 {
                     // Timeout: Check transactions for update
                     if (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLastLP)
                         break;
-                    checktxtime += boost::posix_time::seconds(10);
+                    checktxtime += std::chrono::seconds(10);
                 }
             }
         }

--- a/src/util.h
+++ b/src/util.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include <boost/signals2/signal.hpp>
+#include <boost/thread/thread.hpp>
 
 // Application startup time (used for uptime calculation)
 int64_t GetStartupTime();


### PR DESCRIPTION
Migrate the sync module to use the std-defined (since C++11) condition_variable, mutex and recursive_mutex instead of the boost provided ones.

Boost locking primitives are still used elsewhere in the project. This commit modifies just the sync module itself and the minimum code required to compile and work with its modified interface.

A couple of files were missing boost includes and previously indirectly included them through the sync.h header - added them.

Added TODO comment about changing a polling timeout in mining.cpp to use std::chrono::stable_clock which can't go back in time due to OS changes instead of std::chrono::system_clock which can. Not making the actual fix in this commit to maintain max compatibility with previous behavior.

Resolves #11166 