### PR TITLE
Track best-possible-headers

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -789,9 +789,10 @@ static bool BlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Para
 {
     AssertLockHeld(cs_main);
     if (chainActive.Contains(pindex)) return true;
-    return pindex->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != nullptr) &&
-        (pindexBestHeader->GetBlockTime() - pindex->GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
-        (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, consensusParams) < STALE_RELAY_AGE_LIMIT);
+    const CBlockIndex* best_header = GetBestHeader();
+    return pindex->IsValid(BLOCK_VALID_SCRIPTS) &&
+        (best_header->GetBlockTime() - pindex->GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
+        (GetBlockProofEquivalentTime(*best_header, *pindex, *best_header, consensusParams) < STALE_RELAY_AGE_LIMIT);
 }
 
 PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn, CScheduler &scheduler) : connman(connmanIn), m_stale_tip_check_time(0) {
@@ -1084,7 +1085,7 @@ void static ProcessGetBlockData(CNode* pfrom, const Consensus::Params& consensus
     const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
     // disconnect node in case we have reached the outbound limit for serving historical blocks
     // never disconnect whitelisted nodes
-    if (send && connman->OutboundTargetReached(true) && ( ((pindexBestHeader != nullptr) && (pindexBestHeader->GetBlockTime() - mi->second->GetBlockTime() > HISTORICAL_BLOCK_AGE)) || inv.type == MSG_FILTERED_BLOCK) && !pfrom->fWhitelisted)
+    if (send && connman->OutboundTargetReached(true) && ( (GetBestHeader()->GetBlockTime() - mi->second->GetBlockTime() > HISTORICAL_BLOCK_AGE) || inv.type == MSG_FILTERED_BLOCK) && !pfrom->fWhitelisted)
     {
         LogPrint(BCLog::NET, "historical block serving limit reached, disconnect peer=%d\n", pfrom->GetId());
 
@@ -1298,11 +1299,12 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
         //   nUnconnectingHeaders gets reset back to 0.
         if (mapBlockIndex.find(headers[0].hashPrevBlock) == mapBlockIndex.end() && nCount < MAX_BLOCKS_TO_ANNOUNCE) {
             nodestate->nUnconnectingHeaders++;
-            connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), uint256()));
+            const CBlockIndex* best_header = GetBestHeader();
+            connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(best_header), uint256()));
             LogPrint(BCLog::NET, "received header %s: missing prev block %s, sending getheaders (%d) to end (peer=%d, nUnconnectingHeaders=%d)\n",
                     headers[0].GetHash().ToString(),
                     headers[0].hashPrevBlock.ToString(),
-                    pindexBestHeader->nHeight,
+                    best_header->nHeight,
                     pfrom->GetId(), nodestate->nUnconnectingHeaders);
             // Set hashLastUnknownBlock for this peer, so that if we
             // eventually get the headers - even from a different peer -
@@ -1893,8 +1895,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     // fell back to inv we probably have a reorg which we should get the headers for first,
                     // we now only provide a getheaders response here. When we receive the headers, we will
                     // then ask for the blocks we need.
-                    connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), inv.hash));
-                    LogPrint(BCLog::NET, "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, inv.hash.ToString(), pfrom->GetId());
+                    const CBlockIndex* best_header = GetBestHeader();
+                    connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(best_header), inv.hash));
+                    LogPrint(BCLog::NET, "getheaders (%d) %s to peer=%d\n", best_header->nHeight, inv.hash.ToString(), pfrom->GetId());
                 }
             }
             else
@@ -2308,7 +2311,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (mapBlockIndex.find(cmpctblock.header.hashPrevBlock) == mapBlockIndex.end()) {
             // Doesn't connect (or is genesis), instead of DoSing in AcceptBlockHeader, request deeper headers
             if (!IsInitialBlockDownload())
-                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), uint256()));
+                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::GETHEADERS, chainActive.GetLocator(GetBestHeader()), uint256()));
             return true;
         }
 
@@ -3240,22 +3243,22 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         }
 
         // Start block sync
