### PR TITLE
Evict outbound peers if tip is stale

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2862,3 +2862,15 @@ uint64_t CConnman::CalculateKeyedNetGroup(const CAddress& ad) const
 
     return GetDeterministicRandomizer(RANDOMIZER_ID_NETGROUP).Write(vchNetGroup.data(), vchNetGroup.size()).Finalize();
 }
+
+void CConnman::AddToVNodes(CNode &node)
+{
+    LOCK(cs_vNodes);
+    vNodes.push_back(&node);
+}
+
+void CConnman::ClearVNodes()
+{
+    LOCK(cs_vNodes);
+    vNodes.clear();
+}

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1768,6 +1768,28 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
             }
         }
 
+        // Disconnect outbound peers marked for eviction
+        // Idea: if our outbound peers look bad (based on metrics designed
+        // to ensure connectivity to consensus-compatible peers), then we
+        // may wish to disconnect them if we have other peers we would try
+        // instead.
+        // If we're not yet using all our outbound peer slots, just clear the
+        // eviction flag -- this prevents an unnecessary/undesired eviction
+        // from happening later, if the flag was set before all our peer slots
+        // were in use.
+        {
+            LOCK(cs_vNodes);
+            for (CNode* pnode : vNodes) {
+                if (nOutbound >= nMaxOutbound && !pnode->fInbound && !pnode->m_manual_connection && pnode->m_eviction_candidate) {
+                    LogPrint(BCLog::NET, "disconnecting outbound peer=%d (marked for eviction)\n", pnode->GetId());
+                    pnode->fDisconnect = true;
+                } else {
+                    // If we can't evict for some reason, disable the flag
+                    pnode->m_eviction_candidate = false;
+                }
+            }
+        }
+
         // Feeler Connections
         //
         // Design goals:
@@ -2706,6 +2728,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fWhitelisted = false;
     fOneShot = false;
     m_manual_connection = false;
+    m_eviction_candidate = false;
     fClient = false; // set by version message
     fFeeler = false;
     fSuccessfullyConnected = false;

--- a/src/net.h
+++ b/src/net.h
@@ -619,6 +619,14 @@ public:
     bool fFeeler; // If true this node is being used as a short lived feeler.
     bool fOneShot;
     bool m_manual_connection;
+
+    // m_eviction_candidate should be set to true for outbound,
+    // non-manual-connection peers that are suitable for eviction, if evicting
+    // such a peer would make room for a new outbound peer
+    // m_eviction_candidate will be set to false by CConnman if not all
+    // outbound connections are up.
+    bool m_eviction_candidate;
+
     bool fClient;
     const bool fInbound;
     std::atomic_bool fSuccessfullyConnected;

--- a/src/net.h
+++ b/src/net.h
@@ -295,6 +295,9 @@ public:
     unsigned int GetReceiveFloodSize() const;
 
     void WakeMessageHandler();
