### PR TITLE
Add missing virtual destructor in PeerLogicValidation

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -469,6 +469,13 @@ public:
     virtual bool SendMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;
+
+protected:
+    /**
+     * Protected destructor so that instances can only be deleted by derived classes.
+     * If that restriction is no longer desired, this should be made public and virtual.
+     */
+    ~NetEventsInterface() = default;
 };
 
 enum

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -35,7 +35,7 @@ static constexpr int64_t EXTRA_PEER_CHECK_INTERVAL = 45;
 /** Minimum time an outbound-peer-eviction candidate must be connected for, in order to evict, in seconds */
 static constexpr int64_t MINIMUM_CONNECT_TIME = 30;
 
-class PeerLogicValidation : public CValidationInterface, public NetEventsInterface {
+class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
     CConnman* const connman;
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -56,6 +56,11 @@ void SyncWithValidationInterfaceQueue();
 class CValidationInterface {
 protected:
     /**
+     * Protected destructor so that instances can only be deleted by derived classes.
+     * If that restriction is no longer desired, this should be made public and virtual.
+     */
+    ~CValidationInterface() = default;
+    /**
      * Notifies listeners of updated block chain tip
      *
      * Called on a background thread.


### PR DESCRIPTION
Silence the following compiler warning:

/usr/include/c++/v1/memory:2285:5: error: delete called on non-final 'PeerLogicValidation' that has
      virtual functions but non-virtual destructor [-Werror,-Wdelete-non-virtual-dtor]
    delete __ptr;
    ^
/usr/include/c++/v1/memory:2598:7: note: in instantiation of member function
      'std::__1::default_delete<PeerLogicValidation>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
init.cpp:201:15: note: in instantiation of member function 'std::__1::unique_ptr<PeerLogicValidation,
      std::__1::default_delete<PeerLogicValidation> >::reset' requested here
    peerLogic.reset();
              ^