### PR TITLE
qa: Combine logs on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - CCACHE_COMPRESS=1
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
     - SDK_URL=https://bitcoincore.org/depends-sources/sdks
-    - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
   matrix:
 # ARM

--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -5,7 +5,7 @@ This streams the combined log output to stdout. Use combine_logs.py > outputfile
 to write to an outputfile."""
 
 import argparse
-from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple, deque
 import heapq
 import itertools
 import os
@@ -38,9 +38,13 @@ def main():
         print("Unexpected arguments" + str(unknown_args))
         sys.exit(1)
 
-    log_events = read_logs(unknown_args[0])
+    combine_logs(dir_test=unknown_args[0], use_color=args.color, use_html=args.html)
 
-    print_logs(log_events, color=args.color, html=args.html)
+
+def combine_logs(dir_test, use_color=False, use_html=False, max_lines_to_print=None):
+    log_events = read_logs(dir_test)
+    print_logs(log_events, use_color, use_html, max_lines_to_print)
+
 
 def read_logs(tmp_dir):
     """Reads log files.
@@ -85,8 +89,10 @@ def get_log_events(source, logfile):
     except FileNotFoundError:
         print("File %s could not be opened. Continuing without it." % logfile, file=sys.stderr)
 
-def print_logs(log_events, color=False, html=False):
+
+def print_logs(log_events, color, html, max_lines_to_print):
     """Renders the iterator of log events into text or html."""
+    log_events = deque(log_events, max_lines_to_print)
     if not html:
         colors = defaultdict(lambda: '')
         if color:

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -4,7 +4,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Base class for RPC testing."""
 
-from collections import deque
 from enum import Enum
 import logging
 import optparse
@@ -149,32 +148,19 @@ class BitcoinTestFramework():
             shutil.rmtree(self.options.tmpdir)
         else:
             self.log.warning("Not cleaning up dir %s" % self.options.tmpdir)
-            if os.getenv("PYTHON_DEBUG", ""):
-                # Dump the end of the debug logs, to aid in debugging rare
-                # travis failures.
-                import glob
-                filenames = [self.options.tmpdir + "/test_framework.log"]
-                filenames += glob.glob(self.options.tmpdir + "/node*/regtest/debug.log")
-                MAX_LINES_TO_PRINT = 1000
-                for fn in filenames:
-                    try:
-                        with open(fn, 'r') as f:
-                            print("From", fn, ":")
-                            print("".join(deque(f, MAX_LINES_TO_PRINT)))
-                    except OSError:
-                        print("Opening file %s failed." % fn)
-                        traceback.print_exc()
 
         if success == TestStatus.PASSED:
             self.log.info("Tests successful")
-            sys.exit(TEST_EXIT_PASSED)
+            exit_code = TEST_EXIT_PASSED
         elif success == TestStatus.SKIPPED:
             self.log.info("Test skipped")
-            sys.exit(TEST_EXIT_SKIPPED)
+            exit_code = TEST_EXIT_SKIPPED
         else:
             self.log.error("Test failed. Test logging available at %s/test_framework.log", self.options.tmpdir)
-            logging.shutdown()
-            sys.exit(TEST_EXIT_FAILED)
+            self.log.error("Hint: Call {} '{}' to consolidate all logs".format(os.path.normpath(os.path.dirname(os.path.realpath(__file__)) + "/../combine_logs.py"), self.options.tmpdir))
+            exit_code = TEST_EXIT_FAILED
+        logging.shutdown()
+        sys.exit(exit_code)
 
     # Methods to override in subclass test scripts.
     def set_test_params(self):


### PR DESCRIPTION
Currently, when a functional test fails, the debug logs are printed sequentially to the travis log. This makes debugging race conditions based on the travis log hard. Instead, all logs events should be combined and sorted by their timestamp, then appended to the travis log.

This uses `combine_logs.py` by @jnewbery 