+
+    void AddToVNodes(CNode &node);
+    void ClearVNodes();
 private:
     struct ListenSocket {
         SOCKET socket;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -127,6 +127,12 @@ namespace {
     /** Number of outbound peers with m_protect_from_disconnect. */
     int g_outbound_peers_with_protect_from_disconnect = 0;
 
+    /** When to next check whether our tip is stale. */
+    int64_t g_tip_stale_check_time = 0;
+
+    /** When our tip was last updated. */
+    int64_t g_last_tip_update = 0;
+
     /** Relay map, protected by cs_main. */
     typedef std::map<uint256, CTransactionRef> MapRelay;
     MapRelay mapRelay;
@@ -211,6 +217,8 @@ struct CNodeState {
     const CBlockIndex * m_header_with_required_work;
     //! After timeout is reached, set to true after sending getheaders
     bool m_sent_getheaders_to_check_chain_sync;
+    //! Time of last new block announcement
+    int64_t m_last_block_announcement;
 
     CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn), name(addrNameIn) {
         fCurrentlyConnected = false;
@@ -238,6 +246,7 @@ struct CNodeState {
         m_headers_chain_timeout = 0;
         m_header_with_required_work = nullptr;
         m_sent_getheaders_to_check_chain_sync = false;
+        m_last_block_announcement = 0;
     }
 };
 
@@ -250,6 +259,11 @@ CNodeState *State(NodeId pnode) {
     if (it == mapNodeState.end())
         return nullptr;
     return &it->second;
+}
+
+void UpdateLastBlockAnnouncement(CNodeState *state)
+{
+    if (state != nullptr) state->m_last_block_announcement = GetTime();
 }
 
 void UpdatePreferredDownload(CNode* node, CNodeState* state)
@@ -418,6 +432,17 @@ bool CanDirectFetch(const Consensus::Params &consensusParams)
 }
 
 // Requires cs_main
+bool TipMayBeStale(const Consensus::Params &consensusParams)
+{
+    // Initialize the time of the last tip update to current time on startup.
+    // We use GetTime() so that this logic can be tested using mocktime.
+    if (g_last_tip_update == 0) {
+        g_last_tip_update = GetTime();
+    }
+    return g_last_tip_update < GetTime() - consensusParams.nPowTargetSpacing * 12;
+}
+
+// Requires cs_main
 bool PeerHasHeader(CNodeState *state, const CBlockIndex *pindex)
 {
     if (state->pindexBestKnownBlock && pindex == state->pindexBestKnownBlock->GetAncestor(pindex->nHeight))
@@ -516,6 +541,18 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<con
 }
 
 } // namespace
+
+void PeerLogicValidation::UpdateLastAnnouncement(NodeId id)
+{
+    LOCK(cs_main);
+    UpdateLastBlockAnnouncement(State(id));
+}
+
+void PeerLogicValidation::ClearTipStaleCheckTime()
+{
+    LOCK(cs_main);
+    g_tip_stale_check_time = 0;
+}
 
 void PeerLogicValidation::InitializeNode(CNode *pnode) {
     CAddress addr = pnode->addr;
@@ -774,6 +811,10 @@ void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pb
         }
         LogPrint(BCLog::MEMPOOL, "Erased %d orphan tx included or conflicted by block\n", nErased);
     }
+
+    // Track the most recent tip update time for stale-tip checks
+    // We set this with GetTime() so that this can be tested using mocktime.
+    g_last_tip_update = GetTime();
 }
 
 // All of the following cache a recent block, and are protected by cs_most_recent_block
@@ -2277,6 +2318,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             return true;
         }
 
+        bool received_new_header = false;
         const CBlockIndex *pindexLast = nullptr;
         {
         LOCK(cs_main);
@@ -2317,6 +2359,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
             hashLastBlock = header.GetHash();
         }
+
+        // If we don't have the last header, then they'll have given us
+        // something new (assuming these headers are valid).
+        if (mapBlockIndex.find(hashLastBlock) == mapBlockIndex.end()) {
+            received_new_header = true;
+        }
         }
 
         CValidationState state;
@@ -2341,6 +2389,12 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         assert(pindexLast);
         UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
+
+        // Update time of last block announcement from this peer (used in stale-
+        // tip-based outbound peer eviction logic)
+        if (received_new_header && pindexLast->nChainWork > chainActive.Tip()->nChainWork) {
+            UpdateLastBlockAnnouncement(nodestate);
+        }
 
         if (nCount == MAX_HEADERS_RESULTS) {
             // Headers message had its maximum size; the peer may have more headers.
@@ -3334,6 +3388,58 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
             }
         }
 
