### PR TITLE
[qa] Allow "make cov" out-of-tree; Fix rpc mapping check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1231,6 +1231,7 @@ AC_SUBST(QR_LIBS)
 AC_CONFIG_FILES([Makefile src/Makefile doc/man/Makefile share/setup.nsi share/qt/Info.plist test/config.ini])
 AC_CONFIG_FILES([contrib/devtools/split-debug.sh],[chmod +x contrib/devtools/split-debug.sh])
 AC_CONFIG_FILES([doc/Doxyfile])
+AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
 AC_CONFIG_LINKS([test/functional/test_runner.py:test/functional/test_runner.py])
 AC_CONFIG_LINKS([test/util/bitcoin-util-test.py:test/util/bitcoin-util-test.py])
 

--- a/contrib/devtools/check-rpc-mappings.py
+++ b/contrib/devtools/check-rpc-mappings.py
@@ -63,7 +63,7 @@ def process_commands(fname):
                     else:
                         args = []
                     cmds.append(RPCCommand(name, args))
-    assert not in_rpcs, "Something went wrong with parsing the C++ file: update the regexps"
+    assert not in_rpcs and cmds, "Something went wrong with parsing the C++ file: update the regexps"
     return cmds
 
 def process_mapping(fname):
@@ -86,7 +86,7 @@ def process_mapping(fname):
                     idx = int(m.group(2))
                     argname = parse_string(m.group(3))
                     cmds.append((name, idx, argname))
-    assert not in_rpcs
+    assert not in_rpcs and cmds
     return cmds
 
 def main():


### PR DESCRIPTION
Random qa fixups:

* `make cov` should work for out-of-tree builds
* `check-rpc-mappings.py` should assert that it is actually checking something and the lists are not empty.