### PR TITLE
Force distinct destinations in CWallet::CreateTransaction

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -221,10 +221,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
-        outputs = { self.nodes[0].getnewaddress() : Decimal(4.0) }
+        address = self.nodes[0].getnewaddress()
+        outputs = { address : Decimal(4.0) }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
+
+        assert_raises_rpc_error(-4, "Duplicate address found: addresses should only be used once each.", self.nodes[2].fundrawtransaction, rawtx, {'changeAddress':address})
 
         change = self.nodes[2].getnewaddress()
         assert_raises_rpc_error(-8, "changePosition out of bounds", self.nodes[2].fundrawtransaction, rawtx, {'changeAddress':change, 'changePosition':2})


### PR DESCRIPTION
Check that all transaction destinations, including change address if specified, are distinct.

The error is also raised in the UI:
<img width="922" alt="screen shot 2018-02-13 at 01 17 49" src="https://user-images.githubusercontent.com/3534524/36128715-c25a7720-105b-11e8-8b07-4cc4836c0b52.png">
