### PR TITLE
Fix invalid memory access in CScript::operator+= (guidovranken, ajtowns)

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -420,6 +420,7 @@ public:
 
     CScript& operator+=(const CScript& b)
     {
+        reserve(size() + b.size());
         insert(end(), b.begin(), b.end());
         return *this;
     }

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1451,4 +1451,21 @@ BOOST_AUTO_TEST_CASE(script_HasValidOps)
     BOOST_CHECK(!script.HasValidOps());
 }
 
+BOOST_AUTO_TEST_CASE(script_can_append_self)
+{
+    CScript s, d;
+
+    s = ScriptFromHex("00");
+    s += s;
+    d = ScriptFromHex("0000");
+    BOOST_CHECK(s == d);
+
+    // check doubling a script that's large enough to require reallocation
+    static const char hex[] = "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f";
+    s = CScript() << ParseHex(hex) << OP_CHECKSIG;
+    d = CScript() << ParseHex(hex) << OP_CHECKSIG << ParseHex(hex) << OP_CHECKSIG;
+    s += s;
+    BOOST_CHECK(s == d);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a fix for #11114 -- invoking "s += s" gets turned into "s.insert(s.end(), s.begin(), s.end())" which can result in an invalid memory access is s.capacity() < 2*s.size() (because s gets resized and possibly moved, so s.begin() and s.end() become invalid references when reading the values to be appended).

The fix is straightforward: reserve enough space in advance, so that insert() doesn't need to resize and thus its arguments remain valid.

A simple test case is added as well; though you probably need to run it via valgrind to actually catch the problem when it's not fixed...