### PR TITLE
Wallet: Support disabling implicit Segwit operation

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -24,7 +24,7 @@ void CBasicKeyStore::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey)
     // "Implicitly" refers to fact that scripts are derived automatically from
     // existing keys, and are present in memory, even without being explicitly
     // loaded (e.g. from a file).
-    if (pubkey.IsCompressed()) {
+    if (pubkey.IsCompressed() && m_implicit_segwit) {
         CScript script = GetScriptForDestination(WitnessV0KeyHash(key_id));
         // This does not use AddCScript, as it may be overridden.
         CScriptID id(script);

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -54,9 +54,15 @@ protected:
     ScriptMap mapScripts;
     WatchOnlySet setWatchOnly;
 
+    bool m_implicit_segwit;
+
     void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey);
 
 public:
+    CBasicKeyStore() : m_implicit_segwit(false) { }
+
+    bool HasImplicitSegwit() const { return m_implicit_segwit; }
+
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
     bool AddKey(const CKey &key) { return AddKeyPubKey(key, key.GetPubKey()); }
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -38,6 +38,7 @@ std::string WalletInit::GetHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-wallet=<path>", _("Specify wallet database path. Can be specified multiple times to load multiple wallets. Path is interpreted relative to <walletdir> if it is not absolute, and will be created if it does not exist (as a directory containing a wallet.dat file and log files). For backwards compatibility this will also accept names of existing data files in <walletdir>.)"));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));
     strUsage += HelpMessageOpt("-walletdir=<dir>", _("Specify directory to hold wallets (default: <datadir>/wallets if it exists, otherwise <datadir>)"));
+    strUsage += HelpMessageOpt("-walletimplicitsegwit", strprintf(_("Support segwit when restoring wallet backups and importing keys (default: %u)"), DEFAULT_WALLET_IMPLICIT_SEGWIT));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
     strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)"), DEFAULT_WALLET_RBF));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -72,7 +72,7 @@ bool GetWalletAddressesForKey(CWallet * const pwallet, const CKeyID &keyid, std:
     bool fLabelFound = false;
     CKey key;
     pwallet->GetKey(keyid, key);
-    for (const auto& dest : GetAllDestinationsForKey(key.GetPubKey())) {
+    for (const auto& dest : GetAllDestinationsForKey(key.GetPubKey(), true)) {
         if (pwallet->mapAddressBook.count(dest)) {
             if (!strAddr.empty()) {
                 strAddr += ",";
@@ -152,7 +152,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
         {
             pwallet->MarkDirty();
             // We don't know which corresponding address will be used; label them all
-            for (const auto& dest : GetAllDestinationsForKey(pubkey)) {
+            for (const auto& dest : GetAllDestinationsForKey(pubkey, pwallet->HasImplicitSegwit())) {
                 pwallet->SetAddressBook(dest, strLabel, "receive");
             }
 
@@ -471,7 +471,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
     {
         LOCK2(cs_main, pwallet->cs_wallet);
 
-        for (const auto& dest : GetAllDestinationsForKey(pubKey)) {
+        for (const auto& dest : GetAllDestinationsForKey(pubKey, pwallet->HasImplicitSegwit())) {
             ImportAddress(pwallet, dest, strLabel);
         }
         ImportScript(pwallet, GetScriptForRawPubKey(pubKey), strLabel, false);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3942,6 +3942,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
     int64_t nStart = GetTimeMillis();
     bool fFirstRun = true;
     CWallet *walletInstance = new CWallet(name, CWalletDBWrapper::Create(path));
+    walletInstance->m_implicit_segwit = gArgs.GetBoolArg("-walletimplicitsegwit", DEFAULT_WALLET_IMPLICIT_SEGWIT);
     DBErrors nLoadWalletRet = walletInstance->LoadWallet(fFirstRun);
     if (nLoadWalletRet != DBErrors::LOAD_OK)
     {
@@ -4022,7 +4023,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
         }
     }
 
-    walletInstance->m_default_address_type = ParseOutputType(gArgs.GetArg("-addresstype", ""), DEFAULT_ADDRESS_TYPE);
+    walletInstance->m_default_address_type = ParseOutputType(gArgs.GetArg("-addresstype", ""), (walletInstance->m_implicit_segwit ? DEFAULT_ADDRESS_TYPE : OutputType::LEGACY));
     if (walletInstance->m_default_address_type == OutputType::NONE) {
         InitError(strprintf("Unknown address type '%s'", gArgs.GetArg("-addresstype", "")));
         return nullptr;
@@ -4257,8 +4258,10 @@ void CWallet::LearnRelatedScripts(const CPubKey& key, OutputType type)
 
 void CWallet::LearnAllRelatedScripts(const CPubKey& key)
 {
-    // OutputType::P2SH_SEGWIT always adds all necessary scripts for all types.
-    LearnRelatedScripts(key, OutputType::P2SH_SEGWIT);
+    if (m_implicit_segwit) {
+        // OutputType::P2SH_SEGWIT always adds all necessary scripts for all types.
+        LearnRelatedScripts(key, OutputType::P2SH_SEGWIT);
+    }
 }
 
 CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
@@ -4280,10 +4283,10 @@ CTxDestination GetDestinationForKey(const CPubKey& key, OutputType type)
     }
 }
 
-std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key)
+std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key, const bool include_segwit)
 {
     CKeyID keyid = key.GetID();
-    if (key.IsCompressed()) {
+    if (key.IsCompressed() && include_segwit) {
         CTxDestination segwit = WitnessV0KeyHash(keyid);
         CTxDestination p2sh = CScriptID(GetScriptForDestination(segwit));
         return std::vector<CTxDestination>{std::move(keyid), std::move(p2sh), std::move(segwit)};

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -64,6 +64,7 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
 static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
+static const bool DEFAULT_WALLET_IMPLICIT_SEGWIT = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 
 static const int64_t TIMESTAMP_MIN = 0;
@@ -1241,7 +1242,7 @@ const std::string& FormatOutputType(OutputType type);
 CTxDestination GetDestinationForKey(const CPubKey& key, OutputType);
 
 /** Get all destinations (potentially) supported by the wallet for the given key. */
-std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key);
+std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key, bool include_segwit);
 
 /** RAII object to check and reserve a wallet rescan */
 class WalletRescanReserver

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -42,7 +42,7 @@ class SegWitTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 3
         # This test tests SegWit both pre and post-activation, so use the normal BIP9 activation.
-        self.extra_args = [["-walletprematurewitness", "-rpcserialversion=0", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"],
+        self.extra_args = [["-walletprematurewitness", "-rpcserialversion=0", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress", "-walletimplicitsegwit"],
                            ["-blockversion=4", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-rpcserialversion=1", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"],
                            ["-blockversion=536870915", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"]]
 


### PR DESCRIPTION
This optional feature (disabled by default) leaves Segwit wallet support mostly as-is, except:

1. It disables automatic implied Segwit recognition for keys not explicitly generated as Segwit. This means each Segwit address generated needs a new backup, same as previous versions.
2. Default address/change type is legacy.

`OUTPUT_TYPE_DEFAULT` is changed to an actual `OutputType` value, in expectation of reuse by #12119 as well as enabling the possibility of having the implicit segwit flag be set per-wallet once we have runtime wallet loading.