### PR TITLE
Introduce g_wallet_manager, prepare for better dynamic wallet loading/unloading

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -171,6 +171,7 @@ BITCOIN_CORE_H = \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletdb.h \
+  wallet/walletmanager.h \
   wallet/walletutil.h \
   wallet/coinselection.h \
   warnings.h \
@@ -252,6 +253,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/rpcdump.cpp \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \
+  wallet/walletmanager.cpp \
   wallet/walletdb.cpp \
   wallet/walletutil.cpp \
   wallet/coinselection.cpp \

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -45,6 +45,7 @@
 #include <validationinterface.h>
 #ifdef ENABLE_WALLET
 #include <wallet/init.h>
+#include <wallet/walletmanager.h>
 #endif
 #include <warnings.h>
 #include <stdint.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -191,7 +191,7 @@ void Shutdown()
     StopRPC();
     StopHTTPServer();
 #ifdef ENABLE_WALLET
-    FlushWallets();
+    g_wallet_manager->FlushWallets();
 #endif
     StopMapPort();
 
@@ -251,7 +251,7 @@ void Shutdown()
         pblocktree.reset();
     }
 #ifdef ENABLE_WALLET
-    StopWallets();
+    g_wallet_manager->StopWallets();
 #endif
 
 #if ENABLE_ZMQ
@@ -273,7 +273,7 @@ void Shutdown()
     GetMainSignals().UnregisterBackgroundSignalScheduler();
     GetMainSignals().UnregisterWithMempoolSignals(mempool);
 #ifdef ENABLE_WALLET
-    CloseWallets();
+    g_wallet_manager->CloseWallets();
 #endif
     globalVerifyHandle.reset();
     ECC_Stop();
@@ -1593,7 +1593,7 @@ bool AppInitMain()
 
     // ********************************************************* Step 8: load wallet
 #ifdef ENABLE_WALLET
-    if (!OpenWallets())
+    if (!g_wallet_manager->OpenWallets())
         return false;
 #else
     LogPrintf("No wallet support compiled in!\n");
@@ -1744,7 +1744,7 @@ bool AppInitMain()
     uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET
-    StartWallets(scheduler);
+    g_wallet_manager->StartWallets(scheduler);
 #endif
 
     return true;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -34,8 +34,7 @@
 #include <warnings.h>
 
 #ifdef ENABLE_WALLET
-#include <wallet/init.h>
-#include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 #endif
 
 #include <stdint.h>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -484,7 +484,7 @@ void BitcoinApplication::initializeResult(bool success)
 
 #ifdef ENABLE_WALLET
         bool fFirstWallet = true;
