### PR TITLE
rpc: Add back missing cs_main lock in getrawmempool

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -422,7 +422,7 @@ UniValue mempoolToJSON(bool fVerbose)
 
 UniValue getrawmempool(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() > 1)
+    if (request.fHelp || request.params.size() > 1) {
         throw std::runtime_error(
             "getrawmempool ( verbose )\n"
             "\nReturns all transaction ids in memory pool as a json array of string transaction ids.\n"
@@ -444,12 +444,18 @@ UniValue getrawmempool(const JSONRPCRequest& request)
             + HelpExampleCli("getrawmempool", "true")
             + HelpExampleRpc("getrawmempool", "true")
         );
+    }
 
     bool fVerbose = false;
-    if (!request.params[0].isNull())
+    if (!request.params[0].isNull()) {
         fVerbose = request.params[0].get_bool();
+    }
 
-    return mempoolToJSON(fVerbose);
+    const UniValue txpool_json{mempoolToJSON(fVerbose)};
+
+    // Wait for ATMP calling thread to release the write lock:
+    LOCK(cs_main);
+    return txpool_json;
 }
 
 UniValue getmempoolancestors(const JSONRPCRequest& request)


### PR DESCRIPTION
The `getrawmempool` rpc should wait for ATMP to completely return before sending back the pool contents. Otherwise, the `syncwithvalidationinterface` rpc might race against ATMP and be a noop, even though it shouldn't.

When writing to ATMP, the `cs_main` lock is acquired. So we can wait for to release of `cs_main` to be sure that ATMP is done.


Effectively reverts #8244