### PR TITLE
[qt] move SendCoinsRecipient to its own file

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -148,6 +148,7 @@ QT_MOC_CPP = \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcoinsdialog.cpp \
   qt/moc_sendcoinsentry.cpp \
+  qt/moc_sendcoinsrecipient.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
   qt/moc_trafficgraphwidget.cpp \
@@ -221,6 +222,7 @@ BITCOIN_QT_H = \
   qt/rpcconsole.h \
   qt/sendcoinsdialog.h \
   qt/sendcoinsentry.h \
+  qt/sendcoinsrecipient.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
   qt/trafficgraphwidget.h \
@@ -336,6 +338,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/recentrequeststablemodel.cpp \
   qt/sendcoinsdialog.cpp \
   qt/sendcoinsentry.cpp \
+  qt/sendcoinsrecipient.cpp \
   qt/signverifymessagedialog.cpp \
   qt/transactiondesc.cpp \
   qt/transactiondescdialog.cpp \

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -7,13 +7,13 @@ TESTS += qt/test/test_bitcoin-qt
 
 TEST_QT_MOC_CPP = \
   qt/test/moc_compattests.cpp \
-  qt/test/moc_rpcnestedtests.cpp \
-  qt/test/moc_uritests.cpp
+  qt/test/moc_rpcnestedtests.cpp
 
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += \
   qt/test/moc_paymentservertests.cpp \
-  qt/test/moc_wallettests.cpp
+  qt/test/moc_wallettests.cpp \
+  qt/test/moc_uritests.cpp
 endif
 
 TEST_QT_H = \
@@ -37,12 +37,12 @@ qt_test_test_bitcoin_qt_SOURCES = \
   qt/test/compattests.cpp \
   qt/test/rpcnestedtests.cpp \
   qt/test/test_main.cpp \
-  qt/test/uritests.cpp \
   $(TEST_QT_H) \
   $(TEST_BITCOIN_CPP) \
   $(TEST_BITCOIN_H)
 if ENABLE_WALLET
 qt_test_test_bitcoin_qt_SOURCES += \
+  qt/test/uritests.cpp \
   qt/test/paymentservertests.cpp \
   qt/test/wallettests.cpp \
   wallet/test/wallet_test_fixture.cpp

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -143,6 +143,7 @@ void setupAmountWidget(QLineEdit *widget, QWidget *parent)
     widget->setAlignment(Qt::AlignRight|Qt::AlignVCenter);
 }
 
+#ifdef ENABLE_WALLET
 bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out)
 {
     // return if URI is not valid or is no bitcoin: URI
@@ -245,6 +246,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info)
 
     return ret;
 }
+#endif // ENABLE_WALLET
 
 bool isDust(const QString& address, const CAmount& amount)
 {

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -5,6 +5,10 @@
 #ifndef BITCOIN_QT_GUIUTIL_H
 #define BITCOIN_QT_GUIUTIL_H
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <amount.h>
 #include <fs.h>
 
@@ -18,7 +22,10 @@
 #include <QLabel>
 
 class QValidatedLineEdit;
+
+#ifdef ENABLE_WALLET
 class SendCoinsRecipient;
+#endif // ENABLE_WALLET
 
 QT_BEGIN_NAMESPACE
 class QAbstractItemView;
@@ -44,10 +51,12 @@ namespace GUIUtil
     void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent);
     void setupAmountWidget(QLineEdit *widget, QWidget *parent);
 
+#ifdef ENABLE_WALLET
     // Parse "bitcoin:" URI into recipient object, return true on successful parsing
     bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out);
     bool parseBitcoinURI(QString uri, SendCoinsRecipient *out);
     QString formatBitcoinURI(const SendCoinsRecipient &info);
+#endif // ENABLE_WALLET
 
     // Returns true if given address+amount meets "dust" definition
     bool isDust(const QString& address, const CAmount& amount);

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -32,6 +32,7 @@ QString OpenURIDialog::getURI()
 
 void OpenURIDialog::accept()
 {
+#ifdef ENABLE_WALLET
     SendCoinsRecipient rcp;
     if(GUIUtil::parseBitcoinURI(getURI(), &rcp))
     {
@@ -40,6 +41,7 @@ void OpenURIDialog::accept()
     } else {
         ui->uriEdit->setValid(false);
     }
+#endif // ENABLE_WALLET
 }
 
 void OpenURIDialog::on_selectFileButton_clicked()

--- a/src/qt/sendcoinsrecipient.cpp
+++ b/src/qt/sendcoinsrecipient.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/sendcoinsrecipient.h>
+
+SendCoinsRecipient::SendCoinsRecipient() :
+    amount(0),
+    fSubtractFeeFromAmount(false),
+    nVersion(SendCoinsRecipient::CURRENT_VERSION)
+{
+}
+
+SendCoinsRecipient::SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
+    address(addr),
+    label(_label),
+    amount(_amount),
+    message(_message),
+    fSubtractFeeFromAmount(false),
+    nVersion(SendCoinsRecipient::CURRENT_VERSION)
+{
+}

