### PR TITLE
Move fee estimator into validationinterface/cscheduler thread

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -154,8 +154,7 @@ bool TxIndex::WriteBestBlock(const CBlockIndex* block_index)
     return true;
 }
 
-void TxIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex,
-                    const std::vector<CTransactionRef>& txn_conflicted)
+void TxIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
 {
     if (!m_synced) {
         return;

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -52,9 +52,7 @@ private:
     bool WriteBestBlock(const CBlockIndex* block_index);
 
 protected:
-    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex,
-                        const std::vector<CTransactionRef>& txn_conflicted) override;
-
+    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
     void ChainStateFlushed(const CBlockLocator& locator) override;
 
 public:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -212,6 +212,7 @@ void Shutdown()
     // Because these depend on each-other, we make sure that neither can be
     // using the other before destroying them.
     if (peerLogic) UnregisterValidationInterface(peerLogic.get());
+    if (peerLogic) UnregisterMempoolInterface(peerLogic.get());
     if (g_connman) g_connman->Stop();
     peerLogic.reset();
     g_connman.reset();
@@ -1305,6 +1306,7 @@ bool AppInitMain()
 
     peerLogic.reset(new PeerLogicValidation(&connman, scheduler));
     RegisterValidationInterface(peerLogic.get());
+    RegisterMempoolInterface(peerLogic.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size
     std::vector<std::string> uacomments;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -272,6 +272,7 @@ void Shutdown()
 #if ENABLE_ZMQ
     if (pzmqNotificationInterface) {
         UnregisterValidationInterface(pzmqNotificationInterface);
+        UnregisterMempoolInterface(pzmqNotificationInterface);
         delete pzmqNotificationInterface;
         pzmqNotificationInterface = nullptr;
     }
@@ -284,7 +285,7 @@ void Shutdown()
         LogPrintf("%s: Unable to remove pidfile: %s\n", __func__, e.what());
     }
 #endif
-    UnregisterAllValidationInterfaces();
+    UnregisterAllValidationAndMempoolInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
     GetMainSignals().UnregisterWithMempoolSignals(mempool);
     g_wallet_init_interface.Close();
@@ -1398,6 +1399,7 @@ bool AppInitMain()
 
     if (pzmqNotificationInterface) {
         RegisterValidationInterface(pzmqNotificationInterface);
+        RegisterMempoolInterface(pzmqNotificationInterface);
     }
 #endif
     uint64_t nMaxOutboundLimit = 0; //unlimited unless -maxuploadtarget is set

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -233,6 +233,7 @@ void Shutdown()
 
     if (fFeeEstimatesInitialized)
     {
+        UnregisterMempoolInterface(&::feeEstimator);
         ::feeEstimator.FlushUnconfirmed();
         fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
         CAutoFile est_fileout(fsbridge::fopen(est_path, "wb"), SER_DISK, CLIENT_VERSION);
@@ -1607,6 +1608,7 @@ bool AppInitMain()
     // Allowed to fail as this file IS missing on first startup.
     if (!est_filein.IsNull())
         ::feeEstimator.Read(est_filein);
+    RegisterMempoolInterface(&::feeEstimator);
     fFeeEstimatesInitialized = true;
 
     // ********************************************************* Step 8: start indexers

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -287,7 +287,6 @@ void Shutdown()
 #endif
     UnregisterAllValidationAndMempoolInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
-    GetMainSignals().UnregisterWithMempoolSignals(mempool);
     g_wallet_init_interface.Close();
     globalVerifyHandle.reset();
     ECC_Stop();
@@ -1270,7 +1269,6 @@ bool AppInitMain()
     threadGroup.create_thread(boost::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
     GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
-    GetMainSignals().RegisterWithMempoolSignals(mempool);
 
     /* Register RPC commands regardless of -server setting so they will be
      * available in the GUI RPC console even if external calls are disabled.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -984,7 +984,7 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const CValidationSta
 }
 
 
-void PeerLogicValidation::TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) {
+void PeerLogicValidation::TransactionAddedToMempool(const NewMempoolTransactionInfo& info, const std::vector<CTransactionRef>& txn_replaced) {
     LOCK(g_cs_orphans);
 
     for (const CTransactionRef& tx : txn_replaced) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -826,7 +826,7 @@ PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn, CScheduler &schedu
  * Evict orphan txn pool entries (EraseOrphanTx) based on a newly connected
  * block. Also save the time of the last tip update.
  */
-void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex, const std::vector<CTransactionRef>& vtxConflicted) {
+void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex) {
     LOCK(g_cs_orphans);
 
     std::vector<uint256> vOrphanErase;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -983,6 +983,15 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const CValidationSta
         mapBlockSource.erase(it);
 }
 
+
+void PeerLogicValidation::TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) {
+    LOCK(g_cs_orphans);
+
+    for (const CTransactionRef& tx : txn_replaced) {
+        AddToCompactExtraTransactions(tx);
+    }
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Messages
@@ -2177,10 +2186,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         pfrom->setAskFor.erase(inv.hash);
         mapAlreadyAskedFor.erase(inv.hash);
 
-        std::list<CTransactionRef> lRemovedTxn;
-
         if (!AlreadyHave(inv) &&
-            AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
+            AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
             mempool.check(pcoinsTip.get());
             RelayTransaction(tx, connman);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
@@ -2218,7 +2225,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
                     if (setMisbehaving.count(fromPeer))
                         continue;
-                    if (AcceptToMemoryPool(mempool, stateDummy, porphanTx, &fMissingInputs2, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
+                    if (AcceptToMemoryPool(mempool, stateDummy, porphanTx, &fMissingInputs2, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
                         LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
                         RelayTransaction(orphanTx, connman);
                         for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {
@@ -2317,9 +2324,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 }
             }
         }
-
-        for (const CTransactionRef& removedTx : lRemovedTxn)
-            AddToCompactExtraTransactions(removedTx);
 
         int nDoS = 0;
         if (state.IsInvalid(nDoS))

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -61,7 +61,7 @@ public:
     /**
      * Overridden from MempoolInterface.
      */
-    void TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) override;
+    void TransactionAddedToMempool(const NewMempoolTransactionInfo& info, const std::vector<CTransactionRef>& txn_replaced) override;
 
     /** Initialize a peer by adding it to mapNodeState and pushing a message requesting its version */
     void InitializeNode(CNode* pnode) override;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -35,7 +35,7 @@ static constexpr int64_t EXTRA_PEER_CHECK_INTERVAL = 45;
 /** Minimum time an outbound-peer-eviction candidate must be connected for, in order to evict, in seconds */
 static constexpr int64_t MINIMUM_CONNECT_TIME = 30;
 
-class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
+class PeerLogicValidation final : public CValidationInterface, public MempoolInterface, public NetEventsInterface {
 private:
     CConnman* const connman;
 
@@ -58,6 +58,10 @@ public:
      * Overridden from CValidationInterface.
      */
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
+    /**
+     * Overridden from MempoolInterface.
+     */
+    void TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) override;
 
     /** Initialize a peer by adding it to mapNodeState and pushing a message requesting its version */
     void InitializeNode(CNode* pnode) override;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -45,7 +45,7 @@ public:
     /**
      * Overridden from CValidationInterface.
      */
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     /**
      * Overridden from CValidationInterface.
      */

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -11,6 +11,7 @@
 #include <uint256.h>
 #include <random.h>
 #include <sync.h>
+#include <validationinterface.h>
 
 #include <map>
 #include <memory>
@@ -136,7 +137,7 @@ struct FeeCalculation
  * a certain number of blocks.  Every time a block is added to the best chain, this class records
  * stats on the transactions included in that block
  */
-class CBlockPolicyEstimator
+class CBlockPolicyEstimator : public MempoolInterface
 {
 private:
     /** Track confirm delays up to 12 blocks for short horizon */
@@ -197,20 +198,19 @@ private:
     /** Remove a transaction from the mempool tracking stats*/
     void removeTx(std::map<uint256, TxStatsInfo>::iterator pos, bool inBlock);
 
+    /** Helper method to quickly remove transactions that left mempool without going in a block */
+    void removeTxNotInBlock(const uint256& hash);
+
+protected:
+    // MempoolInterface functions:
+    void TransactionAddedToMempool(const NewMempoolTransactionInfo& info, const std::vector<CTransactionRef>& txn_replaced) override;
+    void TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) override;
+    void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted, int block_height) override;
+
 public:
     /** Create new BlockPolicyEstimator and initialize stats tracking classes with default values */
     CBlockPolicyEstimator();
     ~CBlockPolicyEstimator();
-
-    /** Process all the transactions that have been included in a block */
-    void processBlock(unsigned int nBlockHeight,
-                      const std::vector<CTransactionRef>& txn_removed_in_block);
-
-    /** Process a transaction accepted to the mempool*/
-    void processTransaction(const CTxMemPoolEntry& entry, bool validFeeEstimate);
-
-    /** Remove a transaction from the mempool tracking stats*/
-    bool removeTx(uint256 hash);
 
     /** DEPRECATED. Return a feerate estimate */
     CFeeRate estimateFee(int confTarget) const;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -192,6 +192,7 @@ private:
     {
         unsigned int blockHeight;
         CAmount m_fee_per_k;
+        uint256 witness_hash;
         TxStatsInfo() : blockHeight(0), m_fee_per_k(0) {}
     };
 
@@ -263,7 +264,7 @@ private:
     mutable CCriticalSection cs_feeEstimator;
 
     /** Process a transaction confirmed in a block*/
-    bool processBlockTx(unsigned int nBlockHeight, const uint256& hash);
+    bool processBlockTx(unsigned int nBlockHeight, const CTransactionRef& tx);
 
     /** Helper for estimateSmartFee */
     double estimateCombinedFee(unsigned int confTarget, double successThreshold, bool checkShorterHorizon, EstimationResult *result) const;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1136,7 +1136,7 @@ UniValue sendrawtransaction(const JSONRPCRequest& request)
         CValidationState state;
         bool fMissingInputs;
         if (!AcceptToMemoryPool(mempool, state, std::move(tx), &fMissingInputs,
-                                nullptr /* plTxnReplaced */, false /* bypass_limits */, nMaxRawTxFee)) {
+                                false /* bypass_limits */, nMaxRawTxFee)) {
             if (state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, FormatStateMessage(state));
             } else {
@@ -1241,7 +1241,7 @@ UniValue testmempoolaccept(const JSONRPCRequest& request)
     {
         LOCK(cs_main);
         test_accept_res = AcceptToMemoryPool(mempool, state, std::move(tx), &missing_inputs,
-            nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, /* test_accept */ true);
+            false /* bypass_limits */, max_raw_tx_fee, /* test_accept */ true);
     }
     result_0.pushKV("allowed", test_accept_res);
     if (!test_accept_res) {

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -12,7 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 {

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/validation.h>
 #include <policy/policy.h>
 #include <policy/fees.h>
 #include <txmempool.h>
@@ -11,13 +12,15 @@
 #include <test/test_bitcoin.h>
 
 #include <boost/test/unit_test.hpp>
+#include <future>
 
 BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
 {
     CBlockPolicyEstimator feeEst;
-    CTxMemPool mpool(&feeEst);
+    CTxMemPool mpool;
+    RegisterMempoolInterface(&feeEst);
     TestMemPoolEntryHelper entry;
     CAmount basefee(2000);
     CAmount deltaFee(100);
@@ -58,6 +61,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k; // make transaction unique
                 uint256 hash = tx.GetHash();
                 mpool.addUnchecked(hash, entry.Fee(feeV[j]).Time(GetTime()).Height(blocknum).FromTx(tx));
+                // Since TransactionAddedToMempool callbacks are generated in ATMP,
+                // not addUnchecked, we cheat and create one manually here
+                int64_t virtual_size = GetVirtualTransactionSize(GetTransactionWeight(tx), 0);
+                GetMainSignals().TransactionAddedToMempool({MakeTransactionRef(tx), feeV[j], virtual_size, true}, std::make_shared<std::vector<CTransactionRef>>());
                 txHashes[j].push_back(hash);
             }
         }
@@ -77,6 +84,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         block.clear();
         // Check after just a few txs that combining buckets works as expected
         if (blocknum == 3) {
+            // Wait for fee estimator to catch up
+            SyncWithValidationInterfaceQueue();
+
             // At this point we should need to combine 3 buckets to get enough data points
             // So estimateFee(1) should fail and estimateFee(2) should return somewhere around
             // 9*baserate.  estimateFee(2) %'s are 100,100,90 = average 97%
@@ -114,6 +124,9 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     while (blocknum < 250)
         mpool.removeForBlock(block, ++blocknum);
 
+    // Wait for fee estimator to catch up
+    SyncWithValidationInterfaceQueue();
+
     BOOST_CHECK(feeEst.estimateFee(1) == CFeeRate(0));
     for (int i = 2; i < 10;i++) {
         BOOST_CHECK(feeEst.estimateFee(i).GetFeePerK() < origFeeEst[i-1] + deltaFee);
@@ -129,11 +142,18 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
                 uint256 hash = tx.GetHash();
                 mpool.addUnchecked(hash, entry.Fee(feeV[j]).Time(GetTime()).Height(blocknum).FromTx(tx));
+                // Since TransactionAddedToMempool callbacks are generated in ATMP,
+                // not addUnchecked, we cheat and create one manually here
+                int64_t virtual_size = GetVirtualTransactionSize(GetTransactionWeight(tx), 0);
+                GetMainSignals().TransactionAddedToMempool({MakeTransactionRef(tx), feeV[j], virtual_size, true}, std::make_shared<std::vector<CTransactionRef>>());
                 txHashes[j].push_back(hash);
             }
         }
         mpool.removeForBlock(block, ++blocknum);
     }
+
+    // Wait for fee estimator to catch up
+    SyncWithValidationInterfaceQueue();
 
     for (int i = 1; i < 10;i++) {
         BOOST_CHECK(feeEst.estimateFee(i) == CFeeRate(0) || feeEst.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
@@ -151,6 +171,10 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     }
     mpool.removeForBlock(block, 266);
     block.clear();
+
+    // Wait for fee estimator to catch up
+    SyncWithValidationInterfaceQueue();
+
     BOOST_CHECK(feeEst.estimateFee(1) == CFeeRate(0));
     for (int i = 2; i < 10;i++) {
         BOOST_CHECK(feeEst.estimateFee(i) == CFeeRate(0) || feeEst.estimateFee(i).GetFeePerK() > origFeeEst[i-1] - deltaFee);
@@ -164,19 +188,28 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                 tx.vin[0].prevout.n = 10000*blocknum+100*j+k;
                 uint256 hash = tx.GetHash();
                 mpool.addUnchecked(hash, entry.Fee(feeV[j]).Time(GetTime()).Height(blocknum).FromTx(tx));
+                // Since TransactionAddedToMempool callbacks are generated in ATMP,
+                // not addUnchecked, we cheat and create one manually here
+                int64_t virtual_size = GetVirtualTransactionSize(GetTransactionWeight(tx), 0);
+                GetMainSignals().TransactionAddedToMempool({MakeTransactionRef(tx), feeV[j], virtual_size, true}, std::make_shared<std::vector<CTransactionRef>>());
                 CTransactionRef ptx = mpool.get(hash);
                 if (ptx)
                     block.push_back(ptx);
-
             }
         }
         mpool.removeForBlock(block, ++blocknum);
         block.clear();
     }
+
+    // Wait for fee estimator to catch up
+    SyncWithValidationInterfaceQueue();
+
     BOOST_CHECK(feeEst.estimateFee(1) == CFeeRate(0));
     for (int i = 2; i < 9; i++) { // At 9, the original estimate was already at the bottom (b/c scale = 2)
         BOOST_CHECK(feeEst.estimateFee(i).GetFeePerK() < origFeeEst[i-1] - deltaFee);
     }
+
+    UnregisterMempoolInterface(&feeEst);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -42,7 +42,6 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_reject_coinbase, TestChain100Setup)
             false,
             AcceptToMemoryPool(mempool, state, MakeTransactionRef(coinbaseTx),
                 nullptr /* pfMissingInputs */,
-                nullptr /* plTxnReplaced */,
                 true /* bypass_limits */,
                 0 /* nAbsurdFee */));
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -30,7 +30,7 @@ ToMemPool(CMutableTransaction& tx)
 
     CValidationState state;
     return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), nullptr /* pfMissingInputs */,
