### PR TITLE
qa: Use node.datadir instead of tmpdir in test framework

### DIFF
--- a/test/functional/feature_bip9_softforks.py
+++ b/test/functional/feature_bip9_softforks.py
@@ -241,7 +241,7 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         self.test.clear_all_connections()
         self.stop_nodes()
         self.nodes = []
-        shutil.rmtree(self.options.tmpdir + "/node0")
+        shutil.rmtree(get_datadir_path(self.options.tmpdir, 0))
         self.setup_chain()
         self.setup_network()
         self.test.add_all_connections(self.nodes)

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -7,7 +7,7 @@
 import os
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import get_datadir_path
+
 
 class ConfArgsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -19,7 +19,7 @@ class ConfArgsTest(BitcoinTestFramework):
         # Remove the -datadir argument so it doesn't override the config file
         self.nodes[0].args = [arg for arg in self.nodes[0].args if not arg.startswith("-datadir")]
 
-        default_data_dir = get_datadir_path(self.options.tmpdir, 0)
+        default_data_dir = self.nodes[0].datadir
         new_data_dir = os.path.join(default_data_dir, 'newdatadir')
         new_data_dir_2 = os.path.join(default_data_dir, 'newdatadir2')
 

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -44,7 +44,7 @@ class PruneTest(BitcoinTestFramework):
     def setup_network(self):
         self.setup_nodes()
 
-        self.prunedir = self.options.tmpdir + "/node2/regtest/blocks/"
+        self.prunedir = os.path.join(self.nodes[2].datadir, 'regtest', 'blocks', '')
 
         connect_nodes(self.nodes[0], 1)
         connect_nodes(self.nodes[1], 2)

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -93,8 +93,8 @@ class MempoolPersistTest(BitcoinTestFramework):
         self.start_node(0)
         wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
 
-        mempooldat0 = os.path.join(self.options.tmpdir, 'node0', 'regtest', 'mempool.dat')
-        mempooldat1 = os.path.join(self.options.tmpdir, 'node1', 'regtest', 'mempool.dat')
+        mempooldat0 = os.path.join(self.nodes[0].datadir, 'regtest', 'mempool.dat')
+        mempooldat1 = os.path.join(self.nodes[1].datadir, 'regtest', 'mempool.dat')
         self.log.debug("Remove the mempool.dat file. Verify that savemempool to disk via RPC re-creates it")
         os.remove(mempooldat0)
         self.nodes[0].savemempool()

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -48,7 +48,7 @@ class RPCBindTest(BitcoinTestFramework):
         self.nodes[0].rpchost = None
         self.start_nodes([base_args])
         # connect to node through non-loopback interface
