### PR TITLE
[WIP] Unit test sub-directories

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -12,4 +12,18 @@ FILE *freopen(const fs::path& p, const char *mode, FILE *stream)
     return ::freopen(p.string().c_str(), mode, stream);
 }
 
+// Create and return temporary subdirectory for test outputs
+fs::path unit_test_directory(){
+    std::string sub_dir = "bitcoin_unit_tests";
+    fs::path dir(fs::temp_directory_path() / sub_dir);
+
+    if(fs::create_directory(dir) || fs::exists(dir))
+    {
+        return dir;
+    }
+    else{
+        throw std::runtime_error("Error creating the directory\n");
+    }
+}
+
 } // fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -19,6 +19,7 @@ namespace fs = boost::filesystem;
 namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
     FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
+    fs::path unit_test_directory();
 };
 
 #endif // BITCOIN_FS_H

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
         char key = 'k';
         uint256 in = InsecureRand256();
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         char key = 'i';
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         // The two keys are intentionally chosen for ordering
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -162,7 +162,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 BOOST_AUTO_TEST_CASE(existing_data_reindex)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -197,7 +197,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     char buf[10];
 
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = fsbridge::unit_test_directory() / fs::unique_path();
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -68,7 +68,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
 
         RegisterAllCoreRPCCommands(tableRPC);
         ClearDatadirCache();
-        pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(100000)));
+        fs::path pathTemp = fsbridge::unit_test_directory() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(100000)));
         fs::create_directories(pathTemp);
         gArgs.ForceSetArg("-datadir", pathTemp.string());
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -714,7 +714,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
 
 BOOST_AUTO_TEST_CASE(test_LockDirectory)
 {
-    fs::path dirname = fs::temp_directory_path() / fs::unique_path();
+    fs::path dirname = fsbridge::unit_test_directory() / fs::unique_path();
     const std::string lockname = ".lock";
 #ifndef WIN32
     // Revert SIGCHLD to default, otherwise boost.test will catch and fail on


### PR DESCRIPTION
fixes #12574 

First time contributing - could do with some advice completing this.

To me, issue consists of three parts:

- [x] Creation of sub-directory within temp work-space
   - I have low confidence that I approached this correctly (though I believe it works)
- [ ] Appending the name of the test into the folders the framework is created
  - TODO - would appreciate a nudge in the correct direction to picking out the name of the executing test
- [ ] Iteration number of the test
  - TODO - Relating to the 2nd point, my logic would be when I have the name of the test, check the file system and iterate the trailing int i.e. `dbwrapper_1` to `dbwrapper_2`


I'm happy to iterate this PR a few times until its acceptable, figured it was more sensible to seek advice than declare failure and bin the code 😉 