### PR TITLE
Fix sendrawtransaction hang when sending a tx already in mempool

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -970,6 +970,10 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         }
     } else if (fHaveChain) {
         throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
+    } else {
+        // Make sure we don't block forever if re-sending
+        // a transaction already in mempool.
+        promise.set_value();
     }
 
     } // cs_main


### PR DESCRIPTION
I assume this is what #11721 actually hit.