### PR TITLE
Tests: Improve benchmark precision

### DIFF
--- a/src/bench/Examples.cpp
+++ b/src/bench/Examples.cpp
@@ -15,7 +15,7 @@ static void Sleep100ms(benchmark::State& state)
     }
 }
 
-BENCHMARK(Sleep100ms);
+BENCHMARK(Sleep100ms, 10);
 
 // Extremely fast-running benchmark:
 #include <math.h>
@@ -31,4 +31,4 @@ static void Trig(benchmark::State& state)
     }
 }
 
-BENCHMARK(Trig);
+BENCHMARK(Trig, 12 * 1000 * 1000);

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -54,6 +54,6 @@ static void Base58Decode(benchmark::State& state)
 }
 
 
-BENCHMARK(Base58Encode);
-BENCHMARK(Base58CheckEncode);
-BENCHMARK(Base58Decode);
+BENCHMARK(Base58Encode, 470 * 1000);
+BENCHMARK(Base58CheckEncode, 320 * 1000);
+BENCHMARK(Base58Decode, 800 * 1000);

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -8,98 +8,136 @@
 #include <assert.h>
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
+#include <regex>
+#include <numeric>
 
-benchmark::BenchRunner::BenchmarkMap &benchmark::BenchRunner::benchmarks() {
-    static std::map<std::string, benchmark::BenchFunction> benchmarks_map;
+void benchmark::ConsolePrinter::header()
+{
+    std::cout << "# Benchmark, evals, iterations, total, min, max, median" << std::endl;
+}
+
+void benchmark::ConsolePrinter::result(const State& state)
+{
+    auto results = state.m_elapsed_results;
+    std::sort(results.begin(), results.end());
+
+    double total = state.m_num_iters * std::accumulate(results.begin(), results.end(), 0.0);
+
+    double front = 0;
+    double back = 0;
+    double median = 0;
+
+    if (!results.empty()) {
+        front = results.front();
+        back = results.back();
+
+        size_t mid = results.size() / 2;
+        median = results[mid];
+        if (0 == results.size() % 2) {
+            median = (results[mid] + results[mid + 1]) / 2;
+        }
+    }
+
+    std::cout << std::setprecision(6);
+    std::cout << state.m_name << ", " << state.m_num_evals << ", " << state.m_num_iters << ", " << total << ", " << front << ", " << back << ", " << median << std::endl;
+}
+
+void benchmark::ConsolePrinter::footer() {}
+benchmark::PlotlyPrinter::PlotlyPrinter(std::string plotly_url, int64_t width, int64_t height)
+    : m_plotly_url(plotly_url), m_width(width), m_height(height)
+{
+}
+
+void benchmark::PlotlyPrinter::header()
+{
+    std::cout << "<html><head>"
+              << "<script src=\"" << m_plotly_url << "\"></script>"
+              << "</head><body><div id=\"myDiv\" style=\"width:" << m_width << "px; height:" << m_height << "px\"></div>"
+              << "<script> var data = ["
+              << std::endl;
+}
+
+void benchmark::PlotlyPrinter::result(const State& state)
+{
+    std::cout << "{ " << std::endl
+              << "  name: '" << state.m_name << "', " << std::endl
+              << "  y: [";
+
+    const char* prefix = "";
+    for (const auto& e : state.m_elapsed_results) {
+        std::cout << prefix << std::setprecision(6) << e;
+        prefix = ", ";
+    }
+    std::cout << "]," << std::endl
+              << "  boxpoints: 'all', jitter: 0.3, pointpos: 0, type: 'box',"
+              << std::endl
+              << "}," << std::endl;
+}
+
+void benchmark::PlotlyPrinter::footer()
+{
+    std::cout << "]; var layout = { showlegend: false, yaxis: { rangemode: 'tozero', autorange: true } };"
+              << "Plotly.newPlot('myDiv', data, layout);"
+              << "</script></body></html>";
+}
+
+
+benchmark::BenchRunner::BenchmarkMap& benchmark::BenchRunner::benchmarks()
+{
+    static std::map<std::string, Bench> benchmarks_map;
     return benchmarks_map;
 }
 
-benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction func)
+benchmark::BenchRunner::BenchRunner(std::string name, benchmark::BenchFunction func, uint64_t num_iters_for_one_second)
 {
-    benchmarks().insert(std::make_pair(name, func));
+    benchmarks().insert(std::make_pair(name, Bench{func, num_iters_for_one_second}));
 }
 
