### PR TITLE
ZMQ: Add decodedtx topic for JSON tx publishing

### DIFF
--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -39,6 +39,7 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
     factories["pubhashtx"] = CZMQAbstractNotifier::Create<CZMQPublishHashTransactionNotifier>;
     factories["pubrawblock"] = CZMQAbstractNotifier::Create<CZMQPublishRawBlockNotifier>;
     factories["pubrawtx"] = CZMQAbstractNotifier::Create<CZMQPublishRawTransactionNotifier>;
+    factories["pubdecodedtx"] = CZMQAbstractNotifier::Create<CZMQPublishDecodedTransactionNotifier>;
 
     for (std::map<std::string, CZMQNotifierFactory>::const_iterator i=factories.begin(); i!=factories.end(); ++i)
     {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -4,22 +4,21 @@
 
 #include "chain.h"
 #include "chainparams.h"
-#include "streams.h"
-#include "zmqpublishnotifier.h"
-#include "validation.h"
-#include "util.h"
-#include "rpc/server.h"
-#include "rpc/protocol.h"
-#include <univalue.h>
 #include "core_io.h"
+#include "rpc/server.h"
+#include "streams.h"
+#include <univalue.h>
+#include "util.h"
+#include "validation.h"
+#include "zmqpublishnotifier.h"
 
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
-static const char *MSG_HASHBLOCK     = "hashblock";
-static const char *MSG_HASHTX        = "hashtx";
-static const char *MSG_RAWBLOCK      = "rawblock";
-static const char *MSG_RAWTX         = "rawtx";
-static const char *MSG_DECODEDTX     = "decodedtx";
+static const char *MSG_DECODEDTX = "decodedtx";
+static const char *MSG_HASHBLOCK = "hashblock";
+static const char *MSG_HASHTX    = "hashtx";
+static const char *MSG_RAWBLOCK  = "rawblock";
+static const char *MSG_RAWTX     = "rawtx";
 
 // Internal function to send multipart message
 static int zmq_send_multipart(void *sock, const void* data, size_t size, ...)
@@ -206,7 +205,7 @@ bool CZMQPublishDecodedTransactionNotifier::NotifyTransaction(const CTransaction
     LogPrint(BCLog::ZMQ, "zmq: Publish decodedtx %s\n", hash.GetHex());
     UniValue result(UniValue::VOBJ);
     TxToUniv(transaction, uint256(), result, false);
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
-    ss << result.write();
-    return SendMessage(MSG_DECODEDTX, &(*ss.begin()), ss.size());
+    std::string jsontx = result.write();
+    const char *output = jsontx.c_str();
+    return SendMessage(MSG_DECODEDTX, &(*output), strlen(output));
 }

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -52,4 +52,10 @@ public:
     bool NotifyTransaction(const CTransaction &transaction) override;
 };
 
+class CZMQPublishDecodedTransactionNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool NotifyTransaction(const CTransaction &transaction) override;
+};
+
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -116,7 +116,7 @@ class ZMQTest (BitcoinTestFramework):
         payment_txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
         self.sync_all()
 
-        # Should receive the json broadcasted raw transaction.
+        # Should receive the json decoded transaction.
         decodedtx = self.decodedtx.receive()
         assert_equal(payment_txid, json.loads(decodedtx.decode('utf-8'))['txid'])
 
@@ -124,7 +124,7 @@ class ZMQTest (BitcoinTestFramework):
         txid = self.hashtx.receive()
         assert_equal(payment_txid, bytes_to_hex_str(txid))
 
-        # Should receive the json decoded transaction.
+        # Should receive the broadcasted raw transaction.
         hex = self.rawtx.receive()
         assert_equal(payment_txid, bytes_to_hex_str(hash256(hex)))
 

--- a/test/functional/zmq_test.py
+++ b/test/functional/zmq_test.py
@@ -25,6 +25,7 @@ class ZMQSubscriber:
 
     def receive(self):
         topic, body, seq = self.socket.recv_multipart()
+
         # Topic should match the subscriber topic.
         assert_equal(topic, self.topic)
         # Sequence should be incremental.
@@ -90,11 +91,12 @@ class ZMQTest (BitcoinTestFramework):
         self.sync_all()
 
         for x in range(num_blocks):
-            # Should receive the json broadcasted raw transaction.
+            # Should receive the json decoded transaction.
             decodedtx = self.decodedtx.receive()
 
             # Should receive the coinbase txid.
             txid = self.hashtx.receive()
+            assert_equal(bytes_to_hex_str(txid), json.loads(decodedtx.decode('utf-8'))['txid'])
 
             # Should receive the coinbase raw transaction.
             hex = self.rawtx.receive()
@@ -116,13 +118,13 @@ class ZMQTest (BitcoinTestFramework):
 
         # Should receive the json broadcasted raw transaction.
         decodedtx = self.decodedtx.receive()
-        assert_equal(payment_txid, json.loads(decodedtx[3:])['txid'])
+        assert_equal(payment_txid, json.loads(decodedtx.decode('utf-8'))['txid'])
 
         # Should receive the broadcasted txid.
         txid = self.hashtx.receive()
         assert_equal(payment_txid, bytes_to_hex_str(txid))
 
-        # Should receive the broadcasted raw transaction.
+        # Should receive the json decoded transaction.
         hex = self.rawtx.receive()
         assert_equal(payment_txid, bytes_to_hex_str(hash256(hex)))
 


### PR DESCRIPTION
- Adds a new ZMQ topic called `decodedtx` that uses `TxToUniv` to decode all newly arrived transaction into JSON and publish them over ZMQ.

- Includes functional tests