### PR TITLE
[WIP] Mempool optimized feerate

### DIFF
--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -209,7 +209,7 @@ public:
      *  the closest target where one can be given.  'conservative' estimates are
      *  valid over longer time horizons also.
      */
-    CFeeRate estimateSmartFee(int confTarget, FeeCalculation *feeCalc, bool conservative) const;
+    CFeeRate estimateSmartFee(int confTarget, FeeCalculation *feeCalc, bool conservative, bool mempool_optimized = false) const;
 
     /** Return a specific fee estimate calculation with a given success
      * threshold and time horizon, and optionally return detailed data about

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -126,6 +126,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },
     { "estimatesmartfee", 0, "conf_target" },
+    { "estimatesmartfee", 2, "mempool_optimized" },
     { "estimaterawfee", 0, "conf_target" },
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -772,9 +772,9 @@ UniValue estimatefee(const JSONRPCRequest& request)
 
 UniValue estimatesmartfee(const JSONRPCRequest& request)
 {
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 2)
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
         throw std::runtime_error(
-            "estimatesmartfee conf_target (\"estimate_mode\")\n"
+            "estimatesmartfee conf_target (\"estimate_mode\" mempool_optimized)\n"
             "\nEstimates the approximate fee per kilobyte needed for a transaction to begin\n"
             "confirmation within conf_target blocks if possible and return the number of blocks\n"
             "for which the estimate is valid. Uses virtual transaction size as defined\n"
@@ -790,6 +790,9 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
             "       \"UNSET\" (defaults to CONSERVATIVE)\n"
             "       \"ECONOMICAL\"\n"
             "       \"CONSERVATIVE\"\n"
+            "3. mempool_optimized (boolean, optional, defaults to false) Use the mempool data to optimize\n"
+            "                     the fee (note: use of Replace-By-Fee is strongly recommended, as transactions\n"
+            "                     may get stuck due to a too optimistic fee rate).\n"
             "\nResult:\n"
             "{\n"
             "  \"feerate\" : x.x,     (numeric, optional) estimate fee rate in " + CURRENCY_UNIT + "/kB\n"
@@ -805,10 +808,11 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
             + HelpExampleCli("estimatesmartfee", "6")
             );
 
-    RPCTypeCheck(request.params, {UniValue::VNUM, UniValue::VSTR});
+    RPCTypeCheck(request.params, {UniValue::VNUM, UniValue::VSTR, UniValue::VBOOL});
     RPCTypeCheckArgument(request.params[0], UniValue::VNUM);
     unsigned int conf_target = ParseConfirmTarget(request.params[0]);
     bool conservative = true;
+    bool mempool_optimized = !request.params[2].isNull() && request.params[2].get_bool();
     if (!request.params[1].isNull()) {
         FeeEstimateMode fee_mode;
         if (!FeeModeFromString(request.params[1].get_str(), fee_mode)) {
@@ -820,7 +824,7 @@ UniValue estimatesmartfee(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     UniValue errors(UniValue::VARR);
     FeeCalculation feeCalc;
-    CFeeRate feeRate = ::feeEstimator.estimateSmartFee(conf_target, &feeCalc, conservative);
+    CFeeRate feeRate = ::feeEstimator.estimateSmartFee(conf_target, &feeCalc, conservative, mempool_optimized);
     if (feeRate != CFeeRate(0)) {
         result.pushKV("feerate", ValueFromAmount(feeRate.GetFeePerK()));
     } else {
@@ -946,7 +950,7 @@ static const CRPCCommand commands[] =
     { "generating",         "generatetoaddress",      &generatetoaddress,      {"nblocks","address","maxtries"} },
 
     { "hidden",             "estimatefee",            &estimatefee,            {} },
-    { "util",               "estimatesmartfee",       &estimatesmartfee,       {"conf_target", "estimate_mode"} },
+    { "util",               "estimatesmartfee",       &estimatesmartfee,       {"conf_target", "estimate_mode", "mempool_optimized"} },
 
     { "hidden",             "estimaterawfee",         &estimaterawfee,         {"conf_target", "threshold"} },
 };

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -884,7 +884,7 @@ CFeeRate CTxMemPool::CalculateFeeRate(double portion) const
     auto iters = GetSortedDepthAndScore();
 
     uint64_t weight = 0; // weight of hypothetical block
-    uint64_t target = MAX_BLOCK_WEIGHT * portion; // at what weight do we want to "bump"
+    uint64_t target = MAX_BLOCK_WEIGHT * (1.0 - portion); // at what weight do we want to "bump"
     for (const auto& it : iters) {
         weight += it->GetTxWeight();
         if (weight >= target) return CFeeRate(it->GetFee(), it->GetTxSize());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -878,6 +878,21 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
     mapDeltas.erase(hash);
 }
 
+CFeeRate CTxMemPool::CalculateFeeRate(double portion) const
+{
+    LOCK(cs);
+    auto iters = GetSortedDepthAndScore();
+
+    uint64_t weight = 0; // weight of hypothetical block
+    uint64_t target = MAX_BLOCK_WEIGHT * portion; // at what weight do we want to "bump"
+    for (const auto& it : iters) {
+        weight += it->GetTxWeight();
+        if (weight >= target) return CFeeRate(it->GetFee(), it->GetTxSize());
+        printf("- %llu: %s\n", weight, CFeeRate(it->GetFee(), it->GetTxSize()).ToString().c_str());
+    }
+    return CFeeRate(1000);
+}
+
 bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
 {
     for (unsigned int i = 0; i < tx.vin.size(); i++)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -564,6 +564,13 @@ public:
     void ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const;
     void ClearPrioritisation(const uint256 hash);
 
+    /**
+     * Calculate the fee rate required to bump out `portion` (0..1) portion
+     * of other transactions currently in the mempool from a hypothetical
+     * new block.
+     */
+    CFeeRate CalculateFeeRate(double portion) const;
+
 public:
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must


### PR DESCRIPTION
This is very much a WIP, but feedback is welcome.

This adds support for using the mempool state when calculating the fee rate for transactions. It is currently only supported in `estimatesmartfee` RPC command, but intention is to make it available in `sendtoaddress` and friends eventually.

To do (at minimum):
* [ ] Optimize portion value (in fees.cpp), currently `(0.1+(conservative*0.05))*max(0.5, 1-0.1*confTarget))`
* [ ] Remove debug cruft
