### PR TITLE
[WIP] Better stderr testing in functional tests

### DIFF
--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -25,13 +25,13 @@ class ConfArgsTest(BitcoinTestFramework):
 
         # Check that using -datadir argument on non-existent directory fails
         self.nodes[0].datadir = new_data_dir
-        self.assert_start_raises_init_error(0, ['-datadir='+new_data_dir], 'Error: Specified data directory "' + new_data_dir + '" does not exist.')
+        self.nodes[0].assert_start_raises_init_error(['-datadir='+new_data_dir], 'Error: Specified data directory "' + new_data_dir + '" does not exist.')
 
         # Check that using non-existent datadir in conf file fails
         conf_file = os.path.join(default_data_dir, "bitcoin.conf")
         with open(conf_file, 'a', encoding='utf8') as f:
             f.write("datadir=" + new_data_dir + "\n")
-        self.assert_start_raises_init_error(0, ['-conf='+conf_file], 'Error reading configuration file: specified data directory "' + new_data_dir + '" does not exist.')
+        self.nodes[0].assert_start_raises_init_error(['-conf='+conf_file], 'Error reading configuration file: specified data directory "' + new_data_dir + '" does not exist.')
 
         # Create the directory and ensure the config file now works
         os.mkdir(new_data_dir)

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -24,7 +24,6 @@ class ConfArgsTest(BitcoinTestFramework):
         new_data_dir_2 = os.path.join(default_data_dir, 'newdatadir2')
 
         # Check that using -datadir argument on non-existent directory fails
-        self.nodes[0].datadir = new_data_dir
         self.nodes[0].assert_start_raises_init_error(['-datadir='+new_data_dir], 'Error: Specified data directory "' + new_data_dir + '" does not exist.')
 
         # Check that using non-existent datadir in conf file fails
@@ -35,12 +34,17 @@ class ConfArgsTest(BitcoinTestFramework):
 
         # Create the directory and ensure the config file now works
         os.mkdir(new_data_dir)
+        os.mkdir(os.path.join(new_data_dir, 'stdout'))
+        os.mkdir(os.path.join(new_data_dir, 'stderr'))
+        self.nodes[0].datadir = new_data_dir
         self.start_node(0, ['-conf='+conf_file, '-wallet=w1'])
         self.stop_node(0)
         assert os.path.isfile(os.path.join(new_data_dir, 'regtest', 'wallets', 'w1'))
 
         # Ensure command line argument overrides datadir in conf
         os.mkdir(new_data_dir_2)
+        os.mkdir(os.path.join(new_data_dir_2, 'stdout'))
+        os.mkdir(os.path.join(new_data_dir_2, 'stderr'))
         self.nodes[0].datadir = new_data_dir_2
         self.start_node(0, ['-datadir='+new_data_dir_2, '-conf='+conf_file, '-wallet=w2'])
         assert os.path.isfile(os.path.join(new_data_dir_2, 'regtest', 'wallets', 'w2'))

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -30,7 +30,7 @@ class LoggingTest(BitcoinTestFramework):
         invdir = os.path.join(self.nodes[0].datadir, "regtest", "foo")
         invalidname = os.path.join("foo", "foo.log")
         self.stop_node(0)
-        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % (invalidname)],
+        self.nodes[0].assert_start_raises_init_error(["-debuglogfile=%s" % (invalidname)],
                                                 "Error: Could not open debug log file")
         assert not os.path.isfile(os.path.join(invdir, "foo.log"))
 
@@ -44,7 +44,7 @@ class LoggingTest(BitcoinTestFramework):
         self.stop_node(0)
         invdir = os.path.join(self.options.tmpdir, "foo")
         invalidname = os.path.join(invdir, "foo.log")
