### PR TITLE
BIP-178: Extend WIF format with key type

### DIFF
--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -25,7 +25,7 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
     // Add some keys to the keystore:
     CKey key[4];
     for (int i = 0; i < 4; i++) {
-        key[i].MakeNewKey(i % 2);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED_FLAG(i % 2));
         keystoreRet.AddKey(key[i]);
     }
 

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -62,7 +62,7 @@ static void VerifyScriptBench(benchmark::State& state)
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
         }
     };
-    key.Set(vchKey.begin(), vchKey.end(), false);
+    key.SetWithType(vchKey.begin(), vchKey.end(), KEY_P2PKH_UNCOMPRESSED);
     CPubKey pubkey = key.GetPubKey();
     uint160 pubkeyHash;
     CHash160().Write(pubkey.begin(), pubkey.size()).Finalize(pubkeyHash.begin());

--- a/src/key.h
+++ b/src/key.h
@@ -23,6 +23,29 @@
  */
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CPrivKey;
 
+/**
+ * Key type, based on Electrum 3.0 extension:
+ * https://github.com/spesmilo/electrum/blob/82e88cb89df35288b80dfdbe071da74247351251/RELEASE-NOTES#L95-L108
+ */
+enum KeyType
+{
+    // Legacy style
+    KEY_P2PKH_UNCOMPRESSED = 0x00,
+    KEY_P2PKH_COMPRESSED   = 0x01,
+    // New style
+    KEY_P2PKH              = 0x10,   // compressed P2PKH, same as 0x01
+    KEY_P2WPKH             = 0x11,
+    KEY_P2WPKH_P2SH        = 0x12,
+    KEY_P2SH               = 0x13,
+    KEY_P2WSH              = 0x14,
+    KEY_P2WSH_P2SH         = 0x15,
+    // Ranges for validity
+    KEY_RANGE_LEGACY_START = KEY_P2PKH_UNCOMPRESSED,
+    KEY_RANGE_LEGACY_END   = KEY_P2PKH_COMPRESSED,
+    KEY_RANGE_START        = KEY_P2PKH,
+    KEY_RANGE_END          = KEY_P2WSH_P2SH,
+};
+
 /** An encapsulated private key. */
 class CKey
 {

--- a/src/key.h
+++ b/src/key.h
@@ -46,6 +46,18 @@ enum KeyType
     KEY_RANGE_END          = KEY_P2WSH_P2SH,
 };
 
