### PR TITLE
tests: Avoid test suite name collision in wallet crypto_tests

### DIFF
--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(wallet_crypto_tests, BasicTestingSetup)
 
 class TestCrypter
 {


### PR DESCRIPTION
Seems this makes it impossible to run those with `test_bitcoin -t $test_suite`