### PR TITLE
[net] [validation] Call ProcessNewBlock() asynchronously

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -145,6 +145,7 @@ BITCOIN_CORE_H = \
   policy/policy.h \
   policy/rbf.h \
   pow.h \
+  core/producerconsumerqueue.h \
   protocol.h \
   random.h \
   reverse_iterator.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ BITCOIN_CORE_H = \
   utilmoneystr.h \
   utiltime.h \
   validation.h \
+  validation_layer.h \
   validationinterface.h \
   versionbits.h \
   walletinitinterface.h \
@@ -255,6 +256,7 @@ libbitcoin_server_a_SOURCES = \
   txmempool.cpp \
   ui_interface.cpp \
   validation.cpp \
+  validation_layer.cpp \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -111,6 +111,8 @@ BITCOIN_CORE_H = \
   compressor.h \
   consensus/consensus.h \
   consensus/tx_verify.h \
+  core/consumerthread.h \
+  core/producerconsumerqueue.h \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
@@ -145,7 +147,6 @@ BITCOIN_CORE_H = \
   policy/policy.h \
   policy/rbf.h \
   pow.h \
-  core/producerconsumerqueue.h \
   protocol.h \
   random.h \
   reverse_iterator.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -65,6 +65,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
+  test/producerconsumerqueue_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
   test/reverselock_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -44,6 +44,7 @@ BITCOIN_TESTS =\
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \
   test/compress_tests.cpp \
+  test/consumerthread_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
   test/denialofservice_tests.cpp \

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -9,7 +9,7 @@
 #include <random.h>
 #include <util.h>
 #include <utilstrencodings.h>
-#include <validation.h>
+#include <validation_layer.h>
 
 #include <memory>
 
@@ -20,6 +20,8 @@ static const char* DEFAULT_BENCH_PRINTER = "console";
 static const char* DEFAULT_PLOT_PLOTLYURL = "https://cdn.plot.ly/plotly-latest.min.js";
 static const int64_t DEFAULT_PLOT_WIDTH = 1024;
 static const int64_t DEFAULT_PLOT_HEIGHT = 768;
+
+std::unique_ptr<ValidationLayer> g_validation_layer;
 
 static void SetupBenchArgs()
 {
@@ -68,6 +70,9 @@ int main(int argc, char** argv)
     RandomInit();
     ECC_Start();
     SetupEnvironment();
+
+    g_validation_layer.reset(new ValidationLayer(Params()));
+    g_validation_layer->Start();
 
     int64_t evaluations = gArgs.GetArg("-evals", DEFAULT_BENCH_EVALUATIONS);
     std::string regex_filter = gArgs.GetArg("-filter", DEFAULT_BENCH_FILTER);

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -14,7 +14,7 @@
 #include <txdb.h>
 #include <txmempool.h>
 #include <utiltime.h>
-#include <validation.h>
+#include <validation_layer.h>
 #include <validationinterface.h>
 
 #include <boost/thread.hpp>
@@ -44,7 +44,7 @@ static CTxIn MineBlock(const CScript& coinbase_scriptPubKey)
         assert(++block->nNonce);
     }
 
-    bool processed{ProcessNewBlock(Params(), block, true, nullptr)};
+    bool processed{g_validation_layer->Validate(block, true).block_valid};
     assert(processed);
 
     return CTxIn{block->vtx[0]->GetHash(), 0};

