### PR TITLE
Fix ListCoins test failure due to unset g_address_type, g_change_type

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -602,6 +602,8 @@ public:
     {
         CreateAndProcessBlock({}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
         ::bitdb.MakeMock();
+        g_address_type = OUTPUT_TYPE_DEFAULT;
+        g_change_type = OUTPUT_TYPE_DEFAULT;
         wallet.reset(new CWallet(std::unique_ptr<CWalletDBWrapper>(new CWalletDBWrapper(&bitdb, "wallet_test.dat"))));
         bool firstRun;
         wallet->LoadWallet(firstRun);


### PR DESCRIPTION
New global variables were introduced in #11403 and not setting them causes:

```
test_bitcoin: wallet/wallet.cpp:4199: CTxDestination GetDestinationForKey(const CPubKey&, OutputType): Assertion `false' failed.
unknown location(0): fatal error in "ListCoins": signal: SIGABRT (application abort requested)
```

It's possible to reproduce the failure reliably by running:

```
src/test/test_bitcoin --log_level=test_suite --run_test=wallet_tests/ListCoins
```

Failures happen nondeterministically because boost test framework doesn't run tests in a specified order, and tests that run previously can set the global variables and mask the bug.

Example travis failure: https://travis-ci.org/bitcoin/bitcoin/builds/327642495