### PR TITLE
Remove CWallet dependency from CWalletTx

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -20,8 +20,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<CO
     CWalletTx* wtx = new CWalletTx(&wallet, MakeTransactionRef(std::move(tx)));
 
     int nAge = 6 * 24;
-    COutput output(wtx, nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */);
-    vCoins.push_back(output);
+    vCoins.push_back(wallet.MakeOutput(*wtx, nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */));
 }
 
 // Simple benchmark for wallet coin selection. Note that it maybe be necessary

--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -17,7 +17,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<CO
     tx.nLockTime = nextLockTime++; // so all transactions get different hashes
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
-    CWalletTx* wtx = new CWalletTx(&wallet, MakeTransactionRef(std::move(tx)));
+    CWalletTx* wtx = new CWalletTx(MakeTransactionRef(std::move(tx)));
 
     int nAge = 6 * 24;
     vCoins.push_back(wallet.MakeOutput(*wtx, nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */));

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -73,7 +73,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
                                                       ISMINE_NO);
     }
     result.credit = wtx.GetCredit(ISMINE_ALL);
-    result.debit = wtx.GetDebit(ISMINE_ALL);
+    result.debit = wallet.GetDebit(wtx, ISMINE_ALL);
     result.change = wtx.GetChange();
     result.time = wtx.GetTxTime();
     result.value_map = wtx.mapValue;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -72,7 +72,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
                                                       IsMine(wallet, result.txout_address.back()) :
                                                       ISMINE_NO);
     }
-    result.credit = wtx.GetCredit(ISMINE_ALL);
+    result.credit = wallet.GetCredit(wtx, ISMINE_ALL);
     result.debit = wallet.GetDebit(wtx, ISMINE_ALL);
     result.change = wtx.GetChange();
     result.time = wtx.GetTxTime();

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -90,7 +90,7 @@ WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max()),
     result.blocks_to_maturity = wtx.GetBlocksToMaturity();
     result.depth_in_main_chain = wtx.GetDepthInMainChain();
-    result.request_count = wtx.GetRequestCount();
+    result.request_count = wallet.GetRequestCount(wtx);
     result.time_received = wtx.nTimeReceived;
     result.lock_time = wtx.tx->nLockTime;
     result.is_final = CheckFinalTx(*wtx.tx);

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -82,7 +82,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
 }
 
 //! Construct wallet tx status struct.
-WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
+WalletTxStatus MakeWalletTxStatus(const CWallet& wallet, const CWalletTx& wtx)
 {
     WalletTxStatus result;
     auto mi = ::mapBlockIndex.find(wtx.hashBlock);
@@ -94,7 +94,7 @@ WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
     result.time_received = wtx.nTimeReceived;
     result.lock_time = wtx.tx->nLockTime;
     result.is_final = CheckFinalTx(*wtx.tx);
-    result.is_trusted = wtx.IsTrusted();
+    result.is_trusted = wallet.IsTrusted(wtx);
     result.is_abandoned = wtx.isAbandoned();
     result.is_coinbase = wtx.IsCoinBase();
     result.is_in_main_chain = wtx.IsInMainChain();
@@ -300,7 +300,7 @@ public:
         }
         num_blocks = ::chainActive.Height();
         adjusted_time = GetAdjustedTime();
-        tx_status = MakeWalletTxStatus(mi->second);
+        tx_status = MakeWalletTxStatus(m_wallet, mi->second);
         return true;
     }
     WalletTx getWalletTxDetails(const uint256& txid,
@@ -317,7 +317,7 @@ public:
             adjusted_time = GetAdjustedTime();
             in_mempool = mi->second.InMempool();
             order_form = mi->second.vOrderForm;
-            tx_status = MakeWalletTxStatus(mi->second);
+            tx_status = MakeWalletTxStatus(m_wallet, mi->second);
             return MakeWalletTx(m_wallet, mi->second);
         }
         return {};

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -74,7 +74,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
     }
     result.credit = wallet.GetCredit(wtx, ISMINE_ALL);
     result.debit = wallet.GetDebit(wtx, ISMINE_ALL);
