### PR TITLE
Fix uninitialized URI in batch RPC requests

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -192,7 +192,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 
         // array of requests
         } else if (valRequest.isArray())
-            strReply = JSONRPCExecBatch(valRequest.get_array());
+            strReply = JSONRPCExecBatch(jreq, valRequest.get_array());
         else
             throw JSONRPCError(RPC_PARSE_ERROR, "Top-level object parse error");
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -389,11 +389,10 @@ bool IsDeprecatedRPCEnabled(const std::string& method)
     return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
 }
 
-static UniValue JSONRPCExecOne(const UniValue& req)
+static UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
 {
     UniValue rpc_result(UniValue::VOBJ);
 
-    JSONRPCRequest jreq;
     try {
         jreq.parse(req);
 
@@ -413,11 +412,11 @@ static UniValue JSONRPCExecOne(const UniValue& req)
     return rpc_result;
 }
 
-std::string JSONRPCExecBatch(const UniValue& vReq)
+std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq)
 {
     UniValue ret(UniValue::VARR);
     for (unsigned int reqIdx = 0; reqIdx < vReq.size(); reqIdx++)
-        ret.push_back(JSONRPCExecOne(vReq[reqIdx]));
+        ret.push_back(JSONRPCExecOne(jreq, vReq[reqIdx]));
 
     return ret.write() + "\n";
 }

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -191,7 +191,7 @@ extern std::string HelpExampleRpc(const std::string& methodname, const std::stri
 bool StartRPC();
 void InterruptRPC();
 void StopRPC();
-std::string JSONRPCExecBatch(const UniValue& vReq);
+std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
 
 // Retrieves any serialization flags requested in command line argument
 int RPCSerializationFlags();

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -76,5 +76,9 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(w2.getbalance(), 1)
         assert_equal(w3.getbalance(), 2)
 
+        batch = w1.batch([w1.getblockchaininfo.get_request(), w1.getwalletinfo.get_request()])
+        assert_equal(batch[0]["result"]["chain"], "regtest")
+        assert_equal(batch[1]["result"]["walletname"], "w1")
+
 if __name__ == '__main__':
     MultiWalletTest().main()

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -138,17 +138,20 @@ class AuthServiceProxy(object):
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()
 
-    def __call__(self, *args, **argsn):
+    def get_request(self, *args, **argsn):
         AuthServiceProxy.__id_count += 1
 
         log.debug("-%s-> %s %s"%(AuthServiceProxy.__id_count, self._service_name,
                                  json.dumps(args, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
         if args and argsn:
             raise ValueError('Cannot handle both named and positional arguments')
-        postdata = json.dumps({'version': '1.1',
-                               'method': self._service_name,
-                               'params': args or argsn,
-                               'id': AuthServiceProxy.__id_count}, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
+        return {'version': '1.1',
+                'method': self._service_name,
+                'params': args or argsn,
+                'id': AuthServiceProxy.__id_count}
+
+    def __call__(self, *args, **argsn):
+        postdata = json.dumps(self.get_request(*args, **argsn), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
         response = self._request('POST', self.__url.path, postdata.encode('utf-8'))
         if response['error'] is not None:
             raise JSONRPCException(response['error'])
@@ -158,7 +161,7 @@ class AuthServiceProxy(object):
         else:
             return response['result']
 
-    def _batch(self, rpc_call_list):
+    def batch(self, rpc_call_list):
         postdata = json.dumps(list(rpc_call_list), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
         log.debug("--> "+postdata)
         return self._request('POST', self.__url.path, postdata.encode('utf-8'))

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -54,7 +54,8 @@ class AuthServiceProxyWrapper(object):
         return return_val
 
     def __truediv__(self, relative_uri):
-        return AuthServiceProxyWrapper(self.auth_service_proxy_instance / relative_uri)
+        return AuthServiceProxyWrapper(self.auth_service_proxy_instance / relative_uri,
+                                       self.coverage_logfile)
 
 def get_filename(dirname, n_node):
     """

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -31,10 +31,11 @@ class AuthServiceProxyWrapper(object):
         self.auth_service_proxy_instance = auth_service_proxy_instance
         self.coverage_logfile = coverage_logfile
 
-    def __getattr__(self, *args, **kwargs):
-        return_val = self.auth_service_proxy_instance.__getattr__(
-            *args, **kwargs)
-
+    def __getattr__(self, name):
+        return_val = getattr(self.auth_service_proxy_instance, name)
+        if not isinstance(return_val, type(self.auth_service_proxy_instance)):
+            # If proxy getattr returned an unwrapped value, do the same here.
+            return return_val
         return AuthServiceProxyWrapper(return_val, self.coverage_logfile)
 
     def __call__(self, *args, **kwargs):
@@ -51,10 +52,6 @@ class AuthServiceProxyWrapper(object):
                 f.write("%s\n" % rpc_method)
 
         return return_val
-
-    @property
-    def url(self):
-        return self.auth_service_proxy_instance.url
 
     def __truediv__(self, relative_uri):
         return AuthServiceProxyWrapper(self.auth_service_proxy_instance / relative_uri)

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -45,17 +45,23 @@ class AuthServiceProxyWrapper(object):
 
         """
         return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
+        self._log_call()
+        return return_val
+
+    def _log_call(self):
         rpc_method = self.auth_service_proxy_instance._service_name
 
         if self.coverage_logfile:
             with open(self.coverage_logfile, 'a+', encoding='utf8') as f:
                 f.write("%s\n" % rpc_method)
 
-        return return_val
-
     def __truediv__(self, relative_uri):
         return AuthServiceProxyWrapper(self.auth_service_proxy_instance / relative_uri,
                                        self.coverage_logfile)
+
+    def get_request(self, *args, **kwargs):
+        self._log_call()
+        return self.auth_service_proxy_instance.get_request(*args, **kwargs)
 
 def get_filename(dirname, n_node):
     """


### PR DESCRIPTION
This fixes "Wallet file not specified" errors when making batch wallet RPC calls with more than one wallet loaded. This issue was reported by @NicolasDorier in https://github.com/bitcoin/bitcoin/issues/11257

Request URI is not used for anything except multiwallet request dispatching, so this change has no other effect.