### PR TITLE
Make tests pass after 2020

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -247,14 +247,14 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
     ar = r.get_array();
     BOOST_CHECK_EQUAL(ar.size(), 0U);
 
-    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 1607731200 true")));
+    BOOST_CHECK_NO_THROW(r = CallRPC(std::string("setban 127.0.0.0/24 add 9907731200 true")));
     BOOST_CHECK_NO_THROW(r = CallRPC(std::string("listbanned")));
     ar = r.get_array();
     o1 = ar[0].get_obj();
     adr = find_value(o1, "address");
     UniValue banned_until = find_value(o1, "banned_until");
     BOOST_CHECK_EQUAL(adr.get_str(), "127.0.0.0/24");
-    BOOST_CHECK_EQUAL(banned_until.get_int64(), 1607731200); // absolute time check
+    BOOST_CHECK_EQUAL(banned_until.get_int64(), 9907731200); // absolute time check
 
     BOOST_CHECK_NO_THROW(CallRPC(std::string("clearbanned")));
 


### PR DESCRIPTION
Make tests pass after 2020
and also test that 64 bit integers are properly handled

Without this patch, the failure was
```
unknown location(0): fatal error: in "rpc_tests/rpc_ban": std::runtime_error: JSON value is not an object as expected
test/rpc_tests.cpp(260): last checkpoint
```

I found this when testing reproducible builds for openSUSE Linux packages, building 15 years from now (this is the expected lifespan of today's software)

There is 1 other issue in ./src/qt/test/paymentservertests.cpp that fails to verify a cert that expires in 2022 after 10y.

```
QWARN  : PaymentServerTests::paymentServerTests() PaymentRequestPlus::getMerchant: Payment request: certificate expired or not yet active:  QSslCertificate("3", "01", "Ipbt+DxK8RDQd25/5ueXqw==", (), ("Payment Request Test Merchant"), QMap(), QDateTime(2012-12-10 16:37:24.000 UTC Qt::TimeSpec(UTC)), QDateTime(2022-12-08 16:37:24.000 UTC Qt::TimeSpec(UTC)))
FAIL!  : PaymentServerTests::paymentServerTests() Compared values are not the same
```