### PR TITLE
Fix typos. Use nullptr instead of NULL.

### DIFF
--- a/contrib/verify-commits/verify-commits.sh
+++ b/contrib/verify-commits/verify-commits.sh
@@ -39,7 +39,7 @@ PREV_COMMIT=""
 while true; do
 	if [ "$CURRENT_COMMIT" = $VERIFIED_ROOT ]; then
 		echo "There is a valid path from "$CURRENT_COMMIT" to $VERIFIED_ROOT where all commits are signed!"
-		exit 0;
+		exit 0
 	fi
 
 	if [ "$CURRENT_COMMIT" = $VERIFIED_SHA512_ROOT ]; then

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -291,7 +291,7 @@ struct ProxyCredentials
     std::string password;
 };
 
-/** Convert SOCKS5 reply to a an error message */
+/** Convert SOCKS5 reply to an error message */
 std::string Socks5ErrorString(uint8_t err)
 {
     switch(err) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3870,7 +3870,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         // Top up the keypool
         if (!walletInstance->TopUpKeyPool()) {
             InitError(_("Unable to generate initial keys") += "\n");
-            return NULL;
+            return nullptr;
         }
 
         walletInstance->SetBestChain(chainActive.GetLocator());


### PR DESCRIPTION
Minor cleanups:
* Typo: Fix a vs. an typo
* Typo: Remove accidental stray semicolon (only remaining instance in repo)
* Correctness/consistency: Use `nullptr` instead of `NULL` (only remaining instance in repo)