### PR TITLE
Perform a weaker subtree check in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ install:
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
 before_script:
     - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then contrib/devtools/commit-script-check.sh $TRAVIS_COMMIT_RANGE; fi
+    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/git-subtree-check.sh src/crypto/ctaes; fi
+    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/git-subtree-check.sh src/secp256k1; fi
+    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/git-subtree-check.sh src/univalue; fi
+    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/git-subtree-check.sh src/leveldb; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-rpc-mappings.py .; fi
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/lint-all.sh; fi

--- a/contrib/devtools/git-subtree-check.sh
+++ b/contrib/devtools/git-subtree-check.sh
@@ -41,21 +41,17 @@ find_latest_squash()
 	done
 }
 
+# find latest subtree update
 latest_squash="$(find_latest_squash "$DIR")"
 if [ -z "$latest_squash" ]; then
     echo "ERROR: $DIR is not a subtree" >&2
     exit 2
 fi
-
 set $latest_squash
 old=$1
 rev=$2
-if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
-    echo "ERROR: subtree commit $rev unavailable. Fetch/update the subtree repository" >&2
-    exit 2
-fi
-tree_subtree=$(git show -s --format="%T" $rev)
-echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
+
+# get the tree in the current commit
 tree_actual=$(git ls-tree -d "$COMMIT" "$DIR" | head -n 1)
 if [ -z "$tree_actual" ]; then
     echo "FAIL: subtree directory $DIR not found in $COMMIT" >&2
@@ -69,9 +65,30 @@ if [ "d$tree_actual_type" != "dtree" ]; then
     echo "FAIL: subtree directory $DIR is not a tree in $COMMIT" >&2
     exit 1
 fi
-if [ "$tree_actual_tree" != "$tree_subtree" ]; then
-    git diff-tree $tree_actual_tree $tree_subtree >&2
-    echo "FAIL: subtree directory tree doesn't match subtree commit tree" >&2
+
+# get the tree at the time of the last subtree update
+tree_commit=$(git show -s --format="%T" $old)
+echo "$DIR in $COMMIT was last updated in commit $old (tree $tree_commit)"
+
+# ... and compare the actual tree with it
+if [ "$tree_actual_tree" != "$tree_commit" ]; then
+    git diff $tree_commit $tree_actual_tree >&2
+    echo "FAIL: subtree directory was touched without subtree merge" >&2
     exit 1
 fi
+
+# get the tree in the subtree commit referred to
+if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
+    echo "subtree commit $rev unavailable: cannot compare" >&2
+    exit
+fi
+tree_subtree=$(git show -s --format="%T" $rev)
+echo "$DIR in $COMMIT was last updated to upstream commit $rev (tree $tree_subtree)"
+
+# ... and compare the actual tree with it
+if [ "$tree_actual_tree" != "$tree_subtree" ]; then
+    echo "FAIL: subtree update commit differs from upstream tree!" >&2
+    exit 1
+fi
+
 echo "GOOD"


### PR DESCRIPTION
Apparently many of our subtrees get modified by PRs in this repository, without getting noticed.

To improve upon this:
* Make git-subtree-check.sh capable of doing a weaker consistency check (that doesn't need access to external repositories), but which should be sufficient to detect unintended changes. It can be fooled by a fake subtree merge commit, but that would hopefully be obvious to reviewers.
* Make Travis invoke this subtree check for each of our subtrees.

Note that Travis is currently expected to fail on this PR, as 2 out of 4 subtrees (`src/secp156k1` and `src/univalue` have been modified directly in master).