### PR TITLE
Bind functional test nodes to 127.0.0.1

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -292,6 +292,7 @@ def initialize_datadir(dirname, n):
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
+        f.write("bind=127.0.0.1\n")
     return datadir
 
 def get_datadir_path(dirname, n):


### PR DESCRIPTION
Prevents OSX firewall allow-this-application-to-accept-inbound-connections permission popups and is generally safer.

To test, make an arbitrary whitespace change to `src/bitcoind.cpp` and recompile. This normally resets the firewall's memory.

Easiest way to reproduce a popup without running the test suite:

```sh
src/bitcoind -regtest -bind=127.0.0.1 # No popup
src/bitcoind -regtest # Popup
```
