### PR TITLE
Add dev guideline limiting auto usage.

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -39,6 +39,7 @@ code.
   - `++i` is preferred over `i++`.
   - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
+  - Only use `auto` if it saves significant typing/reading or if it is critical to the functionality of the code.
 
 Block style example:
 ```c++


### PR DESCRIPTION
I'm tired of having an extra level of indirection to review stupid shit like https://github.com/bitcoin/bitcoin/pull/11403/commits/5ae4080cc2c0c50e1093b52005c47cd74bd0261e#diff-ad6efdc354b57bd1fa29fc3abb6e2872R283, it just makes review, scripted-diff and other stuff harder, without materially making the code more flexible (unless we want to do a massive sed to make everything auto, which would be insane).