--- a/src/core/consumerthread.h
+++ b/src/core/consumerthread.h
@@ -1,0 +1,197 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_CONSUMERTHREAD_H
+#define BITCOIN_CORE_CONSUMERTHREAD_H
+
+#include <future>
+#include <thread>
+
+#include <core/producerconsumerqueue.h>
+#include <util.h>
+
+template <WorkerMode MODE>
+class ConsumerThread;
+
+//! A WorkItem() encapsulates a task that can be processed by a ConsumerThread()
+//! @see ConsumerThread()
+template <WorkerMode MODE>
+class WorkItem
+{
+    friend ConsumerThread<MODE>; //<! only a consumer thread can execute a WorkItem
+
+protected:
+    WorkItem(){};
+    virtual void operator()(){};
+};
+
+template <WorkerMode MODE>
+class GenericWorkItem : public WorkItem<MODE>
+{
+    friend ConsumerThread<MODE>;
+
+public:
+    GenericWorkItem(std::function<void()> f) : m_f(f) {}
+
+protected:
+    void operator()() override
+    {
+        m_f();
+    }
+
+    std::function<void()> m_f;
+};
+
+//! A special WorkItem() that is used to interrupt a blocked ConsumerThread() so that it can terminate
+template <WorkerMode MODE>
+class ShutdownPill : public WorkItem<MODE>
+{
+    friend ConsumerThread<MODE>;
+
+private:
+    ShutdownPill(ConsumerThread<MODE>& consumer) : m_consumer(consumer){};
+    void operator()()
+    {
+        std::thread::id id = m_consumer.m_thread.get_id();
+        if (std::this_thread::get_id() != id) {
+            // this ShutdownPill was intended for another thread
+
+            // we haven't seen this pill before
+            if (!m_threads_observed.count(id)) {
+                m_threads_observed.insert(std::this_thread::get_id());
+
+                // resubmit it so that it gets a chance to get to the right thread
+                // when resubmitting, do not block and do not care about failures
+                // theres a potential deadlock where we try to push this to a queue thats
+                // full and there are no other threads still consuming
+                // since the only purpose of reinjecting this is to terminate threads that
+                // may be blocking on an empty queue when the queue is full we do not need to do this
+                m_consumer.m_queue->Push(MakeUnique<ShutdownPill<MODE>>(std::move(*this)), WorkerMode::NONBLOCKING);
+            }
+
+            // if the same pill has been seen by the same thread previously then it can safely be discarded
+            // the intended thread has either terminated or is currently processing a work item and will terminate
+            // after completing that item and before blocking on the queue
+        }
+    };
+
+    ConsumerThread<MODE>& m_consumer;
+    std::set<std::thread::id> m_threads_observed;
+};
+
+template <WorkerMode PRODUCER_MODE>
+class WorkQueue : public BlockingConsumerQueue<std::unique_ptr<WorkItem<PRODUCER_MODE>>, PRODUCER_MODE>
+{
+public:
+    WorkQueue(int capacity) :BlockingConsumerQueue<std::unique_ptr<WorkItem<PRODUCER_MODE>>, PRODUCER_MODE>(capacity) {}
+
+    //! Blocks until everything pushed to the queue prior to this call has been dequeued by a worker
+    void Sync()
+    {
+        std::promise<void> barrier;
+        this->Push(MakeUnique<GenericWorkItem<PRODUCER_MODE>>([&barrier](){ barrier.set_value(); }), WorkerMode::BLOCKING);
+        barrier.get_future().wait();
+    }
+};
+
+/**
+ * A worker thread that interoperates with a BlockingConsumerQueue
+ *
+ * Blocks on the queue, pulls WorkItem() tasks and executes them
+ * No assumptions are made about number of threads operating on this queue
+ *
+ * @see WorkItem
+ * @see WorkQueue
+ * @see BlockingConsumerQueue
+ * @see ProducerConsumerQueue
+ */
+template <WorkerMode PRODUCER_POLICY>
+class ConsumerThread
+{
+    friend ShutdownPill<PRODUCER_POLICY>; //<! needs to introspect in order to cleanly terminate this thread
+
+public:
+    //! Default constructor: not a valid thread
+    ConsumerThread() : m_active(false){};
+
+    //! Constructs a ConsumerThread: RAII
+    //! @param queue the queue from which this thread will pull work
+    ConsumerThread(std::shared_ptr<WorkQueue<PRODUCER_POLICY>> queue, const std::string id = "worker")
+        : m_id(id), m_queue(queue), m_active(true)
+    {
+        m_thread = std::thread(&TraceThread<std::function<void()>>, id.c_str(), std::function<void()>(std::bind(&ConsumerThread<PRODUCER_POLICY>::Loop, this)));
+    };
+
+    //! Terminates a running consumer thread
+    //! Blocks until the thread joins
+    //! Repeated calls are no-ops
+    void Terminate()
+    {
+        RequestTermination();
+        Join();
+    }
+
+    //! Requests termination of a running consumer thread
+    //! Does not wait for the thread to terminate
+    //! Repeated calls are no-ops
+    void RequestTermination()
+    {
+        // locked only so that repeated calls do not push extra ShutdownPills
+        std::unique_lock<CWaitableCriticalSection> l(m_cs_shutdown);
+        if (m_active) {
+            m_active = false;
+
+            // push an empty WorkItem so that we wake the thread up if it is blocking on an empty queue
+            // there is no easy way to determine if this consumer is blocked on the queue without introducing
+            // additional synchronization, but there is little downside to pushing this unnecessarily:
+            // either this is the last active thread on the queue in which case this will be destroyed if/when
+            // the queue (and any other work that may remain is destroyed)
+            // or there are other threads on the queue - in which case this pill will be discarded after any
+            // of the other threads observe it more than once
+            m_queue->Push(std::unique_ptr<ShutdownPill<PRODUCER_POLICY>>(new ShutdownPill<PRODUCER_POLICY>(*this)), WorkerMode::NONBLOCKING);
+        }
+    }
+
+    //! Waits until this thread terminates
+    //! RequestTerminate() must have been previously called or be called by a different thread
+    void Join()
+    {
+        m_thread.join();
+    }
+
+    bool IsActive() const { std::unique_lock<CWaitableCriticalSection> l(m_cs_shutdown); return m_active; }
+
+    const std::string m_id;
+
+private:
+    //! the queue of work that this thread should consume from
+    const std::shared_ptr<WorkQueue<PRODUCER_POLICY>> m_queue;
+
+    //! the thread that this class wraps
+    std::thread m_thread;
+
+    //! whether this thread should continue running: behaves like a latch
+    //! initialized to true in the constructor
+    //! can be set to false by calling Terminate()
+    volatile bool m_active;
+
+    //! protects Terminate()
+    mutable CWaitableCriticalSection m_cs_shutdown;
+
+    //! the body of this thread
+    //! Receives WorkItem() elements from m_queue and executes them until Terminate() is called
+    void Loop()
+    {
+        while (m_active) {
+            Process(m_queue->Pop());
+        }
+    }
+
+    void Process(const std::unique_ptr<WorkItem<PRODUCER_POLICY>> work) const
+    {
+        (*work)();
+    }
+};
+
+#endif // BITCOIN_CORE_CONSUMERTHREAD_H

--- a/src/core/producerconsumerqueue.h
+++ b/src/core/producerconsumerqueue.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_PRODUCERCONSUMERQUEUE_H
+#define BITCOIN_CORE_PRODUCERCONSUMERQUEUE_H
+
+#include <assert.h>
+#include <deque>
+#include <sync.h>
+#include <type_traits>
+
+/**
+ * The mode in which the queue operates
+ * Modes may be specified for both producers and consumers
+ */
+enum class WorkerMode {
+    BLOCKING,   //!< cv_wait until the action may proceed
+    NONBLOCKING //!< do not block, immediately return failure if the action is not possible
+};
+
+/**
+ * A FIFO thread safe producer consumer queue with two operations Push() and Pop()
+ * Producers Push() and Consumers Pop()
+ *
+ * @param T the type of the data contained
+ * @param m_producer_mode queue behavior when calling Push() on a full queue (block till space becomes available, or immediately fail)
+ * @param m_consumer_mode queue behavior when calling Pop() on an empty queue (block until there is data, or immediately fail)
+ *
+ * @see WorkerMode
+ */
+template <typename T, WorkerMode m_producer_mode = WorkerMode::BLOCKING, WorkerMode m_consumer_mode = WorkerMode::BLOCKING>
+class ProducerConsumerQueue
+{
+public:
+    /**
+     * Constructs a ProducerConsumerQueue()
+     * @param[in] capacity the maximum size of this queue
+     */
+    ProducerConsumerQueue(int capacity)
+        : m_capacity(capacity)
+    {
+        assert(m_capacity > 0);
+    };
+
+    /**
+     * Constructs an empty ProducerConsumerQueue with capacity 0
+     * In nonblocking mode all operations will immediately fail
+     * In blocking mode all operations will fail an assertion to avoid blocking forever
+     */
+    ProducerConsumerQueue()
+        : m_capacity(0){};
+    ~ProducerConsumerQueue(){};
+
+    /**
+     * Push an element to the back of the queue
+     * Blocking producer mode: will always eventually succeed
+     * Non-blocking producer mode: Push() returns failure when the queue is at capacity
+     * @param[in] data the data to be pushed
+     * @return the success of the operation
+     * @see WorkerMode
+     */
+    template <typename TT>
+    bool Push(TT&& data, WorkerMode mode = m_producer_mode)
+    {
+        // TT needed for perfect forwarding to vector::push_back
+
+        // attempting a push to a queue of capacity 0 is likely unintended
+        assert(m_capacity > 0);
+
+        {
+            std::unique_lock<std::mutex> l(m_queue_lock);
+            if (m_data.size() >= m_capacity) {
+                if (mode == WorkerMode::NONBLOCKING) {
+                    return false;
+                }
+
+                m_producer_cv.wait(l, [&]() { return m_data.size() < m_capacity; });
+            }
+
+            m_data.push_back(std::forward<TT>(data));
+        }
+        m_consumer_cv.notify_one();
+        return true;
+    };
+
+    /**
+     * Try to pop the oldest element from the front of the queue, if present
+     * Blocking consumer mode: will always eventually succeed
+     * Nonblocking consumer mode: Pop() returns failure when the queue is empty
+     * @param[out] the data popped, if the operation was successful
+     * @return the success of the operation
+     * @see WorkerMode
+     */
+    bool Pop(T& data, WorkerMode mode = m_consumer_mode)
+    {
+        // attempting a pop from a queue of capacity 0 is likely unintended
+        assert(m_capacity > 0);
+
+        {
+            std::unique_lock<std::mutex> l(m_queue_lock);
+            if (m_data.size() <= 0) {
+                if (mode == WorkerMode::NONBLOCKING) {
+                    return false;
+                }
+
+                m_consumer_cv.wait(l, [&]() { return m_data.size() > 0; });
+            }
+
+            data = std::move(m_data.front());
+            m_data.pop_front();
+        }
+        m_producer_cv.notify_one();
+        return true;
+    }
+
+    /**
+     * Shortcut for bool Pop(T&) when consumer mode is blocking
+     * This must always succeed and thus may only be called in producer blocking mode
+     * @return the element popped
+     */
+    T Pop()
+    {
+        static_assert(m_consumer_mode == WorkerMode::BLOCKING, "");
+
+        T ret;
+
+        // use a temporary so theres no side effecting code inside an assert which could be disabled
+        bool success = Pop(ret);
+        assert(success);
+
+        return ret;
+    }
+
+    typename std::deque<T>::size_type size()
+    {
+        std::unique_lock<std::mutex> l(m_queue_lock);
+        return m_data.size();
+    }
+    unsigned int GetCapacity() const { return m_capacity; }
+    static constexpr WorkerMode GetProducerMode() { return m_producer_mode; }
+    static constexpr WorkerMode GetConsumerMode() { return m_consumer_mode; }
+
+private:
+    unsigned int m_capacity; //!< maximum capacity the queue can hold above which pushes will block or fail
+    std::deque<T> m_data;    //!< the data currently in the queue
+
+    std::mutex m_queue_lock;          //!< synchronizes access to m_data
+    CConditionVariable m_consumer_cv; //!< consumers waiting for m_data to become non-empty
+    CConditionVariable m_producer_cv; //!< producers waiting for available space in m_data
+};
+
+template <typename T, WorkerMode consumer_mode>
+using BlockingConsumerQueue = ProducerConsumerQueue<T, WorkerMode::BLOCKING, consumer_mode>;
+
+#endif // BITCOIN_CORE_PRODUCERCONSUMERQUEUE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -48,6 +48,7 @@
 #include <walletinitinterface.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <validation_layer.h>
 
 #ifndef WIN32
 #include <signal.h>
