### PR TITLE
log: Be less confusing in the way we inform the user that logging has started

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -821,14 +821,13 @@ void InitLogging()
     fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);
 
-    LogPrintf("\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n");
     std::string version_string = FormatFullVersion();
 #ifdef DEBUG
     version_string += " (debug build)";
 #else
     version_string += " (release build)";
 #endif
-    LogPrintf(PACKAGE_NAME " version %s\n", version_string);
+    LogPrintf(PACKAGE_NAME " version %s. Logging started.\n", version_string);
 }
 
 namespace { // Variables internal to initialization process only


### PR DESCRIPTION
Be less confusing in the way we inform the user that logging has started.

Before this patch:

```
$ src/bitcoind -printtoconsole
2018-03-16T13:07:59Z



















2018-03-16T13:07:59Z Bitcoin Core version v0.16.99.0-7be9a9a (release build)
…
```

After this patch:

```
$ src/bitcoind -printtoconsole
2018-03-16T13:07:59Z Bitcoin Core version v0.16.99.0-7be9a9a (release build). Logging started.
…
```