-void
-benchmark::BenchRunner::RunAll(benchmark::duration elapsedTimeForOne)
+void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double scaling, const std::string& filter, bool is_list_only)
 {
     perf_init();
-    if (std::ratio_less_equal<benchmark::clock::period, std::micro>::value) {
+    if (!std::ratio_less_equal<benchmark::clock::period, std::micro>::value) {
         std::cerr << "WARNING: Clock precision is worse than microsecond - benchmarks may be less accurate!\n";
     }
-    std::cout << "#Benchmark" << "," << "count" << "," << "min(ns)" << "," << "max(ns)" << "," << "average(ns)" << ","
-              << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 
-    for (const auto &p: benchmarks()) {
-        State state(p.first, elapsedTimeForOne);
-        p.second(state);
+    std::regex reFilter(filter);
+    std::smatch baseMatch;
+
+    printer.header();
+
+    for (const auto& p : benchmarks()) {
+        if (!std::regex_match(p.first, baseMatch, reFilter)) {
+            continue;
+        }
+
+        uint64_t num_iters = static_cast<uint64_t>(p.second.num_iters_for_one_second * scaling);
+        if (0 == num_iters) {
+            num_iters = 1;
+        }
+        State state(p.first, num_evals, num_iters, printer);
+        if (!is_list_only) {
+            p.second.func(state);
+        }
+        printer.result(state);
     }
+
+    printer.footer();
+
     perf_fini();
 }
 
-bool benchmark::State::KeepRunning()
+bool benchmark::State::UpdateTimer(const benchmark::time_point current_time)
 {
-    if (count & countMask) {
-      ++count;
-      return true;
-    }
-    time_point now;
+    if (m_start_time != time_point()) {
+        std::chrono::duration<double> diff = current_time - m_start_time;
+        m_elapsed_results.push_back(diff.count() / m_num_iters);
 
-    uint64_t nowCycles;
-    if (count == 0) {
-        lastTime = beginTime = now = clock::now();
-        lastCycles = beginCycles = nowCycles = perf_cpucycles();
-    }
-    else {
-        now = clock::now();
-        auto elapsed = now - lastTime;
-        auto elapsedOne = elapsed / (countMask + 1);
-        if (elapsedOne < minTime) minTime = elapsedOne;
-        if (elapsedOne > maxTime) maxTime = elapsedOne;
-
-        // We only use relative values, so don't have to handle 64-bit wrap-around specially
-        nowCycles = perf_cpucycles();
-        uint64_t elapsedOneCycles = (nowCycles - lastCycles) / (countMask + 1);
-        if (elapsedOneCycles < minCycles) minCycles = elapsedOneCycles;
-        if (elapsedOneCycles > maxCycles) maxCycles = elapsedOneCycles;
-
-        if (elapsed*128 < maxElapsed) {
-          // If the execution was much too fast (1/128th of maxElapsed), increase the count mask by 8x and restart timing.
-          // The restart avoids including the overhead of this code in the measurement.
-          countMask = ((countMask<<3)|7) & ((1LL<<60)-1);
-          count = 0;
-          minTime = duration::max();
-          maxTime = duration::zero();
-          minCycles = std::numeric_limits<uint64_t>::max();
-          maxCycles = std::numeric_limits<uint64_t>::min();
-          return true;
-        }
-        if (elapsed*16 < maxElapsed) {
-          uint64_t newCountMask = ((countMask<<1)|1) & ((1LL<<60)-1);
-          if ((count & newCountMask)==0) {
-              countMask = newCountMask;
-          }
+        if (m_elapsed_results.size() == m_num_evals) {
+            return false;
         }
     }
-    lastTime = now;
-    lastCycles = nowCycles;
-    ++count;
 
-    if (now - beginTime < maxElapsed) return true; // Keep going
-
-    --count;
-
-    assert(count != 0 && "count == 0 => (now == 0 && beginTime == 0) => return above");
-
-    // Output results
-    // Duration casts are only necessary here because hardware with sub-nanosecond clocks
-    // will lose precision.
-    int64_t min_elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(minTime).count();
-    int64_t max_elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(maxTime).count();
-    int64_t avg_elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>((now-beginTime)/count).count();
-    int64_t averageCycles = (nowCycles-beginCycles)/count;
-    std::cout << std::fixed << std::setprecision(15) << name << "," << count << "," << min_elapsed << "," << max_elapsed << "," << avg_elapsed << ","
-              << minCycles << "," << maxCycles << "," << averageCycles << "\n";
-    std::cout.copyfmt(std::ios(nullptr));
-
-    return false;
+    m_num_iters_left = m_num_iters - 1;
+    return true;
 }

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -10,16 +10,62 @@
 #include <util.h>
 #include <random.h>
 
+#include <boost/lexical_cast.hpp>
+
+#include <memory>
+
+static const int64_t DEFAULT_BENCH_EVALUATIONS = 5;
+static const char* DEFAULT_BENCH_FILTER = ".*";
+static const char* DEFAULT_BENCH_SCALING = "1.0";
+static const char* DEFAULT_BENCH_PRINTER = "console";
+static const char* DEFAULT_PLOT_PLOTLYURL = "https://cdn.plot.ly/plotly-latest.min.js";
+static const int64_t DEFAULT_PLOT_WIDTH = 1024;
+static const int64_t DEFAULT_PLOT_HEIGHT = 768;
+
 int
 main(int argc, char** argv)
 {
+    gArgs.ParseParameters(argc, argv);
+
+    if (gArgs.IsArgSet("-?") || gArgs.IsArgSet("-h") || gArgs.IsArgSet("-help")) {
+        std::cout << HelpMessageGroup(_("Options:"))
+                  << HelpMessageOpt("-?", _("Print this help message and exit"))
+                  << HelpMessageOpt("-list", _("List benchmarks without executing them. Can be combined with -scaling and -filter"))
+                  << HelpMessageOpt("-evals=<n>", strprintf(_("Number of measurement evaluations to perform. (default: %u)"), DEFAULT_BENCH_EVALUATIONS))
+                  << HelpMessageOpt("-filter=<regex>", strprintf(_("Regular expression filter to select benchmark by name (default: %s)"), DEFAULT_BENCH_FILTER))
+                  << HelpMessageOpt("-scaling=<n>", strprintf(_("Scaling factor for benchmark's runtime (default: %u)"), DEFAULT_BENCH_SCALING))
+                  << HelpMessageOpt("-printer=(console|plot)", strprintf(_("Choose printer format. console: print data to console. plot: Print results as HTML graph (default: %s)"), DEFAULT_BENCH_PRINTER))
+                  << HelpMessageOpt("-plot-plotlyurl=<uri>", strprintf(_("URL to use for plotly.js (default: %s)"), DEFAULT_PLOT_PLOTLYURL))
+                  << HelpMessageOpt("-plot-width=<x>", strprintf(_("Plot width in pixel (default: %u)"), DEFAULT_PLOT_WIDTH))
+                  << HelpMessageOpt("-plot-height=<x>", strprintf(_("Plot height in pixel (default: %u)"), DEFAULT_PLOT_HEIGHT));
+
+        return 0;
+    }
+
     SHA256AutoDetect();
     RandomInit();
     ECC_Start();
     SetupEnvironment();
     fPrintToDebugLog = false; // don't want to write to debug.log file
 
-    benchmark::BenchRunner::RunAll();
+    int64_t evaluations = gArgs.GetArg("-evals", DEFAULT_BENCH_EVALUATIONS);
+    std::string regex_filter = gArgs.GetArg("-filter", DEFAULT_BENCH_FILTER);
+    std::string scaling_str = gArgs.GetArg("-scaling", DEFAULT_BENCH_SCALING);
+    bool is_list_only = gArgs.GetBoolArg("-list", false);
+
+    double scaling_factor = boost::lexical_cast<double>(scaling_str);
+
+
+    std::unique_ptr<benchmark::Printer> printer(new benchmark::ConsolePrinter());
+    std::string printer_arg = gArgs.GetArg("-printer", DEFAULT_BENCH_PRINTER);
+    if ("plot" == printer_arg) {
+        printer.reset(new benchmark::PlotlyPrinter(
+            gArgs.GetArg("-plot-plotlyurl", DEFAULT_PLOT_PLOTLYURL),
+            gArgs.GetArg("-plot-width", DEFAULT_PLOT_WIDTH),
+            gArgs.GetArg("-plot-height", DEFAULT_PLOT_HEIGHT)));
+    }
+
+    benchmark::BenchRunner::RunAll(*printer, evaluations, scaling_factor, regex_filter, is_list_only);
 
     ECC_Stop();
 }

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -84,4 +84,4 @@ static void CCoinsCaching(benchmark::State& state)
     }
 }
 
-BENCHMARK(CCoinsCaching);
+BENCHMARK(CCoinsCaching, 170 * 1000);

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -52,5 +52,5 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     }
 }
 
