### PR TITLE
Add a pruning 'high water mark' to reduce the frequency of pruning events

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3346,7 +3346,12 @@ static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfte
     uint64_t nBytesToPrune;
     int count=0;
 
-    if (nCurrentUsage + nBuffer >= nPruneTarget) {
+    // On a prune event, the chainstate DB is flushed.
+    // To avoid excessive prune events negating the benefit of high dbcache
+    // values, we should not prune too rapidly.
+    // Here we use dbcache as an arbitrary high water mark.
+    uint64_t nPruneHWM = nPruneTarget + nCoinCacheUsage;
+    if (nCurrentUsage + nBuffer >= nPruneHWM) {
         for (int fileNumber = 0; fileNumber < nLastBlockFile; fileNumber++) {
             nBytesToPrune = vinfoBlockFile[fileNumber].nSize + vinfoBlockFile[fileNumber].nUndoSize;
 
@@ -3368,8 +3373,9 @@ static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfte
         }
     }
 
-    LogPrint(BCLog::PRUNE, "Prune: target=%dMiB actual=%dMiB diff=%dMiB max_prune_height=%d removed %d blk/rev pairs\n",
-           nPruneTarget/1024/1024, nCurrentUsage/1024/1024,
+    LogPrint(BCLog::PRUNE, "Prune: target=%dMiB hwm=%dMiB actual=%dMiB diff=%dMiB max_prune_height=%d removed %d blk/rev pairs\n",
+           nPruneTarget/1024/1024, nPruneHWM/1024/1024,
+           nCurrentUsage/1024/1024,
            ((int64_t)nPruneTarget - (int64_t)nCurrentUsage)/1024/1024,
            nLastBlockWeCanPrune, count);
 }


### PR DESCRIPTION
Partial fix for issue #11315.

Every prune event flushes the dbcache to disk.
By default this happens approximately every ~160MiB so high dbcache values are negated and IBD takes far longer than without pruning enabled.

This change allows a 'high water mark' for pruning such that the actual size of blk/rev on disk can increase a reasonable amount before flushing.

On a machine with prune=550 and dbcache=3000:
```
2017-09-17 22:04:56 Prune: target=550MiB hwm=3540MiB actual=3510MiB diff=-2960MiB max_prune_height=292477 removed 0 blk/rev pairs
2017-09-17 22:04:56 Prune: target=550MiB hwm=3540MiB actual=3516MiB diff=-2966MiB max_prune_height=292499 removed 0 blk/rev pairs
2017-09-17 22:04:57 Prune: target=550MiB hwm=3540MiB actual=468MiB diff=81MiB max_prune_height=292537 removed 21 blk/rev pairs
2017-09-17 22:04:57 Prune: UnlinkPrunedFiles deleted blk/rev (00103)
...
```

I haven't changed the 'diff' column in debug log (it could perhaps be hwm - actual rather than target - actual).

Not sure if this could potentially increase disk space requirements in some cases - may need documentation. With a very high dbcache value, if say 10GiB of blocks come in that only produce 2GiB of chainstate then you'd overshoot quite a bit, I think. It's a tradeoff - more frequent flushing = slower IBD.

Thanks to sipa and gmaxwell for helping out on IRC.