### PR TITLE
clientversion: Use full commit hash for commit-based version descriptions

### DIFF
--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -44,7 +44,7 @@ const std::string CLIENT_NAME("Satoshi");
 
 //! git will put "#define GIT_ARCHIVE 1" on the next line inside archives. $Format:%n#define GIT_ARCHIVE 1$
 #ifdef GIT_ARCHIVE
-#define GIT_COMMIT_ID "$Format:%h$"
+#define GIT_COMMIT_ID "$Format:%H$"
 #define GIT_COMMIT_DATE "$Format:%cD$"
 #endif
 


### PR DESCRIPTION
git keeps changing the number of digits in abbreviated hashes, resulting in the GitHub archive hash changing because we include it here.
To workaround this and avoid hashes that become increasingly ambiguous later on, just include the full commit hash when building from git.
This has no effect on tagged releases.

(Cleanly mergable back to 0.10 without backport)