### PR TITLE
Make vpwallets usage thread safe

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -34,10 +34,12 @@
 
 #include <boost/algorithm/string/replace.hpp>
 
-static std::vector<CWallet*> vpwallets;
+static CCriticalSection cs_wallets;
+static std::vector<CWallet*> vpwallets GUARDED_BY(cs_wallets);
 
 bool AddWallet(CWallet* wallet)
 {
+    LOCK(cs_wallets);
     assert(wallet);
     std::vector<CWallet*>::const_iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
     if (i != vpwallets.end()) return false;
@@ -47,6 +49,7 @@ bool AddWallet(CWallet* wallet)
 
 bool RemoveWallet(CWallet* wallet)
 {
+    LOCK(cs_wallets);
     assert(wallet);
     std::vector<CWallet*>::iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
     if (i == vpwallets.end()) return false;
@@ -56,16 +59,19 @@ bool RemoveWallet(CWallet* wallet)
 
 bool HasWallets()
 {
+    LOCK(cs_wallets);
     return !vpwallets.empty();
 }
 
 std::vector<CWallet*> GetWallets()
 {
+    LOCK(cs_wallets);
     return vpwallets;
 }
 
 CWallet* GetWallet(const std::string& name)
 {
+    LOCK(cs_wallets);
     for (CWallet* wallet : vpwallets) {
         if (wallet->GetName() == name) return wallet;
     }


### PR DESCRIPTION
This PR turns the functions introduced in #13017 thread safe. This is required to correctly support dynamically loading wallets, which is implemented in #10740.