@@ -73,6 +74,7 @@ static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 
 std::unique_ptr<CConnman> g_connman;
 std::unique_ptr<PeerLogicValidation> peerLogic;
+std::unique_ptr<ValidationLayer> g_validation_layer;
 
 #if !(ENABLE_WALLET)
 class DummyWalletInit : public WalletInitInterface {
@@ -209,6 +211,7 @@ void Shutdown()
     // using the other before destroying them.
     if (peerLogic) UnregisterValidationInterface(peerLogic.get());
     if (g_connman) g_connman->Stop();
+    if (g_validation_layer) g_validation_layer->Stop();
     peerLogic.reset();
     g_connman.reset();
     if (g_txindex) {
@@ -1306,7 +1309,10 @@ bool AppInitMain()
     g_connman = std::unique_ptr<CConnman>(new CConnman(GetRand(std::numeric_limits<uint64_t>::max()), GetRand(std::numeric_limits<uint64_t>::max())));
     CConnman& connman = *g_connman;
 
-    peerLogic.reset(new PeerLogicValidation(&connman, scheduler, gArgs.GetBoolArg("-enablebip61", DEFAULT_ENABLE_BIP61)));
+    g_validation_layer.reset(new ValidationLayer(chainparams));
+    g_validation_layer->Start();
+
+    peerLogic.reset(new PeerLogicValidation(&connman, *g_validation_layer, scheduler, gArgs.GetBoolArg("-enablebip61", DEFAULT_ENABLE_BIP61)));
     RegisterValidationInterface(peerLogic.get());
 
     // sanitize comments per BIP-0014, format user agent and check total size

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -119,6 +119,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::COINDB, "coindb"},
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
+    {BCLog::VALIDATION, "validation"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -53,6 +53,7 @@ namespace BCLog {
         COINDB      = (1 << 18),
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
+        VALIDATION  = (1 << 21),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,11 +14,12 @@
 #include <consensus/consensus.h>
 #include <crypto/common.h>
 #include <crypto/sha256.h>
-#include <primitives/transaction.h>
 #include <netbase.h>
+#include <primitives/transaction.h>
 #include <scheduler.h>
 #include <ui_interface.h>
 #include <utilstrencodings.h>
+#include <validation_layer.h>
 
 #ifdef WIN32
 #include <string.h>
@@ -2045,11 +2046,28 @@ void CConnman::ThreadMessageHandler()
             if (pnode->fDisconnect)
                 continue;
 
-            // Receive messages
-            bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc);
-            fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend);
+            bool request_was_queued = pnode->IsAwaitingInternalRequest();
+
+            // If an internal request was queued and it's not done yet, skip this node
+            if (request_was_queued && !pnode->ProcessInternalRequestResults(m_msgproc))
+                continue;
+
+            // If no internal request was queued receive messages
+            if (!request_was_queued) {
+                bool fMoreNodeWork = m_msgproc->ProcessMessages(pnode, flagInterruptMsgProc);
+                request_was_queued = pnode->IsAwaitingInternalRequest();
+
+                fMoreWork |= (fMoreNodeWork && !pnode->fPauseSend && !request_was_queued);
+            } else {
+                request_was_queued = false;
+            }
+
             if (flagInterruptMsgProc)
                 return;
+
+            if (request_was_queued)
+                continue;
+
             // Send messages
             {
                 LOCK(pnode->cs_sendProcessing);
@@ -2811,6 +2829,37 @@ void CNode::AskFor(const CInv& inv)
     else
         mapAlreadyAskedFor.insert(std::make_pair(inv.hash, nRequestTime));
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
+}
+
+bool CNode::IsAwaitingInternalRequest()
+{
+    return m_block_validation_response.valid();
+}
+
+bool CNode::ProcessInternalRequestResults(NetEventsInterface* peerlogic)
+{
+    bool all_cleared = true;
+
+    if (m_block_validation_response.valid()) {
+        if (m_block_validation_response.wait_for(std::chrono::milliseconds::zero()) == std::future_status::ready) {
+            peerlogic->ProcessBlockValidationResponse(this, m_block_validating, m_block_validating_index, m_block_validation_response.get());
+
+            m_block_validating = nullptr;
+            m_block_validating_index = nullptr;
+            m_block_validation_response = std::future<BlockValidationResponse>();
+        } else {
+            all_cleared = false;
+        }
+    }
+
+    return all_cleared;
+}
+
+void CNode::SetPendingInternalRequest(const std::shared_ptr<const CBlock> block, std::future<BlockValidationResponse>&& pending_response, const CBlockIndex* pindex)
+{
+    m_block_validating = block;
+    m_block_validating_index = pindex;
+    m_block_validation_response = std::move(pending_response);
 }
 
 bool CConnman::NodeFullyConnected(const CNode* pnode)

--- a/src/net.h
+++ b/src/net.h
@@ -23,19 +23,23 @@
 #include <threadinterrupt.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <deque>
+#include <future>
+#include <memory>
 #include <stdint.h>
 #include <thread>
-#include <memory>
-#include <condition_variable>
 
 #ifndef WIN32
 #include <arpa/inet.h>
 #endif
 
-
+struct BlockValidationResponse;
 class CScheduler;
 class CNode;
+class CBlock;
+class CBlockIndex;
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
@@ -478,6 +482,7 @@ public:
     virtual bool SendMessages(CNode* pnode) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;
+    virtual void ProcessBlockValidationResponse(CNode* pfrom, const std::shared_ptr<const CBlock> pblock, const CBlockIndex* pindex, const BlockValidationResponse& validation_response) = 0;
 
 protected:
     /**
@@ -755,6 +760,13 @@ private:
     // Our address, as reported by the peer
     CService addrLocal;
     mutable CCriticalSection cs_addrLocal;
+
+    // If an asynchronous request to validate a block received over the network is pending
+    // these members hold details of that request
+    std::future<BlockValidationResponse> m_block_validation_response;
+    std::shared_ptr<const CBlock> m_block_validating;
+    const CBlockIndex* m_block_validating_index;
+
 public:
 
     NodeId GetId() const {
@@ -865,6 +877,16 @@ public:
     std::string GetAddrName() const;
     //! Sets the addrName only if it was not previously set
     void MaybeSetAddrName(const std::string& addrNameIn);
+
+    //! Is an asynchronous internal request pending
+    bool IsAwaitingInternalRequest();
+
+    //! If a result from an asynchronous internal request is ready, process the results
+    bool ProcessInternalRequestResults(NetEventsInterface*);
+
+    //! Mark this node as waiting for an asynchronous internal request to complete
+    //! before any further processing of this node may occurb
+    void SetPendingInternalRequest(const std::shared_ptr<const CBlock> block, std::future<BlockValidationResponse>&& pending_response, const CBlockIndex* pindex = nullptr);
 };
 
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -11,10 +11,9 @@
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <hash.h>
-#include <validation.h>
 #include <merkleblock.h>
-#include <netmessagemaker.h>
 #include <netbase.h>
+#include <netmessagemaker.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <primitives/block.h>
@@ -28,6 +27,8 @@
 #include <util.h>
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
+#include <validation.h>
+#include <validation_layer.h>
 
 #include <memory>
 
@@ -845,9 +846,9 @@ static bool BlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Para
         (GetBlockProofEquivalentTime(*pindexBestHeader, *pindex, *pindexBestHeader, consensusParams) < STALE_RELAY_AGE_LIMIT);
 }
 
-PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn, CScheduler &scheduler, bool enable_bip61)
-    : connman(connmanIn), m_stale_tip_check_time(0), m_enable_bip61(enable_bip61) {
-
+PeerLogicValidation::PeerLogicValidation(CConnman* connmanIn, ValidationLayer& validation_layer, CScheduler& scheduler, bool enable_bip61)
+    : connman(connmanIn), m_validation_layer(validation_layer), m_stale_tip_check_time(0), m_enable_bip61(enable_bip61)
+{
     // Initialize global variables that cannot be constructed at startup.
     recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
 
@@ -1263,6 +1264,12 @@ void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, c
     }
 }
 
+void SubmitBlock(CConnman* connman, ValidationLayer& validation_layer, CNode* pfrom, const std::shared_ptr<const CBlock> pblock, bool force_processing, const CBlockIndex* pindex = nullptr)
+{
+    std::future<BlockValidationResponse> result = validation_layer.SubmitForValidation(pblock, force_processing, std::bind(&CConnman::WakeMessageHandler, connman));
+    pfrom->SetPendingInternalRequest(pblock, std::move(result), pindex);
+}
+
 void static ProcessGetData(CNode* pfrom, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc)
 {
     AssertLockNotHeld(cs_main);
@@ -1572,7 +1579,7 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     return true;
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
+    bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, ValidationLayer& validation_layer, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
 {
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
     if (gArgs.IsArgSet("-dropmessagestest") && GetRand(gArgs.GetArg("-dropmessagestest", 0)) == 0)
@@ -2552,7 +2559,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         } // cs_main
 
         if (fProcessBLOCKTXN)
-            return ProcessMessage(pfrom, NetMsgType::BLOCKTXN, blockTxnMsg, nTimeReceived, chainparams, connman, interruptMsgProc, enable_bip61);
+            return ProcessMessage(pfrom, NetMsgType::BLOCKTXN, blockTxnMsg, nTimeReceived, chainparams, connman, validation_layer, interruptMsgProc, enable_bip61);
 
         if (fRevertToHeaderProcessing) {
             // Headers received from HB compact block peers are permitted to be
@@ -2570,7 +2577,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 LOCK(cs_main);
                 mapBlockSource.emplace(pblock->GetHash(), std::make_pair(pfrom->GetId(), false));
             }
-            bool fNewBlock = false;
+
             // Setting fForceProcessing to true means that we bypass some of
             // our anti-DoS protections in AcceptBlock, which filters
             // unrequested blocks that might be trying to waste our resources
@@ -2580,21 +2587,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // we have a chain with at least nMinimumChainWork), and we ignore
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
-            if (fNewBlock) {
-                pfrom->nLastBlockTime = GetTime();
-            } else {
-                LOCK(cs_main);
-                mapBlockSource.erase(pblock->GetHash());
-            }
-            LOCK(cs_main); // hold cs_main for CBlockIndex::IsValid()
-            if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS)) {
-                // Clear download state for this block, which is in
-                // process from some other peer.  We do this after calling
-                // ProcessNewBlock so that a malleated cmpctblock announcement
-                // can't be used to interfere with block relay.
-                MarkBlockAsReceived(pblock->GetHash());
-            }
+            SubmitBlock(connman, validation_layer, pfrom, pblock, /*fForceProcessing*/ true, pindex);
         }
 
     }
