### PR TITLE
qa: Add missing syncwithvalidationinterfacequeue to tests

### DIFF
--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -66,16 +66,17 @@ class MempoolPersistTest(BitcoinTestFramework):
 
         self.log.debug("Stop-start the nodes. Verify that node0 has the transactions in its mempool and node1 does not. Verify that node2 calculates its balance correctly after loading wallet transactions.")
         self.stop_nodes()
+        self.start_node(1)  # Give this one a head-start, so we can be "extra-sure" that it didn't load anything later
         self.start_node(0)
-        self.start_node(1)
         self.start_node(2)
         # Give bitcoind a second to reload the mempool
-        time.sleep(1)
-        wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5)
-        wait_until(lambda: len(self.nodes[2].getrawmempool()) == 5)
+        wait_until(lambda: len(self.nodes[0].getrawmempool()) == 5, timeout=1)
+        wait_until(lambda: len(self.nodes[2].getrawmempool()) == 5, timeout=1)
+        # The others have loaded their mempool. If node_1 loaded anything, we'd probably notice by now:
         assert_equal(len(self.nodes[1].getrawmempool()), 0)
 
         # Verify accounting of mempool transactions after restart is correct
+        self.nodes[2].syncwithvalidationinterfacequeue()  # Flush mempool to wallet
         assert_equal(node2_balance, self.nodes[2].getbalance())
 
         self.log.debug("Stop-start node0 with -persistmempool=0. Verify that it doesn't load its mempool.dat file.")

--- a/test/functional/wallet_zapwallettxes.py
+++ b/test/functional/wallet_zapwallettxes.py
@@ -59,6 +59,7 @@ class ZapWalletTXesTest (BitcoinTestFramework):
         self.start_node(0, ["-persistmempool=1", "-zapwallettxes=2"])
 
         wait_until(lambda: self.nodes[0].getmempoolinfo()['size'] == 1, timeout=3)
+        self.nodes[0].syncwithvalidationinterfacequeue()  # Flush mempool to wallet
 
         assert_equal(self.nodes[0].gettransaction(txid1)['txid'], txid1)
         assert_equal(self.nodes[0].gettransaction(txid2)['txid'], txid2)


### PR DESCRIPTION
Fixes intermittent travis failures with those tests caused by a missing flush of mempool txes to the wallet.