### PR TITLE
contrib: Add support for out-of-tree builds in gen-manpages.sh

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -85,6 +85,14 @@ gen-manpages.sh
 A small script to automatically create manpages in ../../doc/man by running the release binaries with the -help option.
 This requires help2man which can be found at: https://www.gnu.org/software/help2man/
 
+With in-tree builds this tool can be run from any directory within the
+repostitory. To use this tool with out-of-tree builds set `BUILDDIR`. For
+example:
+
+```bash
+BUILDDIR=$PWD/build contrib/devtools/gen-manpages.sh
+```
+
 git-subtree-check.sh
 ====================
 

--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
-SRCDIR=${SRCDIR:-$TOPDIR/src}
+BUILDDIR=${BUILDDIR:-$TOPDIR}
+
+BINDIR=${BINDIR:-$BUILDDIR/src}
 MANDIR=${MANDIR:-$TOPDIR/doc/man}
 
-BITCOIND=${BITCOIND:-$SRCDIR/bitcoind}
-BITCOINCLI=${BITCOINCLI:-$SRCDIR/bitcoin-cli}
-BITCOINTX=${BITCOINTX:-$SRCDIR/bitcoin-tx}
-BITCOINQT=${BITCOINQT:-$SRCDIR/qt/bitcoin-qt}
+BITCOIND=${BITCOIND:-$BINDIR/bitcoind}
+BITCOINCLI=${BITCOINCLI:-$BINDIR/bitcoin-cli}
+BITCOINTX=${BITCOINTX:-$BINDIR/bitcoin-tx}
+BITCOINQT=${BITCOINQT:-$BINDIR/qt/bitcoin-qt}
 
 [ ! -x $BITCOIND ] && echo "$BITCOIND not found or not executable." && exit 1
 


### PR DESCRIPTION
This adds support for setting the environment variable `BUILDDIR` to point to executables that are outside the source directory.

E.g. to invoke the tool when the build is in $PWD/build:

```bash
BUILDDIR=$PWD/build contrib/devtools/gen-manpages.sh
```

This avoids having to manually copy the generated manpages after they end up in the build instead of source path, when setting TOPDIR instead.