### PR TITLE
Prevent concurrent savemempool

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4766,6 +4766,9 @@ bool DumpMempool()
     std::map<uint256, CAmount> mapDeltas;
     std::vector<TxMempoolInfo> vinfo;
 
+    static Mutex dump_mutex;
+    LOCK(dump_mutex);
+
     {
         LOCK(mempool.cs);
         for (const auto &i : mempool.mapDeltas) {


### PR DESCRIPTION
Follow up of #12172, this change prevents calling `savemempool` RPC concurrently.