### PR TITLE
[P2P] When clearing addrman clear mapInfo and mapAddr.

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -472,6 +472,8 @@ public:
         nTried = 0;
         nNew = 0;
         nLastGood = 1; //Initially at 1 so that "never" is strictly worse.
+        mapInfo.clear();
+        mapAddr.clear();
     }
 
     CAddrMan()


### PR DESCRIPTION
Power failure on my machine resulted in a corrupted addrman that would hit bad assertions when trying to serialize the "cleared" addrman to disk: https://github.com/bitcoin/bitcoin/blob/6866b4912b8013ed748d12250209f7079a3c92e6/src/addrman.h#L320