### PR TITLE
[wallet] sendtoaddress output type argument

### DIFF
--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -17,6 +17,8 @@ class CCoinControl
 {
 public:
     CTxDestination destChange;
+    //! Style to use for change destination (if destChange unset)
+    OutputType m_change_type;
     //! If false, allows unselected inputs, but requires all selected inputs be used
     bool fAllowOtherInputs;
     //! Includes watch only addresses which match the ISMINE_WATCH_SOLVABLE criteria
@@ -40,6 +42,7 @@ public:
     void SetNull()
     {
         destChange = CNoDestination();
+        m_change_type = g_change_type;
         fAllowOtherInputs = false;
         fAllowWatchOnly = false;
         setSelected.clear();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -446,9 +446,10 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 9)
         throw std::runtime_error(
-            "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount replaceable conf_target \"estimate_mode\")\n"
+            std::string() +
+            "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount replaceable conf_target \"estimate_mode\" \"change_type\" )\n"
             "\nSend an amount to a given address.\n"
             + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
@@ -467,6 +468,7 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
             "       \"UNSET\"\n"
             "       \"ECONOMICAL\"\n"
             "       \"CONSERVATIVE\"\n"
+            "9. \"change_type\"        (string, optional, default=\"" + FormatOutputType(g_change_type) + "\") The address type to use for the change output. Valid options are \"p2pkh\", \"p2sh_p2wpkh\", and \"p2wpkh\"\n"
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
@@ -521,6 +523,12 @@ UniValue sendtoaddress(const JSONRPCRequest& request)
         }
     }
 
+    if (!request.params[8].isNull()) {
+        coin_control.m_change_type = ParseOutputType(request.params[8].get_str());
+        if (coin_control.m_change_type == OUTPUT_TYPE_NONE) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Unknown change address type '%s'", request.params[8].get_str()));
+        }
+    }
 
     EnsureWalletIsUnlocked(pwallet);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2739,8 +2739,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                     return false;
                 }
 
-                LearnRelatedScripts(vchPubKey, g_change_type);
-                scriptChange = GetScriptForDestination(GetDestinationForKey(vchPubKey, g_change_type));
+                LearnRelatedScripts(vchPubKey, coin_control.m_change_type);
+                scriptChange = GetScriptForDestination(GetDestinationForKey(vchPubKey, coin_control.m_change_type));
             }
             CTxOut change_prototype_txout(0, scriptChange);
             size_t change_prototype_size = GetSerializeSize(change_prototype_txout, SER_DISK, 0);


### PR DESCRIPTION
This is an attempt at fixing #11134.

It basically adds the output type flag as is, which is then used to generate the change destination.