### PR TITLE
Add shell script linting: Check for shellcheck warnings in shell scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
     - WINEDEBUG=fixme-all
   matrix:
 # ARM
-    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf python3-pip shellcheck" DEP_OPTS="NO_QT=1" CHECK_DOC=1 GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
 # Win32
     - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
 # Win64

--- a/contrib/devtools/lint-shell.sh
+++ b/contrib/devtools/lint-shell.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for shellcheck warnings in shell scripts.
+
+# Disabled warnings:
+# SC2001: See if you can use ${variable//search/replace} instead.
+# SC2004: $/${} is unnecessary on arithmetic variables.
+# SC2005: Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
+# SC2006: Use $(..) instead of legacy `..`.
+# SC2016: Expressions don't expand in single quotes, use double quotes for that.
+# SC2028: echo won't expand escape sequences. Consider printf.
+# SC2046: Quote this to prevent word splitting.
+# SC2048: Use "$@" (with quotes) to prevent whitespace problems.
+# SC2066: Since you double quoted this, it will not word split, and the loop will only run once.
+# SC2086: Double quote to prevent globbing and word splitting.
+# SC2116: Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
+# SC2148: Tips depend on target shell and yours is unknown. Add a shebang.
+# SC2162: read without -r will mangle backslashes.
+# SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+# SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+# SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+shellcheck -e SC2001,SC2004,SC2005,SC2006,SC2016,SC2028,SC2046,SC2048,SC2066,SC2086,SC2116,SC2148,SC2162,SC2166,SC2181 \
+    $(git ls-files -- "*.sh" | grep -vE 'src/(secp256k1|univalue)/')


### PR DESCRIPTION
Add shell script linting: Check for `shellcheck` warnings in shell scripts.