### PR TITLE
[Init] Remove redundant exit(EXIT_FAILURE) instances and replace with return false

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -120,7 +120,7 @@ bool AppInit(int argc, char* argv[])
         for (int i = 1; i < argc; i++) {
             if (!IsSwitchChar(argv[i][0])) {
                 fprintf(stderr, "Error: Command line contains unexpected token '%s', see bitcoind -h for a list of options.\n", argv[i]);
-                exit(EXIT_FAILURE);
+                return false;
             }
         }
 
@@ -132,17 +132,17 @@ bool AppInit(int argc, char* argv[])
         if (!AppInitBasicSetup())
         {
             // InitError will have been called with detailed error, which ends up on console
-            exit(EXIT_FAILURE);
+            return false;
         }
         if (!AppInitParameterInteraction())
         {
             // InitError will have been called with detailed error, which ends up on console
-            exit(EXIT_FAILURE);
+            return false;
         }
         if (!AppInitSanityChecks())
         {
             // InitError will have been called with detailed error, which ends up on console
-            exit(EXIT_FAILURE);
+            return false;
         }
         if (gArgs.GetBoolArg("-daemon", false))
         {
@@ -163,7 +163,7 @@ bool AppInit(int argc, char* argv[])
         if (!AppInitLockDataDirectory())
         {
             // If locking the data directory failed, exit immediately
-            exit(EXIT_FAILURE);
+            return false;
         }
         fRet = AppInitMain(threadGroup, scheduler);
     }


### PR DESCRIPTION
While reviewing the bitcoin code I noticed that there are a few exit(EXIT_FAILURE) at various places in the AppInit function.

This function returns to main() which will return/exit with EXIT_FAILURE so returning false instead of an explicit exit(EXIT_FAILURE) seems to be cleaner.

This PR attempts to make things a bit more consistent.

There is a subtle difference between exit() and return from main in that the exit() will not clean up any local vars but I don't think this makes a difference in this case. Using exit() might even lead to bugs in the future where the dtor of local objects are expected to be called.