### PR TITLE
contrib: fix typo in install_db4.sh help message

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -7,7 +7,7 @@ set -e
 if [ -z "${1}" ]; then
   echo "Usage: ./install_db4.sh <base-dir> [<extra-bdb-configure-flag> ...]"
   echo
-  echo "Must specify a single argument: the directory in which db5 will be built."
+  echo "Must specify a single argument: the directory in which db4 will be built."
   echo "This is probably \`pwd\` if you're at the root of the bitcoin repository."
   exit 1
 fi


### PR DESCRIPTION
It installs db4, not db5.