-        self.assert_start_raises_init_error(0, ["-debuglogfile=%s" % invalidname],
+        self.nodes[0].assert_start_raises_init_error(["-debuglogfile=%s" % invalidname],
                                                "Error: Could not open debug log file")
         assert not os.path.isfile(os.path.join(invdir, "foo.log"))
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -30,8 +30,8 @@ class LoggingTest(BitcoinTestFramework):
         invdir = os.path.join(self.nodes[0].datadir, "regtest", "foo")
         invalidname = os.path.join("foo", "foo.log")
         self.stop_node(0)
-        self.nodes[0].assert_start_raises_init_error(["-debuglogfile=%s" % (invalidname)],
-                                                "Error: Could not open debug log file")
+        exp_stderr = "Error: Could not open debug log file \S+?$"
+        self.nodes[0].assert_start_raises_init_error(["-debuglogfile=%s" % (invalidname)], exp_stderr)
         assert not os.path.isfile(os.path.join(invdir, "foo.log"))
 
         # check that invalid log (relative) works after path exists
@@ -44,8 +44,7 @@ class LoggingTest(BitcoinTestFramework):
         self.stop_node(0)
         invdir = os.path.join(self.options.tmpdir, "foo")
         invalidname = os.path.join(invdir, "foo.log")
-        self.nodes[0].assert_start_raises_init_error(["-debuglogfile=%s" % invalidname],
-                                               "Error: Could not open debug log file")
+        self.nodes[0].assert_start_raises_init_error(["-debuglogfile=%s" % invalidname], exp_stderr)
         assert not os.path.isfile(os.path.join(invdir, "foo.log"))
 
         # check that invalid log (absolute) works after path exists

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -17,7 +17,7 @@ from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.block_receive_map = defaultdict(int)
@@ -55,7 +55,7 @@ class MaxUploadTest(BitcoinTestFramework):
         p2p_conns = []
 
         for _ in range(3):
-            p2p_conns.append(self.nodes[0].add_p2p_connection(TestNode()))
+            p2p_conns.append(self.nodes[0].add_p2p_connection(TestP2PConn()))
 
         network_thread_start()
         for p2pc in p2p_conns:
@@ -147,7 +147,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.start_node(0, ["-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
 
         # Reconnect to self.nodes[0]
-        self.nodes[0].add_p2p_connection(TestNode())
+        self.nodes[0].add_p2p_connection(TestP2PConn())
 
         network_thread_start()
         self.nodes[0].p2p.wait_for_verack()

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -24,12 +24,12 @@ class UacommentTest(BitcoinTestFramework):
         self.log.info("test -uacomment max length")
         self.stop_node(0)
         expected = "exceeds maximum length (256). Reduce the number or size of uacomments."
-        self.assert_start_raises_init_error(0, ["-uacomment=" + 'a' * 256], expected)
+        self.nodes[0].assert_start_raises_init_error(["-uacomment=" + 'a' * 256], expected)
 
         self.log.info("test -uacomment unsafe characters")
         for unsafe_char in ['/', ':', '(', ')']:
             expected = "User Agent comment (" + unsafe_char + ") contains unsafe characters"
-            self.assert_start_raises_init_error(0, ["-uacomment=" + unsafe_char], expected)
+            self.nodes[0].assert_start_raises_init_error(["-uacomment=" + unsafe_char], expected)
 
 if __name__ == '__main__':
     UacommentTest().main()

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -23,13 +23,13 @@ class UacommentTest(BitcoinTestFramework):
 
         self.log.info("test -uacomment max length")
         self.stop_node(0)
-        expected = "exceeds maximum length (256). Reduce the number or size of uacomments."
+        expected = "Error: Total length of network version string \([0-9]+\) exceeds maximum length \(256\). Reduce the number or size of uacomments."
         self.nodes[0].assert_start_raises_init_error(["-uacomment=" + 'a' * 256], expected)
 
         self.log.info("test -uacomment unsafe characters")
-        for unsafe_char in ['/', ':', '(', ')']:
-            expected = "User Agent comment (" + unsafe_char + ") contains unsafe characters"
-            self.nodes[0].assert_start_raises_init_error(["-uacomment=" + unsafe_char], expected)
+        for unsafe_char in [('/', '\/'), (':', ':'), ('(', '\\('), (')', '\\)')]:
+            expected = "Error: User Agent comment \(" + unsafe_char[1] + "\) contains unsafe characters."
+            self.nodes[0].assert_start_raises_init_error(["-uacomment=" + unsafe_char[0]], expected)
 
 if __name__ == '__main__':
     UacommentTest().main()

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -14,8 +14,8 @@ from test_framework.util import *
 from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment
 from test_framework.script import CScript, OP_TRUE
 
-# TestNode: A peer we use to send messages to bitcoind, and store responses.
-class TestNode(P2PInterface):
+# TestP2PConn: A peer we use to send messages to bitcoind, and store responses.
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.last_sendcmpct = []
@@ -788,9 +788,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
-        self.test_node = self.nodes[0].add_p2p_connection(TestNode())
-        self.segwit_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
-        self.old_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.segwit_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
+        self.old_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
 
         network_thread_start()
 

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -22,7 +22,7 @@ def allInvsMatch(invsExpected, testnode):
         time.sleep(1)
     return False
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.txinvs = []
@@ -48,7 +48,7 @@ class FeeFilterTest(BitcoinTestFramework):
         sync_blocks(self.nodes)
 
         # Setup the p2p connections and start up the network thread.
-        self.nodes[0].add_p2p_connection(TestNode())
+        self.nodes[0].add_p2p_connection(TestP2PConn())
         network_thread_start()
         self.nodes[0].p2p.wait_for_verack()
 

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -59,7 +59,7 @@ def test_witness_block(rpc, p2p, block, accepted, with_witness=True):
     p2p.sync_with_ping()
     assert_equal(rpc.getbestblockhash() == block.hash, accepted)
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def __init__(self):
         super().__init__()
         self.getdataset = set()
@@ -1878,11 +1878,11 @@ class SegWitTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
         # self.test_node sets NODE_WITNESS|NODE_NETWORK
-        self.test_node = self.nodes[0].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
+        self.test_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
         # self.old_node sets only NODE_NETWORK
-        self.old_node = self.nodes[0].add_p2p_connection(TestNode(), services=NODE_NETWORK)
+        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK)
         # self.std_node is for testing node1 (fRequireStandard=true)
-        self.std_node = self.nodes[1].add_p2p_connection(TestNode(), services=NODE_NETWORK|NODE_WITNESS)
+        self.std_node = self.nodes[1].add_p2p_connection(TestP2PConn(), services=NODE_NETWORK|NODE_WITNESS)
 
         network_thread_start()
 

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -27,7 +27,7 @@ from test_framework.mininode import *
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
     def on_version(self, message):
         # Don't send a verack in response
         pass
@@ -39,9 +39,9 @@ class TimeoutsTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections and start up the network thread.
-        no_verack_node = self.nodes[0].add_p2p_connection(TestNode())
-        no_version_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
-        no_send_node = self.nodes[0].add_p2p_connection(TestNode(), send_version=False)
+        no_verack_node = self.nodes[0].add_p2p_connection(TestP2PConn())
+        no_version_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False)
+        no_send_node = self.nodes[0].add_p2p_connection(TestP2PConn(), send_version=False)
 
         network_thread_start()
 

--- a/test/functional/test_framework/comptool.py
+++ b/test/functional/test_framework/comptool.py
@@ -8,7 +8,7 @@ To use, create a class that implements get_tests(), and pass it in
 as the test generator to TestManager.  get_tests() should be a python
 generator that returns TestInstance objects.  See below for definition.
 
-TestNode behaves as follows:
+TestP2PConn behaves as follows:
     Configure with a BlockStore and TxStore
     on_inv: log the message but don't request
     on_headers: log the chain tip
@@ -39,7 +39,7 @@ class RejectResult():
     def __repr__(self):
         return '%i:%s' % (self.code,self.reason or '*')
 
-class TestNode(P2PInterface):
+class TestP2PConn(P2PInterface):
 
     def __init__(self, block_store, tx_store):
         super().__init__()
@@ -170,7 +170,7 @@ class TestManager():
     def add_all_connections(self, nodes):
         for i in range(len(nodes)):
             # Create a p2p connection to each node
-            node = TestNode(self.block_store, self.tx_store)
+            node = TestP2PConn(self.block_store, self.tx_store)
             node.peer_connect('127.0.0.1', p2p_port(i))
             self.p2p_connections.append(node)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -271,27 +271,6 @@ class BitcoinTestFramework():
         self.stop_node(i)
         self.start_node(i, extra_args)
 
-    def assert_start_raises_init_error(self, i, extra_args=None, expected_msg=None, *args, **kwargs):
-        with tempfile.SpooledTemporaryFile(max_size=2**16) as log_stderr:
-            try:
-                self.start_node(i, extra_args, stderr=log_stderr, *args, **kwargs)
-                self.stop_node(i)
-            except Exception as e:
-                assert 'bitcoind exited' in str(e)  # node must have shutdown
-                self.nodes[i].running = False
-                self.nodes[i].process = None
-                if expected_msg is not None:
-                    log_stderr.seek(0)
-                    stderr = log_stderr.read().decode('utf-8')
-                    if expected_msg not in stderr:
-                        raise AssertionError("Expected error \"" + expected_msg + "\" not found in:\n" + stderr)
-            else:
-                if expected_msg is None:
-                    assert_msg = "bitcoind should have exited with an error"
-                else:
-                    assert_msg = "bitcoind should have exited with expected error " + expected_msg
-                raise AssertionError(assert_msg)
-
     def wait_for_node_exit(self, i, timeout):
         self.nodes[i].process.wait(timeout)
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -218,7 +218,7 @@ class BitcoinTestFramework():
         assert_equal(len(extra_args), num_nodes)
         assert_equal(len(binary), num_nodes)
         for i in range(num_nodes):
-            self.nodes.append(TestNode(i, self.options.tmpdir, extra_args[i], rpchost, timewait=timewait, binary=binary[i], stderr=None, mocktime=self.mocktime, coverage_dir=self.options.coveragedir, use_cli=self.options.usecli))
+            self.nodes.append(TestNode(i, self.options.tmpdir, extra_args[i], rpchost, timewait=timewait, binary=binary[i], mocktime=self.mocktime, coverage_dir=self.options.coveragedir, use_cli=self.options.usecli))
 
     def start_node(self, i, *args, **kwargs):
         """Start a bitcoind"""
@@ -369,7 +369,7 @@ class BitcoinTestFramework():
                 args = [os.getenv("BITCOIND", "bitcoind"), "-server", "-keypool=1", "-datadir=" + datadir, "-discover=0"]
                 if i > 0:
                     args.append("-connect=127.0.0.1:" + str(p2p_port(0)))
-                self.nodes.append(TestNode(i, self.options.cachedir, extra_args=[], rpchost=None, timewait=None, binary=None, stderr=None, mocktime=self.mocktime, coverage_dir=None))
+                self.nodes.append(TestNode(i, self.options.cachedir, extra_args=[], rpchost=None, timewait=None, binary=None, mocktime=self.mocktime, coverage_dir=None))
                 self.nodes[i].args = args
                 self.start_node(i)
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -92,7 +92,11 @@ class TestNode():
         if stdout is None:
             stdout = tempfile.NamedTemporaryFile(dir=os.path.join(self.datadir, 'stdout'), delete=False)
 
-        self.process = subprocess.Popen(self.args + extra_args, stdout=stdout, stderr=stderr, *args, **kwargs)
+        # add environment variable LIBC_FATAL_STDERR_=1 so that libc errors are written to stderr and not the terminal
+        subp_env = dict(os.environ, LIBC_FATAL_STDERR_="1")
+
+        self.process = subprocess.Popen(self.args + extra_args, env=subp_env, stdout=stdout, stderr=stderr, *args, **kwargs)
+
         self.running = True
         self.log.debug("bitcoind started, waiting for RPC to come up")
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import subprocess
+import tempfile
 import time
 
 from .authproxy import JSONRPCException
@@ -159,6 +160,33 @@ class TestNode():
 
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT):
         wait_until(self.is_node_stopped, timeout=timeout)
