### PR TITLE
Fix bip68 sequence test to reflect updated rpc error message

### DIFF
--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -14,7 +14,7 @@ SEQUENCE_LOCKTIME_GRANULARITY = 9 # this is a bit-shift
 SEQUENCE_LOCKTIME_MASK = 0x0000ffff
 
 # RPC error for non-BIP68 final transactions
-NOT_FINAL_ERROR = "64: non-BIP68-final"
+NOT_FINAL_ERROR = "non-BIP68-final (code 64)"
 
 class BIP68Test(BitcoinTestFramework):
     def set_test_params(self):


### PR DESCRIPTION
The message changed in #12356, but this test is in the extended test suite, so it didn't fail on CI.