### PR TITLE
Add scripts for doing gitian builds on any platform using VirtualBox + Vagrant + Packer

### DIFF
--- a/contrib/vagrant/.gitignore
+++ b/contrib/vagrant/.gitignore
@@ -1,0 +1,9 @@
+cache
+cache/*
+output
+output/*
+packer_cache
+packer_cache/
+.stamp-*
+.*.manifest
+.vagrant

--- a/contrib/vagrant/Makefile
+++ b/contrib/vagrant/Makefile
@@ -1,0 +1,516 @@
+#
+# Copyright © 2011-2018 Bitcoin Developers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+MAKEFILE := $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
+
+PROJECT  := bitcoin
+
+SHELL    := $(shell bash --help >/dev/null 2>&1 && echo ba)sh
+
+AWK      := $(shell gawk --help >/dev/null 2>&1 && echo g)awk
+GREP     := $(shell egrep --help >/dev/null 2>&1 && echo e)grep
+PATCH    := $(shell gpatch --help >/dev/null 2>&1 && echo g)patch
+SED      := $(shell gsed --help >/dev/null 2>&1 && echo g)sed
+WGET     := wget --no-check-certificate \
+                 --user-agent=$(shell wget --version | \
+            $(SED) -n 's,GNU \(Wget\) \([0-9.]*\).*,\1/\2,p')
+
+REQUIREMENTS := $(AWK) $(SHELL) diff find $(GREP) gzip $(MAKE) openssl	\
+                packer $(PATCH) $(SED) sort tar vagrant xargs xz	\
+                $(word 1,$(WGET))
+
+BUILD_MANIFEST = cd '$(shell dirname '$(MAKEFILE)')'/../.. && \
+	find $(1) -print0 | \
+	xargs -0 -n1 openssl sha256 2>/dev/null | \
+	openssl sha256 | \
+	$(SED) -n 's,^.*\([0-9a-f]\{64\}\),\1,p'
+
+VALIDATE_MANIFEST = \
+	if [ -f "$(1)" ] && echo "$(2)" | diff "$(1)" - 2>&1 >/dev/null; then \
+	    rm -f "$(1)"; \
+	fi
+
+# ===----------------------------------------------------------------------===
+
+PKGS            :=
+CACHE_DIR       := cache
+HOST_CACHE_DIR  := $(CACHE_DIR)
+GUEST_CACHE_DIR := /vagrant/$(CACHE_DIR)
+
+SOURCEFORGE_MIRROR := downloads.sourceforge.net
+
+PKG             := osslsigncode-1.7.1.tar.gz
+$(PKG)_CHECKSUM := cc5a7e0c5baa2a98db93f1d2cc9d86e732e2a8a55fc20bf8e6aa67e2120af37c6be857dfe4b8eb8c82fd40604dbb3c845190b59c7e6b4147f06b710a256b877f
+$(PKG)_URL      := http://$(SOURCEFORGE_MIRROR)/project/osslsigncode/osslsigncode/$(PKG)
+PKGS            += $(PKG)
+
+PKG             := osslsigncode-Backports-to-1.7.1.patch
+$(PKG)_CHECKSUM := 182127638206492a609b4f909465b702f7fa89b3cd69f08f86a2efde86dbe597081fb0fd862560fac89e85baf74976c9bcb6b56d17f0e9015ea0c7e33cae1e3a
+$(PKG)_URL      := http://bitcoincore.org/cfields/osslsigncode-Backports-to-1.7.1.patch
+PKGS            += $(PKG)
+
+# ===----------------------------------------------------------------------===
+
+VAGRANT_UP = \
+	vagrant up
+
+VAGRANT_HALT = \
+	vagrant halt
+
+VAGRANT_RELOAD = \
+	vagrant reload
+
+VAGRANT_DESTROY = \
+	vagrant destroy --force
+
+# ===----------------------------------------------------------------------===
+
+.PHONY: all
+all: linux osx win
+
+.PHONY: mostlyclean
+mostlyclean:
+
+.PHONY: clean
+clean: mostlyclean
+	-rm -rf box
+	-rm -rf output
+	-rm -f .stamp-*
+	-$(call VAGRANT_DESTROY)
+	-rm -rf .vagrant
+
+.PHONY: distclean
+distclean: clean
+	-rm -rf cache
+	-rm -rf output-gitian-host-xenial64
+	-rm -rf packer_cache
+
+.PHONY: maintainer-clean
+maintainer-clean: distclean
+	@echo 'This command is intended for maintainers to use; it'
+	@echo 'deletes files that may need special tools to rebuild.'
+
+.PHONY: dist
+dist: all
+
+# ===----------------------------------------------------------------------===
+
+.PHONY: check-requirements
+define CHECK_REQUIREMENT
+	@if ! $(1) --help &>/dev/null; then \
+	    if ! which $(1) &>/dev/null; then \
+	        echo; \
+	        echo 'Missing requirement: $(1)'; \
+	        echo; \
+	        echo 'Please have a look at "README" to ensure'; \
+	        echo 'that your system meets all requirements.'; \
+	        echo; \
+	        exit 1; \
+	    fi; \
+	fi
+
+endef
+define CHECK_REQUIREMENT_VERSION
+	@if ! $(1) --version | head -1 | grep ' \($(2)\)$$' >/dev/null; then \
+	    echo; \
+	    echo 'Wrong version of requirement: $(1)'; \
+	    echo; \
+	    echo 'Please have a look at "README" to ensure'; \
+	    echo 'that your system meets all requirements.'; \
+	    echo; \
+	    exit 1; \
+	fi
+
+endef
+check-requirements: .stamp-check-requirements.h
+.stamp-check-requirements.h: $(MAKEFILE)
+	@echo '[check requirements]'
+	$(foreach REQUIREMENT,$(REQUIREMENTS),$(call CHECK_REQUIREMENT,$(REQUIREMENT)))
+	$(call CHECK_REQUIREMENT_VERSION,vagrant,[2-9]\.[0-9]\.[0-9])
+	@touch "$@"
+
+# ===----------------------------------------------------------------------===
+
+.PHONY: download
+download: $(addprefix download-,$(PKGS)) download-depends
+
+.PHONY: download-depends
+download-depends: .stamp-download-depends.h
+.stamp-download-depends.h: $(HOST_CACHE_DIR)/src-local.manifest
+	mkdir -p cache/gitian/cache/common
+	make -C ../../depends download SOURCES_PATH="`pwd`/cache/gitian/cache/common"
+	@touch "$@"
+
+PKG_CHECKSUM = \
+	openssl sha512 '$(HOST_CACHE_DIR)/$(1)' 2>/dev/null | $(SED) -n 's,^.*\([0-9a-f]\{128\}\)$$,\1,p'
+
+CHECK_PKG_ARCHIVE = \
+	[ x'$($(1)_CHECKSUM)' == x"`$$(call PKG_CHECKSUM,$(1))`" ]
+
+DOWNLOAD_PKG_ARCHIVE = \
+	mkdir -p '$(HOST_CACHE_DIR)' && \
+	$(if $($(1)_URL_2), \
+	    ( $(WGET) -T 30 -t 3 -O- '$($(1)_URL)' || $(WGET) -O- '$($(1)_URL_2)' ), \
+	    $(WGET) -O- '$($(1)_URL)') \
+	$(if $($(1)_FIX_GZIP), \
+	    | gzip -d | gzip -9n, \
+	    ) \
+	> '$(HOST_CACHE_DIR)/$(1)'
+
+define PKG_RULE
+.PHONY: download-$(1)
+download-$(1): $(HOST_CACHE_DIR)/$(1)
+$(HOST_CACHE_DIR)/$(1): .stamp-check-requirements.h
+	@echo -n "Checking cached package $(1)... "; \
+	if ! $(call CHECK_PKG_ARCHIVE,$(1)); then \
+		echo "failed"; \
+	     $(call DOWNLOAD_PKG_ARCHIVE,$(1)); \
+	     $(call CHECK_PKG_ARCHIVE,$(1)) \
+	        || { echo 'Wrong checksum!'; exit 1; }; \
+	else \
+		echo "ok"; \
+	fi
+
+endef
+$(foreach PKG,$(PKGS),$(eval $(call PKG_RULE,$(PKG))))
+
+# ===----------------------------------------------------------------------===
+
+GITIAN_HOST_FILES    := contrib/vagrant/Makefile \
+                        contrib/vagrant/gitian-host.json \
+                        contrib/vagrant/config/preseed.cfg \
+                        contrib/vagrant/config/vagrant.sh \
+                        contrib/vagrant/config/sshd.sh \
+                        contrib/vagrant/config/packages.sh \
+                        contrib/vagrant/config/cleanup.sh \
+                        contrib/vagrant/Vagrantfile
+GITIAN_HOST_FILES    := $(sort $(GITIAN_HOST_FILES))
+GITIAN_HOST_MANIFEST := $(shell $(call BUILD_MANIFEST,$(GITIAN_HOST_FILES)))
+
+_ := $(shell $(call \
+	VALIDATE_MANIFEST, \
+	.stamp-gitian-host.manifest, \
+	$(GITIAN_HOST_MANIFEST) \
+))
+
+.PHONY: gitian-host
+gitian-host: .stamp-gitian-host.manifest
+.stamp-gitian-host.manifest: \
+	.stamp-check-requirements.h \
+	$(foreach FILE,$(GITIAN_HOST_FILES),$(shell echo $(FILE) | $(SED) 's:^contrib/vagrant/::g'))
+	
+	-$(call VAGRANT_DESTROY)
+	
+	# Remove any temporary files from interupted builds that would
+	# interfere if present.
+	if [ -e output-gitian-host-xenial64 ]; then \
+	    rm -rf output-gitian-host-xenial64; \
+	fi
+	
+	packer build gitian-host.json
+	vagrant box add --name gitian-host-xenial64 --force box/virtualbox/gitian-host-xenial64-0.box
+	-rm -rf box
+	
+	$(call VAGRANT_UP)
+	
+	-$(call VAGRANT_HALT)
+	
+	echo $(GITIAN_HOST_MANIFEST) > "$@"
+
+# ===----------------------------------------------------------------------===
+
+LXC_BASE_FILES    := contrib/vagrant/Makefile
+LXC_BASE_FILES    := $(sort $(LXC_BASE_FILES))
+LXC_BASE_MANIFEST := $(shell $(call BUILD_MANIFEST,$(LXC_BASE_FILES)))
+
+_ := $(shell $(call \
+	VALIDATE_MANIFEST, \
+	.stamp-lxc-base.manifest, \
+	$(LXC_BASE_MANIFEST) \
+))
+
+.PHONY: lxc-base
+lxc-base: .stamp-lxc-base.manifest
+.stamp-lxc-base.manifest: \
+	.stamp-gitian-host.manifest \
+	$(foreach FILE,$(LXC_BASE_FILES),$(shell echo $(FILE) | $(SED) 's:^contrib/vagrant/::g'))
+	
+	$(call VAGRANT_UP)
+	
+	vagrant ssh --command "\
+	    if [ -d ~/gitian-builder ]; then \
+	        rm -rf ~/gitian-builder; \
+	    fi"
+	vagrant ssh --command "\
+	    git clone 'https://github.com/devrandom/gitian-builder' ~/gitian-builder"
+	vagrant ssh --command "cd ~/gitian-builder && \
+	    git checkout e2172de8"
+	vagrant ssh --command "cd ~/gitian-builder && \
+	    ln -s $(GUEST_CACHE_DIR) inputs"
+	
+	vagrant ssh --command "\
+	    cd ~/gitian-builder; \
+	    if [ ! -f $(GUEST_CACHE_DIR)/lxc-base/$(LXC_BASE_MANIFEST)/base-vm.tar.gz ]; then \
+	        env LXC_BRIDGE=lxcbr0 LXC_GUEST_IP=10.0.3.2 _HOST_IP=10.0.3.1 \
+	            bin/make-base-vm --lxc --suite trusty --arch amd64 || exit 1; \
+	        for vm in base-*; do \
+	            tar -Srvf base-vm.tar $$vm || exit 1; \
+	            rm -f $$vm; \
+	        done; \
+	        gzip --fast base-vm.tar || exit 1; \
+	        mkdir -p $(GUEST_CACHE_DIR)/lxc-base/$(LXC_BASE_MANIFEST) || exit 1; \
+	        rsync -av --remove-source-files base-vm.tar.gz $(GUEST_CACHE_DIR)/lxc-base/$(LXC_BASE_MANIFEST); \
+	        tar -tf $(GUEST_CACHE_DIR)/lxc-base/$(LXC_BASE_MANIFEST)/base-vm.tar.gz || \
+	            rm -rf $(GUEST_CACHE_DIR)/lxc-base/$(LXC_BASE_MANIFEST); \
+	    fi; \
+	    tar -Sxzvf $(GUEST_CACHE_DIR)/lxc-base/$(LXC_BASE_MANIFEST)/base-vm.tar.gz"
+	
+ifdef VAGRANT_CYCLE
+	-$(call VAGRANT_HALT)
+endif
+	
+	echo $(LXC_BASE_MANIFEST) > "$@"
+
+# ===----------------------------------------------------------------------===
+
+ifeq ($(shell git log -1 2>&1 >/dev/null && echo true),true)
+SOURCE_FILES := $(shell \
+	git ls-tree --name-only --full-tree -r `git log -1 --format="%H"` \
+	    | $(GREP) -v '^contrib/vagrant/' \
+	    | sort)
+else
+SOURCE_FILES := $(shell cd ../.. && \
+	find -L . -type f -print \
+	    | $(SED) 's:^\./::g' \
+	    | $(GREP) -v '^\.git/' \
+	    | $(GREP) -v '^contrib/vagrant/' \
+	    | sort)
+endif
+
+SOURCE_MANIFEST := $(shell $(call BUILD_MANIFEST,$(SOURCE_FILES)))
+
+_ := $(shell $(call \
+	VALIDATE_MANIFEST, \
+	$(HOST_CACHE_DIR)/src-local.manifest, \
+	$(SOURCE_MANIFEST) \
+))
+
+.PHONY: bundle-source
+bundle-source: $(HOST_CACHE_DIR)/src-local.manifest
+$(HOST_CACHE_DIR)/src-local.manifest: $(HOST_CACHE_DIR)/src-local.tar.xz
+	@echo $(SOURCE_MANIFEST) >'$@'
+$(HOST_CACHE_DIR)/src-local.tar.xz: \
+	$(foreach FILE,$(SOURCE_FILES),$(shell echo $(FILE) | $(SED) 's:^:../../:g'))
+	
+	mkdir -p '$(HOST_CACHE_DIR)'
+	rm -f '$(HOST_CACHE_DIR)'/src-local.{tar,tar.xz}
+	if git log -1 2>&1 >> /dev/null && [ -z "$(shell git status --untracked-files=no --porcelain)" ]; then \
+	    pushd ../../; \
+	    git archive HEAD --format tar --output contrib/vagrant/'$(HOST_CACHE_DIR)'/src-local.tar; \
+	    popd; \
+	else \
+	    COPYFILE_DISABLE=1 tar -C ../.. -rf '$(HOST_CACHE_DIR)'/src-local.tar $(SOURCE_FILES); \
+	fi
+	xz '$(HOST_CACHE_DIR)'/src-local.tar
+	echo "Gitian Builder" >> '$(HOST_CACHE_DIR)'/src-local.committer-name
+	echo "vagrant@vagrant" >> '$(HOST_CACHE_DIR)'/src-local.committer-email
+	echo "Gitian Builder <vagrant@vagrant>" >> '$(HOST_CACHE_DIR)'/src-local.author
+	echo date >> '$(HOST_CACHE_DIR)'/src-local.committer-date
+	cp '$(HOST_CACHE_DIR)'/src-local.committer-date '$(HOST_CACHE_DIR)'/src-local.author-date
+	if git log -1 2>&1 >> /dev/null; then \
+	    if [ -z "$(shell git status --untracked-files=no --porcelain)" ]; then \
+	        git show --format=format:"%cn" | head -n 1 | tee '$(HOST_CACHE_DIR)'/src-local.committer-name; \
+	        git show --format=format:"%ce" | head -n 1 | tee '$(HOST_CACHE_DIR)'/src-local.committer-email; \
+	        git show --format=format:"%cd" | head -n 1 | tee '$(HOST_CACHE_DIR)'/src-local.committer-date; \
+	        git show --format=format:"%an, <%ae>" | head -n 1 | tee '$(HOST_CACHE_DIR)'/src-local.author; \
+	        git show --format=format:"%ad" | head -n 1 | tee '$(HOST_CACHE_DIR)'/src-local.author-date; \
+	    else \
+	        echo `git config user.name`, '<'`git config user.email`'>' >> '$(HOST_CACHE_DIR)'/src-local.author; \
+	    fi; \
+	fi
+
+# ===----------------------------------------------------------------------===
+
+rightparen=)
+CLIENT_VERSION_MAJOR := $(shell $(GREP) _CLIENT_VERSION_MAJOR ../../configure.ac | head -n 1 | $(AWK) -F'[ $(rightparen)]' '{print $$2}')
+CLIENT_VERSION_MINOR := $(shell $(GREP) _CLIENT_VERSION_MINOR ../../configure.ac | head -n 1 | $(AWK) -F'[ $(rightparen)]' '{print $$2}')
+CLIENT_VERSION_REVISION := $(shell $(GREP) _CLIENT_VERSION_REVISION ../../configure.ac | head -n 1 | $(AWK) -F'[ $(rightparen)]' '{print $$2}')
+ifeq ($(CLIENT_VERSION_REVISION), 99)
+SERIES := $(CLIENT_VERSION_MAJOR).$(shell expr 1 + $(CLIENT_VERSION_MINOR))
+else
+SERIES := $(CLIENT_VERSION_MAJOR).$(CLIENT_VERSION_MINOR)
+endif
+
+OUTPUT_DIR         := output
+HOST_OUTPUT_DIR    := $(OUTPUT_DIR)
+GUEST_OUTPUT_DIR   := /vagrant/$(OUTPUT_DIR)
+
+TARGETS            :=
+
+PLATFORM           := linux
+TARGET             := ${PLATFORM}
+$(TARGET)_NAME     := $(TARGET)-$(SERIES)
+$(TARGET)_VERSION  := $(SERIES)
+$(TARGET)_OUTPUT   := $(PROJECT)-$(TARGET)-$($(TARGET)_VERSION)-gitian.zip
+$(TARGET)_SCRIPT   := contrib/gitian-descriptors/gitian-$(TARGET).yml
+$(TARGET)_PKGS     :=
+$(TARGET)_DEPS     := $(HOST_CACHE_DIR)/src-local.tar.xz \
+                      .stamp-download-depends.h
+$(TARGET)_FILES    := $($(TARGET)_SCRIPT) \
+                      contrib/vagrant/$(HOST_CACHE_DIR)/src-local.tar.xz
+$(TARGET)_FILES    += $(foreach PACKAGE, \
+                                $($(TARGET)_PKGS), \
+                                contrib/vagrant/$(HOST_CACHE_DIR)/$(PACKAGE))
+$(TARGET)_FILES    := $(sort $($(TARGET)_FILES))
+$(TARGET)_MANIFEST := $(call BUILD_MANIFEST,$($(TARGET)_FILES))
+TARGETS            += $(TARGET)
+
+PLATFORM           := osx
+TARGET             := ${PLATFORM}
+$(TARGET)_NAME     := $(TARGET)-$(SERIES)
+$(TARGET)_VERSION  := $(SERIES)
+$(TARGET)_OUTPUT   := $(PROJECT)-$(TARGET)-$($(TARGET)_VERSION)-gitian.zip
+$(TARGET)_SCRIPT   := contrib/gitian-descriptors/gitian-$(TARGET).yml
+$(TARGET)_PKGS     := osslsigncode-1.7.1.tar.gz \
+                      osslsigncode-Backports-to-1.7.1.patch
+$(TARGET)_DEPS     := $(HOST_CACHE_DIR)/src-local.tar.xz \
+                      .stamp-download-depends.h
+$(TARGET)_FILES    := $($(TARGET)_SCRIPT) \
+                      contrib/vagrant/$(HOST_CACHE_DIR)/src-local.tar.xz
+$(TARGET)_FILES    += $(foreach PACKAGE, \
+                                $($(TARGET)_PKGS), \
+                                contrib/vagrant/$(HOST_CACHE_DIR)/$(PACKAGE))
+$(TARGET)_FILES    := $(sort $($(TARGET)_FILES))
+$(TARGET)_MANIFEST := $(call BUILD_MANIFEST,$($(TARGET)_FILES))
+TARGETS            += $(TARGET)
+
+PLATFORM           := win
+TARGET             := ${PLATFORM}
+$(TARGET)_NAME     := $(TARGET)-$(SERIES)
+$(TARGET)_VERSION  := $(SERIES)
+$(TARGET)_OUTPUT   := $(PROJECT)-$(TARGET)-$($(TARGET)_VERSION)-gitian.zip
+$(TARGET)_SCRIPT   := contrib/gitian-descriptors/gitian-$(TARGET).yml
+$(TARGET)_PKGS     :=
+$(TARGET)_DEPS     := $(HOST_CACHE_DIR)/src-local.tar.xz \
+                      .stamp-download-depends.h
+$(TARGET)_FILES    := $($(TARGET)_SCRIPT) \
+                      contrib/vagrant/$(HOST_CACHE_DIR)/src-local.tar.xz
+$(TARGET)_FILES    += $(foreach PACKAGE, \
+                                $($(TARGET)_PKGS), \
+                                contrib/vagrant/$(HOST_CACHE_DIR)/$(PACKAGE))
+$(TARGET)_FILES    := $(sort $($(TARGET)_FILES))
+$(TARGET)_MANIFEST := $(call BUILD_MANIFEST,$($(TARGET)_FILES))
+TARGETS            += $(TARGET)
+
+DEPLOY_SOURCE_BUNDLE = \
+	vagrant ssh --command "rm -rf ~/'$(1)' || true"; \
+	vagrant ssh --command "mkdir -p ~/'$(1)'" || exit 1; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    tar -xf $(GUEST_CACHE_DIR)/src-local.tar.xz" || exit 1; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    grep -v 'contrib/vagrant/Makefile' configure.ac >.configure.ac.2 && \
+	    mv .configure.ac.2 configure.ac'"; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    git init" || exit 1; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    git config user.name 'Gitian Builder'" || exit 1; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    git config user.email 'vagrant@vagrant'" || exit 1; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    find . -not \\( -path ./.git -prune \\) -type f -print0 | xargs -0 git add -f" || exit 1; \
+	vagrant ssh --command "cd ~/'$(1)' && \
+	    env GIT_COMMITTER_NAME='`cat '$(HOST_CACHE_DIR)'/src-local.committer-name`' \
+	        GIT_COMMITTER_EMAIL='`cat '$(HOST_CACHE_DIR)'/src-local.committer-email`' \
+	        GIT_COMMITTER_DATE='`cat '$(HOST_CACHE_DIR)'/src-local.committer-date`' \
+	    git commit --author='`cat '$(HOST_CACHE_DIR)'/src-local.author`' \
+	               --date='`cat '$(HOST_CACHE_DIR)'/src-local.author-date`' \
+	               -m tip" || exit 1
+
+define TARGET_RULE
+.PHONY: $(1)
+$(1): $(HOST_OUTPUT_DIR)/$($(1)_OUTPUT)
+$(HOST_OUTPUT_DIR)/$($(1)_OUTPUT): \
+	.stamp-lxc-base.manifest \
+	$(HOST_CACHE_DIR)/src-local.manifest \
+	$(foreach TARGET,$($(1)_DEPS),$(TARGET)) \
+	$(foreach PACKAGE,$($(1)_PKGS),$(HOST_CACHE_DIR)/$(PACKAGE)) \
+	
+	mkdir -p $(HOST_OUTPUT_DIR)
+	
+	$(call VAGRANT_UP)
+	
+	$(call DEPLOY_SOURCE_BUNDLE,$(PROJECT))
+	
+	echo `$($(1)_MANIFEST)` > .$(1).manifest
+	
+	if [ ! -f $(HOST_CACHE_DIR)/$(1)/`cat .$(1).manifest`/$($(1)_OUTPUT) ]; then \
+	    vagrant ssh --command "rm -f ~/gitian-builder/cache"; \
+	    vagrant ssh --command "mkdir -p '$(GUEST_CACHE_DIR)/gitian/cache'" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder && \
+	        ln -s '$(GUEST_CACHE_DIR)/gitian/cache' cache" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder && \
+	        env LXC_BRIDGE=lxcbr0 LXC_GUEST_IP=10.0.3.2 GITIAN_HOST_IP=10.0.3.1 USE_LXC=1 \
+	            bin/gbuild ../$(PROJECT)/$($(1)_SCRIPT) --memory 2000 --url $(PROJECT)=~/$(PROJECT) --commit $(PROJECT)=master" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder/build/out && \
+	        if [ ! -f $($(1)_OUTPUT) ]; then \
+	            zip -r $($(1)_OUTPUT) * || exit 1; \
+	        fi" || exit 1; \
+	    vagrant ssh --command "mkdir -p '$(GUEST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`/" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder && \
+	        mv build/out/$($(1)_OUTPUT) \
+	           '$(GUEST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`/" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder && \
+	        mv result/$(PROJECT)-$($(1)_NAME)-res.yml \
+	           '$(GUEST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$(PROJECT)-$($(1)_NAME)-gitian-res.yml'" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder && \
+	        mv var/build.log \
+	           '$(GUEST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$(PROJECT)-$($(1)_NAME)-gitian-build.log'" || exit 1; \
+	    vagrant ssh --command "cd ~/gitian-builder && \
+	        mv var/install.log \
+	           '$(GUEST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$(PROJECT)-$($(1)_NAME)-gitian-install.log'" || exit 1; \
+	fi
+	
+	cp '$(HOST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$($(1)_OUTPUT)' \
+	   '$(HOST_CACHE_DIR)/'
+	cp '$(HOST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$($(1)_OUTPUT)' \
+	   '$(HOST_OUTPUT_DIR)/'
+	cp '$(HOST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$(PROJECT)-$($(1)_NAME)-gitian-res.yml' \
+	   '$(HOST_OUTPUT_DIR)/'
+	cp '$(HOST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$(PROJECT)-$($(1)_NAME)-gitian-build.log' \
+	   '$(HOST_OUTPUT_DIR)/'
+	cp '$(HOST_CACHE_DIR)/$(1)/'`cat .$(1).manifest`'/$(PROJECT)-$($(1)_NAME)-gitian-install.log' \
+	   '$(HOST_OUTPUT_DIR)/'
+	
+	rm -f .$(1).manifest
+	
+	vagrant ssh --command "rm -rf ~/$(PROJECT)"
+	
+ifdef VAGRANT_CYCLE
+	-$(call VAGRANT_HALT)
+endif
+
+endef
+$(foreach TARGET,$(TARGETS),$(eval $(call TARGET_RULE,$(TARGET))))
+
+#
+# End of File
+#

--- a/contrib/vagrant/README
+++ b/contrib/vagrant/README
@@ -1,0 +1,1 @@
+README.md

--- a/contrib/vagrant/README.md
+++ b/contrib/vagrant/README.md
@@ -1,0 +1,140 @@
+Automated Gitian builds with Vagrant
+====================================
+
+This directory contains platform-independent scripts for building
+bitcoind and Bitcoin-Qt using the deterministic Gitian build process.
+
+Dependencies
+------------
+
+These build scripts depend on a UNIX-like build environment, the
+freely available open-source release of Oracle VirtualBox, and
+HashiCorp's vagrant and packer VM-creation utilities. The makefile
+will complain if any of the required tools are not found. Use the
+makefile to find out which requirements are missing:
+
+    $ cd contrib/vagrant
+    $ make check-requirements
+
+Instructions
+------------
+
+    $ cd contrib/vagrant && make
+
+It really is that simple.
+
+Read the remainder of this document for some platform-specific instructions
+for setting up an appropriate build environment.
+
+Mac OS X
+--------
+
+Install the latest versions of VirtualBox and Vagrant. The scripts are
+known to work with VirtualBox 5.2.8 r121009, Vagrant 2.0.1, and Packer
+1.1.3 on Mac OS X 10.13.3 High Sierra with XCode 9.2 (9C40b) and the
+command-line developer tools installed.
+
+VirtualBox binaries are available from the VirtualBox website:
+
+    https://www.virtualbox.org/wiki/Downloads
+
+The Vagrant installer for Mac OS X works:
+
+    https://www.vagrantup.com/downloads.html
+
+Be sure to install the VirtualBox plugin:
+
+    $ vagrant plugin install vagrant-vbguest
+
+And the Packer binary needs to be placed in your path:
+
+    https://www.packer.io
+
+Use MacPorts or homebrew to install any missing dependencies, for example:
+
+    $ sudo port install openssl wget xz
+
+Then use GNU make to initiate the build:
+
+    $ cd contrib/vagrant
+    $ make
+
+Linux
+-----
+
+Existing binaries for VirtualBox, Vagrant, Packer, git, and the
+various UNIX dependencies provided by your distribution should
+work. Use the makefile to find out which requirements are missing:
+
+    $ cd contrib/vagrant
+    $ make check-requirements
+
+If you cannot find `vagrant` in your distribution's package
+repositories, you can install a binary release from here:
+
+    https://www.vagrantup.com/downloads.html
+
+Be sure to install the VirtualBox plugin:
+
+    $ vagrant plugin install vagrant-vbguest
+
+And for Packer:
+
+    https://www.packer.io/downloads.html
+
+Once the dependencies are met, use GNU make to initiate the build:
+
+    $ cd contrib/vagrant
+    $ make
+
+Windows
+-------
+
+A UNIX-like build environment is required, but due to the peculiarities of the
+required dependencies, the exact combination you have installed probably won't
+work. Here are build instructions that are known to work from an updated fresh
+install of Windows 7:
+
+Install Git for Windows (if you need git):
+
+    http://msysgit.github.com/
+
+You don't need the msys version--we will be installing msys separately.
+
+Install ruby using the one-click ruby installer:
+
+    http://rubyinstaller.org/downloads/
+
+Install ruby development environment, from the same download page.
+Instructions:
+
+    https://github.com/oneclick/rubyinstaller/wiki/Development-Kit
+
+Install Virtualbox (extension pack not required):
+
+    https://www.virtualbox.org/wiki/Downloads
+
+Install the VirtualBox plugin for vagrant:
+
+    $ vagrant plugin install vagrant-vbguest
+
+Install mingw + msys environment:
+
+    http://www.mingw.org/wiki/Getting_Started
+
+Install Vagrant via the installer:
+
+    https://www.vagrantup.com/downloads.html
+
+Install Packer into your path:
+
+    https://www.packer.io/downloads.html
+
+Use mingw-get to install other required packages.
+
+    $ mingw-get install wget
+
+Once the dependencies are met, use GNU make to initiate the build:
+
+    $ cd contrib/vagrant
+    $ make

--- a/contrib/vagrant/Vagrantfile
+++ b/contrib/vagrant/Vagrantfile
@@ -1,0 +1,41 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+#
+# Copyright © 2013-2018 Bitcoin Developers.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+
+Vagrant::configure("2") do |config|
+    # All Vagrant configuration is done here. The most common configuration
+    # options are documented and commented below. For a complete reference,
+    # please see the online documentation at vagrantup.com.
+
+    # Every Vagrant virtual environment requires a box to build off of.
+    config.vm.box = "gitian-host-xenial64"
+
+    config.vm.provider :virtualbox do |vb|
+        # Set RAM to 2.5GB
+        vb.memory = 2560
+
+        # Set CPUs to 2 for faster compilation
+        vb.cpus = 2
+    end
+end

--- a/contrib/vagrant/config/cleanup.sh
+++ b/contrib/vagrant/config/cleanup.sh
@@ -1,0 +1,107 @@
+#!/bin/bash -eux
+
+SSH_USER=${SSH_USERNAME:-vagrant}
+
+# Make sure udev does not block our network - http://6.ptmc.org/?p=164
+echo "==> Cleaning up udev rules"
+rm -rf /dev/.udev/
+rm /lib/udev/rules.d/75-persistent-net-generator.rules
+
+echo "==> Cleaning up leftover dhcp leases"
+# Ubuntu 10.04
+if [ -d "/var/lib/dhcp3" ]; then
+    rm /var/lib/dhcp3/*
+fi
+# Ubuntu 12.04 & 14.04
+if [ -d "/var/lib/dhcp" ]; then
+    rm /var/lib/dhcp/*
+fi 
+
+UBUNTU_VERSION=$(lsb_release -sr)
+if [[ ${UBUNTU_VERSION} == 16.04 ]] || [[ ${UBUNTU_VERSION} == 16.10 ]]; then
+    # Modified version of
+    # https://github.com/cbednarski/packer-ubuntu/blob/master/scripts-1604/vm_cleanup.sh#L9-L15
+    # Instead of eth0 the interface is now called ens5 to mach the PCI
+    # slot, so we need to change the networking scripts to enable the
+    # correct interface.
+    #
+    # NOTE: After the machine is rebooted Packer will not be able to reconnect
+    # (Vagrant will be able to) so make sure this is done in your final
+    # provisioner.
+    sed -i "s/ens3/ens5/g" /etc/network/interfaces
+fi
+
+# Add delay to prevent "vagrant reload" from failing
+echo "pre-up sleep 2" >> /etc/network/interfaces
+
+echo "==> Cleaning up tmp"
+rm -rf /tmp/*
+
+# Cleanup apt cache
+apt-get -y autoremove --purge
+apt-get -y clean
+apt-get -y autoclean
+
+echo "==> Installed packages"
+dpkg --get-selections | grep -v deinstall
+
+DISK_USAGE_BEFORE_CLEANUP=$(df -h)
+
+# Remove Bash history
+unset HISTFILE
+rm -f /root/.bash_history
+rm -f /home/${SSH_USER}/.bash_history
+
+# Clean up log files
+find /var/log -type f | while read f; do echo -ne '' > "${f}"; done;
+
+echo "==> Clearing last login information"
+>/var/log/lastlog
+>/var/log/wtmp
+>/var/log/btmp
+
+# NOTE: Shrinking is not part of the build process
+# so this will only grow the image...
+
+# # Whiteout root
+# count=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
+# let count--
+# dd if=/dev/zero of=/tmp/whitespace bs=1024 count=$count
+# rm /tmp/whitespace
+
+# # Whiteout /boot
+# count=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
+# let count--
+# dd if=/dev/zero of=/boot/whitespace bs=1024 count=$count
+# rm /boot/whitespace
+
+# echo '==> Clear out swap and disable until reboot'
+# set +e
+# swapuuid=$(/sbin/blkid -o value -l -s UUID -t TYPE=swap)
+# case "$?" in
+#     2|0) ;;
+#     *) exit 1 ;;
+# esac
+# set -e
+# if [ "x${swapuuid}" != "x" ]; then
+#     # Whiteout the swap partition to reduce box size
+#     # Swap is disabled till reboot
+#     swappart=$(readlink -f /dev/disk/by-uuid/$swapuuid)
+#     /sbin/swapoff "${swappart}"
+#     dd if=/dev/zero of="${swappart}" bs=1M || echo "dd exit code $? is suppressed"
+#     /sbin/mkswap -U "${swapuuid}" "${swappart}"
+# fi
+
+# # Zero out the free space to save space in the final image
+# dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
+# rm -f /EMPTY
+
+# # Make sure we wait until all the data is written to disk, otherwise
+# # Packer might quite too early before the large files are deleted
+# sync
+
+# echo "==> Disk usage before cleanup"
+# echo ${DISK_USAGE_BEFORE_CLEANUP}
+
+# echo "==> Disk usage after cleanup"
+# df -h

--- a/contrib/vagrant/config/packages.sh
+++ b/contrib/vagrant/config/packages.sh
@@ -1,0 +1,31 @@
+ESSENTIAL_PACKAGES="
+ntp
+nfs-common
+"
+
+GITIAN_PACKAGES="
+git
+apache2
+apt-cacher-ng
+bridge-utils
+python-vm-builder
+ruby
+qemu-utils
+lxc
+"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# Perform ALL security updates for the guest VM distribution.
+echo "==> Updating distribution-provided package lists"
+apt-get -y update
+echo "==> Applying security updates & upgrading default packages"
+apt-get -y dist-upgrade
+
+# Essential packages are necessary for virtualbox/vagrant integration.
+echo "==> Installing packages necessary for virtualbox/vagrant integration"
+apt-get -y install $ESSENTIAL_PACKAGES
+
+# Gitian packages are necessary for gitian-builder.
+echo "==> Installing packages necessary for gitian-builder"
+apt-get -y install $GITIAN_PACKAGES

--- a/contrib/vagrant/config/preseed.cfg
+++ b/contrib/vagrant/config/preseed.cfg
@@ -1,0 +1,22 @@
+choose-mirror-bin mirror/http/proxy string
+d-i debian-installer/framebuffer boolean false
+d-i debconf/frontend select noninteractive
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i partman-auto/method string regular
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i pkgsel/include string openssh-server
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+d-i time/zone string UTC
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+tasksel tasksel/first multiselect standard, ubuntu-server

--- a/contrib/vagrant/config/sshd.sh
+++ b/contrib/vagrant/config/sshd.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eux
+
+echo "==> Disabling UseDNS from sshd configuration"
+echo "UseDNS no" >> /etc/ssh/sshd_config

--- a/contrib/vagrant/config/vagrant.sh
+++ b/contrib/vagrant/config/vagrant.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+date > /etc/vagrant_box_build_time
+
+SSH_USER=${SSH_USERNAME:-vagrant}
+SSH_PASS=${SSH_PASSWORD:-vagrant}
+SSH_USER_HOME=${SSH_USER_HOME:-/home/${SSH_USER}}
+VAGRANT_INSECURE_KEY="ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key"
+
+# Packer passes boolean user variables through as '1', but this might change in
+# the future, so also check for 'true'.
+if [ "$INSTALL_VAGRANT_KEY" = "true" ] || [ "$INSTALL_VAGRANT_KEY" = "1" ]; then
+    # Create Vagrant user (if not already present)
+    if ! id -u $SSH_USER >/dev/null 2>&1; then
+        echo "==> Creating $SSH_USER user"
+        /usr/sbin/groupadd $SSH_USER
+        /usr/sbin/useradd $SSH_USER -g $SSH_USER -G sudo -d $SSH_USER_HOME --create-home
+        echo "${SSH_USER}:${SSH_PASS}" | chpasswd
+    fi
+
+    # Set up sudo
+    echo "==> Giving ${SSH_USER} sudo powers"
+    echo "${SSH_USER}        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/vagrant
+    chmod 440 /etc/sudoers.d/vagrant
+
+    # Fix stdin not being a tty
+    if grep -q -E "^mesg n$" /root/.profile && sed -i "s/^mesg n$/tty -s \\&\\& mesg n/g" /root/.profile; then
+      echo "==> Fixed stdin not being a tty."
+    fi
+
+    echo "==> Installing vagrant key"
+    mkdir $SSH_USER_HOME/.ssh
+    chmod 700 $SSH_USER_HOME/.ssh
+    cd $SSH_USER_HOME/.ssh
+
+    # https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub
+    echo "${VAGRANT_INSECURE_KEY}" > $SSH_USER_HOME/.ssh/authorized_keys
+    chmod 600 $SSH_USER_HOME/.ssh/authorized_keys
+    chown -R $SSH_USER:$SSH_USER $SSH_USER_HOME/.ssh
+fi
+
+# Grub updates have been known to trash vagrant boxen.
+echo "==> Holding packages known to disrupt vagrant"
+echo 'grub-common hold' | dpkg --set-selections

--- a/contrib/vagrant/gitian-host.json
+++ b/contrib/vagrant/gitian-host.json
@@ -1,0 +1,107 @@
+{
+  "_comment": "Build with `packer build gitian-host.json`",
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "guest_os_type": "Ubuntu_64",
+      "boot_command": [
+        "{{user `boot_command_prefix`}}",
+        "/install/vmlinuz noapic ",
+        "file=/floppy/{{user `preseed`}} ",
+        "debian-installer={{user `locale`}} auto locale={{user `locale`}} kbd-chooser/method=us ",
+        "hostname={{user `hostname`}} ",
+        "fb=false debconf/frontend=noninteractive ",
+        "keyboard-configuration/modelcode=SKIP ",
+        "keyboard-configuration/layout=USA ",
+        "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+        "passwd/user-fullname={{user `ssh_fullname`}} ",
+        "passwd/user-password={{user `ssh_password`}} ",
+        "passwd/user-password-again={{user `ssh_password`}} ",
+        "passwd/username={{user `ssh_username`}} ",
+        "initrd=/install/initrd.gz -- <enter>"
+      ],
+      "disk_size": "{{user `disk_size`}}",
+      "floppy_files": [
+        "config/{{user `preseed`}}"
+      ],
+      "guest_additions_mode": "attach",
+      "guest_additions_url": "https://download.virtualbox.org/virtualbox/{{.Version}}/VBoxGuestAdditions_{{.Version}}.iso",
+      "headless": "{{user `headless`}}",
+      "iso_checksum": "{{user `iso_checksum`}}",
+      "iso_checksum_type": "{{user `iso_checksum_type`}}",
+      "iso_urls": [
+        "{{user `mirror_protocol`}}://{{user `mirror`}}/{{user `mirror_directory`}}/{{user `iso_name`}}"
+      ],
+      "output_directory": "output-{{user `vm_name`}}",
+      "shutdown_command": "echo '{{user `ssh_password`}}'|sudo -S shutdown -P now",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "ssh_wait_timeout": "10000s",
+      "vm_name": "{{user `vm_name`}}",
+      "vboxmanage": [
+        ["modifyvm", "{{.Name}}", "--memory", "{{user `memory`}}" ],
+        ["modifyvm", "{{.Name}}", "--cpus", "{{user `cpus`}}"]
+      ]
+    }
+  ],
+  "post-processors": [
+    {
+      "keep_input_artifact": false,
+      "output": "box/{{.Provider}}/{{user `vm_name`}}-{{user `version`}}.box",
+      "type": "vagrant",
+      "vagrantfile_template": "{{user `vagrantfile_template`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "environment_vars": [
+        "UPDATE={{user `update`}}",
+        "INSTALL_VAGRANT_KEY={{user `install_vagrant_key`}}",
+        "SSH_USERNAME={{user `ssh_username`}}",
+        "SSH_PASSWORD={{user `ssh_password`}}",
+        "http_proxy={{user `http_proxy`}}",
+        "https_proxy={{user `https_proxy`}}",
+        "ftp_proxy={{user `ftp_proxy`}}",
+        "rsync_proxy={{user `rsync_proxy`}}",
+        "no_proxy={{user `no_proxy`}}"
+      ],
+      "execute_command": "echo '{{user `ssh_password`}}' | {{.Vars}} sudo -E -S bash '{{.Path}}'",
+      "scripts": [
+        "config/vagrant.sh",
+        "config/sshd.sh",
+        "config/packages.sh",
+        "config/cleanup.sh"
+      ],
+      "type": "shell"
+    }
+  ],
+  "variables": {
+    "boot_command_prefix": "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+    "cpus": "2",
+    "disk_size": "16384",
+    "ftp_proxy": "{{env `ftp_proxy`}}",
+    "headless": "true",
+    "http_proxy": "{{env `http_proxy`}}",
+    "https_proxy": "{{env `https_proxy`}}",
+    "install_vagrant_key": "true",
+    "iso_checksum": "0a03608988cfd2e50567990dc8be96fb3c501e198e2e6efcb846d89efc7b89f2",
+    "iso_checksum_type": "sha256",
+    "iso_name": "ubuntu-16.04.4-server-amd64.iso",
+    "locale": "en_US",
+    "memory": "2560",
+    "mirror": "releases.ubuntu.com",
+    "mirror_directory": "16.04",
+    "mirror_protocol": "http",
+    "no_proxy": "{{env `no_proxy`}}",
+    "preseed" : "preseed.cfg",
+    "rsync_proxy": "{{env `rsync_proxy`}}",
+    "hostname": "vagrant",
+    "ssh_fullname": "vagrant",
+    "ssh_password": "vagrant",
+    "ssh_username": "vagrant",
+    "update": "true",
+    "vagrantfile_template": "Vagrantfile",
+    "version": "0",
+    "vm_name": "gitian-host-xenial64"
+  }
+}


### PR DESCRIPTION
This enables gitian builds from any operating system supporting Oracle VirtualBox and HashiCorp's vagrant and packer VM-creation utilities. Simply checkout a copy of the bitcoin source tree with this PR applied from an internet-connected machine, and do `cd contrib/vagrant && make`. Dependencies and build products are properly cached to provide faster subsequent builds. Builds from dirty working trees are also supported, with the uncommitted changes applied to the source tree.

Builds are nearly identical to the usual gitian process. At this time the only difference is due to a separate bug that makes the length of the `GIT_COMMIT_ID` string exported by git-archive dependent on the state of the local git repository, which has the further implication separate from this use case that over time it would prevent reproducibility of historical releases as well. That issue is logically separate and should be fixed on its own.

This PR is a re-opening of PR #1597 from July of 2012. Unfortunately GitHub forced creation of a new PR.