### PR TITLE
contrib: Only lint our src files for include guards

### DIFF
--- a/contrib/devtools/lint-include-guards.sh
+++ b/contrib/devtools/lint-include-guards.sh
@@ -12,7 +12,7 @@ HEADER_ID_SUFFIX="_H"
 REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"
 
 EXIT_CODE=0
-for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")
+for HEADER_FILE in $(git ls-files -- "src/*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")
 do
     HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr / _ | tr "[:lower:]" "[:upper:]")
     HEADER_ID="${HEADER_ID_PREFIX}${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"


### PR DESCRIPTION
headers in other folders are not subject to the guidelines