### PR TITLE
mininode: add an optimistic write and disable nagle

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1654,6 +1654,7 @@ class NodeConn(asyncore.dispatcher):
         self.dstaddr = dstaddr
         self.dstport = dstport
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self.sendbuf = b""
         self.recvbuf = b""
         self.ver_send = 209
@@ -1792,7 +1793,14 @@ class NodeConn(asyncore.dispatcher):
             tmsg += h[:4]
         tmsg += data
         with mininode_lock:
-            self.sendbuf += tmsg
+            if (len(self.sendbuf) == 0 and not pushbuf):
+                try:
+                    sent = self.send(tmsg)
+                    self.sendbuf = tmsg[sent:]
+                except BlockingIOError:
+                    self.sendbuf = tmsg
+            else:
+                self.sendbuf += tmsg
             self.last_sent = time.time()
 
     def got_message(self, message):


### PR DESCRIPTION
Disclaimer: I'm not familiar with asyncore, so I'm unclear how safe this is. It works for me (tm).

Because the poll/select loop may pause for 100msec before actually doing a send, and we have no way to force the loop awake, try sending from the calling thread if the queue is empty.

Also, disable nagle as all sends should be either full messages or unfinished sends.

This shaves an average of ~1 minute or so off of my accumulated runtime, and 10-15 seconds off of actual runtime.