### PR TITLE
qa: Make tmpdir option an absolute path, misc cleanup

### DIFF
--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -103,7 +103,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         test_node.send_message(msg_block(blocks_h2[0]))
         white_node.send_message(msg_block(blocks_h2[1]))
 
-        [ x.sync_with_ping() for x in [test_node, white_node] ]
+        for x in [test_node, white_node]:
+            x.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 2)
         assert_equal(self.nodes[1].getblockcount(), 2)
         self.log.info("First height 2 block accepted by both nodes")
@@ -116,7 +117,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         test_node.send_message(msg_block(blocks_h2f[0]))
         white_node.send_message(msg_block(blocks_h2f[1]))
 
-        [ x.sync_with_ping() for x in [test_node, white_node] ]
+        for x in [test_node, white_node]:
+            x.sync_with_ping()
         for x in self.nodes[0].getchaintips():
             if x['hash'] == blocks_h2f[0].hash:
                 assert_equal(x['status'], "headers-only")
@@ -135,7 +137,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         test_node.send_message(msg_block(blocks_h3[0]))
         white_node.send_message(msg_block(blocks_h3[1]))
 
-        [ x.sync_with_ping() for x in [test_node, white_node] ]
+        for x in [test_node, white_node]:
+            x.sync_with_ping()
         # Since the earlier block was not processed by node0, the new block
         # can't be fully validated.
         for x in self.nodes[0].getchaintips():

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1615,7 +1615,6 @@ class NodeConnCB(object):
         test_function = lambda: self.last_message.get("pong") and self.last_message["pong"].nonce == self.ping_counter
         wait_until(test_function, timeout=timeout, lock=mininode_lock)
         self.ping_counter += 1
-        return True
 
 # The actual NodeConn class
 # This class provides an interface for a p2p connection to a specified node

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -102,8 +102,11 @@ class BitcoinTestFramework(object):
 
         check_json_precision()
 
+        self.options.cachedir = os.path.abspath(self.options.cachedir)
+
         # Set up temp directory and start logging
         if self.options.tmpdir:
+            self.options.tmpdir = os.path.abspath(self.options.tmpdir)
             os.makedirs(self.options.tmpdir, exist_ok=False)
         else:
             self.options.tmpdir = tempfile.mkdtemp(prefix="test")


### PR DESCRIPTION
This should fix issues with the multiwallet test and its symlinks
when the tmpdir is a relative path.

Rather than fixing os.symlink to work with paths relative to a
directory descriptor, which does not work on Windows, normalize
the path instead.