### PR TITLE
qt: Bump BLOCK_CHAIN_SIZE to 200GB

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -22,7 +22,7 @@
 
 static const uint64_t GB_BYTES = 1000000000LL;
 /* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 150;
+static const uint64_t BLOCK_CHAIN_SIZE = 200;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 3;
 /* Total required space (in GB) depending on user choice (prune, not prune) */


### PR DESCRIPTION
Part of the release process for 0.16.

Value is open for discussion, my blocks/ directory is 163GB but this leaves some slack.