### PR TITLE
Add option to only notify after wallet transactions are confirmed

### DIFF
--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -39,6 +39,7 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-walletbroadcast", _("Make the wallet broadcast transactions") + " " + strprintf(_("(default: %u)"), DEFAULT_WALLETBROADCAST));
     strUsage += HelpMessageOpt("-walletdir=<dir>", _("Specify directory to hold wallets (default: <datadir>/wallets if it exists, otherwise <datadir>)"));
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
+    strUsage += HelpMessageOpt("-walletnotifyconfirmations=<n>", strprintf(_("Number of confirmations to wait before calling wallet notify command (default: %u)"), DEFAULT_WALLETNOTIFY_NCONFIRMATIONS));
     strUsage += HelpMessageOpt("-walletrbf", strprintf(_("Send transactions with full-RBF opt-in enabled (RPC only, default: %u)"), DEFAULT_WALLET_RBF));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
                                " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
@@ -109,6 +110,15 @@ bool WalletParameterInteraction()
         return InitError("-sysperms is not allowed in combination with enabled wallet functionality");
     if (gArgs.GetArg("-prune", 0) && gArgs.GetBoolArg("-rescan", false))
         return InitError(_("Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again."));
+
+    if (gArgs.IsArgSet("-walletnotifyconfirmations")) {
+        int n_confirmations = gArgs.GetArg("-walletnotifyconfirmations", DEFAULT_WALLETNOTIFY_NCONFIRMATIONS);
+        if (n_confirmations < 0) {
+            return InitError(strprintf(_("-walletnotifyconfirmations must be >= 0 (value: %d)"), n_confirmations));
+        } else if (!gArgs.IsArgSet("-walletnotify")) {
+            return InitError(strprintf(_("No -walletnotify command specified but -walletnotifyconfirmations is provided (value: %d)"), n_confirmations));
+        }
+    }
 
     if (::minRelayTxFee.GetFeePerK() > HIGH_TX_FEE_PER_KB)
         InitWarning(AmountHighWarn("-minrelaytxfee") + " " +

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -34,8 +34,6 @@
 #include <assert.h>
 #include <future>
 
-#include <boost/algorithm/string/replace.hpp>
-
 std::vector<CWalletRef> vpwallets;
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
@@ -959,15 +957,10 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
     // Notify UI of new or updated transaction
     NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
 
+    // if nconfirmations=0 then - notify on every transaction change
     // notify an external script when a wallet transaction comes in or is updated
-    std::string strCmd = gArgs.GetArg("-walletnotify", "");
-
-    if (!strCmd.empty())
-    {
-        boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
-        std::thread t(runCommand, strCmd);
-        t.detach(); // thread runs free
-    }
+    if (m_notifier.GetConfirmationsRequired() == 0)
+        m_notifier.AddTransaction(*wtxIn.tx);
 
     return true;
 }
@@ -1206,6 +1199,10 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pin
             it->second.MarkDirty();
         }
     }
+
+    // if we are notifying in confirmed mode and this was due to a connected block
+    if (pindex && m_notifier.GetConfirmationsRequired() > 1)
+        m_notifier.AddTransaction(*ptx, pindex->nHeight);
 }
 
 void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx) {
@@ -1228,6 +1225,13 @@ void CWallet::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
 
 void CWallet::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) {
     LOCK2(cs_main, cs_wallet);
+
+    // call the notifier to notify on any transactions that have now
+    // reached the required number of block confirmations
+    // must be done first as the bucket storing these transactions will be
+    // emptied here and then reused below in SyncTransaction
+    m_notifier.BlockConnected(pindex->nHeight);
+
     // TODO: Temporarily ensure that mempool removals are notified before
     // connected transactions.  This shouldn't matter, but the abandoned
     // state of transactions in our wallet is currently cleared when we
@@ -3989,6 +3993,15 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
         walletInstance->SetMaxVersion(nMaxVersion);
     }
 
