### PR TITLE
update the OpenBSD build guide

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -60,7 +60,7 @@ http_get() {
 
 mkdir -p "${BDB_PREFIX}"
 http_get "${BDB_URL}" "${BDB_VERSION}.tar.gz" "${BDB_HASH}"
-tar -xzvf ${BDB_VERSION}.tar.gz -C "$BDB_PREFIX"
+tar xzf ${BDB_VERSION}.tar.gz -C "$BDB_PREFIX"
 cd "${BDB_PREFIX}/${BDB_VERSION}/"
 
 # Apply a patch necessary when building with clang and c++11 (see https://community.oracle.com/thread/3952592)
@@ -71,16 +71,14 @@ patch -p2 < clang.patch
 
 cd build_unix/
 
-"${BDB_PREFIX}/${BDB_VERSION}/dist/configure" \
-  --enable-cxx --disable-shared --with-pic --prefix="${BDB_PREFIX}" \
-  "${@}"
+${BDB_PREFIX}/${BDB_VERSION}/dist/configure				\
+  --prefix=${BDB_PREFIX} --with-pic --enable-cxx --enable-smallbuild	\
+  --disable-shared --disable-java --disable-mingw --disable-tcl		\
+  ${@}
 
 make install
 
 echo
-echo "db4 build complete."
-echo
-echo 'When compiling bitcoind, run `./configure` in the following way:'
-echo
-echo "  export BDB_PREFIX='${BDB_PREFIX}'"
-echo '  ./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" ...'
+echo DB ${BDB_VERSION} build complete
+echo Add the following to ./configure when building bitcoin:
+echo LDFLAGS=-L${BDB_PREFIX}/lib/ CPPFLAGS=-I${BDB_PREFIX}/include/

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -46,10 +46,12 @@ http_get() {
     echo "File ${2} already exists; not downloading again"
   elif check_exists curl; then
     curl --insecure "${1}" -o "${2}"
-  else
+  elif check_exists wget; then
     wget --no-check-certificate "${1}" -O "${2}"
+  elif check_exists ftp; then
+    ftp -o "${2}" "${1}"
   fi
-
+  test $? -eq 0 || err Cannot download ${1}
   sha256_check "${3}" "${2}"
 }
 

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -1,25 +1,20 @@
 #!/bin/sh
 
-# Install libdb4.8 (Berkeley DB).
+# This script downloads, patches, configures and builds Berkeley DB 4.8
+# and installes it in a given directory. This enables Bitcoin Core
+# to be built with --enable-wallet
 
 set -e
 
-if [ -z "${1}" ]; then
-  echo "Usage: ./install_db4.sh <base-dir> [<extra-bdb-configure-flag> ...]"
-  echo
-  echo "Must specify a single argument: the directory in which db4 will be built."
-  echo "This is probably \`pwd\` if you're at the root of the bitcoin repository."
-  exit 1
-fi
+DBVERS="db-4.8.30.NC"
+DBFILE="$DBVERS.tar.gz"
+DBPAGE="http://download.oracle.com/berkeley-db/$DBFILE"
+DBHASH='12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef'
 
-expand_path() {
-  echo "$(cd "${1}" && pwd -P)"
+err() {
+	echo $@ >&2
+	exit 1
 }
-
-BDB_PREFIX="$(expand_path ${1})/db4"; shift;
-BDB_VERSION='db-4.8.30.NC'
-BDB_HASH='12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef'
-BDB_URL="https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz"
 
 check_exists() {
   which "$1" >/dev/null 2>&1
@@ -58,27 +53,34 @@ http_get() {
   sha256_check "${3}" "${2}"
 }
 
-mkdir -p "${BDB_PREFIX}"
-http_get "${BDB_URL}" "${BDB_VERSION}.tar.gz" "${BDB_HASH}"
-tar xzf ${BDB_VERSION}.tar.gz -C "$BDB_PREFIX"
-cd "${BDB_PREFIX}/${BDB_VERSION}/"
+if [ -z "${1}" ]; then
+  echo "usage: $0 <prefix> [args]"
+  echo "<prefix> is a directory where DB will be installed"
+  echo "Any further arguments will be passed to DB's ./configure"
+  exit 1
+fi
+
+DBHOME="`readlink -f $1`"
+mkdir -p $DBHOME || err Cannot create $DBHOME ; shift
+http_get $DBPAGE $DBFILE $DBHASH || err $DBFILE hash incorrect
+tar xzf $DBFILE -C $DBHOME || err "Cannot untar $DBFILE in $DBHOME"
+cd $DBHOME/$DBVERS || err Cannot chdir to $DBHOME/$DBVERS
 
 # Apply a patch necessary when building with clang and c++11 (see https://community.oracle.com/thread/3952592)
 CLANG_CXX11_PATCH_URL='https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/clang.patch'
 CLANG_CXX11_PATCH_HASH='7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c'
 http_get "${CLANG_CXX11_PATCH_URL}" clang.patch "${CLANG_CXX11_PATCH_HASH}"
-patch -p2 < clang.patch
+patch -p2 < clang.patch || err Cannot apply clang patch
 
-cd build_unix/
-
-${BDB_PREFIX}/${BDB_VERSION}/dist/configure				\
-  --prefix=${BDB_PREFIX} --with-pic --enable-cxx --enable-smallbuild	\
+cd build_unix && ../dist/configure					\
+  --prefix=${DBHOME} --with-pic --enable-cxx --enable-smallbuild	\
   --disable-shared --disable-java --disable-mingw --disable-tcl		\
   ${@}
 
-make install
+test $? -eq 0 || err "Cannot configure in `pwd`"
+make install  || err "Cannot make insatll failed in `pwd`"
 
 echo
-echo DB ${BDB_VERSION} build complete
+echo Build of $DBVERS finished
 echo Add the following to ./configure when building bitcoin:
-echo LDFLAGS=-L${BDB_PREFIX}/lib/ CPPFLAGS=-I${BDB_PREFIX}/include/
+echo LDFLAGS=-L$DBHOME/lib/ CPPFLAGS=-I$DBHOME/include/

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -84,12 +84,6 @@ env AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.15 ./autogen.sh
 ./configure --prefix=$HOME --with-mandir=$HOME/man --disable-ccache --disable-silent-rules --disable-upnp-default --enable-tests --disable-bench --disable-hardening --disable-reduce-exports --disable-glibc-back-compat --disable-experimental-asm --disable-zmq --enable-man --disable-debug --enable-werror --enable-largefile --without-miniupnpc --without-system-univalue --with-utils --with-libs --with-daemon --with-gui=no --disable-wallet CC=egcc CXX=eg++ CPP=ecpp
 ```
 
-/*
-FIXME muniupnpc, protobuf, and zmq do not seem to be required.
-We explictily disable --without-miniupnpc and --disable-zmq  for now.
-There is no --option for protobuf; it gets picked up when present.
-*/
-
 To configure with wallet, replace `--enable-wallet=no` with `--enable-wallet`
 and add the following to the `./configure` line:
 
@@ -98,11 +92,6 @@ BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
 Edit `BDB_PREFIX` to the path where your BDB 4.8 is installed.
-
-/*
-FIXME: doesn't configure pick the db package (4.6) anyway,
-if present in /usr/local, which comes first in both -I and -L?
-*/
 
 ## Build Bitcoin Core
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,106 +1,134 @@
 OpenBSD build guide
-======================
-(updated for OpenBSD 6.2)
+===================
 
-This guide describes how to build bitcoind and command-line utilities on OpenBSD.
+This guide describes how to build Bitcoin Core on OpenBSD.
+It has been tested on OpenBSD-current/amd64 as of Dec 25, 2017.
 
-OpenBSD is most commonly used as a server OS, so this guide does not contain instructions for building the GUI.
+### Preparations
 
-Preparation
--------------
+The compiler
+------------
 
-Run the following as root to install the base dependencies for building:
-
-```bash
-pkg_add git gmake libevent libtool
-pkg_add autoconf # (select highest version, e.g. 2.69)
-pkg_add automake # (select highest version, e.g. 1.15)
-pkg_add python # (select highest version, e.g. 3.6)
-pkg_add boost
-
-git clone https://github.com/bitcoin/bitcoin.git
-```
-
-See [dependencies.md](dependencies.md) for a complete overview.
-
-GCC
--------
-
-The default C++ compiler that comes with OpenBSD 6.2 is g++ 4.2.1. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core because it has no C++11 support. We'll install a newer version of GCC:
-
-```bash
- pkg_add g++
- ```
-
- This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
-
-### Building BerkeleyDB
-
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`.
-
-It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
-from ports, for the same reason as boost above (g++/libstd++ incompatibility).
-If you have to build it yourself, you can use [the installation script included
-in contrib/](contrib/install_db4.sh) like so
+On some platforms, the system compiler that comes with OpenBSD is clang 5.0.0,
+which compiles C++11 just fine. On these system, `c++` is `clang++`
 
 ```shell
+$ ls -li /usr/bin/c++ /usr/bin/clang++
+32869 -r-xr-xr-x  6 root  bin  42331608 Dec 18 18:55 /usr/bin/c++
+32869 -r-xr-xr-x  6 root  bin  42331608 Dec 18 18:55 /usr/bin/clang++
+```
+
+but `g++` might still be the old GCC:
+
+```shell
+$ g++ -v
+Reading specs from /usr/lib/gcc-lib/amd64-unknown-openbsd6.2/4.2.1/specs
+Target: amd64-unknown-openbsd6.2
+Configured with: OpenBSD/amd64 system compiler
+Thread model: posix
+gcc version 4.2.1 20070719
+```
+
+On other platforms, the system compiler is GCC 4.2.1 which is not able to compile
+the current version of Bitcoin Core, as it has no C++11 support.
+In that case (find out with `c++ -v`), you need to install a newer compiler
+with `pkg_add -i g++`. This compiler does not overwrite the system compiler,
+it gets installed as `egcc` and `eg++` in `/usr/local/bin`.
+Similarly, you can install clang with `pkg_add -i llvm`.
+
+/*
+Resource limits
+---------------
+
+The ulimit restrictions in OpenBSD on some platfroms
+can be too restrictive to compile some `.cpp` files in the project,
+at least with GCC 4.9.4 (see issue
+[#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
+
+Check the `datasize-cur` and `datasize-max` restrictions in `/etc/login.conf`
+for your login group. Note that you will need to re-login for the change to take effect.
+*/
+
+Dependencies
+------------
+
+Run the following as root to install the dependencies:
+Note that the OpenBSD package of Berkeley DB is version 4.6,
+while Bitcoin Core requires version 4.8 to build the wallet.
+
+```shell
+# pkg_add -i autoconf automake libtool  # select highest version
+# pkg_add boost libevent                # required libraries
+# pkg_add gmake python                  # required build tools
+# pkg_add qt5                           # needed for the GUI
+# pkg_add git
+```
+
+BerkeleyDB
+----------
+
+BerkeleyDB is only needed for the wallet functionality.
+This can be disabled with `./configure --disable-wallet`.
+
+It is recommended to use Berkeley DB 4.8.
+As mentioned above, the OpenBSD ports only have version 4.6
+If you have to build it yourself, you can use
+[the installation script included in contrib/](contrib/install_db4.sh):
+
+```
 ./contrib/install_db4.sh `pwd` CC=egcc CXX=eg++ CPP=ecpp
 ```
 
-from the root of the repository.
+The source
+----------
 
-### Resource limits
+Clone the Bitcoin Core github repository:
 
-The standard ulimit restrictions in OpenBSD are very strict:
-
-    data(kbytes)         1572864
-
-This, unfortunately, may no longer be enough to compile some `.cpp` files in the project,
-at least with GCC 4.9.4 (see issue [#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
-If your user is in the `staff` group the limit can be raised with:
-
-    ulimit -d 3000000
-
-The change will only affect the current shell and processes spawned by it. To
-make the change system-wide, change `datasize-cur` and `datasize-max` in
-`/etc/login.conf`, and reboot.
-
-### Building Bitcoin Core
-
-**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
-
-Preparation:
-```bash
-export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you installed
-export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
-./autogen.sh
 ```
-Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
-
-To configure with wallet:
-```bash
-./configure --with-gui=no CC=egcc CXX=eg++ CPP=ecpp \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+$ mkdir -p ~/src && cd ~/src
+$ git clone https://github.com/bitcoin/bitcoin.git
 ```
 
-To configure without wallet:
-```bash
-./configure --disable-wallet --with-gui=no CC=egcc CXX=eg++ CPP=ecpp
+### Configure Bitcoin Core
+
+As a start, this configures Bitcoin Core without the wallet and without GUI.
+Make sure to point `CXX` and friends to your C++11 capable compiler.
+Note that you might need to specify `CC=cc CXX=c++` even on clang systems,
+because `./configure` will autodetect `gcc` and `g++` (which is the old 4.2.1)
+before `cc` and `c++` (which is clang).
+
+```
+env AUTOCONF_VERSION=2.69 AUTOMAKE_VERSION=1.15 ./autogen.sh
+./configure --prefix=$HOME --with-mandir=$HOME/man --disable-ccache --disable-silent-rules --disable-upnp-default --enable-tests --disable-bench --disable-hardening --disable-reduce-exports --disable-glibc-back-compat --disable-experimental-asm --disable-zmq --enable-man --disable-debug --enable-werror --enable-largefile --without-miniupnpc --without-system-univalue --with-utils --with-libs --with-daemon --with-gui=no --disable-wallet CC=egcc CXX=eg++ CPP=ecpp
 ```
 
-Build and run the tests:
-```bash
-gmake # use -jX here for parallelism
-gmake check
+/*
+FIXME muniupnpc, protobuf, and zmq do not seem to be required.
+We explictily disable --without-miniupnpc and --disable-zmq  for now.
+There is no --option for protobuf; it gets picked up when present.
+*/
+
+To configure with wallet, replace `--enable-wallet=no` with `--enable-wallet`
+and add the following to the `./configure` line:
+
+```
+BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
-Clang
-------------------------------
+Edit `BDB_PREFIX` to the path where your BDB 4.8 is installed.
 
-```bash
-pkg_add llvm
+/*
+FIXME: doesn't configure pick the db package (4.6) anyway,
+if present in /usr/local, which comes first in both -I and -L?
+*/
 
-./configure --disable-wallet --with-gui=no CC=clang CXX=clang++
-gmake # use -jX here for parallelism
-gmake check
+### Build Bitcoin Core
+
+The Makefiles used by Bitcoin Core need to be processed with GNU make,
+not with the standard BSD make. Make sure to use `gmake`, not `make`.
+
+```
+gmake		# build Bitcoin Core
+gmake check	# run the tests
+gmake install
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,11 +1,11 @@
-#### OpenBSD build guide
+# OpenBSD build guide
 
 This guide describes how to build Bitcoin Core on OpenBSD.
 It has been tested on OpenBSD-current/amd64 as of Dec 25, 2017.
 
-### Preparations
+## Preparations
 
-## The compiler
+### The compiler
 
 On some platforms, the system compiler that comes with OpenBSD is clang 5.0.0,
 which compiles C++11 just fine. On these system, `c++` is `clang++`
@@ -34,19 +34,7 @@ with `pkg_add -i g++`. This compiler does not overwrite the system compiler,
 it gets installed as `egcc` and `eg++` in `/usr/local/bin`.
 Similarly, you can install clang with `pkg_add -i llvm`.
 
-/*
-## Resource limits
-
-The ulimit restrictions in OpenBSD on some platfroms
-can be too restrictive to compile some `.cpp` files in the project,
-at least with GCC 4.9.4 (see issue
-[#6658](https://github.com/bitcoin/bitcoin/issues/6658)).
-
-Check the `datasize-cur` and `datasize-max` restrictions in `/etc/login.conf`
-for your login group. Note that you will need to re-login for the change to take effect.
-*/
-
-## Dependencies
+### Dependencies
 
 Run the following as root to install the dependencies:
 Note that the OpenBSD package of Berkeley DB is version 4.6,
@@ -60,7 +48,7 @@ while Bitcoin Core requires version 4.8 to build the wallet.
 # pkg_add git
 ```
 
-## BerkeleyDB
+### BerkeleyDB
 
 BerkeleyDB is only needed for the wallet functionality.
 This can be disabled with `./configure --disable-wallet`.
@@ -74,7 +62,7 @@ If you have to build it yourself, you can use
 ./contrib/install_db4.sh `pwd` CC=egcc CXX=eg++ CPP=ecpp
 ```
 
-## The source
+### The source
 
 Clone the Bitcoin Core github repository:
 
@@ -83,7 +71,7 @@ $ mkdir -p ~/src && cd ~/src
 $ git clone https://github.com/bitcoin/bitcoin.git
 ```
 
-### Configure Bitcoin Core
+## Configure Bitcoin Core
 
 As a start, this configures Bitcoin Core without the wallet and without GUI.
 Make sure to point `CXX` and friends to your C++11 capable compiler.
@@ -116,7 +104,7 @@ FIXME: doesn't configure pick the db package (4.6) anyway,
 if present in /usr/local, which comes first in both -I and -L?
 */
 
-### Build Bitcoin Core
+## Build Bitcoin Core
 
 The Makefiles used by Bitcoin Core need to be processed with GNU make,
 not with the standard BSD make. Make sure to use `gmake`, not `make`.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -56,7 +56,7 @@ This can be disabled with `./configure --disable-wallet`.
 Bitcoin Core requires Berkeley DB 4.8,
 but the OpenBSD ports only have version 4.6.
 To help you build 4.8 yourself, you can use
-[the installation script included in contrib/](contrib/install_db4.sh):
+[the installation script included in contrib/](../contrib/install_db4.sh):
 
 ```
 ./contrib/install_db4.sh `pwd` CC=egcc CXX=eg++ CPP=ecpp

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -50,12 +50,12 @@ while Bitcoin Core requires version 4.8 to build the wallet.
 
 ### BerkeleyDB
 
-BerkeleyDB is only needed for the wallet functionality.
+BerkeleyDB is needed for the wallet functionality.
 This can be disabled with `./configure --disable-wallet`.
 
-It is recommended to use Berkeley DB 4.8.
-As mentioned above, the OpenBSD ports only have version 4.6
-If you have to build it yourself, you can use
+Bitcoin Core requires Berkeley DB 4.8,
+but the OpenBSD ports only have version 4.6.
+To help you build 4.8 yourself, you can use
 [the installation script included in contrib/](contrib/install_db4.sh):
 
 ```
@@ -88,10 +88,13 @@ To configure with wallet, replace `--enable-wallet=no` with `--enable-wallet`
 and add the following to the `./configure` line:
 
 ```
-BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+LDFLAGS="-L${DB}/lib/db4/" CPPFLAGS="-I${DB}/include/db4/"
 ```
 
-Edit `BDB_PREFIX` to the path where your BDB 4.8 is installed.
+where `DB` is the path where your DB 4.8 is installed.
+The `contrib/install_db4.sh` helper script reports
+the appropriate `./configure` arguments after it is done.
+
 
 ## Build Bitcoin Core
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -42,7 +42,7 @@ while Bitcoin Core requires version 4.8 to build the wallet.
 
 ```shell
 # pkg_add -i autoconf automake libtool  # select highest version
-# pkg_add boost libevent                # required libraries
+# pkg_add boost libevent protobuf       # required libraries
 # pkg_add gmake python                  # required build tools
 # pkg_add qt5                           # needed for the GUI
 # pkg_add git
@@ -94,7 +94,6 @@ LDFLAGS="-L$HOME/db/lib/" CPPFLAGS="-I$HOME/db/include"
 if `$HOME/db` is the path where you installed DB (as above).
 The `contrib/install_db4.sh` helper script reports
 the appropriate `./configure` arguments after it is done.
-
 
 ## Build Bitcoin Core
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -95,6 +95,10 @@ if `$HOME/db` is the path where you installed DB (as above).
 The `contrib/install_db4.sh` helper script reports
 the appropriate `./configure` arguments after it is done.
 
+To configure with GUI, replace `--with-gui=no` with `--with-gui=qt5`,
+add `-L/usr/X11R6/lib` to `./configure`'s `LDFLAGS` and
+add `-I/usr/X11R6/include` to `CPPFLAGS`.
+
 ## Build Bitcoin Core
 
 The Makefiles used by Bitcoin Core need to be processed with GNU make,
@@ -105,3 +109,6 @@ gmake		# build Bitcoin Core
 gmake check	# run the tests
 gmake install
 ```
+
+This will install `bitcoind`, `bitcoin-cli`, `bitcoin-tx`,
+and `bitcoin-qt` (if you have built the Qt GUI).

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -59,7 +59,7 @@ To help you build 4.8 yourself, you can use
 [the installation script included in contrib/](../contrib/install_db4.sh):
 
 ```
-./contrib/install_db4.sh `pwd` CC=egcc CXX=eg++ CPP=ecpp
+./contrib/install_db4.sh $HOME/db CC=egcc CXX=eg++ CPP=ecpp
 ```
 
 ### The source
@@ -88,10 +88,10 @@ To configure with wallet, replace `--enable-wallet=no` with `--enable-wallet`
 and add the following to the `./configure` line:
 
 ```
-LDFLAGS="-L${DB}/lib/db4/" CPPFLAGS="-I${DB}/include/db4/"
+LDFLAGS="-L$HOME/db/lib/" CPPFLAGS="-I$HOME/db/include"
 ```
 
-where `DB` is the path where your DB 4.8 is installed.
+if `$HOME/db` is the path where you installed DB (as above).
 The `contrib/install_db4.sh` helper script reports
 the appropriate `./configure` arguments after it is done.
 

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,13 +1,11 @@
-OpenBSD build guide
-===================
+#### OpenBSD build guide
 
 This guide describes how to build Bitcoin Core on OpenBSD.
 It has been tested on OpenBSD-current/amd64 as of Dec 25, 2017.
 
 ### Preparations
 
-The compiler
-------------
+## The compiler
 
 On some platforms, the system compiler that comes with OpenBSD is clang 5.0.0,
 which compiles C++11 just fine. On these system, `c++` is `clang++`
@@ -37,8 +35,7 @@ it gets installed as `egcc` and `eg++` in `/usr/local/bin`.
 Similarly, you can install clang with `pkg_add -i llvm`.
 
 /*
-Resource limits
----------------
+## Resource limits
 
 The ulimit restrictions in OpenBSD on some platfroms
 can be too restrictive to compile some `.cpp` files in the project,
@@ -49,8 +46,7 @@ Check the `datasize-cur` and `datasize-max` restrictions in `/etc/login.conf`
 for your login group. Note that you will need to re-login for the change to take effect.
 */
 
-Dependencies
-------------
+## Dependencies
 
 Run the following as root to install the dependencies:
 Note that the OpenBSD package of Berkeley DB is version 4.6,
@@ -64,8 +60,7 @@ while Bitcoin Core requires version 4.8 to build the wallet.
 # pkg_add git
 ```
 
-BerkeleyDB
-----------
+## BerkeleyDB
 
 BerkeleyDB is only needed for the wallet functionality.
 This can be disabled with `./configure --disable-wallet`.
@@ -79,8 +74,7 @@ If you have to build it yourself, you can use
 ./contrib/install_db4.sh `pwd` CC=egcc CXX=eg++ CPP=ecpp
 ```
 
-The source
-----------
+## The source
 
 Clone the Bitcoin Core github repository:
 


### PR DESCRIPTION
This updates the instructions to OpenBSD-current
and slightly tweaks the db48 helper script.
