### PR TITLE
[build] Don't fail when passed --disable-lcov and lcov isn't available

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,7 +162,7 @@ AC_ARG_ENABLE([ccache],
 AC_ARG_ENABLE([lcov],
   [AS_HELP_STRING([--enable-lcov],
   [enable lcov testing (default is no)])],
-  [use_lcov=yes],
+  [use_lcov=$enableval],
   [use_lcov=no])
   
 AC_ARG_ENABLE([lcov-branch-coverage],


### PR DESCRIPTION
Fixes #10828
As pointed out in #10828, failing with "lcov not found" when we've been passed --disable-lcov doesn't make sense. Master currently behaves like this (where lcov isn't available):
```
./configure --disable-lcov
checking for pkg-config... /usr/local/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
configure: error: "lcov testing requested but lcov not found"
```

cc @janstary