### PR TITLE
[tests] fixup dbcrash interaction with add_nodes()

### DIFF
--- a/test/functional/dbcrash.py
+++ b/test/functional/dbcrash.py
@@ -64,7 +64,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Need a bit of extra time for the nodes to start up for this test
-        self.add_nodes(self.num_nodes, timewait=90)
+        self.add_nodes(self.num_nodes, extra_args=self.extra_args, timewait=90)
         self.start_nodes()
         # Leave them unconnected, we'll use submitblock directly in this test
 


### PR DESCRIPTION
Another conflict with #11121. Apologies - this is entirely my fault. I didn't run the extended test suite after rebasing on master.

@MarcoFalke @sdaftuar 