### PR TITLE
rpc: update cli for estimate*fee argument rename

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -116,7 +116,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getrawmempool", 0, "verbose" },
     { "estimatefee", 0, "nblocks" },
     { "estimatesmartfee", 0, "nblocks" },
-    { "estimaterawfee", 0, "nblocks" },
+    { "estimaterawfee", 0, "conf_target" },
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },
     { "prioritisetransaction", 2, "fee_delta" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -115,7 +115,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },
     { "estimatefee", 0, "nblocks" },
-    { "estimatesmartfee", 0, "nblocks" },
+    { "estimatesmartfee", 0, "conf_target" },
     { "estimaterawfee", 0, "conf_target" },
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -980,7 +980,7 @@ static const CRPCCommand commands[] =
     { "generating",         "generatetoaddress",      &generatetoaddress,      {"nblocks","address","maxtries"} },
 
     { "util",               "estimatefee",            &estimatefee,            {"nblocks"} },
-    { "util",               "estimatesmartfee",       &estimatesmartfee,       {"nblocks", "estimate_mode"} },
+    { "util",               "estimatesmartfee",       &estimatesmartfee,       {"conf_target", "estimate_mode"} },
 
     { "hidden",             "estimaterawfee",         &estimaterawfee,         {"conf_target", "threshold"} },
 };


### PR DESCRIPTION
The first argument of `estimaterawfee` was renamed from `nblocks` to `conf_target` in 06bcdb8da64502a64df03f3c89fbc6ccb72cd349. Update the client-side table as well.
This makes #10753 pass again.