### PR TITLE
Fix shutdown in case of errors during initialization

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -193,8 +193,8 @@ void Shutdown()
 
     // Because these depend on each-other, we make sure that neither can be
     // using the other before destroying them.
-    UnregisterValidationInterface(peerLogic.get());
-    if(g_connman) g_connman->Stop();
+    if (peerLogic) UnregisterValidationInterface(peerLogic.get());
+    if (g_connman) g_connman->Stop();
     peerLogic.reset();
     g_connman.reset();
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -49,7 +49,9 @@ void CMainSignals::UnregisterBackgroundSignalScheduler() {
 }
 
 void CMainSignals::FlushBackgroundCallbacks() {
-    m_internals->m_schedulerClient.EmptyQueue();
+    if (m_internals) {
+        m_internals->m_schedulerClient.EmptyQueue();
+    }
 }
 
 void CMainSignals::RegisterWithMempoolSignals(CTxMemPool& pool) {
@@ -92,6 +94,9 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
 }
 
 void UnregisterAllValidationInterfaces() {
+    if (!g_signals.m_internals) {
+        return;
+    }
     g_signals.m_internals->BlockChecked.disconnect_all_slots();
     g_signals.m_internals->Broadcast.disconnect_all_slots();
     g_signals.m_internals->Inventory.disconnect_all_slots();


### PR DESCRIPTION
PR #10286 introduced a few steps which are not robust to early shutdown in initialization.

Stumbled upon this with #11781, not sure if there are other scenarios that can trigger it, but it's good to harden against this in any case.

E.g.
```
$ src/bitcoind  -debuglogfile=/dfdf
Error: Could not open debug log file /dfdf
Program received signal SIGSEGV, Segmentation fault.
UnregisterValidationInterface (pwalletIn=0x0) at /.../bitcoin/src/validationinterface.cpp:82
82          g_signals.m_internals->BlockChecked.disconnect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
(gdb) bt
#0  UnregisterValidationInterface (pwalletIn=0x0) at /.../bitcoin/src/validationinterface.cpp:82
#1  0x00005555555a11fc in Shutdown () at /.../bitcoin/src/init.cpp:196
#2  0x00005555555961cc in AppInit (argc=<optimized out>, argv=<optimized out>) at /.../bitcoin/src/bitcoind.cpp:183
#3  0x0000555555596249 in main (argc=0, argv=0x555555ecf200) at /.../bitcoin/src/bitcoind.cpp:19
```