### PR TITLE
[WIP] [RPC] Add verifyrawtransaction RPC

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -126,7 +126,7 @@ void BlockAssembler::resetBlock()
     nFees = 0;
 }
 
-std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx, bool fPopulateTxs)
 {
     int64_t nTimeStart = GetTimeMicros();
 
@@ -170,7 +170,10 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
     int nPackagesSelected = 0;
     int nDescendantsUpdated = 0;
-    addPackageTxs(nPackagesSelected, nDescendantsUpdated);
+
+    if (fPopulateTxs) {
+        addPackageTxs(nPackagesSelected, nDescendantsUpdated);
+    }
 
     int64_t nTime1 = GetTimeMicros();
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -168,7 +168,7 @@ public:
     BlockAssembler(const CChainParams& params, const Options& options);
 
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript& scriptPubKeyIn, bool fMineWitnessTx=true, bool fPopulateTxs=true);
 
 private:
     // utility functions

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -95,6 +95,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "createrawtransaction", 3, "replaceable" },
     { "signrawtransaction", 1, "prevtxs" },
     { "signrawtransaction", 2, "privkeys" },
+    { "verifyrawtransactions", 0, "transactions" },
+    { "verifyrawtransactions", 1, "use_local_policy" },
     { "sendrawtransaction", 1, "allowhighfees" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -13,7 +13,9 @@
 #include "validation.h"
 #include "merkleblock.h"
 #include "net.h"
+#include "miner.h"
 #include "policy/policy.h"
+#include "policy/fees.h"
 #include "policy/rbf.h"
 #include "primitives/transaction.h"
 #include "rpc/safemode.h"
@@ -887,6 +889,224 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
     return result;
 }
 