+        // TODO: This logic is not peer-specific, so it doesn't really make
+        // sense in SendMessages; move this somewhere more fitting.
+        // Our goal here is to avoid being connected to a set of outbound peers
+        // which are all refusing to relay valid blocks to us.
+        // Strategy: if too much time has passed since we last updated our tip,
+        // mark the outbound peer with the least recent block announcement as
+        // evictable by our net.cpp code (which will only evict if we are at
+        // our outbound peer limit).
+        // If multiple peers are tied for least recently announcing a
+        // block to us, prefer to evict the newest peer -- this prevents us
+        // from cycling through all our peers in the event that blocks are just
+        // slow to be found on our chain.
+        if (time_in_seconds > g_tip_stale_check_time) {
+            if (TipMayBeStale(consensusParams)) {
+                // Mark our "worst" outbound peer for potential eviction, in
+                // the hopes of finding an outbound peer who has a new block.
+                NodeId worst_peer = -1;
+                int64_t oldest_block_announcement = GetTime();
+                int64_t worst_peer_connect_time = 0;
+                for (auto it = mapNodeState.begin(); it != mapNodeState.end(); ++it) {
+                    int64_t connect_time = 0;
+                    if (connman->ForNode(it->first, [&](CNode *pnode){
+                        // Figure out if this is an outbound peer we might try
+                        // to evict
+                        if (!(pnode->fInbound || pnode->m_manual_connection || pnode->fOneShot || pnode->fFeeler)) {
+                            // unset eviction status
+                            pnode->m_eviction_candidate = false;
+                            connect_time = pnode->nTimeConnected;
+                            return true;
+                        }
+                        return false;
+                    })) {
+                        // Mark the outbound peer that least recently served us
+                        // a new block announcement; break ties by choosing the
+                        // peer that most recently connected.
+                        if (it->second.m_last_block_announcement < oldest_block_announcement ||
+                                (it->second.m_last_block_announcement == oldest_block_announcement &&
+                                 connect_time > worst_peer_connect_time)) {
+                            worst_peer = it->first;
+                            oldest_block_announcement = it->second.m_last_block_announcement;
+                            worst_peer_connect_time = connect_time;
+                        }
+                    }
+                }
+                connman->ForNode(worst_peer, [&](CNode *pnode){
+                    pnode->m_eviction_candidate = true;
+                    return true;
+                });
+                LogPrint(BCLog::NET, "Tip may be stale; marked peer=%d for potential eviction\n", worst_peer);
+            }
+            g_tip_stale_check_time = time_in_seconds + STALE_TIP_CHECK_INTERVAL;
+        }
 
 
         //

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -124,6 +124,9 @@ namespace {
     /** Number of peers from which we're downloading blocks. */
     int nPeersWithValidatedDownloads = 0;
 
+    /** Number of outbound peers with m_protect_from_disconnect. */
+    int g_outbound_peers_with_protect_from_disconnect = 0;
+
     /** Relay map, protected by cs_main. */
     typedef std::map<uint256, CTransactionRef> MapRelay;
     MapRelay mapRelay;
@@ -200,6 +203,14 @@ struct CNodeState {
      * otherwise: whether this peer sends non-witnesses in cmpctblocks/blocktxns.
      */
     bool fSupportsDesiredCmpctVersion;
+    //! Whether this peer is protected from disconnection due to a bad/slow chain
+    bool m_protect_from_disconnect;
+    //! A timeout used for checking whether our peer has sufficiently synced
+    int64_t m_headers_chain_timeout;
+    //! A header with the work we require on our peer's chain
+    const CBlockIndex * m_header_with_required_work;
+    //! After timeout is reached, set to true after sending getheaders
+    bool m_sent_getheaders_to_check_chain_sync;
 
     CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn), name(addrNameIn) {
         fCurrentlyConnected = false;
@@ -223,6 +234,10 @@ struct CNodeState {
         fHaveWitness = false;
         fWantsCmpctWitness = false;
         fSupportsDesiredCmpctVersion = false;
+        m_protect_from_disconnect = false;
+        m_headers_chain_timeout = 0;
+        m_header_with_required_work = nullptr;
+        m_sent_getheaders_to_check_chain_sync = false;
     }
 };
 
@@ -534,6 +549,8 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     nPreferredDownload -= state->fPreferredDownload;
     nPeersWithValidatedDownloads -= (state->nBlocksInFlightValidHeaders != 0);
     assert(nPeersWithValidatedDownloads >= 0);
+    g_outbound_peers_with_protect_from_disconnect -= state->m_protect_from_disconnect;
+    assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
     mapNodeState.erase(nodeid);
 
@@ -542,6 +559,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
         assert(mapBlocksInFlight.empty());
         assert(nPreferredDownload == 0);
         assert(nPeersWithValidatedDownloads == 0);
+        assert(g_outbound_peers_with_protect_from_disconnect == 0);
     }
     LogPrint(BCLog::NET, "Cleared nodestate for peer=%d\n", nodeid);
 }
