### PR TITLE
Support for SegWit addresses, change addresses and UI request payment

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -384,7 +384,20 @@ QString AddressTableModel::addRow(const QString &type, const QString &label, con
                 return QString();
             }
         }
-        strAddress = EncodeDestination(newKey.GetID());
+        if (::bGetSegwitAddresses) {
+            CScript basescript = GetScriptForDestination(newKey.GetID());
+            CScript witscript = GetScriptForWitness(basescript);
+            CTxDestination result;
+            ExtractDestination(witscript,result);
+            wallet->AddCScript(witscript);
+            if (::bGetSegwitP2shAddresses) {
+                result = CScriptID(witscript);
+            }
+            //pwallet->SetAddressBook(result, strAccount, "receive");
+            strAddress = EncodeDestination(result);
+        } else {
+            strAddress = EncodeDestination(newKey.GetID());
+        }
     }
     else
     {

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -30,6 +30,9 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-rescan", _("Rescan the block chain for missing wallet transactions on startup"));
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet on startup"));
     strUsage += HelpMessageOpt("-spendzeroconfchange", strprintf(_("Spend unconfirmed change when sending transactions (default: %u)"), DEFAULT_SPEND_ZEROCONF_CHANGE));
+    strUsage += HelpMessageOpt("-segwitaddresses", strprintf(_("Return SegWit addresses in RPC requests and UI (default: %u)"), DEFAULT_GET_SEGWIT_ADDRESSES));
+    strUsage += HelpMessageOpt("-segwitchangeaddresses", strprintf(_("Create transactions with SegWit change addresses (default: %u)"), DEFAULT_GET_SEGWIT_CHANGE_ADDRESSES));
+    strUsage += HelpMessageOpt("-segwitp2shaddresses", strprintf(_("Wrap SegWit addresses in P2SH (default: %u)"), DEFAULT_GET_SEGWIT_P2SH_ADDRESSES));
     strUsage += HelpMessageOpt("-txconfirmtarget=<n>", strprintf(_("If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)"), DEFAULT_TX_CONFIRM_TARGET));
     strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (default: %u)"), DEFAULT_WALLET_RBF));
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
@@ -173,6 +176,9 @@ bool WalletParameterInteraction()
     }
     nTxConfirmTarget = gArgs.GetArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);
     bSpendZeroConfChange = gArgs.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
+    bGetSegwitAddresses = gArgs.GetBoolArg("-segwitaddresses", DEFAULT_GET_SEGWIT_ADDRESSES);
+    bGetSegwitChangeAddresses = gArgs.GetBoolArg("-segwitchangeaddresses", DEFAULT_GET_SEGWIT_CHANGE_ADDRESSES);
+    bGetSegwitP2shAddresses = gArgs.GetBoolArg("-segwitp2shaddresses", DEFAULT_GET_SEGWIT_P2SH_ADDRESSES);
     fWalletRbf = gArgs.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
 
     return true;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -169,6 +169,19 @@ UniValue getnewaddress(const JSONRPCRequest& request)
     }
     CKeyID keyID = newKey.GetID();
 
+    if (::bGetSegwitAddresses) {
+        CScript basescript = GetScriptForDestination(keyID);
+        CScript witscript = GetScriptForWitness(basescript);
+        CTxDestination result;
+        ExtractDestination(witscript,result);
+        pwallet->AddCScript(witscript);
+        if (::bGetSegwitP2shAddresses) {
+            result = CScriptID(witscript);
+        }
+        pwallet->SetAddressBook(result, strAccount, "receive");
+        return EncodeDestination(result);
+    }
+    
     pwallet->SetAddressBook(keyID, strAccount, "receive");
 
     return EncodeDestination(keyID);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -280,6 +280,20 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
 
     CKeyID keyID = vchPubKey.GetID();
 
+    if (::bGetSegwitAddresses) {
+        CScript basescript = GetScriptForDestination(keyID);
+        CScript witscript = GetScriptForWitness(basescript);
+        CTxDestination result;
+        ExtractDestination(witscript,result);
+        
+        pwallet->AddCScript(witscript);
+        if (::bGetSegwitP2shAddresses) {
+            result = CScriptID(witscript);
+        }
+        //pwallet->SetAddressBook(result, strAccount, "receive");
+        return EncodeDestination(result);
+    }
+
     return EncodeDestination(keyID);
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -227,6 +227,20 @@ UniValue getaccountaddress(const JSONRPCRequest& request)
 
     UniValue ret(UniValue::VSTR);
 
