### PR TITLE
Codeai fixes: remove dead code, prevent possible division by zero.

### DIFF
--- a/src/leveldb/db/log_reader.cc
+++ b/src/leveldb/db/log_reader.cc
@@ -99,7 +99,6 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch) {
           // of a block followed by a kFullType or kFirstType record
           // at the beginning of the next block.
           if (scratch->empty()) {
-            in_fragmented_record = false;
           } else {
             ReportCorruption(scratch->size(), "partial record without end(1)");
           }

--- a/src/leveldb/db/log_reader.cc
+++ b/src/leveldb/db/log_reader.cc
@@ -39,7 +39,6 @@ bool Reader::SkipToInitialBlock() {
 
   // Don't search a block if we'd be in the trailer
   if (offset_in_block > kBlockSize - 6) {
-    offset_in_block = 0;
     block_start_location += kBlockSize;
   }
 

--- a/src/leveldb/db/log_reader.cc
+++ b/src/leveldb/db/log_reader.cc
@@ -116,7 +116,6 @@ bool Reader::ReadRecord(Slice* record, std::string* scratch) {
           // of a block followed by a kFullType or kFirstType record
           // at the beginning of the next block.
           if (scratch->empty()) {
-            in_fragmented_record = false;
           } else {
             ReportCorruption(scratch->size(), "partial record without end(2)");
           }

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -13,6 +13,7 @@
 #include "streams.h"
 #include "txmempool.h"
 #include "util.h"
+#include <assert.h>
 
 static constexpr double INF_FEERATE = 1e99;
 
@@ -503,6 +504,7 @@ void TxConfirmStats::removeTx(unsigned int entryHeight, unsigned int nBestSeenHe
         }
     }
     if (!inBlock && (unsigned int)blocksAgo >= scale) { // Only counts as a failure if not confirmed for entire period
+        assert(this->scale != 0 && "this->scale is 0");
         unsigned int periodsAgo = blocksAgo / scale;
         for (size_t i = 0; i < periodsAgo && i < failAvg.size(); i++) {
             failAvg[i][bucketindex]++;

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -126,7 +126,6 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context* ctx, secp256k1
         return 0;
     }
     spos = pos;
-    pos += slen;
 
     /* Ignore leading zeroes in R */
     while (rlen > 0 && input[rpos] == 0) {


### PR DESCRIPTION
CodeAi suggests the removal of 4 lines of dead code in log_reader.cc and pubkey.cpp.

CodeAi suggests inserting a check for `scale` to prevent possible division by zero in fees.cpp.