### PR TITLE
Add hdenabled flag in getwalletinfo

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2742,7 +2742,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     if (!masterKeyID.IsNull())
          obj.push_back(Pair("hdmasterkeyid", masterKeyID.GetHex()));
 
-    obj.push_back(Pair("hd", pwallet->IsHDEnabled()));
+    obj.push_back(Pair("hdenabled", pwallet->IsHDEnabled()));
 
     return obj;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2704,7 +2704,8 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"keypoolsize_hd_internal\": xxxx, (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)\n"
             "  \"unlocked_until\": ttt,           (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,              (numeric) the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB\n"
-            "  \"hdmasterkeyid\": \"<hash160>\"     (string) the Hash160 of the HD master pubkey\n"
+            "  \"hdmasterkeyid\": \"<hash160>\",  (string) the Hash160 of the HD master pubkey\n"
+            "  \"hdenabled\": \"true|false\"      (boolean) true if HD is enabled, false otherwise\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getwalletinfo", "")
@@ -2740,6 +2741,9 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
     if (!masterKeyID.IsNull())
          obj.push_back(Pair("hdmasterkeyid", masterKeyID.GetHex()));
+
+    obj.push_back(Pair("hd", pwallet->IsHDEnabled()));
+
     return obj;
 }
 
@@ -3021,7 +3025,7 @@ UniValue fundrawtransaction(const JSONRPCRequest& request)
                             "                         for backward compatibility: passing in a true instead of an object will result in {\"includeWatching\":true}\n"
                             "3. iswitness               (boolean, optional) Whether the transaction hex is a serialized witness transaction \n"
                             "                              If iswitness is not present, heuristic tests will be used in decoding\n"
-                            
+
                             "\nResult:\n"
                             "{\n"
                             "  \"hex\":       \"value\", (string)  The resulting raw transaction (hex-encoded string)\n"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2704,8 +2704,8 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"keypoolsize_hd_internal\": xxxx, (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)\n"
             "  \"unlocked_until\": ttt,           (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,              (numeric) the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB\n"
-            "  \"hdmasterkeyid\": \"<hash160>\",  (string) the Hash160 of the HD master pubkey\n"
-            "  \"hdenabled\": \"true|false\"      (boolean) true if HD is enabled, false otherwise\n"
+            "  \"hdmasterkeyid\": \"<hash160>\",    (string) the Hash160 of the HD master pubkey\n"
+            "  \"hdenabled\": true|false          (boolean) true if HD is enabled, false otherwise\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getwalletinfo", "")


### PR DESCRIPTION
When running `bitcoin-cli getwalletinfo` we can see a new flag called `hdenabled` which is either `true` or `false`. This replicates the behaviour we see in `bitcoin-qt` which displays a "HD Enabled" logo in `BitcoinGUI::setHDStatus()`

The help now look like this:

    bitcoin-cli getwalletinfo help
    error code: -1
    error message:
    getwalletinfo
    Returns an object containing various wallet state info.

    Result:
    {
      "walletname": xxxxx,             (string) the wallet name
      "walletversion": xxxxx,          (numeric) the wallet version
      "balance": xxxxxxx,              (numeric) the total confirmed balance of the wallet in BTC
      "unconfirmed_balance": xxx,      (numeric) the total unconfirmed balance of the wallet in BTC
      "immature_balance": xxxxxx,      (numeric) the total immature balance of the wallet in BTC
      "txcount": xxxxxxx,              (numeric) the total number of transactions in the wallet
      "keypoololdest": xxxxxx,         (numeric) the timestamp (seconds since Unix epoch) of the oldest pre-generated key in the key pool
      "keypoolsize": xxxx,             (numeric) how many new keys are pre-generated (only counts external keys)
      "keypoolsize_hd_internal": xxxx, (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)
      "unlocked_until": ttt,           (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked
      "paytxfee": x.xxxx,              (numeric) the transaction fee configuration, set in BTC/kB
      "hdmasterkeyid": "<hash160>",    (string) the Hash160 of the HD master pubkey
      "hdenabled": true|false          (boolean) true if HD is enabled, false otherwise
    }

    Examples:
    > bitcoin-cli getwalletinfo
    > curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getwalletinfo", "params": [] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/

And the command output:


    bitcoin-cli getwalletinfo
    {
      "walletname": "wallet.dat",
      "walletversion": 139900,
      "balance": 0.00999772,
      "unconfirmed_balance": 0.00000000,
      "immature_balance": 0.00000000,
      "txcount": 7,
      "keypoololdest": 1514388183,
      "keypoolsize": 1000,
      "keypoolsize_hd_internal": 1000,
      "paytxfee": 0.00000000,
      "hdmasterkeyid": "ad304ceaa7bf2bf0a3543526968ee958fb94c847",
      "hdenabled": true
    }