### PR TITLE
Fix stale link in gitian-building.md

### DIFF
--- a/doc/gitian-building.md
+++ b/doc/gitian-building.md
@@ -353,7 +353,7 @@ Building Bitcoin Core
 ----------------
 
 To build Bitcoin Core (for Linux, OS X and Windows) just follow the steps under 'perform
-Gitian builds' in [doc/release-process.md](release-process.md#perform-gitian-builds) in the bitcoin repository.
+Gitian builds' in [doc/release-process.md](release-process.md#setup-and-perform-gitian-builds) in the bitcoin repository.
 
 This may take some time as it will build all the dependencies needed for each descriptor.
 These dependencies will be cached after a successful build to avoid rebuilding them when possible.


### PR DESCRIPTION
The  `perform-gitian-builds`  is  not  exist,
replace  `perform-gitian-builds` with  `setup-and-perform-gitian-builds`.