### PR TITLE
Avoid unintended unsigned integer wraparounds in FormatScript(...) and SplitHostPort(...)

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -58,7 +58,7 @@ std::string FormatScript(const CScript& script)
         ret += strprintf("0x%x ", HexStr(it2, script.end()));
         break;
     }
-    return ret.substr(0, ret.size() - 1);
+    return ret.size() > 0 ? ret.substr(0, ret.size() - 1) : ret;
 }
 
 const std::map<unsigned char, std::string> mapSigHashTypes = {

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -109,7 +109,7 @@ void SplitHostPort(std::string in, int &portOut, std::string &hostOut) {
     // if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
     bool fHaveColon = colon != in.npos;
     bool fBracketed = fHaveColon && (in[0]=='[' && in[colon-1]==']'); // if there is a colon, and in[0]=='[', colon is not 0, so in[colon-1] is safe
-    bool fMultiColon = fHaveColon && (in.find_last_of(':',colon-1) != in.npos);
+    bool fMultiColon = fHaveColon && colon != 0 && (in.find_last_of(':', colon - 1) != in.npos);
     if (fHaveColon && (colon==0 || fBracketed || !fMultiColon)) {
         int32_t n;
         if (ParseInt32(in.substr(colon + 1), &n) && n > 0 && n < 0x10000) {


### PR DESCRIPTION
Avoid unintended unsigned integer wraparounds in `FormatScript(...)` and `SplitHostPort(...)`.