### PR TITLE
Reset pblocktree before deleting LevelDB file

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1425,6 +1425,9 @@ bool AppInitMain()
                 pcoinsTip.reset();
                 pcoinsdbview.reset();
                 pcoinscatcher.reset();
+                // new CBlockTreeDB tries to delete the existing file, which
+                // fails if it's still open from the previous loop. Close it first:
+                pblocktree.reset();
                 pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
 
                 if (fReset) {


### PR DESCRIPTION
#11043 repaced:

```
delete pblocktree;
pblocktree = new CBlockTreeDB(nBlockTreeDBCache, false, fReset);
```

With:

```
pblocktree.reset(new CBlockTreeDB(nBlockTreeDBCache, false, fReset));
```

This is problematic because `new CBlockTreeDB` tries to delete the existing file, which will fail with `LOCK: already held by process` if it's still open. That's the case for QT.

When QT finds a problem with the index it will ask the user if they want to reindex. At that point it has already opened `blocks/index`.  It then runs this [while loop](https://github.com/bitcoin/bitcoin/blob/v0.16.0rc3/src/init.cpp#L1415) again with `fReset = 1`, resulting in the above error.

This change makes that error go away, presumably because `reset()` without an argument closes the file.