### PR TITLE
doc: Document locks - increase LOCK(...) comment coverage from 2 % to 77 %

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -350,7 +350,7 @@ public:
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        LOCK(cs);
+        LOCK(cs); // vRandom
 
         Clear();
 
@@ -489,7 +489,8 @@ public:
     //! Return the number of (unique) addresses in all tables.
     size_t size() const
     {
-        LOCK(cs); // TODO: Cache this in an atomic to avoid this overhead
+        // TODO: Cache this in an atomic to avoid this overhead
+        LOCK(cs); // vRandom
         return vRandom.size();
     }
 

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -103,7 +103,7 @@ ReadStatus PartiallyDownloadedBlock::InitData(const CBlockHeaderAndShortTxIDs& c
 
     std::vector<bool> have_txn(txn_available.size());
     {
-    LOCK(pool->cs);
+    LOCK(pool->cs); // vTxHashes
     const std::vector<std::pair<uint256, CTxMemPool::txiter> >& vTxHashes = pool->vTxHashes;
     for (size_t i = 0; i < vTxHashes.size(); i++) {
         uint64_t shortid = cmpctblock.GetShortID(vTxHashes[i].first);

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -17,7 +17,7 @@ bool CBasicKeyStore::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) con
 {
     CKey key;
     if (!GetKey(address, key)) {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapWatchKeys
         WatchKeyMap::const_iterator it = mapWatchKeys.find(address);
         if (it != mapWatchKeys.end()) {
             vchPubKeyOut = it->second;
@@ -31,7 +31,7 @@ bool CBasicKeyStore::GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) con
 
 bool CBasicKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapKeys
     mapKeys[pubkey.GetID()] = key;
     return true;
 }
@@ -41,20 +41,20 @@ bool CBasicKeyStore::AddCScript(const CScript& redeemScript)
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
         return error("CBasicKeyStore::AddCScript(): redeemScripts > %i bytes are invalid", MAX_SCRIPT_ELEMENT_SIZE);
 
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapScripts
     mapScripts[CScriptID(redeemScript)] = redeemScript;
     return true;
 }
 
 bool CBasicKeyStore::HaveCScript(const CScriptID& hash) const
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapScripts
     return mapScripts.count(hash) > 0;
 }
 
 bool CBasicKeyStore::GetCScript(const CScriptID &hash, CScript& redeemScriptOut) const
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapScripts
     ScriptMap::const_iterator mi = mapScripts.find(hash);
     if (mi != mapScripts.end())
     {
@@ -82,7 +82,7 @@ static bool ExtractPubKey(const CScript &dest, CPubKey& pubKeyOut)
 
 bool CBasicKeyStore::AddWatchOnly(const CScript &dest)
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapWatchKeys, setWatchOnly
     setWatchOnly.insert(dest);
     CPubKey pubKey;
     if (ExtractPubKey(dest, pubKey))
@@ -92,7 +92,7 @@ bool CBasicKeyStore::AddWatchOnly(const CScript &dest)
 
 bool CBasicKeyStore::RemoveWatchOnly(const CScript &dest)
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapWatchKeys, setWatchOnly
     setWatchOnly.erase(dest);
     CPubKey pubKey;
     if (ExtractPubKey(dest, pubKey))
@@ -102,12 +102,12 @@ bool CBasicKeyStore::RemoveWatchOnly(const CScript &dest)
 
 bool CBasicKeyStore::HaveWatchOnly(const CScript &dest) const
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // setWatchOnly
     return setWatchOnly.count(dest) > 0;
 }
 
 bool CBasicKeyStore::HaveWatchOnly() const
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // setWatchOnly
     return (!setWatchOnly.empty());
 }

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -66,14 +66,14 @@ public:
     {
         bool result;
         {
-            LOCK(cs_KeyStore);
+            LOCK(cs_KeyStore); // mapKeys
             result = (mapKeys.count(address) > 0);
         }
         return result;
     }
     std::set<CKeyID> GetKeys() const override
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapKeys
         std::set<CKeyID> set_address;
         for (const auto& mi : mapKeys) {
             set_address.insert(mi.first);
@@ -83,7 +83,7 @@ public:
     bool GetKey(const CKeyID &address, CKey &keyOut) const override
     {
         {
-            LOCK(cs_KeyStore);
+            LOCK(cs_KeyStore); // mapKeys
             KeyMap::const_iterator mi = mapKeys.find(address);
             if (mi != mapKeys.end())
             {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOpsCost.push_back(-1); // updated at end
 
-    LOCK2(cs_main, mempool.cs);
+    LOCK2(cs_main, mempool.cs); // chainActive
     CBlockIndex* pindexPrev = chainActive.Tip();
     assert(pindexPrev != nullptr);
     nHeight = pindexPrev->nHeight + 1;

--- a/src/net.h
+++ b/src/net.h
@@ -183,7 +183,7 @@ public:
     template<typename Callable>
     void ForEachNode(Callable&& func)
     {
-        LOCK(cs_vNodes);
+        LOCK(cs_vNodes); // vNodes
         for (auto&& node : vNodes) {
             if (NodeFullyConnected(node))
                 func(node);
@@ -203,7 +203,7 @@ public:
     template<typename Callable, typename CallableAfter>
     void ForEachNodeThen(Callable&& pre, CallableAfter&& post)
     {
-        LOCK(cs_vNodes);
+        LOCK(cs_vNodes); // vNodes
         for (auto&& node : vNodes) {
             if (NodeFullyConnected(node))
                 pre(node);
@@ -795,14 +795,14 @@ public:
     void AddInventoryKnown(const CInv& inv)
     {
         {
-            LOCK(cs_inventory);
+            LOCK(cs_inventory); // filterInventoryKnown
             filterInventoryKnown.insert(inv.hash);
         }
     }
 
     void PushInventory(const CInv& inv)
     {
-        LOCK(cs_inventory);
+        LOCK(cs_inventory); // vInventoryBlockToSend, filterInventoryKnown
         if (inv.type == MSG_TX) {
             if (!filterInventoryKnown.contains(inv.hash)) {
                 setInventoryTxToSend.insert(inv.hash);
@@ -814,7 +814,7 @@ public:
 
     void PushBlockHash(const uint256 &hash)
     {
-        LOCK(cs_inventory);
+        LOCK(cs_inventory); // vBlockHashesToAnnounce
         vBlockHashesToAnnounce.push_back(hash);
     }
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -490,14 +490,14 @@ bool SetProxy(enum Network net, const proxyType &addrProxy) {
     assert(net >= 0 && net < NET_MAX);
     if (!addrProxy.IsValid())
         return false;
-    LOCK(cs_proxyInfos);
+    LOCK(cs_proxyInfos); // proxyInfo
     proxyInfo[net] = addrProxy;
     return true;
 }
 
 bool GetProxy(enum Network net, proxyType &proxyInfoOut) {
     assert(net >= 0 && net < NET_MAX);
-    LOCK(cs_proxyInfos);
+    LOCK(cs_proxyInfos); // proxyInfo
     if (!proxyInfo[net].IsValid())
         return false;
     proxyInfoOut = proxyInfo[net];
@@ -507,13 +507,13 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut) {
 bool SetNameProxy(const proxyType &addrProxy) {
     if (!addrProxy.IsValid())
         return false;
-    LOCK(cs_proxyInfos);
+    LOCK(cs_proxyInfos); // nameProxy
     nameProxy = addrProxy;
     return true;
 }
 
 bool GetNameProxy(proxyType &nameProxyOut) {
-    LOCK(cs_proxyInfos);
+    LOCK(cs_proxyInfos); // nameProxy
     if(!nameProxy.IsValid())
         return false;
     nameProxyOut = nameProxy;
@@ -521,12 +521,12 @@ bool GetNameProxy(proxyType &nameProxyOut) {
 }
 
 bool HaveNameProxy() {
-    LOCK(cs_proxyInfos);
+    LOCK(cs_proxyInfos); // nameProxy
     return nameProxy.IsValid();
 }
 
 bool IsProxy(const CNetAddr &addr) {
-    LOCK(cs_proxyInfos);
+    LOCK(cs_proxyInfos); // proxyInfo
     for (int i = 0; i < NET_MAX; i++) {
         if (addr == (CNetAddr)proxyInfo[i].proxy)
             return true;

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -79,7 +79,7 @@ public:
     {
         cachedAddressTable.clear();
         {
-            LOCK(wallet->cs_wallet);
+            LOCK(wallet->cs_wallet); // mapAddressBook
             for (const std::pair<CTxDestination, CAddressBookData>& item : wallet->mapAddressBook)
             {
                 const CTxDestination& address = item.first;
@@ -245,7 +245,7 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
 
     if(role == Qt::EditRole)
     {
-        LOCK(wallet->cs_wallet); /* For SetAddressBook / DelAddressBook */
+        LOCK(wallet->cs_wallet); // mapAddressBook
         CTxDestination curAddress = DecodeDestination(rec->address.toStdString());
         if(index.column() == Label)
         {
@@ -357,7 +357,7 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
         }
         // Check for duplicate addresses
         {
-            LOCK(wallet->cs_wallet);
+            LOCK(wallet->cs_wallet); // mapAddressBook
             if(wallet->mapAddressBook.count(DecodeDestination(strAddress)))
             {
                 editStatus = DUPLICATE_ADDRESS;
@@ -422,7 +422,7 @@ bool AddressTableModel::removeRows(int row, int count, const QModelIndex &parent
 QString AddressTableModel::labelForAddress(const QString &address) const
 {
     {
-        LOCK(wallet->cs_wallet);
+        LOCK(wallet->cs_wallet); // mapAddressBook
         CTxDestination destination = DecodeDestination(address.toStdString());
         std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(destination);
         if (mi != wallet->mapAddressBook.end())

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -71,7 +71,7 @@ int ClientModel::getNumConnections(unsigned int flags) const
 
 int ClientModel::getNumBlocks() const
 {
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
     return chainActive.Height();
 }
 
@@ -80,7 +80,7 @@ int ClientModel::getHeaderTipHeight() const
     if (cachedBestHeaderHeight == -1) {
         // make sure we initially populate the cache via a cs_main lock
         // otherwise we need to wait for a tip update
-        LOCK(cs_main);
+        LOCK(cs_main); // pindexBestHeader
         if (pindexBestHeader) {
             cachedBestHeaderHeight = pindexBestHeader->nHeight;
             cachedBestHeaderTime = pindexBestHeader->GetBlockTime();
@@ -92,7 +92,7 @@ int ClientModel::getHeaderTipHeight() const
 int64_t ClientModel::getHeaderTipTime() const
 {
     if (cachedBestHeaderTime == -1) {
-        LOCK(cs_main);
+        LOCK(cs_main); // pindexBestHeader
         if (pindexBestHeader) {
             cachedBestHeaderHeight = pindexBestHeader->nHeight;
             cachedBestHeaderTime = pindexBestHeader->GetBlockTime();
@@ -117,7 +117,7 @@ quint64 ClientModel::getTotalBytesSent() const
 
 QDateTime ClientModel::getLastBlockDate() const
 {
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
 
     if (chainActive.Tip())
         return QDateTime::fromTime_t(chainActive.Tip()->GetBlockTime());
@@ -140,7 +140,7 @@ double ClientModel::getVerificationProgress(const CBlockIndex *tipIn) const
     CBlockIndex *tip = const_cast<CBlockIndex *>(tipIn);
     if (!tip)
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // chainActive
         tip = chainActive.Tip();
     }
     return GuessVerificationProgress(Params().TxData(), tip);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -51,7 +51,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
 {
     QString strHTML;
 
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK2(cs_main, wallet->cs_wallet); // pcoinsTip, FormatTxStatus(...), mapAddressBook
     strHTML.reserve(4000);
     strHTML += "<html><font face='verdana, arial, helvetica, sans-serif'>";
 

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -79,7 +79,7 @@ public:
         qDebug() << "TransactionTablePriv::refreshWallet";
         cachedWallet.clear();
         {
-            LOCK2(cs_main, wallet->cs_wallet);
+            LOCK2(cs_main, wallet->cs_wallet); // mapWallet
             for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end(); ++it)
             {
                 if(TransactionRecord::showTransaction(it->second))
@@ -128,7 +128,7 @@ public:
             }
             if(showTransaction)
             {
-                LOCK2(cs_main, wallet->cs_wallet);
+                LOCK2(cs_main, wallet->cs_wallet); // mapWallet
                 // Find transaction in wallet
                 std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(hash);
                 if(mi == wallet->mapWallet.end())
@@ -214,7 +214,7 @@ public:
     QString describe(TransactionRecord *rec, int unit)
     {
         {
-            LOCK2(cs_main, wallet->cs_wallet);
+            LOCK2(cs_main, wallet->cs_wallet); // mapWallet
             std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
             if(mi != wallet->mapWallet.end())
             {
@@ -226,7 +226,7 @@ public:
 
     QString getTxHex(TransactionRecord *rec)
     {
-        LOCK2(cs_main, wallet->cs_wallet);
+        LOCK2(cs_main, wallet->cs_wallet); // mapWallet
         std::map<uint256, CWalletTx>::iterator mi = wallet->mapWallet.find(rec->hash);
         if(mi != wallet->mapWallet.end())
         {

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -350,7 +350,7 @@ WalletModel::SendCoinsReturn WalletModel::sendCoins(WalletModelTransaction &tran
             CTxDestination dest = DecodeDestination(strAddress);
             std::string strLabel = rcp.label.toStdString();
             {
-                LOCK(wallet->cs_wallet);
+                LOCK(wallet->cs_wallet); // mapAddressBook
 
                 std::map<CTxDestination, CAddressBookData>::iterator mi = wallet->mapAddressBook.find(dest);
 
@@ -573,7 +573,7 @@ bool WalletModel::getPrivKey(const CKeyID &address, CKey& vchPrivKeyOut) const
 // returns a list of COutputs from COutPoints
 void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vector<COutput>& vOutputs)
 {
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK2(cs_main, wallet->cs_wallet); // mapWallet
     for (const COutPoint& outpoint : vOutpoints)
     {
         auto it = wallet->mapWallet.find(outpoint.hash);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -146,7 +146,7 @@ static bool rest_headers(HTTPRequest* req,
     std::vector<const CBlockIndex *> headers;
     headers.reserve(count);
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // chainActive, mapBlockIndex
         BlockMap::const_iterator it = mapBlockIndex.find(hash);
         const CBlockIndex *pindex = (it != mapBlockIndex.end()) ? it->second : nullptr;
         while (pindex != nullptr && chainActive.Contains(pindex)) {
@@ -208,7 +208,7 @@ static bool rest_block(HTTPRequest* req,
     CBlock block;
     CBlockIndex* pblockindex = nullptr;
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         if (mapBlockIndex.count(hash) == 0)
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -160,7 +160,7 @@ UniValue getblockcount(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockcount", "")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
     return chainActive.Height();
 }
 
@@ -177,7 +177,7 @@ UniValue getbestblockhash(const JSONRPCRequest& request)
             + HelpExampleRpc("getbestblockhash", "")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
     return chainActive.Tip()->GetBlockHash().GetHex();
 }
 
@@ -326,7 +326,7 @@ UniValue getdifficulty(const JSONRPCRequest& request)
             + HelpExampleRpc("getdifficulty", "")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // GetDifficulty(...)
     return GetDifficulty();
 }
 
@@ -386,7 +386,7 @@ UniValue mempoolToJSON(bool fVerbose)
 {
     if (fVerbose)
     {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs); // mapTx, entryToJSON(...)
         UniValue o(UniValue::VOBJ);
         for (const CTxMemPoolEntry& e : mempool.mapTx)
         {
@@ -474,7 +474,7 @@ UniValue getmempoolancestors(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
-    LOCK(mempool.cs);
+    LOCK(mempool.cs); // mapTx, entryToJSON(...)
 
     CTxMemPool::txiter it = mempool.mapTx.find(hash);
     if (it == mempool.mapTx.end()) {
@@ -538,7 +538,7 @@ UniValue getmempooldescendants(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
-    LOCK(mempool.cs);
+    LOCK(mempool.cs); // mapTx, entryToJSON(...)
 
     CTxMemPool::txiter it = mempool.mapTx.find(hash);
     if (it == mempool.mapTx.end()) {
@@ -590,7 +590,7 @@ UniValue getmempoolentry(const JSONRPCRequest& request)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
-    LOCK(mempool.cs);
+    LOCK(mempool.cs); // mapTx, entryToJSON(...)
 
     CTxMemPool::txiter it = mempool.mapTx.find(hash);
     if (it == mempool.mapTx.end()) {
@@ -618,7 +618,7 @@ UniValue getblockhash(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockhash", "1000")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
 
     int nHeight = request.params[0].get_int();
     if (nHeight < 0 || nHeight > chainActive.Height())
@@ -662,7 +662,7 @@ UniValue getblockheader(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockheader", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // blockheaderToJSON(...), mapBlockIndex
 
     std::string strHash = request.params[0].get_str();
     uint256 hash(uint256S(strHash));
@@ -737,7 +737,7 @@ UniValue getblock(const JSONRPCRequest& request)
             + HelpExampleRpc("getblock", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\"")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // blockToJSON(...), mapBlockIndex
 
     std::string strHash = request.params[0].get_str();
     uint256 hash(uint256S(strHash));
@@ -819,7 +819,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
     CHashWriter ss(SER_GETHASH, PROTOCOL_VERSION);
     stats.hashBlock = pcursor->GetBestBlock();
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         stats.nHeight = mapBlockIndex.find(stats.hashBlock)->second->nHeight;
     }
     ss << stats.hashBlock;
@@ -866,7 +866,7 @@ UniValue pruneblockchain(const JSONRPCRequest& request)
     if (!fPruneMode)
         throw JSONRPCError(RPC_MISC_ERROR, "Cannot prune blocks because node is not in prune mode.");
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
 
     int heightParam = request.params[0].get_int();
     if (heightParam < 0)
@@ -978,7 +978,7 @@ UniValue gettxout(const JSONRPCRequest& request)
             + HelpExampleRpc("gettxout", "\"txid\", 1")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // pcoinsTip, mapBlockIndex
 
     UniValue ret(UniValue::VOBJ);
 
@@ -1168,7 +1168,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             + HelpExampleRpc("getblockchaininfo", "")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // GetDifficulty(...), pindexBestHeader, chainActive
 
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("chain",                 Params().NetworkIDString()));
@@ -1252,7 +1252,7 @@ UniValue getchaintips(const JSONRPCRequest& request)
             + HelpExampleRpc("getchaintips", "")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive, mapBlockIndex
 
     /*
      * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off of them.
@@ -1378,7 +1378,7 @@ UniValue preciousblock(const JSONRPCRequest& request)
     CBlockIndex* pblockindex;
 
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         if (mapBlockIndex.count(hash) == 0)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
@@ -1414,7 +1414,7 @@ UniValue invalidateblock(const JSONRPCRequest& request)
     CValidationState state;
 
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         if (mapBlockIndex.count(hash) == 0)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
@@ -1452,7 +1452,7 @@ UniValue reconsiderblock(const JSONRPCRequest& request)
     uint256 hash(uint256S(strHash));
 
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         if (mapBlockIndex.count(hash) == 0)
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
 
@@ -1504,7 +1504,7 @@ UniValue getchaintxstats(const JSONRPCRequest& request)
     }
 
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // chainActive, mapBlockIndex
         if (havehash) {
             auto it = mapBlockIndex.find(hash);
             if (it == mapBlockIndex.end()) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -101,7 +101,7 @@ UniValue getnetworkhashps(const JSONRPCRequest& request)
             + HelpExampleRpc("getnetworkhashps", "")
        );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // GetNetworkHashPS(...)
     return GetNetworkHashPS(!request.params[0].isNull() ? request.params[0].get_int() : 120, !request.params[1].isNull() ? request.params[1].get_int() : -1);
 }
 
@@ -112,7 +112,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
     int nHeight = 0;
 
     {   // Don't keep cs_main locked
-        LOCK(cs_main);
+        LOCK(cs_main); // chainActive
         nHeight = chainActive.Height();
         nHeightEnd = nHeight+nGenerate;
     }
@@ -125,7 +125,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
         {
-            LOCK(cs_main);
+            LOCK(cs_main); // chainActive
             IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
         }
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
@@ -210,7 +210,7 @@ UniValue getmininginfo(const JSONRPCRequest& request)
         );
 
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
 
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("blocks",           (int)chainActive.Height()));
@@ -728,7 +728,7 @@ UniValue submitblock(const JSONRPCRequest& request)
     uint256 hash = block.GetHash();
     bool fBlockPresent = false;
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         BlockMap::iterator mi = mapBlockIndex.find(hash);
         if (mi != mapBlockIndex.end()) {
             CBlockIndex *pindex = mi->second;
@@ -744,7 +744,7 @@ UniValue submitblock(const JSONRPCRequest& request)
     }
 
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // mapBlockIndex
         BlockMap::iterator mi = mapBlockIndex.find(block.hashPrevBlock);
         if (mi != mapBlockIndex.end()) {
             UpdateUncommittedBlockStructures(block, mi->second, Params().GetConsensus());

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -472,7 +472,7 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
     obj.push_back(Pair("incrementalfee", ValueFromAmount(::incrementalRelayFee.GetFeePerK())));
     UniValue localAddresses(UniValue::VARR);
     {
-        LOCK(cs_mapLocalHost);
+        LOCK(cs_mapLocalHost); // mapLocalHost
         for (const std::pair<CNetAddr, LocalServiceInfo> &item : mapLocalHost)
         {
             UniValue rec(UniValue::VOBJ);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -132,7 +132,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
             + HelpExampleRpc("getrawtransaction", "\"mytxid\", true")
         );
 
-    LOCK(cs_main);
+    LOCK(cs_main); // TxToJSON(...)
 
     uint256 hash = ParseHashV(request.params[0], "parameter 1");
 
@@ -204,7 +204,7 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
        oneTxid = hash;
     }
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive, mapBlockIndex
 
     CBlockIndex* pblockindex = nullptr;
 
@@ -278,7 +278,7 @@ UniValue verifytxoutproof(const JSONRPCRequest& request)
     if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) != merkleBlock.header.hashMerkleRoot)
         return res;
 
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive, mapBlockIndex
 
     if (!mapBlockIndex.count(merkleBlock.header.GetHash()) || !chainActive.Contains(mapBlockIndex[merkleBlock.header.GetHash()]))
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
@@ -912,7 +912,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK(cs_main);
+    LOCK(cs_main); // pcoinsTip
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VBOOL});
 
     // parse hex string from parameter

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -334,20 +334,20 @@ bool IsRPCRunning()
 
 void SetRPCWarmupStatus(const std::string& newStatus)
 {
-    LOCK(cs_rpcWarmup);
+    LOCK(cs_rpcWarmup); // rpcWarmupStatus
     rpcWarmupStatus = newStatus;
 }
 
 void SetRPCWarmupFinished()
 {
-    LOCK(cs_rpcWarmup);
+    LOCK(cs_rpcWarmup); // fRPCInWarmup
     assert(fRPCInWarmup);
     fRPCInWarmup = false;
 }
 
 bool RPCIsInWarmup(std::string *outStatus)
 {
-    LOCK(cs_rpcWarmup);
+    LOCK(cs_rpcWarmup); // rpcWarmupStatus, fRPCInWarmup
     if (outStatus)
         *outStatus = rpcWarmupStatus;
     return fRPCInWarmup;
@@ -469,7 +469,7 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
 {
     // Return immediately if in warmup
     {
-        LOCK(cs_rpcWarmup);
+        LOCK(cs_rpcWarmup); // fRPCInWarmup
         if (fRPCInWarmup)
             throw JSONRPCError(RPC_IN_WARMUP, rpcWarmupStatus);
     }

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -148,7 +148,7 @@ bool CScheduler::AreThreadsServicingQueue() const {
 
 void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue() {
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_cs_callbacks_pending); // m_are_callbacks_running, m_callbacks_pending
         // Try to avoid scheduling too many copies here, but if we
         // accidentally have two ProcessQueue's scheduled at once its
         // not a big deal.
@@ -161,7 +161,7 @@ void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue() {
 void SingleThreadedSchedulerClient::ProcessQueue() {
     std::function<void (void)> callback;
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_cs_callbacks_pending); // m_are_callbacks_running, m_callbacks_pending
         if (m_are_callbacks_running) return;
         if (m_callbacks_pending.empty()) return;
         m_are_callbacks_running = true;
@@ -191,7 +191,7 @@ void SingleThreadedSchedulerClient::AddToProcessQueue(std::function<void (void)>
     assert(m_pscheduler);
 
     {
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_cs_callbacks_pending); // m_callbacks_pending
         m_callbacks_pending.emplace_back(std::move(func));
     }
     MaybeScheduleProcessQueue();
@@ -202,7 +202,7 @@ void SingleThreadedSchedulerClient::EmptyQueue() {
     bool should_continue = true;
     while (should_continue) {
         ProcessQueue();
-        LOCK(m_cs_callbacks_pending);
+        LOCK(m_cs_callbacks_pending); // m_callbacks_pending
         should_continue = !m_callbacks_pending.empty();
     }
 }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     entry.nFee = 11;
     entry.nHeight = 11;
 
-    LOCK(cs_main);
+    LOCK(cs_main); // pcoinsTip, CreateBlockIndex(...), chainActive
     fCheckpointsEnabled = false;
 
     // Simple block creation, nothing special yet:

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -191,7 +191,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
         spend_tx.vin[0].scriptSig << vchSig;
     }
 
-    LOCK(cs_main);
+    LOCK(cs_main); // pcoinsTip, chainActive
 
     // Test that invalidity under a set of flags doesn't preclude validity
     // under other (eg consensus) flags.

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -28,7 +28,7 @@ static int64_t nTimeOffset = 0;
  */
 int64_t GetTimeOffset()
 {
-    LOCK(cs_nTimeOffset);
+    LOCK(cs_nTimeOffset); // nTimeOffset
     return nTimeOffset;
 }
 
@@ -46,7 +46,7 @@ static int64_t abs64(int64_t n)
 
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
 {
-    LOCK(cs_nTimeOffset);
+    LOCK(cs_nTimeOffset); // nTimeOffset
     // Ignore duplicates
     static std::set<CNetAddr> setKnown;
     if (setKnown.size() == BITCOIN_TIMEDATA_MAX_SAMPLES)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -599,19 +599,19 @@ public:
 
     unsigned long size()
     {
-        LOCK(cs);
+        LOCK(cs); // mapTx
         return mapTx.size();
     }
 
     uint64_t GetTotalTxSize() const
     {
-        LOCK(cs);
+        LOCK(cs); // totalTxSize
         return totalTxSize;
     }
 
     bool exists(uint256 hash) const
     {
-        LOCK(cs);
+        LOCK(cs); // mapTx
         return (mapTx.count(hash) != 0);
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -385,7 +385,7 @@ static void InterpretNegativeSetting(std::string& strKey, std::string& strValue)
 
 void ArgsManager::ParseParameters(int argc, const char* const argv[])
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapArgs, mapMultiArgs
     mapArgs.clear();
     mapMultiArgs.clear();
 
@@ -421,7 +421,7 @@ void ArgsManager::ParseParameters(int argc, const char* const argv[])
 
 std::vector<std::string> ArgsManager::GetArgs(const std::string& strArg) const
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapMultiArgs
     auto it = mapMultiArgs.find(strArg);
     if (it != mapMultiArgs.end()) return it->second;
     return {};
@@ -429,13 +429,13 @@ std::vector<std::string> ArgsManager::GetArgs(const std::string& strArg) const
 
 bool ArgsManager::IsArgSet(const std::string& strArg) const
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapArgs
     return mapArgs.count(strArg);
 }
 
 std::string ArgsManager::GetArg(const std::string& strArg, const std::string& strDefault) const
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapArgs
     auto it = mapArgs.find(strArg);
     if (it != mapArgs.end()) return it->second;
     return strDefault;
@@ -443,7 +443,7 @@ std::string ArgsManager::GetArg(const std::string& strArg, const std::string& st
 
 int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapArgs
     auto it = mapArgs.find(strArg);
     if (it != mapArgs.end()) return atoi64(it->second);
     return nDefault;
@@ -451,7 +451,7 @@ int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
 
 bool ArgsManager::GetBoolArg(const std::string& strArg, bool fDefault) const
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapArgs
     auto it = mapArgs.find(strArg);
     if (it != mapArgs.end()) return InterpretBool(it->second);
     return fDefault;
@@ -475,7 +475,7 @@ bool ArgsManager::SoftSetBoolArg(const std::string& strArg, bool fValue)
 
 void ArgsManager::ForceSetArg(const std::string& strArg, const std::string& strValue)
 {
-    LOCK(cs_args);
+    LOCK(cs_args); // mapArgs, mapMultiArgs
     mapArgs[strArg] = strValue;
     mapMultiArgs[strArg] = {strValue};
 }
@@ -581,7 +581,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
 
 void ClearDatadirCache()
 {
-    LOCK(csPathCached);
+    LOCK(csPathCached); // pathCached, pathCachedNetSpecific
 
     pathCached = fs::path();
     pathCachedNetSpecific = fs::path();
@@ -603,7 +603,7 @@ void ArgsManager::ReadConfigFile(const std::string& confPath)
         return; // No bitcoin.conf file is OK
 
     {
-        LOCK(cs_args);
+        LOCK(cs_args); // mapArgs, mapMultiArgs
         std::set<std::string> setOptions;
         setOptions.insert("*");
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -143,7 +143,7 @@ static bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsi
 
 bool CCryptoKeyStore::SetCrypted()
 {
-    LOCK(cs_KeyStore);
+    LOCK(cs_KeyStore); // mapKeys
     if (fUseCrypto)
         return true;
     if (!mapKeys.empty())
@@ -158,7 +158,7 @@ bool CCryptoKeyStore::Lock()
         return false;
 
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // vMasterKey
         vMasterKey.clear();
     }
 
@@ -169,7 +169,7 @@ bool CCryptoKeyStore::Lock()
 bool CCryptoKeyStore::Unlock(const CKeyingMaterial& vMasterKeyIn)
 {
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapCryptedKeys, vMasterKey
         if (!SetCrypted())
             return false;
 
@@ -229,7 +229,7 @@ bool CCryptoKeyStore::AddKeyPubKey(const CKey& key, const CPubKey &pubkey)
 bool CCryptoKeyStore::AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret)
 {
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapCryptedKeys
         if (!SetCrypted())
             return false;
 
@@ -241,7 +241,7 @@ bool CCryptoKeyStore::AddCryptedKey(const CPubKey &vchPubKey, const std::vector<
 bool CCryptoKeyStore::GetKey(const CKeyID &address, CKey& keyOut) const
 {
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapCryptedKeys
         if (!IsCrypted())
             return CBasicKeyStore::GetKey(address, keyOut);
 
@@ -259,7 +259,7 @@ bool CCryptoKeyStore::GetKey(const CKeyID &address, CKey& keyOut) const
 bool CCryptoKeyStore::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const
 {
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapCryptedKeys
         if (!IsCrypted())
             return CBasicKeyStore::GetPubKey(address, vchPubKeyOut);
 
@@ -277,7 +277,7 @@ bool CCryptoKeyStore::GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) co
 bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial& vMasterKeyIn)
 {
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapKeys, mapCryptedKeys
         if (!mapCryptedKeys.empty() || IsCrypted())
             return false;
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -148,7 +148,7 @@ public:
             return false;
         bool result;
         {
-            LOCK(cs_KeyStore);
+            LOCK(cs_KeyStore); // vMasterKey
             result = vMasterKey.empty();
         }
         return result;
@@ -161,7 +161,7 @@ public:
     bool HaveKey(const CKeyID &address) const override
     {
         {
-            LOCK(cs_KeyStore);
+            LOCK(cs_KeyStore); // mapCryptedKeys
             if (!IsCrypted()) {
                 return CBasicKeyStore::HaveKey(address);
             }
@@ -173,7 +173,7 @@ public:
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
     std::set<CKeyID> GetKeys() const override
     {
-        LOCK(cs_KeyStore);
+        LOCK(cs_KeyStore); // mapCryptedKeys
         if (!IsCrypted()) {
             return CBasicKeyStore::GetKeys();
         }

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -51,7 +51,7 @@ bool CFeeBumper::preconditionChecks(const CWallet *pWallet, const CWalletTx& wtx
     }
 
     {
-        LOCK(mempool.cs);
+        LOCK(mempool.cs); // mapTx
         auto it_mp = mempool.mapTx.find(wtx.GetHash());
         if (it_mp != mempool.mapTx.end() && it_mp->GetCountWithDescendants() > 1) {
             vErrors.push_back("Transaction has descendants in the mempool");

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -101,7 +101,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
         );
 
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapKeyMetadata
 
     EnsureWalletIsUnlocked(pwallet);
 
@@ -319,7 +319,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     unsigned int txnIndex = 0;
     if (merkleBlock.txn.ExtractMatches(vMatch, vIndex) == merkleBlock.header.hashMerkleRoot) {
 
-        LOCK(cs_main);
+        LOCK(cs_main); // chainActive, mapBlockIndex
 
         if (!mapBlockIndex.count(merkleBlock.header.GetHash()) || !chainActive.Contains(mapBlockIndex[merkleBlock.header.GetHash()]))
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found in chain");
@@ -471,7 +471,7 @@ UniValue importwallet(const JSONRPCRequest& request)
     if (fPruneMode)
         throw JSONRPCError(RPC_WALLET_ERROR, "Importing wallets is disabled in pruned mode");
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // chainActive, mapKeyMetadata
 
     EnsureWalletIsUnlocked(pwallet);
 
@@ -612,7 +612,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("dumpwallet", "\"test\"")
         );
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // chainActive, mapKeyMetadata, mapAddressBook
 
     EnsureWalletIsUnlocked(pwallet);
 
@@ -1079,7 +1079,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
         }
     }
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // chainActive, ProcessImport(...)
     EnsureWalletIsUnlocked(pwallet);
 
     // Verify all timestamps are present before importing any keys.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -275,7 +275,7 @@ UniValue setaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("setaccount", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\", \"tabby\"")
         );
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapAddressBook
 
     CTxDestination dest = DecodeDestination(request.params[0].get_str());
     if (!IsValidDestination(dest)) {
@@ -324,7 +324,7 @@ UniValue getaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("getaccount", "\"1D1ZrZNe3JUo7ZycKEYQQiQAWd9y54F4XX\"")
         );
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapAddressBook
 
     CTxDestination dest = DecodeDestination(request.params[0].get_str());
     if (!IsValidDestination(dest)) {
@@ -363,7 +363,7 @@ UniValue getaddressesbyaccount(const JSONRPCRequest& request)
             + HelpExampleRpc("getaddressesbyaccount", "\"tabby\"")
         );
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapAddressBook
 
     std::string strAccount = AccountFromValue(request.params[0]);
 
@@ -533,7 +533,7 @@ UniValue listaddressgroupings(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapAddressBook
 
     UniValue jsonGroupings(UniValue::VARR);
     std::map<CTxDestination, CAmount> balances = pwallet->GetAddressBalances();
@@ -645,7 +645,7 @@ UniValue getreceivedbyaddress(const JSONRPCRequest& request)
        );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapWallet
 
     // Bitcoin address
     CTxDestination dest = DecodeDestination(request.params[0].get_str());
@@ -707,7 +707,7 @@ UniValue getreceivedbyaccount(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapWallet
 
     // Minimum confirmations
     int nMinDepth = 1;
@@ -1229,7 +1229,7 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
     }
 
     {
-        LOCK(cs_main);
+        LOCK(cs_main); // chainActive
         if (!IsWitnessEnabled(chainActive.Tip(), Params().GetConsensus()) && !gArgs.GetBoolArg("-walletprematurewitness", false)) {
             throw JSONRPCError(RPC_WALLET_ERROR, "Segregated witness not enabled on network");
         }
@@ -1423,7 +1423,7 @@ UniValue listreceivedbyaddress(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // ListReceived(...)
 
     return ListReceived(pwallet, request.params, false);
 }
@@ -1463,7 +1463,7 @@ UniValue listreceivedbyaccount(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // ListReceived(...)
 
     return ListReceived(pwallet, request.params, true);
 }
@@ -1651,7 +1651,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // ListTransactions(...)
 
     std::string strAccount = "*";
     if (!request.params[0].isNull())
@@ -1745,7 +1745,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapWallet, mapAddressBook
 
     int nMinDepth = 1;
     if (!request.params[0].isNull())
@@ -1854,7 +1854,7 @@ UniValue listsinceblock(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // chainActive, ListTransactions(...), mapBlockIndex, mapWallet
 
     const CBlockIndex* pindex = nullptr;    // Block index of the specified block or the common ancestor, if the block provided was in a deactivated chain.
     const CBlockIndex* paltindex = nullptr; // Block index of the specified block, even if it's in a deactivated chain.
@@ -1986,7 +1986,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // ListTransactions(...), WalletTxToJSON(...), mapWallet
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
@@ -2048,7 +2048,7 @@ UniValue abandontransaction(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapWallet
 
     uint256 hash;
     hash.SetHex(request.params[0].get_str());
@@ -2112,7 +2112,7 @@ UniValue keypoolrefill(const JSONRPCRequest& request)
             + HelpExampleRpc("keypoolrefill", "")
         );
 
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // GetKeyPoolSize(...)
 
     // 0 is interpreted by TopUpKeyPool() as the default keypool size given by -keypool
     unsigned int kpSize = 0;
@@ -2560,7 +2560,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
         );
 
     ObserveSafeMode();
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // CanSupportFeature(...), GetKeyPoolSize(...), mapWallet
 
     UniValue obj(UniValue::VOBJ);
 
@@ -2772,7 +2772,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     UniValue results(UniValue::VARR);
     std::vector<COutput> vecOutputs;
     assert(pwallet != nullptr);
-    LOCK2(cs_main, pwallet->cs_wallet);
+    LOCK2(cs_main, pwallet->cs_wallet); // mapAddressBook
 
     pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
     for (const COutput& out : vecOutputs) {

--- a/src/wallet/test/accounting_tests.cpp
+++ b/src/wallet/test/accounting_tests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     CAccountingEntry ae;
     std::map<CAmount, CAccountingEntry> results;
 
-    LOCK(pwalletMain->cs_wallet);
+    LOCK(pwalletMain->cs_wallet); // mapWallet, nOrderPosNext
 
     ae.strAccount = "";
     ae.nCreditDebit = 1;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -372,7 +372,7 @@ static void AddKey(CWallet& wallet, const CKey& key)
 
 BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
 {
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
 
     // Cap last block file size, and mine new block in a new block file.
     CBlockIndex* const nullBlock = nullptr;
@@ -449,7 +449,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
 // than or equal to key birthday.
 BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 {
-    LOCK(cs_main);
+    LOCK(cs_main); // chainActive
 
     // Create two blocks with same timestamp to verify that importwallet rescan
     // will pick up both blocks, not just the first.
@@ -467,7 +467,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     // Import key into wallet and call dumpwallet to create backup file.
     {
         CWallet wallet;
-        LOCK(wallet.cs_wallet);
+        LOCK(wallet.cs_wallet); // mapKeyMetadata
         wallet.mapKeyMetadata[coinbaseKey.GetPubKey().GetID()].nCreateTime = KEY_TIME;
         wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
 
@@ -512,7 +512,7 @@ BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
 {
     CWallet wallet;
     CWalletTx wtx(&wallet, MakeTransactionRef(coinbaseTxns.back()));
-    LOCK2(cs_main, wallet.cs_wallet);
+    LOCK2(cs_main, wallet.cs_wallet); // chainActive
     wtx.hashBlock = chainActive.Tip()->GetBlockHash();
     wtx.nIndex = 0;
 
@@ -638,7 +638,7 @@ public:
 BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
 {
     std::string coinbaseAddress = coinbaseKey.GetPubKey().GetID().ToString();
-    LOCK2(cs_main, wallet->cs_wallet);
+    LOCK2(cs_main, wallet->cs_wallet); // AddTx(...)
 
     // Confirm ListCoins initially returns 1 coin grouped under coinbaseKey
     // address.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1011,7 +1011,7 @@ public:
     void Inventory(const uint256 &hash) override
     {
         {
-            LOCK(cs_wallet);
+            LOCK(cs_wallet); // mapRequestCount
             std::map<uint256, int>::iterator mi = mapRequestCount.find(hash);
             if (mi != mapRequestCount.end())
                 (*mi).second++;
@@ -1033,7 +1033,10 @@ public:
     bool SetMaxVersion(int nVersion);
 
     //! get the current wallet format (the oldest client version guaranteed to understand this wallet)
-    int GetVersion() { LOCK(cs_wallet); return nWalletVersion; }
+    int GetVersion() {
+        LOCK(cs_wallet); // nWalletVersion
+        return nWalletVersion;
+    }
 
     //! Get wallet transactions that conflict with given transaction (spend same outputs)
     std::set<uint256> GetConflicts(const uint256& txid) const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -528,7 +528,7 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
-    LOCK(pwallet->cs_wallet);
+    LOCK(pwallet->cs_wallet); // LoadMinVersion(...), mapWallet, ReadKeyValue(...)
     try {
         int nMinVersion = 0;
         if (batch.Read((std::string)"minversion", nMinVersion))
@@ -799,7 +799,7 @@ bool CWalletDB::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDa
     bool fReadOK;
     {
         // Required in LoadKeyMetadata():
-        LOCK(dummyWallet->cs_wallet);
+        LOCK(dummyWallet->cs_wallet); // ReadKeyValue(...)
         fReadOK = ReadKeyValue(dummyWallet, ssKey, ssValue,
                                dummyWss, strType, strErr);
     }

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -15,25 +15,25 @@ bool fLargeWorkInvalidChainFound = false;
 
 void SetMiscWarning(const std::string& strWarning)
 {
-    LOCK(cs_warnings);
+    LOCK(cs_warnings); // strMiscWarning
     strMiscWarning = strWarning;
 }
 
 void SetfLargeWorkForkFound(bool flag)
 {
-    LOCK(cs_warnings);
+    LOCK(cs_warnings); // fLargeWorkForkFound
     fLargeWorkForkFound = flag;
 }
 
 bool GetfLargeWorkForkFound()
 {
-    LOCK(cs_warnings);
+    LOCK(cs_warnings); // fLargeWorkForkFound
     return fLargeWorkForkFound;
 }
 
 void SetfLargeWorkInvalidChainFound(bool flag)
 {
-    LOCK(cs_warnings);
+    LOCK(cs_warnings); // fLargeWorkInvalidChainFound
     fLargeWorkInvalidChainFound = flag;
 }
 
@@ -44,7 +44,7 @@ std::string GetWarnings(const std::string& strFor)
     std::string strGUI;
     const std::string uiAlertSeperator = "<hr />";
 
-    LOCK(cs_warnings);
+    LOCK(cs_warnings); // strMiscWarning, fLargeWorkForkFound, fLargeWorkInvalidChainFound
 
     if (!CLIENT_VERSION_IS_RELEASE) {
         strStatusBar = "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications";


### PR DESCRIPTION
Currently only a tiny fraction of all `LOCK(...)`:s are documented with information on why each lock is held.

In the absence of such comments it can sometimes be hard to see why a specific lock is held from merely reading the code. This risks leading to situations where redundant `LOCK(...)`:s are kept by mistake or "just to be safe" after refactoring, etc.

This PR improves the situation by adding comments with information on why a specific lock is being held by adding a comment using the form:

```
LOCK(cs_lockName); // variableBeingGuardedByThisLock, FunctionRequiringHoldingThisLock(...)
…
variableBeingGuardedByThisLock += 1;
…
FunctionRequiringHoldingThisLock(someThing);
```

Before this patch there were 9 documented and 514 undocumented `LOCK`/`LOCK2`:s –

```
$ git grep -E "[^a-zA-Z_](LOCK|LOCK2)\(" -- "*.h" "*.cpp" | grep -v sync.h | grep "//" | wc -l
9
$ git grep -E "[^a-zA-Z_](LOCK|LOCK2)\(" -- "*.h" "*.cpp" | grep -v sync.h | grep -v "//" | wc -l
514
```

After this patch there are 405 documented and 118 undocumented `LOCK`/`LOCK2`:s – 

```
$ git grep -E "[^a-zA-Z_](LOCK|LOCK2)\(" -- "*.h" "*.cpp" | grep -v sync.h | grep "//" | wc -l
405
$ git grep -E "[^a-zA-Z_](LOCK|LOCK2)\(" -- "*.h" "*.cpp" | grep -v sync.h | grep -v "//" | wc -l
118
```

Note that there are still some locks left that are undocumented. I need help identifying the variable that is ultimately being guarded by each of these locks (it could be that some of these locks are unnecessary - if so, let me know!).

Please help by browsing the remaining undocumented locks using ...

```
$ git grep -3 -n -E '^[^/#]*[^A-Z_](LOCK|LOCK2)\([^/]*$' -- "*.cpp" "*.h"
```

... and see if you can help bring clarity. Each undocumented guarded variable that can be identified helps a lot - just leave a comment on the missing lock/guarded variable pair you've found and I'll track down all instances of that combination and add the appropriate comments :-)

That will be of great help for this comment PR and also for the related thread-safety annotations PR that I'm working on (see #11226).