### PR TITLE
Support serialization as another type without casting

### DIFF
--- a/src/addrman.h
+++ b/src/addrman.h
@@ -59,7 +59,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*static_cast<CAddress*>(this));
+        READWRITE(AsType<CAddress>(*this));
         READWRITE(source);
         READWRITE(nLastSuccess);
         READWRITE(nAttempts);

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -93,7 +93,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*static_cast<CBlockHeader*>(this));
+        READWRITE(AsType<CBlockHeader>(*this));
         READWRITE(vtx);
     }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -349,7 +349,7 @@ public:
         uint64_t nServicesInt = nServices;
         READWRITE(nServicesInt);
         nServices = static_cast<ServiceFlags>(nServicesInt);
-        READWRITE(*static_cast<CService*>(this));
+        READWRITE(AsType<CService>(*this));
     }
 
     // TODO: make private (improves encapsulation)

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -415,7 +415,7 @@ public:
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(static_cast<CScriptBase&>(*this));
+        READWRITE(AsType<CScriptBase>(*this));
     }
 
     CScript& operator+=(const CScript& b)

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -150,6 +150,12 @@ enum
 
 #define READWRITE(...)      (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 
+//! Convert the reference base type to X, without changing constness or reference type.
+template<typename X> X& AsType(X& x) { return x; }
+template<typename X> const X& AsType(const X& x) { return x; }
+template<typename X> X&& AsType(X&& x) { return std::move(x); }
+template<typename X> const X&& AsType(const X&& x) { return std::move(x); }
+
 /** 
  * Implement three methods for serializable objects. These are actually wrappers over
  * "SerializationOp" template, which implements the body of each class' serialization

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -46,7 +46,7 @@ struct CDiskTxPos : public CDiskBlockPos
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(*static_cast<CDiskBlockPos*>(this));
+        READWRITE(AsType<CDiskBlockPos>(*this));
         READWRITE(VARINT(nTxOffset));
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -397,7 +397,7 @@ public:
             mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
         }
 
-        s << *static_cast<const CMerkleTx*>(this);
+        s << AsType<CMerkleTx>(*this);
         std::vector<CMerkleTx> vUnused; //!< Used to be vtxPrev
         s << vUnused << mapValueCopy << vOrderForm << fTimeReceivedIsTxTime << nTimeReceived << fFromMe << fSpent;
     }
@@ -408,7 +408,7 @@ public:
         Init(nullptr);
         char fSpent;
 
-        s >> *static_cast<CMerkleTx*>(this);
+        s >> AsType<CMerkleTx>(*this);
         std::vector<CMerkleTx> vUnused; //!< Used to be vtxPrev
         s >> vUnused >> mapValue >> vOrderForm >> fTimeReceivedIsTxTime >> nTimeReceived >> fFromMe >> fSpent;
 


### PR DESCRIPTION
With the new `AsType` function it's possible to serialize an object as another (compatible) type, and is intended for invoking the serializer of a parent class.

Writing `AsType<Parent>(child)` will work in any context:
* `READWRITE(AsType<Parent>(child))`
* `s << AsType<Parent>(child)`
* `s >> AsType<Parent>(child)`

In case child is `const`, the result will be a reference to a `const Parent` type, resulting in const-correct behavior.

For now this primitive isn't very useful, as the constness is statically known in each of the instances (so a simple cast would work). However, in #10785 I plan to modify the serialization code to have a single implementation which works on a const object when serializing and non-const when deserializing. `AsType` behaves correctly in this case, maintaining the constness of the argument. It's also safer, as this only involves automatic type conversions, and no explicit casts.