### PR TITLE
logs: Make the columns in subsequent UpdateTip log entries horizontally aligned

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1271,12 +1271,12 @@ void static InvalidChainFound(CBlockIndex* pindexNew)
     if (!pindexBestInvalid || pindexNew->nChainWork > pindexBestInvalid->nChainWork)
         pindexBestInvalid = pindexNew;
 
-    LogPrintf("%s: invalid block=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
+    LogPrintf("%s: invalid block=%s  height=%d  log2_work=%f  date=%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight,
       log(pindexNew->nChainWork.getdouble())/log(2.0), FormatISO8601DateTime(pindexNew->GetBlockTime()));
     CBlockIndex *tip = chainActive.Tip();
     assert (tip);
-    LogPrintf("%s:  current best=%s  height=%d  log2_work=%.8g  date=%s\n", __func__,
+    LogPrintf("%s:  current best=%s  height=%d  log2_work=%f  date=%s\n", __func__,
       tip->GetBlockHash().ToString(), chainActive.Height(), log(tip->nChainWork.getdouble())/log(2.0),
       FormatISO8601DateTime(tip->GetBlockTime()));
     CheckForkWarningConditions();
@@ -2245,7 +2245,7 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
             DoWarning(strWarning);
         }
     }
-    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
+    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
       log(pindexNew->nChainWork.getdouble())/log(2.0), (unsigned long)pindexNew->nChainTx,
       FormatISO8601DateTime(pindexNew->GetBlockTime()),


### PR DESCRIPTION
Make the columns in subsequent `UpdateTip` log entries horizontally aligned. This change improves usability by making it easier to follow the `tx`, `date`, `progress` and `cache` values over time.

Before this commit:

```
2019-01-01T00:00:01Z UpdateTip: new best=… log2_work=69.12542 tx=9560969 date='2018-12-05T18:58:07Z' progress=0.029954 cache=442.8MiB(3363038txo)
2019-01-01T00:00:02Z UpdateTip: new best=… log2_work=69.125457 tx=9561022 date='2018-12-05T19:00:07Z' progress=0.029955 cache=442.8MiB(3362966txo)
2019-01-01T00:00:03Z UpdateTip: new best=… log2_work=69.12549 tx=9561034 date='2018-12-05T19:05:44Z' progress=0.029955 cache=442.8MiB(3362970txo)
2019-01-01T00:00:04Z UpdateTip: new best=… log2_work=69.125523 tx=9561231 date='2018-12-05T19:08:07Z' progress=0.029955 cache=442.8MiB(3363051txo)
2019-01-01T00:00:05Z UpdateTip: new best=… log2_work=69.1255 tx=9561382 date='2018-12-05T19:20:45Z' progress=0.029956 cache=442.9MiB(3363120txo)
```

After this commit:

```
2019-01-01T00:00:01Z UpdateTip: new best=… log2_work=69.125420 tx=9560969 date='2018-12-05T18:58:07Z' progress=0.029954 cache=442.8MiB(3363038txo)
2019-01-01T00:00:02Z UpdateTip: new best=… log2_work=69.125457 tx=9561022 date='2018-12-05T19:00:07Z' progress=0.029955 cache=442.8MiB(3362966txo)
2019-01-01T00:00:03Z UpdateTip: new best=… log2_work=69.125490 tx=9561034 date='2018-12-05T19:05:44Z' progress=0.029955 cache=442.8MiB(3362970txo)
2019-01-01T00:00:04Z UpdateTip: new best=… log2_work=69.125523 tx=9561231 date='2018-12-05T19:08:07Z' progress=0.029955 cache=442.8MiB(3363051txo)
2019-01-01T00:00:05Z UpdateTip: new best=… log2_work=69.125500 tx=9561382 date='2018-12-05T19:20:45Z' progress=0.029956 cache=442.9MiB(3363120txo)
```
