### PR TITLE
[Docs] Update CONTRIBUTING.md to reduce unnecessary review workload

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,14 @@ behaviour of code within the pull request (bugs must be preserved as is).
 Project maintainers aim for a quick turnaround on refactoring pull requests, so
 where possible keep them short, uncomplex and easy to verify.
 
+Pull requests that refactor the code should not be made by new contributors. It
+requires a certain level of experience to know where the code belongs to and to
+understand the full ramification (including rebase effort of open pull requests).
+
+Trivial pull requests or pull requests that refactor the code with no clear
+benefits may be immediately closed by the maintainers to reduce unnecessary
+workload on reviewing.
+
 
 "Decision Making" Process
 -------------------------


### PR DESCRIPTION
The current workload for reviewing pull requests is relatively high and trivial, non-beneficial pull requests tend to slow down the overall development process.

We may want to directly close trivial, non-beneficially pull requests during time of high pull request load.

This PR would prepare for possible direct PR closing.