### PR TITLE
cli: Reject arguments to -getinfo

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -213,6 +213,9 @@ public:
     /** Create a simulated `getinfo` request. */
     UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) override
     {
+        if (!args.empty()) {
+            throw std::runtime_error("-getinfo takes no arguments");
+        }
         UniValue result(UniValue::VARR);
         result.push_back(JSONRPCRequestObj("getnetworkinfo", NullUniValue, ID_NETWORKINFO));
         result.push_back(JSONRPCRequestObj("getblockchaininfo", NullUniValue, ID_BLOCKCHAININFO));

--- a/test/functional/bitcoin_cli.py
+++ b/test/functional/bitcoin_cli.py
@@ -35,8 +35,11 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(["foo", "bar"], self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input=password + "\nfoo\nbar").echo())
         assert_raises_process_error(1, "incorrect rpcuser or rpcpassword", self.nodes[0].cli('-rpcuser=%s' % user, '-stdin', '-stdinrpcpass', input="foo").echo)
 
+        self.log.info("Make sure that -getinfo with arguments fails")
+        assert_raises_process_error(1, "-getinfo takes no arguments", self.nodes[0].cli('-getinfo').help)
+
         self.log.info("Compare responses from `bitcoin-cli -getinfo` and the RPCs data is retrieved from.")
-        cli_get_info = self.nodes[0].cli('-getinfo').help()
+        cli_get_info = self.nodes[0].cli().send_cli('-getinfo')
         wallet_info = self.nodes[0].getwalletinfo()
         network_info = self.nodes[0].getnetworkinfo()
         blockchain_info = self.nodes[0].getblockchaininfo()


### PR DESCRIPTION
Currently it's possible to accidentally type e.g.

    bitcoin-cli -getinfo getbalance

and get an answer which can be confusing; the trailing arguments are just ignored.

To avoid this, throw an error if the user provides arguments to
`-getinfo`.