### PR TITLE
[tests] Test that mempool rejects coinbase transactions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -80,6 +80,7 @@ BITCOIN_TESTS =\
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \
+  test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/versionbits_tests.cpp \
   test/uint256_tests.cpp \

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <validation.h>
+#include <txmempool.h>
+#include <amount.h>
+#include <consensus/validation.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <test/test_bitcoin.h>
+
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_AUTO_TEST_SUITE(txvalidation_tests)
+
+/**
+ * Ensure that the mempool won't accept coinbase transactions.
+ */
+BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
+{
+    CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    CMutableTransaction coinbaseTx;
+
+    coinbaseTx.nVersion = 1;
+    coinbaseTx.vin.resize(1);
+    coinbaseTx.vout.resize(1);
+    coinbaseTx.vin[0].scriptSig = CScript() << OP_11 << OP_EQUAL;
+    coinbaseTx.vout[0].nValue = 1 * CENT;
+    coinbaseTx.vout[0].scriptPubKey = scriptPubKey;
+
+    assert(CTransaction(coinbaseTx).IsCoinBase());
+
+    CValidationState state;
+
+    LOCK(cs_main);
+
+    unsigned int initialPoolSize = mempool.size();
+
+    BOOST_CHECK_EQUAL(
+            false,
+            AcceptToMemoryPool(mempool, state, MakeTransactionRef(coinbaseTx),
+                nullptr /* pfMissingInputs */,
+                nullptr /* plTxnReplaced */,
+                true /* bypass_limits */,
+                0 /* nAbsurdFee */));
+
+    // Check that the transaction hasn't been added to mempool.
+    BOOST_CHECK_EQUAL(mempool.size(), initialPoolSize);
+
+    // Check that the validation state reflects the unsuccesful attempt.
+    BOOST_CHECK(state.IsInvalid());
+    BOOST_CHECK_EQUAL(state.GetRejectReason(), "coinbase");
+
+    int nDoS;
+    BOOST_CHECK_EQUAL(state.IsInvalid(nDoS), true);
+    BOOST_CHECK_EQUAL(nDoS, 100);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
![selection_063](https://user-images.githubusercontent.com/73197/32978622-b0fa9d70-cbfa-11e7-9a72-1997409e5ba8.png)

Neither the unit nor functional tests appear to cover rejecting a transaction from acceptance to the mempool on the basis of it being a coinbase. Seems like a decent thing to have a test for.