### PR TITLE
wallet: Remove redundant lambda function arg in handleTransactionChanged

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -422,7 +422,7 @@ public:
     std::unique_ptr<Handler> handleTransactionChanged(TransactionChangedFn fn) override
     {
         return MakeHandler(m_wallet.NotifyTransactionChanged.connect(
-            [fn, this](CWallet*, const uint256& txid, ChangeType status) { fn(txid, status); }));
+            [fn](CWallet*, const uint256& txid, ChangeType status) { fn(txid, status); }));
     }
     std::unique_ptr<Handler> handleWatchOnlyChanged(WatchOnlyChangedFn fn) override
     {


### PR DESCRIPTION
Makes the build warning-clean again here:

    bitcoin/src/interfaces/wallet.cpp:425:18: warning: lambda capture 'this' is not used [-Wunused-lambda-capture]
                [fn, this](CWallet*, const uint256& txid, ChangeType status) { fn(txid, status); }));
                     ^