### PR TITLE
Trivial: Corrected comment array name from pnSeeds6 to pnSeed6

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -124,7 +124,7 @@ bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
     return nBestScore >= 0;
 }
 
-//! Convert the pnSeeds6 array into usable address objects.
+//! Convert the pnSeed6 array into usable address objects.
 static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn)
 {
     // It'll only connect to one or two seed nodes because once it connects,


### PR DESCRIPTION
After reading this comment, I tried to grep the code base for `pnSeeds6` but couldn't find anything.  After some time wasted, I realized the arrays actually start with `pnSeed6`.