### PR TITLE
[trivial] [tests] A few Python3 tidy ups

### DIFF
--- a/test/functional/p2p-fullblocktest.py
+++ b/test/functional/p2p-fullblocktest.py
@@ -20,7 +20,7 @@ from test_framework.key import CECKey
 from test_framework.script import *
 import struct
 
-class PreviousSpendableOutput(object):
+class PreviousSpendableOutput():
     def __init__(self, tx = CTransaction(), n = -1):
         self.tx = tx
         self.n = n  # the output we're spending

--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -89,7 +89,7 @@ class TestNode(NodeConnCB):
         assert_equal(self.connection.rpc.getbestblockhash() == block.hash, accepted)
 
 # Used to keep track of anyone-can-spend outputs that we can use in the tests
-class UTXO(object):
+class UTXO():
     def __init__(self, sha256, n, nValue):
         self.sha256 = sha256
         self.n = n

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -62,7 +62,7 @@ def EncodeDecimal(o):
         return str(o)
     raise TypeError(repr(o) + " is not JSON serializable")
 
-class AuthServiceProxy(object):
+class AuthServiceProxy():
     __id_count = 0
 
     # ensure_ascii: escape unicode as \uXXXX, passed to json.dumps

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -33,20 +33,14 @@ ServiceProxy class:
 - uses standard Python json lib
 """
 
-try:
-    import http.client as httplib
-except ImportError:
-    import httplib
 import base64
 import decimal
+import http.client
 import json
 import logging
 import socket
 import time
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import urllib.parse
 
 USER_AGENT = "AuthServiceProxy/0.1"
 
@@ -60,7 +54,7 @@ class JSONRPCException(Exception):
             errmsg = '%(message)s (%(code)i)' % rpc_error
         except (KeyError, TypeError):
             errmsg = ''
-        Exception.__init__(self, errmsg)
+        super().__init__(errmsg)
         self.error = rpc_error
 
 
@@ -77,7 +71,7 @@ class AuthServiceProxy(object):
         self.__service_url = service_url
         self._service_name = service_name
         self.ensure_ascii = ensure_ascii # can be toggled on the fly by tests
-        self.__url = urlparse.urlparse(service_url)
+        self.__url = urllib.parse.urlparse(service_url)
         if self.__url.port is None:
             port = 80
         else:
@@ -98,10 +92,10 @@ class AuthServiceProxy(object):
             # Callables re-use the connection of the original proxy
             self.__conn = connection
         elif self.__url.scheme == 'https':
-            self.__conn = httplib.HTTPSConnection(self.__url.hostname, port,
+            self.__conn = http.client.HTTPSConnection(self.__url.hostname, port,
                                                   timeout=timeout)
         else:
-            self.__conn = httplib.HTTPConnection(self.__url.hostname, port,
+            self.__conn = http.client.HTTPConnection(self.__url.hostname, port,
                                                  timeout=timeout)
 
     def __getattr__(self, name):
@@ -124,7 +118,7 @@ class AuthServiceProxy(object):
         try:
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()
-        except httplib.BadStatusLine as e:
+        except http.client.BadStatusLine as e:
             if e.line == "''": # if connection was closed, try again
                 self.__conn.close()
                 self.__conn.request(method, path, postdata, headers)

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -42,9 +42,8 @@ import socket
 import time
 import urllib.parse
 
-USER_AGENT = "AuthServiceProxy/0.1"
-
 HTTP_TIMEOUT = 30
+USER_AGENT = "AuthServiceProxy/0.1"
 
 log = logging.getLogger("BitcoinRPC")
 
@@ -70,7 +69,7 @@ class AuthServiceProxy(object):
     def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, ensure_ascii=True):
         self.__service_url = service_url
         self._service_name = service_name
-        self.ensure_ascii = ensure_ascii # can be toggled on the fly by tests
+        self.ensure_ascii = ensure_ascii  # can be toggled on the fly by tests
         self.__url = urllib.parse.urlparse(service_url)
         if self.__url.port is None:
             port = 80
@@ -92,11 +91,9 @@ class AuthServiceProxy(object):
             # Callables re-use the connection of the original proxy
             self.__conn = connection
         elif self.__url.scheme == 'https':
-            self.__conn = http.client.HTTPSConnection(self.__url.hostname, port,
-                                                  timeout=timeout)
+            self.__conn = http.client.HTTPSConnection(self.__url.hostname, port, timeout=timeout)
         else:
-            self.__conn = http.client.HTTPConnection(self.__url.hostname, port,
-                                                 timeout=timeout)
+            self.__conn = http.client.HTTPConnection(self.__url.hostname, port, timeout=timeout)
 
     def __getattr__(self, name):
         if name.startswith('__') and name.endswith('__'):
@@ -119,13 +116,13 @@ class AuthServiceProxy(object):
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()
         except http.client.BadStatusLine as e:
-            if e.line == "''": # if connection was closed, try again
+            if e.line == "''":  # if connection was closed, try again
                 self.__conn.close()
                 self.__conn.request(method, path, postdata, headers)
                 return self._get_response()
             else:
                 raise
-        except (BrokenPipeError,ConnectionResetError):
+        except (BrokenPipeError, ConnectionResetError):
             # Python 3.5+ raises BrokenPipeError instead of BadStatusLine when the connection was reset
             # ConnectionResetError happens on FreeBSD with Python 3.4
             self.__conn.close()
@@ -135,8 +132,8 @@ class AuthServiceProxy(object):
     def get_request(self, *args, **argsn):
         AuthServiceProxy.__id_count += 1
 
-        log.debug("-%s-> %s %s"%(AuthServiceProxy.__id_count, self._service_name,
-                                 json.dumps(args, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
+        log.debug("-%s-> %s %s" % (AuthServiceProxy.__id_count, self._service_name,
+                                   json.dumps(args, default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
         if args and argsn:
             raise ValueError('Cannot handle both named and positional arguments')
         return {'version': '1.1',
@@ -157,7 +154,7 @@ class AuthServiceProxy(object):
 
     def batch(self, rpc_call_list):
         postdata = json.dumps(list(rpc_call_list), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
-        log.debug("--> "+postdata)
+        log.debug("--> " + postdata)
         return self._request('POST', self.__url.path, postdata.encode('utf-8'))
 
     def _get_response(self):
@@ -184,9 +181,9 @@ class AuthServiceProxy(object):
         response = json.loads(responsedata, parse_float=decimal.Decimal)
         elapsed = time.time() - req_start_time
         if "error" in response and response["error"] is None:
-            log.debug("<-%s- [%.6f] %s"%(response["id"], elapsed, json.dumps(response["result"], default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
+            log.debug("<-%s- [%.6f] %s" % (response["id"], elapsed, json.dumps(response["result"], default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
         else:
-            log.debug("<-- [%.6f] %s"%(elapsed,responsedata))
+            log.debug("<-- [%.6f] %s" % (elapsed, responsedata))
         return response
 
     def __truediv__(self, relative_uri):

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -71,19 +71,9 @@ class AuthServiceProxy(object):
         self._service_name = service_name
         self.ensure_ascii = ensure_ascii  # can be toggled on the fly by tests
         self.__url = urllib.parse.urlparse(service_url)
-        if self.__url.port is None:
-            port = 80
-        else:
-            port = self.__url.port
-        (user, passwd) = (self.__url.username, self.__url.password)
-        try:
-            user = user.encode('utf8')
-        except AttributeError:
-            pass
-        try:
-            passwd = passwd.encode('utf8')
-        except AttributeError:
-            pass
+        port = 80 if self.__url.port is None else self.__url.port
+        user = None if self.__url.username is None else self.__url.username.encode('utf8')
+        passwd = None if self.__url.password is None else self.__url.password.encode('utf8')
         authpair = user + b':' + passwd
         self.__auth_header = b'Basic ' + base64.b64encode(authpair)
 

--- a/test/functional/test_framework/blockstore.py
+++ b/test/functional/test_framework/blockstore.py
@@ -10,7 +10,7 @@ import dbm.dumb as dbmd
 
 logger = logging.getLogger("TestFramework.blockstore")
 
-class BlockStore(object):
+class BlockStore():
     """BlockStore helper class.
 
     BlockStore keeps a map of blocks and implements helper functions for
