### PR TITLE
Put back inadvertently removed copyright notices

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2009-2017 The Bitcoin Core developers
+Copyright (c) 2009-2017 Bitcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
In an abundance of caution this restores "Bitcoin Developers" to the COPYING file in
case there were contributors before that point in time that would object to the
current label.  It's harmless and more pedantically correct.

(Change extracted from the Bitcoin-abc github)
