### PR TITLE
[RFC] I Have a Hammer! (Replace parts of ui_interface with validationinterface)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -296,12 +296,6 @@ static void registerSignalHandler(int signal, void(*handler)(int))
 }
 #endif
 
-void OnRPCStopped()
-{
-    cvBlockChange.notify_all();
-    LogPrint(BCLog::RPC, "RPC stopped.\n");
-}
-
 std::string HelpMessage(HelpMessageMode mode)
 {
     const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
@@ -721,7 +715,6 @@ bool InitSanityCheck(void)
 
 bool AppInitServers(boost::thread_group& threadGroup)
 {
-    RPCServer::OnStopped(&OnRPCStopped);
     if (!InitHTTPServer())
         return false;
     if (!StartRPC())

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -296,15 +296,8 @@ static void registerSignalHandler(int signal, void(*handler)(int))
 }
 #endif
 
-void OnRPCStarted()
-{
-    uiInterface.NotifyBlockTip.connect(&RPCNotifyBlockChange);
-}
-
 void OnRPCStopped()
 {
-    uiInterface.NotifyBlockTip.disconnect(&RPCNotifyBlockChange);
-    RPCNotifyBlockChange(false, nullptr);
     cvBlockChange.notify_all();
     LogPrint(BCLog::RPC, "RPC stopped.\n");
 }
@@ -707,7 +700,6 @@ bool InitSanityCheck(void)
 
 bool AppInitServers(boost::thread_group& threadGroup)
 {
-    RPCServer::OnStarted(&OnRPCStarted);
     RPCServer::OnStopped(&OnRPCStopped);
     if (!InitHTTPServer())
         return false;
@@ -1516,7 +1508,6 @@ bool AppInitMain(boost::thread_group& threadGroup, CScheduler& scheduler)
                     {
                         LOCK(cs_main);
                         CBlockIndex* tip = chainActive.Tip();
-                        RPCNotifyBlockChange(true, tip);
                         if (tip && tip->nTime > GetAdjustedTime() + 2 * 60 * 60) {
                             strLoadError = _("The block database contains a block which appears to be from the future. "
                                     "This may be due to your computer's date and time being set incorrectly. "

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -18,9 +18,6 @@ class UniValue;
  */
 double GetDifficulty(const CBlockIndex* blockindex = nullptr);
 
-/** Callback for when block tip changed. */
-void RPCNotifyBlockChange(bool ibd, const CBlockIndex *);
-
 /** Block description to JSON */
 UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool txDetails = false);
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -25,6 +25,18 @@ namespace RPCServer
 {
     void OnStarted(std::function<void ()> slot);
     void OnStopped(std::function<void ()> slot);
+
+    struct InterruptedListenerInternals;
+    /** A scoped listener for when RPC is interrupted (ie IsRPCRunning moves
+     * from true to false immediately prior to the invocation of this callback).
+     */
+    class InterruptedListener {
+    private:
+        std::unique_ptr<InterruptedListenerInternals> m_internals;
+    public:
+        InterruptedListener(std::function<void ()> callback);
+        ~InterruptedListener();
+    };
 }
 
 /** Wrapper for UniValue::VType, which includes typeAny:

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -100,9 +100,6 @@ public:
      */
     boost::signals2::signal<void (const std::string &title, int nProgress, bool resume_possible)> ShowProgress;
 
-    /** New block has been accepted */
-    boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyBlockTip;
-
     /** Best header has changed */
     boost::signals2::signal<void (bool, const CBlockIndex *)> NotifyHeaderTip;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2608,11 +2608,6 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
         // Notify external listeners about the new tip.
         GetMainSignals().UpdatedBlockTip(pindexNewTip, pindexFork, fInitialDownload);
 
-        // Always notify the UI if a new block tip was connected
-        if (pindexFork != pindexNewTip) {
-            uiInterface.NotifyBlockTip(fInitialDownload, pindexNewTip);
-        }
-
         if (nStopAtHeight && pindexNewTip && pindexNewTip->nHeight >= nStopAtHeight) StartShutdown();
     } while (pindexNewTip != pindexMostWork);
     CheckBlockIndex(chainparams.GetConsensus());
@@ -2716,7 +2711,6 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
     }
 
     InvalidChainFound(pindex);
-    uiInterface.NotifyBlockTip(IsInitialBlockDownload(), pindex->pprev);
     GetMainSignals().UpdatedBlockTip(chainActive.Tip(), chainActive.Tip(), IsInitialBlockDownload());
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -201,8 +201,6 @@ CCriticalSection cs_main;
 BlockMap& mapBlockIndex = g_chainstate.mapBlockIndex;
 CChain& chainActive = g_chainstate.chainActive;
 CBlockIndex *pindexBestHeader = nullptr;
-CWaitableCriticalSection csBestBlock;
-CConditionVariable cvBlockChange;
 int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
@@ -2137,8 +2135,6 @@ static void DoWarning(const std::string& strWarning)
 void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainParams) {
     // New best block
     mempool.AddTransactionsUpdated(1);
-
-    cvBlockChange.notify_all();
 
     std::vector<std::string> warningMessages;
     if (!IsInitialBlockDownload())

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2717,6 +2717,7 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
 
     InvalidChainFound(pindex);
     uiInterface.NotifyBlockTip(IsInitialBlockDownload(), pindex->pprev);
+    GetMainSignals().UpdatedBlockTip(chainActive.Tip(), chainActive.Tip(), IsInitialBlockDownload());
     return true;
 }
 bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, CBlockIndex *pindex) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -163,8 +163,6 @@ extern BlockMap& mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockWeight;
 extern const std::string strMessageMagic;
