### PR TITLE
wallet: Logprint the start of a rescan

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1714,6 +1714,9 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
 
     CBlockIndex* pindex = pindexStart;
     CBlockIndex* ret = nullptr;
+
+    if (pindex) LogPrintf("Rescan started from block %d...\n", pindex->nHeight);
+
     {
         fAbortRescan = false;
         ShowProgress(_("Rescanning..."), 0); // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup


### PR DESCRIPTION
Right now, there is no log entry when a rescan starts which is confusing especially when a "still rescanning" log entry appears after the log-update timeout of 60s or when user manually aborts the rescan.

This PR adds a log entry when a rescan starts.