### PR TITLE
[WIP] Add Clang thread safety analysis annotations: GUARDED_BY(lock) / EXCLUSIVE_LOCKS_REQUIRED(lock)

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -65,7 +65,7 @@ double CAddrInfo::GetChance(int64_t nNow) const
     return fChance;
 }
 
-CAddrInfo* CAddrMan::Find(const CNetAddr& addr, int* pnId)
+CAddrInfo* CAddrMan::Find(const CNetAddr& addr, int* pnId) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     std::map<CNetAddr, int>::iterator it = mapAddr.find(addr);
     if (it == mapAddr.end())
@@ -312,7 +312,7 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
     return fNew;
 }
 
-void CAddrMan::Attempt_(const CService& addr, bool fCountFailure, int64_t nTime)
+void CAddrMan::Attempt_(const CService& addr, bool fCountFailure, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     CAddrInfo* pinfo = Find(addr);
 
@@ -334,7 +334,7 @@ void CAddrMan::Attempt_(const CService& addr, bool fCountFailure, int64_t nTime)
     }
 }
 
-CAddrInfo CAddrMan::Select_(bool newOnly)
+CAddrInfo CAddrMan::Select_(bool newOnly) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     if (size() == 0)
         return CAddrInfo();
@@ -480,7 +480,7 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr) EXCLUSIVE_LOCKS_REQUIRED(c
     }
 }
 
-void CAddrMan::Connected_(const CService& addr, int64_t nTime)
+void CAddrMan::Connected_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     CAddrInfo* pinfo = Find(addr);
 
@@ -500,7 +500,7 @@ void CAddrMan::Connected_(const CService& addr, int64_t nTime)
         info.nTime = nTime;
 }
 
-void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices)
+void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     CAddrInfo* pinfo = Find(addr);
 

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -78,7 +78,7 @@ CAddrInfo* CAddrMan::Find(const CNetAddr& addr, int* pnId)
     return nullptr;
 }
 
-CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId)
+CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     int nId = nIdCount++;
     mapInfo[nId] = CAddrInfo(addr, addrSource);
@@ -90,7 +90,7 @@ CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, in
     return &mapInfo[nId];
 }
 
-void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2)
+void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     if (nRndPos1 == nRndPos2)
         return;
@@ -110,7 +110,7 @@ void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2)
     vRandom[nRndPos2] = nId1;
 }
 
-void CAddrMan::Delete(int nId)
+void CAddrMan::Delete(int nId) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     assert(mapInfo.count(nId) != 0);
     CAddrInfo& info = mapInfo[nId];
@@ -124,7 +124,7 @@ void CAddrMan::Delete(int nId)
     nNew--;
 }
 
-void CAddrMan::ClearNew(int nUBucket, int nUBucketPos)
+void CAddrMan::ClearNew(int nUBucket, int nUBucketPos) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     // if there is an entry in the specified bucket, delete it.
     if (vvNew[nUBucket][nUBucketPos] != -1) {
@@ -139,7 +139,7 @@ void CAddrMan::ClearNew(int nUBucket, int nUBucketPos)
     }
 }
 
-void CAddrMan::MakeTried(CAddrInfo& info, int nId)
+void CAddrMan::MakeTried(CAddrInfo& info, int nId) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     // remove the entry from all new buckets
     for (int bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
@@ -187,7 +187,7 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId)
     info.fInTried = true;
 }
 
-void CAddrMan::Good_(const CService& addr, int64_t nTime)
+void CAddrMan::Good_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     int nId;
 
@@ -239,7 +239,7 @@ void CAddrMan::Good_(const CService& addr, int64_t nTime)
     MakeTried(info, nId);
 }
 
-bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimePenalty)
+bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimePenalty) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     if (!addr.IsRoutable())
         return false;
@@ -459,7 +459,7 @@ int CAddrMan::Check_()
 }
 #endif
 
-void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr)
+void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr) EXCLUSIVE_LOCKS_REQUIRED(cs)
 {
     unsigned int nNodes = ADDRMAN_GETADDR_MAX_PCT * vRandom.size() / 100;
     if (nNodes > ADDRMAN_GETADDR_MAX)

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -78,7 +78,7 @@ CAddrInfo* CAddrMan::Find(const CNetAddr& addr, int* pnId)
     return nullptr;
 }
 
-CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId) EXCLUSIVE_LOCKS_REQUIRED(cs)
+CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     int nId = nIdCount++;
     mapInfo[nId] = CAddrInfo(addr, addrSource);
@@ -90,7 +90,7 @@ CAddrInfo* CAddrMan::Create(const CAddress& addr, const CNetAddr& addrSource, in
     return &mapInfo[nId];
 }
 
-void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     if (nRndPos1 == nRndPos2)
         return;
@@ -110,7 +110,7 @@ void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2) EXCLUSIV
     vRandom[nRndPos2] = nId1;
 }
 
-void CAddrMan::Delete(int nId) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CAddrMan::Delete(int nId) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     assert(mapInfo.count(nId) != 0);
     CAddrInfo& info = mapInfo[nId];
@@ -124,7 +124,7 @@ void CAddrMan::Delete(int nId) EXCLUSIVE_LOCKS_REQUIRED(cs)
     nNew--;
 }
 
-void CAddrMan::ClearNew(int nUBucket, int nUBucketPos) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CAddrMan::ClearNew(int nUBucket, int nUBucketPos) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     // if there is an entry in the specified bucket, delete it.
     if (vvNew[nUBucket][nUBucketPos] != -1) {
@@ -139,7 +139,7 @@ void CAddrMan::ClearNew(int nUBucket, int nUBucketPos) EXCLUSIVE_LOCKS_REQUIRED(
     }
 }
 
-void CAddrMan::MakeTried(CAddrInfo& info, int nId) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CAddrMan::MakeTried(CAddrInfo& info, int nId) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     // remove the entry from all new buckets
     for (int bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
@@ -187,7 +187,7 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId) EXCLUSIVE_LOCKS_REQUIRED(cs)
     info.fInTried = true;
 }
 
-void CAddrMan::Good_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CAddrMan::Good_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     int nId;
 
@@ -239,7 +239,7 @@ void CAddrMan::Good_(const CService& addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIR
     MakeTried(info, nId);
 }
 
-bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimePenalty) EXCLUSIVE_LOCKS_REQUIRED(cs)
+bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimePenalty) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     if (!addr.IsRoutable())
         return false;
@@ -459,7 +459,7 @@ int CAddrMan::Check_()
 }
 #endif
 
-void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     unsigned int nNodes = ADDRMAN_GETADDR_MAX_PCT * vRandom.size() / 100;
     if (nNodes > ADDRMAN_GETADDR_MAX)

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -382,7 +382,7 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
 }
 
 #ifdef DEBUG_ADDRMAN
