### PR TITLE
Fix gitian build after libzmq bump

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -29,5 +29,6 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  sed -i.old "s/ -lstdc++//" lib/pkgconfig/libzmq.pc && \
   rm -rf bin share
 endef


### PR DESCRIPTION
Broken gitian builds were introduced with #9254. Big thanks to @jonasschnelli for narrowing down the bisection.

This is broken for a number of reasons, including:
- g++ understands "-static-libstdc++ -lstdc++" to mean "link against whatever libstdc++ exists, probably shared", which in itself is buggy.
- another stdlib (libc++ for example) may be in use