### PR TITLE
wallet: Display non-HD error on first run

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3827,6 +3827,10 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
     if (fFirstRun)
     {
         // ensure this wallet.dat can only be opened by clients supporting HD with chain split and expects no default key
+        if (!gArgs.GetBoolArg("-usehd", true)) {
+            InitError(strprintf(_("Error creating %s: You can't create non-HD wallets with this version."), walletFile));
+            return nullptr;
+        }
         walletInstance->SetMinVersion(FEATURE_NO_DEFAULT_KEY);
 
         // generate a new master key
@@ -3843,9 +3847,9 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         walletInstance->SetBestChain(chainActive.GetLocator());
     }
     else if (gArgs.IsArgSet("-usehd")) {
-        bool useHD = gArgs.GetBoolArg("-usehd", DEFAULT_USE_HD_WALLET);
+        bool useHD = gArgs.GetBoolArg("-usehd", true);
         if (walletInstance->IsHDEnabled() && !useHD) {
-            InitError(strprintf(_("Error loading %s: You can't disable HD on an already existing HD wallet or create new non-HD wallets."), walletFile));
+            InitError(strprintf(_("Error loading %s: You can't disable HD on an already existing HD wallet"), walletFile));
             return nullptr;
         }
         if (!walletInstance->IsHDEnabled() && useHD) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -65,8 +65,6 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
-//! if set, all keys will be derived by using BIP32
-static const bool DEFAULT_USE_HD_WALLET = true;
 
 extern const char * DEFAULT_WALLET_DAT;
 

--- a/test/functional/wallet-hd.py
+++ b/test/functional/wallet-hd.py
@@ -20,6 +20,12 @@ class WalletHDTest(BitcoinTestFramework):
     def run_test (self):
         tmpdir = self.options.tmpdir
 
+        # Make sure can't switch off usehd after wallet creation
+        self.stop_node(1)
+        self.assert_start_raises_init_error(1, ['-usehd=0'], 'already existing HD wallet')
+        self.start_node(1)
+        connect_nodes_bi(self.nodes, 0, 1)
+
         # Make sure we use hd, keep masterkeyid
         masterkeyid = self.nodes[1].getwalletinfo()['hdmasterkeyid']
         assert_equal(len(masterkeyid), 40)


### PR DESCRIPTION
On current master a fresh wallet created with `-usehd=0` is silently created as HD wallet.
An error should be displayed on the first run.

Also, this restores a test that was removed in c22a53c

Fixes: #11313