### PR TITLE
[Wallet] Enable RBF by default in QT

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -67,6 +67,14 @@ Due to a backward-incompatible change in the wallet database, wallets created
 with version 0.16.0 will be rejected by previous versions. Also, version 0.16.0
 will only create hierarchical deterministic (HD) wallets.
 
+Replace-By-Fee by default in GUI
+--------------------------------
+The send screen now uses BIP-125 RBF by default, regardless of `-walletrbf`.
+There is a checkbox to mark the transaction as final.
+
+The RPC default remains unchanged: to use RBF, launch with `-walletrbf=1` or
+use the `replaceable` argument for individual transactions.
+
 Custom wallet directories
 ---------------------
 The ability to specify a directory other than the default data directory in which to store

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -1108,10 +1108,10 @@
            <item>
             <widget class="QCheckBox" name="optInRBF">
              <property name="text">
-              <string>Allow increasing fee</string>
+              <string>Enable Replace-By-Fee</string>
              </property>
              <property name="toolTip">
-              <string>This allows you to increase the fee later if the transaction takes a long time to confirm. This will also cause the recommended fee to be lower. ("Replace-By-Fee", BIP 125)</string>
+              <string>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</string>
              </property>
             </widget>
            </item>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -184,7 +184,7 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         updateSmartFeeLabel();
 
         // set default rbf checkbox state
-        ui->optInRBF->setCheckState(model->getDefaultWalletRbf() ? Qt::Checked : Qt::Unchecked);
+        ui->optInRBF->setCheckState(Qt::Checked);
 
         // set the smartfee-sliders default value (wallets default conf.target or last stored value)
         QSettings settings;
@@ -342,12 +342,14 @@ void SendCoinsDialog::on_sendButton_clicked()
     questionString.append(QString("<span style='font-size:10pt;font-weight:normal;'><br />(=%2)</span>")
         .arg(alternativeUnits.join(" " + tr("or") + "<br />")));
 
-    if (ui->optInRBF->isChecked())
-    {
-        questionString.append("<hr /><span>");
-        questionString.append(tr("You can increase the fee later (signals Replace-By-Fee)."));
-        questionString.append("</span>");
+    questionString.append("<hr /><span>");
+    if (ui->optInRBF->isChecked()) {
+        questionString.append(tr("You can increase the fee later (signals Replace-By-Fee, BIP-125)."));
+    } else {
+        questionString.append(tr("Not signalling Replace-By-Fee, BIP-125."));
     }
+    questionString.append("</span>");
+
 
     SendConfirmationDialog confirmationDialog(tr("Confirm send coins"),
         questionString.arg(formatted.join("<br />")), SEND_CONFIRM_DELAY, this);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -737,8 +737,3 @@ int WalletModel::getDefaultConfirmTarget() const
 {
     return nTxConfirmTarget;
 }
-
-bool WalletModel::getDefaultWalletRbf() const
-{
-    return fWalletRbf;
-}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -216,8 +216,6 @@ public:
 
     int getDefaultConfirmTarget() const;
 
-    bool getDefaultWalletRbf() const;
-
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -31,7 +31,7 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet on startup"));
     strUsage += HelpMessageOpt("-spendzeroconfchange", strprintf(_("Spend unconfirmed change when sending transactions (default: %u)"), DEFAULT_SPEND_ZEROCONF_CHANGE));
     strUsage += HelpMessageOpt("-txconfirmtarget=<n>", strprintf(_("If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)"), DEFAULT_TX_CONFIRM_TARGET));
-    strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (default: %u)"), DEFAULT_WALLET_RBF));
+    strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)"), DEFAULT_WALLET_RBF));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), DEFAULT_WALLET_DAT));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));


### PR DESCRIPTION
~If there are no objections, this would supersede #11556.~

Enabling RBF by default avoids the need to explain all possible use cases of RBF.

This PR does not change the default RPC wallet behavior, as this could break implementations that depend on it and it's not clear what happens when automated services suddenly switch on RBF on a large scale.

After trying various approaches, we settled on just having QT ignore `-walletrbf`.

Send screen:
<img width="388" alt="send" src="https://user-images.githubusercontent.com/10217/34251097-329c8dee-e63f-11e7-9e14-d7f55d2b52cc.png">


Confirmation screen by default (with RBF):
<img width="429" alt="rbf yes" src="https://user-images.githubusercontent.com/10217/32442799-f50d54aa-c2fc-11e7-9392-96339d0f1f74.png">

Confirmation screen without RBF:
<img width="431" alt="rf no" src="https://user-images.githubusercontent.com/10217/32442793-ef30bc34-c2fc-11e7-8ca2-e86a97175278.png">