### PR TITLE
util: Refactor logging code into a global object

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -46,7 +46,7 @@ main(int argc, char** argv)
     RandomInit();
     ECC_Start();
     SetupEnvironment();
-    g_logger->fPrintToDebugLog = false; // don't want to write to debug.log file
+    g_logger->m_print_to_file = false; // don't want to write to debug.log file
 
     int64_t evaluations = gArgs.GetArg("-evals", DEFAULT_BENCH_EVALUATIONS);
     std::string regex_filter = gArgs.GetArg("-filter", DEFAULT_BENCH_FILTER);

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -46,7 +46,7 @@ main(int argc, char** argv)
     RandomInit();
     ECC_Start();
     SetupEnvironment();
-    fPrintToDebugLog = false; // don't want to write to debug.log file
+    g_logger->fPrintToDebugLog = false; // don't want to write to debug.log file
 
     int64_t evaluations = gArgs.GetArg("-evals", DEFAULT_BENCH_EVALUATIONS);
     std::string regex_filter = gArgs.GetArg("-filter", DEFAULT_BENCH_FILTER);

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -46,7 +46,6 @@ main(int argc, char** argv)
     RandomInit();
     ECC_Start();
     SetupEnvironment();
-    g_logger->m_print_to_file = false; // don't want to write to debug.log file
 
     int64_t evaluations = gArgs.GetArg("-evals", DEFAULT_BENCH_EVALUATIONS);
     std::string regex_filter = gArgs.GetArg("-filter", DEFAULT_BENCH_FILTER);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -364,8 +364,8 @@ bool InitHTTPServer()
     // Update libevent's log handling. Returns false if our version of
     // libevent doesn't support debug logging, in which case we should
     // clear the BCLog::LIBEVENT flag.
-    if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
-        logCategories &= ~BCLog::LIBEVENT;
+    if (!UpdateHTTPServerLogging(g_logger->WillLogCategory(BCLog::LIBEVENT))) {
+        g_logger->DisableCategory(BCLog::LIBEVENT);
     }
 
 #ifdef WIN32

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -32,7 +32,7 @@ void InterruptHTTPServer();
 /** Stop HTTP server */
 void StopHTTPServer();
 
-/** Change logging level for libevent. Removes BCLog::LIBEVENT from logCategories if
+/** Change logging level for libevent. Removes BCLog::LIBEVENT from log categories if
  * libevent doesn't support debug logging.*/
 bool UpdateHTTPServerLogging(bool enable);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -968,7 +968,7 @@ bool AppInitParameterInteraction()
                     InitWarning(strprintf(_("Unsupported logging category %s=%s."), "-debug", cat));
                     continue;
                 }
-                logCategories |= flag;
+                g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
             }
         }
     }
@@ -980,7 +980,7 @@ bool AppInitParameterInteraction()
             InitWarning(strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat));
             continue;
         }
-        logCategories &= ~flag;
+        g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
     }
 
     // Check for -debugnet
