### PR TITLE
[tests] Cleanup wildcard imports in functional tests

### DIFF
--- a/test/functional/abandonconflict.py
+++ b/test/functional/abandonconflict.py
@@ -10,8 +10,17 @@
  which are not included in a block and are not currently in the mempool. It has
  no effect on transactions which are already conflicted or abandoned.
 """
+
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    sync_blocks,
+    sync_mempools,
+)
 
 class AbandonConflictTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -29,23 +29,26 @@ Start three nodes:
       block 200. node2 will reject block 102 since it's assumed valid, but it
       isn't buried by at least two weeks' work.
 """
+
 import time
 
-from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.blocktools import create_block, create_coinbase
 from test_framework.key import CECKey
-from test_framework.mininode import (CBlockHeader,
-                                     COutPoint,
-                                     CTransaction,
-                                     CTxIn,
-                                     CTxOut,
-                                     NetworkThread,
-                                     NodeConn,
-                                     NodeConnCB,
-                                     msg_block,
-                                     msg_headers)
-from test_framework.script import (CScript, OP_TRUE)
+from test_framework.mininode import (
+    CBlockHeader,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_block,
+    msg_headers,
+)
+from test_framework.script import OP_TRUE, CScript
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (p2p_port, assert_equal)
+from test_framework.util import assert_equal, p2p_port
 
 class BaseNode(NodeConnCB):
     def send_header_for_blocks(self, new_blocks):

--- a/test/functional/bip65-cltv-p2p.py
+++ b/test/functional/bip65-cltv-p2p.py
@@ -8,12 +8,33 @@ Test that the CHECKLOCKTIMEVERIFY soft-fork activates at (regtest) block height
 1351.
 """
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import *
-from test_framework.blocktools import create_coinbase, create_block
-from test_framework.script import CScript, OP_1NEGATE, OP_CHECKLOCKTIMEVERIFY, OP_DROP, CScriptNum
 from io import BytesIO
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.mininode import (
+    CTransaction,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    ToHex,
+    mininode_lock,
+    msg_block,
+    msg_tx,
+)
+from test_framework.script import (
+    OP_1NEGATE,
+    OP_CHECKLOCKTIMEVERIFY,
+    OP_DROP,
+    CScript,
+    CScriptNum,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    hex_str_to_bytes,
+    p2p_port,
+    wait_until,
+)
 
 CLTV_HEIGHT = 1351
 
@@ -157,7 +178,6 @@ class BIP65Test(BitcoinTestFramework):
 
         node0.send_and_ping(msg_block(block))
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)
-
 
 if __name__ == '__main__':
     BIP65Test().main()

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -43,14 +43,16 @@ bip112txs_vary_OP_CSV_9 - 16 txs with nSequence = 9 evaluated against varying {r
 bip112tx_special - test negative argument to OP_CSV
 """
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
-from test_framework.mininode import ToHex, CTransaction, NetworkThread
-from test_framework.blocktools import create_coinbase, create_block
-from test_framework.comptool import TestInstance, TestManager
-from test_framework.script import *
-from io import BytesIO
 import time
+from decimal import Decimal
+from io import BytesIO
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.mininode import CTransaction, NetworkThread, ToHex
+from test_framework.script import OP_CHECKSEQUENCEVERIFY, OP_DROP, CScript
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import assert_equal, get_bip9_status, hex_str_to_bytes
 
 base_relative_locktime = 10
 seq_disable_flag = 1<<31
@@ -528,7 +530,6 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
         ### Missing aspects of test
         ##  Testing empty stack fails
-
 
 if __name__ == '__main__':
     BIP68_112_113Test().main()

--- a/test/functional/bip68-sequence.py
+++ b/test/functional/bip68-sequence.py
@@ -4,9 +4,26 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test BIP68 implementation."""
 
+from test_framework.blocktools import (
+    COIN,
+    COutPoint,
+    CScript,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    FromHex,
+    ToHex,
+    create_block,
+    create_coinbase,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.blocktools import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    get_bip9_status,
+    satoshi_round,
+    sync_blocks,
+)
 
 SEQUENCE_LOCKTIME_DISABLE_FLAG = (1<<31)
 SEQUENCE_LOCKTIME_TYPE_FLAG = (1<<22) # this means use time (0 means height)
@@ -129,7 +146,7 @@ class BIP68Test(BitcoinTestFramework):
 
             # Track whether any sequence locks used should fail
             should_pass = True
-            
+
             # Track whether this transaction was built with sequence locks
             using_sequence_locks = False
 
@@ -343,7 +360,7 @@ class BIP68Test(BitcoinTestFramework):
         tx2.rehash()
 
         self.nodes[0].sendrawtransaction(ToHex(tx2))
-        
+
         # Now make an invalid spend of tx2 according to BIP68
         sequence_value = 100 # 100 block relative locktime
 

--- a/test/functional/bip9-softforks.py
+++ b/test/functional/bip9-softforks.py
@@ -15,17 +15,27 @@ mine a further 143 blocks (LOCKED_IN)
 test that enforcement has not triggered (which triggers ACTIVE)
 test that enforcement has triggered
 """
-from io import BytesIO
+
+import itertools
 import shutil
 import time
-import itertools
+from io import BytesIO
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
-from test_framework.blocktools import create_coinbase, create_block
+from test_framework.blocktools import create_block, create_coinbase
 from test_framework.comptool import TestInstance, TestManager
