### PR TITLE
qa: Make TestNodeCLI command optional in send_cli

### DIFF
--- a/test/functional/bitcoin_cli.py
+++ b/test/functional/bitcoin_cli.py
@@ -39,7 +39,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_raises_process_error(1, "-getinfo takes no arguments", self.nodes[0].cli('-getinfo').help)
 
         self.log.info("Compare responses from `bitcoin-cli -getinfo` and the RPCs data is retrieved from.")
-        cli_get_info = self.nodes[0].cli().send_cli('-getinfo')
+        cli_get_info = self.nodes[0].cli('-getinfo').send_cli()
         wallet_info = self.nodes[0].getwalletinfo()
         network_info = self.nodes[0].getnetworkinfo()
         blockchain_info = self.nodes[0].getblockchaininfo()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -213,16 +213,16 @@ class TestNodeCLI():
     """Interface to bitcoin-cli for an individual node"""
 
     def __init__(self, binary, datadir):
-        self.args = []
+        self.options = []
         self.binary = binary
         self.datadir = datadir
         self.input = None
         self.log = logging.getLogger('TestFramework.bitcoincli')
 
-    def __call__(self, *args, input=None):
-        # TestNodeCLI is callable with bitcoin-cli command-line args
+    def __call__(self, *options, input=None):
+        # TestNodeCLI is callable with bitcoin-cli command-line options
         cli = TestNodeCLI(self.binary, self.datadir)
-        cli.args = [str(arg) for arg in args]
+        cli.options = [str(o) for o in options]
         cli.input = input
         return cli
 
@@ -244,7 +244,7 @@ class TestNodeCLI():
         pos_args = [str(arg) for arg in args]
         named_args = [str(key) + "=" + str(value) for (key, value) in kwargs.items()]
         assert not (pos_args and named_args), "Cannot use positional arguments and named arguments in the same bitcoin-cli call"
-        p_args = [self.binary, "-datadir=" + self.datadir] + self.args
+        p_args = [self.binary, "-datadir=" + self.datadir] + self.options
         if named_args:
             p_args += ["-named"]
         p_args += [command] + pos_args + named_args

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -238,7 +238,7 @@ class TestNodeCLI():
                results.append(dict(error=e))
         return results
 
-    def send_cli(self, command, *args, **kwargs):
+    def send_cli(self, command=None, *args, **kwargs):
         """Run bitcoin-cli command. Deserializes returned string as python object."""
 
         pos_args = [str(arg) for arg in args]
@@ -247,7 +247,9 @@ class TestNodeCLI():
         p_args = [self.binary, "-datadir=" + self.datadir] + self.options
         if named_args:
             p_args += ["-named"]
-        p_args += [command] + pos_args + named_args
+        if command is not None:
+            p_args += [command]
+        p_args += pos_args + named_args
         self.log.debug("Running bitcoin-cli command: %s" % command)
         process = subprocess.Popen(p_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         cli_stdout, cli_stderr = process.communicate(input=self.input)


### PR DESCRIPTION
Makes the `command` optional, since there are valid bitcoin-cli calls that have no `command`:

* `bitcoin-cli -?`
* `bitcoin-cli -getinfo`
* ...

Also, rename self.args to self.options, since that is the name in the `bitcoin-cli -help` documentation.