-    result.change = wtx.GetChange();
+    result.change = wallet.GetChange(wtx);
     result.time = wtx.GetTxTime();
     result.value_map = wtx.mapValue;
     result.is_coinbase = wtx.IsCoinBase();

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -116,7 +116,7 @@ Result CreateTransaction(const CWallet* wallet, const uint256& txid, const CCoin
     }
 
     // calculate the old fee and fee-rate
-    old_fee = wtx.GetDebit(ISMINE_SPENDABLE) - wtx.tx->GetValueOut();
+    old_fee = wallet->GetDebit(wtx, ISMINE_SPENDABLE) - wtx.tx->GetValueOut();
     CFeeRate nOldFeeRate(old_fee, txSize);
     CFeeRate nNewFeeRate;
     // The wallet uses a conservative WALLET_INCREMENTAL_RELAY_FEE value to

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -349,7 +349,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     if (!DecodeHexTx(tx, request.params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     uint256 hashTx = tx.GetHash();
-    CWalletTx wtx(pwallet, MakeTransactionRef(std::move(tx)));
+    CWalletTx wtx(MakeTransactionRef(std::move(tx)));
 
     CDataStream ssMB(ParseHexV(request.params[1], "proof"), SER_NETWORK, PROTOCOL_VERSION);
     CMerkleBlock merkleBlock;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1675,7 +1675,7 @@ void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::s
     wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
 
     bool fAllAccounts = (strAccount == std::string("*"));
-    bool involvesWatchonly = wtx.IsFromMe(ISMINE_WATCH_ONLY);
+    bool involvesWatchonly = pwallet->IsFromMe(wtx, ISMINE_WATCH_ONLY);
 
     // Sent
     if ((!listSent.empty() || nFee != 0) && (fAllAccounts || strAccount == strSentAccount))
@@ -2208,11 +2208,12 @@ UniValue gettransaction(const JSONRPCRequest& request)
     CAmount nCredit = wtx.GetCredit(filter);
     CAmount nDebit = wtx.GetDebit(filter);
     CAmount nNet = nCredit - nDebit;
-    CAmount nFee = (wtx.IsFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
+    CAmount nFee = pwallet->IsFromMe(wtx, filter) ? wtx.tx->GetValueOut() - nDebit : 0;
 
     entry.pushKV("amount", ValueFromAmount(nNet - nFee));
-    if (wtx.IsFromMe(filter))
+    if (pwallet->IsFromMe(wtx, filter)) {
         entry.pushKV("fee", ValueFromAmount(nFee));
+    }
 
     WalletTxToJSON(wtx, entry);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1672,7 +1672,7 @@ void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::s
     std::list<COutputEntry> listReceived;
     std::list<COutputEntry> listSent;
 
-    wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, filter);
+    pwallet->GetAmounts(wtx, listReceived, listSent, nFee, strSentAccount, filter);
 
     bool fAllAccounts = (strAccount == std::string("*"));
     bool involvesWatchonly = pwallet->IsFromMe(wtx, ISMINE_WATCH_ONLY);
@@ -1963,7 +1963,7 @@ UniValue listaccounts(const JSONRPCRequest& request)
         int nDepth = wtx.GetDepthInMainChain();
         if (wtx.GetBlocksToMaturity() > 0 || nDepth < 0)
             continue;
-        wtx.GetAmounts(listReceived, listSent, nFee, strSentAccount, includeWatchonly);
+        pwallet->GetAmounts(wtx, listReceived, listSent, nFee, strSentAccount, includeWatchonly);
         mapAccountBalances[strSentAccount] -= nFee;
         for (const COutputEntry& s : listSent)
             mapAccountBalances[strSentAccount] -= s.amount;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2205,7 +2205,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     }
     const CWalletTx& wtx = it->second;
 
-    CAmount nCredit = wtx.GetCredit(filter);
+    CAmount nCredit = pwallet->GetCredit(wtx, filter);
     CAmount nDebit = pwallet->GetDebit(wtx, filter);
     CAmount nNet = nCredit - nDebit;
     CAmount nFee = pwallet->IsFromMe(wtx, filter) ? wtx.tx->GetValueOut() - nDebit : 0;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -104,7 +104,7 @@ void WalletTxToJSON(const CWallet* pwallet, const CWalletTx& wtx, UniValue& entr
     uint256 hash = wtx.GetHash();
     entry.pushKV("txid", hash.GetHex());
     UniValue conflicts(UniValue::VARR);
-    for (const uint256& conflict : wtx.GetConflicts())
+    for (const uint256& conflict : pwallet->GetConflicts(hash))
         conflicts.push_back(conflict.GetHex());
     entry.pushKV("walletconflicts", conflicts);
     entry.pushKV("time", wtx.GetTxTime());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -87,7 +87,7 @@ void EnsureWalletIsUnlocked(CWallet * const pwallet)
     }
 }
 
