### PR TITLE
Update chainTxData for 0.16

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -169,11 +169,11 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data as of block 000000000000000000d97e53664d17967bd4ee50b23abb92e54a34eb222d15ae (height 478913).
-            1501801925, // * UNIX timestamp of last known number of transactions
-            243756039,  // * total number of transactions between genesis and that timestamp
+            // Data as of block 0000000000000000002d6cca6761c99b3c2e936f9a0e304b7c7651a993f461de (height 506081).
+            1516903077, // * UNIX timestamp of last known number of transactions
+            295363220,  // * total number of transactions between genesis and that timestamp
                         //   (the tx=... number in the SetBestChain debug.log lines)
-            3.1         // * estimated number of transactions per second after that timestamp
+            3.5         // * estimated number of transactions per second after that timestamp
         };
     }
 };
@@ -260,10 +260,10 @@ public:
         };
 
         chainTxData = ChainTxData{
-            // Data as of block 00000000000001c200b9790dc637d3bb141fe77d155b966ed775b17e109f7c6c (height 1156179)
-            1501802953,
-            14706531,
-            0.15
+            // Data as of block 000000000000033cfa3c975eb83ecf2bb4aaedf68e6d279f6ed2b427c64caff9 (height 1260526)
+            1516903490,
+            17082348,
+            0.09
         };
 
     }


### PR DESCRIPTION
Another part of the release process.

Not sure I did this correctly @sipa . Output from `getchaintxstats`:

mainnet:
```
{
  "time": 1516903077,
  "txcount": 295363220,
  "window_block_count": 4320,
  "window_tx_count": 7882762,
  "window_interval": 2242748,
  "txrate": 3.514778298765621
}
```
testnet:
```
{
  "time": 1516903490,
  "txcount": 17082348,
  "window_block_count": 4320,
  "window_tx_count": 227756,
  "window_interval": 2526261,
  "txrate": 0.090155371911295
}
```