@@ -127,7 +127,7 @@ class BlockStore(object):
         locator.vHave = r
         return locator
 
-class TxStore(object):
+class TxStore():
     def __init__(self, datadir):
         self.txDB = dbmd.open(datadir + "/transactions", 'c')
 

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -27,7 +27,7 @@ logger=logging.getLogger("TestFramework.comptool")
 
 global mininode_lock
 
-class RejectResult(object):
+class RejectResult():
     """Outcome that expects rejection of a transaction or block."""
     def __init__(self, code, reason=b''):
         self.code = code
@@ -156,13 +156,13 @@ class TestNode(NodeConnCB):
 #    across all connections.  (If outcome of final tx is specified as true
 #    or false, then only the last tx is tested against outcome.)
 
-class TestInstance(object):
+class TestInstance():
     def __init__(self, objects=None, sync_every_block=True, sync_every_tx=False):
         self.blocks_and_transactions = objects if objects else []
         self.sync_every_block = sync_every_block
         self.sync_every_tx = sync_every_tx
 
-class TestManager(object):
+class TestManager():
 
     def __init__(self, testgen, datadir):
         self.test_generator = testgen

--- a/test/functional/test_framework/coverage.py
+++ b/test/functional/test_framework/coverage.py
@@ -14,7 +14,7 @@ import os
 REFERENCE_FILENAME = 'rpc_interface.txt'
 
 
