### PR TITLE
[doc] Fix comment in FindForkInGlobalIndex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -263,7 +263,8 @@ CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& loc
 {
     AssertLockHeld(cs_main);
 
-    // Find the first block the caller has in the main chain
+    // Find the latest block common to locator and chain - we expect that
+    // locator.vHave is sorted descending by height.
     for (const uint256& hash : locator.vHave) {
         CBlockIndex* pindex = LookupBlockIndex(hash);
         if (pindex) {


### PR DESCRIPTION
The comment erroneously implies that we're searching `chainActive` for the
first block common to `locator`, but we're using the parameter `chain`.