### PR TITLE
[RPC] Add utility signinput

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -66,6 +66,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listaccounts", 1, "include_watchonly" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },
+    { "signinput", 2, "amount" },
+    { "signinput", 4, "inputindex" },
     { "listsinceblock", 1, "target_confirmations" },
     { "listsinceblock", 2, "include_watchonly" },
     { "listsinceblock", 3, "include_removed" },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -320,6 +320,89 @@ UniValue createmultisig(const JSONRPCRequest& request)
     return result;
 }
 
+UniValue signinput(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() < 6 || request.params.size() > 7)
+        throw std::runtime_error(
+            "signinput \"tx\" \"scriptcode\" amount \"sigversion\" inputindex \"privatekey\" (\"sighashtype\")\n"
+            "\nCreate the a valid signature for the given input\n"
+
+            "\nArguments:\n"
+            "1. \"tx\"                 (string, required) The transaction hex string\n"
+            "2. \"scriptcode\"         (string, required) The scriptCode to sign\n"
+            "3. \"amount\"             (numeric, required) The amount spent in satoshi\n"
+            "4. \"sigversion\"         (string, required) The signature version\n"
+            "       \"BASE\"\n"
+            "       \"WITNESS_V0\"\n"
+            "5. inputindex             (numeric, required) The index of the input to sign\n"
+            "6. \"privatekey\"         (string, required) Private key in base58-encoding\n"
+            "7. \"sighashtype\"        (string, optional, default=ALL) The signature hash type. Must be one of\n"
+            "       \"ALL\"\n"
+            "       \"NONE\"\n"
+            "       \"SINGLE\"\n"
+            "       \"ALL|ANYONECANPAY\"\n"
+            "       \"NONE|ANYONECANPAY\"\n"
+            "       \"SINGLE|ANYONECANPAY\"\n"
+            "\nResult:\n"
+            "\"signature\"             (string) hex string of the signature\n"
+
+            "\nExamples:\n"
+            + HelpExampleCli("signinput", "\"txhex\" \"scriptcode\" \"0.01\" \"WITNESS_V0\" 1 \"privateKey\" \"SINGLE\"")
+            + HelpExampleRpc("signinput", "\"txhex\" \"scriptcode\" \"0.01\" \"WITNESS_V0\" 1 \"privateKey\" \"SINGLE\"")
+        );
+
+    RPCTypeCheck(request.params,
+    {
+        UniValue::VSTR, // tx
+        UniValue::VSTR, // scriptCode
+        UniValue::VNUM, // amount
+        UniValue::VSTR, // sigVersion
+        UniValue::VNUM, // inputIndex
+        UniValue::VSTR  // privatekey
+    }, false);
+
+    CMutableTransaction mtx;
+    if (!DecodeHexTx(mtx, request.params[0].get_str(), true))
+    {
+        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    }
+
+    std::vector<unsigned char> scriptCodeData(ParseHexV(request.params[1], "scriptCode"));
+    CScript scriptCode(scriptCodeData.begin(), scriptCodeData.end());
+
+    CAmount amount = request.params[2].get_int64();
+    if (!MoneyRange(amount))
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount out of range");
+    SigVersion sigVersion;
+    static std::map<std::string, SigVersion> mapSigVersionValues = {
+        { std::string("BASE"), SigVersion::SIGVERSION_BASE },
+        { std::string("WITNESS_V0"), SigVersion::SIGVERSION_WITNESS_V0 },
+    };
+    std::string strHashType = request.params[3].get_str();
+    if (mapSigVersionValues.count(strHashType))
+        sigVersion = mapSigVersionValues[strHashType];
+    else
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid sigversion param");
+
+    int inputIndex = request.params[4].get_int();
+
+    CBitcoinSecret secret;
+    if (!secret.SetString(request.params[5].get_str()))
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
+
+    int nHashType = SIGHASH_ALL;
+    if (!request.params[6].isNull()) {
+        nHashType = ParseSigHash(request.params[6].get_str(), "sighashtype");
+    }
+    std::vector<unsigned char> signature;
+    if (!secret.GetKey().Sign(SignatureHash(scriptCode, mtx, inputIndex, nHashType, amount, sigVersion), signature))
+    {
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Private key outside allowed range");
+    }
+    signature.push_back(static_cast<unsigned char>(nHashType));
+    return HexStr(signature.begin(), signature.end());
+}
+
 UniValue verifymessage(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() != 3)
