### PR TITLE
rpc: Add missing lock in getblocktemplate(...). Work around Clang thread safety analysis quirks.

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -372,8 +372,6 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             + HelpExampleRpc("getblocktemplate", "")
          );
 
-    LOCK(cs_main);
-
     std::string strMode = "template";
     UniValue lpval = NullUniValue;
     std::set<std::string> setClientRules;
@@ -403,6 +401,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
             uint256 hash = block.GetHash();
+            LOCK(cs_main);
             BlockMap::iterator mi = mapBlockIndex.find(hash);
             if (mi != mapBlockIndex.end()) {
                 CBlockIndex *pindex = mi->second;
@@ -468,18 +467,23 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         }
         else
         {
+            LOCK(cs_main);
             // NOTE: Spec does not specify behaviour for non-string longpollid, but this makes testing easier
             hashWatchedChain = chainActive.Tip()->GetBlockHash();
             nTransactionsUpdatedLastLP = nTransactionsUpdatedLast;
         }
 
         // Release the wallet and main lock while waiting
-        LEAVE_CRITICAL_SECTION(cs_main);
         {
             checktxtime = std::chrono::steady_clock::now() + std::chrono::minutes(1);
 
             WaitableLock lock(csBestBlock);
-            while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning())
+            bool keepRunning;
+            {
+                LOCK(cs_main);
+                keepRunning = chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
+            }
+            while (keepRunning)
             {
                 if (cvBlockChange.wait_until(lock, checktxtime) == std::cv_status::timeout)
                 {
@@ -488,9 +492,10 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
                         break;
                     checktxtime += std::chrono::seconds(10);
                 }
+                LOCK(cs_main);
+                keepRunning = chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
             }
         }
-        ENTER_CRITICAL_SECTION(cs_main);
 
         if (!IsRPCRunning())
             throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Shutting down");
@@ -504,6 +509,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     bool fSupportsSegwit = setClientRules.find(segwit_info.name) != setClientRules.end();
 
     // Update block
+    LOCK(cs_main);
     static CBlockIndex* pindexPrev;
     static int64_t nStart;
     static std::unique_ptr<CBlockTemplate> pblocktemplate;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -158,11 +158,8 @@ UniValue validateaddress(const JSONRPCRequest& request)
 
 #ifdef ENABLE_WALLET
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
-
-    LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : nullptr);
-#else
-    LOCK(cs_main);
 #endif
+    LOCK(cs_main);
 
     CTxDestination dest = DecodeDestination(request.params[0].get_str());
     bool isValid = IsValidDestination(dest);
@@ -183,17 +180,17 @@ UniValue validateaddress(const JSONRPCRequest& request)
         ret.push_back(Pair("iswatchonly", bool(mine & ISMINE_WATCH_ONLY)));
         UniValue detail = boost::apply_visitor(DescribeAddressVisitor(pwallet), dest);
         ret.pushKVs(detail);
-        if (pwallet && pwallet->mapAddressBook.count(dest)) {
-            ret.push_back(Pair("account", pwallet->mapAddressBook[dest].name));
-        }
         if (pwallet) {
-            const auto& meta = pwallet->mapKeyMetadata;
-            const CKeyID *keyID = boost::get<CKeyID>(&dest);
-            auto it = keyID ? meta.find(*keyID) : meta.end();
-            if (it == meta.end()) {
-                it = meta.find(CScriptID(scriptPubKey));
+            LOCK(pwallet->cs_wallet);
+            if (pwallet->mapAddressBook.count(dest)) {
+                ret.push_back(Pair("account", pwallet->mapAddressBook[dest].name));
             }
-            if (it != meta.end()) {
+            const CKeyID *keyID = boost::get<CKeyID>(&dest);
+            auto it = keyID ? pwallet->mapKeyMetadata.find(*keyID) : pwallet->mapKeyMetadata.end();
+            if (it == pwallet->mapKeyMetadata.end()) {
+                it = pwallet->mapKeyMetadata.find(CScriptID(scriptPubKey));
+            }
+            if (it != pwallet->mapKeyMetadata.end()) {
                 ret.push_back(Pair("timestamp", it->second.nCreateTime));
                 if (!it->second.hdKeypath.empty()) {
                     ret.push_back(Pair("hdkeypath", it->second.hdKeypath));


### PR DESCRIPTION
**Commit 1: Add missing lock in getblocktemplate(...)**

Reading the variable `chainActive` requires holding the mutex `cs_main`.

Prior to this commit the `cs_main` mutex was not held when accessing `chainActive` in:

```
while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning())
```

**Commit 2: Work around Clang thread safety analysis quirks**

The conditional lock ...

```
LOCK2(cs_main, pwallet ? &pwallet->cs_wallet : nullptr)
```

... confuses Clang's thread safety analysis (it complains about not holding the mutex `pwallet->cs_wallet` even in the case when `pwallet` is non-NULL).

So does the access to `pwallet->mapKeyMetadata` via `meta` (it complains about not holding the mutex `cs_wallet` despite `pwallet->cs_wallet` – which is the correct mutex – is being held).

This commit introduces locking that Clang's thread safety analysis is able to understand correctly.