### PR TITLE
Make travis complain on #bitcoin-core-dev when builds fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,3 +79,9 @@ script:
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG
+notifications:
+    irc:
+        channels:
+            - "chat.freenode.net#bitcoin-core-dev"
+        on_success: change
+        on_failure: always


### PR DESCRIPTION
I suppose this is more of an RFC, but we occasionally have master builds failing and (at least I) dont notice, would be nice to get bugged about it (we already get push notifications, so this shouldn't be *too* much more volume).