### PR TITLE
Add `-debuglogfile` option

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -90,6 +90,9 @@ Low-level RPC changes
   * `getmininginfo`
 - The wallet RPC `getreceivedbyaddress` will return an error if called with an address not in the wallet.
 
+Changed command-line options
+-----------------------------
+- `-debuglogfile=<file>` can be used to specify an alternative debug logging file.
 
 Credits
 =======

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -342,6 +342,7 @@ std::string HelpMessage(HelpMessageMode mode)
     if (showDebug)
         strUsage += HelpMessageOpt("-feefilter", strprintf("Tell other nodes to filter invs to us by our mempool min fee (default: %u)", DEFAULT_FEEFILTER));
     strUsage += HelpMessageOpt("-loadblock=<file>", _("Imports blocks from external blk000??.dat file on startup"));
+    strUsage += HelpMessageOpt("-debuglogfile=<file>", strprintf(_("Specify location of debug log file: this can be an absolute path or a path relative to the data directory (default: %s)"), DEFAULT_DEBUGLOGFILE));
     strUsage += HelpMessageOpt("-maxorphantx=<n>", strprintf(_("Keep at most <n> unconnectable transactions in memory (default: %u)"), DEFAULT_MAX_ORPHAN_TRANSACTIONS));
     strUsage += HelpMessageOpt("-maxmempool=<n>", strprintf(_("Keep the transaction memory pool below <n> megabytes (default: %u)"), DEFAULT_MAX_MEMPOOL_SIZE));
     strUsage += HelpMessageOpt("-mempoolexpiry=<n>", strprintf(_("Do not keep transactions in the mempool longer than <n> hours (default: %u)"), DEFAULT_MEMPOOL_EXPIRY));
@@ -1209,8 +1210,11 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
         ShrinkDebugFile();
     }
 
-    if (fPrintToDebugLog)
-        OpenDebugLog();
+    if (fPrintToDebugLog) {
+        if (!OpenDebugLog()) {
+            return InitError(strprintf("Could not open debug log file %s", GetDebugLogPath().string()));
+        }
+    }
 
     if (!fLogTimestamps)
         LogPrintf("Startup time: %s\n", DateTimeStrFormat("%Y-%m-%d %H:%M:%S", GetTime()));

--- a/src/util.h
+++ b/src/util.h
@@ -36,6 +36,7 @@ int64_t GetStartupTime();
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
+extern const char * const DEFAULT_DEBUGLOGFILE;
 
 /** Signals for translation. */
 class CTranslationInterface
@@ -180,7 +181,8 @@ void CreatePidFile(const fs::path &path, pid_t pid);
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
-void OpenDebugLog();
+fs::path GetDebugLogPath();
+bool OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(const std::string& strCommand);
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -27,15 +27,32 @@ class LoggingTest(BitcoinTestFramework):
         assert os.path.isfile(tempname)
 
         # check that invalid log (relative) will cause error
+        invdir = os.path.join(self.nodes[0].datadir, "regtest", "foo")
+        invalidname = os.path.join("foo", "foo.log")
         self.stop_node(0)
-        self.assert_start_raises_init_error(0, ["-debuglogfile=ssdksjdf/sdasdfa/sdfsdfsfd"],
+        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % (invalidname)],
                                                 "Error: Could not open debug log file")
+        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
+
+        # check that invalid log (relative) works after path exists
+        self.stop_node(0)
+        os.mkdir(invdir)
+        self.start_node(0, ["-debuglogfile=%s" % (invalidname)])
+        assert os.path.isfile(os.path.join(invdir, "foo.log"))
 
         # check that invalid log (absolute) will cause error
         self.stop_node(0)
-        invalidname = os.path.join(self.options.tmpdir, "foo/foo.log")
+        invdir = os.path.join(self.options.tmpdir, "foo")
+        invalidname = os.path.join(invdir, "foo.log")
         self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
                                                "Error: Could not open debug log file")
+        assert not os.path.isfile(os.path.join(invdir, "foo.log"))
+
+        # check that invalid log (absolute) works after path exists
+        self.stop_node(0)
+        os.mkdir(invdir)
+        self.start_node(0, ["-debuglogfile=%s" % (invalidname)])
+        assert os.path.isfile(os.path.join(invdir, "foo.log"))
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test debug logging."""
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+
+class LoggingTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        # test default log file name
+        assert os.path.isfile(os.path.join(self.nodes[0].datadir, "regtest", "debug.log"))
+
+        # test alternative log file name in datadir
+        self.restart_node(0, ["-debuglogfile=foo.log"])
+        assert os.path.isfile(os.path.join(self.nodes[0].datadir, "regtest", "foo.log"))
+
+        # test alternative log file name outside datadir
+        tempname = os.path.join(self.options.tmpdir, "foo.log")
+        self.restart_node(0, ["-debuglogfile=%s" % tempname])
+        assert os.path.isfile(tempname)
+
+        # check that invalid log (relative) will cause error
+        self.stop_node(0)
+        self.assert_start_raises_init_error(0, ["-debuglogfile=ssdksjdf/sdasdfa/sdfsdfsfd"],
+                                                "Error: Could not open debug log file")
+
+        # check that invalid log (absolute) will cause error
+        self.stop_node(0)
+        invalidname = os.path.join(self.options.tmpdir, "foo/foo.log")
+        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
+                                               "Error: Could not open debug log file")
+
+
+if __name__ == '__main__':
+    LoggingTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -126,6 +126,7 @@ BASE_SCRIPTS= [
     'p2p-fingerprint.py',
     'uacomment.py',
     'p2p-acceptblock.py',
+    'feature_logging.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
This patch adds an option to configure the name and/or directory of the debug log file.

The user can specify either a relative path, in which case the path is relative to the (network specific) data directory. They can also specify an absolute path to put the log anywhere else in the file system.

Alternative to #11741 that gets rid of the concept of a "log directory" by specifying the path for the specific kind of log, the debug log. Which happens to be the only kind of log we have at this point*, but a hypothetical new kind of log (say, an audit log) would get a new option. This has more flexibility than specifying a directory which has to contain all of them.

\* excluding `db.log` which is internally generated by the wallet database library, but that one moves along with `-walletdir`.