-                              nullptr /* plTxnReplaced */, true /* bypass_limits */, 0 /* nAbsurdFee */);
+                              true /* bypass_limits */, 0 /* nAbsurdFee */);
 }
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -418,8 +418,10 @@ bool CTxMemPool::addUnchecked(const uint256& hash, const CTxMemPoolEntry &entry,
 
 void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 {
-    if (reason != MemPoolRemovalReason::BLOCK && reason != MemPoolRemovalReason::CONFLICT) {
-        // BLOCK and CONFLICT callbacks are generated in removeForBlock
+    if (reason != MemPoolRemovalReason::BLOCK && reason != MemPoolRemovalReason::CONFLICT &&
+        reason != MemPoolRemovalReason::REPLACED) {
+        // BLOCK and CONFLICT callbacks are generated in removeForBlock; REPLACED
+        // txn are included in TransactionAddedToMempool from AcceptToMemoryPool
         GetMainSignals().MempoolEntryRemoved(it->GetSharedTx(), reason);
     }
     const uint256 hash = it->GetTx().GetHash();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -599,7 +599,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
         removeConflicts(*tx, txn_conflicts);
         ClearPrioritisation(tx->GetHash());
     }
-    GetMainSignals().MempoolUpdatedForBlockConnect(std::move(txn_removed_in_block), std::move(txn_conflicts));
+    GetMainSignals().MempoolUpdatedForBlockConnect(std::move(txn_removed_in_block), std::move(txn_conflicts), nBlockHeight);
     lastRollingFeeUpdate = GetTime();
     blockSinceLastRollingFeeBump = true;
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -9,6 +9,7 @@
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
 #include <validation.h>
+#include <validationinterface.h>
 #include <policy/policy.h>
 #include <policy/fees.h>
 #include <reverse_iterator.h>
@@ -594,6 +595,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
         removeConflicts(*tx, txn_conflicts);
         ClearPrioritisation(tx->GetHash());
     }
+    GetMainSignals().MempoolUpdatedForBlockConnect(std::move(txn_removed_in_block), std::move(txn_conflicts));
     lastRollingFeeUpdate = GetTime();
     blockSinceLastRollingFeeBump = true;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -514,6 +514,8 @@ private:
 
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const;
 
+    void calculateRemoveRecursive(const CTransaction &tx, setEntries &stage);
+
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx;
     std::map<uint256, CAmount> mapDeltas;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -25,7 +25,6 @@
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index/sequenced_index.hpp>
-#include <boost/signals2/signal.hpp>
 
 class CBlockIndex;
 
@@ -647,9 +646,6 @@ public:
     std::vector<TxMempoolInfo> infoAll() const;
 
     size_t DynamicMemoryUsage() const;
-
-    boost::signals2::signal<void (CTransactionRef)> NotifyEntryAdded;
-    boost::signals2::signal<void (CTransactionRef, MemPoolRemovalReason)> NotifyEntryRemoved;
 
 private:
     /** UpdateForDescendants is used by UpdateTransactionsFromBlock to update

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -441,7 +441,6 @@ class CTxMemPool
 private:
     uint32_t nCheckFrequency; //!< Value n means that n times in 2^32 we check.
     unsigned int nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* minerPolicyEstimator;
 
     uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
@@ -522,7 +521,7 @@ public:
 
     /** Create a new CTxMemPool.
      */
-    explicit CTxMemPool(CBlockPolicyEstimator* estimator = nullptr);
+    explicit CTxMemPool();
 
     /**
      * If sanity-checking is turned on, check makes sure the pool is

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -515,6 +515,7 @@ private:
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const;
 
     void calculateRemoveRecursive(const CTransaction &tx, setEntries &stage);
+    void removeConflicts(const CTransaction &tx, std::vector<CTransactionRef> &txn_removed);
 
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx;
@@ -545,7 +546,6 @@ public:
 
     void removeRecursive(const CTransaction &tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
-    void removeConflicts(const CTransaction &tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
 
     void clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -978,7 +978,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
     }
 
-    GetMainSignals().TransactionAddedToMempool(ptx, txn_replaced);
+    GetMainSignals().TransactionAddedToMempool({ptx, nFees, nSize, validForFeeEstimation}, txn_replaced);
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -234,7 +234,7 @@ CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 CAmount maxTxFee = DEFAULT_TRANSACTION_MAXFEE;
 
 CBlockPolicyEstimator feeEstimator;
-CTxMemPool mempool(&feeEstimator);
+CTxMemPool mempool;
 std::atomic_bool g_is_mempool_loaded{false};
 
 /** Constant stuff for coinbase transactions we create: */

--- a/src/validation.h
+++ b/src/validation.h
@@ -308,8 +308,7 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
-                        bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false);
+                        bool* pfMissingInputs, bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -22,7 +22,8 @@
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;
-    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::vector<CTransactionRef>&)> BlockConnected;
+    boost::signals2::signal<void (const std::vector<CTransactionRef> &, const std::vector<CTransactionRef> &)> MempoolUpdatedForBlockConnect;
+    boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex)> BlockConnected;
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &)> BlockDisconnected;
     boost::signals2::signal<void (const CTransactionRef &, MemPoolRemovalReason)> TransactionRemovedFromMempool;
     boost::signals2::signal<void (const CBlockLocator &)> ChainStateFlushed;
