### PR TITLE
Add != to Base58 class

### DIFF
--- a/src/base58.h
+++ b/src/base58.h
@@ -89,6 +89,7 @@ public:
     int CompareTo(const CBase58Data& b58) const;
 
     bool operator==(const CBase58Data& b58) const { return CompareTo(b58) == 0; }
+    bool operator!=(const CBase58Data& b58) const { return CompareTo(b58) != 0; }
     bool operator<=(const CBase58Data& b58) const { return CompareTo(b58) <= 0; }
     bool operator>=(const CBase58Data& b58) const { return CompareTo(b58) >= 0; }
     bool operator< (const CBase58Data& b58) const { return CompareTo(b58) <  0; }


### PR DESCRIPTION
It seems pretty frequently people hit confusion with lack of autogeneration of '!=' operations for Bas58, so this PR adds it. Should lead to fewer people getting caught on this one (I hope).


See: https://github.com/bitcoin/bitcoin/pull/11117
See: https://github.com/bitcoin/bitcoin/pull/9991