### PR TITLE
 Add from_me and bip125-replaceable to listunspent and gettransaction

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -18,9 +18,9 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<CO
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
     CWalletTx* wtx = new CWalletTx(&wallet, MakeTransactionRef(std::move(tx)));
-
+    bool fromMe = wtx->fFromMe == 1;
     int nAge = 6 * 24;
-    COutput output(wtx, nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */);
+    COutput output(wtx, nInput, nAge, true /* spendable */, true /* solvable */, fromMe, true /* safe */);
     vCoins.push_back(output);
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -582,7 +582,8 @@ void WalletModel::getOutputs(const std::vector<COutPoint>& vOutpoints, std::vect
         if (it == wallet->mapWallet.end()) continue;
         int nDepth = it->second.GetDepthInMainChain();
         if (nDepth < 0) continue;
-        COutput out(&it->second, outpoint.n, nDepth, true /* spendable */, true /* solvable */, true /* safe */);
+        bool fFromMe = it->second.fFromMe == 1;        
+        COutput out(&it->second, outpoint.n, nDepth, true /* spendable */, true /* solvable */, fFromMe, true /* safe */);
         vOutputs.push_back(out);
     }
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -85,6 +85,20 @@ void EnsureWalletIsUnlocked(CWallet * const pwallet)
     }
 }
 
