### PR TITLE
[trivial] remove trailing whitespace in streams.h

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -348,7 +348,7 @@ public:
         if (nReadPosNext > vch.size()) {
             throw std::ios_base::failure("CDataStream::read(): end of data");
         }
-        memcpy(pch, &vch[nReadPos], nSize);        
+        memcpy(pch, &vch[nReadPos], nSize);
         if (nReadPosNext == vch.size())
         {
             nReadPos = 0;


### PR DESCRIPTION
Removes trailing whitespace added in #11221. I'm not sure how this passed the Travis linter for the PR, but it's causing some of my branches to fail on Travis.