### PR TITLE
[Refactor] CValidation State

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -159,25 +159,37 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
 bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
 {
     // Basic checks that don't depend on any context
-    if (tx.vin.empty())
-        return state.DoS(10, false, REJECT_INVALID, "bad-txns-vin-empty");
-    if (tx.vout.empty())
-        return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
+    if (tx.vin.empty()) {
+        state.BadTx("bad-txns-vin-empty", "", DoS_SEVERITY::MEDIUM);
+        return false;
+    }
+    if (tx.vout.empty()) {
+        state.BadTx("bad-txns-vout-empty", "", DoS_SEVERITY::MEDIUM);
+        return false;
+    }
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT)
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT) {
+        state.BadTx("bad-txns-oversize");
+        return false;
+    }
 
     // Check for negative or overflow output values
     CAmount nValueOut = 0;
     for (const auto& txout : tx.vout)
     {
-        if (txout.nValue < 0)
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-negative");
-        if (txout.nValue > MAX_MONEY)
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-vout-toolarge");
+        if (txout.nValue < 0) {
+            state.BadTx("bad-txns-vout-negative");
+            return false;
+        }
+        if (txout.nValue > MAX_MONEY) {
+            state.BadTx("bad-txns-vout-toolarge");
+            return false;
+        }
         nValueOut += txout.nValue;
-        if (!MoneyRange(nValueOut))
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-txouttotal-toolarge");
+        if (!MoneyRange(nValueOut)) {
+            state.BadTx("bad-txns-txouttotal-toolarge");
+            return false;
+        }
     }
 
     // Check for duplicate inputs - note that this check is slow so we skip it in CheckBlock
@@ -185,21 +197,27 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
         std::set<COutPoint> vInOutPoints;
         for (const auto& txin : tx.vin)
         {
-            if (!vInOutPoints.insert(txin.prevout).second)
-                return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
+            if (!vInOutPoints.insert(txin.prevout).second) {
+                state.BadTx("bad-txns-inputs-duplicate");
+                return false;
+            }
         }
     }
 
     if (tx.IsCoinBase())
     {
-        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
-            return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
+        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100) {
+            state.BadTx("bad-cb-length");
+            return false;
+        }
     }
     else
     {
         for (const auto& txin : tx.vin)
-            if (txin.prevout.IsNull())
-                return state.DoS(10, false, REJECT_INVALID, "bad-txns-prevout-null");
+            if (txin.prevout.IsNull()) {
+                state.BadTx("bad-txns-prevout-null", "", DoS_SEVERITY::MEDIUM);
+                return false;
+            }
     }
 
     return true;
@@ -209,8 +227,9 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
 {
     // are the actual inputs available?
     if (!inputs.HaveInputs(tx)) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-missingorspent", false,
+        state.BadTx("bad-txns-inputs-missingorspent",
                          strprintf("%s: inputs missing/spent", __func__));
+        return false;
     }
 
     CAmount nValueIn = 0;
@@ -221,28 +240,31 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, CValidationState& state, c
 
         // If prev is coinbase, check that it's matured
         if (coin.IsCoinBase() && nSpendHeight - coin.nHeight < COINBASE_MATURITY) {
-            return state.Invalid(false,
-                REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
+            state.BadTx("bad-txns-premature-spend-of-coinbase",
                 strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
+            return false;
         }
 
         // Check for negative or overflow input values
         nValueIn += coin.out.nValue;
         if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn)) {
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
+            state.BadTx("bad-txns-inputvalues-outofrange");
+            return false;
         }
     }
 
     const CAmount value_out = tx.GetValueOut();
     if (nValueIn < value_out) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-in-belowout", false,
+        state.BadTx("bad-txns-in-belowout",
             strprintf("value in (%s) < value out (%s)", FormatMoney(nValueIn), FormatMoney(value_out)));
+        return false;
     }
 
     // Tally transaction fees
     const CAmount txfee_aux = nValueIn - value_out;
     if (!MoneyRange(txfee_aux)) {
-        return state.DoS(100, false, REJECT_INVALID, "bad-txns-fee-outofrange");
+        state.BadTx("bad-txns-fee-outofrange");
+        return false;
     }
 
     txfee = txfee_aux;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -59,6 +59,7 @@ struct CNodeStateStats {
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch);
+enum class DoS_SEVERITY;
+void Misbehaving(NodeId nodeid, DoS_SEVERITY nDoS);
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -4,6 +4,7 @@
 
 // Unit tests for denial-of-service detection/prevention code
 
+#include "consensus/validation.h"
 #include "chainparams.h"
 #include "keystore.h"
 #include "net.h"
@@ -53,7 +54,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     peerLogic->InitializeNode(&dummyNode1);
     dummyNode1.nVersion = 1;
     dummyNode1.fSuccessfullyConnected = true;
