### PR TITLE
[test] Round target fee to 8 decimals in assert_fee_amount

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -26,7 +26,7 @@ logger = logging.getLogger("TestFramework.utils")
 
 def assert_fee_amount(fee, tx_size, fee_per_kB):
     """Assert the fee was in range"""
-    target_fee = tx_size * fee_per_kB / 1000
+    target_fee = round(tx_size * fee_per_kB / 1000, 8)
     if fee < target_fee:
         raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
     # allow the wallet's estimation to be at most 2 bytes off


### PR DESCRIPTION
The output would produce arbitrary number of decimal points, sometimes resulting in 9 decimals:
```
AssertionError: Fee of 0.00000415 BTC too low! (Should be 0.000006175 BTC)
```
The above looks like the expected fee is 6175 sats when in reality it's 618.