### PR TITLE
RPC: Strict JSON-RPC 2.0 compliance (gated behind flag)

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -180,21 +180,21 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
         // Set the URI
         jreq.URI = req->GetURI();
 
-        std::string strReply;
-        // singleton request
+        UniValue ret;
         if (valRequest.isObject()) {
-            jreq.parse(valRequest);
-
-            UniValue result = tableRPC.execute(jreq);
-
-            // Send reply
-            strReply = JSONRPCReply(result, NullUniValue, jreq.id);
-
-        // array of requests
-        } else if (valRequest.isArray())
-            strReply = JSONRPCExecBatch(jreq, valRequest.get_array());
-        else
+            ret = JSONRPCExecOne(jreq, valRequest);
+        } else if (valRequest.isArray()) {
+            ret = JSONRPCExecBatch(jreq, valRequest.get_array());
+        } else {
             throw JSONRPCError(RPC_PARSE_ERROR, "Top-level object parse error");
+        }
+
+        if (ret.isNull()) {
+            // JSON-RPC 2.0: return nothing at all
+            return false;
+        }
+
+        std::string strReply(ret.write() + "\n");
 
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strReply);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -980,6 +980,9 @@ bool AppInitParameterInteraction()
     if (gArgs.IsArgSet("-blockminsize"))
         InitWarning("Unsupported argument -blockminsize ignored.");
 
+    if (gArgs.IsArgSet("-strictjsonrpcspec"))
+        fStrictJSONRPCSpec = true;
+
     // Checkmempool and checkblockindex default to true in regtest mode
     int ratio = std::min<int>(std::max<int>(gArgs.GetArg("-checkmempool", chainparams.DefaultConsistencyChecks() ? 1 : 0), 0), 1000000);
     if (ratio != 0) {

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -15,6 +15,8 @@
 
 #include <univalue.h>
 
+extern bool fStrictJSONRPCSpec;
+
 //! HTTP status codes
 enum HTTPStatusCode
 {

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -351,15 +351,29 @@ bool RPCIsInWarmup(std::string *outStatus)
     return fRPCInWarmup;
 }
 
-void JSONRPCRequest::parse(const UniValue& valRequest)
+void JSONRPCRequest::parse(const UniValue& valRequest, bool *is_notification)
 {
     // Parse request
     if (!valRequest.isObject())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Invalid Request object");
     const UniValue& request = valRequest.get_obj();
 
-    // Parse id now so errors from here on will have the id
-    id = find_value(request, "id");
+    enum UniValue::keystatus status;
+    id = find_value(request, "id", &status);
+    if (status == UniValue::KEY_NOT_PRESENT) {
+        if (is_notification) { *is_notification = true; }
+    } // we just leave it otherwise, don't care
+
+    // JSON-RPC 2.0 compliance
+    if (fStrictJSONRPCSpec) {
+        UniValue valJsonRPC = find_value(request, "jsonrpc");
+        if (valJsonRPC.isNull())
+            throw JSONRPCError(RPC_INVALID_REQUEST, "Missing jsonrpc field");
+        if (!valJsonRPC.isStr())
+            throw JSONRPCError(RPC_INVALID_REQUEST, "jsonrpc field must be a string");
+        if (valJsonRPC.get_str() != "2.0")
+            throw JSONRPCError(RPC_INVALID_REQUEST, "jsonrpc field must be equal to '2.0'");
+    }
 
     // Parse method
     UniValue valMethod = find_value(request, "method");
@@ -387,22 +401,27 @@ bool IsDeprecatedRPCEnabled(const std::string& method)
     return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
 }
 
-static UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
+UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
 {
     UniValue rpc_result(UniValue::VOBJ);
 
     try {
-        jreq.parse(req);
+        bool is_notification = false;
+        if (fStrictJSONRPCSpec) {
+            jreq.parse(req, &is_notification);
+            // If is_notification, we still need to execute, so we
+            //     don't return until a few lines down here.
+        } else {
+            jreq.parse(req);
+        }
 
         UniValue result = tableRPC.execute(jreq);
+        if (is_notification) return NullUniValue;
+
         rpc_result = JSONRPCReplyObj(result, NullUniValue, jreq.id);
-    }
-    catch (const UniValue& objError)
-    {
+    } catch (const UniValue& objError) {
         rpc_result = JSONRPCReplyObj(NullUniValue, objError, jreq.id);
-    }
-    catch (const std::exception& e)
-    {
+    } catch (const std::exception& e) {
         rpc_result = JSONRPCReplyObj(NullUniValue,
                                      JSONRPCError(RPC_PARSE_ERROR, e.what()), jreq.id);
     }
@@ -410,13 +429,23 @@ static UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
     return rpc_result;
 }
 
-std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq)
+UniValue JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq)
 {
     UniValue ret(UniValue::VARR);
-    for (unsigned int reqIdx = 0; reqIdx < vReq.size(); reqIdx++)
-        ret.push_back(JSONRPCExecOne(jreq, vReq[reqIdx]));
+    for (unsigned int reqIdx = 0; reqIdx < vReq.size(); reqIdx++) {
+        UniValue singleret;
+        singleret = JSONRPCExecOne(jreq, vReq[reqIdx]);
+        if (fStrictJSONRPCSpec && singleret.isNull())
+            // fStrictJSONRPCSpec check doubled up here.
+            continue;
+        ret.push_back(singleret);
+    }
 
-    return ret.write() + "\n";
+    if (ret.size() == 0) {
+        return NullUniValue;
+    }
+
+    return ret;
 }
 
 /**

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -47,7 +47,7 @@ public:
     std::string authUser;
 
     JSONRPCRequest() : id(NullUniValue), params(NullUniValue), fHelp(false) {}
-    void parse(const UniValue& valRequest);
+    void parse(const UniValue& valRequest, bool *is_notification=nullptr);
 };
 
 /** Query whether RPC is running */
