### PR TITLE
Drop IsCompressedOrUncompressedPubKey and IsCompressedPubKey

### DIFF
--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -71,8 +71,20 @@ private:
 
 public:
 
-    bool static ValidSize(const std::vector<unsigned char> &vch) {
-      return vch.size() > 0 && GetLen(vch[0]) == vch.size();
+    /**
+     *  @return true if the pubkey header and size are valid for a pubkey
+     */
+    bool static ValidSize(const std::vector<unsigned char> &vch)
+    {
+        return vch.size() > 0 && GetLen(vch[0]) == vch.size();
+    }
+
+    /**
+     *  @return true if the pubkey header and size match that of a compressed pubkey
+     */
+    bool static IsCompressed(const std::vector<unsigned char>& vch)
+    {
+        return vch.size() > 0 && GetLen(vch[0]) == COMPRESSED_PUBLIC_KEY_SIZE && vch.size() == COMPRESSED_PUBLIC_KEY_SIZE;
     }
 
     //! Construct an invalid public key.


### PR DESCRIPTION
In favor of `CPubKey` methods. As of #12460, `CPubKey::ValidSize` tests relative
to the header-relevant pubkey size, making it an appropriate replacement.

Note that this adds support for 2 new uncompressed header types
to the `CheckPubKeyEncoding` pathway: values 6 and 7.