### PR TITLE
[net] Remove ForNode/ForEachNode

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -685,7 +685,6 @@ void CNode::copyStats(CNodeStats &stats)
     }
     X(fInbound);
     X(m_manual_connection);
-    X(nStartingHeight);
     {
         LOCK(cs_vSend);
         X(mapSendBytesPerMsgCmd);
@@ -2759,7 +2758,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nSendSize = 0;
     nSendOffset = 0;
     hashContinue = uint256();
-    nStartingHeight = -1;
     filterInventoryKnown.reset();
     fSendMempool = false;
     fGetAddr = false;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2831,11 +2831,6 @@ void CNode::AskFor(const CInv& inv)
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
 }
 
-bool CConnman::NodeFullyConnected(const CNode* pnode)
-{
-    return pnode && pnode->fSuccessfullyConnected && !pnode->fDisconnect;
-}
-
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     size_t nMessageSize = msg.data.size();
@@ -2871,19 +2866,6 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
     }
     if (nBytesSent)
         RecordBytesSent(nBytesSent);
-}
-
-bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)
-{
-    CNode* found = nullptr;
-    LOCK(cs_vNodes);
-    for (auto&& pnode : vNodes) {
-        if(pnode->GetId() == id) {
-            found = pnode;
-            break;
-        }
-    }
-    return found != nullptr && NodeFullyConnected(found) && func(found);
 }
 
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2773,7 +2773,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nPingNonceSent = 0;
     nPingUsecStart = 0;
     nPingUsecTime = 0;
-    fPingQueued = false;
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
     minFeeFilter = 0;
     lastSentFeeFilter = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -717,8 +717,6 @@ public:
     std::atomic<int64_t> nPingUsecTime;
     // Best measured round-trip time.
     std::atomic<int64_t> nMinPingUsecTime;
-    // Whether a ping is requested.
-    std::atomic<bool> fPingQueued;
     // Minimum fee rate with which to filter inv's to this node
     CAmount minFeeFilter;
     CCriticalSection cs_feeFilter;

--- a/src/net.h
+++ b/src/net.h
@@ -673,7 +673,6 @@ protected:
 
 public:
     uint256 hashContinue;
-    std::atomic<int> nStartingHeight;
 
     // flood relay
     std::vector<CAddress> vAddrToSend;

--- a/src/net.h
+++ b/src/net.h
@@ -174,51 +174,7 @@ public:
     bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = nullptr, const char *strDest = nullptr, bool fOneShot = false, bool fFeeler = false, bool manual_connection = false);
     bool CheckIncomingNonce(uint64_t nonce);
 
-    bool ForNode(NodeId id, std::function<bool(CNode* pnode)> func);
-
     void PushMessage(CNode* pnode, CSerializedNetMsg&& msg);
-
-    template<typename Callable>
-    void ForEachNode(Callable&& func)
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                func(node);
-        }
-    };
-
-    template<typename Callable>
-    void ForEachNode(Callable&& func) const
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                func(node);
-        }
-    };
-
-    template<typename Callable, typename CallableAfter>
-    void ForEachNodeThen(Callable&& pre, CallableAfter&& post)
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                pre(node);
-        }
-        post();
-    };
-
-    template<typename Callable, typename CallableAfter>
-    void ForEachNodeThen(Callable&& pre, CallableAfter&& post) const
-    {
-        LOCK(cs_vNodes);
-        for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
-                pre(node);
-        }
-        post();
-    };
 
     // Addrman functions
     size_t GetAddressCount() const;
@@ -357,9 +313,6 @@ private:
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
     void RecordBytesSent(uint64_t bytes);
-
-    // Whether the node should be passed out in ForEach* callbacks
-    static bool NodeFullyConnected(const CNode* pnode);
 
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -83,5 +83,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 void Misbehaving(NodeId nodeid, int howmuch);
 /** Relay a transaction that is in mempool to all our peers */
 void RelayTransaction(const uint256& tx_hash, CConnman* connman);
