### PR TITLE
Docs: reflow the text and add better markup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,19 @@
 Contributing to Bitcoin Core
 ============================
 
-The Bitcoin Core project operates an open contributor model where anyone is
-welcome to contribute towards development in the form of peer review, testing
-and patches. This document explains the practical process and guidelines for
-contributing.
+The Bitcoin Core project operates an open contributor model where anyone
+is welcome to contribute towards development in the form of peer review,
+testing and patches. This document explains the practical process and
+guidelines for contributing.
 
 Firstly in terms of structure, there is no particular concept of "Core
 developers" in the sense of privileged people. Open source often naturally
-revolves around meritocracy where longer term contributors gain more trust from
-the developer community. However, some hierarchy is necessary for practical
-purposes. As such there are repository "maintainers" who are responsible for
-merging pull requests as well as a "lead maintainer" who is responsible for the
-release cycle, overall merging, moderation and appointment of maintainers.
+revolves around meritocracy where longer term contributors gain more
+trust from the developer community. However, some hierarchy is necessary
+for practical purposes. As such there are repository "maintainers" who
+are responsible for merging pull requests as well as a "lead maintainer"
+who is responsible for the release cycle, overall merging, moderation
+and appointment of maintainers.
 
 
 Contributor Workflow
@@ -28,26 +29,33 @@ To contribute a patch, the workflow is as follows:
   1. Create topic branch
   1. Commit patches
 
-The project coding conventions in the [developer notes](doc/developer-notes.md)
-must be adhered to.
+The project coding conventions in the [developer notes] must
+be adhered to.
 
