### PR TITLE
Test datadir specified in conf file exists

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -639,6 +639,9 @@ void ArgsManager::ReadConfigFile(const std::string& confPath)
     }
     // If datadir is changed in .conf file:
     ClearDatadirCache();
+    if (!fs::is_directory(GetDataDir(false))) {
+        throw std::runtime_error(strprintf("specified data directory \"%s\" does not exist.", gArgs.GetArg("-datadir", "").c_str()));
+    }
 }
 
 #ifndef WIN32


### PR DESCRIPTION
Provoked by Nick ODell's discovery here: https://bitcoin.stackexchange.com/questions/64189/when-running-bitcoind-i-keep-getting-boostfilesystemspace-operation-not-p/64210#64210

If a custom data directory is specified using `-datadir` argument, its existence is checked before the conf file is loaded. But if the conf file then specifies a different non-existent `datadir`, that isn't tested, and results in esoteric errors like:

    EXCEPTION: N5boost10filesystem16filesystem_errorE       
    boost::filesystem::space: Operation not permitted

This just adds a check for the datadir existence at the end of `ReadConfigFile()`