-void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
+void WalletTxToJSON(const CWallet* pwallet, const CWalletTx& wtx, UniValue& entry)
 {
     int confirms = wtx.GetDepthInMainChain();
     entry.pushKV("confirmations", confirms);
@@ -99,7 +99,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
         entry.pushKV("blockindex", wtx.nIndex);
         entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
     } else {
-        entry.pushKV("trusted", wtx.IsTrusted());
+        entry.pushKV("trusted", pwallet->IsTrusted(wtx));
     }
     uint256 hash = wtx.GetHash();
     entry.pushKV("txid", hash.GetHex());
@@ -1696,7 +1696,7 @@ void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::s
             entry.pushKV("vout", s.vout);
             entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong)
-                WalletTxToJSON(wtx, entry);
+                WalletTxToJSON(pwallet, wtx, entry);
             entry.pushKV("abandoned", wtx.isAbandoned());
             ret.push_back(entry);
         }
@@ -1738,7 +1738,7 @@ void ListTransactions(CWallet* const pwallet, const CWalletTx& wtx, const std::s
                 }
                 entry.pushKV("vout", r.vout);
                 if (fLong)
-                    WalletTxToJSON(wtx, entry);
+                    WalletTxToJSON(pwallet, wtx, entry);
                 ret.push_back(entry);
             }
         }
@@ -2215,7 +2215,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
         entry.pushKV("fee", ValueFromAmount(nFee));
     }
 
-    WalletTxToJSON(wtx, entry);
+    WalletTxToJSON(pwallet, wtx, entry);
 
     UniValue details(UniValue::VARR);
     ListTransactions(pwallet, wtx, "*", 0, false, details, filter);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2206,7 +2206,7 @@ UniValue gettransaction(const JSONRPCRequest& request)
     const CWalletTx& wtx = it->second;
 
     CAmount nCredit = wtx.GetCredit(filter);
-    CAmount nDebit = wtx.GetDebit(filter);
+    CAmount nDebit = pwallet->GetDebit(wtx, filter);
     CAmount nNet = nCredit - nDebit;
     CAmount nFee = pwallet->IsFromMe(wtx, filter) ? wtx.tx->GetValueOut() - nDebit : 0;
 

--- a/src/wallet/test/accounting_tests.cpp
+++ b/src/wallet/test/accounting_tests.cpp
@@ -29,7 +29,7 @@ GetResults(CWallet& wallet, std::map<CAmount, CAccountingEntry>& results)
 BOOST_AUTO_TEST_CASE(acc_orderupgrade)
 {
     std::vector<CWalletTx*> vpwtx;
-    CWalletTx wtx(nullptr /* pwallet */, MakeTransactionRef());
+    CWalletTx wtx(MakeTransactionRef());
     CAccountingEntry ae;
     std::map<CAmount, CAccountingEntry> results;
 

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -65,7 +65,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         // so stop vin being empty, and cache a non-zero Debit to fake out IsFromMe()
         tx.vin.resize(1);
     }
-    std::unique_ptr<CWalletTx> wtx(new CWalletTx(&testWallet, MakeTransactionRef(std::move(tx))));
+    std::unique_ptr<CWalletTx> wtx(new CWalletTx(MakeTransactionRef(std::move(tx))));
     if (fIsFromMe)
     {
         wtx->fDebitCached = true;

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -71,8 +71,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
         wtx->fDebitCached = true;
         wtx->nDebitCached = 1;
     }
