### PR TITLE
Minor optimizations to bech32::Decode(); add tests.

### DIFF
--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -160,9 +160,9 @@ std::pair<std::string, data> Decode(const std::string& str) {
     bool lower = false, upper = false;
     for (size_t i = 0; i < str.size(); ++i) {
         unsigned char c = str[i];
-        if (c < 33 || c > 126) return {};
         if (c >= 'a' && c <= 'z') lower = true;
-        if (c >= 'A' && c <= 'Z') upper = true;
+        else if (c >= 'A' && c <= 'Z') upper = true;
+        else if (c < 33 || c > 126) return {};
     }
     if (lower && upper) return {};
     size_t pos = str.rfind('1');
@@ -172,7 +172,8 @@ std::pair<std::string, data> Decode(const std::string& str) {
     data values(str.size() - 1 - pos);
     for (size_t i = 0; i < str.size() - 1 - pos; ++i) {
         unsigned char c = str[i + pos + 1];
-        int8_t rev = (c < 33 || c > 126) ? -1 : CHARSET_REV[c];
+        int8_t rev = CHARSET_REV[c];
+
         if (rev == -1) {
             return {};
         }

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -57,6 +57,8 @@ BOOST_AUTO_TEST_CASE(bip173_testvectors_invalid)
         "A1G7SGD8",
         "10a06t8",
         "1qzzfhee",
+        "a12UEL5L",
+        "A12uEL5L",
     };
     for (const std::string& str : CASES) {
         auto ret = bech32::Decode(str);


### PR DESCRIPTION
Just a few minor optimizations to bech32::Decode():

1) optimize the order and logic of the conditionals
2) get rid of subsequent '(c < 33 || c > 126)' check which is redundant (already performed above)
3) add a couple more bech32 tests (mixed-case)
