### PR TITLE
Fix for utiltime to compile with msvc.

### DIFF
--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -79,20 +79,32 @@ void MilliSleep(int64_t n)
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
+#ifdef _MSC_VER
+    gmtime_s(&ts, &time_val);
+#else
     gmtime_r(&time_val, &ts);
+#endif
     return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
+#ifdef _MSC_VER
+    gmtime_s(&ts, &time_val);
+#else
     gmtime_r(&time_val, &ts);
+#endif
     return strprintf("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
 }
 
 std::string FormatISO8601Time(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
+#ifdef _MSC_VER
+    gmtime_s(&ts, &time_val);
+#else
     gmtime_r(&time_val, &ts);
+#endif
     return strprintf("%02i:%02i:%02iZ", ts.tm_hour, ts.tm_min, ts.tm_sec);
 }


### PR DESCRIPTION
This PR allows utiltime.cpp to compile with msvc after the changes introduced in #12973.