+// SECP256K1_EC_* conversion with KeyType
+#define KEY_SECP256K1_EC_COMPRESSED_FLAG(type) ((type) != KEY_P2PKH_UNCOMPRESSED ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED)
+
+// Temporary helper for converting compressed=true/false into KEY_P2PKH_*
+#define KEY_P2PKH_COMPRESSED_FLAG(flag) ((flag) ? KEY_P2PKH_COMPRESSED : KEY_P2PKH_UNCOMPRESSED)
+
+// Helper for 'is compressed' check
+#define KEY_IS_COMPRESSED(type) (type != KEY_P2PKH_UNCOMPRESSED)
+
+// Validity check
+#define KEY_VALID_TYPE(type) ((type >= KEY_RANGE_LEGACY_START && type <= KEY_RANGE_LEGACY_END) || (type >= KEY_RANGE_START && type <= KEY_RANGE_END))
+
 /** An encapsulated private key. */
 class CKey
 {
@@ -68,8 +80,9 @@ private:
     //! data, so fValid should always correspond to the actual state.
     bool fValid;
 
-    //! Whether the public key corresponding to this private key is (to be) compressed.
-    bool fCompressed;
+    //! The key type, used to determine which kinds of addresses should be
+    //! tracked.
+    KeyType m_type;
 
     //! The actual byte data
     std::vector<unsigned char, secure_allocator<unsigned char> > keydata;
@@ -79,7 +92,7 @@ private:
 
 public:
     //! Construct an invalid private key.
-    CKey() : fValid(false), fCompressed(false)
+    CKey() : fValid(false), m_type(KEY_P2PKH_UNCOMPRESSED)
     {
         // Important: vch must be 32 bytes in length to not break serialization
         keydata.resize(32);
@@ -87,21 +100,21 @@ public:
 
     friend bool operator==(const CKey& a, const CKey& b)
     {
-        return a.fCompressed == b.fCompressed &&
+        return a.m_type == b.m_type &&
             a.size() == b.size() &&
             memcmp(a.keydata.data(), b.keydata.data(), a.size()) == 0;
     }
 
     //! Initialize using begin and end iterators to byte data.
     template <typename T>
-    void Set(const T pbegin, const T pend, bool fCompressedIn)
+    void SetWithType(const T pbegin, const T pend, KeyType type_in)
     {
         if (size_t(pend - pbegin) != keydata.size()) {
             fValid = false;
         } else if (Check(&pbegin[0])) {
             memcpy(keydata.data(), (unsigned char*)&pbegin[0], keydata.size());
-            fValid = true;
-            fCompressed = fCompressedIn;
+            fValid = KEY_VALID_TYPE(type_in);
+            m_type = type_in;
         } else {
             fValid = false;
         }
@@ -116,10 +129,10 @@ public:
     bool IsValid() const { return fValid; }
 
     //! Check whether the public key corresponding to this private key is (to be) compressed.
-    bool IsCompressed() const { return fCompressed; }
+    KeyType GetType() const { return m_type; }
 
     //! Generate a new private key using a cryptographic PRNG.
-    void MakeNewKey(bool fCompressed);
+    void MakeNewKeyWithType(KeyType type);
 
     /**
      * Convert the private key to a CPrivKey (serialized OpenSSL private key data).

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -199,6 +199,6 @@ CKeyID GetKeyForDestination(const CKeyStore& store, const CTxDestination& dest)
 bool HaveKey(const CKeyStore& store, const CKey& key)
 {
     CKey key2;
-    key2.Set(key.begin(), key.end(), !key.IsCompressed());
+    key2.SetWithType(key.begin(), key.end(), KEY_IS_COMPRESSED(key.GetType()) ? KEY_P2PKH_UNCOMPRESSED : KEY_P2PKH_COMPRESSED);
     return store.HaveKey(key.GetPubKey().GetID()) || store.HaveKey(key2.GetPubKey().GetID());
 }

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -62,7 +62,7 @@ void TestAddAddressesToSendBook()
 
     auto build_address = [&wallet]() {
         CKey key;
-        key.MakeNewKey(true);
+        key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         CTxDestination dest(GetDestinationForKey(
             key.GetPubKey(), wallet.m_default_address_type));
 

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -23,7 +23,7 @@ bool TransactionSignatureCreator::CreateSig(const SigningProvider& provider, std
         return false;
 
     // Signing with uncompressed keys is disabled in witness scripts
-    if (sigversion == SigVersion::WITNESS_V0 && !key.IsCompressed())
+    if (sigversion == SigVersion::WITNESS_V0 && key.GetType() == KEY_P2PKH_UNCOMPRESSED)
         return false;
 
     uint256 hash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -304,7 +304,7 @@ static CTransactionRef RandomOrphan()
 BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
 {
     CKey key;
-    key.MakeNewKey(true);
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     CBasicKeyStore keystore;
     keystore.AddKey(key);
 

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
             // Must be valid private key
             privkey = DecodeSecret(exp_base58string);
             BOOST_CHECK_MESSAGE(privkey.IsValid(), "!IsValid:" + strTest);
-            BOOST_CHECK_MESSAGE(privkey.IsCompressed() == isCompressed, "compressed mismatch:" + strTest);
+            BOOST_CHECK_MESSAGE(KEY_IS_COMPRESSED(privkey.GetType()) == isCompressed, "type mismatch:" + strTest);
             BOOST_CHECK_MESSAGE(privkey.size() == exp_payload.size() && std::equal(privkey.begin(), privkey.end(), exp_payload.begin()), "key mismatch:" + strTest);
 
             // Private key must be invalid public key
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
         if (isPrivkey) {
             bool isCompressed = find_value(metadata, "isCompressed").get_bool();
             CKey key;
-            key.Set(exp_payload.begin(), exp_payload.end(), isCompressed);
+            key.SetWithType(exp_payload.begin(), exp_payload.end(), KEY_P2PKH_COMPRESSED_FLAG(isCompressed));
             assert(key.IsValid());
             BOOST_CHECK_MESSAGE(EncodeSecret(key) == exp_base58string, "result mismatch: " + strTest);
         } else {

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -33,13 +33,13 @@ BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CKey key1  = DecodeSecret(strSecret1);
-    BOOST_CHECK(key1.IsValid() && !key1.IsCompressed());
+    BOOST_CHECK(key1.IsValid() && !KEY_IS_COMPRESSED(key1.GetType()));
     CKey key2  = DecodeSecret(strSecret2);
-    BOOST_CHECK(key2.IsValid() && !key2.IsCompressed());
+    BOOST_CHECK(key2.IsValid() && !KEY_IS_COMPRESSED(key2.GetType()));
     CKey key1C = DecodeSecret(strSecret1C);
-    BOOST_CHECK(key1C.IsValid() && key1C.IsCompressed());
+    BOOST_CHECK(key1C.IsValid() && KEY_IS_COMPRESSED(key1C.GetType()));
     CKey key2C = DecodeSecret(strSecret2C);
-    BOOST_CHECK(key2C.IsValid() && key2C.IsCompressed());
+    BOOST_CHECK(key2C.IsValid() && KEY_IS_COMPRESSED(key2C.GetType()));
     CKey bad_key = DecodeSecret(strAddressBad);
     BOOST_CHECK(!bad_key.IsValid());
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(multisig_verify)
     CKey key[4];
     CAmount amount = 0;
     for (int i = 0; i < 4; i++)
-        key[i].MakeNewKey(true);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
 
     CScript a_and_b;
     a_and_b << OP_2 << ToByteVector(key[0].GetPubKey()) << ToByteVector(key[1].GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(multisig_IsStandard)
 {
     CKey key[4];
     for (int i = 0; i < 4; i++)
-        key[i].MakeNewKey(true);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
 
     txnouttype whichType;
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(multisig_Sign)
     CKey key[4];
     for (int i = 0; i < 4; i++)
     {
-        key[i].MakeNewKey(true);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         keystore.AddKey(key[i]);
     }
 

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(sign)
     CKey key[4];
     for (int i = 0; i < 4; i++)
     {
-        key[i].MakeNewKey(true);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         keystore.AddKey(key[i]);
     }
 
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE(set)
     std::vector<CPubKey> keys;
     for (int i = 0; i < 4; i++)
     {
-        key[i].MakeNewKey(true);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         keystore.AddKey(key[i]);
         keys.push_back(key[i].GetPubKey());
     }
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     std::vector<CPubKey> keys;
     for (int i = 0; i < 6; i++)
     {
-        key[i].MakeNewKey(true);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         keystore.AddKey(key[i]);
     }
     for (int i = 0; i < 3; i++)

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -20,7 +20,7 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
     CKey keys[3];
     CPubKey pubkeys[3];
     for (int i = 0; i < 3; i++) {
-        keys[i].MakeNewKey(true);
+        keys[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         pubkeys[i] = keys[i].GetPubKey();
     }
 
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(script_standard_Solver_failure)
 {
     CKey key;
     CPubKey pubkey;
-    key.MakeNewKey(true);
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     pubkey = key.GetPubKey();
 
     CScript s;
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
 {
     CKey key;
     CPubKey pubkey;
-    key.MakeNewKey(true);
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     pubkey = key.GetPubKey();
 
     CScript s;
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     CKey keys[3];
     CPubKey pubkeys[3];
     for (int i = 0; i < 3; i++) {
-        keys[i].MakeNewKey(true);
+        keys[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         pubkeys[i] = keys[i].GetPubKey();
     }
 
@@ -316,7 +316,7 @@ BOOST_AUTO_TEST_CASE(script_standard_GetScriptFor_)
     CKey keys[3];
     CPubKey pubkeys[3];
     for (int i = 0; i < 3; i++) {
-        keys[i].MakeNewKey(true);
+        keys[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         pubkeys[i] = keys[i].GetPubKey();
     }
 
@@ -388,12 +388,12 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     CKey keys[2];
     CPubKey pubkeys[2];
     for (int i = 0; i < 2; i++) {
-        keys[i].MakeNewKey(true);
+        keys[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         pubkeys[i] = keys[i].GetPubKey();
     }
 
     CKey uncompressedKey;
-    uncompressedKey.MakeNewKey(false);
+    uncompressedKey.MakeNewKeyWithType(KEY_P2PKH_UNCOMPRESSED);
     CPubKey uncompressedPubkey = uncompressedKey.GetPubKey();
 
     CScript scriptPubKey;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -250,20 +250,20 @@ struct KeyData
     KeyData()
     {
 
-        key0.Set(vchKey0, vchKey0 + 32, false);
-        key0C.Set(vchKey0, vchKey0 + 32, true);
+        key0.SetWithType(vchKey0, vchKey0 + 32, KEY_P2PKH_UNCOMPRESSED);
+        key0C.SetWithType(vchKey0, vchKey0 + 32, KEY_P2PKH_COMPRESSED);
         pubkey0 = key0.GetPubKey();
         pubkey0H = key0.GetPubKey();
         pubkey0C = key0C.GetPubKey();
         *const_cast<unsigned char*>(&pubkey0H[0]) = 0x06 | (pubkey0H[64] & 1);
 
-        key1.Set(vchKey1, vchKey1 + 32, false);
-        key1C.Set(vchKey1, vchKey1 + 32, true);
+        key1.SetWithType(vchKey1, vchKey1 + 32, KEY_P2PKH_UNCOMPRESSED);
+        key1C.SetWithType(vchKey1, vchKey1 + 32, KEY_P2PKH_COMPRESSED);
         pubkey1 = key1.GetPubKey();
         pubkey1C = key1C.GetPubKey();
 
-        key2.Set(vchKey2, vchKey2 + 32, false);
-        key2C.Set(vchKey2, vchKey2 + 32, true);
+        key2.SetWithType(vchKey2, vchKey2 + 32, KEY_P2PKH_UNCOMPRESSED);
+        key2C.SetWithType(vchKey2, vchKey2 + 32, KEY_P2PKH_COMPRESSED);
         pubkey2 = key2.GetPubKey();
         pubkey2C = key2C.GetPubKey();
     }
@@ -1066,9 +1066,9 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG12)
 {
     ScriptError err;
     CKey key1, key2, key3;
-    key1.MakeNewKey(true);
-    key2.MakeNewKey(false);
-    key3.MakeNewKey(true);
+    key1.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
+    key2.MakeNewKeyWithType(KEY_P2PKH_UNCOMPRESSED);
+    key3.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
 
     CScript scriptPubKey12;
     scriptPubKey12 << OP_1 << ToByteVector(key1.GetPubKey()) << ToByteVector(key2.GetPubKey()) << OP_2 << OP_CHECKMULTISIG;
@@ -1096,10 +1096,10 @@ BOOST_AUTO_TEST_CASE(script_CHECKMULTISIG23)
 {
     ScriptError err;
     CKey key1, key2, key3, key4;
-    key1.MakeNewKey(true);
-    key2.MakeNewKey(false);
-    key3.MakeNewKey(true);
-    key4.MakeNewKey(false);
+    key1.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
+    key2.MakeNewKeyWithType(KEY_P2PKH_UNCOMPRESSED);
+    key3.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
+    key4.MakeNewKeyWithType(KEY_P2PKH_UNCOMPRESSED);
 
     CScript scriptPubKey23;
     scriptPubKey23 << OP_2 << ToByteVector(key1.GetPubKey()) << ToByteVector(key2.GetPubKey()) << ToByteVector(key3.GetPubKey()) << OP_3 << OP_CHECKMULTISIG;
@@ -1171,7 +1171,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     for (int i = 0; i < 3; i++)
     {
         CKey key;
-        key.MakeNewKey(i%2 == 1);
+        key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED_FLAG(i%2));
         keys.push_back(key);
         pubkeys.push_back(key.GetPubKey());
         keystore.AddKey(key);

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(GetSigOpCount)
     for (int i = 0; i < 3; i++)
     {
         CKey k;
-        k.MakeNewKey(true);
+        k.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         keys.push_back(k.GetPubKey());
     }
     CScript s2 = GetScriptForMultisig(1, keys);
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
     CCoinsViewCache coins(&coinsDummy);
     // Create key
     CKey key;
-    key.MakeNewKey(true);
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     CPubKey pubkey = key.GetPubKey();
     // Default flags
     int flags = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -123,7 +123,7 @@ TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
     // TODO: fix the code to support SegWit blocks.
     UpdateVersionBitsParameters(Consensus::DEPLOYMENT_SEGWIT, 0, Consensus::BIP9Deployment::NO_TIMEOUT);
     // Generate a 100-block chain:
-    coinbaseKey.MakeNewKey(true);
+    coinbaseKey.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     CScript scriptPubKey = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
     for (int i = 0; i < COINBASE_MATURITY; i++)
     {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -296,7 +296,7 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
     CKey key[4];
     for (int i = 0; i < 4; i++)
     {
-        key[i].MakeNewKey(i % 2);
+        key[i].MakeNewKeyWithType(KEY_P2PKH_COMPRESSED_FLAG(i % 2));
         keystoreRet.AddKey(key[i]);
     }
 
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     mtx.nVersion = 1;
 
     CKey key;
-    key.MakeNewKey(true); // Need to use compressed keys in segwit or the signing will fail
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED); // Need to use compressed keys in segwit or the signing will fail
     CBasicKeyStore keystore;
     keystore.AddKeyPubKey(key, key.GetPubKey());
     CKeyID hash = key.GetPubKey().GetID();
@@ -499,11 +499,11 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CBasicKeyStore keystore, keystore2;
     CKey key1, key2, key3, key1L, key2L;
     CPubKey pubkey1, pubkey2, pubkey3, pubkey1L, pubkey2L;
-    key1.MakeNewKey(true);
-    key2.MakeNewKey(true);
-    key3.MakeNewKey(true);
-    key1L.MakeNewKey(false);
-    key2L.MakeNewKey(false);
+    key1.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
+    key2.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
+    key3.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
+    key1L.MakeNewKeyWithType(KEY_P2PKH_UNCOMPRESSED);
+    key2L.MakeNewKeyWithType(KEY_P2PKH_UNCOMPRESSED);
     pubkey1 = key1.GetPubKey();
     pubkey2 = key2.GetPubKey();
     pubkey3 = key3.GetPubKey();
@@ -685,7 +685,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout.resize(1);
     t.vout[0].nValue = 90*CENT;
     CKey key;
-    key.MakeNewKey(true);
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     t.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
 
     std::string reason;

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -137,7 +137,7 @@ static bool DecryptKey(const CKeyingMaterial& vMasterKey, const std::vector<unsi
     if (vchSecret.size() != 32)
         return false;
 
-    key.Set(vchSecret.begin(), vchSecret.end(), vchPubKey.IsCompressed());
+    key.SetWithType(vchSecret.begin(), vchSecret.end(), KEY_P2PKH_COMPRESSED_FLAG(vchPubKey.IsCompressed()));
     return key.VerifyPubKey(vchPubKey);
 }
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -86,7 +86,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
         key.clear();
         key.setObject();
         CKey futureKey;
-        futureKey.MakeNewKey(true);
+        futureKey.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
         key.pushKV("scriptPubKey", HexStr(GetScriptForRawPubKey(futureKey.GetPubKey())));
         key.pushKV("timestamp", newTip->GetBlockTimeMax() + TIMESTAMP_WINDOW + 1);
         key.pushKV("internal", UniValue(true));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -168,7 +168,7 @@ CPubKey CWallet::GenerateNewKey(WalletBatch &batch, bool internal)
     if (IsHDEnabled()) {
         DeriveNewChildKey(batch, metadata, secret, (CanSupportFeature(FEATURE_HD_SPLIT) ? internal : false));
     } else {
-        secret.MakeNewKey(fCompressed);
+        secret.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED_FLAG(fCompressed));
     }
 
     // Compressed public keys were introduced in version 0.6.0
@@ -1453,7 +1453,7 @@ CAmount CWallet::GetChange(const CTransaction& tx) const
 CPubKey CWallet::GenerateNewSeed()
 {
     CKey key;
-    key.MakeNewKey(true);
+    key.MakeNewKeyWithType(KEY_P2PKH_COMPRESSED);
     return DeriveNewSeed(key);
 }
 


### PR DESCRIPTION
BIP pull request: https://github.com/bitcoin/bips/pull/673

This PR does not change the behavior. It only adds underlying support for formats beyond 'compressed pubkey' and 'uncompressed pubkey'. It partially implements [BIP-178](https://github.com/bitcoin/bips/blob/master/bip-0178.mediawiki).

The key types are based on the key types in ~~Ethereum~~ Electrum 3.0: https://github.com/spesmilo/electrum/blob/82e88cb89df35288b80dfdbe071da74247351251/RELEASE-NOTES#L95-L108

The legacy types `KEY_P2PKH_{UN}COMPRESSED` map to the current WIF format. If used/seen, they indicate that the corresponding public key type is *unknown*, and when imported, they will simply iterate over all types and watch all of them (P2PKH, P2SH-P2WPKH, P2WPKH (bech32), and so on). (Current behavior.)

When one of the other types is used, the current code will behave exactly the same as above. In a future PR, the code will be changed to only import the corresponding type when importing a private key.

This is related to #12705, see in particular https://github.com/bitcoin/bitcoin/pull/12705#issuecomment-373973741.