-        node = get_rpc_proxy(rpc_url(get_datadir_path(self.options.tmpdir, 0), 0, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
+        node = get_rpc_proxy(rpc_url(self.nodes[0].datadir, 0, "%s:%d" % (rpchost, rpcport)), 0, coveragedir=self.options.coveragedir)
         node.getnetworkinfo()
         self.stop_nodes()
 

--- a/test/functional/rpc_users.py
+++ b/test/functional/rpc_users.py
@@ -5,13 +5,18 @@
 """Test multiple RPC users."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import str_to_b64str, assert_equal
+from test_framework.util import (
+    assert_equal,
+    get_datadir_path,
+    str_to_b64str,
+)
 
 import os
 import http.client
 import urllib.parse
 
-class HTTPBasicsTest (BitcoinTestFramework):
+
+class HTTPBasicsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
 
@@ -22,10 +27,10 @@ class HTTPBasicsTest (BitcoinTestFramework):
         rpcauth2 = "rpcauth=rt2:f8607b1a88861fac29dfccf9b52ff9f$ff36a0c23c8c62b4846112e50fa888416e94c17bfd4c42f88fd8f55ec6a3137e"
         rpcuser = "rpcuser=rpcuser💻"
         rpcpassword = "rpcpassword=rpcpassword🔑"
-        with open(os.path.join(self.options.tmpdir+"/node0", "bitcoin.conf"), 'a', encoding='utf8') as f:
+        with open(os.path.join(get_datadir_path(self.options.tmpdir, 0), "bitcoin.conf"), 'a', encoding='utf8') as f:
             f.write(rpcauth+"\n")
             f.write(rpcauth2+"\n")
-        with open(os.path.join(self.options.tmpdir+"/node1", "bitcoin.conf"), 'a', encoding='utf8') as f:
+        with open(os.path.join(get_datadir_path(self.options.tmpdir, 1), "bitcoin.conf"), 'a', encoding='utf8') as f:
             f.write(rpcuser+"\n")
             f.write(rpcpassword+"\n")
 
@@ -54,7 +59,7 @@ class HTTPBasicsTest (BitcoinTestFramework):
         resp = conn.getresponse()
         assert_equal(resp.status, 200)
         conn.close()
-        
+
         #Use new authpair to confirm both work
         headers = {"Authorization": "Basic " + str_to_b64str(authpairnew)}
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -228,7 +228,7 @@ class BitcoinTestFramework():
         assert_equal(len(extra_args), num_nodes)
         assert_equal(len(binary), num_nodes)
         for i in range(num_nodes):
-            self.nodes.append(TestNode(i, self.options.tmpdir, rpchost=rpchost, timewait=timewait, binary=binary[i], stderr=None, mocktime=self.mocktime, coverage_dir=self.options.coveragedir, extra_conf=extra_confs[i], extra_args=extra_args[i], use_cli=self.options.usecli))
+            self.nodes.append(TestNode(i, get_datadir_path(self.options.tmpdir, i), rpchost=rpchost, timewait=timewait, binary=binary[i], stderr=None, mocktime=self.mocktime, coverage_dir=self.options.coveragedir, extra_conf=extra_confs[i], extra_args=extra_args[i], use_cli=self.options.usecli))
 
     def start_node(self, i, *args, **kwargs):
         """Start a bitcoind"""
@@ -400,7 +400,7 @@ class BitcoinTestFramework():
                 args = [os.getenv("BITCOIND", "bitcoind"), "-datadir=" + datadir]
                 if i > 0:
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
-                self.nodes.append(TestNode(i, self.options.cachedir, extra_conf=["bind=127.0.0.1"], extra_args=[],rpchost=None, timewait=None, binary=None, stderr=None, mocktime=self.mocktime, coverage_dir=None))
+                self.nodes.append(TestNode(i, get_datadir_path(self.options.cachedir, i), extra_conf=["bind=127.0.0.1"], extra_args=[],rpchost=None, timewait=None, binary=None, stderr=None, mocktime=self.mocktime, coverage_dir=None))
                 self.nodes[i].args = args
                 self.start_node(i)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -43,9 +43,9 @@ class TestNode():
     To make things easier for the test writer, any unrecognised messages will
     be dispatched to the RPC connection."""
 
-    def __init__(self, i, dirname, rpchost, timewait, binary, stderr, mocktime, coverage_dir, extra_conf=None, extra_args=None, use_cli=False):
+    def __init__(self, i, datadir, rpchost, timewait, binary, stderr, mocktime, coverage_dir, extra_conf=None, extra_args=None, use_cli=False):
         self.index = i
-        self.datadir = os.path.join(dirname, "node" + str(i))
+        self.datadir = datadir
         self.rpchost = rpchost
         if timewait:
             self.rpc_timeout = timewait
@@ -59,7 +59,7 @@ class TestNode():
         self.stderr = stderr
         self.coverage_dir = coverage_dir
         if extra_conf != None:
-            append_config(dirname, i, extra_conf)
+            append_config(datadir, extra_conf)
         # Most callers will just need to add extra args to the standard list below.
         # For those callers that need more flexibity, they can just set the args property directly.
         # Note that common args are set in the config file (see initialize_datadir)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -284,7 +284,7 @@ def rpc_url(datadir, i, rpchost=None):
 ################
 
 def initialize_datadir(dirname, n):
-    datadir = os.path.join(dirname, "node" + str(n))
+    datadir = get_datadir_path(dirname, n)
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
     with open(os.path.join(datadir, "bitcoin.conf"), 'w', encoding='utf8') as f:
@@ -300,8 +300,7 @@ def initialize_datadir(dirname, n):
 def get_datadir_path(dirname, n):
     return os.path.join(dirname, "node" + str(n))
 
-def append_config(dirname, n, options):
-    datadir = get_datadir_path(dirname, n)
+def append_config(datadir, options):
     with open(os.path.join(datadir, "bitcoin.conf"), 'a', encoding='utf8') as f:
         for option in options:
             f.write(option + "\n")

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -90,9 +90,9 @@ class WalletBackupTest(BitcoinTestFramework):
         self.stop_node(2)
 
     def erase_three(self):
-        os.remove(self.options.tmpdir + "/node0/regtest/wallets/wallet.dat")
-        os.remove(self.options.tmpdir + "/node1/regtest/wallets/wallet.dat")
-        os.remove(self.options.tmpdir + "/node2/regtest/wallets/wallet.dat")
+        os.remove(os.path.join(self.nodes[0].datadir, 'regtest', 'wallets', 'wallet.dat'))
+        os.remove(os.path.join(self.nodes[1].datadir, 'regtest', 'wallets', 'wallet.dat'))
+        os.remove(os.path.join(self.nodes[2].datadir, 'regtest', 'wallets', 'wallet.dat'))
 
     def run_test(self):
         self.log.info("Generating initial blockchain")
@@ -116,13 +116,13 @@ class WalletBackupTest(BitcoinTestFramework):
             self.do_one_round()
 
         self.log.info("Backing up")
-        tmpdir = self.options.tmpdir
-        self.nodes[0].backupwallet(tmpdir + "/node0/wallet.bak")
-        self.nodes[0].dumpwallet(tmpdir + "/node0/wallet.dump")
-        self.nodes[1].backupwallet(tmpdir + "/node1/wallet.bak")
-        self.nodes[1].dumpwallet(tmpdir + "/node1/wallet.dump")
-        self.nodes[2].backupwallet(tmpdir + "/node2/wallet.bak")
-        self.nodes[2].dumpwallet(tmpdir + "/node2/wallet.dump")
+
+        self.nodes[0].backupwallet(os.path.join(self.nodes[0].datadir, 'wallet.bak'))
+        self.nodes[0].dumpwallet(os.path.join(self.nodes[0].datadir, 'wallet.dump'))
+        self.nodes[1].backupwallet(os.path.join(self.nodes[1].datadir, 'wallet.bak'))
+        self.nodes[1].dumpwallet(os.path.join(self.nodes[1].datadir, 'wallet.dump'))
+        self.nodes[2].backupwallet(os.path.join(self.nodes[2].datadir, 'wallet.bak'))
+        self.nodes[2].dumpwallet(os.path.join(self.nodes[2].datadir, 'wallet.dump'))
 
         self.log.info("More transactions")
         for i in range(5):
@@ -150,13 +150,13 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_three()
 
         # Start node2 with no chain
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(os.path.join(self.nodes[2].datadir, 'regtest', 'blocks'))
+        shutil.rmtree(os.path.join(self.nodes[2].datadir, 'regtest', 'chainstate'))
 
         # Restore wallets from backup
-        shutil.copyfile(tmpdir + "/node0/wallet.bak", tmpdir + "/node0/regtest/wallets/wallet.dat")
-        shutil.copyfile(tmpdir + "/node1/wallet.bak", tmpdir + "/node1/regtest/wallets/wallet.dat")
-        shutil.copyfile(tmpdir + "/node2/wallet.bak", tmpdir + "/node2/regtest/wallets/wallet.dat")
+        shutil.copyfile(os.path.join(self.nodes[0].datadir, 'wallet.bak'), os.path.join(self.nodes[0].datadir, 'regtest', 'wallets', 'wallet.dat'))
+        shutil.copyfile(os.path.join(self.nodes[1].datadir, 'wallet.bak'), os.path.join(self.nodes[1].datadir, 'regtest', 'wallets', 'wallet.dat'))
+        shutil.copyfile(os.path.join(self.nodes[2].datadir, 'wallet.bak'), os.path.join(self.nodes[2].datadir, 'regtest', 'wallets', 'wallet.dat'))
 
         self.log.info("Re-starting nodes")
         self.start_three()
@@ -171,8 +171,8 @@ class WalletBackupTest(BitcoinTestFramework):
         self.erase_three()
 
         #start node2 with no chain
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/blocks")
-        shutil.rmtree(self.options.tmpdir + "/node2/regtest/chainstate")
+        shutil.rmtree(os.path.join(self.nodes[2].datadir, 'regtest', 'blocks'))
+        shutil.rmtree(os.path.join(self.nodes[2].datadir, 'regtest', 'chainstate'))
 
         self.start_three()
 
@@ -180,9 +180,9 @@ class WalletBackupTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance(), 0)
         assert_equal(self.nodes[2].getbalance(), 0)
 
-        self.nodes[0].importwallet(tmpdir + "/node0/wallet.dump")
-        self.nodes[1].importwallet(tmpdir + "/node1/wallet.dump")
-        self.nodes[2].importwallet(tmpdir + "/node2/wallet.dump")
+        self.nodes[0].importwallet(os.path.join(self.nodes[0].datadir, 'wallet.dump'))
+        self.nodes[1].importwallet(os.path.join(self.nodes[1].datadir, 'wallet.dump'))
+        self.nodes[2].importwallet(os.path.join(self.nodes[2].datadir, 'wallet.dump'))
 
         sync_blocks(self.nodes)
 
@@ -192,10 +192,10 @@ class WalletBackupTest(BitcoinTestFramework):
 
         # Backup to source wallet file must fail
         sourcePaths = [
-            tmpdir + "/node0/regtest/wallets/wallet.dat",
-            tmpdir + "/node0/./regtest/wallets/wallet.dat",
-            tmpdir + "/node0/regtest/wallets/",
-            tmpdir + "/node0/regtest/wallets"]
+            os.path.join(self.nodes[0].datadir, 'regtest', 'wallets', 'wallet.dat'),
+            os.path.join(self.nodes[0].datadir, 'regtest', '.', 'wallets', 'wallet.dat'),
+            os.path.join(self.nodes[0].datadir, 'regtest', 'wallets', ''),
+            os.path.join(self.nodes[0].datadir, 'regtest', 'wallets')]
 
         for sourcePath in sourcePaths:
             assert_raises_rpc_error(-4, "backup failed", self.nodes[0].backupwallet, sourcePath)

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -4,13 +4,15 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test Hierarchical Deterministic wallet function."""
 
+import os
+import shutil
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes_bi,
 )
-import shutil
-import os
+
 
 class WalletHDTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -18,9 +20,7 @@ class WalletHDTest(BitcoinTestFramework):
         self.num_nodes = 2
         self.extra_args = [[], ['-keypool=0']]
 
-    def run_test (self):
-        tmpdir = self.options.tmpdir
-
+    def run_test(self):
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
         self.assert_start_raises_init_error(1, ['-usehd=0'], 'already existing HD wallet')
@@ -41,8 +41,8 @@ class WalletHDTest(BitcoinTestFramework):
         self.nodes[1].importprivkey(self.nodes[0].dumpprivkey(non_hd_add))
 
         # This should be enough to keep the master key and the non-HD key
-        self.nodes[1].backupwallet(tmpdir + "/hd.bak")
-        #self.nodes[1].dumpwallet(tmpdir + "/hd.dump")
+        self.nodes[1].backupwallet(os.path.join(self.nodes[1].datadir, "hd.bak"))
+        #self.nodes[1].dumpwallet(os.path.join(self.nodes[1].datadir, "hd.dump"))
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
@@ -71,9 +71,9 @@ class WalletHDTest(BitcoinTestFramework):
         self.stop_node(1)
         # we need to delete the complete regtest directory
         # otherwise node1 would auto-recover all funds in flag the keypool keys as used
-        shutil.rmtree(os.path.join(tmpdir, "node1/regtest/blocks"))
-        shutil.rmtree(os.path.join(tmpdir, "node1/regtest/chainstate"))
-        shutil.copyfile(os.path.join(tmpdir, "hd.bak"), os.path.join(tmpdir, "node1/regtest/wallets/wallet.dat"))
+        shutil.rmtree(os.path.join(self.nodes[1].datadir, "regtest", "blocks"))
+        shutil.rmtree(os.path.join(self.nodes[1].datadir, "regtest", "chainstate"))
+        shutil.copyfile(os.path.join(self.nodes[1].datadir, "hd.bak"), os.path.join(self.nodes[1].datadir, "regtest", "wallets", "wallet.dat"))
         self.start_node(1)
 
         # Assert that derivation is deterministic
@@ -94,9 +94,9 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Try a RPC based rescan
         self.stop_node(1)
-        shutil.rmtree(os.path.join(tmpdir, "node1/regtest/blocks"))
-        shutil.rmtree(os.path.join(tmpdir, "node1/regtest/chainstate"))
-        shutil.copyfile(os.path.join(tmpdir, "hd.bak"), os.path.join(tmpdir, "node1/regtest/wallet.dat"))
+        shutil.rmtree(os.path.join(self.nodes[1].datadir, "regtest", "blocks"))
+        shutil.rmtree(os.path.join(self.nodes[1].datadir, "regtest", "chainstate"))
+        shutil.copyfile(os.path.join(self.nodes[1].datadir, "hd.bak"), os.path.join(self.nodes[1].datadir, "regtest", "wallets", "wallet.dat"))
         self.start_node(1, extra_args=self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_all()

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -10,6 +10,7 @@ Two nodes. Node1 is under test. Node0 is providing transactions and generating b
 - Generate 110 keys (enough to drain the keypool). Store key 90 (in the initial keypool) and key 110 (beyond the initial keypool). Send funds to key 90 and key 110.
 - Stop node1, clear the datadir, move wallet file back into the datadir and restart node1.
 - connect node1 to node0. Verify that they sync and node1 receives its funds."""
