### PR TITLE
[Qt] Optimize SendToSelf rendering with a single non-change output

### DIFF
--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -94,10 +94,23 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
         if (fAllFromMe && fAllToMe)
         {
+            std::string address;
+            if (wtx.tx->vout.size() == 2)
+            {
+                for (const CTxOut& txout : wtx.tx->vout)
+                {
+                    if (wallet->IsChange(txout)) continue;
+
+                    CTxDestination destination;
+                    if (ExtractDestination(txout.scriptPubKey, destination))
+                    {
+                        address = EncodeDestination(destination);
+                    }
+                }
+            }
             // Payment to self
             CAmount nChange = wtx.GetChange();
-
-            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, "",
+            parts.append(TransactionRecord(hash, nTime, TransactionRecord::SendToSelf, address,
                             -(nDebit - nChange), nCredit - nChange));
             parts.last().involvesWatchAddress = involvesWatchAddress;   // maybe pass to TransactionRecord as constructor argument
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -423,6 +423,8 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     case TransactionRecord::SendToOther:
         return QString::fromStdString(wtx->address) + watchAddress;
     case TransactionRecord::SendToSelf:
+        /* Falls through. */
+        if (!wtx->address.empty()) { return lookupAddress(wtx->address, tooltip) + watchAddress; }
     default:
         return tr("(n/a)") + watchAddress;
     }


### PR DESCRIPTION
Partially fixes #11464

This is a simple improvement to render singe non-change output self-to-self transactions with the corresponding output-address/label.
Multi non-change output self-to-self transaction do keep the `(n.a.)` label (we could show all the addresses coma separated).

Screen:
<img width="917" alt="bildschirmfoto 2017-10-09 um 14 18 13" src="https://user-images.githubusercontent.com/178464/31358984-c627acfa-acfc-11e7-990d-8c176c1cb201.png">