-        ForEachWallet([this, &fFirstWallet](CWallet *pwallet) {
+        g_wallet_manager->ForEachWallet([this, &fFirstWallet](CWallet *pwallet) {
             WalletModel * const walletModel = new WalletModel(platformStyle, pwallet, optionsModel);
             window->addWallet(walletModel);
             if (fFirstWallet) {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -34,6 +34,7 @@
 #include <warnings.h>
 
 #ifdef ENABLE_WALLET
+#include <wallet/init.h>
 #include <wallet/wallet.h>
 #endif
 
@@ -484,9 +485,8 @@ void BitcoinApplication::initializeResult(bool success)
 
 #ifdef ENABLE_WALLET
         bool fFirstWallet = true;
-        for (CWalletRef pwallet : vpwallets) {
+        ForEachWallet([this, &fFirstWallet](CWallet *pwallet) {
             WalletModel * const walletModel = new WalletModel(platformStyle, pwallet, optionsModel);
-
             window->addWallet(walletModel);
             if (fFirstWallet) {
                 window->setCurrentWallet(walletModel->getWalletName());
@@ -497,7 +497,7 @@ void BitcoinApplication::initializeResult(bool success)
                              paymentServer, SLOT(fetchPaymentACK(CWallet*,const SendCoinsRecipient&,QByteArray)));
 
             m_wallet_models.push_back(walletModel);
-        }
+        });
 #endif
 
         // If -min option passed, start window minimized.

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -20,6 +20,7 @@
 #include <util.h>
 #include <utilstrencodings.h>
 #ifdef ENABLE_WALLET
+#include <wallet/init.h>
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
@@ -69,7 +70,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     {
 
 #ifdef ENABLE_WALLET
-        if (!::vpwallets.empty() && IsDeprecatedRPCEnabled("validateaddress")) {
+        if (HasWallets() && IsDeprecatedRPCEnabled("validateaddress")) {
             ret.pushKVs(getaddressinfo(request));
         }
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -69,7 +69,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     {
 
 #ifdef ENABLE_WALLET
-        if (HasWallets() && IsDeprecatedRPCEnabled("validateaddress")) {
+        if (g_wallet_manager->HasWallets() && IsDeprecatedRPCEnabled("validateaddress")) {
             ret.pushKVs(getaddressinfo(request));
         }
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -20,10 +20,9 @@
 #include <util.h>
 #include <utilstrencodings.h>
 #ifdef ENABLE_WALLET
-#include <wallet/init.h>
 #include <wallet/rpcwallet.h>
-#include <wallet/wallet.h>
 #include <wallet/walletdb.h>
+#include <wallet/walletmanager.h>
 #endif
 #include <warnings.h>
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -14,6 +14,8 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
+std::vector<CWalletRef> vpwallets;
+
 std::string GetWalletHelpString(bool showDebug)
 {
     std::string strUsage = HelpMessageGroup(_("Wallet options:"));
@@ -309,4 +311,33 @@ void CloseWallets() {
         delete pwallet;
     }
     vpwallets.clear();
+}
+
+void AddWallet(CWallet *wallet) {
+    vpwallets.insert(vpwallets.begin(), wallet);
+}
+
+void DeallocWallet(unsigned int pos) {
+    vpwallets.erase(vpwallets.begin()+pos);
+}
+
+bool HasWallets() {
+    return !vpwallets.empty();
+}
+
+CWallet * GetWalletAtPos(int pos) {
+    return vpwallets[pos];
+}
+
+unsigned int CountWallets() {
+    return vpwallets.size();
+}
+
+CWallet* FindWalletByName(const std::string &name) {
+    for (CWalletRef pwallet : ::vpwallets) {
+        if (pwallet->GetName() == name) {
+            return pwallet;
+        }
+    }
+    return nullptr;
 }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -14,8 +14,6 @@
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
-std::vector<CWalletRef> vpwallets;
-
 std::string GetWalletHelpString(bool showDebug)
 {
     std::string strUsage = HelpMessageGroup(_("Wallet options:"));
@@ -268,76 +266,4 @@ bool VerifyWallets()
     }
 
     return true;
-}
-
-bool OpenWallets()
-{
-    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
-        LogPrintf("Wallet disabled!\n");
-        return true;
-    }
-
-    for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
-        CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile, fs::absolute(walletFile, GetWalletDir()));
-        if (!pwallet) {
-            return false;
-        }
-        vpwallets.push_back(pwallet);
-    }
-
-    return true;
-}
-
-void StartWallets(CScheduler& scheduler) {
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->postInitProcess(scheduler);
-    }
-}
-
-void FlushWallets() {
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->Flush(false);
-    }
-}
-
-void StopWallets() {
-    for (CWalletRef pwallet : vpwallets) {
-        pwallet->Flush(true);
-    }
-}
-
-void CloseWallets() {
-    for (CWalletRef pwallet : vpwallets) {
-        delete pwallet;
-    }
-    vpwallets.clear();
-}
-
-void AddWallet(CWallet *wallet) {
-    vpwallets.insert(vpwallets.begin(), wallet);
-}
-
-void DeallocWallet(unsigned int pos) {
-    vpwallets.erase(vpwallets.begin()+pos);
-}
-
-bool HasWallets() {
-    return !vpwallets.empty();
-}
-
-CWallet * GetWalletAtPos(int pos) {
-    return vpwallets[pos];
-}
-
-unsigned int CountWallets() {
-    return vpwallets.size();
-}
-
-CWallet* FindWalletByName(const std::string &name) {
-    for (CWalletRef pwallet : ::vpwallets) {
-        if (pwallet->GetName() == name) {
-            return pwallet;
-        }
-    }
-    return nullptr;
 }

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_INIT_H
 
 #include <string>
+#include <wallet/wallet.h>
 
 class CRPCTable;
 class CScheduler;
@@ -25,6 +26,9 @@ void RegisterWalletRPC(CRPCTable &tableRPC);
 //  being loaded (WalletParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
 bool VerifyWallets();
 
+typedef CWallet* CWalletRef;
+extern std::vector<CWalletRef> vpwallets;
+
 //! Load wallet databases.
 bool OpenWallets();
 
@@ -39,5 +43,24 @@ void StopWallets();
 
 //! Close all wallets.
 void CloseWallets();
+
+void AddWallet(CWallet *wallet);
+void DeallocWallet(unsigned int pos);
+
+bool HasWallets();
+
+unsigned int CountWallets();
+
+template<typename Callable>
+void ForEachWallet(Callable&& func)
+{
+    for (auto&& wallet : vpwallets) {
+        func(wallet);
+    }
+};
+
+CWallet* GetWalletAtPos(int pos);
+
+CWallet* FindWalletByName(const std::string &name);
 
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/init.h
+++ b/src/wallet/init.h
@@ -7,7 +7,6 @@
 #define BITCOIN_WALLET_INIT_H
 
 #include <string>
-#include <wallet/wallet.h>
 
 class CRPCTable;
 class CScheduler;
@@ -25,42 +24,5 @@ void RegisterWalletRPC(CRPCTable &tableRPC);
 //  This function will perform salvage on the wallet if requested, as long as only one wallet is
 //  being loaded (WalletParameterInteraction forbids -salvagewallet, -zapwallettxes or -upgradewallet with multiwallet).
 bool VerifyWallets();
-
-typedef CWallet* CWalletRef;
-extern std::vector<CWalletRef> vpwallets;
-
-//! Load wallet databases.
-bool OpenWallets();
-
-//! Complete startup of wallets.
-void StartWallets(CScheduler& scheduler);
-
-//! Flush all wallets in preparation for shutdown.
-void FlushWallets();
-
-//! Stop all wallets. Wallets will be flushed first.
-void StopWallets();
-
-//! Close all wallets.
-void CloseWallets();
-
-void AddWallet(CWallet *wallet);
-void DeallocWallet(unsigned int pos);
-
-bool HasWallets();
-
-unsigned int CountWallets();
-
-template<typename Callable>
-void ForEachWallet(Callable&& func)
-{
-    for (auto&& wallet : vpwallets) {
-        func(wallet);
-    }
-};
-
-CWallet* GetWalletAtPos(int pos);
-
-CWallet* FindWalletByName(const std::string &name);
 
 #endif // BITCOIN_WALLET_INIT_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -26,10 +26,9 @@
 #include <utilmoneystr.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
-#include <wallet/init.h>
 #include <wallet/rpcwallet.h>
-#include <wallet/wallet.h>
 #include <wallet/walletdb.h>
+#include <wallet/walletmanager.h>
 #include <wallet/walletutil.h>
 
 #include <init.h>  // For StartShutdown

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -26,6 +26,7 @@
 #include <utilmoneystr.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
+#include <wallet/init.h>
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
@@ -43,15 +44,13 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used
-        std::string requestedWallet = urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size()));
-        for (CWalletRef pwallet : ::vpwallets) {
-            if (pwallet->GetName() == requestedWallet) {
-                return pwallet;
-            }
+        CWallet *wallet = FindWalletByName(urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size())));
+        if (wallet) {
+            return wallet;
         }
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
     }
