### PR TITLE
test: Don't log to stdout in functional tests

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -301,6 +301,7 @@ def initialize_datadir(dirname, n):
         f.write("keypool=1\n")
         f.write("discover=0\n")
         f.write("listenonion=0\n")
+        f.write('logtoconsole=0\n')
     return datadir
 
 def get_datadir_path(dirname, n):


### PR DESCRIPTION
It's overly noisy, and not useful to have the bitcoin nodes log to stdout in the functional tests. In case of troubleshooting the `debug.log` files can be inspected.

This was the behavior before #13004.