### PR TITLE
[tests] Remove 'account' API from wallet functional tests

### DIFF
--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -42,16 +42,15 @@ class Variant(collections.namedtuple("Variant", "call data rescan prune")):
 
     def do_import(self, timestamp):
         """Call one key import RPC."""
+        rescan = self.rescan == Rescan.yes
 
         if self.call == Call.single:
             if self.data == Data.address:
-                response = self.try_rpc(self.node.importaddress, self.address["address"], self.label,
-                                        self.rescan == Rescan.yes)
+                response = self.try_rpc(self.node.importaddress, address=self.address["address"], rescan=rescan)
             elif self.data == Data.pub:
-                response = self.try_rpc(self.node.importpubkey, self.address["pubkey"], self.label,
-                                        self.rescan == Rescan.yes)
+                response = self.try_rpc(self.node.importpubkey, pubkey=self.address["pubkey"], rescan=rescan)
             elif self.data == Data.priv:
-                response = self.try_rpc(self.node.importprivkey, self.key, self.label, self.rescan == Rescan.yes)
+                response = self.try_rpc(self.node.importprivkey, privkey=self.key, rescan=rescan)
             assert_equal(response, None)
 
         elif self.call == Call.multi:
@@ -62,30 +61,22 @@ class Variant(collections.namedtuple("Variant", "call data rescan prune")):
                 "timestamp": timestamp + TIMESTAMP_WINDOW + (1 if self.rescan == Rescan.late_timestamp else 0),
                 "pubkeys": [self.address["pubkey"]] if self.data == Data.pub else [],
                 "keys": [self.key] if self.data == Data.priv else [],
-                "label": self.label,
                 "watchonly": self.data != Data.priv
             }], {"rescan": self.rescan in (Rescan.yes, Rescan.late_timestamp)})
             assert_equal(response, [{"success": True}])
 
     def check(self, txid=None, amount=None, confirmations=None):
-        """Verify that getbalance/listtransactions return expected values."""
+        """Verify that listreceivedbyaddress returns expected values."""
 
-        balance = self.node.getbalance(self.label, 0, True)
-        assert_equal(balance, self.expected_balance)
-
-        txs = self.node.listtransactions(self.label, 10000, 0, True)
-        assert_equal(len(txs), self.expected_txs)
+        addresses = self.node.listreceivedbyaddress(minconf=0, include_watchonly=True, address_filter=self.address['address'])
+        if self.expected_txs:
+            assert_equal(len(addresses[0]["txids"]), self.expected_txs)
 
         if txid is not None:
-            tx, = [tx for tx in txs if tx["txid"] == txid]
-            assert_equal(tx["label"], self.label)
-            assert_equal(tx["address"], self.address["address"])
-            assert_equal(tx["amount"], amount)
-            assert_equal(tx["category"], "receive")
-            assert_equal(tx["label"], self.label)
-            assert_equal(tx["txid"], txid)
-            assert_equal(tx["confirmations"], confirmations)
-            assert_equal("trusted" not in tx, True)
+            address, = [ad for ad in addresses if txid in ad["txids"]]
+            assert_equal(address["address"], self.address["address"])
+            assert_equal(address["amount"], self.expected_balance)
+            assert_equal(address["confirmations"], confirmations)
             # Verify the transaction is correctly marked watchonly depending on
             # whether the transaction pays to an imported public key or
             # imported private key. The test setup ensures that transaction
@@ -93,9 +84,9 @@ class Variant(collections.namedtuple("Variant", "call data rescan prune")):
             # involvesWatchonly will be true if either the transaction output
             # or inputs are watchonly).
             if self.data != Data.priv:
-                assert_equal(tx["involvesWatchonly"], True)
+                assert_equal(address["involvesWatchonly"], True)
             else:
-                assert_equal("involvesWatchonly" not in tx, True)
+                assert_equal("involvesWatchonly" not in address, True)
 
 
 # List of Variants for each way a key or address could be imported.
