### PR TITLE
Use CPrivKey typedef for keydata in CKey

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -42,8 +42,8 @@ private:
     //! Whether the public key corresponding to this private key is (to be) compressed.
     bool fCompressed;
 
-    //! The actual byte data
-    std::vector<unsigned char, secure_allocator<unsigned char> > keydata;
+    //! A generic storage of bytes using secure allocators
+    CPrivKey keydata;
 
     //! Check whether the 32-byte array pointed to by vch is valid keydata.
     bool static Check(const unsigned char* vch);


### PR DESCRIPTION
Seems like the `keydata` member variable in `CKey` should be a `CPrivKey` type.  Is there a reason it was re-declared  as a `std::vector<unsigned char, secure_allocator<unsigned char> >` and the `CPrivKey` typedef isn't used?