+
+    def assert_start_raises_init_error(self, extra_args=None, expected_msg=None, *args, **kwargs):
+        """Attempt to start the node and expect it to raise an error.
+
+        Will throw if bitcoind starts without an error.
+        Will throw if an expected_msg is provided and it does not appear in bitcoind's stdout."""
+        with tempfile.SpooledTemporaryFile(max_size=2**16) as log_stderr:
+            try:
+                self.start(extra_args, stderr=log_stderr, *args, **kwargs)
+                self.wait_for_rpc_connection()
+                self.stop_node()
+                self.wait_util_stopped()
+            except Exception as e:
+                assert 'bitcoind exited' in str(e)  # node must have shutdown
+                self.running = False
+                self.process = None
+                if expected_msg is not None:
+                    log_stderr.seek(0)
+                    stderr = log_stderr.read().decode('utf-8')
+                    if expected_msg not in stderr:
+                        raise AssertionError("Expected error \"" + expected_msg + "\" not found in:\n" + stderr)
+            else:
+                if expected_msg is None:
+                    assert_msg = "bitcoind should have exited with an error"
+                else:
+                    assert_msg = "bitcoind should have exited with expected error " + expected_msg
+                raise AssertionError(assert_msg)
 
     def node_encrypt_wallet(self, passphrase):
         """"Encrypts the wallet.

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -43,7 +43,7 @@ class TestNode():
     To make things easier for the test writer, any unrecognised messages will
     be dispatched to the RPC connection."""
 
