### PR TITLE
Use explicit casting in cuckoocache's compute_hashes(...) to clarify integer conversion

### DIFF
--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -242,14 +242,14 @@ private:
      */
     inline std::array<uint32_t, 8> compute_hashes(const Element& e) const
     {
-        return {{(uint32_t)((hash_function.template operator()<0>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<1>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<2>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<3>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<4>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<5>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<6>(e) * (uint64_t)size) >> 32),
-                 (uint32_t)((hash_function.template operator()<7>(e) * (uint64_t)size) >> 32)}};
+        return {{(uint32_t)(((uint64_t)hash_function.template operator()<0>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<1>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<2>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<3>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<4>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<5>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<6>(e) * (uint64_t)size) >> 32),
+                 (uint32_t)(((uint64_t)hash_function.template operator()<7>(e) * (uint64_t)size) >> 32)}};
     }
 
     /* end


### PR DESCRIPTION
Use explicit casting in cuckoocache's `compute_hashes(...)` to clarify integer conversion.

I discussed this code with the code's author @JeremyRubin who suggested patching it to avoid any confusion.

At least one static analyzer incorrectly warns about a shift past bitwidth (UB) here, so this patch will help avoid confusion for human reviewers and static analyzers alike :-)