### PR TITLE
DRY config header inclusion

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -94,6 +94,7 @@ BITCOIN_CORE_H = \
   compat/endian.h \
   compat/sanity.h \
   compressor.h \
+  config/bitcoin-config-if-present.h \
   consensus/consensus.h \
   consensus/tx_verify.h \
   core_io.h \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "chainparamsbase.h"
 #include "clientversion.h"

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "base58.h"
 #include "clientversion.h"

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "chainparams.h"
 #include "clientversion.h"

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_CLIENTVERSION_H
 #define BITCOIN_CLIENTVERSION_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif //HAVE_CONFIG_H
+#include "config/bitcoin-config-if-present.h"
 
 // Check that required client information is defined
 #if !defined(CLIENT_VERSION_MAJOR) || !defined(CLIENT_VERSION_MINOR) || !defined(CLIENT_VERSION_REVISION) || !defined(CLIENT_VERSION_BUILD) || !defined(CLIENT_VERSION_IS_RELEASE) || !defined(COPYRIGHT_YEAR)

--- a/src/compat.h
+++ b/src/compat.h
@@ -6,9 +6,7 @@
 #ifndef BITCOIN_COMPAT_H
 #define BITCOIN_COMPAT_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_COMPAT_BYTESWAP_H
 #define BITCOIN_COMPAT_BYTESWAP_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <stdint.h>
 

--- a/src/compat/endian.h
+++ b/src/compat/endian.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_COMPAT_ENDIAN_H
 #define BITCOIN_COMPAT_ENDIAN_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "compat/byteswap.h"
 

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <cstddef>
 

--- a/src/compat/glibc_sanity.cpp
+++ b/src/compat/glibc_sanity.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <cstddef>
 

--- a/src/compat/strnlen.cpp
+++ b/src/compat/strnlen.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <cstring>
 

--- a/src/config/bitcoin-config-if-present.h
+++ b/src/config/bitcoin-config-if-present.h
@@ -1,0 +1,7 @@
+// Copyright (c) 2017-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include "config/bitcoin-config.h"
+#endif // defined(HAVE_CONFIG_H)

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_CRYPTO_COMMON_H
 #define BITCOIN_CRYPTO_COMMON_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <stdint.h>
 #include <string.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "init.h"
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "net.h"
 

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifdef HAVE_CONFIG_H
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "netaddress.h"
 #include "hash.h"

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_NETADDRESS_H
 #define BITCOIN_NETADDRESS_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "compat.h"
 #include "serialize.h"

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifdef HAVE_CONFIG_H
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "netbase.h"
 

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_NETBASE_H
 #define BITCOIN_NETBASE_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "compat.h"
 #include "netaddress.h"

--- a/src/qt/addressbookpage.cpp
+++ b/src/qt/addressbookpage.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "addressbookpage.h"
 #include "ui_addressbookpage.h"

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "askpassphrasedialog.h"
 #include "ui_askpassphrasedialog.h"

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "bitcoingui.h"
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "bitcoingui.h"
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_QT_BITCOINGUI_H
 #define BITCOIN_QT_BITCOINGUI_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "amount.h"
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "fs.h"
 #include "intro.h"

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_QT_NOTIFICATOR_H
 #define BITCOIN_QT_NOTIFICATOR_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <QIcon>
 #include <QObject>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "optionsdialog.h"
 #include "ui_optionsdialog.h"

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "optionsmodel.h"
 

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -21,9 +21,7 @@
 #include <QUrl>
 #endif
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h" /* for USE_QRCODE */
-#endif
+#include "config/bitcoin-config-if-present.h" /* for USE_QRCODE */
 
 #ifdef USE_QRCODE
 #include <qrencode.h>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "rpcconsole.h"
 #include "ui_debugwindow.h"

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "splashscreen.h"
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "chainparams.h"
 #include "rpcnestedtests.h"

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "utilitydialog.h"
 

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -5,9 +5,7 @@
 #include "support/lockedpool.h"
 #include "support/cleanse.h"
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "consensus/merkle.h"
 #include "primitives/block.h"

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -2,9 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "timedata.h"
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "util.h"
 

--- a/src/util.h
+++ b/src/util.h
@@ -10,9 +10,7 @@
 #ifndef BITCOIN_UTIL_H
 #define BITCOIN_UTIL_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "compat.h"
 #include "fs.h"

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -3,9 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "utiltime.h"
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -6,9 +6,7 @@
 #ifndef BITCOIN_VALIDATION_H
 #define BITCOIN_VALIDATION_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include "amount.h"
 #include "coins.h"

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_ZMQ_ZMQCONFIG_H
 #define BITCOIN_ZMQ_ZMQCONFIG_H
 
-#if defined(HAVE_CONFIG_H)
-#include "config/bitcoin-config.h"
-#endif
+#include "config/bitcoin-config-if-present.h"
 
 #include <stdarg.h>
 #include <string>


### PR DESCRIPTION
Create a wrapper header file which includes config/bitcoin-config.h only if it exists (according to a macro). Files can include this wrapper header directly instead of having each including file repeat the check-if-config-exists-and-only-include-if-it-does macros.

p.s. Open to suggestions if anyone has a better filename for the wrapper header.