### PR TITLE
gui: Add transaction record type Fee

### DIFF
--- a/doc/release-notes-12578.md
+++ b/doc/release-notes-12578.md
@@ -2,3 +2,4 @@ GUI changes
 -----------
 
 - In the transactions table, there is a new row type "Fee" which represents the transaction fee (only for sent transactions). Previously the fee was accounted in the first transaction destination.
+- In the transactions table, the row background color alternates based on the transaction hash. This helps in identifying related rows.

--- a/doc/release-notes-12578.md
+++ b/doc/release-notes-12578.md
@@ -1,0 +1,4 @@
+GUI changes
+-----------
+
+- In the transactions table, there is a new row type "Fee" which represents the transaction fee (only for sent transactions). Previously the fee was accounted in the first transaction destination.

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -166,7 +166,7 @@ void TestGUI()
     QCOMPARE(transactionTableModel->rowCount({}), 105);
     uint256 txid1 = SendCoins(*wallet.get(), sendCoinsDialog, CKeyID(), 5 * COIN, false /* rbf */);
     uint256 txid2 = SendCoins(*wallet.get(), sendCoinsDialog, CKeyID(), 10 * COIN, true /* rbf */);
-    QCOMPARE(transactionTableModel->rowCount({}), 107);
+    QCOMPARE(transactionTableModel->rowCount({}), 109);
     QVERIFY(FindTx(*transactionTableModel, txid1).isValid());
     QVERIFY(FindTx(*transactionTableModel, txid2).isValid());
 

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -104,7 +104,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
             //
             // Debit
             //
-            CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
 
             for (unsigned int nOut = 0; nOut < wtx.tx->vout.size(); nOut++)
             {
@@ -120,6 +119,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                 TransactionRecord sub(hash, nTime);
                 sub.idx = nOut;
                 sub.involvesWatchAddress = involvesWatchAddress;
+                sub.debit = -txout.nValue;
 
                 if (!boost::get<CNoDestination>(&wtx.txout_address[nOut]))
                 {
@@ -134,15 +134,15 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     sub.address = mapValue["to"];
                 }
 
-                CAmount nValue = txout.nValue;
-                /* Add fee to first output */
-                if (nTxFee > 0)
-                {
-                    nValue += nTxFee;
-                    nTxFee = 0;
-                }
-                sub.debit = -nValue;
+                parts.append(sub);
+            }
 
+            CAmount nTxFee = nDebit - wtx.tx->GetValueOut();
+
+            if (nTxFee > 0) {
+                TransactionRecord sub(hash, nTime);
+                sub.type = TransactionRecord::Fee;
+                sub.debit = -nTxFee;
                 parts.append(sub);
             }
         }

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -109,9 +109,6 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
             for (unsigned int nOut = 0; nOut < wtx.tx->vout.size(); nOut++)
             {
                 const CTxOut& txout = wtx.tx->vout[nOut];
-                TransactionRecord sub(hash, nTime);
-                sub.idx = nOut;
-                sub.involvesWatchAddress = involvesWatchAddress;
 
                 if(wtx.txout_is_mine[nOut])
                 {
@@ -119,6 +116,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     // from a transaction sent back to our own address.
                     continue;
                 }
+
+                TransactionRecord sub(hash, nTime);
+                sub.idx = nOut;
+                sub.involvesWatchAddress = involvesWatchAddress;
 
                 if (!boost::get<CNoDestination>(&wtx.txout_address[nOut]))
                 {

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -81,7 +81,8 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
-        SendToSelf
+        SendToSelf,
+        Fee
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -356,6 +356,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
+    case TransactionRecord::Fee:
+        return tr("Fee");
     default:
         return QString();
     }
@@ -372,6 +374,7 @@ QVariant TransactionTableModel::txAddressDecoration(const TransactionRecord *wtx
         return QIcon(":/icons/tx_input");
     case TransactionRecord::SendToAddress:
     case TransactionRecord::SendToOther:
+    case TransactionRecord::Fee:
         return QIcon(":/icons/tx_output");
     default:
         return QIcon(":/icons/tx_inout");

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -91,6 +91,7 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
                                   TransactionFilterProxy::TYPE(TransactionRecord::SendToOther));
     typeWidget->addItem(tr("To yourself"), TransactionFilterProxy::TYPE(TransactionRecord::SendToSelf));
     typeWidget->addItem(tr("Mined"), TransactionFilterProxy::TYPE(TransactionRecord::Generated));
+    typeWidget->addItem(tr("Fee"), TransactionFilterProxy::TYPE(TransactionRecord::Fee));
     typeWidget->addItem(tr("Other"), TransactionFilterProxy::TYPE(TransactionRecord::Other));
 
     hlayout->addWidget(typeWidget);


### PR DESCRIPTION
Currently, in the transactions table, the fee is added as debit to the first output. It's a different behaviour from `gettransaction` RPC where the values are seen separately:
```
gettransaction 56d4c03f65f32acecd80ec6ec1b5cd12eddcd35d705f2d4c82a90c85b1cf872a

{
  ...
  "details": [
    {
      "account": "",
      "address": "2N3AFooPuYvN6zWPpThPB8w8V48Ph31PuKH",
      "category": "send",
      "amount": -1,
      "label": "",
      "vout": 0,
      "fee": -0.0000022,
      "abandoned": false
    },
    {
      "account": "",
      "address": "2N42JYZHhwRXgrpuztod6CcEXfUDLTqbhY7",
      "category": "send",
      "amount": -1,
      "label": "",
      "vout": 1,
      "fee": -0.0000022,
      "abandoned": false
    }
  ],
  ...
}
```

Before:
<img width="848" alt="screen shot 2018-03-01 at 18 44 20" src="https://user-images.githubusercontent.com/3534524/36863063-940a2b86-1d80-11e8-95ff-a2cb39174fc1.png">
After:
<img width="850" alt="screen shot 2018-03-06 at 13 55 08" src="https://user-images.githubusercontent.com/3534524/37035998-43b6a5f0-2146-11e8-9729-9f79956b2808.png">
The row background now alternates based on txid, so in the capture above, the first 3 rows refer to the same transaction.