### PR TITLE
Add RPC call setscriptthreadsenabled: allow to temp. throttle CPU usage

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1626,6 +1626,54 @@ UniValue savemempool(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+UniValue scriptthreadsinfo(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() > 0) {
+        throw std::runtime_error(
+            "scriptthreadsinfo\n"
+            "\nShow information about the script verification threads.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"enabled\": xx,                      (boolean) true is script verification threads are enabled (see setscriptthreadsenabled).\n"
+            "  \"num_script_check_threads\": xx,     (numeric) The total number of script verification threads.\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("scriptthreadsinfo", "")
+            + HelpExampleRpc("scriptthreadsinfo", "")
+        );
+    }
+
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("enabled", g_script_threads_enabled);
+    ret.pushKV("num_script_check_threads", nScriptCheckThreads);
+    return ret;
+}
+
+UniValue setscriptthreadsenabled(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 1) {
+        throw std::runtime_error(
+            "setscriptthreadsenabled\n"
+            "\nDisable/enable script verification threads and therefore reducing CPU usage on multicore systems.\n"
+            "Disabling script verification threads may result in a significant slow-down during synchronisation.\n"
+            "Has no effect on single core machines or if started with -par=<-<numcores>\n"
+            "\nArguments:\n"
+            "1. state      (boolean, required) false if script verification threads should be disabled (true for re-enabling).\n"
+            "\nExamples:\n"
+            + HelpExampleCli("setscriptthreadsenabled", "false")
+            + HelpExampleRpc("setscriptthreadsenabled", "false")
+        );
+    }
+
+    if (nScriptCheckThreads == 0) {
+        throw JSONRPCError(RPC_MISC_ERROR, "Script verification threads are disabled (single core machine or -par=<-<numcores>)");
+    }
+
+    g_script_threads_enabled = request.params[0].get_bool();
+
+    return NullUniValue;
+}
+
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
@@ -1648,6 +1696,8 @@ static const CRPCCommand commands[] =
     { "blockchain",         "pruneblockchain",        &pruneblockchain,        {"height"} },
     { "blockchain",         "savemempool",            &savemempool,            {} },
     { "blockchain",         "verifychain",            &verifychain,            {"checklevel","nblocks"} },
+    { "blockchain",         "scriptthreadsinfo",      &scriptthreadsinfo,      {} },
+    { "blockchain",         "setscriptthreadsenabled",&setscriptthreadsenabled,{"state"} },
 
     { "blockchain",         "preciousblock",          &preciousblock,          {"blockhash"} },
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -153,6 +153,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "echojson", 9, "arg9" },
     { "rescanblockchain", 0, "start_height"},
     { "rescanblockchain", 1, "stop_height"},
+    { "setscriptthreadsenabled", 0, "state"},
 };
 
 class CRPCConvertTable

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -205,6 +205,7 @@ CBlockIndex *pindexBestHeader = nullptr;
 CWaitableCriticalSection g_best_block_mutex;
 CConditionVariable g_best_block_cv;
 uint256 g_best_block;
+std::atomic_bool g_script_threads_enabled(true);
 int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
@@ -1952,7 +1953,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     CBlockUndo blockundo;
 
-    CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads ? &scriptcheckqueue : nullptr);
+    CCheckQueueControl<CScriptCheck> control(fScriptChecks && nScriptCheckThreads && g_script_threads_enabled ? &scriptcheckqueue : nullptr);
 
     std::vector<int> prevheights;
     CAmount nFees = 0;

--- a/src/validation.h
+++ b/src/validation.h
@@ -171,6 +171,7 @@ extern uint256 g_best_block;
 extern std::atomic_bool fImporting;
 extern std::atomic_bool fReindex;
 extern int nScriptCheckThreads;
+extern std::atomic_bool g_script_threads_enabled;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern bool fRequireStandard;


### PR DESCRIPTION
Bitcoin Core has been designed to synchronise/verify as fast as possible. This is usually desirable, though, on systems where other applications require a reasonable amount of CPU time (ex. desktop systems) the CPU usage maximisation of Bitcoin Core may be intrusive.

This PR adds two RPC calls:
* `setscriptthreadsenabled` allows to disable/re-enable the script verification threads during runtime.
* `scriptthreadsinfo` show information about the script verification threads (enabled/disabled and num threads)

This would be a base requirement for a "cpu throttle" feature in the GUI allowing one to temporary "throttle" verification (and therefore make the system usable for other tasks while syncing in the background)

The concept-draft for long-term resource profile:
https://gist.github.com/jonasschnelli/a3eb47147069b99d7c63d7da997b4225

ToDo:
- [ ] Add tests 
- [ ] Release notes