+UniValue verifyrawtransactions(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+        throw std::runtime_error(
+            "verifyrawtransactions [\"hex_tx\", ...] ( use_local_rules )\n"
+            "\nTests the validity of a series of raw transactions (serialized, hex-encoded), without submitting them.\n"
+            "The transactions can be dependent on one another, or have ancestors residing in the mempool. The\n"
+            "use_local_rules flag determines if the transactions should be validated against the node's local\n"
+            "policies. Setting it to false effectively checks if this node would reject the block containing\n"
+            "these transactions and their mempool resident ancestors, should they be mined.\n"
+            "\nAlso see createrawtransaction and signrawtransaction calls.\n"
+            "\nArguments:\n"
+            "1. \"transactions\"    (array) A json array of hex encoded transactions\n"
+            "    [\n"
+            "      \"hex_tx\"       (string) A hex encoded transaction\n"
+            "      ,...\n"
+            "    ]\n"
+            "2. \"use_local_rules\" (boolean, optional, default=true) If enabled, checks transactions against local policies\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"valid\"  : true|false,    (string) The transaction id\n"
+            "  \"reason\" : \"reason\",      (string) Description of why verification failed or succeeded\n"
+            "}\n"
+            "\nExamples:\n"
+            "Create a transaction\n"
+            + HelpExampleCli("createrawtransaction", "\"[{\\\"txid\\\" : \\\"mytxid\\\",\\\"vout\\\":0}]\" \"{\\\"myaddress\\\":0.01}\"") +
+            "Sign the transaction, and get back the hex\n"
+            + HelpExampleCli("signrawtransaction", "\"myhex\"") +
+            "\nVerify the transaction (signed hex)\n"
+            + HelpExampleCli("verifyrawtransactions", "[\"signedhex\"]") +
+            "\nAs a json rpc call\n"
+            + HelpExampleRpc("verifyrawtransactions", "[\"signedhex\"]")
+        );
+
+    LOCK(cs_main);
+    LOCK(mempool.cs);
+
+    // Type check arguments
+    RPCTypeCheck(request.params, {UniValue::VARR, UniValue::VBOOL}, true);
+    UniValue hex_transactions = request.params[0].get_array();
+
+    // { valid true/false , reason str }
+    UniValue result(UniValue::VOBJ);
+
+    bool use_local_policy = request.params[1].isNull() || request.params[1].get_bool();
+
+    // Parse all of the transactions (map is txhash -> tx).
+    std::map<uint256, CTransactionRef> transactions;
+    std::map<uint256, CTransactionRef>::iterator txit;
+    for (unsigned int idx = 0; idx < hex_transactions.size(); idx++) {
+        const UniValue& hex_tx = hex_transactions[idx];
+        CMutableTransaction mtx;
+        if (!DecodeHexTx(mtx, hex_tx.get_str())) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+        }
+        CTransactionRef ref = MakeTransactionRef(std::move(mtx));
+        transactions.insert(std::pair<uint256, CTransactionRef>(ref->GetHash(), ref));
+    }
+
+    // Should we check against our local policy, or just consensus rules?
+    if (use_local_policy) {
+        // For each input transaction
+        for (auto const& hash_tx : transactions) {
+            CTransactionRef tx(hash_tx.second);
+            const uint256& hash = tx->GetHash();
+            CCoinsViewCache& view = *pcoinsTip;
+
+            // Fail fast if we have an unspent output from this transaction
+            // already in our wallet, which indicates right away that this is a
+            // duplicate tx (copied from sendrawtransaction)
+            bool have_chain = false;
+            for (size_t o = 0; !have_chain && o < tx->vout.size(); o++) {
+                const Coin& existingCoin = view.AccessCoin(COutPoint(hash, o));
+                have_chain = !existingCoin.IsSpent();
+            }
+
+            // Check if transaction already exists in mempool
+            bool have_mempool = mempool.exists(hash);
+
+            if (have_chain) {
+                result.push_back(Pair("valid",  false));
+                result.push_back(Pair("reason", "transaction already in chain"));
+                return result;
+            }
+
+            if (have_mempool) {
+                result.push_back(Pair("valid",  false));
+                result.push_back(Pair("reason", "transaction already in mempool"));
+                return result;
+            }
+
+            // If we are reasonably confident that this transaction is not a
+            // duplicate, do an AcceptToMemoryPool dry run
+            CValidationState state;
+            bool missing_inputs;
+
+            // Call AcceptToMemoryPool with the dryrun flag set
+            if (!AcceptToMemoryPool(mempool, state, std::move(tx), true, &missing_inputs, nullptr, false, true, 0)) {
+                if (state.IsInvalid()) {
+                    result.push_back(Pair("valid",  false));
+                    result.push_back(Pair("reason", strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason())));
+                    return result;
+                } else if (missing_inputs) {
+                    // We want to ignore the "missing inputs" case here, since the input
+                    // may actually be in the mempool. If the input is truly missing, we
+                    // will find out later after the ancestor and consensus check.
+                    continue;
+                }
+                // Unknown error
+                result.push_back(Pair("valid",  false));
+                result.push_back(Pair("reason", "couldn't accept transaction to mempool"));
+                return result;
+            }
+        }
+    }
+
+    // Find the ancestors of all of the transactions, including ones in mempool
+    std::map<uint256, CTransactionRef> ancestors;
+    for (auto const& hash_tx : transactions) {
+        CTransactionRef tx = hash_tx.second;
+        for (const CTxIn& txin : tx->vin) {
+            // Check the mempool
+            const uint256& hash = txin.prevout.hash;
+            CTxMemPool::txiter it = mempool.mapTx.find(hash);
+
+            // Ancestor not in mempool
+            if (it == mempool.mapTx.end()) {
+                continue;
+            }
+
+            // Add the ancestor to the map
+            ancestors.insert(std::pair<uint256, CTransactionRef>(hash, MakeTransactionRef(it->GetTx())));
+
+            // CalculateMemPoolAncestors only works on mempool entries, which is why we are iterating over vin
+            CTxMemPool::setEntries tx_ancestors;
+            uint64_t no_limit = std::numeric_limits<uint64_t>::max();
+            std::string dummy;
+            mempool.CalculateMemPoolAncestors(*it, tx_ancestors, no_limit, no_limit, no_limit, no_limit, dummy, false);
+
+            // Insert ancestors' ancestors into the map
+            for (CTxMemPool::txiter ancestor_it : tx_ancestors) {
+                CTransactionRef atf = MakeTransactionRef(ancestor_it->GetTx());
+                ancestors.insert(std::pair<uint256, CTransactionRef>(atf->GetHash(), atf));
+            }
+        }
+    }
+
+    // Merge the ancestors into the transactions
+    transactions.insert(ancestors.begin(), ancestors.end());
+
+    // Now, come up with a valid topological sort over the transactions
+    std::vector<CTransactionRef> ordered_tx;
+
+    // Iterate over the transactions, removing all of those with no
+    // dependencies in the list each time. Technically, this is worst
+    // case n^2 since the transactions could be dependent in reverse
+    // order. In practice, I think this is better than e.g. implementing
+    // an asymptotically efficient topological sort since input sizes will
+    // likely be small and this is way easier to implement.
+    while (transactions.size() > 0) {
+        auto hash_tx = transactions.begin();
+        bool found_independent = false;
+        while (hash_tx != transactions.end()) {
+            CTransactionRef tx = hash_tx->second;
+            bool is_independent = true;
+            for (const CTxIn& txin : tx->vin) {
+                txit = transactions.find(txin.prevout.hash);
+                if (txit != transactions.end()) {
+                    is_independent = false;
+                    break;
+                }
+            }
+            if (is_independent) {
+                found_independent = true;
+                ordered_tx.push_back(tx);
+                hash_tx = transactions.erase(hash_tx);
+            } else {
+                hash_tx++;
+            }
+        }
+        if (found_independent) {
+            continue;
+        }
+        // We got all the way through without finding an independent tx
+        result.push_back(Pair("valid",  false));
+        result.push_back(Pair("reason", "circular transaction dependency"));
+        return result;
+    }
+
+    // Create the dummy block
+    CScript scriptDummy = CScript() << OP_TRUE;
+    std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(scriptDummy, true, false));
+    CBlock* pblock = &pblocktemplate->block;
+
+    // Add all of the transactions
+    pblock->vtx.reserve(1 + ordered_tx.size());
+    pblock->vtx.insert(pblock->vtx.begin() + 1, ordered_tx.begin(), ordered_tx.end());
+
+    // Check if that block would be valid (modulo PoW and merkle root checks)
+    CBlockIndex* const index_prev = chainActive.Tip();
+    CValidationState state;
+    bool res = TestBlockValidity(state, Params(), *pblock, index_prev, false, false);
+
+    if (!res) {
+        result.push_back(Pair("valid",  false));
+        if (state.IsInvalid()) {
+            result.push_back(Pair("reason", strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason())));
+        } else {
+            result.push_back(Pair("reason", "unknown consensus error"));
+        }
+    } else {
+        result.push_back(Pair("valid",  true));
+        result.push_back(Pair("reason", "transaction(s) appear to be valid"));
+    }
+
+    return result;
+}
+
 UniValue sendrawtransaction(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
@@ -937,7 +1157,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         CValidationState state;
         bool fMissingInputs;
         bool fLimitFree = true;
-        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, nullptr, false, nMaxRawTxFee)) {
+        if (!AcceptToMemoryPool(mempool, state, std::move(tx), fLimitFree, &fMissingInputs, nullptr, false, false, nMaxRawTxFee)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
             } else {
@@ -969,10 +1189,11 @@ static const CRPCCommand commands[] =
     { "rawtransactions",    "decoderawtransaction",   &decoderawtransaction,   {"hexstring"} },
     { "rawtransactions",    "decodescript",           &decodescript,           {"hexstring"} },
     { "rawtransactions",    "sendrawtransaction",     &sendrawtransaction,     {"hexstring","allowhighfees"} },
+    { "rawtransactions",    "verifyrawtransactions",  &verifyrawtransactions,  {"transactions","use_local_policy"} },
     { "rawtransactions",    "combinerawtransaction",  &combinerawtransaction,  {"txs"} },
     { "rawtransactions",    "signrawtransaction",     &signrawtransaction,     {"hexstring","prevtxs","privkeys","sighashtype"} }, /* uses wallet if enabled */
 
-    { "blockchain",         "gettxoutproof",          &gettxoutproof,          {"txids", "blockhash"} },
+    { "blockchain",         "gettxoutproof",          &gettxoutproof,          {"txids","blockhash"} },
     { "blockchain",         "verifytxoutproof",       &verifytxoutproof,       {"proof"} },
 };
 

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -49,6 +49,12 @@ BOOST_AUTO_TEST_CASE(rpc_rawparams)
     BOOST_CHECK_THROW(CallRPC("getrawtransaction not_hex"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("getrawtransaction a3b807410df0b60fcb9736768df5823938b2f838694939ba45f3c0a1bff150ed not_int"), std::runtime_error);
 
+    BOOST_CHECK_THROW(CallRPC("verifyrawtransactions"), std::runtime_error);
+    BOOST_CHECK_THROW(CallRPC("verifyrawtransactions not_array"), std::runtime_error);
+    BOOST_CHECK_THROW(CallRPC("verifyrawtransactions [] not_bool"), std::runtime_error);
+    BOOST_CHECK_THROW(CallRPC("verifyrawtransactions [not_hex]"), std::runtime_error);
+    BOOST_CHECK_THROW(CallRPC("verifyrawtransactions [not_hex] true"), std::runtime_error);
+
     BOOST_CHECK_THROW(CallRPC("createrawtransaction"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction null null"), std::runtime_error);
     BOOST_CHECK_THROW(CallRPC("createrawtransaction not_array"), std::runtime_error);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -463,6 +463,7 @@ public:
 
     mutable CCriticalSection cs;
     indexed_transaction_set mapTx;
+    indexed_transaction_set dryRunMapTx;
 
     typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
     std::vector<std::pair<uint256, txiter> > vTxHashes; //!< All tx witness hashes/entries in mapTx, in random order
@@ -513,8 +514,8 @@ public:
     // to track size/count of descendant transactions.  First version of
     // addUnchecked can be used to have it call CalculateMemPoolAncestors(), and
     // then invoke the second version.
-    bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool validFeeEstimate = true);
-    bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool validFeeEstimate = true);
+    bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, bool validFeeEstimate = true, bool dryRun = false);
+    bool addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry, setEntries &setAncestors, bool validFeeEstimate = true, bool dryRun = false);
 
     void removeRecursive(const CTransaction &tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -442,7 +442,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, CValidationSt
 
 static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool& pool, CValidationState& state, const CTransactionRef& ptx, bool fLimitFree,
                               bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                              bool fOverrideMempoolLimit, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache)
