### PR TITLE
Add -logdir option to control where debug.log lives

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -342,6 +342,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug)
         strUsage += HelpMessageOpt("-feefilter", strprintf("Tell other nodes to filter invs to us by our mempool min fee (default: %u)", DEFAULT_FEEFILTER));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file on startup"));
+    strUsage += HelpMessageOpt("-logdir=<dir>", _("Specify directory for log files (default: datadir)"));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-mempoolexpiry=<n>", strprintf(_("Do not keep transactions in the mempool longer than <n> hours (default: %u)"), DEFAULT_MEMPOOL_EXPIRY));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -189,6 +189,19 @@ static void DebugPrintInit()
     vMsgsBeforeOpenLog = new std::list<std::string>;
 }
 
+/** Get the directory for log files (currently just debug.log) */
+static fs::path GetLogDir()
+{
+  if (gArgs.IsArgSet("-logdir")) {
+    fs::path logdirPath = fs::system_complete(gArgs.GetArg("-logdir", ""));
+    if (!logdirPath.empty()) {
+      fs::create_directories(logdirPath);
+      return logdirPath;
+    }
+  }
+  return GetDataDir();
+}
+
 void OpenDebugLog()
 {
     boost::call_once(&DebugPrintInit, debugPrintInitFlag);
@@ -196,7 +209,7 @@ void OpenDebugLog()
 
     assert(fileout == nullptr);
     assert(vMsgsBeforeOpenLog);
-    fs::path pathDebug = GetDataDir() / "debug.log";
+    fs::path pathDebug = GetLogDir() / "debug.log";
     fileout = fsbridge::fopen(pathDebug, "a");
     if (fileout) {
         setbuf(fileout, nullptr); // unbuffered


### PR DESCRIPTION
I would like `bitcoind` to put its log file in `/var/log/bitcoin`. This PR adds a new `-logdir` option that controls where the `debug.log` file is put.

Note: This flag affects `bitcoind` and `bitcoin-qt`. There appears to be a `db.log` file that is used for wallets, but I didn't update that code path. It would be a minor change to update that as well.