### PR TITLE
Fix validationinterface build on super old boost/clang

### DIFF
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -4,7 +4,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "validationinterface.h"
+
 #include "init.h"
+#include "primitives/block.h"
 #include "scheduler.h"
 #include "sync.h"
 #include "util.h"


### PR DESCRIPTION
This should fix all the non-dependancy issues for termux builds.
See Github issue #11388.