### PR TITLE
Skip tx-rehashing on historic blocks

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -351,6 +351,7 @@ libbitcoin_consensus_a_SOURCES = \
   prevector.h \
   primitives/block.cpp \
   primitives/block.h \
+  primitives/tx_types.h \
   primitives/transaction.cpp \
   primitives/transaction.h \
   pubkey.cpp \

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -17,6 +17,21 @@ namespace block_bench {
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
 
+static void DeserializePureBlockTest(benchmark::State& state)
+{
+    CDataStream stream((const char*)block_bench::block413567,
+        (const char*)&block_bench::block413567[sizeof(block_bench::block413567)],
+        SER_NETWORK, PROTOCOL_VERSION);
+    char a = '\0';
+    stream.write(&a, 1); // Prevent compaction
+
+    while (state.KeepRunning()) {
+        CPureBlock block;
+        stream >> block;
+        assert(stream.Rewind(sizeof(block_bench::block413567)));
+    }
+}
+
 static void DeserializeBlockTest(benchmark::State& state)
 {
     CDataStream stream((const char*)block_bench::block413567,
@@ -55,5 +70,6 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     }
 }
 
+BENCHMARK(DeserializePureBlockTest, 970);
 BENCHMARK(DeserializeBlockTest, 130);
 BENCHMARK(DeserializeAndCheckBlockTest, 160);

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -127,7 +127,7 @@ static void MempoolEviction(benchmark::State& state)
         AddTx(tx6_r, 1100LL, pool);
         AddTx(tx7_r, 9000LL, pool);
         pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4);
