### PR TITLE
[qt] Replaces numbered place marker %2 with %1.

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -336,7 +336,7 @@ void SendCoinsDialog::on_sendButton_clicked()
     }
     questionString.append(tr("Total Amount %1")
         .arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), totalAmount)));
-    questionString.append(QString("<span style='font-size:10pt;font-weight:normal;'><br />(=%2)</span>")
+    questionString.append(QString("<span style='font-size:10pt;font-weight:normal;'><br />(=%1)</span>")
         .arg(alternativeUnits.join(" " + tr("or") + "<br />")));
 
     questionString.append("<hr /><span>");


### PR DESCRIPTION
This PR closes #12015 in which @chen610620 suggests to replace numbered place marker `%2` with `%1`.

Calling member function`QString::arg()` on a `QString` object with one arbitrary numbered place marker within the range [1,99] works, because `QString::arg()` replaces the _lowest_ numbered place marker in the `QString` object it is called on.

[QString::arg documentation:](http://doc.qt.io/qt-5/qstring.html#arg)
> Returns a copy of this string with the lowest numbered place marker replaced by string a, i.e., %1, %2, ..., %99.

I suspect that the `%2` marker is just an unfortunate typo or the remainder of a string that used to have multiple numbered place markers. 

This PR replaces the numbered place marker `%2` with `%1` to avoid any confusion in the future.