### PR TITLE
wallet: Improve ReacceptWalletTransactions performance

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1713,11 +1713,10 @@ void CWallet::ReacceptWalletTransactions()
     }
 
     // Try to add wallet transactions to memory pool
-    for (std::pair<const int64_t, CWalletTx*>& item : mapSorted)
-    {
+    LOCK(mempool.cs);
+    for (std::pair<const int64_t, CWalletTx*>& item : mapSorted) {
         CWalletTx& wtx = *(item.second);
 
-        LOCK(mempool.cs);
         CValidationState state;
         wtx.AcceptToMemoryPool(maxTxFee, state);
     }


### PR DESCRIPTION
Memory pool mutex is locked/unlocked for each wallet transaction in loop resulting in unnecessary overhead. This patch makes it one time lock/unlock (even if there are no wallet transactions).