-from test_framework.script import CScript, OP_1NEGATE, OP_CHECKSEQUENCEVERIFY, OP_DROP
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.script import (
+    OP_1NEGATE,
+    OP_CHECKSEQUENCEVERIFY,
+    OP_DROP,
+    CScript,
+)
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import (
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+)
 
 class BIP9SoftForksTest(ComparisonTestFramework):
     def set_test_params(self):

--- a/test/functional/bipdersig-p2p.py
+++ b/test/functional/bipdersig-p2p.py
@@ -7,12 +7,26 @@
 Test that the DERSIG soft-fork activates at (regtest) height 1251.
 """
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import *
-from test_framework.blocktools import create_coinbase, create_block
-from test_framework.script import CScript
 from io import BytesIO
+
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.mininode import (
+    CTransaction,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    mininode_lock,
+    msg_block,
+    msg_tx,
+)
+from test_framework.script import CScript
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    hex_str_to_bytes,
+    p2p_port,
+    wait_until,
+)
 
 DERSIG_HEIGHT = 1251
 

--- a/test/functional/bitcoin_cli.py
+++ b/test/functional/bitcoin_cli.py
@@ -4,7 +4,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test bitcoin-cli"""
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_process_error, get_auth_cookie
+from test_framework.util import (
+    assert_equal,
+    assert_raises_process_error,
+    get_auth_cookie,
+)
 
 class TestBitcoinCli(BitcoinTestFramework):
 

--- a/test/functional/blockchain.py
+++ b/test/functional/blockchain.py
@@ -17,17 +17,17 @@ Test the following RPCs:
 Tests correspond to code in rpc/blockchain.cpp.
 """
 
-from decimal import Decimal
 import http.client
 import subprocess
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_is_hash_string,
+    assert_is_hex_string,
     assert_raises,
     assert_raises_jsonrpc,
-    assert_is_hex_string,
-    assert_is_hash_string,
 )
 
 class BlockchainTest(BitcoinTestFramework):
@@ -144,7 +144,6 @@ class BlockchainTest(BitcoinTestFramework):
         self.nodes[0].wait_until_stopped()
         self.start_node(0)
         assert_equal(self.nodes[0].getblockcount(), 207)
-
 
 if __name__ == '__main__':
     BlockchainTest().main()

--- a/test/functional/bumpfee.py
+++ b/test/functional/bumpfee.py
@@ -14,20 +14,28 @@ added in the future, they should try to follow the same convention and not
 make assumptions about execution order.
 """
 
+import io
+from decimal import Decimal
+
 from segwit import send_to_witness
-from test_framework.test_framework import BitcoinTestFramework
 from test_framework import blocktools
 from test_framework.mininode import CTransaction
-from test_framework.util import *
-
-import io
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_jsonrpc,
+    bytes_to_hex_str,
+    connect_nodes_bi,
+    hex_str_to_bytes,
+    sync_mempools,
+)
 
 # Sequence number that is BIP 125 opt-in and BIP 68-compliant
 BIP125_SEQUENCE_NUMBER = 0xfffffffd
 
 WALLET_PASSPHRASE = "test"
 WALLET_PASSPHRASE_TIMEOUT = 3600
-
 
 class BumpFeeTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -293,7 +301,6 @@ def submit_block_with_tx(node, tx):
     block.solve()
     node.submitblock(bytes_to_hex_str(block.serialize(True)))
     return block
-
 
 if __name__ == "__main__":
     BumpFeeTest().main()

--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -5,12 +5,12 @@ This streams the combined log output to stdout. Use combine_logs.py > outputfile
 to write to an outputfile."""
 
 import argparse
-from collections import defaultdict, namedtuple
 import heapq
 import itertools
 import os
 import re
 import sys
+from collections import defaultdict, namedtuple
 
 # Matches on the date format at the start of the log event
 TIMESTAMP_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{6}")

--- a/test/functional/dbcrash.py
+++ b/test/functional/dbcrash.py
@@ -31,10 +31,20 @@ import random
 import sys
 import time
 
-from test_framework.mininode import *
-from test_framework.script import *
+from test_framework.mininode import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    ToHex,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    create_confirmed_utxos,
+    hex_str_to_bytes,
+)
 
 HTTP_DISCONNECT_ERRORS = [http.client.CannotSendRequest]
 try:

--- a/test/functional/decodescript.py
+++ b/test/functional/decodescript.py
@@ -4,10 +4,15 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test decoding scripts via decodescript RPC command."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import *
 from io import BytesIO
+
+from test_framework.mininode import CTransaction
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+)
 
 class DecodeScriptTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/disablewallet.py
+++ b/test/functional/disablewallet.py
@@ -9,7 +9,7 @@
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_raises_jsonrpc
 
 class DisableWalletTest (BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -9,12 +9,13 @@ what the test is doing. It's the first thing people see when they open
 the file and should give the reader information about *what* the test
 is testing and *how* it's being tested
 """
+
 # Imports should be in PEP8 ordering (std library first, then third party
 # libraries then local imports).
 from collections import defaultdict
 
 # Avoid wildcard * imports if possible
