### PR TITLE
Avoid cs_main during ReadBlockFromDisk Calls

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -219,10 +219,10 @@ static bool rest_block(HTTPRequest* req,
 
         if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
             return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
-
-        if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus()))
-            return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
     }
+
+    if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus()))
+        return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 
     CDataStream ssBlock(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
     ssBlock << block;
@@ -243,11 +243,7 @@ static bool rest_block(HTTPRequest* req,
     }
 
     case RetFormat::JSON: {
-        UniValue objBlock;
-        {
-            LOCK(cs_main);
-            objBlock = blockToJSON(block, pblockindex, showTxDetails);
-        }
+        UniValue objBlock = blockToJSON(block, pblockindex, showTxDetails);
         std::string strJSON = objBlock.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -179,6 +179,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
     if (!GetTransaction(hash, tx, Params().GetConsensus(), hash_block, true, blockindex)) {
         std::string errmsg;
         if (blockindex) {
+            LOCK(cs_main);
             if (!(blockindex->nStatus & BLOCK_HAVE_DATA)) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Block not available");
             }
@@ -266,13 +267,12 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
 
-    LOCK(cs_main);
-
     if (pblockindex == nullptr)
     {
         CTransactionRef tx;
         if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock, false) || hashBlock.IsNull())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
+        LOCK(cs_main);
         pblockindex = LookupBlockIndex(hashBlock);
         if (!pblockindex) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1019,8 +1019,6 @@ bool GetTransaction(const uint256& hash, CTransactionRef& txOut, const Consensus
 {
     CBlockIndex* pindexSlow = blockIndex;
 
-    LOCK(cs_main);
-
     if (!blockIndex) {
         CTransactionRef ptx = mempool.get(hash);
         if (ptx) {
@@ -1032,6 +1030,7 @@ bool GetTransaction(const uint256& hash, CTransactionRef& txOut, const Consensus
             return g_txindex->FindTx(hash, hashBlock, txOut);
         }
 
+        LOCK(cs_main);
         if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it
             const Coin& coin = AccessByTxid(*pcoinsTip, hash);
             if (!coin.IsSpent()) pindexSlow = chainActive[coin.nHeight];

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -173,7 +173,6 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     const Consensus::Params& consensusParams = Params().GetConsensus();
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
     {
-        LOCK(cs_main);
         CBlock block;
         if(!ReadBlockFromDisk(block, pindex, consensusParams))
         {


### PR DESCRIPTION
Built on #11281 and one commit from #11824, this removes almost all cs_main holds in ReadBlockFromDisk calls in net_processing/RPC/REST. Only real worry here is if something gets pruned out from under us during reading, so some previously-asserts in net_processing are now LogPrints.