+                              bool fOverrideMempoolLimit, bool fDryRun, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache)
 {
     const CTransaction& tx = *ptx;
     const uint256 hash = tx.GetHash();
@@ -839,37 +839,42 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             }
         }
 
-        // Remove conflicting transactions from the mempool
-        for (const CTxMemPool::txiter it : allConflicting)
-        {
-            LogPrint(BCLog::MEMPOOL, "replacing tx %s with %s for %s BTC additional fees, %d delta bytes\n",
-                    it->GetTx().GetHash().ToString(),
-                    hash.ToString(),
-                    FormatMoney(nModifiedFees - nConflictingFees),
-                    (int)nSize - (int)nConflictingSize);
-            if (plTxnReplaced)
-                plTxnReplaced->push_back(it->GetSharedTx());
-        }
-        pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
+        if (!fDryRun) {
+            // Remove conflicting transactions from the mempool
+            for (const CTxMemPool::txiter it : allConflicting) {
+                LogPrint(BCLog::MEMPOOL, "replacing tx %s with %s for %s BTC additional fees, %d delta bytes\n",
+                        it->GetTx().GetHash().ToString(),
+                        hash.ToString(),
+                        FormatMoney(nModifiedFees - nConflictingFees),
+                        (int)nSize - (int)nConflictingSize);
+                if (plTxnReplaced)
+                    plTxnReplaced->push_back(it->GetSharedTx());
+            }
+            pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
 
-        // This transaction should only count for fee estimation if it isn't a
-        // BIP 125 replacement transaction (may not be widely supported), the
-        // node is not behind, and the transaction is not dependent on any other
-        // transactions in the mempool.
-        bool validForFeeEstimation = !fReplacementTransaction && IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
+            // This transaction should only count for fee estimation if it isn't a
+            // BIP 125 replacement transaction (may not be widely supported), the
+            // node is not behind, and the transaction is not dependent on any other
+            // transactions in the mempool.
+            bool validForFeeEstimation = !fReplacementTransaction && IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
 
-        // Store transaction in memory
-        pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation);
+            // Store transaction in memory
+            pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation);
 
