### PR TITLE
[build] .gitignore: add QT Creator artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,12 @@ src/qt/forms/ui_*.h
 
 src/qt/test/moc*.cpp
 
+src/qt/bitcoin-qt.config
+src/qt/bitcoin-qt.creator
+src/qt/bitcoin-qt.creator.user
+src/qt/bitcoin-qt.files
+src/qt/bitcoin-qt.includes
+
 .deps
 .dirstamp
 .libs


### PR DESCRIPTION
These files appear on OSX if you follow the [QT Creator instructions](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md#using-qt-creator-as-ide).

The files don't contain anything terribly useful that might warrant including them in the repo instead.