### PR TITLE
Raise the open fd limit to the maximum allowed

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -713,8 +713,8 @@ bool TruncateFile(FILE *file, unsigned int length) {
 }
 
 /**
- * this function tries to raise the file descriptor limit to the requested number.
- * It returns the actual file descriptor limit (which may be more or less than nMinFD)
+ * this function tries to raise the file descriptor limit to the most that we can support.
+ * It returns the actual file descriptor limit (which may be more or less than nMinFD).
  */
 int RaiseFileDescriptorLimit(int nMinFD) {
 #if defined(WIN32)
@@ -722,16 +722,31 @@ int RaiseFileDescriptorLimit(int nMinFD) {
 #else
     struct rlimit limitFD;
     if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
+        // first request at least the amount passed in
         if (limitFD.rlim_cur < (rlim_t)nMinFD) {
             limitFD.rlim_cur = nMinFD;
             if (limitFD.rlim_cur > limitFD.rlim_max)
                 limitFD.rlim_cur = limitFD.rlim_max;
             setrlimit(RLIMIT_NOFILE, &limitFD);
-            getrlimit(RLIMIT_NOFILE, &limitFD);
         }
-        return limitFD.rlim_cur;
+        // then try to raise to the max we can
+        if (limitFD.rlim_cur < limitFD.rlim_max) {
+            limitFD.rlim_cur = limitFD.rlim_max;
+            setrlimit(RLIMIT_NOFILE, &limitFD);
+        }
+
+        if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
+            if (limitFD.rlim_cur < (rlim_t)nMinFD) {
+                LogPrintf("RaiseFileDescriptorLimit: could not raise limit to %lu fds, only %lu\n",
+                          (unsigned long)nMinFD,
+                          (unsigned long)limitFD.rlim_cur);
+            }
+            return limitFD.rlim_cur;
+        }
     }
-    return nMinFD; // getrlimit failed, assume it's fine
+    LogPrintf("RaiseFileDescriptorLimit error: getrlimit(RLIMIT_NOFILE) returned %s\n", strerror(errno));
+
+    return nMinFD; // getrlimit failed, try to proceed
 #endif
 }
 


### PR DESCRIPTION
As noted in https://github.com/bitcoin/bitcoin/issues/11368 if too many connections are made to the RPC interface, then other code will fail on open(2) syscalls with EMFILE. The result can be that the block database gets into an inconsistent state.

On many Linux distributions, by default, each process has 1024 file descriptors; these are shared between open files and network connections. The main init code attempts to apportion them between uses, but neglects to constrain the RPC layer: https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp#L907

Unfortunately, libevent does not allow a natural way to bound the number of file-descriptors used by the evhttp server. Therefore, we have to resort to requesting to stop new connections by disabling the accept listener in the epoll event structure. This is not a good way to control load, and more connections are accepted until the next epoll cycle is triggered, but it does stop an unbounded number of connections from being created, and does prevent a high number of connections to the RPC layer from damaging the rest of the system.

To avoid problems of a similar nature, the second patch additionally raises the rlimit of number of file descriptors as high as it can go.

To repro the database crash and validate the fix, the following node.js fragment:
```
var uri = 'http://127.0.0.1:8332/rest/block/000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f.json'
for (var message = 0; message < 10000; message++) {
    request(uri)
}
```

The messages around the database crash due to open(2) failing due to too many open files
 
> 2017-11-26 19:35:55 libevent: Error from accept() call: Too many open files
> 2017-11-26 19:35:55 ERROR: WriteBlockToDisk: OpenBlockFile failed
> 2017-11-26 19:35:55 libevent: timeout_next: event: 0x7f59001dcef0, in 15 seconds, 475453 useconds
> 2017-11-26 19:35:55 *** Failed to write block
> 2017-11-26 19:35:55 libevent: epoll_dispatch: epoll_wait reports 1
> 2017-11-26 19:35:55 Error: Error: A fatal internal error occurred, see debug.log for details
