### PR TITLE
Wallet : remove unused fNoncriticalErrors variable from CWalletDB::FindWalletTx

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -626,7 +626,6 @@ DBErrors CWalletDB::LoadWallet(CWallet* pwallet)
 
 DBErrors CWalletDB::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CWalletTx>& vWtx)
 {
-    bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
     try {
@@ -680,9 +679,6 @@ DBErrors CWalletDB::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CWal
     catch (...) {
         result = DB_CORRUPT;
     }
-
-    if (fNoncriticalErrors && result == DB_LOAD_OK)
-        result = DB_NONCRITICAL_ERROR;
 
     return result;
 }


### PR DESCRIPTION
The `CWalletDB::FindWalletTx` method was patterned after `CWalletDB::LoadWallet`, where `fNoncriticalErrors` is used when a tx check fails in `ReadKeyValue`.

Since `FindWalletTx` is only used by methods which are zapping txs, it makes sense that `ReadKeyValue` is not called and the tx is not checked, so I think that deleting the unused `fNoncriticalErrors` boolean variable and its conditional statement is appropriate.