### PR TITLE
Update bitcoin.service to conform to init.md

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -5,20 +5,44 @@
 # See "man systemd.service" for details.
 
 # Note that almost all daemon options could be specified in
-# /etc/bitcoin/bitcoin.conf
+# /etc/bitcoin/bitcoin.conf, except for those explicitly specified as arguments
+# in ExecStart=
 
 [Unit]
 Description=Bitcoin daemon
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
-# Creates /run/bitcoind owned by bitcoin
-RuntimeDirectory=bitcoind
-User=bitcoin
+ExecStart=/usr/bin/bitcoind -daemon \
+                            -pid=/run/bitcoind/bitcoind.pid \
+                            -conf=/etc/bitcoin/bitcoin.conf \
+                            -datadir=/var/lib/bitcoind
+
+# Process management
+####################
+
 Type=forking
 PIDFile=/run/bitcoind/bitcoind.pid
 Restart=on-failure
+
+# Directory creation and permissions
+####################################
+
+# Run as bitcoin:bitcoin
+User=bitcoin
+Group=bitcoin
+
+# /run/bitcoind
+RuntimeDirectory=bitcoind
+RuntimeDirectoryMode=0710
+
+# /etc/bitcoin
+ConfigurationDirectory=bitcoin
+ConfigurationDirectoryMode=0710
+
+# /var/lib/bitcoind
+StateDirectory=bitcoind
+StateDirectoryMode=0710
 
 # Hardening measures
 ####################

--- a/doc/init.md
+++ b/doc/init.md
@@ -56,7 +56,7 @@ All three configurations assume several paths that might need to be adjusted.
 Binary:              `/usr/bin/bitcoind`  
 Configuration file:  `/etc/bitcoin/bitcoin.conf`  
 Data directory:      `/var/lib/bitcoind`  
-PID file:            `/var/run/bitcoind/bitcoind.pid` (OpenRC and Upstart) or `/var/lib/bitcoind/bitcoind.pid` (systemd)  
+PID file:            `/var/run/bitcoind/bitcoind.pid` (OpenRC and Upstart) or `/run/bitcoind/bitcoind.pid` (systemd)
 Lock file:           `/var/lock/subsys/bitcoind` (CentOS)  
 
 The configuration file, PID directory (if applicable) and data directory
@@ -64,6 +64,22 @@ should all be owned by the bitcoin user and group.  It is advised for security
 reasons to make the configuration file and data directory only readable by the
 bitcoin user and group.  Access to bitcoin-cli and other bitcoind rpc clients
 can then be controlled by group membership.
+
+NOTE: When using the systemd .service file, the creation of the aforementioned
+directories and the setting of their permissions is automatically handled by
+systemd. Directories are given a permission of 710, giving the bitcoin group
+access to files under it _if_ the files themselves give permission to the
+bitcoin group to do so (e.g. when `-sysperms` is specified). This does not allow
+for the listing of files under the directory.
+
+NOTE: It is not currently possible to override `datadir` in
+`/etc/bitcoin/bitcoin.conf` with the current systemd, OpenRC, and Upstart init
+files out-of-the-box. This is because the command line options specified in the
+init files take precedence over the configurations in
+`/etc/bitcoin/bitcoin.conf`. However, some init systems have their own
+configuration mechanisms that would allow for overriding the command line
+options specified in the init files (e.g. setting `BITCOIND_DATADIR` for
+OpenRC).
 
 ### macOS
 

--- a/doc/release-notes/release-notes-pr12255.md
+++ b/doc/release-notes/release-notes-pr12255.md
@@ -1,0 +1,17 @@
+systemd init file
+=========
+
+The systemd init file (`contrib/init/bitcoind.service`) has been changed to use
+`/var/lib/bitcoind` as the data directory instead of `~bitcoin/.bitcoin`. This
+change makes Bitcoin Core more consistent with other services, and makes the
+systemd init config more consistent with existing Upstart and OpenRC configs.
+
+The configuration, PID, and data directories are now completely managed by
+systemd, which will take care of their creation, permissions, etc. See
+[`systemd.exec (5)`](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#RuntimeDirectory=)
+for more details.
+
+When using the provided init files under `contrib/init`, overriding the
+`datadir` option in `/etc/bitcoin/bitcoin.conf` will have no effect. This is
+because the command line arguments specified in the init files take precedence
+over the options specified in `/etc/bitcoin/bitcoin.conf`.


### PR DESCRIPTION
- `-datadir` option specified.
- Ask systemd to create and set the right mode for PID directory, configuration directory, and data directory.
- Tell systemd our group so it will set the right owner for aforementioned directories.

More information: https://www.freedesktop.org/software/systemd/man/systemd.exec.html