### PR TITLE
test: Make summary row bold-red if any test failed and show failed tests at end of table

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -367,7 +367,7 @@ def run_tests(test_list, src_dir, build_dir, exeext, tmpdir, jobs=1, enable_cove
 def print_results(test_results, max_len_name, runtime):
     results = "\n" + BOLD[1] + "%s | %s | %s\n\n" % ("TEST".ljust(max_len_name), "STATUS   ", "DURATION") + BOLD[0]
 
-    test_results.sort(key=lambda result: result.name.lower())
+    test_results.sort(key=TestResult.sort_key)
     all_passed = True
     time_sum = 0
 
@@ -458,6 +458,14 @@ class TestResult():
         self.status = status
         self.time = time
         self.padding = 0
+
+    def sort_key(self):
+        if self.status == "Passed":
+            return 0, self.name.lower()
+        elif self.status == "Failed":
+            return 2, self.name.lower()
+        elif self.status == "Skipped":
+            return 1, self.name.lower()
 
     def __repr__(self):
         if self.status == "Passed":

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -378,7 +378,11 @@ def print_results(test_results, max_len_name, runtime):
         results += str(test_result)
 
     status = TICK + "Passed" if all_passed else CROSS + "Failed"
+    if not all_passed:
+        results += RED[1]
     results += BOLD[1] + "\n%s | %s | %s s (accumulated) \n" % ("ALL".ljust(max_len_name), status.ljust(9), time_sum) + BOLD[0]
+    if not all_passed:
+        results += RED[0]
     results += "Runtime: %s s\n" % (runtime)
     print(results)
 


### PR DESCRIPTION
Make the summary row of the test runner bold red if *any* test fails. This helps visibility if something fails.
(yesteryday I had a snafu where I missed that `feature_blocksdir.py` had failed because it's one of the earlier tests in the list, this intends to avoid that in the future)

Before:
![testfailold](https://user-images.githubusercontent.com/126646/38021100-3fbaf1c6-327c-11e8-8bae-d3ba46e77408.png)

After:
![testfailnew](https://user-images.githubusercontent.com/126646/38021108-43ac7ef8-327c-11e8-8566-e52bcbaf89b8.png)

If tests pass it still looks the same:

![testok](https://user-images.githubusercontent.com/126646/38021115-4a8e9954-327c-11e8-8fe4-34e889384d3e.png)