+    if (gArgs.IsArgSet("-walletnotify")) {
+        std::string notify_command = gArgs.GetArg("-walletnotify", "");
+        int confirmations_required = gArgs.GetArg("-walletnotifyconfirmations", DEFAULT_WALLETNOTIFY_NCONFIRMATIONS);
+
+        walletInstance->m_notifier = WalletTransactionNotifier(notify_command, confirmations_required, chainActive.Height());
+        std::string notification_policy = (confirmations_required == 0) ? "all updates" : strprintf("%d confirmations", confirmations_required);
+        LogPrintf("Wallet transaction notifications enabled: command_template='%s' (notification policy: %s)\n", notify_command, notification_policy);
+    }
+
     if (fFirstRun)
     {
         // ensure this wallet.dat can only be opened by clients supporting HD with chain split and expects no default key
@@ -4055,6 +4068,11 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
     walletInstance->m_last_block_processed = chainActive.Tip();
     RegisterValidationInterface(walletInstance);
 
+    // rewind the rescan start to at least the number of confirmations required in the past
+    int max_rescan_height = std::max<int>(0, chainActive.Height() - walletInstance->m_notifier.GetConfirmationsRequired() + 1);
+    if (pindexRescan && pindexRescan->nHeight > max_rescan_height)
+        pindexRescan = chainActive[max_rescan_height];
+
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)
     {
         //We can't rescan beyond non-pruned blocks, stop and throw an error
@@ -4077,7 +4095,7 @@ CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& 
 
         // No need to read and scan block if block was created before
         // our wallet birthday (as adjusted for block time variability)
-        while (pindexRescan && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
+        while (pindexRescan && pindexRescan->nHeight <= max_rescan_height && walletInstance->nTimeFirstKey && (pindexRescan->GetBlockTime() < (walletInstance->nTimeFirstKey - TIMESTAMP_WINDOW))) {
             pindexRescan = chainActive.Next(pindexRescan);
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1201,7 +1201,7 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pin
     }
 
     // if we are notifying in confirmed mode and this was due to a connected block
-    if (pindex && m_notifier.GetConfirmationsRequired() > 1)
+    if (pindex && m_notifier.GetConfirmationsRequired() >= 1)
         m_notifier.AddTransaction(*ptx, pindex->nHeight);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -959,8 +959,9 @@ bool CWallet::AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose)
 
     // if nconfirmations=0 then - notify on every transaction change
     // notify an external script when a wallet transaction comes in or is updated
-    if (m_notifier.GetConfirmationsRequired() == 0)
+    if (m_notifier.GetConfirmationsRequired() == 0) {
         m_notifier.AddTransaction(*wtxIn.tx);
+    }
 
     return true;
 }
@@ -1201,8 +1202,9 @@ void CWallet::SyncTransaction(const CTransactionRef& ptx, const CBlockIndex *pin
     }
 
     // if we are notifying in confirmed mode and this was due to a connected block
-    if (pindex && m_notifier.GetConfirmationsRequired() >= 1)
+    if (pindex && m_notifier.GetConfirmationsRequired() >= 1) {
         m_notifier.AddTransaction(*ptx, pindex->nHeight);
+    }
 }
 
 void CWallet::TransactionAddedToMempool(const CTransactionRef& ptx) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -686,8 +686,8 @@ public:
      * Should be called every time a block is connected
      *
      * When m_confirmations_required > 1, notifies
-     * of transactions that have not reached the
-     * required confirmation count
+     * of transactions that have now reached the
+     * required number of confirmations
      *
      * Internally builds a buffer of transactions from
      * up to the last (m_confirmations_required - 1) blocks

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -720,7 +720,7 @@ public:
         }
 
         // reset the bucket for the block just connected
