### PR TITLE
Introduce WalletManager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -176,6 +176,7 @@ BITCOIN_CORE_H = \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletdb.h \
+  wallet/walletmanager.h \
   wallet/walletutil.h \
   wallet/coinselection.h \
   warnings.h \
@@ -259,6 +260,7 @@ libbitcoin_wallet_a_SOURCES = \
   wallet/rpcwallet.cpp \
   wallet/wallet.cpp \
   wallet/walletdb.cpp \
+  wallet/walletmanager.cpp \
   wallet/walletutil.cpp \
   wallet/coinselection.cpp \
   $(BITCOIN_CORE_H)

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -34,6 +34,7 @@
 #ifdef ENABLE_WALLET
 #include <wallet/fees.h>
 #include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 #define CHECK_WALLET(x) x
 #else
 #define CHECK_WALLET(x) throw std::logic_error("Wallet function called in non-wallet build.")
@@ -222,7 +223,7 @@ class NodeImpl : public Node
     {
 #ifdef ENABLE_WALLET
         std::vector<std::unique_ptr<Wallet>> wallets;
-        for (CWallet* wallet : GetWallets()) {
+        for (CWallet* wallet : g_wallet_manager.GetWallets()) {
             wallets.emplace_back(MakeWallet(*wallet));
         }
         return wallets;

--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -11,6 +11,7 @@
 #include <qt/platformstyle.h>
 #include <qt/qvalidatedlineedit.h>
 #include <qt/walletmodel.h>
+#include <wallet/walletmanager.h>
 
 #include <key.h>
 #include <pubkey.h>
@@ -103,9 +104,9 @@ void TestAddAddressesToSendBook()
     std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);
-    AddWallet(&wallet);
+    g_wallet_manager.AddWallet(&wallet);
     WalletModel walletModel(std::move(node->getWallets()[0]), *node, platformStyle.get(), &optionsModel);
-    RemoveWallet(&wallet);
+    g_wallet_manager.RemoveWallet(&wallet);
     EditAddressDialog editAddressDialog(EditAddressDialog::NewSendingAddress);
     editAddressDialog.setModel(walletModel.getAddressTableModel());
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -16,6 +16,7 @@
 #include <test/test_bitcoin.h>
 #include <validation.h>
 #include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 #include <qt/overviewpage.h>
 #include <qt/receivecoinsdialog.h>
 #include <qt/recentrequeststablemodel.h>
@@ -166,9 +167,9 @@ void TestGUI()
     TransactionView transactionView(platformStyle.get());
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);
-    AddWallet(&wallet);
+    g_wallet_manager.AddWallet(&wallet);
     WalletModel walletModel(std::move(node->getWallets().back()), *node, platformStyle.get(), &optionsModel);
-    RemoveWallet(&wallet);
+    g_wallet_manager.RemoveWallet(&wallet);
     sendCoinsDialog.setModel(&walletModel);
     transactionView.setModel(&walletModel);
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -23,6 +23,7 @@
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
+#include <wallet/walletmanager.h>
 #endif
 #include <warnings.h>
 
