### PR TITLE
[wallet] feebumper: discard change outputs below discard rate

### DIFF
--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -194,7 +194,7 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
 
     // If the output would become dust, discard it (converting the dust to fee)
     poutput->nValue -= nDelta;
-    if (poutput->nValue <= GetDustThreshold(*poutput, ::dustRelayFee)) {
+    if (poutput->nValue <= GetDustThreshold(*poutput, GetDiscardRate(::feeEstimator))) {
         LogPrint(BCLog::RPC, "Bumping fee and discarding dust output\n");
         new_fee += poutput->nValue;
         mtx.vout.erase(mtx.vout.begin() + nOutput);

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -181,7 +181,10 @@ def test_dust_to_fee(rbf_node, dest_address):
     # the bumped tx sets fee=49,900, but it converts to 50,000
     rbfid = spend_one_input(rbf_node, dest_address)
     fulltx = rbf_node.getrawtransaction(rbfid, 1)
-    bumped_tx = rbf_node.bumpfee(rbfid, {"totalFee": 49900})
+    # (32-byte p2sh-pwpkh output size + 148 p2pkh spend estimate) * 10k(discard_rate) / 1000 = 1800
+    # P2SH outputs are slightly "over-discarding" due to the IsDust calculation assuming it will
+    # be spent as a P2PKH.
+    bumped_tx = rbf_node.bumpfee(rbfid, {"totalFee": 50000-1800})
     full_bumped_tx = rbf_node.getrawtransaction(bumped_tx["txid"], 1)
     assert_equal(bumped_tx["fee"], Decimal("0.00050000"))
     assert_equal(len(fulltx["vout"]), 2)


### PR DESCRIPTION
The "discard rate" is the concept we use to ensure the wallet isnt creating not so useful just-above-relay dust.

Outside of bumpfee previous to this PR, and manually creating such an output, the wallet will never make change outputs of that size, preferring to send them to fees instead.

"Worst case" for the user is that users pay a slightly higher feerate than they were expecting, which is already a possibility with relay dust.