### PR TITLE
move banned peer log messages behind -debug=net

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1102,7 +1102,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
 
     if (IsBanned(addr) && !whitelisted)
     {
-        LogPrintf("connection from %s dropped (banned)\n", addr.ToString());
+        LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
         CloseSocket(hSocket);
         return;
     }


### PR DESCRIPTION
There's several peers on the public p2p network which flood reconnections many times a minute. 

If we've banned them, we don't want to hear from them again. 