### PR TITLE
Declare CMutableTransaction a struct in rawtransaction.h

### DIFF
--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -6,7 +6,7 @@
 #define BITCOIN_RPC_RAWTRANSACTION_H
 
 class CBasicKeyStore;
-class CMutableTransaction;
+struct CMutableTransaction;
 class UniValue;
 
 /** Sign a transaction with the given keystore and previous transactions */


### PR DESCRIPTION
Because it's a struct.

Fix for #10579 - this was called out in code review. https://github.com/bitcoin/bitcoin/pull/10579#discussion_r168936821