### PR TITLE
Qt: Fixing restore from system tray behaviour of main window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -937,6 +937,7 @@ void BitcoinGUI::message(const QString &title, const QString &message, unsigned 
 
 void BitcoinGUI::changeEvent(QEvent *e)
 {
+    QMainWindow::changeEvent(e);
 #ifndef Q_OS_MAC // Ignored on Mac
     if(e->type() == QEvent::WindowStateChange)
     {
@@ -949,10 +950,6 @@ void BitcoinGUI::changeEvent(QEvent *e)
                 {
                     QTimer::singleShot(0, this, SLOT(showMaximized()));
                 }
-                else if (wsevt->oldState() & Qt::WindowFullScreen)
-                {
-                    QTimer::singleShot(0, this, SLOT(showFullScreen()));
-                }
                 else
                 {
                     QTimer::singleShot(0, this, SLOT(showNormal()));
@@ -963,7 +960,6 @@ void BitcoinGUI::changeEvent(QEvent *e)
         }
     }
 #endif
-    QMainWindow::changeEvent(e);
 }
 
 void BitcoinGUI::closeEvent(QCloseEvent *event)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -937,7 +937,6 @@ void BitcoinGUI::message(const QString &title, const QString &message, unsigned 
 
 void BitcoinGUI::changeEvent(QEvent *e)
 {
-    QMainWindow::changeEvent(e);
 #ifndef Q_OS_MAC // Ignored on Mac
     if(e->type() == QEvent::WindowStateChange)
     {
@@ -946,12 +945,25 @@ void BitcoinGUI::changeEvent(QEvent *e)
             QWindowStateChangeEvent *wsevt = static_cast<QWindowStateChangeEvent*>(e);
             if(!(wsevt->oldState() & Qt::WindowMinimized) && isMinimized())
             {
+                if (wsevt->oldState() & Qt::WindowMaximized)
+                {
+                    QTimer::singleShot(0, this, SLOT(showMaximized()));
+                }
+                else if (wsevt->oldState() & Qt::WindowFullScreen)
+                {
+                    QTimer::singleShot(0, this, SLOT(showFullScreen()));
+                }
+                else
+                {
+                    QTimer::singleShot(0, this, SLOT(showNormal()));
+                }
                 QTimer::singleShot(0, this, SLOT(hide()));
                 e->ignore();
             }
         }
     }
 #endif
+    QMainWindow::changeEvent(e);
 }
 
 void BitcoinGUI::closeEvent(QCloseEvent *event)


### PR DESCRIPTION
When restoring the main window from the system tray, it always was in minimized state (at least on Windows). This patch should fix this. The window should restore to the same state as it was  at the moment of minimizing it into the tray.

May be related to issue #8225 

To reproduce the bug do following under Windows:
* In Options->Window enable "Minimize to the tray instead of the taskbar"
* Optionally enable "Minimize on close", too
* Minimize the main window
* Klick on the tray icon (or right click on the tray icon and select Show/Hide)

The main window's taskbar icon appears, but the window itself is not restored to its original size.

Expected behaviour: the window should appear.