### PR TITLE
do not truncate .dat extension for wallets in gui

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -748,11 +748,7 @@ int WalletModel::getDefaultConfirmTarget() const
 QString WalletModel::getWalletName() const
 {
     LOCK(wallet->cs_wallet);
-    QString walletName = QString::fromStdString(wallet->GetName());
-    if (walletName.endsWith(".dat")) {
-        walletName.truncate(walletName.size() - 4);
-    }
-    return walletName;
+    return QString::fromStdString(wallet->GetName());
 }
 
 bool WalletModel::isMultiwallet()


### PR DESCRIPTION
Truncating the extension results in wallet name ambiguity and the inability to use the wallet in GUI debug rpc console.

Resolves #12794 