### PR TITLE
Make FastRandomContext support standard C++11 RNG interface

### DIFF
--- a/src/random.h
+++ b/src/random.h
@@ -11,6 +11,7 @@
 #include <uint256.h>
 
 #include <stdint.h>
+#include <limits>
 
 /* Seed OpenSSL PRNG with additional entropy data */
 void RandAddSeed();
@@ -121,6 +122,12 @@ public:
 
     /** Generate a random boolean. */
     bool randbool() { return randbits(1); }
+
+    // Compatibility with the C++11 UniformRandomBitGenerator concept
+    typedef uint64_t result_type;
+    static constexpr uint64_t min() { return 0; }
+    static constexpr uint64_t max() { return std::numeric_limits<uint64_t>::max(); }
+    inline uint64_t operator()() { return rand64(); }
 };
 
 /* Number of random bytes returned by GetOSRand.

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -8,6 +8,9 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <random>
+#include <algorithm>
+
 BOOST_FIXTURE_TEST_SUITE(random_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(osrandom_tests)
@@ -55,6 +58,25 @@ BOOST_AUTO_TEST_CASE(fastrandom_randbits)
             BOOST_CHECK(rand < range);
         }
     }
+}
+
+/** Does-it-compile test for compatibility with standard C++11 RNG interface. */
+BOOST_AUTO_TEST_CASE(stdrandom_test)
+{
+    FastRandomContext ctx;
+    std::uniform_int_distribution<int> distribution(3, 9);
+    for (int i = 0; i < 100; ++i) {
+        int x = distribution(ctx);
+        BOOST_CHECK(x >= 3);
+        BOOST_CHECK(x <= 9);
+
+        std::vector<int> test{1,2,3,4,5,6,7,8,9,10};
+        std::shuffle(test.begin(), test.end(), ctx);
+        for (int j = 1; j <= 10; ++j) {
+            BOOST_CHECK(std::find(test.begin(), test.end(), j) != test.end());
+        }
+    }
+
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This makes it possible to plug it into the various standard C++11 random distribution algorithms and other functions like `std::shuffle`.