### PR TITLE
Simplify GetWarnings()

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -271,7 +271,7 @@ BitcoinCore::BitcoinCore():
 void BitcoinCore::handleRunawayException(const std::exception *e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    Q_EMIT runawayException(QString::fromStdString(GetWarnings("gui")));
+    Q_EMIT runawayException(QString::fromStdString(GetWarnings(true)));
 }
 
 bool BitcoinCore::baseInitialize()
@@ -721,10 +721,10 @@ int main(int argc, char *argv[])
         }
     } catch (const std::exception& e) {
         PrintExceptionContinue(&e, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(GetWarnings("gui")));
+        app.handleRunawayException(QString::fromStdString(GetWarnings(true)));
     } catch (...) {
         PrintExceptionContinue(nullptr, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(GetWarnings("gui")));
+        app.handleRunawayException(QString::fromStdString(GetWarnings(true)));
     }
     return rv;
 }

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -203,7 +203,7 @@ bool ClientModel::getNetworkActive() const
 
 QString ClientModel::getStatusBarWarnings() const
 {
-    return QString::fromStdString(GetWarnings("gui"));
+    return QString::fromStdString(GetWarnings(true));
 }
 
 OptionsModel *ClientModel::getOptionsModel()

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -217,7 +217,7 @@ UniValue getmininginfo(const JSONRPCRequest& request)
     obj.push_back(Pair("currentblockweight", (uint64_t)nLastBlockWeight));
     obj.push_back(Pair("currentblocktx",   (uint64_t)nLastBlockTx));
     obj.push_back(Pair("difficulty",       (double)GetDifficulty()));
-    obj.push_back(Pair("errors",           GetWarnings("statusbar")));
+    obj.push_back(Pair("errors",           GetWarnings()));
     obj.push_back(Pair("networkhashps",    getnetworkhashps(request)));
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
     obj.push_back(Pair("chain",            Params().NetworkIDString()));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -483,7 +483,7 @@ UniValue getnetworkinfo(const JSONRPCRequest& request)
         }
     }
     obj.push_back(Pair("localaddresses", localAddresses));
-    obj.push_back(Pair("warnings",       GetWarnings("statusbar")));
+    obj.push_back(Pair("warnings",       GetWarnings()));
     return obj;
 }
 

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -37,47 +37,39 @@ void SetfLargeWorkInvalidChainFound(bool flag)
     fLargeWorkInvalidChainFound = flag;
 }
 
-std::string GetWarnings(const std::string& strFor)
+std::string GetWarnings(bool htmlMultiline)
 {
-    std::string strStatusBar;
-    std::string strRPC;
-    std::string strGUI;
+    std::string strPlaintext;
+    std::string strHTML;
     const std::string uiAlertSeperator = "<hr />";
 
     LOCK(cs_warnings);
 
     if (!CLIENT_VERSION_IS_RELEASE) {
-        strStatusBar = "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications";
-        strGUI = _("This is a pre-release test build - use at your own risk - do not use for mining or merchant applications");
+        strPlaintext = "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications";
+        strHTML = _("This is a pre-release test build - use at your own risk - do not use for mining or merchant applications");
     }
 
     if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
-        strStatusBar = strRPC = strGUI = "testsafemode enabled";
+        strPlaintext = strHTML = "testsafemode enabled";
 
     // Misc warnings like out of disk space and clock is wrong
     if (strMiscWarning != "")
     {
-        strStatusBar = strMiscWarning;
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + strMiscWarning;
+        strPlaintext = strMiscWarning;
+        strHTML += (strHTML.empty() ? "" : uiAlertSeperator) + strMiscWarning;
     }
 
     if (fLargeWorkForkFound)
     {
-        strStatusBar = strRPC = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
+        strPlaintext = "Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.";
+        strHTML += (strHTML.empty() ? "" : uiAlertSeperator) + _("Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.");
     }
     else if (fLargeWorkInvalidChainFound)
     {
-        strStatusBar = strRPC = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
-        strGUI += (strGUI.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
+        strPlaintext = "Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.";
+        strHTML += (strHTML.empty() ? "" : uiAlertSeperator) + _("Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.");
     }
 
-    if (strFor == "gui")
-        return strGUI;
-    else if (strFor == "statusbar")
-        return strStatusBar;
-    else if (strFor == "rpc")
-        return strRPC;
-    assert(!"GetWarnings(): invalid parameter");
-    return "error";
+    return (htmlMultiline ? strHTML : strPlaintext);
 }

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -13,14 +13,11 @@ void SetMiscWarning(const std::string& strWarning);
 void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);
-/** Format a string that describes several potential problems detected by the core.
- * strFor can have three values:
- * - "rpc": get critical warnings, which should put the client in safe mode if non-empty
- * - "statusbar": get all warnings
- * - "gui": get all warnings, translated (where possible) for GUI
- * This function only returns the highest priority warning of the set selected by strFor.
+/** Format a string that describes several potential detected problems.
+ * If htmlMultiline is set to true, this functiomn returns multiple (and translated) warnings seperated by a <hr> tag.
+ * Otherwise only the highest priority warning will be returned.
  */
-std::string GetWarnings(const std::string& strFor);
+std::string GetWarnings(bool htmlMultiline = false);
 
 static const bool DEFAULT_TESTSAFEMODE = false;
 


### PR DESCRIPTION
Stumbled over this while reviewing https://github.com/bitcoin/bitcoin/pull/10858.
Seem that we have an overcomplicated implementation here.

I think there should be no such things like "statusbar" or "gui" in a non-GUI class (when possible).

Next step would be to handle multi-warnings on RPC level (move from single string to an array).