### PR TITLE
Remove duplicate destination decoding

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -232,8 +232,6 @@ public:
     CBitcoinAddress(const char* pszAddress) { SetString(pszAddress); }
 
     CTxDestination Get() const;
-    bool GetKeyID(CKeyID &keyID) const;
-    bool IsScript() const;
 };
 
 class CBitcoinAddressVisitor : public boost::static_visitor<bool>
@@ -293,21 +291,6 @@ CTxDestination CBitcoinAddress::Get() const
         return CScriptID(id);
     else
         return CNoDestination();
-}
-
-bool CBitcoinAddress::GetKeyID(CKeyID& keyID) const
-{
-    if (!IsValid() || vchVersion != Params().Base58Prefix(CChainParams::PUBKEY_ADDRESS))
-        return false;
-    uint160 id;
-    memcpy(&id, vchData.data(), 20);
-    keyID = CKeyID(id);
-    return true;
-}
-
-bool CBitcoinAddress::IsScript() const
-{
-    return IsValid() && vchVersion == Params().Base58Prefix(CChainParams::SCRIPT_ADDRESS);
 }
 
 void CBitcoinSecret::SetKey(const CKey& vchSecret)

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -91,8 +91,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         if (nNet > 0)
         {
             // Credit
-            if (IsValidDestinationString(rec->address)) {
-                CTxDestination address = DecodeDestination(rec->address);
+            CTxDestination address = DecodeDestination(rec->address);
+            if (IsValidDestination(address)) {
                 if (wallet->mapAddressBook.count(address))
                 {
                     strHTML += "<b>" + tr("From") + ":</b> " + tr("unknown") + "<br>";


### PR DESCRIPTION
Follow up of #11117, this patch removes an extra unnecessary destination decoding that was identified while reviewing #11117. It is also the only case where `IsValidDestinationString` is called before `DecodeDestination`.

For reference see [comment](https://github.com/bitcoin/bitcoin/pull/11117#discussion_r137145517).