### PR TITLE
Make use of cpuid.h bit definitions

### DIFF
--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -180,7 +180,7 @@ std::string SHA256AutoDetect()
 {
 #if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__))
     uint32_t eax, ebx, ecx, edx;
-    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx >> 19) & 1) {
+    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & bit_SSE4_1)) {
         Transform = sha256_sse4::Transform;
         assert(SelfTest(Transform));
         return "sse4";

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -76,11 +76,10 @@ static inline int64_t GetPerformanceCounter()
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 static std::atomic<bool> hwrand_initialized{false};
 static bool rdrand_supported = false;
-static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
 static void RDRandInit()
 {
     uint32_t eax, ebx, ecx, edx;
-    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
+    if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & bit_RDRND)) {
         LogPrintf("Using RdRand as an additional entropy source\n");
         rdrand_supported = true;
     }


### PR DESCRIPTION
These are defined in cpuid.h and are self-documenting for more expressive code.
https://clang.llvm.org/doxygen/cpuid_8h_source.html

Prompted by looking into #12903