### PR TITLE
Introduce BanMan

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ endif
 BITCOIN_CORE_H = \
   addrdb.h \
   addrman.h \
+  banman.h \
   base58.h \
   bech32.h \
   bloom.h \
@@ -196,6 +197,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   addrdb.cpp \
   addrman.cpp \
+  banman.cpp \
   bloom.cpp \
   blockencodings.cpp \
   chain.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -104,9 +104,8 @@ bool DeserializeFileDB(const fs::path& path, Data& data)
 
 }
 
-CBanDB::CBanDB()
+CBanDB::CBanDB(fs::path ban_file) : pathBanlist(std::move(ban_file))
 {
-    pathBanlist = GetDataDir() / "banlist.dat";
 }
 
 bool CBanDB::Write(const banmap_t& banSet)

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -94,7 +94,7 @@ class CBanDB
 private:
     fs::path pathBanlist;
 public:
-    CBanDB();
+    explicit CBanDB(fs::path pathBanlist);
     bool Write(const banmap_t& banSet);
     bool Read(banmap_t& banSet);
 };

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -11,13 +11,13 @@
 #include <ui_interface.h>
 
 
-BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time) : clientInterface(client_interface), m_ban_db(std::move(ban_file)), m_default_ban_time(default_ban_time)
+BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time) : m_client_interface(client_interface), m_ban_db(std::move(ban_file)), m_default_ban_time(default_ban_time)
 {
-    if (clientInterface)
-        clientInterface->InitMessage(_("Loading banlist..."));
+    if (m_client_interface)
+        m_client_interface->InitMessage(_("Loading banlist..."));
 
     int64_t nStart = GetTimeMillis();
-    setBannedIsDirty = false;
+    m_is_dirty = false;
     banmap_t banmap;
     if (m_ban_db.Read(banmap)) {
         SetBanned(banmap); // thread save setter
@@ -60,19 +60,19 @@ void BanMan::DumpBanlist()
 void BanMan::ClearBanned()
 {
     {
-        LOCK(cs_setBanned);
-        setBanned.clear();
-        setBannedIsDirty = true;
+        LOCK(m_cs_banned);
+        m_banned.clear();
+        m_is_dirty = true;
     }
     DumpBanlist(); //store banlist to disk
-    if(clientInterface)
-        clientInterface->BannedListChanged();
+    if(m_client_interface)
+        m_client_interface->BannedListChanged();
 }
 
 bool BanMan::IsBanned(CNetAddr ip)
 {
-    LOCK(cs_setBanned);
-    for (const auto& it : setBanned) {
+    LOCK(m_cs_banned);
+    for (const auto& it : m_banned) {
         CSubNet subNet = it.first;
         CBanEntry banEntry = it.second;
 
@@ -85,9 +85,9 @@ bool BanMan::IsBanned(CNetAddr ip)
 
 bool BanMan::IsBanned(CSubNet subnet)
 {
-    LOCK(cs_setBanned);
-    banmap_t::iterator i = setBanned.find(subnet);
-    if (i != setBanned.end())
+    LOCK(m_cs_banned);
+    banmap_t::iterator i = m_banned.find(subnet);
+    if (i != m_banned.end())
     {
         CBanEntry banEntry = (*i).second;
         if (GetTime() < banEntry.nBanUntil) {
@@ -113,16 +113,16 @@ void BanMan::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bant
     banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime() )+bantimeoffset;
 
     {
-        LOCK(cs_setBanned);
-        if (setBanned[subNet].nBanUntil < banEntry.nBanUntil) {
-            setBanned[subNet] = banEntry;
-            setBannedIsDirty = true;
+        LOCK(m_cs_banned);
+        if (m_banned[subNet].nBanUntil < banEntry.nBanUntil) {
+            m_banned[subNet] = banEntry;
+            m_is_dirty = true;
         }
         else
             return;
     }
-    if(clientInterface)
-        clientInterface->BannedListChanged();
+    if(m_client_interface)
+        m_client_interface->BannedListChanged();
 
     if(banReason == BanReasonManuallyAdded)
         DumpBanlist(); //store banlist to disk immediately if user requested ban
@@ -135,30 +135,30 @@ bool BanMan::Unban(const CNetAddr &addr) {
 
 bool BanMan::Unban(const CSubNet &subNet) {
     {
-        LOCK(cs_setBanned);
-        if (!setBanned.erase(subNet))
+        LOCK(m_cs_banned);
+        if (!m_banned.erase(subNet))
             return false;
-        setBannedIsDirty = true;
+        m_is_dirty = true;
     }
-    if(clientInterface)
-        clientInterface->BannedListChanged();
+    if(m_client_interface)
+        m_client_interface->BannedListChanged();
     DumpBanlist(); //store banlist to disk immediately
     return true;
 }
 
 void BanMan::GetBanned(banmap_t &banMap)
 {
-    LOCK(cs_setBanned);
+    LOCK(m_cs_banned);
     // Sweep the banlist so expired bans are not returned
     SweepBanned();
-    banMap = setBanned; //create a thread safe copy
+    banMap = m_banned; //create a thread safe copy
 }
 
 void BanMan::SetBanned(const banmap_t &banMap)
 {
-    LOCK(cs_setBanned);
-    setBanned = banMap;
-    setBannedIsDirty = true;
+    LOCK(m_cs_banned);
+    m_banned = banMap;
+    m_is_dirty = true;
 }
 
 void BanMan::SweepBanned()
@@ -166,16 +166,16 @@ void BanMan::SweepBanned()
     int64_t now = GetTime();
     bool notifyUI = false;
     {
-        LOCK(cs_setBanned);
-        banmap_t::iterator it = setBanned.begin();
-        while(it != setBanned.end())
+        LOCK(m_cs_banned);
+        banmap_t::iterator it = m_banned.begin();
+        while(it != m_banned.end())
         {
             CSubNet subNet = (*it).first;
             CBanEntry banEntry = (*it).second;
             if(now > banEntry.nBanUntil)
             {
-                setBanned.erase(it++);
-                setBannedIsDirty = true;
+                m_banned.erase(it++);
+                m_is_dirty = true;
                 notifyUI = true;
                 LogPrint(BCLog::NET, "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, subNet.ToString());
             }
@@ -184,19 +184,19 @@ void BanMan::SweepBanned()
         }
     }
     // update UI
-    if(notifyUI && clientInterface) {
-        clientInterface->BannedListChanged();
+    if(notifyUI && m_client_interface) {
+        m_client_interface->BannedListChanged();
     }
 }
 
 bool BanMan::BannedSetIsDirty()
 {
-    LOCK(cs_setBanned);
-    return setBannedIsDirty;
+    LOCK(m_cs_banned);
+    return m_is_dirty;
 }
 
 void BanMan::SetBannedSetDirty(bool dirty)
 {
-    LOCK(cs_setBanned); //reuse setBanned lock for the isDirty flag
-    setBannedIsDirty = dirty;
+    LOCK(m_cs_banned); //reuse m_banned lock for the isDirty flag
+    m_is_dirty = dirty;
 }

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -1,0 +1,202 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <banman.h>
+
+#include <netaddress.h>
+#include <utiltime.h>
+#include <util.h>
+#include <ui_interface.h>
+
+
+BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time) : clientInterface(client_interface), m_ban_db(std::move(ban_file)), m_default_ban_time(default_ban_time)
+{
+    if (clientInterface)
+        clientInterface->InitMessage(_("Loading banlist..."));
+
+    int64_t nStart = GetTimeMillis();
+    setBannedIsDirty = false;
+    banmap_t banmap;
+    if (m_ban_db.Read(banmap)) {
+        SetBanned(banmap); // thread save setter
+        SetBannedSetDirty(false); // no need to write down, just read data
+        SweepBanned(); // sweep out unused entries
+
+        LogPrint(BCLog::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
+            banmap.size(), GetTimeMillis() - nStart);
+    } else {
+        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+        SetBannedSetDirty(true); // force write
+        DumpBanlist();
+    }
+}
+
+BanMan::~BanMan()
+{
+    DumpBanlist();
+}
+
+void BanMan::DumpBanlist()
+{
+    SweepBanned(); // clean unused entries (if bantime has expired)
+
+    if (!BannedSetIsDirty())
+        return;
+
+    int64_t nStart = GetTimeMillis();
+
+    banmap_t banmap;
+    GetBanned(banmap);
+    if (m_ban_db.Write(banmap)) {
+        SetBannedSetDirty(false);
+    }
+
+    LogPrint(BCLog::NET, "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
+        banmap.size(), GetTimeMillis() - nStart);
+}
+
+void BanMan::ClearBanned()
+{
+    {
+        LOCK(cs_setBanned);
+        setBanned.clear();
+        setBannedIsDirty = true;
+    }
+    DumpBanlist(); //store banlist to disk
+    if(clientInterface)
+        clientInterface->BannedListChanged();
+}
+
+bool BanMan::IsBanned(CNetAddr ip)
+{
+    LOCK(cs_setBanned);
+    for (const auto& it : setBanned) {
+        CSubNet subNet = it.first;
+        CBanEntry banEntry = it.second;
+
+        if (subNet.Match(ip) && GetTime() < banEntry.nBanUntil) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool BanMan::IsBanned(CSubNet subnet)
+{
+    LOCK(cs_setBanned);
+    banmap_t::iterator i = setBanned.find(subnet);
+    if (i != setBanned.end())
+    {
+        CBanEntry banEntry = (*i).second;
+        if (GetTime() < banEntry.nBanUntil) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void BanMan::Ban(const CNetAddr& addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
+    CSubNet subNet(addr);
+    Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
+}
+
+void BanMan::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
+    CBanEntry banEntry(GetTime());
+    banEntry.banReason = banReason;
+    if (bantimeoffset <= 0)
+    {
+        bantimeoffset = m_default_ban_time;
+        sinceUnixEpoch = false;
+    }
+    banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime() )+bantimeoffset;
+
+    {
+        LOCK(cs_setBanned);
+        if (setBanned[subNet].nBanUntil < banEntry.nBanUntil) {
+            setBanned[subNet] = banEntry;
+            setBannedIsDirty = true;
+        }
+        else
+            return;
+    }
+    if(clientInterface)
+        clientInterface->BannedListChanged();
+
+    if(banReason == BanReasonManuallyAdded)
+        DumpBanlist(); //store banlist to disk immediately if user requested ban
+}
+
+bool BanMan::Unban(const CNetAddr &addr) {
+    CSubNet subNet(addr);
+    return Unban(subNet);
+}
+
+bool BanMan::Unban(const CSubNet &subNet) {
+    {
+        LOCK(cs_setBanned);
+        if (!setBanned.erase(subNet))
+            return false;
+        setBannedIsDirty = true;
+    }
+    if(clientInterface)
+        clientInterface->BannedListChanged();
+    DumpBanlist(); //store banlist to disk immediately
+    return true;
+}
+
+void BanMan::GetBanned(banmap_t &banMap)
+{
+    LOCK(cs_setBanned);
+    // Sweep the banlist so expired bans are not returned
+    SweepBanned();
+    banMap = setBanned; //create a thread safe copy
+}
+
+void BanMan::SetBanned(const banmap_t &banMap)
+{
+    LOCK(cs_setBanned);
+    setBanned = banMap;
+    setBannedIsDirty = true;
+}
+
+void BanMan::SweepBanned()
+{
+    int64_t now = GetTime();
+    bool notifyUI = false;
+    {
+        LOCK(cs_setBanned);
+        banmap_t::iterator it = setBanned.begin();
+        while(it != setBanned.end())
+        {
+            CSubNet subNet = (*it).first;
+            CBanEntry banEntry = (*it).second;
+            if(now > banEntry.nBanUntil)
+            {
+                setBanned.erase(it++);
+                setBannedIsDirty = true;
+                notifyUI = true;
+                LogPrint(BCLog::NET, "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, subNet.ToString());
+            }
+            else
+                ++it;
+        }
+    }
+    // update UI
+    if(notifyUI && clientInterface) {
+        clientInterface->BannedListChanged();
+    }
+}
+
+bool BanMan::BannedSetIsDirty()
+{
+    LOCK(cs_setBanned);
+    return setBannedIsDirty;
+}
+
+void BanMan::SetBannedSetDirty(bool dirty)
+{
+    LOCK(cs_setBanned); //reuse setBanned lock for the isDirty flag
+    setBannedIsDirty = dirty;
+}

--- a/src/banman.h
+++ b/src/banman.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_BANMAN_H
+#define BITCOIN_BANMAN_H
+
+#include <addrdb.h>
+#include <fs.h>
+#include <sync.h>
+
+// NOTE: When adjusting this, update rpcnet:setban's help ("24h")
+static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
+
+class CClientUIInterface;
+class CNetAddr;
+class CSubNet;
+
+// Denial-of-service detection/prevention
+// The idea is to detect peers that are behaving
+// badly and disconnect/ban them, but do it in a
+// one-coding-mistake-won't-shatter-the-entire-network
+// way.
+// IMPORTANT:  There should be nothing I can give a
+// node that it will forward on that will make that
+// node's peers drop it. If there is, an attacker
+// can isolate a node and/or try to split the network.
+// Dropping a node for sending stuff that is invalid
+// now but might be valid in a later version is also
+// dangerous, because it can cause a network split
+// between nodes running old code and nodes running
+// new code.
+
+class BanMan
+{
+public:
+    ~BanMan();
+    BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time);
+    void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void ClearBanned(); // needed for unit testing
+    bool IsBanned(CNetAddr ip);
+    bool IsBanned(CSubNet subnet);
+    bool Unban(const CNetAddr &ip);
+    bool Unban(const CSubNet &ip);
+    void GetBanned(banmap_t &banmap);
+    void DumpBanlist();
+
+private:
+    void SetBanned(const banmap_t &banmap);
+    bool BannedSetIsDirty();
+    //!set the "dirty" flag for the banlist
+    void SetBannedSetDirty(bool dirty=true);
+    //!clean unused entries (if bantime has expired)
+    void SweepBanned();
+
+    banmap_t setBanned;
+    CCriticalSection cs_setBanned;
+    bool setBannedIsDirty;
+    CClientUIInterface* clientInterface = nullptr;
+    CBanDB m_ban_db;
+    int64_t m_default_ban_time;
+};
+
+extern std::unique_ptr<BanMan> g_banman;
+#endif

--- a/src/banman.h
+++ b/src/banman.h
@@ -54,10 +54,10 @@ private:
     //!clean unused entries (if bantime has expired)
     void SweepBanned();
 
-    banmap_t setBanned;
-    CCriticalSection cs_setBanned;
-    bool setBannedIsDirty;
-    CClientUIInterface* clientInterface = nullptr;
+    banmap_t m_banned;
+    CCriticalSection m_cs_banned;
+    bool m_is_dirty;
+    CClientUIInterface* m_client_interface = nullptr;
     CBanDB m_ban_db;
     int64_t m_default_ban_time;
 };

--- a/src/banman.h
+++ b/src/banman.h
@@ -38,7 +38,7 @@ public:
     BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time);
     void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
-    void ClearBanned(); // needed for unit testing
+    void ClearBanned();
     bool IsBanned(CNetAddr ip);
     bool IsBanned(CSubNet subnet);
     bool Unban(const CNetAddr &ip);
@@ -54,12 +54,12 @@ private:
     //!clean unused entries (if bantime has expired)
     void SweepBanned();
 
-    banmap_t m_banned;
     CCriticalSection m_cs_banned;
-    bool m_is_dirty;
-    CClientUIInterface* m_client_interface = nullptr;
+    banmap_t m_banned GUARDED_BY(m_cs_banned);
+    bool m_is_dirty GUARDED_BY(m_cs_banned);
+    const CClientUIInterface* m_client_interface = nullptr;
     CBanDB m_ban_db;
-    int64_t m_default_ban_time;
+    const int64_t m_default_ban_time;
 };
 
 extern std::unique_ptr<BanMan> g_banman;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -11,6 +11,7 @@
 
 #include <addrman.h>
 #include <amount.h>
+#include <banman.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <checkpoints.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1304,7 +1304,7 @@ bool AppInitMain()
     // need to reindex later.
 
     assert(!g_banman);
-    g_banman = std::unique_ptr<BanMan>(new BanMan(&uiInterface));
+    g_banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", &uiInterface));
     assert(!g_connman);
     g_connman = std::unique_ptr<CConnman>(new CConnman(GetRand(std::numeric_limits<uint64_t>::max()), GetRand(std::numeric_limits<uint64_t>::max())));
     CConnman& connman = *g_connman;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1304,7 +1304,7 @@ bool AppInitMain()
     // need to reindex later.
 
     assert(!g_banman);
-    g_banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", &uiInterface));
+    g_banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", &uiInterface, gArgs.GetArg("-bantime", DEFAULT_MISBEHAVING_BANTIME)));
     assert(!g_connman);
     g_connman = std::unique_ptr<CConnman>(new CConnman(GetRand(std::numeric_limits<uint64_t>::max()), GetRand(std::numeric_limits<uint64_t>::max())));
     CConnman& connman = *g_connman;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -69,8 +69,12 @@ static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 
+// Dump addresses to banlist.dat every 15 minutes (900s)
+static constexpr int DUMP_BANS_INTERVAL = 60 * 15;
+
 std::unique_ptr<CConnman> g_connman;
 std::unique_ptr<PeerLogicValidation> peerLogic;
+std::unique_ptr<BanMan> g_banman;
 
 #if !(ENABLE_WALLET)
 class DummyWalletInit : public WalletInitInterface {
@@ -212,6 +216,7 @@ void Shutdown()
     if (g_connman) g_connman->Stop();
     peerLogic.reset();
     g_connman.reset();
+    g_banman.reset();
 
     StopTorControl();
 
@@ -1298,11 +1303,13 @@ bool AppInitMain()
     // is not yet setup and may end up being set up twice if we
     // need to reindex later.
 
+    assert(!g_banman);
+    g_banman = std::unique_ptr<BanMan>(new BanMan(&uiInterface));
     assert(!g_connman);
     g_connman = std::unique_ptr<CConnman>(new CConnman(GetRand(std::numeric_limits<uint64_t>::max()), GetRand(std::numeric_limits<uint64_t>::max())));
     CConnman& connman = *g_connman;
 
-    peerLogic.reset(new PeerLogicValidation(&connman, scheduler));
+    peerLogic.reset(new PeerLogicValidation(g_connman.get(), g_banman.get(), scheduler));
     RegisterValidationInterface(peerLogic.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size
@@ -1702,6 +1709,7 @@ bool AppInitMain()
     connOptions.nMaxFeeler = 1;
     connOptions.nBestHeight = chain_active_height;
     connOptions.uiInterface = &uiInterface;
+    connOptions.m_banman = g_banman.get();
     connOptions.m_msgproc = peerLogic.get();
     connOptions.nSendBufferMaxSize = 1000*gArgs.GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER);
     connOptions.nReceiveFloodSize = 1000*gArgs.GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER);
@@ -1756,6 +1764,10 @@ bool AppInitMain()
     uiInterface.InitMessage(_("Done loading"));
 
     g_wallet_init_interface.Start(scheduler);
+
+    scheduler.scheduleEvery([]{
+        g_banman->DumpBanlist();
+    }, DUMP_BANS_INTERVAL * 1000);
 
     return true;
 }

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -6,6 +6,7 @@
 
 #include <addrdb.h>
 #include <amount.h>
+#include <banman.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <init.h>

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -116,24 +116,24 @@ class NodeImpl : public Node
     }
     bool getBanned(banmap_t& banmap) override
     {
-        if (g_connman) {
-            g_connman->GetBanned(banmap);
+        if (g_banman) {
+            g_banman->GetBanned(banmap);
             return true;
         }
         return false;
     }
     bool ban(const CNetAddr& net_addr, BanReason reason, int64_t ban_time_offset) override
     {
-        if (g_connman) {
-            g_connman->Ban(net_addr, reason, ban_time_offset);
+        if (g_banman) {
+            g_banman->Ban(net_addr, reason, ban_time_offset);
             return true;
         }
         return false;
     }
     bool unban(const CSubNet& ip) override
     {
-        if (g_connman) {
-            g_connman->Unban(ip);
+        if (g_banman) {
+            g_banman->Unban(ip);
             return true;
         }
         return false;

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -138,6 +138,13 @@ class NodeImpl : public Node
         }
         return false;
     }
+    bool disconnect(const CNetAddr& net_addr) override
+    {
+        if (g_connman) {
+            return g_connman->DisconnectNode(net_addr);
+        }
+        return false;
+    }
     bool disconnect(NodeId id) override
     {
         if (g_connman) {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -19,6 +19,7 @@
 #include <tuple>
 #include <vector>
 
+class BanMan;
 class CCoinControl;
 class CFeeRate;
 class CNodeStats;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -110,7 +110,10 @@ public:
     //! Unban node.
     virtual bool unban(const CSubNet& ip) = 0;
 
-    //! Disconnect node.
+    //! Disconnect node by address.
+    virtual bool disconnect(const CNetAddr& net_addr) = 0;
+
+    //! Disconnect node by id.
     virtual bool disconnect(NodeId id) = 0;
 
     //! Get total bytes recv.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -473,10 +473,9 @@ void BanMan::DumpBanlist()
 
     int64_t nStart = GetTimeMillis();
 
-    CBanDB bandb;
     banmap_t banmap;
     GetBanned(banmap);
-    if (bandb.Write(banmap)) {
+    if (m_ban_db.Write(banmap)) {
         SetBannedSetDirty(false);
     }
 
@@ -2347,17 +2346,15 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     return true;
 }
 
-BanMan::BanMan(CClientUIInterface* client_interface) : clientInterface(client_interface)
+BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface) : clientInterface(client_interface), m_ban_db(std::move(ban_file))
 {
     if (clientInterface)
         clientInterface->InitMessage(_("Loading banlist..."));
-    // Load addresses from banlist.dat
 
     int64_t nStart = GetTimeMillis();
     setBannedIsDirty = false;
-    CBanDB bandb;
     banmap_t banmap;
-    if (bandb.Read(banmap)) {
+    if (m_ban_db.Read(banmap)) {
         SetBanned(banmap); // thread save setter
         SetBannedSetDirty(false); // no need to write down, just read data
         SweepBanned(); // sweep out unused entries

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -36,8 +36,11 @@
 
 #include <math.h>
 
-// Dump addresses to peers.dat and banlist.dat every 15 minutes (900s)
-#define DUMP_ADDRESSES_INTERVAL 900
+// Dump addresses to peers.dat every 15 minutes (900s)
+static constexpr int DUMP_PEERS_INTERVAL = 60 * 15;
+
+// Dump addresses to banlist.dat every 15 minutes (900s)
+static constexpr int DUMP_BANS_INTERVAL = 60 * 15;
 
 // We add a random period time (0 to 1 seconds) to feeler connections to prevent synchronization.
 #define FEELER_SLEEP_WINDOW 1
@@ -1670,12 +1673,6 @@ void CConnman::DumpAddresses()
            addrman.size(), GetTimeMillis() - nStart);
 }
 
-void CConnman::DumpData()
-{
-    DumpAddresses();
-    DumpBanlist();
-}
-
 void CConnman::ProcessOneShot()
 {
     std::string strDest;
@@ -2367,7 +2364,8 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     threadMessageHandler = std::thread(&TraceThread<std::function<void()> >, "msghand", std::function<void()>(std::bind(&CConnman::ThreadMessageHandler, this)));
 
     // Dump network addresses
-    scheduler.scheduleEvery(std::bind(&CConnman::DumpData, this), DUMP_ADDRESSES_INTERVAL * 1000);
+    scheduler.scheduleEvery(std::bind(&CConnman::DumpAddresses, this), DUMP_PEERS_INTERVAL * 1000);
+    scheduler.scheduleEvery(std::bind(&CConnman::DumpBanlist, this), DUMP_BANS_INTERVAL * 1000);
 
     return true;
 }
@@ -2426,7 +2424,8 @@ void CConnman::Stop()
 
     if (fAddressesInitialized)
     {
-        DumpData();
+        DumpAddresses();
+        DumpBanlist();
         fAddressesInitialized = false;
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -544,7 +544,7 @@ void BanMan::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bant
     banEntry.banReason = banReason;
     if (bantimeoffset <= 0)
     {
-        bantimeoffset = gArgs.GetArg("-bantime", DEFAULT_MISBEHAVING_BANTIME);
+        bantimeoffset = m_default_ban_time;
         sinceUnixEpoch = false;
     }
     banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime() )+bantimeoffset;
@@ -2346,7 +2346,7 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     return true;
 }
 
-BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface) : clientInterface(client_interface), m_ban_db(std::move(ban_file))
+BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time) : clientInterface(client_interface), m_ban_db(std::move(ban_file)), m_default_ban_time(default_ban_time)
 {
     if (clientInterface)
         clientInterface->InitMessage(_("Loading banlist..."));

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -9,6 +9,7 @@
 
 #include <net.h>
 
+#include <banman.h>
 #include <chainparams.h>
 #include <clientversion.h>
 #include <consensus/consensus.h>
@@ -464,25 +465,6 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
     return pnode;
 }
 
-void BanMan::DumpBanlist()
-{
-    SweepBanned(); // clean unused entries (if bantime has expired)
-
-    if (!BannedSetIsDirty())
-        return;
-
-    int64_t nStart = GetTimeMillis();
-
-    banmap_t banmap;
-    GetBanned(banmap);
-    if (m_ban_db.Write(banmap)) {
-        SetBannedSetDirty(false);
-    }
-
-    LogPrint(BCLog::NET, "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
-        banmap.size(), GetTimeMillis() - nStart);
-}
-
 void CNode::CloseSocketDisconnect()
 {
     fDisconnect = true;
@@ -493,150 +475,6 @@ void CNode::CloseSocketDisconnect()
         CloseSocket(hSocket);
     }
 }
-
-void BanMan::ClearBanned()
-{
-    {
-        LOCK(cs_setBanned);
-        setBanned.clear();
-        setBannedIsDirty = true;
-    }
-    DumpBanlist(); //store banlist to disk
-    if(clientInterface)
-        clientInterface->BannedListChanged();
-}
-
-bool BanMan::IsBanned(CNetAddr ip)
-{
-    LOCK(cs_setBanned);
-    for (const auto& it : setBanned) {
-        CSubNet subNet = it.first;
-        CBanEntry banEntry = it.second;
-
-        if (subNet.Match(ip) && GetTime() < banEntry.nBanUntil) {
-            return true;
-        }
-    }
-    return false;
-}
-
-bool BanMan::IsBanned(CSubNet subnet)
-{
-    LOCK(cs_setBanned);
-    banmap_t::iterator i = setBanned.find(subnet);
-    if (i != setBanned.end())
-    {
-        CBanEntry banEntry = (*i).second;
-        if (GetTime() < banEntry.nBanUntil) {
-            return true;
-        }
-    }
-    return false;
-}
-
-void BanMan::Ban(const CNetAddr& addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
-    CSubNet subNet(addr);
-    Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
-}
-
-void BanMan::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
-    CBanEntry banEntry(GetTime());
-    banEntry.banReason = banReason;
-    if (bantimeoffset <= 0)
-    {
-        bantimeoffset = m_default_ban_time;
-        sinceUnixEpoch = false;
-    }
-    banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime() )+bantimeoffset;
-
-    {
-        LOCK(cs_setBanned);
-        if (setBanned[subNet].nBanUntil < banEntry.nBanUntil) {
-            setBanned[subNet] = banEntry;
-            setBannedIsDirty = true;
-        }
-        else
-            return;
-    }
-    if(clientInterface)
-        clientInterface->BannedListChanged();
-    if(banReason == BanReasonManuallyAdded)
-        DumpBanlist(); //store banlist to disk immediately if user requested ban
-}
-
-bool BanMan::Unban(const CNetAddr &addr) {
-    CSubNet subNet(addr);
-    return Unban(subNet);
-}
-
-bool BanMan::Unban(const CSubNet &subNet) {
-    {
-        LOCK(cs_setBanned);
-        if (!setBanned.erase(subNet))
-            return false;
-        setBannedIsDirty = true;
-    }
-    if(clientInterface)
-        clientInterface->BannedListChanged();
-    DumpBanlist(); //store banlist to disk immediately
-    return true;
-}
-
-void BanMan::GetBanned(banmap_t &banMap)
-{
-    LOCK(cs_setBanned);
-    // Sweep the banlist so expired bans are not returned
-    SweepBanned();
-    banMap = setBanned; //create a thread safe copy
-}
-
-void BanMan::SetBanned(const banmap_t &banMap)
-{
-    LOCK(cs_setBanned);
-    setBanned = banMap;
-    setBannedIsDirty = true;
-}
-
-void BanMan::SweepBanned()
-{
-    int64_t now = GetTime();
-    bool notifyUI = false;
-    {
-        LOCK(cs_setBanned);
-        banmap_t::iterator it = setBanned.begin();
-        while(it != setBanned.end())
-        {
-            CSubNet subNet = (*it).first;
-            CBanEntry banEntry = (*it).second;
-            if(now > banEntry.nBanUntil)
-            {
-                setBanned.erase(it++);
-                setBannedIsDirty = true;
-                notifyUI = true;
-                LogPrint(BCLog::NET, "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, subNet.ToString());
-            }
-            else
-                ++it;
-        }
-    }
-    // update UI
-    if(notifyUI && clientInterface) {
-        clientInterface->BannedListChanged();
-    }
-}
-
-bool BanMan::BannedSetIsDirty()
-{
-    LOCK(cs_setBanned);
-    return setBannedIsDirty;
-}
-
-void BanMan::SetBannedSetDirty(bool dirty)
-{
-    LOCK(cs_setBanned); //reuse setBanned lock for the isDirty flag
-    setBannedIsDirty = dirty;
-}
-
 
 bool CConnman::IsWhitelistedRange(const CNetAddr &addr) {
     for (const CSubNet& subnet : vWhitelistedRange) {
@@ -2344,33 +2182,6 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
     scheduler.scheduleEvery(std::bind(&CConnman::DumpAddresses, this), DUMP_PEERS_INTERVAL * 1000);
 
     return true;
-}
-
-BanMan::BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time) : clientInterface(client_interface), m_ban_db(std::move(ban_file)), m_default_ban_time(default_ban_time)
-{
-    if (clientInterface)
-        clientInterface->InitMessage(_("Loading banlist..."));
-
-    int64_t nStart = GetTimeMillis();
-    setBannedIsDirty = false;
-    banmap_t banmap;
-    if (m_ban_db.Read(banmap)) {
-        SetBanned(banmap); // thread save setter
-        SetBannedSetDirty(false); // no need to write down, just read data
-        SweepBanned(); // sweep out unused entries
-
-        LogPrint(BCLog::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
-            banmap.size(), GetTimeMillis() - nStart);
-    } else {
-        LogPrintf("Invalid or missing banlist.dat; recreating\n");
-        SetBannedSetDirty(true); // force write
-        DumpBanlist();
-    }
-}
-
-BanMan::~BanMan()
-{
-    DumpBanlist();
 }
 
 class CNetCleanup

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -561,13 +561,6 @@ void CConnman::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t ba
     }
     if(clientInterface)
         clientInterface->BannedListChanged();
-    {
-        LOCK(cs_vNodes);
-        for (CNode* pnode : vNodes) {
-            if (subNet.Match(static_cast<CNetAddr>(pnode->addr)))
-                pnode->fDisconnect = true;
-        }
-    }
     if(banReason == BanReasonManuallyAdded)
         DumpBanlist(); //store banlist to disk immediately if user requested ban
 }
@@ -2560,6 +2553,25 @@ bool CConnman::DisconnectNode(const std::string& strNode)
     }
     return false;
 }
+
+bool CConnman::DisconnectNode(const CSubNet& subnet)
+{
+    bool disconnected = false;
+    LOCK(cs_vNodes);
+    for (CNode* pnode : vNodes) {
+        if (subnet.Match(static_cast<CNetAddr>(pnode->addr))) {
+            pnode->fDisconnect = true;
+            disconnected = true;
+        }
+    }
+    return disconnected;
+}
+
+bool CConnman::DisconnectNode(const CNetAddr& addr)
+{
+    return DisconnectNode(CSubNet(addr));
+}
+
 bool CConnman::DisconnectNode(NodeId id)
 {
     LOCK(cs_vNodes);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -39,9 +39,6 @@
 // Dump addresses to peers.dat every 15 minutes (900s)
 static constexpr int DUMP_PEERS_INTERVAL = 60 * 15;
 
-// Dump addresses to banlist.dat every 15 minutes (900s)
-static constexpr int DUMP_BANS_INTERVAL = 60 * 15;
-
 // We add a random period time (0 to 1 seconds) to feeler connections to prevent synchronization.
 #define FEELER_SLEEP_WINDOW 1
 
@@ -467,7 +464,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
     return pnode;
 }
 
-void CConnman::DumpBanlist()
+void BanMan::DumpBanlist()
 {
     SweepBanned(); // clean unused entries (if bantime has expired)
 
@@ -498,7 +495,7 @@ void CNode::CloseSocketDisconnect()
     }
 }
 