-from test_framework.blocktools import (create_block, create_coinbase)
+from test_framework.blocktools import create_block, create_coinbase
 from test_framework.mininode import (
     CInv,
     NetworkThread,

--- a/test/functional/forknotify.py
+++ b/test/functional/forknotify.py
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the -alertnotify option."""
+
 import os
 import time
 

--- a/test/functional/fundrawtransaction.py
+++ b/test/functional/fundrawtransaction.py
@@ -4,9 +4,18 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the fundrawtransaction RPC."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from decimal import Decimal
 
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_fee_amount,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+    assert_raises_jsonrpc,
+    connect_nodes_bi,
+    count_bytes,
+)
 
 def get_unspent(listunspent, amount):
     for utx in listunspent:

--- a/test/functional/getblocktemplate_longpoll.py
+++ b/test/functional/getblocktemplate_longpoll.py
@@ -4,10 +4,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test longpolling with getblocktemplate."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-
 import threading
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import get_rpc_proxy, random_transaction
 
 class LongpollThread(threading.Thread):
     def __init__(self, node):
@@ -68,4 +69,3 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     GetBlockTemplateLPTest().main()
-

--- a/test/functional/httpbasics.py
+++ b/test/functional/httpbasics.py
@@ -4,11 +4,11 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the RPC HTTP basics."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-
 import http.client
 import urllib.parse
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, str_to_b64str
 
 class HTTPBasicsTest (BitcoinTestFramework):
     def set_test_params(self):
@@ -102,7 +102,6 @@ class HTTPBasicsTest (BitcoinTestFramework):
         conn.request('GET', '/' + ('x'*10000), '', headers)
         out1 = conn.getresponse()
         assert_equal(out1.status, http.client.BAD_REQUEST)
-
 
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -19,18 +19,22 @@ importing nodes pick up the new transactions regardless of whether rescans
 happened previously.
 """
 
-from test_framework.authproxy import JSONRPCException
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (connect_nodes, sync_blocks, assert_equal, set_node_times)
-
 import collections
 import enum
 import itertools
 
+from test_framework.authproxy import JSONRPCException
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    set_node_times,
+    sync_blocks,
+)
+
 Call = enum.Enum("Call", "single multi")
 Data = enum.Enum("Data", "address pub priv")
 Rescan = enum.Enum("Rescan", "no yes late_timestamp")
-
 
 class Variant(collections.namedtuple("Variant", "call data rescan prune")):
     """Helper for importing one key and verifying scanned transactions."""
@@ -185,7 +189,6 @@ def try_rpc(func, *args, **kwargs):
         return func(*args, **kwargs), None
     except JSONRPCException as e:
         return None, e.error
-
 
 if __name__ == "__main__":
     ImportRescanTest().main()

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -3,8 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the importmulti RPC."""
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    JSONRPCException,
+    assert_equal,
+    assert_greater_than,
+    assert_raises_message,
+)
 
 class ImportMultiTest (BitcoinTestFramework):
     def set_test_params(self):
@@ -432,7 +438,6 @@ class ImportMultiTest (BitcoinTestFramework):
                 "scriptPubKey": address['scriptPubKey'],
                 "timestamp": "",
             }])
-
 
 if __name__ == '__main__':
     ImportMultiTest ().main ()

--- a/test/functional/importprunedfunds.py
+++ b/test/functional/importprunedfunds.py
@@ -3,8 +3,11 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the importprunedfunds and removeprunedfunds RPCs."""
+
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class ImportPrunedFundsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -16,7 +19,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         self.nodes[0].generate(101)
 
         self.sync_all()
-        
+
         # address
         address1 = self.nodes[0].getnewaddress()
         # pubkey

--- a/test/functional/invalidateblock.py
+++ b/test/functional/invalidateblock.py
@@ -4,8 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the invalidateblock RPC."""
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, connect_nodes_bi, sync_blocks
 
 class InvalidateTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/invalidblockrequest.py
+++ b/test/functional/invalidblockrequest.py
@@ -11,12 +11,19 @@ In this test we connect to one node over p2p, and test block requests:
 re-requested.
 """
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
-from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
 import copy
 import time
+
+from test_framework.blocktools import (
+    COIN,
+    NetworkThread,
+    create_block,
+    create_coinbase,
+    create_transaction,
+)
+from test_framework.comptool import RejectResult, TestInstance, TestManager
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import assert_equal
 
 # Use the ComparisonTestFramework with 1 node: only use --testbinary.
 class InvalidBlockRequestTest(ComparisonTestFramework):
@@ -110,7 +117,6 @@ class InvalidBlockRequestTest(ComparisonTestFramework):
         block3.solve()
 
         yield TestInstance([[block3, RejectResult(16, b'bad-cb-amount')]])
-
 
 if __name__ == '__main__':
     InvalidBlockRequestTest().main()

--- a/test/functional/invalidtxrequest.py
+++ b/test/functional/invalidtxrequest.py
@@ -7,12 +7,17 @@
 In this test we connect to one node over p2p, and test tx requests.
 """
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
 import time
 
-
+from test_framework.blocktools import (
+    COIN,
+    NetworkThread,
+    create_block,
+    create_coinbase,
+    create_transaction,
+)
+from test_framework.comptool import RejectResult, TestInstance, TestManager
+from test_framework.test_framework import ComparisonTestFramework
 
 # Use the ComparisonTestFramework with 1 node: only use --testbinary.
 class InvalidTxRequestTest(ComparisonTestFramework):

--- a/test/functional/keypool-topup.py
+++ b/test/functional/keypool-topup.py
@@ -10,14 +10,11 @@ Two nodes. Node1 is under test. Node0 is providing transactions and generating b
 - Generate 110 keys (enough to drain the keypool). Store key 90 (in the initial keypool) and key 110 (beyond the initial keypool). Send funds to key 90 and key 110.
 - Stop node1, clear the datadir, move wallet file back into the datadir and restart node1.
 - connect node1 to node0. Verify that they sync and node1 receives its funds."""
