### PR TITLE
Make CKeyStore an interface

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -218,7 +218,7 @@ inconsistencies reported in the debug.log file.
 
 Re-architecting the core code so there are better-defined interfaces
 between the various components is a goal, with any necessary locking
-done by the components (e.g. see the self-contained CKeyStore class
+done by the components (e.g. see the self-contained CBasicKeyStore class
 and its cs_KeyStore lock for example).
 
 Threads

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -7,10 +7,6 @@
 
 #include <util.h>
 
-bool CKeyStore::AddKey(const CKey &key) {
-    return AddKeyPubKey(key, key.GetPubKey());
-}
-
 void CBasicKeyStore::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey)
 {
     AssertLockHeld(cs_KeyStore);

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -17,9 +17,6 @@
 /** A virtual base class for key stores */
 class CKeyStore
 {
-protected:
-    mutable CCriticalSection cs_KeyStore;
-
 public:
     virtual ~CKeyStore() {}
 
@@ -54,6 +51,8 @@ typedef std::set<CScript> WatchOnlySet;
 class CBasicKeyStore : public CKeyStore
 {
 protected:
+    mutable CCriticalSection cs_KeyStore;
+
     KeyMap mapKeys;
     WatchKeyMap mapWatchKeys;
     ScriptMap mapScripts;

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -25,7 +25,6 @@ public:
 
     //! Add a key to the store.
     virtual bool AddKeyPubKey(const CKey &key, const CPubKey &pubkey) =0;
-    virtual bool AddKey(const CKey &key);
 
     //! Check whether a key corresponding to a given address is present in the store.
     virtual bool HaveKey(const CKeyID &address) const =0;
@@ -64,6 +63,7 @@ protected:
 
 public:
     bool AddKeyPubKey(const CKey& key, const CPubKey &pubkey) override;
+    bool AddKey(const CKey &key) { return AddKeyPubKey(key, key.GetPubKey()); }
     bool GetPubKey(const CKeyID &address, CPubKey& vchPubKeyOut) const override;
     bool HaveKey(const CKeyID &address) const override;
     std::set<CKeyID> GetKeys() const override;


### PR DESCRIPTION
Made these simplifications while reviewing #12714. This aims to make `CKeyStore` a *pure* interface:
 - no variable members - the mutex is moved to `CBasicKeyStore` which is where it is used;
 - no method implementations - `AddKey(const CKey &)` is moved to `CBasicKeyStore` which is where it is needed.