### PR TITLE
shutdown: fix crash on shutdown with reindex-chainstate

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2087,7 +2087,7 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
             nLastWrite = nNow;
         }
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
-        if (fDoFullFlush) {
+        if (fDoFullFlush && !pcoinsTip->GetBestBlock().IsNull()) {
             // Typical Coin structures on disk are around 48 bytes in size.
             // Pushing a new one to the database can cause it to be written
             // twice (once in the log, and once in the tables). This is already


### PR DESCRIPTION
Fixes the assertion error reported here: https://github.com/bitcoin/bitcoin/pull/12349#issuecomment-365095741