### PR TITLE
doc: Revert to previous header include policy

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -569,7 +569,8 @@ Source code organization
   - *Rationale*: Shorter and simpler header files are easier to read, and reduce compile time
 
 - Every `.cpp` and `.h` file should `#include` every header file it directly uses classes, functions or other
-  definitions from, even if those headers are already included indirectly through other headers.
+  definitions from, even if those headers are already included indirectly through other headers. One exception
+  is that a `.cpp` file does not need to re-include the includes already included in its corresponding `.h` file.
 
   - *Rationale*: Excluding headers because they are already indirectly included results in compilation
     failures when those indirect dependencies change. Furthermore, it obscures what the real code


### PR DESCRIPTION
It was noted in #12933 that the change to the header include policy was controversial and not agreed upon.

This reverts the guideline to its initial state.