### PR TITLE
Trivial: Fix #include sys/fcntl.h to just fcntl.h (without sys/)

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -33,7 +33,7 @@
 #include <ws2tcpip.h>
 #include <stdint.h>
 #else
-#include <sys/fcntl.h>
+#include <fcntl.h>
 #include <sys/mman.h>
 #include <sys/select.h>
 #include <sys/socket.h>


### PR DESCRIPTION
http://pubs.opengroup.org/onlinepubs/009695399/functions/fcntl.html
http://man7.org/linux/man-pages/man2/fcntl.2.html