-    def __init__(self, i, dirname, extra_args, rpchost, timewait, binary, stderr, mocktime, coverage_dir, use_cli=False):
+    def __init__(self, i, dirname, extra_args, rpchost, timewait, binary, mocktime, coverage_dir, use_cli=False):
         self.index = i
         self.datadir = os.path.join(dirname, "node" + str(i))
         self.rpchost = rpchost
@@ -56,7 +56,6 @@ class TestNode():
             self.binary = os.getenv("BITCOIND", "bitcoind")
         else:
             self.binary = binary
-        self.stderr = stderr
         self.coverage_dir = coverage_dir
         # Most callers will just need to add extra args to the standard list below. For those callers that need more flexibity, they can just set the args property directly.
         self.extra_args = extra_args
@@ -82,13 +81,18 @@ class TestNode():
             assert self.rpc_connected and self.rpc is not None, "Error: no RPC connection"
             return getattr(self.rpc, name)
 
-    def start(self, extra_args=None, stderr=None, *args, **kwargs):
+    def start(self, extra_args=None, stdout=None, stderr=None, *args, **kwargs):
         """Start the node."""
         if extra_args is None:
             extra_args = self.extra_args
+
+        # Add a new stdout and stderr file for each time bitcoind is started
         if stderr is None:
-            stderr = self.stderr
-        self.process = subprocess.Popen(self.args + extra_args, stderr=stderr, *args, **kwargs)
+            stderr = tempfile.NamedTemporaryFile(dir=os.path.join(self.datadir, 'stderr'), delete=False)
+        if stdout is None:
+            stdout = tempfile.NamedTemporaryFile(dir=os.path.join(self.datadir, 'stdout'), delete=False)
+
+        self.process = subprocess.Popen(self.args + extra_args, stdout=stdout, stderr=stderr, *args, **kwargs)
         self.running = True
         self.log.debug("bitcoind started, waiting for RPC to come up")
 
