### PR TITLE
Allow txindex in prune mode

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -925,8 +925,9 @@ bool AppInitParameterInteraction()
 
     // if using block pruning, then disallow txindex
     if (gArgs.GetArg("-prune", 0)) {
-        if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX))
-            return InitError(_("Prune mode is incompatible with -txindex."));
+        if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
+            InitWarning(_("txindex in prune-mode is experimental"));
+        }
     }
 
     // -bind and -whitebind can't be set when not listening

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -178,7 +178,12 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
             }
             errmsg = "No such transaction found in the provided block";
         } else if (res == GetTransactionResult::BLOCK_PRUNED) {
-            throw JSONRPCError(RPC_MISC_ERROR, "Block not available");
+            //TODO: fetch block via peers, wait for download and return transaction
+            //see https://github.com/bitcoin/bitcoin/pull/10794
+            UniValue result(UniValue::VOBJ);
+            result.pushKV("status", "pruned");
+            result.pushKV("inblock", hash_block.GetHex());
+            return result;
         } else if (res == GetTransactionResult::BLOCK_LOAD_ERROR) {
             throw JSONRPCError(RPC_MISC_ERROR, "Block load error");
         } else {

--- a/src/validation.h
+++ b/src/validation.h
@@ -278,7 +278,14 @@ void ThreadScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256& hash, CTransactionRef& tx, const Consensus::Params& params, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
+enum class GetTransactionResult
+{
+    LOAD_OK,
+    NOT_FOUND,
+    BLOCK_LOAD_ERROR,
+    BLOCK_PRUNED,
+};
+GetTransactionResult GetTransaction(const uint256& hash, CTransactionRef& tx, const Consensus::Params& params, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
 /** Find the best known block, and make it the tip of the block chain */
 bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);

--- a/src/validation.h
+++ b/src/validation.h
@@ -299,7 +299,7 @@ uint64_t CalculateCurrentUsage();
 /**
  *  Mark one block file as pruned.
  */
-void PruneOneBlockFile(const int fileNumber);
+void PruneOneBlockFile(const int fileNumber, CValidationState &state);
 
 /**
  *  Actually unlink the specified files

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -55,7 +55,8 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     }
 
     // Prune the older block file.
-    PruneOneBlockFile(oldTip->GetBlockPos().nFile);
+    CValidationState state;
+    PruneOneBlockFile(oldTip->GetBlockPos().nFile, state);
     UnlinkPrunedFiles({oldTip->GetBlockPos().nFile});
 
     // Verify ScanForWalletTransactions only picks transactions in the new block


### PR DESCRIPTION
Idea is outlined here: #12651

This allows to enable the txindex when pruning is enabled.
During pruning a block file, the `CDiskTxPos` objects in the txindex do get migrated to a "per-blockheight" approach allowing to get the blockhash and tx-position of every txid.

Once #10794 (`requestblocks`, or similar) is merged, `getrawtransaction` could wait until the block is fetched via the connected peers and return the transaction. Retrieving a transaction would still be fast enough for non-high-load usage (less then a second to a couple of seconds).

This would allow to run a txindex with ~20GB of diskspace for non high-load usage like personal block explorers.

ToDo:
* [ ] Tests
* [ ] Release-Notes