### PR TITLE
[Trivial] Ignore macOS daemon() depracation warning

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -139,6 +139,10 @@ bool AppInit(int argc, char* argv[])
         if (gArgs.GetBoolArg("-daemon", false))
         {
 #if HAVE_DECL_DAEMON
+#if defined(MAC_OSX)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
             fprintf(stdout, "Bitcoin server starting\n");
 
             // Daemonize
@@ -146,6 +150,9 @@ bool AppInit(int argc, char* argv[])
                 fprintf(stderr, "Error: daemon() failed: %s\n", strerror(errno));
                 return false;
             }
+#if defined(MAC_OSX)
+#pragma GCC diagnostic pop
+#endif
 #else
             fprintf(stderr, "Error: -daemon is not supported on this operating system\n");
             return false;


### PR DESCRIPTION
`daemon()` is deprecated on OSX since 10.5 (should migrate to `posix_spawn()`). There are no signs `daemon()` will get removed by Apple.