### PR TITLE
tests: Initialize recently introduced non-static class member lastCycles to zero in constructor

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -59,12 +59,17 @@ namespace benchmark {
         uint64_t minCycles;
         uint64_t maxCycles;
     public:
-        State(std::string _name, duration _maxElapsed) : name(_name), maxElapsed(_maxElapsed), count(0) {
-            minTime = duration::max();
-            maxTime = duration::zero();
-            minCycles = std::numeric_limits<uint64_t>::max();
-            maxCycles = std::numeric_limits<uint64_t>::min();
-            countMask = 1;
+        State(std::string _name, duration _maxElapsed) :
+            name(_name),
+            maxElapsed(_maxElapsed),
+            minTime(duration::max()),
+            maxTime(duration::zero()),
+            count(0),
+            countMask(1),
+            beginCycles(0),
+            lastCycles(0),
+            minCycles(std::numeric_limits<uint64_t>::max()),
+            maxCycles(std::numeric_limits<uint64_t>::min()) {
         }
         bool KeepRunning();
     };


### PR DESCRIPTION
Initialize recently introduced non-static class member `lastCycles` to zero in constructor.

`lastCycles` was introduced in 35328187463a7078b4206e394c21d5515929c7de which was merged into master yesterday.

Friendly ping  @laanwj :-)