### PR TITLE
Interpret absense of prune= as prune=1 if there are pruned blocks

### DIFF
--- a/doc/release-notes-pr13029.md
+++ b/doc/release-notes-pr13029.md
@@ -1,0 +1,3 @@
+Low-level RPC changes
+---------------------
+- If there are pruned blocks, absence of `prune=` is interpreted as `prune=1`.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -378,7 +378,7 @@ void SetupServerArgs()
 #endif
     gArgs.AddArg("-prune=<n>", strprintf("Reduce storage requirements by enabling pruning (deleting) of old blocks. This allows the pruneblockchain RPC to be called to delete specific blocks, and enables automatic pruning of old blocks if a target size in MiB is provided. This mode is incompatible with -txindex and -rescan. "
             "Warning: Reverting this setting requires re-downloading the entire blockchain. "
-            "(default: 0 = disable pruning blocks, 1 = allow manual pruning via RPC, >%u = automatically prune block files to stay under the specified target size in MiB)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024), false, OptionsCategory::OPTIONS);
+            "(0 = disable pruning blocks, 1 = allow manual pruning via RPC, >%u = automatically prune block files to stay under the specified target size in MiB, default: 0, or 1 if there are pruned blocks)", MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-reindex", "Rebuild chain state and block index from the blk*.dat files on disk", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-reindex-chainstate", "Rebuild chain state from the currently indexed blocks", false, OptionsCategory::OPTIONS);
 #ifndef WIN32
@@ -908,8 +908,9 @@ bool AppInitParameterInteraction()
         return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist.\n"), gArgs.GetArg("-blocksdir", "").c_str()));
     }
 
-    // if using block pruning, then disallow txindex
-    if (gArgs.GetArg("-prune", 0)) {
+    // If using block pruning, then disallow txindex. Because pruning can be
+    // implictly enabled, this check is repeated once fHavePruned is known.
+    if (gArgs.IsArgSet("-prune") && gArgs.GetArg("-prune", 0)) {
         if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX))
             return InitError(_("Prune mode is incompatible with -txindex."));
     }
@@ -1034,16 +1035,18 @@ bool AppInitParameterInteraction()
         return InitError(_("Prune cannot be configured with a negative value."));
     }
     nPruneTarget = (uint64_t) nPruneArg * 1024 * 1024;
