### PR TITLE
Remove unused -testsafemode [AKA: why this PR is wrong]

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -437,7 +437,6 @@ std::string HelpMessage(HelpMessageMode mode)
         strUsage += HelpMessageOpt("-checkpoints", strprintf("Disable expensive verification for known chain history (default: %u)", DEFAULT_CHECKPOINTS_ENABLED));
         strUsage += HelpMessageOpt("-disablesafemode", strprintf("Disable safemode, override a real safe mode event (default: %u)", DEFAULT_DISABLE_SAFEMODE));
         strUsage += HelpMessageOpt("-deprecatedrpc=<method>", "Allows deprecated RPC method(s) to be used");
-        strUsage += HelpMessageOpt("-testsafemode", strprintf("Force safe mode (default: %u)", DEFAULT_TESTSAFEMODE));
         strUsage += HelpMessageOpt("-dropmessagestest=<n>", "Randomly drop 1 of every <n> network messages");
         strUsage += HelpMessageOpt("-fuzzmessagestest=<n>", "Randomly fuzz 1 of every <n> network messages");
         strUsage += HelpMessageOpt("-stopafterblockimport", strprintf("Stop running after importing blocks from disk (default: %u)", DEFAULT_STOPAFTERBLOCKIMPORT));

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -51,9 +51,6 @@ std::string GetWarnings(const std::string& strFor)
         strGUI = _("This is a pre-release test build - use at your own risk - do not use for mining or merchant applications");
     }
 
-    if (gArgs.GetBoolArg("-testsafemode", DEFAULT_TESTSAFEMODE))
-        strStatusBar = strRPC = strGUI = "testsafemode enabled";
-
     // Misc warnings like out of disk space and clock is wrong
     if (strMiscWarning != "")
     {

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -22,6 +22,4 @@ void SetfLargeWorkInvalidChainFound(bool flag);
  */
 std::string GetWarnings(const std::string& strFor);
 
-static const bool DEFAULT_TESTSAFEMODE = false;
-
 #endif //  BITCOIN_WARNINGS_H


### PR DESCRIPTION
Unlike `-disablesafemode`, all `-testsafemode` seems to do is display the following message in QT:

![schermafbeelding 2018-03-14 om 13 10 55](https://user-images.githubusercontent.com/10217/37418681-2d416bcc-2789-11e8-835f-62956881a8ed.png)

However @achow101 and @practicalswift  [point out](https://github.com/bitcoin/bitcoin/pull/10560#issuecomment-307255188) there's more going on:

> `-testsafemode` is not unused. It is part of GetWarnings and will set a warning for strStatusBar, strRPC, and strGUI which will then trigger the safe mode handling of RPCs. Safe mode is still used in the RPCs to disable certain RPCs if safe mode is enabled.

> Ah, sorry. I missed that the safe mode logic in OnRPCPreCommand is triggered by strRPC != nullptr (via GetWarnings("rpc") :-) Thanks for clarifying. Reverting that part of this PR.

That's way too indirect / convoluted for my taste. I'll just leave this PR for future reference.

PS #18 might be closable.