@@ -76,7 +77,7 @@ CMainSignals& GetMainSignals()
 
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
-    g_signals.m_internals->BlockConnected.connect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
+    g_signals.m_internals->BlockConnected.connect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2));
     g_signals.m_internals->BlockDisconnected.connect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
     g_signals.m_internals->ChainStateFlushed.connect(boost::bind(&CValidationInterface::ChainStateFlushed, pwalletIn, _1));
     g_signals.m_internals->Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
@@ -88,6 +89,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
 void RegisterMempoolInterface(MempoolInterface* listener) {
     g_signals.m_internals->TransactionAddedToMempool.connect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1));
     g_signals.m_internals->TransactionRemovedFromMempool.connect(boost::bind(&MempoolInterface::TransactionRemovedFromMempool, listener, _1, _2));
+    g_signals.m_internals->MempoolUpdatedForBlockConnect.connect(boost::bind(&MempoolInterface::MempoolUpdatedForBlockConnect, listener, _1, _2));
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
@@ -95,7 +97,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
     g_signals.m_internals->Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.m_internals->ChainStateFlushed.disconnect(boost::bind(&CValidationInterface::ChainStateFlushed, pwalletIn, _1));
-    g_signals.m_internals->BlockConnected.disconnect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
+    g_signals.m_internals->BlockConnected.disconnect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2));
     g_signals.m_internals->BlockDisconnected.disconnect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
     g_signals.m_internals->UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.m_internals->NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
