### PR TITLE
[script] simplify CheckMinimalPush checks, add safety assert

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -223,22 +223,22 @@ bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
     // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal
     assert(0 <= opcode && opcode <= OP_PUSHDATA4);
     if (data.size() == 0) {
-        // Could have used OP_0.
+        // Should have used OP_0.
         return opcode == OP_0;
     } else if (data.size() == 1 && data[0] >= 1 && data[0] <= 16) {
-        // Could have used OP_1 .. OP_16.
+        // Should have used OP_1 .. OP_16.
         return false;
     } else if (data.size() == 1 && data[0] == 0x81) {
-        // Could have used OP_1NEGATE.
+        // Should have used OP_1NEGATE.
         return false;
     } else if (data.size() <= 75) {
-        // Could have used a direct push (opcode indicating number of bytes pushed + those bytes).
+        // Must have used a direct push (opcode indicating number of bytes pushed + those bytes).
         return opcode == data.size();
     } else if (data.size() <= 255) {
-        // Could have used OP_PUSHDATA.
+        // Must have used OP_PUSHDATA.
         return opcode == OP_PUSHDATA1;
     } else if (data.size() <= 65535) {
-        // Could have used OP_PUSHDATA2.
+        // Must have used OP_PUSHDATA2.
         return opcode == OP_PUSHDATA2;
     }
     return true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -220,15 +220,17 @@ bool static CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, co
 }
 
 bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
+    // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal
+    assert(0 <= opcode && opcode <= OP_PUSHDATA4);
     if (data.size() == 0) {
         // Could have used OP_0.
         return opcode == OP_0;
     } else if (data.size() == 1 && data[0] >= 1 && data[0] <= 16) {
         // Could have used OP_1 .. OP_16.
-        return opcode == OP_1 + (data[0] - 1);
+        return false;
     } else if (data.size() == 1 && data[0] == 0x81) {
         // Could have used OP_1NEGATE.
-        return opcode == OP_1NEGATE;
+        return false;
     } else if (data.size() <= 75) {
         // Could have used a direct push (opcode indicating number of bytes pushed + those bytes).
         return opcode == data.size();


### PR DESCRIPTION
the two conditions could simply never be hit as `true`, as those opcodes have a push payload of size 0 in `data`.

Added the assert for clarity for future readers(matching the gating in the interpreter) and safety for future use.

This effects policy only.