### PR TITLE
travis: Use deprecated trusty image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: required
 dist: trusty
 os: linux
 language: generic
+group: deprecated-2017Q3
 cache:
   directories:
   - depends/built


### PR DESCRIPTION
Hopefully works around travis failure until a proper fix.

To be precise, the macos build now fails with: 
```
pyenv: python3.6: command not found

The `python3.6' command exists in these Python versions:

  3.6

  3.6.1

make: *** [dist/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt] Error 127
```