### PR TITLE
[Build] Adding --enable-mainnet configuration option for running mainnet

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,13 @@ AC_PATH_TOOL(OBJCOPY, objcopy)
 
 AC_ARG_VAR(PYTHONPATH, Augments the default search path for python module files)
 
+# Use mainnet chain by default
+AC_ARG_ENABLE([mainnet],
+  [AS_HELP_STRING([--enable-mainnet],
+  [if mainnet is enabled, binary will use mainnet chain by default (default is no, chain must be explicitly specified)])],
+  [use_mainnet=$enableval],
+  [use_mainnet=no])
+
 # Enable wallet
 AC_ARG_ENABLE([wallet],
   [AS_HELP_STRING([--disable-wallet],
@@ -1064,6 +1071,15 @@ AC_MSG_CHECKING([whether to build bitcoind])
 AM_CONDITIONAL([BUILD_BITCOIND], [test x$build_bitcoind = xyes])
 AC_MSG_RESULT($build_bitcoind)
 
+dnl enable mainnet
+AC_MSG_CHECKING([if mainnet should be used by default])
+if test x$use_mainnet = xyes; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE_UNQUOTED([ENABLE_MAINNET],[1],[Define to 1 to use mainnet chain by default])
+else
+  AC_MSG_RESULT(no)
+fi
+
 AC_MSG_CHECKING([whether to build utils (bitcoin-cli bitcoin-tx)])
 AM_CONDITIONAL([BUILD_BITCOIN_UTILS], [test x$build_bitcoin_utils = xyes])
 AC_MSG_RESULT($build_bitcoin_utils)
@@ -1199,6 +1215,7 @@ fi
 AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
+AM_CONDITIONAL([ENABLE_MAINNET],[test x$use_mainnet = xyes])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
 AM_CONDITIONAL([ENABLE_QT],[test x$bitcoin_enable_qt = xyes])
@@ -1318,6 +1335,7 @@ esac
 
 echo
 echo "Options used to compile and link:"
+echo "  use mainnet   = $use_mainnet"
 echo "  with wallet   = $enable_wallet"
 echo "  with gui / qt = $bitcoin_enable_qt"
 if test x$bitcoin_enable_qt != xno; then

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -35,7 +35,7 @@ script: |
 
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-pc-linux-gnu x86_64-linux-gnu arm-linux-gnueabihf aarch64-linux-gnu"
-  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests --enable-mainnet"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -35,7 +35,7 @@ files:
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="x86_64-apple-darwin11"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests GENISOIMAGE=$WRAP_DIR/genisoimage"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-mainnet GENISOIMAGE=$WRAP_DIR/genisoimage"
   FAKETIME_HOST_PROGS=""
   FAKETIME_PROGS="ar ranlib date dmg genisoimage"
 

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -28,7 +28,7 @@ files: []
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
-  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
+  CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests --enable-mainnet"
   FAKETIME_HOST_PROGS="g++ ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
   HOST_CFLAGS="-O2 -g"

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -22,6 +22,7 @@ void AppendParamsHelpMessages(std::string& strUsage, bool debugHelp)
                                    "This is intended for regression testing tools and app development.");
     }
     strUsage += HelpMessageOpt("-testnet", _("Use the test chain"));
+    strUsage += HelpMessageOpt("-mainnet", _("Use the main chain"));
 }
 
 /**
@@ -91,12 +92,16 @@ std::string ChainNameFromCommandLine()
 {
     bool fRegTest = gArgs.GetBoolArg("-regtest", false);
     bool fTestNet = gArgs.GetBoolArg("-testnet", false);
+    bool fMainNet = gArgs.GetBoolArg("-mainnet", false);
 
-    if (fTestNet && fRegTest)
-        throw std::runtime_error("Invalid combination of -regtest and -testnet.");
-    if (fRegTest)
+    if (fTestNet + fRegTest + fMainNet >= 2) {
+        throw std::runtime_error("Invalid combination of -regtest, -testnet and/or -mainnet. You must select only one.");
+    }
+    if (fRegTest) {
         return CBaseChainParams::REGTEST;
-    if (fTestNet)
+    }
+    if (fTestNet) {
         return CBaseChainParams::TESTNET;
+    }
     return CBaseChainParams::MAIN;
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -902,6 +902,13 @@ bool AppInitParameterInteraction()
 
     // also see: InitParameterInteraction()
 
+    // Only if configured with --enable-mainnet will allow blind run on mainnet. Otherwise, will have to specify the chain you want.
+#ifndef ENABLE_MAINNET
+    std::string chain = ChainNameFromCommandLine();
+    if (chain == CBaseChainParams::MAIN && !gArgs.GetBoolArg("-mainnet", false))
+        return InitError("You did not configure with --enable-mainnet, therefore must set -regtest, -testnet or -mainnet option.");
+#endif
+
     // if using block pruning, then disallow txindex
     if (gArgs.GetArg("-prune", 0)) {
         if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX))


### PR DESCRIPTION
Implementation based on comments/requirements in issue [#11901](https://github.com/bitcoin/bitcoin/issues/11901) quoted below:

 - add a configuration option '--enable-mainnet' which defaults to false
 - When true, behavior is unaffected (is set to true by the gitian builds).
 - When false (the default for someone cloning the repo, building with no configuration options), the resulting binary will require new 'enablemainnet' option to launch the daemon or Qt GUI with main net.
 - This prevents developers or downstream system integrators from accidentally corrupting main net
 - If the configure option is used, mainnet should be the default.
 - Only if configured with --disable-mainnet (default) should a command-line option be required.

Fixes [#11901](https://github.com/bitcoin/bitcoin/issues/11901)

