### PR TITLE
[trivial] Add required package dependencies for depends cross compilation

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -28,6 +28,22 @@ Common `host-platform-triplets` for cross compilation are:
 
 No other options are needed, the paths are automatically configured.
 
+Install the required dependencies: Ubuntu & Debian
+--------------------------------------------------
+
+For macOS cross compilation:
+
+    sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
+
+For Win32/Win64 cross compilation:
+
+- see [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)
+
+For linux (including i386, ARM) cross compilation:
+
+    sudo apt-get install curl g++-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu gcc-4.8-aarch64-linux-gnu binutils-aarch64-linux-gnu g++-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf gcc-4.8-arm-linux-gnueabihf binutils-arm-linux-gnueabihf g++-4.8-multilib gcc-4.8-multilib binutils-gold bsdmainutils
+
+
 Dependency Options:
 The following can be set when running make: make FOO=bar
 


### PR DESCRIPTION
Stumbled over this during a setup of a new depends compile system.
Related to #8913.
