### PR TITLE
Log early messages with -printtoconsole

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -826,11 +826,6 @@ void InitLogging()
     g_logger->m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
     g_logger->m_file_path = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
 
-    // Add newlines to the logfile to distinguish this execution from the last
-    // one; called before console logging is set up, so this is only sent to
-    // debug.log.
-    LogPrintf("\n\n\n\n\n");
-
     g_logger->m_print_to_console = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
     g_logger->m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     g_logger->m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1233,10 +1233,10 @@ bool AppInitMain()
             // and because this needs to happen before any other debug.log printing
             g_logger->ShrinkDebugFile();
         }
-        if (!g_logger->OpenDebugLog()) {
-            return InitError(strprintf("Could not open debug log file %s",
-                                       g_logger->m_file_path.string()));
-        }
+    }
+    if (!g_logger->StartLogging()) {
+        return InitError(strprintf("Could not open debug log file %s",
+                                   g_logger->m_file_path.string()));
     }
 
     if (!g_logger->m_log_timestamps)

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -30,9 +30,10 @@ static int FileWriteStr(const std::string &str, FILE *fp)
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
-bool BCLog::Logger::OpenDebugLog()
+bool BCLog::Logger::StartLogging()
 {
     std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    if (!m_print_to_file) return true;
 
     assert(m_fileout == nullptr);
     assert(!m_file_path.empty());

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -33,22 +33,35 @@ static int FileWriteStr(const std::string &str, FILE *fp)
 bool BCLog::Logger::StartLogging()
 {
     std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
-    if (!m_print_to_file) return true;
 
+    assert(m_buffering);
     assert(m_fileout == nullptr);
     assert(!m_file_path.empty());
 
-    m_fileout = fsbridge::fopen(m_file_path, "a");
-    if (!m_fileout) {
-        return false;
+    if (m_print_to_file) {
+        m_fileout = fsbridge::fopen(m_file_path, "a");
+        if (!m_fileout) {
+            return false;
+        }
+
+        setbuf(m_fileout, nullptr); // unbuffered
+
+        // Add newlines to the logfile to distinguish this execution from the
+        // last one.
+        FileWriteStr("\n\n\n\n\n", m_fileout);
     }
 
-    setbuf(m_fileout, nullptr); // unbuffered
     // dump buffered messages from before we opened the log
+    m_buffering = false;
     while (!m_msgs_before_open.empty()) {
-        FileWriteStr(m_msgs_before_open.front(), m_fileout);
+        const std::string& s = m_msgs_before_open.front();
+
+        if (m_print_to_file) FileWriteStr(s, m_fileout);
+        if (m_print_to_console) fwrite(s.data(), 1, s.size(), stdout);
+
         m_msgs_before_open.pop_front();
     }
+    if (m_print_to_console) fflush(stdout);
 
     return true;
 }
@@ -201,7 +214,14 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
 
 void BCLog::Logger::LogPrintStr(const std::string &str)
 {
+    std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
     std::string strTimestamped = LogTimestampStr(str);
+
+    if (m_buffering) {
+        // buffer if we haven't started logging yet
+        m_msgs_before_open.push_back(strTimestamped);
+        return;
+    }
 
     if (m_print_to_console) {
         // print to console
@@ -209,26 +229,20 @@ void BCLog::Logger::LogPrintStr(const std::string &str)
         fflush(stdout);
     }
     if (m_print_to_file) {
-        std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+        assert(m_fileout != nullptr);
 
-        // buffer if we haven't opened the log yet
-        if (m_fileout == nullptr) {
-            m_msgs_before_open.push_back(strTimestamped);
-        }
-        else
-        {
-            // reopen the log file, if requested
-            if (m_reopen_file) {
-                m_reopen_file = false;
-                FILE* new_fileout = fsbridge::fopen(m_file_path, "a");
-                if (new_fileout) {
-                    setbuf(new_fileout, nullptr); // unbuffered
-                    fclose(m_fileout);
-                    m_fileout = new_fileout;
-                }
+        // reopen the log file, if requested
+        if (m_reopen_file) {
+            m_reopen_file = false;
+            FILE* new_fileout = fsbridge::fopen(m_file_path, "a");
+            if (new_fileout) {
+                setbuf(new_fileout, nullptr); // unbuffered
+                fclose(m_fileout);
+                m_fileout = new_fileout;
             }
-            FileWriteStr(strTimestamped, m_fileout);
         }
+
+        FileWriteStr(strTimestamped, m_fileout);
     }
 }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -32,7 +32,7 @@ static int FileWriteStr(const std::string &str, FILE *fp)
 
 bool BCLog::Logger::StartLogging()
 {
-    std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    LOCK(m_cs_log);
 
     assert(m_buffering);
     assert(m_fileout == nullptr);
@@ -214,7 +214,7 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
 
 void BCLog::Logger::LogPrintStr(const std::string &str)
 {
-    std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    LOCK(m_cs_log);
     std::string strTimestamped = LogTimestampStr(str);
 
     if (m_buffering) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -62,6 +62,7 @@ namespace BCLog {
         FILE* m_fileout = nullptr;
         std::mutex m_file_mutex;
         std::list<std::string> m_msgs_before_open;
+        bool m_buffering = true;
 
         /**
          * m_started_new_line is a state variable that will suppress printing of
@@ -89,7 +90,7 @@ namespace BCLog {
         void LogPrintStr(const std::string &str);
 
         /** Returns whether logs will be written to any output */
-        bool Enabled() const { return m_print_to_console || m_print_to_file; }
+        bool Enabled() const { return m_buffering || m_print_to_console || m_print_to_file; }
 
         bool StartLogging();
         void ShrinkDebugFile();

--- a/src/logging.h
+++ b/src/logging.h
@@ -7,7 +7,9 @@
 #define BITCOIN_LOGGING_H
 
 #include <fs.h>
+#include <sync.h>
 #include <tinyformat.h>
+#include <threadsafety.h>
 
 #include <atomic>
 #include <cstdint>
@@ -59,9 +61,9 @@ namespace BCLog {
     class Logger
     {
     private:
-        FILE* m_fileout = nullptr;
-        std::mutex m_file_mutex;
-        std::list<std::string> m_msgs_before_open;
+        CCriticalSection m_cs_log;
+        FILE* m_fileout GUARDED_BY(m_cs_log) = nullptr;
+        std::list<std::string> m_msgs_before_open GUARDED_BY(m_cs_log);
         bool m_buffering = true;
 
         /**

--- a/src/logging.h
+++ b/src/logging.h
@@ -91,7 +91,7 @@ namespace BCLog {
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
-        bool OpenDebugLog();
+        bool StartLogging();
         void ShrinkDebugFile();
 
         uint32_t GetCategoryMask() const { return m_categories.load(); }

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -12,6 +12,7 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chainparamsbase -> util -> chainparamsbase"
     "checkpoints -> validation -> checkpoints"
     "index/txindex -> validation -> index/txindex"
+    "logging -> sync -> logging"
     "policy/fees -> txmempool -> policy/fees"
     "policy/policy -> validation -> policy/policy"
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"


### PR DESCRIPTION
This allows any log messages sent prior to the `-printtoconsole` option being parsed to be replayed onto the console. This could be handy if option parsing (parameters/config file) wants to output any warnings or info messages.