### PR TITLE
Fix ListCoins test failure due to unset g_wallet_allow_fallback_fee

### DIFF
--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -158,8 +158,6 @@ void TestGUI()
         test.CreateAndProcessBlock({}, GetScriptForRawPubKey(test.coinbaseKey.GetPubKey()));
     }
     bitdb.MakeMock();
-    g_wallet_allow_fallback_fee = true;
-
     std::unique_ptr<CWalletDBWrapper> dbw(new CWalletDBWrapper(&bitdb, "wallet_test.dat"));
     CWallet wallet(std::move(dbw));
     bool firstRun;

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -11,8 +11,6 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     TestingSetup(chainName)
 {
     bitdb.MakeMock();
-    g_wallet_allow_fallback_fee = true;
-
     bool fFirstRun;
     g_address_type = OUTPUT_TYPE_DEFAULT;
     g_change_type = OUTPUT_TYPE_DEFAULT;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -43,7 +43,7 @@ bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
 bool fWalletRbf = DEFAULT_WALLET_RBF;
 OutputType g_address_type = OUTPUT_TYPE_NONE;
 OutputType g_change_type = OUTPUT_TYPE_NONE;
-bool g_wallet_allow_fallback_fee = false; //<! will be defined via chainparams
+bool g_wallet_allow_fallback_fee = true; //<! will be defined via chainparams
 
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -66,7 +66,6 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
-static const bool DEFAULT_WALLET_ALLOW_FALLBACKFEE = true;
 
 extern const char * DEFAULT_WALLET_DAT;
 


### PR DESCRIPTION
New global variable was introduced in #11882 and not setting it causes:

```
wallet/test/wallet_tests.cpp(638): error in "ListCoins": check wallet->CreateTransaction({recipient}, wtx, reservekey, fee, changePos, error, dummy) failed
wallet/test/wallet_tests.cpp(679): error in "ListCoins": check list.begin()->second.size() == 2 failed [1 != 2]
wallet/test/wallet_tests.cpp(686): error in "ListCoins": check available.size() == 2 failed [1 != 2]
wallet/test/wallet_tests.cpp(705): error in "ListCoins": check list.begin()->second.size() == 2 failed [1 != 2]
```

It's possible to reproduce the failure reliably by running:

```
src/test/test_bitcoin --log_level=test_suite --run_test=wallet_tests/ListCoins
```
Failures happen nondeterministically because boost test framework doesn't run tests in a specified order, and tests that run previously can set the global variables and mask the bug.

This is similar to bugs #12150 and #12424. Example travis failures are:

https://travis-ci.org/bitcoin/bitcoin/jobs/348296805#L2676
https://travis-ci.org/bitcoin/bitcoin/jobs/348362560#L2769
https://travis-ci.org/bitcoin/bitcoin/jobs/348362563#L2824
