### PR TITLE
[tests] Test starting bitcoind with -h and -version

### DIFF
--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Verify that starting bitcoin with -h works as expected."""
+import subprocess
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class HelpTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+        # Don't start the node
+
+    def run_test(self):
+        self.log.info("Start bitcoin with -h for help text")
+        self.nodes[0].start(extra_args=['-h'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        # Node should exit immediately and output help to stdout.
+        ret_code = self.nodes[0].process.wait(timeout=1)
+        assert_equal(ret_code, 0)
+        output = self.nodes[0].process.stdout.read()
+        assert b'Options' in output
+        self.log.info("Help text received: {} (...)".format(output[0:60]))
+        self.nodes[0].running = False
+
+        self.log.info("Start bitcoin with -version for version information")
+        self.nodes[0].start(extra_args=['-version'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        # Node should exit immediately and output version to stdout.
+        ret_code = self.nodes[0].process.wait(timeout=1)
+        assert_equal(ret_code, 0)
+        output = self.nodes[0].process.stdout.read()
+        assert b'version' in output
+        self.log.info("Version text received: {} (...)".format(output[0:60]))
+        self.nodes[0].running = False
+
+if __name__ == '__main__':
+    HelpTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -138,6 +138,7 @@ BASE_SCRIPTS= [
     'p2p_node_network_limited.py',
     'feature_blocksdir.py',
     'feature_config_args.py',
+    'feature_help.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]


### PR DESCRIPTION
Test that starting bitcoind/bitcoin-qt with `-h` and `-version` works as expected.

Prompted by https://github.com/bitcoin/bitcoin/pull/10762#commitcomment-28345993, which is a nullpointer dereference triggered by starting bitcoin-qt with `-h`.

On master, this test passes when run over bitcoind, but fails when running over bitcoin-qt. I used xvfb as a virtual frame buffer to test:

```
BITCOIND=/home/ubuntu/bitcoin/src/qt/bitcoin-qt xvfb-run ./feature_help.py --nocleanup
2018-03-30T17:09:37.767000Z TestFramework (INFO): Initializing test directory /tmp/user/1000/testdi4dre13
2018-03-30T17:09:37.767000Z TestFramework (INFO): Start bitcoin with -h for help text
2018-03-30T17:09:37.841000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/home/ubuntu/bitcoin/test/functional/test_framework/test_framework.py", line 126, in main
    self.run_test()
  File "./feature_help.py", line 25, in run_test
    assert_equal(ret_code, 0)
  File "/home/ubuntu/bitcoin/test/functional/test_framework/util.py", line 39, in assert_equal
    raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
AssertionError: not(-11 == 0)
2018-03-30T17:09:37.842000Z TestFramework (INFO): Stopping nodes
Traceback (most recent call last):
  File "./feature_help.py", line 42, in <module>
    HelpTest().main()
  File "/home/ubuntu/bitcoin/test/functional/test_framework/test_framework.py", line 149, in main
    self.stop_nodes()
  File "/home/ubuntu/bitcoin/test/functional/test_framework/test_framework.py", line 273, in stop_nodes
    node.stop_node()
  File "/home/ubuntu/bitcoin/test/functional/test_framework/test_node.py", line 141, in stop_node
    self.stop()
  File "/home/ubuntu/bitcoin/test/functional/test_framework/test_node.py", line 87, in __getattr__
    assert self.rpc_connected and self.rpc is not None, "Error: no RPC connection"
AssertionError: Error: no RPC connection
```

Passes for bitcoind and bitcoin-qt when run on #12836.

Longer term, we should consider running functional tests over bitcoin-qt in one of the Travis jobs.