### PR TITLE
Only accept bare multisig outputs after addmultisigaddress

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -123,6 +123,10 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, bool& 
 
     case TX_MULTISIG:
     {
+        // Do not accept bare multisig payment outputs unless the script is explicitly known.
+        if (!keystore.HaveCScript(CScriptID(scriptPubKey))) {
+            break;
+        }
         // Only consider transactions "mine" if we own ALL the
         // keys involved. Multi-signature transactions that are
         // partially owned (somebody else has a key that can spend

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -561,6 +561,13 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         keystore.AddKey(keys[1]);
 
         result = IsMine(keystore, scriptPubKey, isInvalid);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(!isInvalid);
+
+        // Keystore has 2/2 keys and the script
+        keystore.AddCScript(scriptPubKey);
+
+        result = IsMine(keystore, scriptPubKey, isInvalid);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
         BOOST_CHECK(!isInvalid);
     }


### PR DESCRIPTION
Currently our wallet code will treat bare multisig outputs (meaning scriptPubKeys with multiple public keys + `OP_CHECKMULTISIG` operator in it) as ours without the user asking for it, as long as all public keys in it are ours.

These are:
* hard to test (as there is no explicit address format for them)
* expensive to spend (need multiple signatures)
* wasteful (require more space in the UTXO set than P2PKH/P2SH/P2WPK/P2WSH)
* generally pointless (you won't use multisig just for public keys that are all in the same wallet)

Furthermore, they are problematic in that means that producing a list of all `scriptPubKeys` we accept is not tractable (it involves all combinations of all public keys that are ours). In further wallet changes I'd like to move to a model where all scriptPubKeys that are treated as ours are explicit, rather than defined by whatever keys we have. The current behavior of the wallet is very hard to model in such a design, so I'd like to get rid of it.

I think there are two options:
* Remove it entirely (do not ever accept bare multisig outputs as ours)
* Only accept bare multisig outputs in situations where the P2SH version of that output would also be acceptable

This PR implements the second, though I'm open to discussing the first option.