### PR TITLE
test: add rpcauth-test to AC_CONFIG_LINKS to fix out-of-tree make check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1304,6 +1304,7 @@ AM_COND_IF([HAVE_DOXYGEN], [AC_CONFIG_FILES([doc/Doxyfile])])
 AC_CONFIG_LINKS([contrib/filter-lcov.py:contrib/filter-lcov.py])
 AC_CONFIG_LINKS([test/functional/test_runner.py:test/functional/test_runner.py])
 AC_CONFIG_LINKS([test/util/bitcoin-util-test.py:test/util/bitcoin-util-test.py])
+AC_CONFIG_LINKS([test/util/rpcauth-test.py:test/util/rpcauth-test.py])
 
 dnl boost's m4 checks do something really nasty: they export these vars. As a
 dnl result, they leak into secp256k1's configure and crazy things happen.


### PR DESCRIPTION
Add rpcauth-test (introduced #13056) to AC_CONFIG_LINKS, like the other directly called python scripts, to fix out-of-tree `make check`.
(forgot to test this before merging, unfortunately)