@@ -104,6 +106,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
 void UnregisterMempoolInterface(MempoolInterface* listener) {
     g_signals.m_internals->TransactionAddedToMempool.disconnect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1));
     g_signals.m_internals->TransactionRemovedFromMempool.disconnect(boost::bind(&MempoolInterface::TransactionRemovedFromMempool, listener, _1, _2));
+    g_signals.m_internals->MempoolUpdatedForBlockConnect.disconnect(boost::bind(&MempoolInterface::MempoolUpdatedForBlockConnect, listener, _1, _2));
 }
 
 void UnregisterAllValidationAndMempoolInterfaces() {
@@ -118,6 +121,7 @@ void UnregisterAllValidationAndMempoolInterfaces() {
     g_signals.m_internals->BlockConnected.disconnect_all_slots();
     g_signals.m_internals->BlockDisconnected.disconnect_all_slots();
     g_signals.m_internals->TransactionRemovedFromMempool.disconnect_all_slots();
+    g_signals.m_internals->MempoolUpdatedForBlockConnect.disconnect_all_slots();
     g_signals.m_internals->UpdatedBlockTip.disconnect_all_slots();
     g_signals.m_internals->NewPoWValidBlock.disconnect_all_slots();
 }
@@ -144,6 +148,14 @@ void CMainSignals::MempoolEntryRemoved(CTransactionRef ptx, MemPoolRemovalReason
     }
 }
 
+void CMainSignals::MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted) {
+    auto tx_removed_in_block_ptr = std::make_shared<std::vector<CTransactionRef>>(std::move(tx_removed_in_block));
+    auto tx_removed_conflicted_ptr = std::make_shared<std::vector<CTransactionRef>>(std::move(tx_removed_conflicted));
+    m_internals->m_schedulerClient.AddToProcessQueue([tx_removed_in_block_ptr, tx_removed_conflicted_ptr, this] {
+        m_internals->MempoolUpdatedForBlockConnect(*tx_removed_in_block_ptr, *tx_removed_conflicted_ptr);
+    });
+}
+
 void CMainSignals::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {
     // Dependencies exist that require UpdatedBlockTip events to be delivered in the order in which
     // the chain actually updates. One way to ensure this is for the caller to invoke this signal
@@ -160,13 +172,21 @@ void CMainSignals::TransactionAddedToMempool(const CTransactionRef &ptx) {
     });
 }
 
-void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, const CBlockIndex *pindex, const std::shared_ptr<const std::vector<CTransactionRef>>& pvtxConflicted) {
-    m_internals->m_schedulerClient.AddToProcessQueue([pblock, pindex, pvtxConflicted, this] {
-        m_internals->BlockConnected(pblock, pindex, *pvtxConflicted);
+void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, const CBlockIndex *pindex) {
+    //TODO: To fix unbounded memory usage during reorg we really need to only
+    // have a limited set of blocks in memory, be willing to throw them away
+    // here, and read them back off disk when we find time to call the signal
+    // here.
+    m_internals->m_schedulerClient.AddToProcessQueue([pblock, pindex, this] {
+        m_internals->BlockConnected(pblock, pindex);
     });
 }
 
 void CMainSignals::BlockDisconnected(const std::shared_ptr<const CBlock> &pblock) {
+    //TODO: To fix unbounded memory usage during reorg we really need to only
+    // have a limited set of blocks in memory, be willing to throw them away
+    // here, and read them back off disk when we find time to call the signal
+    // here.
     m_internals->m_schedulerClient.AddToProcessQueue([pblock, this] {
         m_internals->BlockDisconnected(pblock);
     });

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -21,7 +21,7 @@
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
-    boost::signals2::signal<void (const CTransactionRef &, const std::vector<CTransactionRef> &)> TransactionAddedToMempool;
+    boost::signals2::signal<void (const MempoolInterface::NewMempoolTransactionInfo &, const std::vector<CTransactionRef> &)> TransactionAddedToMempool;
     boost::signals2::signal<void (const std::vector<CTransactionRef> &, const std::vector<CTransactionRef> &, int)> MempoolUpdatedForBlockConnect;
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex)> BlockConnected;
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &)> BlockDisconnected;
@@ -156,9 +156,9 @@ void CMainSignals::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockInd
     });
 }
 
