### PR TITLE
CTxMemPool::GetMinFee should not return CFeeRate(0)

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -572,11 +572,10 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 
     SetMockTime(42 + 7*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
-    // ... but feerate should never drop below 1000
 
     SetMockTime(42 + 8*CTxMemPool::ROLLING_FEE_HALFLIFE + CTxMemPool::ROLLING_FEE_HALFLIFE/2 + CTxMemPool::ROLLING_FEE_HALFLIFE/4);
-    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 0);
-    // ... unless it has gone all the way to 0 (after getting past 1000/2)
+    BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), 1000);
+    // ... but feerate should never drop below 1000
 
     SetMockTime(0);
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -996,7 +996,7 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
 
         if (rollingMinimumFeeRate < (double)incrementalRelayFee.GetFeePerK() / 2) {
             rollingMinimumFeeRate = 0;
-            return CFeeRate(0);
+            return ::minRelayTxFee;
         }
     }
     return std::max(CFeeRate(llround(rollingMinimumFeeRate)), incrementalRelayFee);


### PR DESCRIPTION
The ::minRelayTxFee should be taken into account

This patch comes from https://github.com/bitcoin/bitcoin/pull/11410#discussion_r142904723 to include minimal code changes when  fixing a bug.

Relates to #11410 and #6941

Please advise if I should set [fee] in commit message or something similar (thx @fanquake for label :) )

I ran fundrawtransaction many times, didn't get into problems. See https://github.com/bitcoin/bitcoin/pull/11410#issuecomment-333868390

Next PR will cover `::minRelayTxFee` in https://github.com/bitcoin/bitcoin/blob/e93fff1463ae906fc986bf98c3b118c82f171546/src/txmempool.cpp#L1002