### PR TITLE
net: initialize socket to avoid closing random fd's

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -410,7 +410,7 @@ CNode* CConnman::ConnectNode(CAddress addrConnect, const char *pszDest, bool fCo
 
     // Connect
     bool connected = false;
-    SOCKET hSocket;
+    SOCKET hSocket = INVALID_SOCKET;
     proxyType proxy;
     if (addrConnect.IsValid()) {
         bool proxyConnectionFailed = false;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -682,6 +682,9 @@ bool CloseSocket(SOCKET& hSocket)
 #else
     int ret = close(hSocket);
 #endif
+    if (ret) {
+        LogPrintf("Socket close failed: %d. Error: %s\n", hSocket, NetworkErrorString(WSAGetLastError()));
+    }
     hSocket = INVALID_SOCKET;
     return ret != SOCKET_ERROR;
 }


### PR DESCRIPTION
An excellent spot by @david60.

Even if it isn't causing the fd issue we're looking for, this should be fixed.