### PR TITLE
qa: Only allow disconnecting all NodeConns

### DIFF
--- a/test/functional/maxuploadtarget.py
+++ b/test/functional/maxuploadtarget.py
@@ -54,7 +54,7 @@ class MaxUploadTest(BitcoinTestFramework):
         # p2p_conns[2] will test resetting the counters
         p2p_conns = []
 
-        for i in range(3):
+        for _ in range(3):
             p2p_conns.append(self.nodes[0].add_p2p_connection(TestNode()))
 
         NetworkThread().start() # Start up network handling in another thread
@@ -139,8 +139,7 @@ class MaxUploadTest(BitcoinTestFramework):
 
         self.log.info("Peer 2 able to download old block")
 
-        for i in range(3):
-            self.nodes[0].disconnect_p2p()
+        self.nodes[0].disconnect_p2ps()
 
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
         self.log.info("Restarting nodes with -whitelist=127.0.0.1")

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -206,7 +206,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         # The node should have requested the blocks at some point, so
         # disconnect/reconnect first
 
-        self.nodes[0].disconnect_p2p()
+        self.nodes[0].disconnect_p2ps()
         test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
 
         test_node.wait_for_verack()
@@ -291,7 +291,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         except AssertionError:
             test_node.wait_for_disconnect()
 
-            self.nodes[0].disconnect_p2p()
+            self.nodes[0].disconnect_p2ps()
             test_node = self.nodes[0].add_p2p_connection(NodeConnCB())
 
             NetworkThread().start() # Start up network handling in another thread

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -126,8 +126,7 @@ class P2PLeakTest(BitcoinTestFramework):
         assert not unsupported_service_bit5_node.connected
         assert not unsupported_service_bit7_node.connected
 
-        for _ in range(5):
-            self.nodes[0].disconnect_p2p()
+        self.nodes[0].disconnect_p2ps()
 
         # Wait until all connections are closed
         wait_until(lambda: len(self.nodes[0].getpeerinfo()) == 0)

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -182,13 +182,14 @@ class TestNode():
         assert self.p2ps, "No p2p connection"
         return self.p2ps[0]
 
-    def disconnect_p2p(self, index=0):
-        """Close the p2p connection to the node."""
-        # Connection could have already been closed by other end. Calling disconnect_p2p()
-        # on an already disconnected p2p connection is not an error.
-        if self.p2ps[index].connection is not None:
-            self.p2ps[index].connection.disconnect_node()
-        del self.p2ps[index]
+    def disconnect_p2ps(self):
+        """Close all p2p connections to the node."""
+        for p in self.p2ps:
+            # Connection could have already been closed by other end.
+            if p.connection is not None:
+                p.connection.disconnect_node()
+        self.p2ps = []
+
 
 class TestNodeCLI():
     """Interface to bitcoin-cli for an individual node"""


### PR DESCRIPTION
Disconnecting the connection with `index=0` makes no sense when there are more than one connections, as the list "rotates around" and populates index 0 after `del`.

Just disconnect all NodeConns in any case.