### PR TITLE
Used pragma once instead of defines

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -3,8 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_PRIMITIVES_BLOCK_H
-#define BITCOIN_PRIMITIVES_BLOCK_H
+#pragma once
 
 #include <primitives/transaction.h>
 #include <serialize.h>
@@ -151,5 +150,3 @@ struct CBlockLocator
         return vHave.empty();
     }
 };
-
-#endif // BITCOIN_PRIMITIVES_BLOCK_H


### PR DESCRIPTION
For more code clarity, is it possible to use #pragma instead of #defines for headers guard words ?