@@ -2393,8 +2411,18 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // us sync -- disconnect if using an outbound slot (unless
                 // whitelisted or addnode).
                 if (!(pfrom->fInbound || pfrom->fWhitelisted || pfrom->m_manual_connection)) {
+                    LogPrintf("Disconnecting outbound peer %d -- headers chain has insufficient work\n", pfrom->GetId());
                     pfrom->fDisconnect = true;
                 }
+            }
+        }
+
+        if (!pfrom->fDisconnect && !pfrom->fInbound && !pfrom->fOneShot && !pfrom->fFeeler && !pfrom->m_manual_connection) {
+            // If this is an outbound peer, check to see if we should protect
+            // it from the bad/lagging chain logic.
+            if (g_outbound_peers_with_protect_from_disconnect < MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT && nodestate->pindexBestKnownBlock->nChainWork >= chainActive.Tip()->nChainWork && !nodestate->m_protect_from_disconnect) {
+                nodestate->m_protect_from_disconnect = true;
+                ++g_outbound_peers_with_protect_from_disconnect;
             }
         }
         }
@@ -3260,6 +3288,52 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                 state.nHeadersSyncTimeout = std::numeric_limits<int64_t>::max();
             }
         }
+
+        // Check that outbound peers have reasonable chains
+        // GetTime() is used by this anti-DoS logic so we can test this using mocktime
+        int64_t time_in_seconds = GetTime();
+        if (!(state.m_protect_from_disconnect || pto->fInbound || pto->m_manual_connection || pto->fFeeler || pto->fOneShot) && state.fSyncStarted) {
+            // This is an outbound peer subject to disconnection if their chain
+            // lags behind ours (note: if their chain has more work than ours,
+            // we should sync to it, unless it's invalid, in which case we
+            // should find that out and disconnect from them elsewhere).
+            if (state.pindexBestKnownBlock != nullptr && state.pindexBestKnownBlock->nChainWork >= chainActive.Tip()->nChainWork) {
+                if (state.m_headers_chain_timeout != 0) {
+                    state.m_headers_chain_timeout = 0;
+                    state.m_header_with_required_work = nullptr;
+                    state.m_sent_getheaders_to_check_chain_sync = false;
+                }
+            } else if (state.m_headers_chain_timeout == 0 || (state.m_header_with_required_work != nullptr && state.pindexBestKnownBlock != nullptr && state.pindexBestKnownBlock->nChainWork >= state.m_header_with_required_work->nChainWork)) {
+                // Our best block known by this peer is behind our tip, and we're either noticing
+                // that for the first time, OR this peer was able to catch up to some earlier point
+                // where we checked against our tip.
+                // Either way, set a new timeout based on current tip.
+                state.m_headers_chain_timeout = time_in_seconds + CHAIN_SYNC_TIMEOUT;
+                state.m_header_with_required_work = chainActive.Tip();
+                state.m_sent_getheaders_to_check_chain_sync = false;
+            } else if (state.m_headers_chain_timeout > 0 && time_in_seconds > state.m_headers_chain_timeout) {
+                // No evidence yet that our peer has synced to a chain with work equal to that
+                // of our tip, when we first detected it was behind. Send a single getheaders
+                // message to give the peer a chance to update us.
+                if (state.m_sent_getheaders_to_check_chain_sync) {
+                    // They've run out of time to catch up!
+                    LogPrintf("Disconnecting outbound peer %d for old chain, best known block = %s\n", pto->GetId(), state.pindexBestKnownBlock != nullptr ? state.pindexBestKnownBlock->GetBlockHash().ToString() : "<none>");
+                    pto->fDisconnect = true;
+                } else {
+                    LogPrint(BCLog::NET, "sending getheaders to outbound peer=%d to verify chain work (current best known block:%s, benchmark blockhash: %s)\n", pto->GetId(), state.pindexBestKnownBlock != nullptr ? state.pindexBestKnownBlock->GetBlockHash().ToString() : "<none>", state.m_header_with_required_work->GetBlockHash().ToString());
+                    connman->PushMessage(pto, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(state.m_header_with_required_work->pprev), uint256()));
+                    state.m_sent_getheaders_to_check_chain_sync = true;
+                    constexpr int64_t HEADERS_RESPONSE_TIME = 120; // 2 minutes
+                    // Bump the timeout to allow a response, which could clear the timeout
+                    // (if the response shows the peer has synced), reset the timeout (if
+                    // the peer syncs to the required work but not to our tip), or result
+                    // in disconnect (if we advance to the timeout and pindexBestKnownBlock
+                    // has not sufficiently progressed)
+                    state.m_headers_chain_timeout = time_in_seconds + HEADERS_RESPONSE_TIME;
+                }
+            }
+        }
+
 
 
         //

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2383,6 +2383,20 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 }
             }
         }
