### PR TITLE
net: remove more CConnman globals

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1350,6 +1350,13 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     fDiscover = gArgs.GetBoolArg("-discover", true);
     fRelayTxes = !gArgs.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
 
+    int listen_port = chainparams.GetDefaultPort();
+    assert(listen_port <= 0xffff);
+    listen_port = gArgs.GetArg("-port", listen_port);
+    if (listen_port > 0xffff) {
+        return InitError(strprintf(_("Invalid port specified in -port: '%s'"), listen_port));
+    }
+
     for (const std::string& strAddr : gArgs.GetArgs("-externalip")) {
         CService addrLocal;
         if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
@@ -1645,7 +1652,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("mapBlockIndex.size() = %u\n",   mapBlockIndex.size());
     LogPrintf("nBestHeight = %d\n",                   chainActive.Height());
     if (gArgs.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
-        StartTorControl(threadGroup, scheduler);
+        StartTorControl(gArgs.GetArg("-torcontrol", DEFAULT_TOR_CONTROL), listen_port);
 
     Discover(threadGroup);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1359,7 +1359,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     for (const std::string& strAddr : gArgs.GetArgs("-externalip")) {
         CService addrLocal;
-        if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
+        if (Lookup(strAddr.c_str(), addrLocal, listen_port, fNameLookup) && addrLocal.IsValid())
             AddLocal(addrLocal, LOCAL_MANUAL);
         else
             return InitError(ResolveErrMsg("externalip", strAddr));
@@ -1676,10 +1676,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     connOptions.nMaxOutboundTimeframe = nMaxOutboundTimeframe;
     connOptions.nMaxOutboundLimit = nMaxOutboundLimit;
+    connOptions.m_default_listen_port = listen_port;
 
     for (const std::string& strBind : gArgs.GetArgs("-bind")) {
         CService addrBind;
-        if (!Lookup(strBind.c_str(), addrBind, GetListenPort(), false)) {
+        if (!Lookup(strBind.c_str(), addrBind, listen_port, false)) {
             return InitError(ResolveErrMsg("bind", strBind));
         }
         connOptions.vBinds.push_back(addrBind);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1677,6 +1677,7 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     connOptions.nMaxOutboundTimeframe = nMaxOutboundTimeframe;
     connOptions.nMaxOutboundLimit = nMaxOutboundLimit;
     connOptions.m_default_listen_port = listen_port;
+    connOptions.m_default_outbound_port = chainparams.GetDefaultPort();
 
     for (const std::string& strBind : gArgs.GetArgs("-bind")) {
         CService addrBind;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -189,7 +189,7 @@ void Shutdown()
 #ifdef ENABLE_WALLET
     FlushWallets();
 #endif
-    MapPort(false);
+    MapPort(false, 0);
 
     // Because these depend on each-other, we make sure that neither can be
     // using the other before destroying them.
@@ -1651,13 +1651,14 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     //// debug print
     LogPrintf("mapBlockIndex.size() = %u\n",   mapBlockIndex.size());
     LogPrintf("nBestHeight = %d\n",                   chainActive.Height());
+
     if (gArgs.GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(gArgs.GetArg("-torcontrol", DEFAULT_TOR_CONTROL), listen_port);
 
-    Discover(threadGroup);
+    Discover(listen_port);
 
     // Map ports with UPnP
-    MapPort(gArgs.GetBoolArg("-upnp", DEFAULT_UPNP));
+    MapPort(gArgs.GetBoolArg("-upnp", DEFAULT_UPNP), listen_port);
 
     CConnman::Options connOptions;
     connOptions.nLocalServices = nLocalServices;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -378,7 +378,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
     // Connect
     SOCKET hSocket;
     bool proxyConnectionFailed = false;
-    if (pszDest ? ConnectSocketByName(addrConnect, hSocket, pszDest, Params().GetDefaultPort(), nConnectTimeout, &proxyConnectionFailed) :
+    if (pszDest ? ConnectSocketByName(addrConnect, hSocket, pszDest, m_default_outbound_port, nConnectTimeout, &proxyConnectionFailed) :
                   ConnectSocket(addrConnect, hSocket, nConnectTimeout, &proxyConnectionFailed))
     {
         if (!IsSelectableSocket(hSocket)) {
@@ -1605,7 +1605,7 @@ void CConnman::ThreadDNSAddressSeed()
                 for (const CNetAddr& ip : vIPs)
                 {
                     int nOneDay = 24*3600;
-                    CAddress addr = CAddress(CService(ip, Params().GetDefaultPort()), requiredServiceBits);
+                    CAddress addr = CAddress(CService(ip, m_default_outbound_port), requiredServiceBits);
                     addr.nTime = GetTime() - 3*nOneDay - GetRand(4*nOneDay); // use a random age between 3 and 7 days old
                     vAdd.push_back(addr);
                     found++;
@@ -1807,7 +1807,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
             }
 
             // do not allow non-default ports, unless after 50 invalid addresses selected already
-            if (addr.GetPort() != Params().GetDefaultPort() && nTries < 50)
+            if (addr.GetPort() != m_default_outbound_port && nTries < 50)
                 continue;
 
             addrConnect = addr;
@@ -1865,7 +1865,7 @@ std::vector<AddedNodeInfo> CConnman::GetAddedNodeInfo()
     }
 
     for (const std::string& strAddNode : lAddresses) {
-        CService service(LookupNumeric(strAddNode.c_str(), Params().GetDefaultPort()));
+        CService service(LookupNumeric(strAddNode.c_str(), m_default_outbound_port));
         if (service.IsValid()) {
             // strAddNode is an IP:port
             auto it = mapConnected.find(service);
@@ -1905,7 +1905,7 @@ void CConnman::ThreadOpenAddedConnections()
                 // If strAddedNode is an IP/port, decode it immediately, so
                 // OpenNetworkConnection can detect existing connections to that IP/port.
                 tried = true;
-                CService service(LookupNumeric(info.strAddedNode.c_str(), Params().GetDefaultPort()));
+                CService service(LookupNumeric(info.strAddedNode.c_str(), m_default_outbound_port));
                 OpenNetworkConnection(CAddress(service, NODE_NONE), false, &grant, info.strAddedNode.c_str(), false, false, true);
                 if (!interruptNet.sleep_for(std::chrono::milliseconds(500)))
                     return;

--- a/src/net.h
+++ b/src/net.h
@@ -422,8 +422,8 @@ private:
     std::thread threadMessageHandler;
 };
 extern std::unique_ptr<CConnman> g_connman;
-void Discover(boost::thread_group& threadGroup);
-void MapPort(bool fUseUPnP);
+void Discover(uint16_t port);
+void MapPort(bool fUseUPnP, uint16_t port);
 unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
 
@@ -471,7 +471,6 @@ void SetLimited(enum Network net, bool fLimited = true);
 bool IsLimited(enum Network net);
 bool IsLimited(const CNetAddr& addr);
 bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
-bool AddLocal(const CNetAddr& addr, int nScore = LOCAL_NONE);
 bool RemoveLocal(const CService& addr);
 bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);

--- a/src/net.h
+++ b/src/net.h
@@ -148,6 +148,7 @@ public:
         bool m_use_addrman_outgoing = true;
         std::vector<std::string> m_specified_outgoing;
         std::vector<std::string> m_added_nodes;
+        uint16_t m_default_listen_port = 0;
     };
 
     void Init(const Options& connOptions) {
@@ -166,6 +167,7 @@ public:
         nMaxOutboundLimit = connOptions.nMaxOutboundLimit;
         vWhitelistedRange = connOptions.vWhitelistedRange;
         vAddedNodes = connOptions.m_added_nodes;
+        m_default_listen_port = connOptions.m_default_listen_port;
     }
 
     CConnman(uint64_t seed0, uint64_t seed1);
@@ -265,6 +267,7 @@ public:
     bool DisconnectNode(NodeId id);
 
     ServiceFlags GetLocalServices() const;
+    uint16_t GetDefaultListenPort() const;
 
     //!set the max outbound target in bytes
     void SetMaxOutboundTarget(uint64_t limit);
@@ -371,6 +374,8 @@ private:
     unsigned int nSendBufferMaxSize;
     unsigned int nReceiveFloodSize;
 
+    uint16_t m_default_listen_port;
+
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive;
     banmap_t setBanned;
@@ -424,7 +429,6 @@ private:
 extern std::unique_ptr<CConnman> g_connman;
 void Discover(uint16_t port);
 void MapPort(bool fUseUPnP, uint16_t port);
-unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string& strError, bool fWhitelisted = false);
 
 struct CombinerAll
@@ -466,7 +470,7 @@ enum
 };
 
 bool IsPeerAddrLocalGood(CNode *pnode);
-void AdvertiseLocal(CNode *pnode);
+void AdvertiseLocal(CNode *pnode, uint16_t default_listen_port);
 void SetLimited(enum Network net, bool fLimited = true);
 bool IsLimited(enum Network net);
 bool IsLimited(const CNetAddr& addr);
@@ -477,7 +481,7 @@ bool IsLocal(const CService& addr);
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer = nullptr);
 bool IsReachable(enum Network net);
 bool IsReachable(const CNetAddr &addr);
-CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices);
+CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices, uint16_t default_listen_port);
 
 
 extern bool fDiscover;

--- a/src/net.h
+++ b/src/net.h
@@ -149,6 +149,7 @@ public:
         std::vector<std::string> m_specified_outgoing;
         std::vector<std::string> m_added_nodes;
         uint16_t m_default_listen_port = 0;
+        uint16_t m_default_outbound_port = 0;
     };
 
     void Init(const Options& connOptions) {
@@ -168,6 +169,7 @@ public:
         vWhitelistedRange = connOptions.vWhitelistedRange;
         vAddedNodes = connOptions.m_added_nodes;
         m_default_listen_port = connOptions.m_default_listen_port;
+        m_default_outbound_port = connOptions.m_default_outbound_port;
     }
 
     CConnman(uint64_t seed0, uint64_t seed1);
@@ -375,6 +377,7 @@ private:
     unsigned int nReceiveFloodSize;
 
     uint16_t m_default_listen_port;
+    uint16_t m_default_outbound_port;
 
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1329,7 +1329,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // Advertise our address
             if (fListen && !IsInitialBlockDownload())
             {
-                CAddress addr = GetLocalAddress(&pfrom->addr, pfrom->GetLocalServices());
+                CAddress addr = GetLocalAddress(&pfrom->addr, pfrom->GetLocalServices(), connman->GetDefaultListenPort());
                 FastRandomContext insecure_rand;
                 if (addr.IsRoutable())
                 {
@@ -2828,7 +2828,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Address refresh broadcast
         int64_t nNow = GetTimeMicros();
         if (!IsInitialBlockDownload() && pto->nNextLocalAddrSend < nNow) {
-            AdvertiseLocal(pto);
+            AdvertiseLocal(pto, connman->GetDefaultListenPort());
             pto->nNextLocalAddrSend = PoissonNextSend(nNow, AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL);
         }
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -73,17 +73,6 @@ CDataStream AddrmanToStream(CAddrManSerializationMock& _addrman)
 
 BOOST_FIXTURE_TEST_SUITE(net_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(cnode_listen_port)
-{
-    // test default
-    unsigned short port = GetListenPort();
-    BOOST_CHECK(port == Params().GetDefaultPort());
-    // test set port
-    unsigned short altPort = 12345;
-    gArgs.SoftSetArg("-port", std::to_string(altPort));
-    port = GetListenPort();
-    BOOST_CHECK(port == altPort);
-}
 
 BOOST_AUTO_TEST_CASE(caddrdb_read)
 {

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -8,12 +8,13 @@
 #ifndef BITCOIN_TORCONTROL_H
 #define BITCOIN_TORCONTROL_H
 
-#include "scheduler.h"
+#include <stdint.h>
+#include <string>
 
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
 
-void StartTorControl(boost::thread_group& threadGroup, CScheduler& scheduler);
+void StartTorControl(const std::string& target, uint16_t default_port);
 void InterruptTorControl();
 void StopTorControl();
 


### PR DESCRIPTION
This continues some of the great work that @benma has been doing.

More work towards a CConnman with no globals, so that we can test instances against themselves.