### PR TITLE
Trivial: Add logging line in init.cpp that was accidentally removed with #10762

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -80,7 +80,7 @@ public:
     bool ParameterInteraction() override {return true;}
     void RegisterRPC(CRPCTable &) override {}
     bool Verify() override {return true;}
-    bool Open() override {return true;}
+    bool Open() override {LogPrintf("No wallet support compiled in!\n"); return true;}
     void Start(CScheduler& scheduler) override {}
     void Flush() override {}
     void Stop() override {}


### PR DESCRIPTION
I made the change based off of the DummyWalletInit refactor commit. I can rebase once that is merged.

I built with wallet disabled and debug enabled. I then confirmed in the debug output that the logging line I added back indeed printed.