### PR TITLE
Improve CWallet::IsAllFromMe for false results

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1401,7 +1401,7 @@ CAmount CWallet::GetDebit(const CTransaction& tx, const isminefilter& filter) co
 
 bool CWallet::IsAllFromMe(const CTransaction& tx, const isminefilter& filter) const
 {
-    LOCK(cs_wallet);
+    AssertLockHeld(cs_wallet);
 
     std::vector<const CTxOut*> outs;
     outs.reserve(tx.vin.size());


### PR DESCRIPTION
Break the function into 2 loops so that:
 - the fast test is executed first for all inputs.
 - `IsMine(txout)` is only executed after all inputs are checked.

This is relevant since after #12296 `CWallet::IsAllFromMe` is called from the UI.