### PR TITLE
[Qt] Improved copy for RBF checkbox and tooltip

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1108,10 +1108,10 @@
            <item>
             <widget class="QCheckBox" name="optInRBF">
              <property name="text">
-              <string>Request Replace-By-Fee</string>
+              <string>Allow increasing fee</string>
              </property>
              <property name="toolTip">
-              <string>Indicates that the sender may wish to replace this transaction with a new one paying higher fees (prior to being confirmed).</string>
+              <string>This allows you to increase the fee later if the transaction takes a long time to confirm. This will also cause the recommended fee to be lower. ("Replace-By-Fee", BIP 125)</string>
              </property>
             </widget>
            </item>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -345,7 +345,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     if (ui->optInRBF->isChecked())
     {
         questionString.append("<hr /><span>");
-        questionString.append(tr("This transaction signals replaceability (optin-RBF)."));
+        questionString.append(tr("You can increase the fee later (signals Replace-By-Fee)."));
         questionString.append("</span>");
     }
 


### PR DESCRIPTION
Fixes #11344 and replaces #11428.

**Before**:
<img width="588" alt="before" src="https://user-images.githubusercontent.com/10217/31984211-3299e81a-b993-11e7-94e9-bf63d2fed4bd.png">

**After**:
<img width="578" alt="after" src="https://user-images.githubusercontent.com/10217/31984404-11f839da-b994-11e7-86ad-4c17a7d44b86.png">

