### PR TITLE
RFC: Rename -walletdir option to -walletsdir (scripted-diff)

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -78,7 +78,7 @@ use the `replaceable` argument for individual transactions.
 Custom wallet directories
 ---------------------
 The ability to specify a directory other than the default data directory in which to store
-wallets has been added. An existing directory can be specified using the `-walletdir=<dir>`
+wallets has been added. An existing directory can be specified using the `-walletsdir=<dir>`
 argument. Wallets loaded via `-wallet` arguments must be in this wallet directory. Care should be taken
 when choosing a wallet directory location, as if it becomes unavailable during operation,
 funds may be lost.

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -37,7 +37,7 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-upgradewallet", _("Upgrade wallet to latest format on startup"));
     strUsage += HelpMessageOpt("-wallet=<file>", _("Specify wallet file (within data directory)") + " " + strprintf(_("(default: %s)"), DEFAULT_WALLET_DAT));
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));
-    strUsage += HelpMessageOpt("-walletdir=<dir>", _("Specify directory to hold wallets (default: <datadir>/wallets if it exists, otherwise <datadir>)"));
+    strUsage += HelpMessageOpt("-walletsdir=<dir>", _("Specify directory to hold wallets (default: <datadir>/wallets if it exists, otherwise <datadir>)"));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
                                " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
@@ -205,11 +205,11 @@ bool VerifyWallets()
         return true;
     }
 
-    if (gArgs.IsArgSet("-walletdir") && !fs::is_directory(GetWalletDir())) {
-        if (fs::exists(fs::system_complete(gArgs.GetArg("-walletdir", "")))) {
-            return InitError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), gArgs.GetArg("-walletdir", "").c_str()));
+    if (gArgs.IsArgSet("-walletsdir") && !fs::is_directory(GetWalletDir())) {
+        if (fs::exists(fs::system_complete(gArgs.GetArg("-walletsdir", "")))) {
+            return InitError(strprintf(_("Specified -walletsdir \"%s\" is not a directory"), gArgs.GetArg("-walletsdir", "").c_str()));
         }
-        return InitError(strprintf(_("Specified -walletdir \"%s\" does not exist"), gArgs.GetArg("-walletdir", "").c_str()));
+        return InitError(strprintf(_("Specified -walletsdir \"%s\" does not exist"), gArgs.GetArg("-walletsdir", "").c_str()));
     }
 
     LogPrintf("Using wallet directory %s\n", GetWalletDir().string());

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -8,8 +8,8 @@ fs::path GetWalletDir()
 {
     fs::path path;
 
-    if (gArgs.IsArgSet("-walletdir")) {
-        path = fs::system_complete(gArgs.GetArg("-walletdir", ""));
+    if (gArgs.IsArgSet("-walletsdir")) {
+        path = fs::system_complete(gArgs.GetArg("-walletsdir", ""));
         if (!fs::is_directory(path)) {
             // If the path specified doesn't exist, we return the deliberately
             // invalid empty string.

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -45,33 +45,33 @@ class MultiWalletTest(BitcoinTestFramework):
         os.symlink(wallet_dir('w1'), wallet_dir('w12'))
         self.assert_start_raises_init_error(0, ['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
 
-        # should not initialize if the specified walletdir does not exist
-        self.assert_start_raises_init_error(0, ['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
-        # should not initialize if the specified walletdir is not a directory
+        # should not initialize if the specified walletsdir does not exist
+        self.assert_start_raises_init_error(0, ['-walletsdir=bad'], 'Error: Specified -walletsdir "bad" does not exist')
+        # should not initialize if the specified walletsdir is not a directory
         not_a_dir = wallet_dir('notadir')
         open(not_a_dir, 'a').close()
-        self.assert_start_raises_init_error(0, ['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
+        self.assert_start_raises_init_error(0, ['-walletsdir=' + not_a_dir], 'Error: Specified -walletsdir "' + not_a_dir + '" is not a directory')
 
         # if wallets/ doesn't exist, datadir should be the default wallet dir
-        wallet_dir2 = data_dir('walletdir')
+        wallet_dir2 = data_dir('walletsdir')
         os.rename(wallet_dir(), wallet_dir2)
         self.start_node(0, ['-wallet=w4', '-wallet=w5'])
         assert_equal(set(node.listwallets()), {"w4", "w5"})
         w5 = wallet("w5")
         w5.generate(1)
 
-        # now if wallets/ exists again, but the rootdir is specified as the walletdir, w4 and w5 should still be loaded
+        # now if wallets/ exists again, but the rootdir is specified as the walletsdir, w4 and w5 should still be loaded
         os.rename(wallet_dir2, wallet_dir())
-        self.restart_node(0, ['-wallet=w4', '-wallet=w5', '-walletdir=' + data_dir()])
+        self.restart_node(0, ['-wallet=w4', '-wallet=w5', '-walletsdir=' + data_dir()])
         assert_equal(set(node.listwallets()), {"w4", "w5"})
         w5 = wallet("w5")
         w5_info = w5.getwalletinfo()
         assert_equal(w5_info['immature_balance'], 50)
 
-        competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletdir')
+        competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletsdir')
         os.mkdir(competing_wallet_dir)
-        self.restart_node(0, ['-walletdir='+competing_wallet_dir])
-        self.assert_start_raises_init_error(1, ['-walletdir='+competing_wallet_dir], 'Error initializing wallet database environment')
+        self.restart_node(0, ['-walletsdir='+competing_wallet_dir])
+        self.assert_start_raises_init_error(1, ['-walletsdir='+competing_wallet_dir], 'Error initializing wallet database environment')
 
         self.restart_node(0, self.extra_args[0])
 


### PR DESCRIPTION
Reasons for rename:

1. Default value is `<datadir>/wallets` so calling it `-walletsdir` instead of `-walletdir` would be more internally consistent.
2. Directory can contain more than one wallet so plural makes sense
3. This makes it harder to confuse `-walletdir` option with `-wallet` option if we store wallets in their own directories as proposed in https://github.com/bitcoin/bitcoin/pull/11466#issuecomment-335827526 and implemented in https://github.com/bitcoin/bitcoin/pull/12216