-void CMainSignals::TransactionAddedToMempool(const CTransactionRef &ptx, const std::shared_ptr<std::vector<CTransactionRef>>& txn_replaced) {
-    m_internals->m_schedulerClient.AddToProcessQueue([ptx, txn_replaced, this] {
-        m_internals->TransactionAddedToMempool(ptx, *txn_replaced);
+void CMainSignals::TransactionAddedToMempool(const MempoolInterface::NewMempoolTransactionInfo &info, const std::shared_ptr<std::vector<CTransactionRef>>& txn_replaced) {
+    m_internals->m_schedulerClient.AddToProcessQueue([info, txn_replaced, this] {
+        m_internals->TransactionAddedToMempool(info, *txn_replaced);
     });
 }
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -76,10 +76,8 @@ CMainSignals& GetMainSignals()
 
 void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->UpdatedBlockTip.connect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
-    g_signals.m_internals->TransactionAddedToMempool.connect(boost::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, _1));
     g_signals.m_internals->BlockConnected.connect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
     g_signals.m_internals->BlockDisconnected.connect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
-    g_signals.m_internals->TransactionRemovedFromMempool.connect(boost::bind(&CValidationInterface::TransactionRemovedFromMempool, pwalletIn, _1));
     g_signals.m_internals->ChainStateFlushed.connect(boost::bind(&CValidationInterface::ChainStateFlushed, pwalletIn, _1));
     g_signals.m_internals->Inventory.connect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.m_internals->Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
@@ -87,20 +85,28 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->NewPoWValidBlock.connect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
 }
 
+void RegisterMempoolInterface(MempoolInterface* listener) {
+    g_signals.m_internals->TransactionAddedToMempool.connect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1));
+    g_signals.m_internals->TransactionRemovedFromMempool.connect(boost::bind(&MempoolInterface::TransactionRemovedFromMempool, listener, _1));
+}
+
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.m_internals->Broadcast.disconnect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
     g_signals.m_internals->Inventory.disconnect(boost::bind(&CValidationInterface::Inventory, pwalletIn, _1));
     g_signals.m_internals->ChainStateFlushed.disconnect(boost::bind(&CValidationInterface::ChainStateFlushed, pwalletIn, _1));
-    g_signals.m_internals->TransactionAddedToMempool.disconnect(boost::bind(&CValidationInterface::TransactionAddedToMempool, pwalletIn, _1));
     g_signals.m_internals->BlockConnected.disconnect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
     g_signals.m_internals->BlockDisconnected.disconnect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
-    g_signals.m_internals->TransactionRemovedFromMempool.disconnect(boost::bind(&CValidationInterface::TransactionRemovedFromMempool, pwalletIn, _1));
     g_signals.m_internals->UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.m_internals->NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
 }
 
-void UnregisterAllValidationInterfaces() {
+void UnregisterMempoolInterface(MempoolInterface* listener) {
+    g_signals.m_internals->TransactionAddedToMempool.disconnect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1));
+    g_signals.m_internals->TransactionRemovedFromMempool.disconnect(boost::bind(&MempoolInterface::TransactionRemovedFromMempool, listener, _1));
+}
+
+void UnregisterAllValidationAndMempoolInterfaces() {
     if (!g_signals.m_internals) {
         return;
     }

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -62,14 +62,6 @@ size_t CMainSignals::CallbacksPending() {
     return m_internals->m_schedulerClient.CallbacksPending();
 }
 
-void CMainSignals::RegisterWithMempoolSignals(CTxMemPool& pool) {
-    pool.NotifyEntryRemoved.connect(boost::bind(&CMainSignals::MempoolEntryRemoved, this, _1, _2));
-}
-
-void CMainSignals::UnregisterWithMempoolSignals(CTxMemPool& pool) {
-    pool.NotifyEntryRemoved.disconnect(boost::bind(&CMainSignals::MempoolEntryRemoved, this, _1, _2));
-}
-
 CMainSignals& GetMainSignals()
 {
     return g_signals;
@@ -141,11 +133,9 @@ void SyncWithValidationInterfaceQueue() {
 }
 
 void CMainSignals::MempoolEntryRemoved(CTransactionRef ptx, MemPoolRemovalReason reason) {
-    if (reason != MemPoolRemovalReason::BLOCK && reason != MemPoolRemovalReason::CONFLICT) {
-        m_internals->m_schedulerClient.AddToProcessQueue([ptx, reason, this] {
-            m_internals->TransactionRemovedFromMempool(ptx, reason);
-        });
-    }
+    m_internals->m_schedulerClient.AddToProcessQueue([ptx, reason, this] {
+        m_internals->TransactionRemovedFromMempool(ptx, reason);
+    });
 }
 
 void CMainSignals::MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted) {

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -21,7 +21,7 @@
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
-    boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;
+    boost::signals2::signal<void (const CTransactionRef &, const std::vector<CTransactionRef> &)> TransactionAddedToMempool;
     boost::signals2::signal<void (const std::vector<CTransactionRef> &, const std::vector<CTransactionRef> &)> MempoolUpdatedForBlockConnect;
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex)> BlockConnected;
     boost::signals2::signal<void (const std::shared_ptr<const CBlock> &)> BlockDisconnected;
@@ -79,7 +79,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
 }
 
 void RegisterMempoolInterface(MempoolInterface* listener) {
-    g_signals.m_internals->TransactionAddedToMempool.connect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1));
+    g_signals.m_internals->TransactionAddedToMempool.connect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1, _2));
     g_signals.m_internals->TransactionRemovedFromMempool.connect(boost::bind(&MempoolInterface::TransactionRemovedFromMempool, listener, _1, _2));
     g_signals.m_internals->MempoolUpdatedForBlockConnect.connect(boost::bind(&MempoolInterface::MempoolUpdatedForBlockConnect, listener, _1, _2));
 }
