### PR TITLE
[qa] zapwallettxes: Wait up to 3s for mempool reload

### DIFF
--- a/test/functional/zapwallettxes.py
+++ b/test/functional/zapwallettxes.py
@@ -15,9 +15,11 @@
   been zapped.
 """
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (assert_equal,
-                                 assert_raises_jsonrpc,
-                                 )
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+    wait_until,
+)
 
 class ZapWalletTXesTest (BitcoinTestFramework):
     def set_test_params(self):
@@ -55,6 +57,8 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         # transaction is zapped from the wallet, but is re-added when the mempool is reloaded.
         self.stop_node(0)
         self.start_node(0, ["-persistmempool=1", "-zapwallettxes=2"])
+
+        wait_until(lambda: self.nodes[0].getmempoolinfo()['size'] == 1, timeout=3)
 
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)


### PR DESCRIPTION
There had been intermittent test failures on zapwallettxes, as no time was allotted to reload the mempool.