### PR TITLE
Fix crash on shutdown with invalid wallet

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -194,7 +194,7 @@ void Shutdown()
     // Because these depend on each-other, we make sure that neither can be
     // using the other before destroying them.
     UnregisterValidationInterface(peerLogic.get());
-    g_connman->Stop();
+    if(g_connman) g_connman->Stop();
     peerLogic.reset();
     g_connman.reset();
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/11312

As @dooglus pointed out, `g_connman` is uninitialized when an invalid wallet path is passed on start up, but then dereferenced in `Shutdown()`, so this tiny PR just fixes that. 