-        if (pindexBestHeader == nullptr)
-            pindexBestHeader = chainActive.Tip();
+        const CBlockIndex* best_header = GetBestHeader();
+        assert(best_header != nullptr);
         bool fFetch = state.fPreferredDownload || (nPreferredDownload == 0 && !pto->fClient && !pto->fOneShot); // Download if this is a nice peer, or we have no nice peers and this one might do.
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex) {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60) {
+            if ((nSyncStarted == 0 && fFetch) || best_header->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60) {
                 state.fSyncStarted = true;
-                state.nHeadersSyncTimeout = GetTimeMicros() + HEADERS_DOWNLOAD_TIMEOUT_BASE + HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER * (GetAdjustedTime() - pindexBestHeader->GetBlockTime())/(consensusParams.nPowTargetSpacing);
+                state.nHeadersSyncTimeout = GetTimeMicros() + HEADERS_DOWNLOAD_TIMEOUT_BASE + HEADERS_DOWNLOAD_TIMEOUT_PER_HEADER * (GetAdjustedTime() - best_header->GetBlockTime())/(consensusParams.nPowTargetSpacing);
                 nSyncStarted++;
-                const CBlockIndex *pindexStart = pindexBestHeader;
+                const CBlockIndex *pindexStart = best_header;
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
                    non-empty list of headers back as long as the peer
                    is up-to-date.  With a non-empty response, we can initialise
                    the peer's known best block.  This wouldn't be possible
-                   if we requested starting at pindexBestHeader and
+                   if we requested starting at best_header and
                    got back an empty response.  */
                 if (pindexStart->pprev)
                     pindexStart = pindexStart->pprev;
@@ -3574,7 +3577,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
         // Check for headers sync timeouts
         if (state.fSyncStarted && state.nHeadersSyncTimeout < std::numeric_limits<int64_t>::max()) {
             // Detect whether this is a stalling initial-headers-sync peer
-            if (pindexBestHeader->GetBlockTime() <= GetAdjustedTime() - 24*60*60) {
+            if (best_header->GetBlockTime() <= GetAdjustedTime() - 24*60*60) {
                 if (nNow > state.nHeadersSyncTimeout && nSyncStarted == 1 && (nPreferredDownload - state.fPreferredDownload >= 1)) {
                     // Disconnect a (non-whitelisted) peer if it is our only sync peer,
                     // and we have others we could be using instead.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2493,16 +2493,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 mapBlockSource.emplace(pblock->GetHash(), std::make_pair(pfrom->GetId(), false));
             }
             bool fNewBlock = false;
-            // Setting fForceProcessing to true means that we bypass some of
-            // our anti-DoS protections in AcceptBlock, which filters
-            // unrequested blocks that might be trying to waste our resources
-            // (eg disk space). Because we only try to reconstruct blocks when
-            // we're close to caught up (via the CanDirectFetch() requirement
-            // above, combined with the behavior of not requesting blocks until
-            // we have a chain with at least nMinimumChainWork), and we ignore
-            // compact blocks with less work than our tip, it is safe to treat
-            // reconstructed compact blocks as having been requested.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            ProcessNewBlock(chainparams, pblock, &fNewBlock);
             if (fNewBlock) {
                 pfrom->nLastBlockTime = GetTime();
             } else {
@@ -2582,11 +2573,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             bool fNewBlock = false;
             // Since we requested this block (it was in mapBlocksInFlight), force it to be processed,
             // even if it would not be a candidate for new tip (missing previous block, chain not long enough, etc)
-            // This bypasses some anti-DoS logic in AcceptBlock (eg to prevent
-            // disk-space attacks), but this should be safe due to the
-            // protections in the compact block handler -- see related comment
-            // in compact block optimistic reconstruction handling.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            ProcessNewBlock(chainparams, pblock, &fNewBlock);
             if (fNewBlock) {
                 pfrom->nLastBlockTime = GetTime();
             } else {
@@ -2629,19 +2616,16 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         LogPrint(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->GetId());
 
-        bool forceProcessing = false;
         const uint256 hash(pblock->GetHash());
         {
             LOCK(cs_main);
-            // Also always process if we requested the block explicitly, as we may
-            // need it even though it is not a candidate for a new best tip.
-            forceProcessing |= MarkBlockAsReceived(hash);
+            MarkBlockAsReceived(hash);
             // mapBlockSource is only used for sending reject messages and DoS scores,
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         bool fNewBlock = false;
-        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        ProcessNewBlock(chainparams, pblock, &fNewBlock);
         if (fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
         } else {

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -78,12 +78,10 @@ int ClientModel::getNumBlocks() const
 int ClientModel::getHeaderTipHeight() const
 {
     if (cachedBestHeaderHeight == -1) {
-        // make sure we initially populate the cache via a cs_main lock
-        // otherwise we need to wait for a tip update
-        LOCK(cs_main);
-        if (pindexBestHeader) {
-            cachedBestHeaderHeight = pindexBestHeader->nHeight;
-            cachedBestHeaderTime = pindexBestHeader->GetBlockTime();
+        const CBlockIndex* best_header = GetBestHeader();
+        if (best_header) {
+            cachedBestHeaderHeight = best_header->nHeight;
+            cachedBestHeaderTime = best_header->GetBlockTime();
         }
     }
     return cachedBestHeaderHeight;
@@ -92,10 +90,10 @@ int ClientModel::getHeaderTipHeight() const
 int64_t ClientModel::getHeaderTipTime() const
 {
     if (cachedBestHeaderTime == -1) {
-        LOCK(cs_main);
-        if (pindexBestHeader) {
-            cachedBestHeaderHeight = pindexBestHeader->nHeight;
-            cachedBestHeaderTime = pindexBestHeader->GetBlockTime();
+        const CBlockIndex* best_header = GetBestHeader();
+        if (best_header) {
+            cachedBestHeaderHeight = best_header->nHeight;
+            cachedBestHeaderTime = best_header->GetBlockTime();
         }
     }
     return cachedBestHeaderTime;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1188,7 +1188,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("chain",                 Params().NetworkIDString()));
     obj.push_back(Pair("blocks",                (int)chainActive.Height()));
-    obj.push_back(Pair("headers",               pindexBestHeader ? pindexBestHeader->nHeight : -1));
+    obj.push_back(Pair("headers",               GetBestHeader()->nHeight));
     obj.push_back(Pair("bestblockhash",         chainActive.Tip()->GetBlockHash().GetHex()));
     obj.push_back(Pair("difficulty",            (double)GetDifficulty()));
     obj.push_back(Pair("mediantime",            (int64_t)chainActive.Tip()->GetMedianTimePast()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -137,7 +137,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             continue;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))
+        if (!ProcessNewBlock(Params(), shared_pblock, nullptr))
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
@@ -756,7 +756,7 @@ UniValue submitblock(const JSONRPCRequest& request)
 
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool fAccepted = ProcessNewBlock(Params(), blockptr, true, nullptr);
+    bool fAccepted = ProcessNewBlock(Params(), blockptr, nullptr);
     UnregisterValidationInterface(&sc);
     if (fBlockPresent) {
         if (fAccepted && !sc.found) {

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -248,7 +248,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, nullptr));
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -151,7 +151,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    ProcessNewBlock(chainparams, shared_pblock, nullptr);
 
     CBlock result = block;
     return result;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -60,6 +60,7 @@
 namespace {
     struct CBlockIndexWorkComparator
     {
+        // Returns pa < pb in work-order
         bool operator()(const CBlockIndex *pa, const CBlockIndex *pb) const {
             // First sort by most total work, ...
             if (pa->nChainWork > pb->nChainWork) return false;
@@ -107,8 +108,7 @@ class CChainState {
 private:
     /**
      * The set of all CBlockIndex entries with BLOCK_VALID_TRANSACTIONS (for itself and all ancestors) and
-     * as good as our current tip or better. Entries may be failed, though, and pruning nodes may be
-     * missing the data for the block.
+     * as good as our current tip or better. Pruning nodes may be missing the data for the block.
      */
     std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexCandidates;
 
@@ -191,6 +191,7 @@ private:
     CBlockIndex* FindMostWorkChain();
     bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBlockIndex *pindexNew, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
 
+    void PruneInvalidBlockIndexCandidates(CBlockIndex* pindexInvalid);
 
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs, const CChainParams& params);
 } g_chainstate;
@@ -1259,6 +1260,48 @@ static void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     CheckForkWarningConditions();
 }
 
+// Helper for PruneInvalidBlockIndexCandidates
+static void PruneInvalidIndexCandidatesInSet(CBlockIndex* pindexInvalid, std::set<CBlockIndex*, CBlockIndexWorkComparator>& set_candidates) {
+    // Iterate set_candidates downwards, deleting parents of pindexInvalid,
+    // until we get to headers which are lower total-work than pindexInvalid
+    // (at which point they can't be parents of pindexInvalid).
+    std::set<CBlockIndex*, CBlockIndexWorkComparator>::reverse_iterator it = set_candidates.rbegin();
+    while (it != set_candidates.rend() && (*it)->nChainWork > pindexInvalid->nChainWork) {
+        if ((*it)->GetAncestor(pindexInvalid->nHeight) == pindexInvalid) {
+            CBlockIndex* pindexInvalidTip = *it;
+            if (!pindexBestInvalid || pindexInvalidTip->nChainWork > pindexBestInvalid->nChainWork)
+                pindexBestInvalid = pindexInvalidTip;
+
+            while (pindexInvalidTip != pindexInvalid) {
+                if (!(pindexInvalidTip->nStatus & BLOCK_FAILED_MASK)) {
+                    pindexInvalidTip->nStatus |= BLOCK_FAILED_CHILD;
+                    setDirtyBlockIndex.insert(pindexInvalidTip);
+                }
+                pindexInvalidTip = pindexInvalidTip->pprev;
+            }
+            std::set<CBlockIndex*, CBlockIndexWorkComparator>::iterator forward_it = it.base(); // Is one past it
+            forward_it--; // Now points to it
+            forward_it = set_candidates.erase(forward_it);
+            it = std::set<CBlockIndex*, CBlockIndexWorkComparator>::reverse_iterator(forward_it);
+            // forward_it == it.base() now points to one-past previous it, making it point to one-before previous it.
+        } else {
+            it++;
+        }
+    }
+    set_candidates.erase(pindexInvalid);
+}
+
+/**
+ * Removes any descendants of pindexInvalid from candidate blocks,
+ * marking them BLOCK_FAILED_CHILD as we go
+ */
+void CChainState::PruneInvalidBlockIndexCandidates(CBlockIndex* pindexInvalid) {
+    AssertLockHeld(cs_main);
+    assert(pindexInvalid->nStatus & BLOCK_FAILED_MASK);
+
+    PruneInvalidIndexCandidatesInSet(pindexInvalid, setBlockIndexCandidates);
+}
+
 void static InvalidChainFound(CBlockIndex* pindexNew)
 {
     if (!pindexBestInvalid || pindexNew->nChainWork > pindexBestInvalid->nChainWork)
@@ -1281,7 +1324,7 @@ void CChainState::InvalidBlockFound(CBlockIndex *pindex, const CValidationState 
         pindex->nStatus |= BLOCK_FAILED_VALID;
         g_failed_blocks.insert(pindex);
         setDirtyBlockIndex.insert(pindex);
-        setBlockIndexCandidates.erase(pindex);
+        PruneInvalidBlockIndexCandidates(pindex);
         InvalidChainFound(pindex);
     }
 }
@@ -2396,28 +2439,21 @@ CBlockIndex* CChainState::FindMostWorkChain() {
         bool fInvalidAncestor = false;
         while (pindexTest && !chainActive.Contains(pindexTest)) {
             assert(pindexTest->nChainTx || pindexTest->nHeight == 0);
+            assert(pindexTest->IsValid(BLOCK_VALID_TRANSACTIONS));
 
             // Pruned nodes may have entries in setBlockIndexCandidates for
             // which block files have been deleted.  Remove those as candidates
             // for the most work chain if we come across them; we can't switch
             // to a chain unless we have all the non-active-chain parent blocks.
-            bool fFailedChain = pindexTest->nStatus & BLOCK_FAILED_MASK;
-            bool fMissingData = !(pindexTest->nStatus & BLOCK_HAVE_DATA);
-            if (fFailedChain || fMissingData) {
+            if (!(pindexTest->nStatus & BLOCK_HAVE_DATA)) {
                 // Candidate chain is not usable (either invalid or missing data)
-                if (fFailedChain && (pindexBestInvalid == nullptr || pindexNew->nChainWork > pindexBestInvalid->nChainWork))
-                    pindexBestInvalid = pindexNew;
                 CBlockIndex *pindexFailed = pindexNew;
                 // Remove the entire chain from the set.
                 while (pindexTest != pindexFailed) {
-                    if (fFailedChain) {
-                        pindexFailed->nStatus |= BLOCK_FAILED_CHILD;
-                    } else if (fMissingData) {
-                        // If we're missing data, then add back to mapBlocksUnlinked,
-                        // so that if the block arrives in the future we can try adding
-                        // to setBlockIndexCandidates again.
-                        mapBlocksUnlinked.insert(std::make_pair(pindexFailed->pprev, pindexFailed));
-                    }
+                    // If we're missing data, then add back to mapBlocksUnlinked,
+                    // so that if the block arrives in the future we can try adding
+                    // to setBlockIndexCandidates again.
+                    mapBlocksUnlinked.insert(std::make_pair(pindexFailed->pprev, pindexFailed));
                     setBlockIndexCandidates.erase(pindexFailed);
                     pindexFailed = pindexFailed->pprev;
                 }
@@ -4395,20 +4431,27 @@ void CChainState::CheckBlockIndex(const Consensus::Params& consensusParams)
             // Checks for not-invalid blocks.
             assert((pindex->nStatus & BLOCK_FAILED_MASK) == 0); // The failed mask cannot be set for blocks without invalid parents.
         }
-        if (!CBlockIndexWorkComparator()(pindex, chainActive.Tip()) && pindexFirstNeverProcessed == nullptr) {
-            if (pindexFirstInvalid == nullptr) {
-                // If this block sorts at least as good as the current tip and
-                // is valid and we have all data for its parents, it must be in
-                // setBlockIndexCandidates.  chainActive.Tip() must also be there
-                // even if some data has been pruned.
-                if (pindexFirstMissing == nullptr || pindex == chainActive.Tip()) {
-                    assert(setBlockIndexCandidates.count(pindex));
-                }
-                // If some parent is missing, then it could be that this block was in
-                // setBlockIndexCandidates but had to be removed because of the missing data.
-                // In this case it must be in mapBlocksUnlinked -- see test below.
+        if (pindex->nStatus & BLOCK_FAILED_CHILD) {
+            // Blocks which failed with "CHILD" must have an invalid parent
+            assert(pindexFirstInvalid);
+            assert(pindexFirstInvalid != pindex);
+            assert(!(pindex->nStatus & BLOCK_FAILED_VALID));
+        }
+        if (pindex->nStatus & BLOCK_FAILED_VALID) {
+            assert(!(pindex->nStatus & BLOCK_FAILED_CHILD));
+        }
+        if (!CBlockIndexWorkComparator()(pindex, chainActive.Tip()) && pindexFirstNeverProcessed == nullptr && pindexFirstInvalid == nullptr) {
+            // If this block sorts at least as good as the current tip and
+            // is valid and we have all data for its parents, it must be in
+            // setBlockIndexCandidates.  chainActive.Tip() must also be there
+            // even if some data has been pruned.
+            if (pindexFirstMissing == nullptr || pindex == chainActive.Tip()) {
+                assert(setBlockIndexCandidates.count(pindex));
             }
-        } else { // If this block sorts worse than the current tip or some ancestor's block has never been seen, it cannot be in setBlockIndexCandidates.
+            // If some parent is missing, then it could be that this block was in
+            // setBlockIndexCandidates but had to be removed because of the missing data.
+            // In this case it must be in mapBlocksUnlinked -- see test below.
+        } else { // If this block sorts worse than the current tip or some ancestor's block has never been seen or is invalid, it cannot be in setBlockIndexCandidates.
             assert(setBlockIndexCandidates.count(pindex) == 0);
         }
         // Check whether this block is in mapBlocksUnlinked.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -111,6 +111,31 @@ private:
      * as good as our current tip or better. Pruning nodes may be missing the data for the block.
      */
     std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexCandidates;
+    /**
+     * The set of all leaf CBlockIndex entries with BLOCK_VALID_TREE (for itself and all ancestors) and
+     * as good as our current tip or better. Entries here are potential future candidates for insertion
+     * into setBlockIndexCandidates, once we get all the required block data. Thus, entries here
+     * represent chains on which we should be actively downloading block data.
+     *
+     * Note that we define "as good as our current tip or better" slightly differently here than in
+     * setBlockIndexCandidates - we include things which will have a higher nSequence (but have the
+     * same chain work) here, but do not include such entries in setBlockIndexCandidates. This is
+     * because we prefer to also download towards chains which have the same total work as our current
+     * chain (as an optimization since a reorg is very possible in such cases).
+     *
+     * Note that, unlike setBlockIndexCandidates, we only store "leaf" entries here, as we are not as
+     * aggressively prune-able (setBlockIndexCandidates are things which we can, and usually do, try to
+     * connect immediately, and thus entries dont stick around for long). Thus, it may be the case that
+     * chainActive.Tip() is NOT in setBlockIndexHeaderCandidates.
+     *
+     * Additionally, unlike setBlockIndexCandidates, we are happy to store entries which are not
+     * connectable due to pruning here.
+     *
+     * Note that we have to be pretty careful with nSequenceId here - CBlockIndexWorkComparator uses
+     * nSequenceId to sort, but entries may have the same work and sequence! Thus, we don't use the set's
+     * sorter but instead compare using nChainWork while iterating!
+     */
+    std::set<CBlockIndex*, CBlockIndexWorkComparator> setBlockIndexHeaderCandidates;
 
     /**
      * Every received block is assigned a unique and increasing identifier, so we
@@ -192,6 +217,7 @@ private:
     bool ReceivedBlockTransactions(const CBlock &block, CValidationState& state, CBlockIndex *pindexNew, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
 
     void PruneInvalidBlockIndexCandidates(CBlockIndex* pindexInvalid);
+    void MaybeAddNewHeaderCandidate(CBlockIndex* pindex, bool chain_ordered_insertion, bool no_descendants);
 
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs, const CChainParams& params);
 } g_chainstate;
@@ -1260,6 +1286,75 @@ static void CheckForkWarningConditionsOnNewFork(CBlockIndex* pindexNewForkTip)
     CheckForkWarningConditions();
 }
 
+/**
+ * Called when a header (re-)reached BLOCK_VALID_TREE.
+ *
+ * setBlockIndexHeaderCandidates is a bit more complicated than
+ * setBlockIndexCandidates as setBlockIndexCandidates can be rather lazy
+ * as everything in it is about to be connected. In our case, we may have many
+ * headers above the tip leading down different chains, for which we really
+ * only want to keep the tip of each chain.
+ *
+ * Works even if chainActive is empty!
+ *
+ * If chain_ordered_inertion, we assume that if pindex->pprev was previously a
+ * header candidate, it will be when we're called. ie we assume that there are
+ * no header candidates which are parents of us except for possibly our direct
+ * parent.
+ *
+ * no_descendants allows us to make a similar, but inverted, assumption -
+ * assuming no descendant blocks may be header candidates.
+ */
+void CChainState::MaybeAddNewHeaderCandidate(CBlockIndex* pindex, bool chain_ordered_insertion, bool no_descendants) {
+    if (!pindex->IsValid(BLOCK_VALID_TREE)) return; // We only want things that have a valid header tree
+
+    bool lower_work = chainActive.Tip() != nullptr && chainActive.Tip()->nChainWork > pindex->nChainWork;
+    if (lower_work) return; // We don't want things with less work than our current tip
+
+    bool parent_present = false;
+    if (pindex->pprev && setBlockIndexHeaderCandidates.count(pindex->pprev)) {
+        // If the parent is a previous candidate, then no parents of it could
+        // be candidates, either. This is the only thing we need to check by
+        // definition of chain_ordered_insertion, however even in the case of
+        // !chain_ordered_insertion, if this is true, no need to do a full
+        // parent scan (as no further-up parent can be a candidate, either).
+        setBlockIndexHeaderCandidates.erase(pindex->pprev);
+        parent_present = true;
+    } else if (!chain_ordered_insertion) {
+        // We are being called in a for(p : mapBlockIndex) loop, so can make no
+        // assumptions about existing entries. Scan all other entries to check
+        // if we're a descendant of some other candidate.
+        for (auto it = setBlockIndexHeaderCandidates.begin(); it != setBlockIndexHeaderCandidates.end() && (*it)->nChainWork < pindex->nChainWork; it++) {
+            if (pindex->GetAncestor((*it)->nHeight) == *it) {
+                // it should be removed - we only keep the tip of potential
+                // chains, not anything in them. At this point we should be
+                // consistent by adding pindex, there should be more more work
+                // to do here.
+                setBlockIndexHeaderCandidates.erase(it);
+                break;
+                parent_present = true;
+            }
+        }
+    }
+
+    if (!parent_present && !no_descendants) {
+        // Scan higher-work entries to check that we're not a parent of some
+        // other candidate(s). If a parent of ours was already present then we
+        // can be certain that no such child is also a candidate, so we can
+        // skip the whole scan.
+        for (auto it = setBlockIndexHeaderCandidates.rbegin(); it != setBlockIndexHeaderCandidates.rend() && (*it)->nChainWork > pindex->nChainWork; it++) {
+            if ((*it)->GetAncestor(pindex->nHeight) == pindex) {
+                // pindex is useless - even if there are other tips based on it
+                // which we want in setBlockIndexHeaderCandidates, we're not
+                // gonna find them here.
+                return;
+            }
+        }
+    }
+
+    setBlockIndexHeaderCandidates.insert(pindex);
+}
+
 // Helper for PruneInvalidBlockIndexCandidates
 static void PruneInvalidIndexCandidatesInSet(CBlockIndex* pindexInvalid, std::set<CBlockIndex*, CBlockIndexWorkComparator>& set_candidates) {
     // Iterate set_candidates downwards, deleting parents of pindexInvalid,
@@ -1300,6 +1395,7 @@ void CChainState::PruneInvalidBlockIndexCandidates(CBlockIndex* pindexInvalid) {
     assert(pindexInvalid->nStatus & BLOCK_FAILED_MASK);
 
     PruneInvalidIndexCandidatesInSet(pindexInvalid, setBlockIndexCandidates);
+    PruneInvalidIndexCandidatesInSet(pindexInvalid, setBlockIndexHeaderCandidates);
 }
 
 void static InvalidChainFound(CBlockIndex* pindexNew)
@@ -1325,6 +1421,16 @@ void CChainState::InvalidBlockFound(CBlockIndex *pindex, const CValidationState 
         g_failed_blocks.insert(pindex);
         setDirtyBlockIndex.insert(pindex);
         PruneInvalidBlockIndexCandidates(pindex);
+        if (pindex->pprev) {
+            // In the simple case where we tried to advance forward one block,
+            // but failed, we may now have an empty setBlockIndexHeaderCandidates,
+            // so we need to re-add the previous block here. The same is not true
+            // for setBlockIndexCandidates, as it does not have the same leaf-only
+            // precondition which setBlockIndexHeaderCandidates has.
+            // Note that its possible there are later descendants that are candidates
+            // so we cannot set no_descendants here.
+            MaybeAddNewHeaderCandidate(pindex->pprev, true, false);
+        }
         InvalidChainFound(pindex);
     }
 }
@@ -2478,6 +2584,16 @@ void CChainState::PruneBlockIndexCandidates() {
     }
     // Either the current tip or a successor of it we're working towards is left in setBlockIndexCandidates.
     assert(!setBlockIndexCandidates.empty());
+    // Now do the same for setBlockIndexHeaderCandidates (noting that we have to compare manually due to nSequenceId oddities)
+    it = setBlockIndexHeaderCandidates.begin();
+    while (it != setBlockIndexHeaderCandidates.end() && (*it)->nChainWork <= chainActive.Tip()->nChainWork) {
+        if (chainActive.Tip()->nChainWork > (*it)->nChainWork) {
+            setBlockIndexHeaderCandidates.erase(it++);
+        } else {
+            it++;
+        }
+    }
+    assert(!setBlockIndexHeaderCandidates.empty());
 }
 
 /**
@@ -2687,12 +2803,19 @@ bool CChainState::PreciousBlock(CValidationState& state, const CChainParams& par
             nBlockReverseSequenceId = -1;
         }
         nLastPreciousChainwork = chainActive.Tip()->nChainWork;
+        // Make sure to remove from sets which are indexed by nSequenceId first...
         setBlockIndexCandidates.erase(pindex);
+        bool pindex_is_header_candidate = setBlockIndexHeaderCandidates.erase(pindex);
         pindex->nSequenceId = nBlockReverseSequenceId;
         if (nBlockReverseSequenceId > std::numeric_limits<int32_t>::min()) {
             // We can't keep reducing the counter if somebody really wants to
             // call preciousblock 2**31-1 times on the same set of tips...
             nBlockReverseSequenceId--;
+        }
+        if (pindex_is_header_candidate) {
+            // Note that because we only changed the sequence, pindex should be in
+            // setBlockIndexHeaderCandidates iff it was previously in the same.
+            setBlockIndexHeaderCandidates.insert(pindex);
         }
         if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && pindex->nChainTx) {
             setBlockIndexCandidates.insert(pindex);
@@ -2716,12 +2839,8 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
     // are no blocks that meet the "have data and are not invalid per
     // nStatus" criteria for inclusion in setBlockIndexCandidates).
 
-    bool pindex_was_in_chain = false;
-    CBlockIndex *invalid_walk_tip = chainActive.Tip();
-
     DisconnectedBlockTransactions disconnectpool;
     while (chainActive.Contains(pindex)) {
-        pindex_was_in_chain = true;
         // ActivateBestChain considers blocks already in chainActive
         // unconditionally valid already, so force disconnect away from it.
         if (!DisconnectTip(state, chainparams, &disconnectpool)) {
@@ -2732,19 +2851,13 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
         }
     }
 
-    // Now mark the blocks we just disconnected as descendants invalid
-    // (note this may not be all descendants).
-    while (pindex_was_in_chain && invalid_walk_tip != pindex) {
-        invalid_walk_tip->nStatus |= BLOCK_FAILED_CHILD;
-        setDirtyBlockIndex.insert(invalid_walk_tip);
-        setBlockIndexCandidates.erase(invalid_walk_tip);
-        invalid_walk_tip = invalid_walk_tip->pprev;
-    }
-
     // Mark the block itself as invalid.
     pindex->nStatus |= BLOCK_FAILED_VALID;
     setDirtyBlockIndex.insert(pindex);
-    setBlockIndexCandidates.erase(pindex);
+
+    // chainActive.Tip() is always in our candidate sets, so any blocks we just
+    // disconnected will be marked BLOCK_FAILED_CHILD by PruneInvalidBlockIndexCandidates.
+    PruneInvalidBlockIndexCandidates(pindex);
     g_failed_blocks.insert(pindex);
 
     // DisconnectTip will add transactions to disconnectpool; try to add these
@@ -2755,8 +2868,26 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
     // add it again.
     BlockMap::iterator it = mapBlockIndex.begin();
     while (it != mapBlockIndex.end()) {
-        if (it->second->IsValid(BLOCK_VALID_TRANSACTIONS) && it->second->nChainTx && !setBlockIndexCandidates.value_comp()(it->second, chainActive.Tip())) {
-            setBlockIndexCandidates.insert(it->second);
+        if (it->second->nChainWork >= chainActive.Tip()->nChainWork) {
+            if (it->second->GetAncestor(pindex->nHeight) == pindex) {
+                // It is possible that we have a CBlockIndex which is a
+                // descendant of the one we just marked invalid, but which we
+                // did not mark BLOCK_FAILED_CHILD in the
+                // PruneInvalidBlockIndexCandidates pass, as it was below our
+                // previous tip. We should mark it (and its parents) invalid.
+                CBlockIndex* invalid_walk = it->second;
+                while (invalid_walk != pindex && !(invalid_walk->nStatus & BLOCK_FAILED_MASK)) {
+                    invalid_walk->nStatus |= BLOCK_FAILED_CHILD;
+                    setDirtyBlockIndex.insert(invalid_walk);
+                    invalid_walk = invalid_walk->pprev;
+                }
+            } else if (it->second->IsValid(BLOCK_VALID_TREE)) {
+                MaybeAddNewHeaderCandidate(it->second, false, false);
+                if (it->second->IsValid(BLOCK_VALID_TRANSACTIONS) && it->second->nChainTx &&
+                        !setBlockIndexCandidates.value_comp()(it->second, chainActive.Tip())) { // check sequence now because we didn't earlier
+                    setBlockIndexCandidates.insert(it->second);
+                }
+            }
         }
         it++;
     }
@@ -2780,8 +2911,12 @@ bool CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
         if (!it->second->IsValid() && it->second->GetAncestor(nHeight) == pindex) {
             it->second->nStatus &= ~BLOCK_FAILED_MASK;
             setDirtyBlockIndex.insert(it->second);
-            if (it->second->IsValid(BLOCK_VALID_TRANSACTIONS) && it->second->nChainTx && setBlockIndexCandidates.value_comp()(chainActive.Tip(), it->second)) {
-                setBlockIndexCandidates.insert(it->second);
+            if (it->second->IsValid(BLOCK_VALID_TREE) && it->second->nChainWork >= chainActive.Tip()->nChainWork) {
+                MaybeAddNewHeaderCandidate(it->second, false, false);
+                if (it->second->IsValid(BLOCK_VALID_TRANSACTIONS) && it->second->nChainTx &&
+                        setBlockIndexCandidates.value_comp()(chainActive.Tip(), it->second)) { // Check nSequence here
+                    setBlockIndexCandidates.insert(it->second);
+                }
             }
             if (it->second == pindexBestInvalid) {
                 // Reset invalid block marker if it was pointing to one of those.
@@ -2834,6 +2969,7 @@ CBlockIndex* CChainState::AddToBlockIndex(const CBlockHeader& block)
     pindexNew->RaiseValidity(BLOCK_VALID_TREE);
     if (pindexBestHeader == nullptr || pindexBestHeader->nChainWork < pindexNew->nChainWork)
         pindexBestHeader = pindexNew;
+    MaybeAddNewHeaderCandidate(pindexNew, true, true);
 
     setDirtyBlockIndex.insert(pindexNew);
 
@@ -2865,9 +3001,17 @@ bool CChainState::ReceivedBlockTransactions(const CBlock &block, CValidationStat
             CBlockIndex *pindex = queue.front();
             queue.pop_front();
             pindex->nChainTx = (pindex->pprev ? pindex->pprev->nChainTx : 0) + pindex->nTx;
+            // Make sure to remove from sets which are indexed by nSequenceId first...
+            bool was_header_candidate = setBlockIndexHeaderCandidates.erase(pindex);
             {
                 LOCK(cs_nBlockSequenceId);
                 pindex->nSequenceId = nBlockSequenceId++;
+            }
+            if (was_header_candidate) {
+                // It is safe to use chain_ordered_insertion and no_descendants here
+                // as, if the block was previously a header candidate, we know there
+                // are no parents/descendants which are also header candidates.
+                MaybeAddNewHeaderCandidate(pindex, true, true);
             }
             if (chainActive.Tip() == nullptr || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip())) {
                 setBlockIndexCandidates.insert(pindex);
@@ -3279,6 +3423,23 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
         if (!ContextualCheckBlockHeader(block, state, chainparams, pindexPrev, GetAdjustedTime()))
             return error("%s: Consensus::ContextualCheckBlockHeader: %s, %s", __func__, hash.ToString(), FormatStateMessage(state));
 
+        /* Take the following chain:
+         *
+         *                D3
+         *              /
+         *      B2 - C2
+         *    /         \
+         *  A             D2 - E2 - F2
+         *    \
+         *      B1 - C1 - D1 - E1
+         *
+         * In the case that we attempted to reorg from E1 to F2, only to find
+         * C2 to be invalid, we would mark D2, E2, and F2 as BLOCK_FAILED_CHILD
+         * but NOT D3 (it was not in any of our candidate sets at the time).
+         * Thus, if we now are accepting headers built on D3, it may be the
+         * case that they actually have failed parents despite pindexPrev being
+         * !BLOCK_FAILED_MASK. We check for this case here:
+         */
         if (!pindexPrev->IsValid(BLOCK_VALID_SCRIPTS)) {
             for (const CBlockIndex* failedit : g_failed_blocks) {
                 if (pindexPrev->GetAncestor(failedit->nHeight) == failedit) {
@@ -3394,9 +3555,8 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
 
     if (!CheckBlock(block, state, chainparams.GetConsensus()) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
-        if (state.IsInvalid() && !state.CorruptionPossible()) {
-            pindex->nStatus |= BLOCK_FAILED_VALID;
-            setDirtyBlockIndex.insert(pindex);
+        if (state.IsInvalid()) {
+            InvalidBlockFound(pindex, state);
         }
         return error("%s: %s", __func__, FormatStateMessage(state));
     }
@@ -3741,6 +3901,8 @@ bool CChainState::LoadBlockIndex(const Consensus::Params& consensus_params, CBlo
             pindex->nStatus |= BLOCK_FAILED_CHILD;
             setDirtyBlockIndex.insert(pindex);
         }
+        if (pindex->IsValid(BLOCK_VALID_TREE))
+            MaybeAddNewHeaderCandidate(pindex, true, true);
         if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS) && (pindex->nChainTx || pindex->pprev == nullptr))
             setBlockIndexCandidates.insert(pindex);
         if (pindex->nStatus & BLOCK_FAILED_MASK && (!pindexBestInvalid || pindex->nChainWork > pindexBestInvalid->nChainWork))
@@ -4107,6 +4269,11 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
         } else if (pindexIter->IsValid(BLOCK_VALID_TRANSACTIONS) && pindexIter->nChainTx) {
             setBlockIndexCandidates.insert(pindexIter);
         }
+        // In case we disconnected blocks which resulted in new header
+        // candidates, we need to re-add them here.
+        if (pindexIter->IsValid(BLOCK_VALID_TREE)) {
+            MaybeAddNewHeaderCandidate(pindexIter, false, false);
+        }
     }
 
     if (chainActive.Tip() != nullptr) {
@@ -4142,6 +4309,7 @@ void CChainState::UnloadBlockIndex() {
     nBlockSequenceId = 1;
     g_failed_blocks.clear();
     setBlockIndexCandidates.clear();
+    setBlockIndexHeaderCandidates.clear();
 }
 
 // May NOT be used after any connections are up as much
@@ -4388,6 +4556,7 @@ void CChainState::CheckBlockIndex(const Consensus::Params& consensusParams)
     CBlockIndex* pindexFirstNotTransactionsValid = nullptr; // Oldest ancestor of pindex which does not have BLOCK_VALID_TRANSACTIONS (regardless of being valid or not).
     CBlockIndex* pindexFirstNotChainValid = nullptr; // Oldest ancestor of pindex which does not have BLOCK_VALID_CHAIN (regardless of being valid or not).
     CBlockIndex* pindexFirstNotScriptsValid = nullptr; // Oldest ancestor of pindex which does not have BLOCK_VALID_SCRIPTS (regardless of being valid or not).
+    CBlockIndex* pindexFirstInBlockIndexHeaderCandidates = nullptr; // Oldest ancestor of pindex which is in setBlockIndexHeaderCandidates (should always be only pindex)
     while (pindex != nullptr) {
         nNodes++;
         if (pindexFirstInvalid == nullptr && pindex->nStatus & BLOCK_FAILED_VALID) pindexFirstInvalid = pindex;
@@ -4454,6 +4623,23 @@ void CChainState::CheckBlockIndex(const Consensus::Params& consensusParams)
         } else { // If this block sorts worse than the current tip or some ancestor's block has never been seen or is invalid, it cannot be in setBlockIndexCandidates.
             assert(setBlockIndexCandidates.count(pindex) == 0);
         }
+        bool must_be_header_candidate_if_leaf = false;
+        if (pindex->nChainWork < chainActive.Tip()->nChainWork) {
+            // Irrespective of pruned-ness, if this block sorts worse than the current tip, it cannot be in setBlockIndexHeaderCandidates
+            assert(setBlockIndexHeaderCandidates.count(pindex) == 0);
+        } else if (pindexFirstInvalid == nullptr) {
+            // If pindex is a leaf node and sorts at the same or greater height
+            // than chainActive.Tip(), it must be in setBlockIndexHeaderCandidates.
+            must_be_header_candidate_if_leaf = true;
+        }
+        if (setBlockIndexHeaderCandidates.count(pindex)) {
+            // setBlockIndexHeaderCandidates may not contain anything for which a parent is invalid
+            assert(pindexFirstInvalid == nullptr);
+            assert(pindex->IsValid(BLOCK_VALID_TREE));
+            // We should only be in setBlockIndexHeaderCandidates if we are a leaf node
+            assert(pindexFirstInBlockIndexHeaderCandidates == nullptr);
+            pindexFirstInBlockIndexHeaderCandidates = pindex;
+        }
         // Check whether this block is in mapBlocksUnlinked.
         std::pair<std::multimap<CBlockIndex*,CBlockIndex*>::iterator,std::multimap<CBlockIndex*,CBlockIndex*>::iterator> rangeUnlinked = mapBlocksUnlinked.equal_range(pindex->pprev);
         bool foundInUnlinked = false;
@@ -4500,6 +4686,7 @@ void CChainState::CheckBlockIndex(const Consensus::Params& consensusParams)
             continue;
         }
         // This is a leaf node.
+        if (must_be_header_candidate_if_leaf) assert(setBlockIndexHeaderCandidates.count(pindex));
         // Move upwards until we reach a node of which we have not yet visited the last child.
         while (pindex) {
             // We are going to either move to a parent or a sibling of pindex.
@@ -4511,6 +4698,7 @@ void CChainState::CheckBlockIndex(const Consensus::Params& consensusParams)
             if (pindex == pindexFirstNotTransactionsValid) pindexFirstNotTransactionsValid = nullptr;
             if (pindex == pindexFirstNotChainValid) pindexFirstNotChainValid = nullptr;
             if (pindex == pindexFirstNotScriptsValid) pindexFirstNotScriptsValid = nullptr;
+            if (pindex == pindexFirstInBlockIndexHeaderCandidates) pindexFirstInBlockIndexHeaderCandidates = nullptr;
             // Find our parent.
             CBlockIndex* pindexPar = pindex->pprev;
             // Find which child we just visited.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -182,7 +182,7 @@ public:
     bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock);
 
     bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex);
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, const CDiskBlockPos* dbp, bool* fNewBlock);
 
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view);
@@ -3532,7 +3532,7 @@ static CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CCh
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, const CDiskBlockPos* dbp, bool* fNewBlock)
 {
     const CBlock& block = *pblock;
 
@@ -3557,25 +3557,34 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     // not process unrequested blocks.
     bool fTooFarAhead = (pindex->nHeight > int(chainActive.Height() + MIN_BLOCKS_TO_KEEP));
 
-    // TODO: Decouple this function from the block download logic by removing fRequested
-    // This requires some new chain data structure to efficiently look up if a
-    // block is in a chain leading to a candidate for best tip, despite not
-    // being such a candidate itself.
-
     // TODO: deal better with return value and error conditions for duplicate
     // and unrequested blocks.
     if (fAlreadyHave) return true;
-    if (!fRequested) {  // If we didn't ask for it:
-        if (pindex->nTx != 0) return true;    // This is a previously-processed block that was pruned
-        if (!fHasMoreOrSameWork) return true; // Don't process less-work chains
-        if (fTooFarAhead) return true;        // Block height is too high
+    if (!pindex->IsValid(BLOCK_VALID_TREE)) return true; // Parent block somewhere is invalid
+    if (pindex->nTx != 0) return true;                   // This is a previously-processed block that was pruned
+    if (fTooFarAhead) return true;                       // Block height is too high
 
-        // Protect against DoS attacks from low-work chains.
-        // If our tip is behind, a peer could try to send us
-        // low-work blocks on a fake chain that we would never
-        // request; don't process these.
-        if (pindex->nChainWork < nMinimumChainWork) return true;
+    bool parent_of_header_candidate = false;
+    bool parent_of_min_chainwork_header_candidate = false;
+    for (auto it = setBlockIndexHeaderCandidates.rbegin(); it != setBlockIndexHeaderCandidates.rend(); it++) {
+        if ((*it)->GetAncestor(pindex->nHeight) == pindex) {
+            parent_of_header_candidate = true;
+            // Protect against DoS attacks from low-work chains.
+            // If our tip is behind, a peer could try to send us
+            // low-work blocks on a fake chain that we would never
+            // request; don't process these.
+            if ((*it)->nChainWork >= nMinimumChainWork) {
+                parent_of_min_chainwork_header_candidate = true;
+                break;
+            }
+        }
     }
+    if (!fHasMoreOrSameWork && !parent_of_header_candidate) return true; // We dont think this block leads somewhere interesting
+    if (!parent_of_min_chainwork_header_candidate && pindex->nChainWork < nMinimumChainWork) {
+        // Neither this new block, nor any descendants we have, meet our minimum chain work.
+        return true;
+    }
+
     if (fNewBlock) *fNewBlock = true;
 
     if (!CheckBlock(block, state, chainparams.GetConsensus()) ||
@@ -3612,7 +3621,7 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool *fNewBlock)
 {
     AssertLockNotHeld(cs_main);
 
@@ -3628,7 +3637,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 
         if (ret) {
             // Store to disk
-            ret = g_chainstate.AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
+            ret = g_chainstate.AcceptBlock(pblock, state, chainparams, &pindex, nullptr, fNewBlock);
         }
         if (!ret) {
             GetMainSignals().BlockChecked(*pblock, state);
@@ -4483,7 +4492,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                 if (mapBlockIndex.count(hash) == 0 || (mapBlockIndex[hash]->nStatus & BLOCK_HAVE_DATA) == 0) {
                     LOCK(cs_main);
                     CValidationState state;
-                    if (g_chainstate.AcceptBlock(pblock, state, chainparams, nullptr, true, dbp, nullptr))
+                    if (g_chainstate.AcceptBlock(pblock, state, chainparams, nullptr, dbp, nullptr))
                         nLoaded++;
                     if (state.IsError())
                         break;
@@ -4517,7 +4526,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
                                     head.ToString());
                             LOCK(cs_main);
                             CValidationState dummy;
-                            if (g_chainstate.AcceptBlock(pblockrecursive, dummy, chainparams, nullptr, true, &it->second, nullptr))
+                            if (g_chainstate.AcceptBlock(pblockrecursive, dummy, chainparams, nullptr, &it->second, nullptr))
                             {
                                 nLoaded++;
                                 queue.push_back(pblockrecursive->GetHash());

--- a/src/validation.h
+++ b/src/validation.h
@@ -188,8 +188,8 @@ extern uint256 hashAssumeValid;
 /** Minimum work we will assume exists on some valid chain. */
 extern arith_uint256 nMinimumChainWork;
 
-/** Best header we've seen so far (used for getheaders queries' starting points). */
-extern CBlockIndex *pindexBestHeader;
+/** Get the best (potentially-)valid header we've seen so far (used for getheaders queries' starting points). */
+const CBlockIndex* GetBestHeader();
 
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;

--- a/src/validation.h
+++ b/src/validation.h
@@ -234,11 +234,10 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  * Call without cs_main held.
  *
  * @param[in]   pblock  The block we want to process.
- * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
  * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool* fNewBlock);
 
 /**
  * Process incoming block headers.

--- a/test/functional/p2p-acceptblock.py
+++ b/test/functional/p2p-acceptblock.py
@@ -32,22 +32,15 @@ Node1 is unused in tests 3-7:
    Node0 should process all but the last block (too far ahead in height).
 
 5. Send a duplicate of the block in #3 to Node0.
-   Node0 should not process the block because it is unrequested, and stay on
-   the shorter chain.
+   Node0 should process the block even though it is unrequested, and reorg to
+   the longer chain.
 
-6. Send Node0 an inv for the height 3 block produced in #4 above.
-   Node0 should figure out that Node0 has the missing height 2 block and send a
-   getdata.
-
-7. Send Node0 the missing block again.
-   Node0 should process and the tip should advance.
-
-8. Create a fork which is invalid at a height longer than the current chain
+6. Create a fork which is invalid at a height longer than the current chain
    (ie to which the node will try to reorg) but which has headers built on top
    of the invalid block. Check that we get disconnected if we send more headers
    on the chain the node now knows to be invalid.
 
-9. Test Node1 is able to sync when connected to node0 (which should have sufficient
+7. Test Node1 is able to sync when connected to node0 (which should have sufficient
    work on its chain).
 """
 
@@ -107,8 +100,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         for x in [test_node, min_work_node]:
             x.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 2)
-        assert_equal(self.nodes[1].getblockcount(), 1)
-        self.log.info("First height 2 block accepted by node0; correctly rejected by node1")
+        assert_equal(self.nodes[1].getblockcount(), 0)
+        self.log.info("First height 2 block accepted by node0; all blocks correctly rejected by node1")
 
         # 3. Send another block that builds on genesis.
         block_h1f = create_block(int("0x" + self.nodes[0].getblockhash(0), 0), create_coinbase(1), block_time)
@@ -200,8 +193,8 @@ class AcceptBlockTest(BitcoinTestFramework):
         assert_raises_rpc_error(-1, "Block not found on disk", self.nodes[0].getblock, all_blocks[-1].hash)
 
         # 5. Test handling of unrequested block on the node that didn't process
-        # Should still not be processed (even though it has a child that has more
-        # work).
+        # Should be processed as the node can figure out that it leads to a new
+        # chain that it will want.
 
         # The node should have requested the blocks at some point, so
         # disconnect/reconnect first
@@ -217,36 +210,13 @@ class AcceptBlockTest(BitcoinTestFramework):
         test_node.send_message(msg_block(block_h1f))
 
         test_node.sync_with_ping()
-        assert_equal(self.nodes[0].getblockcount(), 2)
-        self.log.info("Unrequested block that would complete more-work chain was ignored")
-
-        # 6. Try to get node to request the missing block.
-        # Poke the node with an inv for block at height 3 and see if that
-        # triggers a getdata on block 2 (it should if block 2 is missing).
-        with mininode_lock:
-            # Clear state so we can check the getdata request
-            test_node.last_message.pop("getdata", None)
-            test_node.send_message(msg_inv([CInv(2, block_h3.sha256)]))
-
-        test_node.sync_with_ping()
-        with mininode_lock:
-            getdata = test_node.last_message["getdata"]
-
-        # Check that the getdata includes the right block
-        assert_equal(getdata.inv[0].hash, block_h1f.sha256)
-        self.log.info("Inv at tip triggered getdata for unprocessed block")
-
-        # 7. Send the missing block for the third time (now it is requested)
-        test_node.send_message(msg_block(block_h1f))
-
-        test_node.sync_with_ping()
         assert_equal(self.nodes[0].getblockcount(), 290)
         self.nodes[0].getblock(all_blocks[286].hash)
         assert_equal(self.nodes[0].getbestblockhash(), all_blocks[286].hash)
         assert_raises_rpc_error(-1, "Block not found on disk", self.nodes[0].getblock, all_blocks[287].hash)
         self.log.info("Successfully reorged to longer chain from non-whitelisted peer")
 
-        # 8. Create a chain which is invalid at a height longer than the
+        # 6. Create a chain which is invalid at a height longer than the
         # current chain, but which has more blocks on top of that
         block_289f = create_block(all_blocks[284].sha256, create_coinbase(289), all_blocks[284].nTime+1)
         block_289f.solve()
@@ -314,7 +284,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         test_node.send_message(headers_message)
         test_node.wait_for_disconnect()
 
-        # 9. Connect node1 to node0 and ensure it is able to sync
+        # 7. Connect node1 to node0 and ensure it is able to sync
         connect_nodes(self.nodes[0], 1)
         sync_blocks([self.nodes[0], self.nodes[1]])
         self.log.info("Successfully synced nodes 1 and 0")

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -55,7 +55,7 @@ class TestNode():
         self.coverage_dir = coverage_dir
         # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
         self.extra_args = extra_args
-        self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i]
+        self.args = [self.binary, "-datadir=" + self.datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-debugexclude=libevent", "-debugexclude=leveldb", "-mocktime=" + str(mocktime), "-uacomment=testnode%d" % i, "-checkblockindex=1"]
 
         self.cli = TestNodeCLI(os.getenv("BITCOINCLI", "bitcoin-cli"), self.datadir)
 


### PR DESCRIPTION
This adds a setBlockIndexHeaderCandidates which mimics setBlockIndexCandidates and is
The set of all leaf CBlockIndex entries with BLOCK_VALID_TREE (for itself and all ancestors) and
as good as our current tip or better. Entries here are potential future candidates for insertion
into setBlockIndexCandidates, once we get all the required block data. Thus, entries here
represent chains on which we should be actively downloading block data.

Note that we define "as good as our current tip or better" slightly differently here than in
setBlockIndexCandidates - we include things which will have a higher nSequence (but have the
same chain work) here, but do not include such entries in setBlockIndexCandidates. This is
because we prefer to also download towards chains which have the same total work as our current
chain (as an optimization since a reorg is very possible in such cases).

Note that, unlike setBlockIndexCandidates, we only store "leaf" entries here, as we are not as
aggressively prune-able (setBlockIndexCandidates are things which we can, and usually do, try to
connect immediately, and thus entries dont stick around for long). Thus, it may be the case that
chainActive.Tip() is NOT in setBlockIndexHeaderCandidates.

Additionally, unlike setBlockIndexCandidates, we are happy to store entries which are not
connectable due to pruning here.

This is useful as it (finally) disconnects net_processing logic from the "store on disk" logic in validation.cpp. More importantly, it represents what you'd need from the consensus logic to implement a spv-first sync mode, as this provides a best-header which will follow invalidity - always pointing to the best-possible header even after block(s) are found to be invalid.