### PR TITLE
[Qt] Use flexible font size for QRCode image address

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -995,6 +995,18 @@ QString formatBytes(uint64_t bytes)
     return QString(QObject::tr("%1 GB")).arg(bytes / 1024 / 1024 / 1024);
 }
 
+qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize, qreal font_size) {
+    while(font_size >= minPointSize) {
+        font.setPointSizeF(font_size);
+        QFontMetrics fm(font);
+        if (fm.width(text) < width) {
+            break;
+        }
+        font_size -= 0.5;
+    }
+    return font_size;
+}
+
 void ClickableLabel::mouseReleaseEvent(QMouseEvent *event)
 {
     Q_EMIT clicked(event->pos());

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -201,6 +201,8 @@ namespace GUIUtil
 
     QString formatBytes(uint64_t bytes);
 
+    qreal calculateIdealFontSize(int width, const QString& text, QFont font, qreal minPointSize = 4, qreal startPointSize = 14);
+
     class ClickableLabel : public QLabel
     {
         Q_OBJECT

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -183,9 +183,13 @@ void ReceiveRequestDialog::update()
             QPainter painter(&qrAddrImage);
             painter.drawImage(0, 0, qrImage.scaled(QR_IMAGE_SIZE, QR_IMAGE_SIZE));
             QFont font = GUIUtil::fixedPitchFont();
-            font.setPixelSize(12);
-            painter.setFont(font);
             QRect paddedRect = qrAddrImage.rect();
+
+            // calculate ideal font size
+            qreal font_size = GUIUtil::calculateIdealFontSize(paddedRect.width() - 20, info.address, font);
+            font.setPointSizeF(font_size);
+
+            painter.setFont(font);
             paddedRect.setHeight(QR_IMAGE_SIZE+12);
             painter.drawText(paddedRect, Qt::AlignBottom|Qt::AlignCenter, info.address);
             painter.end();


### PR DESCRIPTION
Bech32 addresses are currently cut off in the QRCode image in the GUI receive tab.
This adds a simple font size calculation logic that "must" (down to 4pt) fix into the given image width.

Examples OSX HiDPI:
<img width="332" alt="bildschirmfoto 2018-01-12 um 11 25 40" src="https://user-images.githubusercontent.com/178464/34896144-c0c65d76-f78c-11e7-93e1-94dc8e203269.png">
<img width="322" alt="bildschirmfoto 2018-01-12 um 11 25 46" src="https://user-images.githubusercontent.com/178464/34896145-c0edfe1c-f78c-11e7-8c09-c15155e2160e.png">

Examples Ubuntu non HIDPI:
<img width="314" alt="bildschirmfoto 2018-01-12 um 11 27 51" src="https://user-images.githubusercontent.com/178464/34896151-c88347f4-f78c-11e7-8a03-df8049dcfed6.png">
<img width="322" alt="bildschirmfoto 2018-01-12 um 11 27 42" src="https://user-images.githubusercontent.com/178464/34896152-c8bb881c-f78c-11e7-89d2-6f04ec608a19.png">
