### PR TITLE
gui: Show messages as text not html

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -923,6 +923,7 @@ void BitcoinGUI::message(const QString &title, const QString &message, unsigned 
 
         showNormalIfMinimized();
         QMessageBox mBox(static_cast<QMessageBox::Icon>(nMBoxIcon), strTitle, message, buttons, this);
+        mBox.setTextFormat(Qt::PlainText);
         int r = mBox.exec();
         if (ret != nullptr)
             *ret = r == QMessageBox::Ok;


### PR DESCRIPTION
Currently, error messages (such as InitError) are displayed as-is, which means Qt does auto detection on the format.

This means that it's possible to inject HTML from the command line though e.g. specifying a wallet name with HTML in it. This isn't a direct security risk because fetching content from internet is
disabled (and as far as I know we never report strings received from the network this way). However, it can be confusing.

So explicitly force the format as text.