### PR TITLE
Update build-windows.md

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -91,6 +91,7 @@ Ubuntu Xenial 16.04 and Windows Subsystem for Linux <sup>[1](#footnote1),[2](#fo
     sudo apt update
     sudo apt upgrade
     sudo update-alternatives --config x86_64-w64-mingw32-g++ # Set the default mingw32 g++ compiler option to posix.
+    sudo apt install protobuf-compiler
 
 Ubuntu Zesty 17.04 <sup>[2](#footnote2)</sup>:
 


### PR DESCRIPTION
On a fresh and fully updated install of Ubuntu 16.04 LTS, and exactly following the outlined installation instruction for win64bit, in step "make":
  CXX      qt/qt_bitcoin_qt-bitcoin.o   error: #error This file was generated by a newer version of protoc 
fatal error: google/protobuf/arena.h: No such file or directory #include <google/protobuf/arena.h>
Is caused by missing protobuf-compiler:
Geert@Linux: protoc --version
The program 'protoc' is currently not installed. You can install it by typing: sudo apt install protobuf-compiler

I can't reproduce the bug mentioned in footnote 1. The compiled bitcoin-cli.exe bitcoind.exe bitcoin-rpc.exe and bitcoin-qt.exe passed a 2 hour test on my fresh install of windows7-64bit. 

Thank you for building x-platform !