### PR TITLE
Initialize nVersionDummy to zero in deserialization code

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -324,7 +324,7 @@ public:
     void Unserialize(Stream &s) {
         unsigned int nCode = 0;
         // version
-        unsigned int nVersionDummy;
+        unsigned int nVersionDummy = 0;
         ::Unserialize(s, VARINT(nVersionDummy));
         // header code
         ::Unserialize(s, VARINT(nCode));

--- a/src/undo.h
+++ b/src/undo.h
@@ -51,7 +51,7 @@ public:
             // Old versions stored the version number for the last spend of
             // a transaction's outputs. Non-final spends were indicated with
             // height = 0.
-            unsigned int nVersionDummy;
+            unsigned int nVersionDummy = 0;
             ::Unserialize(s, VARINT(nVersionDummy));
         }
         ::Unserialize(s, CTxOutCompressor(REF(txout->out)));


### PR DESCRIPTION
Initialize `nVersionDummy` to zero in deserialization code.

Silences static analyzer warnings.

Hopefully uncontroversial – we're already initializing other variables to zero prior to passing them to  `::Unserialize(…, VARINT(<variable>));`:

```
$ git grep -B1 "::Unserialize.*VARINT"
src/coins.h-        uint32_t code = 0;
src/coins.h:        ::Unserialize(s, VARINT(code));
…
src/undo.h-        unsigned int nCode = 0;
src/undo.h:        ::Unserialize(s, VARINT(nCode));
…
```
