### PR TITLE
[wallet] Don't shut down after encrypting the wallet

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -452,3 +452,10 @@ void AddressTableModel::emitDataChanged(int idx)
 {
     Q_EMIT dataChanged(index(idx, 0, QModelIndex()), index(idx, columns.length()-1, QModelIndex()));
 }
+
+void AddressTableModel::ReloadWallet()
+{
+    this->wallet = vpwallets[0];
+    priv->wallet = vpwallets[0];
+    priv->refreshAddressTable();
+}

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -76,6 +76,8 @@ public:
 
     EditStatus getEditStatus() const { return editStatus; }
 
+    void ReloadWallet();
+
 private:
     WalletModel *walletModel;
     CWallet *wallet;

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -11,6 +11,7 @@
 
 #include <qt/guiconstants.h>
 #include <qt/walletmodel.h>
+#include <wallet/init.h>
 
 #include <support/allocators/secure.h>
 
@@ -123,16 +124,23 @@ void AskPassphraseDialog::accept()
                 {
                     QMessageBox::warning(this, tr("Wallet encrypted"),
                                          "<qt>" +
-                                         tr("%1 will close now to finish the encryption process. "
+                                         tr("Your wallet is now encrypted. "
                                          "Remember that encrypting your wallet cannot fully protect "
-                                         "your bitcoins from being stolen by malware infecting your computer.").arg(tr(PACKAGE_NAME)) +
+                                         "your bitcoins from being stolen by malware infecting your computer.") +
                                          "<br><br><b>" +
                                          tr("IMPORTANT: Any previous backups you have made of your wallet file "
                                          "should be replaced with the newly generated, encrypted wallet file. "
                                          "For security reasons, previous backups of the unencrypted wallet file "
                                          "will become useless as soon as you start using the new, encrypted wallet.") +
                                          "</b></qt>");
-                    QApplication::quit();
+                    model->unsubscribeFromCoreSignals();
+                    model->UnsubscribeTableModelFromCoreSignals();
+                    StopWallets();
+                    CloseWallets();
+                    OpenWallets();
+                    model->ReloadWallet();
+                    model->subscribeToCoreSignals();
+                    model->SubscribeTableModelToCoreSignals();
                 }
                 else
                 {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -534,6 +534,7 @@ bool BitcoinGUI::addWallet(const QString& name, WalletModel *walletModel)
     if(!walletFrame)
         return false;
     setWalletActionsEnabled(true);
+    rpcConsole->setWalletModel(walletModel);
     return walletFrame->addWallet(name, walletModel);
 }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -447,7 +447,9 @@ RPCConsole::RPCConsole(const PlatformStyle *_platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::RPCConsole),
     clientModel(0),
+#ifdef ENABLE_WALLET
     walletModel(0),
+#endif
     historyPtr(0),
     platformStyle(_platformStyle),
     peersTableContextMenu(0),
@@ -688,10 +690,12 @@ void RPCConsole::setClientModel(ClientModel *model)
     }
 }
 
+#ifdef ENABLE_WALLET
 void RPCConsole::setWalletModel(WalletModel *model)
 {
     this->walletModel = model;
 }
+#endif
 
 static QString categoryClass(int category)
 {

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -25,6 +25,7 @@
 #ifdef ENABLE_WALLET
 #include <db_cxx.h>
 #include <wallet/wallet.h>
+#include <wallet/init.h>
 #endif
 
 #include <QDesktopWidget>
@@ -446,6 +447,7 @@ RPCConsole::RPCConsole(const PlatformStyle *_platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::RPCConsole),
     clientModel(0),
+    walletModel(0),
     historyPtr(0),
     platformStyle(_platformStyle),
     peersTableContextMenu(0),
@@ -686,6 +688,11 @@ void RPCConsole::setClientModel(ClientModel *model)
     }
 }
 
