### PR TITLE
Fix ignoring tx data requests when fPauseSend is set on a peer

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1226,10 +1226,10 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
         }
     } // release cs_main
 
-    if (it != pfrom->vRecvGetData.end()) {
+    if (it != pfrom->vRecvGetData.end() && !pfrom->fPauseSend) {
         const CInv &inv = *it;
-        it++;
         if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK || inv.type == MSG_CMPCT_BLOCK || inv.type == MSG_WITNESS_BLOCK) {
+            it++;
             ProcessGetBlockData(pfrom, consensusParams, inv, connman, interruptMsgProc);
         }
     }


### PR DESCRIPTION
This resolves a bug introduced in
66aa1d58a158991a8014a91335b5bc9c00062f56 where, if when responding
to a series of transaction requests in a getdata we hit the send
buffer limit and set fPauseSend, we will skip one transaction per
call to ProcessGetData.

Bug found by Cory Fields (@theuni).

Probably worth slipping into 0.16 :/.