### PR TITLE
[RPC] Adding ::minRelayTxFee amount to getmempoolinfo and updating help

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1358,6 +1358,7 @@ UniValue mempoolInfoToJSON()
     size_t maxmempool = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.push_back(Pair("maxmempool", (int64_t) maxmempool));
     ret.push_back(Pair("mempoolminfee", ValueFromAmount(std::max(mempool.GetMinFee(maxmempool), ::minRelayTxFee).GetFeePerK())));
+    ret.push_back(Pair("minrelaytxfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
 
     return ret;
 }
@@ -1374,7 +1375,8 @@ UniValue getmempoolinfo(const JSONRPCRequest& request)
             "  \"bytes\": xxxxx,              (numeric) Sum of all virtual transaction sizes as defined in BIP 141. Differs from actual serialized size because witness data is discounted\n"
             "  \"usage\": xxxxx,              (numeric) Total memory usage for the mempool\n"
             "  \"maxmempool\": xxxxx,         (numeric) Maximum memory usage for the mempool\n"
-            "  \"mempoolminfee\": xxxxx       (numeric) Minimum fee rate in " + CURRENCY_UNIT + "/kB for tx to be accepted\n"
+            "  \"mempoolminfee\": xxxxx       (numeric) Minimum fee rate in " + CURRENCY_UNIT + "/kB for tx to be accepted. Is the maximum of minrelaytxfee and minimum mempool fee\n"
+            "  \"minrelaytxfee\": xxxxx       (numeric) Current minimum relay fee for transactions\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmempoolinfo", "")

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -17,10 +17,14 @@ class MempoolLimitTest(BitcoinTestFramework):
         txouts = gen_return_txouts()
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
+        self.log.info('Check that mempoolminfee is minrelytxfee')
+        assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
+        assert_equal(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
+
         txids = []
         utxos = create_confirmed_utxos(relayfee, self.nodes[0], 91)
 
-        #create a mempool tx that will be evicted
+        self.log.info('Create a mempool tx that will be evicted')
         us0 = utxos.pop()
         inputs = [{ "txid" : us0["txid"], "vout" : us0["vout"]}]
         outputs = {self.nodes[0].getnewaddress() : 0.0001}
@@ -37,10 +41,14 @@ class MempoolLimitTest(BitcoinTestFramework):
             txids.append([])
             txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
 
-        # by now, the tx should be evicted, check confirmation state
+        self.log.info('The tx should be evicted by now')
         assert(txid not in self.nodes[0].getrawmempool())
         txdata = self.nodes[0].gettransaction(txid)
         assert(txdata['confirmations'] ==  0) #confirmation should still be 0
+
+        self.log.info('Check that mempoolminfee is larger than minrelytxfee')
+        assert_equal(self.nodes[0].getmempoolinfo()['minrelaytxfee'], Decimal('0.00001000'))
+        assert_greater_than(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
 
 if __name__ == '__main__':
     MempoolLimitTest().main()

--- a/test/functional/wallet.py
+++ b/test/functional/wallet.py
@@ -33,9 +33,6 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(len(self.nodes[1].listunspent()), 0)
         assert_equal(len(self.nodes[2].listunspent()), 0)
 
-        self.log.info("Check for mempoolminfee in getmempoolinfo")
-        assert_equal(self.nodes[0].getmempoolinfo()['mempoolminfee'], Decimal('0.00001000'))
-
         self.log.info("Mining blocks...")
 
         self.nodes[0].generate(1)


### PR DESCRIPTION
These are RPC document changes from #11475 which is now merged.  Took into consideration comments from #11475 and #6941 for this PR.

Biggest change here is when calling `getmempoolinfo`, will now show the `minrelaytxfee` in the JSON reponse (see below):

```
$ bitcoin-cli getmempoolinfo
{
  "size": 50,
  "bytes": 13102,
  "usage": 70480,
  "maxmempool": 300000000,
  "mempoolminfee": 0.00001000,
  "minrelaytxfee": 0.00001000
}
```

Fixes #8953