### PR TITLE
Assert compressed keys are strictly shorter than regular

### DIFF
--- a/src/key.h
+++ b/src/key.h
@@ -37,8 +37,8 @@ public:
      * script supports up to 75 for single byte push
      */
     static_assert(
-        PRIVATE_KEY_SIZE >= COMPRESSED_PRIVATE_KEY_SIZE,
-        "COMPRESSED_PRIVATE_KEY_SIZE is larger than PRIVATE_KEY_SIZE");
+        PRIVATE_KEY_SIZE > COMPRESSED_PRIVATE_KEY_SIZE,
+        "COMPRESSED_PRIVATE_KEY_SIZE should be smaller than PRIVATE_KEY_SIZE");
 
 private:
     //! Whether this private key is valid. We check for correctness when modifying the key

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -42,8 +42,8 @@ public:
      * script supports up to 75 for single byte push
      */
     static_assert(
-        PUBLIC_KEY_SIZE >= COMPRESSED_PUBLIC_KEY_SIZE,
-        "COMPRESSED_PUBLIC_KEY_SIZE is larger than PUBLIC_KEY_SIZE");
+        PUBLIC_KEY_SIZE > COMPRESSED_PUBLIC_KEY_SIZE,
+        "COMPRESSED_PUBLIC_KEY_SIZE should be smaller than PUBLIC_KEY_SIZE");
 
 private:
 


### PR DESCRIPTION
This is a stricter and more meaningful test.