### PR TITLE
Interrupt loading thread after shutdown request

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -680,11 +680,13 @@ void ThreadImport(std::vector<fs::path> vImportFiles)
     if (!ActivateBestChain(state, chainparams)) {
         LogPrintf("Failed to connect best block");
         StartShutdown();
+        return;
     }
 
     if (gArgs.GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {
         LogPrintf("Stopping after block import\n");
         StartShutdown();
+        return;
     }
     } // End scope of CImportingNow
     if (gArgs.GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {


### PR DESCRIPTION
This change (currently) avoids loading the mempool if shutdown is requested.