### PR TITLE
fees: Remove fallbackfee default

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -681,11 +681,14 @@ void SendCoinsDialog::updateSmartFeeLabel()
     updateCoinControlState(coin_control);
     coin_control.m_feerate.reset(); // Explicitly use only fee estimation rate for smart fee labels
     FeeCalculation feeCalc;
-    CFeeRate feeRate = CFeeRate(GetMinimumFee(1000, coin_control, ::mempool, ::feeEstimator, &feeCalc));
+    CFeeRate fee_rate = CFeeRate(GetMinimumFee(1000, coin_control, ::mempool, ::feeEstimator, &feeCalc));
 
-    ui->labelSmartFee->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), feeRate.GetFeePerK()) + "/kB");
+    ui->labelSmartFee->setText(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), fee_rate.GetFeePerK()) + "/kB");
 
     if (feeCalc.reason == FeeReason::FALLBACK) {
+        if (fee_rate == 0) {
+            ui->fallbackFeeWarningLabel->setText(tr("No fee estimates available, fallbackfee not set"));
+        }
         ui->labelSmartFee2->show(); // (Smart fee not initialized yet. This usually takes a few blocks...)
         ui->labelFeeEstimation->setText("");
         ui->fallbackFeeWarningLabel->setVisible(true);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -154,6 +154,7 @@ void TestGUI()
     for (int i = 0; i < 5; ++i) {
         test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
     }
+    CWallet::fallbackFee = CFeeRate(20000);
     bitdb.MakeMock();
     std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, "wallet_test.dat"));
     CWallet wallet(std::move(dbw));

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -164,7 +164,12 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
         new_fee = total_fee;
         nNewFeeRate = CFeeRate(total_fee, maxNewTxSize);
     } else {
-        new_fee = GetMinimumFee(maxNewTxSize, coin_control, mempool, ::feeEstimator, nullptr /* FeeCalculation */);
+        FeeCalculation fee_calc;
+        new_fee = GetMinimumFee(maxNewTxSize, coin_control, mempool, ::feeEstimator, &fee_calc);
+        if (new_fee == 0 && fee_calc.reason == FeeReason::FALLBACK) {
+            errors.push_back("No fee estimates available, fallbackfee not set");
+            return Result::WALLET_ERROR;
+        }
         nNewFeeRate = CFeeRate(new_fee, maxNewTxSize);
 
         // New fee rate must be at least old rate + minimum incremental relay rate

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -53,6 +53,7 @@ CAmount GetMinimumFee(unsigned int nTxBytes, const CCoinControl& coin_control, c
             // if we don't have enough data for estimateSmartFee, then use fallbackFee
             fee_needed = CWallet::fallbackFee.GetFee(nTxBytes);
             if (feeCalc) feeCalc->reason = FeeReason::FALLBACK;
+            if (fee_needed == 0) return fee_needed; // fallbackFee is unset, must return
         }
         // Obey mempool min fee when using smart fee estimation
         CAmount min_mempool_fee = pool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nTxBytes);

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -18,8 +18,8 @@ std::string GetWalletHelpString(bool showDebug)
     std::string strUsage = HelpMessageGroup(_("Wallet options:"));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), DEFAULT_KEYPOOL_SIZE));
-    strUsage += HelpMessageOpt("-fallbackfee=<amt>", strprintf(_("A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)"),
-                                                               CURRENCY_UNIT, FormatMoney(DEFAULT_FALLBACK_FEE)));
+    strUsage += HelpMessageOpt("-fallbackfee=<amt>", strprintf(_("A fee rate (in %s/kB) that will be used when fee estimation has insufficient data."), CURRENCY_UNIT) +
+                                                     " " + _("If not specified, and smart fee estimates are not yet available, transactions can not be created."));
     strUsage += HelpMessageOpt("-discardfee=<amt>", strprintf(_("The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). "
                                                                 "Note: An output is discarded if it is dust at this rate, but we will always discard up to the dust relay fee and a discard fee above that is limited by the fee estimate for the longest target"),
                                                               CURRENCY_UNIT, FormatMoney(DEFAULT_DISCARD_FEE)));

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -601,6 +601,7 @@ public:
     ListCoinsTestingSetup()
     {
         CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
+        CWallet::fallbackFee = CFeeRate(20000);
         ::bitdb.MakeMock();
         wallet.reset(new CWallet(std::unique_ptr<CWalletDBWrapper>(new CWalletDBWrapper(&bitdb, "wallet_test.dat"))));
         bool firstRun;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -43,8 +43,6 @@ extern bool fWalletRbf;
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
-//! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 20000;
 //! -m_discard_rate default
 static const CAmount DEFAULT_DISCARD_FEE = 10000;
 //! -mintxfee default

--- a/test/functional/smartfees.py
+++ b/test/functional/smartfees.py
@@ -200,6 +200,9 @@ class EstimateFeeTest(BitcoinTestFramework):
 
         # Check that no transaction can be created when smart fees are uninitialized and fallbackfee not set
         self.start_node(0, extra_args=self.extra_args[0] + ['-fallbackfee='])  # Disable fallbackfee, which is set in the conf file
+        assert_raises_rpc_error(-4, 'No fee estimates available, fallbackfee not set', lambda: self.nodes[0].fundrawtransaction(self.nodes[0].createrawtransaction([], {self.nodes[0].getnewaddress(): 1})))
+        assert_raises_rpc_error(-4, 'No fee estimates available, fallbackfee not set', lambda: self.nodes[0].sendfrom("", self.nodes[0].getnewaddress(), 1))
+        assert_raises_rpc_error(-6, 'No fee estimates available, fallbackfee not set', lambda: self.nodes[0].sendmany("", {self.nodes[0].getnewaddress(): 1}))
         assert_raises_rpc_error(-4, 'No fee estimates available, fallbackfee not set', lambda: self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))
         self.stop_node(0)
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -292,6 +292,7 @@ def initialize_datadir(dirname, n):
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
+        f.write("fallbackfee=0.00020000\n")
     return datadir
 
 def get_datadir_path(dirname, n):


### PR DESCRIPTION
fallbackfee is impossible to keep up-to-date by hardcoding a default value. This removes the default value and hands the responsibility to the user to determine an appropriate fallbackfee in case fee estimates are not available.

Todo:

- [ ] Properly rework the GUI when no fee estimates are available and no fallbackfee is set. (TBD: Upcoming in a later pull request)