### PR TITLE
Improve BSD compatibility of contrib/install_db4.sh

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -17,7 +17,6 @@ expand_path() {
 }
 
 BDB_PREFIX="$(expand_path ${1})/db4"; shift;
-BDB_EXTRA_CONFIGURE_FLAGS="${@}"
 BDB_VERSION='db-4.8.30.NC'
 BDB_HASH='12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef'
 BDB_URL="https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz"
@@ -70,7 +69,7 @@ cd build_unix/
 
 "${BDB_PREFIX}/${BDB_VERSION}/dist/configure" \
   --enable-cxx --disable-shared --with-pic --prefix="${BDB_PREFIX}" \
-  "${BDB_EXTRA_CONFIGURE_FLAGS}"
+  "${@}"
 
 make install
 

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -31,7 +31,11 @@ sha256_check() {
   if check_exists sha256sum; then
     echo "${1}  ${2}" | sha256sum -c
   elif check_exists sha256; then
-    echo "${1}  ${2}" | sha256 -c
+    if [ "$(uname)" = "FreeBSD" ]; then
+      sha256 -c "${1}" "${2}"
+    else
+      echo "${1}  ${2}" | sha256 -c
+    fi
   else
     echo "${1}  ${2}" | shasum -a 256 -c
   fi

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -60,15 +60,11 @@ http_get "${BDB_URL}" "${BDB_VERSION}.tar.gz" "${BDB_HASH}"
 tar -xzvf ${BDB_VERSION}.tar.gz -C "$BDB_PREFIX"
 cd "${BDB_PREFIX}/${BDB_VERSION}/"
 
-# Apply a patch when building on OS X to make the build work with Xcode.
-#
-if [ "$(uname)" = "Darwin" ]; then
-  BDB_OSX_ATOMIC_PATCH_URL='https://raw.githubusercontent.com/narkoleptik/os-x-berkeleydb-patch/0007e2846ae3fc9757849f5277018f4179ad17ef/atomic.patch'
-  BDB_OSX_ATOMIC_PATCH_HASH='ba0e2b4f53e9cb0ec58f60a979b53b8567b4565f0384886196f1fc1ef111d151'
-
-  http_get "${BDB_OSX_ATOMIC_PATCH_URL}" atomic.patch "${BDB_OSX_ATOMIC_PATCH_HASH}"
-  patch -p1 < atomic.patch
-fi
+# Apply a patch necessary when building with clang and c++11 (see https://community.oracle.com/thread/3952592)
+CLANG_CXX11_PATCH_URL='https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/clang.patch'
+CLANG_CXX11_PATCH_HASH='7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c'
+http_get "${CLANG_CXX11_PATCH_URL}" clang.patch "${CLANG_CXX11_PATCH_HASH}"
+patch -p2 < clang.patch
 
 cd build_unix/
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -312,17 +312,13 @@ You need to use GNU make (`gmake`) instead of `make`.
 
 For the wallet (optional):
 
-    pkg install db5
-
-This will give a warning "configure: WARNING: Found Berkeley DB other
-than 4.8; wallets opened by this build will not be portable!", but as FreeBSD never
-had a binary release, this may not matter. If backwards compatibility
-with 4.8-built Bitcoin Core is needed follow the steps under "Berkeley DB" above.
+    ./contrib/install_db4.sh `pwd`
+    setenv BDB_PREFIX $PWD/db4
 
 Then build using:
 
     ./autogen.sh
-    ./configure --with-incompatible-bdb BDB_CFLAGS="-I/usr/local/include/db5" BDB_LIBS="-L/usr/local/lib -ldb_cxx-5"
+    ./configure BDB_CFLAGS="-I${BDB_PREFIX}/include" BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx"
     gmake
 
 *Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).


### PR DESCRIPTION
This PR improves the BSD compatibility of the bdb4 installer script.

See #11921, #11868.

I've tested this on OpenBSD 6.2 (clang) and Ubuntu 16.04 (gcc).

This needs testing on OSX at least, ~~and on gcc/Linux to make sure that applying the patch unconditionally doesn't negatively affect gcc~~.

~~NB: this is not yet sufficient to make `install_db4.sh` work on FreeBSD, as we need to use yet another `sha256` tool there. But it's a step in the right direction.~~

### contrib: New clang patch for install_db4

Replace the clang patch with a new and improved version that also fixes the build issues with OpenBSD and FreeBSD's clang, and apply it unconditionally.

Thanks to @fanquake for finding the patch.

### contrib: Make X=Y arguments work in install_db4

Trailing X=Y arguments are supposed to be passed through unchanged to bdb's configure. This was not the case, at least with OpenBSD 6.2's shell.

Fix this by not storing the arguments in a temporary variable but passing "$@" through directly.

### contrib: FreeBSD compatibility in install_db4.sh

Unfortunately, FreeBSD uses yet another syntax for `sha256`.

Support FreeBSD's syntax too. Using `uname` is a bit of a hack but it works and I found no way to distinguish the two.
