### PR TITLE
Avoid potential null dereference in ReceiveCoinsDialog constructor

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -43,15 +43,6 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
         ui->removeRequestButton->setIcon(_platformStyle->SingleColorIcon(":/icons/remove"));
     }
 
-    // configure bech32 checkbox, disable if launched with legacy as default:
-    if (model->getDefaultAddressType() == OUTPUT_TYPE_BECH32) {
-        ui->useBech32->setCheckState(Qt::Checked);
-    } else {
-        ui->useBech32->setCheckState(Qt::Unchecked);
-    }
-
-    ui->useBech32->setVisible(model->getDefaultAddressType() != OUTPUT_TYPE_LEGACY);
-
     // context menu actions
     QAction *copyURIAction = new QAction(tr("Copy URI"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
@@ -102,6 +93,15 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
             SLOT(recentRequestsView_selectionChanged(QItemSelection, QItemSelection)));
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
         columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH, this);
+
+        // configure bech32 checkbox, disable if launched with legacy as default:
+        if (model->getDefaultAddressType() == OUTPUT_TYPE_BECH32) {
+            ui->useBech32->setCheckState(Qt::Checked);
+        } else {
+            ui->useBech32->setCheckState(Qt::Unchecked);
+        }
+
+        ui->useBech32->setVisible(model->getDefaultAddressType() != OUTPUT_TYPE_LEGACY);
     }
 }
 


### PR DESCRIPTION
Not a bug in practice because current `WalletModel::getDefaultAddressType()` implementation does not dereference its `this` pointer.

Encountered issue while rebasing #10244 after #11991 was merged.