### PR TITLE
Docs: Remove step making cloned repository world-writable for Windows build.

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -102,11 +102,9 @@ Note that for WSL the Bitcoin Core source path MUST be somewhere in the default 
 example /usr/src/bitcoin, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
 This means you cannot use a directory that located directly on the host Windows file system to perform the build.
 
-The next three steps are an example of how to acquire the source in an appropriate way.
+Acquire the source in the usual way:
 
-    cd /usr/src
-    sudo git clone https://github.com/bitcoin/bitcoin.git
-    sudo chmod -R a+rw bitcoin
+    git clone https://github.com/bitcoin/bitcoin.git
 
 Once the source code is ready the build steps are below.
 
@@ -132,11 +130,9 @@ Note that for WSL the Bitcoin Core source path MUST be somewhere in the default 
 example /usr/src/bitcoin, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
 This means you cannot use a directory that located directly on the host Windows file system to perform the build.
 
-The next three steps are an example of how to acquire the source in an appropriate way.
+Acquire the source in the usual way:
 
-    cd /usr/src
-    sudo git clone https://github.com/bitcoin/bitcoin.git
-    sudo chmod -R a+rw bitcoin
+    git clone https://github.com/bitcoin/bitcoin.git
 
 Then build using:
 


### PR DESCRIPTION
Current documentation for Windows build on Ubuntu suggests cloning the repository into /usr/src, as root, and making the tree world-writable(!). I can see no problem this solves, and it introduces obvious security issues.