### PR TITLE
test_runner: Readable output if create_cache.py fails

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -313,9 +313,9 @@ def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_cove
         # Populate cache
         try:
             subprocess.check_output([tests_dir + 'create_cache.py'] + flags + ["--tmpdir=%s/cache" % tmpdir])
-        except Exception as e:
-            print(e.output)
-            raise e
+        except subprocess.CalledProcessError as e:
+            sys.stdout.buffer.write(e.output)
+            raise
 
     #Run Tests
     job_queue = TestHandler(jobs, tests_dir, tmpdir, test_list, flags)


### PR DESCRIPTION
Without this change, create_cache.py process output is shown as a byte() object
with \n escapes in a single line that is hard to read.