### PR TITLE
contrib/init: Update openrc-run filename

### DIFF
--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 
 # backward compatibility for existing gentoo layout 
 #


### PR DESCRIPTION
OpenRC changed their program binary names in 2014 (3 years ago), and using the old names has loud warnings now