+void RPCConsole::setWalletModel(WalletModel *model)
+{
+    this->walletModel = model;
+}
+
 static QString categoryClass(int category)
 {
     switch(category)
@@ -793,6 +800,19 @@ void RPCConsole::keyPressEvent(QKeyEvent *event)
 
 void RPCConsole::message(int category, const QString &message, bool html)
 {
+#ifdef ENABLE_WALLET
+    // TODO: Put this in a more sensible place
+    // Only for encrypting wallets and encryption was successful
+    if (message.indexOf("wallet encrypted;") == 0) {
+        StopWallets();
+        CloseWallets();
+        OpenWallets();
+        walletModel->ReloadWallet();
+        walletModel->subscribeToCoreSignals();
+        walletModel->SubscribeTableModelToCoreSignals();
+    }
+#endif
+
     QTime time = QTime::currentTime();
     QString timeString = time.toString();
     QString out;

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -7,6 +7,9 @@
 
 #include <qt/guiutil.h>
 #include <qt/peertablemodel.h>
+#ifdef ENABLE_WALLET
+#include <qt/walletmodel.h>
+#endif // ENABLE_WALLET
 
 #include <net.h>
 
@@ -42,6 +45,7 @@ public:
     }
 
     void setClientModel(ClientModel *model);
+    void setWalletModel(WalletModel *model);
 
     enum MessageClass {
         MC_ERROR,
@@ -140,6 +144,7 @@ private:
 
     Ui::RPCConsole *ui;
     ClientModel *clientModel;
+    WalletModel *walletModel;
     QStringList history;
     int historyPtr;
     QString cmdBeforeBrowsing;

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -45,7 +45,9 @@ public:
     }
 
     void setClientModel(ClientModel *model);
+#ifdef ENABLE_WALLET
     void setWalletModel(WalletModel *model);
+#endif
 
     enum MessageClass {
         MC_ERROR,
@@ -144,7 +146,9 @@ private:
 
     Ui::RPCConsole *ui;
     ClientModel *clientModel;
+#ifdef ENABLE_WALLET
     WalletModel *walletModel;
+#endif
     QStringList history;
     int historyPtr;
     QString cmdBeforeBrowsing;

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -178,22 +178,11 @@ static void ShowProgress(SplashScreen *splash, const std::string &title, int nPr
             strprintf("\n%d", nProgress) + "%");
 }
 
-#ifdef ENABLE_WALLET
-void SplashScreen::ConnectWallet(CWallet* wallet)
-{
-    wallet->ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2, false));
-    connectedWallets.push_back(wallet);
-}
-#endif
-
 void SplashScreen::subscribeToCoreSignals()
 {
     // Connect signals to client
     uiInterface.InitMessage.connect(boost::bind(InitMessage, this, _1));
     uiInterface.ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2, _3));
-#ifdef ENABLE_WALLET
-    uiInterface.LoadWallet.connect(boost::bind(&SplashScreen::ConnectWallet, this, _1));
-#endif
 }
 
 void SplashScreen::unsubscribeFromCoreSignals()
@@ -201,11 +190,6 @@ void SplashScreen::unsubscribeFromCoreSignals()
     // Disconnect signals from client
     uiInterface.InitMessage.disconnect(boost::bind(InitMessage, this, _1));
     uiInterface.ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2, _3));
-#ifdef ENABLE_WALLET
-    for (CWallet* const & pwallet : connectedWallets) {
-        pwallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2, false));
-    }
-#endif
 }
 
 void SplashScreen::showMessage(const QString &message, int alignment, const QColor &color)

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -44,15 +44,11 @@ private:
     void subscribeToCoreSignals();
     /** Disconnect core signals to splash screen */
     void unsubscribeFromCoreSignals();
-    /** Connect wallet signals to splash screen */
-    void ConnectWallet(CWallet*);
 
     QPixmap pixmap;
     QString curMessage;
     QColor curColor;
     int curAlignment;