+/** Send all of our peers a ping */
+void QueuePingForAllPeers();
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -71,6 +71,7 @@ private:
 
 struct CNodeStateStats {
     int nMisbehavior;
+    int nStartingHeight;
     int nSyncHeight;
     int nCommonHeight;
     std::vector<int> vHeightInFlight;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -81,5 +81,7 @@ struct CNodeStateStats {
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Increase a node's misbehavior score. */
 void Misbehaving(NodeId nodeid, int howmuch);
+/** Relay a transaction that is in mempool to all our peers */
+void RelayTransaction(const uint256& tx_hash, CConnman* connman);
 
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -59,9 +59,7 @@ UniValue ping(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
     // Request that each node send a ping during next message processing pass
-    g_connman->ForEachNode([](CNode* pnode) {
-        pnode->fPingQueued = true;
-    });
+    QueuePingForAllPeers();
     return NullUniValue;
 }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -14,6 +14,7 @@
 #include <validationinterface.h>
 #include <merkleblock.h>
 #include <net.h>
+#include <net_processing.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
@@ -979,12 +980,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
     if(!g_connman)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
-    CInv inv(MSG_TX, hashTx);
-    g_connman->ForEachNode([&inv](CNode* pnode)
-    {
-        pnode->PushInventory(inv);
-    });
-
+    RelayTransaction(hashTx, g_connman.get());
     return hashTx.GetHex();
 }
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -123,8 +123,12 @@ static void push_lock(void* c, const CLockLocation& locklocation)
     }
 }
 
-static void pop_lock()
+static void pop_lock(void* cs)
 {
+    // We assert here that locks are popped in the order they were locked.
+    // This is a super-overly-restrictive requirement, but we need it to
+    // make our deadlock detection work properly.
+    assert((*lockstack).back().first == cs);
     (*lockstack).pop_back();
 }
 
@@ -133,9 +137,9 @@ void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs
     push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry));
 }
 
-void LeaveCritical()
+void LeaveCritical(void* cs)
 {
-    pop_lock();
+    pop_lock(cs);
 }
 
 std::string LocksHeld()

--- a/src/sync.h
+++ b/src/sync.h
@@ -74,14 +74,14 @@ public:
 
 #ifdef DEBUG_LOCKORDER
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false);
-void LeaveCritical();
+void LeaveCritical(void* cs);
 std::string LocksHeld();
 void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs);
 void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs);
 void DeleteLock(void* cs);
 #else
 void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
-void static inline LeaveCritical() {}
+void static inline LeaveCritical(void* cs) {}
 void static inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
 void static inline AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
 void static inline DeleteLock(void* cs) {}
@@ -138,7 +138,7 @@ private:
         EnterCritical(pszName, pszFile, nLine, (void*)(lock.mutex()), true);
         lock.try_lock();
         if (!lock.owns_lock())
-            LeaveCritical();
+            LeaveCritical((void*)(lock.mutex()));
         return lock.owns_lock();
     }
 
@@ -165,7 +165,7 @@ public:
     ~CCriticalBlock() UNLOCK_FUNCTION()
     {
         if (lock.owns_lock())
-            LeaveCritical();
+            LeaveCritical((void*)(lock.mutex()));
     }
 
     operator bool()
@@ -187,10 +187,10 @@ public:
         (cs).lock();                                          \
     }
 
-#define LEAVE_CRITICAL_SECTION(cs) \
-    {                              \
-        (cs).unlock();             \
-        LeaveCritical();           \
+#define LEAVE_CRITICAL_SECTION(cs)   \
+    {                                \
+        (cs).unlock();               \
+        LeaveCritical((void*)(&cs)); \
     }
 
 class CSemaphore

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -17,6 +17,7 @@
 #include <keystore.h>
 #include <validation.h>
 #include <net.h>
+#include <net_processing.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
@@ -1733,11 +1734,7 @@ bool CWalletTx::RelayWalletTransaction(CConnman* connman)
         if (InMempool() || AcceptToMemoryPool(maxTxFee, state)) {
             LogPrintf("Relaying wtx %s\n", GetHash().ToString());
             if (connman) {
-                CInv inv(MSG_TX, GetHash());
-                connman->ForEachNode([&inv](CNode* pnode)
-                {
-                    pnode->PushInventory(inv);
-                });
+                RelayTransaction(GetHash(), connman);
                 return true;
             }
         }


### PR DESCRIPTION
They were only used in places where they really should not have been used.

Replaces #10697.