### PR TITLE
Add P2SH-P2WSH support to signrawtransaction and listunspent RPC

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -63,6 +63,14 @@ RPC changes
 
 - The `fundrawtransaction` rpc will reject the previously deprecated `reserveChangeKey` option.
 
+- The `redeemScript` for each of the `prevtxs` given to `signrawtransaction` can now optionally be an array
+  of scripts, so both the redeemScript and witnessScript for P2SH-P2WSH addresses can be passed in.
+
+- The `listunspent` output will now return an array of scripts as the `redeemScript` in the case of P2SH-P2WSH,
+  for compatibility with the `signrawtransaction` change above. In other cases, `listunspent` will continue to return
+  the only `redeemScript` as a string, as before.
+
+
 Credits
 =======
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -698,7 +698,7 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
             "         \"txid\":\"id\",             (string, required) The transaction id\n"
             "         \"vout\":n,                  (numeric, required) The output number\n"
             "         \"scriptPubKey\": \"hex\",   (string, required) script key\n"
-            "         \"redeemScript\": \"hex\",   (string, required for P2SH or P2WSH) redeem script\n"
+            "         \"redeemScript\": \"hex\" | [\"hex\", ... ],   (string or array, required for P2SH or P2WSH) redeem script\n"
             "         \"amount\": value            (numeric, required) The amount spent\n"
             "       }\n"
             "       ,...\n"
@@ -833,20 +833,28 @@ UniValue signrawtransaction(const JSONRPCRequest& request)
                 view.AddCoin(out, std::move(newcoin), true);
             }
 
-            // if redeemScript given and not using the local wallet (private keys
-            // given), add redeemScript to the tempKeystore so it can be signed:
-            if (fGivenKeys && (scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsPayToWitnessScriptHash())) {
-                RPCTypeCheckObj(prevOut,
-                    {
-                        {"txid", UniValueType(UniValue::VSTR)},
-                        {"vout", UniValueType(UniValue::VNUM)},
-                        {"scriptPubKey", UniValueType(UniValue::VSTR)},
-                        {"redeemScript", UniValueType(UniValue::VSTR)},
-                    });
-                UniValue v = find_value(prevOut, "redeemScript");
-                if (!v.isNull()) {
-                    std::vector<unsigned char> rsData(ParseHexV(v, "redeemScript"));
-                    CScript redeemScript(rsData.begin(), rsData.end());
+            // if redeemScript given add redeemScript to the tempKeystore so it can be signed:
+            UniValue rs = find_value(prevOut, "redeemScript");
+            if (rs.getType() != UniValue::VNULL) {
+                if (!(scriptPubKey.IsPayToScriptHash() || scriptPubKey.IsPayToWitnessScriptHash())) {
+                    // if this isnt P2SH or P2WSH, scripts should not be provided
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Scripts should not be provided if P2SH or P2WSH are not being used");
+                } else if (!fGivenKeys) {
+                    // if private keys aren't given, assume we are using the local wallet, so we don't currently support accepting scripts
+                    throw JSONRPCError(RPC_INVALID_PARAMETER, "Scripts cannot be provided when using local wallet (no keys given)");
+                }
+                std::vector<std::string> scripts;
+                if (rs.getType() == UniValue::VARR) {
+                    // If redeemScript is an array, iterate over all scripts provided
+                    for (const auto& r : rs.getValues()) {
+                        scripts.push_back(r.get_str());
+                    }
+                } else {
+                    scripts.push_back(rs.get_str());
+                }
+                for (const std::string& script : scripts) {
+                    std::vector<unsigned char> script_data(ParseHexV(script, "redeemScript"));
+                    CScript redeemScript(script_data.begin(), script_data.end());
                     tempKeystore.AddCScript(redeemScript);
                 }
             }

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -244,7 +244,7 @@ class RawTransactionsTest(BitcoinTestFramework):
                 break
 
         bal = self.nodes[0].getbalance()
-        inputs = [{ "txid" : txId, "vout" : vout['n'], "scriptPubKey" : vout['scriptPubKey']['hex'], "redeemScript" : mSigObjValid['hex'], "amount" : vout['value']}]
+        inputs = [{ "txid" : txId, "vout" : vout['n'], "scriptPubKey" : vout['scriptPubKey']['hex'], "amount" : vout['value']}]
         outputs = { self.nodes[0].getnewaddress() : 2.19 }
         rawTx2 = self.nodes[2].createrawtransaction(inputs, outputs)
         rawTxPartialSigned1 = self.nodes[1].signrawtransaction(rawTx2, inputs)


### PR DESCRIPTION
Currently `signrawtransaction` works with P2SH-P2WSH which are already in wallet (e.g. `addmultisigaddress` -> `addwitnessaddress`). But when using signrawtransaction with keys which aren't in the wallet, there is currently only a `redeemScript` key so you cannot enter both the P2SH redeemScript and the witness script. There is an undocumented workaround by including the same input twice (suggested on StackExchange [here](https://bitcoin.stackexchange.com/a/62746/51948)), once with each script, but that is unnecessary and hacky. 

This simply allows the optional inclusion of a witnessScript key in the JSON input to `signrawtransaction`. Because it uses JSON, this is a non-breaking change.

Also, as discussed on IRC ([see here](https://botbot.me/freenode/bitcoin-core-dev/2017-11-16/?msg=93580994&page=1)), we add a `witnessScript` output to the listunspent RPC for P2SH-P2WSH addresses because gmaxwell pointed out signrawtransaction should be able to get most of the needed info from listunspent.

Closes https://github.com/bitcoin/bitcoin/issues/11693 

TODO: 
- ~Needs tests + release notes~