### PR TITLE
Docs: Improvements to UNIX documentation

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -42,6 +42,7 @@ The following are developer notes on how to build Bitcoin on your native platfor
 - [Unix Build Notes](build-unix.md)
 - [Windows Build Notes](build-windows.md)
 - [OpenBSD Build Notes](build-openbsd.md)
+- [NetBSD Build Notes](build-netbsd.md)
 - [Gitian Building Guide](gitian-building.md)
 
 Development

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -2,7 +2,8 @@ UNIX BUILD NOTES
 ====================
 Some notes on how to build Bitcoin Core in Unix.
 
-(for OpenBSD specific instructions, see [build-openbsd.md](build-openbsd.md))
+(For BSD specific instructions, see [build-openbsd.md](build-openbsd.md) and/or
+[build-netbsd.md](build-netbsd.md))
 
 Note
 ---------------------

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -62,8 +62,13 @@ tuned to conserve memory with additional CXXFLAGS:
 
     ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
 
-Dependency Build Instructions: Ubuntu & Debian
-----------------------------------------------
+
+## Linux Distribution Specific Instructions
+
+### Ubuntu & Debian
+
+#### Dependency Build Instructions
+
 Build requirements:
 
     sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3
@@ -105,8 +110,7 @@ ZMQ dependencies (provides ZMQ API 4.x):
 
     sudo apt-get install libzmq3-dev
 
-Dependencies for the GUI: Ubuntu & Debian
------------------------------------------
+#### Dependencies for the GUI
 
 If you want to build Bitcoin-Qt, make sure that the required packages for Qt development
 are installed. Either Qt 5 or Qt 4 are necessary to build the GUI.
@@ -128,8 +132,11 @@ libqrencode (optional) can be installed with:
 Once these are installed, they will be found by configure and a bitcoin-qt executable will be
 built by default.
 
-Dependency Build Instructions: Fedora
--------------------------------------
+
+### Fedora
+
+#### Dependency Build Instructions
+
 Build requirements:
 
     sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel python3


### PR DESCRIPTION
* Added references to the newly created [`doc/build-netbsd.md`] (#12294) instructions in the [`doc/README.md`] and the [`doc/build-unix.md`] files.
* Organise [`doc/build-unix.md`] dependency build instructions by Linux distribution. This will help discoverability of dependency build instructions for specific distros. Future instructions will also be able to be added easier.

I am not quite sure about the FreeBSD instructions being in the [`doc/build-unix.md`], while both the OpenBSD and NetBSD instructions are contained within separate files ([`doc/build-openbsd.md`] and [`doc/build-netbsd.md`] respectively).

Feedback is greatly appreciated. 😄 

[`doc/build-netbsd.md`]:https://github.com/bitcoin/bitcoin/blob/master/doc/build-netbsd.md
[`doc/build-unix.md`]:https://github.com/bitcoin/bitcoin/blob/master/doc/build-unix.md
[`doc/build-openbsd.md`]:https://github.com/bitcoin/bitcoin/blob/master/doc/build-openbsd.md
[`doc/README.md`]:https://github.com/bitcoin/bitcoin/blob/master/doc/README.md