### PR TITLE
Bugfix: Include <memory> for std::unique_ptr

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -15,6 +15,7 @@
 #include <util.h>
 #include <utilstrencodings.h>
 
+#include <memory>
 #include <stdio.h>
 
 #include <event2/buffer.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -22,6 +22,7 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+#include <memory>
 #include <stdio.h>
 
 #include <boost/algorithm/string.hpp>

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -11,6 +11,7 @@
 #include <utilstrencodings.h>
 
 #include <assert.h>
+#include <memory>
 
 #include <chainparamsseeds.h>
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -9,6 +9,7 @@
 #include <util.h>
 
 #include <assert.h>
+#include <memory>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,6 +4,7 @@
 
 #include <dbwrapper.h>
 
+#include <memory>
 #include <random.h>
 
 #include <leveldb/cache.h>

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -17,6 +17,8 @@
 #include <crypto/hmac_sha256.h>
 #include <stdio.h>
 
+#include <memory>
+
 #include <boost/algorithm/string.hpp> // boost::trim
 
 /** WWW-Authenticate to present with 401 Unauthorized response */

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -13,6 +13,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 #include <unordered_map>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -27,6 +27,7 @@
 #include <validationinterface.h>
 
 #include <algorithm>
+#include <memory>
 #include <queue>
 #include <utility>
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -20,6 +20,7 @@
 #include <ui_interface.h>
 #include <utilstrencodings.h>
 
+#include <memory>
 #ifdef WIN32
 #include <string.h>
 #else

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,8 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+#include <memory>
+
 #if defined(NDEBUG)
 # error "Bitcoin cannot be compiled without assertions."
 #endif

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -12,6 +12,7 @@
 #include <sync.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -7,6 +7,8 @@
 
 #include <net.h>
 
+#include <memory>
+
 #include <QAbstractTableModel>
 #include <QStringList>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -37,6 +37,7 @@
 #include <wallet/wallet.h>
 #endif
 
+#include <memory>
 #include <stdint.h>
 
 #include <boost/thread.hpp>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -16,6 +16,7 @@
 #include <wallet/wallet.h>
 
 #include <cstdlib>
+#include <memory>
 
 #include <openssl/x509_vfy.h>
 

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -8,6 +8,8 @@
 #include <net_processing.h> // For CNodeStateStats
 #include <net.h>
 
+#include <memory>
+
 #include <QAbstractTableModel>
 #include <QStringList>
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -18,6 +18,8 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/receiverequestdialog.h>
 
+#include <memory>
+
 #include <QAbstractButton>
 #include <QAction>
 #include <QApplication>

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -7,6 +7,8 @@
 
 #include <qt/walletmodel.h>
 
+#include <memory>
+
 #include <QObject>
 
 class SendCoinsRecipient;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -33,6 +33,7 @@
 
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
 
+#include <memory>
 #include <mutex>
 #include <condition_variable>
 

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <algorithm>
+#include <memory>
 
 LockedPoolManager* LockedPoolManager::_instance = nullptr;
 std::once_flag LockedPoolManager::init_flag;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -4,6 +4,7 @@
 
 #include <sync.h>
 
+#include <memory>
 #include <set>
 #include <util.h>
 #include <utilstrencodings.h>

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -7,6 +7,8 @@
 #include <support/allocators/secure.h>
 #include <test/test_bitcoin.h>
 
+#include <memory>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(allocator_tests, BasicTestingSetup)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -7,6 +7,8 @@
 #include <random.h>
 #include <test/test_bitcoin.h>
 
+#include <memory>
+
 #include <boost/test/unit_test.hpp>
 
 // Test if a string consists entirely of null characters

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -13,6 +13,8 @@
 #include <chainparams.h>
 #include <util.h>
 
+#include <memory>
+
 class CAddrManSerializationMock : public CAddrMan
 {
 public:

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -14,6 +14,8 @@
 #include <txdb.h>
 #include <txmempool.h>
 
+#include <memory>
+
 #include <boost/thread.hpp>
 
 extern uint256 insecure_rand_seed;

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <memory>
 #include <vector>
 
 enum TEST_ID {

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -6,6 +6,8 @@
 
 #include <net.h>
 
+#include <memory>
+
 #include <boost/test/unit_test.hpp>
 
 std::unique_ptr<CConnman> g_connman;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,6 +11,7 @@
 #include <chain.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <exception>
 #include <map>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <exception>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdint.h>
 #include <string>

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -9,6 +9,8 @@
 
 #include <wallet/wallet.h>
 
+#include <memory>
+
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup: public TestingSetup {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/wallet.h>
 
+#include <memory>
 #include <set>
 #include <stdint.h>
 #include <utility>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <atomic>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdexcept>
 #include <stdint.h>


### PR DESCRIPTION
Not sure why all these includes were missing, but it's breaking builds for some users:

https://bugs.gentoo.org/show_bug.cgi?id=652142

(Added to all files with a reference to `std::unique_ptr`)