### PR TITLE
logging: bypass timestamp formatting when not logging

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -145,14 +145,16 @@ template<typename T, typename... Args> static inline void MarkUsed(const T& t, c
 #define LogPrint(category, ...) do { MarkUsed(__VA_ARGS__); } while(0)
 #else
 #define LogPrintf(...) do { \
-    std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
-    try { \
-        _log_msg_ = tfm::format(__VA_ARGS__); \
-    } catch (tinyformat::format_error &fmterr) { \
-        /* Original format string will have newline so don't add one here */ \
-        _log_msg_ = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+    if (fPrintToConsole || fPrintToDebugLog) { \
+        std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
+        try { \
+            _log_msg_ = tfm::format(__VA_ARGS__); \
+        } catch (tinyformat::format_error &fmterr) { \
+            /* Original format string will have newline so don't add one here */ \
+            _log_msg_ = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
+        } \
+        LogPrintStr(_log_msg_); \
     } \
-    LogPrintStr(_log_msg_); \
 } while(0)
 
 #define LogPrint(category, ...) do { \


### PR DESCRIPTION
As suggested by @laanwj on IRC:
```
<cfields> whoa
<cfields> Leaving test case "knapsack_solver_test"; testing time: 358694ms
<cfields> i386 + old wine ^^
<cfields> Leaving test case "knapsack_solver_test"; testing time: 6781ms
<cfields> ^^ same, but with the LogPrint commented out
...
<wumpus> if both log-to-file and log-to-console is disabled, it should probably bypass all logging
```
Edit: The painful line commented out being the LogPrintf in CWallet::AddToWallet.