### PR TITLE
scripted-diff: Use <cxxx> instead of deprecated <xxx.h> when including C compatibility headers

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -441,6 +441,8 @@ Source code organization
     failures when those indirect dependencies change. Furthermore, it obscures what the real code
     dependencies are.
 
+- Use `#include <cxxx>` instead of the deprecated form `#include <xxx.h>` when including C compatibility headers (such as `<cstdint>`, `<cstdlib>`, `<cstring>`, etc.).
+
 - Don't import anything into the global namespace (`using namespace ...`). Use
   fully specified types such as `std::string`.
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -15,7 +15,7 @@
 
 #include <map>
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 /**

--- a/src/amount.h
+++ b/src/amount.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_AMOUNT_H
 #define BITCOIN_AMOUNT_H
 
-#include <stdint.h>
+#include <cstdint>
 
 /** Amount in satoshis (Can be negative) */
 typedef int64_t CAmount;

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -9,8 +9,8 @@
 #include "utilstrencodings.h"
 #include "crypto/common.h"
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 template <unsigned int BITS>
 base_uint<BITS>::base_uint(const std::string& str)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,10 +6,10 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
-#include <assert.h>
+#include <cassert>
 #include <cstring>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -7,9 +7,9 @@
 #include "hash.h"
 #include "uint256.h"
 
-#include <assert.h>
-#include <stdint.h>
-#include <string.h>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
 #include <vector>
 #include <string>
 #include <boost/variant/apply_visitor.hpp>

--- a/src/bench/Examples.cpp
+++ b/src/bench/Examples.cpp
@@ -18,7 +18,7 @@ static void Sleep100ms(benchmark::State& state)
 BENCHMARK(Sleep100ms);
 
 // Extremely fast-running benchmark:
-#include <math.h>
+#include <cmath>
 
 volatile double sum = 0.0; // volatile, global so not optimized away
 

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -5,7 +5,7 @@
 #include "bench.h"
 #include "perf.h"
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <iomanip>
 #include <sys/time.h>

--- a/src/bench/perf.h
+++ b/src/bench/perf.h
@@ -6,7 +6,7 @@
 #ifndef H_PERF
 #define H_PERF
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(__i386__)
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -15,7 +15,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <event2/buffer.h>
 #include <event2/keyvalq_struct.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -22,7 +22,7 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/thread.hpp>
 
-#include <stdio.h>
+#include <cstdio>
 
 /* Introduction text for doxygen: */
 

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -11,8 +11,8 @@
 #include "random.h"
 #include "streams.h"
 
-#include <math.h>
-#include <stdlib.h>
+#include <cmath>
+#include <cstdlib>
 
 
 #define LN2SQUARED 0.4804530139182014246671025263266649717305529515945455

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -10,7 +10,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "chainparamsseeds.h"
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -8,7 +8,7 @@
 #include "tinyformat.h"
 #include "util.h"
 
-#include <assert.h>
+#include <cassert>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -10,7 +10,7 @@
 #include "validation.h"
 #include "uint256.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 
 namespace Checkpoints {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -8,7 +8,7 @@
 #include "memusage.h"
 #include "random.h"
 
-#include <assert.h>
+#include <cassert>
 
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }

--- a/src/coins.h
+++ b/src/coins.h
@@ -14,8 +14,8 @@
 #include "serialize.h"
 #include "uint256.h"
 
