### PR TITLE
WIP [RPC] [Wallet] walletdowngrade command (which can remove HD)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1493,6 +1493,18 @@ bool CWallet::SetHDChain(const CHDChain& chain, bool memonly)
     return true;
 }
 
+bool CWallet::DeleteHDChain(bool memonly)
+{
+    LOCK(cs_wallet);
+    
+    hdChain.SetNull();
+
+    if (!memonly && !CWalletDB(*dbw).WriteHDChain(hdChain))
+        throw std::runtime_error(std::string(__func__) + ": deleting chain failed");
+
+    return true;
+}
+
 bool CWallet::IsHDEnabled() const
 {
     return !hdChain.masterKeyID.IsNull();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1106,6 +1106,9 @@ public:
     /* Set the HD chain model (chain child index counters) */
     bool SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
+    
+    /* Delete the HD chain model */
+    bool DeleteHDChain(bool memonly);
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;


### PR DESCRIPTION
Fixes #11716.

This adds a `walletdowngrade [version]` RPC method.

It currently only supports downgrading to v0.12, which removes the HD seed (without deleting previously generated keys). Once downgraded, there's no way back, since there's currently no mechanism to upgrade non-HD wallets.

I don't know if v0.12 downgrade support is at all useful. If not, the code can be reused for adding downgrade support for the upcoming (perhaps more risky) SegWit related changes.

Todo:
- [ ] actually test with v0.12 wallet
- [ ] add functional test
- [ ] add release note (?)