### PR TITLE
qa: Windows fixups for functional tests

### DIFF
--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -37,7 +37,7 @@ class NotificationsTest(BitcoinTestFramework):
 
         # file content should equal the generated blocks hashes
         with open(self.block_filename, 'r') as f:
-            assert_equal(sorted(blocks), sorted(f.read().splitlines()))
+            assert_equal(sorted(blocks), sorted(l.strip() for l in f.read().splitlines()))
 
         self.log.info("test -walletnotify")
         # wait at most 10 seconds for expected file size before reading the content
@@ -46,7 +46,7 @@ class NotificationsTest(BitcoinTestFramework):
         # file content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
         with open(self.tx_filename, 'r') as f:
-            assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
+            assert_equal(sorted(txids_rpc), sorted(l.strip() for l in f.read().splitlines()))
         os.remove(self.tx_filename)
 
         self.log.info("test -walletnotify after rescan")
@@ -59,7 +59,7 @@ class NotificationsTest(BitcoinTestFramework):
         # file content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
         with open(self.tx_filename, 'r') as f:
-            assert_equal(sorted(txids_rpc), sorted(f.read().splitlines()))
+            assert_equal(sorted(txids_rpc), sorted(l.strip() for l in f.read().splitlines()))
 
         # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
         self.log.info("test -alertnotify")

--- a/test/functional/mempool_persist.py
+++ b/test/functional/mempool_persist.py
@@ -107,13 +107,13 @@ class MempoolPersistTest(BitcoinTestFramework):
         wait_until(lambda: len(self.nodes[1].getrawmempool()) == 5)
 
         self.log.debug("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")
-        # to test the exception we are setting bad permissions on a tmp file called mempool.dat.new
+        # to test the exception we are creating a tmp folder called mempool.dat.new
         # which is an implementation detail that could change and break this test
         mempooldotnew1 = mempooldat1 + '.new'
-        with os.fdopen(os.open(mempooldotnew1, os.O_CREAT, 0o000), 'w'):
-            pass
+        os.mkdir(mempooldotnew1)
         assert_raises_rpc_error(-1, "Unable to dump mempool to disk", self.nodes[1].savemempool)
-        os.remove(mempooldotnew1)
+        os.rmdir(mempooldotnew1)
+
 
 if __name__ == '__main__':
     MempoolPersistTest().main()


### PR DESCRIPTION
Just two minor fixups to have less errors when the tests run on native windows.
* Strip whitespace from lines when reading from a notification file
* Instead of clumsily creating a file with weird permissions, just create a folder for the same effect in `mempool_persist.py`