### PR TITLE
WIP: switch to libevent for node socket handling

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2238,9 +2238,9 @@ void CConnman::SetNetworkActive(bool active)
 
     if (!fNetworkActive) {
         LOCK(cs_vNodes);
-        // Close sockets to all nodes
+        // Disconnect all nodes
         for (CNode* pnode : vNodes) {
-            pnode->CloseSocketDisconnect();
+            pnode->fDisconnect = true;
         }
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -412,16 +412,27 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
     if (addrConnect.IsValid()) {
         bool proxyConnectionFailed = false;
 
-        if (GetProxy(addrConnect.GetNetwork(), proxy))
+        if (GetProxy(addrConnect.GetNetwork(), proxy)) {
+            if (!CreateSocket(proxy.proxy, hSocket)) {
+                return nullptr;
+            }
             connected = ConnectThroughProxy(proxy, addrConnect.ToStringIP(), addrConnect.GetPort(), hSocket, nConnectTimeout, &proxyConnectionFailed);
-        else // no proxy needed (none set for target network)
+        } else {
+            // no proxy needed (none set for target network)
+            if (!CreateSocket(addrConnect, hSocket)) {
+                return nullptr;
+            }
             connected = ConnectSocketDirectly(addrConnect, hSocket, nConnectTimeout);
+        }
         if (!proxyConnectionFailed) {
             // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to
             // the proxy, mark this as an attempt.
             addrman.Attempt(addrConnect, fCountFailure);
         }
     } else if (pszDest && GetNameProxy(proxy)) {
+        if (!CreateSocket(proxy.proxy, hSocket)) {
+            return nullptr;
+        }
         std::string host;
         int port = default_port;
         SplitHostPort(std::string(pszDest), port, host);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -836,6 +836,10 @@ int CNode::GetSendVersion() const
     return nSendVersion;
 }
 
+void CNode::EnableReceive()
+{
+    fPauseRecv = false;
+}
 
 int CNetMessage::readHeader(const char *pch, unsigned int nBytes)
 {
@@ -1397,7 +1401,9 @@ void CConnman::ThreadSocketHandler()
                             LOCK(pnode->cs_vProcessMsg);
                             pnode->vProcessMsg.splice(pnode->vProcessMsg.end(), pnode->vRecvMsg, pnode->vRecvMsg.begin(), it);
                             pnode->nProcessQueueSize += nSizeAdded;
-                            pnode->fPauseRecv = pnode->nProcessQueueSize > nReceiveFloodSize;
+                            if (pnode->nProcessQueueSize > nReceiveFloodSize) {
+                                pnode->fPauseRecv = true;
+                            }
                         }
                         WakeMessageHandler();
                     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -900,7 +900,7 @@ size_t CConnman::SocketReceiveData(CNode* pnode)
     {
         bool notify = false;
         if (!pnode->ReceiveMsgBytes(pchBuf, nBytes, notify))
-            pnode->CloseSocketDisconnect();
+            pnode->Disconnect();
 
         auto it(pnode->vRecvMsg.begin());
         size_t nSizeAdded = 0;
@@ -941,7 +941,7 @@ size_t CConnman::SocketReceiveData(CNode* pnode)
         if (!pnode->fDisconnect) {
             LogPrint(BCLog::NET, "socket closed\n");
         }
-        pnode->CloseSocketDisconnect();
+        pnode->Disconnect();
     }
     else if (nBytes < 0)
     {
@@ -949,9 +949,8 @@ size_t CConnman::SocketReceiveData(CNode* pnode)
         int nErr = WSAGetLastError();
         if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
         {
-            if (!pnode->fDisconnect)
-                LogPrintf("socket recv error %s\n", NetworkErrorString(nErr));
-            pnode->CloseSocketDisconnect();
+            LogPrintf("socket recv error %s\n", NetworkErrorString(nErr));
+            pnode->Disconnect();
         }
     }
     if (nBytes < 0) {
@@ -991,7 +990,7 @@ size_t CConnman::SocketSendData(CNode *pnode) const
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
                     LogPrintf("socket send error %s\n", NetworkErrorString(nErr));
-                    pnode->CloseSocketDisconnect();
+                    pnode->Disconnect();
                 }
             }
             // couldn't send anything at all

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -360,14 +360,14 @@ static CAddress GetBindAddress(SOCKET sock)
     return addr_bind;
 }
 
-CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure)
+CNode* CConnman::ConnectNode(NewConnection conn)
 {
-    if (pszDest == nullptr) {
-        if (IsLocal(addrConnect))
+    if (conn.remote_str.empty()) {
+        if (IsLocal(conn.remote_addr))
             return nullptr;
 
         // Look for an existing connection
-        CNode* pnode = FindNode((CService)addrConnect);
+        CNode* pnode = FindNode((CService)conn.remote_addr);
         if (pnode)
         {
             LogPrintf("Failed to open new connection, already connected\n");
@@ -377,17 +377,17 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
 
     /// debug print
     LogPrint(BCLog::NET, "trying connection %s lastseen=%.1fhrs\n",
-        pszDest ? pszDest : addrConnect.ToString(),
-        pszDest ? 0.0 : (double)(GetAdjustedTime() - addrConnect.nTime)/3600.0);
+        !conn.remote_str.empty() ? conn.remote_str : conn.remote_addr.ToString(),
+        !conn.remote_str.empty() ? 0.0 : (double)(GetAdjustedTime() - conn.remote_addr.nTime)/3600.0);
 
     // Resolve
     const int default_port = Params().GetDefaultPort();
-    if (pszDest) {
+    if (!conn.remote_str.empty()) {
         std::vector<CService> resolved;
-        if (Lookup(pszDest, resolved,  default_port, fNameLookup && !HaveNameProxy(), 256) && !resolved.empty()) {
-            addrConnect = CAddress(resolved[GetRand(resolved.size())], NODE_NONE);
-            if (!addrConnect.IsValid()) {
-                LogPrint(BCLog::NET, "Resolver returned invalid address %s for %s", addrConnect.ToString(), pszDest);
+        if (Lookup(conn.remote_str.c_str(), resolved,  default_port, fNameLookup && !HaveNameProxy(), 256) && !resolved.empty()) {
+            conn.remote_addr = CAddress(resolved[GetRand(resolved.size())], NODE_NONE);
+            if (!conn.remote_addr.IsValid()) {
+                LogPrint(BCLog::NET, "Resolver returned invalid address %s for %s", conn.remote_addr.ToString(), conn.remote_str);
                 return nullptr;
             }
             // It is possible that we already have a connection to the IP/port pszDest resolved to.
@@ -395,10 +395,10 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
             // Also store the name we used to connect in that CNode, so that future FindNode() calls to that
             // name catch this early.
             LOCK(cs_vNodes);
-            CNode* pnode = FindNode((CService)addrConnect);
+            CNode* pnode = FindNode((CService)conn.remote_addr);
             if (pnode)
             {
-                pnode->MaybeSetAddrName(std::string(pszDest));
+                pnode->MaybeSetAddrName(conn.remote_str);
                 LogPrintf("Failed to open new connection, already connected\n");
                 return nullptr;
             }
@@ -407,51 +407,59 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
 
     // Connect
     bool connected = false;
-    SOCKET hSocket;
     proxyType proxy;
-    if (addrConnect.IsValid()) {
+    if (conn.remote_addr.IsValid()) {
         bool proxyConnectionFailed = false;
 
-        if (GetProxy(addrConnect.GetNetwork(), proxy)) {
-            if (!CreateSocket(proxy.proxy, hSocket)) {
+        if (GetProxy(conn.remote_addr.GetNetwork(), proxy)) {
+            if (!CreateSocket(proxy.proxy, conn.sock)) {
                 return nullptr;
             }
-            connected = ConnectThroughProxy(proxy, addrConnect.ToStringIP(), addrConnect.GetPort(), hSocket, nConnectTimeout, &proxyConnectionFailed);
+            connected = ConnectThroughProxy(proxy, conn.remote_addr.ToStringIP(), conn.remote_addr.GetPort(), conn.sock, nConnectTimeout, &proxyConnectionFailed);
         } else {
             // no proxy needed (none set for target network)
-            if (!CreateSocket(addrConnect, hSocket)) {
+            if (!CreateSocket(conn.remote_addr, conn.sock)) {
                 return nullptr;
             }
-            connected = ConnectSocketDirectly(addrConnect, hSocket, nConnectTimeout);
+            connected = ConnectSocketDirectly(conn.remote_addr, conn.sock, nConnectTimeout);
         }
         if (!proxyConnectionFailed) {
             // If a connection to the node was attempted, and failure (if any) is not caused by a problem connecting to
             // the proxy, mark this as an attempt.
-            addrman.Attempt(addrConnect, fCountFailure);
+            addrman.Attempt(conn.remote_addr, conn.count_failure);
         }
-    } else if (pszDest && GetNameProxy(proxy)) {
-        if (!CreateSocket(proxy.proxy, hSocket)) {
+    } else if (!conn.remote_str.empty() && GetNameProxy(proxy)) {
+        if (!CreateSocket(proxy.proxy, conn.sock)) {
             return nullptr;
         }
         std::string host;
         int port = default_port;
-        SplitHostPort(std::string(pszDest), port, host);
-        connected = ConnectThroughProxy(proxy, host, port, hSocket, nConnectTimeout, nullptr);
+        SplitHostPort(conn.remote_str, port, host);
+        connected = ConnectThroughProxy(proxy, host, port, conn.sock, nConnectTimeout, nullptr);
     }
     if (connected) {
-        if (!IsSelectableSocket(hSocket)) {
+        if (!IsSelectableSocket(conn.sock)) {
             LogPrintf("Cannot create connection: non-selectable socket created (fd >= FD_SETSIZE ?)\n");
-            CloseSocket(hSocket);
+            CloseSocket(conn.sock);
             return nullptr;
         }
 
         // Add node
         NodeId id = GetNewNodeId();
         uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
-        CAddress addr_bind = GetBindAddress(hSocket);
-        CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), hSocket, addrConnect, CalculateKeyedNetGroup(addrConnect), nonce, addr_bind, pszDest ? pszDest : "", false);
-        pnode->nServicesExpected = ServiceFlags(addrConnect.nServices & nRelevantServices);
+        CAddress addr_bind = GetBindAddress(conn.sock);
+        CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), conn.sock, conn.remote_addr, CalculateKeyedNetGroup(conn.remote_addr), nonce, addr_bind, conn.remote_str, false);
+        pnode->nServicesExpected = ServiceFlags(conn.remote_addr.nServices & nRelevantServices);
         pnode->AddRef();
+
+        if (conn.outbound_grant)
+            conn.outbound_grant->MoveTo(pnode->grantOutbound);
+        if (conn.oneshot)
+            pnode->fOneShot = true;
+        if (conn.feeler)
+            pnode->fFeeler = true;
+        if (conn.addnode)
+            pnode->fAddnode = true;
 
         return pnode;
     }
@@ -1978,18 +1986,21 @@ bool CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     } else if (FindNode(std::string(pszDest)))
         return false;
 
-    CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure);
+    NewConnection conn;
+    conn.sock = INVALID_SOCKET;
+    conn.remote_addr = addrConnect;
+    conn.remote_str = pszDest ? pszDest : "";
+    conn.count_failure = fCountFailure;
+    conn.outbound_grant = grantOutbound;
+    conn.oneshot = fOneShot;
+    conn.feeler = fFeeler;
+    conn.addnode = fAddnode;
+    conn.incoming = false;
+    conn.whitelisted = false;
 
+    CNode* pnode = ConnectNode(std::move(conn));
     if (!pnode)
         return false;
-    if (grantOutbound)
-        grantOutbound->MoveTo(pnode->grantOutbound);
-    if (fOneShot)
-        pnode->fOneShot = true;
-    if (fFeeler)
-        pnode->fFeeler = true;
-    if (fAddnode)
-        pnode->fAddnode = true;
 
     m_msgproc->InitializeNode(pnode);
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1366,7 +1366,7 @@ void CConnman::ThreadSocketHandler()
         int nSelect = select(have_fds ? hSocketMax + 1 : 0,
                              &fdsetRecv, &fdsetSend, &fdsetError, &timeout);
         if (interruptNet)
-            return;
+            break;
 
         if (nSelect == SOCKET_ERROR)
         {
@@ -1380,7 +1380,7 @@ void CConnman::ThreadSocketHandler()
             FD_ZERO(&fdsetSend);
             FD_ZERO(&fdsetError);
             if (!interruptNet.sleep_for(std::chrono::milliseconds(timeout.tv_usec/1000)))
-                return;
+                break;
         }
 
         //
@@ -1407,7 +1407,7 @@ void CConnman::ThreadSocketHandler()
         for (CNode* pnode : vNodesCopy)
         {
             if (interruptNet)
-                return;
+                break;
 
             //
             // Receive
@@ -2052,7 +2052,7 @@ void CConnman::ThreadMessageHandler()
             bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc);
             fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend);
             if (flagInterruptMsgProc)
-                return;
+                break;
             // Send messages
             {
                 LOCK(pnode->cs_sendProcessing);
@@ -2060,7 +2060,7 @@ void CConnman::ThreadMessageHandler()
             }
 
             if (flagInterruptMsgProc)
-                return;
+                break;
         }
 
         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1189,13 +1189,12 @@ bool CConnman::AttemptToEvictConnection()
     return false;
 }
 
-void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
-
+void CConnman::AcceptConnection(const SOCKET& listen_socket, bool whitelisted) {
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
 
     NewConnection conn;
-    conn.sock = accept(hListenSocket.socket, (struct sockaddr*)&sockaddr, &len);
+    conn.sock = accept(listen_socket, (struct sockaddr*)&sockaddr, &len);
     conn.remote_addr = CAddress();
     conn.remote_str = "";
     conn.count_failure = false;
@@ -1204,7 +1203,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     conn.feeler = false;
     conn.addnode = false;
     conn.incoming = true;
-    conn.whitelisted = hListenSocket.whitelisted;
+    conn.whitelisted = whitelisted;
 
     int nInbound = 0;
     int nMaxInbound = nMaxConnections - (nMaxOutbound + nMaxFeeler);
@@ -1423,7 +1422,7 @@ void CConnman::ThreadSocketHandler()
         {
             if (hListenSocket.socket != INVALID_SOCKET && FD_ISSET(hListenSocket.socket, &fdsetRecv))
             {
-                AcceptConnection(hListenSocket);
+                AcceptConnection(hListenSocket.socket, hListenSocket.whitelisted);
             }
         }
 

--- a/src/net.h
+++ b/src/net.h
@@ -348,6 +348,7 @@ private:
 
     NodeId GetNewNodeId();
 
+    size_t SocketReceiveData(CNode *pnode);
     size_t SocketSendData(CNode *pnode) const;
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();

--- a/src/net.h
+++ b/src/net.h
@@ -740,6 +740,10 @@ private:
     mutable CCriticalSection cs_addrLocal;
 public:
 
+    void Disconnect() {
+        fDisconnect = true;
+    }
+
     NodeId GetId() const {
         return id;
     }

--- a/src/net.h
+++ b/src/net.h
@@ -353,7 +353,7 @@ private:
     size_t SocketReceiveData(CNode *pnode);
     size_t SocketSendData(CNode *pnode) const;
     void CheckForTimeout(CNode* pnode);
-    void OnEvents(CNode* pnode, bool receive, bool send);
+    void OnEvents(CNode* pnode, short events);
     void InterruptEvents();
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();
@@ -443,6 +443,7 @@ private:
 
     event_base* m_event_base = nullptr;
     std::vector<event*> m_listen_events;
+    timeval m_event_timeout;
 
     event* m_interrupt_event = nullptr;
     CCriticalSection m_cs_interrupt_event;
@@ -746,14 +747,19 @@ private:
     mutable CCriticalSection cs_addrName;
     std::string addrName;
 
+    event* m_read_event = nullptr;
+    event* m_write_event = nullptr;
+    event* m_read_timeout_event = nullptr;
+    event* m_write_timeout_event = nullptr;
+    event* m_wake_event = nullptr;
+    std::function<void(short)> m_callback;
+
     // Our address, as reported by the peer
     CService addrLocal;
     mutable CCriticalSection cs_addrLocal;
 public:
 
-    void Disconnect() {
-        fDisconnect = true;
-    }
+    void Disconnect();
     void EnableReceive();
 
     NodeId GetId() const {

--- a/src/net.h
+++ b/src/net.h
@@ -350,6 +350,7 @@ private:
 
     size_t SocketReceiveData(CNode *pnode);
     size_t SocketSendData(CNode *pnode) const;
+    void CheckForTimeout(CNode* pnode);
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();
     //!set the "dirty" flag for the banlist

--- a/src/net.h
+++ b/src/net.h
@@ -351,6 +351,7 @@ private:
     size_t SocketReceiveData(CNode *pnode);
     size_t SocketSendData(CNode *pnode) const;
     void CheckForTimeout(CNode* pnode);
+    void OnEvents(CNode* pnode, bool receive, bool send);
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();
     //!set the "dirty" flag for the banlist

--- a/src/net.h
+++ b/src/net.h
@@ -339,7 +339,6 @@ private:
     CNode* FindNode(const CService& addr);
 
     bool AttemptToEvictConnection();
-    void ConnectNode(NewConnection conn);
     bool IsWhitelistedRange(const CNetAddr &addr);
 
     void OnFailedOutgoingConnection(NewConnection conn);

--- a/src/net.h
+++ b/src/net.h
@@ -37,6 +37,8 @@
 class CScheduler;
 class CNode;
 
+struct event_base;
+struct event;
 namespace boost {
     class thread_group;
 } // namespace boost
@@ -352,6 +354,7 @@ private:
     size_t SocketSendData(CNode *pnode) const;
     void CheckForTimeout(CNode* pnode);
     void OnEvents(CNode* pnode, bool receive, bool send);
+    void InterruptEvents();
     //!check is the banlist has unwritten changes
     bool BannedSetIsDirty();
     //!set the "dirty" flag for the banlist
@@ -437,6 +440,12 @@ private:
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;
+
+    event_base* m_event_base = nullptr;
+    std::vector<event*> m_listen_events;
+
+    event* m_interrupt_event = nullptr;
+    CCriticalSection m_cs_interrupt_event;
 };
 extern std::unique_ptr<CConnman> g_connman;
 void Discover(boost::thread_group& threadGroup);

--- a/src/net.h
+++ b/src/net.h
@@ -327,7 +327,7 @@ private:
     void ProcessOneShot();
     void ThreadOpenConnections(std::vector<std::string> connect);
     void ThreadMessageHandler();
-    void AcceptConnection(const ListenSocket& hListenSocket);
+    void AcceptConnection(const SOCKET& socket, bool whitelisted);
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
 

--- a/src/net.h
+++ b/src/net.h
@@ -173,7 +173,7 @@ public:
     void Interrupt();
     bool GetNetworkActive() const { return fNetworkActive; };
     void SetNetworkActive(bool active);
-    bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = nullptr, const char *strDest = nullptr, bool fOneShot = false, bool fFeeler = false, bool fAddnode = false);
+    void OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = nullptr, const char *strDest = nullptr, bool fOneShot = false, bool fFeeler = false, bool fAddnode = false);
     bool CheckIncomingNonce(uint64_t nonce);
 
     bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func);
@@ -339,8 +339,11 @@ private:
     CNode* FindNode(const CService& addr);
 
     bool AttemptToEvictConnection();
-    CNode* ConnectNode(NewConnection conn);
+    void ConnectNode(NewConnection conn);
     bool IsWhitelistedRange(const CNetAddr &addr);
+
+    void OnFailedOutgoingConnection(NewConnection conn);
+    void AddConnection(NewConnection conn);
 
     void DeleteNode(CNode* pnode);
 

--- a/src/net.h
+++ b/src/net.h
@@ -743,6 +743,7 @@ public:
     void Disconnect() {
         fDisconnect = true;
     }
+    void EnableReceive();
 
     NodeId GetId() const {
         return id;

--- a/src/net.h
+++ b/src/net.h
@@ -305,6 +305,20 @@ private:
         ListenSocket(SOCKET socket_, bool whitelisted_) : socket(socket_), whitelisted(whitelisted_) {}
     };
 
+    struct NewConnection
+    {
+        SOCKET sock;
+        CAddress remote_addr;
+        std::string remote_str;
+        CSemaphoreGrant* outbound_grant;
+        bool incoming;
+        bool count_failure;
+        bool oneshot;
+        bool feeler;
+        bool addnode;
+        bool whitelisted;
+    };
+
     bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
     bool Bind(const CService &addr, unsigned int flags);
     bool InitBinds(const std::vector<CService>& binds, const std::vector<CService>& whiteBinds);
@@ -325,7 +339,7 @@ private:
     CNode* FindNode(const CService& addr);
 
     bool AttemptToEvictConnection();
-    CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure);
+    CNode* ConnectNode(NewConnection conn);
     bool IsWhitelistedRange(const CNetAddr &addr);
 
     void DeleteNode(CNode* pnode);

--- a/src/net.h
+++ b/src/net.h
@@ -606,7 +606,6 @@ public:
     uint64_t nSendBytes;
     std::deque<std::vector<unsigned char>> vSendMsg;
     CCriticalSection cs_vSend;
-    CCriticalSection cs_hSocket;
     CCriticalSection cs_vRecv;
 
     CCriticalSection cs_vProcessMsg;

--- a/src/net.h
+++ b/src/net.h
@@ -343,6 +343,7 @@ private:
     bool AttemptToEvictConnection();
     bool IsWhitelistedRange(const CNetAddr &addr);
 
+    void OnNewConnections();
     void OnFailedOutgoingConnection(NewConnection conn);
     void AddConnection(NewConnection conn);
 
@@ -447,6 +448,10 @@ private:
 
     event* m_interrupt_event = nullptr;
     CCriticalSection m_cs_interrupt_event;
+
+    CCriticalSection m_cs_new_connections;
+    std::vector<NewConnection> m_new_connections;
+    event* m_connection_event = nullptr;
 };
 extern std::unique_ptr<CConnman> g_connman;
 void Discover(boost::thread_group& threadGroup);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2673,8 +2673,11 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
             return false;
         // Just take one message
         msgs.splice(msgs.begin(), pfrom->vProcessMsg, pfrom->vProcessMsg.begin());
+
         pfrom->nProcessQueueSize -= msgs.front().vRecv.size() + CMessageHeader::HEADER_SIZE;
-        pfrom->fPauseRecv = pfrom->nProcessQueueSize > connman->GetReceiveFloodSize();
+        if (pfrom->fPauseRecv && pfrom->nProcessQueueSize <= connman->GetReceiveFloodSize()) {
+            pfrom->EnableReceive();
+        }
         fMoreWork = !pfrom->vProcessMsg.empty();
     }
     CNetMessage& msg(msgs.front());

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -399,7 +399,7 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
     return true;
 }
 