-extern CWaitableCriticalSection csBestBlock;
-extern CConditionVariable cvBlockChange;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 extern int nScriptCheckThreads;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -46,7 +46,14 @@ void CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 class CValidationInterface {
 protected:
     /**
-     * Notifies listeners of updated block chain tip
+     * Notifies listeners of updated block chain tip.
+     *
+     * Is called after a series of BlockConnected/BlockDisconnected events once
+     * the chain has made forward progress and is now at the best-known-tip.
+     *
+     * If a block is found to be invalid, this event may trigger without
+     * forward-progress, only to trigger again soon thereafter.
+     * (TODO: remove this edge case)
      *
      * Called on a background thread.
      */
@@ -65,6 +72,13 @@ protected:
      * replacement. This does not include any transactions which are included
      * in BlockConnectedDisconnected either in block->vtx or in txnConflicted.
      *
+     * reason == REORG is not ordered with BlockDisconnected/BlockDisconnected!
+     *
+     * Note that in some rare cases (eg mempool limiting) a
+     * TransactionRemovedFromMempool event may fire with no corresponding
+     * TransactionAddedToMempool event.
+     * (TODO: remove this edge case)
+     *
      * Called on a background thread.
      */
     virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx) {}
@@ -78,11 +92,21 @@ protected:
     /**
      * Notifies listeners of a block being disconnected
      *
+     * The ordering of BlockDisconnected and TransactionRemovedFromMempool
+     * (for transactions removed due to memory constraints or lock time/
+     * coinbase maturity chenges during the disconnection/reorg) is undefined,
+     * and the TransactionRemovedFromMempool callbacks may occur *both* before
+     * and after BlockDisconnected/BlockConnected calls!
+     *
      * Called on a background thread.
      */
     virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block) {}
     /**
      * Notifies listeners of the new active block chain on-disk.
+     *
+     * Because flushing to disk happens in batches, this can happen
+     * significantly after BlockConnected/UpdatedBlockTip calls (and always is
+     * ordered after BlockConnected/UpdatedBlockTip).
      *
      * Called on a background thread.
      */

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -55,6 +55,9 @@ protected:
      * forward-progress, only to trigger again soon thereafter.
      * (TODO: remove this edge case)
      *
+     * In case of manual block invalidation, this event may trigger with
+     * pindexNew == pindexFork both before the previous best tip.
+     *
      * Called on a background thread.
      */
     virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}


### PR DESCRIPTION
Look at my pretty harrmer, watch as I make everything into a nail!

This de-duplicates the NotifyBlockTip/BlockTipChanged callbacks by removing the NotifyBlockTip callback from ui_interface, cleaning up a few things along the way. It does, however, add a good bit of overhead where there was previously none - instead of a simple boost::signal things are now being called on the scheduler background thread. Still, I think its worth it because a) background-threading this stuff makes us less vulnerable to latency spikes in different subsystems because some other subsystem takes forever (at least once validationitnerface is parallel across different clients) and b) avoids lockorder issues creeping in due to cs_main complexity.