### PR TITLE
Remove redundant LOCK(…) and AssertLockHeld(…)

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -459,7 +459,6 @@ bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const
 
 bool ArgsManager::SoftSetArg(const std::string& strArg, const std::string& strValue)
 {
-    LOCK(cs_args);
     if (IsArgSet(strArg)) return false;
     ForceSetArg(strArg, strValue);
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1530,7 +1530,6 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 int64_t CWallet::RescanFromTime(int64_t startTime, bool update)
 {
     AssertLockHeld(cs_main);
-    AssertLockHeld(cs_wallet);
 
     // Find starting block. May be null if nCreateTime is greater than the
     // highest blockchain timestamp, in which case there is nothing that needs


### PR DESCRIPTION
Remove redundant `LOCK(…)` and `AssertLockHeld(…)`:
* Remove `LOCK(cs_args)` from `ArgsManager::SoftSetArg(...)`
* Remove `AssertLockHeld(cs_wallet)` from `CWallet::RescanFromTime(...)`
