### PR TITLE
wallet: Add missing cs_wallet locks when accessing m_last_block_processed

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -728,10 +728,8 @@ private:
      * Note that this is *not* how far we've processed, we may need some rescan
      * to have seen all transactions in the chain, but is only used to track
      * live BlockConnected callbacks.
-     *
-     * Protected by cs_main (see BlockUntilSyncedToCurrentChain)
      */
-    const CBlockIndex* m_last_block_processed;
+    const CBlockIndex* m_last_block_processed GUARDED_BY(cs_wallet);
 
 public:
     /*


### PR DESCRIPTION
Add missing `cs_wallet` locks when accessing `m_last_block_processed`.

`m_last_block_processed` is guarded by `cs_wallet`.

These changes are required to get the Travis CI build (the build job with Clang's thread safety analysis enabled) to pass when the following locking annotation (see #11226) is added:

```
const CBlockIndex* m_last_block_processed GUARDED_BY(cs_wallet);
```