### PR TITLE
[Utils] Remove deprecated PyZMQ call from Python ZMQ example

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -38,7 +38,7 @@ port = 28332
 
 class ZMQHandler():
     def __init__(self):
-        self.loop = zmq.asyncio.install()
+        self.loop = asyncio.get_event_loop()
         self.zmqContext = zmq.asyncio.Context()
 
         self.zmqSubSocket = self.zmqContext.socket(zmq.SUB)

--- a/contrib/zmq/zmq_sub3.4.py
+++ b/contrib/zmq/zmq_sub3.4.py
@@ -42,7 +42,7 @@ port = 28332
 
 class ZMQHandler():
     def __init__(self):
-        self.loop = zmq.asyncio.install()
+        self.loop = asyncio.get_event_loop()
         self.zmqContext = zmq.asyncio.Context()
 
         self.zmqSubSocket = self.zmqContext.socket(zmq.SUB)


### PR DESCRIPTION
PyZMQ 17.0.0 has deprecated and removed zmq.asyncio.install() call
with advice to use asyncio native run-loop instead of zmq specific.

This caused exception when running the contrib/zmq/zmq_sub*.py examples.

This commit simply follows the advice and fixes mentioned examples.