@@ -2645,7 +2638,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 // though the block was successfully read, and rely on the
                 // handling in ProcessNewBlock to ensure the block index is
                 // updated, reject messages go out, etc.
-                MarkBlockAsReceived(resp.blockhash); // it is now an empty pointer
                 fBlockRead = true;
                 // mapBlockSource is only used for sending reject messages and DoS scores,
                 // so the race between here and cs_main in ProcessNewBlock is fine.
@@ -2656,20 +2648,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
         } // Don't hold cs_main when we call into ProcessNewBlock
         if (fBlockRead) {
-            bool fNewBlock = false;
             // Since we requested this block (it was in mapBlocksInFlight), force it to be processed,
             // even if it would not be a candidate for new tip (missing previous block, chain not long enough, etc)
             // This bypasses some anti-DoS logic in AcceptBlock (eg to prevent
             // disk-space attacks), but this should be safe due to the
             // protections in the compact block handler -- see related comment
             // in compact block optimistic reconstruction handling.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
-            if (fNewBlock) {
-                pfrom->nLastBlockTime = GetTime();
-            } else {
-                LOCK(cs_main);
-                mapBlockSource.erase(pblock->GetHash());
-            }
+            SubmitBlock(connman, validation_layer, pfrom, pblock, /*fForceProcessing*/ true);
         }
     }
 