+        // If we're in IBD, we want outbound peers that will serve us a useful
+        // chain. Disconnect peers that are on chains with insufficient work.
+        if (IsInitialBlockDownload() && nCount != MAX_HEADERS_RESULTS) {
+            // When nCount < MAX_HEADERS_RESULTS, we know we have no more
+            // headers to fetch from this peer.
+            if (nodestate->pindexBestKnownBlock->nChainWork < nMinimumChainWork) {
+                // This peer has too little work on their headers chain to help
+                // us sync -- disconnect if using an outbound slot (unless
+                // whitelisted or addnode).
+                if (!(pfrom->fInbound || pfrom->fWhitelisted || pfrom->m_manual_connection)) {
+                    pfrom->fDisconnect = true;
+                }
+            }
+        }
         }
     }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -21,6 +21,12 @@ static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
  *  Timeout = base + per_header * (expected number of headers) */
 static constexpr int64_t HEADERS_DOWNLOAD_TIMEOUT_BASE = 15 * 60 * 1000000; // 15 minutes
 static constexpr int64_t HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER = 1000; // 1ms/header
+/** Protect at least this many outbound peers from disconnection due to slow/
+ * behind headers chain.
+ */
+static constexpr int32_t MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT = 4;
+/** Timeout for (unprotected) outbound peers to sync to our chainwork, in seconds */
+static constexpr int64_t CHAIN_SYNC_TIMEOUT = 20 * 60; // 20 minutes
 
 class PeerLogicValidation : public CValidationInterface, public NetEventsInterface {
 private:

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -27,6 +27,8 @@ static constexpr int64_t HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER = 1000; // 1ms/head
 static constexpr int32_t MAX_OUTBOUND_PEERS_TO_PROTECT_FROM_DISCONNECT = 4;
 /** Timeout for (unprotected) outbound peers to sync to our chainwork, in seconds */
 static constexpr int64_t CHAIN_SYNC_TIMEOUT = 20 * 60; // 20 minutes
+/** Interval for checking whether our tip seems to be stale, in seconds */
+static constexpr int64_t STALE_TIP_CHECK_INTERVAL = 10 * 60; // 10 minutes
 
 class PeerLogicValidation : public CValidationInterface, public NetEventsInterface {
 private:
@@ -53,6 +55,10 @@ public:
     * @return                      True if there is more work to be done
     */
     bool SendMessages(CNode* pto, std::atomic<bool>& interrupt) override;
+
+    // Accessors to clear/update net_processing state, for testing purposes.
+    void UpdateLastAnnouncement(NodeId id);
+    void ClearTipStaleCheckTime();
 };
 
 struct CNodeStateStats {

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -42,6 +42,48 @@ static NodeId id = 0;
 
 BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 
+// Test eviction of an outbound peer whose chain never advances
+// Mock a node connection, and use mocktime to simulate a peer
+// which never sends any headers messages.  PeerLogic should
+// decide to evict that outbound peer, after the appropriate timeouts.
+// Note that we protect 4 outbound nodes from being subject to
+// this logic; this test takes advantage of that protection only
+// being applied to nodes which send headers with sufficient
+// work.
+BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
+{
+    std::atomic<bool> interruptDummy(false);
+
+    // Mock an outbound peer
+    CAddress addr1(ip(0xa0b0c001), NODE_NONE);
+    CNode dummyNode1(id++, ServiceFlags(NODE_NETWORK|NODE_WITNESS), 0, INVALID_SOCKET, addr1, 0, 0, CAddress(), "", /*fInboundIn=*/ false);
+    dummyNode1.SetSendVersion(PROTOCOL_VERSION);
+
+    peerLogic->InitializeNode(&dummyNode1);
+    dummyNode1.nVersion = 1;
+    dummyNode1.fSuccessfullyConnected = true;
+
+    // This test requires that we have a chain with non-zero work.
+    BOOST_CHECK(chainActive.Tip() != nullptr);
+    BOOST_CHECK(chainActive.Tip()->nChainWork > 0);
+
+    // Test starts here
+    peerLogic->SendMessages(&dummyNode1, interruptDummy); // should result in getheaders
+
+    int64_t nStartTime = GetTime();
+    // Wait 21 minutes, to
+    SetMockTime(nStartTime+21*60);
+    peerLogic->SendMessages(&dummyNode1, interruptDummy); // should result in getheaders
+    // Wait 3 more minutes
+    SetMockTime(nStartTime+24*60);
+    peerLogic->SendMessages(&dummyNode1, interruptDummy); // should result in disconnect
+    BOOST_CHECK(dummyNode1.fDisconnect == true);
+    SetMockTime(0);
+
+    bool dummy;
+    peerLogic->FinalizeNode(dummyNode1.GetId(), dummy);
+}
+
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
     std::atomic<bool> interruptDummy(false);
@@ -71,6 +113,10 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     Misbehaving(dummyNode2.GetId(), 50);
     peerLogic->SendMessages(&dummyNode2, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr2));
+
+    bool dummy;
+    peerLogic->FinalizeNode(dummyNode1.GetId(), dummy);
+    peerLogic->FinalizeNode(dummyNode2.GetId(), dummy);
 }
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
@@ -95,6 +141,9 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     peerLogic->SendMessages(&dummyNode1, interruptDummy);
     BOOST_CHECK(connman->IsBanned(addr1));
     gArgs.ForceSetArg("-banscore", std::to_string(DEFAULT_BANSCORE_THRESHOLD));
