### PR TITLE
RPC: Internal named params

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -208,7 +208,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
 
 UniValue help(const JSONRPCRequest& jsonRequest)
 {
-    if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
+    if (jsonRequest.fHelp) {
         throw std::runtime_error(
             "help ( \"command\" )\n"
             "\nList all commands, or get help for a specified command.\n"
@@ -217,10 +217,16 @@ UniValue help(const JSONRPCRequest& jsonRequest)
             "\nResult:\n"
             "\"text\"     (string) The help text\n"
         );
+    }
+
+    RPCTypeCheckObj(jsonRequest.params, {
+        {"command", {UniValue::VSTR, UniValue::VNULL}},
+    }, false, true);
 
     std::string strCommand;
-    if (jsonRequest.params.size() > 0)
-        strCommand = jsonRequest.params[0].get_str();
+    if (!jsonRequest.params["command"].isNull()) {
+        strCommand = jsonRequest.params["command"].get_str();
+    }
 
     return tableRPC.help(strCommand, jsonRequest);
 }
@@ -262,7 +268,7 @@ static const CRPCCommand vRPCCommands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
     /* Overall control/query calls */
-    { "control",            "help",                   &help,                   {"command"}  },
+    { "control",            "help",                   &help,                   {"command"}, true  },
     { "control",            "stop",                   &stop,                   {}  },
     { "control",            "uptime",                 &uptime,                 {}  },
 };

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -94,7 +94,7 @@ void RPCTypeCheckObj(const UniValue& o,
     {
         for (const std::string& k : o.getKeys())
         {
-            if (typesExpected.count(k) == 0)
+            if (typesExpected.count(k) == 0 && !o[k].isNull())
             {
                 std::string err = strprintf("Unexpected key %s", k);
                 throw JSONRPCError(RPC_TYPE_ERROR, err);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -19,6 +19,8 @@
 
 static const unsigned int DEFAULT_RPC_SERIALIZE_VERSION = 1;
 
+static const std::string ARGS_WERE_POSITIONAL = "_positional";
+
 class CRPCCommand;
 
 namespace RPCServer
@@ -135,6 +137,7 @@ public:
     std::string name;
     rpcfn_type actor;
     std::vector<std::string> argNames;
+    bool named_args;
 };
 
 /**


### PR DESCRIPTION
This allows RPC code to use named parameters internally, greatly increasing readability, as well as helping avoid behaviour tied to param count rather than the presence of specific parameters.

Object type checking is expanded to support multiple allowed types, making param and type-checking clean.

Temporarily, a boolean is added to the end of CRPCCommand to indicate whether the function expects named params. Once all RPC functions have been converted, we can drop it (as well as old internal-positional-param code).

Alternative to #11441