-        // trim mempool and check if tx was trimmed
-        if (!fOverrideMempoolLimit) {
-            LimitMempoolSize(pool, gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
-            if (!pool.exists(hash))
-                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
+            // trim mempool and check if tx was trimmed
+            if (!fOverrideMempoolLimit) {
+                // We don't have this failure mode in dry-run mode since we aren't
+                // adding the transaction to the mempool in the first place
+                LimitMempoolSize(pool, gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000, gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
+                if (!pool.exists(hash))
+                    return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
+            }
         }
     }
 
-    GetMainSignals().TransactionAddedToMempool(ptx);
+    if (!fDryRun) {
+        GetMainSignals().TransactionAddedToMempool(ptx);
+    }
 
     return true;
 }
@@ -877,10 +882,14 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 /** (try to) add transaction to memory pool with a specified acceptance time **/
 static bool AcceptToMemoryPoolWithTime(const CChainParams& chainparams, CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                        bool fOverrideMempoolLimit, const CAmount nAbsurdFee)
+                        bool fOverrideMempoolLimit, bool fDryRun, const CAmount nAbsurdFee)
 {
     std::vector<COutPoint> coins_to_uncache;
-    bool res = AcceptToMemoryPoolWorker(chainparams, pool, state, tx, fLimitFree, pfMissingInputs, nAcceptTime, plTxnReplaced, fOverrideMempoolLimit, nAbsurdFee, coins_to_uncache);
+    bool res = AcceptToMemoryPoolWorker(chainparams, pool, state, tx, fLimitFree, pfMissingInputs, nAcceptTime, plTxnReplaced, fOverrideMempoolLimit, fDryRun, nAbsurdFee, coins_to_uncache);
+    if (fDryRun) {
+        // If we are just testing the transaction, don't mess with the caches
+        return res;
+    }
     if (!res) {
         for (const COutPoint& hashTx : coins_to_uncache)
             pcoinsTip->Uncache(hashTx);
@@ -893,10 +902,10 @@ static bool AcceptToMemoryPoolWithTime(const CChainParams& chainparams, CTxMemPo
 
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool fOverrideMempoolLimit, const CAmount nAbsurdFee)
+                        bool fOverrideMempoolLimit, bool fDryRun, const CAmount nAbsurdFee)
 {
     const CChainParams& chainparams = Params();
-    return AcceptToMemoryPoolWithTime(chainparams, pool, state, tx, fLimitFree, pfMissingInputs, GetTime(), plTxnReplaced, fOverrideMempoolLimit, nAbsurdFee);
+    return AcceptToMemoryPoolWithTime(chainparams, pool, state, tx, fLimitFree, pfMissingInputs, GetTime(), plTxnReplaced, fOverrideMempoolLimit, fDryRun, nAbsurdFee);
 }
 
 /** Return transaction in txOut, and if it was found inside a block, its hash is placed in hashBlock */
@@ -4305,7 +4314,7 @@ bool LoadMempool(void)
             CValidationState state;
             if (nTime + nExpiryTimeout > nNow) {
                 LOCK(cs_main);
-                AcceptToMemoryPoolWithTime(chainparams, mempool, state, tx, true, nullptr, nTime, nullptr, false, 0);
+                AcceptToMemoryPoolWithTime(chainparams, mempool, state, tx, true, nullptr, nTime, nullptr, false, false, 0);
                 if (state.IsValid()) {
                     ++count;
                 } else {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -570,7 +570,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         // be mined yet.
         // Must keep pool.cs for this unless we change CheckSequenceLocks to take a
         // CoinsViewCache instead of create its own
-        if (!CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp))
+        if (!CheckSequenceLocks(tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp, false))
             return state.DoS(0, false, REJECT_NONSTANDARD, "non-BIP68-final");
         }
 
@@ -851,6 +851,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                     plTxnReplaced->push_back(it->GetSharedTx());
             }
             pool.RemoveStaged(allConflicting, false, MemPoolRemovalReason::REPLACED);