-BENCHMARK(DeserializeBlockTest);
-BENCHMARK(DeserializeAndCheckBlockTest);
+BENCHMARK(DeserializeBlockTest, 130);
+BENCHMARK(DeserializeAndCheckBlockTest, 160);

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -12,51 +12,11 @@
 #include <random.h>
 
 
-// This Benchmark tests the CheckQueue with the lightest
-// weight Checks, so it should make any lock contention
-// particularly visible
 static const int MIN_CORES = 2;
 static const size_t BATCHES = 101;
 static const size_t BATCH_SIZE = 30;
 static const int PREVECTOR_SIZE = 28;
 static const unsigned int QUEUE_BATCH_SIZE = 128;
-static void CCheckQueueSpeed(benchmark::State& state)
-{
-    struct FakeJobNoWork {
-        bool operator()()
-        {
-            return true;
-        }
-        void swap(FakeJobNoWork& x){};
-    };
-    CCheckQueue<FakeJobNoWork> queue {QUEUE_BATCH_SIZE};
-    boost::thread_group tg;
-    for (auto x = 0; x < std::max(MIN_CORES, GetNumCores()); ++x) {
-       tg.create_thread([&]{queue.Thread();});
-    }
-    while (state.KeepRunning()) {
-        CCheckQueueControl<FakeJobNoWork> control(&queue);
-
-        // We call Add a number of times to simulate the behavior of adding
-        // a block of transactions at once.
-
-        std::vector<std::vector<FakeJobNoWork>> vBatches(BATCHES);
-        for (auto& vChecks : vBatches) {
-            vChecks.resize(BATCH_SIZE);
-        }
-        for (auto& vChecks : vBatches) {
-            // We can't make vChecks in the inner loop because we want to measure
-            // the cost of getting the memory to each thread and we might get the same
-            // memory
-            control.Add(vChecks);
-        }
-        // control waits for completion by RAII, but
-        // it is done explicitly here for clarity
-        control.Wait();
-    }
-    tg.interrupt_all();
-    tg.join_all();
-}
 
 // This Benchmark tests the CheckQueue with a slightly realistic workload,
 // where checks all contain a prevector that is indirect 50% of the time