@@ -119,7 +110,7 @@ class ImportRescanTest(BitcoinTestFramework):
         self.num_nodes = 2 + len(IMPORT_NODES)
 
     def setup_network(self):
-        extra_args = [["-addresstype=legacy", '-deprecatedrpc=accounts'] for _ in range(self.num_nodes)]
+        extra_args = [["-addresstype=legacy"] for _ in range(self.num_nodes)]
         for i, import_node in enumerate(IMPORT_NODES, 2):
             if import_node.prune:
                 extra_args[i] += ["-prune=1"]
@@ -130,11 +121,10 @@ class ImportRescanTest(BitcoinTestFramework):
             connect_nodes(self.nodes[i], 0)
 
     def run_test(self):
-        # Create one transaction on node 0 with a unique amount and label for
+        # Create one transaction on node 0 with a unique amount for
         # each possible type of wallet import RPC.
         for i, variant in enumerate(IMPORT_VARIANTS):
-            variant.label = "label {} {}".format(i, variant)
-            variant.address = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress(variant.label))
+            variant.address = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress())
             variant.key = self.nodes[1].dumpprivkey(variant.address["address"])
             variant.initial_amount = 10 - (i + 1) / 4.0
             variant.initial_txid = self.nodes[0].sendtoaddress(variant.address["address"], variant.initial_amount)

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -25,7 +25,7 @@ class KeypoolRestoreTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
-        self.extra_args = [['-deprecatedrpc=accounts'], ['-deprecatedrpc=accounts', '-keypool=100', '-keypoolmin=20']]
+        self.extra_args = [[], ['-keypool=100']]
 
     def run_test(self):
         wallet_path = os.path.join(self.nodes[1].datadir, "regtest", "wallets", "wallet.dat")

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -14,7 +14,6 @@ from test_framework.util import (assert_array_result,
 class ReceivedByTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [['-deprecatedrpc=accounts']] * 2
 
     def run_test(self):
         # Generate block to get out of IBD
@@ -112,8 +111,9 @@ class ReceivedByTest(BitcoinTestFramework):
         self.log.info("listreceivedbylabel + getreceivedbylabel Test")
 
         # set pre-state
+        label = ''
         address = self.nodes[1].getnewaddress()
-        label = self.nodes[1].getaccount(address)
+        assert_equal(self.nodes[1].getaddressinfo(address)['label'], label)
         received_by_label_json = [r for r in self.nodes[1].listreceivedbylabel() if r["label"] == label][0]
         balance_by_label = self.nodes[1].getreceivedbylabel(label)
 
@@ -141,7 +141,8 @@ class ReceivedByTest(BitcoinTestFramework):
         assert_equal(balance, balance_by_label + Decimal("0.1"))
 
         # Create a new label named "mynewlabel" that has a 0 balance
-        self.nodes[1].getlabeladdress(label="mynewlabel", force=True)
+        address = self.nodes[1].getnewaddress()
+        self.nodes[1].setlabel(address, "mynewlabel")
         received_by_label_json = [r for r in self.nodes[1].listreceivedbylabel(0, True) if r["label"] == "mynewlabel"][0]
 
         # Test includeempty of listreceivedbylabel

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -11,7 +11,6 @@ class ListSinceBlockTest (BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.setup_clean_chain = True
-        self.extra_args = [['-deprecatedrpc=accounts']] * 4
 
     def run_test(self):
         self.nodes[2].generate(101)

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -25,7 +25,6 @@ def tx_from_hex(hexstring):
 class ListTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [['-deprecatedrpc=accounts']] * 2
         self.enable_mocktime()
 
     def run_test(self):
@@ -34,19 +33,19 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid},
-                            {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 0})
+                            {"category": "send", "amount": Decimal("-0.1"), "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
                             {"txid": txid},
-                            {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 0})
+                            {"category": "receive", "amount": Decimal("0.1"), "confirmations": 0})
         # mine a block, confirmations should change:
         self.nodes[0].generate(1)
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid},
-                            {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 1})
+                            {"category": "send", "amount": Decimal("-0.1"), "confirmations": 1})
         assert_array_result(self.nodes[1].listtransactions(),
                             {"txid": txid},
-                            {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 1})
+                            {"category": "receive", "amount": Decimal("0.1"), "confirmations": 1})
 
         # send-to-self:
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
@@ -60,8 +59,8 @@ class ListTransactionsTest(BitcoinTestFramework):
         # sendmany from node1: twice to self, twice to node2:
         send_to = {self.nodes[0].getnewaddress(): 0.11,
                    self.nodes[1].getnewaddress(): 0.22,
-                   self.nodes[0].getaccountaddress("from1"): 0.33,
-                   self.nodes[1].getaccountaddress("toself"): 0.44}
+                   self.nodes[0].getnewaddress(): 0.33,
+                   self.nodes[1].getnewaddress(): 0.44}
         txid = self.nodes[1].sendmany("", send_to)
         self.sync_all()
         assert_array_result(self.nodes[1].listtransactions(),
@@ -81,13 +80,13 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"txid": txid})
         assert_array_result(self.nodes[0].listtransactions(),
                             {"category": "receive", "amount": Decimal("0.33")},
-                            {"txid": txid, "account": "from1"})
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
                             {"category": "send", "amount": Decimal("-0.44")},
