### PR TITLE
[arith_uint256] Avoid unnecessary this-copy using prefix operator

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -85,7 +85,7 @@ public:
         base_uint ret;
         for (int i = 0; i < WIDTH; i++)
             ret.pn[i] = ~pn[i];
-        ret++;
+        ++ret;
         return ret;
     }
 


### PR DESCRIPTION
I noticed while profiling a related project that `operator-()` actually calls the `base_uint` constructor, which is because the postfix operator version of `operator++` (used in `operator-()`) creates a copy of `this` and returns it.