### PR TITLE
 Check that new headers are not a descendant of an invalid block

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2396,7 +2396,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         // unless we're still syncing with the network.
         // Such an unrequested block may still be processed, subject to the
         // conditions in AcceptBlock().
-        bool forceProcessing = pfrom->fWhitelisted && !IsInitialBlockDownload();
+        bool forceProcessing = false;
         const uint256 hash(pblock->GetHash());
         {
             LOCK(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3113,7 +3113,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     // process an unrequested block if it's new and has enough work to
     // advance our tip, and isn't too many blocks ahead.
     bool fAlreadyHave = pindex->nStatus & BLOCK_HAVE_DATA;
-    bool fHasMoreWork = (chainActive.Tip() ? pindex->nChainWork > chainActive.Tip()->nChainWork : true);
+    bool fHasMoreOrSameWork = (chainActive.Tip() ? pindex->nChainWork >= chainActive.Tip()->nChainWork : true);
     // Blocks that are too out-of-order needlessly limit the effectiveness of
     // pruning, because pruning will not delete block files that contain any
     // blocks which are too close in height to the tip.  Apply this test
@@ -3130,9 +3130,9 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     // and unrequested blocks.
     if (fAlreadyHave) return true;
     if (!fRequested) {  // If we didn't ask for it:
-        if (pindex->nTx != 0) return true;  // This is a previously-processed block that was pruned
-        if (!fHasMoreWork) return true;     // Don't process less-work chains
-        if (fTooFarAhead) return true;      // Block height is too high
+        if (pindex->nTx != 0) return true;    // This is a previously-processed block that was pruned
+        if (!fHasMoreOrSameWork) return true; // Don't process less-work chains
+        if (fTooFarAhead) return true;        // Block height is too high
     }
     if (fNewBlock) *fNewBlock = true;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3032,7 +3032,17 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     return true;
 }
 
-static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex)
+/**
+ * Validates and stores a new block header.
+ *
+ * Returns the new CBlockIndex in ppindex.
+ *
+ * known_not_failed_index may be provided to speed up validation. It must be a
+ * block which is known to have no failed parents (ie for which that fact was
+ * checked in the same cs_main context, eg something which was added via
+ * AcceptBlockHeader in the same cs_main lock).
+ */
+static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, CBlockIndex* known_not_failed_index)
 {
     AssertLockHeld(cs_main);
     // Check for duplicate
@@ -3064,6 +3074,20 @@ static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state
             return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
         if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
             return error("%s: Consensus::ContextualCheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
+
+        CBlockIndex* walk_index = pindexPrev;
+        while (walk_index && !walk_index->IsValid(BLOCK_VALID_SCRIPTS) && walk_index != known_not_failed_index) {
+            if (walk_index->nStatus & BLOCK_FAILED_MASK) {
+                CBlockIndex* invalid_walk_index = pindexPrev;
+                while (invalid_walk_index != walk_index) {
+                    invalid_walk_index->nStatus |= BLOCK_FAILED_CHILD;
+                    setDirtyBlockIndex.insert(invalid_walk_index);
+                    invalid_walk_index = invalid_walk_index->pprev;
+                }
+                return state.DoS(100, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+            }
+            walk_index = walk_index->pprev;
+        }
     }
     if (pindex == nullptr)
         pindex = AddToBlockIndex(block);
@@ -3081,9 +3105,9 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
 {
     {
         LOCK(cs_main);
+        CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
         for (const CBlockHeader& header : headers) {
-            CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
-            if (!AcceptBlockHeader(header, state, chainparams, &pindex)) {
+            if (!AcceptBlockHeader(header, state, chainparams, &pindex, pindex)) {
                 return false;
             }
             if (ppindex) {
@@ -3106,7 +3130,7 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
     CBlockIndex *pindexDummy = nullptr;
     CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
 
-    if (!AcceptBlockHeader(block, state, chainparams, &pindex))
+    if (!AcceptBlockHeader(block, state, chainparams, &pindex, nullptr))
         return false;
 
     // Try to process all requested blocks that we don't have, but only

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -35,13 +35,18 @@ The test:
 
 7. Send Node0 the missing block again.
    Node0 should process and the tip should advance.
+
+8. Create a fork which is invalid at a height longer than the current chain
+   (ie to which the node will try to reorg) but which has headers built on top
+   of the invalid block. Check that we get disconnected if we send more headers
+   on the chain the node now knows to be invalid.
 """
 
 from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 import time
-from test_framework.blocktools import create_block, create_coinbase
+from test_framework.blocktools import create_block, create_coinbase, create_transaction
 
 class AcceptBlockTest(BitcoinTestFramework):
     def add_options(self, parser):
@@ -220,7 +225,76 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 290)
+        self.nodes[0].getblock(all_blocks[286].hash)
+        assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash)
+        assert_raises_rpc_error(-1, "Block not found on disk", self.nodes[0].getblock, all_blocks[287].hash)
         self.log.info("Successfully reorged to longer chain from non-whitelisted peer")
+
+        # 8. Create a chain which is invalid at a height longer than the
+        # current chain, but which has more blocks on top of that
+        block_289f = create_block(all_blocks[284].sha256, create_coinbase(289), all_blocks[284].nTime+1)
+        block_289f.solve()
+        block_290f = create_block(block_289f.sha256, create_coinbase(290), block_289f.nTime+1)
+        block_290f.solve()
+        block_291 = create_block(block_290f.sha256, create_coinbase(291), block_290f.nTime+1)
+        # block_291 spends a coinbase below maturity!
+        block_291.vtx.append(create_transaction(block_290f.vtx[0], 0, b"42", 1))
+        block_291.hashMerkleRoot = block_291.calc_merkle_root()
+        block_291.solve()
+        block_292 = create_block(block_291.sha256, create_coinbase(292), block_291.nTime+1)
+        block_292.solve()
+
+        # Now send all the headers on the chain and enough blocks to trigger reorg
+        headers_message = msg_headers()
+        headers_message.headers.append(CBlockHeader(block_289f))
+        headers_message.headers.append(CBlockHeader(block_290f))
+        headers_message.headers.append(CBlockHeader(block_291))
+        headers_message.headers.append(CBlockHeader(block_292))
+        test_node.send_message(headers_message)
+
+        test_node.sync_with_ping()
+        tip_entry_found = False
+        for x in self.nodes[0].getchaintips():
+            if x['hash'] == block_292.hash:
+                assert_equal(x['status'], "headers-only")
+                tip_entry_found = True
+        assert(tip_entry_found)
+
+        test_node.send_message(msg_block(block_289f))
+        test_node.send_message(msg_block(block_290f))
+
+        test_node.sync_with_ping()
+        self.nodes[0].getblock(block_289f.hash)
+        self.nodes[0].getblock(block_290f.hash)
+
+        test_node.send_message(msg_block(block_291))
+
+        # At this point we've sent an obviously-bogus block, wait for full processing
+        # without assuming whether we will be disconnected or not
+        try:
+            test_node.sync_with_ping(timeout=1)
+        except AssertionError:
+            test_node.wait_for_disconnect()
+
+            test_node = NodeConnCB()   # connects to node (not whitelisted)
+            connections[0] = NodeConn('127.0.0.1', p2p_port(0), self.nodes[0], test_node)
+            test_node.add_connection(connections[0])
+
+            NetworkThread().start() # Start up network handling in another thread
+            test_node.wait_for_verack()
+
+        # We should have failed reorg and switched back to 290 (but have block 291)
+        assert_equal(self.nodes[0].getblockcount(), 290)
+        assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash)
+        assert_equal(self.nodes[0].getblock(block_291.hash)["confirmations"], -1)
+
+        # Now send a new header on the invalid chain, indicating we're forked off, and expect to get disconnected
+        block_293 = create_block(block_292.sha256, create_coinbase(293), block_292.nTime+1)
+        block_293.solve()
+        headers_message = msg_headers()
+        headers_message.headers.append(CBlockHeader(block_293))
+        test_node.send_message(headers_message)
+        test_node.wait_for_disconnect()
 
         [ c.disconnect_node() for c in connections ]
 

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -121,8 +121,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert(tip_entry_found)
 
         # But this block should be accepted by node since it has equal work.
-        # TODO: We currently drop this block but likely shouldn't
-        #self.nodes[0].getblock(block_h2f.hash)
+        self.nodes[0].getblock(block_h2f.hash)
         self.log.info("Second height 2 block accepted, but not reorg'ed to")
 
         # 4b. Now send another block that builds on the forking chain.
@@ -195,7 +194,6 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         test_node.wait_for_verack()
         test_node.send_message(msg_block(block_h1f))
-        test_node.send_message(msg_block(block_h2f)) # This should not be required
 
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 2)
@@ -219,7 +217,6 @@ class AcceptBlockTest(BitcoinTestFramework):
 
         # 7. Send the missing block for the third time (now it is requested)
         test_node.send_message(msg_block(block_h1f))
-        test_node.send_message(msg_block(block_h2f)) # This should not be required
 
         test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 290)


### PR DESCRIPTION
This is symmetric with the check in FindNextBlocksToDownload.
Because we do not mark all children of a failed block as invalid
during connection (we cannot walk down the block tree), this may
prevent accepting an invalid block/header.

Plus some other AcceptBlock cleanups.