-void CConnman::ClearBanned()
+void BanMan::ClearBanned()
 {
     {
         LOCK(cs_setBanned);
@@ -510,7 +507,7 @@ void CConnman::ClearBanned()
         clientInterface->BannedListChanged();
 }
 
-bool CConnman::IsBanned(CNetAddr ip)
+bool BanMan::IsBanned(CNetAddr ip)
 {
     LOCK(cs_setBanned);
     for (const auto& it : setBanned) {
@@ -524,7 +521,7 @@ bool CConnman::IsBanned(CNetAddr ip)
     return false;
 }
 
-bool CConnman::IsBanned(CSubNet subnet)
+bool BanMan::IsBanned(CSubNet subnet)
 {
     LOCK(cs_setBanned);
     banmap_t::iterator i = setBanned.find(subnet);
@@ -538,12 +535,12 @@ bool CConnman::IsBanned(CSubNet subnet)
     return false;
 }
 
-void CConnman::Ban(const CNetAddr& addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
+void BanMan::Ban(const CNetAddr& addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
     CSubNet subNet(addr);
     Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
 }
 
-void CConnman::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
+void BanMan::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch) {
     CBanEntry banEntry(GetTime());
     banEntry.banReason = banReason;
     if (bantimeoffset <= 0)
@@ -568,12 +565,12 @@ void CConnman::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t ba
         DumpBanlist(); //store banlist to disk immediately if user requested ban
 }
 
-bool CConnman::Unban(const CNetAddr &addr) {
+bool BanMan::Unban(const CNetAddr &addr) {
     CSubNet subNet(addr);
     return Unban(subNet);
 }
 
-bool CConnman::Unban(const CSubNet &subNet) {
+bool BanMan::Unban(const CSubNet &subNet) {
     {
         LOCK(cs_setBanned);
         if (!setBanned.erase(subNet))
@@ -586,7 +583,7 @@ bool CConnman::Unban(const CSubNet &subNet) {
     return true;
 }
 
-void CConnman::GetBanned(banmap_t &banMap)
+void BanMan::GetBanned(banmap_t &banMap)
 {
     LOCK(cs_setBanned);
     // Sweep the banlist so expired bans are not returned
@@ -594,14 +591,14 @@ void CConnman::GetBanned(banmap_t &banMap)
     banMap = setBanned; //create a thread safe copy
 }
 
-void CConnman::SetBanned(const banmap_t &banMap)
+void BanMan::SetBanned(const banmap_t &banMap)
 {
     LOCK(cs_setBanned);
     setBanned = banMap;
     setBannedIsDirty = true;
 }
 
-void CConnman::SweepBanned()
+void BanMan::SweepBanned()
 {
     int64_t now = GetTime();
     bool notifyUI = false;
@@ -629,13 +626,13 @@ void CConnman::SweepBanned()
     }
 }
 
-bool CConnman::BannedSetIsDirty()
+bool BanMan::BannedSetIsDirty()
 {
     LOCK(cs_setBanned);
     return setBannedIsDirty;
 }
 
-void CConnman::SetBannedSetDirty(bool dirty)
+void BanMan::SetBannedSetDirty(bool dirty)
 {
     LOCK(cs_setBanned); //reuse setBanned lock for the isDirty flag
     setBannedIsDirty = dirty;
@@ -1115,7 +1112,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     // on all platforms.  Set it again here just to be sure.
     SetSocketNoDelay(hSocket);
 
-    if (IsBanned(addr) && !whitelisted)
+    if (m_banman && m_banman->IsBanned(addr) && !whitelisted)
     {
         LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
         CloseSocket(hSocket);
@@ -1978,7 +1975,7 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     }
     if (!pszDest) {
         if (IsLocal(addrConnect) ||
-            FindNode(static_cast<CNetAddr>(addrConnect)) || IsBanned(addrConnect) ||
+            FindNode(static_cast<CNetAddr>(addrConnect)) || (m_banman && m_banman->IsBanned(addrConnect)) ||
             FindNode(addrConnect.ToStringIPPort()))
             return;
     } else if (FindNode(std::string(pszDest)))
@@ -2202,7 +2199,6 @@ void CConnman::SetNetworkActive(bool active)
 CConnman::CConnman(uint64_t nSeed0In, uint64_t nSeed1In) : nSeed0(nSeed0In), nSeed1(nSeed1In)
 {
     fNetworkActive = true;
-    setBannedIsDirty = false;
     fAddressesInitialized = false;
     nLastNodeId = 0;
     nSendBufferMaxSize = 0;
@@ -2293,24 +2289,6 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
             DumpAddresses();
         }
     }
-    if (clientInterface)
-        clientInterface->InitMessage(_("Loading banlist..."));
-    // Load addresses from banlist.dat
-    nStart = GetTimeMillis();
-    CBanDB bandb;
-    banmap_t banmap;
-    if (bandb.Read(banmap)) {
-        SetBanned(banmap); // thread save setter
-        SetBannedSetDirty(false); // no need to write down, just read data
-        SweepBanned(); // sweep out unused entries
-
-        LogPrint(BCLog::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
-            banmap.size(), GetTimeMillis() - nStart);
-    } else {
-        LogPrintf("Invalid or missing banlist.dat; recreating\n");
-        SetBannedSetDirty(true); // force write
-        DumpBanlist();
-    }
 
     uiInterface.InitMessage(_("Starting network threads..."));
 
@@ -2365,9 +2343,37 @@ bool CConnman::Start(CScheduler& scheduler, const Options& connOptions)
 
     // Dump network addresses
     scheduler.scheduleEvery(std::bind(&CConnman::DumpAddresses, this), DUMP_PEERS_INTERVAL * 1000);
-    scheduler.scheduleEvery(std::bind(&CConnman::DumpBanlist, this), DUMP_BANS_INTERVAL * 1000);
 
     return true;
+}
+
+BanMan::BanMan(CClientUIInterface* client_interface) : clientInterface(client_interface)
+{
+    if (clientInterface)
+        clientInterface->InitMessage(_("Loading banlist..."));
+    // Load addresses from banlist.dat
+
+    int64_t nStart = GetTimeMillis();
+    setBannedIsDirty = false;
+    CBanDB bandb;
+    banmap_t banmap;
+    if (bandb.Read(banmap)) {
+        SetBanned(banmap); // thread save setter
+        SetBannedSetDirty(false); // no need to write down, just read data
+        SweepBanned(); // sweep out unused entries
+
+        LogPrint(BCLog::NET, "Loaded %d banned node ips/subnets from banlist.dat  %dms\n",
+            banmap.size(), GetTimeMillis() - nStart);
+    } else {
+        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+        SetBannedSetDirty(true); // force write
+        DumpBanlist();
+    }
+}
+
+BanMan::~BanMan()
+{
+    DumpBanlist();
 }
 
 class CNetCleanup
@@ -2425,7 +2431,6 @@ void CConnman::Stop()
     if (fAddressesInitialized)
     {
         DumpAddresses();
-        DumpBanlist();
         fAddressesInitialized = false;
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -81,7 +81,7 @@ static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
-static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
+static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 
 typedef int64_t NodeId;
 
@@ -109,6 +109,50 @@ struct CSerializedNetMsg
     std::string command;
 };
 
+
+class BanMan
+{
+public:
+    // Denial-of-service detection/prevention
+    // The idea is to detect peers that are behaving
+    // badly and disconnect/ban them, but do it in a
+    // one-coding-mistake-won't-shatter-the-entire-network
+    // way.
+    // IMPORTANT:  There should be nothing I can give a
+    // node that it will forward on that will make that
+    // node's peers drop it. If there is, an attacker
+    // can isolate a node and/or try to split the network.
+    // Dropping a node for sending stuff that is invalid
+    // now but might be valid in a later version is also
+    // dangerous, because it can cause a network split
+    // between nodes running old code and nodes running
+    // new code.
+    ~BanMan();
+    BanMan(CClientUIInterface* client_interface);
+    void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void ClearBanned(); // needed for unit testing
+    bool IsBanned(CNetAddr ip);
+    bool IsBanned(CSubNet subnet);
+    bool Unban(const CNetAddr &ip);
+    bool Unban(const CSubNet &ip);
+    void GetBanned(banmap_t &banmap);
+    void DumpBanlist();
+
+private:
+    void SetBanned(const banmap_t &banmap);
+    bool BannedSetIsDirty();
+    //!set the "dirty" flag for the banlist
+    void SetBannedSetDirty(bool dirty=true);
+    //!clean unused entries (if bantime has expired)
+    void SweepBanned();
+
+    banmap_t setBanned;
+    CCriticalSection cs_setBanned;
+    bool setBannedIsDirty;
+    CClientUIInterface* clientInterface = nullptr;
+};
+
 class NetEventsInterface;
 class CConnman
 {
@@ -131,6 +175,7 @@ public:
         int nBestHeight = 0;
         CClientUIInterface* uiInterface = nullptr;
         NetEventsInterface* m_msgproc = nullptr;
+        BanMan* m_banman = nullptr;
         unsigned int nSendBufferMaxSize = 0;
         unsigned int nReceiveFloodSize = 0;
         uint64_t nMaxOutboundTimeframe = 0;
@@ -151,6 +196,7 @@ public:
         nMaxFeeler = connOptions.nMaxFeeler;
         nBestHeight = connOptions.nBestHeight;
         clientInterface = connOptions.uiInterface;
+        m_banman = connOptions.m_banman;
         m_msgproc = connOptions.m_msgproc;
         nSendBufferMaxSize = connOptions.nSendBufferMaxSize;
         nReceiveFloodSize = connOptions.nReceiveFloodSize;
@@ -228,30 +274,6 @@ public:
     void MarkAddressGood(const CAddress& addr);
     void AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
     std::vector<CAddress> GetAddresses();
-
-    // Denial-of-service detection/prevention
-    // The idea is to detect peers that are behaving
-    // badly and disconnect/ban them, but do it in a
-    // one-coding-mistake-won't-shatter-the-entire-network
-    // way.
-    // IMPORTANT:  There should be nothing I can give a
-    // node that it will forward on that will make that
-    // node's peers drop it. If there is, an attacker
-    // can isolate a node and/or try to split the network.
-    // Dropping a node for sending stuff that is invalid
-    // now but might be valid in a later version is also
-    // dangerous, because it can cause a network split
-    // between nodes running old code and nodes running
-    // new code.
-    void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
-    void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
-    void ClearBanned(); // needed for unit testing
-    bool IsBanned(CNetAddr ip);
-    bool IsBanned(CSubNet subnet);
-    bool Unban(const CNetAddr &ip);
-    bool Unban(const CSubNet &ip);
-    void GetBanned(banmap_t &banmap);
-    void SetBanned(const banmap_t &banmap);
 
     // This allows temporarily exceeding nMaxOutbound, with the goal of finding
     // a peer that is better than all our current peers.
@@ -348,15 +370,7 @@ private:
     NodeId GetNewNodeId();
 
     size_t SocketSendData(CNode *pnode) const;
-    //!check is the banlist has unwritten changes
-    bool BannedSetIsDirty();
-    //!set the "dirty" flag for the banlist
-    void SetBannedSetDirty(bool dirty=true);
-    //!clean unused entries (if bantime has expired)
-    void SweepBanned();
     void DumpAddresses();
-    void DumpData();
-    void DumpBanlist();
 
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
@@ -386,9 +400,6 @@ private:
 
     std::vector<ListenSocket> vhListenSocket;
     std::atomic<bool> fNetworkActive;
-    banmap_t setBanned;
-    CCriticalSection cs_setBanned;
-    bool setBannedIsDirty;
     bool fAddressesInitialized;
     CAddrMan addrman;
     std::deque<std::string> vOneShots;
@@ -412,6 +423,7 @@ private:
     std::atomic<int> nBestHeight;
     CClientUIInterface* clientInterface;
     NetEventsInterface* m_msgproc;
+    BanMan* m_banman;
 
     /** SipHasher seeds for deterministic randomness */
     const uint64_t nSeed0, nSeed1;
@@ -439,6 +451,7 @@ private:
     friend struct CConnmanTest;
 };
 extern std::unique_ptr<CConnman> g_connman;
+extern std::unique_ptr<BanMan> g_banman;
 void Discover();
 void StartMapPort();
 void InterruptMapPort();

--- a/src/net.h
+++ b/src/net.h
@@ -128,7 +128,7 @@ public:
     // between nodes running old code and nodes running
     // new code.
     ~BanMan();
-    BanMan(fs::path ban_file, CClientUIInterface* client_interface);
+    BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time);
     void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     void ClearBanned(); // needed for unit testing
@@ -152,6 +152,7 @@ private:
     bool setBannedIsDirty;
     CClientUIInterface* clientInterface = nullptr;
     CBanDB m_ban_db;
+    int64_t m_default_ban_time;
 };
 
 class NetEventsInterface;

--- a/src/net.h
+++ b/src/net.h
@@ -273,6 +273,8 @@ public:
     size_t GetNodeCount(NumConnections num);
     void GetNodeStats(std::vector<CNodeStats>& vstats);
     bool DisconnectNode(const std::string& node);
+    bool DisconnectNode(const CSubNet& subnet);
+    bool DisconnectNode(const CNetAddr& addr);
     bool DisconnectNode(NodeId id);
 
     ServiceFlags GetLocalServices() const;

--- a/src/net.h
+++ b/src/net.h
@@ -128,7 +128,7 @@ public:
     // between nodes running old code and nodes running
     // new code.
     ~BanMan();
-    BanMan(CClientUIInterface* client_interface);
+    BanMan(fs::path ban_file, CClientUIInterface* client_interface);
     void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
     void ClearBanned(); // needed for unit testing
@@ -151,6 +151,7 @@ private:
     CCriticalSection cs_setBanned;
     bool setBannedIsDirty;
     CClientUIInterface* clientInterface = nullptr;
+    CBanDB m_ban_db;
 };
 
 class NetEventsInterface;

--- a/src/net.h
+++ b/src/net.h
@@ -36,6 +36,7 @@
 
 class CScheduler;
 class CNode;
+class BanMan;
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
@@ -80,9 +81,6 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
-// NOTE: When adjusting this, update rpcnet:setban's help ("24h")
-static constexpr unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
-
 typedef int64_t NodeId;
 
 struct AddedNodeInfo
@@ -109,51 +107,6 @@ struct CSerializedNetMsg
     std::string command;
 };
 