-bool ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRet, int nTimeout)
+bool CreateSocket(const CService &addrConnect, SOCKET& hSocketRet)
 {
     hSocketRet = INVALID_SOCKET;
 
@@ -428,7 +428,23 @@ bool ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRet, int 
         CloseSocket(hSocket);
         return error("ConnectSocketDirectly: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
     }
+    hSocketRet = hSocket;
+    return true;
+}
 
+bool ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocket, int nTimeout)
+{
+    struct sockaddr_storage sockaddr;
+    socklen_t len = sizeof(sockaddr);
+    if (hSocket == INVALID_SOCKET) {
+        LogPrintf("Cannot connect to %s: invalid socket\n", addrConnect.ToString());
+        return false;
+    }
+    if (!addrConnect.GetSockAddr((struct sockaddr*)&sockaddr, &len)) {
+        LogPrintf("Cannot connect to %s: unsupported network\n", addrConnect.ToString());
+        CloseSocket(hSocket);
+        return false;
+    }
     if (connect(hSocket, (struct sockaddr*)&sockaddr, len) == SOCKET_ERROR)
     {
         int nErr = WSAGetLastError();
@@ -481,8 +497,6 @@ bool ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRet, int 
             return false;
         }
     }
-
-    hSocketRet = hSocket;
     return true;
 }
 