--- a/src/qt/sendcoinsrecipient.h
+++ b/src/qt/sendcoinsrecipient.h
@@ -1,0 +1,68 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SENDCOINSRECIPIENT_H
+#define BITCOIN_QT_SENDCOINSRECIPIENT_H
+
+#include <qt/paymentrequestplus.h>
+
+class SendCoinsRecipient
+{
+public:
+    explicit SendCoinsRecipient();
+    explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message);
+
+    // If from an unauthenticated payment request, this is used for storing
+    // the addresses, e.g. address-A<br />address-B<br />address-C.
+    // Info: As we don't need to process addresses in here when using
+    // payment requests, we can abuse it for displaying an address list.
+    // Todo: This is a hack, should be replaced with a cleaner solution!
+    QString address;
+    QString label;
+    CAmount amount;
+    // If from a payment request, this is used for storing the memo
+    QString message;
+
+    // If from a payment request, paymentRequest.IsInitialized() will be true
+    PaymentRequestPlus paymentRequest;
+    // Empty if no authentication or invalid signature/cert/etc.
+    QString authenticatedMerchant;
+
+    bool fSubtractFeeFromAmount; // memory only
+
+    static const int CURRENT_VERSION = 1;
+    int nVersion;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        std::string sAddress = address.toStdString();
+        std::string sLabel = label.toStdString();
+        std::string sMessage = message.toStdString();
+        std::string sPaymentRequest;
+        if (!ser_action.ForRead() && paymentRequest.IsInitialized())
+            paymentRequest.SerializeToString(&sPaymentRequest);
+        std::string sAuthenticatedMerchant = authenticatedMerchant.toStdString();
+
+        READWRITE(this->nVersion);
+        READWRITE(sAddress);
+        READWRITE(sLabel);
+        READWRITE(amount);
+        READWRITE(sMessage);
+        READWRITE(sPaymentRequest);
+        READWRITE(sAuthenticatedMerchant);
+
+        if (ser_action.ForRead())
+        {
+            address = QString::fromStdString(sAddress);
+            label = QString::fromStdString(sLabel);
+            message = QString::fromStdString(sMessage);
+            if (!sPaymentRequest.empty())
+                paymentRequest.parse(QByteArray::fromRawData(sPaymentRequest.data(), sPaymentRequest.size()));
+            authenticatedMerchant = QString::fromStdString(sAuthenticatedMerchant);
+        }
+    }
+};
+#endif // BITCOIN_QT_SENDCOINSRECIPIENT_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -9,19 +9,18 @@
 #include <chainparams.h>
 #include <qt/test/rpcnestedtests.h>
 #include <util.h>
-#include <qt/test/uritests.h>
 #include <qt/test/compattests.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/test/paymentservertests.h>
 #include <qt/test/wallettests.h>
+#include <qt/test/uritests.h>
+#include <openssl/ssl.h>
 #endif
 
 #include <QApplication>
 #include <QObject>
 #include <QTest>
-
-#include <openssl/ssl.h>
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -74,13 +73,14 @@ int main(int argc, char *argv[])
     QApplication app(argc, argv);
     app.setApplicationName("Bitcoin-Qt-test");
 
+#ifdef ENABLE_WALLET
     SSL_library_init();
 
     URITests test1;
     if (QTest::qExec(&test1) != 0) {
         fInvalid = true;
     }
-#ifdef ENABLE_WALLET
+
     PaymentServerTests test2;
     if (QTest::qExec(&test2) != 0) {
         fInvalid = true;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_QT_WALLETMODEL_H
 #define BITCOIN_QT_WALLETMODEL_H
 
-#include <qt/paymentrequestplus.h>
+#include <qt/sendcoinsrecipient.h>
 #include <qt/walletmodeltransaction.h>
 
 #include <support/allocators/secure.h>
@@ -35,66 +35,6 @@ class uint256;
 QT_BEGIN_NAMESPACE
 class QTimer;
 QT_END_NAMESPACE
-
-class SendCoinsRecipient
-{
-public:
-    explicit SendCoinsRecipient() : amount(0), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) { }
-    explicit SendCoinsRecipient(const QString &addr, const QString &_label, const CAmount& _amount, const QString &_message):
-        address(addr), label(_label), amount(_amount), message(_message), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION) {}
-
-    // If from an unauthenticated payment request, this is used for storing
-    // the addresses, e.g. address-A<br />address-B<br />address-C.
-    // Info: As we don't need to process addresses in here when using
-    // payment requests, we can abuse it for displaying an address list.
-    // Todo: This is a hack, should be replaced with a cleaner solution!
-    QString address;
-    QString label;
-    CAmount amount;
-    // If from a payment request, this is used for storing the memo
-    QString message;
-
-    // If from a payment request, paymentRequest.IsInitialized() will be true
-    PaymentRequestPlus paymentRequest;
-    // Empty if no authentication or invalid signature/cert/etc.
-    QString authenticatedMerchant;
-
-    bool fSubtractFeeFromAmount; // memory only
-
-    static const int CURRENT_VERSION = 1;
-    int nVersion;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        std::string sAddress = address.toStdString();
-        std::string sLabel = label.toStdString();
-        std::string sMessage = message.toStdString();
-        std::string sPaymentRequest;
-        if (!ser_action.ForRead() && paymentRequest.IsInitialized())
-            paymentRequest.SerializeToString(&sPaymentRequest);
-        std::string sAuthenticatedMerchant = authenticatedMerchant.toStdString();
-
-        READWRITE(this->nVersion);
-        READWRITE(sAddress);
-        READWRITE(sLabel);
-        READWRITE(amount);
-        READWRITE(sMessage);
-        READWRITE(sPaymentRequest);
-        READWRITE(sAuthenticatedMerchant);
-
-        if (ser_action.ForRead())
-        {
-            address = QString::fromStdString(sAddress);
-            label = QString::fromStdString(sLabel);
-            message = QString::fromStdString(sMessage);
-            if (!sPaymentRequest.empty())
-                paymentRequest.parse(QByteArray::fromRawData(sPaymentRequest.data(), sPaymentRequest.size()));
-            authenticatedMerchant = QString::fromStdString(sAuthenticatedMerchant);
-        }
-    }
-};
 
 /** Interface to Bitcoin wallet from Qt view code. */
 class WalletModel : public QObject


### PR DESCRIPTION
I plan to add some instance methods to `SendCoinsRecipient` in an upcoming PR, so this might be a good time to give it its own file.