### PR TITLE
Make listsinceblock refuse unknown block hash

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -76,6 +76,9 @@ will only create hierarchical deterministic (HD) wallets.
 
 Low-level RPC changes
 ----------------------
+- `listsinceblock` will now throw an error if an unknown `blockhash` argument
+  value is passed, instead of returning a list of all wallet transactions since
+  the genesis block.
 - The "currentblocksize" value in getmininginfo has been removed.
 - The deprecated RPC `getinfo` was removed. It is recommended that the more specific RPCs are used:
   * `getblockchaininfo`

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1893,19 +1893,20 @@ UniValue listsinceblock(const JSONRPCRequest& request)
     int target_confirms = 1;
     isminefilter filter = ISMINE_SPENDABLE;
 
-    if (!request.params[0].isNull()) {
+    if (!request.params[0].isNull() && !request.params[0].get_str().empty()) {
         uint256 blockId;
 
         blockId.SetHex(request.params[0].get_str());
         BlockMap::iterator it = mapBlockIndex.find(blockId);
-        if (it != mapBlockIndex.end()) {
-            paltindex = pindex = it->second;
-            if (chainActive[pindex->nHeight] != pindex) {
-                // the block being asked for is a part of a deactivated chain;
-                // we don't want to depend on its perceived height in the block
-                // chain, we want to instead use the last common ancestor
-                pindex = chainActive.FindFork(pindex);
-            }
+        if (it == mapBlockIndex.end()) {
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+        }
+        paltindex = pindex = it->second;
+        if (chainActive[pindex->nHeight] != pindex) {
+            // the block being asked for is a part of a deactivated chain;
+            // we don't want to depend on its perceived height in the block
+            // chain, we want to instead use the last common ancestor
+            pindex = chainActive.FindFork(pindex);
         }
     }
 


### PR DESCRIPTION
Change suggested by @theuni  who noticed listsinceblock would ignore invalid block hashes causing it to return a completely unfiltered list of transactions.