### PR TITLE
Log debug build status and warn when running benchmarks

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -100,6 +100,9 @@ void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double
     if (!std::ratio_less_equal<benchmark::clock::period, std::micro>::value) {
         std::cerr << "WARNING: Clock precision is worse than microsecond - benchmarks may be less accurate!\n";
     }
+#ifdef DEBUG
+    std::cerr << "WARNING: This is a debug build - may result in slower benchmarks.\n";
+#endif
 
     std::regex reFilter(filter);
     std::smatch baseMatch;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -808,7 +808,13 @@ void InitLogging()
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);
 
     LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
-    LogPrintf("Bitcoin version %s\n", FormatFullVersion());
+    std::string version_string = FormatFullVersion();
+#ifdef DEBUG
+    version_string += " (debug build)";
+#else
+    version_string += " (release build)";
+#endif
+    LogPrintf("Bitcoin version %s\n", version_string);
 }
 
 namespace { // Variables internal to initialization process only

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -814,7 +814,7 @@ void InitLogging()
 #else
     version_string += " (release build)";
 #endif
-    LogPrintf("Bitcoin version %s\n", version_string);
+    LogPrintf(PACKAGE_NAME " version %s\n", version_string);
 }
 
 namespace { // Variables internal to initialization process only


### PR DESCRIPTION
Log whether the starting instance of bitcoin core is a debug or release build (--enable-debug).

Also warn when running the benchmarks with a debug build, to prevent mistakes comparing debug to non-debug results.