+    if (::bGetSegwitAddresses) {
+        CTxDestination keyID = GetAccountAddress(pwallet, strAccount);
+        CScript basescript = GetScriptForDestination(keyID);
+        CScript witscript = GetScriptForWitness(basescript);
+        CTxDestination result;
+        ExtractDestination(witscript,result);
+        
+        pwallet->AddCScript(witscript);
+        if (::bGetSegwitP2shAddresses) {
+            result = CScriptID(witscript);
+        }
+        pwallet->SetAddressBook(result, strAccount, "receive");
+        return EncodeDestination(result);
+    }
     ret = EncodeDestination(GetAccountAddress(pwallet, strAccount));
     return ret;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -831,11 +831,13 @@ bool CWallet::GetAccountPubkey(CPubKey &pubKey, std::string strAccount, bool bFo
         else {
             // Check if the current key has been used
             CScript scriptPubKey = GetScriptForDestination(account.vchPubKey.GetID());
+            CScript scriptWitness = GetScriptForWitness(scriptPubKey);
+            CScript scriptWitnessP2sh = GetScriptForDestination(scriptWitness);
             for (std::map<uint256, CWalletTx>::iterator it = mapWallet.begin();
                  it != mapWallet.end() && account.vchPubKey.IsValid();
                  ++it)
                 for (const CTxOut& txout : (*it).second.tx->vout)
-                    if (txout.scriptPubKey == scriptPubKey) {
+                    if (txout.scriptPubKey == scriptPubKey || txout.scriptPubKey == scriptWitness || txout.scriptPubKey == scriptWitnessP2sh) {
                         bForceNew = true;
                         break;
                     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -43,6 +43,9 @@ std::vector<CWalletRef> vpwallets;
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
+bool bGetSegwitAddresses = DEFAULT_GET_SEGWIT_ADDRESSES;
+bool bGetSegwitChangeAddresses = DEFAULT_GET_SEGWIT_CHANGE_ADDRESSES;
+bool bGetSegwitP2shAddresses = DEFAULT_GET_SEGWIT_P2SH_ADDRESSES;
 bool fWalletRbf = DEFAULT_WALLET_RBF;
 
 const char * DEFAULT_WALLET_DAT = "wallet.dat";

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2742,6 +2742,14 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CWalletT
                 }
 
                 scriptChange = GetScriptForDestination(vchPubKey.GetID());
+                if (::bGetSegwitChangeAddresses) {
+                    CScript witnessScript = GetScriptForWitness(scriptChange);
+                    this->AddCScript(witnessScript);
+                    scriptChange = witnessScript;
+                    if (::bGetSegwitP2shAddresses) {
+                        scriptChange = GetScriptForDestination(scriptChange);
+                    }
+                }
             }
             CTxOut change_prototype_txout(0, scriptChange);
             size_t change_prototype_size = GetSerializeSize(change_prototype_txout, SER_DISK, 0);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -38,6 +38,9 @@ extern std::vector<CWalletRef> vpwallets;
 extern CFeeRate payTxFee;
 extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
+extern bool bGetSegwitAddresses;
+extern bool bGetSegwitChangeAddresses;
+extern bool bGetSegwitP2shAddresses;
 extern bool fWalletRbf;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
@@ -57,6 +60,12 @@ static const CAmount MIN_CHANGE = CENT;
 static const CAmount MIN_FINAL_CHANGE = MIN_CHANGE/2;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
+//! Default for -segwitaddresses
+static const bool DEFAULT_GET_SEGWIT_ADDRESSES = false;
+//! Default for -segwitchangeaddresses
+static const bool DEFAULT_GET_SEGWIT_CHANGE_ADDRESSES = false;
+//! Default for -segwitp2shddresses
+static const bool DEFAULT_GET_SEGWIT_P2SH_ADDRESSES = false;
 //! Default for -walletrejectlongchains
 static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = false;
 //! -txconfirmtarget default


### PR DESCRIPTION
Added startup parameters:

-segwitaddresses - Return SegWit address in RPC commands and QT interface
-segwitchangeaddresses - Use SegWit change addresses when creating transactions
-segwitp2shaddresses - Wrap SegWit destinations in P2SH

RPC Support:
getaccountaddress, getrawchangeaddress, getnewaddress