-class AuthServiceProxyWrapper(object):
+class AuthServiceProxyWrapper():
     """
     An object that wraps AuthServiceProxy to record specific RPC calls.
 

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -84,7 +84,7 @@ def _check_result(val, func, args):
 ssl.EC_KEY_new_by_curve_name.restype = ctypes.c_void_p
 ssl.EC_KEY_new_by_curve_name.errcheck = _check_result
 
-class CECKey(object):
+class CECKey():
     """Wrapper around OpenSSL's EC_KEY"""
 
     POINT_CONVERSION_COMPRESSED = 2

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -219,7 +219,7 @@ def ToHex(obj):
 
 # Objects that map to bitcoind objects, which can be serialized/deserialized
 
-class CAddress(object):
+class CAddress():
     def __init__(self):
         self.nServices = 1
         self.pchReserved = b"\x00" * 10 + b"\xff" * 2
@@ -246,7 +246,7 @@ class CAddress(object):
 
 MSG_WITNESS_FLAG = 1<<30
 
-class CInv(object):
+class CInv():
     typemap = {
         0: "Error",
         1: "TX",
@@ -275,7 +275,7 @@ class CInv(object):
             % (self.typemap[self.type], self.hash)
 
 
-class CBlockLocator(object):
+class CBlockLocator():
     def __init__(self):
         self.nVersion = MY_VERSION
         self.vHave = []
@@ -295,7 +295,7 @@ class CBlockLocator(object):
             % (self.nVersion, repr(self.vHave))
 
 
-class COutPoint(object):
+class COutPoint():
     def __init__(self, hash=0, n=0):
         self.hash = hash
         self.n = n
@@ -314,7 +314,7 @@ class COutPoint(object):
         return "COutPoint(hash=%064x n=%i)" % (self.hash, self.n)
 
 
-class CTxIn(object):
+class CTxIn():
     def __init__(self, outpoint=None, scriptSig=b"", nSequence=0):
         if outpoint is None:
             self.prevout = COutPoint()
@@ -342,7 +342,7 @@ class CTxIn(object):
                self.nSequence)
 
 
-class CTxOut(object):
+class CTxOut():
     def __init__(self, nValue=0, scriptPubKey=b""):
         self.nValue = nValue
         self.scriptPubKey = scriptPubKey
@@ -363,7 +363,7 @@ class CTxOut(object):
                bytes_to_hex_str(self.scriptPubKey))
 
 
-class CScriptWitness(object):
+class CScriptWitness():
     def __init__(self):
         # stack is a vector of strings
         self.stack = []
@@ -378,7 +378,7 @@ class CScriptWitness(object):
         return True
 
 
-class CTxInWitness(object):
+class CTxInWitness():
     def __init__(self):
         self.scriptWitness = CScriptWitness()
 
@@ -395,7 +395,7 @@ class CTxInWitness(object):
         return self.scriptWitness.is_null()
 
 
-class CTxWitness(object):
+class CTxWitness():
     def __init__(self):
         self.vtxinwit = []
 
