### PR TITLE
macOS: Prevent Xcode 9.3 build warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -630,11 +630,7 @@ if test x$use_hardening != xno; then
   AX_CHECK_LINK_FLAG([[-Wl,--high-entropy-va]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,--high-entropy-va"])
   AX_CHECK_LINK_FLAG([[-Wl,-z,relro]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,relro"])
   AX_CHECK_LINK_FLAG([[-Wl,-z,now]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-z,now"])
-
-  if test x$TARGET_OS != xwindows; then
-    AX_CHECK_COMPILE_FLAG([-fPIE],[PIE_FLAGS="-fPIE"])
-    AX_CHECK_LINK_FLAG([[-pie]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"])
-  fi
+  AX_CHECK_LINK_FLAG([[-fPIE -pie]], [PIE_FLAGS="-fPIE"; HARDENED_LDFLAGS="$HARDENED_LDFLAGS -pie"],, [[$CXXFLAG_WERROR]])
 
   case $host in
     *mingw*)


### PR DESCRIPTION
This PR intends to solve #12867 

1. clang (Apple LLVM version 9.1.0 (clang-902.0.39.1)) warns unused argument '-pie' during compilation. This parameter should pass to the linker, so use '-Wl,-pie' style in configure.ac.
2. The other hand, when linking libbitcoinconsensus.la with passing '-Wl,-pie', ld warns that '-pie' being ignored because not link a main executable. So remove it from $libbitcoinconsensus_la_LDFLAGS in src/Makefile.am.

- In order to apply this change to Makefile, you need to run autogen.sh and ./configure.
- I think no need to add if-clause by target-os because also g++ can recognize/handle  '-Wl,-pie'.
- I confirmed that the build was successful on macos10.13.4/XCode9.3 and ubuntu 17.10/g++7.2.0 and that warning was not issued.