### PR TITLE
Make sure ~/.bitcoin doesn't exist before build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ before_script:
     - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/commit-script-check.sh $TRAVIS_COMMIT_RANGE; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
     - unset CC; unset CXX
+    - rm -rf ~/.bitcoin
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi


### PR DESCRIPTION
We've been getting some random travis failures since https://github.com/bitcoin/bitcoin/pull/11260 was merged, because the `~/.bitcoin` directory exists after tests are run. Not sure exactly what's causing it, but this PR ensures the directory doesn't exist before running the build and tests, to see if this fixes the issue.

Edit: travis has been run on this merge twice, and all tests passed both times, so either this fixes the issue or it just got lucky