-    return ::vpwallets.size() == 1 || (request.fHelp && ::vpwallets.size() > 0) ? ::vpwallets[0] : nullptr;
+    return CountWallets() == 1 || (request.fHelp && CountWallets() > 0) ? GetWalletAtPos(0) : nullptr;
 }
 
 std::string HelpRequiringPassphrase(CWallet * const pwallet)
@@ -65,7 +64,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 {
     if (pwallet) return true;
     if (avoidException) return false;
-    if (::vpwallets.empty()) {
+    if (!HasWallets()) {
         // Note: It isn't currently possible to trigger this error because
         // wallet RPC methods aren't registered unless a wallet is loaded. But
         // this error is being kept as a precaution, because it's possible in
@@ -2845,18 +2844,19 @@ UniValue listwallets(const JSONRPCRequest& request)
 
     UniValue obj(UniValue::VARR);
 
-    for (CWalletRef pwallet : vpwallets) {
-
+    bool not_available_found = false;
+    ForEachWallet([&not_available_found, &request,&obj](CWallet *pwallet) {
         if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
-            return NullUniValue;
+            not_available_found = true;
+            return;
         }
 
         LOCK(pwallet->cs_wallet);
 
         obj.push_back(pwallet->GetName());
-    }
+    });
 
-    return obj;
+    return not_available_found ? NullUniValue : obj;
 }
 
 UniValue resendwallettransactions(const JSONRPCRequest& request)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -43,13 +43,13 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
 {
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used
-        CWallet *wallet = FindWalletByName(urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size())));
+        CWallet *wallet = g_wallet_manager->FindWalletByName(urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size())));
         if (wallet) {
             return wallet;
         }
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
     }
