### PR TITLE
Make script interpreter independent from storage type CScript

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -2117,7 +2117,7 @@ size_t static WitnessSigOps(int witversion, Span<const unsigned char> witprogram
     return 0;
 }
 
-size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags)
+size_t CountWitnessSigOps(Span<const unsigned char> scriptSig, Span<const unsigned char> scriptPubKey, const CScriptWitness* witness, unsigned int flags)
 {
     static const CScriptWitness witnessEmpty;
 
@@ -2133,13 +2133,12 @@ size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey,
     }
 
     if (IsPayToScriptHash(scriptPubKey) && IsPushOnly(scriptSig)) {
-        CScript::const_iterator pc = scriptSig.begin();
-        std::vector<unsigned char> data;
-        while (pc < scriptSig.end()) {
+        Span<const unsigned char> pc = scriptSig;
+        Span<const unsigned char> subscript;
+        while (pc.size()) {
             opcodetype opcode;
-            scriptSig.GetOp(pc, opcode, data);
+            GetScriptOp(pc, opcode, &subscript);
         }
-        CScript subscript(data.begin(), data.end());
         if (IsWitnessProgram(subscript, witnessversion, witnessprogram)) {
             return WitnessSigOps(witnessversion, witnessprogram, witness ? *witness : witnessEmpty);
         }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -342,7 +342,7 @@ bool EvalScript(std::vector<std::vector<unsigned char>>& stack, Span<const unsig
 bool EvalScript(std::vector<std::vector<unsigned char>>& stack, Span<const unsigned char> script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
 bool VerifyScript(Span<const unsigned char> scriptSig, Span<const unsigned char> scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
 
-size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags);
+size_t CountWitnessSigOps(Span<const unsigned char> scriptSig, Span<const unsigned char> scriptPubKey, const CScriptWitness* witness, unsigned int flags);
 
 int FindAndDelete(CScript& script, const CScript& b);
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -338,8 +338,8 @@ uint256 ComputeTapleafHash(uint8_t leaf_version, const CScript& script);
  *  Requires control block to have valid length (33 + k*32, with k in {0,1,..,128}). */
 uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash);
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
+bool EvalScript(std::vector<std::vector<unsigned char>>& stack, Span<const unsigned char> script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
+bool EvalScript(std::vector<std::vector<unsigned char>>& stack, Span<const unsigned char> script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
 bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
 
 size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags);

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -333,14 +333,14 @@ public:
 };
 
 /** Compute the BIP341 tapleaf hash from leaf version & script. */
-uint256 ComputeTapleafHash(uint8_t leaf_version, const CScript& script);
+uint256 ComputeTapleafHash(uint8_t leaf_version, Span<const unsigned char> script);
 /** Compute the BIP341 taproot script tree Merkle root from control block and leaf hash.
  *  Requires control block to have valid length (33 + k*32, with k in {0,1,..,128}). */
 uint256 ComputeTaprootMerkleRoot(Span<const unsigned char> control, const uint256& tapleaf_hash);
 
 bool EvalScript(std::vector<std::vector<unsigned char>>& stack, Span<const unsigned char> script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptExecutionData& execdata, ScriptError* error = nullptr);
 bool EvalScript(std::vector<std::vector<unsigned char>>& stack, Span<const unsigned char> script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* error = nullptr);
-bool VerifyScript(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
+bool VerifyScript(Span<const unsigned char> scriptSig, Span<const unsigned char> scriptPubKey, const CScriptWitness* witness, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror = nullptr);
 
 size_t CountWitnessSigOps(const CScript& scriptSig, const CScript& scriptPubKey, const CScriptWitness* witness, unsigned int flags);
 

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -334,7 +334,7 @@ bool IsOpSuccess(const opcodetype& opcode)
            (opcode >= 187 && opcode <= 254);
 }
 
-bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode) {
+bool CheckMinimalPush(Span<const unsigned char> data, opcodetype opcode) {
     // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal
     assert(0 <= opcode && opcode <= OP_PUSHDATA4);
     if (data.size() == 0) {

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -5,6 +5,7 @@
 
 #include <script/script.h>
 
+#include <span.h>
 #include <util/strencodings.h>
 
 #include <string>
@@ -280,18 +281,15 @@ bool CScript::HasValidOps() const
     return true;
 }
 
-bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet)
+bool GetScriptOp(Span<const unsigned char>& script, opcodetype& opcodeRet, Span<const unsigned char>* data_out)
 {
     opcodeRet = OP_INVALIDOPCODE;
-    if (pvchRet)
-        pvchRet->clear();
-    if (pc >= end)
-        return false;
+    if (data_out) *data_out = {};
 
     // Read instruction
-    if (end - pc < 1)
-        return false;
-    unsigned int opcode = *pc++;
+    if (script.size() < 1) return false;
+    unsigned int opcode = script.front();
+    script = script.subspan(1);
 
     // Immediate operand
     if (opcode <= OP_PUSHDATA4)
@@ -303,29 +301,25 @@ bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator en
         }
         else if (opcode == OP_PUSHDATA1)
         {
-            if (end - pc < 1)
-                return false;
-            nSize = *pc++;
+            if (script.size() < 1) return false;
+            nSize = script.front();
+            script = script.subspan(1);
         }
         else if (opcode == OP_PUSHDATA2)
         {
-            if (end - pc < 2)
-                return false;
-            nSize = ReadLE16(&pc[0]);
-            pc += 2;
+            if (script.size() < 2) return false;
+            nSize = ReadLE16(script.data());
+            script = script.subspan(2);
         }
         else if (opcode == OP_PUSHDATA4)
         {
-            if (end - pc < 4)
-                return false;
-            nSize = ReadLE32(&pc[0]);
-            pc += 4;
+            if (script.size() < 4) return false;
+            nSize = ReadLE32(script.data());
+            script = script.subspan(4);
         }
-        if (end - pc < 0 || (unsigned int)(end - pc) < nSize)
-            return false;
-        if (pvchRet)
-            pvchRet->assign(pc, pc + nSize);
-        pc += nSize;
+        if (script.size() < nSize) return false;
+        if (data_out) *data_out = script.first(nSize);
+        script = script.subspan(nSize);
     }
 
     opcodeRet = static_cast<opcodetype>(opcode);
@@ -363,4 +357,15 @@ bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode)
         return opcode == OP_PUSHDATA2;
     }
     return true;