+        }
 
             // This transaction should only count for fee estimation if it isn't a
             // BIP 125 replacement transaction (may not be widely supported), the
@@ -859,8 +860,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             bool validForFeeEstimation = !fReplacementTransaction && IsCurrentForFeeEstimation() && pool.HasNoInputsOf(tx);
 
             // Store transaction in memory
-            pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation);
+            pool.addUnchecked(hash, entry, setAncestors, validForFeeEstimation, fDryRun);
 
+        if (!fDryRun) {
             // trim mempool and check if tx was trimmed
             if (!fOverrideMempoolLimit) {
                 // We don't have this failure mode in dry-run mode since we aren't

--- a/src/validation.h
+++ b/src/validation.h
@@ -301,7 +301,7 @@ void PruneBlockFilesManual(int nManualPruneHeight);
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx, bool fLimitFree,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced = nullptr,
-                        bool fOverrideMempoolLimit=false, const CAmount nAbsurdFee=0);
+                        bool fOverrideMempoolLimit=false, bool fDryRun=false, const CAmount nAbsurdFee=0);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4021,5 +4021,5 @@ int CMerkleTx::GetBlocksToMaturity() const
 
 bool CMerkleTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state)
 {
-    return ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, nullptr, false, nAbsurdFee);
+    return ::AcceptToMemoryPool(mempool, state, tx, true, nullptr, nullptr, false, false, nAbsurdFee);
 }

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -35,17 +35,176 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),4.0)
+        self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),3.0)
         self.sync_all()
         self.nodes[0].generate(5)
         self.sync_all()
 
