### PR TITLE
wallet: Assert holding cs_wallet lock in GetAvailableCredit/GetAvailableWatchOnlyCredit [wip]

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1789,6 +1789,8 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
     if (pwallet == nullptr)
         return 0;
 
+    AssertLockHeld(pwallet->cs_wallet);
+
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)
         return 0;
@@ -1832,6 +1834,8 @@ CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool& fUseCache) const
 {
     if (pwallet == nullptr)
         return 0;
+
+    AssertLockHeld(pwallet->cs_wallet);
 
     // Must wait until coinbase is safely deep enough in the chain before valuing it
     if (IsCoinBase() && GetBlocksToMaturity() > 0)


### PR DESCRIPTION
**Note:** Still investigating. WIP.

~~Add missing `cs_wallet` locks in `GetAvailableCredit`, `GetAvailableWatchOnlyCredit` and `CreateWalletFromFile`:~~
* ~~`GetAvailableCredit` and `GetAvailableWatchOnlyCredit` read the variables `mapTxSpends` and `mapWallet` via the call to `IsSpent(...)` without holding `cs_wallet`.~~
* ~~`CreateWalletFromFile` reads the variable `nTimeFirstKey` without holding `cs_wallet`.~~