### PR TITLE
rpc: Fix estimatesmartfee to properly handle a null estimate_mode arg

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -805,10 +805,11 @@ static UniValue estimatesmartfee(const JSONRPCRequest& request)
             + HelpExampleCli("estimatesmartfee", "6")
             );
 
-    RPCTypeCheck(request.params, {UniValue::VNUM, UniValue::VSTR});
     RPCTypeCheckArgument(request.params[0], UniValue::VNUM);
     unsigned int conf_target = ParseConfirmTarget(request.params[0]);
     bool conservative = true;
+
+    RPCTypeCheckArgument(request.params[1], UniValue::VSTR, true /* allow_null */);
     if (!request.params[1].isNull()) {
         FeeEstimateMode fee_mode;
         if (!FeeModeFromString(request.params[1].get_str(), fee_mode)) {
@@ -874,10 +875,11 @@ static UniValue estimaterawfee(const JSONRPCRequest& request)
             + HelpExampleCli("estimaterawfee", "6 0.9")
             );
 
-    RPCTypeCheck(request.params, {UniValue::VNUM, UniValue::VNUM}, true);
     RPCTypeCheckArgument(request.params[0], UniValue::VNUM);
     unsigned int conf_target = ParseConfirmTarget(request.params[0]);
     double threshold = 0.95;
+
+    RPCTypeCheckArgument(request.params[1], UniValue::VNUM, true /* allow_null */);
     if (!request.params[1].isNull()) {
         threshold = request.params[1].get_real();
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -59,16 +59,14 @@ void RPCTypeCheck(const UniValue& params,
             break;
 
         const UniValue& v = params[i];
-        if (!(fAllowNull && v.isNull())) {
-            RPCTypeCheckArgument(v, t);
-        }
+        RPCTypeCheckArgument(v, t, fAllowNull);
         i++;
     }
 }
 
-void RPCTypeCheckArgument(const UniValue& value, const UniValueType& typeExpected)
+void RPCTypeCheckArgument(const UniValue& value, const UniValueType& typeExpected, bool allow_null)
 {
-    if (!typeExpected.typeAny && value.type() != typeExpected.type) {
+    if (!(allow_null && value.isNull()) && !typeExpected.typeAny && value.type() != typeExpected.type) {
         throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Expected type %s, got %s", uvTypeName(typeExpected.type), uvTypeName(value.type())));
     }
 }
@@ -83,7 +81,7 @@ void RPCTypeCheckObj(const UniValue& o,
         if (!fAllowNull && v.isNull())
             throw JSONRPCError(RPC_TYPE_ERROR, strprintf("Missing %s", t.first));
 
-        if (!(t.second.typeAny || v.type() == t.second.type || (fAllowNull && v.isNull()))) {
+        if (!(fAllowNull && v.isNull()) && !t.second.typeAny && v.type() != t.second.type) {
             std::string err = strprintf("Expected type %s for %s, got %s",
                 uvTypeName(t.second.type), t.first, uvTypeName(v.type()));
             throw JSONRPCError(RPC_TYPE_ERROR, err);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -75,7 +75,7 @@ void RPCTypeCheck(const UniValue& params,
 /**
  * Type-check one argument; throws JSONRPCError if wrong type given.
  */
-void RPCTypeCheckArgument(const UniValue& value, const UniValueType& typeExpected);
+void RPCTypeCheckArgument(const UniValue& value, const UniValueType& typeExpected, bool allow_null = false);
 
 /*
   Check for expected keys/value types in an Object.

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -99,7 +99,20 @@ def split_inputs(from_node, txins, txouts, initial_split=False):
     txouts.append({"txid": txid, "vout": 0, "amount": half_change})
     txouts.append({"txid": txid, "vout": 1, "amount": rem_change})
 
-def check_estimates(node, fees_seen):
+def check_raw_estimates(node, fees_seen):
+    """Call estimaterawfee and verify that the estimates meet certain invariants."""
+
+    delta = 1.0e-6  # account for rounding error
+    for i in range(1, 26):
+        for time_horizon, e in node.estimaterawfee(i).items():
+            feerate = float(e["feerate"])
+            assert_greater_than(feerate, 0)
+
+            if feerate + delta < min(fees_seen) or feerate - delta > max(fees_seen):
+                raise AssertionError("Estimated fee (%f) out of range (%f,%f)"
+                                     % (feerate, min(fees_seen), max(fees_seen)))
+
+def check_smart_estimates(node, fees_seen):
     """Call estimatesmartfee and verify that the estimates meet certain invariants."""
 
     delta = 1.0e-6  # account for rounding error
@@ -121,6 +134,10 @@ def check_estimates(node, fees_seen):
             assert_equal(e["blocks"], 2)
         else:
             assert_greater_than_or_equal(i + 1, e["blocks"])
+
+def check_estimates(node, fees_seen):
+    check_raw_estimates(node, fees_seen)
+    check_smart_estimates(node, fees_seen)
 
 class EstimateFeeTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_estimatefee.py
+++ b/test/functional/rpc_estimatefee.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the estimatefee RPCs.
+
+Test the following RPCs:
+   - estimatesmartfee
+   - estimaterawfee
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class EstimateFeeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def run_test(self):
+        # missing required params
+        assert_raises_rpc_error(-1, "estimatesmartfee", self.nodes[0].estimatesmartfee)
+        assert_raises_rpc_error(-1, "estimaterawfee", self.nodes[0].estimaterawfee)
+
+        # wrong type for conf_target
+        assert_raises_rpc_error(-3, "Expected type number, got string", self.nodes[0].estimatesmartfee, 'foo')
+        assert_raises_rpc_error(-3, "Expected type number, got string", self.nodes[0].estimaterawfee, 'foo')
+
+        # wrong type for estimatesmartfee(estimate_mode)
+        assert_raises_rpc_error(-3, "Expected type string, got number", self.nodes[0].estimatesmartfee, 1, 1)
+        assert_raises_rpc_error(-8, "Invalid estimate_mode parameter", self.nodes[0].estimatesmartfee, 1, 'foo')
+
+        # wrong type for estimaterawfee(threshold)
+        assert_raises_rpc_error(-3, "Expected type number, got string", self.nodes[0].estimaterawfee, 1, 'foo')
+
+        # extra params
+        assert_raises_rpc_error(-1, "estimatesmartfee", self.nodes[0].estimatesmartfee, 1, 'ECONOMICAL', 1)
+        assert_raises_rpc_error(-1, "estimaterawfee", self.nodes[0].estimaterawfee, 1, 1, 1)
+
+        # valid calls
+        self.nodes[0].estimatesmartfee(1)
+        self.nodes[0].estimatesmartfee(1, None)
+        self.nodes[0].estimatesmartfee(1, 'ECONOMICAL')
+
+        self.nodes[0].estimaterawfee(1)
+        self.nodes[0].estimaterawfee(1, None)
+        self.nodes[0].estimaterawfee(1, 1)
+
+
+if __name__ == '__main__':
+    EstimateFeeTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -102,6 +102,7 @@ BASE_SCRIPTS = [
     'rpc_users.py',
     'feature_proxy.py',
     'rpc_signrawtransaction.py',
+    'rpc_estimatefee.py',
     'p2p_disconnect_ban.py',
     'rpc_decodescript.py',
     'rpc_blockchain.py',


### PR DESCRIPTION
The estimate_mode arg is optional in documentation and handling,
but the RPCTypeCheck applied to it did not allow null, therefore
its presence was enforced. Note this only affected null values,
not entirely absent arguments because RPCTypeCheck only tests
against the params list as exists and no farther, so this is a
narrow bug.

This also replaces redundant testing via RPCTypeCheck &
RPCTypeCheckArgument in favor of non-redundant calls to
RPCTypeCheckArgument. The prior redundancy existed due
to the prior limitation of the RPCTypeCheckArgument not
being able to allow null.

Added some call and light functional testing on estimatesmartfee
and estimaterawfee as well.