### PR TITLE
[Docs] Update Windows build instructions for using WSL and Ubuntu 17.04

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -72,6 +72,7 @@ To build executables for Windows 64-bit, install the following dependencies:
 
 Then build using:
 
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     cd depends
     make HOST=x86_64-w64-mingw32
     cd ..
@@ -87,6 +88,7 @@ To build executables for Windows 32-bit, install the following dependencies:
 
 Then build using:
 
+    PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     cd depends
     make HOST=i686-w64-mingw32
     cd ..

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -4,10 +4,11 @@ WINDOWS BUILD NOTES
 Below are some notes on how to build Bitcoin Core for Windows.
 
 Most developers use cross-compilation from Ubuntu to build executables for
-Windows. This is also used to build the release binaries.
+Windows. Cross-compilation is also used to build the release binaries.
 
-Currently only building on Ubuntu Trusty 14.04 is supported.
-Other versions are unsupported or known to be broken (e.g. Ubuntu Xenial 16.04).
+Currently only building on Ubuntu Trusty 14.04 or Ubuntu Zesty 17.04 or later is supported.
+Building on Ubuntu Xenial 16.04 is known to be broken, see extensive discussion in issue [8732](https://github.com/bitcoin/bitcoin/issues/8732).
+While it may be possible to do so with work arounds, it's potentially dangerous and not recommended.
 
 While there are potentially a number of ways to build on Windows (for example using msys / mingw-w64),
 using the Windows Subsystem For Linux is the most straightforward. If you are building with
@@ -64,6 +65,13 @@ build process.
 
 See also: [dependencies.md](dependencies.md).
 
+If you're building on Ubuntu 17.04 or later, run these two commands, selecting the 'posix' variant for both,
+to work around issues with mingw-w64. See issue [8732](https://github.com/bitcoin/bitcoin/issues/8732) for more information.
+```
+sudo update-alternatives --config x86_64-w64-mingw32-g++
+sudo update-alternatives --config x86_64-w64-mingw32-gcc
+```
+
 ## Building for 64-bit Windows
 
 To build executables for Windows 64-bit, install the following dependencies:
@@ -84,7 +92,7 @@ Then build using:
 
 To build executables for Windows 32-bit, install the following dependencies:
 
-    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev 
+    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev
 
 Then build using:
 


### PR DESCRIPTION
This updates the Windows build documentation with the workaround required to build using Ubuntu 17.04 on WSL, and makes it's explicit that building on Ubuntu 16.04 is broken, and not recommended.

This includes a commit from @donaloconnor in #11244, and is mostly the investigative work of @laanwj throughout #8732, #8653 and quite a few other issues.

I tested building on 14.04, 16.04.3 and 17.04 [here](https://github.com/bitcoin/bitcoin/pull/11244#issuecomment-327990251) and got the results we expect.

---

Built master at https://github.com/bitcoin/bitcoin/commit/c22a53cd6351b3f0e96de971b001ad712b83fc47 on a Windows 10 VM (Version 1607, OS Build 14393.1593) using WSL with Ubuntu 14.04.
![windows](https://user-images.githubusercontent.com/863730/30195033-867f1f24-9489-11e7-932c-e87b8764a627.png)

Upgraded WSL to 16.04.3, and tried building https://github.com/bitcoin/bitcoin/commit/c22a53cd6351b3f0e96de971b001ad712b83fc47 using these instructions. The result is as expected.
![ubuntu 16 04 3](https://user-images.githubusercontent.com/863730/30235670-b9bf36bc-953d-11e7-8c1d-4debf7113032.png)


Upgraded WSL to 17.04 and tried building https://github.com/bitcoin/bitcoin/commit/3255d6347b1f9eccbec3d6d93d4a424087a3b35b using these instructions.
![ubuntu 17 04](https://user-images.githubusercontent.com/863730/30235669-b7473434-953d-11e7-8ea3-d05a319ae2d4.png)

If someone else could also verify that builds are working on both 14.04 and 17.04 with these instructions, that would be great.