### PR TITLE
Interrupt rescan on shutdown request

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -11,6 +11,7 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <fs.h>
+#include <init.h>
 #include <key.h>
 #include <key_io.h>
 #include <keystore.h>
@@ -1753,7 +1754,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
             dProgressTip = GuessVerificationProgress(chainParams.TxData(), tip);
         }
         double gvp = dProgressStart;
-        while (pindex && !fAbortRescan)
+        while (pindex && !fAbortRescan && !ShutdownRequested())
         {
             if (pindex->nHeight % 100 == 0 && dProgressTip - dProgressStart > 0.0) {
                 ShowProgress(_("Rescanning..."), std::max(1, std::min(99, (int)((gvp - dProgressStart) / (dProgressTip - dProgressStart) * 100))));
@@ -1794,6 +1795,8 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
         }
         if (pindex && fAbortRescan) {
             LogPrintf("Rescan aborted at block %d. Progress=%f\n", pindex->nHeight, gvp);
+        } else if (pindex && ShutdownRequested()) {
+            LogPrintf("Rescan interrupted by shutdown request at block %d. Progress=%f\n", pindex->nHeight, gvp);
         }
         ShowProgress(_("Rescanning..."), 100); // hide progress dialog in GUI
     }


### PR DESCRIPTION
Fixes #10987.

Here are the steps to test the feature:

1. start bitcoind, generate a couple of transactions and then stop:
```
bitcoind -regtest -printtoconsole
bitcoin-cli -regtest generate 100
```
2. apply the following patch
```diff
diff --git a/src/wallet/wallet.cpp b/src/wallet/wallet.cpp
index 2478d67ce..8f8cea40c 100644
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1671,6 +1671,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
         }
         while (pindex && !fAbortRescan && !ShutdownRequested())
         {
+            MilliSleep(500);
             if (pindex->nHeight % 100 == 0 && dProgressTip - dProgressStart > 0.0) {
                 double gvp = 0;
                 {
```
3. start bitcoind with rescan flag, interrupt with CTRL+C and the output should look like:
```
bitcoind -regtest -printtoconsole -rescan
...
^C2018-02-22 01:00:55 AddToWallet e8bfb4501b630ad2acb91e88ab0112a779766536d2c564b04faae45ae90e18f7
2018-02-22 01:00:55 Rescan interrupted by shutdown request at block 5. Progress=1.000000
2018-02-22 01:00:55  rescan                 1774ms
2018-02-22 01:00:55 setKeyPool.size() = 1995
2018-02-22 01:00:55 mapWallet.size() = 10145
2018-02-22 01:00:55 mapAddressBook.size() = 3
2018-02-22 01:00:55 Shutdown: In progress...
2018-02-22 01:00:55 scheduler thread interrupt
2018-02-22 01:00:55 Shutdown: done
```
