### PR TITLE
build: Make "make clean" remove all files created when running "make check"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -476,8 +476,7 @@ CLEANFILES += univalue/*.gcda univalue/*.gcno
 CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
-
-DISTCLEANFILES = obj/build.h
+CLEANFILES += obj/build.h
 
 EXTRA_DIST = $(CTAES_DIST)
 

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -6,11 +6,12 @@ bin_PROGRAMS += bench/bench_bitcoin
 BENCH_SRCDIR = bench
 BENCH_BINARY = bench/bench_bitcoin$(EXEEXT)
 
-RAW_TEST_FILES = \
+RAW_BENCH_FILES = \
   bench/data/block413567.raw
-GENERATED_TEST_FILES = $(RAW_TEST_FILES:.raw=.raw.h)
+GENERATED_BENCH_FILES = $(RAW_BENCH_FILES:.raw=.raw.h)
 
 bench_bench_bitcoin_SOURCES = \
+  $(RAW_BENCH_FILES) \
   bench/bench_bitcoin.cpp \
   bench/bench.cpp \
   bench/bench.h \
@@ -28,7 +29,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/perf.h \
   bench/prevector_destructor.cpp
 
-nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
+nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_BENCH_FILES)
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -56,7 +57,7 @@ endif
 bench_bench_bitcoin_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS)
 bench_bench_bitcoin_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 
-CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_TEST_FILES)
+CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_BENCH_FILES)
 
 CLEANFILES += $(CLEAN_BITCOIN_BENCH)
 


### PR DESCRIPTION
Make `make clean` remove all files created when running `make check`. More specifically: remove also `obj/build.h` and `bench/data/block413567.raw.h` as part of `make clean`.

Before this patch:

```bash
$ git clone https://github.com/bitcoin/bitcoin.git
$ cd bitcoin/
$ ./autogen.sh
$ ./configure
$ cp -r ../bitcoin ../bitcoin-before-make
$ make check
$ make clean
$ cp -r ../bitcoin ../bitcoin-after-make-and-make-clean
$ cd ..
$ diff -rq bitcoin-before-make/ bitcoin-after-make-and-make-clean/ | grep -E "^Only in bitcoin-after-make-and-make-clean/" | grep -v dirstamp
Only in bitcoin-after-make-and-make-clean/src/bench/data: block413567.raw.h
Only in bitcoin-after-make-and-make-clean/src/obj: build.h
$
```

After this patch:

```bash
$ git clone https://github.com/bitcoin/bitcoin.git
$ cd bitcoin/
$ ./autogen.sh
$ ./configure
$ cp -r ../bitcoin ../bitcoin-before-make
$ make check
$ make clean
$ cp -r ../bitcoin ../bitcoin-after-make-and-make-clean
$ cd ..
$ diff -rq bitcoin-before-make/ bitcoin-after-make-and-make-clean/ | grep -E "^Only in bitcoin-after-make-and-make-clean/" | grep -v dirstamp
$
```