### PR TITLE
[trivial] Make namespace explicit for is_regular_file

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -588,7 +588,7 @@ void CleanupBlockRevFiles()
     LogPrintf("Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune\n");
     fs::path blocksdir = GetDataDir() / "blocks";
     for (fs::directory_iterator it(blocksdir); it != fs::directory_iterator(); it++) {
-        if (is_regular_file(*it) &&
+        if (fs::is_regular_file(*it) &&
             it->path().filename().string().length() == 12 &&
             it->path().filename().string().substr(8,4) == ".dat")
         {


### PR DESCRIPTION
is_regular_file resolves using argument dependent lookup. Make the
namespace explicit so it's obvious where the function is defined.

For those not familiar with argument dependent lookups:

- http://en.cppreference.com/w/cpp/language/adl
- https://en.wikipedia.org/wiki/Argument-dependent_name_lookup

Thanks to C++ guru @ryanofsky for pointing this out to me.