### PR TITLE
net: Add missing lock in ProcessHeadersMessage(...)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1262,8 +1262,8 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     if (!ProcessNewBlockHeaders(headers, state, chainparams, &pindexLast, &first_invalid_header)) {
         int nDoS;
         if (state.IsInvalid(nDoS)) {
+            LOCK(cs_main);
             if (nDoS > 0) {
-                LOCK(cs_main);
                 Misbehaving(pfrom->GetId(), nDoS);
             }
             if (punish_duplicate_invalid && mapBlockIndex.find(first_invalid_header.GetHash()) != mapBlockIndex.end()) {


### PR DESCRIPTION
Add missing lock in `ProcessHeadersMessage(...)`.

Reading the variable `mapBlockIndex` requires holding the mutex `cs_main`.

The new "Disconnect outbound peers relaying invalid headers" code added in commit 37886d5e2f9992678dea4b1bd893f4f10d61d3ad and merged as part of #11568 two days ago did not lock `cs_main` prior to accessing `mapBlockIndex`.