### PR TITLE
Qt: Fixed styling in modaloverlay.cpp

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -36,7 +36,8 @@ ModalOverlay::~ModalOverlay()
     delete ui;
 }
 
-bool ModalOverlay::eventFilter(QObject * obj, QEvent * ev) {
+bool ModalOverlay::eventFilter(QObject * obj, QEvent * ev)
+{
     if (obj == parent()) {
         if (ev->type() == QEvent::Resize) {
             QResizeEvent * rev = static_cast<QResizeEvent*>(ev);
@@ -53,7 +54,8 @@ bool ModalOverlay::eventFilter(QObject * obj, QEvent * ev) {
 }
 
 //! Tracks parent widget changes
-bool ModalOverlay::event(QEvent* ev) {
+bool ModalOverlay::event(QEvent* ev)
+{
     if (ev->type() == QEvent::ParentAboutToChange) {
         if (parent()) parent()->removeEventFilter(this);
     }
@@ -104,7 +106,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
         ui->progressIncreasePerH->setText(QString::number(progressPerHour * 100, 'f', 2)+"%");
 
         // show expected remaining time
-        if(remainingMSecs >= 0) {	
+        if(remainingMSecs >= 0) {
             ui->expectedTimeLeft->setText(GUIUtil::formatNiceTimeOffset(remainingMSecs / 1000.0));
         } else {
             ui->expectedTimeLeft->setText(QObject::tr("unknown"));


### PR DESCRIPTION
First commit here.

Pushing some style changes as I understand the repo better.

Fixed braces on some method declaration and removed an extra tab to keep in line with other method declarations in the project.
 
EDIT: As a side note, I couldn't find a styling / coding convention doc to describe what style should be used. If there is none I am fine with creating one.