@@ -99,5 +59,4 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
     tg.interrupt_all();
     tg.join_all();
 }
-BENCHMARK(CCheckQueueSpeed, 29000);
 BENCHMARK(CCheckQueueSpeedPrevectorJob, 1400);

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -99,5 +99,5 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
     tg.interrupt_all();
     tg.join_all();
 }
-BENCHMARK(CCheckQueueSpeed);
-BENCHMARK(CCheckQueueSpeedPrevectorJob);
+BENCHMARK(CCheckQueueSpeed, 29000);
+BENCHMARK(CCheckQueueSpeedPrevectorJob, 1400);

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -56,4 +56,4 @@ static void CoinSelection(benchmark::State& state)
     }
 }
 
-BENCHMARK(CoinSelection);
+BENCHMARK(CoinSelection, 650);

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -46,9 +46,9 @@ static void SHA256_32b(benchmark::State& state)
 {
     std::vector<uint8_t> in(32,0);
     while (state.KeepRunning()) {
-        for (int i = 0; i < 1000000; i++) {
-            CSHA256().Write(in.data(), in.size()).Finalize(in.data());
-        }
+        CSHA256()
+            .Write(in.data(), in.size())
+            .Finalize(in.data());
     }
 }
 
@@ -63,10 +63,9 @@ static void SHA512(benchmark::State& state)
 static void SipHash_32b(benchmark::State& state)
 {
     uint256 x;
+    uint64_t k1 = 0;
     while (state.KeepRunning()) {
-        for (int i = 0; i < 1000000; i++) {
-            *((uint64_t*)x.begin()) = SipHashUint256(0, i, x);
-        }
+        *((uint64_t*)x.begin()) = SipHashUint256(0, ++k1, x);
     }
 }
 
