### PR TITLE
Fix crash via division by zero assertion

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -582,8 +582,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     QString toolTipDust = tr("This label turns red if any recipient receives an amount smaller than the current dust threshold.");
 
     // how many satoshis the estimated fee can vary per byte we guess wrong
-    assert(nBytes != 0);
-    double dFeeVary = (double)nPayFee / nBytes;
+    double dFeeVary = (nBytes != 0) ? (double)nPayFee / nBytes : 0;
 
     QString toolTip4 = tr("Can vary +/- %1 satoshi(s) per input.").arg(dFeeVary);
 


### PR DESCRIPTION
Replaces the newly added `assert` for a devision by zero protection by a control structure. Floating point division by zero is defined by the floating point standard and results in +inf or -inf.

Introduced in #11133
Reported by @mzhou, fixes #11501