+        unspent = self.nodes[2].listunspent()
+
+        fivebtc  = [tx for tx in unspent if tx["amount"] == Decimal("5.0")][0]
+        fourbtc  = [tx for tx in unspent if tx["amount"] == Decimal("4.0")][0]
+        threebtc = [tx for tx in unspent if tx["amount"] == Decimal("3.0")][0]
+
         #########################################
-        # sendrawtransaction with missing input #
+        # {create|verify|send}rawtransaction with valid or empty transaction #
+        #########################################
+        inputs  = [ {'txid' : fivebtc["txid"], 'vout' : fivebtc["vout"]} ]
+        outputs = { self.nodes[0].getnewaddress(): 4.9 }
+        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
+
+        # This transaction is not signed and thus should not validate
+        res = self.nodes[2].verifyrawtransactions([rawtx])
+        assert_equal(res['valid'], False)
+        assert_equal("mandatory-script-verify" in res['reason'], True)
+
+        # Sign the transaction
+        rawtx = self.nodes[2].signrawtransaction(rawtx)
+
+        # This transaction is signed and valid, so verifyrawtransaction should succeed
+        res = self.nodes[2].verifyrawtransactions([rawtx['hex']])
+        assert_equal(res['valid'], True)
+        assert_equal("appear to be valid" in res['reason'], True)
+
+        # Verifying no transactions should succeed
+        res = self.nodes[2].verifyrawtransactions([])
+        assert_equal(res['valid'], True)
+
+        res = self.nodes[2].verifyrawtransactions([], False)
+        assert_equal(res['valid'], True)
+
+        # Add transaction to mempool
+        assert_equal(len(self.nodes[2].getrawmempool()), 0)
+        self.nodes[2].sendrawtransaction(rawtx['hex'])
+
+        # mempool should have one entry now
+        assert_equal(len(self.nodes[2].getrawmempool()), 1)
+
+        # verifyrawtransactions should fail now since the tx is already in the mempool
+        res = self.nodes[2].verifyrawtransactions([rawtx['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("mempool" in res['reason'], True)
+
+        # mempool should still have one entry (should not be touched by verifyrawtransaction)
+        assert_equal(len(self.nodes[2].getrawmempool()), 1)
+
+        # Mine the transaction
+        self.sync_all()
+        self.nodes[2].generate(1)
+        self.sync_all()
+
+        # Once confirmed, should no longer be spendable
+        res = self.nodes[2].verifyrawtransactions([rawtx['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("chain" in res['reason'], True)
+
+        #########################################
+        # {create|verify|send}rawtransaction with verifying multiple tx/mempool ancestor #
+        #########################################
+        inputs  = [ {'txid' : fourbtc["txid"], 'vout' : fourbtc["vout"]} ]
+        outputs = { self.nodes[2].getnewaddress(): 3.9 }
+        rawtx0  = self.nodes[2].createrawtransaction(inputs, outputs)
+        rawtx0  = self.nodes[2].signrawtransaction(rawtx0)
+
+        # This transaction is signed and valid, so verifyrawtransaction should succeed
+        res = self.nodes[2].verifyrawtransactions([rawtx0['hex']])
+        assert_equal(res['valid'], True)
+
+        txdec = self.nodes[2].decoderawtransaction(rawtx0["hex"])
+
+        # Create another transaction dependent on the first
+        inputs  = [ {'txid' : txdec["txid"], 'vout' : 0} ]
+        outputs = { self.nodes[2].getnewaddress(): 3.8 }
+        rawtx1  = self.nodes[2].createrawtransaction(inputs, outputs)
+        rawtx1  = self.nodes[2].signrawtransaction(rawtx1, [{"txid": txdec["txid"], "vout": 0,
+                                    "scriptPubKey": txdec["vout"][0]["scriptPubKey"]["hex"]}])
+
+        txdec = self.nodes[2].decoderawtransaction(rawtx1["hex"])
+
+        # One more, so we can test multiple mempool ancestors
+        inputs  = [ {'txid' : txdec["txid"], 'vout' : 0} ]
+        outputs = { self.nodes[2].getnewaddress(): 3.7 }
+        rawtx2  = self.nodes[2].createrawtransaction(inputs, outputs)
+        rawtx2  = self.nodes[2].signrawtransaction(rawtx2, [{"txid": txdec["txid"], "vout": 0,
+                                    "scriptPubKey": txdec["vout"][0]["scriptPubKey"]["hex"]}])
+
+        # We don't know about the first tx yet, so verifyrawtransaction should fail
+        res = self.nodes[2].verifyrawtransactions([rawtx1['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("missingorspent" in res['reason'], True)
+        res = self.nodes[2].verifyrawtransactions([rawtx2['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("missingorspent" in res['reason'], True)
+
+        # Passing 0, 1, 2 or 0, 1 should work, though
+        res = self.nodes[2].verifyrawtransactions([rawtx0['hex'], rawtx1['hex']])
+        assert_equal(res['valid'], True)
+
+        res = self.nodes[2].verifyrawtransactions([rawtx0['hex'], rawtx1['hex'], rawtx2['hex']])
+        assert_equal(res['valid'], True)
+
+        # Order shouldn't matter
+        res = self.nodes[2].verifyrawtransactions([rawtx1['hex'], rawtx0['hex']])
+        assert_equal(res['valid'], True)
+
+        res = self.nodes[2].verifyrawtransactions([rawtx2['hex'], rawtx0['hex'], rawtx1['hex']])
+        assert_equal(res['valid'], True)
+
+        # Add the first transaction to the mempool
+        self.nodes[2].sendrawtransaction(rawtx0['hex'])
+
+        # Now that the first tx is in the mempool, verifyrawtransactions for the second should succeed
+        res = self.nodes[2].verifyrawtransactions([rawtx1['hex']])
+        assert_equal(res['valid'], True)
+
+        # Third should still fail
+        res = self.nodes[2].verifyrawtransactions([rawtx2['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("missingorspent" in res['reason'], True)
+
+        # Add the second transaction to the mempool
+        self.nodes[2].sendrawtransaction(rawtx1['hex'])
+
+        # Third should work now
+        res = self.nodes[2].verifyrawtransactions([rawtx2['hex']])
+        assert_equal(res['valid'], True)
+
+        #########################################
+        # {create|verify}rawtransaction with violation of local rules #
+        #########################################
+
+        inputs  = [ {'txid' : threebtc["txid"], 'vout' : threebtc["vout"]} ]
+        outputs = { self.nodes[2].getnewaddress(): 3.0 } # no fee
+
+        nofee = self.nodes[2].createrawtransaction(inputs, outputs)
+        nofee = self.nodes[2].signrawtransaction(nofee)
+
+        # There is no fee, so verifyrawtransactions should fail if use_local_rules is default or true
+        res = self.nodes[2].verifyrawtransactions([nofee['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("relay fee" in res['reason'], True)
+
+        res = self.nodes[2].verifyrawtransactions([nofee['hex']], True)
+        assert_equal(res['valid'], False)
+        assert_equal("relay fee" in res['reason'], True)
+
+        # But this transaction would be fine if it were mined into a block
+        res = self.nodes[2].verifyrawtransactions([nofee['hex']], False)
+        assert_equal(res['valid'], True)
+
+        #########################################
+        # {create|verify|send}rawtransaction with missing input #
         #########################################
         inputs  = [ {'txid' : "1d1d4e24ed99057e84c3f80fd8fbec79ed9e1acee37da269356ecea000000000", 'vout' : 1}] #won't exists
         outputs = { self.nodes[0].getnewaddress() : 4.998 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        rawtx   = self.nodes[2].signrawtransaction(rawtx)
+        rawtx = self.nodes[2].signrawtransaction(rawtx)
+
+        # This transaction is missing inputs and thus should not validate
+        res = self.nodes[2].verifyrawtransactions([rawtx['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("missingorspent" in res['reason'], True)
 
         # This will raise an exception since there are missing inputs
         assert_raises_jsonrpc(-25, "Missing inputs", self.nodes[2].sendrawtransaction, rawtx['hex'])
@@ -92,6 +251,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
+        # verifyrawtransaction should fail since output was already spent
+        res = self.nodes[0].verifyrawtransactions([decTx['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("in chain" in res['reason'], True)
+
         #THIS IS A INCOMPLETE FEATURE
         #NODE2 HAS TWO OF THREE KEY AND THE FUNDS SHOULD BE SPENDABLE AND COUNT AT BALANCE CALCULATION
         assert_equal(self.nodes[2].getbalance(), bal) #for now, assume the funds of a 2of3 multisig tx are not marked as spendable
@@ -111,8 +275,18 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawTxPartialSigned = self.nodes[1].signrawtransaction(rawTx, inputs)
         assert_equal(rawTxPartialSigned['complete'], False) #node1 only has one key, can't comp. sign the tx
 
+        # verifyrawtransaction should fail since output is not fully signed
+        res = self.nodes[0].verifyrawtransactions([rawTxPartialSigned['hex']])
+        assert_equal(res['valid'], False)
+        assert_equal("mandatory-script-verify" in res['reason'], True)
+
         rawTxSigned = self.nodes[2].signrawtransaction(rawTx, inputs)
         assert_equal(rawTxSigned['complete'], True) #node2 can sign the tx compl., own two of three keys
+
+        # verifyrawtransaction should succeed since output is fully signed
+        res = self.nodes[0].verifyrawtransactions([rawTxSigned['hex']])
+        assert_equal(res['valid'], True)
+
         self.nodes[2].sendrawtransaction(rawTxSigned['hex'])
         rawTx = self.nodes[0].decoderawtransaction(rawTxSigned['hex'])
         self.sync_all()


### PR DESCRIPTION
Currently, there is not an RPC that allows for the validation of a raw transaction without actually submitting that transaction to the network. This PR implements `verifyrawtransaction`, which accepts a hex encoded raw transaction and determines if it could be included in the next block. It does this by creating a "fake" block with the proposed transaction, and then checking that the block is valid with `TestBlockValidity`.

This is my first attempt at contributing to bitcoin, so if I've already managed to break any unspoken (or spoken) rules, please let me know 😅 