+
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-    connect_nodes_bi,
-    sync_blocks,
-)
+from test_framework.util import assert_equal, connect_nodes_bi, sync_blocks
 
 class KeypoolRestoreTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/keypool.py
+++ b/test/functional/keypool.py
@@ -4,8 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet keypool and interaction with wallet encryption/locking."""
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class KeyPoolTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/listtransactions.py
+++ b/test/functional/listtransactions.py
@@ -4,10 +4,18 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the listtransactions API."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import CTransaction, COIN
+from decimal import Decimal
 from io import BytesIO
+
+from test_framework.mininode import COIN, CTransaction
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+    sync_mempools,
+)
 
 def txFromHex(hexstring):
     tx = CTransaction()
@@ -195,7 +203,5 @@ class ListTransactionsTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
         assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")
 
-
 if __name__ == '__main__':
     ListTransactionsTest().main()
-

--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -10,12 +10,19 @@ if uploadtarget has been reached.
 if uploadtarget has been reached.
 * Verify that the upload counters are reset after 24 hours.
 """
-from collections import defaultdict
-import time
 
-from test_framework.mininode import *
+import time
+from collections import defaultdict
+
+from test_framework.mininode import (
+    CInv,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_getdata,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, mine_large_block, p2p_port
 
 class TestNode(NodeConnCB):
     def __init__(self):

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -5,7 +5,11 @@
 """Test mempool limiting together/eviction with the wallet."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    create_confirmed_utxos,
+    create_lots_of_big_transactions,
+    gen_return_txouts,
+)
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -4,9 +4,17 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test descendant package tracking code."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from decimal import Decimal
+
 from test_framework.mininode import COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    satoshi_round,
+    sync_blocks,
+    sync_mempools,
+)
 
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
@@ -100,7 +108,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         for x in chain:
             ancestor_fees += mempool[x]['fee']
             assert_equal(mempool[x]['ancestorfees'], ancestor_fees * COIN + 1000)
-        
+
         # Undo the prioritisetransaction for later tests
         self.nodes[0].prioritisetransaction(txid=chain[0], fee_delta=-1000)
 
@@ -232,7 +240,7 @@ class MempoolPackagesTest(BitcoinTestFramework):
         signedtx = self.nodes[0].signrawtransaction(rawtx)
         txid = self.nodes[0].sendrawtransaction(signedtx['hex'])
         sync_mempools(self.nodes)
-        
+
         # Now try to disconnect the tip on each node...
         self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -33,13 +33,14 @@ Test is as follows:
     mempool.
   - Verify that savemempool throws when the RPC is called if
     node1 can't write to disk.
-
 """
+
 import os
 import time
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, wait_until
 
 class MempoolPersistTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -9,7 +9,7 @@ that spend (directly or indirectly) coinbase transactions.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, create_tx
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):

--- a/test/functional/mempool_resurrect_test.py
+++ b/test/functional/mempool_resurrect_test.py
@@ -5,7 +5,7 @@
 """Test resurrection of mined transactions when the blockchain is re-organized."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, create_tx
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolCoinbaseTest(BitcoinTestFramework):
@@ -62,7 +62,6 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         for txid in spends1_id+spends2_id:
             tx = self.nodes[0].gettransaction(txid)
             assert(tx["confirmations"] > 0)
-
 
 if __name__ == '__main__':
     MempoolCoinbaseTest().main()

--- a/test/functional/mempool_spendcoinbase.py
+++ b/test/functional/mempool_spendcoinbase.py
@@ -13,7 +13,7 @@ but less mature coinbase spends are NOT.
 """
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, assert_raises_jsonrpc, create_tx
 
 # Create one-input, one-output, no-fee transaction:
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):

--- a/test/functional/merkle_blocks.py
+++ b/test/functional/merkle_blocks.py
@@ -5,7 +5,11 @@
 """Test gettxoutproof and verifytxoutproof RPCs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    connect_nodes,
+)
 
 class MerkleBlockTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -77,7 +81,6 @@ class MerkleBlockTest(BitcoinTestFramework):
         assert_equal(self.nodes[2].verifytxoutproof(self.nodes[3].gettxoutproof([txid_spent])), [txid_spent])
         # We can't get a proof if we specify transactions from different blocks
         assert_raises_jsonrpc(-5, "Not all transactions found in specified or retrieved block", self.nodes[2].gettxoutproof, [txid1, txid3])
-
 
 if __name__ == '__main__':
     MerkleBlockTest().main()

--- a/test/functional/minchainwork.py
+++ b/test/functional/minchainwork.py
@@ -18,7 +18,7 @@ only succeeds past a given node once its nMinimumChainWork has been exceeded.
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import sync_blocks, connect_nodes, assert_equal
+from test_framework.util import assert_equal, connect_nodes
 
 # 2 hashes required per regtest block (with no difficulty adjustment)
 REGTEST_WORK_PER_BLOCK = 2

--- a/test/functional/multi_rpc.py
+++ b/test/functional/multi_rpc.py
@@ -4,14 +4,14 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test multiple RPC users."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import str_to_b64str, assert_equal
-
-import os
 import http.client
+import os
 import urllib.parse
 
-class HTTPBasicsTest (BitcoinTestFramework):
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, str_to_b64str
+
+class HTTPBasicsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
 
@@ -147,7 +147,6 @@ class HTTPBasicsTest (BitcoinTestFramework):
         resp = conn.getresponse()
         assert_equal(resp.status, 401)
         conn.close()
-
 
 if __name__ == '__main__':
     HTTPBasicsTest ().main ()

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -13,13 +13,23 @@ Generate 427 more blocks.
 [Policy/Consensus] Check that the new NULLDUMMY rules are enforced on the 432nd block.
 """
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import CTransaction, NetworkThread
-from test_framework.blocktools import create_coinbase, create_block, add_witness_commitment
-from test_framework.script import CScript
-from io import BytesIO
 import time