@@ -423,7 +423,7 @@ class CTxWitness(object):
         return True
 
 
-class CTransaction(object):
+class CTransaction():
     def __init__(self, tx=None):
         if tx is None:
             self.nVersion = 1
@@ -526,7 +526,7 @@ class CTransaction(object):
             % (self.nVersion, repr(self.vin), repr(self.vout), repr(self.wit), self.nLockTime)
 
 
-class CBlockHeader(object):
+class CBlockHeader():
     def __init__(self, header=None):
         if header is None:
             self.set_null()
@@ -666,7 +666,7 @@ class CBlock(CBlockHeader):
                time.ctime(self.nTime), self.nBits, self.nNonce, repr(self.vtx))
 
 
-class CUnsignedAlert(object):
+class CUnsignedAlert():
     def __init__(self):
         self.nVersion = 1
         self.nRelayUntil = 0
@@ -721,7 +721,7 @@ class CUnsignedAlert(object):
                self.strComment, self.strStatusBar, self.strReserved)
 
 
-class CAlert(object):
+class CAlert():
     def __init__(self):
         self.vchMsg = b""
         self.vchSig = b""
@@ -741,7 +741,7 @@ class CAlert(object):
             % (len(self.vchMsg), len(self.vchSig))
 
 
-class PrefilledTransaction(object):
+class PrefilledTransaction():
     def __init__(self, index=0, tx = None):
         self.index = index
         self.tx = tx
@@ -767,7 +767,7 @@ class PrefilledTransaction(object):
         return "PrefilledTransaction(index=%d, tx=%s)" % (self.index, repr(self.tx))
 
 # This is what we send on the wire, in a cmpctblock message.
-class P2PHeaderAndShortIDs(object):
+class P2PHeaderAndShortIDs():
     def __init__(self):
         self.header = CBlockHeader()
         self.nonce = 0
@@ -819,7 +819,7 @@ def calculate_shortid(k0, k1, tx_hash):
 
 # This version gets rid of the array lengths, and reinterprets the differential
 # encoding into indices that can be used for lookup.
-class HeaderAndShortIDs(object):
+class HeaderAndShortIDs():
     def __init__(self, p2pheaders_and_shortids = None):
         self.header = CBlockHeader()
         self.nonce = 0
@@ -880,7 +880,7 @@ class HeaderAndShortIDs(object):
         return "HeaderAndShortIDs(header=%s, nonce=%d, shortids=%s, prefilledtxn=%s" % (repr(self.header), self.nonce, repr(self.shortids), repr(self.prefilled_txn))
 
 
-class BlockTransactionsRequest(object):
+class BlockTransactionsRequest():
 
     def __init__(self, blockhash=0, indexes = None):
         self.blockhash = blockhash
@@ -920,7 +920,7 @@ class BlockTransactionsRequest(object):
         return "BlockTransactionsRequest(hash=%064x indexes=%s)" % (self.blockhash, repr(self.indexes))
 
 
-class BlockTransactions(object):
+class BlockTransactions():
 
     def __init__(self, blockhash=0, transactions = None):
         self.blockhash = blockhash
@@ -944,7 +944,7 @@ class BlockTransactions(object):
 
 
 # Objects that correspond to messages on the wire
-class msg_version(object):
+class msg_version():
     command = b"version"
 
     def __init__(self):
@@ -1012,7 +1012,7 @@ class msg_version(object):
                self.strSubVer, self.nStartingHeight, self.nRelay)
 
 
-class msg_verack(object):
+class msg_verack():
     command = b"verack"
 
     def __init__(self):
@@ -1028,7 +1028,7 @@ class msg_verack(object):
         return "msg_verack()"
 
 
-class msg_addr(object):
+class msg_addr():
     command = b"addr"
 
     def __init__(self):
@@ -1044,7 +1044,7 @@ class msg_addr(object):
         return "msg_addr(addrs=%s)" % (repr(self.addrs))
 
 
-class msg_alert(object):
+class msg_alert():
     command = b"alert"
 
     def __init__(self):
@@ -1063,7 +1063,7 @@ class msg_alert(object):
         return "msg_alert(alert=%s)" % (repr(self.alert), )
 
 
