### PR TITLE
Bugfix: RPC/Wallet: Include HD key metadata in dumpwallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -833,7 +833,10 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             } else {
                 file << "change=1";
             }
-            file << strprintf(" # addr=%s%s\n", strAddr, (meta.has_key_origin ? (" hdkeypath=" + WriteHDKeypath(meta.key_origin.path)) : ""));
+            if (meta.has_key_origin) {
+                file << " hdkeypath=" + WriteHDKeypath(meta.key_origin.path);
+            }
+            file << strprintf(" # addr=%s\n", strAddr);
         }
     }
     file << "\n";

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -814,6 +814,13 @@ UniValue dumpwallet(const JSONRPCRequest& request)
         std::string strLabel;
         CKey key;
         if (spk_man.GetKey(keyid, key)) {
+            CKeyMetadata meta;
+            {
+                const auto meta_it = spk_man.mapKeyMetadata.find(keyid);
+                if (meta_it != spk_man.mapKeyMetadata.end()) {
+                    meta = meta_it->second;
+                }
+            }
             file << strprintf("%s %s ", EncodeSecret(key), strTime);
             if (GetWalletAddressesForKey(&spk_man, pwallet, keyid, strAddr, strLabel)) {
                file << strprintf("label=%s", strLabel);
@@ -821,12 +828,12 @@ UniValue dumpwallet(const JSONRPCRequest& request)
                 file << "hdseed=1";
             } else if (mapKeyPool.count(keyid)) {
                 file << "reserve=1";
-            } else if (spk_man.mapKeyMetadata[keyid].hdKeypath == "s") {
+            } else if (meta.hdKeypath == "s") {
                 file << "inactivehdseed=1";
             } else {
                 file << "change=1";
             }
-            file << strprintf(" # addr=%s%s\n", strAddr, (spk_man.mapKeyMetadata[keyid].has_key_origin ? " hdkeypath="+WriteHDKeypath(spk_man.mapKeyMetadata[keyid].key_origin.path) : ""));
+            file << strprintf(" # addr=%s%s\n", strAddr, (meta.has_key_origin ? (" hdkeypath=" + WriteHDKeypath(meta.key_origin.path)) : ""));
         }
     }
     file << "\n";

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -836,7 +836,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             if (meta.has_key_origin) {
                 file << " hdkeypath=" + WriteHDKeypath(meta.key_origin.path);
                 if (!(meta.hd_seed_id.IsNull() || (meta.hdKeypath == "s" && meta.hd_seed_id == keyid))) {
-                    file << " hdmasterkeyid=" + EncodeDestination(meta.hd_seed_id);
+                    file << " hdseedid=" + meta.hd_seed_id.GetHex();
                 }
             }
             file << strprintf(" # addr=%s\n", strAddr);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -835,6 +835,9 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             }
             if (meta.has_key_origin) {
                 file << " hdkeypath=" + WriteHDKeypath(meta.key_origin.path);
+                if (!(meta.hd_seed_id.IsNull() || (meta.hdKeypath == "s" && meta.hd_seed_id == keyid))) {
+                    file << " hdmasterkeyid=" + EncodeDestination(meta.hd_seed_id);
+                }
             }
             file << strprintf(" # addr=%s\n", strAddr);
         }

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -30,10 +30,10 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
             if line[0] != "#" and len(line) > 10:
                 # split out some data
                 key_date_label, comment = line.split("#")
-                key_date_label = key_date_label.split(" ")
+                key_date_label = key_date_label.rstrip().split(" ")
                 # key = key_date_label[0]
                 date = key_date_label[1]
-                keytype = key_date_label[2]
+                key_params = dict(map(lambda x: x.split('=', 1), key_date_label[2:]))
 
                 imported_key = date == '1970-01-01T00:00:01Z'
                 if imported_key:
@@ -41,25 +41,25 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
                     # Skip them
                     continue
 
-                addr_keypath = comment.split(" addr=")[1]
-                addr = addr_keypath.split(" ")[0]
+                comment_params = dict(map(lambda x: x.split('=', 1), comment.strip().split(" ")))
+                addr = comment_params['addr']
                 keypath = None
-                if keytype == "inactivehdseed=1":
+                if key_params.get('inactivehdseed'):
                     # ensure the old master is still available
                     assert hd_master_addr_old == addr
-                elif keytype == "hdseed=1":
+                elif key_params.get('hdseed'):
                     # ensure we have generated a new hd master key
                     assert hd_master_addr_old != addr
                     hd_master_addr_ret = addr
-                elif keytype == "script=1":
+                elif key_params.get('script'):
                     # scripts don't have keypaths
                     keypath = None
                 else:
-                    keypath = addr_keypath.rstrip().split("hdkeypath=")[1]
+                    keypath = key_params['hdkeypath']
 
                 # count key types
                 for addrObj in addrs:
-                    if addrObj['address'] == addr.split(",")[0] and addrObj['hdkeypath'] == keypath and keytype == "label=":
+                    if addrObj['address'] == addr.split(",")[0] and addrObj['hdkeypath'] == keypath and key_params.get('label') == "":
                         if addr.startswith('m') or addr.startswith('n'):
                             # P2PKH address
                             found_legacy_addr += 1
@@ -69,16 +69,16 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
                         elif addr.startswith('bcrt1'):
                             found_bech32_addr += 1
                         break
-                    elif keytype == "change=1":
+                    elif key_params.get('change'):
                         found_addr_chg += 1
                         break
-                    elif keytype == "reserve=1":
+                    elif key_params.get('reserve'):
                         found_addr_rsv += 1
                         break
 
                 # count scripts
                 for script_addr in script_addrs:
-                    if script_addr == addr.rstrip() and keytype == "script=1":
+                    if script_addr == addr.rstrip() and key_params.get('script'):
                         found_script_addr += 1
                         break
 


### PR DESCRIPTION
When restoring a backup, we should restore the wallet metadata. This moves some of it out of "comment" sections so that it can be sensibly handled by parsing tools.

(`importwallet` doesn't currently support it, but that's another matter to address)