### PR TITLE
Fix unsigned integer wrap-around in GetBlockProofEquivalentTime

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -147,7 +147,7 @@ int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& fr
     if (r.bits() > 63) {
         return sign * std::numeric_limits<int64_t>::max();
     }
-    return sign * r.GetLow64();
+    return sign * static_cast<int64_t>(r.GetLow64());
 }
 
 /** Find the last common ancestor two blocks have.

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -10,7 +10,6 @@ unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h
 unsigned-integer-overflow:bitcoin-tx.cpp
 unsigned-integer-overflow:bloom.cpp
-unsigned-integer-overflow:chain.cpp
 unsigned-integer-overflow:chain.h
 unsigned-integer-overflow:coded_stream.h
 unsigned-integer-overflow:core_write.cpp


### PR DESCRIPTION
Fix likely unintentional unsigned integer wrap-around in `GetBlockProofEquivalentTime(...)` when `to.nChainWork <= from.nChainWork`.

**Description:**

`int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, …)`
contains the following code:

```
int sign = 1;
if (to.nChainWork > from.nChainWork) {
…
} else {
    …
    sign = -1;
}
…
return sign * r.GetLow64();
```

`r.GetLow64()` is of type `uint64_t`.

Note that the types of the two operands in `sign * r.GetLow64()` differ in signedness.

Since `uint64_t` is wider than `int` the signed operand (`sign`) is converted to the unsigned type.

In the case of `sign == -1` (`to.nChainWork <= from.nChainWork`) we wrap around and end up with `18446744073709551615 * r.GetLow64()` (`std::numeric_limits<uint64_t>::max() * r.GetLow64()`) instead of the intended `-1 * r.GetLow64()`.

Note however that another conversion takes place when the result is converted into the return type 
(`int64_t`), so the resulting value should be the expected one (equivalent to `-1 * r.GetLow64()`).

In the case that this behaviour (wrap-around + relying on return type to fix) is intentional a comment should probably be added to indicate so :-)

`GetBlockProofEquivalentTime(…)` was introduced in f7303f97933be33e34d482cf8348d180c8da2a26. Friendly ping @sipa - intentional or not? :-)