-    if (nPruneArg == 1) {  // manual pruning: -prune=1
+    if (gArgs.IsArgSet("-prune") && nPruneArg == 0) { // pruning explicitly disabled
+        fPruneMode = PruneMode::DISABLED;
+    } else if (nPruneArg == 1) {  // manual pruning: -prune=1
         LogPrintf("Block pruning enabled.  Use RPC call pruneblockchain(height) to manually prune block and undo files.\n");
         nPruneTarget = std::numeric_limits<uint64_t>::max();
-        fPruneMode = true;
+        fPruneMode = PruneMode::ENABLED;
     } else if (nPruneTarget) {
         if (nPruneTarget < MIN_DISK_SPACE_FOR_BLOCK_FILES) {
             return InitError(strprintf(_("Prune configured below the minimum of %d MiB.  Please use a higher number."), MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
         }
         LogPrintf("Prune configured to target %uMiB on disk for block and undo files.\n", nPruneTarget / 1024 / 1024);
-        fPruneMode = true;
+        fPruneMode = PruneMode::ENABLED;
     }
 
     nConnectTimeout = gArgs.GetArg("-timeout", DEFAULT_CONNECT_TIMEOUT);
@@ -1436,9 +1439,12 @@ bool AppInitMain()
 
                 if (fReset) {
                     pblocktree->WriteReindexing(true);
-                    //If we're reindexing in prune mode, wipe away unusable block files and all undo data files
-                    if (fPruneMode)
-                        CleanupBlockRevFiles();
+                    // If we're reindexing in prune mode, wipe away unusable block files and all undo data files
+                    // This is skipped if there are pruned blocks but prune= is currently not set.
+                    assert(fPruneMode != PruneMode::UNKNOWN || !gArgs.IsArgSet("-prune"));
+                    if ((fPruneMode != PruneMode::UNKNOWN && gArgs.GetArg("-prune", 0)) || fPruneMode == PruneMode::ENABLED) {
+                      CleanupBlockRevFiles();
+                    }
                 }
 
                 if (fRequestShutdown) break;
@@ -1452,6 +1458,24 @@ bool AppInitMain()
                     break;
                 }
 
+                // If prune= is not set but blocks have previously been pruned,
+                // behave as if prune=1, otherwise behave as if prune=0.
+                if (fPruneMode == PruneMode::UNKNOWN && !gArgs.IsArgSet("-prune")) {
+                    if (fHavePruned) {
+                        fPruneMode = PruneMode::ENABLED;
+                        // Repeat check from AppInitParameterInteraction:
+                        if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
+                            return InitError(_("Prune mode is incompatible with -txindex."));
+                        }
+                        // Repeat check from WalletInit::AppInitParameterInteraction:
+                        if (gArgs.GetBoolArg("-rescan", false)) {
+                            return InitError(_("Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again."));
+                        }
+                    } else {
+                        fPruneMode = PruneMode::DISABLED;
+                    }
+                }
+
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
                 if (!mapBlockIndex.empty() && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
@@ -1460,7 +1484,8 @@ bool AppInitMain()
 
                 // Check for changed -prune state.  What we are concerned about is a user who has pruned blocks
                 // in the past, but is now trying to run unpruned.
-                if (fHavePruned && !fPruneMode) {
+                assert(fPruneMode != PruneMode::UNKNOWN);
+                if (fHavePruned && fPruneMode == PruneMode::DISABLED) {
                     strLoadError = _("You need to rebuild the database using -reindex to go back to unpruned mode.  This will redownload the entire blockchain");
                     break;
                 }
@@ -1601,7 +1626,8 @@ bool AppInitMain()
 
     // if pruning, unset the service bit and perform the initial blockstore prune
     // after any wallet rescanning has taken place.
-    if (fPruneMode) {
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    if (fPruneMode == PruneMode::ENABLED) {
         LogPrintf("Unsetting NODE_NETWORK on prune mode\n");
         nLocalServices = ServiceFlags(nLocalServices & ~NODE_NETWORK);
         if (!fReindex) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2039,9 +2039,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
             // for some reasonable time window (1 hour) that block relay might require.
+            assert(fPruneMode != PruneMode::UNKNOWN);
             const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / chainparams.GetConsensus().nPowTargetSpacing;
-            if (fPruneMode && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= chainActive.Tip()->nHeight - nPrunedBlocksLikelyToHave))
-            {
+            if (fPruneMode == PruneMode::ENABLED && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= chainActive.Tip()->nHeight - nPrunedBlocksLikelyToHave)) {
                 LogPrint(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -924,8 +924,10 @@ static UniValue pruneblockchain(const JSONRPCRequest& request)
             + HelpExampleCli("pruneblockchain", "1000")
             + HelpExampleRpc("pruneblockchain", "1000"));
 
-    if (!fPruneMode)
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    if (fPruneMode == PruneMode::DISABLED) {
         throw JSONRPCError(RPC_MISC_ERROR, "Cannot prune blocks because node is not in prune mode.");
+    }
 
     LOCK(cs_main);
 
@@ -1246,8 +1248,9 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     obj.pushKV("initialblockdownload",  IsInitialBlockDownload());
     obj.pushKV("chainwork",             chainActive.Tip()->nChainWork.GetHex());
     obj.pushKV("size_on_disk",          CalculateCurrentUsage());
-    obj.pushKV("pruned",                fPruneMode);
-    if (fPruneMode) {
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    obj.pushKV("pruned",                fPruneMode == PruneMode::ENABLED);
+    if (fPruneMode == PruneMode::ENABLED) {
         CBlockIndex* block = chainActive.Tip();
         assert(block);
         while (block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA)) {
@@ -1256,6 +1259,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
 
         obj.pushKV("pruneheight",        block->nHeight);
 
+        assert(fPruneMode != PruneMode::UNKNOWN);
         // if 0, execution bypasses the whole if block.
         bool automatic_pruning = (gArgs.GetArg("-prune", 0) != 1);
         obj.pushKV("automatic_pruning",  automatic_pruning);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -76,6 +76,9 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         fs::create_directories(pathTemp);
         gArgs.ForceSetArg("-datadir", pathTemp.string());
 
+        // All tests currently assume an unpruned node:
+        fPruneMode = PruneMode::DISABLED;
+
         // We have to run a scheduler thread to prevent ActivateBestChain
         // from blocking due to queue overrun.
         threadGroup.create_thread(boost::bind(&CScheduler::serviceQueue, &scheduler));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -225,7 +225,7 @@ int nScriptCheckThreads = 0;
 std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fHavePruned = false;
-bool fPruneMode = false;
+PruneMode fPruneMode = PruneMode::UNKNOWN;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;
@@ -2131,7 +2131,8 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
         bool fFlushForPrune = false;
         bool fDoFullFlush = false;
         LOCK(cs_LastBlockFile);
-        if (fPruneMode && (fCheckForPruning || nManualPruneHeight > 0) && !fReindex) {
+        assert(fPruneMode != PruneMode::UNKNOWN);
+        if (fPruneMode == PruneMode::ENABLED && (fCheckForPruning || nManualPruneHeight > 0) && !fReindex) {
             if (nManualPruneHeight > 0) {
                 FindFilesToPruneManual(setFilesToPrune, nManualPruneHeight);
             } else {
@@ -3042,8 +3043,10 @@ static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int
         unsigned int nOldChunks = (pos.nPos + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
         unsigned int nNewChunks = (vinfoBlockFile[nFile].nSize + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
         if (nNewChunks > nOldChunks) {
-            if (fPruneMode)
+            assert(fPruneMode != PruneMode::UNKNOWN);
+            if (fPruneMode == PruneMode::ENABLED) {
                 fCheckForPruning = true;
+            }
             if (CheckDiskSpace(nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos, true)) {
                 FILE *file = OpenBlockFile(pos);
                 if (file) {
@@ -3075,8 +3078,10 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
     unsigned int nOldChunks = (pos.nPos + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
     unsigned int nNewChunks = (nNewSize + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
     if (nNewChunks > nOldChunks) {
-        if (fPruneMode)
+        assert(fPruneMode != PruneMode::UNKNOWN);
+        if (fPruneMode == PruneMode::ENABLED) {
             fCheckForPruning = true;
+        }
         if (CheckDiskSpace(nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos, true)) {
             FILE *file = OpenUndoFile(pos);
             if (file) {
@@ -3671,7 +3676,8 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune)
 /* Calculate the block/rev files to delete based on height specified by user with RPC command pruneblockchain */
 static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight)
 {
-    assert(fPruneMode && nManualPruneHeight > 0);
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    assert(fPruneMode == PruneMode::ENABLED && nManualPruneHeight > 0);
 
     LOCK2(cs_main, cs_LastBlockFile);
     if (chainActive.Tip() == nullptr)
@@ -4008,7 +4014,8 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         uiInterface.ShowProgress(_("Verifying blocks..."), percentageDone, false);
         if (pindex->nHeight < chainActive.Height()-nCheckDepth)
             break;
-        if (fPruneMode && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
+        assert(fPruneMode != PruneMode::UNKNOWN);
+        if (fPruneMode == PruneMode::ENABLED && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
             // If pruning, only go back as far as we have data.
             LogPrintf("VerifyDB(): block verification stopping at height %d (pruning, no data)\n", pindex->nHeight);
             break;
@@ -4183,7 +4190,8 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
     CValidationState state;
     CBlockIndex* pindex = chainActive.Tip();
     while (chainActive.Height() >= nHeight) {
-        if (fPruneMode && !(chainActive.Tip()->nStatus & BLOCK_HAVE_DATA)) {
+        assert(fPruneMode != PruneMode::UNKNOWN);
+        if (fPruneMode == PruneMode::ENABLED && !(chainActive.Tip()->nStatus & BLOCK_HAVE_DATA)) {
             // If pruning, don't try rewinding past the HAVE_DATA point;
             // since older blocks can't be served anyway, there's
             // no need to walk further, and trying to DisconnectTip()

--- a/src/validation.h
+++ b/src/validation.h
@@ -197,10 +197,18 @@ extern CBlockIndex *pindexBestHeader;
 static const uint64_t nMinDiskSpace = 52428800;
 
 /** Pruning-related variables and constants */
+enum class PruneMode {
+    UNKNOWN,  // -prune is absent or has not been parsed yet
+    DISABLED, // -prune=0
+    ENABLED   // -prune=N or blocks have been pruned in the past
+};
+
+/** Whether we're running in -prune mode */
+extern PruneMode fPruneMode;
+
 /** True if any block files have ever been pruned. */
 extern bool fHavePruned;
-/** True if we're running in -prune mode. */
-extern bool fPruneMode;
+
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -135,7 +135,9 @@ bool WalletInit::ParameterInteraction() const
 
     if (gArgs.GetBoolArg("-sysperms", false))
         return InitError("-sysperms is not allowed in combination with enabled wallet functionality");
-    if (gArgs.GetArg("-prune", 0) && gArgs.GetBoolArg("-rescan", false))
+
+    // Because pruning can be implictly enabled, this check is repeated once fHavePruned is known.
+    if (gArgs.IsArgSet("-prune") && gArgs.GetArg("-prune", 0) && gArgs.GetBoolArg("-rescan", false))
         return InitError(_("Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again."));
 
     if (::minRelayTxFee.GetFeePerK() > HIGH_TX_FEE_PER_KB)

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -136,7 +136,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
         if (!request.params[2].isNull())
             fRescan = request.params[2].get_bool();
 
-        if (fRescan && fPruneMode)
+        assert(fPruneMode != PruneMode::UNKNOWN);
+        if (fRescan && fPruneMode == PruneMode::ENABLED)
             throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
         if (fRescan && !reserver.reserve()) {
@@ -287,7 +288,8 @@ UniValue importaddress(const JSONRPCRequest& request)
     if (!request.params[2].isNull())
         fRescan = request.params[2].get_bool();
 
-    if (fRescan && fPruneMode)
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    if (fRescan && fPruneMode == PruneMode::ENABLED)
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     WalletRescanReserver reserver(pwallet);
@@ -470,7 +472,8 @@ UniValue importpubkey(const JSONRPCRequest& request)
     if (!request.params[2].isNull())
         fRescan = request.params[2].get_bool();
 
-    if (fRescan && fPruneMode)
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    if (fRescan && fPruneMode == PruneMode::ENABLED)
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     WalletRescanReserver reserver(pwallet);
@@ -533,8 +536,10 @@ UniValue importwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("importwallet", "\"test\"")
         );
 
-    if (fPruneMode)
+      assert(fPruneMode != PruneMode::UNKNOWN);
+      if (fPruneMode == PruneMode::ENABLED) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Importing wallets is disabled in pruned mode");
+      }
 
     WalletRescanReserver reserver(pwallet);
     if (!reserver.reserve()) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3854,7 +3854,8 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
     }
 
     // We can't rescan beyond non-pruned blocks, stop and throw an error
-    if (fPruneMode) {
+    assert(fPruneMode != PruneMode::UNKNOWN);
+    if (fPruneMode == PruneMode::ENABLED) {
         LOCK(cs_main);
         CBlockIndex *block = pindexStop ? pindexStop : pChainTip;
         while (block && block->nHeight >= pindexStart->nHeight) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4278,8 +4278,8 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         //We can't rescan beyond non-pruned blocks, stop and throw an error
         //this might happen if a user uses an old wallet within a pruned node
         // or if he ran -disablewallet for a longer time, then decided to re-enable
-        if (fPruneMode)
-        {
+        assert(fPruneMode != PruneMode::UNKNOWN);
+        if (fPruneMode == PruneMode::ENABLED) {
             CBlockIndex *block = chainActive.Tip();
             while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA) && block->pprev->nTx > 0 && pindexRescan != block)
                 block = block->pprev;


### PR DESCRIPTION
`bool fPruneMode` is replaced by an enum class to include an `UNKNOWN` state.

`fHavePruned` is used to set `fPruneNode` if argument is not explictly set.