-        pool.TrimToSize(GetVirtualTransactionSize(tx1));
+        pool.TrimToSize(GetVirtualTransactionSize(*tx1_r));
     }
 }
 

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -176,7 +176,7 @@ bool PartiallyDownloadedBlock::IsTxAvailable(size_t index) const {
 ReadStatus PartiallyDownloadedBlock::FillBlock(CBlock& block, const std::vector<CTransactionRef>& vtx_missing) {
     assert(!header.IsNull());
     uint256 hash = header.GetHash();
-    block = header;
+    block = CBlock{header};
     block.vtx.resize(txn_available.size());
 
     size_t tx_missing_offset = 0;

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -5,12 +5,12 @@
 #ifndef BITCOIN_BLOOM_H
 #define BITCOIN_BLOOM_H
 
+#include <primitives/tx_types.h>
 #include <serialize.h>
 
 #include <vector>
 
 class COutPoint;
-class CTransaction;
 class uint256;
 
 //! 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -6,13 +6,13 @@
 #define BITCOIN_CONSENSUS_TX_VERIFY_H
 
 #include <amount.h>
+#include <primitives/tx_types.h>
 
 #include <stdint.h>
 #include <vector>
 
 class CBlockIndex;
 class CCoinsViewCache;
-class CTransaction;
 class CValidationState;
 
 /** Transaction validation functions */

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -6,14 +6,13 @@
 #define BITCOIN_CORE_IO_H
 
 #include <amount.h>
+#include <primitives/tx_types.h>
 
 #include <string>
 #include <vector>
 
-class CBlock;
 class CBlockHeader;
 class CScript;
-class CTransaction;
 struct CMutableTransaction;
 struct PartiallySignedTransaction;
 class uint256;

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -90,10 +90,10 @@ CScript ParseScript(const std::string& s)
 }
 
 // Check that all of the input and output scripts of a transaction contains valid opcodes
-static bool CheckTxScriptsSanity(const CMutableTransaction& tx)
+static bool CheckTxScriptsSanity(const CPureTransaction& tx)
 {
     // Check input scripts for non-coinbase txs
-    if (!CTransaction(tx).IsCoinBase()) {
+    if (!tx.IsCoinBase()) {
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
             if (!tx.vin[i].scriptSig.HasValidOps() || tx.vin[i].scriptSig.size() > MAX_SCRIPT_SIZE) {
                 return false;
@@ -122,7 +122,7 @@ bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no
         CDataStream ssData(txData, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
         try {
             ssData >> tx;
-            if (ssData.eof() && (!try_witness || CheckTxScriptsSanity(tx))) {
+            if (ssData.eof() && (!try_witness || CheckTxScriptsSanity(CPureTransaction{tx}))) {
                 return true;
             }
         } catch (const std::exception&) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1178,7 +1178,8 @@ void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, c
         std::shared_ptr<const CBlock> pblock;
         if (a_recent_block && a_recent_block->GetHash() == pindex->GetBlockHash()) {
             pblock = a_recent_block;
-        } else if (inv.type == MSG_WITNESS_BLOCK) {
+        }
+        if (!pblock && inv.type == MSG_WITNESS_BLOCK) {
             // Fast-path: in this case it is possible to serve the block directly from disk,
             // as the network format matches the format on disk
             std::vector<uint8_t> block_data;
@@ -1187,61 +1188,72 @@ void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, c
             }
             connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::BLOCK, MakeSpan(block_data)));
             // Don't set pblock as we've sent the block
-        } else {
-            // Send block from disk
-            std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
-            if (!ReadBlockFromDisk(*pblockRead, pindex, consensusParams))
-                assert(!"cannot load block from disk");
-            pblock = pblockRead;
-        }
-        if (pblock) {
-            if (inv.type == MSG_BLOCK)
-                connman->PushMessage(pfrom, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::BLOCK, *pblock));
-            else if (inv.type == MSG_WITNESS_BLOCK)
-                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::BLOCK, *pblock));
-            else if (inv.type == MSG_FILTERED_BLOCK)
-            {
-                bool sendMerkleBlock = false;
-                CMerkleBlock merkleBlock;
-                {
-                    LOCK(pfrom->cs_filter);
-                    if (pfrom->pfilter) {
-                        sendMerkleBlock = true;
-                        merkleBlock = CMerkleBlock(*pblock, *pfrom->pfilter);
-                    }
-                }
-                if (sendMerkleBlock) {
-                    connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::MERKLEBLOCK, merkleBlock));
-                    // CMerkleBlock just contains hashes, so also push any transactions in the block the client did not see
-                    // This avoids hurting performance by pointlessly requiring a round-trip
-                    // Note that there is currently no way for a node to request any single transactions we didn't send here -
-                    // they must either disconnect and retry or request the full block.
-                    // Thus, the protocol spec specified allows for us to provide duplicate txn here,
-                    // however we MUST always provide at least what the remote peer needs
-                    typedef std::pair<unsigned int, uint256> PairType;
-                    for (PairType& pair : merkleBlock.vMatchedTxn)
-                        connman->PushMessage(pfrom, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::TX, *pblock->vtx[pair.first]));
-                }
-                // else
-                    // no response
+        } else if (inv.type == MSG_WITNESS_BLOCK || inv.type == MSG_BLOCK) {
+            const int ser_flags{inv.type == MSG_BLOCK ? SERIALIZE_TRANSACTION_NO_WITNESS : 0};
+            if (pblock) {
+                connman->PushMessage(pfrom, msgMaker.Make(ser_flags, NetMsgType::BLOCK, *pblock));
+            } else {
+                CPureBlock pure_block;
+                if (!ReadBlockFromDisk(pure_block, pindex, consensusParams)) assert(!"cannot load block from disk");
+                connman->PushMessage(pfrom, msgMaker.Make(ser_flags, NetMsgType::BLOCK, pure_block));
             }
-            else if (inv.type == MSG_CMPCT_BLOCK)
+        } else if (inv.type == MSG_FILTERED_BLOCK) {
+            CBlock basic_block;
+            if (!pblock && !ReadBlockFromDisk(basic_block, pindex, consensusParams)) assert(!"cannot load block from disk");
+            bool sendMerkleBlock = false;
+            CMerkleBlock merkleBlock;
             {
-                // If a peer is asking for old blocks, we're almost guaranteed
-                // they won't have a useful mempool to match against a compact block,
-                // and we don't feel like constructing the object for them, so
-                // instead we respond with the full, non-compact block.
-                bool fPeerWantsWitness = State(pfrom->GetId())->fWantsCmpctWitness;
-                int nSendFlags = fPeerWantsWitness ? 0 : SERIALIZE_TRANSACTION_NO_WITNESS;
-                if (CanDirectFetch(consensusParams) && pindex->nHeight >= chainActive.Height() - MAX_CMPCTBLOCK_DEPTH) {
-                    if ((fPeerWantsWitness || !fWitnessesPresentInARecentCompactBlock) && a_recent_compact_block && a_recent_compact_block->header.GetHash() == pindex->GetBlockHash()) {
-                        connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, *a_recent_compact_block));
-                    } else {
-                        CBlockHeaderAndShortTxIDs cmpctblock(*pblock, fPeerWantsWitness);
-                        connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, cmpctblock));
-                    }
+                LOCK(pfrom->cs_filter);
+                if (pfrom->pfilter) {
+                    sendMerkleBlock = true;
+                    merkleBlock = pblock ? CMerkleBlock(*pblock, *pfrom->pfilter) : CMerkleBlock(basic_block, *pfrom->pfilter);
+                }
+            }
+            if (sendMerkleBlock) {
+                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::MERKLEBLOCK, merkleBlock));
+                // CMerkleBlock just contains hashes, so also push any transactions in the block the client did not see
+                // This avoids hurting performance by pointlessly requiring a round-trip
+                // Note that there is currently no way for a node to request any single transactions we didn't send here -
+                // they must either disconnect and retry or request the full block.
+                // Thus, the protocol spec specified allows for us to provide duplicate txn here,
+                // however we MUST always provide at least what the remote peer needs
+                typedef std::pair<unsigned int, uint256> PairType;
+                for (PairType& pair : merkleBlock.vMatchedTxn) {
+                    pblock ?
+                        connman->PushMessage(pfrom, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::TX, pblock->vtx[pair.first])) :
+                        connman->PushMessage(pfrom, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::TX, basic_block.vtx[pair.first]));
+                }
+            }
+            // else
+            // no response
+        } else if (inv.type == MSG_CMPCT_BLOCK) {
+            // If a peer is asking for old blocks, we're almost guaranteed
+            // they won't have a useful mempool to match against a compact block,
+            // and we don't feel like constructing the object for them, so
+            // instead we respond with the full, non-compact block.
+            bool fPeerWantsWitness = State(pfrom->GetId())->fWantsCmpctWitness;
+            int nSendFlags = fPeerWantsWitness ? 0 : SERIALIZE_TRANSACTION_NO_WITNESS;
+            if (CanDirectFetch(consensusParams) && pindex->nHeight >= chainActive.Height() - MAX_CMPCTBLOCK_DEPTH) {
+                if ((fPeerWantsWitness || !fWitnessesPresentInARecentCompactBlock) && a_recent_compact_block && a_recent_compact_block->header.GetHash() == pindex->GetBlockHash()) {
+                    connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, *a_recent_compact_block));
                 } else {
-                    connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCK, *pblock));
+                    CBlockHeaderAndShortTxIDs cmpctblock;
+                    CBlock block_read;
+                    if (pblock) {
+                        cmpctblock = CBlockHeaderAndShortTxIDs{*pblock, fPeerWantsWitness};
+                    } else {
+                        if (!ReadBlockFromDisk(block_read, pindex, consensusParams)) assert(!"cannot load block from disk");
+                        cmpctblock = CBlockHeaderAndShortTxIDs{block_read, fPeerWantsWitness};
+                    }
+                    connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, cmpctblock));
+                }
+            } else {
+                if (pblock) {
+                    connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCK, pblock));
+                } else {
+                    CPureBlock block_pure;
+                    if (!ReadBlockFromDisk(block_pure, pindex, consensusParams)) assert(!"cannot load block from disk");
+                    connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCK, block_pure));
                 }
             }
         }
