### PR TITLE
[contrib] Use BDB_LIBS/CFLAGS and pass --disable-replication

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -83,4 +83,4 @@ echo
 echo 'When compiling bitcoind, run `./configure` in the following way:'
 echo
 echo "  export BDB_PREFIX='${BDB_PREFIX}'"
-echo '  ./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" ...'
+echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...'

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -72,7 +72,7 @@ patch -p2 < clang.patch
 cd build_unix/
 
 "${BDB_PREFIX}/${BDB_VERSION}/dist/configure" \
-  --enable-cxx --disable-shared --with-pic --prefix="${BDB_PREFIX}" \
+  --enable-cxx --disable-shared --disable-replication --with-pic --prefix="${BDB_PREFIX}" \
   "${@}"
 
 make install


### PR DESCRIPTION
Switch install_db4 to use BDB_LIBS/BDB_CFLAGS, mentioned [here](https://github.com/bitcoin/bitcoin/pull/12041/files#r159616003).

Pass ```--disable-replication``` to configure to match what we do in [depends](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/bdb.mk#L9).

Documentation about --disable-replication is available [here](https://docs.oracle.com/cd/E17275_01/html/programmer_reference/build_unix_small.html).