-int CAddrMan::Check_()
+int CAddrMan::Check_() EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan)
 {
     std::set<int> setTried;
     std::map<int, int> mapNew;

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -455,8 +455,10 @@ public:
 
     void Clear()
     {
-        LOCK(cs);
-        std::vector<int>().swap(vRandom);
+        {
+            LOCK(cs_addrMan);
+            std::vector<int>().swap(vRandom);
+        }
         nKey = GetRandHash();
         for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
             for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; entry++) {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -195,7 +195,7 @@ private:
     std::map<CNetAddr, int> mapAddr;
 
     //! randomly-ordered vector of all nIds
-    std::vector<int> vRandom;
+    std::vector<int> vRandom GUARDED_BY(cs);
 
     // number of "tried" entries
     int nTried;

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -186,31 +186,31 @@ private:
     mutable CCriticalSection cs_addrMan;
 
     //! last used nId
-    int nIdCount;
+    int nIdCount GUARDED_BY(cs_addrMan);
 
     //! table with information about all nIds
-    std::map<int, CAddrInfo> mapInfo;
+    std::map<int, CAddrInfo> mapInfo GUARDED_BY(cs_addrMan);
 
     //! find an nId based on its network address
-    std::map<CNetAddr, int> mapAddr;
+    std::map<CNetAddr, int> mapAddr GUARDED_BY(cs_addrMan);
 
     //! randomly-ordered vector of all nIds
     std::vector<int> vRandom GUARDED_BY(cs_addrMan);
 
     // number of "tried" entries
-    int nTried;
+    int nTried GUARDED_BY(cs_addrMan);
 
     //! list of "tried" buckets
-    int vvTried[ADDRMAN_TRIED_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
+    int vvTried[ADDRMAN_TRIED_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs_addrMan);
 
     //! number of (unique) "new" entries
-    int nNew;
+    int nNew GUARDED_BY(cs_addrMan);
 
     //! list of "new" buckets
-    int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
+    int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE] GUARDED_BY(cs_addrMan);
 
     //! last time Good was called (memory only)
-    int64_t nLastGood;
+    int64_t nLastGood GUARDED_BY(cs_addrMan);
 
 protected:
     //! secret key to randomize bucket select with
@@ -455,10 +455,8 @@ public:
 
     void Clear()
     {
-        {
-            LOCK(cs_addrMan);
-            std::vector<int>().swap(vRandom);
-        }
+        LOCK(cs_addrMan);
+        std::vector<int>().swap(vRandom);
         nKey = GetRandHash();
         for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {
             for (size_t entry = 0; entry < ADDRMAN_BUCKET_SIZE; entry++) {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -183,7 +183,7 @@ class CAddrMan
 {
 private:
     //! critical section to protect the inner data structures
-    mutable CCriticalSection cs;
+    mutable CCriticalSection cs_addrMan;
 
     //! last used nId
     int nIdCount;
@@ -195,7 +195,7 @@ private:
     std::map<CNetAddr, int> mapAddr;
 
     //! randomly-ordered vector of all nIds
-    std::vector<int> vRandom GUARDED_BY(cs);
+    std::vector<int> vRandom GUARDED_BY(cs_addrMan);
 
     // number of "tried" entries
     int nTried;
@@ -300,7 +300,7 @@ public:
     template<typename Stream>
     void Serialize(Stream &s) const
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
 
         unsigned char nVersion = 1;
         s << nVersion;
@@ -350,7 +350,7 @@ public:
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
 
         Clear();
 
@@ -490,7 +490,7 @@ public:
     //! Return the number of (unique) addresses in all tables.
     size_t size() const
     {
-        LOCK(cs); // TODO: Cache this in an atomic to avoid this overhead
+        LOCK(cs_addrMan); // TODO: Cache this in an atomic to avoid this overhead
         return vRandom.size();
     }
 
@@ -499,7 +499,7 @@ public:
     {
 #ifdef DEBUG_ADDRMAN
         {
-            LOCK(cs);
+            LOCK(cs_addrMan);
             int err;
             if ((err=Check_()))
                 LogPrintf("ADDRMAN CONSISTENCY CHECK FAILED!!! err=%i\n", err);
@@ -510,7 +510,7 @@ public:
     //! Add a single address.
     bool Add(const CAddress &addr, const CNetAddr& source, int64_t nTimePenalty = 0)
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
         bool fRet = false;
         Check();
         fRet |= Add_(addr, source, nTimePenalty);
@@ -524,7 +524,7 @@ public:
     //! Add multiple addresses.
     bool Add(const std::vector<CAddress> &vAddr, const CNetAddr& source, int64_t nTimePenalty = 0)
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
         int nAdd = 0;
         Check();
         for (std::vector<CAddress>::const_iterator it = vAddr.begin(); it != vAddr.end(); it++)
@@ -539,7 +539,7 @@ public:
     //! Mark an entry as accessible.
     void Good(const CService &addr, int64_t nTime = GetAdjustedTime())
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
         Check();
         Good_(addr, nTime);
         Check();
@@ -548,7 +548,7 @@ public:
     //! Mark an entry as connection attempted to.
     void Attempt(const CService &addr, bool fCountFailure, int64_t nTime = GetAdjustedTime())
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
         Check();
         Attempt_(addr, fCountFailure, nTime);
         Check();
@@ -561,7 +561,7 @@ public:
     {
         CAddrInfo addrRet;
         {
-            LOCK(cs);
+            LOCK(cs_addrMan);
             Check();
             addrRet = Select_(newOnly);
             Check();
@@ -575,7 +575,7 @@ public:
         Check();
         std::vector<CAddress> vAddr;
         {
-            LOCK(cs);
+            LOCK(cs_addrMan);
             GetAddr_(vAddr);
         }
         Check();
@@ -585,7 +585,7 @@ public:
     //! Mark an entry as currently-connected-to.
     void Connected(const CService &addr, int64_t nTime = GetAdjustedTime())
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
         Check();
         Connected_(addr, nTime);
         Check();
@@ -593,7 +593,7 @@ public:
 
     void SetServices(const CService &addr, ServiceFlags nServices)
     {
-        LOCK(cs);
+        LOCK(cs_addrMan);
         Check();
         SetServices_(addr, nServices);
         Check();

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -220,52 +220,52 @@ protected:
     FastRandomContext insecure_rand;
 
     //! Find an entry.
-    CAddrInfo* Find(const CNetAddr& addr, int *pnId = nullptr);
+    CAddrInfo* Find(const CNetAddr& addr, int *pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! find an entry, creating it if necessary.
     //! nTime and nServices of the found node are updated, if necessary.
-    CAddrInfo* Create(const CAddress &addr, const CNetAddr &addrSource, int *pnId = nullptr);
+    CAddrInfo* Create(const CAddress &addr, const CNetAddr &addrSource, int *pnId = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Swap two elements in vRandom.
-    void SwapRandom(unsigned int nRandomPos1, unsigned int nRandomPos2);
+    void SwapRandom(unsigned int nRandomPos1, unsigned int nRandomPos2) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Move an entry from the "new" table(s) to the "tried" table
-    void MakeTried(CAddrInfo& info, int nId);
+    void MakeTried(CAddrInfo& info, int nId) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Delete an entry. It must not be in tried, and have refcount 0.
-    void Delete(int nId);
+    void Delete(int nId) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Clear a position in a "new" table. This is the only place where entries are actually deleted.
-    void ClearNew(int nUBucket, int nUBucketPos);
+    void ClearNew(int nUBucket, int nUBucketPos) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Mark an entry "good", possibly moving it from "new" to "tried".
-    void Good_(const CService &addr, int64_t nTime);
+    void Good_(const CService &addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Add an entry to the "new" table.
-    bool Add_(const CAddress &addr, const CNetAddr& source, int64_t nTimePenalty);
+    bool Add_(const CAddress &addr, const CNetAddr& source, int64_t nTimePenalty) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Mark an entry as attempted to connect.
-    void Attempt_(const CService &addr, bool fCountFailure, int64_t nTime);
+    void Attempt_(const CService &addr, bool fCountFailure, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Select an address to connect to, if newOnly is set to true, only the new table is selected from.
-    CAddrInfo Select_(bool newOnly);
+    CAddrInfo Select_(bool newOnly) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Wraps GetRandInt to allow tests to override RandomInt and make it determinismistic.
     virtual int RandomInt(int nMax);
 
 #ifdef DEBUG_ADDRMAN
     //! Perform consistency check. Returns an error code or zero.
-    int Check_();
+    int Check_() EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 #endif
 
     //! Select several addresses at once.
-    void GetAddr_(std::vector<CAddress> &vAddr);
+    void GetAddr_(std::vector<CAddress> &vAddr) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Mark an entry as currently-connected-to.
-    void Connected_(const CService &addr, int64_t nTime);
+    void Connected_(const CService &addr, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
     //! Update an entry's service bits.
-    void SetServices_(const CService &addr, ServiceFlags nServices);
+    void SetServices_(const CService &addr, ServiceFlags nServices) EXCLUSIVE_LOCKS_REQUIRED(cs_addrMan);
 
 public:
     /**

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -103,7 +103,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
 
     std::vector<bool> have_txn(txn_available.size());
     {
-    LOCK(pool->cs);
+    LOCK(pool->cs_txMemPool);
     const std::vector<std::pair<uint256, CTxMemPool::txiter> >& vTxHashes = pool->vTxHashes;
     for (size_t i = 0; i < vTxHashes.size(); i++) {
         uint64_t shortid = cmpctblock.GetShortID(vTxHashes[i].first);

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -104,13 +104,12 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
     std::vector<bool> have_txn(txn_available.size());
     {
     LOCK(pool->cs_txMemPool);
-    const std::vector<std::pair<uint256, CTxMemPool::txiter> >& vTxHashes = pool->vTxHashes;
-    for (size_t i = 0; i < vTxHashes.size(); i++) {
-        uint64_t shortid = cmpctblock.GetShortID(vTxHashes[i].first);
+    for (size_t i = 0; i < pool->vTxHashes.size(); i++) {
+        uint64_t shortid = cmpctblock.GetShortID(pool->vTxHashes[i].first);
         std::unordered_map<uint64_t, uint16_t>::iterator idit = shorttxids.find(shortid);
         if (idit != shorttxids.end()) {
             if (!have_txn[idit->second]) {
-                txn_available[idit->second] = vTxHashes[i].second->GetSharedTx();
+                txn_available[idit->second] = pool->vTxHashes[i].second->GetSharedTx();
                 have_txn[idit->second]  = true;
                 mempool_count++;
             } else {

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -15,7 +15,7 @@
 
 namespace Checkpoints {
 
-    CBlockIndex* GetLastCheckpoint(const CCheckpointData& data)
+    CBlockIndex* GetLastCheckpoint(const CCheckpointData& data) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         const MapCheckpoints& checkpoints = data.mapCheckpoints;
 

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -5,12 +5,14 @@
 #ifndef BITCOIN_CHECKPOINTS_H
 #define BITCOIN_CHECKPOINTS_H
 
+#include <sync.h>
 #include <uint256.h>
 
 #include <map>
 
 class CBlockIndex;
 struct CCheckpointData;
+extern CCriticalSection cs_main;
 
 /**
  * Block-chain checkpoints are compiled-in sanity checks.
@@ -20,7 +22,7 @@ namespace Checkpoints
 {
 
 //! Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
-CBlockIndex* GetLastCheckpoint(const CCheckpointData& data);
+CBlockIndex* GetLastCheckpoint(const CCheckpointData& data) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 } //namespace Checkpoints
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1200,7 +1200,7 @@ bool AppInitLockDataDirectory()
     return true;
 }
 
-bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
+bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THREAD_SAFETY_ANALYSIS
 {
     const CChainParams& chainparams = Params();
     // ********************************************************* Step 4a: application initialization

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -634,7 +634,7 @@ void ThreadImport(std::vector<fs::path> vImportFiles) EXCLUSIVE_LOCKS_REQUIRED(c
             nFile++;
         }
         {
-            LOCK(cs_main);
+            LOCK(cs_main); // reading the value pointed to by 'pblocktree' requires holding mutex 'cs_main'
             pblocktree->WriteReindexing(false);
         }
         fReindex = false;
@@ -1200,9 +1200,7 @@ bool AppInitLockDataDirectory()
     return true;
 }
 
-// NO_THREAD_SAFETY_ANALYSIS: Access to guarded variables happens before any
-// thread is started.
-bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THREAD_SAFETY_ANALYSIS
+bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 {
     const CChainParams& chainparams = Params();
     // ********************************************************* Step 4a: application initialization
@@ -1424,7 +1422,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THR
 
                 if (fReset) {
                     {
-                        LOCK(cs_main);
+                        LOCK(cs_main); // reading the value pointed to by 'pblocktree' requires holding mutex 'cs_main'
                         pblocktree->WriteReindexing(true);
                     }
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
@@ -1483,7 +1481,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THR
                 // If necessary, upgrade from older database format.
                 // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
                 {
-                    LOCK(cs_main);
+                    LOCK(cs_main); // reading the value pointed to by 'pcoinsdbview' requires holding mutex 'cs_main'
                     if (!pcoinsdbview->Upgrade()) {
                         strLoadError = _("Error upgrading chainstate database");
                         break;
@@ -1501,7 +1499,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THR
 
                 bool is_coinsview_empty;
                 {
-                    LOCK(cs_main);
+                    LOCK(cs_main); // reading the value pointed to by 'pcoinsTip' requires holding mutex 'cs_main'
                     is_coinsview_empty = fReset || fReindexChainState || pcoinsTip->GetBestBlock().IsNull();
                 }
                 if (!is_coinsview_empty) {
@@ -1671,7 +1669,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THR
 
     //// debug print
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // reading variables 'mapBlockIndex' and 'chainActive' require holding mutex 'cs_main'
         LogPrintf("mapBlockIndex.size() = %u\n", mapBlockIndex.size());
         chain_active_height = chainActive.Height();
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1200,6 +1200,8 @@ bool AppInitLockDataDirectory()
     return true;
 }
 
+// NO_THREAD_SAFETY_ANALYSIS: Access to guarded variables happens before any
+// thread is started.
 bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler) NO_THREAD_SAFETY_ANALYSIS
 {
     const CChainParams& chainparams = Params();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -634,7 +634,7 @@ void ThreadImport(std::vector<fs::path> vImportFiles) EXCLUSIVE_LOCKS_REQUIRED(c
             nFile++;
         }
         {
-            LOCK(cs_main); // reading the value pointed to by 'pblocktree' requires holding mutex 'cs_main'
+            LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
             pblocktree->WriteReindexing(false);
         }
         fReindex = false;
@@ -1422,7 +1422,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 if (fReset) {
                     {
-                        LOCK(cs_main); // reading the value pointed to by 'pblocktree' requires holding mutex 'cs_main'
+                        LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
                         pblocktree->WriteReindexing(true);
                     }
                     //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
@@ -1445,7 +1445,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
                 {
-                    LOCK(cs_main);
+                    LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
                     if (!mapBlockIndex.empty() && mapBlockIndex.count(chainparams.GetConsensus().hashGenesisBlock) == 0)
                         return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
                 }
@@ -1481,7 +1481,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                 // If necessary, upgrade from older database format.
                 // This is a no-op if we cleared the coinsviewdb with -reindex or -reindex-chainstate
                 {
-                    LOCK(cs_main); // reading the value pointed to by 'pcoinsdbview' requires holding mutex 'cs_main'
+                    LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
                     if (!pcoinsdbview->Upgrade()) {
                         strLoadError = _("Error upgrading chainstate database");
                         break;
@@ -1499,7 +1499,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
                 bool is_coinsview_empty;
                 {
-                    LOCK(cs_main); // reading the value pointed to by 'pcoinsTip' requires holding mutex 'cs_main'
+                    LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
                     is_coinsview_empty = fReset || fReindexChainState || pcoinsTip->GetBestBlock().IsNull();
                 }
                 if (!is_coinsview_empty) {
@@ -1508,7 +1508,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                         strLoadError = _("Error initializing block database");
                         break;
                     }
-                    LOCK(cs_main);
+                    LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
                     assert(chainActive.Tip() != nullptr);
                 }
 
@@ -1533,7 +1533,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     {
                         CBlockIndex* tip;
                         {
-                            LOCK(cs_main);
+                            LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
                             tip = chainActive.Tip();
                         }
                         RPCNotifyBlockChange(true, tip);
@@ -1636,7 +1636,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // Either install a handler to notify us when genesis activates, or set fHaveGenesis directly.
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
         if (chainActive.Tip() == nullptr) {
             uiInterface.NotifyBlockTip.connect(BlockNotifyGenesisWait);
         } else {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -611,7 +611,7 @@ void CleanupBlockRevFiles()
     }
 }
 
-void ThreadImport(std::vector<fs::path> vImportFiles)
+void ThreadImport(std::vector<fs::path> vImportFiles) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     const CChainParams& chainparams = Params();
     RenameThread("bitcoin-loadblk");

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1674,7 +1674,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     //// debug print
     {
-        LOCK(cs_main); // reading variables 'mapBlockIndex' and 'chainActive' require holding mutex 'cs_main'
+        LOCK(cs_main);
         LogPrintf("mapBlockIndex.size() = %u\n", mapBlockIndex.size());
         chain_active_height = chainActive.Height();
     }

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -54,10 +54,10 @@ typedef std::set<CScript> WatchOnlySet;
 class CBasicKeyStore : public CKeyStore
 {
 protected:
-    KeyMap mapKeys;
-    WatchKeyMap mapWatchKeys;
-    ScriptMap mapScripts;
-    WatchOnlySet setWatchOnly;
+    KeyMap mapKeys GUARDED_BY(cs_KeyStore);
+    WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
+    ScriptMap mapScripts GUARDED_BY(cs_KeyStore);
+    WatchOnlySet setWatchOnly GUARDED_BY(cs_KeyStore);
 
 public:
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
-    LOCK2(cs_main, mempool.cs);
+    LOCK2(cs_main, mempool.cs_txMemPool);
     CBlockIndex* pindexPrev = chainActive.Tip();
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;
@@ -283,7 +283,7 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
 // guaranteed to fail again, but as a belt-and-suspenders check we put it in
 // failedTx and avoid re-evaluation, since the re-evaluation would be using
 // cached size/sigops/fee values that are not actually correct.
-bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs)
+bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs_txMemPool)
 {
     assert (it != mempool.mapTx.end());
     return mapModifiedTx.count(it) || inBlock.count(it) || failedTx.count(it);
@@ -310,7 +310,7 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, CTxMemP
 // Each time through the loop, we compare the best transaction in
 // mapModifiedTxs with the next transaction in the mempool to decide what
 // transaction package to work on next.
-void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs)
+void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs_txMemPool)
 {
     // mapModifiedTx will store sorted packages after they are modified
     // because some of their txs are already in the block

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -283,7 +283,7 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
 // guaranteed to fail again, but as a belt-and-suspenders check we put it in
 // failedTx and avoid re-evaluation, since the re-evaluation would be using
 // cached size/sigops/fee values that are not actually correct.
-bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx)
+bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs)
 {
     assert (it != mempool.mapTx.end());
     return mapModifiedTx.count(it) || inBlock.count(it) || failedTx.count(it);
@@ -310,7 +310,7 @@ void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, CTxMemP
 // Each time through the loop, we compare the best transaction in
 // mapModifiedTxs with the next transaction in the mempool to decide what
 // transaction package to work on next.
-void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated)
+void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs)
 {
     // mapModifiedTx will store sorted packages after they are modified
     // because some of their txs are already in the block

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,6 +8,7 @@
 
 #include <primitives/block.h>
 #include <txmempool.h>
+#include <validation.h>
 
 #include <stdint.h>
 #include <memory>
@@ -178,7 +179,7 @@ private:
     /** Add transactions based on feerate including unconfirmed ancestors
       * Increments nPackagesSelected / nDescendantsUpdated with corresponding
       * statistics from the package selection (for logging statistics). */
-    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated);
+    void addPackageTxs(int &nPackagesSelected, int &nDescendantsUpdated) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs_txMemPool);
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */
@@ -192,7 +193,7 @@ private:
     bool TestPackageTransactions(const CTxMemPool::setEntries& package);
     /** Return true if given transaction from mapTx has already been evaluated,
       * or if the transaction's cached data in mapTx is incorrect. */
-    bool SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx);
+    bool SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set &mapModifiedTx, CTxMemPool::setEntries &failedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs_txMemPool);
     /** Sort the package in an order that is valid to appear in a block */
     void SortForBlock(const CTxMemPool::setEntries& package, CTxMemPool::txiter entry, std::vector<CTxMemPool::txiter>& sortedEntries);
     /** Add descendants of given transactions to mapModifiedTx with ancestor

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2271,11 +2271,11 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     Init(connOptions);
 
     {
-        LOCK(cs_totalBytesRecv); // writing variable 'nTotalBytesRecv' requires holding mutex 'cs_totalBytesRecv' exclusively
+        LOCK(cs_totalBytesRecv); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11744/files
         nTotalBytesRecv = 0;
     }
     {
-        LOCK(cs_totalBytesSent); // writing variables 'nTotalBytesSent'/'nMaxOutboundTotalBytesSentInCycle'/'nMaxOutboundCycleStartTime' require holding mutex 'cs_totalBytesSent' exclusively
+        LOCK(cs_totalBytesSent); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11744/files
         nTotalBytesSent = 0;
         nMaxOutboundTotalBytesSentInCycle = 0;
         nMaxOutboundCycleStartTime = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -992,7 +992,6 @@ bool CConnman::AttemptToEvictConnection()
                 continue;
             if (node->fDisconnect)
                 continue;
-            LOCK(node->cs_filter);
             NodeEvictionCandidate candidate = {node->GetId(), node->nTimeConnected, node->nMinPingUsecTime,
                                                node->nLastBlockTime, node->nLastTXTime,
                                                HasAllDesirableServiceFlags(node->nServices),

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -83,8 +83,8 @@ bool fDiscover = true;
 bool fListen = true;
 bool fRelayTxes = true;
 CCriticalSection cs_mapLocalHost;
-std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
-static bool vfLimited[NET_MAX] = {};
+std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(cs_mapLocalHost);
+static bool vfLimited[NET_MAX] GUARDED_BY(cs_mapLocalHost) = {};
 std::string strSubVersion;
 
 limitedmap<uint256, int64_t> mapAlreadyAskedFor(MAX_INV_SZ);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -992,6 +992,7 @@ bool CConnman::AttemptToEvictConnection()
                 continue;
             if (node->fDisconnect)
                 continue;
+            LOCK(node->cs_filter);
             NodeEvictionCandidate candidate = {node->GetId(), node->nTimeConnected, node->nMinPingUsecTime,
                                                node->nLastBlockTime, node->nLastTXTime,
                                                HasAllDesirableServiceFlags(node->nServices),

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2270,11 +2270,11 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     Init(connOptions);
 
     {
-        LOCK(cs_totalBytesRecv);
+        LOCK(cs_totalBytesRecv); // writing variable 'nTotalBytesRecv' requires holding mutex 'cs_totalBytesRecv' exclusively
         nTotalBytesRecv = 0;
     }
     {
-        LOCK(cs_totalBytesSent);
+        LOCK(cs_totalBytesSent); // writing variables 'nTotalBytesSent'/'nMaxOutboundTotalBytesSentInCycle'/'nMaxOutboundCycleStartTime' require holding mutex 'cs_totalBytesSent' exclusively
         nTotalBytesSent = 0;
         nMaxOutboundTotalBytesSentInCycle = 0;
         nMaxOutboundCycleStartTime = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2265,7 +2265,7 @@ bool CConnman::InitBinds(const std::vector<CService>& binds, const std::vector<C
     return fBound;
 }
 
-bool CConnman::Start(CScheduler& scheduler, const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(cs_totalBytesRecv, cs_totalBytesSent)
+bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 {
     Init(connOptions);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -985,13 +985,14 @@ bool CConnman::AttemptToEvictConnection()
     {
         LOCK(cs_vNodes);
 
-        for (const CNode* node : vNodes) {
+        for (CNode* node : vNodes) {
             if (node->fWhitelisted)
                 continue;
             if (!node->fInbound)
                 continue;
             if (node->fDisconnect)
                 continue;
+            LOCK(node->cs_filter);
             NodeEvictionCandidate candidate = {node->GetId(), node->nTimeConnected, node->nMinPingUsecTime,
                                                node->nLastBlockTime, node->nLastTXTime,
                                                HasAllDesirableServiceFlags(node->nServices),

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -864,7 +864,7 @@ const uint256& CNetMessage::GetMessageHash() const
 
 
 // requires LOCK(cs_vSend)
-size_t CConnman::SocketSendData(CNode *pnode) const
+size_t CConnman::SocketSendData(CNode *pnode) const EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend)
 {
     auto it = pnode->vSendMsg.begin();
     size_t nSentSize = 0;
@@ -2266,7 +2266,7 @@ bool CConnman::InitBinds(const std::vector<CService>& binds, const std::vector<C
     return fBound;
 }
 
-bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
+bool CConnman::Start(CScheduler& scheduler, const Options& connOptions) EXCLUSIVE_LOCKS_REQUIRED(cs_totalBytesRecv, cs_totalBytesSent)
 {
     Init(connOptions);
 
@@ -2424,7 +2424,7 @@ void CConnman::Interrupt()
     }
 }
 
-void CConnman::Stop()
+void CConnman::Stop() EXCLUSIVE_LOCKS_REQUIRED(cs_vNodes)
 {
     if (threadMessageHandler.joinable())
         threadMessageHandler.join();

--- a/src/net.h
+++ b/src/net.h
@@ -738,8 +738,8 @@ private:
     std::string addrName;
 
     // Our address, as reported by the peer
-    CService addrLocal;
     mutable CCriticalSection cs_addrLocal;
+    CService addrLocal GUARDED_BY(cs_addrLocal);
 public:
 
     NodeId GetId() const {

--- a/src/net.h
+++ b/src/net.h
@@ -650,11 +650,12 @@ public:
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs
     //    unless it loads a bloom filter.
-    bool fRelayTxes; //protected by cs_filter
+    CCriticalSection cs_filter;
+    bool fRelayTxes GUARDED_BY(cs_filter);
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
-    std::unique_ptr<CBloomFilter> pfilter;
+    std::unique_ptr<CBloomFilter> pfilter PT_GUARDED_BY(cs_filter);
     std::atomic<int> nRefCount;
 
     const uint64_t nKeyedNetGroup;

--- a/src/net.h
+++ b/src/net.h
@@ -678,24 +678,24 @@ public:
     int64_t nNextAddrSend;
     int64_t nNextLocalAddrSend;
 
+    CCriticalSection cs_inventory;
     // inventory based relay
-    CRollingBloomFilter filterInventoryKnown;
+    CRollingBloomFilter filterInventoryKnown GUARDED_BY(cs_inventory);
     // Set of transaction ids we still have to announce.
     // They are sorted by the mempool before relay, so the order is not important.
     std::set<uint256> setInventoryTxToSend;
     // List of block ids we still have announce.
     // There is no final sorting before sending, as they are always sent immediately
     // and in the order requested.
-    std::vector<uint256> vInventoryBlockToSend;
-    CCriticalSection cs_inventory;
+    std::vector<uint256> vInventoryBlockToSend GUARDED_BY(cs_inventory);
     std::set<uint256> setAskFor;
     std::multimap<int64_t, CInv> mapAskFor;
     int64_t nNextInvSend;
     // Used for headers announcements - unfiltered blocks to relay
     // Also protected by cs_inventory
-    std::vector<uint256> vBlockHashesToAnnounce;
+    std::vector<uint256> vBlockHashesToAnnounce GUARDED_BY(cs_inventory);
     // Used for BIP35 mempool sending, also protected by cs_inventory
-    bool fSendMempool;
+    bool fSendMempool GUARDED_BY(cs_inventory);
 
     // Last time a "MEMPOOL" request was serviced.
     std::atomic<int64_t> timeLastMempoolReq;

--- a/src/net.h
+++ b/src/net.h
@@ -505,8 +505,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
 
 extern bool fDiscover;
 extern bool fListen;
-extern CCriticalSection cs_filter;
-extern bool fRelayTxes GUARDED_BY(cs_filter);
+extern bool fRelayTxes;
 
 extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 

--- a/src/net.h
+++ b/src/net.h
@@ -715,8 +715,8 @@ public:
     // Whether a ping is requested.
     std::atomic<bool> fPingQueued;
     // Minimum fee rate with which to filter inv's to this node
-    CAmount minFeeFilter;
     CCriticalSection cs_feeFilter;
+    CAmount minFeeFilter GUARDED_BY(cs_feeFilter);
     CAmount lastSentFeeFilter;
     int64_t nextSendTimeFeeFilter;
 

--- a/src/net.h
+++ b/src/net.h
@@ -653,8 +653,7 @@ public:
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs
     //    unless it loads a bloom filter.
-    CCriticalSection cs_filter;
-    bool fRelayTxes GUARDED_BY(cs_filter);
+    bool fRelayTxes; //protected by cs_filter
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;

--- a/src/net.h
+++ b/src/net.h
@@ -735,7 +735,7 @@ private:
     std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
 
     mutable CCriticalSection cs_addrName;
-    std::string addrName;
+    std::string addrName GUARDED_BY(cs_addrName);
 
     // Our address, as reported by the peer
     mutable CCriticalSection cs_addrLocal;

--- a/src/net.h
+++ b/src/net.h
@@ -147,10 +147,7 @@ public:
         std::vector<std::string> m_added_nodes;
     };
 
-    // NO_THREAD_SAFETY_ANALYSIS: Intentionally setting
-    // nMaxOutboundTimeframe/nMaxOutboundLimit without holding
-    // cs_totalBytesSent.
-    void Init(const Options& connOptions) NO_THREAD_SAFETY_ANALYSIS {
+    void Init(const Options& connOptions) {
         nLocalServices = connOptions.nLocalServices;
         nMaxConnections = connOptions.nMaxConnections;
         nMaxOutbound = std::min(connOptions.nMaxOutbound, connOptions.nMaxConnections);
@@ -175,7 +172,7 @@ public:
 
     CConnman(uint64_t seed0, uint64_t seed1);
     ~CConnman();
-    bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(cs_totalBytesRecv, cs_totalBytesSent);
+    bool Start(CScheduler& scheduler, const Options& options);
     void Stop();
     void Interrupt();
     bool GetNetworkActive() const { return fNetworkActive; };

--- a/src/net.h
+++ b/src/net.h
@@ -159,13 +159,13 @@ public:
         nSendBufferMaxSize = connOptions.nSendBufferMaxSize;
         nReceiveFloodSize = connOptions.nReceiveFloodSize;
         {
-            LOCK(cs_totalBytesSent);
+            LOCK(cs_totalBytesSent); // writing variable 'nMaxOutboundTimeframe'/'nMaxOutboundLimit' require holding mutex 'cs_totalBytesSent' exclusively
             nMaxOutboundTimeframe = connOptions.nMaxOutboundTimeframe;
             nMaxOutboundLimit = connOptions.nMaxOutboundLimit;
         }
         vWhitelistedRange = connOptions.vWhitelistedRange;
         {
-            LOCK(cs_vAddedNodes);
+            LOCK(cs_vAddedNodes); // writing variable 'vAddedNodes' requires holding mutex 'cs_vAddedNodes' exclusively
             vAddedNodes = connOptions.m_added_nodes;
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -675,8 +675,8 @@ public:
     CRollingBloomFilter addrKnown;
     bool fGetAddr;
     std::set<uint256> setKnown;
-    int64_t nNextAddrSend;
-    int64_t nNextLocalAddrSend;
+    int64_t nNextAddrSend GUARDED_BY(cs_sendProcessing);
+    int64_t nNextLocalAddrSend GUARDED_BY(cs_sendProcessing);
 
     CCriticalSection cs_inventory;
     // inventory based relay

--- a/src/net.h
+++ b/src/net.h
@@ -397,9 +397,9 @@ private:
     std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
     CCriticalSection cs_vAddedNodes;
     std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
-    std::vector<CNode*> vNodes;
-    std::list<CNode*> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;
+    std::vector<CNode*> vNodes GUARDED_BY(cs_vNodes);
+    std::list<CNode*> vNodesDisconnected;
     std::atomic<NodeId> nLastNodeId;
 
     /** Services this instance offers */

--- a/src/net.h
+++ b/src/net.h
@@ -393,10 +393,10 @@ private:
     bool setBannedIsDirty GUARDED_BY(cs_setBanned);
     bool fAddressesInitialized;
     CAddrMan addrman;
-    std::deque<std::string> vOneShots;
     CCriticalSection cs_vOneShots;
     std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
     CCriticalSection cs_vAddedNodes;
+    std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
     std::vector<CNode*> vNodes;
     std::list<CNode*> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;

--- a/src/net.h
+++ b/src/net.h
@@ -388,9 +388,9 @@ private:
 
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive;
-    banmap_t setBanned;
     CCriticalSection cs_setBanned;
-    bool setBannedIsDirty;
+    banmap_t setBanned GUARDED_BY(cs_setBanned);
+    bool setBannedIsDirty GUARDED_BY(cs_setBanned);
     bool fAddressesInitialized;
     CAddrMan addrman;
     std::deque<std::string> vOneShots;

--- a/src/net.h
+++ b/src/net.h
@@ -175,7 +175,7 @@ public:
 
     CConnman(uint64_t seed0, uint64_t seed1);
     ~CConnman();
-    bool Start(CScheduler& scheduler, const Options& options);
+    bool Start(CScheduler& scheduler, const Options& options) EXCLUSIVE_LOCKS_REQUIRED(cs_totalBytesRecv, cs_totalBytesSent);
     void Stop();
     void Interrupt();
     bool GetNetworkActive() const { return fNetworkActive; };

--- a/src/net.h
+++ b/src/net.h
@@ -147,7 +147,10 @@ public:
         std::vector<std::string> m_added_nodes;
     };
 
-    void Init(const Options& connOptions) {
+    // NO_THREAD_SAFETY_ANALYSIS: Intentionally setting
+    // nMaxOutboundTimeframe/nMaxOutboundLimit without holding
+    // cs_totalBytesSent.
+    void Init(const Options& connOptions) NO_THREAD_SAFETY_ANALYSIS {
         nLocalServices = connOptions.nLocalServices;
         nMaxConnections = connOptions.nMaxConnections;
         nMaxOutbound = std::min(connOptions.nMaxOutbound, connOptions.nMaxConnections);

--- a/src/net.h
+++ b/src/net.h
@@ -604,13 +604,13 @@ class CNode
 public:
     // socket
     std::atomic<ServiceFlags> nServices;
-    SOCKET hSocket;
+    CCriticalSection cs_hSocket;
+    SOCKET hSocket GUARDED_BY(cs_hSocket);
     size_t nSendSize; // total size of all vSendMsg entries
     size_t nSendOffset; // offset inside the first vSendMsg already sent
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
     CCriticalSection cs_vSend;
-    CCriticalSection cs_hSocket;
     CCriticalSection cs_vRecv;
 
     CCriticalSection cs_vProcessMsg;

--- a/src/net.h
+++ b/src/net.h
@@ -515,7 +515,7 @@ struct LocalServiceInfo {
 };
 
 extern CCriticalSection cs_mapLocalHost;
-extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
+extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(cs_mapLocalHost);
 typedef std::map<std::string, uint64_t> mapMsgCmdSize; //command, total bytes
 
 class CNodeStats

--- a/src/net.h
+++ b/src/net.h
@@ -159,13 +159,13 @@ public:
         nSendBufferMaxSize = connOptions.nSendBufferMaxSize;
         nReceiveFloodSize = connOptions.nReceiveFloodSize;
         {
-            LOCK(cs_totalBytesSent); // writing variable 'nMaxOutboundTimeframe'/'nMaxOutboundLimit' require holding mutex 'cs_totalBytesSent' exclusively
+            LOCK(cs_totalBytesSent); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11744/files
             nMaxOutboundTimeframe = connOptions.nMaxOutboundTimeframe;
             nMaxOutboundLimit = connOptions.nMaxOutboundLimit;
         }
         vWhitelistedRange = connOptions.vWhitelistedRange;
         {
-            LOCK(cs_vAddedNodes); // writing variable 'vAddedNodes' requires holding mutex 'cs_vAddedNodes' exclusively
+            LOCK(cs_vAddedNodes); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11744/files
             vAddedNodes = connOptions.m_added_nodes;
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -614,7 +614,7 @@ public:
     CCriticalSection cs_vRecv;
 
     CCriticalSection cs_vProcessMsg;
-    std::list<CNetMessage> vProcessMsg;
+    std::list<CNetMessage> vProcessMsg GUARDED_BY(cs_vProcessMsg);
     size_t nProcessQueueSize;
 
     CCriticalSection cs_sendProcessing;

--- a/src/net.h
+++ b/src/net.h
@@ -394,7 +394,7 @@ private:
     bool fAddressesInitialized;
     CAddrMan addrman;
     CCriticalSection cs_vOneShots;
-    std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
+    std::deque<std::string> vOneShots GUARDED_BY(cs_vOneShots);
     CCriticalSection cs_vAddedNodes;
     std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
     mutable CCriticalSection cs_vNodes;

--- a/src/net.h
+++ b/src/net.h
@@ -502,7 +502,8 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
 
 extern bool fDiscover;
 extern bool fListen;
-extern bool fRelayTxes;
+extern CCriticalSection cs_filter;
+extern bool fRelayTxes GUARDED_BY(cs_filter);
 
 extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 

--- a/src/net.h
+++ b/src/net.h
@@ -608,8 +608,8 @@ public:
     SOCKET hSocket GUARDED_BY(cs_hSocket);
     size_t nSendSize; // total size of all vSendMsg entries
     size_t nSendOffset; // offset inside the first vSendMsg already sent
-    uint64_t nSendBytes;
-    std::deque<std::vector<unsigned char>> vSendMsg;
+    uint64_t nSendBytes GUARDED_BY(cs_vSend);
+    std::deque<std::vector<unsigned char>> vSendMsg GUARDED_BY(cs_vSend);
     CCriticalSection cs_vSend;
     CCriticalSection cs_vRecv;
 
@@ -663,7 +663,7 @@ public:
     std::atomic_bool fPauseSend;
 protected:
 
-    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    mapMsgCmdSize mapSendBytesPerMsgCmd GUARDED_BY(cs_vSend);
     mapMsgCmdSize mapRecvBytesPerMsgCmd;
 
 public:

--- a/src/net.h
+++ b/src/net.h
@@ -620,7 +620,7 @@ public:
     CCriticalSection cs_sendProcessing;
 
     std::deque<CInv> vRecvGetData;
-    uint64_t nRecvBytes;
+    uint64_t nRecvBytes GUARDED_BY(cs_vRecv);
     std::atomic<int> nRecvVersion;
 
     std::atomic<int64_t> nLastSend;
@@ -664,7 +664,7 @@ public:
 protected:
 
     mapMsgCmdSize mapSendBytesPerMsgCmd GUARDED_BY(cs_vSend);
-    mapMsgCmdSize mapRecvBytesPerMsgCmd;
+    mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);
 
 public:
     uint256 hashContinue;

--- a/src/net.h
+++ b/src/net.h
@@ -636,8 +636,8 @@ public:
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
     // store the sanitized version in cleanSubVer. The original should be used when dealing with
     // the network or wire types and the cleaned string used when displayed or logged.
-    std::string strSubVer, cleanSubVer;
     CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
+    std::string strSubVer GUARDED_BY(cs_SubVer), cleanSubVer GUARDED_BY(cs_SubVer);
     bool fWhitelisted; // This peer can bypass DoS banning.
     bool fFeeler; // If true this node is being used as a short lived feeler.
     bool fOneShot;

--- a/src/net.h
+++ b/src/net.h
@@ -650,11 +650,11 @@ public:
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs
     //    unless it loads a bloom filter.
-    bool fRelayTxes; //protected by cs_filter
+    bool fRelayTxes GUARDED_BY(cs_filter); //protected by cs_filter
     bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
-    std::unique_ptr<CBloomFilter> pfilter PT_GUARDED_BY(cs_filter);
+    std::unique_ptr<CBloomFilter> pfilter GUARDED_BY(cs_filter);
     std::atomic<int> nRefCount;
 
     const uint64_t nKeyedNetGroup;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -129,7 +129,7 @@ namespace {
     int g_outbound_peers_with_protect_from_disconnect = 0;
 
     /** When our tip was last updated. */
-    int64_t g_last_tip_update = 0;
+    int64_t g_last_tip_update GUARDED_BY(cs_main) = 0;
 
     /** Relay map, protected by cs_main. */
     typedef std::map<uint256, CTransactionRef> MapRelay;
@@ -435,7 +435,7 @@ void MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid, CConnman* connman) EXCL
     }
 }
 
-bool TipMayBeStale(const Consensus::Params &consensusParams)
+bool TipMayBeStale(const Consensus::Params &consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     if (g_last_tip_update == 0) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -776,7 +776,7 @@ void Misbehaving(NodeId pnode, int howmuch) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 // active chain if they are no more than a month older (both in time, and in
 // best equivalent proof of work) than the best header chain we know about and
 // we fully-validated them at some point.
-static bool BlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+static bool BlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     if (chainActive.Contains(pindex)) return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -286,7 +286,7 @@ void UpdatePreferredDownload(CNode* node, CNodeState* state)
     nPreferredDownload += state->fPreferredDownload;
 }
 
-void PushNodeVersion(CNode *pnode, CConnman* connman, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
+void PushNodeVersion(CNode *pnode, CConnman* connman, int64_t nTime)
 {
     ServiceFlags nLocalNodeServices = pnode->GetLocalServices();
     uint64_t nonce = pnode->GetLocalNonce();
@@ -1451,7 +1451,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     return true;
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
+bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc)
 {
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
     if (gArgs.IsArgSet("-dropmessagestest") && GetRand(gArgs.GetArg("-dropmessagestest", 0)) == 0)
@@ -2843,7 +2843,7 @@ static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman* connman) EXCLUSI
     return false;
 }
 
-bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
+bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
     //

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -445,7 +445,7 @@ bool TipMayBeStale(const Consensus::Params &consensusParams)
 }
 
 // Requires cs_main
-bool CanDirectFetch(const Consensus::Params &consensusParams)
+bool CanDirectFetch(const Consensus::Params &consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     return chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - consensusParams.nPowTargetSpacing * 20;
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -82,7 +82,7 @@ namespace {
      * Set mapBlockSource[hash].second to false if the node should not be
      * punished if the block is invalid.
      */
-    std::map<uint256, std::pair<NodeId, bool>> mapBlockSource;
+    std::map<uint256, std::pair<NodeId, bool>> mapBlockSource GUARDED_BY(cs_main);
 
     /**
      * Filter for transactions that were recently rejected by
@@ -114,7 +114,7 @@ namespace {
         bool fValidatedHeaders;                                  //!< Whether this block has validated headers at the time of request.
         std::unique_ptr<PartiallyDownloadedBlock> partialBlock;  //!< Optional, used for CMPCTBLOCK downloads
     };
-    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator>> mapBlocksInFlight GUARDED_BY(cs_main);
 
     /** Stack of nodes which we have set to announce using compact blocks */
     std::list<NodeId> lNodesAnnouncingHeaderAndIDs;
@@ -266,7 +266,7 @@ struct CNodeState {
 };
 
 /** Map maintaining per-node state. Requires cs_main. */
-std::map<NodeId, CNodeState> mapNodeState;
+std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
 
 // Requires cs_main.
 CNodeState *State(NodeId pnode) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -863,7 +863,8 @@ void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std:
         // TODO: Avoid the repeated-serialization here
         if (pnode->nVersion < INVALID_CB_NO_BAN_VERSION || pnode->fDisconnect)
             return;
-        LOCK(cs_main);
+        AssertLockHeld(cs_main);
+        LOCK(cs_main); // [remove lock when https://github.com/bitcoin/bitcoin/pull/11604 has been merged] repeat lock inside lambda to please clang -Wthread-safety
         ProcessBlockAvailability(pnode->GetId());
         CNodeState &state = *State(pnode->GetId());
         // If the peer has, or we announced to them the previous block already,
@@ -3032,7 +3033,7 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
 
         connman->ForEachNode([&](CNode* pnode) {
             AssertLockHeld(cs_main);
-            LOCK(cs_main); // repeat lock in inside lambda to please clang -Wthread-safety
+            LOCK(cs_main); // [remove lock when https://github.com/bitcoin/bitcoin/pull/11604 has been merged] repeat lock inside lambda to please clang -Wthread-safety
             // Ignore non-outbound peers, or nodes marked for disconnect already
             if (!IsOutboundDisconnectionCandidate(pnode) || pnode->fDisconnect) return;
             CNodeState *state = State(pnode->GetId());
@@ -3047,7 +3048,7 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
         if (worst_peer != -1) {
             bool disconnected = connman->ForNode(worst_peer, [&](CNode *pnode) {
                 AssertLockHeld(cs_main);
-                LOCK(cs_main); // repeat lock inside lambda to please clang -Wthread-safety
+                LOCK(cs_main); // [remove lock when https://github.com/bitcoin/bitcoin/pull/11604 has been merged] repeat lock inside lambda to please clang -Wthread-safety
                 // Only disconnect a peer that has been connected to us for
                 // some reasonable fraction of our check-frequency, to give
                 // it time for new information to have arrived.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -870,6 +870,7 @@ void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std:
         // TODO: Avoid the repeated-serialization here
         if (pnode->nVersion < INVALID_CB_NO_BAN_VERSION || pnode->fDisconnect)
             return;
+        LOCK(cs_main);
         ProcessBlockAvailability(pnode->GetId());
         CNodeState &state = *State(pnode->GetId());
         // If the peer has, or we announced to them the previous block already,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3031,6 +3031,8 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
         LOCK(cs_main);
 
         connman->ForEachNode([&](CNode* pnode) {
+            AssertLockHeld(cs_main);
+            LOCK(cs_main); // repeat lock in inside lambda to please clang -Wthread-safety
             // Ignore non-outbound peers, or nodes marked for disconnect already
             if (!IsOutboundDisconnectionCandidate(pnode) || pnode->fDisconnect) return;
             CNodeState *state = State(pnode->GetId());
@@ -3044,6 +3046,8 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
         });
         if (worst_peer != -1) {
             bool disconnected = connman->ForNode(worst_peer, [&](CNode *pnode) {
+                AssertLockHeld(cs_main);
+                LOCK(cs_main); // repeat lock inside lambda to please clang -Wthread-safety
                 // Only disconnect a peer that has been connected to us for
                 // some reasonable fraction of our check-frequency, to give
                 // it time for new information to have arrived.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -566,7 +566,7 @@ bool IsOutboundDisconnectionCandidate(const CNode *node)
     return !(node->fInbound || node->m_manual_connection || node->fFeeler || node->fOneShot);
 }
 
-void PeerLogicValidation::InitializeNode(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_filter) {
+void PeerLogicValidation::InitializeNode(CNode *pnode) {
     CAddress addr = pnode->addr;
     std::string addrName = pnode->GetAddrName();
     NodeId nodeid = pnode->GetId();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2963,7 +2963,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     return fMoreWork;
 }
 
-void PeerLogicValidation::ConsiderEviction(CNode *pto, int64_t time_in_seconds)
+void PeerLogicValidation::ConsiderEviction(CNode *pto, int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -286,7 +286,7 @@ void UpdatePreferredDownload(CNode* node, CNodeState* state)
     nPreferredDownload += state->fPreferredDownload;
 }
 
-void PushNodeVersion(CNode *pnode, CConnman* connman, int64_t nTime)
+void PushNodeVersion(CNode *pnode, CConnman* connman, int64_t nTime) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
 {
     ServiceFlags nLocalNodeServices = pnode->GetLocalServices();
     uint64_t nonce = pnode->GetLocalNonce();
@@ -566,7 +566,7 @@ bool IsOutboundDisconnectionCandidate(const CNode *node)
     return !(node->fInbound || node->m_manual_connection || node->fFeeler || node->fOneShot);
 }
 
-void PeerLogicValidation::InitializeNode(CNode *pnode) {
+void PeerLogicValidation::InitializeNode(CNode *pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_filter) {
     CAddress addr = pnode->addr;
     std::string addrName = pnode->GetAddrName();
     NodeId nodeid = pnode->GetId();
@@ -1451,7 +1451,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     return true;
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc)
+bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
 {
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
     if (gArgs.IsArgSet("-dropmessagestest") && GetRand(gArgs.GetArg("-dropmessagestest", 0)) == 0)
@@ -2843,7 +2843,7 @@ static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman* connman) EXCLUSI
     return false;
 }
 
-bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
+bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
 {
     const CChainParams& chainparams = Params();
     //

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -832,8 +832,8 @@ void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pb
 
 // All of the following cache a recent block, and are protected by cs_most_recent_block
 static CCriticalSection cs_most_recent_block;
-static std::shared_ptr<const CBlock> most_recent_block PT_GUARDED_BY(cs_most_recent_block);
-static std::shared_ptr<const CBlockHeaderAndShortTxIDs> most_recent_compact_block PT_GUARDED_BY(cs_most_recent_block);
+static std::shared_ptr<const CBlock> most_recent_block GUARDED_BY(cs_most_recent_block);
+static std::shared_ptr<const CBlockHeaderAndShortTxIDs> most_recent_compact_block GUARDED_BY(cs_most_recent_block);
 static uint256 most_recent_block_hash GUARDED_BY(cs_most_recent_block);
 static bool fWitnessesPresentInMostRecentCompactBlock GUARDED_BY(cs_most_recent_block);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -104,8 +104,8 @@ namespace {
      *
      * Memory used: 1.3 MB
      */
-    std::unique_ptr<CRollingBloomFilter> recentRejects;
-    uint256 hashRecentRejectsChainTip;
+    std::unique_ptr<CRollingBloomFilter> recentRejects GUARDED_BY(cs_main);
+    uint256 hashRecentRejectsChainTip GUARDED_BY(cs_main);
 
     /** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
     struct QueuedBlock {
@@ -133,9 +133,9 @@ namespace {
 
     /** Relay map, protected by cs_main. */
     typedef std::map<uint256, CTransactionRef> MapRelay;
-    MapRelay mapRelay;
+    MapRelay mapRelay GUARDED_BY(cs_main);
     /** Expiration-time ordered list of (expire time, relay map entry) pairs, protected by cs_main). */
-    std::deque<std::pair<int64_t, MapRelay::iterator>> vRelayExpiration;
+    std::deque<std::pair<int64_t, MapRelay::iterator>> vRelayExpiration GUARDED_BY(cs_main);
 } // namespace
 
 namespace {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -839,10 +839,10 @@ void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pb
 
 // All of the following cache a recent block, and are protected by cs_most_recent_block
 static CCriticalSection cs_most_recent_block;
-static std::shared_ptr<const CBlock> most_recent_block;
-static std::shared_ptr<const CBlockHeaderAndShortTxIDs> most_recent_compact_block;
-static uint256 most_recent_block_hash;
-static bool fWitnessesPresentInMostRecentCompactBlock;
+static std::shared_ptr<const CBlock> most_recent_block PT_GUARDED_BY(cs_most_recent_block);
+static std::shared_ptr<const CBlockHeaderAndShortTxIDs> most_recent_compact_block PT_GUARDED_BY(cs_most_recent_block);
+static uint256 most_recent_block_hash GUARDED_BY(cs_most_recent_block);
+static bool fWitnessesPresentInMostRecentCompactBlock GUARDED_BY(cs_most_recent_block);
 
 void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) {
     std::shared_ptr<const CBlockHeaderAndShortTxIDs> pcmpctblock = std::make_shared<const CBlockHeaderAndShortTxIDs> (*pblock, true);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -59,7 +59,7 @@ public:
     * @param[in]   interrupt       Interrupt condition for processing threads
     * @return                      True if there is more work to be done
     */
-    bool SendMessages(CNode* pto, std::atomic<bool>& interrupt) override;
+    bool SendMessages(CNode* pto, std::atomic<bool>& interrupt) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
 
     void ConsiderEviction(CNode *pto, int64_t time_in_seconds);
     void CheckForStaleTipAndEvictPeers(const Consensus::Params &consensusParams);

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -10,6 +10,8 @@
 #include <validationinterface.h>
 #include <consensus/params.h>
 
+extern CCriticalSection cs_main;
+
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Expiration time for orphan transactions in seconds */
@@ -61,7 +63,7 @@ public:
     */
     bool SendMessages(CNode* pto, std::atomic<bool>& interrupt) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
 
-    void ConsiderEviction(CNode *pto, int64_t time_in_seconds);
+    void ConsiderEviction(CNode *pto, int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     void CheckForStaleTipAndEvictPeers(const Consensus::Params &consensusParams);
     void EvictExtraOutboundPeers(int64_t time_in_seconds);
 
@@ -79,6 +81,6 @@ struct CNodeStateStats {
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch);
+void Misbehaving(NodeId nodeid, int howmuch) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -30,9 +30,9 @@
 #endif
 
 // Settings
-static proxyType proxyInfo[NET_MAX];
-static proxyType nameProxy;
 static CCriticalSection cs_proxyInfos;
+static proxyType proxyInfo[NET_MAX] GUARDED_BY(cs_proxyInfos);
+static proxyType nameProxy GUARDED_BY(cs_proxyInfos);
 int nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 bool fNameLookup = DEFAULT_NAME_LOOKUP;
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -683,6 +683,7 @@ CFeeRate CBlockPolicyEstimator::estimateFee(int confTarget) const
 
 CFeeRate CBlockPolicyEstimator::estimateRawFee(int confTarget, double successThreshold, FeeEstimateHorizon horizon, EstimationResult* result) const
 {
+    LOCK(cs_feeEstimator);
     TxConfirmStats* stats;
     double sufficientTxs = SUFFICIENT_FEETXS;
     switch (horizon) {
@@ -704,7 +705,6 @@ CFeeRate CBlockPolicyEstimator::estimateRawFee(int confTarget, double successThr
     }
     }
 
-    LOCK(cs_feeEstimator);
     // Return failure if trying to analyze a target we're not tracking
     if (confTarget <= 0 || (unsigned int)confTarget > stats->GetMaxConfirms())
         return CFeeRate(0);

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -247,9 +247,9 @@ private:
     std::map<uint256, TxStatsInfo> mapMemPoolTxs GUARDED_BY(cs_feeEstimator);
 
     /** Classes to track historical data on transaction confirmations */
-    std::unique_ptr<TxConfirmStats> feeStats PT_GUARDED_BY(cs_feeEstimator);
-    std::unique_ptr<TxConfirmStats> shortStats PT_GUARDED_BY(cs_feeEstimator);
-    std::unique_ptr<TxConfirmStats> longStats PT_GUARDED_BY(cs_feeEstimator);
+    std::unique_ptr<TxConfirmStats> feeStats GUARDED_BY(cs_feeEstimator);
+    std::unique_ptr<TxConfirmStats> shortStats GUARDED_BY(cs_feeEstimator);
+    std::unique_ptr<TxConfirmStats> longStats GUARDED_BY(cs_feeEstimator);
 
     unsigned int trackedTxs GUARDED_BY(cs_feeEstimator);
     unsigned int untrackedTxs GUARDED_BY(cs_feeEstimator);

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -258,18 +258,18 @@ private:
     std::map<double, unsigned int> bucketMap GUARDED_BY(cs_feeEstimator); // Map of bucket upper-bound to index into all vectors by bucket
 
     /** Process a transaction confirmed in a block*/
-    bool processBlockTx(unsigned int nBlockHeight, const CTxMemPoolEntry* entry);
+    bool processBlockTx(unsigned int nBlockHeight, const CTxMemPoolEntry* entry) EXCLUSIVE_LOCKS_REQUIRED(cs_feeEstimator);
 
     /** Helper for estimateSmartFee */
-    double estimateCombinedFee(unsigned int confTarget, double successThreshold, bool checkShorterHorizon, EstimationResult *result) const;
+    double estimateCombinedFee(unsigned int confTarget, double successThreshold, bool checkShorterHorizon, EstimationResult *result) const EXCLUSIVE_LOCKS_REQUIRED(cs_feeEstimator);
     /** Helper for estimateSmartFee */
-    double estimateConservativeFee(unsigned int doubleTarget, EstimationResult *result) const;
+    double estimateConservativeFee(unsigned int doubleTarget, EstimationResult *result) const EXCLUSIVE_LOCKS_REQUIRED(cs_feeEstimator);
     /** Number of blocks of data recorded while fee estimates have been running */
-    unsigned int BlockSpan() const;
+    unsigned int BlockSpan() const EXCLUSIVE_LOCKS_REQUIRED(cs_feeEstimator);
     /** Number of blocks of recorded fee estimate data represented in saved data file */
-    unsigned int HistoricalBlockSpan() const;
+    unsigned int HistoricalBlockSpan() const EXCLUSIVE_LOCKS_REQUIRED(cs_feeEstimator);
     /** Calculation of highest target that reasonable estimate can be provided for */
-    unsigned int MaxUsableEstimate() const;
+    unsigned int MaxUsableEstimate() const EXCLUSIVE_LOCKS_REQUIRED(cs_feeEstimator);
 };
 
 class FeeFilterRounder

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -14,7 +14,7 @@ bool SignalsOptInRBF(const CTransaction &tx)
     return false;
 }
 
-RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool)
+RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     AssertLockHeld(pool.cs);
 

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -14,9 +14,9 @@ bool SignalsOptInRBF(const CTransaction &tx)
     return false;
 }
 
-RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs_txMemPool)
 {
-    AssertLockHeld(pool.cs);
+    AssertLockHeld(pool.cs_txMemPool);
 
     CTxMemPool::setEntries setAncestors;
 

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -23,6 +23,6 @@ bool SignalsOptInRBF(const CTransaction &tx);
 // according to BIP 125
 // This involves checking sequence numbers of the transaction, as well
 // as the sequence numbers of all in-mempool ancestors.
-RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool);
+RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool) EXCLUSIVE_LOCKS_REQUIRED(pool.cs_txMemPool);
 
 #endif // BITCOIN_POLICY_RBF_H

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <string>
 
-QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)
+QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     if (!CheckFinalTx(*wtx.tx))

--- a/src/qt/transactiondesc.h
+++ b/src/qt/transactiondesc.h
@@ -8,10 +8,14 @@
 #include <QObject>
 #include <QString>
 
+#include "sync.h"
+
 class TransactionRecord;
 
 class CWallet;
 class CWalletTx;
+
+extern CCriticalSection cs_main;
 
 /** Provide a human-readable extended HTML description of a transaction.
  */
@@ -25,7 +29,7 @@ public:
 private:
     TransactionDesc() {}
 
-    static QString FormatTxStatus(const CWalletTx& wtx);
+    static QString FormatTxStatus(const CWalletTx& wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 #endif // BITCOIN_QT_TRANSACTIONDESC_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -161,7 +161,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     return parts;
 }
 
-void TransactionRecord::updateStatus(const CWalletTx &wtx)
+void TransactionRecord::updateStatus(const CWalletTx &wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     // Determine transaction status
@@ -248,7 +248,7 @@ void TransactionRecord::updateStatus(const CWalletTx &wtx)
     status.needsUpdate = false;
 }
 
-bool TransactionRecord::statusUpdateNeeded() const
+bool TransactionRecord::statusUpdateNeeded() const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     return status.cur_num_blocks != chainActive.Height() || status.needsUpdate;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_TRANSACTIONRECORD_H
 
 #include <amount.h>
+#include <sync.h>
 #include <uint256.h>
 
 #include <QList>
@@ -13,6 +14,8 @@
 
 class CWallet;
 class CWalletTx;
+
+extern CCriticalSection cs_main;
 
 /** UI model for transaction status. The transaction status is the part of a transaction that will change over time.
  */
@@ -136,11 +139,11 @@ public:
 
     /** Update status from core wallet tx.
      */
-    void updateStatus(const CWalletTx &wtx);
+    void updateStatus(const CWalletTx &wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Return whether a status update is needed.
      */
-    bool statusUpdateNeeded() const;
+    bool statusUpdateNeeded() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 };
 
 #endif // BITCOIN_QT_TRANSACTIONRECORD_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -737,7 +737,7 @@ private:
 static bool fQueueNotifications = false;
 static std::vector< TransactionNotification > vQueueNotifications;
 
-static void NotifyTransactionChanged(TransactionTableModel *ttm, CWallet *wallet, const uint256 &hash, ChangeType status)
+static void NotifyTransactionChanged(TransactionTableModel *ttm, CWallet *wallet, const uint256 &hash, ChangeType status) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet)
 {
     // Find transaction in wallet
     std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(hash);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -487,7 +487,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     std::vector<bool> hits;
     bitmap.resize((vOutPoints.size() + 7) / 8);
     {
-        LOCK2(cs_main, mempool.cs);
+        LOCK2(cs_main, mempool.cs_txMemPool);
 
         CCoinsView viewDummy;
         CCoinsViewCache view(&viewDummy);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -517,7 +517,10 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         // serialize data
         // use exact same output as mentioned in Bip64
         CDataStream ssGetUTXOResponse(SER_NETWORK, PROTOCOL_VERSION);
-        ssGetUTXOResponse << chainActive.Height() << chainActive.Tip()->GetBlockHash() << bitmap << outs;
+        {
+            LOCK(cs_main);
+            ssGetUTXOResponse << chainActive.Height() << chainActive.Tip()->GetBlockHash() << bitmap << outs;
+        }
         std::string ssGetUTXOResponseString = ssGetUTXOResponse.str();
 
         req->WriteHeader("Content-Type", "application/octet-stream");
@@ -527,7 +530,10 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
 
     case RF_HEX: {
         CDataStream ssGetUTXOResponse(SER_NETWORK, PROTOCOL_VERSION);
-        ssGetUTXOResponse << chainActive.Height() << chainActive.Tip()->GetBlockHash() << bitmap << outs;
+        {
+            LOCK(cs_main);
+            ssGetUTXOResponse << chainActive.Height() << chainActive.Tip()->GetBlockHash() << bitmap << outs;
+        }
         std::string strHex = HexStr(ssGetUTXOResponse.begin(), ssGetUTXOResponse.end()) + "\n";
 
         req->WriteHeader("Content-Type", "text/plain");
@@ -540,8 +546,11 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
 
         // pack in some essentials
         // use more or less the same output as mentioned in Bip64
-        objGetUTXOResponse.push_back(Pair("chainHeight", chainActive.Height()));
-        objGetUTXOResponse.push_back(Pair("chaintipHash", chainActive.Tip()->GetBlockHash().GetHex()));
+        {
+            LOCK(cs_main);
+            objGetUTXOResponse.push_back(Pair("chainHeight", chainActive.Height()));
+            objGetUTXOResponse.push_back(Pair("chaintipHash", chainActive.Tip()->GetBlockHash().GetHex()));
+        }
         objGetUTXOResponse.push_back(Pair("bitmap", bitmapStringRepresentation));
 
         UniValue utxos(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -47,7 +47,7 @@ static CUpdatedBlock latestblock;
 
 extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
 
-double GetDifficulty(const CBlockIndex* blockindex)
+double GetDifficulty(const CBlockIndex* blockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (blockindex == nullptr)
     {
@@ -76,7 +76,7 @@ double GetDifficulty(const CBlockIndex* blockindex)
     return dDiff;
 }
 
-UniValue blockheaderToJSON(const CBlockIndex* blockindex)
+UniValue blockheaderToJSON(const CBlockIndex* blockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     UniValue result(UniValue::VOBJ);
@@ -105,7 +105,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     return result;
 }
 
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails)
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     UniValue result(UniValue::VOBJ);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -354,7 +354,7 @@ std::string EntryDescriptionString()
 
 void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
 {
-    AssertLockHeld(mempool.cs);
+    AssertLockHeld(mempool.cs_txMemPool);
 
     info.push_back(Pair("size", (int)e.GetTxSize()));
     info.push_back(Pair("fee", ValueFromAmount(e.GetFee())));
@@ -389,7 +389,7 @@ UniValue mempoolToJSON(bool fVerbose)
 {
     if (fVerbose)
     {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         UniValue o(UniValue::VOBJ);
         for (const CTxMemPoolEntry& e : mempool.mapTx)
         {
@@ -477,7 +477,7 @@ UniValue getmempoolancestors(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
-    LOCK(mempool.cs);
+    LOCK(mempool.cs_txMemPool);
 
     CTxMemPool::txiter it = mempool.mapTx.find(hash);
     if (it == mempool.mapTx.end()) {
@@ -541,7 +541,7 @@ UniValue getmempooldescendants(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
-    LOCK(mempool.cs);
+    LOCK(mempool.cs_txMemPool);
 
     CTxMemPool::txiter it = mempool.mapTx.find(hash);
     if (it == mempool.mapTx.end()) {
@@ -593,7 +593,7 @@ UniValue getmempoolentry(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
-    LOCK(mempool.cs);
+    LOCK(mempool.cs_txMemPool);
 
     CTxMemPool::txiter it = mempool.mapTx.find(hash);
     if (it == mempool.mapTx.end()) {
@@ -995,7 +995,7 @@ UniValue gettxout(const JSONRPCRequest& request)
 
     Coin coin;
     if (fMempool) {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         CCoinsViewMemPool view(pcoinsTip.get(), mempool);
         if (!view.GetCoin(out, coin) || mempool.isSpent(out)) {
             return NullUniValue;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -928,6 +928,7 @@ UniValue gettxoutsetinfo(const JSONRPCRequest& request)
 
     CCoinsStats stats;
     FlushStateToDisk();
+    LOCK(cs_main);
     if (GetUTXOStats(pcoinsdbview.get(), stats)) {
         ret.push_back(Pair("height", (int64_t)stats.nHeight));
         ret.push_back(Pair("bestblock", stats.hashBlock.GetHex()));

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -45,7 +45,7 @@ static std::mutex cs_blockchange;
 static std::condition_variable cond_blockchange;
 static CUpdatedBlock latestblock;
 
-extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry);
+extern void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 double GetDifficulty(const CBlockIndex* blockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -352,7 +352,7 @@ std::string EntryDescriptionString()
            "       ... ]\n";
 }
 
-void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
+void entryToJSON(UniValue &info, const CTxMemPoolEntry &e) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs_txMemPool)
 {
     AssertLockHeld(mempool.cs_txMemPool);
 

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -5,9 +5,13 @@
 #ifndef BITCOIN_RPC_BLOCKCHAIN_H
 #define BITCOIN_RPC_BLOCKCHAIN_H
 
+#include "sync.h"
+
 class CBlock;
 class CBlockIndex;
 class UniValue;
+
+extern CCriticalSection cs_main;
 
 /**
  * Get the difficulty of the net wrt to the given block index, or the chain tip if
@@ -16,13 +20,13 @@ class UniValue;
  * @return A floating point number that is a multiple of the main net minimum
  * difficulty (4295032833 hashes).
  */
-double GetDifficulty(const CBlockIndex* blockindex = nullptr);
+double GetDifficulty(const CBlockIndex* blockindex = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Callback for when block tip changed. */
 void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
 
 /** Block description to JSON */
-UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
+UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Mempool information to JSON */
 UniValue mempoolInfoToJSON();
@@ -31,7 +35,7 @@ UniValue mempoolInfoToJSON();
 UniValue mempoolToJSON(bool fVerbose = false);
 
 /** Block header to JSON */
-UniValue blockheaderToJSON(const CBlockIndex* blockindex);
+UniValue blockheaderToJSON(const CBlockIndex* blockindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 #endif
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -105,7 +105,7 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
     return GetNetworkHashPS(!request.params[0].isNull() ? request.params[0].get_int() : 120, !request.params[1].isNull() ? request.params[1].get_int() : -1);
 }
 
-UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript)
+UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGenerate, uint64_t nMaxTries, bool keepScript) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     static const int nInnerLoopCount = 0x10000;
     int nHeightEnd = 0;
@@ -153,7 +153,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
     return blockHashes;
 }
 
-UniValue generatetoaddress(const JSONRPCRequest& request)
+UniValue generatetoaddress(const JSONRPCRequest& request) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 3)
         throw std::runtime_error(
@@ -707,7 +707,7 @@ protected:
     }
 };
 
-UniValue submitblock(const JSONRPCRequest& request)
+UniValue submitblock(const JSONRPCRequest& request) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     // We allow 2 arguments for compliance with BIP22. Argument 2 is ignored.
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -46,7 +46,7 @@ unsigned int ParseConfirmTarget(const UniValue& value)
  * or from the last difficulty change if 'lookup' is nonpositive.
  * If 'height' is nonnegative, compute the estimate at the time when a given block was found.
  */
-UniValue GetNetworkHashPS(int lookup, int height) {
+UniValue GetNetworkHashPS(int lookup, int height) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     CBlockIndex *pb = chainActive.Tip();
 
     if (height >= 0 && height < chainActive.Height())
@@ -293,7 +293,7 @@ std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
     return s;
 }
 
-UniValue getblocktemplate(const JSONRPCRequest& request)
+UniValue getblocktemplate(const JSONRPCRequest& request) NO_THREAD_SAFETY_ANALYSIS
 {
     if (request.fHelp || request.params.size() > 1)
         throw std::runtime_error(

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -372,6 +372,8 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             + HelpExampleRpc("getblocktemplate", "")
          );
 
+    LOCK(cs_main);
+
     std::string strMode = "template";
     UniValue lpval = NullUniValue;
     std::set<std::string> setClientRules;
@@ -401,7 +403,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
             uint256 hash = block.GetHash();
-            LOCK(cs_main);
             BlockMap::iterator mi = mapBlockIndex.find(hash);
             if (mi != mapBlockIndex.end()) {
                 CBlockIndex *pindex = mi->second;
@@ -467,23 +468,25 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         }
         else
         {
-            LOCK(cs_main);
             // NOTE: Spec does not specify behaviour for non-string longpollid, but this makes testing easier
             hashWatchedChain = chainActive.Tip()->GetBlockHash();
             nTransactionsUpdatedLastLP = nTransactionsUpdatedLast;
         }
 
         // Release the wallet and main lock while waiting
+        LEAVE_CRITICAL_SECTION(cs_main);
         {
             checktxtime = std::chrono::steady_clock::now() + std::chrono::minutes(1);
 
             WaitableLock lock(csBestBlock);
-            bool keepRunning;
-            {
+
+            auto KeepRunning = [&]() -> bool {
                 LOCK(cs_main);
-                keepRunning = chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
-            }
-            while (keepRunning)
+                assert(chainActive.Tip());
+                return chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
+            };
+
+            while (KeepRunning())
             {
                 if (cvBlockChange.wait_until(lock, checktxtime) == std::cv_status::timeout)
                 {
@@ -492,10 +495,9 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                         break;
                     checktxtime += std::chrono::seconds(10);
                 }
-                LOCK(cs_main);
-                keepRunning = chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
             }
         }
+        ENTER_CRITICAL_SECTION(cs_main);
 
         if (!IsRPCRunning())
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");
@@ -509,7 +511,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     bool fSupportsSegwit = setClientRules.find(segwit_info.name) != setClientRules.end();
 
     // Update block
-    LOCK(cs_main);
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
     static std::unique_ptr<CBlockTemplate> pblocktemplate;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -293,6 +293,8 @@ std::string gbt_vb_name(const Consensus::DeploymentPos pos) {
     return s;
 }
 
+// NO_THREAD_SAFETY_ANALYSIS: Intentionally accessing chainActive without
+// holding cs_main (see LEAVE_CRITICAL_SECTION(cs_main)).
 UniValue getblocktemplate(const JSONRPCRequest& request) NO_THREAD_SAFETY_ANALYSIS
 {
     if (request.fHelp || request.params.size() > 1)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -120,6 +120,8 @@ public:
 };
 #endif
 
+// NO_THREAD_SAFETY_ANALYSIS: The conditional cs_wallet lock confuses the
+// thread-safety analyzer.
 UniValue validateaddress(const JSONRPCRequest& request) NO_THREAD_SAFETY_ANALYSIS
 {
     if (request.fHelp || request.params.size() != 1)

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -120,7 +120,7 @@ public:
 };
 #endif
 
-UniValue validateaddress(const JSONRPCRequest& request)
+UniValue validateaddress(const JSONRPCRequest& request) NO_THREAD_SAFETY_ANALYSIS
 {
     if (request.fHelp || request.params.size() != 1)
         throw std::runtime_error(

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -158,8 +158,11 @@ UniValue validateaddress(const JSONRPCRequest& request)
 
 #ifdef ENABLE_WALLET
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-#endif
+
+    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : nullptr);
+#else
     LOCK(cs_main);
+#endif
 
     CTxDestination dest = DecodeDestination(request.params[0].get_str());
     bool isValid = IsValidDestination(dest);

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -121,7 +121,7 @@ public:
 #endif
 
 // NO_THREAD_SAFETY_ANALYSIS: The conditional cs_wallet lock confuses the
-// thread-safety analyzer.
+// Clang thread-safety analyzer.
 UniValue validateaddress(const JSONRPCRequest& request) NO_THREAD_SAFETY_ANALYSIS
 {
     if (request.fHelp || request.params.size() != 1)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -413,7 +413,7 @@ static UniValue GetNetworksInfo()
     return networks;
 }
 
-UniValue getnetworkinfo(const JSONRPCRequest& request) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
+UniValue getnetworkinfo(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -413,7 +413,7 @@ static UniValue GetNetworksInfo()
     return networks;
 }
 
-UniValue getnetworkinfo(const JSONRPCRequest& request)
+UniValue getnetworkinfo(const JSONRPCRequest& request) EXCLUSIVE_LOCKS_REQUIRED(cs_filter)
 {
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -37,7 +37,7 @@
 #include <univalue.h>
 
 
-void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
+void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.
     //

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -602,7 +602,7 @@ UniValue combinerawtransaction(const JSONRPCRequest& request)
     CCoinsViewCache view(&viewDummy);
     {
         LOCK(cs_main);
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         CCoinsViewCache &viewChain = *pcoinsTip;
         CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
@@ -723,7 +723,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
     CCoinsView viewDummy;
     CCoinsViewCache view(&viewDummy);
     {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         CCoinsViewCache &viewChain = *pcoinsTip;
         CCoinsViewMemPool viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -27,8 +27,8 @@
 
 static CCriticalSection cs_rpcWarmup;
 static bool fRPCRunning = false;
-static bool fRPCInWarmup = true; // GUARDED_BY(cs_rpcWarmup)
-static std::string rpcWarmupStatus("RPC server started"); // GUARDED_BY(cs_rpcWarmup)
+static bool fRPCInWarmup GUARDED_BY(cs_rpcWarmup) = true;
+static std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";
 /* Timer-creating functions */
 static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -25,10 +25,10 @@
 #include <memory> // for unique_ptr
 #include <unordered_map>
 
-static bool fRPCRunning = false;
-static bool fRPCInWarmup = true;
-static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
+static bool fRPCRunning = false;
+static bool fRPCInWarmup = true; // GUARDED_BY(cs_rpcWarmup)
+static std::string rpcWarmupStatus("RPC server started"); // GUARDED_BY(cs_rpcWarmup)
 /* Timer-creating functions */
 static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -148,7 +148,7 @@ bool CScheduler::AreThreadsServicingQueue() const {
 
 void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue() {
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(cs_callbacks_pending);
         // Try to avoid scheduling too many copies here, but if we
         // accidentally have two ProcessQueue's scheduled at once its
         // not a big deal.
@@ -161,7 +161,7 @@ void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue() {
 void SingleThreadedSchedulerClient::ProcessQueue() {
     std::function<void (void)> callback;
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(cs_callbacks_pending);
         if (m_are_callbacks_running) return;
         if (m_callbacks_pending.empty()) return;
         m_are_callbacks_running = true;
@@ -177,7 +177,7 @@ void SingleThreadedSchedulerClient::ProcessQueue() {
         explicit RAIICallbacksRunning(SingleThreadedSchedulerClient* _instance) : instance(_instance) {}
         ~RAIICallbacksRunning() {
             {
-                LOCK(instance->m_cs_callbacks_pending);
+                LOCK(instance->cs_callbacks_pending);
                 instance->m_are_callbacks_running = false;
             }
             instance->MaybeScheduleProcessQueue();
@@ -191,7 +191,7 @@ void SingleThreadedSchedulerClient::AddToProcessQueue(std::function<void (void)>
     assert(m_pscheduler);
 
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(cs_callbacks_pending);
         m_callbacks_pending.emplace_back(std::move(func));
     }
     MaybeScheduleProcessQueue();
@@ -202,7 +202,7 @@ void SingleThreadedSchedulerClient::EmptyQueue() {
     bool should_continue = true;
     while (should_continue) {
         ProcessQueue();
-        LOCK(m_cs_callbacks_pending);
+        LOCK(cs_callbacks_pending);
         should_continue = !m_callbacks_pending.empty();
     }
 }

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -94,8 +94,8 @@ class SingleThreadedSchedulerClient {
 private:
     CScheduler *m_pscheduler;
 
-    CCriticalSection m_cs_callbacks_pending;
-    std::list<std::function<void (void)>> m_callbacks_pending GUARDED_BY(m_cs_callbacks_pending);
+    CCriticalSection cs_callbacks_pending;
+    std::list<std::function<void (void)>> m_callbacks_pending GUARDED_BY(cs_callbacks_pending);
     bool m_are_callbacks_running = false;
 
     void MaybeScheduleProcessQueue();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -96,7 +96,7 @@ private:
 
     CCriticalSection cs_callbacks_pending;
     std::list<std::function<void (void)>> m_callbacks_pending GUARDED_BY(cs_callbacks_pending);
-    bool m_are_callbacks_running = false;
+    bool m_are_callbacks_running GUARDED_BY(cs_callbacks_pending) = false;
 
     void MaybeScheduleProcessQueue();
     void ProcessQueue();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -95,7 +95,7 @@ private:
     CScheduler *m_pscheduler;
 
     CCriticalSection m_cs_callbacks_pending;
-    std::list<std::function<void (void)>> m_callbacks_pending;
+    std::list<std::function<void (void)>> m_callbacks_pending GUARDED_BY(m_cs_callbacks_pending);
     bool m_are_callbacks_running = false;
 
     void MaybeScheduleProcessQueue();

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -29,7 +29,7 @@ struct COrphanTx {
     NodeId fromPeer;
     int64_t nTimeExpire;
 };
-extern std::map<uint256, COrphanTx> mapOrphanTransactions;
+extern std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);
 
 CService ip(uint32_t i)
 {

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -38,17 +38,17 @@ public:
         return (unsigned int)(state % nMax);
     }
 
-    CAddrInfo* Find(const CNetAddr& addr, int* pnId = nullptr)
+    CAddrInfo* Find(const CNetAddr& addr, int* pnId = nullptr) NO_THREAD_SAFETY_ANALYSIS
     {
         return CAddrMan::Find(addr, pnId);
     }
 
-    CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId = nullptr)
+    CAddrInfo* Create(const CAddress& addr, const CNetAddr& addrSource, int* pnId = nullptr) NO_THREAD_SAFETY_ANALYSIS
     {
         return CAddrMan::Create(addr, addrSource, pnId);
     }
 
-    void Delete(int nId)
+    void Delete(int nId) NO_THREAD_SAFETY_ANALYSIS
     {
         CAddrMan::Delete(nId);
     }

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(SimpleRoundTripTest)
     CBlock block(BuildBlockTestCase());
 
     pool.addUnchecked(block.vtx[2]->GetHash(), entry.FromTx(*block.vtx[2]));
-    LOCK(pool.cs);
+    LOCK(pool.cs_txMemPool);
     BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2]->GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 
     // Do a simple ShortTxIDs RT
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(NonCoinbasePreforwardRTTest)
     CBlock block(BuildBlockTestCase());
 
     pool.addUnchecked(block.vtx[2]->GetHash(), entry.FromTx(*block.vtx[2]));
-    LOCK(pool.cs);
+    LOCK(pool.cs_txMemPool);
     BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[2]->GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 
     uint256 txhash;
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(SufficientPreforwardRTTest)
     CBlock block(BuildBlockTestCase());
 
     pool.addUnchecked(block.vtx[1]->GetHash(), entry.FromTx(*block.vtx[1]));
-    LOCK(pool.cs);
+    LOCK(pool.cs_txMemPool);
     BOOST_CHECK_EQUAL(pool.mapTx.find(block.vtx[1]->GetHash())->GetSharedTx().use_count(), SHARED_TX_OFFSET + 0);
 
     uint256 txhash;

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 }
 
 template<typename name>
-void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder)
+void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
     typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx.get<name>().begin();

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 }
 
 template<typename name>
-void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder) EXCLUSIVE_LOCKS_REQUIRED(pool.cs_txMemPool)
 {
     BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
     typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx.get<name>().begin();
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder[2] = tx1.GetHash().ToString(); // 10000
     sortedOrder[3] = tx4.GetHash().ToString(); // 15000
     sortedOrder[4] = tx2.GetHash().ToString(); // 20000
-    LOCK(pool.cs);
+    LOCK(pool.cs_txMemPool);
     CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee but with high fee child */
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     }
     sortedOrder[4] = tx3.GetHash().ToString(); // 0
 
-    LOCK(pool.cs);
+    LOCK(pool.cs_txMemPool);
     CheckSort<ancestor_score>(pool, sortedOrder);
 
     /* low fee parent with high fee child */

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -81,7 +81,7 @@ CBlockIndex CreateBlockIndex(int nHeight)
 
 bool TestSequenceLocks(const CTransaction &tx, int flags)
 {
-    LOCK(mempool.cs);
+    LOCK(mempool.cs_txMemPool);
     return CheckSequenceLocks(tx, flags);
 }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -79,9 +79,9 @@ CBlockIndex CreateBlockIndex(int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return index;
 }
 
-bool TestSequenceLocks(const CTransaction &tx, int flags)
+bool TestSequenceLocks(const CTransaction &tx, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    LOCK2(cs_main, mempool.cs_txMemPool);
+    LOCK(mempool.cs_txMemPool);
     return CheckSequenceLocks(tx, flags);
 }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -71,7 +71,7 @@ struct {
     {2, 0xbbbeb305}, {2, 0xfe1c810a},
 };
 
-CBlockIndex CreateBlockIndex(int nHeight)
+CBlockIndex CreateBlockIndex(int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CBlockIndex index;
     index.nHeight = nHeight;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -81,7 +81,7 @@ CBlockIndex CreateBlockIndex(int nHeight) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 bool TestSequenceLocks(const CTransaction &tx, int flags)
 {
-    LOCK(mempool.cs_txMemPool);
+    LOCK2(cs_main, mempool.cs_txMemPool);
     return CheckSequenceLocks(tx, flags);
 }
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -24,9 +24,9 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
 BOOST_AUTO_TEST_SUITE(tx_validationcache_tests)
 
 static bool
-ToMemPool(CMutableTransaction& tx)
+ToMemPool(CMutableTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    LOCK(cs_main);
+    AssertLockHeld(cs_main);
 
     CValidationState state;
     return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), nullptr /* pfMissingInputs */,

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -120,6 +120,7 @@ void ValidateCheckInputsForAllFlags(CMutableTransaction &tx, uint32_t failing_fl
             // WITNESS requires P2SH
             test_flags |= SCRIPT_VERIFY_P2SH;
         }
+        LOCK(cs_main);
         bool ret = CheckInputs(tx, state, pcoinsTip.get(), true, test_flags, true, add_to_cache, txdata, nullptr);
         // CheckInputs should succeed iff test_flags doesn't intersect with
         // failing_flags

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -20,17 +20,17 @@ BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(util_criticalsection)
 {
-    CCriticalSection cs;
+    CCriticalSection cs_test;
 
     do {
-        LOCK(cs);
+        LOCK(cs_test);
         break;
 
         BOOST_ERROR("break was swallowed!");
     } while(0);
 
     do {
-        TRY_LOCK(cs, lockTest);
+        TRY_LOCK(cs_test, lockTest);
         if (lockTest)
             break;
 

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -17,7 +17,7 @@
 
 
 static CCriticalSection cs_nTimeOffset;
-static int64_t nTimeOffset = 0;
+static int64_t nTimeOffset GUARDED_BY(cs_nTimeOffset) = 0;
 
 /**
  * "Never go to sea with two chronometers; take one or three."

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -624,6 +624,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     if (GetRand(std::numeric_limits<uint32_t>::max()) >= nCheckFrequency)
         return;
 
+    LOCK(cs);
     LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
     uint64_t checkTotal = 0;
@@ -632,7 +633,6 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
     const int64_t spendheight = GetSpendHeight(mempoolDuplicate);
 
-    LOCK(cs);
     std::list<const CTxMemPoolEntry*> waitingOnDependants;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         unsigned int i = 0;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -624,14 +624,14 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     if (GetRand(std::numeric_limits<uint32_t>::max()) >= nCheckFrequency)
         return;
 
-    LOCK(cs_txMemPool);
-    LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
-
     uint64_t checkTotal = 0;
     uint64_t innerUsage = 0;
 
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
     const int64_t spendheight = GetSpendHeight(mempoolDuplicate);
+
+    LOCK(cs_txMemPool);
+    LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
     std::list<const CTxMemPoolEntry*> waitingOnDependants;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -539,10 +539,10 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
     RemoveStaged(setAllRemoves, false, MemPoolRemovalReason::REORG);
 }
 
-void CTxMemPool::removeConflicts(const CTransaction &tx)
+void CTxMemPool::removeConflicts(const CTransaction &tx) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     // Remove transactions which depend on inputs of tx, recursively
-    LOCK(cs_txMemPool);
+    AssertLockHeld(cs_txMemPool);
     for (const CTxIn &txin : tx.vin) {
         auto it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -618,20 +618,21 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
 
 void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 {
+    LOCK(cs_txMemPool);
+
     if (nCheckFrequency == 0)
         return;
 
     if (GetRand(std::numeric_limits<uint32_t>::max()) >= nCheckFrequency)
         return;
 
+    LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
+
     uint64_t checkTotal = 0;
     uint64_t innerUsage = 0;
 
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
     const int64_t spendheight = GetSpendHeight(mempoolDuplicate);
-
-    LOCK(cs_txMemPool);
-    LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
     std::list<const CTxMemPoolEntry*> waitingOnDependants;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -59,7 +59,7 @@ size_t CTxMemPoolEntry::GetTxSize() const
 // Update the given tx for any in-mempool descendants.
 // Assumes that setMemPoolChildren is correct for the given tx and all
 // descendants.
-void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendants, const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     setEntries stageEntries, setAllDescendants;
     stageEntries = GetMemPoolChildren(updateIt);
@@ -108,7 +108,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
 // for each such descendant, also update the ancestor state to include the parent.
 void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashesToUpdate)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     // For each entry in vHashesToUpdate, store the set of in-mempool, but not
     // in-vHashesToUpdate transactions, so that we don't have to recalculate
     // descendants when we come across a previously seen entry.
@@ -151,7 +151,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
 
 bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntries &setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string &errString, bool fSearchForParents /* = true */) const
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
 
     setEntries parentHashes;
     const CTransaction &tx = entry.GetTx();
@@ -213,7 +213,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
     return true;
 }
 
-void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     setEntries parentIters = GetMemPoolParents(it);
     // add or remove this tx as a child of each parent
@@ -228,7 +228,7 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors
     }
 }
 
-void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     int64_t updateCount = setAncestors.size();
     int64_t updateSize = 0;
@@ -250,7 +250,7 @@ void CTxMemPool::UpdateChildrenForRemoval(txiter it)
     }
 }
 
-void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     // For each entry, walk back all ancestors and decrement size associated with this
     // transaction
@@ -341,19 +341,19 @@ CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator) :
 
 bool CTxMemPool::isSpent(const COutPoint& outpoint)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     return mapNextTx.count(outpoint);
 }
 
 unsigned int CTxMemPool::GetTransactionsUpdated() const
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     return nTransactionsUpdated;
 }
 
 void CTxMemPool::AddTransactionsUpdated(unsigned int n)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     nTransactionsUpdated += n;
 }
 
@@ -363,7 +363,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     // Add to memory pool without checking anything.
     // Used by AcceptToMemoryPool(), which DOES do
     // all the appropriate checks.
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     indexed_transaction_set::iterator newit = mapTx.insert(entry).first;
     mapLinks.insert(make_pair(newit, TxLinks()));
 
@@ -416,7 +416,7 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
     return true;
 }
 
-void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     NotifyEntryRemoved(it->GetSharedTx(), reason);
     const uint256 hash = it->GetTx().GetHash();
@@ -474,7 +474,7 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 {
     // Remove transaction from memory pool
     {
-        LOCK(cs);
+        LOCK(cs_txMemPool);
         setEntries txToRemove;
         txiter origit = mapTx.find(origTx.GetHash());
         if (origit != mapTx.end()) {
@@ -505,7 +505,7 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
 {
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     setEntries txToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->GetTx();
@@ -542,7 +542,7 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
 void CTxMemPool::removeConflicts(const CTransaction &tx)
 {
     // Remove transactions which depend on inputs of tx, recursively
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     for (const CTxIn &txin : tx.vin) {
         auto it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
@@ -561,7 +561,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
  */
 void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     std::vector<const CTxMemPoolEntry*> entries;
     for (const auto& tx : vtx)
     {
@@ -588,7 +588,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     blockSinceLastRollingFeeBump = true;
 }
 
-void CTxMemPool::_clear() EXCLUSIVE_LOCKS_REQUIRED(cs)
+void CTxMemPool::_clear() EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     mapLinks.clear();
     mapTx.clear();
@@ -603,7 +603,7 @@ void CTxMemPool::_clear() EXCLUSIVE_LOCKS_REQUIRED(cs)
 
 void CTxMemPool::clear()
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     _clear();
 }
 
@@ -624,7 +624,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     if (GetRand(std::numeric_limits<uint32_t>::max()) >= nCheckFrequency)
         return;
 
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
     uint64_t checkTotal = 0;
@@ -740,7 +740,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
 bool CTxMemPool::CompareDepthAndScore(const uint256& hasha, const uint256& hashb)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     indexed_transaction_set::const_iterator i = mapTx.find(hasha);
     if (i == mapTx.end()) return false;
     indexed_transaction_set::const_iterator j = mapTx.find(hashb);
@@ -769,10 +769,10 @@ public:
 };
 } // namespace
 
-std::vector<CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs)
+std::vector<CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     std::vector<indexed_transaction_set::const_iterator> iters;
-    AssertLockHeld(cs);
+    AssertLockHeld(cs_txMemPool);
 
     iters.reserve(mapTx.size());
 
@@ -785,7 +785,7 @@ std::vector<CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::Get
 
 void CTxMemPool::queryHashes(std::vector<uint256>& vtxid)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     auto iters = GetSortedDepthAndScore();
 
     vtxid.clear();
@@ -802,7 +802,7 @@ static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator
 
 std::vector<TxMempoolInfo> CTxMemPool::infoAll() const
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     auto iters = GetSortedDepthAndScore();
 
     std::vector<TxMempoolInfo> ret;
@@ -816,7 +816,7 @@ std::vector<TxMempoolInfo> CTxMemPool::infoAll() const
 
 CTransactionRef CTxMemPool::get(const uint256& hash) const
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     indexed_transaction_set::const_iterator i = mapTx.find(hash);
     if (i == mapTx.end())
         return nullptr;
@@ -825,7 +825,7 @@ CTransactionRef CTxMemPool::get(const uint256& hash) const
 
 TxMempoolInfo CTxMemPool::info(const uint256& hash) const
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     indexed_transaction_set::const_iterator i = mapTx.find(hash);
     if (i == mapTx.end())
         return TxMempoolInfo();
@@ -835,7 +835,7 @@ TxMempoolInfo CTxMemPool::info(const uint256& hash) const
 void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)
 {
     {
-        LOCK(cs);
+        LOCK(cs_txMemPool);
         CAmount &delta = mapDeltas[hash];
         delta += nFeeDelta;
         txiter it = mapTx.find(hash);
@@ -864,7 +864,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
 
 void CTxMemPool::ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     std::map<uint256, CAmount>::const_iterator pos = mapDeltas.find(hash);
     if (pos == mapDeltas.end())
         return;
@@ -874,7 +874,7 @@ void CTxMemPool::ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const
 
 void CTxMemPool::ClearPrioritisation(const uint256 hash)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     mapDeltas.erase(hash);
 }
 
@@ -905,13 +905,13 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 }
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     // Estimate the overhead of mapTx to be 15 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 15 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs) {
-    AssertLockHeld(cs);
+void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool) {
+    AssertLockHeld(cs_txMemPool);
     UpdateForRemoveFromMempool(stage, updateDescendants);
     for (const txiter& it : stage) {
         removeUnchecked(it, reason);
@@ -919,7 +919,7 @@ void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPool
 }
 
 int CTxMemPool::Expire(int64_t time) {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     indexed_transaction_set::index<entry_time>::type::iterator it = mapTx.get<entry_time>().begin();
     setEntries toremove;
     while (it != mapTx.get<entry_time>().end() && it->GetTime() < time) {
@@ -936,7 +936,7 @@ int CTxMemPool::Expire(int64_t time) {
 
 bool CTxMemPool::addUnchecked(const uint256&hash, const CTxMemPoolEntry &entry, bool validFeeEstimate)
 {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     setEntries setAncestors;
     uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
@@ -964,7 +964,7 @@ void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
     }
 }
 
-const CTxMemPool::setEntries & CTxMemPool::GetMemPoolParents(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs)
+const CTxMemPool::setEntries & CTxMemPool::GetMemPoolParents(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     assert (entry != mapTx.end());
     txlinksMap::const_iterator it = mapLinks.find(entry);
@@ -972,7 +972,7 @@ const CTxMemPool::setEntries & CTxMemPool::GetMemPoolParents(txiter entry) const
     return it->second.parents;
 }
 
-const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs)
+const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     assert (entry != mapTx.end());
     txlinksMap::const_iterator it = mapLinks.find(entry);
@@ -981,7 +981,7 @@ const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) cons
 }
 
 CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     if (!blockSinceLastRollingFeeBump || rollingMinimumFeeRate == 0)
         return CFeeRate(llround(rollingMinimumFeeRate));
 
@@ -1005,7 +1005,7 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
 }
 
 void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {
-    AssertLockHeld(cs);
+    AssertLockHeld(cs_txMemPool);
     if (rate.GetFeePerK() > rollingMinimumFeeRate) {
         rollingMinimumFeeRate = rate.GetFeePerK();
         blockSinceLastRollingFeeBump = false;
@@ -1013,7 +1013,7 @@ void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {
 }
 
 void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining) {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
 
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
@@ -1056,7 +1056,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
 }
 
 bool CTxMemPool::TransactionWithinChainLimit(const uint256& txid, size_t chainLimit) const {
-    LOCK(cs);
+    LOCK(cs_txMemPool);
     auto it = mapTx.find(txid);
     return it == mapTx.end() || (it->GetCountWithAncestors() < chainLimit &&
        it->GetCountWithDescendants() < chainLimit);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -944,7 +944,7 @@ bool CTxMemPool::addUnchecked(const uint256&hash, const CTxMemPoolEntry &entry, 
     return addUnchecked(hash, entry, setAncestors, validFeeEstimate);
 }
 
-void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
+void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     setEntries s;
     if (add && mapLinks[entry].children.insert(child).second) {
@@ -954,7 +954,7 @@ void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
     }
 }
 
-void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
+void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     setEntries s;
     if (add && mapLinks[entry].parents.insert(parent).second) {
@@ -1004,7 +1004,7 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
     return std::max(CFeeRate(llround(rollingMinimumFeeRate)), incrementalRelayFee);
 }
 
-void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {
+void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool) {
     AssertLockHeld(cs_txMemPool);
     if (rate.GetFeePerK() > rollingMinimumFeeRate) {
         rollingMinimumFeeRate = rate.GetFeePerK();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -242,7 +242,7 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncesto
     mapTx.modify(it, update_ancestor_state(updateSize, updateFee, updateCount, updateSigOpsCost));
 }
 
-void CTxMemPool::UpdateChildrenForRemoval(txiter it)
+void CTxMemPool::UpdateChildrenForRemoval(txiter it) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     const setEntries &setMemPoolChildren = GetMemPoolChildren(it);
     for (txiter updateIt : setMemPoolChildren) {
@@ -447,7 +447,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason) EXCLUSI
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-void CTxMemPool::CalculateDescendants(txiter entryit, setEntries &setDescendants)
+void CTxMemPool::CalculateDescendants(txiter entryit, setEntries &setDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs_txMemPool)
 {
     setEntries stage;
     if (setDescendants.count(entryit) == 0) {
@@ -502,7 +502,7 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
     }
 }
 
-void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
+void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
     LOCK(cs_txMemPool);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -413,10 +413,10 @@ class CTxMemPool
 {
 private:
     uint32_t nCheckFrequency; //!< Value n means that n times in 2^32 we check.
-    unsigned int nTransactionsUpdated GUARDED_BY(cs); //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
+    unsigned int nTransactionsUpdated GUARDED_BY(cs_txMemPool); //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
     CBlockPolicyEstimator* minerPolicyEstimator;
 
-    uint64_t totalTxSize GUARDED_BY(cs); //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
+    uint64_t totalTxSize GUARDED_BY(cs_txMemPool); //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
     mutable int64_t lastRollingFeeUpdate;
@@ -461,11 +461,11 @@ public:
         >
     > indexed_transaction_set;
 
-    mutable CCriticalSection cs;
-    indexed_transaction_set mapTx GUARDED_BY(cs);
+    mutable CCriticalSection cs_txMemPool;
+    indexed_transaction_set mapTx GUARDED_BY(cs_txMemPool);
 
     typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
-    std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
+    std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs_txMemPool); //!< All tx witness hashes/entries in mapTx, in random order
 
     struct CompareIteratorByHash {
         bool operator()(const txiter &a, const txiter &b) const {
@@ -493,8 +493,8 @@ private:
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const;
 
 public:
-    indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
-    std::map<uint256, CAmount> mapDeltas GUARDED_BY(cs);
+    indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs_txMemPool);
+    std::map<uint256, CAmount> mapDeltas GUARDED_BY(cs_txMemPool);
 
     /** Create a new CTxMemPool.
      */
@@ -602,19 +602,19 @@ public:
 
     unsigned long size()
     {
-        LOCK(cs);
+        LOCK(cs_txMemPool);
         return mapTx.size();
     }
 
     uint64_t GetTotalTxSize() const
     {
-        LOCK(cs);
+        LOCK(cs_txMemPool);
         return totalTxSize;
     }
 
     bool exists(uint256 hash) const
     {
-        LOCK(cs);
+        LOCK(cs_txMemPool);
         return (mapTx.count(hash) != 0);
     }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -412,7 +412,7 @@ public:
 class CTxMemPool
 {
 private:
-    uint32_t nCheckFrequency; //!< Value n means that n times in 2^32 we check.
+    uint32_t nCheckFrequency GUARDED_BY(cs_txMemPool); //!< Value n means that n times in 2^32 we check.
     unsigned int nTransactionsUpdated GUARDED_BY(cs_txMemPool); //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
     CBlockPolicyEstimator* minerPolicyEstimator PT_GUARDED_BY(cs_txMemPool);
 
@@ -507,7 +507,7 @@ public:
      * check does nothing.
      */
     void check(const CCoinsViewCache *pcoins) const;
-    void setSanityCheck(double dFrequency = 1.0) { nCheckFrequency = static_cast<uint32_t>(dFrequency * 4294967295.0); }
+    void setSanityCheck(double dFrequency = 1.0) { LOCK(cs_txMemPool); nCheckFrequency = static_cast<uint32_t>(dFrequency * 4294967295.0); }
 
     // addUnchecked must updated state for all ancestors of a given transaction,
     // to track size/count of descendant transactions.  First version of

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -414,7 +414,7 @@ class CTxMemPool
 private:
     uint32_t nCheckFrequency GUARDED_BY(cs_txMemPool); //!< Value n means that n times in 2^32 we check.
     unsigned int nTransactionsUpdated GUARDED_BY(cs_txMemPool); //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* minerPolicyEstimator PT_GUARDED_BY(cs_txMemPool);
+    CBlockPolicyEstimator* minerPolicyEstimator GUARDED_BY(cs_txMemPool);
 
     uint64_t totalTxSize GUARDED_BY(cs_txMemPool); //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage GUARDED_BY(cs_txMemPool); //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -413,10 +413,10 @@ class CTxMemPool
 {
 private:
     uint32_t nCheckFrequency; //!< Value n means that n times in 2^32 we check.
-    unsigned int nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
+    unsigned int nTransactionsUpdated GUARDED_BY(cs); //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
     CBlockPolicyEstimator* minerPolicyEstimator;
 
-    uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
+    uint64_t totalTxSize GUARDED_BY(cs); //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
     mutable int64_t lastRollingFeeUpdate;
@@ -462,10 +462,10 @@ public:
     > indexed_transaction_set;
 
     mutable CCriticalSection cs;
-    indexed_transaction_set mapTx;
+    indexed_transaction_set mapTx GUARDED_BY(cs);
 
     typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
-    std::vector<std::pair<uint256, txiter> > vTxHashes; //!< All tx witness hashes/entries in mapTx, in random order
+    std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
 
     struct CompareIteratorByHash {
         bool operator()(const txiter &a, const txiter &b) const {
@@ -493,8 +493,8 @@ private:
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const;
 
 public:
-    indirectmap<COutPoint, const CTransaction*> mapNextTx;
-    std::map<uint256, CAmount> mapDeltas;
+    indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
+    std::map<uint256, CAmount> mapDeltas GUARDED_BY(cs);
 
     /** Create a new CTxMemPool.
      */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -414,14 +414,14 @@ class CTxMemPool
 private:
     uint32_t nCheckFrequency; //!< Value n means that n times in 2^32 we check.
     unsigned int nTransactionsUpdated GUARDED_BY(cs_txMemPool); //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* minerPolicyEstimator;
+    CBlockPolicyEstimator* minerPolicyEstimator PT_GUARDED_BY(cs_txMemPool);
 
     uint64_t totalTxSize GUARDED_BY(cs_txMemPool); //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
-    uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
+    uint64_t cachedInnerUsage GUARDED_BY(cs_txMemPool); //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
 
-    mutable int64_t lastRollingFeeUpdate;
-    mutable bool blockSinceLastRollingFeeBump;
-    mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
+    mutable int64_t lastRollingFeeUpdate GUARDED_BY(cs_txMemPool);
+    mutable bool blockSinceLastRollingFeeBump GUARDED_BY(cs_txMemPool);
+    mutable double rollingMinimumFeeRate GUARDED_BY(cs_txMemPool); //!< minimum fee to get into the pool, decreases exponentially
 
     void trackPackageRemoved(const CFeeRate& rate);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -562,9 +562,9 @@ fs::path GetDefaultDataDir()
 #endif
 }
 
-static fs::path pathCached;
-static fs::path pathCachedNetSpecific;
 static CCriticalSection csPathCached;
+static fs::path pathCached GUARDED_BY(csPathCached);
+static fs::path pathCachedNetSpecific GUARDED_BY(csPathCached);
 
 const fs::path &GetDataDir(bool fNetSpecific)
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -106,6 +106,10 @@ std::atomic<uint32_t> logCategories(0);
 
 /** Init OpenSSL library multithreading support */
 static std::unique_ptr<CCriticalSection[]> ppmutexOpenSSL;
+
+// NO_THREAD_SAFETY_ANALYSIS: Intentionally silencing the following warnings:
+// * error: releasing mutex 'operator[](ppmutexOpenSSL, i)' that was not held [-Werror,-Wthread-safety-analysis]
+// * error: mutex 'operator[](ppmutexOpenSSL, i)' is not held on every path through here [-Werror,-Wthread-safety-analysis]
 void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
 {
     if (mode & CRYPTO_LOCK) {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -562,14 +562,14 @@ fs::path GetDefaultDataDir()
 #endif
 }
 
-static CCriticalSection csPathCached;
-static fs::path pathCached GUARDED_BY(csPathCached);
-static fs::path pathCachedNetSpecific GUARDED_BY(csPathCached);
+static CCriticalSection cs_pathCached;
+static fs::path pathCached GUARDED_BY(cs_pathCached);
+static fs::path pathCachedNetSpecific GUARDED_BY(cs_pathCached);
 
 const fs::path &GetDataDir(bool fNetSpecific)
 {
 
-    LOCK(csPathCached);
+    LOCK(cs_pathCached);
 
     fs::path &path = fNetSpecific ? pathCachedNetSpecific : pathCached;
 
@@ -600,7 +600,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
 
 void ClearDatadirCache()
 {
-    LOCK(csPathCached);
+    LOCK(cs_pathCached);
 
     pathCached = fs::path();
     pathCachedNetSpecific = fs::path();

--- a/src/util.h
+++ b/src/util.h
@@ -199,8 +199,8 @@ class ArgsManager
 {
 protected:
     mutable CCriticalSection cs_args;
-    std::map<std::string, std::string> mapArgs;
-    std::map<std::string, std::vector<std::string>> mapMultiArgs;
+    std::map<std::string, std::string> mapArgs GUARDED_BY(cs_args);
+    std::map<std::string, std::vector<std::string>> mapMultiArgs GUARDED_BY(cs_args);
 public:
     void ParseParameters(int argc, const char*const argv[]);
     void ReadConfigFile(const std::string& confPath);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2727,8 +2727,11 @@ static bool ReceivedBlockTransactions(const CBlock &block, CValidationState& sta
                 LOCK(cs_nBlockSequenceId);
                 pindex->nSequenceId = nBlockSequenceId++;
             }
-            if (chainActive.Tip() == nullptr || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip())) {
-                setBlockIndexCandidates.insert(pindex);
+            {
+                LOCK(cs_main);
+                if (chainActive.Tip() == nullptr || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip())) {
+                    setBlockIndexCandidates.insert(pindex);
+                }
             }
             std::pair<std::multimap<CBlockIndex*, CBlockIndex*>::iterator, std::multimap<CBlockIndex*, CBlockIndex*>::iterator> range = mapBlocksUnlinked.equal_range(pindex);
             while (range.first != range.second) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3265,6 +3265,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
         return AbortNode(state, std::string("System error: ") + e.what());
     }
 
+    LOCK(cs_LastBlockFile);
     if (fCheckForPruning)
         FlushStateToDisk(chainparams, state, FLUSH_STATE_NONE); // we just allocated more disk space for block files
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -137,7 +137,7 @@ namespace {
 
     CCriticalSection cs_LastBlockFile;
     std::vector<CBlockFileInfo> vinfoBlockFile;
-    int nLastBlockFile = 0; // GUARDED_BY(cs_LastBlockFile)
+    int nLastBlockFile GUARDED_BY(cs_LastBlockFile) = 0;
     /** Global flag to indicate we should check to see if there are
      *  block/undo files that should be deleted.  Set on startup
      *  or if we allocate more file space when we're in prune mode
@@ -3963,7 +3963,7 @@ bool RewindBlockIndex(const CChainParams& params)
 // May NOT be used after any connections are up as much
 // of the peer-processing logic assumes a consistent
 // block index state
-void UnloadBlockIndex()
+void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     LOCK(cs_main);
     setBlockIndexCandidates.clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -150,7 +150,7 @@ namespace {
      */
     CCriticalSection cs_nBlockSequenceId;
     /** Blocks loaded from disk are assigned id 0, so start the counter at 1. */
-    int32_t nBlockSequenceId = 1;
+    int32_t nBlockSequenceId GUARDED_BY(cs_nBlockSequenceId) = 1;
     /** Decreasing counter (used by subsequent preciousblock calls). */
     int32_t nBlockReverseSequenceId = -1;
     /** chainwork for the last block that preciousblock has been applied to. */
@@ -3963,7 +3963,7 @@ bool RewindBlockIndex(const CChainParams& params)
 // May NOT be used after any connections are up as much
 // of the peer-processing logic assumes a consistent
 // block index state
-void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
+void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile, cs_nBlockSequenceId)
 {
     LOCK(cs_main);
     setBlockIndexCandidates.clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1242,10 +1242,10 @@ int GetSpendHeight(const CCoinsViewCache& inputs)
 }
 
 
-static CuckooCache::cache<uint256, SignatureCacheHasher> scriptExecutionCache;
+static CuckooCache::cache<uint256, SignatureCacheHasher> scriptExecutionCache GUARDED_BY(cs_main);
 static uint256 scriptExecutionCacheNonce(GetRandHash());
 
-void InitScriptExecutionCache() {
+void InitScriptExecutionCache() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
     // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = std::min(std::max((int64_t)0, gArgs.GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
@@ -1272,7 +1272,7 @@ void InitScriptExecutionCache() {
  *
  * Non-static (and re-declared) in src/test/txvalidationcache_tests.cpp
  */
-bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks)
+bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsViewCache &inputs, bool fScriptChecks, unsigned int flags, bool cacheSigStore, bool cacheFullScriptStore, PrecomputedTransactionData& txdata, std::vector<CScriptCheck> *pvChecks) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (!tx.IsCoinBase())
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1612,7 +1612,7 @@ public:
 // Protected by cs_main
 static ThresholdConditionCache warningcache[VERSIONBITS_NUM_BITS] GUARDED_BY(cs_main);
 
-static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& consensusparams) {
+static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& consensusparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     AssertLockHeld(cs_main);
 
     unsigned int flags = SCRIPT_VERIFY_NONE;
@@ -3026,7 +3026,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
  *  in ConnectBlock().
  *  Note that -reindex-chainstate skips the validation that happens here!
  */
-static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)
+static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -137,7 +137,7 @@ namespace {
 
     CCriticalSection cs_LastBlockFile;
     std::vector<CBlockFileInfo> vinfoBlockFile;
-    int nLastBlockFile = 0;
+    int nLastBlockFile = 0; // GUARDED_BY(cs_LastBlockFile)
     /** Global flag to indicate we should check to see if there are
      *  block/undo files that should be deleted.  Set on startup
      *  or if we allocate more file space when we're in prune mode
@@ -3544,7 +3544,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
     return pindexNew;
 }
 
-bool static LoadBlockIndexDB(const CChainParams& chainparams)
+bool static LoadBlockIndexDB(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     LOCK(cs_main);
     if (!pblocktree->LoadBlockIndexGuts(chainparams.GetConsensus(), InsertBlockIndex))
@@ -3996,7 +3996,7 @@ void UnloadBlockIndex()
     fHavePruned = false;
 }
 
-bool LoadBlockIndex(const CChainParams& chainparams)
+bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
 {
     // Load block index from databases
     bool needs_init = fReindex;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -138,7 +138,7 @@ namespace {
      */
     std::multimap<CBlockIndex*, CBlockIndex*> mapBlocksUnlinked;
 
-    std::vector<CBlockFileInfo> vinfoBlockFile;
+    std::vector<CBlockFileInfo> vinfoBlockFile GUARDED_BY(cs_LastBlockFile);
     int nLastBlockFile GUARDED_BY(cs_LastBlockFile) = 0;
     /** Global flag to indicate we should check to see if there are
      *  block/undo files that should be deleted.  Set on startup
@@ -3973,10 +3973,10 @@ void UnloadBlockIndex()
     pindexBestHeader = nullptr;
     mempool.clear();
     mapBlocksUnlinked.clear();
-    vinfoBlockFile.clear();
     {
         LOCK(cs_LastBlockFile); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
         nLastBlockFile = 0;
+        vinfoBlockFile.clear();
     }
     {
         LOCK(cs_nBlockSequenceId); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1252,7 +1252,7 @@ void InitScriptExecutionCache() {
     size_t nMaxCacheSize = std::min(std::max((int64_t)0, gArgs.GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
     size_t nElems;
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
         nElems = scriptExecutionCache.setup_bytes(nMaxCacheSize);
     }
     LogPrintf("Using %zu MiB out of %zu/2 requested for script execution cache, able to store %zu elements\n",
@@ -2032,7 +2032,7 @@ void FlushStateToDisk() {
 void PruneAndFlush() {
     CValidationState state;
     {
-        LOCK(cs_LastBlockFile);
+        LOCK(cs_LastBlockFile); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
         fCheckForPruning = true;
     }
     const CChainParams& chainparams = Params();
@@ -3265,9 +3265,8 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
         return AbortNode(state, std::string("System error: ") + e.what());
     }
 
-    LOCK(cs_LastBlockFile);
-    if (fCheckForPruning)
-        FlushStateToDisk(chainparams, state, FLUSH_STATE_NONE); // we just allocated more disk space for block files
+    // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11617/files
+    FlushStateToDisk(chainparams, state, FLUSH_STATE_NONE); // we just allocated more disk space for block files
 
     return true;
 }
@@ -3548,7 +3547,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 
 bool static LoadBlockIndexDB(const CChainParams& chainparams)
 {
-    LOCK(cs_main);
+    LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
     if (!pblocktree->LoadBlockIndexGuts(chainparams.GetConsensus(), InsertBlockIndex))
         return false;
 
@@ -3596,7 +3595,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
             pindexBestHeader = pindex;
     }
 
-    LOCK(cs_LastBlockFile);
+    LOCK(cs_LastBlockFile); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
     // Load block file info
     pblocktree->ReadLastBlockFile(nLastBlockFile);
     vinfoBlockFile.resize(nLastBlockFile + 1);
@@ -3651,7 +3650,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams)
 
 bool LoadChainTip(const CChainParams& chainparams)
 {
-    LOCK(cs_main);
+    LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
     if (chainActive.Tip() && chainActive.Tip()->GetBlockHash() == pcoinsTip->GetBestBlock()) return true;
 
     if (pcoinsTip->GetBestBlock().IsNull() && mapBlockIndex.size() == 1) {
@@ -3976,11 +3975,11 @@ void UnloadBlockIndex()
     mapBlocksUnlinked.clear();
     vinfoBlockFile.clear();
     {
-        LOCK(cs_LastBlockFile);
+        LOCK(cs_LastBlockFile); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
         nLastBlockFile = 0;
     }
     {
-        LOCK(cs_nBlockSequenceId);
+        LOCK(cs_nBlockSequenceId); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11652/files
         nBlockSequenceId = 1;
     }
     setDirtyBlockIndex.clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -62,7 +62,7 @@
 
 CCriticalSection cs_main;
 
-BlockMap mapBlockIndex;
+BlockMap mapBlockIndex GUARDED_BY(cs_main);
 CChain chainActive;
 CBlockIndex *pindexBestHeader = nullptr;
 CWaitableCriticalSection csBestBlock;
@@ -183,7 +183,7 @@ namespace {
     std::set<int> setDirtyFileInfo;
 } // anon namespace
 
-CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
+CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Find the first block the caller has in the main chain
     for (const uint256& hash : locator.vHave) {
@@ -2664,7 +2664,7 @@ bool ResetBlockFailureFlags(CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_mai
     return true;
 }
 
-static CBlockIndex* AddToBlockIndex(const CBlockHeader& block)
+static CBlockIndex* AddToBlockIndex(const CBlockHeader& block) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // Check for duplicate
     uint256 hash = block.GetHash();
@@ -3107,7 +3107,7 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     return true;
 }
 
-static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex)
+static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     // Check for duplicate
@@ -3345,7 +3345,7 @@ uint64_t CalculateCurrentUsage()
 }
 
 /* Prune a block file (modify associated database entries)*/
-void PruneOneBlockFile(const int fileNumber)
+void PruneOneBlockFile(const int fileNumber) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     LOCK(cs_LastBlockFile);
 
@@ -3529,7 +3529,7 @@ fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix)
     return GetDataDir() / "blocks" / strprintf("%s%05u.dat", prefix, pos.nFile);
 }
 
-CBlockIndex * InsertBlockIndex(uint256 hash)
+CBlockIndex * InsertBlockIndex(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (hash.IsNull())
         return nullptr;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -64,7 +64,7 @@ CCriticalSection cs_main;
 
 BlockMap mapBlockIndex GUARDED_BY(cs_main);
 CChain chainActive;
-CBlockIndex *pindexBestHeader = nullptr;
+CBlockIndex *pindexBestHeader PT_GUARDED_BY(cs_main) = nullptr;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
 int nScriptCheckThreads = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1568,7 +1568,7 @@ void ThreadScriptCheck() {
 }
 
 // Protected by cs_main
-VersionBitsCache versionbitscache;
+VersionBitsCache versionbitscache GUARDED_BY(cs_main);
 
 int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)
 {
@@ -1610,7 +1610,7 @@ public:
 };
 
 // Protected by cs_main
-static ThresholdConditionCache warningcache[VERSIONBITS_NUM_BITS];
+static ThresholdConditionCache warningcache[VERSIONBITS_NUM_BITS] GUARDED_BY(cs_main);
 
 static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& consensusparams) {
     AssertLockHeld(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1661,7 +1661,7 @@ static int64_t nBlocksTotal = 0;
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()
  *  can fail if those validity checks fail (among other reasons). */
 static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pindex,
-                  CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck = false)
+                         CCoinsViewCache& view, const CChainParams& chainparams, bool fJustCheck = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     assert(pindex);
@@ -3302,7 +3302,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
     return true;
 }
 
-bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot)
+bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     assert(pindexPrev && pindexPrev == chainActive.Tip());
@@ -3544,7 +3544,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash)
     return pindexNew;
 }
 
-bool static LoadBlockIndexDB(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
+bool static LoadBlockIndexDB(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_LastBlockFile)
 {
     LOCK(cs_main);
     if (!pblocktree->LoadBlockIndexGuts(chainparams.GetConsensus(), InsertBlockIndex))
@@ -3996,7 +3996,7 @@ void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile, cs_nBlockSequ
     fHavePruned = false;
 }
 
-bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
+bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile, cs_main)
 {
     // Load block index from databases
     bool needs_init = fReindex;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1246,7 +1246,7 @@ int GetSpendHeight(const CCoinsViewCache& inputs)
 static CuckooCache::cache<uint256, SignatureCacheHasher> scriptExecutionCache GUARDED_BY(cs_main);
 static uint256 scriptExecutionCacheNonce(GetRandHash());
 
-void InitScriptExecutionCache() EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
+void InitScriptExecutionCache() {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
     // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = std::min(std::max((int64_t)0, gArgs.GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
@@ -2029,7 +2029,7 @@ void FlushStateToDisk() {
     FlushStateToDisk(chainparams, state, FLUSH_STATE_ALWAYS);
 }
 
-void PruneAndFlush() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile) {
+void PruneAndFlush() {
     CValidationState state;
     {
         LOCK(cs_LastBlockFile);
@@ -3546,7 +3546,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return pindexNew;
 }
 
-bool static LoadBlockIndexDB(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_LastBlockFile)
+bool static LoadBlockIndexDB(const CChainParams& chainparams)
 {
     LOCK(cs_main);
     if (!pblocktree->LoadBlockIndexGuts(chainparams.GetConsensus(), InsertBlockIndex))
@@ -3649,7 +3649,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams) EXCLUSIVE_LOCKS_RE
     return true;
 }
 
-bool LoadChainTip(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool LoadChainTip(const CChainParams& chainparams)
 {
     LOCK(cs_main);
     if (chainActive.Tip() && chainActive.Tip()->GetBlockHash() == pcoinsTip->GetBestBlock()) return true;
@@ -3965,7 +3965,7 @@ bool RewindBlockIndex(const CChainParams& params)
 // May NOT be used after any connections are up as much
 // of the peer-processing logic assumes a consistent
 // block index state
-void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile, cs_nBlockSequenceId)
+void UnloadBlockIndex()
 {
     LOCK(cs_main);
     setBlockIndexCandidates.clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -64,7 +64,7 @@ CCriticalSection cs_main;
 
 BlockMap mapBlockIndex GUARDED_BY(cs_main);
 CChain chainActive;
-CBlockIndex *pindexBestHeader PT_GUARDED_BY(cs_main) = nullptr;
+CBlockIndex *pindexBestHeader GUARDED_BY(cs_main) = nullptr;
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
 int nScriptCheckThreads = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3271,7 +3271,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
 {
     {
         CBlockIndex *pindex = nullptr;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4102,25 +4102,28 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                 nRewind = blkdat.GetPos();
 
                 // detect out of order blocks, and store them for later
-                uint256 hash = block.GetHash();
-                if (hash != chainparams.GetConsensus().hashGenesisBlock && mapBlockIndex.find(block.hashPrevBlock) == mapBlockIndex.end()) {
-                    LogPrint(BCLog::REINDEX, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
-                            block.hashPrevBlock.ToString());
-                    if (dbp)
-                        mapBlocksUnknownParent.insert(std::make_pair(block.hashPrevBlock, *dbp));
-                    continue;
-                }
-
-                // process in case the block isn't known yet
-                if (mapBlockIndex.count(hash) == 0 || (mapBlockIndex[hash]->nStatus & BLOCK_HAVE_DATA) == 0) {
+                uint256 hash;
+                {
                     LOCK(cs_main);
-                    CValidationState state;
-                    if (AcceptBlock(pblock, state, chainparams, nullptr, true, dbp, nullptr))
-                        nLoaded++;
-                    if (state.IsError())
-                        break;
-                } else if (hash != chainparams.GetConsensus().hashGenesisBlock && mapBlockIndex[hash]->nHeight % 1000 == 0) {
-                    LogPrint(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), mapBlockIndex[hash]->nHeight);
+                    hash = block.GetHash();
+                    if (hash != chainparams.GetConsensus().hashGenesisBlock && mapBlockIndex.find(block.hashPrevBlock) == mapBlockIndex.end()) {
+                        LogPrint(BCLog::REINDEX, "%s: Out of order block %s, parent %s not known\n", __func__, hash.ToString(),
+                                 block.hashPrevBlock.ToString());
+                        if (dbp)
+                            mapBlocksUnknownParent.insert(std::make_pair(block.hashPrevBlock, *dbp));
+                        continue;
+                    }
+
+                    // process in case the block isn't known yet
+                    if (mapBlockIndex.count(hash) == 0 || (mapBlockIndex[hash]->nStatus & BLOCK_HAVE_DATA) == 0) {
+                        CValidationState state;
+                        if (AcceptBlock(pblock, state, chainparams, nullptr, true, dbp, nullptr))
+                            nLoaded++;
+                        if (state.IsError())
+                            break;
+                    } else if (hash != chainparams.GetConsensus().hashGenesisBlock && mapBlockIndex[hash]->nHeight % 1000 == 0) {
+                        LogPrint(BCLog::REINDEX, "Block Import: already had block %s at height %d\n", hash.ToString(), mapBlockIndex[hash]->nHeight);
+                    }
                 }
 
                 // Activate the genesis block so normal node progress can continue

--- a/src/validation.h
+++ b/src/validation.h
@@ -444,7 +444,7 @@ bool ResetBlockFailureFlags(CBlockIndex *pindex);
 extern CChain chainActive;
 
 /** Global variable that points to the coins database (protected by cs_main) */
-extern std::unique_ptr<CCoinsViewDB> pcoinsdbview;
+extern std::unique_ptr<CCoinsViewDB> pcoinsdbview PT_GUARDED_BY(cs_main);
 
 /** Global variable that points to the active CCoinsView (protected by cs_main) */
 extern std::unique_ptr<CCoinsViewCache> pcoinsTip;

--- a/src/validation.h
+++ b/src/validation.h
@@ -450,7 +450,7 @@ extern std::unique_ptr<CCoinsViewDB> pcoinsdbview PT_GUARDED_BY(cs_main);
 extern std::unique_ptr<CCoinsViewCache> pcoinsTip PT_GUARDED_BY(cs_main);
 
 /** Global variable that points to the active block tree (protected by cs_main) */
-extern std::unique_ptr<CBlockTreeDB> pblocktree;
+extern std::unique_ptr<CBlockTreeDB> pblocktree PT_GUARDED_BY(cs_main);
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().

--- a/src/validation.h
+++ b/src/validation.h
@@ -266,11 +266,11 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
 bool LoadGenesisBlock(const CChainParams& chainparams);
 /** Load the block tree and coins database from disk,
  * initializing state if we're running with -reindex. */
-bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile, cs_main);
+bool LoadBlockIndex(const CChainParams& chainparams);
 /** Update the chain tip based on database information. */
-bool LoadChainTip(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+bool LoadChainTip(const CChainParams& chainparams);
 /** Unload database information */
-void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile, cs_nBlockSequenceId);
+void UnloadBlockIndex();
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
@@ -302,7 +302,7 @@ CBlockIndex * InsertBlockIndex(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
 /** Prune block files and flush state to disk. */
-void PruneAndFlush() EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile);
+void PruneAndFlush();
 /** Prune block files up to a given height */
 void PruneBlockFilesManual(int nManualPruneHeight);
 
@@ -393,7 +393,7 @@ public:
 };
 
 /** Initializes the script-execution cache */
-void InitScriptExecutionCache() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+void InitScriptExecutionCache();
 
 
 /** Functions for disk access for blocks */

--- a/src/validation.h
+++ b/src/validation.h
@@ -447,7 +447,7 @@ extern CChain chainActive;
 extern std::unique_ptr<CCoinsViewDB> pcoinsdbview PT_GUARDED_BY(cs_main);
 
 /** Global variable that points to the active CCoinsView (protected by cs_main) */
-extern std::unique_ptr<CCoinsViewCache> pcoinsTip;
+extern std::unique_ptr<CCoinsViewCache> pcoinsTip PT_GUARDED_BY(cs_main);
 
 /** Global variable that points to the active block tree (protected by cs_main) */
 extern std::unique_ptr<CBlockTreeDB> pblocktree;

--- a/src/validation.h
+++ b/src/validation.h
@@ -459,7 +459,7 @@ extern std::unique_ptr<CBlockTreeDB> pblocktree PT_GUARDED_BY(cs_main);
  */
 int GetSpendHeight(const CCoinsViewCache& inputs);
 
-extern VersionBitsCache versionbitscache;
+extern VersionBitsCache versionbitscache GUARDED_BY(cs_main);
 
 /**
  * Determine what nVersion a new block should use.

--- a/src/validation.h
+++ b/src/validation.h
@@ -189,7 +189,7 @@ extern uint256 hashAssumeValid;
 extern arith_uint256 nMinimumChainWork;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
-extern CBlockIndex *pindexBestHeader PT_GUARDED_BY(cs_main);
+extern CBlockIndex *pindexBestHeader GUARDED_BY(cs_main);
 
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;
@@ -447,13 +447,13 @@ bool ResetBlockFailureFlags(CBlockIndex *pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_mai
 extern CChain chainActive GUARDED_BY(cs_main);
 
 /** Global variable that points to the coins database (protected by cs_main) */
-extern std::unique_ptr<CCoinsViewDB> pcoinsdbview PT_GUARDED_BY(cs_main);
+extern std::unique_ptr<CCoinsViewDB> pcoinsdbview GUARDED_BY(cs_main);
 
 /** Global variable that points to the active CCoinsView (protected by cs_main) */
-extern std::unique_ptr<CCoinsViewCache> pcoinsTip PT_GUARDED_BY(cs_main);
+extern std::unique_ptr<CCoinsViewCache> pcoinsTip GUARDED_BY(cs_main);
 
 /** Global variable that points to the active block tree (protected by cs_main) */
-extern std::unique_ptr<CBlockTreeDB> pblocktree PT_GUARDED_BY(cs_main);
+extern std::unique_ptr<CBlockTreeDB> pblocktree GUARDED_BY(cs_main);
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().

--- a/src/validation.h
+++ b/src/validation.h
@@ -159,7 +159,7 @@ extern CCriticalSection cs_main;
 extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
 typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
-extern BlockMap mapBlockIndex;
+extern BlockMap mapBlockIndex GUARDED_BY(cs_main);
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockWeight;
 extern const std::string strMessageMagic;

--- a/src/validation.h
+++ b/src/validation.h
@@ -189,7 +189,7 @@ extern uint256 hashAssumeValid;
 extern arith_uint256 nMinimumChainWork;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
-extern CBlockIndex *pindexBestHeader;
+extern CBlockIndex *pindexBestHeader PT_GUARDED_BY(cs_main);
 
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;

--- a/src/validation.h
+++ b/src/validation.h
@@ -441,7 +441,7 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
 bool ResetBlockFailureFlags(CBlockIndex *pindex);
 
 /** The currently-connected chain of blocks (protected by cs_main). */
-extern CChain chainActive;
+extern CChain chainActive GUARDED_BY(cs_main);
 
 /** Global variable that points to the coins database (protected by cs_main) */
 extern std::unique_ptr<CCoinsViewDB> pcoinsdbview PT_GUARDED_BY(cs_main);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -132,7 +132,7 @@ protected:
     bool EncryptKeys(CKeyingMaterial& vMasterKeyIn);
 
     bool Unlock(const CKeyingMaterial& vMasterKeyIn);
-    CryptedKeyMap mapCryptedKeys;
+    CryptedKeyMap mapCryptedKeys GUARDED_BY(cs_KeyStore);
 
 public:
     CCryptoKeyStore() : fUseCrypto(false), fDecryptionThoroughlyChecked(false)

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -116,7 +116,7 @@ class CCryptoKeyStore : public CBasicKeyStore
 {
 private:
 
-    CKeyingMaterial vMasterKey;
+    CKeyingMaterial vMasterKey GUARDED_BY(cs_KeyStore);
 
     //! if fUseCrypto is true, mapKeys must be empty
     //! if fUseCrypto is false, vMasterKey must be empty

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -31,7 +31,7 @@ namespace {
 //! (https://docs.oracle.com/cd/E17275_01/html/programmer_reference/program_copy.html),
 //! so bitcoin should never create different databases with the same fileid, but
 //! this error can be triggered if users manually copy database files.
-void CheckUniqueFileid(const CDBEnv& env, const std::string& filename, Db& db)
+void CheckUniqueFileid(const CDBEnv& env, const std::string& filename, Db& db) EXCLUSIVE_LOCKS_REQUIRED(env.cs_db)
 {
     if (env.IsMock()) return;
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -639,7 +639,7 @@ bool CDB::PeriodicFlush(CWalletDBWrapper& dbw)
     bool ret = false;
     CDBEnv *env = dbw.env;
     const std::string& strFile = dbw.strFile;
-    TRY_LOCK(bitdb.cs_db,lockDb);
+    TRY_LOCK(env->cs_db, lockDb);
     if (lockDb)
     {
         // Don't do this if any databases are in use

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -37,8 +37,8 @@ private:
 public:
     mutable CCriticalSection cs_db;
     std::unique_ptr<DbEnv> dbenv;
-    std::map<std::string, int> mapFileUseCount;
-    std::map<std::string, Db*> mapDb;
+    std::map<std::string, int> mapFileUseCount GUARDED_BY(cs_db);
+    std::map<std::string, Db*> mapDb GUARDED_BY(cs_db);
 
     CDBEnv();
     ~CDBEnv();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -45,7 +45,7 @@ static int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWalle
 
 //! Check whether transaction has descendant in wallet or mempool, or has been
 //! mined, or conflicts with a mined transaction. Return a feebumper::Result.
-static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWalletTx& wtx, std::vector<std::string>& errors) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pWallet->cs_wallet)
+static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWalletTx& wtx, std::vector<std::string>& errors) EXCLUSIVE_LOCKS_REQUIRED(cs_main, wallet->cs_wallet)
 {
     if (wallet->HasWalletSpend(wtx.GetHash())) {
         errors.push_back("Transaction has descendants in the wallet");

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -23,7 +23,7 @@
 // calculation, but we should be able to refactor after priority is removed).
 // NOTE: this requires that all inputs must be in mapWallet (eg the tx should
 // be IsAllFromMe).
-static int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet)
+static int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet) EXCLUSIVE_LOCKS_REQUIRED(wallet->cs_wallet)
 {
     CMutableTransaction txNew(tx);
     std::vector<CInputCoin> vCoins;

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -45,7 +45,7 @@ static int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWalle
 
 //! Check whether transaction has descendant in wallet or mempool, or has been
 //! mined, or conflicts with a mined transaction. Return a feebumper::Result.
-static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWalletTx& wtx, std::vector<std::string>& errors) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWalletTx& wtx, std::vector<std::string>& errors) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pWallet->cs_wallet)
 {
     if (wallet->HasWalletSpend(wtx.GetHash())) {
         errors.push_back("Transaction has descendants in the wallet");

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -45,7 +45,7 @@ static int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWalle
 
 //! Check whether transaction has descendant in wallet or mempool, or has been
 //! mined, or conflicts with a mined transaction. Return a feebumper::Result.
-static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWalletTx& wtx, std::vector<std::string>& errors)
+static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWalletTx& wtx, std::vector<std::string>& errors) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (wallet->HasWalletSpend(wtx.GetHash())) {
         errors.push_back("Transaction has descendants in the wallet");

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -53,7 +53,7 @@ static feebumper::Result PreconditionChecks(const CWallet* wallet, const CWallet
     }
 
     {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         auto it_mp = mempool.mapTx.find(wtx.GetHash());
         if (it_mp != mempool.mapTx.end() && it_mp->GetCountWithDescendants() > 1) {
             errors.push_back("Transaction has descendants in the mempool");

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -251,7 +251,7 @@ bool VerifyWallets()
     return true;
 }
 
-bool OpenWallets()
+bool OpenWallets() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         LogPrintf("Wallet disabled!\n");
@@ -269,7 +269,7 @@ bool OpenWallets()
     return true;
 }
 
-void StartWallets(CScheduler& scheduler) {
+void StartWallets(CScheduler& scheduler) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     for (CWalletRef pwallet : vpwallets) {
         pwallet->postInitProcess(scheduler);
     }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -182,7 +182,7 @@ UniValue abortrescan(const JSONRPCRequest& request)
 }
 
 void ImportAddress(CWallet*, const CTxDestination& dest, const std::string& strLabel);
-void ImportScript(CWallet* const pwallet, const CScript& script, const std::string& strLabel, bool isRedeemScript)
+void ImportScript(CWallet* const pwallet, const CScript& script, const std::string& strLabel, bool isRedeemScript) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     if (!isRedeemScript && ::IsMine(*pwallet, script) == ISMINE_SPENDABLE) {
         throw JSONRPCError(RPC_WALLET_ERROR, "The wallet already contains the private key for this address or script");
@@ -207,7 +207,7 @@ void ImportScript(CWallet* const pwallet, const CScript& script, const std::stri
     }
 }
 
-void ImportAddress(CWallet* const pwallet, const CTxDestination& dest, const std::string& strLabel)
+void ImportAddress(CWallet* const pwallet, const CTxDestination& dest, const std::string& strLabel) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     CScript script = GetScriptForDestination(dest);
     ImportScript(pwallet, script, strLabel, false);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -704,7 +704,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 }
 
 
-UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int64_t timestamp)
+UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     try {
         bool success = false;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1338,7 +1338,7 @@ struct tallyitem
     }
 };
 
-UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByAccounts)
+UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByAccounts) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     // Minimum confirmations
     int nMinDepth = 1;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1569,7 +1569,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
  * @param  ret        The UniValue into which the result is stored.
  * @param  filter     The "is mine" filter bool.
  */
-void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwallet->cs_wallet)
 {
     CAmount nFee;
     std::string strSentAccount;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -175,7 +175,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
 }
 
 
-CTxDestination GetAccountAddress(CWallet* const pwallet, std::string strAccount, bool bForceNew=false)
+CTxDestination GetAccountAddress(CWallet* const pwallet, std::string strAccount, bool bForceNew=false) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     CPubKey pubKey;
     if (!pwallet->GetAccountPubkey(pubKey, strAccount, bForceNew)) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -108,7 +108,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     // Add opt-in RBF status
     std::string rbfStatus = "no";
     if (confirms <= 0) {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         RBFTransactionState rbfState = IsRBFOptIn(*wtx.tx, mempool);
         if (rbfState == RBF_TRANSACTIONSTATE_UNKNOWN)
             rbfStatus = "unknown";

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1338,7 +1338,7 @@ struct tallyitem
     }
 };
 
-UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByAccounts) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool fByAccounts) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwallet->cs_wallet)
 {
     // Minimum confirmations
     int nMinDepth = 1;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -82,7 +82,7 @@ void EnsureWalletIsUnlocked(CWallet * const pwallet)
     }
 }
 
-void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
+void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     int confirms = wtx.GetDepthInMainChain();
     entry.push_back(Pair("confirmations", confirms));
@@ -1569,7 +1569,7 @@ static void MaybePushAddress(UniValue & entry, const CTxDestination &dest)
  * @param  ret        The UniValue into which the result is stored.
  * @param  filter     The "is mine" filter bool.
  */
-void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter)
+void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::string& strAccount, int nMinDepth, bool fLong, UniValue& ret, const isminefilter& filter) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     CAmount nFee;
     std::string strSentAccount;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -616,7 +616,7 @@ public:
         ::bitdb.Reset();
     }
 
-    CWalletTx& AddTx(CRecipient recipient)
+    CWalletTx& AddTx(CRecipient recipient) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     {
         CWalletTx wtx;
         CReserveKey reservekey(wallet.get());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3199,7 +3199,7 @@ bool CWallet::DelAddressBook(const CTxDestination& address)
     return CWalletDB(*dbw).EraseName(EncodeDestination(address));
 }
 
-const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const
+const std::string& CWallet::GetAccountName(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     CTxDestination address;
     if (ExtractDestination(scriptPubKey, address) && !scriptPubKey.IsUnspendable()) {
@@ -3804,7 +3804,7 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const EXCLUSIVE_LOC
     return nTimeSmart;
 }
 
-bool CWallet::AddDestData(const CTxDestination &dest, const std::string &key, const std::string &value)
+bool CWallet::AddDestData(const CTxDestination &dest, const std::string &key, const std::string &value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     if (boost::get<CNoDestination>(&dest))
         return false;
@@ -3813,20 +3813,20 @@ bool CWallet::AddDestData(const CTxDestination &dest, const std::string &key, co
     return CWalletDB(*dbw).WriteDestData(EncodeDestination(dest), key, value);
 }
 
-bool CWallet::EraseDestData(const CTxDestination &dest, const std::string &key)
+bool CWallet::EraseDestData(const CTxDestination &dest, const std::string &key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     if (!mapAddressBook[dest].destdata.erase(key))
         return false;
     return CWalletDB(*dbw).EraseDestData(EncodeDestination(dest), key);
 }
 
-bool CWallet::LoadDestData(const CTxDestination &dest, const std::string &key, const std::string &value)
+bool CWallet::LoadDestData(const CTxDestination &dest, const std::string &key, const std::string &value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     mapAddressBook[dest].destdata.insert(std::make_pair(key, value));
     return true;
 }
 
-bool CWallet::GetDestData(const CTxDestination &dest, const std::string &key, std::string *value) const
+bool CWallet::GetDestData(const CTxDestination &dest, const std::string &key, std::string *value) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     std::map<CTxDestination, CAddressBookData>::const_iterator i = mapAddressBook.find(dest);
     if(i != mapAddressBook.end())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1892,7 +1892,7 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const EXCL
         return nAvailableWatchCreditCached;
 
     CAmount nCredit = 0;
-    LOCK(pwallet->cs_wallet); // calling function 'IsSpent' requires holding mutex 'pwallet->cs_wallet' exclusively
+    LOCK(pwallet->cs_wallet); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11634/files
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
         if (!pwallet->IsSpent(GetHash(), i))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2689,16 +2689,20 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     // enough, that fee sniping isn't a problem yet, but by implementing a fix
     // now we ensure code won't be written that makes assumptions about
     // nLockTime that preclude a fix later.
-    txNew.nLockTime = chainActive.Height();
-
+    {
+        LOCK(cs_main);
+        txNew.nLockTime = chainActive.Height();
+    }
     // Secondly occasionally randomly pick a nLockTime even further back, so
     // that transactions that are delayed after signing for whatever reason,
     // e.g. high-latency mix networks and some CoinJoin implementations, have
     // better privacy.
     if (GetRandInt(10) == 0)
         txNew.nLockTime = std::max(0, (int)txNew.nLockTime - GetRandInt(100));
-
-    assert(txNew.nLockTime <= (unsigned int)chainActive.Height());
+    {
+        LOCK(cs_main);
+        assert(txNew.nLockTime <= (unsigned int)chainActive.Height());
+    }
     assert(txNew.nLockTime < LOCKTIME_THRESHOLD);
     FeeCalculation feeCalc;
     CAmount nFeeNeeded;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3095,7 +3095,10 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
     }
 
     // This wallet is in its first run if all of these are empty
-    fFirstRunRet = mapKeys.empty() && mapCryptedKeys.empty() && mapWatchKeys.empty() && setWatchOnly.empty() && mapScripts.empty();
+    {
+        LOCK(cs_KeyStore);
+        fFirstRunRet = mapKeys.empty() && mapCryptedKeys.empty() && mapWatchKeys.empty() && setWatchOnly.empty() && mapScripts.empty();
+    }
 
     if (nLoadWalletRet != DB_LOAD_OK)
         return nLoadWalletRet;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1607,7 +1607,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
  * @return Earliest timestamp that could be successfully scanned from. Timestamp
  * returned will be higher than startTime if relevant blocks could not be read.
  */
-int64_t CWallet::RescanFromTime(int64_t startTime, bool update)
+int64_t CWallet::RescanFromTime(int64_t startTime, bool update) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet);
@@ -3684,7 +3684,7 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_L
 
 /** @} */ // end of Actions
 
-void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) {
+void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_wallet) {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     mapKeyBirth.clear();
 
@@ -3852,7 +3852,7 @@ std::vector<std::string> CWallet::GetDestValues(const std::string& prefix) const
     return values;
 }
 
-CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
+CWallet* CWallet::CreateWalletFromFile(const std::string walletFile) NO_THREAD_SAFETY_ANALYSIS
 {
     // needed to restore wallet transaction meta data after -zapwallettxes
     std::vector<CWalletTx> vWtx;
@@ -4093,7 +4093,7 @@ void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
     nIndex = posInBlock;
 }
 
-int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const
+int CMerkleTx::GetDepthInMainChain(const CBlockIndex* &pindexRet) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     if (hashUnset())
         return 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3757,7 +3757,7 @@ void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) c
  * https://bitcointalk.org/?topic=54527, or
  * https://github.com/bitcoin/bitcoin/pull/1393.
  */
-unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const
+unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     unsigned int nTimeSmart = wtx.nTimeReceived;
     if (!wtx.hashUnset()) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1610,7 +1610,6 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 int64_t CWallet::RescanFromTime(int64_t startTime, bool update) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
-    AssertLockHeld(cs_wallet);
 
     // Find starting block. May be null if nCreateTime is greater than the
     // highest blockchain timestamp, in which case there is nothing that needs

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1892,9 +1892,9 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const EXCL
         return nAvailableWatchCreditCached;
 
     CAmount nCredit = 0;
+    LOCK(pwallet->cs_wallet); // calling function 'IsSpent' requires holding mutex 'pwallet->cs_wallet' exclusively
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
-        LOCK(pwallet->cs_wallet);
         if (!pwallet->IsSpent(GetHash(), i))
         {
             const CTxOut &txout = tx->vout[i];

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4009,6 +4009,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
             for (const CWalletTx& wtxOld : vWtx)
             {
                 uint256 hash = wtxOld.GetHash();
+                LOCK(walletInstance->cs_wallet);
                 std::map<uint256, CWalletTx>::iterator mi = walletInstance->mapWallet.find(hash);
                 if (mi != walletInstance->mapWallet.end())
                 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2700,10 +2700,6 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     // better privacy.
     if (GetRandInt(10) == 0)
         txNew.nLockTime = std::max(0, (int)txNew.nLockTime - GetRandInt(100));
-    {
-        LOCK(cs_main);
-        assert(txNew.nLockTime <= (unsigned int)chainActive.Height());
-    }
     assert(txNew.nLockTime < LOCKTIME_THRESHOLD);
     FeeCalculation feeCalc;
     CAmount nFeeNeeded;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3852,7 +3852,7 @@ std::vector<std::string> CWallet::GetDestValues(const std::string& prefix) const
     return values;
 }
 
-CWallet* CWallet::CreateWalletFromFile(const std::string walletFile) NO_THREAD_SAFETY_ANALYSIS
+CWallet* CWallet::CreateWalletFromFile(const std::string walletFile) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     // needed to restore wallet transaction meta data after -zapwallettxes
     std::vector<CWalletTx> vWtx;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1848,9 +1848,9 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const EXCLUSIVE_LOCKS_REQU
 
     CAmount nCredit = 0;
     uint256 hashTx = GetHash();
+    LOCK(pwallet->cs_wallet); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11634/files
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
-        LOCK(pwallet->cs_wallet);
         if (!pwallet->IsSpent(hashTx, i))
         {
             const CTxOut &txout = tx->vout[i];
@@ -2691,7 +2691,7 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
     // now we ensure code won't be written that makes assumptions about
     // nLockTime that preclude a fix later.
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11596/files
         txNew.nLockTime = chainActive.Height();
     }
     // Secondly occasionally randomly pick a nLockTime even further back, so
@@ -3092,7 +3092,7 @@ DBErrors CWallet::LoadWallet(bool& fFirstRunRet)
 
     // This wallet is in its first run if all of these are empty
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11634/files
         fFirstRunRet = mapKeys.empty() && mapCryptedKeys.empty() && mapWatchKeys.empty() && setWatchOnly.empty() && mapScripts.empty();
     }
 
@@ -3996,7 +3996,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile) EXCLUSIVE_L
         // No need to read and scan block if block was created before
         // our wallet birthday (as adjusted for block time variability)
         {
-            LOCK(walletInstance->cs_wallet);
+            LOCK(walletInstance->cs_wallet); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11634/files
             while (pindexRescan && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
                 pindexRescan = chainActive.Next(pindexRescan);
             }
@@ -4011,12 +4011,12 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile) EXCLUSIVE_L
         // Restore wallet transaction metadata after -zapwallettxes=1
         if (gArgs.GetBoolArg("-zapwallettxes", false) && gArgs.GetArg("-zapwallettxes", "1") != "2")
         {
+            LOCK(walletInstance->cs_wallet); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11634/files
             CWalletDB walletdb(*walletInstance->dbw);
 
             for (const CWalletTx& wtxOld : vWtx)
             {
                 uint256 hash = wtxOld.GetHash();
-                LOCK(walletInstance->cs_wallet);
                 std::map<uint256, CWalletTx>::iterator mi = walletInstance->mapWallet.find(hash);
                 if (mi != walletInstance->mapWallet.end())
                 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -769,7 +769,7 @@ DBErrors CWallet::ReorderTransactions()
     return DB_LOAD_OK;
 }
 
-int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb)
+int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     AssertLockHeld(cs_wallet); // nOrderPosNext
     int64_t nRet = nOrderPosNext++;
@@ -781,7 +781,7 @@ int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb)
     return nRet;
 }
 
-bool CWallet::AccountMove(std::string strFrom, std::string strTo, CAmount nAmount, std::string strComment)
+bool CWallet::AccountMove(std::string strFrom, std::string strTo, CAmount nAmount, std::string strComment) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     CWalletDB walletdb(*dbw);
     if (!walletdb.TxnBegin())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1717,7 +1717,7 @@ void CWallet::ReacceptWalletTransactions()
     {
         CWalletTx& wtx = *(item.second);
 
-        LOCK(mempool.cs);
+        LOCK(mempool.cs_txMemPool);
         CValidationState state;
         wtx.AcceptToMemoryPool(maxTxFee, state);
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -224,7 +224,7 @@ void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKe
         throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
 }
 
-bool CWallet::AddKeyPubKeyWithDB(CWalletDB &walletdb, const CKey& secret, const CPubKey &pubkey)
+bool CWallet::AddKeyPubKeyWithDB(CWalletDB &walletdb, const CKey& secret, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
 
@@ -260,7 +260,7 @@ bool CWallet::AddKeyPubKeyWithDB(CWalletDB &walletdb, const CKey& secret, const 
     return true;
 }
 
-bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey)
+bool CWallet::AddKeyPubKey(const CKey& secret, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     CWalletDB walletdb(*dbw);
     return CWallet::AddKeyPubKeyWithDB(walletdb, secret, pubkey);
@@ -284,7 +284,7 @@ bool CWallet::AddCryptedKey(const CPubKey &vchPubKey,
     }
 }
 
-bool CWallet::LoadKeyMetadata(const CTxDestination& keyID, const CKeyMetadata &meta)
+bool CWallet::LoadKeyMetadata(const CTxDestination& keyID, const CKeyMetadata &meta) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     UpdateTimeFirstKey(meta.nCreateTime);
@@ -336,7 +336,7 @@ bool CWallet::LoadCScript(const CScript& redeemScript)
     return CCryptoKeyStore::AddCScript(redeemScript);
 }
 
-bool CWallet::AddWatchOnly(const CScript& dest)
+bool CWallet::AddWatchOnly(const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     if (!CCryptoKeyStore::AddWatchOnly(dest))
         return false;
@@ -346,7 +346,7 @@ bool CWallet::AddWatchOnly(const CScript& dest)
     return CWalletDB(*dbw).WriteWatchOnly(dest, meta);
 }
 
-bool CWallet::AddWatchOnly(const CScript& dest, int64_t nCreateTime)
+bool CWallet::AddWatchOnly(const CScript& dest, int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     mapKeyMetadata[CScriptID(dest)].nCreateTime = nCreateTime;
     return AddWatchOnly(dest);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1834,7 +1834,7 @@ CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
     return 0;
 }
 
-CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
 {
     if (pwallet == nullptr)
         return 0;
@@ -1850,6 +1850,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const EXCLUSIVE_LOCKS_REQU
     uint256 hashTx = GetHash();
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
+        LOCK(pwallet->cs_wallet);
         if (!pwallet->IsSpent(hashTx, i))
         {
             const CTxOut &txout = tx->vout[i];
@@ -1878,7 +1879,7 @@ CAmount CWalletTx::GetImmatureWatchOnlyCredit(const bool& fUseCache) const
     return 0;
 }
 
-CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
+CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const
 {
     if (pwallet == nullptr)
         return 0;
@@ -1893,6 +1894,7 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const EXCL
     CAmount nCredit = 0;
     for (unsigned int i = 0; i < tx->vout.size(); i++)
     {
+        LOCK(pwallet->cs_wallet);
         if (!pwallet->IsSpent(GetHash(), i))
         {
             const CTxOut &txout = tx->vout[i];

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1272,10 +1272,7 @@ void CWallet::BlockUntilSyncedToCurrentChain() {
     {
         // Skip the queue-draining stuff if we know we're caught up with
         // chainActive.Tip()...
-        // We could also take cs_wallet here, and call m_last_block_processed
-        // protected by cs_wallet instead of cs_main, but as long as we need
-        // cs_main here anyway, its easier to just call it cs_main-protected.
-        LOCK(cs_main);
+        LOCK2(cs_main, cs_wallet);
         const CBlockIndex* initialChainTip = chainActive.Tip();
 
         if (m_last_block_processed->GetAncestor(initialChainTip->nHeight) == initialChainTip) {
@@ -3970,7 +3967,10 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile) EXCLUSIVE_L
             pindexRescan = FindForkInGlobalIndex(chainActive, locator);
     }
 
-    walletInstance->m_last_block_processed = chainActive.Tip();
+    {
+        LOCK(walletInstance->cs_wallet);
+        walletInstance->m_last_block_processed = chainActive.Tip();
+    }
     RegisterValidationInterface(walletInstance);
 
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -143,7 +143,7 @@ const CWalletTx* CWallet::GetWalletTx(const uint256& hash) const
     return &(it->second);
 }
 
-CPubKey CWallet::GenerateNewKey(CWalletDB &walletdb, bool internal)
+CPubKey CWallet::GenerateNewKey(CWalletDB &walletdb, bool internal) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     bool fCompressed = CanSupportFeature(FEATURE_COMPRPUBKEY); // default to compressed public keys if we want 0.6.0 wallets
@@ -178,7 +178,7 @@ CPubKey CWallet::GenerateNewKey(CWalletDB &walletdb, bool internal)
     return pubkey;
 }
 
-void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKey& secret, bool internal)
+void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKey& secret, bool internal) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
 {
     // for now we use a fixed keypath scheme of m/0'/0'/k
     CKey key;                      //master key seed (256bit)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -29,6 +29,8 @@
 #include <utility>
 #include <vector>
 
+extern CCriticalSection cs_main;
+
 typedef CWallet* CWalletRef;
 extern std::vector<CWalletRef> vpwallets;
 
@@ -244,9 +246,9 @@ public:
      *  0  : in memory pool, waiting to be included in a block
      * >=1 : this many blocks deep in the main chain
      */
-    int GetDepthInMainChain(const CBlockIndex* &pindexRet) const;
-    int GetDepthInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
-    bool IsInMainChain() const { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
+    int GetDepthInMainChain(const CBlockIndex* &pindexRet) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    int GetDepthInMainChain() const EXCLUSIVE_LOCKS_REQUIRED(cs_main) { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
+    bool IsInMainChain() const EXCLUSIVE_LOCKS_REQUIRED(cs_main) { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
     int GetBlocksToMaturity() const;
     bool hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
     bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -701,8 +701,8 @@ private:
     /* HD derive new child key (on internal or external chain) */
     void DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKey& secret, bool internal = false);
 
-    std::set<int64_t> setInternalKeyPool;
-    std::set<int64_t> setExternalKeyPool;
+    std::set<int64_t> setInternalKeyPool GUARDED_BY(cs_wallet);
+    std::set<int64_t> setExternalKeyPool GUARDED_BY(cs_wallet);
     int64_t m_max_keypool_index;
     std::map<CKeyID, int64_t> m_pool_key_to_index;
 
@@ -766,7 +766,7 @@ public:
     std::map<CTxDestination, CKeyMetadata> mapKeyMetadata;
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
-    MasterKeyMap mapMasterKeys;
+    MasterKeyMap mapMasterKeys GUARDED_BY(cs_wallet);
     unsigned int nMasterKeyMaxID;
 
     // Create wallet with dummy database handle
@@ -805,7 +805,7 @@ public:
         fScanningWallet = false;
     }
 
-    std::map<uint256, CWalletTx> mapWallet;
+    std::map<uint256, CWalletTx> mapWallet GUARDED_BY(cs_wallet);
     std::list<CAccountingEntry> laccentries;
 
     typedef std::pair<CWalletTx*, CAccountingEntry*> TxPair;
@@ -814,11 +814,11 @@ public:
 
     int64_t nOrderPosNext;
     uint64_t nAccountingEntryNumber;
-    std::map<uint256, int> mapRequestCount;
+    std::map<uint256, int> mapRequestCount GUARDED_BY(cs_wallet);
 
     std::map<CTxDestination, CAddressBookData> mapAddressBook;
 
-    std::set<COutPoint> setLockedCoins;
+    std::set<COutPoint> setLockedCoins GUARDED_BY(cs_wallet);
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -787,13 +787,16 @@ public:
         pwalletdbEncryption = nullptr;
     }
 
+    // NO_THREAD_SAFETY_ANALYSIS: Intentionally setting
+    // nOrderPosNext/nTimeFirstKey/nWalletVersion/nWalletMaxVersion without
+    // holding cs_wallet.
     void SetNull() NO_THREAD_SAFETY_ANALYSIS
     {
         nWalletVersion = FEATURE_BASE;
         nWalletMaxVersion = FEATURE_BASE;
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = nullptr;
-        nOrderPosNext = 0; // NO_THREAD_SAFETY_ANALYSIS
+        nOrderPosNext = 0;
         nAccountingEntryNumber = 0;
         nNextResend = 0;
         nLastResend = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -667,10 +667,10 @@ private:
     CWalletDB *pwalletdbEncryption;
 
     //! the current wallet version: clients below this version are not able to load the wallet
-    int nWalletVersion; // GUARDED_BY(cs_wallet)
+    int nWalletVersion GUARDED_BY(cs_wallet);
 
     //! the maximum wallet format version: memory-only variable that specifies to what version this wallet may be upgraded
-    int nWalletMaxVersion; // GUARDED_BY(cs_wallet)
+    int nWalletMaxVersion GUARDED_BY(cs_wallet);
 
     int64_t nNextResend;
     int64_t nLastResend;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -731,9 +731,9 @@ private:
      * to have seen all transactions in the chain, but is only used to track
      * live BlockConnected callbacks.
      *
-     * Protected by cs_main (see BlockUntilSyncedToCurrentChain)
+     * Protected by cs_wallet
      */
-    const CBlockIndex* m_last_block_processed;
+    const CBlockIndex* m_last_block_processed GUARDED_BY(cs_wallet);
 
 public:
     /*
@@ -798,6 +798,7 @@ public:
             nOrderPosNext = 0;
             nTimeFirstKey = 0;
             nRelockTime = 0;
+            m_last_block_processed = nullptr;
         }
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = nullptr;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -787,13 +787,13 @@ public:
         pwalletdbEncryption = nullptr;
     }
 
-    void SetNull()
+    void SetNull() NO_THREAD_SAFETY_ANALYSIS
     {
         nWalletVersion = FEATURE_BASE;
         nWalletMaxVersion = FEATURE_BASE;
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = nullptr;
-        nOrderPosNext = 0;
+        nOrderPosNext = 0; // NO_THREAD_SAFETY_ANALYSIS
         nAccountingEntryNumber = 0;
         nNextResend = 0;
         nLastResend = 0;
@@ -812,7 +812,7 @@ public:
     typedef std::multimap<int64_t, TxPair > TxItems;
     TxItems wtxOrdered;
 
-    int64_t nOrderPosNext;
+    int64_t nOrderPosNext GUARDED_BY(cs_wallet);
     uint64_t nAccountingEntryNumber;
     std::map<uint256, int> mapRequestCount GUARDED_BY(cs_wallet);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -792,7 +792,7 @@ public:
     void SetNull()
     {
         {
-            LOCK(cs_wallet); // writing variable 'nWalletVersion'/'nWalletMaxVersion'/'nOrderPosNext'/'nTimeFirstKey' requires holding mutex 'cs_wallet' exclusively
+            LOCK(cs_wallet); // WIP: lock submitted in https://github.com/bitcoin/bitcoin/pull/11634/files
             nWalletVersion = FEATURE_BASE;
             nWalletMaxVersion = FEATURE_BASE;
             nOrderPosNext = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -667,10 +667,10 @@ private:
     CWalletDB *pwalletdbEncryption;
 
     //! the current wallet version: clients below this version are not able to load the wallet
-    int nWalletVersion;
+    int nWalletVersion; // GUARDED_BY(cs_wallet)
 
     //! the maximum wallet format version: memory-only variable that specifies to what version this wallet may be upgraded
-    int nWalletMaxVersion;
+    int nWalletMaxVersion; // GUARDED_BY(cs_wallet)
 
     int64_t nNextResend;
     int64_t nLastResend;
@@ -823,7 +823,7 @@ public:
     const CWalletTx* GetWalletTx(const uint256& hash) const;
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
-    bool CanSupportFeature(enum WalletFeature wf) const { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
+    bool CanSupportFeature(enum WalletFeature wf) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }
 
     /**
      * populate vCoins with vector of available COutputs.
@@ -876,7 +876,7 @@ public:
     //! Load metadata (used by LoadWallet)
     bool LoadKeyMetadata(const CTxDestination& pubKey, const CKeyMetadata &metadata);
 
-    bool LoadMinVersion(int nVersion) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
+    bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
     void UpdateTimeFirstKey(int64_t nCreateTime);
 
     //! Adds an encrypted key to the store, and saves it to disk.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1032,7 +1032,7 @@ public:
 
     void GetScriptForMining(std::shared_ptr<CReserveScript> &script);
     
-    unsigned int GetKeyPoolSize()
+    unsigned int GetKeyPoolSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
     {
         AssertLockHeld(cs_wallet); // set{Ex,In}ternalKeyPool
         return setInternalKeyPool.size() + setExternalKeyPool.size();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -249,7 +249,7 @@ public:
     int GetDepthInMainChain(const CBlockIndex* &pindexRet) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     int GetDepthInMainChain() const EXCLUSIVE_LOCKS_REQUIRED(cs_main) { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet); }
     bool IsInMainChain() const EXCLUSIVE_LOCKS_REQUIRED(cs_main) { const CBlockIndex *pindexRet; return GetDepthInMainChain(pindexRet) > 0; }
-    int GetBlocksToMaturity() const;
+    int GetBlocksToMaturity() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     bool hashUnset() const { return (hashBlock.IsNull() || hashBlock == ABANDON_HASH); }
     bool isAbandoned() const { return (hashBlock == ABANDON_HASH); }
     void setAbandoned() { hashBlock = ABANDON_HASH; }
@@ -445,10 +445,10 @@ public:
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
-    CAmount GetImmatureCredit(bool fUseCache=true) const;
-    CAmount GetAvailableCredit(bool fUseCache=true) const;
-    CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const;
-    CAmount GetAvailableWatchOnlyCredit(const bool& fUseCache=true) const;
+    CAmount GetImmatureCredit(bool fUseCache=true) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CAmount GetAvailableCredit(bool fUseCache=true) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    CAmount GetAvailableWatchOnlyCredit(const bool& fUseCache=true) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CAmount GetChange() const;
 
     void GetAmounts(std::list<COutputEntry>& listReceived,
@@ -463,13 +463,13 @@ public:
     bool IsEquivalentTo(const CWalletTx& tx) const;
 
     bool InMempool() const;
-    bool IsTrusted() const;
+    bool IsTrusted() const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     int64_t GetTxTime() const;
     int GetRequestCount() const;
 
     // RelayWalletTransaction may only be called if fBroadcastTransactions!
-    bool RelayWalletTransaction(CConnman* connman);
+    bool RelayWalletTransaction(CConnman* connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */
     bool AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state);
@@ -664,7 +664,7 @@ private:
      * all coins from coinControl are selected; Never select unconfirmed coins
      * if they are not ours
      */
-    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = nullptr) const;
+    bool SelectCoins(const std::vector<COutput>& vAvailableCoins, const CAmount& nTargetValue, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CCoinControl *coinControl = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     CWalletDB *pwalletdbEncryption;
 
@@ -685,23 +685,23 @@ private:
      */
     typedef std::multimap<COutPoint, uint256> TxSpends;
     TxSpends mapTxSpends GUARDED_BY(cs_wallet);
-    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
-    void AddToSpends(const uint256& wtxid);
+    void AddToSpends(const COutPoint& outpoint, const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AddToSpends(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     void MarkConflicted(const uint256& hashBlock, const uint256& hashTx);
 
-    void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
+    void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* Used by TransactionAddedToMemorypool/BlockConnected/Disconnected.
      * Should be called with pindexBlock and posInBlock if this is for a transaction that is included in a block. */
-    void SyncTransaction(const CTransactionRef& tx, const CBlockIndex *pindex = nullptr, int posInBlock = 0);
+    void SyncTransaction(const CTransactionRef& tx, const CBlockIndex *pindex = nullptr, int posInBlock = 0) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* the HD chain data model (external chain counters) */
     CHDChain hdChain;
 
     /* HD derive new child key (on internal or external chain) */
-    void DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKey& secret, bool internal = false);
+    void DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKey& secret, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::set<int64_t> setInternalKeyPool GUARDED_BY(cs_wallet);
     std::set<int64_t> setExternalKeyPool GUARDED_BY(cs_wallet);
@@ -719,7 +719,7 @@ private:
      * of the other AddWatchOnly which accepts a timestamp and sets
      * nTimeFirstKey more intelligently for more efficient rescans.
      */
-    bool AddWatchOnly(const CScript& dest) override;
+    bool AddWatchOnly(const CScript& dest) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::unique_ptr<CWalletDBWrapper> dbw;
 
@@ -761,7 +761,7 @@ public:
         }
     }
 
-    void LoadKeyPool(int64_t nIndex, const CKeyPool &keypool);
+    void LoadKeyPool(int64_t nIndex, const CKeyPool &keypool) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     // Map from Key ID (for regular keys) or Script ID (for watch-only keys) to
     // key metadata.
@@ -843,7 +843,7 @@ public:
     /**
      * Find non-change parent output.
      */
-    const CTxOut& FindNonChangeParentOutput(const CTransaction& tx, int output) const;
+    const CTxOut& FindNonChangeParentOutput(const CTransaction& tx, int output) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Shuffle and select coins until nTargetValue is reached while avoiding
@@ -853,13 +853,13 @@ public:
      */
     bool SelectCoinsMinConf(const CAmount& nTargetValue, int nConfMine, int nConfTheirs, uint64_t nMaxAncestors, std::vector<COutput> vCoins, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet) const;
 
-    bool IsSpent(const uint256& hash, unsigned int n) const;
+    bool IsSpent(const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_wallet);
 
-    bool IsLockedCoin(uint256 hash, unsigned int n) const;
-    void LockCoin(const COutPoint& output);
-    void UnlockCoin(const COutPoint& output);
-    void UnlockAllCoins();
-    void ListLockedCoins(std::vector<COutPoint>& vOutpts) const;
+    bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void LockCoin(const COutPoint& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void UnlockCoin(const COutPoint& output) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void UnlockAllCoins()EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void ListLockedCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /*
      * Rescan abort properties
@@ -872,17 +872,17 @@ public:
      * keystore implementation
      * Generate a new key
      */
-    CPubKey GenerateNewKey(CWalletDB& walletdb, bool internal = false);
+    CPubKey GenerateNewKey(CWalletDB& walletdb, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, and saves it to disk.
-    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
-    bool AddKeyPubKeyWithDB(CWalletDB &walletdb,const CKey& key, const CPubKey &pubkey);
+    bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddKeyPubKeyWithDB(CWalletDB &walletdb,const CKey& key, const CPubKey &pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a key to the store, without saving it to disk (used by LoadWallet)
     bool LoadKey(const CKey& key, const CPubKey &pubkey) { return CCryptoKeyStore::AddKeyPubKey(key, pubkey); }
     //! Load metadata (used by LoadWallet)
-    bool LoadKeyMetadata(const CTxDestination& pubKey, const CKeyMetadata &metadata);
+    bool LoadKeyMetadata(const CTxDestination& pubKey, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
-    void UpdateTimeFirstKey(int64_t nCreateTime);
+    void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Adds an encrypted key to the store, and saves it to disk.
     bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret) override;
@@ -892,18 +892,18 @@ public:
     bool LoadCScript(const CScript& redeemScript);
 
     //! Adds a destination data tuple to the store, and saves it to disk
-    bool AddDestData(const CTxDestination &dest, const std::string &key, const std::string &value);
+    bool AddDestData(const CTxDestination &dest, const std::string &key, const std::string &value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Erases a destination data tuple in the store and on disk
-    bool EraseDestData(const CTxDestination &dest, const std::string &key);
+    bool EraseDestData(const CTxDestination &dest, const std::string &key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a destination data tuple to the store, without saving it to disk
-    bool LoadDestData(const CTxDestination &dest, const std::string &key, const std::string &value);
+    bool LoadDestData(const CTxDestination &dest, const std::string &key, const std::string &value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Look up a destination data tuple in the store, return true if found false otherwise
-    bool GetDestData(const CTxDestination &dest, const std::string &key, std::string *value) const;
+    bool GetDestData(const CTxDestination &dest, const std::string &key, std::string *value) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Get all destination values matching a prefix.
     std::vector<std::string> GetDestValues(const std::string& prefix) const;
 
     //! Adds a watch-only address to the store, and saves it to disk.
-    bool AddWatchOnly(const CScript& dest, int64_t nCreateTime);
+    bool AddWatchOnly(const CScript& dest, int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool RemoveWatchOnly(const CScript &dest) override;
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);
@@ -915,32 +915,32 @@ public:
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 
-    void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const;
-    unsigned int ComputeTimeSmart(const CWalletTx& wtx) const;
+    void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_wallet);
+    unsigned int ComputeTimeSmart(const CWalletTx& wtx) const EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** 
      * Increment the next transaction order id
      * @return next transaction order id
      */
-    int64_t IncOrderPosNext(CWalletDB *pwalletdb = nullptr);
+    int64_t IncOrderPosNext(CWalletDB *pwalletdb = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     DBErrors ReorderTransactions();
-    bool AccountMove(std::string strFrom, std::string strTo, CAmount nAmount, std::string strComment = "");
-    bool GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bForceNew = false);
+    bool AccountMove(std::string strFrom, std::string strTo, CAmount nAmount, std::string strComment = "") EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bForceNew = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
-    bool LoadToWallet(const CWalletTx& wtxIn);
+    bool LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
-    int64_t RescanFromTime(int64_t startTime, bool update);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    int64_t RescanFromTime(int64_t startTime, bool update) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop, bool fUpdate = false);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions();
-    void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
+    void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
-    std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
+    std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     CAmount GetBalance() const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
@@ -955,7 +955,7 @@ public:
      * calling CreateTransaction();
      */
     bool FundTransaction(CMutableTransaction& tx, CAmount& nFeeRet, int& nChangePosInOut, std::string& strFailReason, bool lockUnspents, const std::set<int>& setSubtractFeeFromOutputs, CCoinControl);
-    bool SignTransaction(CMutableTransaction& tx);
+    bool SignTransaction(CMutableTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Create a new transaction paying the recipients with a set of coins
@@ -977,7 +977,7 @@ public:
     static CFeeRate m_discard_rate;
 
     bool NewKeyPool();
-    size_t KeypoolCountExternalKeys();
+    size_t KeypoolCountExternalKeys() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool TopUpKeyPool(unsigned int kpSize = 0);
     void ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fRequestedInternal);
     void KeepKey(int64_t nIndex);
@@ -987,11 +987,11 @@ public:
     /**
      * Marks all keys in the keypool up to and including reserve_key as used.
      */
-    void MarkReserveKeysAsUsed(int64_t keypool_id);
+    void MarkReserveKeysAsUsed(int64_t keypool_id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     const std::map<CKeyID, int64_t>& GetAllReserveKeys() const { return m_pool_key_to_index; }
 
-    std::set< std::set<CTxDestination> > GetAddressGroupings();
-    std::map<CTxDestination, CAmount> GetAddressBalances();
+    std::set< std::set<CTxDestination> > GetAddressGroupings() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    std::map<CTxDestination, CAmount> GetAddressBalances() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     std::set<CTxDestination> GetAccountAddresses(const std::string& strAccount) const;
 
@@ -1017,13 +1017,13 @@ public:
 
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);
-    DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
+    DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& purpose);
 
     bool DelAddressBook(const CTxDestination& address);
 
-    const std::string& GetAccountName(const CScript& scriptPubKey) const;
+    const std::string& GetAccountName(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     void Inventory(const uint256 &hash) override
     {
@@ -1053,10 +1053,10 @@ public:
     int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
-    std::set<uint256> GetConflicts(const uint256& txid) const;
+    std::set<uint256> GetConflicts(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Check if a given transaction has any of its outputs spent by another transaction in the wallet
-    bool HasWalletSpend(const uint256& txid) const;
+    bool HasWalletSpend(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Flush wallet (bitdb flush)
     void Flush(bool shutdown=false);
@@ -1098,13 +1098,13 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static CWallet* CreateWalletFromFile(const std::string walletFile);
+    static CWallet* CreateWalletFromFile(const std::string walletFile) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**
      * Wallet post-init setup
      * Gives the wallet a chance to register repetitive tasks and complete post-init tasks
      */
-    void postInitProcess(CScheduler& scheduler);
+    void postInitProcess(CScheduler& scheduler) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     bool BackupWallet(const std::string& strDest);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -819,7 +819,7 @@ public:
     uint64_t nAccountingEntryNumber;
     std::map<uint256, int> mapRequestCount GUARDED_BY(cs_wallet);
 
-    std::map<CTxDestination, CAddressBookData> mapAddressBook;
+    std::map<CTxDestination, CAddressBookData> mapAddressBook GUARDED_BY(cs_wallet);
 
     std::set<COutPoint> setLockedCoins GUARDED_BY(cs_wallet);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -789,9 +789,6 @@ public:
         pwalletdbEncryption = nullptr;
     }
 
-    // NO_THREAD_SAFETY_ANALYSIS: Intentionally setting
-    // nOrderPosNext/nTimeFirstKey/nWalletVersion/nWalletMaxVersion without
-    // holding cs_wallet.
     void SetNull()
     {
         {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -792,7 +792,7 @@ public:
     void SetNull()
     {
         {
-            LOCK(cs_wallet);
+            LOCK(cs_wallet); // writing variable 'nWalletVersion'/'nWalletMaxVersion'/'nOrderPosNext'/'nTimeFirstKey' requires holding mutex 'cs_wallet' exclusively
             nWalletVersion = FEATURE_BASE;
             nWalletMaxVersion = FEATURE_BASE;
             nOrderPosNext = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -682,7 +682,7 @@ private:
      * mutated transactions where the mutant gets mined).
      */
     typedef std::multimap<COutPoint, uint256> TxSpends;
-    TxSpends mapTxSpends;
+    TxSpends mapTxSpends GUARDED_BY(cs_wallet);
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid);
     void AddToSpends(const uint256& wtxid);
 
@@ -706,7 +706,7 @@ private:
     int64_t m_max_keypool_index;
     std::map<CKeyID, int64_t> m_pool_key_to_index;
 
-    int64_t nTimeFirstKey;
+    int64_t nTimeFirstKey GUARDED_BY(cs_wallet);
 
     /**
      * Private version of AddWatchOnly method which does not accept a

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -792,18 +792,21 @@ public:
     // NO_THREAD_SAFETY_ANALYSIS: Intentionally setting
     // nOrderPosNext/nTimeFirstKey/nWalletVersion/nWalletMaxVersion without
     // holding cs_wallet.
-    void SetNull() NO_THREAD_SAFETY_ANALYSIS
+    void SetNull()
     {
-        nWalletVersion = FEATURE_BASE;
-        nWalletMaxVersion = FEATURE_BASE;
+        {
+            LOCK(cs_wallet);
+            nWalletVersion = FEATURE_BASE;
+            nWalletMaxVersion = FEATURE_BASE;
+            nOrderPosNext = 0;
+            nTimeFirstKey = 0;
+        }
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = nullptr;
-        nOrderPosNext = 0;
         nAccountingEntryNumber = 0;
         nNextResend = 0;
         nLastResend = 0;
         m_max_keypool_index = 0;
-        nTimeFirstKey = 0;
         fBroadcastTransactions = false;
         nRelockTime = 0;
         fAbortRescan = false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -763,7 +763,7 @@ public:
 
     // Map from Key ID (for regular keys) or Script ID (for watch-only keys) to
     // key metadata.
-    std::map<CTxDestination, CKeyMetadata> mapKeyMetadata;
+    std::map<CTxDestination, CKeyMetadata> mapKeyMetadata GUARDED_BY(cs_wallet);
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
     MasterKeyMap mapMasterKeys GUARDED_BY(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -797,6 +797,7 @@ public:
             nWalletMaxVersion = FEATURE_BASE;
             nOrderPosNext = 0;
             nTimeFirstKey = 0;
+            nRelockTime = 0;
         }
         nMasterKeyMaxID = 0;
         pwalletdbEncryption = nullptr;
@@ -805,7 +806,6 @@ public:
         nLastResend = 0;
         m_max_keypool_index = 0;
         fBroadcastTransactions = false;
-        nRelockTime = 0;
         fAbortRescan = false;
         fScanningWallet = false;
     }
@@ -909,7 +909,7 @@ public:
     bool LoadWatchOnly(const CScript &dest);
 
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
-    int64_t nRelockTime;
+    int64_t nRelockTime GUARDED_BY(cs_wallet);
 
     bool Unlock(const SecureString& strWalletPassphrase);
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -242,7 +242,7 @@ public:
 
 bool
 ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
-             CWalletScanState &wss, std::string& strType, std::string& strErr)
+             CWalletScanState &wss, std::string& strType, std::string& strErr) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     try {
         // Unserialize

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -522,13 +522,13 @@ bool CWalletDB::IsKeyType(const std::string& strType)
             strType == "mkey" || strType == "ckey");
 }
 
-DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
+DBErrors CWalletDB::LoadWallet(CWallet* pwallet) EXCLUSIVE_LOCKS_REQUIRED(pwallet->cs_wallet)
 {
     CWalletScanState wss;
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
-    LOCK(pwallet->cs_wallet);
+    AssertLockHeld(pwallet->cs_wallet);
     try {
         int nMinVersion = 0;
         if (batch.Read((std::string)"minversion", nMinVersion))

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -9,7 +9,7 @@
 #include <warnings.h>
 
 CCriticalSection cs_warnings;
-std::string strMiscWarning;
+std::string strMiscWarning GUARDED_BY(cs_warnings);
 bool fLargeWorkForkFound = false;
 bool fLargeWorkInvalidChainFound = false;
 

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -10,8 +10,8 @@
 
 CCriticalSection cs_warnings;
 std::string strMiscWarning GUARDED_BY(cs_warnings);
-bool fLargeWorkForkFound = false;
-bool fLargeWorkInvalidChainFound = false;
+bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
+bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
 
 void SetMiscWarning(const std::string& strWarning)
 {


### PR DESCRIPTION
Add additional Clang thread safety analysis annotations as discussed with @sipa (https://github.com/bitcoin/bitcoin/pull/10866#issuecomment-316238630) and others.

This is a follow-up to #10866 ~~which this PR is rebased upon (awaiting merge of #10866). The first three commits (8a1dc09, e022990 and cbae151) can be reviewed in #10866.~~

This PR contains three types of changes:
1. Add missing locks (based on the `GUARDED_BY(...)` analysis below). Please review thoroughly.
2. Add `GUARDED_BY(...)` annotations to allow for Clang's thread safety analysis at compile-time. Does not change run-time behaviour.
3. Add `EXCLUSIVE_LOCKS_REQUIRED(...)` annotations to allow for Clang's thread safety analysis at compile-time. Does not change run-time behaviour.

Background reading: The ["C/C++ Thread Safety Analysis"](https://research.google.com/pubs/archive/42958.pdf) paper (Hutchins, Ballman & Sutherland, 2014) paper describing Clang thread safety analysis and how it is used for the Google C++ codebase:

> They essentially provide a static type system for threads, and can detect potential race conditions and deadlocks. This paper describes Clang Thread Safety Analysis, a tool which uses annotations to declare and enforce thread safety policies in C and C++ programs.
> […]
> It has been deployed on a large scale at Google; all C++ code at Google is now compiled with thread safety analysis enabled by default.
> […]
> The `GUARDED_BY` attribute declares that a thread must lock `mu` before it can read or write to `balance`, thus ensuring that the increment and decrement operations are atomic. Similarly, `REQUIRES` declares that the calling thread must lock mu before calling `withdrawImpl`. Because the caller is assumed to have locked `mu,` it is safe to modify `balance` within the body of the method.