### PR TITLE
[RPC] Add utility getsignaturehash

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -66,6 +66,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listaccounts", 1, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },
+    { "getsignaturehash", 2, "amount" },
+    { "getsignaturehash", 4, "inputindex" },
     { "listsinceblock", 1, "target_confirmations" },
     { "listsinceblock", 2, "include_watchonly" },
     { "listsinceblock", 3, "include_removed" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -829,19 +829,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 
     int nHashType = SIGHASH_ALL;
     if (!request.params[3].isNull()) {
-        static std::map<std::string, int> mapSigHashValues = {
-            {std::string("ALL"), int(SIGHASH_ALL)},
-            {std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY)},
-            {std::string("NONE"), int(SIGHASH_NONE)},
-            {std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY)},
-            {std::string("SINGLE"), int(SIGHASH_SINGLE)},
-            {std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY)},
-        };
-        std::string strHashType = request.params[3].get_str();
-        if (mapSigHashValues.count(strHashType))
-            nHashType = mapSigHashValues[strHashType];
-        else
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid sighash param");
+        nHashType = ParseSigHash(request.params[3].get_str(), "sighashtype");
     }
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -131,6 +131,30 @@ uint256 ParseHashV(const UniValue& v, std::string strName)
     result.SetHex(strHex);
     return result;
 }
+
+int ParseSigHash(const std::string& sigHash, const std::string& parameterName)
+{
+    int nHashType = 0;
+    static std::map<std::string, int> mapSigHashValues = {
+        { std::string("ALL"), int(SIGHASH_ALL) },
+        { std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL | SIGHASH_ANYONECANPAY) },
+        { std::string("NONE"), int(SIGHASH_NONE) },
+        { std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE | SIGHASH_ANYONECANPAY) },
+        { std::string("SINGLE"), int(SIGHASH_SINGLE) },
+        { std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY) },
+    };
+    auto it = mapSigHashValues.find(sigHash);
+    if (it != mapSigHashValues.end())
+    {
+        nHashType = (*it).second;
+    }
+    else
+    {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid %s param", parameterName));
+    }
+    return nHashType;
+}
+
 uint256 ParseHashO(const UniValue& o, std::string strKey)
 {
     return ParseHashV(find_value(o, strKey), strKey);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -184,6 +184,7 @@ extern uint256 ParseHashO(const UniValue& o, std::string strKey);
 extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
 extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
+extern int ParseSigHash(const std::string& sigHash, const std::string& parameterName);
 extern CAmount AmountFromValue(const UniValue& value);
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);

--- a/test/functional/getsignaturehash.py
+++ b/test/functional/getsignaturehash.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the RPC call related to the uptime command.
+
+Test corresponds to code in rpc/server.cpp.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class GetSignatureHashTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        tx = "010000000243ec7a579f5561a42a7e9637ad4156672735a658be2752181801f723ba3316d200000000844730440220449a203d0062ea01022f565c94c4b62bf2cc9a05de20519bc18cded9e99aa5f702201a2b8361e2af179eb93e697d9fedd0bf1e036f0a5be39af4b1f791df803bdb6501210363e38e2e0e55cdebfb7e27d0cb53ded150c320564a4614c18738feb124c8efd21976a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088acffffffff43ec7a579f5561a42a7e9637ad4156672735a658be2752181801f723ba3316d20100000085483045022100ff6e7edffa5e0758244af6af77edd14f1d80226d66f81ed58dba2def34778236022057d95177497758e467c194f0d897f175645d30e7ac2f9490247e13227ac4d2fc01210363e38e2e0e55cdebfb7e27d0cb53ded150c320564a4614c18738feb124c8efd21976a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088acffffffff0100752b7d000000001976a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088ac00000000"
+        scriptcode = "76a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088ac"
+        amount = 100000000
+        sigversion = "BASE"
+        input_index = 0
+        sighash = "ALL"
+        expected_hash = "64e049981a10cf597406a175d7443c8499d308168915377637e3f706ce186137" 
+        assert_equal(expected_hash, self.nodes[0].getsignaturehash(
+            tx,
+            scriptcode,
+            amount,
+            sigversion,
+            input_index,
+            sighash
+        ))
+
+        # optional parameter
+        assert_equal(expected_hash, self.nodes[0].getsignaturehash(
+            tx,
+            scriptcode,
+            amount,
+            sigversion,
+            input_index
+        ))
+
+
+
+
+if __name__ == '__main__':
+    GetSignatureHashTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -126,6 +126,7 @@ BASE_SCRIPTS= [
     'p2p-fingerprint.py',
     'uacomment.py',
     'p2p-acceptblock.py',
+    'getsignaturehash.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
Add an utility to get the signature hash in a generic way.
`signrawtransaction` can't create a signature for an arbitrary scriptCode, as it is using `ProduceSignature` internally. This make it impossible to create complex scripts without a library.