### PR TITLE
qt: Initialize members in WalletModel

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -42,6 +42,7 @@ WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, O
     transactionTableModel(0),
     recentRequestsTableModel(0),
     cachedBalance(0), cachedUnconfirmedBalance(0), cachedImmatureBalance(0),
+    cachedWatchOnlyBalance{0}, cachedWatchUnconfBalance{0}, cachedWatchImmatureBalance{0},
     cachedEncryptionStatus(Unencrypted),
     cachedNumBlocks(0)
 {


### PR DESCRIPTION
This prevents segfaults (or errors when running qt in valgrind)

```
Conditional jump or move depends on uninitialised value(s)
    WalletModel::checkBalanceChanged() (walletmodel.cpp:156)