@@ -166,9 +170,10 @@ class TestNode():
 
         Will throw if bitcoind starts without an error.
         Will throw if an expected_msg is provided and it does not appear in bitcoind's stdout."""
-        with tempfile.SpooledTemporaryFile(max_size=2**16) as log_stderr:
+        with tempfile.NamedTemporaryFile(dir=os.path.join(self.datadir, 'stderr'), delete=False) as log_stderr, \
+             tempfile.NamedTemporaryFile(dir=os.path.join(self.datadir, 'stdout'), delete=False) as log_stdout:
             try:
-                self.start(extra_args, stderr=log_stderr, *args, **kwargs)
+                self.start(extra_args, stderr=log_stderr, stdout=log_stdout, *args, **kwargs)
                 self.wait_for_rpc_connection()
                 self.stop_node()
                 self.wait_util_stopped()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -292,6 +292,8 @@ def initialize_datadir(dirname, n):
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
+        os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
+        os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir
 
 def get_datadir_path(dirname, n):

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -23,7 +23,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
-        self.assert_start_raises_init_error(1, ['-usehd=0'], 'already existing HD wallet')
+        self.nodes[1].assert_start_raises_init_error(['-usehd=0'], 'already existing HD wallet')
         self.start_node(1)
         connect_nodes_bi(self.nodes, 0, 1)
 

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -23,7 +23,7 @@ class WalletHDTest(BitcoinTestFramework):
 
         # Make sure can't switch off usehd after wallet creation
         self.stop_node(1)
