### PR TITLE
[Docs] [Qt] RPC-Console nested commands documentation 

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -392,11 +392,37 @@ void RPCExecutor::request(const QString &command)
     {
         std::string result;
         std::string executableCommand = command.toStdString() + "\n";
+
+        // Catch the console-only-help command before RPC call is executed and reply with help text as-if a RPC reply.
+        if(executableCommand == "help-console\n")
+        {
+            Q_EMIT reply(RPCConsole::CMD_REPLY, QString(("\n"
+                "This console accepts RPC commands using the standard syntax.\n"
+                "   example:    getblockhash 0\n\n"
+
+                "This console can also accept RPC commands using parenthesized syntax.\n"
+                "   example:    getblockhash(0)\n\n"
+
+                "Commands may be nested when specified with the parenthesized syntax.\n"
+                "   example:    getblock(getblockhash(0) 1)\n\n"
+
+                "A space or a comma can be used to delimit arguments for either syntax.\n"
+                "   example:    getblockhash 0\n"
+                "               getblockhash,0\n\n"
+
+                "Named results can be queried with a non-quoted key string in brackets.\n"
+                "   example:    getblock(getblockhash(0) true)[tx]\n\n"
+
+                "Results without keys can be queried using an integer in brackets.\n"
+                "   example:    getblock(getblockhash(0),true)[tx][0]\n\n")));
+            return;
+        }
         if(!RPCConsole::RPCExecuteCommandLine(result, executableCommand))
         {
             Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
             return;
         }
+
         Q_EMIT reply(RPCConsole::CMD_REPLY, QString::fromStdString(result));
     }
     catch (UniValue& objError)
@@ -645,6 +671,7 @@ void RPCConsole::setClientModel(ClientModel *model)
             wordList << ("help " + commandList[i]).c_str();
         }
 
+        wordList << "help-console";
         wordList.sort();
         autoCompleter = new QCompleter(wordList, this);
         autoCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
@@ -750,10 +777,11 @@ void RPCConsole::clear(bool clearHistory)
 	 
     message(CMD_REPLY, (tr("Welcome to the %1 RPC console.").arg(tr(PACKAGE_NAME)) + "<br>" +
                         tr("Use up and down arrows to navigate history, and %1 to clear screen.").arg("<b>"+clsKey+"</b>") + "<br>" +
-                        tr("Type <b>help</b> for an overview of available commands.")) +
-                        "<br><span class=\"secwarning\">" +
+                        tr("Type %1 for an overview of available commands.").arg("<b>help</b>") + "<br>" +
+                        tr("For more information on using this console type %1.").arg("<b>help-console</b>") +
+                        "<br><span class=\"secwarning\"><br>" +
                         tr("WARNING: Scammers have been active, telling users to type commands here, stealing their wallet contents. Do not use this console without fully understanding the ramifications of a command.") +
-                        "</span>",
+                        "</span>"),
                         true);
 }
 


### PR DESCRIPTION
This PR would close issue #9195 by adding documentation for the debug console features (mainly nested commands) which were added in [PR #7783](https://github.com/bitcoin/bitcoin/pull/7783).

The following changes were made to QT debug console code:
- Added a line to the initial message text at the top of the debug console:  

> For more information on using this console type **help-console**.

- Added a pseudo-command `help-console` which is hooked after parsing the request, but before actually executing the RPC thread. It prints the following text to the console as if it were a valid RPC response.

> This console accepts RPC commands using the standard syntax.
>    example:    getblockhash 8
> This console can also accept RPC commands using bracketed syntax.
>    example:    getblockhash(8)
> A space or a comma can be used to separate arguments for either syntax.
>    example:    sendtoaddress \<address\> \<amount\>
>                    sendtoaddress,\<address\>,\<amount\>
> Commands may be nested when specified with the bracketed syntax.
>    example:    getblockinfo(getblockhash(0),true).
> Result values can be queried with a non-quoted string in brackets.
>    example:    getblock(getblockhash(0) true)[height]

This seemed like a reasonably sane way to introduce a fake RPC help command, but 
