### PR TITLE
Clarify BIP9 behaviour when nTimeout <= 0

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -29,7 +29,12 @@ struct BIP9Deployment {
     int bit;
     /** Start MedianTime for version bits miner confirmation. Can be a date in the past */
     int64_t nStartTime;
-    /** Timeout/expiry MedianTime for the deployment attempt. */
+    /** Timeout/expiry MedianTime for the deployment attempt.
+     * Setting to 0 will prevent advertising presence of softfork,
+     * allowing code to be merged without defining the softfork's
+     * activation parameters.
+     */
+
     int64_t nTimeout;
 };
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1597,10 +1597,8 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         }
     }
 
-    if (chainparams.GetConsensus().vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout != 0) {
+    if (chainparams.GetConsensus().vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout > 0) {
         // Only advertise witness capabilities if they have a reasonable start time.
-        // This allows us to have the code merged without a defined softfork, by setting its
-        // end time to 0.
         // Note that setting NODE_WITNESS is never required: the only downside from not
         // doing so is that after activation, no upgraded nodes will fetch from you.
         nLocalServices = ServiceFlags(nLocalServices | NODE_WITNESS);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2884,7 +2884,7 @@ std::vector<unsigned char> GenerateCoinbaseCommitment(CBlock& block, const CBloc
     std::vector<unsigned char> commitment;
     int commitpos = GetWitnessCommitmentIndex(block);
     std::vector<unsigned char> ret(32, 0x00);
-    if (consensusParams.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout != 0) {
+    if (consensusParams.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout > 0) {
         if (commitpos == -1) {
             uint256 witnessroot = BlockWitnessMerkleRoot(block, nullptr);
             CHash256().Write(witnessroot.begin(), 32).Write(ret.data(), 32).Finalize(witnessroot.begin());


### PR DESCRIPTION
Adds a comment in the BIP9Deployment class declaration for when to set
nTimeout=0, and changes the checks for (nTimeout!=0) to (nTimeout>0)
for consistency.

The remaining comparison for nTimeout is in rpc/blockchain.cpp:BIP9SoftForkDescPushBack which already checks for >0 rather than !=0.

Compatible with #11389 which adds another special case behaviour (negative nStartTime) for defining "BIP9" deployments.