### PR TITLE
RPC: add weight to mempool entry output

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -333,6 +333,7 @@ UniValue getdifficulty(const JSONRPCRequest& request)
 std::string EntryDescriptionString()
 {
     return "    \"size\" : n,             (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n"
+           "    \"weight\" : n,           (numeric) transaction weight as defined in BIP 141.\n"
            "    \"fee\" : n,              (numeric) transaction fee in " + CURRENCY_UNIT + "\n"
            "    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority\n"
            "    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n"
@@ -354,6 +355,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     AssertLockHeld(mempool.cs);
 
     info.push_back(Pair("size", (int)e.GetTxSize()));
+    info.push_back(Pair("weight", (int)e.GetTxWeight()));
     info.push_back(Pair("fee", ValueFromAmount(e.GetFee())));
     info.push_back(Pair("modifiedfee", ValueFromAmount(e.GetModifiedFee())));
     info.push_back(Pair("time", e.GetTime()));

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -249,6 +249,9 @@ class SegWitTest(BitcoinTestFramework):
         hex_tx = self.nodes[0].gettransaction(txid1)['hex']
         tx = FromHex(CTransaction(), hex_tx)
 
+        # Check that wtxid is properly reported in mempool entry (txid1)
+        assert_equal(int(self.nodes[0].getmempoolentry(txid1)["wtxid"], 16), tx.calc_sha256(True))
+
         # Check that weight and sizei (actually vsize) are properly reported in mempool entry (txid1)
         assert_equal(self.nodes[0].getmempoolentry(txid1)["size"], (self.nodes[0].getmempoolentry(txid1)["weight"] + 3) // 4)
         assert_equal(self.nodes[0].getmempoolentry(txid1)["weight"], len(tx.serialize())*3 + len(tx.serialize_with_witness()))
@@ -261,6 +264,9 @@ class SegWitTest(BitcoinTestFramework):
         txid2 = self.nodes[0].sendrawtransaction(tx2_hex)
         tx = FromHex(CTransaction(), tx2_hex)
         assert(not tx.wit.is_null())
+
+        # Check that wtxid is properly reported in mempool entry (txid2)
+        assert_equal(int(self.nodes[0].getmempoolentry(txid2)["wtxid"], 16), tx.calc_sha256(True))
 
         # Check that weight and size (actually vsize) are properly reported in mempool entry (txid2)
         assert_equal(self.nodes[0].getmempoolentry(txid2)["size"], (self.nodes[0].getmempoolentry(txid2)["weight"] + 3) // 4)
@@ -290,7 +296,7 @@ class SegWitTest(BitcoinTestFramework):
         assert(txid2 in template_txids)
         assert(txid3 in template_txids)
 
-        # Check that wtxid is properly reported in mempool entry
+        # Check that wtxid is properly reported in mempool entry (txid3)
         assert_equal(int(self.nodes[0].getmempoolentry(txid3)["wtxid"], 16), tx.calc_sha256(True))
 
         # Check that weight and size (actually vsize) are properly reported in mempool entry (txid3)


### PR DESCRIPTION
Tested against master using the REST api (/rest/mempool/contents), simple addition of a field.

Personal use case is for fee analysis software.