### PR TITLE
Docs: tweak the OSX build instructions

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -69,7 +69,7 @@ Build Bitcoin Core
     as well as the GUI (if Qt is found).
     You can disable the GUI build by passing `--without-gui` to `./configure`,
     and you can disable the wallet with `--disable-wallet`.
-    The defaut `--prefix` is `/usr/local`.
+    The default `--prefix` is `/usr/local`.
     Check the other options with `./configure --help`.
 
         ./autogen.sh
@@ -82,11 +82,11 @@ Build Bitcoin Core
 
 4.  Install the compiled software:
 
-	sudo make install
+        sudo make install
 
 5.  You can also create a .dmg that contains the .app bundle (optional):
 
-	sudo port install librsvg
+        sudo port install librsvg
         make deploy
 
 Running

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,5 +1,10 @@
 Mac OS X Build Instructions and Notes
 ====================================
+
+Note that Bitcoin Core up to 0.15.1 is available as a MacOS package
+and Bitcoin Core 0.14.1 is present in [MacPorts](https://www.macports.org).
+These instructions are for those who _want_ to build from source.
+
 The commands in this guide should be executed in a Terminal application.
 The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
@@ -11,34 +16,44 @@ Install the OS X command line tools:
 
 When the popup appears, click `Install`.
 
-Then install [Homebrew](https://brew.sh).
-
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf python3 qt libevent
-
+There are several dependencies that need to be installed
+before you try to build Bitcoin Core itself.
 See [dependencies.md](dependencies.md) for a complete overview.
+If you want to build the disk image with `make deploy`,
+you will also need RSVG (librsvg).
 
-If you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
+You might want to use one of the packaging systems
+available for MacOS, such as
+[MacPorts](https://www.macports.org),
+[Homebrew](https://brew.sh) or
+[Fink](http://www.finkproject.org).
+to install these dependencies.
 
-    brew install librsvg
+For example, this is how you would install the required packages
+with MacPort's `port` and Homebrew's `brew`, respectively:
 
-NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
+```shell
+sudo port install autoconf automake db48 libtool boost miniupnpc openssl pkgconfig protobuf-cpp python36 qt5 libevent zmq
+```
+
+```shell
+brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf python3 qt libevent
+```
+
+**Note**: Building with Qt4 is still supported, however,
+could result in a broken UI. Building with Qt5 is recommended.
 
 Berkeley DB
 -----------
-It is recommended to use Berkeley DB 4.8. If you have to build it yourself,
-you can use [the installation script included in contrib/](/contrib/install_db4.sh)
-like so
+It is recommended to use Berkeley DB 4.8.
+If you have to build it yourself, you can use
+[the installation script included in contrib/](/contrib/install_db4.sh).
+Run `./contrib/install_db4.sh` from the root of the repository.
 
-```shell
-./contrib/install_db4.sh .
-```
-
-from the root of the repository.
-
-**Note**: You only need Berkeley DB if the wallet is enabled (see the section *Disable-Wallet mode* below).
+**Note**: You only need Berkeley DB if the wallet is enabled.
 
 Build Bitcoin Core
 ------------------------
@@ -50,9 +65,12 @@ Build Bitcoin Core
 
 2.  Build bitcoin-core:
 
-    Configure and build the headless bitcoin binaries as well as the GUI (if Qt is found).
-
-    You can disable the GUI build by passing `--without-gui` to configure.
+    Configure and build the headless bitcoin binaries
+    as well as the GUI (if Qt is found).
+    You can disable the GUI build by passing `--without-gui` to `./configure`,
+    and you can disable the wallet with `--disable-wallet`.
+    The defaut `--prefix` is `/usr/local`.
+    Check the other options with `./configure --help`.
 
         ./autogen.sh
         ./configure
@@ -62,24 +80,33 @@ Build Bitcoin Core
 
         make check
 
-4.  You can also create a .dmg that contains the .app bundle (optional):
+4.  Install the compiled software:
 
+	sudo make install
+
+5.  You can also create a .dmg that contains the .app bundle (optional):
+
+	sudo port install librsvg
         make deploy
 
 Running
 -------
 
-Bitcoin Core is now available at `./src/bitcoind`
-
+Bitcoin Core is now available as `bitcoind`.
 Before running, it's recommended you create an RPC configuration file.
+in `${HOME}/Library/Application Support/Bitcoin/bitcoin.conf`
+(remember to `chmod 600` the file) containing
 
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+```
+rpcuser=bitcoinrpc
+rpcpassword=PASSWORD
+```
 
-    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+You can get a good password by running e.g. `xxd -l 16 -p /dev/random`.
 
-The first time you run bitcoind, it will start downloading the blockchain. This process could take several hours.
-
-You can monitor the download process by looking at the debug.log file:
+The first time you run bitcoind, it will start downloading the blockchain.
+This process could take several hours or days. You can monitor the download
+process by looking at the debug.log file:
 
     tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 
@@ -96,7 +123,7 @@ You can use Qt Creator as an IDE, for bitcoin development.
 Download and install the community edition of [Qt Creator](https://www.qt.io/download/).
 Uncheck everything except Qt Creator during the installation process.
 
-1. Make sure you installed everything through Homebrew mentioned above
+1. Make sure you installed the dependencies mentioned above
 2. Do a proper ./configure --enable-debug
 3. In Qt Creator do "New Project" -> Import Project -> Import Existing Project
 4. Enter "bitcoin-qt" as project name, enter src/qt as location


### PR DESCRIPTION
This is a revision of doc/build-osx.md, tested on 10.13.2

* Don't dictate Homebrew, mention also MacPorts and Fink
* Drop a link to a nonexistent section
* Mention `./configre --prefix`,  `--disable-wallet` and  `--without-gui`
* Include `make install`
* Fix the `bitcoin.conf` instructions (the directory doesn't exist yet)