-
-class BanMan
-{
-public:
-    // Denial-of-service detection/prevention
-    // The idea is to detect peers that are behaving
-    // badly and disconnect/ban them, but do it in a
-    // one-coding-mistake-won't-shatter-the-entire-network
-    // way.
-    // IMPORTANT:  There should be nothing I can give a
-    // node that it will forward on that will make that
-    // node's peers drop it. If there is, an attacker
-    // can isolate a node and/or try to split the network.
-    // Dropping a node for sending stuff that is invalid
-    // now but might be valid in a later version is also
-    // dangerous, because it can cause a network split
-    // between nodes running old code and nodes running
-    // new code.
-    ~BanMan();
-    BanMan(fs::path ban_file, CClientUIInterface* client_interface, int64_t default_ban_time);
-    void Ban(const CNetAddr& netAddr, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
-    void Ban(const CSubNet& subNet, const BanReason& reason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
-    void ClearBanned(); // needed for unit testing
-    bool IsBanned(CNetAddr ip);
-    bool IsBanned(CSubNet subnet);
-    bool Unban(const CNetAddr &ip);
-    bool Unban(const CSubNet &ip);
-    void GetBanned(banmap_t &banmap);
-    void DumpBanlist();
-
-private:
-    void SetBanned(const banmap_t &banmap);
-    bool BannedSetIsDirty();
-    //!set the "dirty" flag for the banlist
-    void SetBannedSetDirty(bool dirty=true);
-    //!clean unused entries (if bantime has expired)
-    void SweepBanned();
-
-    banmap_t setBanned;
-    CCriticalSection cs_setBanned;
-    bool setBannedIsDirty;
-    CClientUIInterface* clientInterface = nullptr;
-    CBanDB m_ban_db;
-    int64_t m_default_ban_time;
-};
 
 class NetEventsInterface;
 class CConnman

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -6,6 +6,7 @@
 #include <net_processing.h>
 
 #include <addrman.h>
+#include <banman.h>
 #include <arith_uint256.h>
 #include <blockencodings.h>
 #include <chainparams.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2909,14 +2909,14 @@ static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman* connman)
             LogPrintf("Warning: not punishing whitelisted peer %s!\n", pnode->addr.ToString());
         else if (pnode->m_manual_connection)
             LogPrintf("Warning: not punishing manually-connected peer %s!\n", pnode->addr.ToString());
-        else {
-            pnode->fDisconnect = true;
-            if (pnode->addr.IsLocal())
-                LogPrintf("Warning: not banning local peer %s!\n", pnode->addr.ToString());
-            else
-            {
-                connman->Ban(pnode->addr, BanReasonNodeMisbehaving);
-            }
+        else if (pnode->addr.IsLocal()) {
+            // Disconnect but don't ban _this_ local node
+            LogPrintf("Warning: disconnecting but not banning local peer %s!\n", pnode->addr.ToString());
+            connman->DisconnectNode(pnode->GetId());
+        } else {
+            // Disconnect and ban all nodes sharing the address
+            connman->Ban(pnode->addr, BanReasonNodeMisbehaving);
+            connman->DisconnectNode(pnode->addr);
         }
         return true;
     }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -38,9 +38,11 @@ static constexpr int64_t MINIMUM_CONNECT_TIME = 30;
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
     CConnman* const connman;
+    BanMan* const m_banman;
 
+    bool SendRejectsAndCheckIfBanned(CNode* pnode);
 public:
-    explicit PeerLogicValidation(CConnman* connman, CScheduler &scheduler);
+    PeerLogicValidation(CConnman* connman, BanMan* banman, CScheduler &scheduler);
 
     /**
      * Overridden from CValidationInterface.

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1215,16 +1215,17 @@ void RPCConsole::banSelectedNode(int bantime)
         // Get currently selected peer address
         NodeId id = nodes.at(i).data().toLongLong();
 
-	// Get currently selected peer address
-	int detailNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(id);
-	if(detailNodeRow < 0)
+    // Get currently selected peer address
+    int detailNodeRow = clientModel->getPeerTableModel()->getRowByNodeId(id);
+    if(detailNodeRow < 0)
 	    return;
 
-	// Find possible nodes, ban it and clear the selected node
-	const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(detailNodeRow);
-	if(stats) {
+    // Find possible nodes, ban it and clear the selected node
+    const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(detailNodeRow);
+    if(stats) {
             m_node.ban(stats->nodeStats.addr, BanReasonManuallyAdded, bantime);
-	}
+            m_node.disconnect(stats->nodeStats.addr);
+        }
     }
     clearSelectedNode();
     clientModel->getBanTableModel()->refresh();

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -4,6 +4,7 @@
 
 #include <rpc/server.h>
 
+#include <banman.h>
 #include <chainparams.h>
 #include <clientversion.h>
 #include <core_io.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -543,7 +543,13 @@ UniValue setban(const JSONRPCRequest& request)
         if (request.params[3].isTrue())
             absolute = true;
 
-        isSubnet ? g_connman->Ban(subNet, BanReasonManuallyAdded, banTime, absolute) : g_connman->Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
+        if (isSubnet) {
+            g_connman->Ban(subNet, BanReasonManuallyAdded, banTime, absolute);
+            g_connman->DisconnectNode(subNet);
+        } else {
+            g_connman->Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
+            g_connman->DisconnectNode(netAddr);
+        }
     }
     else if(strCommand == "remove")
     {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -509,8 +509,8 @@ UniValue setban(const JSONRPCRequest& request)
                             + HelpExampleCli("setban", "\"192.168.0.0/24\" \"add\"")
                             + HelpExampleRpc("setban", "\"192.168.0.6\", \"add\", 86400")
                             );
-    if(!g_connman)
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+    if(!g_banman)
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
 
     CSubNet subNet;
     CNetAddr netAddr;
@@ -532,7 +532,7 @@ UniValue setban(const JSONRPCRequest& request)
 
     if (strCommand == "add")
     {
-        if (isSubnet ? g_connman->IsBanned(subNet) : g_connman->IsBanned(netAddr))
+        if (isSubnet ? g_banman->IsBanned(subNet) : g_banman->IsBanned(netAddr))
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: IP/Subnet already banned");
 
         int64_t banTime = 0; //use standard bantime if not specified
@@ -544,16 +544,20 @@ UniValue setban(const JSONRPCRequest& request)
             absolute = true;
 
         if (isSubnet) {
-            g_connman->Ban(subNet, BanReasonManuallyAdded, banTime, absolute);
-            g_connman->DisconnectNode(subNet);
+            g_banman->Ban(subNet, BanReasonManuallyAdded, banTime, absolute);
+            if (g_connman) {
+                g_connman->DisconnectNode(subNet);
+            }
         } else {
-            g_connman->Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
-            g_connman->DisconnectNode(netAddr);
+            g_banman->Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
+            if (g_connman) {
+                g_connman->DisconnectNode(netAddr);
+            }
         }
     }
     else if(strCommand == "remove")
     {
-        if (!( isSubnet ? g_connman->Unban(subNet) : g_connman->Unban(netAddr) ))
+        if (!( isSubnet ? g_banman->Unban(subNet) : g_banman->Unban(netAddr) ))
             throw JSONRPCError(RPC_CLIENT_INVALID_IP_OR_SUBNET, "Error: Unban failed. Requested address/subnet was not previously banned.");
     }
     return NullUniValue;
@@ -570,11 +574,11 @@ UniValue listbanned(const JSONRPCRequest& request)
                             + HelpExampleRpc("listbanned", "")
                             );
 
-    if(!g_connman)
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+    if(!g_banman)
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
 
     banmap_t banMap;
-    g_connman->GetBanned(banMap);
+    g_banman->GetBanned(banMap);
 
     UniValue bannedAddresses(UniValue::VARR);
     for (const auto& entry : banMap)
@@ -602,10 +606,10 @@ UniValue clearbanned(const JSONRPCRequest& request)
                             + HelpExampleCli("clearbanned", "")
                             + HelpExampleRpc("clearbanned", "")
                             );
-    if(!g_connman)
-        throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
+    if(!g_banman)
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Error: Ban database not loaded");
 
-    g_connman->ClearBanned();
+    g_banman->ClearBanned();
 
     return NullUniValue;
 }

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -4,6 +4,7 @@
 
 // Unit tests for denial-of-service detection/prevention code
 
+#include <banman.h>
 #include <chainparams.h>
 #include <keystore.h>
 #include <net.h>

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -72,7 +72,7 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 {
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
-    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), scheduler));
+    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), nullptr, scheduler));
 
     std::atomic<bool> interruptDummy(false);
 
@@ -129,7 +129,7 @@ void AddRandomOutboundPeer(std::vector<CNode *> &vNodes, PeerLogicValidation &pe
 BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 {
     auto connman = std::unique_ptr<CConnmanTest>(new CConnmanTest(0x1337, 0x1337));
-    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), scheduler));
+    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), nullptr, scheduler));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     constexpr int nMaxOutbound = 8;
@@ -200,11 +200,12 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
+    auto banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
-    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), scheduler));
+    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
 
-    connman->ClearBanned();
+    banman->ClearBanned();
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 0, 0, CAddress(), "", true);
     dummyNode1.SetSendVersion(PROTOCOL_VERSION);
@@ -217,8 +218,8 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     LOCK(dummyNode1.cs_sendProcessing);
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr1));
-    BOOST_CHECK(!connman->IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
+    BOOST_CHECK(banman->IsBanned(addr1));
+    BOOST_CHECK(!banman->IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
     CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr2, 1, 1, CAddress(), "", true);
@@ -232,14 +233,14 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     LOCK(dummyNode2.cs_sendProcessing);
     peerLogic->SendMessages(&dummyNode2, interruptDummy);
-    BOOST_CHECK(!connman->IsBanned(addr2)); // 2 not banned yet...
-    BOOST_CHECK(connman->IsBanned(addr1));  // ... but 1 still should be
+    BOOST_CHECK(!banman->IsBanned(addr2)); // 2 not banned yet...
+    BOOST_CHECK(banman->IsBanned(addr1));  // ... but 1 still should be
     {
         LOCK(cs_main);
         Misbehaving(dummyNode2.GetId(), 50);
     }
     peerLogic->SendMessages(&dummyNode2, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr2));
+    BOOST_CHECK(banman->IsBanned(addr2));
 
     bool dummy;
     peerLogic->FinalizeNode(dummyNode1.GetId(), dummy);
@@ -248,11 +249,12 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
+    auto banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
-    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), scheduler));
+    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
 
-    connman->ClearBanned();
+    banman->ClearBanned();
     gArgs.ForceSetArg("-banscore", "111"); // because 11 is my favorite number
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 3, 1, CAddress(), "", true);
@@ -266,19 +268,19 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     LOCK(dummyNode1.cs_sendProcessing);
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
-    BOOST_CHECK(!connman->IsBanned(addr1));
+    BOOST_CHECK(!banman->IsBanned(addr1));
     {
         LOCK(cs_main);
         Misbehaving(dummyNode1.GetId(), 10);
     }
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
-    BOOST_CHECK(!connman->IsBanned(addr1));
+    BOOST_CHECK(!banman->IsBanned(addr1));
     {
         LOCK(cs_main);
         Misbehaving(dummyNode1.GetId(), 1);
     }
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr1));
+    BOOST_CHECK(banman->IsBanned(addr1));
     gArgs.ForceSetArg("-banscore", std::to_string(DEFAULT_BANSCORE_THRESHOLD));
 
     bool dummy;
@@ -287,11 +289,12 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
+    auto banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
-    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), scheduler));
+    auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
 
-    connman->ClearBanned();
+    banman->ClearBanned();
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
@@ -308,13 +311,13 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     }
     LOCK(dummyNode.cs_sendProcessing);
     peerLogic->SendMessages(&dummyNode, interruptDummy);
-    BOOST_CHECK(connman->IsBanned(addr));
+    BOOST_CHECK(banman->IsBanned(addr));
 
     SetMockTime(nStartTime+60*60);
-    BOOST_CHECK(connman->IsBanned(addr));
+    BOOST_CHECK(banman->IsBanned(addr));
 
     SetMockTime(nStartTime+60*60*24+1);
-    BOOST_CHECK(!connman->IsBanned(addr));
+    BOOST_CHECK(!banman->IsBanned(addr));
 
     bool dummy;
     peerLogic->FinalizeNode(dummyNode.GetId(), dummy);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
-    auto banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
+    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
     auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
-    auto banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
+    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
     auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
-    auto banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
+    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
     auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(stale_tip_peer_management)
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
-    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
+    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
     auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
-    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
+    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
     auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
-    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
+    auto banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME));
     auto connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337));
     auto peerLogic = std::unique_ptr<PeerLogicValidation>(new PeerLogicValidation(connman.get(), banman.get(), scheduler));
     std::atomic<bool> interruptDummy(false);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -76,7 +76,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);
-        g_banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
+        g_banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME));
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
 }
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -76,7 +76,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);
-        g_banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
+        g_banman = std::unique_ptr<BanMan>(new BanMan(GetDataDir() / "banlist.dat", nullptr));
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
 }
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -4,6 +4,7 @@
 
 #include <test/test_bitcoin.h>
 
+#include <banman.h>
 #include <chainparams.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -76,6 +76,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);
+        g_banman = std::unique_ptr<BanMan>(new BanMan(nullptr));
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
 }
 
@@ -86,6 +87,7 @@ TestingSetup::~TestingSetup()
         GetMainSignals().FlushBackgroundCallbacks();
         GetMainSignals().UnregisterBackgroundSignalScheduler();
         g_connman.reset();
+        g_banman.reset();
         UnloadBlockIndex();
         pcoinsTip.reset();
         pcoinsdbview.reset();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -17,21 +17,6 @@
 #include <rpc/register.h>
 #include <script/sigcache.h>
 
-void CConnmanTest::AddNode(CNode& node)
-{
-    LOCK(g_connman->cs_vNodes);
-    g_connman->vNodes.push_back(&node);
-}
-
-void CConnmanTest::ClearNodes()
-{
-    LOCK(g_connman->cs_vNodes);
-    for (CNode* node : g_connman->vNodes) {
-        delete node;
-    }
-    g_connman->vNodes.clear();
-}
-
 uint256 insecure_rand_seed = GetRandHash();
 FastRandomContext insecure_rand_ctx(insecure_rand_seed);
 
@@ -92,8 +77,6 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         for (int i=0; i < nScriptCheckThreads-1; i++)
             threadGroup.create_thread(&ThreadScriptCheck);
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
-        connman = g_connman.get();
-        peerLogic.reset(new PeerLogicValidation(connman, scheduler));
 }
 
 TestingSetup::~TestingSetup()
@@ -103,7 +86,6 @@ TestingSetup::~TestingSetup()
         GetMainSignals().FlushBackgroundCallbacks();
         GetMainSignals().UnregisterBackgroundSignalScheduler();
         g_connman.reset();
-        peerLogic.reset();
         UnloadBlockIndex();
         pcoinsTip.reset();
         pcoinsdbview.reset();

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -52,18 +52,12 @@ struct BasicTestingSetup {
  */
 class CConnman;
 class CNode;
-struct CConnmanTest {
-    static void AddNode(CNode& node);
-    static void ClearNodes();
-};
 
 class PeerLogicValidation;
 struct TestingSetup: public BasicTestingSetup {
     fs::path pathTemp;
     boost::thread_group threadGroup;
-    CConnman* connman;
     CScheduler scheduler;
-    std::unique_ptr<PeerLogicValidation> peerLogic;
 
     explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~TestingSetup();

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -11,6 +11,7 @@
 #include <boost/test/unit_test.hpp>
 
 std::unique_ptr<CConnman> g_connman;
+std::unique_ptr<BanMan> g_banman;
 
 [[noreturn]] void Shutdown(void* parg)
 {

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -4,6 +4,7 @@
 
 #define BOOST_TEST_MODULE Bitcoin Test Suite
 
+#include <banman.h>
 #include <net.h>
 
 #include <memory>


### PR DESCRIPTION
BanMan is not a bad Man, he's just a different class of Man. He's an ex-ConnMan Man, looking to take a different path and make a new namespace for himself.

Beware BanMan's banhammer as he banishes bandits with the bandwidth to jam him. Not standing for non-canon, he’ll ban and he’ll ban. Some heroes wear capes, but BanMan? A Bandana.

--

Despite the diff size, this is mostly move-only. It breaks the ban/unban functions out of CConnman and into a new class because, while logically bans are tied to connections, they're really just entries in a database. Like CConnman, a global is still required due to RPC (and qt). I plan to address this along with CAddrMan, which I'll be breaking out next.

This also makes testing easier as different implementations can be dropped in.

There are a few small behavioral changes here, which are pretty insignificant:
- Banning no longer implies disconnecting. If you want both, you need to call both.
- For simplicity, The ban db is read in the constructor, meaning that it happens in init rather than net.
- RPC returns RPC_DATABASE_ERROR if the bandb is not loaded. This should not be possible now, but the idea is for future changes to allow us to disable p2p but still interact with the ban commands.