### PR TITLE
Remove redundant includes. Conform to header include guidelines.

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -4,7 +4,6 @@
 
 #include <base58.h>
 #include <keystore.h>
-#include <pubkey.h>
 #include <rpc/protocol.h>
 #include <rpc/util.h>
 #include <tinyformat.h>

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -8,7 +8,6 @@
 #include <pubkey.h>
 #include <script/standard.h>
 #include <univalue.h>
-#include <utilstrencodings.h>
 
 #include <boost/variant/static_visitor.hpp>
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util.h>
-#include <fs.h>
 
 #include <chainparamsbase.h>
 #include <random.h>


### PR DESCRIPTION
From the header include guidelines ([developer-notes.md](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#source-code-organization)):

> "One exception is that a `.cpp` file does not need to re-include the includes already included in its corresponding `.h` file."

Covered in this PR:
* `rpc/util.h` includes `pubkey.h` + `utilstrencodings.h`. `rpc/util.cpp` includes `rpc/util.h`.
* `util.h` includes `fs.h`. `util.cpp` includes `util.h`.