### PR TITLE
[build] .gitignore: add background.tiff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ src/qt/test/moc*.cpp
 Makefile
 bitcoin-qt
 Bitcoin-Qt.app
+background.tiff*
 
 # Unit-tests
 Makefile.test


### PR DESCRIPTION
On OSX, running `make deploy` results in three files that were not covered by `.gitignore`:

	background.tiff
	background.tiff.png
	background.tiff@2x.png 