@@ -2166,7 +2178,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         LogPrint(BCLog::NET, "getheaders %d to %s from peer=%d\n", (pindex ? pindex->nHeight : -1), hashStop.IsNull() ? "end" : hashStop.ToString(), pfrom->GetId());
         for (; pindex; pindex = chainActive.Next(pindex))
         {
-            vHeaders.push_back(pindex->GetBlockHeader());
+            vHeaders.emplace_back(pindex->GetBlockHeader());
             if (--nLimit <= 0 || pindex->GetBlockHash() == hashStop)
                 break;
         }
@@ -3399,14 +3411,14 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     pBestIndex = pindex;
                     if (fFoundStartingHeader) {
                         // add this to the headers message
-                        vHeaders.push_back(pindex->GetBlockHeader());
+                        vHeaders.emplace_back(pindex->GetBlockHeader());
                     } else if (PeerHasHeader(&state, pindex)) {
                         continue; // keep looking for the first new block
                     } else if (pindex->pprev == nullptr || PeerHasHeader(&state, pindex->pprev)) {
                         // Peer doesn't have this header but they do have the prior one.
                         // Start sending headers.
                         fFoundStartingHeader = true;
-                        vHeaders.push_back(pindex->GetBlockHeader());
+                        vHeaders.emplace_back(pindex->GetBlockHeader());
                     } else {
                         // Peer doesn't have this header or the prior one -- nothing will
                         // connect, so bail out.

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -15,7 +15,8 @@ uint256 CBlockHeader::GetHash() const
     return SerializeHash(*this);
 }
 