+std::string GetRBFStatusString(const int confirms, const CTransaction &tx, CTxMemPool &pool)
+{
+    std::string rbfStatus = "no";
+    if (confirms <= 0) {
+        LOCK(mempool.cs);
+        RBFTransactionState rbfState = IsRBFOptIn(tx, pool);
+        if (rbfState == RBFTransactionState::UNKNOWN)
+            rbfStatus = "unknown";
+        else if (rbfState == RBFTransactionState::REPLACEABLE_BIP125)
+            rbfStatus = "yes";
+    }
+    return rbfStatus;
+}
+
 void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
 {
     int confirms = wtx.GetDepthInMainChain();
@@ -109,16 +123,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     entry.pushKV("timereceived", (int64_t)wtx.nTimeReceived);
 
     // Add opt-in RBF status
-    std::string rbfStatus = "no";
-    if (confirms <= 0) {
-        LOCK(mempool.cs);
-        RBFTransactionState rbfState = IsRBFOptIn(*wtx.tx, mempool);
-        if (rbfState == RBFTransactionState::UNKNOWN)
-            rbfStatus = "unknown";
-        else if (rbfState == RBFTransactionState::REPLACEABLE_BIP125)
-            rbfStatus = "yes";
-    }
-    entry.pushKV("bip125-replaceable", rbfStatus);
+    entry.pushKV("bip125-replaceable", GetRBFStatusString(confirms, *wtx.tx, mempool));
 
     for (const std::pair<std::string, std::string>& item : wtx.mapValue)
         entry.pushKV(item.first, item.second);
@@ -2139,6 +2144,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
             "  \"txid\" : \"transactionid\",   (string) The transaction id.\n"
             "  \"time\" : ttt,            (numeric) The transaction time in seconds since epoch (1 Jan 1970 GMT)\n"
             "  \"timereceived\" : ttt,    (numeric) The time received in seconds since epoch (1 Jan 1970 GMT)\n"
+            "  \"from_me\" : \"yes|no\",  (string) Whether this transaction was sent from wallet on this node\n"
             "  \"bip125-replaceable\": \"yes|no|unknown\",  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n"
             "                                                   may be unknown for unconfirmed transactions not in the mempool\n"
             "  \"details\" : [\n"
@@ -2192,12 +2198,14 @@ UniValue gettransaction(const JSONRPCRequest& request)
     CAmount nDebit = wtx.GetDebit(filter);
     CAmount nNet = nCredit - nDebit;
     CAmount nFee = (wtx.IsFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
+    bool fFromMe = wtx.IsFromMe(ISMINE_SPENDABLE); // Ignoring include_watchonly for transaction source
 
     entry.pushKV("amount", ValueFromAmount(nNet - nFee));
     if (wtx.IsFromMe(filter))
         entry.pushKV("fee", ValueFromAmount(nFee));
 
     WalletTxToJSON(wtx, entry);
+    entry.pushKV("from_me", fFromMe? "yes" : "no");
 
     UniValue details(UniValue::VARR);
     ListTransactions(pwallet, wtx, "*", 0, false, details, filter);
@@ -2894,6 +2902,20 @@ UniValue resendwallettransactions(const JSONRPCRequest& request)
     return result;
 }
 
+bool TransactionSourceFromString(const std::string& source_string, TransactionSource& transaction_source) {
+    static const std::map<std::string, TransactionSource> sources = {
+        {"all", TransactionSource::ALL},
+        {"from_me", TransactionSource::FROM_ME},
+        {"external", TransactionSource::EXTERNAL},
+    };
+    auto source = sources.find(source_string);
+
+    if (source == sources.end()) return false;
+
+    transaction_source = source->second;
+    return true;
+}
+
 UniValue listunspent(const JSONRPCRequest& request)
 {
     CWallet * const pwallet = GetWalletForJSONRPCRequest(request);
@@ -2923,6 +2945,10 @@ UniValue listunspent(const JSONRPCRequest& request)
             "      \"maximumAmount\"    (numeric or string, default=unlimited) Maximum value of each UTXO in " + CURRENCY_UNIT + "\n"
             "      \"maximumCount\"     (numeric or string, default=unlimited) Maximum number of UTXOs\n"
             "      \"minimumSumAmount\" (numeric or string, default=unlimited) Minimum sum value of all UTXOs in " + CURRENCY_UNIT + "\n"
+            "      \"source\"           (string, default=\"all\") Output source, must be one of:\n"
+            "           \"all\""
+            "           \"from_me\""
+            "           \"external\""
             "    }\n"
             "\nResult\n"
             "[                   (array of json object)\n"
@@ -2938,6 +2964,8 @@ UniValue listunspent(const JSONRPCRequest& request)
             "    \"redeemScript\" : n        (string) The redeemScript if scriptPubKey is P2SH\n"
             "    \"spendable\" : xxx,        (bool) Whether we have the private keys to spend this output\n"
             "    \"solvable\" : xxx,         (bool) Whether we know how to spend this output, ignoring the lack of keys\n"
+            "    \"from_me\" : xxx,          (bool) Whether output was created by wallet on this node\n"
+            "    \"bip125-replaceable\": xxx,   (string) Whether transaction of this output is marked as BIP125 replaceable (yes|no|unknown)\n"
             "    \"safe\" : xxx              (bool) Whether this output is considered safe to spend. Unconfirmed transactions\n"
             "                              from outside keys and unconfirmed replacement transactions are considered unsafe\n"
             "                              and are not eligible for spending by fundrawtransaction and sendtoaddress.\n"
@@ -2993,6 +3021,7 @@ UniValue listunspent(const JSONRPCRequest& request)
     CAmount nMaximumAmount = MAX_MONEY;
     CAmount nMinimumSumAmount = MAX_MONEY;
     uint64_t nMaximumCount = 0;
+    TransactionSource source = TransactionSource::ALL;
 
     if (!request.params[4].isNull()) {
         const UniValue& options = request.params[4].get_obj();
@@ -3008,6 +3037,12 @@ UniValue listunspent(const JSONRPCRequest& request)
 
         if (options.exists("maximumCount"))
             nMaximumCount = options["maximumCount"].get_int64();
+
+        if (options.exists("source")) {
+            if (!TransactionSourceFromString(options["source"].get_str(), source)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid source parameter");
+            }
+        }
     }
 
     // Make sure the results are valid at least up to the most recent block
@@ -3018,7 +3053,8 @@ UniValue listunspent(const JSONRPCRequest& request)
     std::vector<COutput> vecOutputs;
     LOCK2(cs_main, pwallet->cs_wallet);
 
-    pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount, nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth);
+    pwallet->AvailableCoins(vecOutputs, !include_unsafe, nullptr, nMinimumAmount, nMaximumAmount,
+        nMinimumSumAmount, nMaximumCount, nMinDepth, nMaxDepth, source);
     for (const COutput& out : vecOutputs) {
         CTxDestination address;
         const CScript& scriptPubKey = out.tx->tx->vout[out.i].scriptPubKey;
@@ -3053,6 +3089,8 @@ UniValue listunspent(const JSONRPCRequest& request)
         entry.pushKV("confirmations", out.nDepth);
         entry.pushKV("spendable", out.fSpendable);
         entry.pushKV("solvable", out.fSolvable);
+        entry.pushKV("from_me", out.fFromMe);
+        entry.pushKV("bip125-replaceable", GetRBFStatusString(out.nDepth, *out.tx->tx, mempool));
         entry.pushKV("safe", out.fSafe);
         results.push_back(entry);
     }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2144,7 +2144,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
             "  \"txid\" : \"transactionid\",   (string) The transaction id.\n"
             "  \"time\" : ttt,            (numeric) The transaction time in seconds since epoch (1 Jan 1970 GMT)\n"
             "  \"timereceived\" : ttt,    (numeric) The time received in seconds since epoch (1 Jan 1970 GMT)\n"
-            "  \"from_me\" : \"yes|no\",  (string) Whether this transaction was sent from wallet on this node\n"
+            "  \"from_me\" : \"xxx\",  (bool) Whether this transaction was sent from wallet on this node\n"
             "  \"bip125-replaceable\": \"yes|no|unknown\",  (string) Whether this transaction could be replaced due to BIP125 (replace-by-fee);\n"
             "                                                   may be unknown for unconfirmed transactions not in the mempool\n"
             "  \"details\" : [\n"
@@ -2205,7 +2205,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
         entry.pushKV("fee", ValueFromAmount(nFee));
 
     WalletTxToJSON(wtx, entry);
-    entry.pushKV("from_me", fFromMe? "yes" : "no");
+    entry.pushKV("from_me", fFromMe);
 
     UniValue details(UniValue::VARR);
     ListTransactions(pwallet, wtx, "*", 0, false, details, filter);

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -71,7 +71,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;
     }
