### PR TITLE
qa: Remove unused NodeConn members

### DIFF
--- a/test/functional/p2p-segwit.py
+++ b/test/functional/p2p-segwit.py
@@ -32,9 +32,10 @@ def get_virtual_size(witness_block):
     return vsize
 
 class TestNode(NodeConnCB):
-    def __init__(self):
+    def __init__(self, rpc):
         super().__init__()
         self.getdataset = set()
+        self.rpc = rpc
 
     def on_getdata(self, conn, message):
         for inv in message.inv:
@@ -73,7 +74,7 @@ class TestNode(NodeConnCB):
             tx_message = msg_witness_tx(tx)
         self.send_message(tx_message)
         self.sync_with_ping()
-        assert_equal(tx.hash in self.connection.rpc.getrawmempool(), accepted)
+        assert_equal(tx.hash in self.rpc.getrawmempool(), accepted)
         if (reason != None and not accepted):
             # Check the rejection reason as well.
             with mininode_lock:
@@ -86,7 +87,7 @@ class TestNode(NodeConnCB):
         else:
             self.send_message(msg_block(block))
         self.sync_with_ping()
-        assert_equal(self.connection.rpc.getbestblockhash() == block.hash, accepted)
+        assert_equal(self.rpc.getbestblockhash() == block.hash, accepted)
 
 # Used to keep track of anyone-can-spend outputs that we can use in the tests
 class UTXO():
@@ -1869,11 +1870,11 @@ class SegWitTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
         # self.test_node sets NODE_WITNESS|NODE_NETWORK
-        self.test_node = self.nodes[0].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
+        self.test_node = self.nodes[0].add_p2p_connection(TestNode(self.nodes[0].rpc), services=NODE_NETWORK|NODE_WITNESS)
         # self.old_node sets only NODE_NETWORK
-        self.old_node = self.nodes[0].add_p2p_connection(TestNode(), services=NODE_NETWORK)
+        self.old_node = self.nodes[0].add_p2p_connection(TestNode(self.nodes[0].rpc), services=NODE_NETWORK)
         # self.std_node is for testing node1 (fRequireStandard=true)
-        self.std_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
+        self.std_node = self.nodes[1].add_p2p_connection(TestNode(self.nodes[1].rpc), services=NODE_NETWORK|NODE_WITNESS)
 
         NetworkThread().start() # Start up network handling in another thread
 

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -177,7 +177,7 @@ class TestManager():
             # Create a p2p connection to each node
             test_node = TestNode(self.block_store, self.tx_store)
             self.test_nodes.append(test_node)
-            self.connections.append(NodeConn('127.0.0.1', p2p_port(i), nodes[i], test_node))
+            self.connections.append(NodeConn('127.0.0.1', p2p_port(i), test_node))
             # Make sure the TestNode (callback class) has a reference to its
             # associated NodeConn
             test_node.add_connection(self.connections[-1])

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -1420,7 +1420,6 @@ class NodeConnCB():
         conn.send_message(msg_pong(message.nonce))
 
     def on_verack(self, conn, message):
-        conn.ver_recv = conn.ver_send
         self.verack_received = True
 
     def on_version(self, conn, message):
@@ -1516,7 +1515,7 @@ class NodeConn(asyncore.dispatcher):
         "regtest": b"\xfa\xbf\xb5\xda",   # regtest
     }
 
-    def __init__(self, dstaddr, dstport, rpc, callback, net="regtest", services=NODE_NETWORK|NODE_WITNESS, send_version=True):
+    def __init__(self, dstaddr, dstport, callback, net="regtest", services=NODE_NETWORK|NODE_WITNESS, send_version=True):
         asyncore.dispatcher.__init__(self, map=mininode_socket_map)
         self.dstaddr = dstaddr
         self.dstport = dstport
@@ -1524,8 +1523,6 @@ class NodeConn(asyncore.dispatcher):
         self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         self.sendbuf = b""
         self.recvbuf = b""
-        self.ver_send = 209
-        self.ver_recv = 209
         self.last_sent = 0
         self.state = "connecting"
         self.network = net
@@ -1549,7 +1546,6 @@ class NodeConn(asyncore.dispatcher):
             self.connect((dstaddr, dstport))
         except:
             self.handle_close()
-        self.rpc = rpc
 
     def handle_connect(self):
         if self.state != "connected":

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -168,7 +168,7 @@ class TestNode():
         if 'dstaddr' not in kwargs:
             kwargs['dstaddr'] = '127.0.0.1'
         self.p2ps.append(p2p_conn)
-        kwargs.update({'rpc': self.rpc, 'callback': p2p_conn})
+        kwargs.update({'callback': p2p_conn})
         p2p_conn.add_connection(NodeConn(**kwargs))
 
         return p2p_conn


### PR DESCRIPTION
* `ver_send` and `ver_recv` were completely unused
* `rpc` was only used once, in p2p-segwit. Imo better only pass it to the constructor in that single test