### PR TITLE
qt: Don't log to console by default

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -403,6 +403,10 @@ void BitcoinApplication::startThread()
 
 void BitcoinApplication::parameterSetup()
 {
+    // Default printtoconsole to false for the GUI. GUI programs should not
+    // print to the console unnecessarily.
+    gArgs.SoftSetBoolArg("-printtoconsole", false);
+
     m_node.initLogging();
     m_node.initParameterInteraction();
 }


### PR DESCRIPTION
Default `-printtoconsole` to false for the GUI. GUI programs should not print to the console unnecessarily. For example, when launched by the window manager, the output might end up in the X session log file,
resulting in duplicate logging. On Windows, it is pointless as well because bitcoin-qt isn't a console application.

This same mechanism is used to set `-server` to true by default for bitcoind: https://github.com/bitcoin/bitcoin/blob/master/src/bitcoind.cpp#L116

(fixes #13004)