### PR TITLE
validation: Consistently use FormatStateMessage

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3489,7 +3489,7 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         }
         if (!ret) {
             GetMainSignals().BlockChecked(*pblock, state);
-            return error("%s: AcceptBlock FAILED (%s)", __func__, state.GetDebugMessage());
+            return error("%s: AcceptBlock FAILED (%s)", __func__, FormatStateMessage(state));
         }
     }
 


### PR DESCRIPTION
To output CValidationState info.

This includes the reject reason and code as well as debug info.

Previously converted in #12356, but these snuck in since.