### PR TITLE
[REST] added blockhash api, tests and documentation

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -31,6 +31,11 @@ With the /notxdetails/ option JSON response will only contain the transaction ha
 
 Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
 
+#### Block hash
+`GET /rest/blockhash/<HEIGHT>.<bin|hex|json>`
+
+Given a block height: returns the hash of the block at <HEIGHT> in the active chain, in binary, hex-encoded binary or JSON formats.
+
 #### Chaininfos
 `GET /rest/chaininfo.json`
 


### PR DESCRIPTION
Added a /rest/blockhash/<HEIGHT>.json endpoint, so that the user can fetch a block hash by height via REST (analogous to the 'getblockhash' RPC method).

For someone wanting to gather block or header data via REST only, there was no way to begin fetching blocks/headers at specific heights without knowing the block hashes at those heights.  This endpoint might also come in handy for someone wanting to quickly verify a block existing at a specific height in the active chain.