### PR TITLE
[WIP] Unit test sub-directories - Continued

### DIFF
--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -6,11 +6,12 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <test/util_tests.h>
 #include <chainparams.h>
-#include <qt/test/rpcnestedtests.h>
-#include <util.h>
-#include <qt/test/uritests.h>
 #include <qt/test/compattests.h>
+#include <qt/test/rpcnestedtests.h>
+#include <qt/test/uritests.h>
+#include <util.h>
 
 #ifdef ENABLE_WALLET
 #include <qt/test/addressbooktests.h>
@@ -55,7 +56,7 @@ int main(int argc, char *argv[])
     SelectParams(CBaseChainParams::MAIN);
     noui_connect();
     ClearDatadirCache();
-    fs::path pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin-qt_%lu_%i", (unsigned long)GetTime(), (int)GetRand(100000));
+    fs::path pathTemp = util_tests::unit_test_directory("test_main");
     fs::create_directories(pathTemp);
     gArgs.ForceSetArg("-datadir", pathTemp.string());
 

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
         char key = 'k';
         uint256 in = InsecureRand256();
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         char key = 'i';
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         // The two keys are intentionally chosen for ordering
@@ -123,7 +123,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 BOOST_AUTO_TEST_CASE(existing_data_reindex)
 {
     // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     char buf[10];
 
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fs::path ph = util_tests::unit_test_directory("dbwrapper_tests");
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -4,19 +4,20 @@
 
 #include <test/test_bitcoin.h>
 
+#include <test/util_tests.h>
 #include <chainparams.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
-#include <validation.h>
 #include <miner.h>
 #include <net_processing.h>
 #include <pow.h>
-#include <ui_interface.h>
-#include <streams.h>
-#include <rpc/server.h>
 #include <rpc/register.h>
+#include <rpc/server.h>
 #include <script/sigcache.h>
+#include <streams.h>
+#include <ui_interface.h>
+#include <validation.h>
 
 void CConnmanTest::AddNode(CNode& node)
 {
@@ -72,9 +73,9 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
 
         RegisterAllCoreRPCCommands(tableRPC);
         ClearDatadirCache();
-        pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30)));
-        fs::create_directories(pathTemp);
-        gArgs.ForceSetArg("-datadir", pathTemp.string());
+        m_path_temp = util_tests::unit_test_directory("test_bitcoin");
+        fs::create_directories(m_path_temp);
+        gArgs.ForceSetArg("-datadir", m_path_temp.string());
 
         // We have to run a scheduler thread to prevent ActivateBestChain
         // from blocking due to queue overrun.
@@ -114,7 +115,7 @@ TestingSetup::~TestingSetup()
         pcoinsTip.reset();
         pcoinsdbview.reset();
         pblocktree.reset();
-        fs::remove_all(pathTemp);
+        fs::remove_all(m_path_temp);
 }
 
 TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_TEST_BITCOIN_H
 #define BITCOIN_TEST_TEST_BITCOIN_H
 
+#include <test/util_tests.h>
 #include <chainparamsbase.h>
 #include <fs.h>
 #include <key.h>
@@ -59,7 +60,7 @@ struct CConnmanTest {
 
 class PeerLogicValidation;
 struct TestingSetup: public BasicTestingSetup {
-    fs::path pathTemp;
+    fs::path m_path_temp;
     boost::thread_group threadGroup;
     CConnman* connman;
     CScheduler scheduler;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <util.h>
 
+#include <test/util_tests.h>
 #include <clientversion.h>
 #include <primitives/transaction.h>
 #include <sync.h>
@@ -20,6 +21,18 @@
 #endif
 
 #include <boost/test/unit_test.hpp>
+
+namespace util_tests {
+// Create and return temporary subdirectory for test outputs
+fs::path unit_test_directory(const std::string& fileName)
+{
+    std::string sub_dir = "bitcoin_unit_tests";
+    fs::path dir(fs::temp_directory_path() / sub_dir);
+    fs::path test_dir(dir / fileName / std::string(boost::unit_test::framework::current_test_case().p_name));
+
+    return test_dir;
+}
+} // namespace util_tests
 
 BOOST_FIXTURE_TEST_SUITE(util_tests, BasicTestingSetup)
 
@@ -1100,7 +1113,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
 
 BOOST_AUTO_TEST_CASE(test_LockDirectory)
 {
-    fs::path dirname = fs::temp_directory_path() / fs::unique_path();
+    fs::path dirname = unit_test_directory("util_tests");
     const std::string lockname = ".lock";
 #ifndef WIN32
     // Revert SIGCHLD to default, otherwise boost.test will catch and fail on

--- a/src/test/util_tests.h
+++ b/src/test/util_tests.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_TESTS_H
+#define BITCOIN_TEST_UTIL_TESTS_H
+
+#include <fs.h>
+
+namespace util_tests {
+    fs::path unit_test_directory(const std::string& fileName);
+}; //namespace util_tests
+
+#endif // BITCOIN_TEST_UTIL_TESTS_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back((m_path_temp / "wallet.backup").string());
         AddWallet(wallet);
         ::dumpwallet(request);
         RemoveWallet(wallet);
@@ -152,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back((m_path_temp / "wallet.backup").string());
         AddWallet(wallet);
         ::importwallet(request);
         RemoveWallet(wallet);


### PR DESCRIPTION
fixes #12583

Continuing on the work of @chrislennon.

I've applied his changes to the tests and also updated: 

`unit_test_directory(const std::string fileName)` 

* It now passes in the the current fileName to be used as part of the temp directory file path.

Any guidance on further improvements or refactored would be very much welcomed 