### PR TITLE
Qt: Minimize to tray functionality only on Windows

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -65,6 +65,12 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabWindow));
 #endif
 
+#ifndef Q_OS_WIN
+    /* hide tray icon related stuff from Window tab */
+    ui->hideTrayIcon->hide();
+    ui->minimizeToTray->hide();
+#endif
+
     /* remove Wallet tab in case of -disablewallet */
     if (!enableWallet) {
         ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabWallet));

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -56,6 +56,8 @@ void OptionsModel::Init(bool resetSettings)
     // These are Qt-only settings:
 
     // Window
+#ifdef Q_OS_WIN
+    // Tray icon functionality is only available on Windows.
     if (!settings.contains("fHideTrayIcon"))
         settings.setValue("fHideTrayIcon", false);
     fHideTrayIcon = settings.value("fHideTrayIcon").toBool();
@@ -64,6 +66,15 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fMinimizeToTray"))
         settings.setValue("fMinimizeToTray", false);
     fMinimizeToTray = settings.value("fMinimizeToTray").toBool() && !fHideTrayIcon;
+#else
+    // On systems without tray icon functionality we set some default values
+    // and remove settings from previous versions of the software to not
+    // confuse people looking into the .config or .plist file.
+    fHideTrayIcon = true;
+    settings.remove("fHideTrayIcon");
+    fMinimizeToTray = false;
+    settings.remove("fMinimizeToTray");
+#endif
 
     if (!settings.contains("fMinimizeOnClose"))
         settings.setValue("fMinimizeOnClose", false);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -67,13 +67,11 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("fMinimizeToTray", false);
     fMinimizeToTray = settings.value("fMinimizeToTray").toBool() && !fHideTrayIcon;
 #else
-    // On systems without tray icon functionality we set some default values
-    // and remove settings from previous versions of the software to not
-    // confuse people looking into the .config or .plist file.
+    // On systems without tray icon functionality we always hide the tray icon
+    // and we never minimize to tray. Therefore, these settings are not read
+    // from the configuration file/registry.
     fHideTrayIcon = true;
-    settings.remove("fHideTrayIcon");
     fMinimizeToTray = false;
-    settings.remove("fMinimizeToTray");
 #endif
 
     if (!settings.contains("fMinimizeOnClose"))


### PR DESCRIPTION
Minimizing to tray should only be possible on Windows.
Therefore, on non-Winodws systems the tray icon and related
settings are hidden, the related option variables are set to
predefined values. Furthermore, not used entries are removed
from the configuration files at initialization.
See also discussions in PR #11859