@@ -2712,19 +2697,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             LOCK(cs_main);
             // Also always process if we requested the block explicitly, as we may
             // need it even though it is not a candidate for a new best tip.
-            forceProcessing |= MarkBlockAsReceived(hash);
+            forceProcessing = mapBlocksInFlight.count(hash);
+
             // mapBlockSource is only used for sending reject messages and DoS scores,
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
-        bool fNewBlock = false;
-        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
-        if (fNewBlock) {
-            pfrom->nLastBlockTime = GetTime();
-        } else {
-            LOCK(cs_main);
-            mapBlockSource.erase(pblock->GetHash());
-        }
+        SubmitBlock(connman, validation_layer, pfrom, pblock, forceProcessing);
     }
 
 
@@ -3045,7 +3024,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime, chainparams, connman, interruptMsgProc, m_enable_bip61);
+        fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime, chainparams, connman, m_validation_layer, interruptMsgProc, m_enable_bip61);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())
@@ -3090,6 +3069,26 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     SendRejectsAndCheckIfBanned(pfrom, connman, m_enable_bip61);
 
     return fMoreWork;
+}
+
+void PeerLogicValidation::ProcessBlockValidationResponse(CNode* pfrom, const std::shared_ptr<const CBlock> pblock, const CBlockIndex* pindex, const BlockValidationResponse& validation_response)
+{
+    LOCK(cs_main);
+
+    // If we've reconstructed this block via compactblocks then
+    // Clear download state for this block, which is in
+    // process from some other peer.  We do this after calling
+    // ProcessNewBlock so that a malleated cmpctblock announcement
+    // can't be used to interfere with block relay.
+    if (!pindex || pindex->IsValid(BLOCK_VALID_TRANSACTIONS)) {
+        MarkBlockAsReceived(pblock->GetHash());
+    }
+
+    if (validation_response.is_new) {
+        pfrom->nLastBlockTime = GetTime();
+    } else {
+        mapBlockSource.erase(pblock->GetHash());
+    }
 }
 
 void PeerLogicValidation::ConsiderEviction(CNode *pto, int64_t time_in_seconds)

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -10,6 +10,9 @@
 #include <validationinterface.h>
 #include <consensus/params.h>
 
+struct BlockValidationResponse;
+class ValidationLayer;
+
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
@@ -20,9 +23,10 @@ static constexpr bool DEFAULT_ENABLE_BIP61 = true;
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
     CConnman* const connman;
+    ValidationLayer& m_validation_layer;
 
 public:
-    explicit PeerLogicValidation(CConnman* connman, CScheduler &scheduler, bool enable_bip61);
+    explicit PeerLogicValidation(CConnman* connman, ValidationLayer& validation_layer, CScheduler& scheduler, bool enable_bip61);
 
     /**
      * Overridden from CValidationInterface.
@@ -66,6 +70,8 @@ public:
     void CheckForStaleTipAndEvictPeers(const Consensus::Params &consensusParams);
     /** If we have extra outbound peers, try to disconnect the one with the oldest block announcement */
     void EvictExtraOutboundPeers(int64_t time_in_seconds);
+
+    void ProcessBlockValidationResponse(CNode*, std::shared_ptr<const CBlock>, const CBlockIndex*, const BlockValidationResponse&) override;
 
 private:
     int64_t m_stale_tip_check_time; //! Next time to check for stale tip

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -23,6 +23,7 @@
 #include <txmempool.h>
 #include <util.h>
 #include <utilstrencodings.h>
+#include <validation_layer.h>
 #include <validationinterface.h>
 #include <warnings.h>
 
@@ -137,7 +138,7 @@ UniValue generateBlocks(std::shared_ptr<CReserveScript> coinbaseScript, int nGen
             continue;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))
