### PR TITLE
RPC: Chainparams: Simplify -rpcport and CBaseMainParams 

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -16,6 +16,13 @@ To receive security and update notifications, please subscribe to:
 
   <https://bitcoincore.org/en/list/announcements/join/>
 
+Testnets interface changes:
+
+- Command line argument -rpcport no longer has a complex default to
+  think about. The default for bitcoin is 8332 and remains that.
+  For testnet3 and regtest; explicitly specifying -rpcport=18332 and -rpcport=18443
+  respectively is still possible as always. 
+
 How to Upgrade
 ==============
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -40,7 +40,7 @@ std::string HelpMessageCli()
     AppendParamsHelpMessages(strUsage);
     strUsage += HelpMessageOpt("-named", strprintf(_("Pass named instead of positional arguments (default: %s)"), DEFAULT_NAMED));
     strUsage += HelpMessageOpt("-rpcconnect=<ip>", strprintf(_("Send commands to node running on <ip> (default: %s)"), DEFAULT_RPCCONNECT));
-    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u or testnet: %u)"), defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()));
+    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Connect to JSON-RPC on <port> (default: %u)"), DEFAULT_RPC_PORT));
     strUsage += HelpMessageOpt("-rpcwait", _("Wait for RPC server to start"));
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
@@ -198,7 +198,7 @@ static UniValue CallRPC(const std::string& strMethod, const UniValue& params)
     //     1. -rpcport
     //     2. port in -rpcconnect (ie following : in ipv4 or ]: in ipv6)
     //     3. default port for chain
-    int port = BaseParams().RPCPort();
+    int port = DEFAULT_RPC_PORT;
     SplitHostPort(gArgs.GetArg("-rpcconnect", DEFAULT_RPCCONNECT), port, host);
     port = gArgs.GetArg("-rpcport", port);
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -24,44 +24,6 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
     }
 }
 
-/**
- * Main network
- */
-class CBaseMainParams : public CBaseChainParams
-{
-public:
-    CBaseMainParams()
-    {
-        nRPCPort = 8332;
-    }
-};
-
-/**
- * Testnet (v3)
- */
-class CBaseTestNetParams : public CBaseChainParams
-{
-public:
-    CBaseTestNetParams()
-    {
-        nRPCPort = 18332;
-        strDataDir = "testnet3";
-    }
-};
-
-/*
- * Regression test
- */
-class CBaseRegTestParams : public CBaseChainParams
-{
-public:
-    CBaseRegTestParams()
-    {
-        nRPCPort = 18443;
-        strDataDir = "regtest";
-    }
-};
-
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()
@@ -73,11 +35,11 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return std::unique_ptr<CBaseChainParams>(new CBaseMainParams());
+        return std::unique_ptr<CBaseChainParams>(new CBaseChainParams());
     else if (chain == CBaseChainParams::TESTNET)
-        return std::unique_ptr<CBaseChainParams>(new CBaseTestNetParams());
+        return std::unique_ptr<CBaseChainParams>(new CBaseChainParams("testnet3"));
     else if (chain == CBaseChainParams::REGTEST)
-        return std::unique_ptr<CBaseChainParams>(new CBaseRegTestParams());
+        return std::unique_ptr<CBaseChainParams>(new CBaseChainParams("regtest"));
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -21,13 +21,14 @@ public:
     static const std::string TESTNET;
     static const std::string REGTEST;
 
+    CBaseChainParams() {};
+    CBaseChainParams(const std::string& chain)
+    {
+        strDataDir = chain;
+    }
     const std::string& DataDir() const { return strDataDir; }
-    int RPCPort() const { return nRPCPort; }
 
 protected:
-    CBaseChainParams() {}
-
-    int nRPCPort;
     std::string strDataDir;
 };
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -9,6 +9,7 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "netbase.h"
+#include "rpc/client.h"
 #include "rpc/protocol.h" // For HTTP status codes
 #include "sync.h"
 #include "ui_interface.h"
@@ -309,7 +310,7 @@ static bool ThreadHTTP(struct event_base* base, struct evhttp* http)
 /** Bind HTTP server to specified addresses */
 static bool HTTPBindAddresses(struct evhttp* http)
 {
-    int defaultPort = gArgs.GetArg("-rpcport", BaseParams().RPCPort());
+    int defaultPort = gArgs.GetArg("-rpcport", DEFAULT_RPC_PORT);
     std::vector<std::pair<std::string, uint16_t> > endpoints;
 
     // Determine what addresses to bind to

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -28,6 +28,7 @@
 #include "policy/feerate.h"
 #include "policy/fees.h"
 #include "policy/policy.h"
+#include "rpc/client.h"
 #include "rpc/server.h"
 #include "rpc/register.h"
 #include "rpc/safemode.h"
@@ -496,7 +497,7 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-rpcuser=<user>", _("Username for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcpassword=<pw>", _("Password for JSON-RPC connections"));
     strUsage += HelpMessageOpt("-rpcauth=<userpw>", _("Username and hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcuser. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times"));
-    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)"), defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()));
+    strUsage += HelpMessageOpt("-rpcport=<port>", strprintf(_("Listen for JSON-RPC connections on <port> (default: %u)"), DEFAULT_RPC_PORT));
     strUsage += HelpMessageOpt("-rpcallowip=<ip>", _("Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times"));
     strUsage += HelpMessageOpt("-rpcserialversion", strprintf(_("Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)"), DEFAULT_RPC_SERIALIZE_VERSION));
     strUsage += HelpMessageOpt("-rpcthreads=<n>", strprintf(_("Set the number of threads to service RPC calls (default: %d)"), DEFAULT_HTTP_THREADS));

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -8,6 +8,8 @@
 
 #include <univalue.h>
 
+static const int DEFAULT_RPC_PORT = 8332;
+
 /** Convert positional arguments to command-specific RPC representation */
 UniValue RPCConvertValues(const std::string& strMethod, const std::vector<std::string>& strParams);
 


### PR DESCRIPTION
(the latter is just a very encapsulated global string var now [but it still
decides what dir to read fikes from]).

 Command line argument -rpcport no longer has a complex default to
 think about. The default for bitcoin is 8332 and remains that.
 For testnet3 and regtest; explicitly specifying -rpcport=18332 and -rpcport=18443
 respectively is still possible as always. 
