### PR TITLE
build: update ax_boost_chrono/unit_test_framework

### DIFF
--- a/build-aux/m4/ax_boost_chrono.m4
+++ b/build-aux/m4/ax_boost_chrono.m4
@@ -81,7 +81,6 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
 			LDFLAGS_SAVE=$LDFLAGS
             if test "x$ax_boost_user_chrono_lib" = "x"; then
-                ax_lib=
                 for libextension in `ls $BOOSTLIBDIR/libboost_chrono*.so* $BOOSTLIBDIR/libboost_chrono*.dylib* $BOOSTLIBDIR/libboost_chrono*.a* 2>/dev/null | sed 's,.*/,,' | sed -e 's;^lib\(boost_chrono.*\)\.so.*$;\1;' -e 's;^lib\(boost_chrono.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_chrono.*\)\.a.*$;\1;'` ; do
                      ax_lib=${libextension}
 				    AC_CHECK_LIB($ax_lib, exit,
@@ -106,7 +105,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_chrono library!)
+                AC_MSG_ERROR(Could not find a version of the library!)
             fi
 			if test "x$link_chrono" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_unit_test_framework.m4
+++ b/build-aux/m4/ax_boost_unit_test_framework.m4
@@ -76,7 +76,6 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
 
             if test "x$ax_boost_user_unit_test_framework_lib" = "x"; then
 			saved_ldflags="${LDFLAGS}"
-                ax_lib=
                 for monitor_library in `ls $BOOSTLIBDIR/libboost_unit_test_framework*.so* $BOOSTLIBDIR/libboost_unit_test_framework*.dylib* $BOOSTLIBDIR/libboost_unit_test_framework*.a* 2>/dev/null` ; do
                     if test -r $monitor_library ; then
                        libextension=`echo $monitor_library | sed 's,.*/,,' | sed -e 's;^lib\(boost_unit_test_framework.*\)\.so.*$;\1;' -e 's;^lib\(boost_unit_test_framework.*\)\.dylib.*$;\1;' -e 's;^lib\(boost_unit_test_framework.*\)\.a.*$;\1;'`
@@ -125,7 +124,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_unit_test_framework library!)
+                AC_MSG_ERROR(Could not find a version of the library!)
             fi
 			if test "x$link_unit_test_framework" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)


### PR DESCRIPTION
[ax_boost_chrono](https://github.com/bitcoin/bitcoin/blob/master/build-aux/m4/ax_boost_chrono.m4) and [ax_boost_unit_test_framework](https://github.com/bitcoin/bitcoin/blob/master/build-aux/m4/ax_boost_unit_test_framework.m4) were updated from upstream in #12678. However some minor upstream changes were missed. Pull those changes in here so these files actually reflect their upstream serial.