### PR TITLE
Qt: Setting for deciding address type (legacy, p2sh or bech32) 

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -167,6 +167,57 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="groupBoxAddressType">
+         <property name="title">
+          <string>Address type</string>
+         </property>
+         <property name="checkable">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QRadioButton" name="addressTypeLegacy">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Legacy</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="addressTypeP2SHSegWit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>P2SH-SegWit</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="addressTypeBech32">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Native SegWit (bech32)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_Wallet">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -152,6 +152,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
         mapper->toFirst();
 
         updateDefaultProxyNets();
+        setActiveAddressType();
     }
 
     /* warn when one of the following settings changes by user action (placed here so init via mapper doesn't trigger them) */
@@ -180,6 +181,10 @@ void OptionsDialog::setMapper()
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);
     mapper->addMapping(ui->coinControlFeatures, OptionsModel::CoinControlFeatures);
+
+    mapper->addMapping(ui->addressTypeLegacy, OptionsModel::AddressTypeLegacy);
+    mapper->addMapping(ui->addressTypeP2SHSegWit, OptionsModel::AddressTypeP2SHSegWit);
+    mapper->addMapping(ui->addressTypeBech32, OptionsModel::AddressTypeBech32);
 
     /* Network */
     mapper->addMapping(ui->mapPortUpnp, OptionsModel::MapPortUPnP);
@@ -328,6 +333,23 @@ void OptionsDialog::updateDefaultProxyNets()
     strProxy = proxy.proxy.ToStringIP() + ":" + proxy.proxy.ToStringPort();
     strDefaultProxyGUI = ui->proxyIp->text() + ":" + ui->proxyPort->text();
     (strProxy == strDefaultProxyGUI.toStdString()) ? ui->proxyReachTor->setChecked(true) : ui->proxyReachTor->setChecked(false);
+}
+
+void OptionsDialog::setActiveAddressType() {
+    switch(g_address_type) {
+    case OUTPUT_TYPE_LEGACY:
+        ui->addressTypeLegacy->setChecked(true);
+        break;
+    case OUTPUT_TYPE_P2SH_SEGWIT:
+        ui->addressTypeP2SHSegWit->setChecked(true);
+        break;
+    case OUTPUT_TYPE_BECH32:
+        ui->addressTypeBech32->setChecked(true);
+        break;
+    case OUTPUT_TYPE_NONE:
+    default:
+        break;
+    }
 }
 
 ProxyAddressValidator::ProxyAddressValidator(QObject *parent) :

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -58,6 +58,7 @@ private Q_SLOTS:
     void updateProxyValidationState();
     /* query the networks, for which the default proxy is used */
     void updateDefaultProxyNets();
+    void setActiveAddressType();
 
 Q_SIGNALS:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -107,6 +107,11 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("bSpendZeroConfChange", true);
     if (!m_node.softSetBoolArg("-spendzeroconfchange", settings.value("bSpendZeroConfChange").toBool()))
         addOverriddenOption("-spendzeroconfchange");
+
+    if (!settings.contains("strAddressType"))
+        settings.setValue("strAddressType", QString::fromStdString(FormatOutputType(OUTPUT_TYPE_DEFAULT)));
+    if (!gArgs.SoftSetArg("-addresstype", settings.value("strAddressType").toString().toStdString()))
+        addOverriddenOption("-addresstype");
 #endif
 
     // Network
@@ -381,6 +386,27 @@ bool OptionsModel::setData(const QModelIndex & index, const QVariant & value, in
             if (settings.value("bSpendZeroConfChange") != value) {
                 settings.setValue("bSpendZeroConfChange", value);
                 setRestartRequired(true);
+            }
+            break;
+        case AddressTypeLegacy:
+            if (value.toBool()) {
+                settings.setValue("strAddressType", QString::fromStdString(FormatOutputType(OUTPUT_TYPE_LEGACY)));
+                g_address_type = OUTPUT_TYPE_LEGACY;
+                g_change_type = ParseOutputType(gArgs.GetArg("-changetype", ""), g_address_type);
+            }
+            break;
+        case AddressTypeP2SHSegWit:
+            if (value.toBool()) {
+                settings.setValue("strAddressType", QString::fromStdString(FormatOutputType(OUTPUT_TYPE_P2SH_SEGWIT)));
+                g_address_type = OUTPUT_TYPE_P2SH_SEGWIT;
+                g_change_type = ParseOutputType(gArgs.GetArg("-changetype", ""), g_address_type);
+            }
+            break;
+        case AddressTypeBech32:
+            if (value.toBool()) {
+                settings.setValue("strAddressType", QString::fromStdString(FormatOutputType(OUTPUT_TYPE_BECH32)));
+                g_address_type = OUTPUT_TYPE_BECH32;
+                g_change_type = ParseOutputType(gArgs.GetArg("-changetype", ""), g_address_type);
             }
             break;
 #endif

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_OPTIONSMODEL_H
 
 #include <amount.h>
+#include <wallet/wallet.h>
 
 #include <QAbstractListModel>
 
@@ -52,6 +53,9 @@ public:
         ThreadsScriptVerif,     // int
         DatabaseCache,          // int
         SpendZeroConfChange,    // bool
+        AddressTypeLegacy,      // bool
+        AddressTypeP2SHSegWit,  // bool
+        AddressTypeBech32,      // bool
         Listen,                 // bool
         OptionIDRowCount,
     };


### PR DESCRIPTION
Related PR #11403, needs to be merged first. I'll rebase this PR to be up to date with #11403, and rebase it to master once it has been merged.

Exposes the `addresstype` parameter through the GUI.
Currently directly changes the `g_address_type` global variable instead of requiring an application restart, I'm not sure if this is good practice, but could easily be changed if needed.

Radio buttons seem to be acting a bit different compared to other GUI elements, so that's why the code is somewhat different than for other settings.