@@ -191,7 +191,8 @@ extern std::string HelpExampleRpc(const std::string& methodname, const std::stri
 bool StartRPC();
 void InterruptRPC();
 void StopRPC();
-std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
+UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req);
+UniValue JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);
 
 // Retrieves any serialization flags requested in command line argument
 int RPCSerializationFlags();

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -14,12 +14,15 @@
 #include <map>
 #include <cassert>
 
+#include <stdexcept>
+
 #include <sstream>        // .get_int64()
 #include <utility>        // std::pair
 
 class UniValue {
 public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };
+    enum keystatus { KEY_NOT_PRESENT, KEY_PRESENT };
 
     UniValue() { typ = VNULL; }
     UniValue(UniValue::VType initialType, const std::string& initialStr = "") {
@@ -180,7 +183,7 @@ public:
     bool push_back(std::pair<std::string,UniValue> pear) {
         return pushKV(pear.first, pear.second);
     }
-    friend const UniValue& find_value( const UniValue& obj, const std::string& name);
+    friend const UniValue& find_value(const UniValue& obj, const std::string& name, enum UniValue::keystatus *status);
 };
 
 //
@@ -302,6 +305,6 @@ static inline bool json_isspace(int ch)
 
 extern const UniValue NullUniValue;
 
-const UniValue& find_value( const UniValue& obj, const std::string& name);
+const UniValue& find_value(const UniValue& obj, const std::string& name, enum UniValue::keystatus *status=NULL);
 
 #endif // __UNIVALUE_H__

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -233,12 +233,15 @@ const char *uvTypeName(UniValue::VType t)
     return NULL;
 }
 
-const UniValue& find_value(const UniValue& obj, const std::string& name)
+const UniValue& find_value(const UniValue& obj, const std::string& name, enum UniValue::keystatus *status)
 {
-    for (unsigned int i = 0; i < obj.keys.size(); i++)
-        if (obj.keys[i] == name)
+    for (unsigned int i = 0; i < obj.keys.size(); i++) {
+        if (obj.keys[i] == name) {
+            if (status) { *status = UniValue::KEY_PRESENT; }
             return obj.values.at(i);
+        }
+    }
 
+    if (status) { *status = UniValue::KEY_NOT_PRESENT; }
     return NullUniValue;
 }
-

