### PR TITLE
[depends] mac_alias 2.0.6, ds_store 1.1.2

### DIFF
--- a/depends/packages/native_ds_store.mk
+++ b/depends/packages/native_ds_store.mk
@@ -1,9 +1,8 @@
 package=native_ds_store
-$(package)_version=1.1.0
-$(package)_download_path=https://bitbucket.org/al45tair/ds_store/get
-$(package)_download_file=v$($(package)_version).tar.bz2
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=921596764d71d1bbd3297a90ef6d286f718794d667e4f81d91d14053525d64c1
+$(package)_version=1.1.2
+$(package)_download_path=https://github.com/al45tair/ds_store/archive/
+$(package)_file_name=v$($(package)_version).tar.gz
+$(package)_sha256_hash=3b3ecb7bf0a5157f5b6010bc3af7c141fb0ad3527084e63336220d22744bc20c
 $(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
 $(package)_dependencies=native_biplist
 

--- a/depends/packages/native_mac_alias.mk
+++ b/depends/packages/native_mac_alias.mk
@@ -1,14 +1,13 @@
 package=native_mac_alias
-$(package)_version=1.1.0
-$(package)_download_path=https://bitbucket.org/al45tair/mac_alias/get
-$(package)_download_file=v$($(package)_version).tar.bz2
-$(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=87ad827e66790028361e43fc754f68ed041a9bdb214cca03c853f079b04fb120
+$(package)_version=2.0.6
+$(package)_download_path=https://github.com/al45tair/mac_alias/archive/
+$(package)_file_name=v$($(package)_version).tar.gz
+$(package)_sha256_hash=78a3332d9a597eebf09ae652d38ad1e263b28db5c2e6dd725fad357b03b77371
 $(package)_install_libdir=$(build_prefix)/lib/python/dist-packages
 $(package)_patches=python3.patch
 
 define $(package)_preprocess_cmds
-  patch -p1 < $($(package)_patch_dir)/python3.patch
+    patch -p1 < $($(package)_patch_dir)/python3.patch
 endef
 
 define $(package)_build_cmds

--- a/depends/patches/native_mac_alias/python3.patch
+++ b/depends/patches/native_mac_alias/python3.patch
@@ -1,7 +1,7 @@
 diff -dur a/mac_alias/alias.py b/mac_alias/alias.py
---- a/mac_alias/alias.py	2015-10-19 12:12:48.000000000 +0200
-+++ b/mac_alias/alias.py	2016-04-03 12:13:12.037159417 +0200
-@@ -243,10 +243,10 @@
+--- a/mac_alias/alias.py
++++ b/mac_alias/alias.py
+@@ -258,10 +258,10 @@
          alias = Alias()
          alias.appinfo = appinfo
              
@@ -14,7 +14,7 @@ diff -dur a/mac_alias/alias.py b/mac_alias/alias.py
                                     folder_cnid, cnid,
                                     crdate, creator_code, type_code)
          alias.target.levels_from = levels_from
-@@ -261,9 +261,9 @@
+@@ -276,9 +276,9 @@
                  b.read(1)
  
              if tag == TAG_CARBON_FOLDER_NAME:
@@ -26,7 +26,7 @@ diff -dur a/mac_alias/alias.py b/mac_alias/alias.py
                                                             value)
              elif tag == TAG_CARBON_PATH:
                  alias.target.carbon_path = value
-@@ -298,9 +298,9 @@
+@@ -313,9 +313,9 @@
                  alias.target.creation_date \
                      = mac_epoch + datetime.timedelta(seconds=seconds)
              elif tag == TAG_POSIX_PATH:
@@ -38,23 +38,7 @@ diff -dur a/mac_alias/alias.py b/mac_alias/alias.py
              elif tag == TAG_RECURSIVE_ALIAS_OF_DISK_IMAGE:
                  alias.volume.disk_image_alias = Alias.from_bytes(value)
              elif tag == TAG_USER_HOME_LENGTH_PREFIX:
-@@ -422,13 +422,13 @@
-         #       (so doing so is ridiculous, and nothing could rely on it).
-         b.write(struct.pack(b'>h28pI2shI64pII4s4shhI2s10s',
-                             self.target.kind,
--                            carbon_volname, voldate,
-+                            carbon_volname, int(voldate),
-                             self.volume.fs_type,
-                             self.volume.disk_type,
-                             self.target.folder_cnid,
-                             carbon_filename,
-                             self.target.cnid,
--                            crdate,
-+                            int(crdate),
-                             self.target.creator_code,
-                             self.target.type_code,
-                             self.target.levels_from,
-@@ -449,12 +449,12 @@
+@@ -467,12 +467,12 @@
  
          b.write(struct.pack(b'>hhQhhQ',
                  TAG_HIGH_RES_VOLUME_CREATION_DATE,


### PR DESCRIPTION
mac_alias and ds_store have moved from Bitbucket to GitHub. 
See https://github.com/al45tair/mac_alias and https://github.com/al45tair/ds_store.

mac_alias has been updated to be compatible with Python 3? ~~~so we should be able to drop our patch.~~~ I've dropped some of the patch for now.

Quickly tested on macOS, because depends building is broken with latest the Xcode see #11461.
Related #8134.