### PR TITLE
test: Make ua_comment test pass on 0.16.0

### DIFF
--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -23,7 +23,7 @@ class UacommentTest(BitcoinTestFramework):
 
         self.log.info("test -uacomment max length")
         self.stop_node(0)
-        expected = "Total length of network version string (286) exceeds maximum length (256). Reduce the number or size of uacomments."
+        expected = "exceeds maximum length (256). Reduce the number or size of uacomments."
         self.assert_start_raises_init_error(0, ["-uacomment=" + 'a' * 256], expected)
 
         self.log.info("test -uacomment unsafe characters")


### PR DESCRIPTION
The specific length of the uacomment is one shorter on `0.16.0` than on `0.15.99` causing the (stupid) test to fail.

This change makes `assert_start_raises_init_error` optionally take a regexp, so that the error message can be checked without being specific about the reported length.