### PR TITLE
rpcuser.py: Use 'python' not 'python2'

### DIFF
--- a/share/rpcuser/rpcuser.py
+++ b/share/rpcuser/rpcuser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2 
+#!/usr/bin/env python
 # Copyright (c) 2015-2016 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying 
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.


### PR DESCRIPTION
Note that `rpcuser.py` seems to handle either version when called explicitly like `python2 rpcuser.py` / `python3 rpcuser.py`. This change allows the user's `python` to be used to interpret the script.

There's not always a `python2` installed, e.g. if only Python 3.0+ is installed as `python` / `python3`, like on Arch Linux (https://github.com/hkjn/src/blob/master/bitcoin/Dockerfile#L14) but `python` is almost always present.

# Tested

Script is already compatible with both major versions:
```
$ python2 share/rpcuser/rpcuser.py foobar
String to be appended to bitcoin.conf:
rpcauth=foobar:2951d04c215769c8887c1fa4a8f712c$63c9a08e3b69f811e3837c0d5b6a355b7f798afc7094d80008f5c56a056c387f
Your password:
TV4I54T6W38v1sj3iF4Xsw7A-wYav-Cn8uTr8qv4xZ8=

$ python3 share/rpcuser/rpcuser.py foobar
String to be appended to bitcoin.conf:
rpcauth=foobar:129afbbd214c1f85fb6b9941402506f$4c5af73a2f3fd0a1d8232c28bc5c36f9b0cffd62b7b139beb328d089b16028dc
Your password:
qqbeWrGHqbYL1tUDh1wHKkejzxiGvOa3SPkDbbCwBfs=
 
$ python2 --version
Python 2.7.12

$ python3 --version
Python 3.5.2
```