+import os
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
@@ -19,6 +20,7 @@ from test_framework.util import (
     sync_blocks,
 )
 
+
 class KeypoolRestoreTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
@@ -26,26 +28,23 @@ class KeypoolRestoreTest(BitcoinTestFramework):
         self.extra_args = [[], ['-keypool=100', '-keypoolmin=20']]
 
     def run_test(self):
-        self.tmpdir = self.options.tmpdir
+        wallet_path = os.path.join(self.nodes[1].datadir, "regtest", "wallets", "wallet.dat")
+        wallet_backup_path = os.path.join(self.nodes[1].datadir, "wallet.bak")
         self.nodes[0].generate(101)
 
         self.log.info("Make backup of wallet")
-
         self.stop_node(1)
-
-        shutil.copyfile(self.tmpdir + "/node1/regtest/wallets/wallet.dat", self.tmpdir + "/wallet.bak")
+        shutil.copyfile(wallet_path, wallet_backup_path)
         self.start_node(1, self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
 
         self.log.info("Generate keys for wallet")
-
         for _ in range(90):
             addr_oldpool = self.nodes[1].getnewaddress()
         for _ in range(20):
             addr_extpool = self.nodes[1].getnewaddress()
 
         self.log.info("Send funds to wallet")
-
         self.nodes[0].sendtoaddress(addr_oldpool, 10)
         self.nodes[0].generate(1)
         self.nodes[0].sendtoaddress(addr_extpool, 5)
@@ -53,22 +52,18 @@ class KeypoolRestoreTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         self.log.info("Restart node with wallet backup")
-
         self.stop_node(1)
-
-        shutil.copyfile(self.tmpdir + "/wallet.bak", self.tmpdir + "/node1/regtest/wallets/wallet.dat")
-
-        self.log.info("Verify keypool is restored and balance is correct")
-
+        shutil.copyfile(wallet_backup_path, wallet_path)
         self.start_node(1, self.extra_args[1])
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_all()
 
+        self.log.info("Verify keypool is restored and balance is correct")
         assert_equal(self.nodes[1].getbalance(), 15)
         assert_equal(self.nodes[1].listtransactions()[0]['category'], "receive")
-
         # Check that we have marked all keys up to the used keypool key as used
         assert_equal(self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress())['hdkeypath'], "m/0'/0'/110'")
+
 
 if __name__ == '__main__':
     KeypoolRestoreTest().main()

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -10,7 +10,11 @@ import os
 import shutil
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
 
 class MultiWalletTest(BitcoinTestFramework):
     def set_test_params(self):


### PR DESCRIPTION
Commit c53c9831eedaf3b311bb942945268830f9ba3abc introduced the utility function `get_datadir_path`, however not all places in the code use this util function. Using the util function everywhere makes it easier to review pull requests related to the datadir.

This commit replaces datadir path creation with the `datadir` member of `TestNode`, which itself uses `get_datadir_path`.