### PR TITLE
Refactor HaveKeys to early return on false result

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -13,16 +13,13 @@
 
 typedef std::vector<unsigned char> valtype;
 
-unsigned int HaveKeys(const std::vector<valtype>& pubkeys, const CKeyStore& keystore)
+static bool HaveKeys(const std::vector<valtype>& pubkeys, const CKeyStore& keystore)
 {
-    unsigned int nResult = 0;
-    for (const valtype& pubkey : pubkeys)
-    {
+    for (const valtype& pubkey : pubkeys) {
         CKeyID keyID = CPubKey(pubkey).GetID();
-        if (keystore.HaveKey(keyID))
-            ++nResult;
+        if (!keystore.HaveKey(keyID)) return false;
     }
-    return nResult;
+    return true;
 }
 
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey, SigVersion sigversion)
@@ -140,7 +137,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
                 }
             }
         }
-        if (HaveKeys(keys, keystore) == keys.size())
+        if (HaveKeys(keys, keystore))
             return ISMINE_SPENDABLE;
         break;
     }


### PR DESCRIPTION
This consists in a trivial change where the return type of `HaveKeys()` is now `bool` meaning that it returns whether all keys are in the keystore, and early returns when one isn't.