### PR TITLE
[rpc] mempoolinfo should take ::minRelayTxFee into account

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1345,7 +1345,7 @@ UniValue mempoolInfoToJSON()
     ret.push_back(Pair("usage", (int64_t) mempool.DynamicMemoryUsage()));
     size_t maxmempool = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
-    ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK())));
+    ret.push_back(Pair("mempoolminfee", ValueFromAmount(std::max(mempool.GetMinFee(maxmempool), ::minRelayTxFee).GetFeePerK())));
 
     return ret;
 }

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -33,6 +33,9 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listunspent()), 0)
         assert_equal(len(self.nodes[2].listunspent()), 0)
 
+        self.log.info("Check for mempoolminfee in getmempoolinfo")
+        assert_equal(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+
         self.log.info("Mining blocks...")
 
         self.nodes[0].generate(1)


### PR DESCRIPTION
Fixes #6941 following https://github.com/bitcoin/bitcoin/pull/11410#issuecomment-332991078 's suggestion

This takes care of the mentioned ticket without changing the behavior of https://github.com/bitcoin/bitcoin/pull/11410/files#diff-24efdb00bfbe56b140fb006b562cc70bL629

By modifying https://github.com/bitcoin/bitcoin/blob/5a9da37fb3f4b53f556e1d46509b94dc3c661d75/src/txmempool.cpp#L984 the syncing mempools becomes problematic as per https://github.com/bitcoin/bitcoin/pull/11410#issuecomment-333868390

~~Same code causes different tests to fail: https://travis-ci.org/bitcoin/bitcoin/jobs/286128241 https://travis-ci.org/bitcoin/bitcoin/jobs/286128241 . I can't reproduce the problems locally, am I doing something wrong?~~ travis sometimes fails unexpectedly