### PR TITLE
[qa] 0.16: Backport 12302

### DIFF
--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -23,7 +23,7 @@ class UacommentTest(BitcoinTestFramework):
 
         self.log.info("test -uacomment max length")
         self.stop_node(0)
-        expected = "Total length of network version string (286) exceeds maximum length (256). Reduce the number or size of uacomments."
+        expected = "exceeds maximum length (256). Reduce the number or size of uacomments."
         self.assert_start_raises_init_error(0, ["-uacomment=" + 'a' * 256], expected)
 
         self.log.info("test -uacomment unsafe characters")


### PR DESCRIPTION
The specific length of the uacomment is one shorter on `0.16.0` than on
`0.15.99` causing the (stupid) test to fail.
Just match the latter part of the message only.

Github-Pull: #12302
Rebased-From: aac6bce11219574e097a51da867e736c3d6ad96e