@@ -534,9 +548,8 @@ bool IsProxy(const CNetAddr &addr) {
     return false;
 }
 
-bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDest, int port, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed)
+bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDest, int port, SOCKET& hSocket, int nTimeout, bool *outProxyConnectionFailed)
 {
-    SOCKET hSocket = INVALID_SOCKET;
     // first connect to proxy server
     if (!ConnectSocketDirectly(proxy.proxy, hSocket, nTimeout)) {
         if (outProxyConnectionFailed)
@@ -548,14 +561,16 @@ bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDest, int
         ProxyCredentials random_auth;
         static std::atomic_int counter(0);
         random_auth.username = random_auth.password = strprintf("%i", counter++);
-        if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
+        if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket)) {
+            CloseSocket(hSocket);
             return false;
+        }
     } else {
-        if (!Socks5(strDest, (unsigned short)port, 0, hSocket))
+        if (!Socks5(strDest, (unsigned short)port, 0, hSocket)) {
+            CloseSocket(hSocket);
             return false;
+        }
     }
-
-    hSocketRet = hSocket;
     return true;
 }
 bool LookupSubNet(const char* pszName, CSubNet& ret)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -51,6 +51,7 @@ bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLoo
 bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
 CService LookupNumeric(const char *pszName, int portDefault = 0);
 bool LookupSubNet(const char *pszName, CSubNet& subnet);
+bool CreateSocket(const CService &addrConnect, SOCKET& hSocketRet);
 bool ConnectSocketDirectly(const CService &addrConnect, SOCKET& hSocketRet, int nTimeout);
 bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDest, int port, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed);
 /** Return readable error string for a network error code */


### PR DESCRIPTION
Not yet ready for review. This can be considered a staging area. Chunks of this will be PR'd until only the actual libevent switch-over is ready, at which point this PR should be ready for review.

These changes remove our old select() loop for socket handling in favor of libevent, which uses epoll/kqueue/etc. as a back-end. In addition to being faster and more efficient, this allows us to drop some annoying restrictions, namely that select can only handle 1024 sockets in practice on most systems.

Note that this does _not_ yet make the switch to libevent for outgoing connections, that work is happening in parallel, and will be easier to merge after this.

Also, for any reviewers, several of these commits would individually introduce some regressions or slow-downs, but they've been split up in order to clarify why some of the changes are being made.

Depends on:
- [x] #10663 
- [x] #11363

Todo:
- Add a ton of documentation
- RAII the libevent structures
- Add some tests where possible