### PR TITLE
Revert "Remove unused variable in shell script"

### DIFF
--- a/contrib/devtools/git-subtree-check.sh
+++ b/contrib/devtools/git-subtree-check.sh
@@ -48,6 +48,7 @@ if [ -z "$latest_squash" ]; then
 fi
 
 set $latest_squash
+old=$1
 rev=$2
 if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
     echo "ERROR: subtree commit $rev unavailable. Fetch/update the subtree repository" >&2


### PR DESCRIPTION
This partially reverts commit ab8e8b97a359e1c4f1bca8e1769021c95019f2c4 (#10771), as the variable is still used. See for example #11394.