### PR TITLE
make clean removes src/qt/moc_ files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -293,6 +293,5 @@ clean-docs:
 	rm -rf doc/doxygen
 
 clean-local: clean-docs
-	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ test/tmp/ cache/ $(OSX_APP)
+	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ test/tmp/ cache/ $(OSX_APP) src/qt/moc_*
 	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache
-


### PR DESCRIPTION
Prevents build errors when making e.g. the following switch:

```sh
./configure
make
make clean

./configure --with-gui=qt4
make
```