### PR TITLE
[scripts] Add missing univalue file to copyright_header.py

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -24,8 +24,10 @@ EXCLUDE = [
     'src/secp256k1/src/java/org_bitcoin_NativeSecp256k1.h',
     'src/secp256k1/src/java/org_bitcoin_Secp256k1Context.c',
     'src/secp256k1/src/java/org_bitcoin_Secp256k1Context.h',
-    # auto generated:
+    # univalue:
+    'src/univalue/test/object.cpp',
     'src/univalue/lib/univalue_escapes.h',
+    # auto generated:
     'src/qt/bitcoinstrings.cpp',
     'src/chainparamsseeds.h',
     # other external copyrights:


### PR DESCRIPTION
This needs to be added so that PRs like #12062 don't modify the subtree.