### PR TITLE
Don't return a CExtPubKey filled with random data when DecodeExt{Pub,}Key is given input not passing DecodeBase58Check(...)

### DIFF
--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -161,7 +161,7 @@ std::string EncodeSecret(const CKey& key)
 
 CExtPubKey DecodeExtPubKey(const std::string& str)
 {
-    CExtPubKey key;
+    CExtPubKey key = {};
     std::vector<unsigned char> data;
     if (DecodeBase58Check(str, data)) {
         const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_PUBLIC_KEY);
@@ -184,7 +184,7 @@ std::string EncodeExtPubKey(const CExtPubKey& key)
 
 CExtKey DecodeExtKey(const std::string& str)
 {
-    CExtKey key;
+    CExtKey key = {};
     std::vector<unsigned char> data;
     if (DecodeBase58Check(str, data)) {
         const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_SECRET_KEY);


### PR DESCRIPTION
Don't return a `CExtPubKey` filled with random data when `DecodeExt{Pub,}Key` is given input not passing `DecodeBase58Check(...)`.

Before this patch:

```
$ cat > test.cpp
…
int main(void) {
  CExtPubKey key = DecodeExtPubKey("foo");
  std::cout << key.nChild << "\n";
}
^D
$ g++ -o test test.cpp
$ ./test
109452364
$ ./test
-1789494196
$ ./test
-1568076724
$ ./test
1483189324
$ ./test
-1168606132
```

Introduced in ebfe217b15d21656a173e5c102f826d17c6c8be4.