### PR TITLE
test: Add missing signal.h header

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -14,6 +14,7 @@
 #include <stdint.h>
 #include <vector>
 #ifndef WIN32
+#include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #endif


### PR DESCRIPTION
util_tests.cpp needs to include the signal.h header on FreeBSD.

Reported by denis2342 on IRC.