@@ -75,9 +74,7 @@ static void FastRandom_32bit(benchmark::State& state)
     FastRandomContext rng(true);
     uint32_t x = 0;
     while (state.KeepRunning()) {
-        for (int i = 0; i < 1000000; i++) {
-            x += rng.rand32();
-        }
+        x += rng.rand32();
     }
 }
 
@@ -86,18 +83,16 @@ static void FastRandom_1bit(benchmark::State& state)
     FastRandomContext rng(true);
     uint32_t x = 0;
     while (state.KeepRunning()) {
-        for (int i = 0; i < 1000000; i++) {
-            x += rng.randbool();
-        }
+        x += rng.randbool();
     }
 }
 
-BENCHMARK(RIPEMD160);
-BENCHMARK(SHA1);
-BENCHMARK(SHA256);
-BENCHMARK(SHA512);
+BENCHMARK(RIPEMD160, 440);
+BENCHMARK(SHA1, 570);
+BENCHMARK(SHA256, 340);
+BENCHMARK(SHA512, 330);
 
-BENCHMARK(SHA256_32b);
-BENCHMARK(SipHash_32b);
-BENCHMARK(FastRandom_32bit);
-BENCHMARK(FastRandom_1bit);
+BENCHMARK(SHA256_32b, 4700 * 1000);
+BENCHMARK(SipHash_32b, 40 * 1000 * 1000);
+BENCHMARK(FastRandom_32bit, 110 * 1000 * 1000);
+BENCHMARK(FastRandom_1bit, 440 * 1000 * 1000);

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -43,5 +43,4 @@ static void BenchLockedPool(benchmark::State& state)
     addr.clear();
 }
 
-BENCHMARK(BenchLockedPool);
-
+BENCHMARK(BenchLockedPool, 530);

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -111,4 +111,4 @@ static void MempoolEviction(benchmark::State& state)
     }
 }
 
-BENCHMARK(MempoolEviction);
+BENCHMARK(MempoolEviction, 41000);

--- a/src/bench/prevector_destructor.cpp
+++ b/src/bench/prevector_destructor.cpp
@@ -32,5 +32,5 @@ static void PrevectorClear(benchmark::State& state)
     }
 }
 
-BENCHMARK(PrevectorDestructor);
-BENCHMARK(PrevectorClear);
+BENCHMARK(PrevectorDestructor, 5700);
+BENCHMARK(PrevectorClear, 5600);

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -12,8 +12,6 @@ static void RollingBloom(benchmark::State& state)
     CRollingBloomFilter filter(120000, 0.000001);
     std::vector<unsigned char> data(32);
     uint32_t count = 0;
-    uint32_t nEntriesPerGeneration = (120000 + 1) / 2;
-    uint32_t countnow = 0;
     uint64_t match = 0;
     while (state.KeepRunning()) {
         count++;
@@ -21,16 +19,8 @@ static void RollingBloom(benchmark::State& state)
         data[1] = count >> 8;
         data[2] = count >> 16;
         data[3] = count >> 24;
-        if (countnow == nEntriesPerGeneration) {
-            auto b = benchmark::clock::now();
-            filter.insert(data);
-            auto total = std::chrono::duration_cast<std::chrono::nanoseconds>(benchmark::clock::now() - b).count();
-            std::cout << "RollingBloom-refresh,1," << total << "," << total << "," << total << "\n";
-            countnow = 0;
-        } else {
-            filter.insert(data);
-        }
-        countnow++;
+        filter.insert(data);
+
         data[0] = count >> 24;
         data[1] = count >> 16;
         data[2] = count >> 8;
@@ -39,4 +29,4 @@ static void RollingBloom(benchmark::State& state)
     }
 }
 
-BENCHMARK(RollingBloom);
+BENCHMARK(RollingBloom, 1500 * 1000);

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -105,4 +105,4 @@ static void VerifyScriptBench(benchmark::State& state)
     }
 }
 
-BENCHMARK(VerifyScriptBench);
+BENCHMARK(VerifyScriptBench, 6300);


### PR DESCRIPTION
The benchmark's KeepRunning() used to make a function call for each call, inflating measurement times for short running code. This change inlines the critical code that is executed each run and moves the slow timer updates into a new function.

This change increases the average runtime for Trig from 0.000000082339208 sec to 0.000000080948591.