### PR TITLE
rpc: Add missing cs_main lock in getblocktemplate(...)

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -479,7 +479,12 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             checktxtime = std::chrono::steady_clock::now() + std::chrono::minutes(1);
 
             WaitableLock lock(csBestBlock);
-            while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning())
+            auto KeepRunning = [&]() -> bool {
+                LOCK(cs_main);
+                assert(chainActive.Tip());
+                return chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
+            };
+            while (KeepRunning())
             {
                 if (cvBlockChange.wait_until(lock, checktxtime) == std::cv_status::timeout)
                 {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -479,13 +479,14 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
             checktxtime = std::chrono::steady_clock::now() + std::chrono::minutes(1);
 
             WaitableLock lock(csBestBlock);
-            auto KeepRunning = [&]() -> bool {
-                LOCK(cs_main);
-                assert(chainActive.Tip());
-                return chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning();
-            };
-            while (KeepRunning())
+            while (IsRPCRunning())
             {
+                {
+                    LOCK(cs_main);
+                    if (chainActive.Tip()->GetBlockHash() != hashWatchedChain) {
+                        break;
+                    }
+                }
                 if (cvBlockChange.wait_until(lock, checktxtime) == std::cv_status::timeout)
                 {
                     // Timeout: Check transactions for update


### PR DESCRIPTION
Reading the variable `chainActive` requires holding the mutex `cs_main`.

Prior to this commit the `cs_main` mutex was not held when accessing `chainActive` in:

```
while (chainActive.Tip()->GetBlockHash() == hashWatchedChain && IsRPCRunning())
```