### PR TITLE
Use thread names in logs and deadlock diagnostics

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -153,6 +153,7 @@ BITCOIN_CORE_H = \
   support/events.h \
   support/lockedpool.h \
   sync.h \
+  threadnames.h \
   threadsafety.h \
   threadinterrupt.h \
   timedata.h \
@@ -372,6 +373,7 @@ libbitcoin_util_a_SOURCES = \
   support/cleanse.cpp \
   sync.cpp \
   threadinterrupt.cpp \
+  threadnames.cpp \
   util.cpp \
   utilmoneystr.cpp \
   utilstrencodings.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -80,6 +80,7 @@ BITCOIN_TESTS =\
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/streams_tests.cpp \
+  test/threadnames_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -11,6 +11,7 @@
 #include <netbase.h>
 #include <rpc/protocol.h> // For HTTP status codes
 #include <sync.h>
+#include <threadnames.h>
 #include <ui_interface.h>
 
 #include <memory>
@@ -281,7 +282,7 @@ static void http_reject_request_cb(struct evhttp_request* req, void*)
 /** Event dispatcher thread */
 static bool ThreadHTTP(struct event_base* base, struct evhttp* http)
 {
-    RenameThread("bitcoin-http");
+    g_thread_names->Rename("http");
     LogPrint(BCLog::HTTP, "Entering http event loop\n");
     event_base_dispatch(base);
     // Event loop will be interrupted by InterruptHTTPServer()
@@ -330,7 +331,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
 /** Simple wrapper to set thread name and run work queue */
 static void HTTPWorkQueueRun(WorkQueue<HTTPClosure>* queue)
 {
-    RenameThread("bitcoin-httpworker");
+    g_thread_names->Rename("httpworker", /*expect_multiple=*/ true);
     queue->Run();
 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include <script/standard.h>
 #include <script/sigcache.h>
 #include <scheduler.h>
+#include <threadnames.h>
 #include <timedata.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -199,7 +200,7 @@ void Shutdown()
     /// for example if the data directory was found to be locked.
     /// Be sure that anything that writes files or flushes caches only does this if the respective
     /// module was initialized.
-    RenameThread("bitcoin-shutoff");
+    g_thread_names->Rename("shutoff");
     mempool.AddTransactionsUpdated(1);
 
     StopHTTPRPC();
@@ -633,7 +634,7 @@ void CleanupBlockRevFiles()
 void ThreadImport(std::vector<fs::path> vImportFiles)
 {
     const CChainParams& chainparams = Params();
-    RenameThread("bitcoin-loadblk");
+    g_thread_names->Rename("loadblk");
     ScheduleBatchPriority();
 
     {

--- a/src/logging.h
+++ b/src/logging.h
@@ -7,6 +7,7 @@
 #define BITCOIN_LOGGING_H
 
 #include <fs.h>
+#include <threadnames.h>
 #include <tinyformat.h>
 
 #include <atomic>
@@ -147,7 +148,7 @@ template<typename T, typename... Args> static inline void MarkUsed(const T& t, c
     if (g_logger->Enabled()) { \
         std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
         try { \
-            _log_msg_ = tfm::format(__VA_ARGS__); \
+            _log_msg_ = tfm::format("[%s] %s", g_thread_names->GetName(), tfm::format(__VA_ARGS__)); \
         } catch (tinyformat::format_error &fmterr) { \
             /* Original format string will have newline so don't add one here */ \
             _log_msg_ = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \

--- a/src/test/threadnames_tests.cpp
+++ b/src/test/threadnames_tests.cpp
@@ -1,0 +1,131 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <threadnames.h>
+#include <test/test_bitcoin.h>
+
+#include <thread>
+#include <vector>
+#include <set>
+#include <mutex>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(threadnames_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(threadnames_test_process_rename_serial)
+{
+    ThreadNameRegistry reg;
+
+    std::string original_process_name = reg.GetProcessName();
+
+    reg.RenameProcess("bazzz");
+#ifdef CAN_READ_PROCESS_NAME
+    BOOST_CHECK_EQUAL(reg.GetProcessName(), "bazzz");
+#else
+    // Special case for platforms which don't support reading of process name.
+    BOOST_CHECK_EQUAL(reg.GetProcessName(), "<unknown>");
+#endif
+
+    reg.RenameProcess("barrr");
+#ifdef CAN_READ_PROCESS_NAME
+    BOOST_CHECK_EQUAL(reg.GetProcessName(), "barrr");
+#else
+    // Special case for platforms which don't support reading of process name.
+    BOOST_CHECK_EQUAL(reg.GetProcessName(), "<unknown>");
+#endif
+
+    reg.RenameProcess(original_process_name.c_str());
+    BOOST_CHECK_EQUAL(reg.GetProcessName(), original_process_name);
+}
+
+/**
+ * Ensure that expect_multiple prevents collisions by appending a numeric suffix.
+ */
+BOOST_AUTO_TEST_CASE(threadnames_test_rename_multiple_serial)
+{
+    ThreadNameRegistry reg;
+
+    std::string original_process_name = reg.GetProcessName();
+
+    BOOST_CHECK(reg.Rename("foo", /*expect_multiple=*/ true));
+    BOOST_CHECK_EQUAL(reg.GetName(), "foo.0");
+
+    // Can't rename to "foo" as that would be a collision.
+    BOOST_CHECK_EQUAL(reg.Rename("foo", /*expect_multiple=*/ false), false);
+    BOOST_CHECK_EQUAL(reg.GetName(), "foo.0");
+
+    BOOST_CHECK(reg.Rename("foo", /*expect_multiple=*/ true));
+    BOOST_CHECK_EQUAL(reg.GetName(), "foo.1");
+
+    BOOST_CHECK(reg.Rename("foo", /*expect_multiple=*/ true));
+    BOOST_CHECK_EQUAL(reg.GetName(), "foo.2");
+
+    reg.RenameProcess(original_process_name.c_str());
+    BOOST_CHECK_EQUAL(reg.GetProcessName(), original_process_name);
+}
+
+/**
+ * Run a bunch of threads to all call Rename with some parameters.
+ *
+ * @return the set of name each thread has after attempted renaming.
+ */
+std::set<std::string> RenameEnMasse(int num_threads, bool expect_multiple)
+{
+    ThreadNameRegistry reg;
+    std::vector<std::thread> threads;
+    std::set<std::string> names;
+    std::mutex lock;
+
+    auto RenameThisThread = [&]() {
+        reg.Rename("test_thread", /*expect_multiple=*/ expect_multiple);
+        std::lock_guard<std::mutex> guard(lock);
+        names.insert(reg.GetName());
+    };
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.push_back(std::thread(RenameThisThread));
+    }
+
+    for (std::thread& thread : threads) thread.join();
+
+    return names;
+}
+
+/**
+ * Rename a bunch of threads with the same basename (expect_multiple=true), ensuring suffixes are
+ * applied properly.
+ */
+BOOST_AUTO_TEST_CASE(threadnames_test_rename_multiple_threaded)
+{
+    std::set<std::string> names = RenameEnMasse(100, true);
+
+    BOOST_CHECK_EQUAL(names.size(), 100);
+
+    // Names "test_thread.[n]" should exist for n = [0, 99]
+    for (int i = 0; i < 100; ++i) {
+        BOOST_CHECK(names.find("test_thread." + std::to_string(i)) != names.end());
+    }
+
+}
+
+/**
+ * Rename a bunch of threads with the same basename (expect_multiple=false), ensuring only one
+ * rename succeeds.
+ */
+BOOST_AUTO_TEST_CASE(threadnames_test_rename_threaded)
+{
+    std::set<std::string> names = RenameEnMasse(100, false);
+
+    // Only one thread's Rename should have succeeded for the same name.
+    BOOST_CHECK_EQUAL(names.count("test_thread"), 1);
+    BOOST_CHECK_EQUAL(names.size(), 2);  // test_thread and test_bitcoin (name of parent thread)
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/threadnames.cpp
+++ b/src/threadnames.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <threadnames.h>
+#include <tinyformat.h>
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <sstream>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h> // For HAVE_SYS_PRCTL_H
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h> // For prctl, PR_SET_NAME, PR_GET_NAME
+#endif
+
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+#include <pthread.h>
+#include <pthread_np.h>
+#endif
+
+std::unique_ptr<ThreadNameRegistry> g_thread_names(new ThreadNameRegistry());
+
+bool ThreadNameRegistry::Rename(std::string name, bool expect_multiple)
+{
+    std::lock_guard<std::mutex> guard(m_map_lock);
+    std::string name_without_suffix = name;
+
+    if (expect_multiple) {
+        name = tfm::format("%s.%d", name_without_suffix, m_name_to_count[name_without_suffix]);
+    }
+
+    std::thread::id thread_id = std::this_thread::get_id();
+    std::string process_name = name;
+
+    auto it_name = m_name_to_count.find(name);
+
+    // Don't allow name collisions.
+    if (it_name != m_name_to_count.end()) {
+        return false;
+    }
+
+    RenameProcess(process_name.c_str());
+    m_id_to_name[thread_id] = name;
+    m_name_to_count[name_without_suffix]++;
+
+    return true;
+}
+
+std::string ThreadNameRegistry::GetName()
+{
+    std::lock_guard<std::mutex> guard(m_map_lock);
+
+    std::thread::id thread_id = std::this_thread::get_id();
+    auto found = m_id_to_name.find(thread_id);
+
+    if (found != m_id_to_name.end()) {
+        return found->second;
+    }
+
+    std::string pname = GetProcessName();
+    ++m_name_to_count[pname];
+    m_id_to_name[thread_id] = pname;
+    return pname;
+}
+
+void ThreadNameRegistry::RenameProcess(const char* name)
+{
+#if defined(PR_SET_NAME)
+    // Only the first 15 characters are used (16 - NUL terminator)
+    ::prctl(PR_SET_NAME, name, 0, 0, 0);
+#elif (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+    pthread_set_name_np(pthread_self(), name);
+#elif defined(MAC_OSX)
+    pthread_setname_np(name);
+#else
+    // Prevent warnings for unused parameters...
+    (void)name;
+#endif
+}
+
+std::string ThreadNameRegistry::GetProcessName()
+{
+    char threadname_buff[16];
+    char* pthreadname_buff = (char*)(&threadname_buff);
+
+#if defined(PR_GET_NAME)
+    ::prctl(PR_GET_NAME, pthreadname_buff);
+#elif defined(MAC_OSX)
+    pthread_getname_np(pthread_self(), pthreadname_buff, sizeof(threadname_buff));
+#else
+    return "<unknown>";
+#endif
+    return std::string(pthreadname_buff);
+}

--- a/src/threadnames.h
+++ b/src/threadnames.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_THREADNAMES_H
+#define BITCOIN_THREADNAMES_H
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h> // For HAVE_SYS_PRCTL_H
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h> // For PR_GET_NAME
+#endif
+
+#if (defined(PR_GET_NAME) || defined(MAC_OSX))
+#define CAN_READ_PROCESS_NAME
+#endif
+
+/**
+ * Keeps a map of thread IDs to string names and handles system-level thread naming.
+ */
+class ThreadNameRegistry
+{
+public:
+    /**
+     * @return the name of the current thread, falling back to the process
+     *     name if a value has not been explicitly set with Rename.
+     */
+    std::string GetName();
+
+    /**
+     * Name the current thread; doesn't allow colliding names unless `expect_multiple` is true.
+     *
+     * @param[in] name             The desired name of the process.
+     * @param[in] expect_multiple  If true, allow name reuse by appending an ordered ".[n]" suffix
+     *                             to the given name.
+     *
+     * @return true if the name was registered successfully.
+     */
+    bool Rename(std::string name, bool expect_multiple = false);
+
+    /**
+     * Rename the current thread at the system level, e.g. `prctrl(PR_SET_NAME, ...)`.
+     */
+    void RenameProcess(const char* name);
+
+    /**
+     * @return the system's name for the current thread.
+     */
+    std::string GetProcessName();
+
+private:
+    std::mutex m_map_lock;
+    std::map<std::thread::id, std::string> m_id_to_name;
+    /**
+     * The number of times this name has been used to identify a thread;
+     * used to generate numeric suffix.
+     */
+    std::map<std::string, size_t> m_name_to_count;
+
+};
+
+extern std::unique_ptr<ThreadNameRegistry> g_thread_names;
+
+#endif // BITCOIN_THREADNAMES_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,10 +63,6 @@
 #include <shlobj.h>
 #endif
 
-#ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h>
-#endif
-
 #ifdef HAVE_MALLOPT_ARENA_MAX
 #include <malloc.h>
 #endif
@@ -919,22 +915,6 @@ void runCommand(const std::string& strCommand)
     int nErr = ::system(strCommand.c_str());
     if (nErr)
         LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
-}
-
-void RenameThread(const char* name)
-{
-#if defined(PR_SET_NAME)
-    // Only the first 15 characters are used (16 - NUL terminator)
-    ::prctl(PR_SET_NAME, name, 0, 0, 0);
-#elif (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
-    pthread_set_name_np(pthread_self(), name);
-
-#elif defined(MAC_OSX)
-    pthread_setname_np(name);
-#else
-    // Prevent warnings for unused parameters...
-    (void)name;
-#endif
 }
 
 void SetupEnvironment()

--- a/src/util.h
+++ b/src/util.h
@@ -19,6 +19,7 @@
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
+#include <threadnames.h>
 #include <utiltime.h>
 
 #include <atomic>
@@ -261,15 +262,12 @@ std::string HelpMessageOpt(const std::string& option, const std::string& message
  */
 int GetNumCores();
 
-void RenameThread(const char* name);
-
 /**
  * .. and a wrapper that just calls func once
  */
 template <typename Callable> void TraceThread(const char* name,  Callable func)
 {
-    std::string s = strprintf("bitcoin-%s", name);
-    RenameThread(s.c_str());
+    g_thread_names->Rename(std::string(name));
     try
     {
         LogPrintf("%s thread start\n", name);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -31,6 +31,7 @@
 #include <script/standard.h>
 #include <timedata.h>
 #include <tinyformat.h>
+#include <threadnames.h>
 #include <txdb.h>
 #include <txmempool.h>
 #include <ui_interface.h>
@@ -1651,7 +1652,7 @@ static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, CValidationState&
 static CCheckQueue<CScriptCheck> scriptcheckqueue(128);
 
 void ThreadScriptCheck() {
-    RenameThread("bitcoin-scriptch");
+    g_thread_names->Rename("scriptch", /*expect_multiple=*/ true);
     scriptcheckqueue.Thread();
 }
 


### PR DESCRIPTION
While trying to debug the apparent deadlock revealed in https://github.com/bitcoin/bitcoin/pull/12873, I realized it'd be nice to have the `POTENTIAL DEADLOCK DETECTED` message display which thread acquired each lock. I also think it'd be generally useful to have log lines display the name of the originating thread.

This changeset does both of those things by introducing a class which manages thread naming, `ThreadNameRegistry`. The class abstracts process-control calls responsible for thread naming and provides automatic number suffixing to threads which use the same name (e.g. `httpworker.0`, `httpworker.1`, ...).

With this patch, thread names look like this

```
 $ pstree -p `pgrep bitcoind`

bitcoind(3415)─┬─{addcon}(3465)
               ├─{httpworker.0}(3454)
               ├─{httpworker.1}(3455)
               ├─{httpworker.2}(3456)
               ├─{httpworker.3}(3457)
               ├─{http}(3453)
               ├─{msghand}(3467)
               ├─{net}(3463)
               ├─{opencon}(3466)
               ├─{scheduler}(3452)
               ├─{scriptch.0}(3445)
               ├─{scriptch.1}(3446)
               ├─{scriptch.2}(3447)
               ├─{scriptch.3}(3448)
               ├─{scriptch.4}(3449)
               ├─{scriptch.5}(3450)
               ├─{scriptch.6}(3451)
               └─{torcontrol}(3462)
```
and the debug log looks like this
```
2018-04-26T21:54:23Z [bitcoind] init message: Loading wallet...
2018-04-26T21:54:24Z [bitcoind] mapBlockIndex.size() = 1
2018-04-26T21:54:24Z [bitcoind] nBestHeight = 0
2018-04-26T21:54:24Z [loadblk] Imported mempool transactions from disk: 0 succeeded, 0 failed, 0 expired, 0 already there
2018-04-26T21:54:24Z [torcontrol] torcontrol thread start
2018-04-26T21:54:24Z [bitcoind] Bound to [::]:18444
2018-04-26T21:54:24Z [torcontrol] tor: Error connecting to Tor control socket
2018-04-26T21:54:24Z [torcontrol] tor: Not connected to Tor control port 127.0.0.1:9051, trying to reconnect
2018-04-26T21:54:24Z [bitcoind] Bound to 0.0.0.0:18444
2018-04-26T21:54:24Z [bitcoind] init message: Loading P2P addresses...
2018-04-26T21:54:24Z [bitcoind] Loaded 0 addresses from peers.dat  0ms
2018-04-26T21:54:24Z [dnsseed] dnsseed thread start
2018-04-26T21:54:24Z [bitcoind] init message: Done loading
2018-04-26T21:54:24Z [addcon] addcon thread start
2018-04-26T21:54:24Z [dnsseed] Loading addresses from DNS seeds (could take a while)
2018-04-26T21:54:24Z [net] net thread start
2018-04-26T21:54:24Z [dnsseed] 0 addresses found from DNS seeds
2018-04-26T21:54:24Z [dnsseed] dnsseed thread exit
2018-04-26T21:54:24Z [msghand] msghand thread start
2018-04-26T21:54:24Z [opencon] opencon thread start
2018-04-26T21:54:25Z [torcontrol] tor: Error connecting to Tor control socket
2018-04-26T21:54:25Z [torcontrol] tor: Not connected to Tor control port 127.0.0.1:9051, trying to reconnect
```

Note that child thread names have changed; I'm no longer using the `bitcoin-` prefix. Because we're limited to 16 characters for thread name (on Linux, anyway), that prefix was causing the numeric suffix some names have to be hidden. If it's desirable to keep the prefix, I can revert this change.

#### Implementation considerations

A basic version of this change could be done pretty trivially with something like 
```cpp
thread_local std::string threadname;
```
but per @theuni (https://github.com/bitcoin/bitcoin/pull/11722#pullrequestreview-79322658), we can't rely on having `thread_local`. Also note that with a basic implementation like that, we wouldn't be able to do the automatic numbering scheme to differentiate between threads with the same basename (e.g. `httpworker`, `scriptch`).

We could also rely solely on thread-related system calls. I don't like this much either because of [how poorly defined or unavailable `getname` is on some platforms](https://stackoverflow.com/a/7989973), e.g. OS X, FreeBSD; not to mention the 16 character limit.

#### Tests

~~If this gets a Concept ACK or two, I'll implement some.~~ Unittests attached.

