### PR TITLE
[0.15] doc: Add compilation note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Bitcoin Core integration/staging tree
 =====================================
 
+**Note**: If you want to compile 0.15.x, use this branch instead of the latest tagged release, as this branch contains additional bug fixes.
+
 [![Build Status](https://travis-ci.org/bitcoin/bitcoin.svg?branch=master)](https://travis-ci.org/bitcoin/bitcoin)
 
 https://bitcoincore.org


### PR DESCRIPTION
I've seen a few cases of someone trying to compile 0.15.x using the 0.15.1 tag, and failing because they are missing some back-ported fix (the Boost issue fixed by #12032 comes up a bit).

Add a note to the top of the README mentioning that you should compile the 0.15.x branch rather than use the latest tag.