### PR TITLE
[Trivial] Add missing comma from rescanblockchain example

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3233,7 +3233,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("rescanblockchain", "100000 120000")
-            + HelpExampleRpc("rescanblockchain", "100000 120000")
+            + HelpExampleRpc("rescanblockchain", "100000, 120000")
             );
     }
 


### PR DESCRIPTION
#7061 forgot a comma in the HelpExampleRpc() for the rescanblockchain RPC, giving an incorrect example command output:
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "rescanblockchain", "params": [100000 120000] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/

Was just missed during nit-fixing. This is a trivial fix to add that comma in.