### PR TITLE
 Store the current config file at read time, and return it from GetConfigFile if set

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -16,7 +16,8 @@ JSON_TEST_FILES = \
   test/data/tx_invalid.json \
   test/data/tx_valid.json
 
-RAW_TEST_FILES =
+RAW_TEST_FILES = \
+  test/data/conf.raw
 
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -372,7 +372,7 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
         if (failedToGetAuthCookie) {
             throw std::runtime_error(strprintf(
                 "Could not locate RPC credentials. No authentication cookie could be found, and RPC password is not set.  See -rpcpassword and -stdinrpcpass.  Configuration file: (%s)",
-                GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string().c_str()));
+                gArgs.GetConfigFile().string().c_str()));
         } else {
             throw std::runtime_error("Authorization failed: Incorrect rpcuser or rpcpassword");
         }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1240,7 +1240,7 @@ bool AppInitMain()
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
-    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
+    LogPrintf("Using config file %s\n", gArgs.GetConfigFile().string());
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     // Warn about relative -datadir path.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -403,7 +403,7 @@ void openDebugLogfile()
 
 bool openBitcoinConf()
 {
-    boost::filesystem::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+    boost::filesystem::path pathConfig = gArgs.GetConfigFile();
 
     /* Create the file */
     boost::filesystem::ofstream configFile(pathConfig, std::ios_base::app);

--- a/src/test/data/conf.raw
+++ b/src/test/data/conf.raw
@@ -1,0 +1,10 @@
+##
+## bitcoin.conf test configuration file. Lines beginning with # are comments.
+##
+
+foo=
+bar=false
+baz=11
+qux=eleven
+quux=
+noquux=

--- a/src/util.h
+++ b/src/util.h
@@ -89,7 +89,6 @@ fs::path GetDefaultDataDir();
 const fs::path &GetBlocksDir(bool fNetSpecific = true);
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
-fs::path GetConfigFile(const std::string& confPath);
 #ifndef WIN32
 fs::path GetPidFile();
 void CreatePidFile(const fs::path &path, pid_t pid);
@@ -156,6 +155,7 @@ protected:
     std::string m_network;
     std::set<std::string> m_network_only_args;
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args;
+    fs::path m_current_config_path;
 
     bool ReadConfigStream(std::istream& stream, std::string& error, bool ignore_invalid_keys = false);
 
@@ -169,6 +169,8 @@ public:
 
     bool ParseParameters(int argc, const char* const argv[], std::string& error);
     bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);
+
+    fs::path GetConfigFile() const;
 
     /**
      * Log warnings for options in m_section_only_args when


### PR DESCRIPTION
This maintains accuracy in the context of `datadirectory` changes,
e.g. #12722

Also drop the related arguments to `GetConfigFile` and `ReadConfigFile`, and follow the example of `GetDebugLogPath` by calling `GetArg` within the `GetConfigFile` function.