### PR TITLE
[tests] Add abortrescan RPC test

### DIFF
--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -179,6 +179,8 @@ class ImportRescanTest(BitcoinTestFramework):
             else:
                 variant.check()
 
+        assert_equal(try_rpc(self.nodes[0].abortrescan)[1], None)
+
 
 def try_rpc(func, *args, **kwargs):
     try:


### PR DESCRIPTION
I opted for testing only the interface existence, since I don't think the RPC can be tested in a sane and clean way (please advise otherwise).

This is the last RPC method which was missing coverage when running the extended tests :)