### PR TITLE
Use override in CCoinsView* subclasses

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -207,11 +207,11 @@ public:
     CCoinsViewCache(CCoinsView *baseIn);
 
     // Standard CCoinsView methods
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const;
-    bool HaveCoin(const COutPoint &outpoint) const;
-    uint256 GetBestBlock() const;
+    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    bool HaveCoin(const COutPoint &outpoint) const override;
+    uint256 GetBestBlock() const override;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) override;
 
     /**
      * Check if we have the given utxo already loaded in this cache.

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -88,12 +88,12 @@ class CCoinsViewDBCursor: public CCoinsViewCursor
 public:
     ~CCoinsViewDBCursor() {}
 
-    bool GetKey(COutPoint &key) const;
-    bool GetValue(Coin &coin) const;
-    unsigned int GetValueSize() const;
+    bool GetKey(COutPoint &key) const override;
+    bool GetValue(Coin &coin) const override;
+    unsigned int GetValueSize() const override;
 
-    bool Valid() const;
-    void Next();
+    bool Valid() const override;
+    void Next() override;
 
 private:
     CCoinsViewDBCursor(CDBIterator* pcursorIn, const uint256 &hashBlockIn):

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -685,8 +685,8 @@ protected:
 
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const;
-    bool HaveCoin(const COutPoint &outpoint) const;
+    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    bool HaveCoin(const COutPoint &outpoint) const override;
 };
 
 /**


### PR DESCRIPTION
Add the `override` keyword where applicable on derived classes from `coins.h`.

Using the `override` keyword on suitable subclass member functions gives us compile-time assurance that we haven't unknowingly deviated from the signature of base class functions we're trying to override. This avoids situations where calls to "overridden" functions on a derived class actually go to the base class implementation due to potentially subtle differences (e.g. `const`-ness of arguments).

If others think this is a worthwhile change, I plan on doing this in other applicable regions of the codebase in followup PRs, though I'd be happy to fold all changes into a single PR if that's preferable.