### PR TITLE
Fix lint error that is making travis builds fail 

### DIFF
--- a/contrib/devtools/clang-format-diff.py
+++ b/contrib/devtools/clang-format-diff.py
@@ -71,7 +71,6 @@ import argparse
 import difflib
 import io
 import re
-import string
 import subprocess
 import sys
 


### PR DESCRIPTION
Some [travis builds are failing](https://travis-ci.org/bitcoin/bitcoin/jobs/359545066) due to lint-python.sh error checking `clang-format-diff.py` (unused import). 

Think this should do the trick. Let's see how travis reacts. 