### PR TITLE
rpc: Avoid KeyError in getpeerinfo bytes per msg

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2754,8 +2754,10 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fPauseSend = false;
     nProcessQueueSize = 0;
 
-    for (const std::string &msg : getAllNetMessageTypes())
+    for (const std::string& msg : getAllNetMessageTypes()) {
         mapRecvBytesPerMsgCmd[msg] = 0;
+        mapSendBytesPerMsgCmd[msg] = 0;
+    }
     mapRecvBytesPerMsgCmd[NET_MESSAGE_COMMAND_OTHER] = 0;
 
     if (fLogIPs) {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -172,15 +172,13 @@ UniValue getpeerinfo(const JSONRPCRequest& request)
 
         UniValue sendPerMsgCmd(UniValue::VOBJ);
         for (const mapMsgCmdSize::value_type &i : stats.mapSendBytesPerMsgCmd) {
-            if (i.second > 0)
-                sendPerMsgCmd.push_back(Pair(i.first, i.second));
+            sendPerMsgCmd.pushKV(i.first, i.second);
         }
         obj.push_back(Pair("bytessent_per_msg", sendPerMsgCmd));
 
         UniValue recvPerMsgCmd(UniValue::VOBJ);
         for (const mapMsgCmdSize::value_type &i : stats.mapRecvBytesPerMsgCmd) {
-            if (i.second > 0)
-                recvPerMsgCmd.push_back(Pair(i.first, i.second));
+            recvPerMsgCmd.pushKV(i.first, i.second);
         }
         obj.push_back(Pair("bytesrecv_per_msg", recvPerMsgCmd));
 


### PR DESCRIPTION
After this change key-value pairs of the `bytessent_per_msg` and `bytesrecv_per_msg` are pushed unconditionally. Obviously this makes the object larger (with some values always equal to zero), but avoids some KeyErrors on common values such as "pong", e.g. when a pong was not yet received.