### PR TITLE
wallet: Set m_last_block_processed to nullptr in SetNull()

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -31,6 +31,7 @@
 
 typedef CWallet* CWalletRef;
 extern std::vector<CWalletRef> vpwallets;
+extern CCriticalSection cs_main;
 
 /**
  * Settings
@@ -803,6 +804,10 @@ public:
         nRelockTime = 0;
         fAbortRescan = false;
         fScanningWallet = false;
+        {
+            LOCK(cs_main);
+            m_last_block_processed = nullptr;
+        }
     }
 
     std::map<uint256, CWalletTx> mapWallet;


### PR DESCRIPTION
Prior to this commit the non-static class member `m_last_block_processed` was not initialized in the `CWallet` constructor nor in any functions that the constructor calls.

`m_last_block_processed` was introduced in 5ee31726360cbe343f5a1a50a5e440db736da5b7 (part of PR #10286) which was merged into master a couple of days ago.

Friendly ping @TheBlueMatt :-)