### PR TITLE
[trivial] Fix the StartupWMClass for bitoin-qt, so gnome-shell can recognize it

### DIFF
--- a/contrib/debian/bitcoin-qt.desktop
+++ b/contrib/debian/bitcoin-qt.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Encoding=UTF-8
+Version=1.0
 Name=Bitcoin Core
 Comment=Connect to the Bitcoin P2P Network
 Comment[de]=Verbinde mit dem Bitcoin peer-to-peer Netzwerk
@@ -11,3 +11,4 @@ Type=Application
 Icon=bitcoin128
 MimeType=x-scheme-handler/bitcoin;
 Categories=Office;Finance;
+StartupWMClass=Bitcoin-qt


### PR DESCRIPTION
I spent some time trying to figure out how to get the provided `.desktop` file to work correctly in GNOME. When a non-absolute path is used in the desktop file, you need to specify `StartupWMClass` in order for gnome-shell to know that a running application matches one in its desktop database. I also set a version and removed the deprecated `Encoding` field. With these changes, the desktop file passes `desktop-file-validate` cleanly.

P.S. I found this while working on a new spec file for Bitcoin, which you can find here: https://github.com/eklitzke/bitcoin-copr/blob/master/bitcoin.spec . I plan to contribute this work back upstream as well, once I've figured out more of these packaging issues (desktop files being one of them!).