### PR TITLE
streamlined the use of include_hex

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -174,8 +174,9 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
             in.pushKV("vout", (int64_t)txin.prevout.n);
             UniValue o(UniValue::VOBJ);
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
-            if (include_hex)
+            if (include_hex) {
                 o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+            }
             in.pushKV("scriptSig", o);
             if (!tx.vin[i].scriptWitness.IsNull()) {
                 UniValue txinwitness(UniValue::VARR);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -129,14 +129,14 @@ std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags)
 }
 
 void ScriptPubKeyToUniv(const CScript& scriptPubKey,
-                        UniValue& out, bool fIncludeHex)
+                        UniValue& out, bool include_hex)
 {
     txnouttype type;
     std::vector<CTxDestination> addresses;
     int nRequired;
 
     out.pushKV("asm", ScriptToAsmStr(scriptPubKey));
-    if (fIncludeHex)
+    if (include_hex)
         out.pushKV("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 
     if (!ExtractDestinations(scriptPubKey, type, addresses, nRequired)) {
@@ -174,7 +174,8 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
             in.pushKV("vout", (int64_t)txin.prevout.n);
             UniValue o(UniValue::VOBJ);
             o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
-            o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+            if (include_hex)
+                o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
             in.pushKV("scriptSig", o);
             if (!tx.vin[i].scriptWitness.IsNull()) {
                 UniValue txinwitness(UniValue::VARR);
@@ -199,7 +200,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
         out.pushKV("n", (int64_t)i);
 
         UniValue o(UniValue::VOBJ);
-        ScriptPubKeyToUniv(txout.scriptPubKey, o, true);
+        ScriptPubKeyToUniv(txout.scriptPubKey, o, include_hex);
         out.pushKV("scriptPubKey", o);
         vout.push_back(out);
     }


### PR DESCRIPTION
ScriptPubKeyToUniv is using include_hex now instead of 'true'
the printout of scriptsig is now also in a include_hex condition