-    Misbehaving(dummyNode1.GetId(), 100); // Should get banned
+    Misbehaving(dummyNode1.GetId(), DoS_SEVERITY::CRITICAL); // Should get banned
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr1));
     BOOST_CHECK(!connman->IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
@@ -64,11 +65,11 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     peerLogic->InitializeNode(&dummyNode2);
     dummyNode2.nVersion = 1;
     dummyNode2.fSuccessfullyConnected = true;
-    Misbehaving(dummyNode2.GetId(), 50);
+    Misbehaving(dummyNode2.GetId(), DoS_SEVERITY::HIGH);
     peerLogic->SendMessages(&dummyNode2, interruptDummy);
     BOOST_CHECK(!connman->IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(connman->IsBanned(addr1));  // ... but 1 still should be
-    Misbehaving(dummyNode2.GetId(), 50);
+    Misbehaving(dummyNode2.GetId(), DoS_SEVERITY::HIGH);
     peerLogic->SendMessages(&dummyNode2, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr2));
 }
@@ -85,13 +86,13 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     peerLogic->InitializeNode(&dummyNode1);
     dummyNode1.nVersion = 1;
     dummyNode1.fSuccessfullyConnected = true;
-    Misbehaving(dummyNode1.GetId(), 100);
+    Misbehaving(dummyNode1.GetId(), DoS_SEVERITY::CRITICAL);
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
     BOOST_CHECK(!connman->IsBanned(addr1));
-    Misbehaving(dummyNode1.GetId(), 10);
+    Misbehaving(dummyNode1.GetId(), DoS_SEVERITY::MEDIUM);
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
     BOOST_CHECK(!connman->IsBanned(addr1));
-    Misbehaving(dummyNode1.GetId(), 1);
+    Misbehaving(dummyNode1.GetId(), DoS_SEVERITY::LOW);
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr1));
     gArgs.ForceSetArg("-banscore", std::to_string(DEFAULT_BANSCORE_THRESHOLD));
@@ -112,7 +113,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     dummyNode.nVersion = 1;
     dummyNode.fSuccessfullyConnected = true;
 
-    Misbehaving(dummyNode.GetId(), 100);
+    Misbehaving(dummyNode.GetId(), DoS_SEVERITY::CRITICAL);
     peerLogic->SendMessages(&dummyNode, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr));
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -465,14 +465,6 @@ extern VersionBitsCache versionbitscache;
  */
 int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
-/** Reject codes greater or equal to this can be returned by AcceptToMemPool
- * for transactions, to signal internal conditions. They cannot and should not
- * be sent over the P2P network.
- */
-static const unsigned int REJECT_INTERNAL = 0x100;
-/** Too high fee. Can not be triggered by P2P transactions */
-static const unsigned int REJECT_HIGHFEE = 0x100;
-
 /** Get block file info entry for one block file */
 CBlockFileInfo* GetBlockFileInfo(size_t n);
 


### PR DESCRIPTION
This PR is a refactor only (i.e., any functional changes should be reported in review) which does the following:

- Replace `state.DoS` with more descriptive calls where straightforward.  Rather than just call DoS or Invalid, different causes of invalidity have different functions. This makes it easier to quickly find all related causes of that class of error.
- Convert all `nDoS` usage to an enum class with named levels (none 0, low 1, medium 10, elevated 20, high 50, and critical 100)
- Use a custom enum class for reporting corruption to make it more clear where corruption occurs
- return false directly from `CValidtationState` update call sites. state.DoS never returns true, so it makes it easier to see that the return value is not dependent on the call.
- Don't pass `error()` as an argument to a function in DoS. error always returns false, and this is confusing for readers/reviewers.


If anyone is interested, there's an unsquashed version too, but I figured this is simple enough to review squashed. 

The only code quality 'decrease' is that some reject codes move from `validation.h` to `consensus/validation.h`. This abstraction barrier violation is already present (the `CValidationState` class is expected to handle those reject codes appropriately) so I think that this change is a lesser evil.




Motivation 
===
I'm currently working on reworking the separation between reporting errors and DoS. As a first step in this process, I've cleaned up the interface without making any functional changes or major architecture changes. The resulting code should be easier to read and review changes to. The future plan to split `CValidationState` up into ~3 different subclasses (one to handle DoS, one to handle consensus correctness, and one to handle system errors) and then migrate the DoS completely to `net_processing.cpp`. This is a superior architecture because it better respects the boundaries between events on the network and faults in validation. I decided to start with this PR because I think it is an low hanging fruit immediate improvement independent of further modularization efforts.



Thanks to @ryanofsky and @TheBlueMatt for feedback on an earlier version of this PR.