### PR TITLE
Revert "[tests] bind functional test nodes to 127.0.0.1"

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -292,7 +292,6 @@ def initialize_datadir(dirname, n):
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("listenonion=0\n")
-        f.write("bind=127.0.0.1\n")
     return datadir
 
 def get_datadir_path(dirname, n):


### PR DESCRIPTION
#12200 was merged without test, and breaks `rpc_bind.py`. (Tested locally by @MarcoFalke and me).

This PR backs out the change.

Fixes #12462