### PR TITLE
Avoid yearly updates for copyright

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2017 The Bitcoin Core developers
-Copyright (c) 2009-2017 Bitcoin Developers
+Copyright (c) 2009-Present The Bitcoin Core developers
+Copyright (c) 2009-Present Bitcoin Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Following Facebook's style to avoid updating copyright date yearly