### PR TITLE
wallet: Add compile-time checking of (non-)locking assumptions for BlockUntilSyncedToCurrentChain() [wip]

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1265,7 +1265,7 @@ void CWallet::BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) {
 
 
 
-void CWallet::BlockUntilSyncedToCurrentChain() {
+void CWallet::BlockUntilSyncedToCurrentChain() LOCKS_EXCLUDED(cs_main, cs_wallet) {
     AssertLockNotHeld(cs_main);
     AssertLockNotHeld(cs_wallet);
 


### PR DESCRIPTION
Add compile-time checking of (non-)locking assumptions for `BlockUntilSyncedToCurrentChain()`.