### PR TITLE
Fix hdmaster-key / seed-key confusion

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -273,7 +273,7 @@ bool CExtKey::Derive(CExtKey &out, unsigned int _nChild) const {
     return key.Derive(out.key, out.chaincode, _nChild, chaincode);
 }
 
-void CExtKey::SetMaster(const unsigned char *seed, unsigned int nSeedLen) {
+void CExtKey::SetSeed(const unsigned char *seed, unsigned int nSeedLen) {
     static const unsigned char hashkey[] = {'B','i','t','c','o','i','n',' ','s','e','e','d'};
     std::vector<unsigned char, secure_allocator<unsigned char>> vout(64);
     CHMAC_SHA512(hashkey, sizeof(hashkey)).Write(seed, nSeedLen).Finalize(vout.data());

--- a/src/key.h
+++ b/src/key.h
@@ -158,7 +158,7 @@ struct CExtKey {
     void Decode(const unsigned char code[BIP32_EXTKEY_SIZE]);
     bool Derive(CExtKey& out, unsigned int nChild) const;
     CExtPubKey Neuter() const;
-    void SetMaster(const unsigned char* seed, unsigned int nSeedLen);
+    void SetSeed(const unsigned char* seed, unsigned int nSeedLen);
     template <typename Stream>
     void Serialize(Stream& s) const
     {

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -91,7 +91,7 @@ void RunTest(const TestVector &test) {
     std::vector<unsigned char> seed = ParseHex(test.strHexMaster);
     CExtKey key;
     CExtPubKey pubkey;
-    key.SetMaster(seed.data(), seed.size());
+    key.SetSeed(seed.data(), seed.size());
     pubkey = key.Neuter();
     for (const TestDerivation &derive : test.vDerive) {
         unsigned char data[74];

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -759,11 +759,11 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             if (GetWalletAddressesForKey(pwallet, keyid, strAddr, strLabel)) {
                file << strprintf("label=%s", strLabel);
             } else if (keyid == seedKeyID) {
-                file << "hdmaster=1";
+                file << "hdseed=1";
             } else if (mapKeyPool.count(keyid)) {
                 file << "reserve=1";
             } else if (pwallet->mapKeyMetadata[keyid].hdKeypath == "m") {
-                file << "inactivehdmaster=1";
+                file << "inactivehdseed=1";
             } else {
                 file << "change=1";
             }

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -740,7 +740,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
         CKey key;
         if (pwallet->GetKey(masterKeyID, key)) {
             CExtKey masterKey;
-            masterKey.SetMaster(key.begin(), key.size());
+            masterKey.SetSeed(key.begin(), key.size());
 
             CBitcoinExtKey b58extkey;
             b58extkey.SetKey(masterKey);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -762,7 +762,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
                 file << "hdseed=1";
             } else if (mapKeyPool.count(keyid)) {
                 file << "reserve=1";
-            } else if (pwallet->mapKeyMetadata[keyid].hdKeypath == "m") {
+            } else if (pwallet->mapKeyMetadata[keyid].hdKeypath == "s") {
                 file << "inactivehdseed=1";
             } else {
                 file << "change=1";

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -734,11 +734,11 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     file << "\n";
 
     // add the base58check encoded extended master if the wallet uses HD
-    CKeyID masterKeyID = pwallet->GetHDChain().masterKeyID;
-    if (!masterKeyID.IsNull())
+    CKeyID seedKeyID = pwallet->GetHDChain().seedKeyID;
+    if (!seedKeyID.IsNull())
     {
         CKey key;
-        if (pwallet->GetKey(masterKeyID, key)) {
+        if (pwallet->GetKey(seedKeyID, key)) {
             CExtKey masterKey;
             masterKey.SetSeed(key.begin(), key.size());
 
@@ -758,7 +758,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             file << strprintf("%s %s ", CBitcoinSecret(key).ToString(), strTime);
             if (GetWalletAddressesForKey(pwallet, keyid, strAddr, strLabel)) {
                file << strprintf("label=%s", strLabel);
-            } else if (keyid == masterKeyID) {
+            } else if (keyid == seedKeyID) {
                 file << "hdmaster=1";
             } else if (mapKeyPool.count(keyid)) {
                 file << "reserve=1";

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2791,7 +2791,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.pushKV("txcount",       (int)pwallet->mapWallet.size());
     obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
     obj.pushKV("keypoolsize", (int64_t)kpExternalSize);
-    CKeyID masterKeyID = pwallet->GetHDChain().seedKeyID;
+    CKeyID seedKeyID = pwallet->GetHDChain().seedKeyID;
     if (!seedKeyID.IsNull() && pwallet->CanSupportFeature(FEATURE_HD_SPLIT)) {
         obj.pushKV("keypoolsize_hd_internal",   (int64_t)(pwallet->GetKeyPoolSize() - kpExternalSize));
     }
@@ -3782,7 +3782,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
         ret.pushKV("timestamp", meta->nCreateTime);
         if (!meta->hdKeypath.empty()) {
             ret.pushKV("hdkeypath", meta->hdKeypath);
-            ret.pushKV("hdmasterkeyid", meta->hdMasterKeyID.GetHex());
+            ret.pushKV("hdmasterkeyid", meta->hdSeedKeyID.GetHex());
         }
     }
     return ret;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2765,7 +2765,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"keypoolsize_hd_internal\": xxxx, (numeric) how many new keys are pre-generated for internal use (used for change outputs, only appears if the wallet is using this feature, otherwise external keys are used)\n"
             "  \"unlocked_until\": ttt,           (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,              (numeric) the transaction fee configuration, set in " + CURRENCY_UNIT + "/kB\n"
-            "  \"hdmasterkeyid\": \"<hash160>\"     (string, optional) the Hash160 of the HD master pubkey (only present when HD is enabled)\n"
+            "  \"hdseedkeyid\": \"<hash160>\"       (string) the Hash160 of the HD seed pubkey (only present when HD is enabled)\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getwalletinfo", "")
@@ -2800,7 +2800,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     }
     obj.pushKV("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK()));
     if (!seedKeyID.IsNull())
-         obj.pushKV("hdmasterkeyid", seedKeyID.GetHex());
+         obj.pushKV("hdseedkeyid", seedKeyID.GetHex());
     return obj;
 }
 
@@ -3732,7 +3732,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
             "  \"account\" : \"account\"         (string) The account associated with the address, \"\" is the default account\n"
             "  \"timestamp\" : timestamp,      (number, optional) The creation time of the key if available in seconds since epoch (Jan 1 1970 GMT)\n"
             "  \"hdkeypath\" : \"keypath\"       (string, optional) The HD keypath if the key is HD and available\n"
-            "  \"hdmasterkeyid\" : \"<hash160>\" (string, optional) The Hash160 of the HD master pubkey\n"
+            "  \"hdseedkeyid\" : \"<hash160>\"   (string, optional) The Hash160 of the HD seed pubkey\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getaddressinfo", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
@@ -3782,7 +3782,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
         ret.pushKV("timestamp", meta->nCreateTime);
         if (!meta->hdKeypath.empty()) {
             ret.pushKV("hdkeypath", meta->hdKeypath);
-            ret.pushKV("hdmasterkeyid", meta->hdSeedKeyID.GetHex());
+            ret.pushKV("hdseedkeyid", meta->hdSeedKeyID.GetHex());
         }
     }
     return ret;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2791,16 +2791,16 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     obj.pushKV("txcount",       (int)pwallet->mapWallet.size());
     obj.pushKV("keypoololdest", pwallet->GetOldestKeyPoolTime());
     obj.pushKV("keypoolsize", (int64_t)kpExternalSize);
-    CKeyID masterKeyID = pwallet->GetHDChain().masterKeyID;
-    if (!masterKeyID.IsNull() && pwallet->CanSupportFeature(FEATURE_HD_SPLIT)) {
+    CKeyID masterKeyID = pwallet->GetHDChain().seedKeyID;
+    if (!seedKeyID.IsNull() && pwallet->CanSupportFeature(FEATURE_HD_SPLIT)) {
         obj.pushKV("keypoolsize_hd_internal",   (int64_t)(pwallet->GetKeyPoolSize() - kpExternalSize));
     }
     if (pwallet->IsCrypted()) {
         obj.pushKV("unlocked_until", pwallet->nRelockTime);
     }
     obj.pushKV("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK()));
-    if (!masterKeyID.IsNull())
-         obj.pushKV("hdmasterkeyid", masterKeyID.GetHex());
+    if (!seedKeyID.IsNull())
+         obj.pushKV("hdmasterkeyid", seedKeyID.GetHex());
     return obj;
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1451,8 +1451,8 @@ CPubKey CWallet::GenerateNewHDSeedKey()
     CPubKey pubkey = key.GetPubKey();
     assert(key.VerifyPubKey(pubkey));
 
-    // set the hd keypath to "m" -> Seed, refers the hdSeedKeyID to itself
-    metadata.hdKeypath     = "m";
+    // set the hd keypath to "s" -> Seed, refers the hdSeedKeyID to itself
+    metadata.hdKeypath     = "s";
     metadata.hdSeedKeyID = pubkey.GetID();
 
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -217,7 +217,7 @@ void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKe
         }
     } while (HaveKey(childKey.key.GetPubKey().GetID()));
     secret = childKey.key;
-    metadata.hdMasterKeyID = hdChain.seedKeyID;
+    metadata.hdSeedKeyID = hdChain.seedKeyID;
     // update the chain model in the database
     if (!walletdb.WriteHDChain(hdChain))
         throw std::runtime_error(std::string(__func__) + ": Writing HD chain model failed");
@@ -1453,7 +1453,7 @@ CPubKey CWallet::GenerateNewHDMasterKey()
 
     // set the hd keypath to "m" -> Master, refers the masterkeyid to itself
     metadata.hdKeypath     = "m";
-    metadata.hdMasterKeyID = pubkey.GetID();
+    metadata.hdSeedKeyID = pubkey.GetID();
 
     {
         LOCK(cs_wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -678,7 +678,7 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
 
         // if we are using HD, replace the HD seed key with a new one
         if (IsHDEnabled()) {
-            if (!SetHDSeedKey(GenerateNewHDMasterKey())) {
+            if (!SetHDSeedKey(GenerateNewHDSeedKey())) {
                 return false;
             }
         }
@@ -1439,7 +1439,7 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
     return nChange;
 }
 
-CPubKey CWallet::GenerateNewHDMasterKey()
+CPubKey CWallet::GenerateNewHDSeedKey()
 {
     CKey key;
     key.MakeNewKey(true);
@@ -1451,7 +1451,7 @@ CPubKey CWallet::GenerateNewHDMasterKey()
     CPubKey pubkey = key.GetPubKey();
     assert(key.VerifyPubKey(pubkey));
 
-    // set the hd keypath to "m" -> Master, refers the masterkeyid to itself
+    // set the hd keypath to "m" -> Seed, refers the hdSeedKeyID to itself
     metadata.hdKeypath     = "m";
     metadata.hdSeedKeyID = pubkey.GetID();
 
@@ -3986,7 +3986,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         walletInstance->SetMinVersion(FEATURE_NO_DEFAULT_KEY);
 
         // generate a new HD seed key
-        CPubKey masterPubKey = walletInstance->GenerateNewHDMasterKey();
+        CPubKey masterPubKey = walletInstance->GenerateNewHDSeedKey();
         if (!walletInstance->SetHDSeedKey(masterPubKey))
             throw std::runtime_error(std::string(__func__) + ": Storing HD seed key failed");
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -190,7 +190,7 @@ void CWallet::DeriveNewChildKey(CWalletDB &walletdb, CKeyMetadata& metadata, CKe
     if (!GetKey(hdChain.masterKeyID, key))
         throw std::runtime_error(std::string(__func__) + ": Master key not found");
 
-    masterKey.SetMaster(key.begin(), key.size());
+    masterKey.SetSeed(key.begin(), key.size());
 
     // derive m/0'
     // use hardened derivation (child keys >= 0x80000000 are hardened after bip32)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -676,9 +676,9 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)
         Lock();
         Unlock(strWalletPassphrase);
 
-        // if we are using HD, replace the HD master key (seed) with a new one
+        // if we are using HD, replace the HD seed key with a new one
         if (IsHDEnabled()) {
-            if (!SetHDMasterKey(GenerateNewHDMasterKey())) {
+            if (!SetHDSeedKey(GenerateNewHDMasterKey())) {
                 return false;
             }
         }
@@ -1469,7 +1469,7 @@ CPubKey CWallet::GenerateNewHDMasterKey()
     return pubkey;
 }
 
-bool CWallet::SetHDMasterKey(const CPubKey& pubkey)
+bool CWallet::SetHDSeedKey(const CPubKey& pubkey)
 {
     LOCK(cs_wallet);
     // store the keyid (hash160) together with
@@ -3985,10 +3985,10 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile)
         }
         walletInstance->SetMinVersion(FEATURE_NO_DEFAULT_KEY);
 
-        // generate a new master key
+        // generate a new HD seed key
         CPubKey masterPubKey = walletInstance->GenerateNewHDMasterKey();
-        if (!walletInstance->SetHDMasterKey(masterPubKey))
-            throw std::runtime_error(std::string(__func__) + ": Storing master key failed");
+        if (!walletInstance->SetHDSeedKey(masterPubKey))
+            throw std::runtime_error(std::string(__func__) + ": Storing HD seed key failed");
 
         // Top up the keypool
         if (!walletInstance->TopUpKeyPool()) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1135,11 +1135,11 @@ public:
     /* Generates a new HD master key (will not be activated) */
     CPubKey GenerateNewHDMasterKey();
     
-    /* Set the current HD master key (will reset the chain child index counters)
-       Sets the master key's version based on the current wallet version (so the
+    /* Set the current HD seed key (will reset the chain child index counters)
+       Sets the hd chains version based on the current wallet version (so the
        caller must ensure the current wallet version is correct before calling
        this function). */
-    bool SetHDMasterKey(const CPubKey& key);
+    bool SetHDSeedKey(const CPubKey& key);
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1132,8 +1132,8 @@ public:
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;
 
-    /* Generates a new HD master key (will not be activated) */
-    CPubKey GenerateNewHDMasterKey();
+    /* Generates a new HD seed key (will not be activated) */
+    CPubKey GenerateNewHDSeedKey();
     
     /* Set the current HD seed key (will reset the chain child index counters)
        Sets the hd chains version based on the current wallet version (so the

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -62,7 +62,7 @@ class CHDChain
 public:
     uint32_t nExternalChainCounter;
     uint32_t nInternalChainCounter;
-    CKeyID masterKeyID; //!< master key hash160
+    CKeyID seedKeyID; //!< seed key hash160
 
     static const int VERSION_HD_BASE        = 1;
     static const int VERSION_HD_CHAIN_SPLIT = 2;
@@ -76,7 +76,7 @@ public:
     {
         READWRITE(this->nVersion);
         READWRITE(nExternalChainCounter);
-        READWRITE(masterKeyID);
+        READWRITE(seedKeyID);
         if (this->nVersion >= VERSION_HD_CHAIN_SPLIT)
             READWRITE(nInternalChainCounter);
     }
@@ -86,7 +86,7 @@ public:
         nVersion = CHDChain::CURRENT_VERSION;
         nExternalChainCounter = 0;
         nInternalChainCounter = 0;
-        masterKeyID.SetNull();
+        seedKeyID.SetNull();
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -99,7 +99,7 @@ public:
     int nVersion;
     int64_t nCreateTime; // 0 means unknown
     std::string hdKeypath; //optional HD/bip32 keypath
-    CKeyID hdMasterKeyID; //id of the HD masterkey used to derive this key
+    CKeyID hdSeedKeyID; //id of the HD seed key used to derive this key
 
     CKeyMetadata()
     {
@@ -120,7 +120,7 @@ public:
         if (this->nVersion >= VERSION_WITH_HDDATA)
         {
             READWRITE(hdKeypath);
-            READWRITE(hdMasterKeyID);
+            READWRITE(hdSeedKeyID);
         }
     }
 
@@ -129,7 +129,7 @@ public:
         nVersion = CKeyMetadata::CURRENT_VERSION;
         nCreateTime = 0;
         hdKeypath.clear();
-        hdMasterKeyID.SetNull();
+        hdSeedKeyID.SetNull();
     }
 };
 

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -27,9 +27,9 @@ class WalletHDTest(BitcoinTestFramework):
         self.start_node(1)
         connect_nodes_bi(self.nodes, 0, 1)
 
-        # Make sure we use hd, keep masterkeyid
-        masterkeyid = self.nodes[1].getwalletinfo()['hdmasterkeyid']
-        assert_equal(len(masterkeyid), 40)
+        # Make sure we use hd, keep seedkeyid
+        seedkeyid = self.nodes[1].getwalletinfo()['hdseedkeyid']
+        assert_equal(len(seedkeyid), 40)
 
         # create an internal key
         change_addr = self.nodes[1].getrawchangeaddress()
@@ -40,7 +40,7 @@ class WalletHDTest(BitcoinTestFramework):
         non_hd_add = self.nodes[0].getnewaddress()
         self.nodes[1].importprivkey(self.nodes[0].dumpprivkey(non_hd_add))
 
-        # This should be enough to keep the master key and the non-HD key
+        # This should be enough to keep the seed key and the non-HD key
         self.nodes[1].backupwallet(tmpdir + "/hd.bak")
         #self.nodes[1].dumpwallet(tmpdir + "/hd.dump")
 
@@ -53,7 +53,7 @@ class WalletHDTest(BitcoinTestFramework):
             hd_add = self.nodes[1].getnewaddress()
             hd_info = self.nodes[1].getaddressinfo(hd_add)
             assert_equal(hd_info["hdkeypath"], "m/0'/0'/"+str(i)+"'")
-            assert_equal(hd_info["hdmasterkeyid"], masterkeyid)
+            assert_equal(hd_info["hdseedkeyid"], seedkeyid)
             self.nodes[0].sendtoaddress(hd_add, 1)
             self.nodes[0].generate(1)
         self.nodes[0].sendtoaddress(non_hd_add, 1)
@@ -82,7 +82,7 @@ class WalletHDTest(BitcoinTestFramework):
             hd_add_2 = self.nodes[1].getnewaddress()
             hd_info_2 = self.nodes[1].getaddressinfo(hd_add_2)
             assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/"+str(_)+"'")
-            assert_equal(hd_info_2["hdmasterkeyid"], masterkeyid)
+            assert_equal(hd_info_2["hdseedkeyid"], seedkeyid)
         assert_equal(hd_add, hd_add_2)
         connect_nodes_bi(self.nodes, 0, 1)
         self.sync_all()

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -16,7 +16,7 @@ class KeyPoolTest(BitcoinTestFramework):
         addr_before_encrypting = nodes[0].getnewaddress()
         addr_before_encrypting_data = nodes[0].getaddressinfo(addr_before_encrypting)
         wallet_info_old = nodes[0].getwalletinfo()
-        assert(addr_before_encrypting_data['hdmasterkeyid'] == wallet_info_old['hdmasterkeyid'])
+        assert(addr_before_encrypting_data['hdseedkeyid'] == wallet_info_old['hdseedkeyid'])
         
         # Encrypt wallet and wait to terminate
         nodes[0].node_encrypt_wallet('test')
@@ -26,8 +26,8 @@ class KeyPoolTest(BitcoinTestFramework):
         addr = nodes[0].getnewaddress()
         addr_data = nodes[0].getaddressinfo(addr)
         wallet_info = nodes[0].getwalletinfo()
-        assert(addr_before_encrypting_data['hdmasterkeyid'] != wallet_info['hdmasterkeyid'])
-        assert(addr_data['hdmasterkeyid'] == wallet_info['hdmasterkeyid'])
+        assert(addr_before_encrypting_data['hdseedkeyid'] != wallet_info['hdseedkeyid'])
+        assert(addr_data['hdseedkeyid'] == wallet_info['hdseedkeyid'])
         assert_raises_rpc_error(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
 
         # put six (plus 2) new keys in the keypool (100% external-, +100% internal-keys, 1 in min)


### PR DESCRIPTION
Addresses #12084 and #8684

This renames a couple of functions and members (no functional changes, expect log prints):
* Rename CKey::SetMaster to CKey::SetSeed
* Rename CHDChain::masterKeyId to CHDChain::seedKeyID
* Rename CHDChain::hdMasterKeyID to CHDChain::hdSeedKeyID
* Rename CWallet::GenerateNewHDMasterKey to CWallet::GenerateNewHDSeedKey
* Rename CWallet::SetHDMasterKey to CWallet::SetHDSeedKey

As well it introduces a tiny API change (a649ab2):
* RPC API change: Rename "hdmasterkeyid" to "hdseedkeyid", rename "hdmaster" in wallet-dump output to "hdseed"

Fixes also a bug (16d49e1):
* Bugfix: use "s" instead of the incorrect "m" for the seed-key hd-keypath key metadata