### PR TITLE
mempool: Avoid locking mutex that is already held by the same thread

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -505,7 +505,7 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
 {
     // Remove transactions spending a coinbase which are now immature and no-longer-final transactions
-    LOCK(cs);
+    AssertLockHeld(cs);
     setEntries txToRemove;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         const CTransaction& tx = it->GetTx();


### PR DESCRIPTION
Avoid locking mutex that is already held by the same thread.

This is a subset of #12665.

Related PR #11762.

Ping @MarcoFalke :-)