### PR TITLE
Don't test against the mempool min fee information in mempool_limit.py

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -58,7 +58,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         # specifically fund this tx with a fee < mempoolminfee, >= than minrelaytxfee
         txF = self.nodes[0].fundrawtransaction(tx, {'feeRate': relayfee})
         txFS = self.nodes[0].signrawtransactionwithwallet(txF['hex'])
-        assert_raises_rpc_error(-26, "mempool min fee not met, 166 < 411 (code 66)", self.nodes[0].sendrawtransaction, txFS['hex'])
+        assert_raises_rpc_error(-26, "mempool min fee not met", self.nodes[0].sendrawtransaction, txFS['hex'])
 
 if __name__ == '__main__':
     MempoolLimitTest().main()


### PR DESCRIPTION
Because the right-hand side of this comparison can be influenced
externally, e.g. via the -maxmempool argument, the existing mempool state,
host memory usage, etc.

Called out by @MarcoFalke here: https://github.com/bitcoin/bitcoin/pull/12356#discussion_r170094948