### PR TITLE
Add state message print to AcceptBlock failure message.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3189,7 +3189,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         CheckBlockIndex(chainparams.GetConsensus());
         if (!ret) {
             GetMainSignals().BlockChecked(*pblock, state);
-            return error("%s: AcceptBlock FAILED", __func__);
+            return error("%s: AcceptBlock FAILED (%s)", __func__, state.GetDebugMessage());
         }
     }
 


### PR DESCRIPTION
This should make it easier to debug issues where the CheckBlock at
the top of ProcessNewBlock fails (which does not print, in contrast
to AcceptBlock, which always prints).

This was motivated by #11371 which appears to be exactly such a case, and is not debuggable from the information provided. Not sure how much this would have helped in that case, but it is kinda weird that we can reject a block without ever printing why.