### PR TITLE
Multiselect in coincontrol treewidget and display selected count

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -71,6 +71,7 @@ CoinControlDialog::CoinControlDialog(const PlatformStyle *_platformStyle, QWidge
 
     // context menu signals
     connect(ui->treeWidget, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showMenu(QPoint)));
+    connect(ui->treeWidget, SIGNAL(itemSelectionChanged()), this, SLOT(updateLabelSelected()));
     connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
@@ -166,6 +167,7 @@ void CoinControlDialog::setModel(WalletModel *_model)
     {
         updateView();
         updateLabelLocked();
+        updateLabelSelected();
         CoinControlDialog::updateLabels(_model, this);
     }
 }
@@ -414,6 +416,15 @@ void CoinControlDialog::updateLabelLocked()
        ui->labelLocked->setVisible(true);
     }
     else ui->labelLocked->setVisible(false);
+}
+
+// shows count of selected outputs
+void CoinControlDialog::updateLabelSelected()
+{
+    QList<QTreeWidgetItem *> selected = ui->treeWidget->selectedItems();
+    int count = selected.size();
+    ui->labelSelected->setVisible(count > 0);
+    ui->labelSelected->setText(tr("(%1 selected)").arg(count));
 }
 
 void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -107,6 +107,7 @@ private Q_SLOTS:
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
     void updateLabelLocked();
+    void updateLabelSelected();
 };
 
 #endif // BITCOIN_QT_COINCONTROLDIALOG_H

--- a/src/qt/coincontroltreewidget.cpp
+++ b/src/qt/coincontroltreewidget.cpp
@@ -8,17 +8,17 @@
 CoinControlTreeWidget::CoinControlTreeWidget(QWidget *parent) :
     QTreeWidget(parent)
 {
-
+    setSelectionMode(QAbstractItemView::ExtendedSelection);
 }
 
 void CoinControlTreeWidget::keyPressEvent(QKeyEvent *event)
 {
-    if (event->key() == Qt::Key_Space) // press spacebar -> select checkbox
+    if (event->key() == Qt::Key_Space) // press spacebar -> toggle checkbox
     {
         event->ignore();
-        if (this->currentItem()) {
+        for (QTreeWidgetItem* item : selectedItems()) {
             int COLUMN_CHECKBOX = 0;
-            this->currentItem()->setCheckState(COLUMN_CHECKBOX, ((this->currentItem()->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
+            item->setCheckState(COLUMN_CHECKBOX, ((item->checkState(COLUMN_CHECKBOX) == Qt::Checked) ? Qt::Unchecked : Qt::Checked));
         }
     }
     else if (event->key() == Qt::Key_Escape) // press esc -> close dialog

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -376,6 +376,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QLabel" name="labelSelected">
+          <property name="text">
+           <string notr="true">(1 selected)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This patch allow multiple out selection in coincontrol dialog.
Only for changing the checked state, locking need single select.

usecase: someone gets lost of payments from zpool/miningrigrentals/nicehash/etc, its easy to select inputs for sending (no need to click many times in intems or space-down-space-down-space-down... by keyboard)
