### PR TITLE
Fix ComputeTimeSmart test failure with -DDEBUG_LOCKORDER

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -553,7 +553,10 @@ static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64
     if (block) {
         wtx.SetMerkleBranch(block, 0);
     }
-    wallet.AddToWallet(wtx);
+    {
+        LOCK(cs_main);
+        wallet.AddToWallet(wtx);
+    }
     LOCK(wallet.cs_wallet);
     return wallet.mapWallet.at(wtx.GetHash()).nTimeSmart;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3813,12 +3813,7 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const
 {
     unsigned int nTimeSmart = wtx.nTimeReceived;
     if (!wtx.hashUnset()) {
-        const CBlockIndex* pindex = nullptr;
-        {
-            LOCK(cs_main);
-            pindex = LookupBlockIndex(wtx.hashBlock);
-        }
-        if (pindex) {
+        if (const CBlockIndex* pindex = LookupBlockIndex(wtx.hashBlock)) {
             int64_t latestNow = wtx.nTimeReceived;
             int64_t latestEntry = 0;
 


### PR DESCRIPTION
Failure looks like:

```
Entering test case "ComputeTimeSmart"
test_bitcoin: sync.cpp:100: void potential_deadlock_detected(const std::pair<void*, void*>&, const LockStack&, const LockStack&): Assertion `false' failed.
unknown location(0): fatal error in "ComputeTimeSmart": signal: SIGABRT (application abort requested)
wallet/test/wallet_tests.cpp(566): last checkpoint
```

Reproducible with:

```
./configure --enable-debug
make -C src test/test_bitcoin && src/test/test_bitcoin --log_level=test_suite --run_test=wallet_tests/ComputeTimeSmart
```

Seems to be caused by acquiring `cs_main` inside `CWallet::ComputeTimeSmart` in #11041.

I think this may be causing timeouts on travis like: https://travis-ci.org/bitcoin/bitcoin/jobs/353005676#L2692