@@ -96,7 +96,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
 }
 
 void UnregisterMempoolInterface(MempoolInterface* listener) {
-    g_signals.m_internals->TransactionAddedToMempool.disconnect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1));
+    g_signals.m_internals->TransactionAddedToMempool.disconnect(boost::bind(&MempoolInterface::TransactionAddedToMempool, listener, _1, _2));
     g_signals.m_internals->TransactionRemovedFromMempool.disconnect(boost::bind(&MempoolInterface::TransactionRemovedFromMempool, listener, _1, _2));
     g_signals.m_internals->MempoolUpdatedForBlockConnect.disconnect(boost::bind(&MempoolInterface::MempoolUpdatedForBlockConnect, listener, _1, _2));
 }
@@ -156,9 +156,9 @@ void CMainSignals::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockInd
     });
 }
 
-void CMainSignals::TransactionAddedToMempool(const CTransactionRef &ptx) {
-    m_internals->m_schedulerClient.AddToProcessQueue([ptx, this] {
-        m_internals->TransactionAddedToMempool(ptx);
+void CMainSignals::TransactionAddedToMempool(const CTransactionRef &ptx, const std::shared_ptr<std::vector<CTransactionRef>>& txn_replaced) {
+    m_internals->m_schedulerClient.AddToProcessQueue([ptx, txn_replaced, this] {
+        m_internals->TransactionAddedToMempool(ptx, *txn_replaced);
     });
 }
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -112,7 +112,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) {}
+    virtual void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted, int block_height) {}
     friend void ::RegisterMempoolInterface(MempoolInterface*);
     friend void ::UnregisterMempoolInterface(MempoolInterface*);
 };
@@ -231,7 +231,7 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &, const std::shared_ptr<std::vector<CTransactionRef>>& txn_replaced);
-    void MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted);
+    void MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted, int block_height);
     void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -81,14 +81,14 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void TransactionAddedToMempool(const CTransactionRef &ptxn) {}
+    virtual void TransactionAddedToMempool(const CTransactionRef &ptxn, const std::vector<CTransactionRef>& txn_replaced) {}
     /**
      * Notifies listeners of a transaction leaving mempool.
      *
      * This only fires for transactions which leave mempool because of expiry,
-     * size limiting, reorg (changes in lock times/coinbase maturity), or
-     * replacement. This does not include any transactions which are included
-     * in MempoolUpdatedForBlockConnect.
+     * size limiting, or reorg (changes in lock times/coinbase maturity). This
+     * does not include any transactions which are included in
+     * MempoolUpdatedForBlockConnect or TransactionAddedToMempool(txn_replaced)
      *
      * reason == REORG is not ordered with BlockConnected/BlockDisconnected!
      *
@@ -230,7 +230,7 @@ public:
     size_t CallbacksPending();
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
-    void TransactionAddedToMempool(const CTransactionRef &);
+    void TransactionAddedToMempool(const CTransactionRef &, const std::shared_ptr<std::vector<CTransactionRef>>& txn_replaced);
     void MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted);
     void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -88,7 +88,7 @@ protected:
      * This only fires for transactions which leave mempool because of expiry,
      * size limiting, reorg (changes in lock times/coinbase maturity), or
      * replacement. This does not include any transactions which are included
-     * in BlockConnectedDisconnected either in block->vtx or in txnConflicted.
+     * in MempoolUpdatedForBlockConnect.
      *
      * reason == REORG is not ordered with BlockConnected/BlockDisconnected!
      *
@@ -219,8 +219,6 @@ private:
     friend void ::UnregisterAllValidationAndMempoolInterfaces();
     friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 
-    void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
-
 public:
     /** Register a CScheduler to give callbacks which should run in the background (may only be called once) */
     void RegisterBackgroundSignalScheduler(CScheduler& scheduler);
@@ -231,14 +229,10 @@ public:
 
     size_t CallbacksPending();
 
-    /** Register with mempool to call TransactionRemovedFromMempool callbacks */
-    void RegisterWithMempoolSignals(CTxMemPool& pool);
-    /** Unregister with mempool */
-    void UnregisterWithMempoolSignals(CTxMemPool& pool);
-
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &);
     void MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted);
+    void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &);
     void ChainStateFlushed(const CBlockLocator &);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -100,6 +100,19 @@ protected:
      * Called on a background thread.
      */
     virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) {}
+    /**
+     * Notifies listeners of mempool being updated for a block connection.
+     *
+     * Entries in tx_removed_in_block represent transactions which were in the
+     * block and thus removed from the mempool. The tx_removed_in_block txn are
+     * as they appear in the block, and may have different witnesses from the
+     * version which was previously in the mempool.
+     *
+     * This callback fires prior to BlockConnected in CValidationInterface.
+     *
+     * Called on a background thread.
+     */
+    virtual void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) {}
     friend void ::RegisterMempoolInterface(MempoolInterface*);
     friend void ::UnregisterMempoolInterface(MempoolInterface*);
 };
@@ -136,11 +149,10 @@ protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     /**
      * Notifies listeners of a block being connected.
-     * Provides a vector of transactions evicted from the mempool as a result.
      *
      * Called on a background thread.
      */
-    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex, const std::vector<CTransactionRef> &txnConflicted) {}
+    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
     /**
      * Notifies listeners of a block being disconnected
      *
@@ -226,7 +238,8 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &);
-    void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::shared_ptr<const std::vector<CTransactionRef>> &);
+    void MempoolUpdatedForBlockConnect(std::vector<CTransactionRef>&& tx_removed_in_block, std::vector<CTransactionRef>&& tx_removed_conflicted);
+    void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &);
     void ChainStateFlushed(const CBlockLocator &);
     void Inventory(const uint256 &);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -99,7 +99,7 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx) {}
+    virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) {}
     friend void ::RegisterMempoolInterface(MempoolInterface*);
     friend void ::UnregisterMempoolInterface(MempoolInterface*);
 };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -23,15 +23,20 @@ class uint256;
 class CScheduler;
 class CTxMemPool;
 enum class MemPoolRemovalReason;
+class MempoolInterface;
 
 // These functions dispatch to one or all registered wallets
 
-/** Register a wallet to receive updates from core */
+/** Register a wallet to receive updates from validation */
 void RegisterValidationInterface(CValidationInterface* pwalletIn);
-/** Unregister a wallet from core */
+/** Unregister a wallet from validation */
 void UnregisterValidationInterface(CValidationInterface* pwalletIn);
-/** Unregister all wallets from core */
-void UnregisterAllValidationInterfaces();
+/** Register a listener to receive updates from mempool */
+void RegisterMempoolInterface(MempoolInterface* listener);
+/** Unregister a listener from mempool */
+void UnregisterMempoolInterface(MempoolInterface* listener);
+/** Unregister all listeners from core and mempool */
+void UnregisterAllValidationAndMempoolInterfaces();
 /**
  * Pushes a function to callback onto the notification queue, guaranteeing any
  * callbacks generated prior to now are finished when the function is called.
@@ -53,26 +58,24 @@ void CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
  */
 void SyncWithValidationInterfaceQueue();
 
