### PR TITLE
Bugfix: respect user defined configuration file (-conf) in QT settings

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -417,7 +417,7 @@ void openDebugLogfile()
 
 bool openBitcoinConf()
 {
-    boost::filesystem::path pathConfig = GetConfigFile(BITCOIN_CONF_FILENAME);
+    boost::filesystem::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
 
     /* Create the file */
     boost::filesystem::ofstream configFile(pathConfig, std::ios_base::app);


### PR DESCRIPTION
Fixes #12488.

In master, opening the configuration file from the GUI settings will always open the file "bitcoin.conf" regardless of the `-conf=` settings.
This PR makes the GUI settings open configuration file function respect the `-conf` option.