### PR TITLE
Docs: Add extra step to clean $PATH var to strip out windows %PATH% paths.

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -70,6 +70,7 @@ To build executables for Windows 64-bit, install the following dependencies:
 
 Then build using:
 
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     cd depends
     make HOST=x86_64-w64-mingw32
     cd ..
@@ -85,6 +86,7 @@ To build executables for Windows 32-bit, install the following dependencies:
 
 Then build using:
 
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     cd depends
     make HOST=i686-w64-mingw32
     cd ..


### PR DESCRIPTION
I experienced the same ( error mentioned in #10269) . The suggested extra step in this PR removes the problematic Windows paths from the $PATH var.
