### PR TITLE
rpc: Rename size to vsize in mempool related calls

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -198,6 +198,12 @@ RPC
 - A new `submitheader` RPC allows submitting block headers independently
   from their block.  This is likely only useful for testing.
 
+- In getmempoolancestors, getmempooldescendants, getmempoolentry and
+  getrawmempool RPCs, to be consistent with the returned value and other
+  RPCs such as getrawtransaction, vsize has been added and size is now
+  deprecated. size will only be returned if bitcoind is started with
+  -deprecatedrpc=size.
+
 Configuration
 -------------
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -359,7 +359,9 @@ static UniValue getdifficulty(const JSONRPCRequest& request)
 
 static std::string EntryDescriptionString()
 {
-    return "    \"size\" : n,             (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n"
+    return "    \"vsize\" : n,            (numeric) virtual transaction size as defined in BIP 141. This is different from actual serialized size for witness transactions as witness data is discounted.\n"
+           "    \"size\" : n,             (numeric) (DEPRECATED) same as vsize. Only returned if bitcoind is started with -deprecatedrpc=size\n"
+           "                              size will be completely removed in v0.19.\n"
            "    \"fee\" : n,              (numeric) transaction fee in " + CURRENCY_UNIT + " (DEPRECATED)\n"
            "    \"modifiedfee\" : n,      (numeric) transaction fee with fee deltas used for mining priority (DEPRECATED)\n"
            "    \"time\" : n,             (numeric) local time transaction entered pool in seconds since 1 Jan 1970 GMT\n"
@@ -397,7 +399,8 @@ static void entryToJSON(UniValue &info, const CTxMemPoolEntry &e) EXCLUSIVE_LOCK
     fees.pushKV("descendant", ValueFromAmount(e.GetModFeesWithDescendants()));
     info.pushKV("fees", fees);
 
-    info.pushKV("size", (int)e.GetTxSize());
+    info.pushKV("vsize", (int)e.GetTxSize());
+    if (IsDeprecatedRPCEnabled("size")) info.pushKV("size", (int)e.GetTxSize());
     info.pushKV("fee", ValueFromAmount(e.GetFee()));
     info.pushKV("modifiedfee", ValueFromAmount(e.GetModifiedFee()));
     info.pushKV("time", e.GetTime());

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -58,9 +58,9 @@ class MempoolPackagesTest(BitcoinTestFramework):
         assert_equal(len(mempool), MAX_ANCESTORS)
         descendant_count = 1
         descendant_fees = 0
-        descendant_size = 0
+        descendant_vsize = 0
 
-        ancestor_size = sum([mempool[tx]['size'] for tx in mempool])
+        ancestor_vsize = sum([mempool[tx]['vsize'] for tx in mempool])
         ancestor_count = MAX_ANCESTORS
         ancestor_fees = sum([mempool[tx]['fee'] for tx in mempool])
 
@@ -79,15 +79,15 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x]['fees']['modified'], mempool[x]['modifiedfee'])
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN)
             assert_equal(mempool[x]['fees']['descendant'], descendant_fees)
-            descendant_size += mempool[x]['size']
-            assert_equal(mempool[x]['descendantsize'], descendant_size)
+            descendant_vsize += mempool[x]['vsize']
+            assert_equal(mempool[x]['descendantsize'], descendant_vsize)
             descendant_count += 1
 
             # Check that ancestor calculations are correct
             assert_equal(mempool[x]['ancestorcount'], ancestor_count)
             assert_equal(mempool[x]['ancestorfees'], ancestor_fees * COIN)
-            assert_equal(mempool[x]['ancestorsize'], ancestor_size)
-            ancestor_size -= mempool[x]['size']
+            assert_equal(mempool[x]['ancestorsize'], ancestor_vsize)
+            ancestor_vsize -= mempool[x]['vsize']
             ancestor_fees -= mempool[x]['fee']
             ancestor_count -= 1
 

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -64,7 +64,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         for i in range(3):
             for j in txids[i]:
                 assert(j in mempool)
-                sizes[i] += mempool[j]['size']
+                sizes[i] += mempool[j]['vsize']
             assert(sizes[i] > MAX_BLOCK_BASE_SIZE) # Fail => raise utxo_count
 
         # add a fee delta to something in the cheapest bucket and make sure it gets mined


### PR DESCRIPTION
In `getmempoolancestors`, `getmempooldescendants`, `getmempoolentry` and `getrawmempool` RPCs `size` returns the virtual transaction size as defined in BIP 141. Renaming it to `vsize` makes it consistent with returned value and other calls such as `getrawtransaction`.

Related to #11218.