### PR TITLE
Remove unused fTry from push_lock

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -98,7 +98,7 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
     assert(false);
 }
 
-static void push_lock(void* c, const CLockLocation& locklocation, bool fTry)
+static void push_lock(void* c, const CLockLocation& locklocation)
 {
     if (lockstack.get() == nullptr)
         lockstack.reset(new LockStack);
@@ -130,7 +130,7 @@ static void pop_lock()
 
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry)
 {
-    push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry), fTry);
+    push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry));
 }
 
 void LeaveCritical()


### PR DESCRIPTION
After #9674 (618ee92) the `fTry` argument in `push_lock` is no longer needed.