### PR TITLE
Avoid std::locale/imbue madness in DateTimeStrFormat

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -159,17 +159,6 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
 }
 
 
-BOOST_AUTO_TEST_CASE(util_DateTimeStrFormat)
-{
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 0), "1970-01-01 00:00:00");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 0x7FFFFFFF), "2038-01-19 03:14:07");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M:%S", 1317425777), "2011-09-30 23:36:17");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%dT%H:%M:%SZ", 1317425777), "2011-09-30T23:36:17Z");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%H:%M:%SZ", 1317425777), "23:36:17Z");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%Y-%m-%d %H:%M", 1317425777), "2011-09-30 23:36");
-    BOOST_CHECK_EQUAL(DateTimeStrFormat("%a, %d %b %Y %H:%M:%S +0000", 1317425777), "Fri, 30 Sep 2011 23:36:17 +0000");
-}
-
 BOOST_AUTO_TEST_CASE(util_FormatISO8601DateTime)
 {
     BOOST_CHECK_EQUAL(FormatISO8601DateTime(1317425777), "2011-09-30T23:36:17Z");

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -10,9 +10,10 @@
 #include <utiltime.h>
 
 #include <atomic>
-
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
+#include <ctime>
+#include <tinyformat.h>
 
 static std::atomic<int64_t> nMockTime(0); //!< For unit testing
 
@@ -75,25 +76,23 @@ void MilliSleep(int64_t n)
 #endif
 }
 
-std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime)
-{
-    static std::locale classic(std::locale::classic());
-    // std::locale takes ownership of the pointer
-    std::locale loc(classic, new boost::posix_time::time_facet(pszFormat));
-    std::stringstream ss;
-    ss.imbue(loc);
-    ss << boost::posix_time::from_time_t(nTime);
-    return ss.str();
-}
-
 std::string FormatISO8601DateTime(int64_t nTime) {
-    return DateTimeStrFormat("%Y-%m-%dT%H:%M:%SZ", nTime);
+    struct tm ts;
+    time_t time_val = nTime;
+    gmtime_r(&time_val, &ts);
+    return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
 std::string FormatISO8601Date(int64_t nTime) {
-    return DateTimeStrFormat("%Y-%m-%d", nTime);
+    struct tm ts;
+    time_t time_val = nTime;
+    gmtime_r(&time_val, &ts);
+    return strprintf("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
 }
 
 std::string FormatISO8601Time(int64_t nTime) {
-    return DateTimeStrFormat("%H:%M:%SZ", nTime);
+    struct tm ts;
+    time_t time_val = nTime;
+    gmtime_r(&time_val, &ts);
+    return strprintf("%02i:%02i:%02iZ", ts.tm_hour, ts.tm_min, ts.tm_sec);
 }

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -31,8 +31,6 @@ void MilliSleep(int64_t n);
  * ISO 8601 formatting is preferred. Use the FormatISO8601{DateTime,Date,Time}
  * helper functions if possible.
  */
-std::string DateTimeStrFormat(const char* pszFormat, int64_t nTime);
-
 std::string FormatISO8601DateTime(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
 std::string FormatISO8601Time(int64_t nTime);


### PR DESCRIPTION
And replace them with just hardcoded ISO8601 strings and `gmtime_r`.

Pointed out by @laanwj here: https://github.com/bitcoin/bitcoin/pull/12970#issuecomment-380962488