### PR TITLE
Add -walletupdates: resolves #12632

### DIFF
--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -31,6 +31,7 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-paytxfee=<amt>", strprintf(_("Fee (in %s/kB) to add to transactions you send (default: %s)"),
                                                             CURRENCY_UNIT, FormatMoney(payTxFee.GetFeePerK())));
     strUsage += HelpMessageOpt("-rescan", _("Rescan the block chain for missing wallet transactions on startup"));
+    strUsage += HelpMessageOpt("-disablewalletupdates", _("Do not update the wallet with any new blocks that have been seen since last load"));
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet on startup"));
     strUsage += HelpMessageOpt("-spendzeroconfchange", strprintf(_("Spend unconfirmed change when sending transactions (default: %u)"), DEFAULT_SPEND_ZEROCONF_CHANGE));
     strUsage += HelpMessageOpt("-txconfirmtarget=<n>", strprintf(_("If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)"), DEFAULT_TX_CONFIRM_TARGET));

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -31,7 +31,6 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-paytxfee=<amt>", strprintf(_("Fee (in %s/kB) to add to transactions you send (default: %s)"),
                                                             CURRENCY_UNIT, FormatMoney(payTxFee.GetFeePerK())));
     strUsage += HelpMessageOpt("-rescan", _("Rescan the block chain for missing wallet transactions on startup"));
-    strUsage += HelpMessageOpt("-disablewalletupdates", _("Do not update the wallet with any new blocks that have been seen since last load"));
     strUsage += HelpMessageOpt("-salvagewallet", _("Attempt to recover private keys from a corrupt wallet on startup"));
     strUsage += HelpMessageOpt("-spendzeroconfchange", strprintf(_("Spend unconfirmed change when sending transactions (default: %u)"), DEFAULT_SPEND_ZEROCONF_CHANGE));
     strUsage += HelpMessageOpt("-txconfirmtarget=<n>", strprintf(_("If paytxfee is not set, include enough fee so transactions begin confirmation on average within n blocks (default: %u)"), DEFAULT_TX_CONFIRM_TARGET));
@@ -52,6 +51,7 @@ std::string GetWalletHelpString(bool showDebug)
         strUsage += HelpMessageOpt("-flushwallet", strprintf("Run a thread to flush wallet periodically (default: %u)", DEFAULT_FLUSHWALLET));
         strUsage += HelpMessageOpt("-privdb", strprintf("Sets the DB_PRIVATE flag in the wallet db environment (default: %u)", DEFAULT_WALLET_PRIVDB));
         strUsage += HelpMessageOpt("-walletrejectlongchains", strprintf(_("Wallet will not create transactions that violate mempool chain limits (default: %u)"), DEFAULT_WALLET_REJECT_LONG_CHAINS));
+        strUsage += HelpMessageOpt("-walletupdates", _("Update the wallet with new blocks that have been seen since last load (default: 1)"));
     }
 
     return strUsage;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -439,7 +439,7 @@ void CWallet::SetBestChain(const CBlockLocator& loc)
     // do not update the best block seen so that we
     // always eventually scan the chain for transactions
     // that should be indexed by this wallet
-    if(gArgs.GetBoolArg("-disablewalletupdates", false))
+    if (!gArgs.GetBoolArg("-walletupdates", true))
         return;
 
     CWalletDB walletdb(*dbw);
@@ -4041,25 +4041,26 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
 
     LOCK(cs_main);
 
-    bool subscribe_to_chain_updates = !gArgs.GetBoolArg("-disablewalletupdates", false);
+    bool subscribe_to_chain_updates = gArgs.GetBoolArg("-walletupdates", true);
     CBlockIndex *pindexRescan = chainActive.Genesis();
     if (!gArgs.GetBoolArg("-rescan", false))
     {
-        if(subscribe_to_chain_updates) {
+        if (subscribe_to_chain_updates) {
             CWalletDB walletdb(*walletInstance->dbw);
             CBlockLocator locator;
-            if (walletdb.ReadBestBlock(locator))
+            if (walletdb.ReadBestBlock(locator)) {
                 pindexRescan = FindForkInGlobalIndex(chainActive, locator);
+            }
         } else {
             pindexRescan = chainActive.Tip();
         }
     }
 
     walletInstance->m_last_block_processed = chainActive.Tip();
-    if(subscribe_to_chain_updates) {
+    if (subscribe_to_chain_updates) {
         RegisterValidationInterface(walletInstance);
     } else {
-        LogPrintf("Not registering ValidationInterface for wallet as -disablewalletupdates is set\n");
+        LogPrintf("Not registering CValidationInterface for wallet as -walletupdates=0\n");
     }
 
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)


### PR DESCRIPTION
When false, wallet does not rescan the chain from its last known best block on startup or subscribe to CValidationInterface notifications.  Useful for wallet maintenance type activities where one desires to avoid the overhead of rescan on startup.

Fixes #12632.