-    return CountWallets() == 1 || (request.fHelp && CountWallets() > 0) ? GetWalletAtPos(0) : nullptr;
+    return g_wallet_manager->CountWallets() == 1 || (request.fHelp && g_wallet_manager->CountWallets() > 0) ? g_wallet_manager->GetWalletAtPos(0) : nullptr;
 }
 
 std::string HelpRequiringPassphrase(CWallet * const pwallet)
@@ -63,7 +63,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 {
     if (pwallet) return true;
     if (avoidException) return false;
-    if (!HasWallets()) {
+    if (!g_wallet_manager->HasWallets()) {
         // Note: It isn't currently possible to trigger this error because
         // wallet RPC methods aren't registered unless a wallet is loaded. But
         // this error is being kept as a precaution, because it's possible in
@@ -2844,7 +2844,7 @@ UniValue listwallets(const JSONRPCRequest& request)
     UniValue obj(UniValue::VARR);
 
     bool not_available_found = false;
-    ForEachWallet([&not_available_found, &request,&obj](CWallet *pwallet) {
+    g_wallet_manager->ForEachWallet([&not_available_found, &request,&obj](CWallet *pwallet) {
         if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
             not_available_found = true;
             return;

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,7 +6,7 @@
 
 #include <rpc/server.h>
 #include <wallet/db.h>
-#include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
     TestingSetup(chainName), m_wallet("mock", CWalletDBWrapper::CreateMock())

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -14,6 +14,7 @@
 #include <test/test_bitcoin.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
+#include <wallet/init.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>
@@ -73,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // after.
     {
         CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
-        vpwallets.insert(vpwallets.begin(), &wallet);
+        AddWallet(&wallet);
         UniValue keys;
         keys.setArray();
         UniValue key;
@@ -104,7 +105,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
                       "downloading and rescanning the relevant blocks (see -reindex and -rescan "
                       "options).\"}},{\"success\":true}]",
                               0, oldTip->GetBlockTimeMax(), TIMESTAMP_WINDOW));
-        vpwallets.erase(vpwallets.begin());
+        DeallocWallet(0);
     }
 }
 
@@ -139,7 +140,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        vpwallets.insert(vpwallets.begin(), &wallet);
+        AddWallet(&wallet);
         ::dumpwallet(request);
     }
 
@@ -151,7 +152,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        vpwallets[0] = &wallet;
+        DeallocWallet(0);
+        AddWallet(&wallet);
         ::importwallet(request);
 
         LOCK(wallet.cs_wallet);
@@ -165,7 +167,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     }
 
     SetMockTime(0);
-    vpwallets.erase(vpwallets.begin());
+    DeallocWallet(0);
 }
 
 // Check that GetImmatureCredit() returns a newly calculated value instead of

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -14,8 +14,8 @@
 #include <test/test_bitcoin.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
-#include <wallet/init.h>
 #include <wallet/test/wallet_test_fixture.h>
+#include <wallet/walletmanager.h>
 
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -74,7 +74,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // after.
     {
         CWallet wallet("dummy", CWalletDBWrapper::CreateDummy());
-        AddWallet(&wallet);
+        g_wallet_manager->AddWallet(&wallet);
         UniValue keys;
         keys.setArray();
         UniValue key;
@@ -105,7 +105,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
                       "downloading and rescanning the relevant blocks (see -reindex and -rescan "
                       "options).\"}},{\"success\":true}]",
                               0, oldTip->GetBlockTimeMax(), TIMESTAMP_WINDOW));
