### PR TITLE
[script] lint-whitespace: find errors more easily

### DIFF
--- a/contrib/devtools/lint-whitespace.sh
+++ b/contrib/devtools/lint-whitespace.sh
@@ -37,20 +37,25 @@ if showdiff | grep -E -q '^\+.*\s+$'; then
   echo "The following changes were suspected:"
   FILENAME=""
   SEEN=0
+  SEENLN=0
   while read -r line; do
     if [[ "$line" =~ ^diff ]]; then
       FILENAME="$line"
       SEEN=0
     elif [[ "$line" =~ ^@@ ]]; then
       LINENUMBER="$line"
+      SEENLN=0
     else
       if [ "$SEEN" -eq 0 ]; then
         # The first time a file is seen with trailing whitespace, we print the
         # filename (preceded by a newline).
         echo
         echo "$FILENAME"
-        echo "$LINENUMBER"
         SEEN=1
+      fi
+      if [ "$SEENLN" -eq 0 ]; then
+        echo "$LINENUMBER"
+        SEENLN=1
       fi
       echo "$line"
     fi
@@ -64,20 +69,25 @@ if showcodediff | grep -P -q '^\+.*\t'; then
   echo "The following changes were suspected:"
   FILENAME=""
   SEEN=0
+  SEENLN=0
   while read -r line; do
     if [[ "$line" =~ ^diff ]]; then
       FILENAME="$line"
       SEEN=0
     elif [[ "$line" =~ ^@@ ]]; then
       LINENUMBER="$line"
+      SEENLN=0
     else
       if [ "$SEEN" -eq 0 ]; then
         # The first time a file is seen with a tab character, we print the
         # filename (preceded by a newline).
         echo
         echo "$FILENAME"
-        echo "$LINENUMBER"
         SEEN=1
+      fi
+      if [ "$SEENLN" -eq 0 ]; then
+        echo "$LINENUMBER"
+        SEENLN=1
       fi
       echo "$line"
     fi


### PR DESCRIPTION
Before this PR, the linenumber infomaition is output if trailing-space or tab code was found, but the output occurence is only per a file.
This PR separates the output timing of file name and line number.
As a result, users will find where they need to fix more easily.

example:

0) git diff
```
diff --git a/dummy.txt b/dummy.txt
index c0ce4d776..aebbdb88d 100644
--- a/dummy.txt
+++ b/dummy.txt
@@ -1,2 +1,2 @@
-1
-2
+1 
+       2
@@ -8,2 +8,2 @@
-8
-9
+       8
+9 
```

1) before this PR - Is there "9 " in second line? It may lead to be misunderstood.
```
This diff appears to have added new lines with trailing whitespace.
The following changes were suspected:

diff --git a/dummy.txt b/dummy.txt
@@ -1,2 +1,2 @@
+1
+9
```

2) after this PR
```
This diff appears to have added new lines with trailing whitespace.
The following changes were suspected:

diff --git a/dummy.txt b/dummy.txt
@@ -1,2 +1,2 @@
+1
@@ -8,2 +8,2 @@
+9
```