### PR TITLE
[Docs] Create NetBSD build instructions and fix compilation.

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -64,7 +64,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
   
   if test "x$BDB_LIBS" = "x"; then
     # TODO: Ideally this could find the library version and make sure it matches the headers being used
-    for searchlib in db_cxx-4.8 db_cxx; do
+    for searchlib in db_cxx-4.8 db_cxx db4_cxx; do
       AC_CHECK_LIB([$searchlib],[main],[
         BDB_LIBS="-l${searchlib}"
         break

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -25,23 +25,25 @@ python27
 
 Download the source code:
 ```
-git clone https://github.com/bitcoin/bitcoin.git
+git clone https://github.com/bitcoin/bitcoin
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
 ### Building Bitcoin Core
 
-**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with an error.
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
-To configure with wallet:
+With wallet:
 ```
+./autogen.sh
 ./configure CPPFLAGS="-I/usr/pkg/include -DOS_NETBSD" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
 gmake
 ```
 
-To configure without wallet:
+Without wallet:
 ```
+./autogen.sh
 ./configure --disable-wallet CPPFLAGS="-I/usr/pkg/include -DOS_NETBSD" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
 gmake
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -11,7 +11,8 @@ Preparation
 
 You will need the following modules, which can be installed via pkgsrc or pkgin:
 
-```autoconf
+```
+autoconf
 automake
 boost
 db4
@@ -23,7 +24,8 @@ python27
 ```
 
 Download the source code:
-```git clone https://github.com/bitcoin/bitcoin.git
+```
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
@@ -33,11 +35,13 @@ See [dependencies.md](dependencies.md) for a complete overview.
 **Important**: use `gmake`, not `make`. The non-GNU `make` will exit with an error.
 
 To configure with wallet:
-```./configure CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
+```
+./configure CPPFLAGS="-I/usr/pkg/include -DOS_NETBSD" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
 gmake
 ```
 
 To configure without wallet:
-```./configure --disable-wallet  CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
+```
+./configure --disable-wallet CPPFLAGS="-I/usr/pkg/include -DOS_NETBSD" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
 gmake
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,0 +1,43 @@
+NetBSD build guide
+======================
+(updated for NetBSD 7.0)
+
+This guide describes how to build bitcoind and command-line utilities on NetBSD.
+
+This guide does not contain instructions for building the GUI.
+
+Preparation
+-------------
+
+You will need the following modules, which can be installed via pkgsrc or pkgin:
+
+```autoconf
+automake
+boost
+db4
+git
+gmake
+libevent
+libtool
+python27
+```
+
+Download the source code:
+```git clone https://github.com/bitcoin/bitcoin.git
+```
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+### Building Bitcoin Core
+
+**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with an error.
+
+To configure with wallet:
+```./configure CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
+gmake
+```
+
+To configure without wallet:
+```./configure --disable-wallet  CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
+gmake
+```

--- a/src/leveldb/port/port_posix.h
+++ b/src/leveldb/port/port_posix.h
@@ -22,7 +22,7 @@
     #define PLATFORM_IS_LITTLE_ENDIAN false
   #endif
 #elif defined(OS_FREEBSD) || defined(OS_OPENBSD) ||\
-      defined(OS_NETBSD) || defined(__NetBSD__) || defined(OS_DRAGONFLYBSD)
+      defined(OS_NETBSD) || defined(OS_DRAGONFLYBSD)
   #include <sys/types.h>
   #include <sys/endian.h>
   #define PLATFORM_IS_LITTLE_ENDIAN (_BYTE_ORDER == _LITTLE_ENDIAN)

--- a/src/leveldb/port/port_posix.h
+++ b/src/leveldb/port/port_posix.h
@@ -22,7 +22,7 @@
     #define PLATFORM_IS_LITTLE_ENDIAN false
   #endif
 #elif defined(OS_FREEBSD) || defined(OS_OPENBSD) ||\
-      defined(OS_NETBSD) || defined(OS_DRAGONFLYBSD)
+      defined(OS_NETBSD) || defined(__NetBSD__) || defined(OS_DRAGONFLYBSD)
   #include <sys/types.h>
   #include <sys/endian.h>
   #define PLATFORM_IS_LITTLE_ENDIAN (_BYTE_ORDER == _LITTLE_ENDIAN)


### PR DESCRIPTION
This change makes it possible to build/compile Bitcoin on NetBSD (specifically, NetBSD 7.0, and very likely other recent versions too).  One .m4 file has one minor change so that ./configure can find Berkeley DB 4.8, and one .md file was created that provides instructions for NetBSD users.

Thank you to the many helpful people in the #netbsd and #bitcoin-core-dev channels on irc.freenode.net for your help with this.