### PR TITLE
Fixed a couple small grammatical errors.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ in init.cpp") in which case a single title line is sufficient. Commit messages s
 helpful to people reading your code in the future, so explain the reasoning for
 your decisions. Further explanation [here](http://chris.beams.io/posts/git-commit/).
 
-If a particular commit references another issue, please add the reference, for
-example `refs #1234`, or `fixes #4321`. Using the `fixes` or `closes` keywords
+If a particular commit references another issue, please add the reference. For
+example: `refs #1234` or `fixes #4321`. Using the `fixes` or `closes` keywords
 will cause the corresponding issue to be closed when the pull request is merged.
 
 Please refer to the [Git manual](https://git-scm.com/doc) for more information
@@ -85,7 +85,7 @@ Note that translations should not be submitted as pull requests, please see
 [Translation Process](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md) 
 for more information on helping with translations.
 
-If a pull request is specifically not to be considered for merging (yet) please
+If a pull request is not to be considered for merging (yet), please
 prefix the title with [WIP] or use [Tasks Lists](https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists)
 in the body of the pull request to indicate tasks are pending.
 


### PR DESCRIPTION
1. "If a pull request is not to be considered for merging (yet), please
prefix the ..."

2. If a particular commit references another issue, please add the reference. For
example: `refs #1234` or `fixes #4321`.