-class CValidationInterface {
+/**
+ * An interface to get callbacks about transactions entering and leaving
+ * mempool.
+ *
+ * Any class which extends both MempoolInterface and CValidationInterface will
+ * see all callbacks across both well-ordered (see individual callback text for
+ * details on the order guarantees).
+ *
+ * Callbacks called on a background thread have a separate order from those
+ * called on the thread generating the callbacks.
+ */
+class MempoolInterface {
 protected:
     /**
      * Protected destructor so that instances can only be deleted by derived classes.
      * If that restriction is no longer desired, this should be made public and virtual.
      */
-    ~CValidationInterface() = default;
-    /**
-     * Notifies listeners of updated block chain tip.
-     *
-     * Is called after a series of BlockConnected/BlockDisconnected events once
-     * the chain has made forward progress and is now at the best-known-tip.
-     *
-     * If a block is found to be invalid, this event may trigger without
-     * forward-progress, only to trigger again soon thereafter.
-     * (TODO: remove this edge case)
-     *
-     * Called on a background thread.
-     */
-    virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
+    ~MempoolInterface() = default;
     /**
      * Notifies listeners of a transaction having been added to mempool.
      *
@@ -97,6 +100,40 @@ protected:
      * Called on a background thread.
      */
     virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx) {}
+    friend void ::RegisterMempoolInterface(MempoolInterface*);
+    friend void ::UnregisterMempoolInterface(MempoolInterface*);
+};
+
+/**
+ * An interface to get callbacks about block connection/disconnection.
+ *
+ * Any class which extends both MempoolInterface and CValidationInterface will
+ * see all callbacks across both well-ordered (see individual callback text for
+ * details on the order guarantees).
+ *
+ * Callbacks called on a background thread have a separate order from those
+ * called on the thread generating the callbacks.
+ */
+class CValidationInterface {
+protected:
+    /**
+     * Protected destructor so that instances can only be deleted by derived classes.
+     * If that restriction is no longer desired, this should be made public and virtual.
+     */
+    ~CValidationInterface() = default;
+    /**
+     * Notifies listeners of updated block chain tip
+     *
+     * Is called after a series of BlockConnected/BlockDisconnected events once
+     * the chain has made forward progress and is now at the best-known-tip.
+     *
+     * If a block is found to be invalid, this event may trigger without
+     * forward-progress, only to trigger again soon thereafter.
+     * (TODO: remove this edge case) *
+     *
+     * Called on a background thread.
+     */
+    virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     /**
      * Notifies listeners of a block being connected.
      * Provides a vector of transactions evicted from the mempool as a result.
@@ -156,7 +193,6 @@ protected:
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
-    friend void ::UnregisterAllValidationInterfaces();
 };
 
 struct MainSignalsInstance;
@@ -166,7 +202,9 @@ private:
 
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
-    friend void ::UnregisterAllValidationInterfaces();
+    friend void ::RegisterMempoolInterface(MempoolInterface*);
+    friend void ::UnregisterMempoolInterface(MempoolInterface*);
+    friend void ::UnregisterAllValidationAndMempoolInterfaces();
     friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 
     void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -13,6 +13,7 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     bool fFirstRun;
     m_wallet.LoadWallet(fFirstRun);
     RegisterValidationInterface(&m_wallet);
+    RegisterMempoolInterface(&m_wallet);
 
     RegisterWalletRPCCommands(tableRPC);
 }
@@ -20,4 +21,5 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
 WalletTestingSetup::~WalletTestingSetup()
 {
     UnregisterValidationInterface(&m_wallet);
+    UnregisterMempoolInterface(&m_wallet);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1249,7 +1249,7 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolR
     }
 }
 
-void CWallet::MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) {
+void CWallet::MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted, int block_height) {
     LOCK2(cs_main, cs_wallet);
     for (const CTransactionRef& ptx : tx_removed_conflicted) {
         SyncTransaction(ptx);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1238,7 +1238,7 @@ void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx) {
     }
 }
 
-void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
+void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) {
     LOCK(cs_wallet);
     auto it = mapWallet.find(ptx->GetHash());
     if (it != mapWallet.end()) {
@@ -1258,11 +1258,11 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
 
     for (const CTransactionRef& ptx : vtxConflicted) {
         SyncTransaction(ptx);
-        TransactionRemovedFromMempool(ptx);
+        TransactionRemovedFromMempool(ptx, MemPoolRemovalReason::CONFLICT);
     }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
         SyncTransaction(pblock->vtx[i], pindex, i);
-        TransactionRemovedFromMempool(pblock->vtx[i]);
+        TransactionRemovedFromMempool(pblock->vtx[i], MemPoolRemovalReason::BLOCK);
     }
 
     m_last_block_processed = pindex;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4143,6 +4143,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
 
     walletInstance->m_last_block_processed = chainActive.Tip();
     RegisterValidationInterface(walletInstance);
+    RegisterMempoolInterface(walletInstance);
 
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1228,14 +1228,14 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pin
     }
 }
 
-void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) {
+void CWallet::TransactionAddedToMempool(const NewMempoolTransactionInfo& info, const std::vector<CTransactionRef>& txn_replaced) {
     LOCK2(cs_main, cs_wallet);
 
     for (const CTransactionRef& txit : txn_replaced) TransactionRemovedFromMempool(txit, MemPoolRemovalReason::REPLACED);
 
-    SyncTransaction(ptx);
+    SyncTransaction(info.m_tx);
 
-    auto it = mapWallet.find(ptx->GetHash());
+    auto it = mapWallet.find(info.m_tx->GetHash());
     if (it != mapWallet.end()) {
         it->second.fInMempool = true;
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1246,7 +1246,16 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolR
     }
 }
 
-void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) {
+void CWallet::MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) {
+    LOCK2(cs_main, cs_wallet);
+    for (const CTransactionRef& ptx : tx_removed_conflicted) {
+        SyncTransaction(ptx);
+        TransactionRemovedFromMempool(ptx, MemPoolRemovalReason::CONFLICT);
+    }
+    // We can ignore tx_removed_in_block, we'll get it in BlockConnected
+}
+
+void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex) {
     LOCK2(cs_main, cs_wallet);
     // TODO: Temporarily ensure that mempool removals are notified before
     // connected transactions.  This shouldn't matter, but the abandoned
@@ -1255,11 +1264,6 @@ void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const 
     // notification of a connected conflict might cause an outside process
     // to abandon a transaction and then have it inadvertently cleared by
     // the notification that the conflicted transaction was evicted.
-
-    for (const CTransactionRef& ptx : vtxConflicted) {
-        SyncTransaction(ptx);
-        TransactionRemovedFromMempool(ptx, MemPoolRemovalReason::CONFLICT);
-    }
     for (size_t i = 0; i < pblock->vtx.size(); i++) {
         SyncTransaction(pblock->vtx[i], pindex, i);
         TransactionRemovedFromMempool(pblock->vtx[i], MemPoolRemovalReason::BLOCK);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1228,8 +1228,11 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pin
     }
 }
 
-void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx) {
+void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) {
     LOCK2(cs_main, cs_wallet);
+
+    for (const CTransactionRef& txit : txn_replaced) TransactionRemovedFromMempool(txit, MemPoolRemovalReason::REPLACED);
+
     SyncTransaction(ptx);
 
     auto it = mapWallet.find(ptx->GetHash());
@@ -4304,7 +4307,7 @@ bool CWalletTx::AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& 
     // because we think that this newly generated transaction's change is
     // unavailable as we're not yet aware that it is in the mempool.
     bool ret = ::AcceptToMemoryPool(mempool, state, tx, nullptr /* pfMissingInputs */,
-                                nullptr /* plTxnReplaced */, false /* bypass_limits */, nAbsurdFee);
+                                false /* bypass_limits */, nAbsurdFee);
     fInMempool |= ret;
     return ret;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -909,7 +909,7 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     bool LoadToWallet(const CWalletTx& wtxIn);