+        if (!g_validation_layer->Validate(shared_pblock, true).block_valid)
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
@@ -748,10 +749,10 @@ static UniValue submitblock(const JSONRPCRequest& request)
     bool new_block;
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool accepted = ProcessNewBlock(Params(), blockptr, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
+    BlockValidationResponse resp = g_validation_layer->Validate(blockptr, true);
     UnregisterValidationInterface(&sc);
-    if (!new_block) {
-        if (!accepted) {
+    if (!resp.is_new) {
+        if (!resp.block_valid) {
             // TODO Maybe pass down fNewBlock to AcceptBlockHeader, so it is properly set to true in this case?
             return "invalid";
         }

--- a/src/test/consumerthread_tests.cpp
+++ b/src/test/consumerthread_tests.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <atomic>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <test/test_bitcoin.h>
+
+#include <core/consumerthread.h>
+#include <core/producerconsumerqueue.h>
+
+BOOST_FIXTURE_TEST_SUITE(consumerthread_tests, BasicTestingSetup)
+
+class TestWorkItem : public WorkItem<WorkerMode::BLOCKING>
+{
+public:
+    TestWorkItem(int& i) : m_i(i){};
+    void operator()()
+    {
+        // yield to make unit tests somewhat more unpredictable
+        std::this_thread::yield();
+        ++m_i;
+        std::this_thread::yield();
+        ++m_i;
+    }
+
+private:
+    int& m_i;
+};
+
+void ConsumerThreadTest(int n_elements, int n_threads)
+{
+    std::vector<int> work(n_elements);
+    auto queue = std::shared_ptr<WorkQueue<WorkerMode::BLOCKING>>(new WorkQueue<WorkerMode::BLOCKING>(n_elements + 1));
+
+    std::vector<std::unique_ptr<ConsumerThread<WorkerMode::BLOCKING>>> threads;
+    for (int i = 0; i < n_threads; i++) {
+        threads.emplace_back(std::unique_ptr<ConsumerThread<WorkerMode::BLOCKING>>(new ConsumerThread<WorkerMode::BLOCKING>(queue, std::to_string(i))));
+    }
+
+    for (int i = 0; i < n_elements; i++) {
+        work[i] = i;
+        queue->Push(std::unique_ptr<TestWorkItem>(new TestWorkItem(work[i])));
+    }
+
+    while (queue->size() > 0) {
+        std::this_thread::yield();
+    }
+    queue->Sync();
+
+    for (int i = 0; i < n_threads / 2; i++) {
+        threads[i]->Terminate();
+    }
+
+    BOOST_CHECK_LT(queue->size(), n_threads + 1);
+    for (int i = 0; i < n_elements; i++) {
+        BOOST_CHECK_EQUAL(work[i], i + 2);
+    }
+
+    for (int i = 0; i < n_elements; i++) {
+        queue->Push(std::unique_ptr<TestWorkItem>(new TestWorkItem(work[i])));
+    }
+
+    while (queue->size() > 0) {
+        std::this_thread::yield();
+    }
+    queue->Sync();
+
+    for (int i = n_threads / 2; i < n_threads; i++) {
+        threads[i]->Terminate();
+    }
+
+    BOOST_CHECK_LT(queue->size(), n_threads + 1);
+    for (int i = 0; i < n_elements; i++) {
+        BOOST_CHECK_EQUAL(work[i], i + 4);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(foo)
+{
+    ConsumerThreadTest(100, 1);
+    ConsumerThreadTest(100, 10);
+    ConsumerThreadTest(0, 10);
+    ConsumerThreadTest(3, 10);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -17,6 +17,7 @@
 #include <uint256.h>
 #include <util.h>
 #include <utilstrencodings.h>
+#include <validation_layer.h>
 
 #include <test/test_bitcoin.h>
 
@@ -207,6 +208,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Note that by default, these tests run with size accounting enabled.
     const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     const CChainParams& chainparams = *chainParams;
+
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     CMutableTransaction tx;
@@ -248,7 +250,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        BOOST_CHECK(g_validation_layer->Validate(shared_pblock, true).block_valid);
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/producerconsumerqueue_tests.cpp
+++ b/src/test/producerconsumerqueue_tests.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <test/test_bitcoin.h>
+
+#include <core/producerconsumerqueue.h>
+
+BOOST_FIXTURE_TEST_SUITE(producerconsumerqueue_tests, BasicTestingSetup)
+
+typedef ProducerConsumerQueue<int, WorkerMode::BLOCKING, WorkerMode::BLOCKING> QueueBB;
+typedef ProducerConsumerQueue<int, WorkerMode::BLOCKING, WorkerMode::NONBLOCKING> QueueBN;
+typedef ProducerConsumerQueue<int, WorkerMode::NONBLOCKING, WorkerMode::BLOCKING> QueueNB;
+typedef ProducerConsumerQueue<int, WorkerMode::NONBLOCKING, WorkerMode::NONBLOCKING> QueueNN;
+
+typedef boost::mpl::list<QueueBB, QueueBN, QueueNB, QueueNN> queue_types;
+
+template <typename Q>
+void Producer(Q& push, Q& recv, int id, int elements_to_push)
+{
+    // push all of these elements to one queue
+    int elements_pushed = 0;
+    while (elements_pushed < elements_to_push) {
+        if (push.Push(id * elements_to_push + elements_pushed)) {
+            elements_pushed++;
+        } else if (push.GetProducerMode() == WorkerMode::BLOCKING) {
+            BOOST_FAIL("a blocking push should always succeed");
+        } else {
+            std::this_thread::yield();
+        }
+    }
+
+    std::set<int> received;
+    while (received.size() < (unsigned)elements_to_push) {
+        int e;
+        if (recv.Pop(e)) {
+            assert(!received.count(e));
+            received.insert(e);
+        } else if (recv.GetConsumerMode() == WorkerMode::BLOCKING) {
+            BOOST_FAIL("a blocking pop should always succeed");
+        } else {
+            std::this_thread::yield();
+        }
+    }
+
+    for (int i = 0; i < elements_to_push; i++) {
+        assert(received.count(-i));
+    }
+}
+
+template <typename Q>
+void Consumer(Q& work, std::vector<Q*> push, int id, int n_producers, int bucket_size, int elements_to_receive)
+{
+    int elements_received = 0;
+    std::vector<int> latest(n_producers, -1);
+
+    while (elements_received != elements_to_receive) {
+        int w;
+        if (work.Pop(w)) {
+            int producer_id = w / bucket_size;
+            int i = w % bucket_size;
+
+            assert(producer_id < n_producers);
+            assert(i > latest[producer_id]);
+            latest[producer_id] = i;
+
+            while (!push[producer_id]->Push(-i)) {
+                if (push[producer_id]->GetProducerMode() == WorkerMode::BLOCKING) {
+                    BOOST_FAIL("a blocking push should always succeed");
+                }
+                std::this_thread::yield();
+            }
+            elements_received++;
+        } else if (work.GetConsumerMode() == WorkerMode::BLOCKING) {
+            BOOST_FAIL("a blocking pop should always succeed");
+        } else {
+            std::this_thread::yield();
+        }
+    }
+}
+
+template <typename Q>
+void QueueTest(int capacity, int n_elements, int n_producers, int n_consumers)
+{
+    int bucket_size = n_elements / n_producers;
+
+    Q push(capacity);
+    std::vector<Q*> pull;
+    for (int i = 0; i < n_producers; i++)
+        pull.push_back(new Q(bucket_size));
+
+    boost::thread_group test_threads;
+
+    for (int i = 0; i < n_producers; i++) {
+        test_threads.create_thread([&, i] { Producer(push, *(pull[i]), i, bucket_size); });
+    }
+
+    for (int i = 0; i < n_consumers; i++) {
+        test_threads.create_thread([&, i] { Consumer(push, pull, i, n_producers, bucket_size, n_elements / n_consumers); });
+    }
+
+    test_threads.join_all();
+
+    // queue should be empty
+    BOOST_CHECK_EQUAL(push.size(), 0);
+    for (int i = 0; i < n_producers; i++) {
+        BOOST_CHECK_EQUAL(pull[i]->size(), 0);
+        delete pull[i];
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(invalid_queue, Q, queue_types)
+{
+    Q q;
+    BOOST_CHECK(q.GetCapacity() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(basic_operation)
+{
+    int n = 10;
+    QueueBB qBB(n);
+    QueueBN qBN(n);
+    QueueNB qNB(n);
+    QueueNN qNN(n);
+
+    BOOST_CHECK((int)qBB.GetCapacity() == n);
+    for (int i = 0; i < n; i++) {
+        BOOST_CHECK(qBB.Push(i));
+        BOOST_CHECK(qBN.Push(i));
+        BOOST_CHECK(qNB.Push(i));
+        BOOST_CHECK(qNN.Push(i));
+    }
+
+    BOOST_CHECK(!qNB.Push(0));
+    BOOST_CHECK(!qNN.Push(0));
+
+    int t;
+    for (int i = 0; i < n; i++) {
+        BOOST_CHECK_EQUAL(qBB.Pop(), i);
+
+        BOOST_CHECK(qBN.Pop(t));
+        BOOST_CHECK_EQUAL(t, i);
+
+        BOOST_CHECK_EQUAL(qNB.Pop(), i);
+
+        BOOST_CHECK(qNN.Pop(t));
+        BOOST_CHECK_EQUAL(t, i);
+    }
+
+    int ret;
+    BOOST_CHECK(!qBN.Pop(ret));
+    BOOST_CHECK(!qNN.Pop(ret));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(multithreaded_operation, Q, queue_types)
+{
+    QueueTest<Q>(1000, 100, 1, 1);
+    QueueTest<Q>(100, 1000, 1, 1);
+
+    QueueTest<Q>(1000, 100, 1, 10);
+    QueueTest<Q>(100, 1000, 1, 10);
+
+    QueueTest<Q>(1000, 100, 10, 1);
+    QueueTest<Q>(100, 1000, 10, 1);
+
+    QueueTest<Q>(1000, 100, 10, 10);
+    QueueTest<Q>(100, 1000, 10, 10);
+
+    QueueTest<Q>(1000, 100, 10, 5);
+    QueueTest<Q>(100, 1000, 10, 5);
+
+    QueueTest<Q>(1000, 100, 5, 10);
+    QueueTest<Q>(100, 1000, 5, 10);
+};
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -18,6 +18,8 @@
 
 #include <boost/thread.hpp>
 
+class ValidationLayer;
+
 extern uint256 insecure_rand_seed;
 extern FastRandomContext insecure_rand_ctx;
 

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -5,12 +5,14 @@
 #define BOOST_TEST_MODULE Bitcoin Test Suite
 
 #include <net.h>
+#include <validation_layer.h>
 
 #include <memory>
 
 #include <boost/test/unit_test.hpp>
 
 std::unique_ptr<CConnman> g_connman;
+std::unique_ptr<ValidationLayer> g_validation_layer;
 
 [[noreturn]] void Shutdown(void* parg)
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -208,28 +208,6 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
 /**
- * Process an incoming block. This only returns after the best known valid
- * block is made active. Note that it does not, however, guarantee that the
- * specific block passed to it has been checked for validity!
- *
- * If you want to *possibly* get feedback on whether pblock is valid, you must
- * install a CValidationInterface (see validationinterface.h) - this will have
- * its BlockChecked method called whenever *any* block completes validation.
- *
- * Note that we guarantee that either the proof-of-work is valid on pblock, or
- * (and possibly also) BlockChecked will have been called.
- *
- * May not be called in a
- * validationinterface callback.
- *
- * @param[in]   pblock  The block we want to process.
- * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
- * @return True if state.IsValid()
- */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
-
-/**
  * Process incoming block headers.
  *
  * May not be called in a

--- a/src/validation_layer.cpp
+++ b/src/validation_layer.cpp
@@ -3,7 +3,28 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <validation_layer.h>
-#include <validation.h>
+
+/**
+ * Process an incoming block. This only returns after the best known valid
+ * block is made active. Note that it does not, however, guarantee that the
+ * specific block passed to it has been checked for validity!
+ *
+ * If you want to *possibly* get feedback on whether pblock is valid, you must
+ * install a CValidationInterface (see validationinterface.h) - this will have
+ * its BlockChecked method called whenever *any* block completes validation.
+ *
+ * Note that we guarantee that either the proof-of-work is valid on pblock, or
+ * (and possibly also) BlockChecked will have been called.
+ *
+ * May not be called in a
+ * validationinterface callback.
+ *
+ * @param[in]   pblock  The block we want to process.
+ * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
+ * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
+ * @return True if state.IsValid()
+ */
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
 
 void BlockValidationRequest::operator()()
 {

--- a/src/validation_layer.cpp
+++ b/src/validation_layer.cpp
@@ -10,7 +10,7 @@ void BlockValidationRequest::operator()()
     LogPrint(BCLog::VALIDATION, "%s: validating request=%s\n", __func__, GetId());
     auto res = m_validation_layer.ValidateInternal(m_block, m_force_processing);
     LogPrint(BCLog::VALIDATION, "%s: validation result request=%s block_valid=%d is_new=%d\n",
-        __func__, GetId(), res.block_valid, res.is_new);
+             __func__, GetId(), res.block_valid, res.is_new);
 
     m_promise.set_value(res);
     if (m_on_ready) {

--- a/src/validation_layer.cpp
+++ b/src/validation_layer.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <validation_layer.h>
+#include <validation.h>
+
+void BlockValidationRequest::operator()()
+{
+    LogPrint(BCLog::VALIDATION, "%s: validating request=%s\n", __func__, GetId());
+    auto res = m_validation_layer.ValidateInternal(m_block, m_force_processing);
+    LogPrint(BCLog::VALIDATION, "%s: validation result request=%s block_valid=%d is_new=%d\n",
+        __func__, GetId(), res.block_valid, res.is_new);
+
+    m_promise.set_value(res);
+    if (m_on_ready) {
+        m_on_ready();
+    }
+}
+
+std::string BlockValidationRequest::GetId() const
+{
+    return strprintf("BlockValidationRequest[%s]", m_block->GetHash().ToString());
+}
+
+void ValidationLayer::Start()
+{
+    assert(!m_thread || !m_thread->IsActive());
+    m_thread = std::unique_ptr<ValidationThread>(new ValidationThread(m_validation_queue));
+}
+
+void ValidationLayer::Stop()
+{
+    assert(m_thread && m_thread->IsActive());
+    m_thread->Terminate();
+}
+
+std::future<BlockValidationResponse> ValidationLayer::SubmitForValidation(const std::shared_ptr<const CBlock> block, bool force_processing, std::function<void()> on_ready)
+{
+    BlockValidationRequest* req = new BlockValidationRequest(*this, block, force_processing, on_ready);
+    return SubmitForValidation<BlockValidationResponse>(req);
+}
+
+BlockValidationResponse ValidationLayer::Validate(const std::shared_ptr<const CBlock> block, bool force_processing)
+{
+    return SubmitForValidation(block, force_processing).get();
+}
+
+BlockValidationResponse ValidationLayer::ValidateInternal(const std::shared_ptr<const CBlock> block, bool force_processing) const
+{
+    bool is_new = false;
+    bool block_valid = ProcessNewBlock(m_chainparams, block, force_processing, &is_new);
+    return BlockValidationResponse(block_valid, is_new);
+};

--- a/src/validation_layer.h
+++ b/src/validation_layer.h
@@ -1,0 +1,144 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_VALIDATION_LAYER_H
+#define BITCOIN_VALIDATION_LAYER_H
+
+#include <future>
+
+#include <chainparams.h>
+#include <core/consumerthread.h>
+#include <core/producerconsumerqueue.h>
+#include <util.h>
+
+class ValidationLayer;
+extern std::unique_ptr<ValidationLayer> g_validation_layer;
+
+/**
+ * Encapsulates a request to validate an object (currently only a block)
+ * Submitted to ValidationLayer for asynchronous validation
+ *
+ * @see ValidationLayer
+ */
+template <typename RESPONSE>
+class ValidationRequest : public WorkItem<WorkerMode::BLOCKING>
+{
+    friend ValidationLayer;
+
+private:
+    //! Guts of the validation
+    virtual void operator()() = 0;
+
+    //! Returns a string identifier (for logging)
+    virtual std::string GetId() const = 0;
+
+protected:
+    //! Promise that will deliver the validation result to the caller who generated this request
+    std::promise<RESPONSE> m_promise;
+};
+
+/**
+ * Holds the results of asynchronous block validation
+ */
+struct BlockValidationResponse {
+    //! Is this the first time this block has been validated
+    const bool is_new;
+
+    //! Did initial validation pass (a block can still pass initial validation but then later fail to connect to an active chain)
+    const bool block_valid;
+
+    BlockValidationResponse(bool _block_valid, bool _is_new)
+        : is_new(_is_new), block_valid(_block_valid){};
+};
+
+/**
+ * Encapsulates a request to validate a block
+ */
+class BlockValidationRequest : public ValidationRequest<BlockValidationResponse>
+{
+    friend ValidationLayer;
+
+private:
+    BlockValidationRequest(ValidationLayer& validation_layer, const std::shared_ptr<const CBlock> block, bool force_processing, const std::function<void()> on_ready)
+        : m_validation_layer(validation_layer), m_block(block), m_force_processing(force_processing), m_on_ready(on_ready){};
+
+    //! Does the validation
+    void operator()() override;
+
+    //! Returns a block hash
+    std::string GetId() const override;
+
+    const ValidationLayer& m_validation_layer;
+
+    //! The block to be validated
+    const std::shared_ptr<const CBlock> m_block;
+
+    //! Was this block explicitly requested (currently required by ProcessNewBlock)
+    const bool m_force_processing;
+
+    //! A callback to invoke when ready
+    //! This is a workaround because c++11 does not support multiplexed waiting on futures
+    //! In a move to subsequent standards when this behavior is supported this can probably be removed
+    const std::function<void()> m_on_ready;
+};
+
+/**
+ * Public interface to block validation
+ *
+ * Two apis:
+ *  - asynchronous: SubmitForValidation(object) -> future<Response>
+ *  - synchronous:  Validate(object) -> Response (just calls SubmitForValidation and blocks on the response)
+ *
+ * Internally, a validation thread pulls validations requests from a queue, processes them and satisfies the promise
+ * with the result of validation.
+ */
+class ValidationLayer
+{
+    friend BlockValidationRequest;
+
+    typedef WorkQueue<WorkerMode::BLOCKING> ValidationQueue;
+    typedef ConsumerThread<WorkerMode::BLOCKING> ValidationThread;
+
+public:
+    ValidationLayer(const CChainParams& chainparams)
+        : m_chainparams(chainparams), m_validation_queue(std::make_shared<ValidationQueue>(100)) {}
+    ~ValidationLayer(){};
+
+    //! Starts the validation layer (creating the validation thread)
+    void Start();
+
+    //! Stops the validation layer (stopping the validation thread)
+    void Stop();
+
+    //! Submit a block for asynchronous validation
+    std::future<BlockValidationResponse> SubmitForValidation(const std::shared_ptr<const CBlock> block, bool force_processing, std::function<void()> on_ready = []() {});
+
+    //! Submit a block for validation and block on the response
+    BlockValidationResponse Validate(const std::shared_ptr<const CBlock> block, bool force_processing);
+
+private:
+    //! Internal utility method - sets up and calls ProcessNewBlock
+    BlockValidationResponse ValidateInternal(const std::shared_ptr<const CBlock> block, bool force_processing) const;
+
+    //! Internal utility method that wraps a request in a unique pointer and deposits it on the validation queue
+    template <typename RESPONSE>
+    std::future<RESPONSE> SubmitForValidation(ValidationRequest<RESPONSE>* request)
+    {
+        LogPrint(BCLog::VALIDATION, "%s<%s>: submitting request=%s\n", __func__, typeid(RESPONSE).name(), request->GetId());
+
+        auto ret = request->m_promise.get_future();
+        m_validation_queue->Push(std::unique_ptr<ValidationRequest<RESPONSE>>(request));
+        return ret;
+    };
+
+    const CChainParams& m_chainparams;
+
+    //! a queue that holds validation requests that are sequentially processed by m_thread
+    const std::shared_ptr<ValidationQueue> m_validation_queue;
+
+    //! the validation thread - sequentially processes validation requests from m_validation_queue
+    std::unique_ptr<ValidationThread> m_thread;
+};
+
+#endif


### PR DESCRIPTION
Update
-
I think this is now in a state for code review
Summary of discussion of overall design as well as some concept acks: https://bitcoincore.org/en/meetings/2018/05/03/

---
Description
-

~~This is still in progress and not fully completed yet, but wanted to put it out for review in terms of overall design/architecture~~

The high level goal here (in this, and if accepted, subsequent PRs) is to allow for net and validation to live on separate threads and communicate mostly via message passing - both for the efficiency benefits that further parallelism in the net layer might provide, but also perhaps moreso as a step towards the goal of reducing the amount of shared state and forcing a cleaner separation between the net and validation layers in the core node. 

To keep this PR as self contained as possible - this set of commits does the following:
  - defines `ProducerConsumerQueue() / ConsumerThread()`: infrastructure to facilitate async communication between the net and validation layers
  - defines ValidationLayer(): an interface where requests for (just `CBlock` for now) validation can be submitted and processed asynchronously
  - replaces synchronous calls of `ProcessNewBlock()` in net_processing with the new async interface `ValidationLayer::SubmitForValidation(CBlock) -> std::future<BlockValidationResult>`

Because the P2P layer assumes that for a given node every message is fully processed before any subsequent messages are processed, when an asynchronous validation request is submitted for a block coming from a node - that node is "frozen" until that request has been fully validated. In the meantime - the net layer may continue servicing other nodes that do not have pending asynchronous validation requests.

The ProducerConsumerQueue() was left sufficiently generic so that it may be interposed  in other places where separation of components via asynchronous message passing might make sense from a design perspective.