### PR TITLE
Add configuration file/argument testing

### DIFF
--- a/test/functional/conf_args.py
+++ b/test/functional/conf_args.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test various command line arguments and configuration file parameters."""
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import get_datadir_path
+
+class ConfArgsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.stop_node(0)
+        # Remove the -datadir argument so it doesn't override the config file
+        self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-datadir")]
+
+        default_data_dir = get_datadir_path(self.options.tmpdir, 0)
+        new_data_dir = os.path.join(default_data_dir, 'newdatadir')
+        new_data_dir_2 = os.path.join(default_data_dir, 'newdatadir2')
+
+        # Check that using -datadir argument on non-existent directory fails
+        self.nodes[0].datadir = new_data_dir
+        self.assert_start_raises_init_error(0, ['-datadir='+new_data_dir], 'Error: Specified data directory "' + new_data_dir + '" does not exist.')
+
+        # Check that using non-existent datadir in conf file fails
+        conf_file = os.path.join(default_data_dir, "bitcoin.conf")
+        with open(conf_file, 'a', encoding='utf8') as f:
+            f.write("datadir=" + new_data_dir + "\n")
+        self.assert_start_raises_init_error(0, ['-conf='+conf_file], 'Error reading configuration file: specified data directory "' + new_data_dir + '" does not exist.')
+
+        # Create the directory and ensure the config file now works
+        os.mkdir(new_data_dir)
+        self.start_node(0, ['-conf='+conf_file, '-wallet=w1'])
+        self.stop_node(0)
+        assert os.path.isfile(os.path.join(new_data_dir, 'regtest', 'wallets', 'w1'))
+
+        # Ensure command line argument overrides datadir in conf
+        os.mkdir(new_data_dir_2)
+        self.nodes[0].datadir = new_data_dir_2
+        self.start_node(0, ['-datadir='+new_data_dir_2, '-conf='+conf_file, '-wallet=w2'])
+        assert os.path.isfile(os.path.join(new_data_dir_2, 'regtest', 'wallets', 'w2'))
+
+if __name__ == '__main__':
+    ConfArgsTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -129,6 +129,7 @@ BASE_SCRIPTS= [
     'p2p-acceptblock.py',
     'feature_logging.py',
     'node_network_limited.py',
+    'conf_args.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
Adds a new functional test for testing various command line and configuration file argument interactions, that aren't specific enough to other functionality to be placed in other tests.

Currently this tests the error messages for non-existent datadir, which would have caught the bug fixed in https://github.com/bitcoin/bitcoin/pull/11829. It also tests that command line arguments override the ones in the config file.

I plan on working on a fix for https://github.com/bitcoin/bitcoin/issues/11819 / https://github.com/bitcoin/bitcoin/issues/1044 and then expanding this test with cases for that.