### PR TITLE
[depends] Allow depends system to support armv7l

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -21,7 +21,6 @@ BUILD_ID_SALT ?= salt
 host:=$(BUILD)
 ifneq ($(HOST),)
 host:=$(HOST)
-host_toolchain:=$(HOST)-
 endif
 
 ifneq ($(DEBUG),)

--- a/depends/hosts/default.mk
+++ b/depends/hosts/default.mk
@@ -1,3 +1,7 @@
+ifneq ($(host),$(build))
+host_toolchain:=$(host)-
+endif
+
 default_host_CC = $(host_toolchain)gcc
 default_host_CXX = $(host_toolchain)g++
 default_host_AR = $(host_toolchain)ar

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -47,6 +47,7 @@ $(package)_config_opts_linux=-fPIC -Wa,--noexecstack
 $(package)_config_opts_x86_64_linux=linux-x86_64
 $(package)_config_opts_i686_linux=linux-generic32
 $(package)_config_opts_arm_linux=linux-generic32
+$(package)_config_opts_armv7l_linux=linux-generic32
 $(package)_config_opts_aarch64_linux=linux-generic64
 $(package)_config_opts_mipsel_linux=linux-generic32
 $(package)_config_opts_mips_linux=linux-generic32


### PR DESCRIPTION
Credit for the actual patches goes to @theuni, I just tested them on an armv7l machine.

This change allows the depends system to build our dependencies on 32-bit ARM / armv7l architecture. I.e. with this patch, the following steps now builds fine:
```
$ uname -m
armv7l
$ ./autogen.sh
$ cd depends && make NO_QT=1 && cd ..
$ ./configure --prefix=$(pwd)/depends/armv7l-unknown-linux-gnueabihf
$ make
```

Without this patch, the `cd depends && make NO_QT=1` command fails on armv7l.