### PR TITLE
[macOS] remove Growl support, remove unused code

### DIFF
--- a/src/qt/macnotificationhandler.h
+++ b/src/qt/macnotificationhandler.h
@@ -7,19 +7,16 @@
 
 #include <QObject>
 
-/** Macintosh-specific notification handler (supports UserNotificationCenter and Growl).
+/** Macintosh-specific notification handler (supports UserNotificationCenter).
  */
 class MacNotificationHandler : public QObject
 {
     Q_OBJECT
 
 public:
-    /** shows a 10.8+ UserNotification in the UserNotificationCenter
+    /** shows a macOS 10.8+ UserNotification in the UserNotificationCenter
      */
     void showNotification(const QString &title, const QString &text);
-
-    /** executes AppleScript */
-    void sendAppleScript(const QString &script);
 
     /** check if OS can handle UserNotifications */
     bool hasUserNotificationCenterSupport(void);

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -47,20 +47,6 @@ void MacNotificationHandler::showNotification(const QString &title, const QStrin
     }
 }
 
-// sendAppleScript just take a QString and executes it as apple script
-void MacNotificationHandler::sendAppleScript(const QString &script)
-{
-    QByteArray utf8 = script.toUtf8();
-    char* cString = (char *)utf8.constData();
-    NSString *scriptApple = [[NSString alloc] initWithUTF8String:cString];
-
-    NSAppleScript *as = [[NSAppleScript alloc] initWithSource:scriptApple];
-    NSDictionary *err = nil;
-    [as executeAndReturnError:&err];
-    [as release];
-    [scriptApple release];
-}
-
 bool MacNotificationHandler::hasUserNotificationCenterSupport(void)
 {
     Class possibleClass = NSClassFromString(@"NSUserNotificationCenter");

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -58,8 +58,6 @@ private:
         None,                       /**< Ignore informational notifications, and show a modal pop-up dialog for Critical notifications. */
         Freedesktop,                /**< Use DBus org.freedesktop.Notifications */
         QSystemTray,                /**< Use QSystemTray::showMessage */
-        Growl12,                    /**< Use the Growl 1.2 notification system (Mac only) */
-        Growl13,                    /**< Use the Growl 1.3 notification system (Mac only) */
         UserNotificationCenter      /**< Use the 10.8+ User Notification Center (Mac only) */
     };
     QString programName;
@@ -72,7 +70,6 @@ private:
 #endif
     void notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
 #ifdef Q_OS_MAC
-    void notifyGrowl(Class cls, const QString &title, const QString &text, const QIcon &icon);
     void notifyMacUserNotificationCenter(Class cls, const QString &title, const QString &text, const QIcon &icon);
 #endif
 };


### PR DESCRIPTION
There is no longer a reason to support Growl.
A) It went to pay-ware since a couple of years
B) Since OSX 10.8, the operating system has its own modal notification options (Notification Center).

This PR removes support for Growl.
OSX notification centre is still supported after this PR.