### PR TITLE
[rpc] Fix issue: "Negative version of transaction using json-rpc"

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -158,7 +158,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("hash", tx.GetWitnessHash().GetHex());
-    entry.pushKV("version", tx.nVersion);
+    entry.pushKV("version", static_cast<uint64_t>(tx.nVersion) & 0xffffffff);
     entry.pushKV("size", (int)::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
     entry.pushKV("vsize", (GetTransactionWeight(tx) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR);
     entry.pushKV("locktime", (int64_t)tx.nLockTime);


### PR DESCRIPTION
In case that it is a valid issue, this PR fixes #11561 ("Negative version of transaction using json-rpc").

The verbose output of the `getrawtransaction` RPC gives a response with a negative transaction version number if the MSB of the transaction version number is set.

This behavior can easily be reproduced by requesting the verbose transaction data of Mainnet transaction c659729a7fea5071361c2c1a68551ca2bf77679b27086cc415adeeb03852e369, via the `getrawtransaction` RPC, which gives a response with a negative transaction version number:

```
{
  ...
  "version": -1703168784,
  ...
}
```

To fix the issue, commit 42df694 casts the transaction version number to an `uint64_t` and masks off its most significant 32 bits to pass a positive transaction version number to `UniValue::pushKV(const std::string&, uint64_t):bool`.

In the case of the example above it gives a response with a positive transaction version number:

```
{
  ...
  "version": 2591798512,
  ...
}
```

This transaction version number is equal to the transaction version number created by block explorers that show a positive transaction version number. See for example:

[Transaction c659729a7fea5071361c2c1a68551ca2bf77679b27086cc415adeeb03852e369  on Blockcypher.com](https://live.blockcypher.com/btc/tx/c659729a7fea5071361c2c1a68551ca2bf77679b27086cc415adeeb03852e369)