-class msg_inv(object):
+class msg_inv():
     command = b"inv"
 
     def __init__(self, inv=None):
@@ -1082,7 +1082,7 @@ class msg_inv(object):
         return "msg_inv(inv=%s)" % (repr(self.inv))
 
 
-class msg_getdata(object):
+class msg_getdata():
     command = b"getdata"
 
     def __init__(self, inv=None):
@@ -1098,7 +1098,7 @@ class msg_getdata(object):
         return "msg_getdata(inv=%s)" % (repr(self.inv))
 
 
-class msg_getblocks(object):
+class msg_getblocks():
     command = b"getblocks"
 
     def __init__(self):
@@ -1121,7 +1121,7 @@ class msg_getblocks(object):
             % (repr(self.locator), self.hashstop)
 
 
-class msg_tx(object):
+class msg_tx():
     command = b"tx"
 
     def __init__(self, tx=CTransaction()):
@@ -1142,7 +1142,7 @@ class msg_witness_tx(msg_tx):
         return self.tx.serialize_with_witness()
 
 
-class msg_block(object):
+class msg_block():
     command = b"block"
 
     def __init__(self, block=None):
@@ -1162,7 +1162,7 @@ class msg_block(object):
 
 # for cases where a user needs tighter control over what is sent over the wire
 # note that the user must supply the name of the command, and the data
-class msg_generic(object):
+class msg_generic():
     def __init__(self, command, data=None):
         self.command = command
         self.data = data
@@ -1179,7 +1179,7 @@ class msg_witness_block(msg_block):
         r = self.block.serialize(with_witness=True)
         return r
 
-class msg_getaddr(object):
+class msg_getaddr():
     command = b"getaddr"
 
     def __init__(self):
@@ -1195,7 +1195,7 @@ class msg_getaddr(object):
         return "msg_getaddr()"
 
 
-class msg_ping_prebip31(object):
+class msg_ping_prebip31():
     command = b"ping"
 
     def __init__(self):
@@ -1211,7 +1211,7 @@ class msg_ping_prebip31(object):
         return "msg_ping() (pre-bip31)"
 
 
-class msg_ping(object):
+class msg_ping():
     command = b"ping"
 
     def __init__(self, nonce=0):
@@ -1229,7 +1229,7 @@ class msg_ping(object):
         return "msg_ping(nonce=%08x)" % self.nonce
 
 
-class msg_pong(object):
+class msg_pong():
     command = b"pong"
 
     def __init__(self, nonce=0):
@@ -1247,7 +1247,7 @@ class msg_pong(object):
         return "msg_pong(nonce=%08x)" % self.nonce
 
 
-class msg_mempool(object):
+class msg_mempool():
     command = b"mempool"
 
     def __init__(self):
@@ -1262,7 +1262,7 @@ class msg_mempool(object):
     def __repr__(self):
         return "msg_mempool()"
 
-class msg_sendheaders(object):
+class msg_sendheaders():
     command = b"sendheaders"
 
     def __init__(self):
@@ -1282,7 +1282,7 @@ class msg_sendheaders(object):
 # number of entries
 # vector of hashes
 # hash_stop (hash of last desired block header, 0 to get as many as possible)
-class msg_getheaders(object):
+class msg_getheaders():
     command = b"getheaders"
 
     def __init__(self):
@@ -1307,7 +1307,7 @@ class msg_getheaders(object):
 
 # headers message has
 # <count> <vector of block headers>
-class msg_headers(object):
+class msg_headers():
     command = b"headers"
 
     def __init__(self, headers=None):
@@ -1327,7 +1327,7 @@ class msg_headers(object):
         return "msg_headers(headers=%s)" % repr(self.headers)
 
 
-class msg_reject(object):
+class msg_reject():
     command = b"reject"
     REJECT_MALFORMED = 1
 
@@ -1358,7 +1358,7 @@ class msg_reject(object):
         return "msg_reject: %s %d %s [%064x]" \
             % (self.message, self.code, self.reason, self.data)
 
-class msg_feefilter(object):
+class msg_feefilter():
     command = b"feefilter"
 
     def __init__(self, feerate=0):
@@ -1375,7 +1375,7 @@ class msg_feefilter(object):
     def __repr__(self):
         return "msg_feefilter(feerate=%08x)" % self.feerate
 
