### PR TITLE
Add -usehd to excluded args in check-doc.py

### DIFF
--- a/contrib/devtools/check-doc.py
+++ b/contrib/devtools/check-doc.py
@@ -22,7 +22,7 @@ CMD_GREP_DOCS = r"egrep -r -I 'HelpMessageOpt\(\"\-[^\"=]+?(=|\")' %s" % (CMD_RO
 REGEX_ARG = re.compile(r'(?:map(?:Multi)?Args(?:\.count\(|\[)|Get(?:Bool)?Arg\()\"(\-[^\"]+?)\"')
 REGEX_DOC = re.compile(r'HelpMessageOpt\(\"(\-[^\"=]+?)(?:=|\")')
 # list unsupported, deprecated and duplicate args as they need no documentation
-SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize', '-dbcrashratio', '-forcecompactdb'])
+SET_DOC_OPTIONAL = set(['-rpcssl', '-benchmark', '-h', '-help', '-socks', '-tor', '-debugnet', '-whitelistalwaysrelay', '-prematurewitness', '-walletprematurewitness', '-promiscuousmempoolflags', '-blockminsize', '-dbcrashratio', '-forcecompactdb', '-usehd'])
 
 def main():
   used = check_output(CMD_GREP_ARGS, shell=True)


### PR DESCRIPTION
All Travis builds on master are currently failing due to contrib/devtools/check-doc.py picking up `-usehd` in `src/wallet/wallet.cpp#L3845` as an undocumented argument (removed in https://github.com/bitcoin/bitcoin/pull/11250). Just need to add it to the list of unsupported, deprecated and duplicate args in check-doc.py so that it's ignored. Otherwise all builds on top of https://github.com/bitcoin/bitcoin/pull/11250 will fail until this is merged.