### PR TITLE
[depends] Revert "ccache 3.4.1"

### DIFF
--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,8 +1,8 @@
 package=native_ccache
-$(package)_version=3.4.1
+$(package)_version=3.3.4
 $(package)_download_path=https://samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
-$(package)_sha256_hash=ca5a01fb4868cdb5176c77b8b4a390be7929a6064be80741217e0686f03f8389
+$(package)_sha256_hash=fa9d7f38367431bc86b19ad107d709ca7ecf1574fdacca01698bdf0a47cd8567
 
 define $(package)_set_vars
 $(package)_config_opts=

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -7,7 +7,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | --- | --- | --- | --- | --- | --- |
 | Berkeley DB | [4.8.30](http://www.oracle.com/technetwork/database/database-technologies/berkeleydb/downloads/index.html) | 4.8.x | No |  |  |
 | Boost | [1.64.0](http://www.boost.org/users/download/) | [1.47.0](https://github.com/bitcoin/bitcoin/pull/8920) | No |  |  |
-| ccache | [3.3.6](https://ccache.samba.org/download.html) |  | No |  |  |
+| ccache | [3.3.4](https://ccache.samba.org/download.html) |  | No |  |  |
 | Clang |  | [3.3+](http://llvm.org/releases/download.html) (C++11 support) |  |  |  |
 | D-Bus | [1.10.18](https://cgit.freedesktop.org/dbus/dbus/tree/NEWS?h=dbus-1.10) |  | No | Yes |  |
 | Expat | [2.2.5](https://libexpat.github.io/) |  | No | Yes |  |


### PR DESCRIPTION
According to #12515 cross-compiling for windows on linux requires a work-around. I believe that for this reason, the nightly builds for linux and windows are not available: https://bitcoin.jonasschnelli.ch/build/522

It should be safe to just revert to the previously known-to-be-working version of ccache.

Fixes #12515

Reverts one commit of #12402