### PR TITLE
qa: Fix race condition failures in replace-by-fee.py, sendheaders.py

### DIFF
--- a/test/functional/replace-by-fee.py
+++ b/test/functional/replace-by-fee.py
@@ -72,11 +72,13 @@ class ReplaceByFeeTest(BitcoinTestFramework):
                            ["-mempoolreplacement=0"]]
 
     def run_test(self):
-        # Leave IBD and ensure nodes are synced
+        # Leave IBD
         self.nodes[0].generate(1)
-        self.sync_all()
 
         make_utxo(self.nodes[0], 1*COIN)
+
+        # Ensure nodes are synced
+        self.sync_all()
 
         self.log.info("Running test simple doublespend...")
         self.test_simple_doublespend()

--- a/test/functional/sendheaders.py
+++ b/test/functional/sendheaders.py
@@ -225,6 +225,10 @@ class SendHeadersTest(BitcoinTestFramework):
         inv_node.wait_for_verack()
         test_node.wait_for_verack()
 
+        # Ensure verack's have been processed by our peer
+        inv_node.sync_with_ping()
+        test_node.sync_with_ping()
+
         tip = int(self.nodes[0].getbestblockhash(), 16)
 
         # PART 1


### PR DESCRIPTION
I think #11407 broke replace-by-fee by introducing a race condition.  I was observing frequent failures of replace-by-fee locally, always with a mempool sync failure (the sync call was added in #11407).

It appeared to me like there were two causes: sometimes the node would be in IBD and not request the transaction that was relayed; other times the blocks generated in make_utxo wouldn't have relayed quickly enough for the spend of the transaction to be accepted.  I believe I've fixed both potential errors.

ping @instagibbs 

Edit: I found a race condition in the sendheaders.py test, where if the verack from the python node wasn't processed before the first block in the test was generated, then no block announcement would go out to that peer, breaking the test.  Fixed by adding a sync_with_ping after waiting for verack.