-        DeallocWallet(0);
+        g_wallet_manager->DeallocWallet(0);
     }
 }
 
@@ -140,7 +140,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        AddWallet(&wallet);
+        g_wallet_manager->AddWallet(&wallet);
         ::dumpwallet(request);
     }
 
@@ -152,8 +152,8 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        DeallocWallet(0);
-        AddWallet(&wallet);
+        g_wallet_manager->DeallocWallet(0);
+        g_wallet_manager->AddWallet(&wallet);
         ::importwallet(request);
 
         LOCK(wallet.cs_wallet);
@@ -167,7 +167,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
     }
 
     SetMockTime(0);
-    DeallocWallet(0);
+    g_wallet_manager->DeallocWallet(0);
 }
 
 // Check that GetImmatureCredit() returns a newly calculated value instead of

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -36,7 +36,6 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
-std::vector<CWalletRef> vpwallets;
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -31,8 +31,6 @@
 #include <utility>
 #include <vector>
 
-typedef CWallet* CWalletRef;
-
 /**
  * Settings
  */
@@ -1246,10 +1244,10 @@ std::vector<CTxDestination> GetAllDestinationsForKey(const CPubKey& key);
 class WalletRescanReserver
 {
 private:
-    CWalletRef m_wallet;
+    CWallet* m_wallet;
     bool m_could_reserve;
 public:
-    explicit WalletRescanReserver(CWalletRef w) : m_wallet(w), m_could_reserve(false) {}
+    explicit WalletRescanReserver(CWallet* w) : m_wallet(w), m_could_reserve(false) {}
 
     bool reserve()
     {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -32,7 +32,6 @@
 #include <vector>
 
 typedef CWallet* CWalletRef;
-extern std::vector<CWalletRef> vpwallets;
 
 /**
  * Settings

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -14,6 +14,7 @@
 #include <sync.h>
 #include <util.h>
 #include <utiltime.h>
+#include <wallet/init.h>
 #include <wallet/wallet.h>
 
 #include <atomic>
@@ -748,7 +749,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    for (CWalletRef pwallet : vpwallets) {
+    ForEachWallet([](CWallet* pwallet) {
         CWalletDBWrapper& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;
@@ -763,7 +764,7 @@ void MaybeCompactWalletDB()
                 dbh.nLastFlushed = nUpdateCounter;
             }
         }
-    }
+    });
 
     fOneThread = false;
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -14,8 +14,7 @@
 #include <sync.h>
 #include <util.h>
 #include <utiltime.h>
-#include <wallet/init.h>
-#include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 
 #include <atomic>
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -748,7 +748,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    ForEachWallet([](CWallet* pwallet) {
+    g_wallet_manager->ForEachWallet([](CWallet* pwallet) {
         CWalletDBWrapper& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;

--- a/src/wallet/walletmanager.cpp
+++ b/src/wallet/walletmanager.cpp
@@ -27,25 +27,25 @@ bool CWalletManager::OpenWallets()
 }
 
 void CWalletManager::StartWallets(CScheduler& scheduler) {
-    for (CWalletRef pwallet : m_vpwallets) {
+    for (CWallet* pwallet : m_vpwallets) {
         pwallet->postInitProcess(scheduler);
     }
 }
 
 void CWalletManager::FlushWallets() {
-    for (CWalletRef pwallet : m_vpwallets) {
+    for (CWallet* pwallet : m_vpwallets) {
         pwallet->Flush(false);
     }
 }
 
 void CWalletManager::StopWallets() {
-    for (CWalletRef pwallet : m_vpwallets) {
+    for (CWallet* pwallet : m_vpwallets) {
         pwallet->Flush(true);
     }
 }
 
 void CWalletManager::CloseWallets() {
-    for (CWalletRef pwallet : m_vpwallets) {
+    for (CWallet* pwallet : m_vpwallets) {
         delete pwallet;
     }
     m_vpwallets.clear();
@@ -72,7 +72,7 @@ unsigned int CWalletManager::CountWallets() {
 }
 
 CWallet* CWalletManager::FindWalletByName(const std::string &name) {
-    for (CWalletRef pwallet : m_vpwallets) {
+    for (CWallet* pwallet : m_vpwallets) {
         if (pwallet->GetName() == name) {
             return pwallet;
         }

--- a/src/wallet/walletmanager.cpp
+++ b/src/wallet/walletmanager.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
+#include <wallet/walletutil.h>
+
+std::vector<CWalletRef> vpwallets;
+
+bool OpenWallets()
+{
+    if (gArgs.GetBoolArg("-disablewallet", DEFAULT_DISABLE_WALLET)) {
+        LogPrintf("Wallet disabled!\n");
+        return true;
+    }
+
+    for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
+        CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile, fs::absolute(walletFile, GetWalletDir()));
+        if (!pwallet) {
+            return false;
+        }
+        vpwallets.push_back(pwallet);
+    }
+
+    return true;
+}
+
+void StartWallets(CScheduler& scheduler) {
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->postInitProcess(scheduler);
+    }
+}
+
+void FlushWallets() {
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->Flush(false);
+    }
+}
+
+void StopWallets() {
+    for (CWalletRef pwallet : vpwallets) {
+        pwallet->Flush(true);
+    }
+}
+
+void CloseWallets() {
+    for (CWalletRef pwallet : vpwallets) {
+        delete pwallet;
+    }
+    vpwallets.clear();
+}
+
+void AddWallet(CWallet *wallet) {
+    vpwallets.insert(vpwallets.begin(), wallet);
+}
+
+void DeallocWallet(unsigned int pos) {
+    vpwallets.erase(vpwallets.begin()+pos);
+}
+
+bool HasWallets() {
+    return !vpwallets.empty();
+}
+
+CWallet * GetWalletAtPos(int pos) {
+    return vpwallets[pos];
+}
+
+unsigned int CountWallets() {
+    return vpwallets.size();
+}
+
+CWallet* FindWalletByName(const std::string &name) {
+    for (CWalletRef pwallet : ::vpwallets) {
+        if (pwallet->GetName() == name) {
+            return pwallet;
+        }
+    }
+    return nullptr;
+}

--- a/src/wallet/walletmanager.h
+++ b/src/wallet/walletmanager.h
@@ -11,40 +11,47 @@
 #include <util.h>
 
 typedef CWallet* CWalletRef;
-extern std::vector<CWalletRef> vpwallets;
 
-//! Load wallet databases.
-bool OpenWallets();
+class CWalletManager {
+private:
+    std::vector<CWalletRef> m_vpwallets;
 
-//! Complete startup of wallets.
-void StartWallets(CScheduler& scheduler);
+public:
+    //! Load wallet databases.
+    bool OpenWallets();
 
-//! Flush all wallets in preparation for shutdown.
-void FlushWallets();
+    //! Complete startup of wallets.
+    void StartWallets(CScheduler& scheduler);
 
-//! Stop all wallets. Wallets will be flushed first.
-void StopWallets();
+    //! Flush all wallets in preparation for shutdown.
+    void FlushWallets();
 
-//! Close all wallets.
-void CloseWallets();
+    //! Stop all wallets. Wallets will be flushed first.
+    void StopWallets();
 
-void AddWallet(CWallet *wallet);
-void DeallocWallet(unsigned int pos);
+    //! Close all wallets.
+    void CloseWallets();
 
-bool HasWallets();
+    void AddWallet(CWallet *wallet);
+    void DeallocWallet(unsigned int pos);
 
-unsigned int CountWallets();
+    bool HasWallets();
 
-template<typename Callable>
-void ForEachWallet(Callable&& func)
-{
-    for (auto&& wallet : vpwallets) {
-        func(wallet);
-    }
+    unsigned int CountWallets();
+
+    template<typename Callable>
+    void ForEachWallet(Callable&& func)
+    {
+        for (auto&& wallet : m_vpwallets) {
+            func(wallet);
+        }
+    };
+
+    CWallet* GetWalletAtPos(int pos);
+    CWallet* FindWalletByName(const std::string &name);
 };
 
-CWallet* GetWalletAtPos(int pos);
-
-CWallet* FindWalletByName(const std::string &name);
+// global wallet manager instance
+extern std::unique_ptr<CWalletManager> g_wallet_manager;
 
 #endif // BITCOIN_WALLET_WALLETMANAGER_H

--- a/src/wallet/walletmanager.h
+++ b/src/wallet/walletmanager.h
@@ -10,11 +10,9 @@
 #include <vector>
 #include <util.h>
 
-typedef CWallet* CWalletRef;
-
 class CWalletManager {
 private:
-    std::vector<CWalletRef> m_vpwallets;
+    std::vector<CWallet*> m_vpwallets;
 
 public:
     //! Load wallet databases.

--- a/src/wallet/walletmanager.h
+++ b/src/wallet/walletmanager.h
@@ -1,0 +1,50 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_WALLETMANAGER_H
+#define BITCOIN_WALLET_WALLETMANAGER_H
+
+#include <wallet/wallet.h>
+
+#include <vector>
+#include <util.h>
+
+typedef CWallet* CWalletRef;
+extern std::vector<CWalletRef> vpwallets;
+
+//! Load wallet databases.
+bool OpenWallets();
+
+//! Complete startup of wallets.
+void StartWallets(CScheduler& scheduler);
+
+//! Flush all wallets in preparation for shutdown.
+void FlushWallets();
+
+//! Stop all wallets. Wallets will be flushed first.
+void StopWallets();
+
+//! Close all wallets.
+void CloseWallets();
+
+void AddWallet(CWallet *wallet);
+void DeallocWallet(unsigned int pos);
+
+bool HasWallets();
+
+unsigned int CountWallets();
+
+template<typename Callable>
+void ForEachWallet(Callable&& func)
+{
+    for (auto&& wallet : vpwallets) {
+        func(wallet);
+    }
+};
+
+CWallet* GetWalletAtPos(int pos);
+
+CWallet* FindWalletByName(const std::string &name);
+
+#endif // BITCOIN_WALLET_WALLETMANAGER_H


### PR DESCRIPTION
This PR moves manipulation and knowledge of `vpwallet` (the vector holding the CWallet* pointers) into `CWalletManager`. All access will go through the global g_wallet_manager (similar to g_connman).
This should it make easier to later add concurrency protection for wallet adding (loading) / unloading as well as it cleans up the code.

There is a lot of room for optimisation, but, to make faster progress, the scope of this PR should not be widened.