### PR TITLE
Docs: Bump OS X version to 10.13

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -110,6 +110,6 @@ Uncheck everything except Qt Creator during the installation process.
 Notes
 -----
 
-* Tested on OS X 10.8 through 10.12 on 64-bit Intel processors only.
+* Tested on OS X 10.8 through 10.13 on 64-bit Intel processors only.
 
 * Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)


### PR DESCRIPTION
Core works fine on macOS 10.13