-        self.nodes[1].assert_start_raises_init_error(['-usehd=0'], 'already existing HD wallet')
+        self.nodes[1].assert_start_raises_init_error(['-usehd=0'], "Error: Error loading wallet.dat: You can't disable HD on an already existing HD wallet")
         self.start_node(1)
         connect_nodes_bi(self.nodes, 0, 1)
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -35,19 +35,23 @@ class MultiWalletTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(['-walletdir=debug.log'], 'Error: Specified -walletdir "debug.log" is not a directory', cwd=data_dir())
 
         # should not initialize if there are duplicate wallets
-        self.nodes[0].assert_start_raises_init_error(['-wallet=w1', '-wallet=w1'], 'Error loading wallet w1. Duplicate -wallet filename specified.')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w1', '-wallet=w1'], 'Error: Error loading wallet w1. Duplicate -wallet filename specified.')
 
         # should not initialize if wallet file is a directory
         os.mkdir(wallet_dir('w11'))
-        self.nodes[0].assert_start_raises_init_error(['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w11'], 'Error: Error loading wallet w11. -wallet filename must be a regular file.')
 
         # should not initialize if one wallet is a copy of another
         shutil.copyfile(wallet_dir('w2'), wallet_dir('w22'))
-        self.nodes[0].assert_start_raises_init_error(['-wallet=w2', '-wallet=w22'], 'duplicates fileid')
+        exp_stderr = "\n\n\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\*\n" + \
+                     "EXCEPTION: St13runtime_error       \n" + \
+                     "CDB: Can't open database w22 \(duplicates fileid [0-9A-Fa-f]+ from w2\)       \n" + \
+                     "bitcoin in AppInit\(\)       \n"
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w2', '-wallet=w22'], exp_stderr)
 
         # should not initialize if wallet file is a symlink
         os.symlink(wallet_dir('w1'), wallet_dir('w12'))