@@ -1232,7 +1232,7 @@ bool AppInitMain()
     CreatePidFile(GetPidFile(), getpid());
 #endif
     if (g_logger->fPrintToDebugLog) {
-        if (gArgs.GetBoolArg("-shrinkdebugfile", logCategories == BCLog::NONE)) {
+        if (gArgs.GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile())) {
             // Do this first since it both loads a bunch of debug.log into memory,
             // and because this needs to happen before any other debug.log printing
             g_logger->ShrinkDebugFile();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -305,7 +305,7 @@ static void HandleSIGTERM(int)
 
 static void HandleSIGHUP(int)
 {
-    fReopenDebugLog = true;
+    g_logger->fReopenDebugLog = true;
 }
 
 #ifndef WIN32
@@ -831,10 +831,11 @@ void InitLogging()
     // debug.log.
     LogPrintf("\n\n\n\n\n");
 
-    fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
-    fPrintToDebugLog = !gArgs.IsArgNegated("-debuglogfile");
-    fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
-    fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+    g_logger->fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
+    g_logger->fPrintToDebugLog = !gArgs.IsArgNegated("-debuglogfile");
+    g_logger->fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
+    g_logger->fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);
 
     std::string version_string = FormatFullVersion();
@@ -1230,7 +1231,7 @@ bool AppInitMain()
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
-    if (fPrintToDebugLog) {
+    if (g_logger->fPrintToDebugLog) {
         if (gArgs.GetBoolArg("-shrinkdebugfile", logCategories == BCLog::NONE)) {
             // Do this first since it both loads a bunch of debug.log into memory,
             // and because this needs to happen before any other debug.log printing
@@ -1241,7 +1242,7 @@ bool AppInitMain()
         }
     }
 
-    if (!fLogTimestamps)
+    if (!g_logger->fLogTimestamps)
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -305,7 +305,7 @@ static void HandleSIGTERM(int)
 
 static void HandleSIGHUP(int)
 {
-    g_logger->fReopenDebugLog = true;
+    g_logger->m_reopen_file = true;
 }
 
 #ifndef WIN32
@@ -831,10 +831,10 @@ void InitLogging()
     // debug.log.
     LogPrintf("\n\n\n\n\n");
 
-    g_logger->fPrintToConsole = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
-    g_logger->fPrintToDebugLog = !gArgs.IsArgNegated("-debuglogfile");
-    g_logger->fLogTimestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
-    g_logger->fLogTimeMicros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+    g_logger->m_print_to_console = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
+    g_logger->m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
+    g_logger->m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
+    g_logger->m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
 
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);
 
@@ -1225,7 +1225,7 @@ bool AppInitMain()
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
-    if (g_logger->fPrintToDebugLog) {
+    if (g_logger->m_print_to_file) {
         if (gArgs.GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile())) {
             // Do this first since it both loads a bunch of debug.log into memory,
             // and because this needs to happen before any other debug.log printing
@@ -1237,7 +1237,7 @@ bool AppInitMain()
         }
     }
 
-    if (!g_logger->fLogTimestamps)
+    if (!g_logger->m_log_timestamps)
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -826,13 +826,15 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
  */
 void InitLogging()
 {
+    g_logger->m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
+    g_logger->m_file_path = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
+
     // Add newlines to the logfile to distinguish this execution from the last
     // one; called before console logging is set up, so this is only sent to
     // debug.log.
     LogPrintf("\n\n\n\n\n");
 
     g_logger->m_print_to_console = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
-    g_logger->m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
     g_logger->m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     g_logger->m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
 
@@ -1233,7 +1235,7 @@ bool AppInitMain()
         }
         if (!g_logger->OpenDebugLog()) {
             return InitError(strprintf("Could not open debug log file %s",
-                                       g_logger->GetDebugLogPath().string()));
+                                       g_logger->m_file_path.string()));
         }
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -963,24 +963,18 @@ bool AppInitParameterInteraction()
         if (std::none_of(categories.begin(), categories.end(),
             [](std::string cat){return cat == "0" || cat == "none";})) {
             for (const auto& cat : categories) {
-                uint32_t flag = 0;
-                if (!GetLogCategory(&flag, &cat)) {
+                if (!g_logger->EnableCategory(cat)) {
                     InitWarning(strprintf(_("Unsupported logging category %s=%s."), "-debug", cat));
-                    continue;
                 }
-                g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
             }
         }
     }
 
     // Now remove the logging categories which were explicitly excluded
     for (const std::string& cat : gArgs.GetArgs("-debugexclude")) {
-        uint32_t flag = 0;
-        if (!GetLogCategory(&flag, &cat)) {
+        if (!g_logger->DisableCategory(cat)) {
             InitWarning(strprintf(_("Unsupported logging category %s=%s."), "-debugexclude", cat));
-            continue;
         }
-        g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
     }
 
     // Check for -debugnet

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1235,10 +1235,11 @@ bool AppInitMain()
         if (gArgs.GetBoolArg("-shrinkdebugfile", logCategories == BCLog::NONE)) {
             // Do this first since it both loads a bunch of debug.log into memory,
             // and because this needs to happen before any other debug.log printing
-            ShrinkDebugFile();
+            g_logger->ShrinkDebugFile();
         }
-        if (!OpenDebugLog()) {
-            return InitError(strprintf("Could not open debug log file %s", GetDebugLogPath().string()));
+        if (!g_logger->OpenDebugLog()) {
+            return InitError(strprintf("Could not open debug log file %s",
+                                       g_logger->GetDebugLogPath().string()));
         }
     }
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -60,7 +60,7 @@ class NodeImpl : public Node
     void initLogging() override { InitLogging(); }
     void initParameterInteraction() override { InitParameterInteraction(); }
     std::string getWarnings(const std::string& type) override { return GetWarnings(type); }
-    uint32_t getLogCategories() override { return ::logCategories; }
+    uint32_t getLogCategories() override { return g_logger->GetCategoryMask(); }
     bool baseInitialize() override
     {
         return AppInitBasicSetup() && AppInitParameterInteraction() && AppInitSanityChecks() &&

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -26,9 +26,6 @@ BCLog::Logger* const g_logger = new BCLog::Logger();
 
 bool fLogIPs = DEFAULT_LOGIPS;
 
-/** Log categories bitfield. */
-std::atomic<uint32_t> logCategories(0);
-
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
@@ -60,6 +57,26 @@ bool BCLog::Logger::OpenDebugLog()
     }
 
     return true;
+}
+
+void BCLog::Logger::EnableCategory(BCLog::LogFlags flag)
+{
+    logCategories |= flag;
+}
+
+void BCLog::Logger::DisableCategory(BCLog::LogFlags flag)
+{
+    logCategories &= ~flag;
+}
+
+bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
+{
+    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
+}
+
+bool BCLog::Logger::DefaultShrinkDebugFile() const
+{
+    return logCategories == BCLog::NONE;
 }
 
 struct CLogCategoryDesc

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -7,9 +7,6 @@
 #include <util.h>
 #include <utilstrencodings.h>
 
