### PR TITLE
Ensure that data types are consistent

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -204,14 +204,14 @@ public:
     unsigned int nChainTx;
 
     //! Verification status of this block. See enum BlockStatus
-    unsigned int nStatus;
+    uint32_t nStatus;
 
     //! block header
-    int nVersion;
+    int32_t nVersion;
     uint256 hashMerkleRoot;
-    unsigned int nTime;
-    unsigned int nBits;
-    unsigned int nNonce;
+    uint32_t nTime;
+    uint32_t nBits;
+    uint32_t nNonce;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;


### PR DESCRIPTION

1. nStatus of CBlockIndex  is consistent with the definition of Enum(BlockStatus)
2. The BlockHeader is consistent with the type of variable defined in CBlockHeader