-In general [commits should be atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention)
-and diffs should be easy to read. For this reason do not mix any formatting
-fixes or code moves with actual code changes.
+[developer notes]: doc/developer-notes.md
+
+In general [commits should be atomic][c] and diffs should be easy
+to read. For this reason do not mix any formatting fixes or code moves
+with actual code changes.
+
+[c]: https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention
 
 Commit messages should be verbose by default consisting of a short subject line
 (50 chars max), a blank line and detailed explanatory text as separate
 paragraph(s), unless the title alone is self-explanatory (like "Corrected typo
 in init.cpp") in which case a single title line is sufficient. Commit messages should be
 helpful to people reading your code in the future, so explain the reasoning for
-your decisions. Further explanation [here](http://chris.beams.io/posts/git-commit/).
+your decisions. Further explanation [here].
+
+[here]: https://chris.beams.io/posts/git-commit/
 
 If a particular commit references another issue, please add the reference. For
 example: `refs #1234` or `fixes #4321`. Using the `fixes` or `closes` keywords
 will cause the corresponding issue to be closed when the pull request is merged.
 
-Please refer to the [Git manual](https://git-scm.com/doc) for more information
-about Git.
+Please refer to the [Git manual] for more information about Git.
+
+[Git manual]: https://git-scm.com/doc
 
   - Push changes to your fork
   - Create pull request
@@ -81,28 +89,35 @@ Examples:
     Qt: Add feed bump button
     Trivial: Fix typo in init.cpp
 
-Note that translations should not be submitted as pull requests, please see
-[Translation Process](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md) 
-for more information on helping with translations.
+Note that translations should not be submitted as pull requests,
+please see [Translation Process] for more information on helping with
+translations.
+
+[Translation Process]: doc/translation_process.md
 
 If a pull request is not to be considered for merging (yet), please
-prefix the title with [WIP] or use [Tasks Lists](https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists)
-in the body of the pull request to indicate tasks are pending.
+prefix the title with [WIP] or use [Tasks Lists] in the body of the pull
+request to indicate tasks are pending.
 
-The body of the pull request should contain enough description about what the
-patch does together with any justification/reasoning. You should include
-references to any discussions (for example other tickets or mailing list
-discussions).
+[Tasks Lists]: https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists
 
-At this stage one should expect comments and review from other contributors. You
-can add more commits to your pull request by committing them locally and pushing
-to your fork until you have satisfied all feedback.
+The body of the pull request should contain enough description about what
+the patch does together with any justification/reasoning. You should
+include references to any discussions (for example other tickets or
+mailing list discussions).
+
+At this stage one should expect comments and review from other
+contributors. You can add more commits to your pull request by committing
+them locally and pushing to your fork until you have satisfied all
+feedback.
 
 Squashing Commits
 ---------------------------
-If your pull request is accepted for merging, you may be asked by a maintainer
-to squash and or [rebase](https://git-scm.com/docs/git-rebase) your commits
-before it will be merged. The basic squashing workflow is shown below.
+If your pull request is accepted for merging, you may be asked by a
+maintainer to squash and or [rebase] your commits before it will be
+merged. The basic squashing workflow is shown below.
+
+[rebase]: https://git-scm.com/docs/git-rebase
 
     git checkout your_branch_name
     git rebase -i HEAD~n
@@ -112,35 +127,36 @@ before it will be merged. The basic squashing workflow is shown below.
     # save and quit
     git push -f # (force push to GitHub)
 
-If you have problems with squashing (or other workflows with `git`), you can
-alternatively enable "Allow edits from maintainers" in the right GitHub
-sidebar and ask for help in the pull request.
+If you have problems with squashing (or other workflows with `git`),
+you can alternatively enable "Allow edits from maintainers" in the right
+GitHub sidebar and ask for help in the pull request.
 
 Please refrain from creating several pull requests for the same change.
-Use the pull request that is already open (or was created earlier) to amend
-changes. This preserves the discussion and review that happened earlier for
-the respective change set.
+Use the pull request that is already open (or was created earlier) to
+amend changes. This preserves the discussion and review that happened
+earlier for the respective change set.
 
-The length of time required for peer review is unpredictable and will vary from
-pull request to pull request.
+The length of time required for peer review is unpredictable and will
+vary from pull request to pull request.
 
 
 Pull Request Philosophy
 -----------------------
 
-Patchsets should always be focused. For example, a pull request could add a
-feature, fix a bug, or refactor code; but not a mixture. Please also avoid super
-pull requests which attempt to do too much, are overly large, or overly complex
-as this makes review difficult.
+Patchsets should always be focused. For example, a pull request could
+add a feature, fix a bug, or refactor code; but not a mixture. Please
+also avoid super pull requests which attempt to do too much, are overly
+large, or overly complex as this makes review difficult.
 
 
 ### Features
 
-When adding a new feature, thought must be given to the long term technical debt
-and maintenance that feature may require after inclusion. Before proposing a new
-feature that will require maintenance, please consider if you are willing to
-maintain it (including bug fixing). If features get orphaned with no maintainer
-in the future, they may be removed by the Repository Maintainer.
+When adding a new feature, thought must be given to the long
+term technical debt and maintenance that feature may require after
+inclusion. Before proposing a new feature that will require maintenance,
+please consider if you are willing to maintain it (including bug
+fixing). If features get orphaned with no maintainer in the future,
+they may be removed by the Repository Maintainer.
 
 
 ### Refactoring
@@ -148,125 +164,144 @@ in the future, they may be removed by the Repository Maintainer.
 Refactoring is a necessary part of any software project's evolution. The
 following guidelines cover refactoring pull requests for the project.
 
-There are three categories of refactoring, code only moves, code style fixes,
-code refactoring. In general refactoring pull requests should not mix these
-three kinds of activity in order to make refactoring pull requests easy to
-review and uncontroversial. In all cases, refactoring PRs must not change the
-behaviour of code within the pull request (bugs must be preserved as is).
+There are three categories of refactoring, code only moves, code style
+fixes, code refactoring. In general refactoring pull requests should
+not mix these three kinds of activity in order to make refactoring pull
+requests easy to review and uncontroversial. In all cases, refactoring
+PRs must not change the behaviour of code within the pull request (bugs
+must be preserved as is).
 
-Project maintainers aim for a quick turnaround on refactoring pull requests, so
-where possible keep them short, uncomplex and easy to verify.
+Project maintainers aim for a quick turnaround on refactoring pull
+requests, so where possible keep them short, uncomplex and easy to verify.
 
-Pull requests that refactor the code should not be made by new contributors. It
-requires a certain level of experience to know where the code belongs to and to
-understand the full ramification (including rebase effort of open pull requests).
+Pull requests that refactor the code should not be made by new
+contributors. It requires a certain level of experience to know where
+the code belongs to and to understand the full ramification (including
+rebase effort of open pull requests).
 
-Trivial pull requests or pull requests that refactor the code with no clear
-benefits may be immediately closed by the maintainers to reduce unnecessary
-workload on reviewing.
+Trivial pull requests or pull requests that refactor the code with no
+clear benefits may be immediately closed by the maintainers to reduce
+unnecessary workload on reviewing.
 
 
 "Decision Making" Process
 -------------------------
 
-The following applies to code changes to the Bitcoin Core project (and related
-projects such as libsecp256k1), and is not to be confused with overall Bitcoin
-Network Protocol consensus changes.
+The following applies to code changes to the Bitcoin Core project (and
+related projects such as libsecp256k1), and is not to be confused with
+overall Bitcoin Network Protocol consensus changes.
 
-Whether a pull request is merged into Bitcoin Core rests with the project merge
-maintainers and ultimately the project lead.
+Whether a pull request is merged into Bitcoin Core rests with the project
+merge maintainers and ultimately the project lead.
 
-Maintainers will take into consideration if a patch is in line with the general
-principles of the project; meets the minimum standards for inclusion; and will
-judge the general consensus of contributors.
+Maintainers will take into consideration if a patch is in line with
+the general principles of the project; meets the minimum standards for
+inclusion; and will judge the general consensus of contributors.
 
 In general, all pull requests must:
 
-  - Have a clear use case, fix a demonstrable bug or serve the greater good of
-    the project (for example refactoring for modularisation);
+  - Have a clear use case, fix a demonstrable bug or serve the greater
+    good of the project (for example refactoring for modularisation);
   - Be well peer reviewed;
   - Have unit tests and functional tests where appropriate;
-  - Follow code style guidelines ([C++](doc/developer-notes.md), [functional tests](test/functional/README.md));
+  - Follow code style guidelines ([C++], [functional tests]);
   - Not break the existing test suite;
   - Where bugs are fixed, where possible, there should be unit tests
-    demonstrating the bug and also proving the fix. This helps prevent regression.
+    demonstrating the bug and also proving the fix. This helps prevent
+    regression.
 
-Patches that change Bitcoin consensus rules are considerably more involved than
-normal because they affect the entire ecosystem and so must be preceded by
-extensive mailing list discussions and have a numbered BIP. While each case will
-be different, one should be prepared to expend more time and effort than for
-other kinds of patches because of increased peer review and consensus building
-requirements.
+[C++]: doc/developer-notes.md
+[functional tests]: test/functional/README.md
+
+Patches that change Bitcoin consensus rules are considerably more
+involved than normal because they affect the entire ecosystem and so must
+be preceded by extensive mailing list discussions and have a numbered
+BIP. While each case will be different, one should be prepared to expend
+more time and effort than for other kinds of patches because of increased
+peer review and consensus building requirements.
 
 
 ### Peer Review
 
-Anyone may participate in peer review which is expressed by comments in the pull
-request. Typically reviewers will review the code for obvious errors, as well as
-test out the patch set and opine on the technical merits of the patch. Project
-maintainers take into account the peer review when determining if there is
-consensus to merge a pull request (remember that discussions may have been
-spread out over GitHub, mailing list and IRC discussions). The following
-language is used within pull-request comments:
+Anyone may participate in peer review which is expressed by comments
+in the pull request. Typically reviewers will review the code for
+obvious errors, as well as test out the patch set and opine on the
+technical merits of the patch. Project maintainers take into account
+the peer review when determining if there is consensus to merge a pull
+request (remember that discussions may have been spread out over GitHub,
+mailing list and IRC discussions). The following language is used within
+pull-request comments:
 
   - ACK means "I have tested the code and I agree it should be merged";
-  - NACK means "I disagree this should be merged", and must be accompanied by
-    sound technical justification (or in certain cases of copyright/patent/licensing
-    issues, legal justification). NACKs without accompanying reasoning may be
-    disregarded;
-  - utACK means "I have not tested the code, but I have reviewed it and it looks
-    OK, I agree it can be merged";
-  - Concept ACK means "I agree in the general principle of this pull request";
+  - NACK means "I disagree this should be merged", and must be
+    accompanied by sound technical justification (or in certain cases
+    of copyright/patent/licensing issues, legal justification). NACKs
+    without accompanying reasoning may be disregarded;
+  - utACK means "I have not tested the code, but I have reviewed it and
+    it looks OK, I agree it can be merged";
+  - Concept ACK means "I agree in the general principle of this pull
+    request";
   - Nit refers to trivial, often non-blocking issues.
 
-Reviewers should include the commit hash which they reviewed in their comments.
+Reviewers should include the commit hash which they reviewed in their
+comments.
 
-Project maintainers reserve the right to weigh the opinions of peer reviewers
-using common sense judgement and also may weight based on meritocracy: Those
-that have demonstrated a deeper commitment and understanding towards the project
-(over time) or have clear domain expertise may naturally have more weight, as
-one would expect in all walks of life.
+Project maintainers reserve the right to weigh the opinions of peer
+reviewers using common sense judgement and also may weight based on
+meritocracy: Those that have demonstrated a deeper commitment and
+understanding towards the project (over time) or have clear domain
+expertise may naturally have more weight, as one would expect in all
+walks of life.
 
-Where a patch set affects consensus critical code, the bar will be set much
-higher in terms of discussion and peer review requirements, keeping in mind that
-mistakes could be very costly to the wider community. This includes refactoring
-of consensus critical code.
+Where a patch set affects consensus critical code, the bar will be set
+much higher in terms of discussion and peer review requirements, keeping
+in mind that mistakes could be very costly to the wider community. This
+includes refactoring of consensus critical code.
 
-Where a patch set proposes to change the Bitcoin consensus, it must have been
-discussed extensively on the mailing list and IRC, be accompanied by a widely
-discussed BIP and have a generally widely perceived technical consensus of being
-a worthwhile change based on the judgement of the maintainers.
+Where a patch set proposes to change the Bitcoin consensus, it must have
+been discussed extensively on the mailing list and IRC, be accompanied by
+a widely discussed BIP and have a generally widely perceived technical
+consensus of being a worthwhile change based on the judgement of the
+maintainers.
 
 ### Finding Reviewers
 
-As most reviewers are themselves developers with their own projects, the review
-process can be quite lengthy, and some amount of patience is required. If you find
-that you've been waiting for a pull request to be given attention for several
-months, there may be a number of reasons for this, some of which you can do something
-about:
+As most reviewers are themselves developers with their own projects,
+the review process can be quite lengthy, and some amount of patience
+is required. If you find that you've been waiting for a pull request to
+be given attention for several months, there may be a number of reasons
+for this, some of which you can do something about:
 
-  - It may be because of a feature freeze due to an upcoming release. During this time,
-    only bug fixes are taken into consideration. If your pull request is a new feature,
-    it will not be prioritized until the release is over. Wait for release.
-  - It may be because the changes you are suggesting do not appeal to people. Rather than
-    nits and critique, which require effort and means they care enough to spend time on your
-    contribution, thundering silence is a good sign of widespread (mild) dislike of a given change
-    (because people don't assume *others* won't actually like the proposal). Don't take
-    that personally, though! Instead, take another critical look at what you are suggesting
-    and see if it: changes too much, is too broad, doesn't adhere to the
-    [developer notes](doc/developer-notes.md), is dangerous or insecure, is messily written, etc.
-    Identify and address any of the issues you find. Then ask e.g. on IRC if someone could give
-    their opinion on the concept itself.
-  - It may be because your code is too complex for all but a few people. And those people
-    may not have realized your pull request even exists. A great way to find people who
-    are qualified and care about the code you are touching is the
-    [Git Blame feature](https://help.github.com/articles/tracing-changes-in-a-file/). Simply
-    find the person touching the code you are touching before you and see if you can find
-    them and give them a nudge. Don't be incessant about the nudging though.
-  - Finally, if all else fails, ask on IRC or elsewhere for someone to give your pull request
-    a look. If you think you've been waiting an unreasonably long amount of time (month+) for
-    no particular reason (few lines changed, etc), this is totally fine. Try to return the favor
-    when someone else is asking for feedback on their code, and universe balances out.
+  - It may be because of a feature freeze due to an upcoming
+    release. During this time, only bug fixes are taken into
+    consideration. If your pull request is a new feature, it will not
+    be prioritized until the release is over. Wait for release.
+  - It may be because the changes you are suggesting do not appeal
+    to people. Rather than nits and critique, which require effort
+    and means they care enough to spend time on your contribution,
+    thundering silence is a good sign of widespread (mild) dislike of a
+    given change (because people don't assume *others* won't actually
+    like the proposal). Don't take that personally, though! Instead,
+    take another critical look at what you are suggesting and see if it:
+    changes too much, is too broad, doesn't adhere to the [developer
+    notes](doc/developer-notes.md), is dangerous or insecure, is messily
+    written, etc.  Identify and address any of the issues you find. Then
+    ask e.g. on IRC if someone could give their opinion on the concept
+    itself.
+  - It may be because your code is too complex for all but a few
+    people. And those people may not have realized your pull request
+    even exists. A great way to find people who are qualified
+    and care about the code you are touching is the [Git Blame
+    feature](https://help.github.com/articles/tracing-changes-in-a-file/).
+    Simply find the person touching the code you are touching before
+    you and see if you can find them and give them a nudge. Don't be
+    incessant about the nudging though.
+  - Finally, if all else fails, ask on IRC or elsewhere for someone to
+    give your pull request a look. If you think you've been waiting an
+    unreasonably long amount of time (month+) for no particular reason
+    (few lines changed, etc), this is totally fine. Try to return the
+    favor when someone else is asking for feedback on their code, and
+    universe balances out.
 
 
 Release Policy

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,5 @@
 Building Bitcoin
 ================
 
-See doc/build-*.md for instructions on building the various
+See `doc/build-*.md` for instructions on building the various
 elements of the Bitcoin Core reference implementation of Bitcoin.

--- a/contrib/qos/README.md
+++ b/contrib/qos/README.md
@@ -1,5 +1,10 @@
 ### QoS (Quality of service) ###
 
-This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN.
+This is a Linux bash script that will set up tc to limit the outgoing
+bandwidth for connections to the Bitcoin network. It limits outbound
+TCP traffic with a source or destination port of 8333, but not if the
+destination IP is within a LAN.
 
-This means one can have an always-on bitcoind instance running, and another local bitcoind/bitcoin-qt instance which connects to this node and receives blocks from it.
+This means one can have an always-on bitcoind instance running, and
+another local bitcoind/bitcoin-qt instance which connects to this node
+and receives blocks from it.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,12 +1,12 @@
-(note: this is a temporary file, to be added-to by anybody, and moved to
-release-notes at release time)
+(note: this is a temporary file, to be added-to by anybody, and moved
+to release-notes at release time)
 
 Bitcoin Core version *version* is now available from:
 
   <https://bitcoin.org/bin/bitcoin-core-*version*/>
 
-This is a new major version release, including new features, various bugfixes
-and performance improvements, as well as updated translations.
+This is a new major version release, including new features, various
+bugfixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
@@ -19,27 +19,29 @@ To receive security and update notifications, please subscribe to:
 How to Upgrade
 ==============
 
-If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
-or `bitcoind`/`bitcoin-qt` (on Linux).
+If you are running an older version, shut it down. Wait until it
+has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+`/Applications/Bitcoin-Qt` (on Mac) or `bitcoind`/`bitcoin-qt` (on Linux).
 
-The first time you run version 0.15.0, your chainstate database will be converted to a
-new format, which will take anywhere from a few minutes to half an hour,
-depending on the speed of your machine.
+The first time you run version 0.15.0, your chainstate database will be
+converted to a new format, which will take anywhere from a few minutes
+to half an hour, depending on the speed of your machine.
 
-Note that the block database format also changed in version 0.8.0 and there is no
-automatic upgrade code from before version 0.8 to version 0.15.0. Upgrading
-directly from 0.7.x and earlier without redownloading the blockchain is not supported.
-However, as usual, old wallet versions are still supported.
+Note that the block database format also changed in version 0.8.0 and
+there is no automatic upgrade code from before version 0.8 to version
+0.15.0. Upgrading directly from 0.7.x and earlier without redownloading
+the blockchain is not supported.  However, as usual, old wallet versions
+are still supported.
 
 Downgrading warning
 -------------------
 
-The chainstate database for this release is not compatible with previous
-releases, so if you run 0.15 and then decide to switch back to any
-older version, you will need to run the old release with the `-reindex-chainstate`
-option to rebuild the chainstate data structures in the old format.
+The chainstate database for this release is not compatible with
+previous releases, so if you run 0.15 and then decide to switch back
+to any older version, you will need to run the old release with the
+`-reindex-chainstate` option to rebuild the chainstate data structures
+in the old format.
 
 If your node has pruning enabled, this will entail re-downloading and
 processing the entire blockchain.
@@ -48,78 +50,86 @@ Compatibility
 ==============
 
 Bitcoin Core is extensively tested on multiple operating systems using
-the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
+the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP
+is not supported.
 
-Bitcoin Core should also work on most other Unix-like systems but is not
-frequently tested on them.
+Bitcoin Core should also work on most other Unix-like systems but is
+not frequently tested on them.
 
 Notable changes
 ===============
 
 GCC 4.8.x
 --------------
-The minimum version of GCC required to compile Bitcoin Core is now 4.8. No effort will be
-made to support older versions of GCC. See discussion in issue #11732 for more information.
+The minimum version of GCC required to compile Bitcoin Core is now 4.8. No
+effort will be made to support older versions of GCC. See discussion in
+issue #11732 for more information.
 
 HD-wallets by default
 ---------------------
-Due to a backward-incompatible change in the wallet database, wallets created
-with version 0.16.0 will be rejected by previous versions. Also, version 0.16.0
-will only create hierarchical deterministic (HD) wallets.
+Due to a backward-incompatible change in the wallet database, wallets
+created with version 0.16.0 will be rejected by previous versions. Also,
+version 0.16.0 will only create hierarchical deterministic (HD) wallets.
 
 Replace-By-Fee by default in GUI
 --------------------------------
-The send screen now uses BIP-125 RBF by default, regardless of `-walletrbf`.
-There is a checkbox to mark the transaction as final.
+The send screen now uses BIP-125 RBF by default, regardless of
+`-walletrbf`.  There is a checkbox to mark the transaction as final.
 
-The RPC default remains unchanged: to use RBF, launch with `-walletrbf=1` or
-use the `replaceable` argument for individual transactions.
+The RPC default remains unchanged: to use RBF, launch with `-walletrbf=1`
+or use the `replaceable` argument for individual transactions.
 
 Wallets directory configuration (`-walletdir`)
 ----------------------------------------------
 
-Bitcoin Core now has more flexibility in where the wallets directory can be
-located. Previously wallet database files were stored at the top level of the
-bitcoin data directory. The behavior is now:
+Bitcoin Core now has more flexibility in where the wallets directory
+can be located. Previously wallet database files were stored at the top
+level of the bitcoin data directory. The behavior is now:
 
 - For new installations (where the data directory doesn't already exist),
-  wallets will now be stored in a new `wallets/` subdirectory inside the data
-  directory by default.
-- For existing nodes (where the data directory already exists), wallets will be
-  stored in the data directory root by default. If a `wallets/` subdirectory
-  already exists in the data directory root, then wallets will be stored in the
-  `wallets/` subdirectory by default.
+  wallets will now be stored in a new `wallets/` subdirectory inside
+  the data directory by default.
+- For existing nodes (where the data directory already exists), wallets
+  will be stored in the data directory root by default. If a `wallets/`
+  subdirectory already exists in the data directory root, then wallets
+  will be stored in the `wallets/` subdirectory by default.
 - The location of the wallets directory can be overridden by specifying a
-  `-walletdir=<path>` option where `<path>` can be an absolute path to a
-  directory or directory symlink.
+  `-walletdir=<path>` option where `<path>` can be an absolute path to
+  a directory or directory symlink.
 
-Care should be taken when choosing the wallets directory location, as if it
-becomes unavailable during operation, funds may be lost.
+Care should be taken when choosing the wallets directory location,
+as if it becomes unavailable during operation, funds may be lost.
 
 Low-level RPC changes
 ----------------------
-- The deprecated RPC `getinfo` was removed. It is recommended that the more specific RPCs are used:
+- The deprecated RPC `getinfo` was removed. It is recommended that the
+  more specific RPCs are used:
   * `getblockchaininfo`
   * `getnetworkinfo`
   * `getwalletinfo`
   * `getmininginfo`
-- The wallet RPC `getreceivedbyaddress` will return an error if called with an address not in the wallet.
-- The wallet RPC `addwitnessaddress` was deprecated and will be removed in version 0.17,
-  set the `address_type` argument of `getnewaddress`, or option `-addresstype=[bech32|p2sh-segwit]` instead.
+- The wallet RPC `getreceivedbyaddress` will return an error if called
+  with an address not in the wallet.
+- The wallet RPC `addwitnessaddress` was deprecated and will be removed
+  in version 0.17, set the `address_type` argument of `getnewaddress`,
+  or option `-addresstype=[bech32|p2sh-segwit]` instead.
 
 Changed command-line options
 -----------------------------
-- `-debuglogfile=<file>` can be used to specify an alternative debug logging file.
+- `-debuglogfile=<file>` can be used to specify an alternative debug
+  logging file.
 
 Renamed script for creating JSON-RPC credentials
 -----------------------------
-The `share/rpcuser/rpcuser.py` script was renamed to `share/rpcauth/rpcauth.py`. This script can be
-used to create `rpcauth` credentials for a JSON-RPC user.
+The `share/rpcuser/rpcuser.py` script was renamed to
+`share/rpcauth/rpcauth.py`. This script can be used to create `rpcauth`
+credentials for a JSON-RPC user.
 
 
-- `dumpwallet` now includes hex-encoded scripts from the wallet in the dumpfile, and
-  `importwallet` now imports these scripts, but corresponding addresses may not be added
-  correctly or a manual rescan may be required to find relevant transactions.
+- `dumpwallet` now includes hex-encoded scripts from the wallet in the
+  dumpfile, and `importwallet` now imports these scripts, but corresponding
+  addresses may not be added correctly or a manual rescan may be required
+  to find relevant transactions.
 
 Credits
 =======
@@ -127,4 +137,5 @@ Credits
 Thanks to everyone who directly contributed to this release:
 
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on
+[Transifex](https://www.transifex.com/projects/p/bitcoin/).


### PR DESCRIPTION
Here are some very uninportant fixes that just make the modified files look a bit more professional (one in rendered output, the other in terminal as plain-text).

No changes to the text were done here. Just markup (monospace, multi-line links) and `fmt`.