### PR TITLE
Use shared pointer for wallet instances

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -485,9 +485,9 @@ void BitcoinApplication::initializeResult(bool success)
 
 #ifdef ENABLE_WALLET
         // TODO: Expose secondary wallets
-        if (!vpwallets.empty())
-        {
-            walletModel = new WalletModel(platformStyle, vpwallets[0], optionsModel);
+        auto wallets = GetWallets();
+        if (!wallets.empty()) {
+            walletModel = new WalletModel(platformStyle, wallets[0].get(), optionsModel);
 
             window->addWallet(BitcoinGUI::DEFAULT_WALLET, walletModel);
             window->setCurrentWallet(BitcoinGUI::DEFAULT_WALLET);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -305,9 +305,10 @@ bool RPCConsole::RPCParseCommandLine(std::string &strResult, const std::string &
                             req.strMethod = stack.back()[0];
 #ifdef ENABLE_WALLET
                             // TODO: Move this logic to WalletModel
-                            if (!vpwallets.empty()) {
+                            auto wallets = GetWallets();
+                            if (!wallets.empty()) {
                                 // in Qt, use always the wallet with index 0 when running with multiple wallets
-                                QByteArray encodedName = QUrl::toPercentEncoding(QString::fromStdString(vpwallets[0]->GetName()));
+                                QByteArray encodedName = QUrl::toPercentEncoding(QString::fromStdString(wallets[0]->GetName()));
                                 req.URI = "/wallet/"+std::string(encodedName.constData(), encodedName.length());
                             }
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -113,7 +113,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
         );
 
 #ifdef ENABLE_WALLET
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
 
     LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : nullptr);
 #else
@@ -137,7 +137,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
         isminetype mine = pwallet ? IsMine(*pwallet, dest) : ISMINE_NO;
         ret.push_back(Pair("ismine", bool(mine & ISMINE_SPENDABLE)));
         ret.push_back(Pair("iswatchonly", bool(mine & ISMINE_WATCH_ONLY)));
-        UniValue detail = boost::apply_visitor(DescribeAddressVisitor(pwallet), dest);
+        UniValue detail = boost::apply_visitor(DescribeAddressVisitor(pwallet.get()), dest);
         ret.pushKVs(detail);
         if (pwallet && pwallet->mapAddressBook.count(dest)) {
             ret.push_back(Pair("account", pwallet->mapAddressBook[dest].name));
@@ -231,9 +231,9 @@ CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& pa
 UniValue createmultisig(const JSONRPCRequest& request)
 {
 #ifdef ENABLE_WALLET
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
 #else
-    CWallet * const pwallet = nullptr;
+    auto const pwallet = nullptr;
 #endif
 
     if (request.fHelp || request.params.size() < 2 || request.params.size() > 2)
@@ -266,7 +266,7 @@ UniValue createmultisig(const JSONRPCRequest& request)
     }
 
     // Construct using pay-to-script-hash:
-    CScript inner = _createmultisig_redeemScript(pwallet, request.params);
+    CScript inner = _createmultisig_redeemScript(pwallet.get(), request.params);
     CScriptID innerID(inner);
 
     UniValue result(UniValue::VOBJ);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -643,7 +643,7 @@ UniValue combinerawtransaction(const JSONRPCRequest& request)
 UniValue signrawtransaction(const JSONRPCRequest& request)
 {
 #ifdef ENABLE_WALLET
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
 #endif
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
@@ -655,7 +655,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
             "The third optional argument (may be null) is an array of base58-encoded private\n"
             "keys that, if given, will be the only keys used to sign the transaction.\n"
 #ifdef ENABLE_WALLET
-            + HelpRequiringPassphrase(pwallet) + "\n"
+            + HelpRequiringPassphrase(pwallet.get()) + "\n"
 #endif
 
             "\nArguments:\n"
@@ -752,7 +752,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
     }
 #ifdef ENABLE_WALLET
     else if (pwallet) {
-        EnsureWalletIsUnlocked(pwallet);
+        EnsureWalletIsUnlocked(pwallet.get());
     }
 #endif
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -242,38 +242,35 @@ bool OpenWallets()
         return true;
     }
 
-    for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
-        CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
+    for (const std::string& wallet_file : gArgs.GetArgs("-wallet")) {
+        auto pwallet = CWallet::CreateWalletFromFile(wallet_file);
         if (!pwallet) {
             return false;
         }
-        vpwallets.push_back(pwallet);
+        AddWallet(pwallet);
     }
 
     return true;
 }
 
 void StartWallets(CScheduler& scheduler) {
-    for (CWalletRef pwallet : vpwallets) {
+    for (auto pwallet : GetWallets()) {
         pwallet->postInitProcess(scheduler);
     }
 }
 
 void FlushWallets() {
-    for (CWalletRef pwallet : vpwallets) {
+    for (auto pwallet : GetWallets()) {
         pwallet->Flush(false);
     }
 }
 
 void StopWallets() {
-    for (CWalletRef pwallet : vpwallets) {
+    for (auto pwallet : GetWallets()) {
         pwallet->Flush(true);
     }
 }
 
 void CloseWallets() {
-    for (CWalletRef pwallet : vpwallets) {
-        delete pwallet;
-    }
-    vpwallets.clear();
+    ClearWallets();
 }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -73,8 +73,8 @@ std::string DecodeDumpString(const std::string &str) {
 
 UniValue importprivkey(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -103,7 +103,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(pwallet.get());
 
     std::string strSecret = request.params[0].get_str();
     std::string strLabel = "";
@@ -157,8 +157,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
 
 UniValue abortrescan(const JSONRPCRequest& request)
 {
-    CWallet* const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -218,8 +218,8 @@ void ImportAddress(CWallet* const pwallet, const CTxDestination& dest, const std
 
 UniValue importaddress(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -270,10 +270,10 @@ UniValue importaddress(const JSONRPCRequest& request)
         if (fP2SH) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Cannot use the p2sh flag with an address - use a script instead");
         }
-        ImportAddress(pwallet, dest, strLabel);
+        ImportAddress(pwallet.get(), dest, strLabel);
     } else if (IsHex(request.params[0].get_str())) {
         std::vector<unsigned char> data(ParseHex(request.params[0].get_str()));
-        ImportScript(pwallet, CScript(data.begin(), data.end()), strLabel, fP2SH);
+        ImportScript(pwallet.get(), CScript(data.begin(), data.end()), strLabel, fP2SH);
     } else {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
     }
@@ -289,8 +289,8 @@ UniValue importaddress(const JSONRPCRequest& request)
 
 UniValue importprunedfunds(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -307,7 +307,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     if (!DecodeHexTx(tx, request.params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     uint256 hashTx = tx.GetHash();
-    CWalletTx wtx(pwallet, MakeTransactionRef(std::move(tx)));
+    CWalletTx wtx(pwallet.get(), MakeTransactionRef(std::move(tx)));
 
     CDataStream ssMB(ParseHexV(request.params[1], "proof"), SER_NETWORK, PROTOCOL_VERSION);
     CMerkleBlock merkleBlock;
@@ -350,8 +350,8 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
 
 UniValue removeprunedfunds(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -388,8 +388,8 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
 
 UniValue importpubkey(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -433,8 +433,8 @@ UniValue importpubkey(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    ImportAddress(pwallet, pubKey.GetID(), strLabel);
-    ImportScript(pwallet, GetScriptForRawPubKey(pubKey), strLabel, false);
+    ImportAddress(pwallet.get(), pubKey.GetID(), strLabel);
+    ImportScript(pwallet.get(), GetScriptForRawPubKey(pubKey), strLabel, false);
 
     if (fRescan)
     {
@@ -448,8 +448,8 @@ UniValue importpubkey(const JSONRPCRequest& request)
 
 UniValue importwallet(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -473,7 +473,7 @@ UniValue importwallet(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(pwallet.get());
 
     std::ifstream file;
     file.open(request.params[0].get_str().c_str(), std::ios::in | std::ios::ate);
@@ -549,8 +549,8 @@ UniValue importwallet(const JSONRPCRequest& request)
 
 UniValue dumpprivkey(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -571,7 +571,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(pwallet.get());
 
     std::string strAddress = request.params[0].get_str();
     CTxDestination dest = DecodeDestination(strAddress);
@@ -592,8 +592,8 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 
 UniValue dumpwallet(const JSONRPCRequest& request)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet.get(), request.fHelp)) {
         return NullUniValue;
     }
 
@@ -614,7 +614,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(pwallet.get());
 
     std::ofstream file;
     boost::filesystem::path filepath = request.params[0].get_str();
@@ -691,7 +691,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 }
 
 
-UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int64_t timestamp)
+static UniValue ProcessImport(CWallet * const pwallet, const UniValue& data, const int64_t timestamp)
 {
     try {
         bool success = false;
@@ -1020,8 +1020,8 @@ int64_t GetImportTimestamp(const UniValue& data, int64_t now)
 
 UniValue importmulti(const JSONRPCRequest& mainRequest)
 {
-    CWallet * const pwallet = GetWalletForJSONRPCRequest(mainRequest);
-    if (!EnsureWalletIsAvailable(pwallet, mainRequest.fHelp)) {
+    auto const pwallet = GetWalletForJSONRPCRequest(mainRequest);
+    if (!EnsureWalletIsAvailable(pwallet.get(), mainRequest.fHelp)) {
         return NullUniValue;
     }
 
@@ -1080,7 +1080,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
     }
 
     LOCK2(cs_main, pwallet->cs_wallet);
-    EnsureWalletIsUnlocked(pwallet);
+    EnsureWalletIsUnlocked(pwallet.get());
 
     // Verify all timestamps are present before importing any keys.
     const int64_t now = chainActive.Tip() ? chainActive.Tip()->GetMedianTimePast() : 0;
@@ -1102,7 +1102,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     for (const UniValue& data : requests.getValues()) {
         const int64_t timestamp = std::max(GetImportTimestamp(data, now), minimumTimestamp);
-        const UniValue result = ProcessImport(pwallet, data, timestamp);
+        const UniValue result = ProcessImport(pwallet.get(), data, timestamp);
         response.push_back(result);
 
         if (!fRescan) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -35,7 +35,7 @@
 
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 
-std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
+CWalletRef GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
     auto wallets = GetWallets();
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -19,10 +19,10 @@ void RegisterWalletRPCCommands(CRPCTable &t);
  * @param[in] request JSONRPCRequest that wishes to access a wallet
  * @return nullptr if no wallet should be used, or a pointer to the CWallet
  */
-CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
-std::string HelpRequiringPassphrase(CWallet *);
-void EnsureWalletIsUnlocked(CWallet *);
-bool EnsureWalletIsAvailable(CWallet *, bool avoidException);
+std::string HelpRequiringPassphrase(CWallet* const);
+void EnsureWalletIsUnlocked(CWallet* const);
+bool EnsureWalletIsAvailable(CWallet* const, bool avoidException);
 
 #endif //BITCOIN_WALLET_RPCWALLET_H

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -19,7 +19,7 @@ void RegisterWalletRPCCommands(CRPCTable &t);
  * @param[in] request JSONRPCRequest that wishes to access a wallet
  * @return nullptr if no wallet should be used, or a pointer to the CWallet
  */
-std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
+CWalletRef GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
 std::string HelpRequiringPassphrase(CWallet* const);
 void EnsureWalletIsUnlocked(CWallet* const);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -37,10 +37,12 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 
-static std::vector<std::shared_ptr<CWallet>> vpwallets;
+static CCriticalSection cs_wallets;
+static std::vector<CWalletRef> wallets;
 
 bool AddWallet(std::shared_ptr<CWallet> pwallet)
 {
+    LOCK(cs_wallets);
     for (auto it = vpwallets.begin(); it != vpwallets.end(); ++it) {
         if (*it == pwallet) {
             return false;
@@ -52,6 +54,7 @@ bool AddWallet(std::shared_ptr<CWallet> pwallet)
 
 bool RemoveWallet(std::shared_ptr<CWallet> pwallet)
 {
+    LOCK(cs_wallets);
     for (auto it = vpwallets.begin(); it != vpwallets.end(); ++it) {
         if (*it == pwallet) {
             vpwallets.erase(it);
@@ -63,11 +66,13 @@ bool RemoveWallet(std::shared_ptr<CWallet> pwallet)
 
 std::vector<std::shared_ptr<CWallet>> GetWallets()
 {
+    LOCK(cs_wallets);
     return vpwallets;
 }
 
 bool ClearWallets()
 {
+    LOCK(cs_wallets);
     vpwallets.clear();
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -40,40 +40,40 @@
 static CCriticalSection cs_wallets;
 static std::vector<CWalletRef> wallets;
 
-bool AddWallet(std::shared_ptr<CWallet> pwallet)
+bool AddWallet(CWalletRef wallet)
 {
     LOCK(cs_wallets);
-    for (auto it = vpwallets.begin(); it != vpwallets.end(); ++it) {
-        if (*it == pwallet) {
+    for (auto it = wallets.begin(); it != wallets.end(); ++it) {
+        if (*it == wallet) {
             return false;
         }
     }
-    vpwallets.push_back(pwallet);
+    wallets.push_back(wallet);
     return true;
 }
 
-bool RemoveWallet(std::shared_ptr<CWallet> pwallet)
+bool RemoveWallet(CWalletRef wallet)
 {
     LOCK(cs_wallets);
-    for (auto it = vpwallets.begin(); it != vpwallets.end(); ++it) {
-        if (*it == pwallet) {
-            vpwallets.erase(it);
+    for (auto it = wallets.begin(); it != wallets.end(); ++it) {
+        if (*it == wallet) {
+            wallets.erase(it);
             return true;
         }
     }
     return false;
 }
 
-std::vector<std::shared_ptr<CWallet>> GetWallets()
+std::vector<CWalletRef> GetWallets()
 {
     LOCK(cs_wallets);
-    return vpwallets;
+    return wallets;
 }
 
 bool ClearWallets()
 {
     LOCK(cs_wallets);
-    vpwallets.clear();
+    wallets.clear();
     return true;
 }
 
@@ -3794,7 +3794,7 @@ std::vector<std::string> CWallet::GetDestValues(const std::string& prefix) const
     return values;
 }
 
-std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string walletFile)
+CWalletRef CWallet::CreateWalletFromFile(const std::string walletFile)
 {
     // needed to restore wallet transaction meta data after -zapwallettxes
     std::vector<CWalletTx> vWtx;
@@ -3816,7 +3816,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string walletF
     int64_t nStart = GetTimeMillis();
     bool fFirstRun = true;
     std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, walletFile));
-    std::shared_ptr<CWallet> walletInstance = std::make_shared<CWallet>(std::move(dbw));
+    CWalletRef walletInstance = std::make_shared<CWallet>(std::move(dbw));
     DBErrors nLoadWalletRet = walletInstance->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DB_LOAD_OK)
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -41,6 +41,11 @@ static std::vector<std::shared_ptr<CWallet>> vpwallets;
 
 bool AddWallet(std::shared_ptr<CWallet> pwallet)
 {
+    for (auto it = vpwallets.begin(); it != vpwallets.end(); ++it) {
+        if (*it == pwallet) {
+            return false;
+        }
+    }
     vpwallets.push_back(pwallet);
     return true;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -29,8 +29,10 @@
 #include <utility>
 #include <vector>
 
-typedef CWallet* CWalletRef;
-extern std::vector<CWalletRef> vpwallets;
+bool AddWallet(std::shared_ptr<CWallet> pwallet);
+bool RemoveWallet(std::shared_ptr<CWallet> pwallet);
+std::vector<std::shared_ptr<CWallet>> GetWallets();
+bool ClearWallets();
 
 /**
  * Settings
@@ -1081,7 +1083,7 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static CWallet* CreateWalletFromFile(const std::string walletFile);
+    static std::shared_ptr<CWallet> CreateWalletFromFile(const std::string walletFile);
 
     /**
      * Wallet post-init setup
@@ -1112,15 +1114,14 @@ public:
 class CReserveKey final : public CReserveScript
 {
 protected:
-    CWallet* pwallet;
+    CWallet* const pwallet;
     int64_t nIndex;
     CPubKey vchPubKey;
     bool fInternal;
 public:
-    explicit CReserveKey(CWallet* pwalletIn)
+    explicit CReserveKey(CWallet* pwalletIn) : pwallet(pwalletIn)
     {
         nIndex = -1;
-        pwallet = pwalletIn;
         fInternal = false;
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <atomic>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdexcept>
 #include <stdint.h>
@@ -29,9 +30,11 @@
 #include <utility>
 #include <vector>
 
-bool AddWallet(std::shared_ptr<CWallet> pwallet);
-bool RemoveWallet(std::shared_ptr<CWallet> pwallet);
-std::vector<std::shared_ptr<CWallet>> GetWallets();
+typedef std::shared<CWallet> CWalletRef;
+
+bool AddWallet(CWalletRef wallet);
+bool RemoveWallet(CWalletRef wallet);
+std::vector<CWalletRef> GetWallets();
 bool ClearWallets();
 
 /**
@@ -1083,7 +1086,7 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static std::shared_ptr<CWallet> CreateWalletFromFile(const std::string walletFile);
+    static CWalletRef CreateWalletFromFile(const std::string walletFile);
 
     /**
      * Wallet post-init setup

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -756,7 +756,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    for (CWalletRef pwallet : vpwallets) {
+    for (auto pwallet : GetWallets()) {
         CWalletDBWrapper& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;


### PR DESCRIPTION
This is a small step towards better multi wallet management. Starts by removing the global `vpwallets` and adding an interface to add/remove/retrieve wallets.

The way it is now it is possible to have, for instance, `listunspent` RPC and in parallel unload the wallet (once #10740 is merged) without blocking. Once the RPC finishes, the shared pointer will release the wallet.

It is also possible to get all existing wallets without blocking because the caller keeps a local list of shared pointers.

I would like to include either here or in follow ups:
- kind of `WalletManager` class;
- keep a weak pointer so when the app terminates it is possible to gracefully unload the wallet;
- make the new interface thread safe.

Please consider this RFC.

This is related to #10615, #11383 and #10740.