### PR TITLE
Disconnect Peers for Duplicate Invalid blocks.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2289,6 +2289,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     LOCK(cs_main);
                     Misbehaving(pfrom->GetId(), nDoS);
                 }
+                pfrom->fDisconnect = true;
                 return error("invalid header received");
             }
         }


### PR DESCRIPTION
I have updated this to be as we discussed in the IRC meeting. If we see a block header for a block we already know is invalid, we disconnect from the node that sent it. The only exception are our HB CB nodes.

~~This is an implementation of the bad block interrogation idea that @gmaxwell has talked about.~~

~~To ensure that the nodes we are connected to are following the same consens rules as we are, ban all nodes that relay us an invalid block or block header instead of only banning the first peer.~~

~~Then when we receive an invalid block, we want to check that all of our peers also found that block to be invalid, so we ask all of our peers for the header of that invalid block. If they found it valid, the header will be relayed and we will then ban them. Otherwise we keep the connection.~~

~~To ensure that our newly connected nodes are also following the same consensus rules, we ask them for the headers of blocks that we know are invalid when they connect after the version handshake. If they respond with a header, then we will ban them.~~

~~This still needs tests, but I'm not sure how we should do that. If you have any suggestions, I'm all ears.~~

***

~~Note, I know the implementation is slightly wrong, still working on it.~~