### PR TITLE
Don't test size_t variables for negative values

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -643,7 +643,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
 void AddToCompactExtraTransactions(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans)
 {
     size_t max_extra_txn = gArgs.GetArg("-blockreconstructionextratxn", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN);
-    if (max_extra_txn <= 0)
+    if (max_extra_txn == 0)
         return;
     if (!vExtraTxnForCompact.size())
         vExtraTxnForCompact.resize(max_extra_txn);

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -432,7 +432,7 @@ void TxConfirmStats::Read(CAutoFile& filein, int nFileVersion, size_t numBuckets
     maxPeriods = confAvg.size();
     maxConfirms = scale * maxPeriods;
 
-    if (maxConfirms <= 0 || maxConfirms > 6 * 24 * 7) { // one week
+    if (maxConfirms == 0 || maxConfirms > 6 * 24 * 7) { // one week
         throw std::runtime_error("Corrupt estimates file.  Must maintain estimates for between 1 and 1008 (one week) confirms");
     }
     for (unsigned int i = 0; i < maxPeriods; i++) {


### PR DESCRIPTION
Don't test `size_t` variables for negative values.