### PR TITLE
Optional update rescan option in importmulti RPC

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1189,6 +1189,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
                     {"options", RPCArg::Type::OBJ, /* opt */ true, /* default_val */ "null", "",
                         {
                             {"rescan", RPCArg::Type::BOOL, /* opt */ true, /* default_val */ "true", "Stating if should rescan the blockchain after all imports"},
+                            {"update", RPCArg::Type::BOOL, /* opt */ true, /* default_val */ "true", "Stating if rescan should notify existent transactions"},
                         },
                         "\"options\""},
                 }}
@@ -1210,12 +1211,17 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     //Default options
     bool fRescan = true;
+    bool update = true;
 
     if (!mainRequest.params[1].isNull()) {
         const UniValue& options = mainRequest.params[1];
 
         if (options.exists("rescan")) {
             fRescan = options["rescan"].get_bool();
+        }
+
+        if (options.exists("update")) {
+            update = options["update"].get_bool();
         }
     }
 
@@ -1268,7 +1274,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
         }
     }
     if (fRescan && fRunScan && requests.size()) {
-        int64_t scannedTime = pwallet->RescanFromTime(nLowestTimestamp, reserver, true /* update */);
+        int64_t scannedTime = pwallet->RescanFromTime(nLowestTimestamp, reserver, update /* update */);
         pwallet->ReacceptWalletTransactions();
 
         if (pwallet->IsAbortingRescan()) {


### PR DESCRIPTION
This PR adds a new option `rescanUpdate` in `importmulti` RPC method to optionally do not rescan transactions that already exist in the wallet. 

This is very important for large wallets when importing a single address with a old timestamp, which in this moment triggers a rescan to the whole wallet, replaying several already known wallet events (via notify-wallet). 