### PR TITLE
docs: Update osx brew install instruction

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](https://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python3 qt libevent
+    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent
 
 See [dependencies.md](dependencies.md) for a complete overview.
 


### PR DESCRIPTION
Python 3.x is now the default python formula in [homebrew](https://github.com/Homebrew/homebrew-core/blob/master/Formula/python.rb).
https://brew.sh/2018/01/19/homebrew-1.5.0/ has some more info. 