### PR TITLE
doc: Mention configure without wallet in FreeBSD instructions

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -318,6 +318,7 @@ For the wallet (optional):
 Then build using:
 
     ./autogen.sh
+    ./configure --disable-wallet # OR
     ./configure BDB_CFLAGS="-I${BDB_PREFIX}/include" BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx"
     gmake
 


### PR DESCRIPTION
The wallet part is described as optional, but apparently isn't