### PR TITLE
depends: Fix Qt build with XCode 9.3

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -8,7 +8,8 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
-$(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch fix-cocoahelpers-macos.patch
+$(package)_patches=mac-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch
+$(package)_patches+=fix_qt_pkgconfig.patch fix-cocoahelpers-macos.patch qfixed-coretext.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=3a15aebd523c6d89fb97b2d3df866c94149653a26d27a00aac9b6d3020bc5a1d
@@ -141,6 +142,7 @@ define $(package)_preprocess_cmds
   patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch && \
   patch -p1 < $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \
   patch -p1 < $($(package)_patch_dir)/fix-cocoahelpers-macos.patch && \
+  patch -p1 < $($(package)_patch_dir)/qfixed-coretext.patch && \
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \

--- a/depends/patches/qt/qfixed-coretext.patch
+++ b/depends/patches/qt/qfixed-coretext.patch
@@ -1,0 +1,34 @@
+From dbdd5f0ffbce52c8b789ed09f1aa3f1da6c02e23 Mon Sep 17 00:00:00 2001
+From: Gabriel de Dietrich <gabriel.dedietrich@qt.io>
+Date: Fri, 30 Mar 2018 11:58:16 -0700
+Subject: [PATCH] QCoreTextFontEngine: Fix build with Xcode 9.3
+
+Apple LLVM version 9.1.0 (clang-902.0.39.1)
+
+Error message:
+
+.../qfontengine_coretext.mm:827:20: error: qualified reference to
+      'QFixed' is a constructor name rather than a type in this context
+    return QFixed::QFixed(int(CTFontGetUnitsPerEm(ctfont)));
+
+Change-Id: Iebe26b3b087a16b10664208fc8851cbddb47f043
+Reviewed-by: Konstantin Ritt <ritt.ks@gmail.com>
+---
+ src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git old/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm new/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
+index 25ff69d877d..98b753eff96 100644
+--- old/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
++++ new/qtbase/src/platformsupport/fontdatabases/mac/qfontengine_coretext.mm
+@@ -824,7 +824,7 @@ void QCoreTextFontEngine::getUnscaledGlyph(glyph_t glyph, QPainterPath *path, gl
+ 
+ QFixed QCoreTextFontEngine::emSquareSize() const
+ {
+-    return QFixed::QFixed(int(CTFontGetUnitsPerEm(ctfont)));
++    return QFixed(int(CTFontGetUnitsPerEm(ctfont)));
+ }
+ 
+ QFontEngine *QCoreTextFontEngine::cloneWithSize(qreal pixelSize) const
+-- 
+2.16.3


### PR DESCRIPTION
Building Qt with Xcode 9.3 is currently broken with:
```
compiling kernel/qmacgesturerecognizer.cpp
fontdatabases/mac/qfontengine_coretext.mm:775:20: error: qualified reference to 'QFixed' is a constructor name rather than a type in this context
    return QFixed::QFixed(int(CTFontGetUnitsPerEm(ctfont)));
                   ^
compiling .moc/moc_qfbscreen_p.cpp
1 error generated.
make[2]: *** [.obj/qfontengine_coretext.o] Error 1
make[2]: *** Waiting for unfinished jobs....

```
This patch should fix that, and will hopefully be the last time we have to patch Qt 5.7.

I've only made minor adjustments from the [original patch](https://codereview.qt-project.org/#/c/224900/), so that it will apply, although still not completely cleanly. We can cleanup if required.