-    COutput output(wtx.get(), nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */);
-    vCoins.push_back(output);
+    vCoins.push_back(testWallet.MakeOutput(*wtx.get(), nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */));
     testWallet.AddToWallet(*wtx.get());
     wtxn.emplace_back(std::move(wtx));
 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
 {
     CWallet wallet("dummy", WalletDatabase::CreateDummy());
-    CWalletTx wtx(&wallet, m_coinbase_txns.back());
+    CWalletTx wtx(m_coinbase_txns.back());
     LOCK2(cs_main, wallet.cs_wallet);
     wtx.hashBlock = chainActive.Tip()->GetBlockHash();
     wtx.nIndex = 0;
@@ -211,7 +211,7 @@ static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64
         block->phashBlock = &hash;
     }
 
-    CWalletTx wtx(&wallet, MakeTransactionRef(tx));
+    CWalletTx wtx(MakeTransactionRef(tx));
     if (block) {
         wtx.SetMerkleBranch(block, 0);
     }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -186,13 +186,13 @@ BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
 
     // Call GetImmatureCredit() once before adding the key to the wallet to
     // cache the current immature credit amount, which is 0.
-    BOOST_CHECK_EQUAL(wtx.GetImmatureCredit(), 0);
+    BOOST_CHECK_EQUAL(wallet.GetImmatureCredit(wtx), 0);
 
     // Invalidate the cached value, add the key, and make sure a new immature
     // credit amount is calculated.
     wtx.MarkDirty();
     wallet.AddKeyPubKey(coinbaseKey, coinbaseKey.GetPubKey());
-    BOOST_CHECK_EQUAL(wtx.GetImmatureCredit(), 50*COIN);
+    BOOST_CHECK_EQUAL(wallet.GetImmatureCredit(wtx), 50*COIN);
 }
 
 static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64_t blockTime)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1639,35 +1639,35 @@ int64_t CWalletTx::GetTxTime() const
     return n ? n : nTimeReceived;
 }
 
-int CWalletTx::GetRequestCount() const
+int CWallet::GetRequestCount(const CWalletTx& wtx) const
 {
     // Returns -1 if it wasn't being tracked
     int nRequests = -1;
     {
-        LOCK(pwallet->cs_wallet);
-        if (IsCoinBase())
+        LOCK(cs_wallet);
+        if (wtx.IsCoinBase())
         {
             // Generated block
-            if (!hashUnset())
+            if (!wtx.hashUnset())
             {
-                std::map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
-                if (mi != pwallet->mapRequestCount.end())
+                std::map<uint256, int>::const_iterator mi = mapRequestCount.find(wtx.hashBlock);
+                if (mi != mapRequestCount.end())
                     nRequests = (*mi).second;
             }
         }
         else
         {
             // Did anyone request this transaction?
-            std::map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(GetHash());
-            if (mi != pwallet->mapRequestCount.end())
+            std::map<uint256, int>::const_iterator mi = mapRequestCount.find(wtx.GetHash());
+            if (mi != mapRequestCount.end())
             {
                 nRequests = (*mi).second;
 
                 // How about the block it's in?
-                if (nRequests == 0 && !hashUnset())
+                if (nRequests == 0 && !wtx.hashUnset())
                 {
-                    std::map<uint256, int>::const_iterator _mi = pwallet->mapRequestCount.find(hashBlock);
-                    if (_mi != pwallet->mapRequestCount.end())
+                    std::map<uint256, int>::const_iterator _mi = mapRequestCount.find(wtx.hashBlock);
+                    if (_mi != mapRequestCount.end())
                         nRequests = (*_mi).second;
                     else
                         nRequests = 1; // If it's in someone else's block it must have got out

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -494,6 +494,10 @@ std::set<uint256> CWallet::GetConflicts(const uint256& txid) const
         for (TxSpends::const_iterator _it = range.first; _it != range.second; ++_it)
             result.insert(_it->second);
     }
+
+    // txid should not conflict with itself
+    result.erase(txid);
+
     return result;
 }
 
@@ -1977,18 +1981,6 @@ bool CWallet::RelayWalletTransaction(CWalletTx& wtx, CConnman* connman)
         }
     }
     return false;
-}
-
-std::set<uint256> CWalletTx::GetConflicts() const
-{
-    std::set<uint256> result;
-    if (pwallet != nullptr)
-    {
-        uint256 myHash = GetHash();
-        result = pwallet->GetConflicts(myHash);
-        result.erase(myHash);
-    }
-    return result;
 }
 
 bool CWalletTx::InMempool() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1381,6 +1381,16 @@ CAmount CWallet::GetChange(const CTxOut& txout) const
     return (IsChange(txout) ? txout.nValue : 0);
 }
 
