### PR TITLE
[qt] Optimizes boolean expression model && model->haveWatchOnly()

### DIFF
--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -365,7 +365,7 @@ void TransactionView::exportClicked()
     // name, column, role
     writer.setModel(transactionProxyModel);
     writer.addColumn(tr("Confirmed"), 0, TransactionTableModel::ConfirmedRole);
-    if (model && model->haveWatchOnly())
+    if (model->haveWatchOnly())
         writer.addColumn(tr("Watch-only"), TransactionTableModel::Watchonly);
     writer.addColumn(tr("Date"), 0, TransactionTableModel::DateRole);
     writer.addColumn(tr("Type"), TransactionTableModel::Type, Qt::EditRole);


### PR DESCRIPTION
This PR optimizes the boolean expression `model && model->haveWatchOnly()` to `model->haveWatchOnly()`.

The boolean expression can be optimized because the method `TransactionView::exportClicked` already guards against a potential dereferenced null pointer by returning early if `model` is null.
https://github.com/bitcoin/bitcoin/blob/63a4dc10876bfc61c2e87d35dcf17da2f0f8c316/src/qt/transactionview.cpp#L351-L353