### PR TITLE
qa: Fix python TypeError in script.py

### DIFF
--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -526,11 +526,9 @@ class CScript(bytes):
                     yield CScriptOp(opcode)
 
     def __repr__(self):
-        # For Python3 compatibility add b before strings so testcases don't
-        # need to change
         def _repr(o):
             if isinstance(o, bytes):
-                return b"x('%s')" % hexlify(o).decode('ascii')
+                return "x('%s')" % hexlify(o).decode('ascii')
             else:
                 return repr(o)
 


### PR DESCRIPTION
`__repr__` returns string, so don't mix it with byte strings.

This fixes

```
TypeError: %b requires a bytes-like object, or an object that implements __bytes__, not 'str'