+CAmount CWallet::GetChange(const CWalletTx& wtx) const
+{
+    if (wtx.fChangeCached) {
+        return wtx.nChangeCached;
+    }
+    wtx.nChangeCached = GetChange(*wtx.tx);
+    wtx.fChangeCached = true;
+    return wtx.nChangeCached;
+}
+
 bool CWallet::IsMine(const CTransaction& tx) const
 {
     for (const CTxOut& txout : tx.vout)
@@ -1979,15 +1989,6 @@ std::set<uint256> CWalletTx::GetConflicts() const
         result.erase(myHash);
     }
     return result;
-}
-
-CAmount CWalletTx::GetChange() const
-{
-    if (fChangeCached)
-        return nChangeCached;
-    nChangeCached = pwallet->GetChange(*tx);
-    fChangeCached = true;
-    return nChangeCached;
 }
 
 bool CWalletTx::InMempool() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4316,6 +4316,6 @@ COutput CWallet::MakeOutput(const CWalletTx& wtx, int index, int depth, bool is_
 {
     // If known and signable by the given wallet, compute input bytes
     // Failure will keep this value -1
-    int input_bytes = is_spendable ? wtx.GetSpendSize(index) : -1;
+    int input_bytes = is_spendable ? GetSpendSize(wtx, index) : -1;
     return {&wtx, index, depth, input_bytes, is_spendable, is_solvable, is_safe};
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -448,12 +448,6 @@ public:
 
     int64_t GetTxTime() const;
 
-    // RelayWalletTransaction may only be called if fBroadcastTransactions!
-    bool RelayWalletTransaction(CConnman* connman);
-
-    /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */
-    bool AcceptToMemoryPool(const CAmount& nAbsurdFee, CValidationState& state);
-
     std::set<uint256> GetConflicts() const;
 };
 
@@ -787,6 +781,13 @@ public:
     bool IsTrusted(const CWalletTx& wtx) const;
 
     int GetRequestCount(const CWalletTx& wtx) const;
+
+    // RelayWalletTransaction may only be called if fBroadcastTransactions!
+    bool RelayWalletTransaction(CWalletTx& wtx, CConnman* connman);
+
+    /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */
+    bool AcceptToMemoryPool(CWalletTx& wtx, const CAmount& nAbsurdFee, CValidationState& state);
+
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) const { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -447,7 +447,6 @@ public:
     bool InMempool() const;
 
     int64_t GetTxTime() const;
-    int GetRequestCount() const;
 
     // RelayWalletTransaction may only be called if fBroadcastTransactions!
     bool RelayWalletTransaction(CConnman* connman);
@@ -786,6 +785,8 @@ public:
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
 
     bool IsTrusted(const CWalletTx& wtx) const;
+
+    int GetRequestCount(const CWalletTx& wtx) const;
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) const { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -274,9 +274,6 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet)
  */
 class CWalletTx : public CMerkleTx
 {
-private:
-    const CWallet* pwallet;
-
 public:
     /**
      * Key/value map with information about the transaction.
@@ -347,14 +344,13 @@ public:
     mutable CAmount nAvailableWatchCreditCached;
     mutable CAmount nChangeCached;
 
-    CWalletTx(const CWallet* pwalletIn, CTransactionRef arg) : CMerkleTx(std::move(arg))
+    explicit CWalletTx(CTransactionRef arg) : CMerkleTx(std::move(arg))
     {
-        Init(pwalletIn);
+        Init();
     }
 
-    void Init(const CWallet* pwalletIn)
+    void Init()
     {
-        pwallet = pwalletIn;
         mapValue.clear();
         vOrderForm.clear();
         fTimeReceivedIsTxTime = false;
@@ -404,7 +400,7 @@ public:
     template<typename Stream>
     void Unserialize(Stream& s)
     {
-        Init(nullptr);
+        Init();
         char fSpent;
 
         s >> static_cast<CMerkleTx&>(*this);
@@ -433,12 +429,6 @@ public:
         fImmatureWatchCreditCached = false;
         fDebitCached = false;
         fChangeCached = false;
-    }
-
-    void BindWallet(CWallet *pwalletIn)
-    {
-        pwallet = pwalletIn;
-        MarkDirty();
     }
 
     // True if only scriptSigs are different

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,12 +441,6 @@ public:
         MarkDirty();
     }
 
-    // Get the marginal bytes if spending the specified output from this transaction
-    int GetSpendSize(unsigned int out) const
-    {
-        return CalculateMaximumSignedInputSize(tx->vout[out], pwallet);
-    }
-
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
 
@@ -785,6 +779,12 @@ public:
     std::set<COutPoint> setLockedCoins;
 
     const CWalletTx* GetWalletTx(const uint256& hash) const;
+
+    // Get the marginal bytes if spending the specified output from this transaction
+    int GetSpendSize(const CWalletTx& wtx, unsigned int out) const
+    {
+        return CalculateMaximumSignedInputSize(wtx.tx->vout[out], this);
+    }
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) const { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -442,7 +442,6 @@ public:
     }
 
     //! filter decides which addresses will count towards the debit
-    CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true) const;
@@ -982,6 +981,7 @@ public:
      * filter, otherwise returns 0
      */
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
+    CAmount GetDebit(const CWalletTx& wtx, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
     CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
     bool IsChange(const CTxOut& txout) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,7 +441,6 @@ public:
         MarkDirty();
     }
 
-    CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetAvailableWatchOnlyCredit(const bool fUseCache=true) const;
@@ -994,6 +993,8 @@ public:
     bool IsAllFromMe(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CWalletTx& wtx, const isminefilter& filter) const;
+    CAmount GetImmatureCredit(const CWalletTx& wtx) const;
+
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,7 +441,6 @@ public:
         MarkDirty();
     }
 