@@ -611,6 +694,7 @@ static const CRPCCommand commands[] =
     { "control",            "logging",                &logging,                {"include", "exclude"}},
     { "util",               "validateaddress",        &validateaddress,        {"address"} }, /* uses wallet if enabled */
     { "util",               "createmultisig",         &createmultisig,         {"nrequired","keys"} },
+    { "util",               "signinput",       &signinput,                     { "tx", "scriptcode", "amount", "sigversion", "inputindex", "privatekey", "sighashtype" } },
     { "util",               "verifymessage",          &verifymessage,          {"address","signature","message"} },
     { "util",               "signmessagewithprivkey", &signmessagewithprivkey, {"privkey","message"} },
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -829,19 +829,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
 
     int nHashType = SIGHASH_ALL;
     if (!request.params[3].isNull()) {
-        static std::map<std::string, int> mapSigHashValues = {
-            {std::string("ALL"), int(SIGHASH_ALL)},
-            {std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL|SIGHASH_ANYONECANPAY)},
-            {std::string("NONE"), int(SIGHASH_NONE)},
-            {std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE|SIGHASH_ANYONECANPAY)},
-            {std::string("SINGLE"), int(SIGHASH_SINGLE)},
-            {std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE|SIGHASH_ANYONECANPAY)},
-        };
-        std::string strHashType = request.params[3].get_str();
-        if (mapSigHashValues.count(strHashType))
-            nHashType = mapSigHashValues[strHashType];
-        else
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid sighash param");
+        nHashType = ParseSigHash(request.params[3].get_str(), "sighashtype");
     }
 
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -131,6 +131,23 @@ uint256 ParseHashV(const UniValue& v, std::string strName)
     result.SetHex(strHex);
     return result;
 }
