### PR TITLE
More user-friendly error message when partially signing

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -873,7 +873,12 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 
         ScriptError serror = SCRIPT_ERR_OK;
         if (!VerifyScript(txin.scriptSig, prevPubKey, &txin.scriptWitness, STANDARD_SCRIPT_VERIFY_FLAGS, TransactionSignatureChecker(&txConst, i, amount), &serror)) {
-            TxInErrorToJSON(txin, vErrors, ScriptErrorString(serror));
+            if (serror == SCRIPT_ERR_INVALID_STACK_OPERATION) {
+                // Unable to sign input and verification failed (possible attempt to partially sign).
+                TxInErrorToJSON(txin, vErrors, "Unable to sign input, invalid stack size (possibly missing key)");
+            } else {
+                TxInErrorToJSON(txin, vErrors, ScriptErrorString(serror));
+            }
         }
     }
     bool fComplete = vErrors.empty();


### PR DESCRIPTION
When partially signing a transaction using `signrawtransaction`, if the wallet doesn't have access to a key, it will output a scary error message `"error": "Operation not valid with the current stack size"`, yet it will partially sign the transaction anyway. This puts a lot of users off, because they don't realise the signing actually succeeded for some inputs. This catches that specific error when signing, and outputs a friendlier message which says `Unable to sign input, invalid stack size (possibly missing key)`. 

This is the best way I could think of to fix the issue, but please let me know if you come up with a better way to do it :)

Fixes https://github.com/bitcoin/bitcoin/issues/9988