### PR TITLE
Ensure nStatus is set properly for all invalid blocks

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -221,7 +221,7 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
@@ -232,7 +232,7 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  *
  * Note that we guarantee that either the proof-of-work is valid on pblock, or
  * (and possibly also) BlockChecked will have been called.
- * 
+ *
  * Call without cs_main held.
  *
  * @param[in]   pblock  The block we want to process.
@@ -358,7 +358,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = null
 
 /**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {
@@ -446,7 +446,11 @@ CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& loc
 /** Mark a block as precious and reorganize. */
 bool PreciousBlock(CValidationState& state, const CChainParams& params, CBlockIndex *pindex);
 
-/** Mark a block as invalid. */
+/**
+ * Mark a block as being invalid. If the block is in the active chain,
+ * disconnect any children and add any contained transactions back to the
+ * mempool.
+ */
 bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, CBlockIndex *pindex);
 
 /** Remove invalidity status from a block and its descendants. */


### PR DESCRIPTION
- [x] **Prerequisite PR**: #12431 (it wouldn't be catastrophic to merge this before that, but preferable to get that in first.)

In trying to fix the fork warning code (`validation.cpp:CheckForkWarningConditions*`), it became apparent that we are marking some (but not all) invalid blocks as invalid (via `nStatus`) when they are received and subsequently dropped. The fact that we never mark some invalid blocks as such prevents us from e.g. detecting and warning on invalid chains with significant work.

This change has `ProcessNewBlock` call `InvalidateBlock` on the invalid block to do the expected bookkeeping in `mapBlockIndex` before dropping the block.

This change also consolidates the setting of CBlockIndex's `nStatus |= BLOCK_FAILED_VALID` to a single function (`InvalidBlockFound`) since there's peripheral bookkeeping (e.g. `g_failed_blocks.insert()`) that we want to do consistently but is duplicated in some places or not done in other cases when it apparently should be. 

[One such replacement with InvalidBlockFound](https://github.com/bitcoin/bitcoin/pull/12407/files?diff=unified#diff-24efdb00bfbe56b140fb006b562cc70bL3420) ensures addition of invalid blocks to `g_failed_blocks` and so (in theory) reduces CPU burden when being spammed with descendants of an invalid block, since we no longer have to walk `mapBlockIndex` to determine its invalidity. Based on reading usage of `g_failed_blocks` I can't tell if this savings is real, but in any case it seems worthwhile to keep that set consistent (i.e. 1-1 with blocks marked BLOCK_FAILED_VALID since last restart).