+from io import BytesIO
+
+from test_framework.blocktools import (
+    add_witness_commitment,
+    create_block,
+    create_coinbase,
+)
+from test_framework.mininode import CTransaction, NetworkThread
+from test_framework.script import CScript
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+)
 
 NULLDUMMY_ERROR = "64: non-mandatory-script-verify-flag (Dummy CHECKMULTISIG argument must be zero)"
 

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -48,11 +48,23 @@ The test:
    Node0 should process and the tip should advance.
 """
 
-from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+import os
 import time
+
 from test_framework.blocktools import create_block, create_coinbase
+from test_framework.mininode import (
+    CBlockHeader,
+    CInv,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    mininode_lock,
+    msg_block,
+    msg_headers,
+    msg_inv,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_jsonrpc, p2p_port
 
 class AcceptBlockTest(BitcoinTestFramework):
     def add_options(self, parser):

--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -8,11 +8,15 @@ Version 1 compact blocks are pre-segwit (txids)
 Version 2 compact blocks are post-segwit (wtxids)
 """
 
+from test_framework.blocktools import (
+    add_witness_commitment,
+    create_block,
+    create_coinbase,
+)
 from test_framework.mininode import *
+from test_framework.script import OP_TRUE, CScript
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment
-from test_framework.script import CScript, OP_TRUE
 
 # TestNode: A peer we use to send messages to bitcoind, and store responses.
 class TestNode(NodeConnCB):

--- a/test/functional/p2p-feefilter.py
+++ b/test/functional/p2p-feefilter.py
@@ -4,11 +4,18 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test processing of feefilter messages."""
 
-from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
 import time
+from decimal import Decimal
 
+from test_framework.mininode import (
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    mininode_lock,
+    msg_feefilter,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import p2p_port, sync_blocks, sync_mempools
 
 def hashToHex(hash):
     return format(hash, '064x')

--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -11,14 +11,15 @@ We use the testing framework in which we expect a particular answer from
 each test.
 """
 
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
-from test_framework.comptool import TestManager, TestInstance, RejectResult
-from test_framework.blocktools import *
+import struct
 import time
+
+from test_framework.blocktools import *
+from test_framework.comptool import RejectResult, TestInstance, TestManager
 from test_framework.key import CECKey
 from test_framework.script import *
-import struct
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import *
 
 class PreviousSpendableOutput(object):
     def __init__(self, tx = CTransaction(), n = -1):

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -14,9 +14,22 @@ Also test that nodes that send unsupported service bits to bitcoind are disconne
 and don't receive a VERACK. Unsupported service bits are currently 1 << 5 and
 1 << 7 (until August 1st 2018)."""
 
-from test_framework.mininode import *
+import time
+
+from test_framework.mininode import (
+    NODE_NETWORK,
+    NODE_UNSUPPORTED_SERVICE_BIT_5,
+    NODE_UNSUPPORTED_SERVICE_BIT_7,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    mininode_lock,
+    msg_getaddr,
+    msg_ping,
+    msg_verack,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import p2p_port, wait_until
 
 banscore = 10
 

--- a/test/functional/p2p-mempool.py
+++ b/test/functional/p2p-mempool.py
@@ -8,9 +8,14 @@ Test that nodes are disconnected if they send mempool messages when bloom
 filters are not enabled.
 """
 
