### PR TITLE
Improve ScanForWalletTransactions return value

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3609,7 +3609,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
         }
     }
 
-    CBlockIndex *stopBlock = pwallet->ScanForWalletTransactions(pindexStart, pindexStop, reserver, true);
+    const CBlockIndex *stopBlock = pwallet->ScanForWalletTransactions(pindexStart, pindexStop, reserver, true).last_failed;
     if (!stopBlock) {
         if (pwallet->IsAbortingRescan()) {
             throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted.");

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -50,7 +50,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
-        BOOST_CHECK_EQUAL(nullBlock, wallet.ScanForWalletTransactions(oldTip, nullptr, reserver));
+        BOOST_CHECK_EQUAL(nullBlock, wallet.ScanForWalletTransactions(oldTip, nullptr, reserver).last_failed);
         BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 100 * COIN);
     }
 
@@ -65,7 +65,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
-        BOOST_CHECK_EQUAL(oldTip, wallet.ScanForWalletTransactions(oldTip, nullptr, reserver));
+        BOOST_CHECK_EQUAL(oldTip, wallet.ScanForWalletTransactions(oldTip, nullptr, reserver).last_failed);
         BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 50 * COIN);
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -920,7 +920,23 @@ public:
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, const CBlockIndex* pIndex, int posInBlock, bool fUpdate);
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
-    CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop, const WalletRescanReserver& reserver, bool fUpdate = false);
+
+    //! Result of wallet scan.
+    //!
+    //! If scan was not completely successful, the failed pointers will be
+    //! non-null and [first_failed, last_failed] will indicate the range of
+    //! blocks that could not be scanned. The caller can assume that all blocks
+    //! in the complementary ranges [first_scanned, last_first) and
+    //! (last_failed, last_scanned] were successfully scanned.
+    struct ScanResult
+    {
+        const CBlockIndex* first_scanned = nullptr;
+        const CBlockIndex* last_scanned = nullptr;
+        const CBlockIndex* first_failed = nullptr;
+        const CBlockIndex* last_failed = nullptr;
+    };
+
+    ScanResult ScanForWalletTransactions(const CBlockIndex* pindexStart, const CBlockIndex* pindexStop, const WalletRescanReserver& reserver, bool fUpdate = false);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;


### PR DESCRIPTION
Return more information about scan status from ScanForWalletTransactions and
try to describe the return value more clearly.

There is a slight change in behavior here where rescans that end early due to a
reorg will no longer trigger errors. (I incorrectly suggested that that they
should trigger errors in the PR where this behavior was introduced:
https://github.com/bitcoin/bitcoin/pull/11281#discussion_r163070403)