### PR TITLE
doc: Add note about our preference for scoped enumerations ("enum class")

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -39,6 +39,7 @@ code.
   - `++i` is preferred over `i++`.
   - `nullptr` is preferred over `NULL` or `(void*)0`.
   - `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.
+  - `enum class` is preferred over `enum` where possible. Scoped enumerations avoid two potential pitfalls/problems with traditional C++ enumerations: implicit conversions to int, and name clashes due to enumerators being exported to the surrounding scope.
 
 Block style example:
 ```c++


### PR DESCRIPTION
Add note about our preference for scoped enumerations (`enum class`).

Context: #10742