### PR TITLE
scripted-diff: prefix [address|change]type parameters with 'default'

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -98,7 +98,7 @@ Low-level RPC changes
   * `getmininginfo`
 - The wallet RPC `getreceivedbyaddress` will return an error if called with an address not in the wallet.
 - The wallet RPC `addwitnessaddress` was deprecated and will be removed in version 0.17,
-  set the `address_type` argument of `getnewaddress`, or option `-addresstype=[bech32|p2sh-segwit]` instead.
+  set the `address_type` argument of `getnewaddress`, or option `-defaultaddresstype=[bech32|p2sh-segwit]` instead.
 
 Changed command-line options
 -----------------------------

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -16,8 +16,8 @@
 std::string GetWalletHelpString(bool showDebug)
 {
     std::string strUsage = HelpMessageGroup(_("Wallet options:"));
-    strUsage += HelpMessageOpt("-addresstype", strprintf(_("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")"), FormatOutputType(OUTPUT_TYPE_DEFAULT)));
-    strUsage += HelpMessageOpt("-changetype", _("What type of change to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default is same as -addresstype)"));
+    strUsage += HelpMessageOpt("-defaultaddresstype", strprintf(_("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")"), FormatOutputType(OUTPUT_TYPE_DEFAULT)));
+    strUsage += HelpMessageOpt("-defaultchangetype", _("What type of change to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default is same as -defaultaddresstype)"));
     strUsage += HelpMessageOpt("-disablewallet", _("Do not load the wallet and disable wallet RPC calls"));
     strUsage += HelpMessageOpt("-keypool=<n>", strprintf(_("Set key pool size to <n> (default: %u)"), DEFAULT_KEYPOOL_SIZE));
     strUsage += HelpMessageOpt("-fallbackfee=<amt>", strprintf(_("A fee rate (in %s/kB) that will be used when fee estimation has insufficient data (default: %s)"),
@@ -177,14 +177,14 @@ bool WalletParameterInteraction()
     bSpendZeroConfChange = gArgs.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     fWalletRbf = gArgs.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
 
-    g_address_type = ParseOutputType(gArgs.GetArg("-addresstype", ""));
+    g_address_type = ParseOutputType(gArgs.GetArg("-defaultaddresstype", ""));
     if (g_address_type == OUTPUT_TYPE_NONE) {
-        return InitError(strprintf(_("Unknown address type '%s'"), gArgs.GetArg("-addresstype", "")));
+        return InitError(strprintf(_("Unknown address type '%s'"), gArgs.GetArg("-defaultaddresstype", "")));
     }
 
-    g_change_type = ParseOutputType(gArgs.GetArg("-changetype", ""), g_address_type);
+    g_change_type = ParseOutputType(gArgs.GetArg("-defaultchangetype", ""), g_address_type);
     if (g_change_type == OUTPUT_TYPE_NONE) {
-        return InitError(strprintf(_("Unknown change type '%s'"), gArgs.GetArg("-changetype", "")));
+        return InitError(strprintf(_("Unknown change type '%s'"), gArgs.GetArg("-defaultchangetype", "")));
     }
 
     return true;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -144,7 +144,7 @@ UniValue getnewaddress(const JSONRPCRequest& request)
             "so payments received with the address will be credited to 'account'.\n"
             "\nArguments:\n"
             "1. \"account\"        (string, optional) DEPRECATED. The account name for the address to be linked to. If not provided, the default account \"\" is used. It can also be set to the empty string \"\" to represent the default account. The account does not need to exist, it will be created if there is no account by the given name.\n"
-            "2. \"address_type\"   (string, optional) The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -addresstype.\n"
+            "2. \"address_type\"   (string, optional) The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -defaultaddresstype.\n"
             "\nResult:\n"
             "\"address\"    (string) The new bitcoin address\n"
             "\nExamples:\n"
@@ -242,7 +242,7 @@ UniValue getrawchangeaddress(const JSONRPCRequest& request)
             "\nReturns a new Bitcoin address, for receiving change.\n"
             "This is for use with raw transactions, NOT normal use.\n"
             "\nArguments:\n"
-            "1. \"address_type\"           (string, optional) The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -changetype.\n"
+            "1. \"address_type\"           (string, optional) The address type to use. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\". Default is set by -defaultchangetype.\n"
             "\nResult:\n"
             "\"address\"    (string) The address\n"
             "\nExamples:\n"
@@ -1285,7 +1285,7 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
     {
         std::string msg = "addwitnessaddress \"address\" ( p2sh )\n"
-            "\nDEPRECATED: set the address_type argument of getnewaddress, or option -addresstype=[bech32|p2sh-segwit] instead.\n"
+            "\nDEPRECATED: set the address_type argument of getnewaddress, or option -defaultaddresstype=[bech32|p2sh-segwit] instead.\n"
             "Add a witness address for a script (with pubkey or redeemscript known). Requires a new wallet backup.\n"
             "It returns the witness script.\n"
 
@@ -1303,7 +1303,7 @@ UniValue addwitnessaddress(const JSONRPCRequest& request)
     if (!IsDeprecatedRPCEnabled("addwitnessaddress")) {
         throw JSONRPCError(RPC_METHOD_DEPRECATED, "addwitnessaddress is deprecated and will be fully removed in v0.17. "
             "To use addwitnessaddress in v0.16, restart bitcoind with -deprecatedrpc=addwitnessaddress.\n"
-            "Projects should transition to using the address_type argument of getnewaddress, or option -addresstype=[bech32|p2sh-segwit] instead.\n");
+            "Projects should transition to using the address_type argument of getnewaddress, or option -defaultaddresstype=[bech32|p2sh-segwit] instead.\n");
     }
 
     {

--- a/test/functional/address_types.py
+++ b/test/functional/address_types.py
@@ -35,7 +35,7 @@ from test_framework.util import assert_equal, assert_greater_than, connect_nodes
 class AddressTypeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 5
-        self.extra_args = [["-addresstype=legacy"], ["-addresstype=p2sh-segwit"], ["-addresstype=p2sh-segwit", "-changetype=bech32"], ["-addresstype=bech32"], []]
+        self.extra_args = [["-defaultaddresstype=legacy"], ["-defaultaddresstype=p2sh-segwit"], ["-defaultaddresstype=p2sh-segwit", "-defaultchangetype=bech32"], ["-defaultaddresstype=bech32"], []]
 
     def setup_network(self):
         self.setup_nodes()

--- a/test/functional/bip68-112-113-p2p.py
+++ b/test/functional/bip68-112-113-p2p.py
@@ -95,7 +95,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=4', '-addresstype=legacy']]
+        self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=4', '-defaultaddresstype=legacy']]
 
     def run_test(self):
         test = TestManager(self, self.options.tmpdir)

--- a/test/functional/import-rescan.py
+++ b/test/functional/import-rescan.py
@@ -119,7 +119,7 @@ class ImportRescanTest(BitcoinTestFramework):
         self.num_nodes = 2 + len(IMPORT_NODES)
 
     def setup_network(self):
-        extra_args = [["-addresstype=legacy"] for _ in range(self.num_nodes)]
+        extra_args = [["-defaultaddresstype=legacy"] for _ in range(self.num_nodes)]
         for i, import_node in enumerate(IMPORT_NODES, 2):
             if import_node.prune:
                 extra_args[i] += ["-prune=1"]

--- a/test/functional/importmulti.py
+++ b/test/functional/importmulti.py
@@ -9,7 +9,7 @@ from test_framework.util import *
 class ImportMultiTest (BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [["-addresstype=legacy"], ["-addresstype=legacy"]]
+        self.extra_args = [["-defaultaddresstype=legacy"], ["-defaultaddresstype=legacy"]]
         self.setup_clean_chain = True
 
     def setup_network(self):

--- a/test/functional/nulldummy.py
+++ b/test/functional/nulldummy.py
@@ -42,7 +42,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         # This script tests NULLDUMMY activation, which is part of the 'segwit' deployment, so we go through
         # normal segwit activation here (and don't use the default always-on behaviour).
-        self.extra_args = [['-whitelist=127.0.0.1', '-walletprematurewitness', '-vbparams=segwit:0:999999999999', '-addresstype=legacy', "-deprecatedrpc=addwitnessaddress"]]
+        self.extra_args = [['-whitelist=127.0.0.1', '-walletprematurewitness', '-vbparams=segwit:0:999999999999', '-defaultaddresstype=legacy', "-deprecatedrpc=addwitnessaddress"]]
 
     def run_test(self):
         self.address = self.nodes[0].getnewaddress()

--- a/test/functional/rawtransactions.py
+++ b/test/functional/rawtransactions.py
@@ -39,7 +39,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
-        self.extra_args = [["-addresstype=legacy"], ["-addresstype=legacy"], ["-addresstype=legacy"]]
+        self.extra_args = [["-defaultaddresstype=legacy"], ["-defaultaddresstype=legacy"], ["-defaultaddresstype=legacy"]]
 
     def setup_network(self, split=False):
         super().setup_network()

--- a/test/functional/segwit.py
+++ b/test/functional/segwit.py
@@ -40,9 +40,9 @@ class SegWitTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 3
         # This test tests SegWit both pre and post-activation, so use the normal BIP9 activation.
-        self.extra_args = [["-walletprematurewitness", "-rpcserialversion=0", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"],
-                           ["-blockversion=4", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-rpcserialversion=1", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"],
-                           ["-blockversion=536870915", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-vbparams=segwit:0:999999999999", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"]]
+        self.extra_args = [["-walletprematurewitness", "-rpcserialversion=0", "-vbparams=segwit:0:999999999999", "-defaultaddresstype=legacy", "-deprecatedrpc=addwitnessaddress"],
+                           ["-blockversion=4", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-rpcserialversion=1", "-vbparams=segwit:0:999999999999", "-defaultaddresstype=legacy", "-deprecatedrpc=addwitnessaddress"],
+                           ["-blockversion=536870915", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-vbparams=segwit:0:999999999999", "-defaultaddresstype=legacy", "-deprecatedrpc=addwitnessaddress"]]
 
     def setup_network(self):
         super().setup_network()

--- a/test/functional/signmessages.py
+++ b/test/functional/signmessages.py
@@ -11,7 +11,7 @@ class SignMessagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-addresstype=legacy"]]
+        self.extra_args = [["-defaultaddresstype=legacy"]]
 
     def run_test(self):
         message = 'This is just a test message'

--- a/test/functional/wallet-dump.py
+++ b/test/functional/wallet-dump.py
@@ -69,7 +69,7 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
 class WalletDumpTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [["-keypool=90", "-addresstype=legacy", "-deprecatedrpc=addwitnessaddress"]]
+        self.extra_args = [["-keypool=90", "-defaultaddresstype=legacy", "-deprecatedrpc=addwitnessaddress"]]
 
     def setup_network(self, split=False):
         # Use 1 minute timeout because the initial getnewaddress RPC can take


### PR DESCRIPTION
Making it clear that these parameters can be overridden by individual wallet commands.

Requesting 0.16 tag, as it's probably not worth changing otherwise.

This makes grateful use of the fact that @sipa used an underscore for `address_type` and `change_type` RPC arguments.