### PR TITLE
Add `available` field to listwallets RPC

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -91,6 +91,10 @@ Low-level RPC changes
 - The wallet RPC `getreceivedbyaddress` will return an error if called with an address not in the wallet.
 
 
+- `listwallets` now returns two arrays of wallet names, one listing the `loaded` wallets
+  and one listing the `available` BDB database files in the wallet directory (generally these
+  will be wallets but may return false positives if there are other BDB files present).
+
 Credits
 =======
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2746,12 +2746,13 @@ UniValue listwallets(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() != 0)
         throw std::runtime_error(
             "listwallets\n"
-            "Returns a list of currently loaded wallets.\n"
-            "For full information on the wallet, use \"getwalletinfo\"\n"
+            "Returns a list of currently loaded wallets, and a list of potential wallet files in the wallet directory.\n"
+            "For full information about a loaded wallet, use \"getwalletinfo\"\n"
             "\nResult:\n"
             "{\n"
             "  \"loaded\":     [ \"walletname\" ... ] (json array of strings) Names of loaded wallets\n"
-            "  \"available\":  [ \"walletname\" ... ] (json array of strings) Names of BDB files in wallet directory (may not always actually be wallets)\n"
+            "  \"available\":  [ \"walletname\" ... ] (json array of strings) Names of BDB files in wallet directory"
+            "           (may not always actually be wallets, e.g. other files from pre-0.8, or may include duplicate wallets which cannot be opened simultaneously)\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("listwallets", "")


### PR DESCRIPTION
Modifies `listwallets` to return a list of 'available' wallets in the wallet directory, by looking for the BDB magic bytes (`0x00053162` source: https://github.com/file/file/blob/master/magic/Magdir/database) . 

This is a breaking change to listwallets, but multiwallet RPC calls are experimental in 0.15 so shouldn't be a big concern to change it. c.f. @jnewbery's comment [here](https://github.com/bitcoin/bitcoin/pull/11466#discussion_r143791327). Split from #11466.

Would be great if someone could confirm if this is endianness independent too :)