### PR TITLE
addrman: Add missing lock in Clear() (CAddrMan)

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -455,6 +455,7 @@ public:
 
     void Clear()
     {
+        LOCK(cs);
         std::vector<int>().swap(vRandom);
         nKey = GetRandHash();
         for (size_t bucket = 0; bucket < ADDRMAN_NEW_BUCKET_COUNT; bucket++) {


### PR DESCRIPTION
Add missing lock in `Clear()` (`CAddrMan`).

The variable `vRandom` is guarded by the mutex `cs`.

**Note to reviewers:** Does this look correct? Should the lock cover the entire scope of the method, or should it be limited to cover only `std::vector<int>().swap(vRandom);`?