### PR TITLE
Fix possible crash with invalid nCustomFeeRadio in QSettings (achow101, TheBlueMatt)

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -128,7 +128,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     ui->groupFee->setId(ui->radioCustomFee, 1);
     ui->groupFee->button((int)std::max(0, std::min(1, settings.value("nFeeRadio").toInt())))->setChecked(true);
     ui->groupCustomFee->setId(ui->radioCustomPerKilobyte, 0);
-    ui->groupCustomFee->button((int)std::max(0, std::min(1, settings.value("nCustomFeeRadio").toInt())))->setChecked(true);
+    ui->groupCustomFee->button(0)->setChecked(true);
     ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
     ui->checkBoxMinimumFee->setChecked(settings.value("fPayOnlyMinFee").toBool());
     minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());


### PR DESCRIPTION
`QButtonGroup->button()` may return a nullptr.
Accessing the object directly with `setChecked` seems fragile.

This is a simple fix to ensure to never call a button out of bounds (nullptr).

There are probably other places where a sanity check for `QSettings` are required.

Found by @achow101.
Code by @TheBlueMatt.