-from test_framework.mininode import *
+from test_framework.mininode import (
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_mempool,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_equal, p2p_port
 
 class P2PMempoolTests(BitcoinTestFramework):
     def set_test_params(self):
@@ -32,6 +37,6 @@ class P2PMempoolTests(BitcoinTestFramework):
 
         #mininode must be disconnected at this point
         assert_equal(len(self.nodes[0].getpeerinfo()), 0)
-    
+
 if __name__ == '__main__':
     P2PMempoolTests().main()

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -4,15 +4,22 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test segwit transactions and blocks on P2P network."""
 
+import random
+import time
+from binascii import hexlify
+
+from test_framework.blocktools import (
+    WITNESS_COMMITMENT_HEADER,
+    add_witness_commitment,
+    create_block,
+    create_coinbase,
+    get_witness_script,
+)
+from test_framework.key import CECKey, CPubKey
 from test_framework.mininode import *
+from test_framework.script import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.script import *
-from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment, get_witness_script, WITNESS_COMMITMENT_HEADER
-from test_framework.key import CECKey, CPubKey
-import time
-import random
-from binascii import hexlify
 
 # The versionbit bit used to signal activation of SegWit
 VB_WITNESS_BIT = 1
@@ -20,7 +27,6 @@ VB_PERIOD = 144
 VB_TOP_BITS = 0x20000000
 
 MAX_SIGOP_COST = 80000
-
 
 # Calculate the virtual size of a witness block:
 # (base + witness/4)
@@ -1943,7 +1949,6 @@ class SegWitTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
         self.test_upgrade_after_activation(node_id=2)
         self.test_witness_sigops()
-
 
 if __name__ == '__main__':
     SegWitTest().main()

--- a/test/functional/p2p-timeouts.py
+++ b/test/functional/p2p-timeouts.py
@@ -23,9 +23,14 @@
 
 from time import sleep
 
-from test_framework.mininode import *
+from test_framework.mininode import (
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_ping,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import p2p_port
 
 class TestNode(NodeConnCB):
     def on_version(self, conn, message):

--- a/test/functional/p2p-versionbits-warning.py
+++ b/test/functional/p2p-versionbits-warning.py
@@ -8,11 +8,18 @@ Generate chains with block versions that appear to be signalling unknown
 soft-forks, and test that warning alerts are generated.
 """
 
-from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+import os
 import re
+
 from test_framework.blocktools import create_block, create_coinbase
+from test_framework.mininode import (
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    msg_block,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import p2p_port
 
 VB_PERIOD = 144 # versionbits period length for regtest
 VB_THRESHOLD = 108 # versionbits activation threshold for regtest

--- a/test/functional/preciousblock.py
+++ b/test/functional/preciousblock.py
@@ -8,8 +8,8 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes_bi,
-    sync_chain,
     sync_blocks,
+    sync_chain,
 )
 
 def unidirectional_node_sync_via_rpc(node_src, node_dest):

--- a/test/functional/prioritise_transaction.py
+++ b/test/functional/prioritise_transaction.py
@@ -4,9 +4,17 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the prioritisetransaction mining RPC."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+import time
+
 from test_framework.mininode import COIN, MAX_BLOCK_BASE_SIZE
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    create_confirmed_utxos,
+    create_lots_of_big_transactions,
+    gen_return_txouts,
+)
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/proxy_test.py
+++ b/test/functional/proxy_test.py
@@ -27,17 +27,18 @@ addnode connect to onion
 addnode connect to generic DNS name
 """
 
-import socket
 import os
+import socket
 
-from test_framework.socks5 import Socks5Configuration, Socks5Command, Socks5Server, AddressType
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    PORT_MIN,
-    PORT_RANGE,
-    assert_equal,
-)
 from test_framework.netutil import test_ipv6_local
+from test_framework.socks5 import (
+    AddressType,
+    Socks5Command,
+    Socks5Configuration,
+    Socks5Server,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import PORT_MIN, PORT_RANGE, assert_equal
 
 RANGE_BEGIN = PORT_MIN + 2 * PORT_RANGE  # Start after p2p and rpc ports
 
@@ -182,7 +183,7 @@ class ProxyTest(BitcoinTestFramework):
         assert_equal(n1['onion']['proxy'], '%s:%i' % (self.conf2.addr))
         assert_equal(n1['onion']['proxy_randomize_credentials'], False)
         assert_equal(n1['onion']['reachable'], True)
-        
+
         n2 = networks_dict(self.nodes[2].getnetworkinfo())
         for net in ['ipv4','ipv6','onion']:
             assert_equal(n2[net]['proxy'], '%s:%i' % (self.conf2.addr))

--- a/test/functional/pruning.py
+++ b/test/functional/pruning.py
@@ -9,10 +9,18 @@ This test uses 4GB of disk space.
 This test takes 30 mins or more (up to 2 hours)
 """
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-import time
 import os
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_raises_jsonrpc,
+    connect_nodes,
+    mine_large_block,
+    sync_blocks,
+)
 
 MIN_BLOCKS_TO_KEEP = 288
 
@@ -20,7 +28,6 @@ MIN_BLOCKS_TO_KEEP = 288
 # the manual prune RPC avoids pruning blocks in the same window to be
 # compatible with pruning based on key creation time.
 TIMESTAMP_WINDOW = 2 * 60 * 60
