### PR TITLE
Utils: Fix launchctl not being able to stop bitcoind

### DIFF
--- a/contrib/init/org.bitcoin.bitcoind.plist
+++ b/contrib/init/org.bitcoin.bitcoind.plist
@@ -7,7 +7,6 @@
 	<key>ProgramArguments</key>
 	<array>
 		<string>/usr/local/bin/bitcoind</string>
-		<string>-daemon</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
`bitcoind` should not be launched as daemon from the Launch Agent. Otherwise, the process cannot be stopped from `launchctl stop`/`launchctl unload`.

To reproduce the issue:

```console
$ launchctl load ~/Library/LaunchAgents/org.bitcoin.bitcoind.plist
$ pgrep -fla bitcoin
60225 /usr/local/opt/bitcoin/bin/bitcoind
$ launchctl unload ~/Library/LaunchAgents/org.bitcoin.bitcoind.plist
```

Wait a few seconds and then run `pgrep` again:

```console
$ pgrep -fla bitcoin
60225 /usr/local/opt/bitcoin/bin/bitcoind
```

The node is still running. This happens because Launch Agent is not supposed to run programs as daemons, since the agent makes sure they run in the background. Running them as daemons makes the Launch Agent lose control of the process and, so, it cannot be stopped.