### PR TITLE
[scripts] lint-whitespace: use perl instead of grep -P

### DIFF
--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -59,7 +59,7 @@ if showdiff | grep -E -q '^\+.*\s+$'; then
 fi
 
 # Check if tab characters were found in the diff.
-if showcodediff | grep -P -q '^\+.*\t'; then
+if showcodediff | perl -nle '$MATCH++ if m{^\+.*\t}; END{exit 1 unless $MATCH>0}' > /dev/null; then
   echo "This diff appears to have added new lines with tab characters instead of spaces."
   echo "The following changes were suspected:"
   FILENAME=""
@@ -81,7 +81,7 @@ if showcodediff | grep -P -q '^\+.*\t'; then
       fi
       echo "$line"
     fi
-  done < <(showcodediff | grep -P '^(diff --git |@@|\+.*\t)')
+  done < <(showcodediff | perl -nle 'print if m{^(diff --git |@@|\+.*\t)}')
   RET=1
 fi
 


### PR DESCRIPTION
MacOS does not support `grep -P` out of the box. This change makes
it easier for developers to check for whitespace problems locally.

Based on [this](https://stackoverflow.com/a/16658690) and [this](https://serverfault.com/a/504387) Stack Exchange answer.

Tested with:
```sh
export TRAVIS_COMMIT_RANGE='fe78c9a...62e0453'
contrib/devtools/lint-whitespace.sh 
This diff appears to have added new lines with tab characters instead of spaces.
The following changes were suspected:

diff --git a/src/test/bignum_tests.cpp b/src/test/bignum_tests.cpp
@@ -0,0 +1,110 @@
+	num.setint64(n);
```
  