### PR TITLE
Improve -disablewallet parameter interaction

### DIFF
--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -53,11 +53,16 @@ std::string GetWalletHelpString(bool showDebug)
 
 bool WalletParameterInteraction()
 {
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
+        for (const std::string& wallet : gArgs.GetArgs("-wallet")) {
+            LogPrintf("%s: parameter interaction: -disablewallet -> ignoring -wallet=%s\n", __func__, wallet);
+        }
+
+        return true;
+    }
+
     gArgs.SoftSetArg("-wallet", DEFAULT_WALLET_DAT);
     const bool is_multiwallet = gArgs.GetArgs("-wallet").size() > 1;
-
-    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
-        return true;
 
     if (gArgs.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY) && gArgs.SoftSetBoolArg("-walletbroadcast", false)) {
         LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -walletbroadcast=0\n", __func__);

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -178,15 +178,18 @@ bool WalletParameterInteraction()
 
 void RegisterWalletRPC(CRPCTable &t)
 {
-    if (gArgs.GetBoolArg("-disablewallet", false)) return;
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
+        return;
+    }
 
     RegisterWalletRPCCommands(t);
 }
 
 bool VerifyWallets()
 {
-    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET))
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
         return true;
+    }
 
     uiInterface.InitMessage(_("Verifying wallet(s)..."));
 


### PR DESCRIPTION
The first commit logs a message for each configured wallet if `-disablewallet` is set:
```
bitcoind -printtoconsole -regtest -disablewallet -wallet=foo -wallet=bar
...
WalletParameterInteraction: parameter interaction: -disablewallet -> ignoring -wallet=foo
WalletParameterInteraction: parameter interaction: -disablewallet -> ignoring -wallet=bar
```
It also moves up the `-disablewallet` check which avoids the unnecessary `-wallet` soft set.

The second commit fixes the default value of `-disablewallet`, currently the value is correct, but it should use `DEFAULT_DISABLE_WALLET`.

The third commit can be dropped or squashed, just took the opportunity to fix the coding style there.