### PR TITLE
Require a steady clock for bench with at least micro precision

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -23,6 +23,9 @@ void
 benchmark::BenchRunner::RunAll(benchmark::duration elapsedTimeForOne)
 {
     perf_init();
+    if (std::ratio_less_equal<benchmark::clock::period, std::micro>::value) {
+        std::cerr << "WARNING: Clock precision is worse than microsecond - benchmarks may be less accurate!\n";
+    }
     std::cout << "#Benchmark" << "," << "count" << "," << "min(ns)" << "," << "max(ns)" << "," << "average(ns)" << ","
               << "min_cycles" << "," << "max_cycles" << "," << "average_cycles" << "\n";
 

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -37,13 +37,11 @@ BENCHMARK(CODE_TO_TIME);
  */
  
 namespace benchmark {
-    // On many systems, the high_resolution_clock offers no better resolution than the steady_clock.
-    // If that's the case, prefer the steady_clock.
+    // In case high_resolution_clock is steady, prefer that, otherwise use steady_clock.
     struct best_clock {
         using hi_res_clock = std::chrono::high_resolution_clock;
         using steady_clock = std::chrono::steady_clock;
-        static constexpr bool steady_is_high_res = std::ratio_less_equal<steady_clock::period, hi_res_clock::period>::value;
-        using type = std::conditional<steady_is_high_res, steady_clock, hi_res_clock>::type;
+        using type = std::conditional<hi_res_clock::is_steady, hi_res_clock, steady_clock>::type;
     };
     using clock = best_clock::type;
     using time_point = clock::time_point;


### PR DESCRIPTION
Using a non-steady high_precision_clock by default is definitely not what we want, and in practice steady_clock has more than enough precision. Should double-check that travis passes on this one to make sure we actually have at least microsecond precision on all platforms.