### PR TITLE
Avoid slow transaction search with txindex enabled

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -939,6 +939,9 @@ bool GetTransaction(const uint256 &hash, CTransactionRef &txOut, const Consensus
                 return error("%s: txid mismatch", __func__);
             return true;
         }
+
+        // transaction not found in index, nothing more can be done
+        return false;
     }
 
     if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it


### PR DESCRIPTION
This is an alternative to #11507 where a slow search is not attempted (in any case) if `txindex` is enabled.