### PR TITLE
Extend #11583 to include "version handshake timeout" message

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1431,7 +1431,7 @@ void CConnman::ThreadSocketHandler()
                 }
                 else if (!pnode->fSuccessfullyConnected)
                 {
-                    LogPrintf("version handshake timeout from %d\n", pnode->GetId());
+                    LogPrint(BCLog::NET, "version handshake timeout from %d\n", pnode->GetId());
                     pnode->fDisconnect = true;
                 }
             }


### PR DESCRIPTION
37% of the default log entries for a node that has been up for ~24hrs was "version handshake timeout..."