### PR TITLE
gitian: bump descriptors for (0.)17

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-linux-0.16"
+name: "bitcoin-linux-0.17"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-osx-0.16"
+name: "bitcoin-osx-0.17"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-win-0.16"
+name: "bitcoin-win-0.17"
 enable_cache: true
 suites:
 - "trusty"


### PR DESCRIPTION
Bumping before we forget again. If we end up calling the next release 17.0, we'll have to fixup the descriptors anyway, so there's no harm in just doing the trivial bump now.