+
+int ParseSigHash(const std::string& sighash, const std::string& parameter_name)
+{
+    int nHashType = 0;
+    static const std::map<std::string, int> sighash_values = {
+        { std::string("ALL"), int(SIGHASH_ALL) },
+        { std::string("ALL|ANYONECANPAY"), int(SIGHASH_ALL | SIGHASH_ANYONECANPAY) },
+        { std::string("NONE"), int(SIGHASH_NONE) },
+        { std::string("NONE|ANYONECANPAY"), int(SIGHASH_NONE | SIGHASH_ANYONECANPAY) },
+        { std::string("SINGLE"), int(SIGHASH_SINGLE) },
+        { std::string("SINGLE|ANYONECANPAY"), int(SIGHASH_SINGLE | SIGHASH_ANYONECANPAY) },
+    };
+    auto it = sighash_values.find(sighash);
+    if (it == sighash_values.end()) throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid %s param", parameter_name));
+    return (*it).second;
+}
+
 uint256 ParseHashO(const UniValue& o, std::string strKey)
 {
     return ParseHashV(find_value(o, strKey), strKey);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -184,6 +184,7 @@ extern uint256 ParseHashO(const UniValue& o, std::string strKey);
 extern std::vector<unsigned char> ParseHexV(const UniValue& v, std::string strName);
 extern std::vector<unsigned char> ParseHexO(const UniValue& o, std::string strKey);
 
+extern int ParseSigHash(const std::string& sighash, const std::string& parameter_name);
 extern CAmount AmountFromValue(const UniValue& value);
 extern std::string HelpExampleCli(const std::string& methodname, const std::string& args);
 extern std::string HelpExampleRpc(const std::string& methodname, const std::string& args);

--- a/test/functional/signinput.py
+++ b/test/functional/signinput.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the RPC call related to the uptime command.
+
+Test corresponds to code in rpc/server.cpp.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class SignInputTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        privatekey = "cPbVfYM4UUuxKeJUotfq791Z36QN8br9yyAi61JghziH6LDgiqWF"
+        tx = "010000000243ec7a579f5561a42a7e9637ad4156672735a658be2752181801f723ba3316d200000000844730440220449a203d0062ea01022f565c94c4b62bf2cc9a05de20519bc18cded9e99aa5f702201a2b8361e2af179eb93e697d9fedd0bf1e036f0a5be39af4b1f791df803bdb6501210363e38e2e0e55cdebfb7e27d0cb53ded150c320564a4614c18738feb124c8efd21976a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088acffffffff43ec7a579f5561a42a7e9637ad4156672735a658be2752181801f723ba3316d20100000085483045022100ff6e7edffa5e0758244af6af77edd14f1d80226d66f81ed58dba2def34778236022057d95177497758e467c194f0d897f175645d30e7ac2f9490247e13227ac4d2fc01210363e38e2e0e55cdebfb7e27d0cb53ded150c320564a4614c18738feb124c8efd21976a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088acffffffff0100752b7d000000001976a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088ac00000000"
+        scriptcode = "76a9141a5fdcb6201f7e4fd160f9dca81075bd8537526088ac"
+        amount = 100000000
+        sigversion = "BASE"
+        input_index = 0
+        sighash = "ALL"
+        expected_sig = "3045022100cc79eb5596db1e5cf48acf67dd67626110698d4c504995ae00dd421edc721f91022053b5f23c1808b4a22e6364deed5eceda8967d1d3af2d2c7edf4727f1d1a4df6501"
+        assert_equal(expected_sig, self.nodes[0].signinput(
+            tx,
+            scriptcode,
+            amount,
+            sigversion,
+            input_index,
+            privatekey,
+            sighash
+        ))
+
+        # optional parameter
+        assert_equal(expected_sig, self.nodes[0].signinput(
+            tx,
+            scriptcode,
+            amount,
+            sigversion,
+            input_index,
+            privatekey
+        ))
+
+        # WITNESS_0
+        sigversion = "WITNESS_V0"
+        expected_sig = "304402207618e6c93582612b25024cab7a6b3a0ce0a4389f0ee81cc6a8efb9345a47df2402205a15ba66ea375e25fcd9758453c14d7596d59eae5702a339f2c3f793c68f1a9801"
+        assert_equal(expected_sig, self.nodes[0].signinput(
+            tx,
+            scriptcode,
+            amount,
+            sigversion,
+            input_index,
+            privatekey
+        ))
+
+        # WITNESS_0/SINGLE
+        sigversion = "WITNESS_V0"
+        sighash = "SINGLE"
+        expected_sig = "3044022053a587a195c93b4d0816e03aa7922e010d64f08fdadf1d69ec5589e0163ff30002207daf9b3ca2b5fb3c584ef8e91e1e5e42d3b16fbb87fcdbf59be6462421f4bac003"
+        assert_equal(expected_sig, self.nodes[0].signinput(
+            tx,
+            scriptcode,
+            amount,
+            sigversion,
+            input_index,
+            privatekey,
+            sighash
+        ))
+
+if __name__ == '__main__':
+    SignInputTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -126,6 +126,7 @@ BASE_SCRIPTS= [
     'p2p-fingerprint.py',
     'uacomment.py',
     'p2p-acceptblock.py',
+    'signinput.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
An alternative to https://github.com/bitcoin/bitcoin/pull/11653 , an utility to sign an input. This is very useful when dealing with several bitcoin-based crypto currencies (typically a cross chain swap tool), as several crypto currencies signs in different ways.
