### PR TITLE
[tests] Check connectivity before sending in assumevalid.py

### DIFF
--- a/test/functional/assumevalid.py
+++ b/test/functional/assumevalid.py
@@ -68,6 +68,8 @@ class AssumeValidTest(BitcoinTestFramework):
     def send_blocks_until_disconnected(self, node):
         """Keep sending blocks to the node until we're disconnected."""
         for i in range(len(self.blocks)):
+            if not node.connection:
+                break
             try:
                 node.send_message(msg_block(self.blocks[i]))
             except IOError as e:


### PR DESCRIPTION
assumevalid.py would try to send over a closed P2P connection in a loop,
hitting the following failure many times:

`TestFramework.mininode (ERROR): Cannot send message. No connection to node!`

The test still passed, but this is a lot of noise in the test log.

Just check that the connection is open before trying to send.