### PR TITLE
rpc: Add deprecation error for `getinfo`

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -668,6 +668,18 @@ UniValue echo(const JSONRPCRequest& request)
     return request.params;
 }
 
+static UniValue getinfo_deprecated(const JSONRPCRequest& request)
+{
+    throw JSONRPCError(RPC_METHOD_NOT_FOUND,
+        "getinfo\n"
+        "\nThis call was removed in version 0.16.0. Use the appropriate fields from:\n"
+        "- getblockchaininfo: blocks, difficulty, chain\n"
+        "- getnetworkinfo: version, protocolversion, timeoffset, connections, proxy, relayfee, warnings\n"
+        "- getwalletinfo: balance, keypoololdest, keypoolsize, paytxfee, unlocked_until, walletversion\n"
+        "\nbitcoin-cli has the option -getinfo to collect and format these in the old format."
+    );
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
@@ -682,6 +694,7 @@ static const CRPCCommand commands[] =
     { "hidden",             "setmocktime",            &setmocktime,            {"timestamp"}},
     { "hidden",             "echo",                   &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
     { "hidden",             "echojson",               &echo,                   {"arg0","arg1","arg2","arg3","arg4","arg5","arg6","arg7","arg8","arg9"}},
+    { "hidden",             "getinfo",                &getinfo_deprecated,     {}},
 };
 
 void RegisterMiscRPCCommands(CRPCTable &t)


### PR DESCRIPTION
Add a short informative deprecation message when users use `getinfo`, that points them to the new calls 
 here to get the different information fields.
This is meant to be temporary, for one release only.