### PR TITLE
[WIP] misc. backwards compatibility tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   - depends/built
   - depends/sdk-sources
   - $HOME/.ccache
+  - build/releases
 env:
   global:
     - MAKEJOBS=-j3
@@ -31,7 +32,7 @@ env:
 # Win64
     - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # x86_64 Linux (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
-    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
+    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true COMPILE_PREVIOUS_VERSIONS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
 # x86_64 Linux, No wallet
     - HOST=x86_64-unknown-linux-gnu PACKAGES="python3" DEP_OPTS="NO_WALLET=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Cross-Mac
@@ -60,6 +61,7 @@ before_script:
     - if [ -z "$NO_DEPENDS" ]; then make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi
     # Start xvfb if needed, as documented at https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
     - if [ "$NEED_XVFB" = 1 ]; then export DISPLAY=:99.0; /sbin/start-stop-daemon --start --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac; fi
+    - if [ "$COMPILE_PREVIOUS_VERSIONS" = "true" ]; then contrib/devtools/previous_release.sh -d -f v0.15.1 v0.14.2; fi
 script:
     - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then while read LINE; do travis_retry gpg --keyserver hkp://subset.pool.sks-keyservers.net --recv-keys $LINE; done < contrib/verify-commits/trusted-keys; fi
     - if [ "$CHECK_DOC" = 1 -a "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then git fetch --unshallow; fi
@@ -70,7 +72,7 @@ script:
     - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
     - if [ -z "$NO_DEPENDS" ]; then depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE; fi
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
-    - mkdir build && cd build
+    - mkdir -p build && cd build
     - ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make distdir VERSION=$HOST
     - cd bitcoin-$HOST
@@ -80,6 +82,7 @@ script:
     - if [ "$RUN_TESTS" = "true" ]; then travis_wait 30 make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then extended="--extended --exclude pruning,dbcrash"; fi
     - if [ "$RUN_TESTS" = "true" ]; then test/functional/test_runner.py --combinedlogslen=4000 --coverage --quiet ${extended}; fi
+    - if [ "$COMPILE_PREVIOUS_VERSIONS" = "true" ]; then mkdir build; ln -s ../../../build/releases build/releases; test/functional/backwards_compatibility.py; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/contrib/devtools/previous_release.sh
+++ b/contrib/devtools/previous_release.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Build previous releases.
+
+CONFIG_FLAGS=""
+FUNCTIONAL_TESTS=0
+DELETE_EXISTING=0
+USE_DEPENDS=0
+
+while getopts ":hfrd" opt; do
+  case $opt in
+    h)
+      echo "Usage: .previous_release.sh [options] tag1 tag2"
+      echo "  options:"
+      echo "  -h   Print this message"
+      echo "  -f   Configure for functional tests"
+      echo "  -r   Remove existing directory"
+      echo "  -d   Use depends"
+      exit 0
+      ;;
+    f)
+      FUNCTIONAL_TESTS=1
+      ;;
+    r)
+      DELETE_EXISTING=1
+      ;;
+    d)
+      USE_DEPENDS=1
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+shift $((OPTIND-1))
+
+if [ -z "$1" ]; then
+  echo "Specify release tag(s), e.g.: .previous_release v0.15.1"
+  exit 1
+fi
+
+for tag in "$@"
+do
+  if [ "$DELETE_EXISTING" -eq "1" ]; then
+    rm -rf build/releases/$tag
+  fi
+
+  if [ "$FUNCTIONAL_TESTS" -eq "1" ]; then
+    CONFIG_FLAGS="--without-gui --disable-tests --disable-bench"
+  fi
+
+  if [ ! -d "build/releases/$tag" ]; then
+    if [ -f $(git rev-parse --git-dir)/shallow ]; then
+      git fetch --unshallow --tags
+    fi
+
+    if [ -z $(git tag -l "$tag") ]; then
+      echo "Tag $tag not found"
+      exit 1
+    fi
+
+    git clone . build/releases/$tag
+    pushd build/releases/$tag
+    git checkout $tag
+
+    if [ "$USE_DEPENDS" -eq "1" ]; then
+      pushd depends
+      if [ "$FUNCTIONAL_TESTS" -eq "1" ]; then
+        make NO_QT=1
+      else
+        make
+      fi
+      HOST="${HOST:-$(./config.guess)}"
+      popd
+      CONFIG_FLAGS="--prefix=$PWD/depends/$HOST $CONFIG_FLAGS"
+    fi
+
+    ./autogen.sh
+    ./configure $CONFIG_FLAGS
+    make
+    popd
+  fi
+done

