### PR TITLE
[gui] script addresses for sending, not signing

### DIFF
--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -22,7 +22,7 @@ EditAddressDialog::EditAddressDialog(Mode _mode, QWidget *parent) :
 {
     ui->setupUi(this);
 
-    GUIUtil::setupAddressWidget(ui->addressEdit, this);
+    GUIUtil::setupScriptAddressWidget(ui->addressEdit, this);
 
     switch(mode)
     {

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -68,7 +68,7 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
         ui->sendButton->setIcon(_platformStyle->SingleColorIcon(":/icons/send"));
     }
 
-    GUIUtil::setupAddressWidget(ui->lineEditCoinControlChange, this);
+    GUIUtil::setupScriptAddressWidget(ui->lineEditCoinControlChange, this);
 
     addEntry();
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -37,7 +37,7 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
 #endif
 
     // normal bitcoin address field
-    GUIUtil::setupAddressWidget(ui->payTo, this);
+    GUIUtil::setupScriptAddressWidget(ui->payTo, this);
     // just a label for displaying bitcoin address(es)
     ui->payTo_is->setFont(GUIUtil::fixedPitchFont());
 


### PR DESCRIPTION
pull request to change all dummy addresses to script addresses was a bad idea, since signing with script address is not possible. this PR keeps pubkey addresses for signing example addresses.

I am unfamiliar with git, which is why I reset this repository.

If someone else can do this better in C++, then good luck. Perhaps the type of dummy address can be a parameter in the setupAddressWidget function.