### PR TITLE
[net] Skip stale tip checks in regtest

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3123,6 +3123,10 @@ void PeerLogicValidation::CheckForStaleTipAndEvictPeers(const Consensus::Params 
 
     EvictExtraOutboundPeers(time_in_seconds);
 
+    // We skip the stale tip stuff if fPowNoRetargeting is set, as that
+    // indicates we are running on regtest
+    if (consensusParams.fPowNoRetargeting) return;
+
     if (time_in_seconds > m_stale_tip_check_time) {
         LOCK(cs_main);
         // Check whether our tip is stale, and if so, allow using an extra


### PR DESCRIPTION
Starting a regtest node and leaving it for a bit would start spamming 
```
2018-02-19 20:05:25 Potential stale tip detected, will try using extra outbound peer (last tip update: 32809 seconds ago)
```
which seems unnecessary. I check if it's regtest by seeing if `Consensus::Params.fPowNoRetargeting` is `true`, which is perhaps not ideal, but works.