### PR TITLE
[Qt] Display transaction fee with sat/vbyte value in SendCoinsDialog

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -318,23 +318,16 @@ void SendCoinsDialog::on_sendButton_clicked()
         // append fee string if a fee is required
         questionString.append("<hr /><span style='color:#aa0000;'>");
         questionString.append(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), txFee));
-
         questionString.append("</span> ");
         questionString.append(tr("added as transaction fee"));
 
-        double txSize = (double)currentTransaction.getTransactionSize();
-
-        // safe to assume that txSize cannot be 0 at this point?
-        double satPerVByte = txFee / txSize; // txFee is already in satoshis
-
+        unsigned int txSize = currentTransaction.getTransactionSize();
         // append transaction size
-        questionString.append(" (");
-        questionString.append(GUIUtil::formatBytes(txSize));
+        questionString.append(" (" + QString::number(txSize / 1000.0) + " kB");
 
-
+        double satPerVByte = currentTransaction.getTransactionFeePerByte();
         // append sat/vbyte as another representation of the fee
         questionString.append(" at " + QString::number(satPerVByte) + " sat/vbyte");
-
         questionString.append(")");
     }
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -318,11 +318,23 @@ void SendCoinsDialog::on_sendButton_clicked()
         // append fee string if a fee is required
         questionString.append("<hr /><span style='color:#aa0000;'>");
         questionString.append(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), txFee));
+
         questionString.append("</span> ");
         questionString.append(tr("added as transaction fee"));
 
+        double txSize = (double)currentTransaction.getTransactionSize();
+
+        // safe to assume that txSize cannot be 0 at this point?
+        double satPerVByte = txFee / txSize; // txFee is already in satoshis
+
         // append transaction size
-        questionString.append(" (" + QString::number((double)currentTransaction.getTransactionSize() / 1000) + " kB)");
+        questionString.append(" (");
+        questionString.append(QString::number(txSize / 1000) + " kB");
+
+        // append sat/vbyte as another representation of the fee
+        questionString.append(" at " + QString::number(satPerVByte) + " sat/vbyte");
+
+        questionString.append(")");
     }
 
     // add total amount in all subdivision units

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -329,7 +329,8 @@ void SendCoinsDialog::on_sendButton_clicked()
 
         // append transaction size
         questionString.append(" (");
-        questionString.append(QString::number(txSize / 1000) + " kB");
+        questionString.append(GUIUtil::formatBytes(txSize));
+
 
         // append sat/vbyte as another representation of the fee
         questionString.append(" at " + QString::number(satPerVByte) + " sat/vbyte");

--- a/src/qt/walletmodeltransaction.cpp
+++ b/src/qt/walletmodeltransaction.cpp
@@ -35,6 +35,19 @@ unsigned int WalletModelTransaction::getTransactionSize()
     return (!walletTransaction ? 0 : ::GetVirtualTransactionSize(*walletTransaction->tx));
 }
 
+double WalletModelTransaction::getTransactionFeePerByte()
+{
+    CAmount txFee = this->getTransactionFee();
+    double txSize = (double)this->getTransactionSize();
+
+    // Prevent divide by 0
+    if (txSize <= 0) {
+      return 0;
+    }
+
+    return txFee / txSize;
+}
+
 CAmount WalletModelTransaction::getTransactionFee() const
 {
     return fee;

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -26,6 +26,7 @@ public:
 
     CWalletTx *getTransaction() const;
     unsigned int getTransactionSize();
+    double getTransactionFeePerByte();
 
     void setTransactionFee(const CAmount& newFee);
     CAmount getTransactionFee() const;


### PR DESCRIPTION
Related to issue #11564, this PR designed to provide feedback to the user about their relative transaction fee before they finish broadcasting their tx to the bitcoin network. 

Displaying the sat/vbyte is useful for knowing how likely their tx will be included in an upcoming block when using public fee estimation tools like https://jochen-hoenicke.de/queue/#24h, https://estimatefee.com, and https://bitcoinfees.earn.com.

This updates the SendCoinsDialog to look like this:

<img width="838" alt="screen shot 2018-01-15 at 12 46 14" src="https://user-images.githubusercontent.com/534/34943625-4f0037a6-f9f4-11e7-8a77-49d35df34c76.png">