### PR TITLE
[build] Tune wildcards for LIBSECP256K1 target

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,7 +53,7 @@ LIBBITCOIN_CRYPTO_AVX2 = crypto/libbitcoin_crypto_avx2.a
 LIBBITCOIN_CRYPTO += $(LIBBITCOIN_CRYPTO_AVX2)
 endif
 
-$(LIBSECP256K1): $(wildcard secp256k1/src/*) $(wildcard secp256k1/include/*)
+$(LIBSECP256K1): $(wildcard secp256k1/src/*.h) $(wildcard secp256k1/src/*.c) $(wildcard secp256k1/include/*)
 	$(AM_V_at)$(MAKE) $(AM_MAKEFLAGS) -C $(@D) $(@F)
 
 # Make is not made aware of per-object dependencies to avoid limiting building parallelization


### PR DESCRIPTION
Automake would think the target was out of date every time because e.g. '.deps' was updated.

Note: I am assuming that secp256k1 depends on `*.h`, `*.c`, ~~and `libsecp256k1-config.h`~~ (it's `.h` so already included), aside from pre-existing `include/*`. If there are other files that would require a rebuild of the `LIBSECP256K1` target, they should probably be added.

It would be neat if you could exclude specific files, rather than split it up like this, but it doesn't seem possible (https://www.gnu.org/software/make/manual/html_node/Wildcard-Function.html#Wildcard-Function)

Should probably note this:
```Bash
$ V=1 make check VERBOSE=1
Making check in src
make[1]: Entering directory '/home/user/workspace/bitcoin/src'
make[2]: Entering directory '/home/user/workspace/bitcoin/src'
make  -C secp256k1 libsecp256k1.la
make[3]: Entering directory '/home/user/workspace/bitcoin/src/secp256k1'
make[3]: 'libsecp256k1.la' is up to date.
make[3]: Leaving directory '/home/user/workspace/bitcoin/src/secp256k1'
make  check-TESTS check-local
make[3]: Entering directory '/home/user/workspace/bitcoin/src'
make[4]: Entering directory '/home/user/workspace/bitcoin/src'
make  -C secp256k1 libsecp256k1.la
make[5]: Entering directory '/home/user/workspace/bitcoin/src/secp256k1'
make[5]: 'libsecp256k1.la' is up to date.
make[5]: Leaving directory '/home/user/workspace/bitcoin/src/secp256k1'
PASS: test/test_bitcoin.exe
```
