### PR TITLE
doc: Give hint about gitian not able to download

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -93,7 +93,9 @@ Create the OS X SDK tarball, see the [OS X readme](README_osx.md) for details, a
 
 ### Optional: Seed the Gitian sources cache and offline git repositories
 
-By default, Gitian will fetch source files as needed. To cache them ahead of time:
+NOTE: Gitian is sometimes unable to download files. If you have errors, try the step below.
+
+By default, Gitian will fetch source files as needed. To cache them ahead of time, make sure you have checked out the tag you want to build in bitcoin, then:
 
     pushd ./gitian-builder
     make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common


### PR DESCRIPTION
Gitian fails to perform downloads right now on my set up. This can be circumvented by first checking out the tag being built and then doing the depends download step before running `gbuild`.

This should of course be fixed in gitian, but having this note until it's fixed is definitely useful.