+
+    bool dummy;
+    peerLogic->FinalizeNode(dummyNode1.GetId(), dummy);
 }
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
@@ -121,6 +170,9 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     SetMockTime(nStartTime+60*60*24+1);
     BOOST_CHECK(!connman->IsBanned(addr));
+
+    bool dummy;
+    peerLogic->FinalizeNode(dummyNode.GetId(), dummy);
 }
 
 CTransactionRef RandomOrphan()

--- a/test/functional/minchainwork.py
+++ b/test/functional/minchainwork.py
@@ -27,7 +27,7 @@ class MinimumChainWorkTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
-        self.extra_args = [[], ["-minimumchainwork=0x65"], ["-minimumchainwork=0x65"]]
+        self.extra_args = [['-whitelist=127.0.0.1'], ["-minimumchainwork=0x65", '-whitelist=127.0.0.1'], ["-minimumchainwork=0x65"]]
         self.node_min_work = [0, 101, 101]
 
     def setup_network(self):
@@ -74,6 +74,12 @@ class MinimumChainWorkTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
 
         self.log.info("Verifying nodes are all synced")
+
+        # May need to reconnect the nodes -- node1 may have abandoned node0 as a poor
+        # outbound peer for having a low-work chain.
+        if (len(self.nodes[0].getpeerinfo()) == 0):
+            connect_nodes(self.nodes[1], 0)
+
         self.sync_all()
         self.log.info("Blockcounts: %s", [n.getblockcount() for n in self.nodes])
 


### PR DESCRIPTION
This builds on #11490 and is related to the work there, but I've separated this for review in order to not hold up #11490 (which I think is done).

This pr attempts to implement a strategy suggested by @gmaxwell, of choosing a peer for outbound eviction if our tip has not been updated in a while.  I'd like to suggest this for consideration in 0.15.0.2 as well, as it is designed to mitigate p2p disruption in the event that all our outbound peers stop relaying blocks to us.

@theuni  If you have a chance to review, I could use feedback on the first new commit here (`Add hacky accessors for manipulating connman peers in tests`).  I did the quickest thing I could in order to get a unit test working, but I'm pretty sure I violated all sorts of design goals, so I could use some guidance about the right way to add peers to connman in a unit test.