### PR TITLE
[REST] add a rest endpoint for estimatesmartfee, docs, and test

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -111,6 +111,11 @@ Only supports JSON as output format.
 Returns transactions in the TX mempool.
 Only supports JSON as output format.
 
+#### Fees
+`GET /rest/fee/<MODE>/<TARGET>.json`
+
+Returns fee and blocknumber where estimation was found. `<MODE>` should be one of `<unset|conservative|economical>`.
+`<TARGET>` is the desired confirmation time (in block height).
 Risks
 -------------
 Running a web browser on the same node with a REST enabled bitcoind can be a risk. Accessing prepared XSS websites could read out tx/block data of your node by placing links like `<script src="http://127.0.0.1:8332/rest/tx/1234567890.json">` which might break the nodes privacy.

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -326,5 +326,17 @@ class RESTTest (BitcoinTestFramework):
         json_obj = self.test_rest_request("/chaininfo")
         assert_equal(json_obj['bestblockhash'], bb_hash)
 
+        # Prepare for Fee estimation
+        for i in range(18):
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
+            self.sync_all()
+            self.nodes[1].generatetoaddress(1, not_related_address)
+        self.sync_all()
+
+        json_obj = self.test_rest_request("/fee/conservative/1")
+        assert_greater_than(float(json_obj["feerate"]), 0)
+        assert_greater_than(int(json_obj["blocks"]), 0)
+
+
 if __name__ == '__main__':
     RESTTest().main()


### PR DESCRIPTION
This could be useful if other clients want to use the core's fee estimation logic via REST.