### PR TITLE
[depends] zeromq 4.2.3

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.2.2
+$(package)_version=4.2.3
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b
+$(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0
 $(package)_patches=0001-fix-build-with-older-mingw64.patch
 
 define $(package)_set_vars

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -3,7 +3,7 @@ $(package)_version=4.2.3
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0
-$(package)_patches=0001-fix-build-with-older-mingw64.patch
+$(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-docs --disable-shared --without-libsodium --disable-curve --disable-curve-keygen --disable-perf
@@ -13,7 +13,7 @@ endef
 
 define $(package)_preprocess_cmds
    patch -p1 < $($(package)_patch_dir)/0001-fix-build-with-older-mingw64.patch && \
-  ./autogen.sh
+   patch -p1 < $($(package)_patch_dir)/0002-disable-pthread_set_name_np.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,0 +1,35 @@
+From 6e6b47d5ab381c3df3b30bb0b0a6cf210dfb1eba Mon Sep 17 00:00:00 2001
+From: Cory Fields <cory-nospam-@coryfields.com>
+Date: Mon, 5 Mar 2018 14:22:05 -0500
+Subject: [PATCH] disable pthread_set_name_np
+
+pthread_set_name_np adds a Glibc requirement on >= 2.12.
+---
+ src/thread.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index 4fc59c3e..c3fdfd46 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -220,7 +220,7 @@ void zmq::thread_t::setThreadName(const char *name_)
+  */
+     if (!name_)
+         return;
+-
++#if 0
+ #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
+     int rc = pthread_setname_np(name_);
+     if(rc) return;
+@@ -233,6 +233,8 @@ void zmq::thread_t::setThreadName(const char *name_)
+ #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
+     pthread_set_name_np(descriptor, name_);
+ #endif
++#endif
++    return;
+ }
+ 
+ #endif
+-- 
+2.11.1
+

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -27,5 +27,5 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | Qt | [5.7.1](https://download.qt.io/official_releases/qt/) | 4.7+ | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L94) (Linux only) |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L93) (Linux only) |
-| ZeroMQ | [4.2.2](https://github.com/zeromq/libzmq/releases) |  | No |  |  |
+| ZeroMQ | [4.2.3](https://github.com/zeromq/libzmq/releases) |  | No |  |  |
 | zlib | [1.2.11](http://zlib.net/) |  |  |  | No |


### PR DESCRIPTION
This is a followup to #9254 and #11981. Zeromq 4.2.3 was released just after #9254 was merged, and contains a years worth of improvements/bug fixes. See the release notes [here](https://github.com/zeromq/libzmq/releases/tag/v4.2.3).

Todo:
- [ ] Add zeromq-4.2.3.tar.gz to /depends-sources on bitcoincore.org
- [ ] Verify gitian builds are still OK
- [ ] Check: https://github.com/zeromq/libzmq/pull/2787