-                            {"txid": txid, "account": ""})
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
                             {"category": "receive", "amount": Decimal("0.44")},
-                            {"txid": txid, "account": "toself"})
+                            {"txid": txid})
 
         pubkey = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress())['pubkey']
         multisig = self.nodes[1].createmultisig(1, [pubkey])
@@ -95,10 +94,9 @@ class ListTransactionsTest(BitcoinTestFramework):
         txid = self.nodes[1].sendtoaddress(multisig["address"], 0.1)
         self.nodes[1].generate(1)
         self.sync_all()
-        assert(len(self.nodes[0].listtransactions("watchonly", 100, 0, False)) == 0)
-        assert_array_result(self.nodes[0].listtransactions("watchonly", 100, 0, True),
-                            {"category": "receive", "amount": Decimal("0.1")},
-                            {"txid": txid, "account": "watchonly"})
+        assert not [tx for tx in self.nodes[0].listtransactions(dummy="*", count=100, skip=0, include_watchonly=False) if "label" in tx and tx["label"] == "watchonly"]
+        txs = [tx for tx in self.nodes[0].listtransactions(dummy="*", count=100, skip=0, include_watchonly=True) if "label" in tx and tx['label'] == 'watchonly']
+        assert_array_result(txs, {"category": "receive", "amount": Decimal("0.1")}, {"txid": txid})
 
         self.run_rbf_opt_in_test()
 

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -17,7 +17,6 @@ from test_framework.util import (
 class TxnMallTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.extra_args = [['-deprecatedrpc=accounts']] * 4
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
@@ -36,20 +35,20 @@ class TxnMallTest(BitcoinTestFramework):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!
 
-        # Assign coins to foo and bar accounts:
-        node0_address_foo = self.nodes[0].getnewaddress("foo")
-        fund_foo_txid = self.nodes[0].sendfrom("", node0_address_foo, 1219)
+        # Assign coins to foo and bar addresses:
+        node0_address_foo = self.nodes[0].getnewaddress()
+        fund_foo_txid = self.nodes[0].sendtoaddress(node0_address_foo, 1219)
         fund_foo_tx = self.nodes[0].gettransaction(fund_foo_txid)
 
-        node0_address_bar = self.nodes[0].getnewaddress("bar")
-        fund_bar_txid = self.nodes[0].sendfrom("", node0_address_bar, 29)
+        node0_address_bar = self.nodes[0].getnewaddress()
+        fund_bar_txid = self.nodes[0].sendtoaddress(node0_address_bar, 29)
         fund_bar_tx = self.nodes[0].gettransaction(fund_bar_txid)
 
-        assert_equal(self.nodes[0].getbalance(""),
-                     starting_balance - 1219 - 29 + fund_foo_tx["fee"] + fund_bar_tx["fee"])
+        assert_equal(self.nodes[0].getbalance(),
+                     starting_balance + fund_foo_tx["fee"] + fund_bar_tx["fee"])
 
         # Coins are sent to node1_address
-        node1_address = self.nodes[1].getnewaddress("from0")
+        node1_address = self.nodes[1].getnewaddress()
 
         # First: use raw transaction API to send 1240 BTC to node1_address,
         # but don't broadcast:
@@ -70,8 +69,8 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(doublespend["complete"], True)
 
         # Create two spends using 1 50 BTC coin each
-        txid1 = self.nodes[0].sendfrom("foo", node1_address, 40, 0)
-        txid2 = self.nodes[0].sendfrom("bar", node1_address, 20, 0)
+        txid1 = self.nodes[0].sendtoaddress(node1_address, 40)
+        txid2 = self.nodes[0].sendtoaddress(node1_address, 20)
 
         # Have node0 mine a block:
         if (self.options.mine_block):
@@ -90,15 +89,11 @@ class TxnMallTest(BitcoinTestFramework):
         expected += tx2["amount"] + tx2["fee"]
         assert_equal(self.nodes[0].getbalance(), expected)
 
-        # foo and bar accounts should be debited:
-        assert_equal(self.nodes[0].getbalance("foo", 0), 1219 + tx1["amount"] + tx1["fee"])
-        assert_equal(self.nodes[0].getbalance("bar", 0), 29 + tx2["amount"] + tx2["fee"])
-
         if self.options.mine_block:
             assert_equal(tx1["confirmations"], 1)
             assert_equal(tx2["confirmations"], 1)
-            # Node1's "from0" balance should be both transaction amounts:
-            assert_equal(self.nodes[1].getbalance("from0"), -(tx1["amount"] + tx2["amount"]))
+            # Node1's balance should be both transaction amounts:
+            assert_equal(self.nodes[1].getbalance(), starting_balance - tx1["amount"] - tx2["amount"])
         else:
             assert_equal(tx1["confirmations"], 0)
             assert_equal(tx2["confirmations"], 0)
@@ -129,17 +124,9 @@ class TxnMallTest(BitcoinTestFramework):
         # negative):
         expected = starting_balance + 100 - 1240 + fund_foo_tx["fee"] + fund_bar_tx["fee"] + doublespend_fee
         assert_equal(self.nodes[0].getbalance(), expected)
-        assert_equal(self.nodes[0].getbalance("*"), expected)
 
-        # Final "" balance is starting_balance - amount moved to accounts - doublespend + subsidies +
-        # fees (which are negative)
-        assert_equal(self.nodes[0].getbalance("foo"), 1219)
-        assert_equal(self.nodes[0].getbalance("bar"), 29)
-        assert_equal(self.nodes[0].getbalance(""),
-                     starting_balance - 1219 - 29 - 1240 + 100 + fund_foo_tx["fee"] + fund_bar_tx["fee"] + doublespend_fee)
-
-        # Node1's "from0" account balance should be just the doublespend:
-        assert_equal(self.nodes[1].getbalance("from0"), 1240)
+        # Node1's balance should be its initial balance (1250 for 25 block rewards) plus the doublespend:
+        assert_equal(self.nodes[1].getbalance(), 1250 + 1240)
 
 if __name__ == '__main__':
     TxnMallTest().main()


### PR DESCRIPTION
Next step in #12952. Removes all usage of the 'account' API from the wallet functional tests, except:

- rpc_deprecated.py (which specifically tests the `-deprecatedrpc=accounts` command line argument is working properly).
- `wallet_labels.py` (which tests that both the 'label' and 'account' APIs work in V0.17).

'account' API usage for both of those tests can be removed once V0.17 has been branched.

Also excluded is:

- `wallet_importprunedfunds.py` (which fails due to a bitcoind OOM error)