### PR TITLE
tests: move pwalletMain to wallet test fixture

### DIFF
--- a/src/wallet/test/accounting_tests.cpp
+++ b/src/wallet/test/accounting_tests.cpp
@@ -10,18 +10,16 @@
 
 #include <boost/test/unit_test.hpp>
 
-extern std::unique_ptr<CWallet> pwalletMain;
-
 BOOST_FIXTURE_TEST_SUITE(accounting_tests, WalletTestingSetup)
 
 static void
-GetResults(std::map<CAmount, CAccountingEntry>& results)
+GetResults(CWallet *wallet, std::map<CAmount, CAccountingEntry>& results)
 {
     std::list<CAccountingEntry> aes;
 
     results.clear();
-    BOOST_CHECK(pwalletMain->ReorderTransactions() == DB_LOAD_OK);
-    pwalletMain->ListAccountCreditDebit("", aes);
+    BOOST_CHECK(wallet->ReorderTransactions() == DB_LOAD_OK);
+    wallet->ListAccountCreditDebit("", aes);
     for (CAccountingEntry& ae : aes)
     {
         results[ae.nOrderPos] = ae;
@@ -54,7 +52,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     ae.strOtherAccount = "c";
     pwalletMain->AddAccountingEntry(ae);
 
-    GetResults(results);
+    GetResults(pwalletMain.get(), results);
 
     BOOST_CHECK(pwalletMain->nOrderPosNext == 3);
     BOOST_CHECK(2 == results.size());
@@ -70,7 +68,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     ae.nOrderPos = pwalletMain->IncOrderPosNext();
     pwalletMain->AddAccountingEntry(ae);
 
-    GetResults(results);
+    GetResults(pwalletMain.get(), results);
 
     BOOST_CHECK(results.size() == 3);
     BOOST_CHECK(pwalletMain->nOrderPosNext == 4);
@@ -102,7 +100,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     vpwtx[2]->nTimeReceived = (unsigned int)1333333329;
     vpwtx[2]->nOrderPos = -1;
 
-    GetResults(results);
+    GetResults(pwalletMain.get(), results);
 
     BOOST_CHECK(results.size() == 3);
     BOOST_CHECK(pwalletMain->nOrderPosNext == 6);
@@ -120,7 +118,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     ae.nOrderPos = -1;
     pwalletMain->AddAccountingEntry(ae);
 
-    GetResults(results);
+    GetResults(pwalletMain.get(), results);
 
     BOOST_CHECK(results.size() == 4);
     BOOST_CHECK(pwalletMain->nOrderPosNext == 7);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,9 +6,6 @@
 
 #include <rpc/server.h>
 #include <wallet/db.h>
-#include <wallet/wallet.h>
-
-std::unique_ptr<CWallet> pwalletMain;
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     TestingSetup(chainName)
@@ -27,7 +24,6 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
 WalletTestingSetup::~WalletTestingSetup()
 {
     UnregisterValidationInterface(pwalletMain.get());
-    pwalletMain.reset();
 
     bitdb.Flush(true);
     bitdb.Reset();

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -7,11 +7,15 @@
 
 #include <test/test_bitcoin.h>
 
+#include <wallet/wallet.h>
+
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup: public TestingSetup {
     explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~WalletTestingSetup();
+
+    std::unique_ptr<CWallet> pwalletMain;
 };
 
 #endif

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -19,8 +19,6 @@
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
 
-extern std::unique_ptr<CWallet> pwalletMain;
-
 extern UniValue importmulti(const JSONRPCRequest& request);
 extern UniValue dumpwallet(const JSONRPCRequest& request);
 extern UniValue importwallet(const JSONRPCRequest& request);


### PR DESCRIPTION
Scope the variable instead of using an external global; this is how test fixtures are intended to be used.

Followup to #11713.