### PR TITLE
Remove most recent transaction timestamp stuff from nTimeSmart

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -569,13 +569,8 @@ BOOST_AUTO_TEST_CASE(ComputeTimeSmart)
     // New transaction should use block time if lower than clock time.
     BOOST_CHECK_EQUAL(AddTx(wallet, 3, 420, 400), 400);
 
-    // New transaction should use latest entry time if higher than
-    // min(block time, clock time).
-    BOOST_CHECK_EQUAL(AddTx(wallet, 4, 500, 390), 400);
-
-    // If there are future entries, new transaction should use time of the
-    // newest entry that is no more than 300 seconds ahead of the clock time.
-    BOOST_CHECK_EQUAL(AddTx(wallet, 5, 50, 600), 300);
+    // If there are future entries, new transaction should clock time
+    BOOST_CHECK_EQUAL(AddTx(wallet, 5, 50, 600), 50);
 
     // Reset mock time for other tests.
     SetMockTime(0);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3744,13 +3744,11 @@ void CWallet::GetKeyBirthTimes(std::map<CTxDestination, int64_t> &mapKeyBirth) c
  *   current time.
  * - If receiving a block with a future timestamp, assign all its (not already
  *   known) transactions' timestamps to the current time.
- * - If receiving a block with a past timestamp, before the most recent known
- *   transaction (that we care about), assign all its (not already known)
- *   transactions' timestamps to the same timestamp as that most-recent-known
- *   transaction.
- * - If receiving a block with a past timestamp, but after the most recent known
- *   transaction, assign all its (not already known) transactions' timestamps to
+ * - If receiving a block with a past timestamp, assign all its (not already known) transactions' timestamps to
  *   the block time.
+ *
+ * Note that this behavior is different from the original nTimeSmart implementation.
+ * The timestamp of the most recent transaction is disregarded.
  *
  * For more information see CWalletTx::nTimeSmart,
  * https://bitcointalk.org/?topic=54527, or
@@ -3761,38 +3759,10 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const
     unsigned int nTimeSmart = wtx.nTimeReceived;
     if (!wtx.hashUnset()) {
         if (mapBlockIndex.count(wtx.hashBlock)) {
-            int64_t latestNow = wtx.nTimeReceived;
-            int64_t latestEntry = 0;
-
-            // Tolerate times up to the last timestamp in the wallet not more than 5 minutes into the future
-            int64_t latestTolerated = latestNow + 300;
-            const TxItems& txOrdered = wtxOrdered;
-            for (auto it = txOrdered.rbegin(); it != txOrdered.rend(); ++it) {
-                CWalletTx* const pwtx = it->second.first;
-                if (pwtx == &wtx) {
-                    continue;
-                }
-                CAccountingEntry* const pacentry = it->second.second;
-                int64_t nSmartTime;
-                if (pwtx) {
-                    nSmartTime = pwtx->nTimeSmart;
-                    if (!nSmartTime) {
-                        nSmartTime = pwtx->nTimeReceived;
-                    }
-                } else {
-                    nSmartTime = pacentry->nTime;
-                }
-                if (nSmartTime <= latestTolerated) {
-                    latestEntry = nSmartTime;
-                    if (nSmartTime > latestNow) {
-                        latestNow = nSmartTime;
-                    }
-                    break;
-                }
+            unsigned int block_time = mapBlockIndex[wtx.hashBlock]->GetBlockTime();
+            if (block_time < nTimeSmart) {
+                nTimeSmart = block_time;
             }
-
-            int64_t blocktime = mapBlockIndex[wtx.hashBlock]->GetBlockTime();
-            nTimeSmart = std::max(latestEntry, std::min(blocktime, latestNow));
         } else {
             LogPrintf("%s: found %s in block %s not in index\n", __func__, wtx.GetHash().ToString(), wtx.hashBlock.ToString());
         }


### PR DESCRIPTION
This will show accurate and correct timestamps for transactions. Order in `listtransactions` is still maintained because that ordering is done separately from the timestamps.

Fixes #11703 and 
fixes #6662