### PR TITLE
trivial: Mention that wallet needs to be enabled for gettransaction

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -179,7 +179,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
               ? "No such mempool or blockchain transaction"
               : "No such mempool transaction. Use -txindex to enable blockchain transaction queries";
         }
-        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, errmsg + ". Use gettransaction for wallet transactions.");
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, errmsg + ". Use gettransaction for wallet transactions, if wallet is enabled.");
     }
 
     if (!fVerbose) {


### PR DESCRIPTION
trivial: Mention that wallet needs to be enabled for gettransaction

If we were compiled from `./configure --disable-wallet`, the `gettransaction` RPC will not be available.

~~After this change, when we were compiled from `./configure --disable-wallet`, the message changes to no longer mention `gettransaction` RPC, which will not be available:~~

~~$ bitcoin-cli getrawtransaction
5644a275cfe20ca22f7de6bdd8c5313317b5937ae4bcefb6f109ca0dfdc346db
error code: -5
error message:
No such mempool transaction. Use -txindex to enable blockchain
transaction queries.~~

~~When `./configure` is run with `--enable-wallet` or without `--disable-wallet` (enabling wallet is the default), the message remains the same after this change:~~

~~$ bitcoin-cli getrawtransaction
5644a275cfe20ca22f7de6bdd8c5313317b5937ae4bcefb6f109ca0dfdc346db
error code: -5
error message:
No such mempool transaction. Use -txindex to enable blockchain
transaction queries. Use gettransaction for wallet transactions.~~
