### PR TITLE
Add GetBlockIndex(const uint256& hash) for when the caller assumes that the block index exists for the given block hash

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -859,7 +859,7 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
     stats.hashBlock = pcursor->GetBestBlock();
     {
         LOCK(cs_main);
-        stats.nHeight = LookupBlockIndex(stats.hashBlock)->nHeight;
+        stats.nHeight = GetBlockIndex(stats.hashBlock)->nHeight;
     }
     ss << stats.hashBlock;
     uint256 prevkey;
@@ -1042,7 +1042,7 @@ UniValue gettxout(const JSONRPCRequest& request)
         }
     }
 
-    const CBlockIndex* pindex = LookupBlockIndex(pcoinsTip->GetBestBlock());
+    const CBlockIndex* pindex = GetBlockIndex(pcoinsTip->GetBestBlock());
     ret.pushKV("bestblock", pindex->GetBlockHash().GetHex());
     if (coin.nHeight == MEMPOOL_HEIGHT) {
         ret.pushKV("confirmations", 0);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1322,7 +1322,7 @@ bool CScriptCheck::operator()() {
 int GetSpendHeight(const CCoinsViewCache& inputs)
 {
     LOCK(cs_main);
-    CBlockIndex* pindexPrev = LookupBlockIndex(inputs.GetBestBlock());
+    CBlockIndex* pindexPrev = GetBlockIndex(inputs.GetBestBlock());
     return pindexPrev->nHeight + 1;
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -430,11 +430,36 @@ public:
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
+/** Find and retrieve the block index for the given block hash.
+ *  The caller must check if the block index is valid. If the block index
+ *  always exists then use GetBlockIndex instead.
+ *  Call with cs_main held.
+ *
+ *  @param[in] hash The block hash
+ *  @return The block index pointer if found, nullptr otherwise
+ *  @see GetBlockIndex
+ */
 inline CBlockIndex* LookupBlockIndex(const uint256& hash)
 {
     AssertLockHeld(cs_main);
     BlockMap::const_iterator it = mapBlockIndex.find(hash);
     return it == mapBlockIndex.end() ? nullptr : it->second;
+}
+
+/** Retrieve the block index for the given block hash.
+ *  The block index must exists otherwise an assertion fails. If the block index
+ *  can not exist then use LookupBlockIndex instead.
+ *  Call with cs_main held.
+ *
+ *  @param[in] hash The block hash
+ *  @return The block index pointer
+ *  @see LookupBlockIndex
+ */
+inline CBlockIndex* GetBlockIndex(const uint256& hash)
+{
+    CBlockIndex* index = LookupBlockIndex(hash);
+    assert(index);
+    return index;
 }
 
 /** Find the last common block between the parameter chain and a locator. */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -95,7 +95,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     {
         entry.pushKV("blockhash", wtx.hashBlock.GetHex());
         entry.pushKV("blockindex", wtx.nIndex);
-        entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
+        entry.pushKV("blocktime", GetBlockIndex(wtx.hashBlock)->GetBlockTime());
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
     }


### PR DESCRIPTION
Add `GetBlockIndex(const uint256& hash)` for when the caller assumes that the block index exists for the given block hash. As suggested by @promag in #12782.

Rationale: Explicit is better than implicit. Especially for assumptions :-)