### PR TITLE
interpreter: Use safer casting in IsValidSignatureEncoding(...)

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -138,7 +138,7 @@ bool static IsValidSignatureEncoding(const std::vector<unsigned char> &sig) {
 
     // Verify that the length of the signature matches the sum of the length
     // of the elements.
-    if ((size_t)(lenR + lenS + 7) != sig.size()) return false;
+    if ((size_t)lenR + (size_t)lenS + 7 != sig.size()) return false;
  
     // Check whether the R element is an integer.
     if (sig[2] != 0x02) return false;


### PR DESCRIPTION
Use safer casting in `IsValidSignatureEncoding(...)`.

This was found when looking at the `c-lightning` codebase which contains a copy of this function.