### PR TITLE
gui: Fix issue: "default port not shown correctly in settings dialog"

### DIFF
--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -24,6 +24,8 @@
 
 const char *DEFAULT_GUI_PROXY_HOST = "127.0.0.1";
 
+static const QString GetDefaultProxyAddress();
+
 OptionsModel::OptionsModel(interfaces::Node& node, QObject *parent, bool resetSettings) :
     QAbstractListModel(parent), m_node(node)
 {
@@ -121,7 +123,7 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fUseProxy"))
         settings.setValue("fUseProxy", false);
     if (!settings.contains("addrProxy"))
-        settings.setValue("addrProxy", QString("%1:%2").arg(DEFAULT_GUI_PROXY_HOST, DEFAULT_GUI_PROXY_PORT));
+        settings.setValue("addrProxy", GetDefaultProxyAddress());
     // Only try to set -proxy, if user has enabled fUseProxy
     if (settings.value("fUseProxy").toBool() && !m_node.softSetArg("-proxy", settings.value("addrProxy").toString().toStdString()))
         addOverriddenOption("-proxy");
@@ -131,7 +133,7 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("fUseSeparateProxyTor"))
         settings.setValue("fUseSeparateProxyTor", false);
     if (!settings.contains("addrSeparateProxyTor"))
-        settings.setValue("addrSeparateProxyTor", QString("%1:%2").arg(DEFAULT_GUI_PROXY_HOST, DEFAULT_GUI_PROXY_PORT));
+        settings.setValue("addrSeparateProxyTor", GetDefaultProxyAddress());
     // Only try to set -onion, if user has enabled fUseSeparateProxyTor
     if (settings.value("fUseSeparateProxyTor").toBool() && !m_node.softSetArg("-onion", settings.value("addrSeparateProxyTor").toString().toStdString()))
         addOverriddenOption("-onion");
@@ -221,6 +223,11 @@ static ProxySetting GetProxySetting(QSettings &settings, const QString &name)
 static void SetProxySetting(QSettings &settings, const QString &name, const ProxySetting &ip_port)
 {
     settings.setValue(name, ip_port.ip + ":" + ip_port.port);
+}
+
+static const QString GetDefaultProxyAddress()
+{
+    return QString("%1:%2").arg(DEFAULT_GUI_PROXY_HOST).arg(DEFAULT_GUI_PROXY_PORT);
 }
 
 // read QSettings values and return them
@@ -484,5 +491,17 @@ void OptionsModel::checkAndMigrate()
             settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
 
         settings.setValue(strSettingsVersionKey, CLIENT_VERSION);
+    }
+
+    // Overwrite the 'addrProxy' setting in case it has been set to an illegal
+    // default value (see issue #12623; PR #12650).
+    if (settings.contains("addrProxy") && settings.value("addrProxy").toString().endsWith("%2")) {
+        settings.setValue("addrProxy", GetDefaultProxyAddress());
+    }
+
+    // Overwrite the 'addrSeparateProxyTor' setting in case it has been set to an illegal
+    // default value (see issue #12623; PR #12650).
+    if (settings.contains("addrSeparateProxyTor") && settings.value("addrSeparateProxyTor").toString().endsWith("%2")) {
+        settings.setValue("addrSeparateProxyTor", GetDefaultProxyAddress());
     }
 }


### PR DESCRIPTION
In f05d349 the value of the `addrProxy` and `addrSeparateProxyTor` settings is set to an illegal default value, because the value of `DEFAULT_GUI_PROXY_PORT ` is passed to the `fieldWidth` parameter of the `QString QString::arg(const QString &a, int fieldWidth = 0, QChar fillChar = QLatin1Char( ' ' )) const` method:

https://github.com/bitcoin/bitcoin/blob/29fad97c320c892ab6a480c81e2078ec22ab354b/src/qt/optionsmodel.cpp#L129

https://github.com/bitcoin/bitcoin/blob/29fad97c320c892ab6a480c81e2078ec22ab354b/src/qt/optionsmodel.cpp#L139

This will create a default proxy setting that consists of 9053 characters and ends with the string `127.0.0.1:%2`.

This PR attempts to resolve #12623 by setting the correct value for the `addrProxy` and `addrSeparateProxyTor` settings (i) if the proxy setting does not exist; or (ii) if the proxy setting has an illegal value caused by to the aforementioned bug. 

The second condition is *only* relevant if we don't want Bitcoin Core 0.16.0 users to explicitly reset their settings to see the correct default proxy port value.