### PR TITLE
[build] Warn that only libconsensus can be built without Boost

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -761,6 +761,9 @@ define(MINIMUM_REQUIRED_BOOST, 1.47.0)
 
 dnl Check for boost libs
 AX_BOOST_BASE([MINIMUM_REQUIRED_BOOST])
+if test x$want_boost = xno; then
+    AC_MSG_ERROR([[only libbitcoinconsensus can be built without boost]])
+fi
 AX_BOOST_SYSTEM
 AX_BOOST_FILESYSTEM
 AX_BOOST_PROGRAM_OPTIONS


### PR DESCRIPTION
This replaces the "configure: error: Could not find a version of the boost_system library!" message you receive when trying to build without Boost, with "only libbitcoinconsensus can be built without boost". 

`./configure --with-utils=no --disable-bench --disable-gui-tests --disable-tests --with-daemon=no --without-gui --disable-wallet --with-boost=no` builds libconsensus.

`./configure --with-boost=no` should always fail with:
```
checking whether to build Bitcoin Core GUI... yes (Qt5)
configure: error: only libbitcoinconsensus can be built without boost
```

For anyone wondering why the check comes after the AX_BOOST_BASE check, see this [comment](https://github.com/bitcoin/bitcoin/pull/11806#discussion_r155359394). "the AX_BOOST_BASE macro that does the --with-boost handling (along with the actual checks), and sets "want_boost". "

Fixes #10826, replaces #11806.

@theuni if you re-ACK we can get this merged.