-        self.nodes[0].assert_start_raises_init_error(['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w12'], 'Error: Error loading wallet w12. -wallet filename must be a regular file.')
 
         # should not initialize if the specified walletdir does not exist
         self.nodes[0].assert_start_raises_init_error(['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
@@ -74,8 +78,11 @@ class MultiWalletTest(BitcoinTestFramework):
 
         competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletdir')
         os.mkdir(competing_wallet_dir)
-        self.restart_node(0, ['-walletdir='+competing_wallet_dir])
-        self.nodes[1].assert_start_raises_init_error(['-walletdir='+competing_wallet_dir], 'Error initializing wallet database environment')
+        self.restart_node(0, ['-walletdir=' + competing_wallet_dir])
+        exp_stderr = "Error: Error initializing wallet database environment \"\S+?\"!\n" + \
+                     "terminate called after throwing an instance of 'std::system_error'\n" + \
+                     "  what\(\):  Invalid argument"
+        self.nodes[1].assert_start_raises_init_error(['-walletdir=' + competing_wallet_dir], exp_stderr)
 
         self.restart_node(0, self.extra_args[0])
 

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -30,31 +30,31 @@ class MultiWalletTest(BitcoinTestFramework):
 
         self.stop_nodes()
 
-        self.assert_start_raises_init_error(0, ['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" does not exist')
-        self.assert_start_raises_init_error(0, ['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" is a relative path', cwd=data_dir())
-        self.assert_start_raises_init_error(0, ['-walletdir=debug.log'], 'Error: Specified -walletdir "debug.log" is not a directory', cwd=data_dir())
+        self.nodes[0].assert_start_raises_init_error(['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" does not exist')
+        self.nodes[0].assert_start_raises_init_error(['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" is a relative path', cwd=data_dir())
+        self.nodes[0].assert_start_raises_init_error(['-walletdir=debug.log'], 'Error: Specified -walletdir "debug.log" is not a directory', cwd=data_dir())
 
         # should not initialize if there are duplicate wallets
-        self.assert_start_raises_init_error(0, ['-wallet=w1', '-wallet=w1'], 'Error loading wallet w1. Duplicate -wallet filename specified.')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w1', '-wallet=w1'], 'Error loading wallet w1. Duplicate -wallet filename specified.')
 
         # should not initialize if wallet file is a directory
         os.mkdir(wallet_dir('w11'))
-        self.assert_start_raises_init_error(0, ['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
 
         # should not initialize if one wallet is a copy of another
         shutil.copyfile(wallet_dir('w2'), wallet_dir('w22'))
-        self.assert_start_raises_init_error(0, ['-wallet=w2', '-wallet=w22'], 'duplicates fileid')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w2', '-wallet=w22'], 'duplicates fileid')
 
         # should not initialize if wallet file is a symlink
         os.symlink(wallet_dir('w1'), wallet_dir('w12'))
-        self.assert_start_raises_init_error(0, ['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
 
         # should not initialize if the specified walletdir does not exist
-        self.assert_start_raises_init_error(0, ['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
+        self.nodes[0].assert_start_raises_init_error(['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
         # should not initialize if the specified walletdir is not a directory
         not_a_dir = wallet_dir('notadir')
         open(not_a_dir, 'a').close()
-        self.assert_start_raises_init_error(0, ['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
+        self.nodes[0].assert_start_raises_init_error(['-walletdir=' + not_a_dir], 'Error: Specified -walletdir "' + not_a_dir + '" is not a directory')
 
         # if wallets/ doesn't exist, datadir should be the default wallet dir
         wallet_dir2 = data_dir('walletdir')
@@ -75,7 +75,7 @@ class MultiWalletTest(BitcoinTestFramework):
         competing_wallet_dir = os.path.join(self.options.tmpdir, 'competing_walletdir')
         os.mkdir(competing_wallet_dir)
         self.restart_node(0, ['-walletdir='+competing_wallet_dir])
-        self.assert_start_raises_init_error(1, ['-walletdir='+competing_wallet_dir], 'Error initializing wallet database environment')
+        self.nodes[1].assert_start_raises_init_error(['-walletdir='+competing_wallet_dir], 'Error initializing wallet database environment')
 
         self.restart_node(0, self.extra_args[0])
 


### PR DESCRIPTION
(WIP because if we're not careful this could result in a lot of false +ves. Should be tested on different platforms to verify portability).

#12362 was only observed when running the functional tests locally because:
- by defatul libc logs to `/dev/tty` instead of stderr
- the functional tests only check for substring inclusion in stderr when we're expecting bitcoind to fail.

This PR tightens our checking of stderr and will cause tests to fail if there is any unexpected message in stderr:

- commit _rename TestNode to TestP2PConn in tests_ is not necessary in this PR, but it removes a name conflict in the functional tests (which makes it difficult to see all the places that `TestNode` is being called)
- commit _Move assert_start_raises_init_error method to TestNode_ moves a method from test_framework to test_node (in general, methods which only affect a single node should be methods in `TestNode`).
- commit _Write stdout/stderr to datadir instead of temp file_ writes stderr to a file in the datadir instead of a temporary file. This helps with debugging in the case of failure.
- commit _Use LIBC_FATAL_STDERR_=1 in tests_ ensures that libc failures are logged to stderr instead of the terminal.
- commit _Update assert_start_raises_init_eror() to test for an exact m…_ changes `assert_start_raises_init_eror()` to match on an exact regex instead of a substring (with due [apologies](https://github.com/bitcoin/bitcoin/pull/12302#issuecomment-361691241) to @laanwj for #12302).
- commit _Assert that bitcoind stdout is empty on shutdown_ asserts that stderr is empty on bitcoind shutdown.