### PR TITLE
[tests] Change feature_csv_activation.py to use BitcoinTestFramework

### DIFF
--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -42,21 +42,30 @@ bip112txs_vary_OP_CSV - 16 txs with nSequence = 10 evaluated against varying {re
 bip112txs_vary_OP_CSV_9 - 16 txs with nSequence = 9 evaluated against varying {relative_locktimes of 10} OP_CSV OP_DROP
 bip112tx_special - test negative argument to OP_CSV
 """
-
-from test_framework.test_framework import ComparisonTestFramework
-from test_framework.util import *
-from test_framework.mininode import ToHex, CTransaction, network_thread_start
-from test_framework.blocktools import create_coinbase, create_block
-from test_framework.comptool import TestInstance, TestManager
-from test_framework.script import *
+from decimal import Decimal
 from io import BytesIO
 import time
 
+from test_framework.blocktools import create_coinbase, create_block
+from test_framework.comptool import TestInstance, TestManager
+from test_framework.mininode import ToHex, CTransaction, network_thread_start
+from test_framework.script import (
+    CScript,
+    OP_CHECKSEQUENCEVERIFY,
+    OP_DROP,
+)
+from test_framework.test_framework import ComparisonTestFramework
+from test_framework.util import (
+    assert_equal,
+    get_bip9_status,
+    hex_str_to_bytes,
+)
+
 base_relative_locktime = 10
-seq_disable_flag = 1<<31
-seq_random_high_bit = 1<<25
-seq_type_flag = 1<<22
-seq_random_low_bit = 1<<18
+seq_disable_flag = 1 << 31
+seq_random_high_bit = 1 << 25
+seq_type_flag = 1 << 22
+seq_random_low_bit = 1 << 18
 
 # b31,b25,b22,b18 represent the 31st, 25th, 22nd and 18th bits respectively in the nSequence field
 # relative_locktimes[b31][b25][b22][b18] is a base_relative_locktime with the indicated bits set if their indices are 1
@@ -108,8 +117,8 @@ class BIP68_112_113Test(ComparisonTestFramework):
         return node.sendrawtransaction(ToHex(self.sign_transaction(node, self.create_transaction(node, node.getblock(coinbases.pop())['tx'][0], self.nodeaddress, amount))))
 
     def create_transaction(self, node, txid, to_address, amount):
-        inputs = [{ "txid" : txid, "vout" : 0}]
-        outputs = { to_address : amount }
+        inputs = [{"txid": txid, "vout": 0}]
+        outputs = {to_address: amount}
         rawtx = node.createrawtransaction(inputs, outputs)
         tx = CTransaction()
         f = BytesIO(hex_str_to_bytes(rawtx))
@@ -124,7 +133,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         tx.deserialize(f)
         return tx
 
-    def generate_blocks(self, number, version, test_blocks = []):
+    def generate_blocks(self, number, version, test_blocks=[]):
         for i in range(number):
             block = self.create_test_block([], version)
             test_blocks.append([block, True])
@@ -133,7 +142,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
             self.tipheight += 1
         return test_blocks
 
-    def create_test_block(self, txs, version = 536870912):
+    def create_test_block(self, txs, version=536870912):
         block = create_block(self.tip, create_coinbase(self.tipheight + 1), self.last_block_time + 600)
         block.nVersion = version
         block.vtx.extend(txs)
@@ -142,7 +151,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         block.solve()
         return block
 
-    def create_bip68txs(self, bip68inputs, txversion, locktime_delta = 0):
+    def create_bip68txs(self, bip68inputs, txversion, locktime_delta=0):
         txs = []
         assert(len(bip68inputs) >= 16)
         i = 0
@@ -153,7 +162,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
                 for b22 in range(2):
                     b18txs = []
                     for b18 in range(2):
-                        tx =  self.create_transaction(self.nodes[0], bip68inputs[i], self.nodeaddress, Decimal("49.98"))
+                        tx = self.create_transaction(self.nodes[0], bip68inputs[i], self.nodeaddress, Decimal("49.98"))
                         i += 1
                         tx.nVersion = txversion
                         tx.vin[0].nSequence = relative_locktimes[b31][b25][b22][b18] + locktime_delta
@@ -170,7 +179,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         signtx.vin[0].scriptSig = CScript([-1, OP_CHECKSEQUENCEVERIFY, OP_DROP] + list(CScript(signtx.vin[0].scriptSig)))
         return signtx
 
-    def create_bip112txs(self, bip112inputs, varyOP_CSV, txversion, locktime_delta = 0):
+    def create_bip112txs(self, bip112inputs, varyOP_CSV, txversion, locktime_delta=0):
         txs = []
         assert(len(bip112inputs) >= 16)
         i = 0
@@ -181,11 +190,11 @@ class BIP68_112_113Test(ComparisonTestFramework):
                 for b22 in range(2):
                     b18txs = []
                     for b18 in range(2):
-                        tx =  self.create_transaction(self.nodes[0], bip112inputs[i], self.nodeaddress, Decimal("49.98"))
+                        tx = self.create_transaction(self.nodes[0], bip112inputs[i], self.nodeaddress, Decimal("49.98"))
                         i += 1
-                        if (varyOP_CSV): # if varying OP_CSV, nSequence is fixed
+                        if (varyOP_CSV):  # if varying OP_CSV, nSequence is fixed
                             tx.vin[0].nSequence = base_relative_locktime + locktime_delta
-                        else: # vary nSequence instead, OP_CSV is fixed
+                        else:  # vary nSequence instead, OP_CSV is fixed
                             tx.vin[0].nSequence = relative_locktimes[b31][b25][b22][b18] + locktime_delta
                         tx.nVersion = txversion
                         signtx = self.sign_transaction(self.nodes[0], tx)
@@ -200,46 +209,47 @@ class BIP68_112_113Test(ComparisonTestFramework):
         return txs
 
     def get_tests(self):
-        long_past_time = int(time.time()) - 600 * 1000 # enough to build up to 1000 blocks 10 minutes apart without worrying about getting into the future
-        self.nodes[0].setmocktime(long_past_time - 100) # enough so that the generated blocks will still all be before long_past_time
-        self.coinbase_blocks = self.nodes[0].generate(1 + 16 + 2*32 + 1) # 82 blocks generated for inputs
-        self.nodes[0].setmocktime(0) # set time back to present so yielded blocks aren't in the future as we advance last_block_time
-        self.tipheight = 82 # height of the next block to build
+        long_past_time = int(time.time()) - 600 * 1000  # enough to build up to 1000 blocks 10 minutes apart without worrying about getting into the future
+        self.nodes[0].setmocktime(long_past_time - 100)  # enough so that the generated blocks will still all be before long_past_time
+        self.coinbase_blocks = self.nodes[0].generate(1 + 16 + 2 * 32 + 1)  # 82 blocks generated for inputs
+        self.nodes[0].setmocktime(0)  # set time back to present so yielded blocks aren't in the future as we advance last_block_time
+        self.tipheight = 82  # height of the next block to build
         self.last_block_time = long_past_time
-        self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
+        self.tip = int(self.nodes[0].getbestblockhash(), 16)
         self.nodeaddress = self.nodes[0].getnewaddress()
 
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'defined')
         test_blocks = self.generate_blocks(61, 4)
-        yield TestInstance(test_blocks, sync_every_block=False) # 1
+        yield TestInstance(test_blocks, sync_every_block=False)
         # Advanced from DEFINED to STARTED, height = 143
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'started')
 
         # Fail to achieve LOCKED_IN 100 out of 144 signal bit 0
         # using a variety of bits to simulate multiple parallel softforks
-        test_blocks = self.generate_blocks(50, 536870913) # 0x20000001 (signalling ready)
-        test_blocks = self.generate_blocks(20, 4, test_blocks) # 0x00000004 (signalling not)
-        test_blocks = self.generate_blocks(50, 536871169, test_blocks) # 0x20000101 (signalling ready)
-        test_blocks = self.generate_blocks(24, 536936448, test_blocks) # 0x20010000 (signalling not)
-        yield TestInstance(test_blocks, sync_every_block=False) # 2
+        test_blocks = self.generate_blocks(50, 536870913)  # 0x20000001 (signalling ready)
+        test_blocks = self.generate_blocks(20, 4, test_blocks)  # 0x00000004 (signalling not)
+        test_blocks = self.generate_blocks(50, 536871169, test_blocks)  # 0x20000101 (signalling ready)
+        test_blocks = self.generate_blocks(24, 536936448, test_blocks)  # 0x20010000 (signalling not)
+        yield TestInstance(test_blocks, sync_every_block=False)
         # Failed to advance past STARTED, height = 287
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'started')
 
         # 108 out of 144 signal bit 0 to achieve lock-in
         # using a variety of bits to simulate multiple parallel softforks
-        test_blocks = self.generate_blocks(58, 536870913) # 0x20000001 (signalling ready)
-        test_blocks = self.generate_blocks(26, 4, test_blocks) # 0x00000004 (signalling not)
-        test_blocks = self.generate_blocks(50, 536871169, test_blocks) # 0x20000101 (signalling ready)
-        test_blocks = self.generate_blocks(10, 536936448, test_blocks) # 0x20010000 (signalling not)
-        yield TestInstance(test_blocks, sync_every_block=False) # 3
+        test_blocks = self.generate_blocks(58, 536870913)  # 0x20000001 (signalling ready)
+        test_blocks = self.generate_blocks(26, 4, test_blocks)  # 0x00000004 (signalling not)
+        test_blocks = self.generate_blocks(50, 536871169, test_blocks)  # 0x20000101 (signalling ready)
+        test_blocks = self.generate_blocks(10, 536936448, test_blocks)  # 0x20010000 (signalling not)
+        yield TestInstance(test_blocks, sync_every_block=False)
         # Advanced from STARTED to LOCKED_IN, height = 431
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'locked_in')
 
         # 140 more version 4 blocks
         test_blocks = self.generate_blocks(140, 4)
-        yield TestInstance(test_blocks, sync_every_block=False) # 4
+        yield TestInstance(test_blocks, sync_every_block=False)
 
-        ### Inputs at height = 572
+        # Inputs at height = 572
+        #
         # Put inputs for all tests in the chain at height 572 (tip now = 571) (time increases by 600s per block)
         # Note we reuse inputs for v1 and v2 txs so must test these separately
         # 16 normal inputs
@@ -266,16 +276,16 @@ class BIP68_112_113Test(ComparisonTestFramework):
         bip113input = self.send_generic_input_tx(self.nodes[0], self.coinbase_blocks)
 
         self.nodes[0].setmocktime(self.last_block_time + 600)
-        inputblockhash = self.nodes[0].generate(1)[0] # 1 block generated for inputs to be in chain at height 572
+        inputblockhash = self.nodes[0].generate(1)[0]  # 1 block generated for inputs to be in chain at height 572
         self.nodes[0].setmocktime(0)
-        self.tip = int("0x" + inputblockhash, 0)
+        self.tip = int(inputblockhash, 16)
         self.tipheight += 1
         self.last_block_time += 600
-        assert_equal(len(self.nodes[0].getblock(inputblockhash,True)["tx"]), 82+1)
+        assert_equal(len(self.nodes[0].getblock(inputblockhash, True)["tx"]), 82 + 1)
 
         # 2 more version 4 blocks
         test_blocks = self.generate_blocks(2, 4)
-        yield TestInstance(test_blocks, sync_every_block=False) # 5
+        yield TestInstance(test_blocks, sync_every_block=False)
         # Not yet advanced to ACTIVE, height = 574 (will activate for block 576, not 575)
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'locked_in')
 
@@ -318,7 +328,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
         ### Version 1 txs ###
         success_txs = []
         # add BIP113 tx and -1 CSV tx
-        bip113tx_v1.nLockTime = self.last_block_time - 600 * 5 # = MTP of prior block (not <) but < time put on current block
+        bip113tx_v1.nLockTime = self.last_block_time - 600 * 5  # = MTP of prior block (not <) but < time put on current block
         bip113signed1 = self.sign_transaction(self.nodes[0], bip113tx_v1)
         success_txs.append(bip113signed1)
         success_txs.append(bip112tx_special_v1)
@@ -330,13 +340,13 @@ class BIP68_112_113Test(ComparisonTestFramework):
         # try BIP 112 with seq=9 txs
         success_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_9_v1))
         success_txs.extend(all_rlt_txs(bip112txs_vary_OP_CSV_9_v1))
-        yield TestInstance([[self.create_test_block(success_txs), True]]) # 6
+        yield TestInstance([[self.create_test_block(success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
         ### Version 2 txs ###
         success_txs = []
         # add BIP113 tx and -1 CSV tx
-        bip113tx_v2.nLockTime = self.last_block_time - 600 * 5 # = MTP of prior block (not <) but < time put on current block
+        bip113tx_v2.nLockTime = self.last_block_time - 600 * 5  # = MTP of prior block (not <) but < time put on current block
         bip113signed2 = self.sign_transaction(self.nodes[0], bip113tx_v2)
         success_txs.append(bip113signed2)
         success_txs.append(bip112tx_special_v2)
@@ -348,46 +358,44 @@ class BIP68_112_113Test(ComparisonTestFramework):
         # try BIP 112 with seq=9 txs
         success_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_9_v2))
         success_txs.extend(all_rlt_txs(bip112txs_vary_OP_CSV_9_v2))
-        yield TestInstance([[self.create_test_block(success_txs), True]]) # 7
+        yield TestInstance([[self.create_test_block(success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
-
 
         # 1 more version 4 block to get us to height 575 so the fork should now be active for the next block
         test_blocks = self.generate_blocks(1, 4)
-        yield TestInstance(test_blocks, sync_every_block=False) # 8
+        yield TestInstance(test_blocks, sync_every_block=False)
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'active')
-
 
         #################################
         ### After Soft Forks Activate ###
         #################################
         ### BIP 113 ###
         # BIP 113 tests should now fail regardless of version number if nLockTime isn't satisfied by new rules
-        bip113tx_v1.nLockTime = self.last_block_time - 600 * 5 # = MTP of prior block (not <) but < time put on current block
+        bip113tx_v1.nLockTime = self.last_block_time - 600 * 5  # = MTP of prior block (not <) but < time put on current block
         bip113signed1 = self.sign_transaction(self.nodes[0], bip113tx_v1)
-        bip113tx_v2.nLockTime = self.last_block_time - 600 * 5 # = MTP of prior block (not <) but < time put on current block
+        bip113tx_v2.nLockTime = self.last_block_time - 600 * 5  # = MTP of prior block (not <) but < time put on current block
         bip113signed2 = self.sign_transaction(self.nodes[0], bip113tx_v2)
         for bip113tx in [bip113signed1, bip113signed2]:
-            yield TestInstance([[self.create_test_block([bip113tx]), False]]) # 9,10
+            yield TestInstance([[self.create_test_block([bip113tx]), False]])
         # BIP 113 tests should now pass if the locktime is < MTP
-        bip113tx_v1.nLockTime = self.last_block_time - 600 * 5 - 1 # < MTP of prior block
+        bip113tx_v1.nLockTime = self.last_block_time - 600 * 5 - 1  # < MTP of prior block
         bip113signed1 = self.sign_transaction(self.nodes[0], bip113tx_v1)
-        bip113tx_v2.nLockTime = self.last_block_time - 600 * 5 - 1 # < MTP of prior block
+        bip113tx_v2.nLockTime = self.last_block_time - 600 * 5 - 1  # < MTP of prior block
         bip113signed2 = self.sign_transaction(self.nodes[0], bip113tx_v2)
         for bip113tx in [bip113signed1, bip113signed2]:
-            yield TestInstance([[self.create_test_block([bip113tx]), True]]) # 11,12
+            yield TestInstance([[self.create_test_block([bip113tx]), True]])
             self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
         # Next block height = 580 after 4 blocks of random version
         test_blocks = self.generate_blocks(4, 1234)
-        yield TestInstance(test_blocks, sync_every_block=False) # 13
+        yield TestInstance(test_blocks, sync_every_block=False)
 
         ### BIP 68 ###
         ### Version 1 txs ###
         # All still pass
         success_txs = []
         success_txs.extend(all_rlt_txs(bip68txs_v1))
-        yield TestInstance([[self.create_test_block(success_txs), True]]) # 14
+        yield TestInstance([[self.create_test_block(success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
         ### Version 2 txs ###
@@ -397,7 +405,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
             for b22 in range(2):
                 for b18 in range(2):
                     bip68success_txs.append(bip68txs_v2[1][b25][b22][b18])
-        yield TestInstance([[self.create_test_block(bip68success_txs), True]]) # 15
+        yield TestInstance([[self.create_test_block(bip68success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         # All txs without flag fail as we are at delta height = 8 < 10 and delta time = 8 * 600 < 10 * 512
         bip68timetxs = []
@@ -405,39 +413,38 @@ class BIP68_112_113Test(ComparisonTestFramework):
             for b18 in range(2):
                 bip68timetxs.append(bip68txs_v2[0][b25][1][b18])
         for tx in bip68timetxs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 16 - 19
+            yield TestInstance([[self.create_test_block([tx]), False]])
         bip68heighttxs = []
         for b25 in range(2):
             for b18 in range(2):
                 bip68heighttxs.append(bip68txs_v2[0][b25][0][b18])
         for tx in bip68heighttxs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 20 - 23
+            yield TestInstance([[self.create_test_block([tx]), False]])
 
         # Advance one block to 581
         test_blocks = self.generate_blocks(1, 1234)
-        yield TestInstance(test_blocks, sync_every_block=False) # 24
+        yield TestInstance(test_blocks, sync_every_block=False)
 
         # Height txs should fail and time txs should now pass 9 * 600 > 10 * 512
         bip68success_txs.extend(bip68timetxs)
-        yield TestInstance([[self.create_test_block(bip68success_txs), True]]) # 25
+        yield TestInstance([[self.create_test_block(bip68success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         for tx in bip68heighttxs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 26 - 29
+            yield TestInstance([[self.create_test_block([tx]), False]])
 
         # Advance one block to 582
         test_blocks = self.generate_blocks(1, 1234)
-        yield TestInstance(test_blocks, sync_every_block=False) # 30
+        yield TestInstance(test_blocks, sync_every_block=False)
 
         # All BIP 68 txs should pass
         bip68success_txs.extend(bip68heighttxs)
-        yield TestInstance([[self.create_test_block(bip68success_txs), True]]) # 31
+        yield TestInstance([[self.create_test_block(bip68success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
-
 
         ### BIP 112 ###
         ### Version 1 txs ###
         # -1 OP_CSV tx should fail
-        yield TestInstance([[self.create_test_block([bip112tx_special_v1]), False]]) #32
+        yield TestInstance([[self.create_test_block([bip112tx_special_v1]), False]])
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 1 txs should still pass
         success_txs = []
         for b25 in range(2):
@@ -445,7 +452,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
                 for b18 in range(2):
                     success_txs.append(bip112txs_vary_OP_CSV_v1[1][b25][b22][b18])
                     success_txs.append(bip112txs_vary_OP_CSV_9_v1[1][b25][b22][b18])
-        yield TestInstance([[self.create_test_block(success_txs), True]]) # 33
+        yield TestInstance([[self.create_test_block(success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is unset in argument to OP_CSV, version 1 txs should now fail
@@ -459,60 +466,61 @@ class BIP68_112_113Test(ComparisonTestFramework):
                     fail_txs.append(bip112txs_vary_OP_CSV_9_v1[0][b25][b22][b18])
 
         for tx in fail_txs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 34 - 81
+            yield TestInstance([[self.create_test_block([tx]), False]])
 
         ### Version 2 txs ###
         # -1 OP_CSV tx should fail
-        yield TestInstance([[self.create_test_block([bip112tx_special_v2]), False]]) #82
+        yield TestInstance([[self.create_test_block([bip112tx_special_v2]), False]])
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in argument to OP_CSV, version 2 txs should pass (all sequence locks are met)
         success_txs = []
         for b25 in range(2):
             for b22 in range(2):
                 for b18 in range(2):
-                    success_txs.append(bip112txs_vary_OP_CSV_v2[1][b25][b22][b18]) # 8/16 of vary_OP_CSV
-                    success_txs.append(bip112txs_vary_OP_CSV_9_v2[1][b25][b22][b18]) # 8/16 of vary_OP_CSV_9
+                    success_txs.append(bip112txs_vary_OP_CSV_v2[1][b25][b22][b18])  # 8/16 of vary_OP_CSV
+                    success_txs.append(bip112txs_vary_OP_CSV_9_v2[1][b25][b22][b18])  # 8/16 of vary_OP_CSV_9
 
-        yield TestInstance([[self.create_test_block(success_txs), True]]) # 83
+        yield TestInstance([[self.create_test_block(success_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
-        ## SEQUENCE_LOCKTIME_DISABLE_FLAG is unset in argument to OP_CSV for all remaining txs ##
+        # SEQUENCE_LOCKTIME_DISABLE_FLAG is unset in argument to OP_CSV for all remaining txs ##
+
         # All txs with nSequence 9 should fail either due to earlier mismatch or failing the CSV check
         fail_txs = []
-        fail_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_9_v2)) # 16/16 of vary_nSequence_9
+        fail_txs.extend(all_rlt_txs(bip112txs_vary_nSequence_9_v2))  # 16/16 of vary_nSequence_9
         for b25 in range(2):
             for b22 in range(2):
                 for b18 in range(2):
-                    fail_txs.append(bip112txs_vary_OP_CSV_9_v2[0][b25][b22][b18]) # 16/16 of vary_OP_CSV_9
+                    fail_txs.append(bip112txs_vary_OP_CSV_9_v2[0][b25][b22][b18])  # 16/16 of vary_OP_CSV_9
 
         for tx in fail_txs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 84 - 107
+            yield TestInstance([[self.create_test_block([tx]), False]])
 
         # If SEQUENCE_LOCKTIME_DISABLE_FLAG is set in nSequence, tx should fail
         fail_txs = []
         for b25 in range(2):
             for b22 in range(2):
                 for b18 in range(2):
-                    fail_txs.append(bip112txs_vary_nSequence_v2[1][b25][b22][b18]) # 8/16 of vary_nSequence
+                    fail_txs.append(bip112txs_vary_nSequence_v2[1][b25][b22][b18])  # 8/16 of vary_nSequence
         for tx in fail_txs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 108-115
+            yield TestInstance([[self.create_test_block([tx]), False]])
 
         # If sequencelock types mismatch, tx should fail
         fail_txs = []
         for b25 in range(2):
             for b18 in range(2):
-                fail_txs.append(bip112txs_vary_nSequence_v2[0][b25][1][b18]) # 12/16 of vary_nSequence
-                fail_txs.append(bip112txs_vary_OP_CSV_v2[0][b25][1][b18]) # 12/16 of vary_OP_CSV
+                fail_txs.append(bip112txs_vary_nSequence_v2[0][b25][1][b18])  # 12/16 of vary_nSequence
+                fail_txs.append(bip112txs_vary_OP_CSV_v2[0][b25][1][b18])  # 12/16 of vary_OP_CSV
         for tx in fail_txs:
-            yield TestInstance([[self.create_test_block([tx]), False]]) # 116-123
+            yield TestInstance([[self.create_test_block([tx]), False]])
 
         # Remaining txs should pass, just test masking works properly
         success_txs = []
         for b25 in range(2):
             for b18 in range(2):
-                success_txs.append(bip112txs_vary_nSequence_v2[0][b25][0][b18]) # 16/16 of vary_nSequence
-                success_txs.append(bip112txs_vary_OP_CSV_v2[0][b25][0][b18]) # 16/16 of vary_OP_CSV
-        yield TestInstance([[self.create_test_block(success_txs), True]]) # 124
+                success_txs.append(bip112txs_vary_nSequence_v2[0][b25][0][b18])  # 16/16 of vary_nSequence
+                success_txs.append(bip112txs_vary_OP_CSV_v2[0][b25][0][b18])  # 16/16 of vary_OP_CSV
+        yield TestInstance([[self.create_test_block(success_txs), True]])  # 124
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
         # Additional test, of checking that comparison of two time types works properly
@@ -523,12 +531,10 @@ class BIP68_112_113Test(ComparisonTestFramework):
                 tx.vin[0].nSequence = base_relative_locktime | seq_type_flag
                 signtx = self.sign_transaction(self.nodes[0], tx)
                 time_txs.append(signtx)
-        yield TestInstance([[self.create_test_block(time_txs), True]]) # 125
+        yield TestInstance([[self.create_test_block(time_txs), True]])
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
 
-        ### Missing aspects of test
-        ##  Testing empty stack fails
-
+        # TODO: Test empty stack fails
 
 if __name__ == '__main__':
     BIP68_112_113Test().main()


### PR DESCRIPTION
Next step in #10603.

- first four commits tidy up bip68-112-113-p2p.py
- fifth commit removes usage of ComparisonTestFramework