### PR TITLE
Fix warnings when building with -Wthread-safety-analysis

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -607,7 +607,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
 // mapOrphanTransactions
 //
 
-void AddToCompactExtraTransactions(const CTransactionRef& tx)
+void AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     size_t max_extra_txn = gArgs.GetArg("-blockreconstructionextratxn", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN);
     if (max_extra_txn <= 0)


### PR DESCRIPTION
This fix makes the build pass when building with `-Werror=thread-safety-analysis`.

Prior to this commit:

```
net_processing.cpp:615:10: error: reading variable 'vExtraTxnForCompact' requires holding mutex 'cs_main' [-Werror,-Wthread-safety-analysis]
    if (!vExtraTxnForCompact.size())
         ^
net_processing.cpp:616:9: error: reading variable 'vExtraTxnForCompact' requires holding mutex 'cs_main' [-Werror,-Wthread-safety-analysis]
        vExtraTxnForCompact.resize(max_extra_txn);
        ^
net_processing.cpp:617:5: error: reading variable 'vExtraTxnForCompact' requires holding mutex 'cs_main' [-Werror,-Wthread-safety-analysis]
    vExtraTxnForCompact[vExtraTxnForCompactIt] = std::make_pair(tx->GetWitnessHash(), tx);
    ^
3 errors generated.
Makefile:5617: recipe for target 'libbitcoin_server_a-net_processing.o' failed
```

The full `-Wthread-safety-analysis` machinery (including new annotations) is added in #11226 (>100 commits, awaiting review). This small fix is worth doing just to get the current master branch buildable under `-Werror=thread-safety-analysis`.