### PR TITLE
qt: Make sure splash screen is freed on AppInitMain fail

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -516,14 +516,14 @@ void BitcoinApplication::initializeResult(bool success)
         QTimer::singleShot(100, paymentServer, SLOT(uiReady()));
 #endif
     } else {
-        Q_EMIT splashFinished(window);
-        quit(); // Exit main loop
+        Q_EMIT splashFinished(window); // Make sure splash screen doesn't stick around during shutdown
+        quit(); // Exit first main loop invocation
     }
 }
 
 void BitcoinApplication::shutdownResult()
 {
-    quit(); // Exit main loop after shutdown finished
+    quit(); // Exit second main loop invocation after shutdown finished
 }
 
 void BitcoinApplication::handleRunawayException(const QString &message)

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -516,6 +516,7 @@ void BitcoinApplication::initializeResult(bool success)
         QTimer::singleShot(100, paymentServer, SLOT(uiReady()));
 #endif
     } else {
+        Q_EMIT splashFinished(window);
         quit(); // Exit main loop
     }
 }


### PR DESCRIPTION
The `splashFinished` event was never sent if AppInitMain fails, causing the splash screen to stick around, causing problems later.

This bug has existed for a while but is now trigging potential crashed because the splash screen subscribes to wallet events.

Meant to fix #12372.