### PR TITLE
configure: UniValue 1.0.4 is required for pushKV(, bool)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1025,7 +1025,7 @@ if test x$system_univalue != xno ; then
     m4_ifdef(
       [PKG_CHECK_MODULES],
       [
-        PKG_CHECK_MODULES([UNIVALUE],[libunivalue],[found_univalue=yes],[true])
+        PKG_CHECK_MODULES([UNIVALUE],[libunivalue >= 1.0.4],[found_univalue=yes],[true])
       ]
     )
   else


### PR DESCRIPTION
The breaking changes (#12193) are already merged, so this blocks 0.17.0.

It depends on jgarzik/univalue#42 or jgarzik/univalue#50 being merged and released in UniValue 1.0.4.