### PR TITLE
tests: Remove unused constant MAX_INV_SZ

### DIFF
--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -31,7 +31,6 @@ MY_VERSION = 70014  # past bip-31 for ping/pong
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
-MAX_INV_SZ = 50000
 MAX_BLOCK_BASE_SIZE = 1000000
 
 COIN = 100000000  # 1 btc in satoshis


### PR DESCRIPTION
Remove unused constant `MAX_INV_SZ`.

Last use removed in 9c92c8c82716d0c35b638142a1125d07b3f240a8.