### PR TITLE
Handle witness version and OP_N results as an unsigned char

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -53,7 +53,7 @@ static CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, co
 static void VerifyScriptBench(benchmark::State& state)
 {
     const int flags = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH;
-    const int witnessversion = 0;
+    const unsigned char witnessversion = 0;
 
     // Keypair.
     CKey key;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -35,7 +35,7 @@ CAmount GetDustThreshold(const CTxOut& txout, const CFeeRate& dustRelayFeeIn)
         return 0;
 
     size_t nSize = GetSerializeSize(txout, SER_DISK, 0);
-    int witnessversion = 0;
+    unsigned char witnessversion = 0;
     std::vector<unsigned char> witnessprogram;
 
     if (txout.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
@@ -222,7 +222,7 @@ bool IsWitnessStandard(const CTransaction& tx, const CCoinsViewCache& mapInputs)
             prevScript = CScript(stack.back().begin(), stack.back().end());
         }
 
-        int witnessversion = 0;
+        unsigned char witnessversion = 0;
         std::vector<unsigned char> witnessprogram;
 
         // Non-witness program must not be associated with any witness

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -468,7 +468,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
 
         // Bytes
         CTxDestination address;
-        int witnessversion = 0;
+        unsigned char witnessversion = 0;
         std::vector<unsigned char> witnessprogram;
         if (out.txout.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram))
         {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1355,7 +1355,7 @@ bool TransactionSignatureChecker::CheckSequence(const CScriptNum& nSequence) con
     return true;
 }
 
-static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
+static bool VerifyWitnessProgram(const CScriptWitness& witness, unsigned char witversion, const std::vector<unsigned char>& program, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
 {
     std::vector<std::vector<unsigned char> > stack;
     CScript scriptPubKey;
@@ -1437,7 +1437,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
         return set_error(serror, SCRIPT_ERR_EVAL_FALSE);
 
     // Bare witness programs
-    int witnessversion;
+    unsigned char witnessversion;
     std::vector<unsigned char> witnessprogram;
     if (flags & SCRIPT_VERIFY_WITNESS) {
         if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
@@ -1527,7 +1527,7 @@ bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const C
     return set_success(serror);
 }
 
-size_t static WitnessSigOps(int witversion, const std::vector<unsigned char>& witprogram, const CScriptWitness& witness, int flags)
+size_t static WitnessSigOps(unsigned char witversion, const std::vector<unsigned char>& witprogram, const CScriptWitness& witness, int flags)
 {
     if (witversion == 0) {
         if (witprogram.size() == 20)
@@ -1552,7 +1552,7 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
     }
     assert((flags & SCRIPT_VERIFY_P2SH) != 0);
 
-    int witnessversion;
+    unsigned char witnessversion;
     std::vector<unsigned char> witnessprogram;
     if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
         return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty, flags);

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -218,7 +218,7 @@ bool CScript::IsPayToWitnessScriptHash() const
 
 // A witness program is any valid CScript that consists of a 1-byte push opcode
 // followed by a data push between 2 and 40 bytes.
-bool CScript::IsWitnessProgram(int& version, std::vector<unsigned char>& program) const
+bool CScript::IsWitnessProgram(unsigned char& version, std::vector<unsigned char>& program) const
 {
     if (this->size() < 4 || this->size() > 42) {
         return false;

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -573,13 +573,15 @@ public:
     }
 
     /** Encode/decode small integers: */
-    static int DecodeOP_N(opcodetype opcode)
+    static unsigned char DecodeOP_N(opcodetype opcode)
     {
         if (opcode == OP_0)
             return 0;
         assert(opcode >= OP_1 && opcode <= OP_16);
-        return (int)opcode - (int)(OP_1 - 1);
+        return (unsigned char)opcode - (unsigned char)(OP_1 - 1);
     }
+    static_assert((unsigned char)OP_16 - (unsigned char)(OP_1 - 1) == 16, "Unexpected value for OP_N calculation");
+
     static opcodetype EncodeOP_N(int n)
     {
         assert(n >= 0 && n <= 16);
@@ -642,7 +644,7 @@ public:
 
     bool IsPayToScriptHash() const;
     bool IsPayToWitnessScriptHash() const;
-    bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
+    bool IsWitnessProgram(unsigned char& version, std::vector<unsigned char>& program) const;
 
     /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
     bool IsPushOnly(const_iterator pc) const;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -63,7 +63,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
         return true;
     }
 
-    int witnessversion;
+    unsigned char witnessversion;
     std::vector<unsigned char> witnessprogram;
     if (scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
         if (witnessversion == 0 && witnessprogram.size() == 20) {
@@ -78,7 +78,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
         }
         if (witnessversion != 0) {
             typeRet = TX_WITNESS_UNKNOWN;
-            vSolutionsRet.push_back(std::vector<unsigned char>{(unsigned char)witnessversion});
+            vSolutionsRet.push_back(std::vector<unsigned char>{witnessversion});
             vSolutionsRet.push_back(std::move(witnessprogram));
             return true;
         }
@@ -161,7 +161,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
                 if (opcode1 == OP_0 ||
                     (opcode1 >= OP_1 && opcode1 <= OP_16))
                 {
-                    char n = (char)CScript::DecodeOP_N(opcode1);
+                    unsigned char n = CScript::DecodeOP_N(opcode1);
                     vSolutionsRet.push_back(valtype(1, n));
                 }
                 else

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -308,7 +308,7 @@ private:
     }
 
 public:
-    TestBuilder(const CScript& script_, const std::string& comment_, int flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, int witnessversion = 0, CAmount nValue_ = 0) : script(script_), havePush(false), comment(comment_), flags(flags_), scriptError(SCRIPT_ERR_OK), nValue(nValue_)
+    TestBuilder(const CScript& script_, const std::string& comment_, int flags_, bool P2SH = false, WitnessMode wm = WitnessMode::NONE, unsigned char witnessversion = 0, CAmount nValue_ = 0) : script(script_), havePush(false), comment(comment_), flags(flags_), scriptError(SCRIPT_ERR_OK), nValue(nValue_)
     {
         CScript scriptPubKey = script;
         if (wm == WitnessMode::PKH) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1270,7 +1270,7 @@ public:
     bool operator()(const CScriptID &scriptID) {
         CScript subscript;
         if (pwallet && pwallet->GetCScript(scriptID, subscript)) {
-            int witnessversion;
+            unsigned char witnessversion;
             std::vector<unsigned char> witprog;
             if (subscript.IsWitnessProgram(witnessversion, witprog)) {
                 ExtractDestination(subscript, result);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2659,7 +2659,7 @@ OutputType CWallet::TransactionChangeType(OutputType change_type, const std::vec
     // output.
     for (const auto& recipient : vecSend) {
         // Check if any destination contains a witness program:
-        int witnessversion = 0;
+        unsigned char witnessversion = 0;
         std::vector<unsigned char> witnessprogram;
         if (recipient.scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) {
             return OutputType::BECH32;


### PR DESCRIPTION
According to BIP 141, the version range is 0-16 and stored as a byte.
Similarly, DecodeOP_N presents a range of 0-16. Thus an unsigned char
is a natural/direct representation for the value.

Removes the need for 2 casts in script/standard.cpp.