### PR TITLE
Make fixed CAmounts and related sanity function constexpr

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -11,8 +11,8 @@
 /** Amount in satoshis (Can be negative) */
 typedef int64_t CAmount;
 
-static const CAmount COIN = 100000000;
-static const CAmount CENT = 1000000;
+constexpr CAmount COIN = 100000000;
+constexpr CAmount CENT = 1000000;
 
 /** No amount larger than this (in satoshi) is valid.
  *
@@ -23,7 +23,7 @@ static const CAmount CENT = 1000000;
  * critical; in unusual circumstances like a(nother) overflow bug that allowed
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
-static const CAmount MAX_MONEY = 21000000 * COIN;
-inline bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+constexpr CAmount MAX_MONEY = 21000000 * COIN;
+constexpr bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
 
 #endif //  BITCOIN_AMOUNT_H

--- a/src/amount.h
+++ b/src/amount.h
@@ -24,6 +24,6 @@ constexpr CAmount CENT = 1000000;
  * for the creation of coins out of thin air modification could lead to a fork.
  * */
 constexpr CAmount MAX_MONEY = 21000000 * COIN;
-constexpr bool MoneyRange(const CAmount& nValue) { return (nValue >= 0 && nValue <= MAX_MONEY); }
+constexpr bool MoneyRange(const CAmount& amount) { return amount >= 0 && amount <= MAX_MONEY; }
 
 #endif //  BITCOIN_AMOUNT_H


### PR DESCRIPTION
This would allow the fixed amounts and sanity function to be used in constexpr contexts.