### PR TITLE
[Tests] Add Qt GUI tests to Overview and ReceiveCoin Page

### DIFF
--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -13,6 +13,10 @@
 #include "test/test_bitcoin.h"
 #include "validation.h"
 #include "wallet/wallet.h"
+#include "qt/overviewpage.h"
+#include "qt/receivecoinsdialog.h"
+#include "qt/recentrequeststablemodel.h"
+#include "qt/receiverequestdialog.h"
 
 #include <QAbstractButton>
 #include <QAction>
@@ -21,6 +25,9 @@
 #include <QPushButton>
 #include <QTimer>
 #include <QVBoxLayout>
+#include <QTextEdit>
+#include <QListView>
+#include <QDialogButtonBox>
 
 namespace
 {
@@ -140,7 +147,7 @@ void BumpFee(TransactionView& view, const uint256& txid, bool expectDisabled, st
 //     src/qt/test/test_bitcoin-qt -platform xcb      # Linux
 //     src/qt/test/test_bitcoin-qt -platform windows  # Windows
 //     src/qt/test/test_bitcoin-qt -platform cocoa    # macOS
-void TestSendCoins()
+void TestGUI()
 {
     // Set up wallet and chain with 105 blocks (5 mature blocks for spending).
     TestChain100Setup test;
@@ -184,6 +191,68 @@ void TestSendCoins()
     BumpFee(transactionView, txid2, false /* expect disabled */, {} /* expected error */, false /* cancel */);
     BumpFee(transactionView, txid2, true /* expect disabled */, "already bumped" /* expected error */, false /* cancel */);
 
+    // Check current balance on OverviewPage
+    OverviewPage overviewPage(platformStyle.get());
+    overviewPage.setWalletModel(&walletModel);
+    QLabel* balanceLabel = overviewPage.findChild<QLabel*>("labelBalance");
+    QString balanceText = balanceLabel->text();
+    int unit = walletModel.getOptionsModel()->getDisplayUnit();
+    CAmount balance = walletModel.getBalance();
+    QString balanceComparison = BitcoinUnits::formatWithUnit(unit, balance, false, BitcoinUnits::separatorAlways);
+    QCOMPARE(balanceText, balanceComparison);
+
+    // Check Request Payment button
+    ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
+    receiveCoinsDialog.setModel(&walletModel);
+    RecentRequestsTableModel* requestTableModel = walletModel.getRecentRequestsTableModel();
+
+    // Label input
+    QLineEdit* labelInput = receiveCoinsDialog.findChild<QLineEdit*>("reqLabel");
+    labelInput->setText("TEST_LABEL_1");
+
+    // Amount input
+    BitcoinAmountField* amountInput = receiveCoinsDialog.findChild<BitcoinAmountField*>("reqAmount");
+    amountInput->setValue(1);
+
+    // Message input
+    QLineEdit* messageInput = receiveCoinsDialog.findChild<QLineEdit*>("reqMessage");
+    messageInput->setText("TEST_MESSAGE_1");
+    int initialRowCount = requestTableModel->rowCount({});
+    QPushButton* requestPaymentButton = receiveCoinsDialog.findChild<QPushButton*>("receiveButton");
+    requestPaymentButton->click();
+    for (QWidget* widget : QApplication::topLevelWidgets()) {
+        if (widget->inherits("ReceiveRequestDialog")) {
+            ReceiveRequestDialog* receiveRequestDialog = qobject_cast<ReceiveRequestDialog*>(widget);
+            QTextEdit* rlist = receiveRequestDialog->QObject::findChild<QTextEdit*>("outUri");
+            QString paymentText = rlist->toPlainText();
+            QStringList paymentTextList = paymentText.split('\n');
+            QCOMPARE(paymentTextList.at(0), QString("Payment information"));
+            QVERIFY(paymentTextList.at(1).indexOf(QString("URI: bitcoin:")) != -1);
+            QVERIFY(paymentTextList.at(2).indexOf(QString("Address:")) != -1);
+            QCOMPARE(paymentTextList.at(3), QString("Amount: 0.00000001 ") + QString::fromStdString(CURRENCY_UNIT));
+            QCOMPARE(paymentTextList.at(4), QString("Label: TEST_LABEL_1"));
+            QCOMPARE(paymentTextList.at(5), QString("Message: TEST_MESSAGE_1"));
+        }
+    }
+
+    // Clear button
+    QPushButton* clearButton = receiveCoinsDialog.findChild<QPushButton*>("clearButton");
+    clearButton->click();
+    QCOMPARE(labelInput->text(), QString(""));
+    QCOMPARE(amountInput->value(), CAmount(0));
+    QCOMPARE(messageInput->text(), QString(""));
+
+    // Check addition to history
+    int currentRowCount = requestTableModel->rowCount({});
+    QCOMPARE(currentRowCount, initialRowCount+1);
+
+    // Check Remove button
+    QTableView* table = receiveCoinsDialog.findChild<QTableView*>("recentRequestsView");
+    table->selectRow(currentRowCount-1);
+    QPushButton* removeRequestButton = receiveCoinsDialog.findChild<QPushButton*>("removeRequestButton");
+    removeRequestButton->click();
+    QCOMPARE(requestTableModel->rowCount({}), currentRowCount-1);
+
     bitdb.Flush(true);
     bitdb.Reset();
 }
@@ -192,5 +261,5 @@ void TestSendCoins()
 
 void WalletTests::walletTests()
 {
-    TestSendCoins();
+    TestGUI();
 }


### PR DESCRIPTION
I've added some Qt wallet tests based on #9974, namely the input & buttons on ReceiveCoin.