-        m_unconfirmed_wallet_transactions[buffer_pos(height)].empty();
+        m_unconfirmed_wallet_transactions[buffer_pos(height)].clear();
         m_buffer_height_max = height;
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -649,10 +649,6 @@ public:
         }
 
         m_active = (notify_command_template != "");
-        if (m_active) {
-            LogPrintf("WalletTransactionnotifier: notifying on wallet transactions with %d confirmations (cmd: %s)\n",
-                m_confirmations_required, m_notify_command_template);
-        }
     }
 
     /*
@@ -662,9 +658,7 @@ public:
      * If m_confirmations_required is 1, notifies immediately
      * Otherwise:
      * Updates a circular buffer which contains transactions
-     * from the last (m_confirmations_required - 1)
-     * blocks.
-     *
+     * from the last (m_confirmations_required - 1) blocks.
      */
     void AddTransaction(const CTransaction& tx, unsigned int height)
     {
@@ -696,7 +690,7 @@ public:
      * required confirmation count
      *
      * Internally builds a buffer of transactions from
-     * up to the last m_confirmations_required - 1 blocks
+     * up to the last (m_confirmations_required - 1) blocks
      * And thus in order to function correctly, this
      * must be called consistently on every newly connected block
      */

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -60,6 +60,7 @@ class NotificationsTest(BitcoinTestFramework):
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
         with open(self.tx_filename, 'r') as f:
             assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
+        os.remove(self.tx_filename)
 
         # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
         self.log.info("test -alertnotify")
@@ -81,6 +82,37 @@ class NotificationsTest(BitcoinTestFramework):
 
         self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
         assert_equal(alert_text, alert_text2)
+
+        self.log.info("test -walletnotify with -walletnotifyconfirmations > 1")
+        n_confirmations = 6
+
+        # first have a different node generate blocks that we shouldn't see confirmations for
+        self.nodes[0].generate(n_confirmations + 1)
+        self.sync_all()
+        os.remove(self.tx_filename)
+
+        # now generate some blocks but don't bury any enough to be confirmed (they'll be confirmed later)
+        generated_before_restart = self.nodes[1].generate(n_confirmations - 2)
+        confirmed_txids = [t['txid'] for t in self.nodes[1].listtransactions("*", 100) if t['blockhash'] in generated_before_restart]
+
+        # restart node with notify on confirmations enabled
+        self.restart_node(1, ["-walletnotifyconfirmations=%s" % n_confirmations,
+                              "-walletnotify=echo %%s >> %s" % self.tx_filename])
+
+        # mine some more blocks (we should receive notifications on the ones above plus all but the last n_confirmations - 1 of these)
+        generated_after_restart = self.nodes[1].generate(block_count + n_confirmations - 1)[:-n_confirmations + 1]
+        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+
+        # get the list of block hashes that should now be confirmed
+        buried_blocks = generated_before_restart + generated_after_restart
+
+        # file content should equal the generated transaction hashes that are confirmed
+        confirmed_txids += [t['txid'] for t in self.nodes[1].listtransactions("*", 1000) if t['blockhash'] in generated_after_restart]
+
+        with open(self.tx_filename, 'r') as f:
+            notified = f.read().splitlines()
+
+            assert_equal(sorted(confirmed_txids), sorted(notified))
 
 if __name__ == '__main__':
     NotificationsTest().main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -103,9 +103,6 @@ class NotificationsTest(BitcoinTestFramework):
         generated_after_restart = self.nodes[1].generate(block_count + n_confirmations - 1)[:-n_confirmations + 1]
         wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
 
-        # get the list of block hashes that should now be confirmed
-        buried_blocks = generated_before_restart + generated_after_restart
-
         # file content should equal the generated transaction hashes that are confirmed
         confirmed_txids += [t['txid'] for t in self.nodes[1].listtransactions("*", 1000) if t['blockhash'] in generated_after_restart]
 


### PR DESCRIPTION
Optionally only call -walletnotify command when a certain number of confirmations have been seen

This addresses issue #10021