-    CAmount GetImmatureWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetAvailableWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
 
@@ -994,6 +993,7 @@ public:
     CAmount GetCredit(const CWalletTx& wtx, const isminefilter& filter) const;
     CAmount GetImmatureCredit(const CWalletTx& wtx) const;
     CAmount GetAvailableCredit(const CWalletTx& wtx) const;
+    CAmount GetImmatureWatchOnlyCredit(const CWalletTx& wtx) const;
 
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -505,16 +505,6 @@ public:
      */
     bool fSafe;
 
-    COutput(const CWalletTx *txIn, int iIn, int nDepthIn, bool fSpendableIn, bool fSolvableIn, bool fSafeIn)
-    {
-        tx = txIn; i = iIn; nDepth = nDepthIn; fSpendable = fSpendableIn; fSolvable = fSolvableIn; fSafe = fSafeIn; nInputBytes = -1;
-        // If known and signable by the given wallet, compute nInputBytes
-        // Failure will keep this value -1
-        if (fSpendable && tx) {
-            nInputBytes = tx->GetSpendSize(i);
-        }
-    }
-
     std::string ToString() const;
 };
 
@@ -1150,6 +1140,8 @@ public:
 
     /** Whether a given output is spendable by this wallet */
     bool OutputEligibleForSpending(const COutput& output, const CoinEligibilityFilter& eligibility_filter) const;
+
+    COutput MakeOutput(const CWalletTx& wtx, int index, int depth, bool is_spendable, bool is_solvableIn, bool is_safe) const;
 };
 
 /** A key allocated from the key pool. */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -445,7 +445,6 @@ public:
     bool IsEquivalentTo(const CWalletTx& tx) const;
 
     bool InMempool() const;
-    bool IsTrusted() const;
 
     int64_t GetTxTime() const;
     int GetRequestCount() const;
@@ -785,6 +784,8 @@ public:
 
     void GetAmounts(const CWalletTx& wtx, std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
+
+    bool IsTrusted(const CWalletTx& wtx) const;
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) const { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,8 +441,6 @@ public:
         MarkDirty();
     }
 
