### PR TITLE
Net: Pass MSG_MORE flag when sending non-final network messages

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -891,7 +891,13 @@ size_t CConnman::SocketSendData(CNode *pnode) const
             LOCK(pnode->cs_hSocket);
             if (pnode->hSocket == INVALID_SOCKET)
                 break;
-            nBytes = send(pnode->hSocket, reinterpret_cast<const char*>(data.data()) + pnode->nSendOffset, data.size() - pnode->nSendOffset, MSG_NOSIGNAL | MSG_DONTWAIT);
+            int flags = MSG_NOSIGNAL | MSG_DONTWAIT;
+#ifdef MSG_MORE
+            if (it + 1 != pnode->vSendMsg.end()) {
+                flags |= MSG_MORE;
+            }
+#endif
+            nBytes = send(pnode->hSocket, reinterpret_cast<const char*>(data.data()) + pnode->nSendOffset, data.size() - pnode->nSendOffset, flags);
         }
         if (nBytes > 0) {
             pnode->nLastSend = GetSystemTimeInSeconds();


### PR DESCRIPTION
Since Nagle's algorithm is disabled, each and every call to send(2) can potentially generate a separate TCP segment on the wire. This is especially inefficient when sending the tiny header preceding each message payload.

Linux implements a `MSG_MORE` flag that tells the kernel not to push the passed data immediately to the connected peer but rather to collect it in the socket's internal transmit buffer where it can be combined with data from successive calls to send(2). Where available, specify this flag when calling send(2) in `CConnman::SocketSendData(CNode *)` if the data buffer being sent is not the last one in `pnode->vSendMsg`.