### PR TITLE
[qa] Handle potential cookie race when starting node

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -20,6 +20,7 @@ from .authproxy import JSONRPCException
 from .util import (
     append_config,
     assert_equal,
+    delete_cookie_file,
     get_rpc_proxy,
     rpc_url,
     wait_until,
@@ -105,6 +106,10 @@ class TestNode():
             extra_args = self.extra_args
         if stderr is None:
             stderr = self.stderr
+        # Delete any existing cookie file -- if such a file exists (eg due to
+        # unclean shutdown), it will get overwritten anyway by bitcoind, and
+        # potentially interfere with our attempt to authenticate
+        delete_cookie_file(self.datadir)
         self.process = subprocess.Popen(self.args + extra_args, stderr=stderr, *args, **kwargs)
         self.running = True
         self.log.debug("bitcoind started, waiting for RPC to come up")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -332,6 +332,12 @@ def get_auth_cookie(datadir):
         raise ValueError("No RPC credentials")
     return user, password
 
+# If a cookie file exists in the given datadir, delete it.
+def delete_cookie_file(datadir):
+    if os.path.isfile(os.path.join(datadir, "regtest", ".cookie")):
+        logger.debug("Deleting leftover cookie file")
+        os.remove(os.path.join(datadir, "regtest", ".cookie"))
+
 def get_bip9_status(node, key):
     info = node.getblockchaininfo()
     return info['bip9_softforks'][key]


### PR DESCRIPTION
When a node is restarted during a test after an unclean shutdown (such
as with -dbcrashratio), it's possible an old cookie file was left
behind. This can cause a race condition when restarting the node, where
the test framework might try to connect using credentials from the
old cookie file, just as the node will generate new credentials and
overwrite the old file.

Delete any such cookie file if present prior to startup.