### PR TITLE
Trivial: Fix parameter name typo in ErasePurpose walletdb method

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -41,9 +41,9 @@ bool CWalletDB::WritePurpose(const std::string& strAddress, const std::string& s
     return WriteIC(std::make_pair(std::string("purpose"), strAddress), strPurpose);
 }
 
-bool CWalletDB::ErasePurpose(const std::string& strPurpose)
+bool CWalletDB::ErasePurpose(const std::string& strAddress)
 {
-    return EraseIC(std::make_pair(std::string("purpose"), strPurpose));
+    return EraseIC(std::make_pair(std::string("purpose"), strAddress));
 }
 
 bool CWalletDB::WriteTx(const CWalletTx& wtx)


### PR DESCRIPTION
The header file has the correct method signature and the one usage in CWallet::DelAddressBook is correctly passing in EncodeDestination(address)