-    COutput output(wtx.get(), nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */);
+    COutput output(wtx.get(), nInput, nAge, true /* spendable */, true /* solvable */, fIsFromMe, true /* safe */);
     vCoins.push_back(output);
     testWallet.AddToWallet(*wtx.get());
     wtxn.emplace_back(std::move(wtx));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -104,6 +104,12 @@ enum class OutputType {
     BECH32,
 };
 
+enum class TransactionSource {
+    ALL,
+    FROM_ME,
+    EXTERNAL
+};
+
 //! Default for -addresstype
 constexpr OutputType DEFAULT_ADDRESS_TYPE{OutputType::P2SH_SEGWIT};
 
@@ -504,9 +510,19 @@ public:
      */
     bool fSafe;
 
-    COutput(const CWalletTx *txIn, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn, bool fSafeIn)
+    /** Whether this output belongs to a transaction that was sent from wallet in this node */
+    bool fFromMe;
+
+    COutput(const CWalletTx *txIn, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn, bool fFromMeIn, bool fSafeIn)
     {
-        tx = txIn; i = iIn; nDepth = nDepthIn; fSpendable = fSpendableIn; fSolvable = fSolvableIn; fSafe = fSafeIn; nInputBytes = -1;
+        tx = txIn;
+        i = iIn;
+        nDepth = nDepthIn;
+        fSpendable = fSpendableIn;
+        fSolvable = fSolvableIn;
+        fFromMe = fFromMeIn;
+        fSafe = fSafeIn;
+        nInputBytes = -1;
         // If known and signable by the given wallet, compute nInputBytes
         // Failure will keep this value -1
         if (fSpendable && tx) {
@@ -834,7 +850,7 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999) const;
+    void AvailableCoins(std::vector<COutput>& vCoins, bool fOnlySafe=true, const CCoinControl *coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const int nMinDepth = 0, const int nMaxDepth = 9999999, const TransactionSource source = TransactionSource::ALL) const;
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.


### PR DESCRIPTION
This closes #11613 
* Added ```from_me``` to ```listunspent``` and ```gettransaction```. This field indicates whether the source of the transaction was an address on the current node
* Added ```source``` query filter to ```listunspent```. Using this filter a user can list transactions from all sources (all), only from the current node (from_me) or from external sources (external)
* Added ```bip125-replaceable``` to ```listunspent```. This field indicates whether the transactions was marked as bip125-replaceable