### PR TITLE
Issue #10542 Signmessage doesn't work with segwit addresses

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -316,6 +316,21 @@ public:
 };
 } // namespace
 
+bool PubkeyConsistencyVisitor::operator() (const CKeyID & keyid) const {
+	return m_pkey.GetID() == keyid;
+}
+
+bool PubkeyConsistencyVisitor::operator() (const CScriptID & id) const {
+	CScript redeemscript;
+	redeemscript.clear();
+	redeemscript << OP_0 << ToByteVector(WitnessV0KeyHash(m_pkey.GetID()));
+	return id == CScriptID(redeemscript);
+}
+
+bool PubkeyConsistencyVisitor::operator() (const WitnessV0KeyHash & keyid) const {
+	return WitnessV0KeyHash(m_pkey.GetID()) == keyid;
+}
+
 CScript GetScriptForDestination(const CTxDestination& dest)
 {
     CScript script;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -317,18 +317,18 @@ public:
 } // namespace
 
 bool PubkeyConsistencyVisitor::operator() (const CKeyID & keyid) const {
-	return m_pkey.GetID() == keyid;
+    return m_pkey.GetID() == keyid;
 }
 
 bool PubkeyConsistencyVisitor::operator() (const CScriptID & id) const {
-	CScript redeemscript;
-	redeemscript.clear();
-	redeemscript << OP_0 << ToByteVector(WitnessV0KeyHash(m_pkey.GetID()));
-	return id == CScriptID(redeemscript);
+    CScript redeemscript;
+    redeemscript.clear();
+    redeemscript << OP_0 << ToByteVector(WitnessV0KeyHash(m_pkey.GetID()));
+    return id == CScriptID(redeemscript);
 }
 
 bool PubkeyConsistencyVisitor::operator() (const WitnessV0KeyHash & keyid) const {
-	return WitnessV0KeyHash(m_pkey.GetID()) == keyid;
+    return WitnessV0KeyHash(m_pkey.GetID()) == keyid;
 }
 
 CScript GetScriptForDestination(const CTxDestination& dest)

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -121,6 +121,21 @@ struct WitnessUnknown
  */
 typedef boost::variant<CNoDestination, CKeyID, CScriptID, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown> CTxDestination;
 
+/** Check CTxDestination for being based on given public key. Usefull in checking P2SH-segwit verifymessage */
+
+class PubkeyConsistencyVisitor: public boost::static_visitor<bool> {
+	const CPubKey& m_pkey;
+public:
+	bool operator() (const CKeyID& keyid) const;
+	bool operator() (const CScriptID& id) const;
+	bool operator() (const WitnessV0KeyHash& wid) const;
+	bool operator() (const CNoDestination& noid) const { return false; }
+	bool operator() (const WitnessV0ScriptHash& wid) const { return false; }
+	bool operator() (const WitnessUnknown& wid) const { return false; }
+	explicit PubkeyConsistencyVisitor(const CPubKey& pkey) : m_pkey(pkey) {}
+};
+
+
 /** Check whether a CTxDestination is a CNoDestination. */
 bool IsValidDestination(const CTxDestination& dest);
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -124,15 +124,15 @@ typedef boost::variant<CNoDestination, CKeyID, CScriptID, WitnessV0ScriptHash, W
 /** Check CTxDestination for being based on given public key. Usefull in checking P2SH-segwit verifymessage */
 
 class PubkeyConsistencyVisitor: public boost::static_visitor<bool> {
-	const CPubKey& m_pkey;
+    const CPubKey& m_pkey;
 public:
-	bool operator() (const CKeyID& keyid) const;
-	bool operator() (const CScriptID& id) const;
-	bool operator() (const WitnessV0KeyHash& wid) const;
-	bool operator() (const CNoDestination& noid) const { return false; }
-	bool operator() (const WitnessV0ScriptHash& wid) const { return false; }
-	bool operator() (const WitnessUnknown& wid) const { return false; }
-	explicit PubkeyConsistencyVisitor(const CPubKey& pkey) : m_pkey(pkey) {}
+    bool operator() (const CKeyID& keyid) const;
+    bool operator() (const CScriptID& id) const;
+    bool operator() (const WitnessV0KeyHash& wid) const;
+    bool operator() (const CNoDestination& noid) const { return false; }
+    bool operator() (const WitnessV0ScriptHash& wid) const { return false; }
+    bool operator() (const WitnessUnknown& wid) const { return false; }
+    explicit PubkeyConsistencyVisitor(const CPubKey& pkey) : m_pkey(pkey) {}
 };
 
 


### PR DESCRIPTION
bitcoin-cli verifymessage was extended to verify signatures against both
bech32 and segwit-p2sh. Class PubkeyConsistencyVisitor has been added
which takes extracted public key as constructor argument and verifies
signatures against all meaningful CTxDestinations.

Signmessage will be implemented in a next step.