### PR TITLE
Improve Fatal LevelDB Log Messages

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -218,14 +218,10 @@ void HandleError(const leveldb::Status& status)
 {
     if (status.ok())
         return;
-    LogPrintf("%s\n", status.ToString());
-    if (status.IsCorruption())
-        throw dbwrapper_error("Database corrupted");
-    if (status.IsIOError())
-        throw dbwrapper_error("Database I/O error");
-    if (status.IsNotFound())
-        throw dbwrapper_error("Database entry missing");
-    throw dbwrapper_error("Unknown database error");
+    const std::string errmsg = "Fatal LevelDB error: " + status.ToString();
+    LogPrintf("%s\n", errmsg);
+    LogPrintf("You can use -debug=leveldb to get more complete diagnostic messages\n");
+    throw dbwrapper_error(errmsg);
 }
 
 const std::vector<unsigned char>& GetObfuscateKey(const CDBWrapper &w)


### PR DESCRIPTION
The `leveldb::Status` class logs the filename of corrupted files, which might be useful when looking at error reports from usres. In theory this is already logged via the `LogPrintf()` statement in `HandleError()`, but that may not always be close to where the final error message is logged, e.g. see https://github.com/bitcoin/bitcoin/issues/11355#issuecomment-340340542 where the log trace provided by the user does not contain that information (and other user comments in the same issue).

This also adds a log message instructing the user to run the process with `-debug=leveldb`, which provides much more verbose error messages about LevelDB internals. This may not really help much, but improving the error messages here can't hurt.