### PR TITLE
contrib: Remove unused import string

### DIFF
--- a/contrib/devtools/clang-format-diff.py
+++ b/contrib/devtools/clang-format-diff.py
@@ -71,7 +71,6 @@ import argparse
 import difflib
 import io
 import re
-import string
 import subprocess
 import sys
 


### PR DESCRIPTION
Tiny oversight in #11881, that broke travis.