### PR TITLE
[build] Add missing stuff to clean-local

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -279,4 +279,4 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-man
 
 clean-local:
 	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ test/tmp/ cache/ $(OSX_APP)
-	rm -rf test/functional/__pycache__
+	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache


### PR DESCRIPTION
After doing
```
./autogen.sh && ./configure && make
make clean
make distclean
```
and moving `.gitignore` aside, the following files still remain after this patch:
```
	Makefile.in
	aclocal.m4
	autom4te.cache/
	build-aux/compile
	build-aux/config.guess
	build-aux/config.sub
	build-aux/depcomp
	build-aux/install-sh
	build-aux/ltmain.sh
	build-aux/m4/libtool.m4
	build-aux/m4/ltoptions.m4
	build-aux/m4/ltsugar.m4
	build-aux/m4/ltversion.m4
	build-aux/m4/lt~obsolete.m4
	build-aux/missing
	build-aux/test-driver
	configure
	doc/man/Makefile.in
	src/Makefile.in
	src/config/bitcoin-config.h.in
```

Most are automake related so I guess it's fine if they litter around.