### PR TITLE
util: Pass pthread_self() to pthread_setschedparam instead of 0

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1064,7 +1064,7 @@ fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific)
 int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
-    const static sched_param param{.sched_priority = 0};
+    const static sched_param param{0};
     if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1065,7 +1065,7 @@ int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
     const static sched_param param{.sched_priority = 0};
-    if (int ret = pthread_setschedparam(0, SCHED_BATCH, &param)) {
+    if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;
     }


### PR DESCRIPTION
Nowhere in the man page of `pthread_setschedparam` it is mentioned that `0` is a valid value. The example uses `pthread_self()`, so should we.

(noticed by Anthony Towns)
Fixes #12915.