@@ -69,7 +70,7 @@ UniValue validateaddress(const JSONRPCRequest& request)
     {
 
 #ifdef ENABLE_WALLET
-        if (HasWallets() && IsDeprecatedRPCEnabled("validateaddress")) {
+        if (g_wallet_manager.HasWallets() && IsDeprecatedRPCEnabled("validateaddress")) {
             ret.pushKVs(getaddressinfo(request));
         }
 #endif

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -12,6 +12,7 @@
 #include <walletinitinterface.h>
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 #include <wallet/walletutil.h>
 
 class WalletInit : public WalletInitInterface {
@@ -263,7 +264,7 @@ bool WalletInit::Open() const
         if (!pwallet) {
             return false;
         }
-        AddWallet(pwallet);
+        g_wallet_manager.AddWallet(pwallet);
     }
 
     return true;
@@ -271,29 +272,29 @@ bool WalletInit::Open() const
 
 void WalletInit::Start(CScheduler& scheduler) const
 {
-    for (CWallet* pwallet : GetWallets()) {
+    for (CWallet* pwallet : g_wallet_manager.GetWallets()) {
         pwallet->postInitProcess(scheduler);
     }
 }
 
 void WalletInit::Flush() const
 {
-    for (CWallet* pwallet : GetWallets()) {
+    for (CWallet* pwallet : g_wallet_manager.GetWallets()) {
         pwallet->Flush(false);
     }
 }
 
 void WalletInit::Stop() const
 {
-    for (CWallet* pwallet : GetWallets()) {
+    for (CWallet* pwallet : g_wallet_manager.GetWallets()) {
         pwallet->Flush(true);
     }
 }
 
 void WalletInit::Close() const
 {
-    for (CWallet* pwallet : GetWallets()) {
-        RemoveWallet(pwallet);
+    for (CWallet* pwallet : g_wallet_manager.GetWallets()) {
+        g_wallet_manager.RemoveWallet(pwallet);
         delete pwallet;
     }
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -28,6 +28,7 @@
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
+#include <wallet/walletmanager.h>
 #include <wallet/walletutil.h>
 
 #include <init.h>  // For StartShutdown
@@ -45,12 +46,12 @@ CWallet *GetWalletForJSONRPCRequest(const JSONRPCRequest& request)
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used
         std::string requestedWallet = urlDecode(request.URI.substr(WALLET_ENDPOINT_BASE.size()));
-        CWallet* pwallet = GetWallet(requestedWallet);
+        CWallet* pwallet = g_wallet_manager.GetWallet(requestedWallet);
         if (!pwallet) throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Requested wallet does not exist or is not loaded");
         return pwallet;
     }
 
-    std::vector<CWallet*> wallets = GetWallets();
+    std::vector<CWallet*> wallets = g_wallet_manager.GetWallets();
     return wallets.size() == 1 || (request.fHelp && wallets.size() > 0) ? wallets[0] : nullptr;
 }
 
@@ -65,7 +66,7 @@ bool EnsureWalletIsAvailable(CWallet * const pwallet, bool avoidException)
 {
     if (pwallet) return true;
     if (avoidException) return false;
-    if (!HasWallets()) {
+    if (!g_wallet_manager.HasWallets()) {
         // Note: It isn't currently possible to trigger this error because
         // wallet RPC methods aren't registered unless a wallet is loaded. But
         // this error is being kept as a precaution, because it's possible in
@@ -2984,7 +2985,7 @@ UniValue listwallets(const JSONRPCRequest& request)
 
     UniValue obj(UniValue::VARR);
 
-    for (CWallet* pwallet : GetWallets()) {
+    for (CWallet* pwallet : g_wallet_manager.GetWallets()) {
         if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
             return NullUniValue;
         }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -15,6 +15,7 @@
 #include <test/test_bitcoin.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
+#include <wallet/walletmanager.h>
 #include <wallet/test/wallet_test_fixture.h>
 
 #include <boost/test/unit_test.hpp>
@@ -74,7 +75,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
     // after.
     {
         CWallet wallet("dummy", WalletDatabase::CreateDummy());
-        AddWallet(&wallet);
+        g_wallet_manager.AddWallet(&wallet);
         UniValue keys;
         keys.setArray();
         UniValue key;
@@ -105,7 +106,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
                       "downloading and rescanning the relevant blocks (see -reindex and -rescan "
                       "options).\"}},{\"success\":true}]",
                               0, oldTip->GetBlockTimeMax(), TIMESTAMP_WINDOW));
-        RemoveWallet(&wallet);
+        g_wallet_manager.RemoveWallet(&wallet);
     }
 }
 
@@ -140,9 +141,9 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        AddWallet(&wallet);
+        g_wallet_manager.AddWallet(&wallet);
         ::dumpwallet(request);
-        RemoveWallet(&wallet);
+        g_wallet_manager.RemoveWallet(&wallet);
     }
 
     // Call importwallet RPC and verify all blocks with timestamps >= BLOCK_TIME
@@ -153,9 +154,9 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         JSONRPCRequest request;
         request.params.setArray();
         request.params.push_back((pathTemp / "wallet.backup").string());
-        AddWallet(&wallet);
+        g_wallet_manager.AddWallet(&wallet);
         ::importwallet(request);
-        RemoveWallet(&wallet);
+        g_wallet_manager.RemoveWallet(&wallet);
 
         LOCK(wallet.cs_wallet);
         BOOST_CHECK_EQUAL(wallet.mapWallet.size(), 3U);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -28,55 +28,11 @@
 #include <utilmoneystr.h>
 #include <wallet/fees.h>
 
-#include <algorithm>
 #include <assert.h>
 #include <future>
 
 #include <boost/algorithm/string/replace.hpp>
 
-static CCriticalSection cs_wallets;
-static std::vector<CWallet*> vpwallets GUARDED_BY(cs_wallets);
-
-bool AddWallet(CWallet* wallet)
-{
-    LOCK(cs_wallets);
-    assert(wallet);
-    std::vector<CWallet*>::const_iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
-    if (i != vpwallets.end()) return false;
-    vpwallets.push_back(wallet);
-    return true;
-}
-
-bool RemoveWallet(CWallet* wallet)
-{
-    LOCK(cs_wallets);
-    assert(wallet);
-    std::vector<CWallet*>::iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
-    if (i == vpwallets.end()) return false;
-    vpwallets.erase(i);
-    return true;
-}
-
-bool HasWallets()
-{
-    LOCK(cs_wallets);
-    return !vpwallets.empty();
-}
-
-std::vector<CWallet*> GetWallets()
-{
-    LOCK(cs_wallets);
-    return vpwallets;
-}
-
-CWallet* GetWallet(const std::string& name)
-{
-    LOCK(cs_wallets);
-    for (CWallet* wallet : vpwallets) {
-        if (wallet->GetName() == name) return wallet;
-    }
-    return nullptr;
-}
 
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -32,11 +32,6 @@
 #include <utility>
 #include <vector>
 
-bool AddWallet(CWallet* wallet);
-bool RemoveWallet(CWallet* wallet);
-bool HasWallets();
-std::vector<CWallet*> GetWallets();
-CWallet* GetWallet(const std::string& name);
 
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -15,6 +15,7 @@
 #include <util.h>
 #include <utiltime.h>
 #include <wallet/wallet.h>
+#include <wallet/walletmanager.h>
 
 #include <atomic>
 
@@ -756,7 +757,7 @@ void MaybeCompactWalletDB()
         return;
     }
 
-    for (CWallet* pwallet : GetWallets()) {
+    for (CWallet* pwallet : g_wallet_manager.GetWallets()) {
         WalletDatabase& dbh = pwallet->GetDBHandle();
 
         unsigned int nUpdateCounter = dbh.nUpdateCounter;

--- a/src/wallet/walletmanager.cpp
+++ b/src/wallet/walletmanager.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <wallet/walletmanager.h>
+
+#include <wallet/wallet.h>
+
+#include <algorithm>
+
+
+WalletManager g_wallet_manager;
+
+bool WalletManager::AddWallet(CWallet* wallet)
+{
+    LOCK(m_cs);
+    assert(wallet);
+    std::vector<CWallet*>::const_iterator i = std::find(m_wallets.begin(), m_wallets.end(), wallet);
+    if (i != m_wallets.end()) return false;
+    m_wallets.push_back(wallet);
+    return true;
+}
+
+bool WalletManager::RemoveWallet(CWallet* wallet)
+{
+    LOCK(m_cs);
+    assert(wallet);
+    std::vector<CWallet*>::iterator i = std::find(m_wallets.begin(), m_wallets.end(), wallet);
+    if (i == m_wallets.end()) return false;
+    m_wallets.erase(i);
+    return true;
+}
+
+bool WalletManager::HasWallets() const
+{
+    LOCK(m_cs);
+    return !m_wallets.empty();
+}
+
+std::vector<CWallet*> WalletManager::GetWallets() const
+{
+    LOCK(m_cs);
+    return m_wallets;
+}
+
+CWallet* WalletManager::GetWallet(const std::string& name) const
+{
+    LOCK(m_cs);
+    for (CWallet* wallet : m_wallets) {
+        if (wallet->GetName() == name) return wallet;
+    }
+    return nullptr;
+}

--- a/src/wallet/walletmanager.h
+++ b/src/wallet/walletmanager.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_WALLETMANAGER_H
+#define BITCOIN_WALLET_WALLETMANAGER_H
+
+#include <sync.h>
+
+#include <string>
+#include <vector>
+
+class CWallet;
+
+//! A thread safe wallet manager.
+class WalletManager final
+{
+    mutable CCriticalSection m_cs;
+    std::vector<CWallet*> m_wallets GUARDED_BY(m_cs);
+
+public:
+    WalletManager() = default;
+    WalletManager(const WalletManager&) = delete;
+    WalletManager& operator=(const WalletManager&) = delete;
+    ~WalletManager() = default;
+
+    //! Add wallet to the registered wallets.
+    bool AddWallet(CWallet* wallet);
+
+    //! Remove wallet from the registered wallets.
+    bool RemoveWallet(CWallet* wallet);
+
+    //! Check if there are registered wallets.
+    bool HasWallets() const;
+
+    //! Retrieve all registered wallets.
+    std::vector<CWallet*> GetWallets() const;
+
+    //! Retrieve wallet by name or nullptr if not found.
+    CWallet* GetWallet(const std::string& name) const;
+};
+
+//! Global wallet manager.
+extern WalletManager g_wallet_manager;
+
+#endif // BITCOIN_WALLET_WALLETMANAGER_H


### PR DESCRIPTION
This PR (re)introduces `WalletManager` but follows a different approach than #12587 by @jonasschnelli. It builds on top of #13028 and #13017.

A global `g_wallet_manager` instance is also added which is only available in builds with `ENABLE_WALLET`.

The goal here is to have a better place for all code that manages wallet instances, which will be useful for: 
 - wallet lifecycle;
 - wallet background tasks coordination (flush for instance);
 - src/interface/walletmanager.h for UI and process separation (@ryanofsky sgty?);
 - RPC wallet load/unload calls.