### PR TITLE
[0.16] depends: Switch to downloading expat from GitHub

### DIFF
--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -1,6 +1,6 @@
 package=expat
 $(package)_version=2.2.1
-$(package)_download_path=https://downloads.sourceforge.net/project/expat/expat/$($(package)_version)
+$(package)_download_path=https://github.com/libexpat/libexpat/releases/download/R_2_2_1/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=1868cadae4c82a018e361e2b2091de103cd820aaacb0d6cfa49bd2cd83978885
 


### PR DESCRIPTION
@droark [mentioned](https://github.com/bitcoin/bitcoin/pull/12402#issuecomment-370098383) the expat download was failing when trying to gitian build 0.16. 
I tried locally and also saw issues:
```
make download
Checksum missing or mismatched for expat source. Forcing re-download.
Fetching expat-2.2.1.tar.bz2 from https://downloads.sourceforge.net/project/expat/expat/2.2.1
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
100   652  100   652    0     0    361      0  0:00:01  0:00:01 --:--:--     0
/Users/xxx/Github/bitcoin/depends/work/download/expat-2.2.1/expat-2.2.1.tar.bz2.temp: FAILED
shasum: WARNING: 1 computed checksum did NOT match
Fetching expat-2.2.1.tar.bz2 from https://bitcoincore.org/depends-sources
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:01 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
make[1]: *** [/Users/xxx/Github/bitcoin/depends/sources/download-stamps/.stamp_fetched-expat-expat-2.2.1.tar.bz2.hash] Error 22
make: *** [download-linux] Error 2
```
This switches to downloading from GitHub, as we are doing in master.