### PR TITLE
[Docs] Remove boost --c++ flag from osx build instructions

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](https://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf python3 qt libevent
+    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python3 qt libevent
 
 See [dependencies.md](dependencies.md) for a complete overview.
 


### PR DESCRIPTION
the c++ is not needed since the listed brew formulas no longer have this option. It also raises a warning that may generate confusion.