--- a/test/functional/backwards_compatibility.py
+++ b/test/functional/backwards_compatibility.py
@@ -10,30 +10,87 @@ contrib/devtools/previous_release.sh -f v0.15.1 v0.14.2
 
 Due to RPC changes introduced in v0.14 the below tests won't work for older
 versions without some patches or workarounds.
+
+Use only the latest patch version of each release, unless a test specifically
+needs an older patch version.
 """
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    sync_blocks
+    assert_not_equal,
+    assert_raises,
+    sync_blocks,
+    connect_nodes
 )
+from shutil import copy2
+
+# Node alias:
+V0_15 = 2
+V0_14 = 3
 
 class DowngradeTest(BitcoinTestFramework):
+
+    
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.num_nodes = 3
+        self.num_nodes = 4
+        # TODO: add new version after each release
         self.extra_args = [
-            [],
+            [], # Pre-release: use to mine blocks
+            [], # Pre-release: use to receive coins, swap wallets, etc
             ["-vbparams=segwit:0:0", "-vbparams=csv:0:0"], # v0.15.1
-            ["-vbparams=segwit:0:0", "-vbparams=csv:0:0"] # v0.14.2
+            ["-vbparams=segwit:0:0", "-vbparams=csv:0:0"], # v0.14.2
         ]
 
     def setup_nodes(self):
         self.add_nodes(self.num_nodes, extra_args=self.extra_args, binary=[
             None,
+            None,
             "build/releases/v0.15.1/src/bitcoind",
-            "build/releases/v0.14.2/src/bitcoind"
+            "build/releases/v0.14.2/src/bitcoind",
         ])
         self.start_nodes()
+    
+    def node_wallet_path(self, node):
+        # TODO:
+        # * make part of test framework
+        # * avoid hardcoded path
+        # * don't hardcode node version
+
+        if (node < 2): # >= v0.16
+            return self.nodes[1].datadir + "/regtest/wallets/wallet.dat"
+        else: # <= v0.15
+            return self.nodes[node].datadir + "/regtest/wallet.dat"
+    
+    def backup_wallet_push(self, node):
+        # TODO: actually stack backups
+        # TODO: use dynamic wallet load / unload once merged
+        self.stop_node(node)
+        copy2(self.node_wallet_path(node), self.node_wallet_path(node) + "-backup")
+        self.start_node(node)
+        connect_nodes(self.nodes[node - 1], node)
+        connect_nodes(self.nodes[node], node + 1)
+    
+    def backup_wallet_pop(self, node):
+        # TODO: actually pop backup stack
+        # TODO: use dynamic wallet load / unload once merged
+        copy2(self.node_wallet_path(node) + "-backup", self.node_wallet_path(node))
+        # TODO: start node and restore connections
+    
+    def copy_wallet(self, origin, destination):
+        # TODO: make part of test framework
+        # TODO: use dynamic wallet load / unload once merged
+
+        self.stop_node(origin)
+        self.stop_node(destination)
+        copy2(self.node_wallet_path(origin), self.node_wallet_path(destination))
+        self.start_node(origin)
+        self.start_node(destination)
+        connect_nodes(self.nodes[origin - 1], origin)
+        connect_nodes(self.nodes[origin], origin + 1)
+        connect_nodes(self.nodes[destination - 1], destination)
+        connect_nodes(self.nodes[destination], destination + 1)
+        sync_blocks(self.nodes)
 
     def run_test(self):
         self.nodes[0].generate(101)
@@ -43,5 +100,113 @@ class DowngradeTest(BitcoinTestFramework):
         # Santity check the test framework:
         res = self.nodes[self.num_nodes - 1].getblockchaininfo()
         assert_equal(res['blocks'], 101)
+        
+        # Check that v0.16 wallet can't be used on v0.15 node
+        # TODO: use v0.16 node after release
+        self.backup_wallet_push(V0_15)
+        self.log.debug("Expecting bitcoind to fail with:")
+        self.log.debug("Error loading wallet.dat: Wallet requires newer version of Bitcoin Core")
+        # TODO: use something like assert_raises_process_error to check
+        #       specific bitcoind launch error 
+        assert_raises(AssertionError, lambda: self.copy_wallet(1,V0_15))
+        self.log.info('Restoring backup')
+        self.backup_wallet_pop(V0_15)
+        self.start_node(V0_15)
+        connect_nodes(self.nodes[V0_15 - 1], V0_15)
+        connect_nodes(self.nodes[V0_15], V0_15 + 1)
+        sync_blocks(self.nodes)
+        
+        # Upgrade v0.15.1 wallet from node2 on node1
+        self.copy_wallet(V0_15,1)
+        
+        # SegWit wallet related scenarios from gist:
+        # https://gist.github.com/sipa/125cfa1615946d0c3f3eec2ad7f250a2#segwit-wallet-support
+        # 1) make backup, upgrade, create segwit address, restore from backup
+        # 2) upgrade, make backup, downgrade, restore backup
+        # 3) upgrade, new address, downgrade: P2SH-P2WPKH should still exist
+        # 4) backup, upgrade, new address, downgrade, restore backup: not supported
+        # 5) upgrade, backup, new address, receive coins, restore backup, downgrade
+
+        # Generate and fund a legacy, segwit-p2sh and bech32 address on node1
+        address1 = self.nodes[1].getnewaddress(account="legacy", address_type='legacy')
+        address2 = self.nodes[1].getnewaddress(account="p2sh", address_type='p2sh-segwit')
+        address3 = self.nodes[1].getnewaddress(account="p2sh-nocoin", address_type='p2sh-segwit')
+        address4 = self.nodes[1].getnewaddress(account="bech32", address_type='bech32')
+        self.nodes[0].sendtoaddress(address1, 1)
+        self.nodes[0].sendtoaddress(address2, 1)
+        # no coins sent to address3
+        self.nodes[0].sendtoaddress(address4, 1)
+
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        assert_equal(self.nodes[1].getbalance("legacy"), 1)
+        assert_equal(self.nodes[1].getbalance("p2sh"), 1)
+        assert_equal(self.nodes[1].getbalance("bech32"), 1)
+
+        # Copy node1 wallet to node2 and check v0.15.1 can still spend this:
+        assert_equal(self.nodes[V0_15].getbalance("legacy"), 0)
+        assert_equal(self.nodes[V0_15].getbalance("p2sh"), 0)
+        assert_equal(self.nodes[V0_15].getbalance("bech32"), 0)
+
+        self.copy_wallet(1,V0_15)
+        assert_equal(self.nodes[V0_15].getbalance("legacy"), 1)
+        assert_equal(self.nodes[V0_15].getbalance("p2sh"), 1) # Scenario 3
+        
+        # bech32 account will appear empty:
+        assert_equal(self.nodes[V0_15].getbalance("bech32"), 0) 
+        
+        # Check address formats:
+        assert_equal(self.nodes[V0_15].getaddressesbyaccount("legacy"), [address1]) 
+        assert_equal(self.nodes[V0_15].getaddressesbyaccount("p2sh"), [address2]) 
+        
+        # bech32 address is corrupted until the next upgrade:
+        assert_equal(self.nodes[V0_15].getaddressesbyaccount("bech32"), ["3QJmnh"])
+        
+        # Scenario 1: create and fund address on node 1 before we override with backup
+        address5 = self.nodes[1].getnewaddress(account="p2sh-post-backup", address_type='p2sh-segwit')
+        address6 = self.nodes[1].getnewaddress(account="bech32-post-backup", address_type='bech32')
+        address7 = self.nodes[1].getnewaddress(account="p2sh-disappear", address_type='p2sh-segwit')
+        self.nodes[0].sendtoaddress(address5, 1)
+        self.nodes[0].sendtoaddress(address6, 1)
+        self.nodes[0].sendtoaddress(address7, 1)
+        self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
+        assert_equal(self.nodes[1].getbalance("p2sh-post-backup"), 1)
+        assert_equal(self.nodes[1].getbalance("bech32-post-backup"), 1)
+        assert_equal(self.nodes[1].getbalance("p2sh-disappear"), 1)
+
+        # Upgrade back to v0.16 by copying to node1:
+        # TODO: use v0.16 node after release
+        self.copy_wallet(V0_15,1)
+
+        assert_equal(self.nodes[1].getbalance("legacy"), 1)
+        assert_equal(self.nodes[1].getbalance("p2sh"), 1) # Scenerio 5
+
+        # Scenario 2
+        assert_equal(self.nodes[1].getaddressesbyaccount("p2sh-nocoin"), [address3])
+        
+        # bech32 account should show funds again (scenerio 2):
+        assert_equal(self.nodes[1].getbalance("bech32"), 1) 
+        
+        # bech32 address format should be restored:
+        assert_equal(self.nodes[1].getaddressesbyaccount("bech32"), [address4])
+        
+        # Check scenario 1, SegWit addresses should come back, even if not explictly requested:
+        self.nodes[1].getnewaddress(account="p2sh-post-backup", address_type='p2sh-segwit')
+        assert_equal(self.nodes[1].getaddressesbyaccount("p2sh-post-backup"), [address5])
+        self.nodes[1].getnewaddress(account="bech32-post-backup", address_type='bech32')
+        assert_equal(self.nodes[1].getaddressesbyaccount("bech32-post-backup"), [address6])
+        
+        self.nodes[1].getnewaddress(account="p2sh-disappear", address_type='bech32') # wrong type!
+        self.nodes[1].getnewaddress(account="p2sh-disappear", address_type='p2sh-segwit') # next key...
+        assert_not_equal(self.nodes[1].getaddressesbyaccount("p2sh-disappear"), [address7])
+        assert_equal(self.nodes[1].getbalance("p2sh-disappear"), 0)
+
+        # Balance won't immedidately update:
+        self.nodes[1].rescanblockchain()
+        assert_equal(self.nodes[1].getbalance("p2sh-post-backup"), 1)
+        assert_equal(self.nodes[1].getbalance("bech32-post-backup"), 1) 
+        assert_equal(self.nodes[1].getbalance("p2sh-disappear"), 0)
+        
 if __name__ == '__main__':
     DowngradeTest().main()

--- a/test/functional/backwards_compatibility.py
+++ b/test/functional/backwards_compatibility.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Downgrade functional test
+
+Test various downgrade scenarios. Compile the previous node binaries:
+
+contrib/devtools/previous_release.sh -f v0.15.1 v0.14.2
+
+Due to RPC changes introduced in v0.14 the below tests won't work for older
+versions without some patches or workarounds.
+"""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    sync_blocks
+)
+
+class DowngradeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 3
+        self.extra_args = [
+            [],
+            ["-vbparams=segwit:0:0", "-vbparams=csv:0:0"], # v0.15.1
+            ["-vbparams=segwit:0:0", "-vbparams=csv:0:0"] # v0.14.2
+        ]
+
+    def setup_nodes(self):
+        self.add_nodes(self.num_nodes, extra_args=self.extra_args, binary=[
+            None,
+            "build/releases/v0.15.1/src/bitcoind",
+            "build/releases/v0.14.2/src/bitcoind"
+        ])
+        self.start_nodes()
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+
+        sync_blocks(self.nodes)
+
+        # Santity check the test framework:
+        res = self.nodes[self.num_nodes - 1].getblockchaininfo()
+        assert_equal(res['blocks'], 101)
+if __name__ == '__main__':
+    DowngradeTest().main()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -37,6 +37,10 @@ def assert_equal(thing1, thing2, *args):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
+def assert_not_equal(thing1, thing2, *args):
+    if thing1 == thing2 or any(thing1 == arg for arg in args):
+        raise AssertionError("not(%s)" % " != ".join(str(arg) for arg in (thing1, thing2) + args))
+
 def assert_greater_than(thing1, thing2):
     if thing1 <= thing2:
         raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -158,6 +158,7 @@ EXTENDED_SCRIPTS = [
     'assumevalid.py',
     'example_test.py',
     'txn_doublespend.py',
+    'backwards_compatibility.py',
     'txn_clone.py --mineblock',
     'notifications.py',
     'invalidateblock.py',


### PR DESCRIPTION
Builds on top of #12134.

Tests:
- [x] v0.16 generated wallets don't work on older versions
- [x] the five SegWit wallet scenario's (including bech32 address)  

Test framework changes (or: things I'm doing wrong):
- [ ] method to copy wallet
- [ ] method to push and pop wallet backups
- [ ] remember network topology between start and restart

Suggestions for additional tests welcome. I'll make individual PR's later.