-
-    QList<CWallet*> connectedWallets;
 };
 
 #endif // BITCOIN_QT_SPLASHSCREEN_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -789,3 +789,10 @@ void TransactionTableModel::unsubscribeFromCoreSignals()
     wallet->NotifyTransactionChanged.disconnect(boost::bind(NotifyTransactionChanged, this, _1, _2, _3));
     wallet->ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
 }
+
+void TransactionTableModel::ReloadWallet()
+{
+    this->wallet = vpwallets[0];
+    priv->wallet = vpwallets[0];
+    priv->refreshWallet();
+}

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -81,6 +81,11 @@ public:
     QModelIndex index(int row, int column, const QModelIndex & parent = QModelIndex()) const;
     bool processingQueuedTransactions() const { return fProcessingQueuedTransactions; }
 
+    void ReloadWallet();
+
+    void subscribeToCoreSignals();
+    void unsubscribeFromCoreSignals();
+
 private:
     CWallet* wallet;
     WalletModel *walletModel;
@@ -88,9 +93,6 @@ private:
     TransactionTablePriv *priv;
     bool fProcessingQueuedTransactions;
     const PlatformStyle *platformStyle;
-
-    void subscribeToCoreSignals();
-    void unsubscribeFromCoreSignals();
 
     QString lookupAddress(const std::string &address, bool tooltip) const;
     QVariant addressColor(const TransactionRecord *wtx) const;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -742,3 +742,19 @@ int WalletModel::getDefaultConfirmTarget() const
 {
     return nTxConfirmTarget;
 }
+void WalletModel::ReloadWallet()
+{
+    this->wallet = vpwallets[0];
+    addressTableModel->ReloadWallet();
+    transactionTableModel->ReloadWallet();
+}
+
+void WalletModel::SubscribeTableModelToCoreSignals()
+{
+    transactionTableModel->subscribeToCoreSignals();
+}
+
+void WalletModel::UnsubscribeTableModelFromCoreSignals()
+{
+    transactionTableModel->unsubscribeFromCoreSignals();
+}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -220,6 +220,14 @@ public:
 
     int getDefaultConfirmTarget() const;
 
+    void ReloadWallet();
+
+    void subscribeToCoreSignals();
+    void unsubscribeFromCoreSignals();
+
+    void SubscribeTableModelToCoreSignals();
+    void UnsubscribeTableModelFromCoreSignals();
+
 private:
     CWallet *wallet;
     bool fHaveWatchOnly;
@@ -245,8 +253,6 @@ private:
 
     QTimer *pollTimer;
 
-    void subscribeToCoreSignals();
-    void unsubscribeFromCoreSignals();
     void checkBalanceChanged();
 
 Q_SIGNALS:

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -279,6 +279,7 @@ bool OpenWallets()
         return true;
     }
 
