### PR TITLE
Fix possible data race when committing block files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -623,6 +623,7 @@ if test x$TARGET_OS = xdarwin; then
 fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
+AC_CHECK_FUNCS([fdatasync])
 
 AC_CHECK_DECLS([strnlen])
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -732,14 +732,21 @@ void FileCommit(FILE *file)
 #ifdef WIN32
     HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
     FlushFileBuffers(hFile);
-#else
-    #if defined(__linux__) || defined(__NetBSD__)
-    fdatasync(fileno(file));
-    #elif defined(__APPLE__) && defined(F_FULLFSYNC)
+#elif defined(__APPLE__) && defined(F_FULLFSYNC)
     fcntl(fileno(file), F_FULLFSYNC, 0);
-    #else
+#elif HAVE_FDATASYNC
+    fdatasync(fileno(file));
+#else
     fsync(fileno(file));
-    #endif
+#endif
+}
+
+void DirectoryCommit(const fs::path &dirname)
+{
+#ifndef WIN32
+    FILE* file = fsbridge::fopen(dirname, "r");
+    fsync(fileno(file));
+    fclose(file);
 #endif
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -168,7 +168,19 @@ bool error(const char* fmt, const Args&... args)
 }
 
 void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
+
+/**
+ * Ensure file contents are fully committed to disk, using a platform-specific
+ * feature analogous to fsync().
+ */
 void FileCommit(FILE *file);
+
+/**
+ * Sync directory contents. This is required on some environments to ensure that
+ * newly created files are committed to disk.
+ */
+void DirectoryCommit(const fs::path &dirname);
+
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1614,6 +1614,7 @@ void static FlushBlockFile(bool fFinalize = false)
         if (fFinalize)
             TruncateFile(fileOld, vinfoBlockFile[nLastBlockFile].nSize);
         FileCommit(fileOld);
+        DirectoryCommit(GetDataDir() / "blocks");
         fclose(fileOld);
     }
 


### PR DESCRIPTION
It was recently pointed out to me that calling `fsync()` or `fdatasync()` on a new file is not sufficient to ensure it's persisted to disk, as the existence of the file itself is stored in the directory inode. This means that ensuring that a new file is actually committed also requires an `fsync()` on the parent directory. There are lots of discussions about this topic online, e.g. [here](https://www.quora.com/When-should-you-fsync-the-containing-directory-in-addition-to-the-file-itself). This only applies to new files, calling `fsync()` on an old file is always fine.

In theory this means that the block index can race block persistence, as a poorly timed power outage could cause us to commit data to the block index that gets lost in the filesystem. The change here ensures that we call `fsync()` on the blocks directory after committing new block files. I checked the LevelDB source code and they already do this when updating their writeahead log. In theory this could happen at the same time as a chain split and that could cause you to come back online and then miss the block you had committed to the index, which would put you permanently out of sync between the two. This seems pretty far fetched, but we should handle this case correctly anyway.

I'm using a new autoconf macro as well, `AC_CHECK_FUNCS()`. It checks that a function is available and then defines a `HAVE_*` macro if it is, analogous to `AC_CHECK_HEADERS`. Right now `autoscan` complains a lot about the fact that we're not using this, so I figured I might as well start now while I was in this part of the code.

Apparently Windows doesn't have an similar method of syncing filesystem metadata---I'm not an expert on that though.

Also not strictly related to this change, but I have been working on a lot of platform-specific PRs recently and want to refactor `util.h` and `util.cpp` so the platform-specific bits are isolated from the generic util stuff. I intend to create an issue later today to describe how I think that should be done so I can get feedback before starting that work.