### PR TITLE
Add Travis check for duplicate includes

### DIFF
--- a/contrib/devtools/lint-includes.sh
+++ b/contrib/devtools/lint-includes.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for duplicate includes.
+
+filter_suffix() {
+    git ls-files | grep -E "^src/.*\.${1}"'$' | grep -Ev "/(leveldb|secp256k1|univalue)/"
+}
+
+EXIT_CODE=0
+for HEADER_FILE in $(filter_suffix h); do
+    DUPLICATE_INCLUDES_IN_HEADER_FILE=$(grep -E "^#include " < "${HEADER_FILE}" | sort | uniq -d)
+    if [[ ${DUPLICATE_INCLUDES_IN_HEADER_FILE} != "" ]]; then
+        echo "Duplicate include(s) in ${HEADER_FILE}:"
+        echo "${DUPLICATE_INCLUDES_IN_HEADER_FILE}"
+        echo
+        EXIT_CODE=1
+    fi
+    CPP_FILE=${HEADER_FILE/%\.h/.cpp}
+    if [[ ! -e $CPP_FILE ]]; then
+        continue
+    fi
+    DUPLICATE_INCLUDES_IN_HEADER_AND_CPP_FILES=$(grep -hE "^#include " <(sort -u < "${HEADER_FILE}") <(sort -u < "${CPP_FILE}") | grep -E "^#include " | sort | uniq -d)
+    if [[ ${DUPLICATE_INCLUDES_IN_HEADER_AND_CPP_FILES} != "" ]]; then
+        echo "Include(s) from ${HEADER_FILE} duplicated in ${CPP_FILE}:"
+        echo "${DUPLICATE_INCLUDES_IN_HEADER_AND_CPP_FILES}"
+        echo
+        EXIT_CODE=1
+    fi
+done
+for CPP_FILE in $(filter_suffix cpp); do
+    DUPLICATE_INCLUDES_IN_CPP_FILE=$(grep -E "^#include " < "${CPP_FILE}" | sort | uniq -d)
+    if [[ ${DUPLICATE_INCLUDES_IN_CPP_FILE} != "" ]]; then
+        echo "Duplicate include(s) in ${CPP_FILE}:"
+        echo "${DUPLICATE_INCLUDES_IN_CPP_FILE}"
+        echo
+        EXIT_CODE=1
+    fi
+done
+exit ${EXIT_CODE}

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -11,7 +11,6 @@
 #include <utilstrencodings.h>
 
 #include <assert.h>
-#include <memory>
 
 #include <chainparamsseeds.h>
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -9,7 +9,6 @@
 #include <util.h>
 
 #include <assert.h>
-#include <memory>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -47,7 +47,6 @@
 #include <walletinitinterface.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <memory>
 
 #ifndef WIN32
 #include <signal.h>

--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -7,7 +7,6 @@
 #include <util.h>
 
 #include <boost/signals2/connection.hpp>
-#include <memory>
 #include <utility>
 
 namespace interfaces {

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -22,8 +22,6 @@
 #include <wallet/feebumper.h>
 #include <wallet/wallet.h>
 
-#include <memory>
-
 namespace interfaces {
 namespace {
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -27,7 +27,6 @@
 #include <validationinterface.h>
 
 #include <algorithm>
-#include <memory>
 #include <queue>
 #include <utility>
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -20,7 +20,6 @@
 #include <ui_interface.h>
 #include <utilstrencodings.h>
 
-#include <memory>
 #ifdef WIN32
 #include <string.h>
 #else

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -9,7 +9,6 @@
 
 #include <qt/paymentrequestplus.h>
 
-#include <script/script.h>
 #include <util.h>
 
 #include <stdexcept>

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -15,7 +15,6 @@
 #include <utilstrencodings.h> // for GetTime()
 
 #include <stdlib.h>
-#include <limits>
 #include <chrono>
 #include <thread>
 

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -27,7 +27,6 @@
 #endif
 
 #include <algorithm>
-#include <memory>
 
 LockedPoolManager* LockedPoolManager::_instance = nullptr;
 std::once_flag LockedPoolManager::init_flag;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -17,8 +17,6 @@
 #include <rpc/register.h>
 #include <script/sigcache.h>
 
-#include <memory>
-
 void CConnmanTest::AddNode(CNode& node)
 {
     LOCK(g_connman->cs_vNodes);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -8,7 +8,6 @@
 #include <addrman.h>
 #include <hash.h>
 #include <protocol.h>
-#include <util.h>
 #include <utilstrencodings.h>
 #include <wallet/walletutil.h>
 

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,7 +6,6 @@
 
 #include <rpc/server.h>
 #include <wallet/db.h>
-#include <wallet/wallet.h>
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     TestingSetup(chainName), m_wallet("mock", CWalletDBWrapper::CreateMock())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -8,7 +8,6 @@
 #include <checkpoints.h>
 #include <chain.h>
 #include <wallet/coincontrol.h>
-#include <wallet/coinselection.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <fs.h>
@@ -26,7 +25,6 @@
 #include <scheduler.h>
 #include <timedata.h>
 #include <txmempool.h>
-#include <util.h>
 #include <utilmoneystr.h>
 #include <wallet/fees.h>
 


### PR DESCRIPTION
This enforces parts of the project header include guidelines (added by @sipa in #10575).

Example run:

```
$ git diff
diff --git a/src/warnings.cpp b/src/warnings.cpp
index c52a1fd..d8994dd 100644
--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -5,6 +5,8 @@

 #include <sync.h>
 #include <clientversion.h>
+#include <string>
 #include <util.h>
 #include <warnings.h>
+#include <util.h>

diff --git a/src/warnings.h b/src/warnings.h
index e8e982c..8d2252e 100644
--- a/src/warnings.h
+++ b/src/warnings.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WARNINGS_H

 #include <stdlib.h>
 #include <string>
+#include <stdlib.h>

 void SetMiscWarning(const std::string& strWarning);
$ contrib/devtools/lint-includes.sh
Duplicate include(s) in src/warnings.h:
#include <stdlib.h>

Include(s) from src/warnings.h duplicated in src/warnings.cpp:
#include <string>

Duplicate include(s) in src/warnings.cpp:
#include <util.h>
$ echo $?
1
$ git checkout .
$ contrib/devtools/lint-includes.sh
$ echo $?
0
```