### PR TITLE
[Util] Update tinyformat.h

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -495,7 +495,11 @@ namespace detail {
 class FormatArg
 {
     public:
-        FormatArg() {}
+        FormatArg()
+             : m_value(nullptr),
+             m_formatImpl(nullptr),
+             m_toIntImpl(nullptr)
+         { }
 
         template<typename T>
         explicit FormatArg(const T& value)
@@ -507,11 +511,15 @@ class FormatArg
         void format(std::ostream& out, const char* fmtBegin,
                     const char* fmtEnd, int ntrunc) const
         {
+            assert(m_value);
+            assert(m_formatImpl);
             m_formatImpl(out, fmtBegin, fmtEnd, ntrunc, m_value);
         }
 
         int toInt() const
         {
+            assert(m_value);
+            assert(m_toIntImpl);
             return m_toIntImpl(m_value);
         }
 
@@ -712,23 +720,27 @@ inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositi
             break;
         case 'X':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'x': case 'p':
             out.setf(std::ios::hex, std::ios::basefield);
             intConversion = true;
             break;
         case 'E':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'e':
             out.setf(std::ios::scientific, std::ios::floatfield);
             out.setf(std::ios::dec, std::ios::basefield);
             break;
         case 'F':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'f':
             out.setf(std::ios::fixed, std::ios::floatfield);
             break;
         case 'G':
             out.setf(std::ios::uppercase);
+            // Falls through
         case 'g':
             out.setf(std::ios::dec, std::ios::basefield);
             // As in boost::format, let stream decide float format.


### PR DESCRIPTION
Updates `tinyformat.h` to commit c42f/tinyformat@689695c upstream. Including:
https://github.com/c42f/tinyformat/commit/8a2812d8480bfb66923eea0bb5cdda79fe4f17ba
https://github.com/c42f/tinyformat/commit/5d9e05a3479d1b2ec6a4602fd797f0ec26440db2
https://github.com/c42f/tinyformat/commit/48e2e48789907f80a7aec24a3f1d69196b78ed43

@achow101 mentioned that since upgrading to Ubuntu 17.10 (GCC 7), tinyformat had been throwing lots of -Wimplicit-fallthrough warnings. However fallthrough warnings should have been silenced by #10489. cc @theuni.

The upstream commit to fix fallthrough warnings is in this PR https://github.com/c42f/tinyformat/pull/39.

The last time tinyformat.h was updated in this repo was in #8274.