+}
+
+bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet)
+{
+    if (pc >= end) return false;
+    Span<const unsigned char> script(&*pc, end - pc);
+    Span<const unsigned char> data;
+    bool ret = GetScriptOp(script, opcodeRet, &data);
+    if (pvchRet) pvchRet->assign(data.begin(), data.end());
+    pc = end - script.size();
+    return ret;
 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -536,7 +536,7 @@ public:
     bool IsPayToWitnessScriptHash() const;
     bool IsWitnessProgram(int& version, std::vector<unsigned char>& program) const;
 
-    /** Called by IsStandardTx and P2SH/BIP62 VerifyScript (which makes it consensus-critical). */
+    /** Called by IsStandardTx. */
     bool IsPushOnly(const_iterator pc) const;
     bool IsPushOnly() const;
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -460,7 +460,7 @@ public:
         return *this;
     }
 
-    CScript& operator<<(const std::vector<unsigned char>& b) LIFETIMEBOUND
+    CScript& operator<<(const Span<const unsigned char>& b) LIFETIMEBOUND
     {
         if (b.size() < OP_PUSHDATA1)
         {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -580,7 +580,7 @@ struct CScriptWitness
 /** Test for OP_SUCCESSx opcodes as defined by BIP342. */
 bool IsOpSuccess(const opcodetype& opcode);
 
-bool CheckMinimalPush(const std::vector<unsigned char>& data, opcodetype opcode);
+bool CheckMinimalPush(Span<const unsigned char> data, opcodetype opcode);
 
 /** Build a script by concatenating other scripts, or any argument accepted by CScript::operator<<. */
 template<typename... Ts>

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -10,6 +10,7 @@
 #include <crypto/common.h>
 #include <prevector.h>
 #include <serialize.h>
+#include <span.h>
 
 #include <assert.h>
 #include <climits>
@@ -404,6 +405,7 @@ private:
  */
 typedef prevector<28, unsigned char> CScriptBase;
 
+bool GetScriptOp(Span<const unsigned char>& script, opcodetype& opcodeRet, Span<const unsigned char>* data_out);
 bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet);
 
 /** Serialized script, used inside transaction inputs and outputs */

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -10,7 +10,7 @@
 #include <string.h>
 
 template <unsigned int BITS>
-base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
+base_blob<BITS>::base_blob(Span<const unsigned char> vch)
 {
     assert(vch.size() == sizeof(m_data));
     memcpy(m_data, vch.data(), sizeof(m_data));
@@ -67,14 +67,14 @@ std::string base_blob<BITS>::ToString() const
 }
 
 // Explicit instantiations for base_blob<160>
-template base_blob<160>::base_blob(const std::vector<unsigned char>&);
+template base_blob<160>::base_blob(Span<const unsigned char>);
 template std::string base_blob<160>::GetHex() const;
 template std::string base_blob<160>::ToString() const;
 template void base_blob<160>::SetHex(const char*);
 template void base_blob<160>::SetHex(const std::string&);
 
 // Explicit instantiations for base_blob<256>
-template base_blob<256>::base_blob(const std::vector<unsigned char>&);
+template base_blob<256>::base_blob(Span<const unsigned char>);
 template std::string base_blob<256>::GetHex() const;
 template std::string base_blob<256>::ToString() const;
 template void base_blob<256>::SetHex(const char*);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -28,7 +28,7 @@ public:
     /* constructor for constants between 1 and 255 */
     constexpr explicit base_blob(uint8_t v) : m_data{v} {}
 
-    explicit base_blob(const std::vector<unsigned char>& vch);
+    explicit base_blob(Span<const unsigned char> vch);
 
     bool IsNull() const
     {
@@ -115,7 +115,7 @@ public:
 class uint160 : public base_blob<160> {
 public:
     constexpr uint160() {}
-    explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
+    explicit uint160(Span<const unsigned char> vch) : base_blob<160>(vch) {}
 };
 
 /** 256-bit opaque blob.
@@ -127,7 +127,7 @@ class uint256 : public base_blob<256> {
 public:
     constexpr uint256() {}
     constexpr explicit uint256(uint8_t v) : base_blob<256>(v) {}
-    explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
+    explicit uint256(Span<const unsigned char> vch) : base_blob<256>(vch) {}
     static const uint256 ZERO;
     static const uint256 ONE;
 };


### PR DESCRIPTION
This introduces versions of `GetScriptOp`, `EvalScript`, and `VerifyScript` that operate on scripts represented by `Span<const unsigned char>`. This makes it possible to use different representation types for scripts, as Spans can be used to refer to scripts stored in any continuous fashion in memory, regardless of the container.

This is also a step towards reducing the consensus-criticalness of CScript, but not entirely. The interpreter code still uses CScript internally for a few purposes (notably `DecodeOP_N`, and `operator<<`).

Longer term, the goal is removing the need for all scripts to share the same representation. Currently `CScript` is a prevector with 28 preallocated bytes - a choice we need because it's favorable for scriptPubKeys in the UTXO cache, but it's pretty terrible for storing scriptSigs. With this change, separate (or even custom) data structures can be used for UTXO scriptPubKeys, and scriptPubKeys/scriptSigs in transactions. One possibility for the latter is storing all scripts in a transaction concatenated in a single allocated area, rather than using separate allocations for each.