--- a/test/functional/interface_jsonrpc2.py
+++ b/test/functional/interface_jsonrpc2.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the JSON-RPC 2.0 strict support."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+from test_framework.authproxy import JSONRPCException
+
+import http.client
+import urllib.parse
+import json
+
+class JSONRPC2Test(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.extra_args = [["-strictjsonrpcspec"]]
+        self.skip_rpc_check = True
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        url = urllib.parse.urlparse(self.nodes[0].url)
+        authpair = url.username + ':' + url.password
+        headers = {"Authorization": "Basic " + str_to_b64str(authpair)}
+
+        conn = http.client.HTTPConnection(url.hostname, url.port)
+        conn.connect()
+
+        # jsonrpc field must exist
+        conn.request('POST', '/', '{"method": "getbestblockhash"}', headers)
+        out1 = conn.getresponse().read()
+        obj1 = json.loads(out1.decode("utf-8"))
+        assert "error" in obj1
+        assert "result" not in obj1
+        assert_equal(obj1["error"]["code"], -32600) # The JSON sent is not a valid Request object.
+        assert_equal(obj1["error"]["message"], "Missing jsonrpc field")
+
+        # jsonrpc field MUST be exactly "2.0"
+        conn.request('POST', '/', '{"method": "getbestblockhash", "jsonrpc": "dog"}', headers)
+        out2 = conn.getresponse().read()
+        obj2 = json.loads(out2.decode("utf-8"))
+        assert "error" in obj2 # result OR error
+        assert "result" not in obj2
+        assert_equal(obj2["error"]["code"], -32600) # The JSON sent is not a valid Request object.
+        assert_equal(obj2["error"]["message"], "jsonrpc field must be equal to '2.0'")
+
+        # Notifications (no id) should be ignored (no response)
+        conn.request('POST', '/', '{"method": "getbestblockhash", "jsonrpc": "2.0"}', headers)
+        out3 = conn.getresponse().read()
+        assert_equal(out3, b"Unhandled request")
+
+        # Valid request - id SHOULD normally not be null, but can be.
+        conn.request('POST', '/', '{"method": "getbestblockhash", "id": null, "jsonrpc": "2.0"}', headers)
+        out4 = conn.getresponse().read()
+        obj4 = json.loads(out4.decode("utf-8"))
+        assert "result" in obj4
+        assert "error" not in obj4 # result _or_ error
+        assert obj4["result"] is not None
+        assert_equal(obj4["id"], None)
+        assert_equal(obj4["jsonrpc"], "2.0")
+
+        # Notifications within batch requests should be ignored
+        conn.request('POST', '/', json.dumps([
+            {"method": "getbestblockhash", "id": "2", "jsonrpc": "2.0"},
+            {"method": "getbestblockhash", "jsonrpc": "2.0"},
+        ]), headers)
+        out4 = conn.getresponse().read()
+        obj4 = json.loads(out4.decode("utf-8"))
+        assert len(obj4) == 1
+
+        # Empty batch requests should be ignored (no response), not "[]"
+        conn.request('POST', '/', json.dumps([
+            {"method": "getbestblockhash", "jsonrpc": "2.0"},
+            {"method": "getbestblockhash", "jsonrpc": "2.0"},
+        ]), headers)
+        out5 = conn.getresponse().read()
+        assert_equal(out5, b"Unhandled request")
+
+if __name__ == '__main__':
+    JSONRPC2Test().main ()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -93,6 +93,7 @@ BASE_SCRIPTS= [
     'mempool_spend_coinbase.py',
     'mempool_reorg.py',
     'mempool_persist.py',
+    'interface_jsonrpc2.py',
     'wallet_multiwallet.py',
     'wallet_multiwallet.py --usecli',
     'interface_http.py',


### PR DESCRIPTION
This patch adds a -strictjsonrpcspec flag.

If the flag is used, bitcoind enters JSON-RPC 2.0 mode, which allows it to be fully spec-compliant (and thus work with libraries like libjson-rpc-cpp without modification).

I've added a functional test for the specific bits of the spec that I've changed.

univalue changes are included in this commit for ease of review but I can pull those out (see https://github.com/bitcoin-core/univalue/pull/12)