### PR TITLE
Allow dustrelayfee to be set to zero

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1057,7 +1057,7 @@ bool AppInitParameterInteraction()
     if (gArgs.IsArgSet("-dustrelayfee"))
     {
         CAmount n = 0;
-        if (!ParseMoney(gArgs.GetArg("-dustrelayfee", ""), n) || 0 == n)
+        if (!ParseMoney(gArgs.GetArg("-dustrelayfee", ""), n))
             return InitError(AmountErrMsg("dustrelayfee", gArgs.GetArg("-dustrelayfee", "")));
         dustRelayFee = CFeeRate(n);
     }


### PR DESCRIPTION
I don't see and can't think of any rationale for forbidding this configuration.