-
 
 def calc_usage(blockdir):
     return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(blockdir+f)) / (1024. * 1024.)

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -12,8 +12,14 @@ Test the following RPCs:
    - getrawtransaction
 """
 
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    connect_nodes_bi,
+)
 
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):

--- a/test/functional/receivedby.py
+++ b/test/functional/receivedby.py
@@ -4,8 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the listreceivedbyaddress RPC."""
 
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import assert_array_result
 
 def get_sub_array_from_array(object_array, to_match):
     '''

--- a/test/functional/reindex.py
+++ b/test/functional/reindex.py
@@ -9,9 +9,10 @@
 - Stop the node and restart it with -reindex-chainstate. Verify that the node has reindexed up to block 3.
 """
 
+import time
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
-import time
 
 class ReindexTest(BitcoinTestFramework):
 

--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -4,10 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the RBF code."""
 
+from test_framework.mininode import *
+from test_framework.script import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
-from test_framework.script import *
-from test_framework.mininode import *
 
 MAX_REPLACEMENT_LIMIT = 100
 

--- a/test/functional/rest.py
+++ b/test/functional/rest.py
@@ -4,14 +4,21 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the REST API."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from struct import *
-from io import BytesIO
-from codecs import encode
-
 import http.client
+import json
 import urllib.parse
+from codecs import encode
+from decimal import Decimal
+from io import BytesIO
+from struct import pack, unpack
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    connect_nodes_bi,
+    hex_str_to_bytes,
+)
 
 def deser_uint256(f):
     r = 0

--- a/test/functional/rpcbind_test.py
+++ b/test/functional/rpcbind_test.py
@@ -7,9 +7,16 @@
 import socket
 import sys
 
+from test_framework.netutil import addr_to_hex, all_interfaces, get_bind_addrs
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
-from test_framework.util import *
-from test_framework.netutil import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    get_datadir_path,
+    get_rpc_proxy,
+    rpc_port,
+    rpc_url,
+)
 
 class RPCBindTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/rpcnamedargs.py
+++ b/test/functional/rpcnamedargs.py
@@ -5,10 +5,7 @@
 """Test using named arguments for RPCs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-    assert_raises_jsonrpc,
-)
+from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class NamedArgumentTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -4,12 +4,44 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the SegWit changeover logic."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import sha256, CTransaction, CTxIn, COutPoint, CTxOut, COIN, ToHex, FromHex
-from test_framework.address import script_to_p2sh, key_to_p2pkh
-from test_framework.script import CScript, OP_HASH160, OP_CHECKSIG, OP_0, hash160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_1, OP_2, OP_CHECKMULTISIG, OP_TRUE
+from decimal import Decimal
 from io import BytesIO
+
+from test_framework.address import key_to_p2pkh, script_to_p2sh
+from test_framework.mininode import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    FromHex,
+    ToHex,
+    sha256,
+)
+from test_framework.script import (
+    OP_0,
+    OP_1,
+    OP_2,
+    OP_CHECKMULTISIG,
+    OP_CHECKSIG,
+    OP_DUP,
+    OP_EQUAL,
+    OP_EQUALVERIFY,
+    OP_HASH160,
+    OP_TRUE,
+    CScript,
+    hash160,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    JSONRPCException,
+    assert_equal,
+    assert_raises_jsonrpc,
+    bytes_to_hex_str,
+    connect_nodes,
+    hex_str_to_bytes,
+    sync_blocks,
+)
 
 NODE_0 = 0
 NODE_2 = 2

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -73,11 +73,24 @@ e. Announce one more that doesn't connect.
    Expect: disconnect.
 """
 
-from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
 from test_framework.blocktools import create_block, create_coinbase
-
+from test_framework.mininode import (
+    CBlockHeader,
+    CInv,
+    NetworkThread,
+    NodeConn,
+    NodeConnCB,
+    mininode_lock,
+    msg_block,
+    msg_getblocks,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_sendheaders,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, p2p_port, sync_blocks, wait_until
 
 direct_fetch_response_time = 0.05
 

--- a/test/functional/signrawtransactions.py
+++ b/test/functional/signrawtransactions.py
@@ -5,8 +5,7 @@
 """Test transaction signing using the signrawtransaction RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-
+from test_framework.util import JSONRPCException, assert_equal, assert_raises
 
 class SignRawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -137,7 +136,6 @@ class SignRawTransactionsTest(BitcoinTestFramework):
     def run_test(self):
         self.successful_signing_test()
         self.script_verification_error_test()
-
 
 if __name__ == '__main__':
     SignRawTransactionsTest().main()

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -4,10 +4,34 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test fee estimation code."""
 
+import random
+from decimal import Decimal
+
+from test_framework.mininode import (
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    ToHex,
+)
+from test_framework.script import (
+    OP_1,
+    OP_2,
+    OP_DROP,
+    OP_EQUAL,
+    OP_HASH160,
+    OP_TRUE,
+    CScript,
+    hash160,
+)
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.script import CScript, OP_1, OP_DROP, OP_2, OP_HASH160, OP_EQUAL, hash160, OP_TRUE
-from test_framework.mininode import CTransaction, CTxIn, CTxOut, COutPoint, ToHex, COIN
+from test_framework.util import (
+    connect_nodes,
+    satoshi_round,
+    sync_blocks,
+    sync_mempools,
+)
 
 # Construct 2 trivial P2SH's and the ScriptSigs that spend them
 # So we can create many transactions without needing to spend

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -523,6 +523,5 @@ class RPCCoverage(object):
 
         return all_cmds - covered_cmds
 
-
 if __name__ == '__main__':
     main()

--- a/test/functional/txn_clone.py
+++ b/test/functional/txn_clone.py
@@ -5,7 +5,12 @@
 """Test the wallet accounts properly when there are cloned transactions with malleated scriptsigs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    sync_blocks,
+)
 
 class TxnMallTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/txn_doublespend.py
+++ b/test/functional/txn_doublespend.py
@@ -4,8 +4,16 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet accounts properly when there is a double-spend conflict."""
 
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    find_output,
+    sync_blocks,
+)
 
 class TxnMallTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -27,7 +35,7 @@ class TxnMallTest(BitcoinTestFramework):
         for i in range(4):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!
-        
+
         # Assign coins to foo and bar accounts:
         node0_address_foo = self.nodes[0].getnewaddress("foo")
         fund_foo_txid = self.nodes[0].sendfrom("", node0_address_foo, 1219)
@@ -64,7 +72,7 @@ class TxnMallTest(BitcoinTestFramework):
         # Create two spends using 1 50 BTC coin each
         txid1 = self.nodes[0].sendfrom("foo", node1_address, 40, 0)
         txid2 = self.nodes[0].sendfrom("bar", node1_address, 20, 0)
-        
+
         # Have node0 mine a block:
         if (self.options.mine_block):
             self.nodes[0].generate(1)
@@ -93,7 +101,7 @@ class TxnMallTest(BitcoinTestFramework):
         else:
             assert_equal(tx1["confirmations"], 0)
             assert_equal(tx2["confirmations"], 0)
-        
+
         # Now give doublespend and its parents to miner:
         self.nodes[2].sendrawtransaction(fund_foo_tx["hex"])
         self.nodes[2].sendrawtransaction(fund_bar_tx["hex"])

--- a/test/functional/uptime.py
+++ b/test/functional/uptime.py
@@ -11,7 +11,6 @@ import time
 
 from test_framework.test_framework import BitcoinTestFramework
 
-
 class UptimeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -24,7 +23,6 @@ class UptimeTest(BitcoinTestFramework):
         wait_time = 10
         self.nodes[0].setmocktime(int(time.time() + wait_time))
         assert(self.nodes[0].uptime() >= wait_time)
-
 
 if __name__ == '__main__':
     UptimeTest().main()

--- a/test/functional/wallet-accounts.py
+++ b/test/functional/wallet-accounts.py
@@ -78,23 +78,23 @@ class WalletAccountsTest(BitcoinTestFramework):
         for account in accounts:
             address = node.getaccountaddress(account)
             account_addresses[account] = address
-            
+
             node.getnewaddress(account)
             assert_equal(node.getaccount(address), account)
             assert(address in node.getaddressesbyaccount(account))
-            
+
             node.sendfrom("", address, amount_to_send)
-        
+
         node.generate(1)
-        
+
         for i in range(len(accounts)):
             from_account = accounts[i]
             to_account = accounts[(i+1) % len(accounts)]
             to_address = account_addresses[to_account]
             node.sendfrom(from_account, to_address, amount_to_send)
-        
+
         node.generate(1)
-        
+
         for account in accounts:
             address = node.getaccountaddress(account)
             assert(address != account_addresses[account])
@@ -102,30 +102,30 @@ class WalletAccountsTest(BitcoinTestFramework):
             node.move(account, "", node.getbalance(account))
 
         node.generate(101)
-        
+
         expected_account_balances = {"": 5200}
         for account in accounts:
             expected_account_balances[account] = 0
-        
+
         assert_equal(node.listaccounts(), expected_account_balances)
-        
+
         assert_equal(node.getbalance(""), 5200)
-        
+
         for account in accounts:
             address = node.getaccountaddress("")
             node.setaccount(address, account)
             assert(address in node.getaddressesbyaccount(account))
             assert(address not in node.getaddressesbyaccount(""))
-        
+
         for account in accounts:
             addresses = []
             for x in range(10):
                 addresses.append(node.getnewaddress())
             multisig_address = node.addmultisigaddress(5, addresses, account)
             node.sendfrom("", multisig_address, 50)
-        
+
         node.generate(101)
-        
+
         for account in accounts:
             assert_equal(node.getbalance(account), 50)
 

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -9,7 +9,6 @@ import os
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
-
 def read_dump(file_name, addrs, hd_master_addr_old):
     """
     Read the given dump, count the addrs that match, count change and reserve.

--- a/test/functional/wallet-encryption.py
+++ b/test/functional/wallet-encryption.py
@@ -7,10 +7,7 @@
 import time
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-    assert_raises_jsonrpc,
-)
+from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class WalletEncryptionTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -4,12 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test Hierarchical Deterministic wallet function."""
 
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (
-    assert_equal,
-    connect_nodes_bi,
-)
 import shutil
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, connect_nodes_bi
 
 class WalletHDTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -3,8 +3,21 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the wallet."""
+
+import time
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    assert_fee_amount,
+    assert_raises_jsonrpc,
+    connect_nodes_bi,
+    count_bytes,
+    sync_blocks,
+    sync_mempools,
+)
 
 class WalletTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/walletbackup.py
+++ b/test/functional/walletbackup.py
@@ -30,11 +30,19 @@ confirm 1/2/3/4 balances are same as before.
 Shutdown again, restore using importwallet,
 and confirm again balances are correct.
 """
-from random import randint
+
+import os
 import shutil
+from decimal import Decimal
+from random import randint
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    sync_blocks,
+    sync_mempools,
+)
 
 class WalletBackupTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -189,7 +197,6 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance(), balance0)
         assert_equal(self.nodes[1].getbalance(), balance1)
         assert_equal(self.nodes[2].getbalance(), balance2)
-
 
 if __name__ == '__main__':
     WalletBackupTest().main()

--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -14,10 +14,9 @@
   transactions are still available, but that the unconfirmed transaction has
   been zapped.
 """
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (assert_equal,
-                                 assert_raises_jsonrpc,
-                                 )
+from test_framework.util import assert_equal, assert_raises_jsonrpc
 
 class ZapWalletTXesTest (BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -3,16 +3,15 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the ZMQ API."""
+
 import configparser
 import os
 import struct
 
 from test_framework.test_framework import BitcoinTestFramework, SkipTest
-from test_framework.util import (assert_equal,
-                                 bytes_to_hex_str,
-                                 )
+from test_framework.util import assert_equal, bytes_to_hex_str
 
-class ZMQTest (BitcoinTestFramework):
+class ZMQTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
 


### PR DESCRIPTION
* Unless it makes sense (p2p-compactblocks, p2p-fullblocktest, p2p-segwit, replace-by-fee)
* Also remove double new lines
* Remove whitespaces