### PR TITLE
Avoid assertion failure in coin control dialog. Fixes #11501.

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -582,8 +582,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
     QString toolTipDust = tr("This label turns red if any recipient receives an amount smaller than the current dust threshold.");
 
     // how many satoshis the estimated fee can vary per byte we guess wrong
-    assert(nBytes != 0);
-    double dFeeVary = (double)nPayFee / nBytes;
+    double dFeeVary = nBytes != 0 ? (double)nPayFee / nBytes : 0;
 
     QString toolTip4 = tr("Can vary +/- %1 satoshi(s) per input.").arg(dFeeVary);
 


### PR DESCRIPTION
Avoid assertion failure in coin control dialog. Fixes #11501.

Fix suggested by @MeshCollider in https://github.com/bitcoin/bitcoin/issues/11501#issuecomment-336735830:

> Perhaps instead of the assert(), dFeeVary should just be set to 0 if nBytes is 0.