### PR TITLE
wallet: Show fee in results for signrawtransaction* for segwit inputs

### DIFF
--- a/doc/release-notes-pr12911.md
+++ b/doc/release-notes-pr12911.md
@@ -1,0 +1,7 @@
+RPC changes
+------------
+
+### Low-level changes
+
+- `signrawtransactionwithkey` and `signrawtransactionwithwallet` will now include a `fee` entry in the results,
+  for cases where the fee is known.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -741,6 +741,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
                     {
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
+                        {RPCResult::Type::NUM, "fee", "The fee (input amounts minus output amounts), if known"},
                         {RPCResult::Type::ARR, "errors", "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -742,6 +742,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
                         {RPCResult::Type::NUM, "fee", "The fee (input amounts minus output amounts), if known"},
+                        {RPCResult::Type::NUM, "feerate", "The fee rate (in " + CURRENCY_UNIT + "/kB), if fee is known"},
                         {RPCResult::Type::ARR, "errors", "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -325,13 +325,19 @@ void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
     }
     bool fComplete = vErrors.empty();
 
-    result.pushKV("hex", EncodeHexTx(CTransaction(mtx)));
+    CTransaction tx(mtx);
+    result.pushKV("hex", EncodeHexTx(tx));
     result.pushKV("complete", fComplete);
     if (known_inputs) {
         for (const CTxOut& txout : mtx.vout) {
             inout_amount -= txout.nValue;
         }
         result.pushKV("fee", ValueFromAmount(inout_amount));
+        result.pushKV("feerate",
+            ValueFromAmount(
+                CFeeRate(inout_amount, GetVirtualTransactionSize(tx)).GetFeePerK()
+            )
+        );
     }
     if (!vErrors.empty()) {
         if (result.exists("errors")) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3288,6 +3288,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
                     {
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
+                        {RPCResult::Type::NUM, "fee", "The fee (input amounts minus output amounts), if known"},
                         {RPCResult::Type::ARR, "errors", "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3289,6 +3289,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
                         {RPCResult::Type::NUM, "fee", "The fee (input amounts minus output amounts), if known"},
+                        {RPCResult::Type::NUM, "feerate", "The fee rate (in " + CURRENCY_UNIT + "/kB), if fee is known"},
                         {RPCResult::Type::ARR, "errors", "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",


### PR DESCRIPTION
This adds a "fee" field to the resulting JSON for `signrawtransaction*` so a user can double check the fee they're paying before sending a transaction. The field is only shown in cases where the input amounts are all known ⇔ are all segwit inputs.

```
$ ./bitcoin-cli -regtest signrawtransactionwithwallet 0200000001901c16d5ac11824ca64c9c9dbe925c83fc1af9872bb23bbc9c6cd25419e2f69c0000000000feffffff0210b2d0df0000000017a914d9214ccd777e5cce540d38c3466c2cb5545339c5874031354a0000000017a914bee793caf793996dc9f617a5ad04ec2b87c6f9538700000000
{
  "hex": "0200000001901c16d5ac11824ca64c9c9dbe925c83fc1af9872bb23bbc9c6cd25419e2f69c00000000494830450221008fd0d0cfd16a06f282e720129351f2756f416b916f7a0a3be8d5db0c7db107af022028dafae6ec7d30882efe101c16b5f3893254bf5385664eddadf0d3f6e479381c01feffffff0210b2d0df0000000017a914d9214ccd777e5cce540d38c3466c2cb5545339c5874031354a0000000017a914bee793caf793996dc9f617a5ad04ec2b87c6f9538700000000",
  "complete": true,
  "fee": 0.00003760,
  "feerate": 0.00020000
}
```

* [x] Re-write tests.