### PR TITLE
Minimal code changes to allow msvc compilation

### DIFF
--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -22,7 +22,7 @@ static void Base58Encode(benchmark::State& state)
         }
     };
     while (state.KeepRunning()) {
-        EncodeBase58(buff.begin(), buff.end());
+        EncodeBase58(buff.data(), buff.data() + buff.size());
     }
 }
 

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -19,7 +19,7 @@ static const int MIN_CORES = 2;
 static const size_t BATCHES = 101;
 static const size_t BATCH_SIZE = 30;
 static const int PREVECTOR_SIZE = 28;
-static const int QUEUE_BATCH_SIZE = 128;
+static const unsigned int QUEUE_BATCH_SIZE = 128;
 static void CCheckQueueSpeed(benchmark::State& state)
 {
     struct FakeJobNoWork {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -146,7 +146,7 @@ public:
         fRequireStandard = true;
         fMineBlocksOnDemand = false;
 
-        checkpointData = (CCheckpointData) {
+        checkpointData = {
             {
                 { 11111, uint256S("0x0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d")},
                 { 33333, uint256S("0x000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6")},
@@ -248,7 +248,7 @@ public:
         fMineBlocksOnDemand = false;
 
 
-        checkpointData = (CCheckpointData) {
+        checkpointData = {
             {
                 {546, uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70")},
             }
@@ -319,7 +319,7 @@ public:
         fRequireStandard = false;
         fMineBlocksOnDemand = true;
 
-        checkpointData = (CCheckpointData) {
+        checkpointData = {
             {
                 {0, uint256S("0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206")},
             }

--- a/src/compat.h
+++ b/src/compat.h
@@ -31,6 +31,7 @@
 #include <mswsock.h>
 #include <windows.h>
 #include <ws2tcpip.h>
+#include <stdint.h>
 #else
 #include <sys/fcntl.h>
 #include <sys/mman.h>
@@ -70,6 +71,15 @@ typedef unsigned int SOCKET;
 #endif
 #else
 #define MAX_PATH            1024
+#endif
+#ifdef _MSC_VER
+#if !defined(ssize_t)
+#ifdef _WIN64
+typedef int64_t ssize_t;
+#else
+typedef int32_t ssize_t;
+#endif
+#endif
 #endif
 
 #if HAVE_DECL_STRNLEN == 0

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -41,7 +41,7 @@ std::atomic<int64_t> nTimeBestReceived(0); // Used only to inform the wallet of 
 struct IteratorComparator
 {
     template<typename I>
-    bool operator()(const I& a, const I& b)
+    bool operator()(const I& a, const I& b) const
     {
         return &(*a) < &(*b);
     }

--- a/src/random.h
+++ b/src/random.h
@@ -128,7 +128,7 @@ public:
  * sure that the underlying OS APIs for all platforms support the number.
  * (many cap out at 256 bytes).
  */
-static const ssize_t NUM_OS_RANDOM_BYTES = 32;
+static const int NUM_OS_RANDOM_BYTES = 32;
 
 /** Get 32 bytes of system entropy. Do not use this in application code: use
  * GetStrongRandBytes instead.

--- a/src/support/cleanse.cpp
+++ b/src/support/cleanse.cpp
@@ -7,6 +7,10 @@
 
 #include <cstring>
 
+#if defined(_MSC_VER)
+#include <Windows.h> // For SecureZeroMemory.
+#endif
+
 /* Compilers have a bad habit of removing "superfluous" memset calls that
  * are trying to zero memory. For example, when memset()ing a buffer and
  * then free()ing it, the compiler might decide that the memset is
@@ -32,7 +36,7 @@ void memory_cleanse(void *ptr, size_t len)
        might try to eliminate "superfluous" memsets. If there's an easy way to
        detect memset_s, it would be better to use that. */
 #if defined(_MSC_VER)
-    __asm;
+    SecureZeroMemory(ptr, len);
 #else
     __asm__ __volatile__("" : : "r"(ptr) : "memory");
 #endif

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -24,7 +24,7 @@
 // otherwise.
 BOOST_FIXTURE_TEST_SUITE(checkqueue_tests, TestingSetup)
 
-static const int QUEUE_BATCH_SIZE = 128;
+static const unsigned int QUEUE_BATCH_SIZE = 128;
 
 struct FakeCheck {
     bool operator()()


### PR DESCRIPTION
These changes are required to allow the Bitcoin source to build with Microsoft's C++ compiler (#11562 is also required).

I looked around for a better place for the typedef of ssize_t which is in random.h. The best candidate looks like src/compat.h but I figured including that header in random.h is a bigger change than the typedef. Note that the same typedef is in at least two other places including the OpenSSL and Berkeley DB headers so some of the Bitcoin code already picks it up.