-#include <assert.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
 
 #include <unordered_map>
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -42,7 +42,7 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 #include <ifaddrs.h>
-#include <limits.h>
+#include <climits>
 #include <netdb.h>
 #include <unistd.h>
 #endif

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -9,7 +9,7 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(HAVE_BYTESWAP_H)
 #include <byteswap.h>

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -11,7 +11,7 @@
 
 #include "compat/byteswap.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(HAVE_ENDIAN_H)
 #include <endian.h>

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,8 +6,8 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-#include <stdlib.h>
-#include <stdint.h>
+#include <cstdlib>
+#include <cstdint>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */
 static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_MERKLE
 #define BITCOIN_MERKLE
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include "primitives/transaction.h"

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_CONSENSUS_TX_VERIFY_H
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 class CBlockIndex;

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -5,8 +5,8 @@
 #include "aes.h"
 #include "crypto/common.h"
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 
 extern "C" {
 #include "crypto/ctaes/ctaes.c"

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,7 +8,7 @@
 #include "crypto/common.h"
 #include "crypto/chacha20.h"
 
-#include <string.h>
+#include <cstring>
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
 

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_CHACHA20_H
 #define BITCOIN_CRYPTO_CHACHA20_H
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 /** A PRNG class for ChaCha20. */
 class ChaCha20

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -9,8 +9,8 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 #include "compat/endian.h"
 

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -4,7 +4,7 @@
 
 #include "crypto/hmac_sha256.h"
 
-#include <string.h>
+#include <cstring>
 
 CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -7,8 +7,8 @@
 
 #include "crypto/sha256.h"
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -4,7 +4,7 @@
 
 #include "crypto/hmac_sha512.h"
 
-#include <string.h>
+#include <cstring>
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -7,8 +7,8 @@
 
 #include "crypto/sha512.h"
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for HMAC-SHA-512. */
 class CHMAC_SHA512

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -6,7 +6,7 @@
 
 #include "crypto/common.h"
 
-#include <string.h>
+#include <cstring>
 
 // Internal implementation code.
 namespace

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_RIPEMD160_H
 #define BITCOIN_CRYPTO_RIPEMD160_H
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -6,7 +6,7 @@
 
 #include "crypto/common.h"
 
-#include <string.h>
+#include <cstring>
 
 // Internal implementation code.
 namespace

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA1_H
 #define BITCOIN_CRYPTO_SHA1_H
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for SHA1. */
 class CSHA1

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -5,8 +5,8 @@
 #include "crypto/sha256.h"
 #include "crypto/common.h"
 
-#include <assert.h>
-#include <string.h>
+#include <cassert>
+#include <cstring>
 #include <atomic>
 
 #if defined(__x86_64__) || defined(__amd64__)

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA256_H
 #define BITCOIN_CRYPTO_SHA256_H
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 #include <string>
 
 /** A hasher class for SHA-256. */

--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -5,8 +5,8 @@
 // This is a translation to GCC extended asm syntax from YASM code by Intel
 // (available at the bottom of this file).
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 #if defined(__x86_64__) || defined(__amd64__)
 

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -6,7 +6,7 @@
 
 #include "crypto/common.h"
 
-#include <string.h>
+#include <cstring>
 
 // Internal implementation code.
 namespace

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA512_H
 #define BITCOIN_CRYPTO_SHA512_H
 
-#include <stdint.h>
-#include <stdlib.h>
+#include <cstdint>
+#include <cstdlib>
 
 /** A hasher class for SHA-512. */
 class CSHA512

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -12,7 +12,7 @@
 #include <leveldb/env.h>
 #include <leveldb/filter_policy.h>
 #include <memenv.h>
-#include <stdint.h>
+#include <cstdint>
 #include <algorithm>
 
 class CBitcoinLevelDBLogger : public leveldb::Logger {

--- a/src/fs.h
+++ b/src/fs.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_FS_H
 #define BITCOIN_FS_H
 
-#include <stdio.h>
+#include <cstdio>
 #include <string>
 
 #include <boost/filesystem.hpp>

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -15,7 +15,7 @@
 #include "utilstrencodings.h"
 #include "ui_interface.h"
 #include "crypto/hmac_sha256.h"
-#include <stdio.h>
+#include <cstdio>
 
 #include <boost/algorithm/string.hpp> // boost::trim
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -13,13 +13,13 @@
 #include "sync.h"
 #include "ui_interface.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <signal.h>
+#include <csignal>
 #include <future>
 
 #include <event2/thread.h>

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -6,7 +6,7 @@
 #define BITCOIN_HTTPSERVER_H
 
 #include <string>
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 
 static const int DEFAULT_HTTP_THREADS=4;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -48,12 +48,12 @@
 #include "wallet/wallet.h"
 #endif
 #include "warnings.h"
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include <memory>
 
 #ifndef WIN32
-#include <signal.h>
+#include <csignal>
 #endif
 
 #include <boost/algorithm/string/classification.hpp>

--- a/src/limitedmap.h
+++ b/src/limitedmap.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_LIMITEDMAP_H
 #define BITCOIN_LIMITEDMAP_H
 
-#include <assert.h>
+#include <cassert>
 #include <map>
 
 /** STL-like map container that only keeps the N elements with the highest value. */

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -7,7 +7,7 @@
 
 #include "indirectmap.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <map>
 #include <set>

--- a/src/miner.h
+++ b/src/miner.h
@@ -9,7 +9,7 @@
 #include "primitives/block.h"
 #include "txmempool.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <memory>
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/ordered_index.hpp>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -23,7 +23,7 @@
 #include "utilstrencodings.h"
 
 #ifdef WIN32
-#include <string.h>
+#include <cstring>
 #else
 #include <fcntl.h>
 #endif
@@ -36,7 +36,7 @@
 #endif
 
 
-#include <math.h>
+#include <cmath>
 
 // Dump addresses to peers.dat and banlist.dat every 15 minutes (900s)
 #define DUMP_ADDRESSES_INTERVAL 900

--- a/src/net.h
+++ b/src/net.h
@@ -24,7 +24,7 @@
 
 #include <atomic>
 #include <deque>
-#include <stdint.h>
+#include <cstdint>
 #include <thread>
 #include <memory>
 #include <condition_variable>

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -12,7 +12,7 @@
 #include "compat.h"
 #include "serialize.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -13,7 +13,7 @@
 #include "netaddress.h"
 #include "serialize.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -9,7 +9,7 @@
 #include "util.h"
 
 #include <cstdio>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 static bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)

--- a/src/pow.h
+++ b/src/pow.h
@@ -8,7 +8,7 @@
 
 #include "consensus/params.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 class CBlockHeader;
 class CBlockIndex;

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -5,10 +5,10 @@
 #ifndef BITCOIN_PREVECTOR_H
 #define BITCOIN_PREVECTOR_H
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstdint>
+#include <cstring>
 
 #include <iterator>
 #include <type_traits>

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_PRIMITIVES_TRANSACTION_H
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
-#include <stdint.h>
+#include <cstdint>
 #include "amount.h"
 #include "script/script.h"
 #include "serialize.h"

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,7 +15,7 @@
 #include "uint256.h"
 #include "version.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 /** Message header.

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -37,7 +37,7 @@
 #include "wallet/wallet.h"
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/thread.hpp>
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -20,7 +20,7 @@
 #include "util.h"
 #include "warnings.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <QDebug>
 #include <QTimer>

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -15,7 +15,7 @@
 #include <QTemporaryFile>
 #include <QVariant>
 #ifdef USE_DBUS
-#include <stdint.h>
+#include <cstdint>
 #include <QtDBus>
 #endif
 // Include ApplicationServices.h after QtDbus to avoid redefinition of check().

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -18,7 +18,7 @@
 #include "wallet/db.h"
 #include "wallet/wallet.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 QString TransactionDesc::FormatTxStatus(const CWalletTx& wtx)

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -10,7 +10,7 @@
 #include "timedata.h"
 #include "wallet/wallet.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 
 /* Return positive answer if transaction should be shown in list.

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -21,7 +21,7 @@
 #include "init.h"
 #include "util.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <QCloseEvent>
 #include <QLabel>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -29,7 +29,7 @@
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h" // for BackupWallet
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <QDebug>
 #include <QMessageBox>

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -14,7 +14,7 @@
 #include "util.h"             // for LogPrint()
 #include "utilstrencodings.h" // for GetTime()
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <limits>
 #include <chrono>
 #include <thread>

--- a/src/random.h
+++ b/src/random.h
@@ -10,7 +10,7 @@
 #include "crypto/common.h"
 #include "uint256.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 /* Seed OpenSSL PRNG with additional entropy data */
 void RandAddSeed();

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -25,7 +25,7 @@
 #include "utilstrencodings.h"
 #include "hash.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <univalue.h>
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -8,7 +8,7 @@
 #include "util.h"
 
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 
 #include <univalue.h>
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -27,7 +27,7 @@
 #include "warnings.h"
 
 #include <memory>
-#include <stdint.h>
+#include <cstdint>
 
 #include <univalue.h>
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -24,7 +24,7 @@
 #endif
 #include "warnings.h"
 
-#include <stdint.h>
+#include <cstdint>
 #ifdef HAVE_MALLOC_INFO
 #include <malloc.h>
 #endif

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -12,7 +12,7 @@
 #include "utiltime.h"
 #include "version.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <fstream>
 
 /**

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -10,7 +10,7 @@
 
 #include <list>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <univalue.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -30,7 +30,7 @@
 #include "wallet/wallet.h"
 #endif
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <univalue.h>
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -12,7 +12,7 @@
 
 #include <list>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <univalue.h>

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -7,7 +7,7 @@
 #include "random.h"
 #include "reverselock.h"
 
-#include <assert.h>
+#include <cassert>
 #include <boost/bind.hpp>
 #include <utility>
 

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_BITCOINCONSENSUS_H
 #define BITCOIN_BITCOINCONSENSUS_H
 
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(BUILD_BITCOIN_INTERNAL) && defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -10,7 +10,7 @@
 #include "primitives/transaction.h"
 
 #include <vector>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 class CPubKey;

--- a/src/script/ismine.h
+++ b/src/script/ismine.h
@@ -8,7 +8,7 @@
 
 #include "script/standard.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 class CKeyStore;
 class CScript;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -10,12 +10,12 @@
 #include "prevector.h"
 #include "serialize.h"
 
-#include <assert.h>
+#include <cassert>
 #include <climits>
 #include <limits>
 #include <stdexcept>
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 #include <string>
 #include <vector>
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -11,7 +11,7 @@
 
 #include <boost/variant.hpp>
 
-#include <stdint.h>
+#include <cstdint>
 
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -9,15 +9,15 @@
 #include "compat/endian.h"
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <ios>
 #include <limits>
 #include <map>
 #include <memory>
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <utility>
 #include <vector>
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -10,15 +10,15 @@
 #include "serialize.h"
 
 #include <algorithm>
-#include <assert.h>
+#include <cassert>
 #include <ios>
 #include <limits>
 #include <map>
 #include <set>
-#include <stdint.h>
-#include <stdio.h>
+#include <cstdint>
+#include <cstdio>
 #include <string>
-#include <string.h>
+#include <cstring>
 #include <utility>
 #include <vector>
 

--- a/src/support/cleanse.h
+++ b/src/support/cleanse.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_SUPPORT_CLEANSE_H
 #define BITCOIN_SUPPORT_CLEANSE_H
 
-#include <stdlib.h>
+#include <cstdlib>
 
 // Attempt to overwrite data in the specified memory span.
 void memory_cleanse(void *ptr, size_t len);

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -22,7 +22,7 @@
 #else
 #include <sys/mman.h> // for mmap
 #include <sys/resource.h> // for getrlimit
-#include <limits.h> // for PAGESIZE
+#include <climits> // for PAGESIZE
 #include <unistd.h> // for sysconf
 #endif
 

--- a/src/support/lockedpool.h
+++ b/src/support/lockedpool.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_SUPPORT_LOCKEDPOOL_H
 #define BITCOIN_SUPPORT_LOCKEDPOOL_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <list>
 #include <map>
 #include <mutex>

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -7,7 +7,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <stdio.h>
+#include <cstdio>
 
 #include <boost/thread.hpp>
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -16,7 +16,7 @@
 
 #include "test/test_bitcoin.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <boost/test/unit_test.hpp>
-#include <stdint.h>
+#include <cstdint>
 #include <sstream>
 #include <iomanip>
 #include <limits>

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -6,7 +6,7 @@
 #include "util.h"
 #include "test/test_bitcoin.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -8,7 +8,7 @@
 // It would probably be ideal to define dummy test(s) that report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
 
 #include <map>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include "support/events.h"
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -20,7 +20,7 @@
 #endif
 
 #include <fstream>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <limits>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "assert.h"

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -7,8 +7,8 @@
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
-#include <limits.h>
-#include <stdint.h>
+#include <climits>
+#include <cstdint>
 
 BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -7,7 +7,7 @@
 #include "hash.h"
 #include "test/test_bitcoin.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -20,7 +20,7 @@
 #include "version.h"
 #include "pubkey.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <unistd.h>
 
 #include <algorithm>

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -7,13 +7,13 @@
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
-#include <stdint.h>
+#include <cstdint>
 #include <sstream>
 #include <iomanip>
 #include <limits>
 #include <cmath>
 #include <string>
-#include <stdio.h>
+#include <cstdio>
 
 BOOST_FIXTURE_TEST_SUITE(uint256_tests, BasicTestingSetup)
 

--- a/src/test/univalue_tests.cpp
+++ b/src/test/univalue_tests.cpp
@@ -3,7 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <map>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -11,7 +11,7 @@
 #include "utilmoneystr.h"
 #include "test/test_bitcoin.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -6,8 +6,8 @@
 #define BITCOIN_TIMEDATA_H
 
 #include <algorithm>
-#include <assert.h>
-#include <stdint.h>
+#include <cassert>
+#include <cstdint>
 #include <vector>
 
 static const int64_t DEFAULT_MAX_TIME_ADJUSTMENT = 70 * 60;

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 #include <deque>
 #include <set>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -14,7 +14,7 @@
 #include "ui_interface.h"
 #include "init.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/thread.hpp>
 

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_UI_INTERFACE_H
 #define BITCOIN_UI_INTERFACE_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include <boost/signals2/last_value.hpp>

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -7,8 +7,8 @@
 
 #include "utilstrencodings.h"
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -6,10 +6,10 @@
 #ifndef BITCOIN_UINT256_H
 #define BITCOIN_UINT256_H
 
-#include <assert.h>
+#include <cassert>
 #include <cstring>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include "crypto/common.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -16,7 +16,7 @@
 #include "utilstrencodings.h"
 #include "utiltime.h"
 
-#include <stdarg.h>
+#include <cstdarg>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>

--- a/src/util.h
+++ b/src/util.h
@@ -23,7 +23,7 @@
 #include <atomic>
 #include <exception>
 #include <map>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/utilmoneystr.h
+++ b/src/utilmoneystr.h
@@ -9,7 +9,7 @@
 #ifndef BITCOIN_UTILMONEYSTR_H
 #define BITCOIN_UTILMONEYSTR_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 #include "amount.h"

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -9,7 +9,7 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <errno.h>
+#include <cerrno>
 #include <limits>
 
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -9,7 +9,7 @@
 #ifndef BITCOIN_UTILSTRENCODINGS_H
 #define BITCOIN_UTILSTRENCODINGS_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_UTILTIME_H
 #define BITCOIN_UTILTIME_H
 
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 
 /**

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,7 +23,7 @@
 #include <exception>
 #include <map>
 #include <set>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -12,7 +12,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #ifndef WIN32
 #include <sys/stat.h>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -20,7 +20,7 @@
 #include "rpcwallet.h"
 
 #include <fstream>
-#include <stdint.h>
+#include <cstdint>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -29,7 +29,7 @@
 
 #include <init.h>  // For StartShutdown
 
-#include <stdint.h>
+#include <cstdint>
 
 #include <univalue.h>
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -32,7 +32,7 @@
 #include "utilmoneystr.h"
 #include "wallet/fees.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -24,7 +24,7 @@
 #include <map>
 #include <set>
 #include <stdexcept>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -12,7 +12,7 @@
 #include "key.h"
 
 #include <list>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_WARNINGS_H
 #define BITCOIN_WARNINGS_H
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -9,7 +9,7 @@
 #include "config/bitcoin-config.h"
 #endif
 
-#include <stdarg.h>
+#include <cstdarg>
 #include <string>
 
 #if ENABLE_ZMQ


### PR DESCRIPTION
Use `<cxxx>` instead of deprecated `<xxx.h>` when including C compatibility headers.

Includes changed:

```
<assert.h>
<errno.h>
<limits.h>
<math.h>
<signal.h>
<stdarg.h>
<stdint.h>
<stdio.h>
<stdlib.h>
<string.h>
```