### PR TITLE
Doc: do update before fetching packages in WSL build guide

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -62,6 +62,8 @@ installing the toolchain will be different.
 
 First, install the general dependencies:
 
+    sudo apt update
+    sudo apt upgrade
     sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git
 
 A host toolchain (`build-essential`) is necessary because some dependency


### PR DESCRIPTION
Add update and upgrade commands to enable the installation of the first dependencies on ubuntu xenial. If those are not executed some packages can not be found.