-class msg_sendcmpct(object):
+class msg_sendcmpct():
     command = b"sendcmpct"
 
     def __init__(self):
@@ -1395,7 +1395,7 @@ class msg_sendcmpct(object):
     def __repr__(self):
         return "msg_sendcmpct(announce=%s, version=%lu)" % (self.announce, self.version)
 
-class msg_cmpctblock(object):
+class msg_cmpctblock():
     command = b"cmpctblock"
 
     def __init__(self, header_and_shortids = None):
@@ -1413,7 +1413,7 @@ class msg_cmpctblock(object):
     def __repr__(self):
         return "msg_cmpctblock(HeaderAndShortIDs=%s)" % repr(self.header_and_shortids)
 
-class msg_getblocktxn(object):
+class msg_getblocktxn():
     command = b"getblocktxn"
 
     def __init__(self):
@@ -1431,7 +1431,7 @@ class msg_getblocktxn(object):
     def __repr__(self):
         return "msg_getblocktxn(block_txn_request=%s)" % (repr(self.block_txn_request))
 
-class msg_blocktxn(object):
+class msg_blocktxn():
     command = b"blocktxn"
 
     def __init__(self):
@@ -1454,7 +1454,7 @@ class msg_witness_blocktxn(msg_blocktxn):
         r += self.block_transactions.serialize(with_witness=True)
         return r
 
-class NodeConnCB(object):
+class NodeConnCB():
     """Callback and helper functions for P2P connection to a bitcoind node.
 
     Individual testcases should subclass this and override the on_* methods

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -370,7 +370,7 @@ class CScriptTruncatedPushDataError(CScriptInvalidError):
         super(CScriptTruncatedPushDataError, self).__init__(msg)
 
 # This is used, eg, for blockchain heights in coinbase scripts (bip34)
-class CScriptNum(object):
+class CScriptNum():
     def __init__(self, d=0):
         self.value = d
 

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -31,7 +31,7 @@ def recvall(s, n):
     return rv
 
 ### Implementation classes
-class Socks5Configuration(object):
+class Socks5Configuration():
     """Proxy configuration."""
     def __init__(self):
         self.addr = None # Bind address (must be set)
@@ -39,7 +39,7 @@ class Socks5Configuration(object):
         self.unauth = False  # Support unauthenticated
         self.auth = False  # Support authentication
 
-class Socks5Command(object):
+class Socks5Command():
     """Information about an incoming socks5 command."""
     def __init__(self, cmd, atyp, addr, port, username, password):
         self.cmd = cmd # Command (one of Command.*)
@@ -51,7 +51,7 @@ class Socks5Command(object):
     def __repr__(self):
         return 'Socks5Command(%s,%s,%s,%s,%s,%s)' % (self.cmd, self.atyp, self.addr, self.port, self.username, self.password)
 
-class Socks5Connection(object):
+class Socks5Connection():
     def __init__(self, serv, conn, peer):
         self.serv = serv
         self.conn = conn
@@ -122,7 +122,7 @@ class Socks5Connection(object):
         finally:
             self.conn.close()
 
-class Socks5Server(object):
+class Socks5Server():
     def __init__(self, conf):
         self.conf = conf
         self.s = socket.socket(conf.af)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -43,7 +43,7 @@ TEST_EXIT_PASSED = 0
 TEST_EXIT_FAILED = 1
 TEST_EXIT_SKIPPED = 77
 
-class BitcoinTestFramework(object):
+class BitcoinTestFramework():
     """Base class for a bitcoin test script.
 
     Individual bitcoin test scripts should subclass this class and override the set_test_params() and run_test() methods.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -459,7 +459,7 @@ def check_script_list(src_dir):
             # On travis this warning is an error to prevent merging incomplete commits into master
             sys.exit(1)
 
-class RPCCoverage(object):
+class RPCCoverage():
     """
     Coverage reporting utilities for test_runner.
 


### PR DESCRIPTION
A few trivial tidyups in the test_framework:

- the test_framework can only be run in Python3, so remove the py2/3 compatibility workarounds in authproxy.py
- while there, do some general tidying up of the module - fix flake8 warnings, make initialization code more compact
- All classes in Python3 are new-style. No need to explicitly inherit from `object`.