### PR TITLE
[Build]: Modify error if boost lib is not found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -761,6 +761,9 @@ define(MINIMUM_REQUIRED_BOOST, 1.47.0)
 
 dnl Check for boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
+if test x$want_boost = xno; then
+    AC_MSG_ERROR([[only libbitcoinconsensus can be built without boost]])
+fi
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS


### PR DESCRIPTION
Related Issue: #10826

The fix in this PR was suggested by theuni, but since it wasn't implemented yet, thought I'd put in a PR for it. We do fail now if `--with-boost=no` is specified but the error message is as follows:
```
[...]
checking whether to build Bitcoin Core GUI... yes (Qt5)
configure: error: only libbitcoinconsensus can be built without boost
```
Removes the ambiguous `checking whether the Boost::System library is available... yes` message that comes now.