### PR TITLE
Try to use posix_fadvise with CBufferedFile

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -8,6 +8,7 @@
 
 #include <support/allocators/zeroafterfree.h>
 #include <serialize.h>
+#include <util.h>
 
 #include <algorithm>
 #include <assert.h>
@@ -593,10 +594,8 @@ protected:
 
 public:
     CBufferedFile(FILE *fileIn, uint64_t nBufSize, uint64_t nRewindIn, int nTypeIn, int nVersionIn) :
-        nType(nTypeIn), nVersion(nVersionIn), nSrcPos(0), nReadPos(0), nReadLimit((uint64_t)(-1)), nRewind(nRewindIn), vchBuf(nBufSize, 0)
-    {
-        src = fileIn;
-    }
+        nType(nTypeIn), nVersion(nVersionIn), src(AdviseSequential(fileIn)), nSrcPos(0), nReadPos(0), nReadLimit((uint64_t)(-1)), nRewind(nRewindIn), vchBuf(nBufSize, 0)
+    {}
 
     ~CBufferedFile()
     {
@@ -613,7 +612,7 @@ public:
     void fclose()
     {
         if (src) {
-            ::fclose(src);
+            CloseAndDiscard(src);
             src = nullptr;
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -19,16 +19,6 @@
 #endif
 
 #ifndef WIN32
-// for posix_fallocate
-#ifdef __linux__
-
-#ifdef _POSIX_C_SOURCE
-#undef _POSIX_C_SOURCE
-#endif
-
-#define _POSIX_C_SOURCE 200112L
-
-#endif // __linux__
 
 #include <algorithm>
 #include <fcntl.h>
@@ -798,8 +788,9 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
         fcntl(fileno(file), F_PREALLOCATE, &fst);
     }
     ftruncate(fileno(file), fst.fst_length);
-#elif defined(__linux__)
-    // Version using posix_fallocate
+#elif _POSIX_C_SOURCE >= 200112L
+    // Use posix_fallocate to advise the kernel how much data we have to write,
+    // if this system supports it.
     off_t nEndPos = (off_t)offset + length;
     posix_fallocate(fileno(file), 0, nEndPos);
 #else
@@ -815,6 +806,49 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
         length -= now;
     }
 #endif
+}
+
+FILE* AdviseSequential(FILE *file) {
+#if _POSIX_C_SOURCE >= 200112L
+    // Since this whole thing is advisory anyway, we can ignore any errors
+    // encountered up to and including the posix_fadvise call. However, we must
+    // rewind the file to the appropriate position if we've changed the seek
+    // offset.
+    if (file == nullptr)
+        return nullptr;
+    int fd = fileno(file);
+    if (fd == -1)
+        return file;
+    off_t start = lseek(fd, 0, SEEK_CUR);
+    if (start == -1)
+        return file;
+    off_t end = lseek(fd, 0, SEEK_END);
+    if (end != -1) {
+        posix_fadvise(fd, start, end - start, POSIX_FADV_WILLNEED);
+        posix_fadvise(fd, start, end - start, POSIX_FADV_SEQUENTIAL);
+    }
+    lseek(fd, start, SEEK_SET);
+#endif
+    return file;
+}
+
+int CloseAndDiscard(FILE *file) {
+#if _POSIX_C_SOURCE >= 200112L
+    // Ignore any errors up to and including the posix_fadvise call since it's
+    // advisory.
+    if (file != nullptr) {
+        off_t end;
+        int fd = fileno(file);
+        if (fd == -1)
+            goto close;
+        end = lseek(fd, 0, SEEK_END);
+        if (end == -1)
+            goto close;
+        posix_fadvise(fd, 0, end, POSIX_FADV_DONTNEED);
+    }
+#endif
+ close:
+    return fclose(file);
 }
 
 void ShrinkDebugFile()

--- a/src/util.h
+++ b/src/util.h
@@ -175,6 +175,15 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
 bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 
+//! Return the original FILE* unchanged. On POSIX systems that support it,
+//! also advise the kernel that the file will be accessed sequentially.
+FILE* AdviseSequential(FILE *file);
+
+//! Close a file and return the result of fclose(). On POSIX systems that
+//! support it, advise the kernel to remove the file contents from the page
+//! cache (which can help on memory-constrained systems).
+int CloseAndDiscard(FILE *file);
+
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.
  */


### PR DESCRIPTION
I've been working in another branch on speeding up IBD/reindexing, and have been looking at how to improve page cache hits on Linux. This is a minor (but safe) improvement I've discovered during that work.

The change here uses `posix_fadvise()` on systems that support it (Linux, BSD, macOS) such that:
 * When opening a block file for processing, it advises the kernel that the block will be read immediately, and that the read will be sequential.
 * When closing a block file, it advises the kernel that it can discard entries in the page cache associated with that block file, which potentially leaves a bit more page cache room for things like chainstate files when chainstate reindexing happens.

There's also a minor/pedantic fix to related to an existing `posix_fallocate()` call to make sure it doesn't redefine `_POSIX_C_SOURCE` (which could potentially affect the behavior of header files included after the redefinition).

I don't expect this to be a huge performance win, but it's safe and well contained. The new util functions are potentially useful elsewhere. The speedup here is potentially bigger by using these methods selectively on CAutoFile, as that's how block files are loaded during the chainstate reindexing phase. I'm working on that as well, but that's more delicate since CAutoFile is used all over the place (compared to CBufferedFile which is just used when reindexing block files).