### PR TITLE
Correction in choice of words in QT (dutch)

### DIFF
--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -67,7 +67,7 @@
     </message>
     <message>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>Dit zijn uw Bitcoin-adressen waarmee u betalingen kunt ontvangen. We raden u aan om een nieuw ontvangstadres voor elke transactie te gebruiken.</translation>
+        <translation>Dit zijn uw Bitcoin-adressen waarmee u betalingen kunt ontvangen. Het wordt aanbevolen om een nieuw ontvangstadres voor elke transactie te gebruiken.</translation>
     </message>
     <message>
         <source>&amp;Copy Address</source>


### PR DESCRIPTION
"We raden u aan" means "We recommend you". 

In my opinion "we" should not be used beause "Who is we?" 
Its cleaner to just say its recommended to...