-    CAmount GetChange() const;
-
     // Get the marginal bytes if spending the specified output from this transaction
     int GetSpendSize(unsigned int out) const
     {
@@ -996,6 +994,8 @@ public:
     CAmount GetAvailableWatchOnlyCredit(const CWalletTx& wtx) const;
 
     CAmount GetChange(const CTransaction& tx) const;
+    CAmount GetChange(const CWalletTx& wtx) const;
+
     void SetBestChain(const CBlockLocator& loc) override;
 
     DBErrors LoadWallet(bool& fFirstRunRet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,8 +441,6 @@ public:
         MarkDirty();
     }
 
-    //! filter decides which addresses will count towards the debit
-    CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool fUseCache=true) const;
@@ -995,6 +993,7 @@ public:
     /** Returns whether all of the inputs match the filter */
     bool IsAllFromMe(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
+    CAmount GetCredit(const CWalletTx& wtx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,7 +441,6 @@ public:
         MarkDirty();
     }
 
-    CAmount GetAvailableWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
 
     // Get the marginal bytes if spending the specified output from this transaction
@@ -994,6 +993,7 @@ public:
     CAmount GetImmatureCredit(const CWalletTx& wtx) const;
     CAmount GetAvailableCredit(const CWalletTx& wtx) const;
     CAmount GetImmatureWatchOnlyCredit(const CWalletTx& wtx) const;
+    CAmount GetAvailableWatchOnlyCredit(const CWalletTx& wtx) const;
 
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -459,11 +459,6 @@ public:
     void GetAmounts(std::list<COutputEntry>& listReceived,
                     std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
 
-    bool IsFromMe(const isminefilter& filter) const
-    {
-        return (GetDebit(filter) > 0);
-    }
-
     // True if only scriptSigs are different
     bool IsEquivalentTo(const CWalletTx& tx) const;
 
@@ -994,6 +989,8 @@ public:
     bool IsMine(const CTransaction& tx) const;
     /** should probably be renamed to IsRelevantToMe */
     bool IsFromMe(const CTransaction& tx) const;
+    bool IsFromMe(const CWalletTx& wtx, const isminefilter& filter) const;
+
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
     /** Returns whether all of the inputs match the filter */
     bool IsAllFromMe(const CTransaction& tx, const isminefilter& filter) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,9 +441,6 @@ public:
         MarkDirty();
     }
 
-    void GetAmounts(std::list<COutputEntry>& listReceived,
-                    std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
-
     // True if only scriptSigs are different
     bool IsEquivalentTo(const CWalletTx& tx) const;
 
@@ -785,6 +782,9 @@ public:
     {
         return CalculateMaximumSignedInputSize(wtx.tx->vout[out], this);
     }
+
+    void GetAmounts(const CWalletTx& wtx, std::list<COutputEntry>& listReceived,
+                    std::list<COutputEntry>& listSent, CAmount& nFee, std::string& strSentAccount, const isminefilter& filter) const;
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf) const { AssertLockHeld(cs_wallet); return nWalletMaxVersion >= wf; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -441,7 +441,6 @@ public:
         MarkDirty();
     }
 
-    CAmount GetAvailableCredit(bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetAvailableWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
@@ -994,6 +993,7 @@ public:
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetCredit(const CWalletTx& wtx, const isminefilter& filter) const;
     CAmount GetImmatureCredit(const CWalletTx& wtx) const;
+    CAmount GetAvailableCredit(const CWalletTx& wtx) const;
 
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -447,8 +447,6 @@ public:
     bool InMempool() const;
 
     int64_t GetTxTime() const;
-
-    std::set<uint256> GetConflicts() const;
 };
 
 class COutput

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -271,7 +271,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
         {
             uint256 hash;
             ssKey >> hash;
-            CWalletTx wtx(nullptr /* pwallet */, MakeTransactionRef());
+            CWalletTx wtx(MakeTransactionRef());
             ssValue >> wtx;
             CValidationState state;
             if (!(CheckTransaction(*wtx.tx, state) && (wtx.GetHash() == hash) && state.IsValid()))
@@ -672,7 +672,7 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CW
                 uint256 hash;
                 ssKey >> hash;
 
-                CWalletTx wtx(nullptr /* pwallet */, MakeTransactionRef());
+                CWalletTx wtx(MakeTransactionRef());
                 ssValue >> wtx;
 
                 vTxHash.push_back(hash);


### PR DESCRIPTION
This PR doesn't change behaviour, it's purely a refactor.

All `CWalletTx` methods that use the wallet pointer are moved to `CWallet` and then the wallet pointer is removed from `CWalletTx`.

This should also ease adding thread safety analysis annotations like #11634.