### PR TITLE
Always return true if AppInitMain got to the end

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1726,5 +1726,5 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
     StartWallets(scheduler);
 #endif
 
-    return !fRequestShutdown;
+    return true;
 }


### PR DESCRIPTION
This should fix a rare zapwallettxes failure on travis, but also
avoids having init operations (re-adding wallet transactions to
mempool) running after RPC is free'd.

I believe this was the failure at https://travis-ci.org/bitcoin/bitcoin/jobs/311747844 (from #11605).