### PR TITLE
Prefix leveldb debug logging

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -64,7 +64,7 @@ public:
 
                 assert(p <= limit);
                 base[std::min(bufsize - 1, (int)(p - base))] = '\0';
-                LogPrintStr(base);
+                LogPrintf("leveldb: %s", base);
                 if (base != buffer) {
                     delete[] base;
                 }


### PR DESCRIPTION
Add leveldb: prefix to leveldb debug logging lines.
leveldb debug messages come in various scary flavors such as:

    2017-11-30 08:26:31 leveldb: Recovering log #26
    2017-11-30 08:26:31 leveldb: Level-0 table #28: started
    2017-11-30 08:26:31 leveldb: Level-0 table #28: 597 bytes OK
    2017-11-30 08:26:31 leveldb: Delete type=0 #26
    2017-11-30 08:26:31 leveldb: Delete type=3 #24

so it's reasonably important to mark them as coming from leveldb internals and not from consensus validation wallet or such.
This is consistent with the `libevent:` prefix for libevent messages.

(this only affects `-debug=leveldb` or `-debug=1` otherwise you won't see them in the first place)