### PR TITLE
Use std::nth_element instead of std::sort to calculate median time past

### DIFF
--- a/src/bench/Examples.cpp
+++ b/src/bench/Examples.cpp
@@ -32,3 +32,44 @@ static void Trig(benchmark::State& state)
 }
 
 BENCHMARK(Trig);
+
+
+volatile int64_t sort_result_dummy = 0; // volatile, global so not optimized away
+
+static void SmallSort(benchmark::State& state)
+{
+    int64_t pmedian[11] = {1, 3, 2, 4, 5, 6, 8, 7, 9, 11, 10};
+    auto* pbegin = &pmedian[11];
+    auto* pend = &pmedian[11];
+    int mutate_index = 0;
+
+    while (state.KeepRunning()) {
+        ++pmedian[mutate_index++];
+        mutate_index %= 11;
+        std::sort(pbegin, pend);
+    }
+    sort_result_dummy = pmedian[0];
+}
+
+BENCHMARK(SmallSort);
+
+
+volatile int64_t median_result_dummy = 0; // volatile, global so not optimized away
+
+static void SmallMedian(benchmark::State& state)
+{
+    int64_t pmedian[11] = {1, 3, 2, 4, 5, 6, 8, 7, 9, 11, 10};
+    auto* pbegin = &pmedian[11];
+    auto* pend = &pmedian[11];
+    int mutate_index = 0;
+
+    while (state.KeepRunning()) {
+        ++pmedian[mutate_index++];
+        mutate_index %= 11;
+        const size_t median_index = (pend - pbegin) / 2;
+        std::nth_element(pbegin, pbegin + median_index, pend);
+    }
+    median_result_dummy = pmedian[0];
+}
+
+BENCHMARK(SmallMedian);

--- a/src/chain.h
+++ b/src/chain.h
@@ -309,12 +309,13 @@ public:
     int64_t GetMedianTimePast() const
     {
         int64_t pmedian[nMedianTimeSpan];
-        int64_t* pbegin = &pmedian[nMedianTimeSpan];
-        int64_t* pend = &pmedian[nMedianTimeSpan];
+        auto* pbegin = &pmedian[nMedianTimeSpan];
+        auto* pend = &pmedian[nMedianTimeSpan];
 
         const CBlockIndex* pindex = this;
-        for (int i = 0; i < nMedianTimeSpan && pindex; i++, pindex = pindex->pprev)
+        for (int i = 0; i < nMedianTimeSpan && pindex; ++i, pindex = pindex->pprev) {
             *(--pbegin) = pindex->GetBlockTime();
+        }
 
         const size_t median_index = (pend - pbegin) / 2;
         std::nth_element(pbegin, pbegin + median_index, pend);

--- a/src/chain.h
+++ b/src/chain.h
@@ -316,8 +316,9 @@ public:
         for (int i = 0; i < nMedianTimeSpan && pindex; i++, pindex = pindex->pprev)
             *(--pbegin) = pindex->GetBlockTime();
 
-        std::sort(pbegin, pend);
-        return pbegin[(pend - pbegin)/2];
+        const size_t median_index = (pend - pbegin) / 2;
+        std::nth_element(pbegin, pbegin + median_index, pend);
+        return pbegin[median_index];
     }
 
     std::string ToString() const


### PR DESCRIPTION
In `GetMedianTimePast`, there is no need to fully sort the time of the previous blocks since we are only interested in the median. Therefore we can use `std::nth_element` instead of `std::sort` which better matches the semantics of what we want to do and might perform a bit better.