-#include <list>
-#include <mutex>
-
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
 /**
@@ -31,57 +28,23 @@ bool fLogIPs = DEFAULT_LOGIPS;
 
 /** Log categories bitfield. */
 std::atomic<uint32_t> logCategories(0);
-/**
- * LogPrintf() has been broken a couple of times now
- * by well-meaning people adding mutexes in the most straightforward way.
- * It breaks because it may be called by global destructors during shutdown.
- * Since the order of destruction of static/global objects is undefined,
- * defining a mutex as a global object doesn't work (the mutex gets
- * destroyed, and then some later destructor calls OutputDebugStringF,
- * maybe indirectly, and you get a core dump at shutdown trying to lock
- * the mutex).
- */
-
-static std::once_flag debugPrintInitFlag;
-
-/**
- * We use std::call_once() to make sure mutexDebugLog and
- * vMsgsBeforeOpenLog are initialized in a thread-safe manner.
- *
- * NOTE: fileout, mutexDebugLog and sometimes vMsgsBeforeOpenLog
- * are leaked on exit. This is ugly, but will be cleaned up by
- * the OS/libc. When the shutdown sequence is fully audited and
- * tested, explicit destruction of these objects can be implemented.
- */
-static FILE* fileout = nullptr;
-static std::mutex* mutexDebugLog = nullptr;
-static std::list<std::string>* vMsgsBeforeOpenLog;
 
 static int FileWriteStr(const std::string &str, FILE *fp)
 {
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
-static void DebugPrintInit()
-{
-    assert(mutexDebugLog == nullptr);
-    mutexDebugLog = new std::mutex();
-    vMsgsBeforeOpenLog = new std::list<std::string>;
-}
-
-fs::path GetDebugLogPath()
+fs::path BCLog::Logger::GetDebugLogPath() const
 {
     fs::path logfile(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
     return AbsPathForConfigVal(logfile);
 }
 
-bool OpenDebugLog()
+bool BCLog::Logger::OpenDebugLog()
 {
-    std::call_once(debugPrintInitFlag, &DebugPrintInit);
-    std::lock_guard<std::mutex> scoped_lock(*mutexDebugLog);
+    std::lock_guard<std::mutex> scoped_lock(mutexDebugLog);
 
     assert(fileout == nullptr);
-    assert(vMsgsBeforeOpenLog);
     fs::path pathDebug = GetDebugLogPath();
 
     fileout = fsbridge::fopen(pathDebug, "a");
@@ -91,13 +54,11 @@ bool OpenDebugLog()
 
     setbuf(fileout, nullptr); // unbuffered
     // dump buffered messages from before we opened the log
-    while (!vMsgsBeforeOpenLog->empty()) {
-        FileWriteStr(vMsgsBeforeOpenLog->front(), fileout);
-        vMsgsBeforeOpenLog->pop_front();
+    while (!vMsgsBeforeOpenLog.empty()) {
+        FileWriteStr(vMsgsBeforeOpenLog.front(), fileout);
+        vMsgsBeforeOpenLog.pop_front();
     }
 
-    delete vMsgsBeforeOpenLog;
-    vMsgsBeforeOpenLog = nullptr;
     return true;
 }
 
@@ -225,14 +186,12 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
         fflush(stdout);
     }
     if (fPrintToDebugLog) {
-        std::call_once(debugPrintInitFlag, &DebugPrintInit);
-        std::lock_guard<std::mutex> scoped_lock(*mutexDebugLog);
+        std::lock_guard<std::mutex> scoped_lock(mutexDebugLog);
 
         // buffer if we haven't opened the log yet
         if (fileout == nullptr) {
-            assert(vMsgsBeforeOpenLog);
             ret = strTimestamped.length();
-            vMsgsBeforeOpenLog->push_back(strTimestamped);
+            vMsgsBeforeOpenLog.push_back(strTimestamped);
         }
         else
         {
@@ -250,7 +209,7 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
     return ret;
 }
 
-void ShrinkDebugFile()
+void BCLog::Logger::ShrinkDebugFile()
 {
     // Amount of debug.log to save at end when shrinking (must fit in memory)
     constexpr size_t RECENT_DEBUG_HISTORY_SIZE = 10 * 1000000;

--- a/src/logging.h
+++ b/src/logging.h
@@ -23,8 +23,6 @@ extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
 
-extern std::atomic<uint32_t> logCategories;
-
 struct CLogCategoryActive
 {
     std::string category;
@@ -72,6 +70,9 @@ namespace BCLog {
          */
         std::atomic_bool fStartedNewLine{true};
 
+        /** Log categories bitfield. */
+        std::atomic<uint32_t> logCategories{0};
+
         std::string LogTimestampStr(const std::string& str);
 
     public:
@@ -92,6 +93,13 @@ namespace BCLog {
         fs::path GetDebugLogPath() const;
         bool OpenDebugLog();
         void ShrinkDebugFile();
+
+        uint32_t GetCategoryMask() const { return logCategories.load(); }
+        void EnableCategory(LogFlags flag);
+        void DisableCategory(LogFlags flag);
+        bool WillLogCategory(LogFlags category) const;
+
+        bool DefaultShrinkDebugFile() const;
     };
 
 } // namespace BCLog
@@ -99,9 +107,9 @@ namespace BCLog {
 extern BCLog::Logger* const g_logger;
 
 /** Return true if log accepts specified category */
-static inline bool LogAcceptCategory(uint32_t category)
+static inline bool LogAcceptCategory(BCLog::LogFlags category)
 {
-    return (logCategories.load(std::memory_order_relaxed) & category) != 0;
+    return g_logger->WillLogCategory(category);
 }
 
 /** Returns a string with the log categories. */

--- a/src/logging.h
+++ b/src/logging.h
@@ -77,11 +77,12 @@ namespace BCLog {
 
     public:
         bool m_print_to_console = false;
-        bool m_print_to_file = true;
+        bool m_print_to_file = false;
 
         bool m_log_timestamps = DEFAULT_LOGTIMESTAMPS;
         bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
 
+        fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
@@ -90,7 +91,6 @@ namespace BCLog {
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
-        fs::path GetDebugLogPath() const;
         bool OpenDebugLog();
         void ShrinkDebugFile();
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -59,42 +59,42 @@ namespace BCLog {
     class Logger
     {
     private:
-        FILE* fileout = nullptr;
-        std::mutex mutexDebugLog;
-        std::list<std::string> vMsgsBeforeOpenLog;
+        FILE* m_fileout = nullptr;
+        std::mutex m_file_mutex;
+        std::list<std::string> m_msgs_before_open;
 
         /**
-         * fStartedNewLine is a state variable that will suppress printing of
+         * m_started_new_line is a state variable that will suppress printing of
          * the timestamp when multiple calls are made that don't end in a
          * newline.
          */
-        std::atomic_bool fStartedNewLine{true};
+        std::atomic_bool m_started_new_line{true};
 
         /** Log categories bitfield. */
-        std::atomic<uint32_t> logCategories{0};
+        std::atomic<uint32_t> m_categories{0};
 
         std::string LogTimestampStr(const std::string& str);
 
     public:
-        bool fPrintToConsole = false;
-        bool fPrintToDebugLog = true;
+        bool m_print_to_console = false;
+        bool m_print_to_file = true;
 
-        bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
-        bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
+        bool m_log_timestamps = DEFAULT_LOGTIMESTAMPS;
+        bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
 
-        std::atomic<bool> fReopenDebugLog{false};
+        std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
         int LogPrintStr(const std::string &str);
 
         /** Returns whether logs will be written to any output */
-        bool Enabled() const { return fPrintToConsole || fPrintToDebugLog; }
+        bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
         fs::path GetDebugLogPath() const;
         bool OpenDebugLog();
         void ShrinkDebugFile();
 
-        uint32_t GetCategoryMask() const { return logCategories.load(); }
+        uint32_t GetCategoryMask() const { return m_categories.load(); }
 
         void EnableCategory(LogFlags flag);
         bool EnableCategory(const std::string& str);

--- a/src/logging.h
+++ b/src/logging.h
@@ -11,6 +11,8 @@
 
 #include <atomic>
 #include <cstdint>
+#include <list>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -59,6 +61,10 @@ namespace BCLog {
     class Logger
     {
     private:
+        FILE* fileout = nullptr;
+        std::mutex mutexDebugLog;
+        std::list<std::string> vMsgsBeforeOpenLog;
+
         /**
          * fStartedNewLine is a state variable that will suppress printing of
          * the timestamp when multiple calls are made that don't end in a
@@ -82,6 +88,10 @@ namespace BCLog {
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return fPrintToConsole || fPrintToDebugLog; }
+
+        fs::path GetDebugLogPath() const;
+        bool OpenDebugLog();
+        void ShrinkDebugFile();
     };
 
 } // namespace BCLog
@@ -140,9 +150,5 @@ template<typename T, typename... Args> static inline void MarkUsed(const T& t, c
     } \
 } while(0)
 #endif
-
-fs::path GetDebugLogPath();
-bool OpenDebugLog();
-void ShrinkDebugFile();
 
 #endif // BITCOIN_LOGGING_H

--- a/src/logging.h
+++ b/src/logging.h
@@ -95,8 +95,12 @@ namespace BCLog {
         void ShrinkDebugFile();
 
         uint32_t GetCategoryMask() const { return logCategories.load(); }
+
         void EnableCategory(LogFlags flag);
+        bool EnableCategory(const std::string& str);
         void DisableCategory(LogFlags flag);
+        bool DisableCategory(const std::string& str);
+
         bool WillLogCategory(LogFlags category) const;
 
         bool DefaultShrinkDebugFile() const;
@@ -118,8 +122,8 @@ std::string ListLogCategories();
 /** Returns a vector of the active log categories. */
 std::vector<CLogCategoryActive> ListActiveLogCategories();
 
-/** Return true if str parses as a log category and set the flags in f */
-bool GetLogCategory(uint32_t *f, const std::string *str);
+/** Return true if str parses as a log category and set the flag */
+bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 
 /** Get format string from VA_ARGS for error reporting */
 template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -349,18 +349,17 @@ UniValue getmemoryinfo(const JSONRPCRequest& request)
 void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     cats = cats.get_array();
     for (unsigned int i = 0; i < cats.size(); ++i) {
-        uint32_t flag = 0;
         std::string cat = cats[i].get_str();
-        if (!GetLogCategory(&flag, &cat)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
-        }
-        if (flag == BCLog::NONE) {
-            return;
-        }
+
+        bool success;
         if (enable) {
-            g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
+            success = g_logger->EnableCategory(cat);
         } else {
-            g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
+            success = g_logger->DisableCategory(cat);
+        }
+
+        if (!success) {
+            throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
         }
     }
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -346,9 +346,8 @@ UniValue getmemoryinfo(const JSONRPCRequest& request)
     }
 }
 
-uint32_t getCategoryMask(UniValue cats) {
+void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     cats = cats.get_array();
-    uint32_t mask = 0;
     for (unsigned int i = 0; i < cats.size(); ++i) {
         uint32_t flag = 0;
         std::string cat = cats[i].get_str();
@@ -356,11 +355,14 @@ uint32_t getCategoryMask(UniValue cats) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "unknown logging category " + cat);
         }
         if (flag == BCLog::NONE) {
-            return 0;
+            return;
         }
-        mask |= flag;
+        if (enable) {
+            g_logger->EnableCategory(static_cast<BCLog::LogFlags>(flag));
+        } else {
+            g_logger->DisableCategory(static_cast<BCLog::LogFlags>(flag));
+        }
     }
-    return mask;
 }
 
 UniValue logging(const JSONRPCRequest& request)
@@ -399,25 +401,25 @@ UniValue logging(const JSONRPCRequest& request)
         );
     }
 
-    uint32_t originalLogCategories = logCategories;
+    uint32_t original_log_categories = g_logger->GetCategoryMask();
     if (request.params[0].isArray()) {
-        logCategories |= getCategoryMask(request.params[0]);
+        EnableOrDisableLogCategories(request.params[0], true);
     }
-
     if (request.params[1].isArray()) {
-        logCategories &= ~getCategoryMask(request.params[1]);
+        EnableOrDisableLogCategories(request.params[1], false);
     }
+    uint32_t updated_log_categories = g_logger->GetCategoryMask();
+    uint32_t changed_log_categories = original_log_categories ^ updated_log_categories;
 
     // Update libevent logging if BCLog::LIBEVENT has changed.
     // If the library version doesn't allow it, UpdateHTTPServerLogging() returns false,
     // in which case we should clear the BCLog::LIBEVENT flag.
     // Throw an error if the user has explicitly asked to change only the libevent
     // flag and it failed.
-    uint32_t changedLogCategories = originalLogCategories ^ logCategories;
-    if (changedLogCategories & BCLog::LIBEVENT) {
-        if (!UpdateHTTPServerLogging(logCategories & BCLog::LIBEVENT)) {
-            logCategories &= ~BCLog::LIBEVENT;
-            if (changedLogCategories == BCLog::LIBEVENT) {
+    if (changed_log_categories & BCLog::LIBEVENT) {
+        if (!UpdateHTTPServerLogging(g_logger->WillLogCategory(BCLog::LIBEVENT))) {
+            g_logger->DisableCategory(BCLog::LIBEVENT);
+            if (changed_log_categories == BCLog::LIBEVENT) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "libevent logging cannot be updated when using libevent before v2.1.1.");
             }
         }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -47,7 +47,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
         SetupNetworking();
         InitSignatureCache();
         InitScriptExecutionCache();
-        g_logger->fPrintToDebugLog = false; // don't want to write to debug.log file
+        g_logger->m_print_to_file = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(chainName);
         noui_connect();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -47,7 +47,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
         SetupNetworking();
         InitSignatureCache();
         InitScriptExecutionCache();
-        g_logger->m_print_to_file = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(chainName);
         noui_connect();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -47,7 +47,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
         SetupNetworking();
         InitSignatureCache();
         InitScriptExecutionCache();
-        fPrintToDebugLog = false; // don't want to write to debug.log file
+        g_logger->fPrintToDebugLog = false; // don't want to write to debug.log file
         fCheckBlockIndex = true;
         SelectParams(chainName);
         noui_connect();

--- a/src/util.h
+++ b/src/util.h
@@ -66,7 +66,7 @@ bool SetupNetworking();
 template<typename... Args>
 bool error(const char* fmt, const Args&... args)
 {
-    LogPrintStr("ERROR: " + tfm::format(fmt, args...) + "\n");
+    LogPrintf("ERROR: %s\n", tfm::format(fmt, args...));
     return false;
 }
 


### PR DESCRIPTION
This is purely a refactor with no behavior changes.

This creates a new class `BCLog::Logger` to encapsulate all global logging configuration and state.