+    bitdb.Reset();
     for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
         CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile);
         if (!pwallet) {
@@ -305,6 +306,7 @@ void FlushWallets() {
 void StopWallets() {
     for (CWalletRef pwallet : vpwallets) {
         pwallet->Flush(true);
+        UnregisterValidationInterface(pwallet);
     }
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2530,6 +2530,7 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     StopWallets();
     CloseWallets();
     OpenWallets();
+    // NOTE: This string is used to check that wallet encryption happened so that the rpcconsole can reset the GUI if encryptwallet is called from the rpcconsole.
     return "wallet encrypted; The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -26,6 +26,7 @@
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
 #include <wallet/wallet.h>
+#include <wallet/init.h>
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
 
@@ -2484,7 +2485,6 @@ UniValue encryptwallet(const JSONRPCRequest& request)
             "will require the passphrase to be set prior the making these calls.\n"
             "Use the walletpassphrase call for this, and then walletlock call.\n"
             "If the wallet is already encrypted, use the walletpassphrasechange call.\n"
-            "Note that this will shutdown the server.\n"
             "\nArguments:\n"
             "1. \"passphrase\"    (string) The pass phrase to encrypt the wallet with. It must be at least 1 character, but should be long.\n"
             "\nExamples:\n"
@@ -2527,8 +2527,10 @@ UniValue encryptwallet(const JSONRPCRequest& request)
     // BDB seems to have a bad habit of writing old data into
     // slack space in .dat files; that is bad if the old data is
     // unencrypted private keys. So:
-    StartShutdown();
-    return "wallet encrypted; Bitcoin server stopping, restart to run with encrypted wallet. The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
+    StopWallets();
+    CloseWallets();
+    OpenWallets();
+    return "wallet encrypted; The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
 }
 
 UniValue lockunspent(const JSONRPCRequest& request)

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -458,7 +458,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         # locked wallet test
         self.stop_node(0)
-        self.nodes[1].node_encrypt_wallet("test")
+        self.nodes[1].encryptwallet("test")
+        self.stop_node(1)
         self.stop_node(2)
         self.stop_node(3)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -160,14 +160,6 @@ class TestNode():
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT):
         wait_until(self.is_node_stopped, timeout=timeout)
 
-    def node_encrypt_wallet(self, passphrase):
-        """"Encrypts the wallet.
-
-        This causes bitcoind to shutdown, so this method takes
-        care of cleaning up resources."""
-        self.encryptwallet(passphrase)
-        self.wait_until_stopped()
-
     def add_p2p_connection(self, p2p_conn, *args, **kwargs):
         """Add a p2p connection to the node.
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -38,8 +38,7 @@ class BumpFeeTest(BitcoinTestFramework):
 
     def run_test(self):
         # Encrypt wallet for test_locked_wallet_fails test
-        self.nodes[1].node_encrypt_wallet(WALLET_PASSPHRASE)
-        self.start_node(1)
+        self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
         self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
 
         connect_nodes_bi(self.nodes, 0, 1)

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -120,8 +120,7 @@ class WalletDumpTest(BitcoinTestFramework):
         assert_equal(witness_addr_ret, witness_addr) # p2sh-p2wsh address added to the first key
 
         #encrypt wallet, restart, unlock and dump
-        self.nodes[0].node_encrypt_wallet('test')
-        self.start_node(0)
+        self.nodes[0].encryptwallet('test')
         self.nodes[0].walletpassphrase('test', 10)
         # Should be a no-op:
         self.nodes[0].keypoolrefill()

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -30,8 +30,7 @@ class WalletEncryptionTest(BitcoinTestFramework):
         assert_equal(len(privkey), 52)
 
         # Encrypt the wallet
-        self.nodes[0].node_encrypt_wallet(passphrase)
-        self.start_node(0)
+        self.nodes[0].encryptwallet(passphrase)
 
         # Test that the wallet is encrypted
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -19,9 +19,7 @@ class KeyPoolTest(BitcoinTestFramework):
         assert(addr_before_encrypting_data['hdmasterkeyid'] == wallet_info_old['hdmasterkeyid'])
         
         # Encrypt wallet and wait to terminate
-        nodes[0].node_encrypt_wallet('test')
-        # Restart node 0
-        self.start_node(0)
+        nodes[0].encryptwallet('test')
         # Keep creating keys
         addr = nodes[0].getnewaddress()
         addr_data = nodes[0].validateaddress(addr)


### PR DESCRIPTION
Instead of shutting down the entire software after encrypting a wallet, instead just stop and close all of the wallets and then reopen them. This will flush the wallets, clear them from memory, and then reopen them to ensure that no unencrypted keys remain after encrypting.

This is marked as WIP because there are a few bugs that I am still trying to figure out.  ~~~is a locking bug that I'm still trying to figure out. After encrypting a wallet from the GUI, the GUI freezes. This appears to be a lock contention issue with `cs_KeyStore` at wallet/crypter.cpp:160. However I can't figure out why this is happening.~~~