### PR TITLE
RPC/Wallet: Refuse to dumpprivkey for derived addresses

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -578,6 +578,9 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
     if (!IsValidDestination(dest)) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
     }
+    if (pwallet->IsKeyDerived(dest)) {
+        throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key (derived)");
+    }
     const CKeyID *keyID = boost::get<CKeyID>(&dest);
     if (!keyID) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to a key");

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3586,6 +3586,20 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const
 
 /** @} */ // end of Actions
 
+bool CWallet::IsKeyDerived(const CTxDestination& txdest) const {
+    AssertLockHeld(cs_wallet); // mapKeyMetadata
+
+    const auto it = mapKeyMetadata.find(txdest);
+    if (it == mapKeyMetadata.end()) {
+        return false;
+    }
+    const CKeyMetadata& meta = it->second;
+    if (meta.hdKeypath.empty() || meta.hdKeypath == "m") {
+        return false;
+    }
+    return true;
+}
+
 void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const {
     AssertLockHeld(cs_wallet); // mapKeyMetadata
     mapKeyBirth.clear();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -899,6 +899,7 @@ public:
     bool ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase, const SecureString& strNewWalletPassphrase);
     bool EncryptWallet(const SecureString& strWalletPassphrase);
 
+    bool IsKeyDerived(const CTxDestination&) const;
     void GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) const;
     unsigned int ComputeTimeSmart(const CWalletTx& wtx) const;
 


### PR DESCRIPTION
The specific ECDSA "private key" of a derived key is merely a midstate of the signature algorithm. It doesn't really make sense to dump it.