### PR TITLE
Fixing env variables/arguments in OpenBSD build instructions

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -44,7 +44,7 @@ If you have to build it yourself, you can use [the installation script included
 in contrib/](contrib/install_db4.sh) like so
 
 ```shell
-./contrib/install_db4.sh `pwd` CC=egcc CXX=eg++ CPP=ecpp
+CC=egcc CXX=eg++ CPP=ecpp ./contrib/install_db4.sh `pwd`
 ```
 
 from the root of the repository.
@@ -79,13 +79,14 @@ Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
 
 To configure with wallet:
 ```bash
-./configure --with-gui=no CC=egcc CXX=eg++ CPP=ecpp \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+CC=egcc CXX=eg++ CPP=ecpp \
+  BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+  ./configure --with-gui=no
 ```
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no CC=egcc CXX=eg++ CPP=ecpp
+CC=egcc CXX=eg++ CPP=ecpp ./configure --disable-wallet --with-gui=no
 ```
 
 Build and run the tests:
@@ -100,7 +101,7 @@ Clang
 ```bash
 pkg_add llvm
 
-./configure --disable-wallet --with-gui=no CC=clang CXX=clang++
+CC=clang CXX=clang++ ./configure --disable-wallet --with-gui=no
 gmake # use -jX here for parallelism
 gmake check
 ```


### PR DESCRIPTION
When the `before` version of the commands are executed, `./configure` fails with:

```
 configure: error: C compiler cannot create executables
```

However, when the arguments are passed as environment variables rather than arguments (at least on BSD), the `./configure` runs with no issues and the build succeeds.