### PR TITLE
Fixing pointer asterisk

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -48,7 +48,7 @@ CBlockLocator CChain::GetLocator(const CBlockIndex *pindex) const {
     return CBlockLocator(vHave);
 }
 
-const CBlockIndex *CChain::FindFork(const CBlockIndex *pindex) const {
+const CBlockIndex* CChain::FindFork(const CBlockIndex *pindex) const {
     if (pindex == nullptr) {
         return nullptr;
     }


### PR DESCRIPTION

The pointer asterisk for const FindFork was not conforming to the rest of the functions' placement of an asterisk. I read the contributing guidelines and code styling and could find nothing about this, but when I was looking through the code it caught my eye.