### PR TITLE
Remove lxcbr0 lines from gitian-build.sh

### DIFF
--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -179,8 +179,6 @@ done
 if [[ $lxc = true ]]
 then
     export USE_LXC=1
-    export LXC_BRIDGE=lxcbr0
-    sudo ifconfig lxcbr0 up 10.0.2.2
 fi
 
 # Check for OSX SDK


### PR DESCRIPTION
The `gitian-build.sh` script crashes with an error when I tried to use it, @kallewoof also had this same issue:

	lxcbr0: ERROR while getting interface flags: No such device
	SIOCSIFADDR: No such device
	lxcbr0: ERROR while getting interface flags: No such device

And then:

	lxc-execute: failed to find gateway addresses
	lxc-execute: failed to spawn 'gitian'
	./bin/gbuild:21:in `system!': failed to run make-clean-vm --suite trusty --arch amd64 (RuntimeError)

I believe it's because of the two lines which this PR removes, I tested it and seems to work as expected now. These lines are unique to this script and aren't mentioned in `gitian-building.md` or `release-process.md`. We discussed it on IRC, @achow101 agrees removing these lines would probably fix it: https://botbot.me/freenode/bitcoin-core-dev/2017-09-19/?msg=91299782&page=2

Has anyone successfully used this script as-is? Or does everyone else manually run the builds/write their own script like I have up til this point?