### PR TITLE
Ignore old format estimation file

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -944,32 +944,9 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
         unsigned int nFileBestSeenHeight;
         filein >> nFileBestSeenHeight;
 
-        if (nVersionThatWrote < 149900) {
-            // Read the old fee estimates file for temporary use, but then discard.  Will start collecting data from scratch.
-            // decay is stored before buckets in old versions, so pre-read decay and pass into TxConfirmStats constructor
-            double tempDecay;
-            filein >> tempDecay;
-            if (tempDecay <= 0 || tempDecay >= 1)
-                throw std::runtime_error("Corrupt estimates file. Decay must be between 0 and 1 (non-inclusive)");
-
-            std::vector<double> tempBuckets;
-            filein >> tempBuckets;
-            size_t tempNum = tempBuckets.size();
-            if (tempNum <= 1 || tempNum > 1000)
-                throw std::runtime_error("Corrupt estimates file. Must have between 2 and 1000 feerate buckets");
-
-            std::map<double, unsigned int> tempMap;
-
-            std::unique_ptr<TxConfirmStats> tempFeeStats(new TxConfirmStats(tempBuckets, tempMap, MED_BLOCK_PERIODS, tempDecay, 1));
-            tempFeeStats->Read(filein, nVersionThatWrote, tempNum);
-            // if nVersionThatWrote < 139900 then another TxConfirmStats (for priority) follows but can be ignored.
-
-            tempMap.clear();
-            for (unsigned int i = 0; i < tempBuckets.size(); i++) {
-                tempMap[tempBuckets[i]] = i;
-            }
-        }
-        else { // nVersionThatWrote >= 149900
+        if (nVersionRequired < 149900) {
+            LogPrintf("%s: incompatible old fee estimation data (non-fatal). Version: %d\n", __func__, nVersionRequired);
+        } else { // New format introduced in 149900
             unsigned int nFileHistoricalFirst, nFileHistoricalBest;
             filein >> nFileHistoricalFirst >> nFileHistoricalBest;
             if (nFileHistoricalFirst > nFileHistoricalBest || nFileHistoricalBest > nFileBestSeenHeight) {


### PR DESCRIPTION
The fee estimation data format changed from 0.14.x to 0.15.0, so we should no longer read the old data. H/T @jnewbery, @morcos 

Pending testing.