### PR TITLE
Minor improvements to checkpoints code

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -8,25 +8,19 @@
 #include "chainparams.h"
 #include "reverse_iterator.h"
 #include "validation.h"
-#include "uint256.h"
-
-#include <stdint.h>
-
 
 namespace Checkpoints {
 
-    CBlockIndex* GetLastCheckpoint(const CCheckpointData& data)
-    {
-        const MapCheckpoints& checkpoints = data.mapCheckpoints;
-
-        for (const MapCheckpoints::value_type& i : reverse_iterate(checkpoints))
-        {
-            const uint256& hash = i.second;
-            BlockMap::const_iterator t = mapBlockIndex.find(hash);
-            if (t != mapBlockIndex.end())
-                return t->second;
+CBlockIndex* GetLastCheckpoint(const CCheckpointData& data)
+{
+    for (const auto& checkpoint : reverse_iterate(data.mapCheckpoints)) {
+        const auto& hash = checkpoint.second;
+        const auto match = mapBlockIndex.find(hash);
+        if (match != mapBlockIndex.end()) {
+            return match->second;
         }
-        return nullptr;
     }
+    return nullptr;
+}
 
 } // namespace Checkpoints

--- a/src/checkpoints.h
+++ b/src/checkpoints.h
@@ -5,10 +5,6 @@
 #ifndef BITCOIN_CHECKPOINTS_H
 #define BITCOIN_CHECKPOINTS_H
 
-#include "uint256.h"
-
-#include <map>
-
 class CBlockIndex;
 struct CCheckpointData;
 
@@ -20,8 +16,8 @@ namespace Checkpoints
 {
 
 //! Returns last CBlockIndex* in mapBlockIndex that is a checkpoint
-CBlockIndex* GetLastCheckpoint(const CCheckpointData& data);
+CBlockIndex* GetLastCheckpoint(const CCheckpointData&);
 
-} //namespace Checkpoints
+} // namespace Checkpoints
 
 #endif // BITCOIN_CHECKPOINTS_H


### PR DESCRIPTION
- Use `auto` where appropriate, improved var names keep code obvious
- Removed redundant `checkpoints` intermediate variable in `GetLastCheckpoint()`
- Remove redundant includes (made more obviously redundant by using `auto`)
- Remove redundant parameter name in `GetLastCheckpoint()` declaration
- Whitespace, braces follow developer notes