### PR TITLE
tests: Add note about test suite name uniqueness requirement to developer notes

### DIFF
--- a/contrib/devtools/lint-tests.sh
+++ b/contrib/devtools/lint-tests.sh
@@ -4,7 +4,9 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
-# Check the test suite naming convention
+# Check the test suite naming conventions
+
+EXIT_CODE=0
 
 NAMING_INCONSISTENCIES=$(git grep -E '^BOOST_FIXTURE_TEST_SUITE\(' -- \
     "src/test/**.cpp" "src/wallet/test/**.cpp" | \
@@ -15,5 +17,18 @@ if [[ ${NAMING_INCONSISTENCIES} != "" ]]; then
     echo "that convention:"
     echo
     echo "${NAMING_INCONSISTENCIES}"
-    exit 1
+    EXIT_CODE=1
 fi
+
+TEST_SUITE_NAME_COLLISSIONS=$(git grep -E '^BOOST_FIXTURE_TEST_SUITE\(' -- \
+    "src/test/**.cpp" "src/wallet/test/**.cpp" | cut -f2 -d'(' | cut -f1 -d, | \
+    sort | uniq -d)
+if [[ ${TEST_SUITE_NAME_COLLISSIONS} != "" ]]; then
+    echo "Test suite names must be unique. The following test suite names"
+    echo "appear to be used more than once:"
+    echo
+    echo "${TEST_SUITE_NAME_COLLISSIONS}"
+    EXIT_CODE=1
+fi
+
+exit ${EXIT_CODE}

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -72,7 +72,8 @@ code.
   - Class names, function names and method names are UpperCamelCase
     (PascalCase). Do not prefix class names with `C`.
   - Test suite naming convention: The Boost test suite in file
-    `src/test/foo_tests.cpp` should be named `foo_tests`.
+    `src/test/foo_tests.cpp` should be named `foo_tests`. Test suite names
+    must be unique.
 
 - **Miscellaneous**
   - `++i` is preferred over `i++`.

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,7 +94,7 @@ BITCOIN_TESTS += \
   wallet/test/wallet_test_fixture.h \
   wallet/test/accounting_tests.cpp \
   wallet/test/wallet_tests.cpp \
-  wallet/test/crypto_tests.cpp \
+  wallet/test/wallet_crypto_tests.cpp \
   wallet/test/coinselector_tests.cpp
 endif
 

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -67,7 +67,7 @@ public:
 
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
 
-namespace crypto_tests
+namespace wallet_crypto_tests
 {
     class TestCrypter;
 }
@@ -75,7 +75,7 @@ namespace crypto_tests
 /** Encryption/decryption context with key information */
 class CCrypter
 {
-friend class crypto_tests::TestCrypter; // for test access to chKey/chIV
+friend class wallet_crypto_tests::TestCrypter; // for test access to chKey/chIV
 private:
     std::vector<unsigned char, secure_allocator<unsigned char>> vchKey;
     std::vector<unsigned char, secure_allocator<unsigned char>> vchIV;

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -10,7 +10,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(crypto_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(wallet_crypto_tests, BasicTestingSetup)
 
 class TestCrypter
 {


### PR DESCRIPTION
* Add documentation: Add note about test suite name uniqueness requirement in developer notes
* Add regression test: Update `lint-tests.sh` to make it check also for test suite name uniqueness

Context: #12894 (`tests: Avoid test suite name collision in wallet crypto_tests`)