### PR TITLE
Tests: Add a lint check for trailing whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
     - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/commit-script-check.sh $TRAVIS_COMMIT_RANGE; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-rpc-mappings.py .; fi
+    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/lint-all.sh; fi
     - unset CC; unset CXX
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi

--- a/contrib/devtools/lint-all.sh
+++ b/contrib/devtools/lint-all.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs all contrib/devtools/lint-*.sh files, and fails if any exit
+# with a non-zero status code.
+
+set -u
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+LINTALL=$(basename "${BASH_SOURCE[0]}")
+
+for f in "${SCRIPTDIR}"/lint-*.sh; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    if ! "$f"; then
+      echo "^---- failure generated from $f"
+      exit 1
+    fi
+  fi
+done

--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for new lines in diff that introduce trailing whitespace.
+
+# We can't run this check unless we know the commit range for the PR.
+if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
+  exit 0
+fi
+
+showdiff() {
+  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" --; then
+    echo "Failed to get a diff"
+    exit 1
+  fi
+}
+
+# Do a first pass, and if no trailing whitespace was found then exit early.
+if ! showdiff | grep -E -q '^\+.*\s+$'; then
+  exit
+fi
+
+echo "This diff appears to have added new lines with trailing whitespace."
+echo "The following changes were suspected:"
+
+FILENAME=""
+SEEN=0
+
+while read -r line; do
+  if [[ "$line" =~ ^diff ]]; then
+    FILENAME="$line"
+    SEEN=0
+  else
+    if [ "$SEEN" -eq 0 ]; then
+      # The first time a file is seen with trailing whitespace, we print the
+      # filename (preceded by a newline).
+      echo
+      echo "$FILENAME"
+      SEEN=1
+    fi
+    echo "$line"
+  fi
+done < <(showdiff | grep -E '^(diff --git |\+.*\s+$)')
+exit 1

--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -8,40 +8,81 @@
 
 # We can't run this check unless we know the commit range for the PR.
 if [ -z "${TRAVIS_COMMIT_RANGE}" ]; then
-  exit 0
+  echo "Cannot run lint-whitespace.sh without commit range. To run locally, use:"
+  echo "TRAVIS_COMMIT_RANGE='<commit range>' .lint-whitespace.sh"
+  echo "For example:"
+  echo "TRAVIS_COMMIT_RANGE='47ba2c3...ee50c9e' .lint-whitespace.sh"
+  exit 1
 fi
 
 showdiff() {
-  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" --; then
+  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" -- "." ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/"; then
     echo "Failed to get a diff"
     exit 1
   fi
 }
 
-# Do a first pass, and if no trailing whitespace was found then exit early.
-if ! showdiff | grep -E -q '^\+.*\s+$'; then
-  exit
+showcodediff() {
+  if ! git diff -U0 "${TRAVIS_COMMIT_RANGE}" -- *.cpp *.h *.md *.py *.sh ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/"; then
+    echo "Failed to get a diff"
+    exit 1
+  fi
+}
+
+RET=0
+
+# Check if trailing whitespace was found in the diff.
+if showdiff | grep -E -q '^\+.*\s+$'; then
+  echo "This diff appears to have added new lines with trailing whitespace."
+  echo "The following changes were suspected:"
+  FILENAME=""
+  SEEN=0
+  while read -r line; do
+    if [[ "$line" =~ ^diff ]]; then
+      FILENAME="$line"
+      SEEN=0
+    elif [[ "$line" =~ ^@@ ]]; then
+      LINENUMBER="$line"
+    else
+      if [ "$SEEN" -eq 0 ]; then
+        # The first time a file is seen with trailing whitespace, we print the
+        # filename (preceded by a newline).
+        echo
+        echo "$FILENAME"
+        echo "$LINENUMBER"
+        SEEN=1
+      fi
+      echo "$line"
+    fi
+  done < <(showdiff | grep -E '^(diff --git |@@|\+.*\s+$)')
+  RET=1
 fi
 
-echo "This diff appears to have added new lines with trailing whitespace."
-echo "The following changes were suspected:"
-
-FILENAME=""
-SEEN=0
-
-while read -r line; do
-  if [[ "$line" =~ ^diff ]]; then
-    FILENAME="$line"
-    SEEN=0
-  else
-    if [ "$SEEN" -eq 0 ]; then
-      # The first time a file is seen with trailing whitespace, we print the
-      # filename (preceded by a newline).
-      echo
-      echo "$FILENAME"
-      SEEN=1
+# Check if tab characters were found in the diff.
+if showcodediff | grep -P -q '^\+.*\t'; then
+  echo "This diff appears to have added new lines with tab characters instead of spaces."
+  echo "The following changes were suspected:"
+  FILENAME=""
+  SEEN=0
+  while read -r line; do
+    if [[ "$line" =~ ^diff ]]; then
+      FILENAME="$line"
+      SEEN=0
+    elif [[ "$line" =~ ^@@ ]]; then
+      LINENUMBER="$line"
+    else
+      if [ "$SEEN" -eq 0 ]; then
+        # The first time a file is seen with a tab character, we print the
+        # filename (preceded by a newline).
+        echo
+        echo "$FILENAME"
+        echo "$LINENUMBER"
+        SEEN=1
+      fi
+      echo "$line"
     fi
-    echo "$line"
-  fi
-done < <(showdiff | grep -E '^(diff --git |\+.*\s+$)')
-exit 1
+  done < <(showcodediff | grep -P '^(diff --git |@@|\+.*\t)')
+  RET=1
+fi
+
+exit $RET


### PR DESCRIPTION
This is a new attempt at #11005

Addressed nits, excluded imported dependencies, squashed the original commits, and added a test for tab characters in the *.cpp *.h *.md *.py *.sh files too as per @practicalswift suggestion