-    void TransactionAddedToMempool(const CTransactionRef& tx) override;
+    void TransactionAddedToMempool(const CTransactionRef& tx, const std::vector<CTransactionRef>& txn_replaced) override;
     void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -909,7 +909,7 @@ public:
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     bool LoadToWallet(const CWalletTx& wtxIn);
-    void TransactionAddedToMempool(const CTransactionRef& tx, const std::vector<CTransactionRef>& txn_replaced) override;
+    void TransactionAddedToMempool(const NewMempoolTransactionInfo& info, const std::vector<CTransactionRef>& txn_replaced) override;
     void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted, int block_height) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -915,7 +915,7 @@ public:
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
     CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop, const WalletRescanReserver& reserver, bool fUpdate = false);
-    void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
+    void TransactionRemovedFromMempool(const CTransactionRef &ptx, MemPoolRemovalReason reason) override;
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -910,7 +910,7 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     bool LoadToWallet(const CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx, const std::vector<CTransactionRef>& txn_replaced) override;
-    void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) override;
+    void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted, int block_height) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -651,7 +651,7 @@ class WalletRescanReserver; //forward declarations for ScanForWalletTransactions
  * A CWallet is an extension of a keystore, which also maintains a set of transactions and balances,
  * and provides the ability to create new transactions.
  */
-class CWallet final : public CCryptoKeyStore, public CValidationInterface
+class CWallet final : public CCryptoKeyStore, public CValidationInterface, public MempoolInterface
 {
 private:
     static std::atomic<bool> fFlushScheduled;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -910,7 +910,8 @@ public:
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     bool LoadToWallet(const CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void MempoolUpdatedForBlockConnect(const std::vector<CTransactionRef>& tx_removed_in_block, const std::vector<CTransactionRef>& tx_removed_conflicted) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -165,7 +165,7 @@ void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef&
     }
 }
 
-void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted)
+void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction added in the block

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -165,8 +165,9 @@ void CZMQNotificationInterface::NotifyTransaction(const CTransactionRef& ptx)
     }
 }
 
-void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) {
-    NotifyTransaction(ptx);
+void CZMQNotificationInterface::TransactionAddedToMempool(const NewMempoolTransactionInfo& info, const std::vector<CTransactionRef>& txn_replaced) {
+    // We only notify for new data, not data that was removed, so ignore txn_replaced.
+    NotifyTransaction(info.m_tx);
 }
 
 void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected)

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -144,7 +144,7 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, co
     }
 }
 
-void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx)
+void CZMQNotificationInterface::NotifyTransaction(const CTransactionRef& ptx)
 {
     // Used by BlockConnected and BlockDisconnected as well, because they're
     // all the same external callback.
@@ -165,11 +165,15 @@ void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef&
     }
 }
 
+void CZMQNotificationInterface::TransactionAddedToMempool(const CTransactionRef& ptx, const std::vector<CTransactionRef>& txn_replaced) {
+    NotifyTransaction(ptx);
+}
+
 void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction added in the block
-        TransactionAddedToMempool(ptx);
+        NotifyTransaction(ptx);
     }
 }
 
@@ -177,6 +181,6 @@ void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CB
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         // Do a normal notify for each transaction removed in block disconnection
-        TransactionAddedToMempool(ptx);
+        NotifyTransaction(ptx);
     }
 }

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -25,7 +25,7 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void TransactionAddedToMempool(const CTransactionRef& tx, const std::vector<CTransactionRef>& txn_replaced) override;
+    void TransactionAddedToMempool(const NewMempoolTransactionInfo& tx, const std::vector<CTransactionRef>& txn_replaced) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -25,13 +25,16 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void TransactionAddedToMempool(const CTransactionRef& tx) override;
+    void TransactionAddedToMempool(const CTransactionRef& tx, const std::vector<CTransactionRef>& txn_replaced) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
 private:
     CZMQNotificationInterface();
+
+    // Does the actual sending of the tx through the ZMQ interface
+    void NotifyTransaction(const CTransactionRef& tx);
 
     void *pcontext;
     std::list<CZMQAbstractNotifier*> notifiers;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -13,7 +13,7 @@
 class CBlockIndex;
 class CZMQAbstractNotifier;
 
-class CZMQNotificationInterface final : public CValidationInterface
+class CZMQNotificationInterface final : public CValidationInterface, public MempoolInterface
 {
 public:
     virtual ~CZMQNotificationInterface();

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -26,7 +26,7 @@ protected:
 
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected, const std::vector<CTransactionRef>& vtxConflicted) override;
+    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 


### PR DESCRIPTION
This does a few things in a PR, so I'm happy to split it up if people prefer.

a) It clarifies the validationinterface stuff into a mempoolinterface and the validationinterface, splitting the two up into separate systems with the mempool creating events for mempoolinterface and validationinterface functions coming from validation. They are conjoined in the backend to provide ordering guarantees for listeners which are *both* mempool interfaces and validation interfaces, but are otherwise fully separated. There are a few cleanups that are enabled here, which I went ahead and did.

b) fee estimator becomes a listener to the mempool interface which provides a bit of additional info about transactions being added more than just the tx (eg feerate, etc)

c) a few minor edge cases in the fee estimator are handled (witness malleation changing feerate, and handling reorgs better, specifically).