### PR TITLE
[rpc] Adds a functional test to validate the transaction version number in the RPC output

### DIFF
--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -14,12 +14,9 @@ Test the following RPCs:
 
 from collections import OrderedDict
 from io import BytesIO
+from test_framework.messages import CTransaction, ToHex
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.messages import (
-    CTransaction,
-)
 from test_framework.util import *
-
 
 class multidict(dict):
     """Dictionary that allows duplicate keys.
@@ -362,6 +359,24 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[0].createrawtransaction(inputs, outputs)
         decrawtx= self.nodes[0].decoderawtransaction(rawtx)
         assert_equal(decrawtx['vin'][0]['sequence'], 4294967294)
+
+        ####################################
+        # TRANSACTION VERSION NUMBER TESTS #
+        ####################################
+
+        # Test the minimum transaction version number that fits in a signed 32-bit integer.
+        tx = CTransaction()
+        tx.nVersion = -0x80000000
+        rawtx = ToHex(tx)
+        decrawtx = self.nodes[0].decoderawtransaction(rawtx)
+        assert_equal(decrawtx['version'], -0x80000000)
+
+        # Test the maximum transaction version number that fits in a signed 32-bit integer.
+        tx = CTransaction()
+        tx.nVersion = 0x7fffffff
+        rawtx = ToHex(tx)
+        decrawtx = self.nodes[0].decoderawtransaction(rawtx)
+        assert_equal(decrawtx['version'], 0x7fffffff)
 
 if __name__ == '__main__':
     RawTransactionsTest().main()


### PR DESCRIPTION
This PR attempts to resolve #11561 by addressing the feedback from @MarcoFalke; and @gmaxwell in #12430.

Commit 30e9d24 adds a functional test to `rpc_rawtransaction.py` to assert that the transaction version number in the RPC output is a signed 32-bit integer.

The functional test uses the raw transaction data from Mainnet transaction `c659729a7fea5071361c2c1a68551ca2bf77679b27086cc415adeeb03852e369`. 