### PR TITLE
Rename LevelDB background compaction thread

### DIFF
--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -3,6 +3,8 @@
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 #if !defined(LEVELDB_PLATFORM_WINDOWS)
 
+#include <util.h>  // Bitcoin util.h for RenameThread()
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -642,6 +644,7 @@ void PosixEnv::Schedule(void (*function)(void*), void* arg) {
 }
 
 void PosixEnv::BGThread() {
+  RenameThread("leveldb-bgcompact");
   while (true) {
     // Wait until there is an item that is ready to run
     PthreadCall("lock", pthread_mutex_lock(&mu_));


### PR DESCRIPTION
LevelDB performs frequent and potentially expensive background compactions, especially at process start time. It launches its own thread to manage this task. Unfortunately this thread inherits the name of the whatever thread initiated the write, usually `bitcoin-loadblk` or `bitcoin-msghand`. This can lead to erroneous assumptions about what those threads are doing.

This change isn't really that useful by itself, but in general I am interested in making more changes to the LevelDB environment. Other changes I'd like to make:

 * Have the environment report if it uses mmap, and what the limit is
 * Allow changing the mmap and fd limits
 * Make limits per-handle rather than global
 * De-prioritizing CPU on the background compaction thread

Another way to do this is to not modify `env_posix.cc`, and bring all of the environment code in tree. This is what the LevelDB documentation recommends doing, and is also what Chome and Chromium do (they do not use `env_posix.cc` at all). I am open to doing that too (it's not as much work as it sounds), this PR is kind of a litmus test for how people feel about the topic generally.