-std::string CBlock::ToString() const
+template <typename TxRef>
+std::string Block<TxRef>::ToString() const
 {
     std::stringstream s;
     s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
@@ -30,3 +31,4 @@ std::string CBlock::ToString() const
     }
     return s.str();
 }
+template std::string Block<CTransactionRef>::ToString() const;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -7,6 +7,7 @@
 #define BITCOIN_PRIMITIVES_BLOCK_H
 
 #include <primitives/transaction.h>
+#include <primitives/tx_types.h>
 #include <serialize.h>
 #include <uint256.h>
 
@@ -69,21 +70,22 @@ public:
 };
 
 
-class CBlock : public CBlockHeader
+template <typename TxRef>
+class Block : public CBlockHeader
 {
 public:
     // network and disk
-    std::vector<CTransactionRef> vtx;
+    std::vector<TxRef> vtx;
 
     // memory only
     mutable bool fChecked;
 
-    CBlock()
+    Block()
     {
         SetNull();
     }
 
-    CBlock(const CBlockHeader &header)
+    explicit Block(const CBlockHeader& header)
     {
         SetNull();
         *(static_cast<CBlockHeader*>(this)) = header;

--- a/src/primitives/tx_types.h
+++ b/src/primitives/tx_types.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_PRIMITIVES_TX_TYPES_H
+#define BITCOIN_PRIMITIVES_TX_TYPES_H
+
+#include <memory>
+
+// Forward declarations and typedefs to be used as replacement for the full
+// transaction.h or block.h header
+
+class CPureTransaction;
+class CTransaction;
+
+using CPureTransactionRef = std::shared_ptr<const CPureTransaction>;
+using CTransactionRef = std::shared_ptr<const CTransaction>;
+
+template <typename TxRef>
+class Block;
+
+using CPureBlock = Block<CPureTransactionRef>;
+using CBlock = Block<CTransactionRef>;
+
+#endif // BITCOIN_PRIMITIVES_TX_TYPES_H

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -7,9 +7,10 @@
 
 #include <vector>
 #include <stdint.h>
-#include <amount.h>
 
-class CBlock;
+#include <amount.h>
+#include <primitives/tx_types.h>
+
 class CBlockIndex;
 class UniValue;
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -15,8 +15,6 @@
 
 class CPubKey;
 class CScript;
-class CTransaction;
-class uint256;
 
 /** Signature hash types/flags */
 enum

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -7,7 +7,9 @@
 #define BITCOIN_SCRIPT_SIGN_H
 
 #include <boost/optional.hpp>
+
 #include <hash.h>
+#include <primitives/tx_types.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <streams.h>
@@ -16,7 +18,6 @@ class CKey;
 class CKeyID;
 class CScript;
 class CScriptID;
-class CTransaction;
 
 struct CMutableTransaction;
 

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
 }
 
 // Store of all necessary tx and undo data for next test
-typedef std::map<COutPoint, std::tuple<CTransaction,CTxUndo,Coin>> UtxoData;
+typedef std::map<COutPoint, std::tuple<CPureTransaction, CTxUndo, Coin>> UtxoData;
 UtxoData utxoData;
 
 UtxoData::iterator FindRandomFrom(const std::set<COutPoint> &utxoSet) {
@@ -382,14 +382,14 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             utxoset.insert(outpoint);
 
             // Track this tx and undo info to use later
-            utxoData.emplace(outpoint, std::make_tuple(tx,undo,old_coin));
+            utxoData.emplace(outpoint, std::make_tuple(CPureTransaction{tx}, undo, old_coin));
         } else if (utxoset.size()) {
             //1/20 times undo a previous transaction
             auto utxod = FindRandomFrom(utxoset);
 
-            CTransaction &tx = std::get<0>(utxod->second);
-            CTxUndo &undo = std::get<1>(utxod->second);
-            Coin &orig_coin = std::get<2>(utxod->second);
+            const CPureTransaction& tx = std::get<0>(utxod->second);
+            const CTxUndo& undo = std::get<1>(utxod->second);
+            const Coin& orig_coin = std::get<2>(utxod->second);
 
             // Update the expected result
             // Remove new outputs

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -8,6 +8,7 @@
 #include <chainparamsbase.h>
 #include <fs.h>
 #include <key.h>
+#include <primitives/tx_types.h>
 #include <pubkey.h>
 #include <random.h>
 #include <scheduler.h>
@@ -73,7 +74,6 @@ struct TestingSetup: public BasicTestingSetup {
     ~TestingSetup();
 };
 
-class CBlock;
 struct CMutableTransaction;
 class CScript;
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1073,7 +1073,8 @@ static bool WriteBlockToDisk(const CBlock& block, CDiskBlockPos& pos, const CMes
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams)
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams)
 {
     block.SetNull();
 
@@ -1096,8 +1097,11 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
 
     return true;
 }
+template bool ReadBlockFromDisk<CPureBlock>(CPureBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
+template bool ReadBlockFromDisk<CBlock>(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
 
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
     CDiskBlockPos blockPos;
     {
@@ -1112,6 +1116,8 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
                 pindex->ToString(), pindex->GetBlockPos().ToString());
     return true;
 }
+template bool ReadBlockFromDisk<CPureBlock>(CPureBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+template bool ReadBlockFromDisk<CBlock>(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start)
 {

--- a/src/validation.h
+++ b/src/validation.h
@@ -389,8 +389,10 @@ void InitScriptExecutionCache();
 
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -13,7 +13,6 @@
 #include <memory>
 
 extern CCriticalSection cs_main;
-class CBlock;
 class CBlockIndex;
 struct CBlockLocator;
 class CBlockIndex;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -174,9 +174,8 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
     {
         LOCK(cs_main);
-        CBlock block;
-        if(!ReadBlockFromDisk(block, pindex, consensusParams))
-        {
+        CPureBlock block;
+        if (!ReadBlockFromDisk(block, pindex, consensusParams)) {
             zmqError("Can't read block from disk");
             return false;
         }


### PR DESCRIPTION
When serving historic blocks, there is no need to calculate the hash of each transaction, so just skip it.

This is mostly refactoring with the following changes:
* Introduce a `CPureTransaction`, a stripped down version of `CTransaction` (no `hash` or `GetHash()` members). Then derive `class CTransaction` from `CPureTransaction`
* Deduce a `CPureBlock` which references `CPureTransactions` in its `vtx`.

Deserialization now only takes 14% of the wall clock time it took previously on my machine. You can check locally with:
```
./bench_bitcoin --filter=DeserializeBlockTest && ./bench_bitcoin --filter=DeserializePureBlockTest
```
Sending a single historic block now takes slightly less (90% of the wall clock time it took previously) on a local network. I presume the speedup is more pronounced when sending more than one block.