### PR TITLE
[refactor] Remove magic numbers from HMAC SHA256

### DIFF
--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -18,7 +18,7 @@ private:
     CSHA256 inner;
 
 public:
-    static const size_t OUTPUT_SIZE = 32;
+    static constexpr const size_t OUTPUT_SIZE = CSHA256::OUTPUT_SIZE;
 
     CHMAC_SHA256(const unsigned char* key, size_t keylen);
     CHMAC_SHA256& Write(const unsigned char* data, size_t len)

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -18,7 +18,7 @@ private:
     uint64_t bytes;
 
 public:
-    static const size_t OUTPUT_SIZE = 32;
+    static constexpr const size_t OUTPUT_SIZE = 32;
 
     CSHA256();
     CSHA256& Write(const unsigned char* data, size_t len);


### PR DESCRIPTION
Problem:
- Magic numbers are used to determine sizes, but are error prone.

Solution:
- Change `OUTPUT_SIZE` to be `constexpr` so that it can be used in
  array sizes.
- Use arrays so the size is carried with the variable instead of
  external computation.
- Cleanup initialization and further setting of `rkey` which can now
  be simplified because it is a `std::array` instead of a C-array.