### PR TITLE
gui: Add dynamic wallets support 

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -39,6 +39,16 @@ std::vector<std::shared_ptr<CWallet>> GetWallets()
     throw std::logic_error("Wallet function called in non-wallet build.");
 }
 
+std::shared_ptr<CWallet> CreateWallet(const std::string& /* wallet_file */, uint64_t /* wallet_creation_flags */, std::string& error, std::string& /* warning */)
+{
+    throw std::logic_error("Wallet function called in non-wallet build.");
+}
+
+std::shared_ptr<CWallet> LoadWallet(const std::string& /* wallet_file */, std::string& /* error */, std::string& /* warning */)
+{
+    throw std::logic_error("Wallet function called in non-wallet build.");
+}
+
 namespace interfaces {
 
 class Wallet;

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -38,7 +38,10 @@
 #include <univalue.h>
 
 class CWallet;
+std::string GetWalletDir();
 std::vector<std::shared_ptr<CWallet>> GetWallets();
+std::shared_ptr<CWallet> CreateWallet(const std::string& wallet_file, uint64_t wallet_creation_flags, std::string& error, std::string& warning);
+std::shared_ptr<CWallet> LoadWallet(const std::string& wallet_file, std::string& error, std::string& warning);
 
 namespace interfaces {
 
@@ -218,6 +221,10 @@ class NodeImpl : public Node
         LOCK(::cs_main);
         return ::pcoinsTip->GetCoin(output, coin);
     }
+    std::string getWalletDir() override
+    {
+        return GetWalletDir();
+    }
     std::vector<std::unique_ptr<Wallet>> getWallets() override
     {
         std::vector<std::unique_ptr<Wallet>> wallets;
@@ -228,19 +235,11 @@ class NodeImpl : public Node
     }
     bool createWallet(const std::string& wallet_file, std::string& error, std::string& warning) override
     {
-#ifdef ENABLE_WALLET
         return CreateWallet(wallet_file, 0, error, warning) != nullptr;
-#else
-        throw std::logic_error("Node::createWallet() called in non-wallet build.");
-#endif
     }
     bool loadWallet(const std::string& wallet_file, std::string& error, std::string& warning) override
     {
-#ifdef ENABLE_WALLET
         return LoadWallet(wallet_file, error, warning) != nullptr;
-#else
-        throw std::logic_error("Node::loadWallet() called in non-wallet build.");
-#endif
     }
     std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) override
     {

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -226,6 +226,22 @@ class NodeImpl : public Node
         }
         return wallets;
     }
+    bool createWallet(const std::string& wallet_file, std::string& error, std::string& warning) override
+    {
+#ifdef ENABLE_WALLET
+        return CreateWallet(wallet_file, 0, error, warning) != nullptr;
+#else
+        throw std::logic_error("Node::createWallet() called in non-wallet build.");
+#endif
+    }
+    bool loadWallet(const std::string& wallet_file, std::string& error, std::string& warning) override
+    {
+#ifdef ENABLE_WALLET
+        return LoadWallet(wallet_file, error, warning) != nullptr;
+#else
+        throw std::logic_error("Node::loadWallet() called in non-wallet build.");
+#endif
+    }
     std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) override
     {
         return MakeHandler(::uiInterface.InitMessage_connect(fn));

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -176,6 +176,12 @@ public:
     //! Return interfaces for accessing wallets (if any).
     virtual std::vector<std::unique_ptr<Wallet>> getWallets() = 0;
 
+    //! Attempts to create a wallet from file or directory.
+    virtual bool createWallet(const std::string& wallet_file, std::string& error, std::string& warning) = 0;
+
+    //! Attempts to load a wallet from file or directory.
+    virtual bool loadWallet(const std::string& wallet_file, std::string& error, std::string& warning) = 0;
+
     //! Register handler for init messages.
     using InitMessageFn = std::function<void(const std::string& message)>;
     virtual std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -173,6 +173,9 @@ public:
     //! Get unspent outputs associated with a transaction.
     virtual bool getUnspentOutput(const COutPoint& output, Coin& coin) = 0;
 
+    //! Return default wallet directory.
+    virtual std::string getWalletDir() = 0;
+
     //! Return interfaces for accessing wallets (if any).
     virtual std::vector<std::unique_ptr<Wallet>> getWallets() = 0;
 

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -245,6 +245,13 @@ public:
     // Get default change type.
     virtual OutputType getDefaultChangeType() = 0;
 
+    // Request wallet unload.
+    virtual void unload() = 0;
+
+    //! Register handler for load message.
+    using LoadFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleLoad(LoadFn fn) = 0;
+
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleUnload(UnloadFn fn) = 0;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -212,7 +212,6 @@ public Q_SLOTS:
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString &message);
     void addWallet(WalletModel* walletModel);
-    void removeWallet();
 
 Q_SIGNALS:
     void requestedInitialize();
@@ -442,19 +441,13 @@ void BitcoinApplication::addWallet(WalletModel* walletModel)
 
     connect(walletModel, &WalletModel::coinsSent,
         paymentServer, &PaymentServer::fetchPaymentACK);
-    connect(walletModel, &WalletModel::unload, this, &BitcoinApplication::removeWallet);
+    connect(walletModel, &WalletModel::unload, [=]() {
+        m_wallet_models.erase(std::find(m_wallet_models.begin(), m_wallet_models.end(), walletModel));
+        window->removeWallet(walletModel);
+        walletModel->deleteLater();
+    });
 
     m_wallet_models.push_back(walletModel);
-#endif
-}
-
-void BitcoinApplication::removeWallet()
-{
-#ifdef ENABLE_WALLET
-    WalletModel* walletModel = static_cast<WalletModel*>(sender());
-    m_wallet_models.erase(std::find(m_wallet_models.begin(), m_wallet_models.end(), walletModel));
-    window->removeWallet(walletModel);
-    walletModel->deleteLater();
 #endif
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -516,7 +516,7 @@ bool BitcoinGUI::addWallet(WalletModel *walletModel)
     if(!walletFrame)
         return false;
     const QString name = walletModel->getWalletName();
-    QString display_name = name.isEmpty() ? "["+tr("default wallet")+"]" : name;
+    const QString display_name = walletModel->getDisplayName();
     setWalletActionsEnabled(true);
     m_wallet_selector->addItem(display_name, name);
     if (m_wallet_selector->count() == 2) {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -332,14 +332,14 @@ void BitcoinGUI::createActions()
     openAction = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Open &URI..."), this);
     openAction->setStatusTip(tr("Open a bitcoin: URI or payment request"));
 
-    m_new_wallet_action = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("New &Wallet..."), this);
+    m_new_wallet_action = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("New &Wallet"), this);
     m_new_wallet_action->setStatusTip(tr("Create a wallet"));
 
-    m_open_wallet_action = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Open &Wallet..."), this);
+    m_open_wallet_action = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Open &Wallet"), this);
     m_open_wallet_action->setStatusTip(tr("Open a wallet"));
 
-    m_close_wallet_action = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Close Wallet..."), this);
-    m_close_wallet_action->setStatusTip(tr("Close wallet..."));
+    m_close_wallet_action = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Close Wallet"), this);
+    m_close_wallet_action->setStatusTip(tr("Close wallet"));
 
     showHelpMessageAction = new QAction(platformStyle->TextColorIcon(":/icons/info"), tr("&Command-line options"), this);
     showHelpMessageAction->setMenuRole(QAction::NoRole);
@@ -393,6 +393,7 @@ void BitcoinGUI::createMenuBar()
         file->addAction(m_new_wallet_action);
         file->addAction(m_open_wallet_action);
         file->addAction(m_close_wallet_action);
+        file->addSeparator();
         file->addAction(openAction);
         file->addAction(backupWalletAction);
         file->addAction(signMessageAction);
@@ -713,7 +714,7 @@ void BitcoinGUI::openClicked()
 
 void BitcoinGUI::newWallet()
 {
-    QString file_name = QFileDialog::getSaveFileName(this, tr("New Wallet"));
+    QString file_name = QFileDialog::getSaveFileName(this, tr("New Wallet"), QString::fromStdString(m_node.getWalletDir()));
     if (file_name.isEmpty()) return;
 
     std::string error, warning;
@@ -728,7 +729,7 @@ void BitcoinGUI::newWallet()
 
 void BitcoinGUI::openWallet()
 {
-    QString file_name = QFileDialog::getExistingDirectory(this, tr("Open Wallet"), QString(), QFileDialog::DontResolveSymlinks);
+    QString file_name = QFileDialog::getOpenFileName(this, tr("Open Wallet"), QString::fromStdString(m_node.getWalletDir()), QString(), nullptr, QFileDialog::DontResolveSymlinks);
     if (file_name.isEmpty()) return;
 
     std::string error, warning;

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -130,6 +130,9 @@ private:
     QAction* openRPCConsoleAction = nullptr;
     QAction* openAction = nullptr;
     QAction* showHelpMessageAction = nullptr;
+    QAction* m_new_wallet_action = nullptr;
+    QAction* m_open_wallet_action = nullptr;
+    QAction* m_close_wallet_action = nullptr;
     QAction* m_wallet_selector_label_action = nullptr;
     QAction* m_wallet_selector_action = nullptr;
 
@@ -246,6 +249,12 @@ public Q_SLOTS:
 
     /** Show open dialog */
     void openClicked();
+    /** New wallet dialog */
+    void newWallet();
+    /** Show open wallet dialog */
+    void openWallet();
+    /** Close current wallet */
+    void closeWallet();
 #endif // ENABLE_WALLET
     /** Show configuration dialog */
     void optionsClicked();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -695,7 +695,7 @@ void RPCConsole::addWallet(WalletModel * const walletModel)
 {
     const QString name = walletModel->getWalletName();
     // use name for text and internal data object (to allow to move to a wallet id later)
-    QString display_name = name.isEmpty() ? "["+tr("default wallet")+"]" : name;
+    const QString display_name = walletModel->getDisplayName();
     ui->WalletSelector->addItem(display_name, name);
     if (ui->WalletSelector->count() == 2 && !isVisible()) {
         // First wallet added, set to default so long as the window isn't presently visible (and potentially in use)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -303,6 +303,11 @@ AddressTableModel *WalletModel::getAddressTableModel()
     return addressTableModel;
 }
 
+void WalletModel::requestUnload()
+{
+    m_wallet->unload();
+}
+
 TransactionTableModel *WalletModel::getTransactionTableModel()
 {
     return transactionTableModel;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -567,6 +567,12 @@ QString WalletModel::getWalletName() const
     return QString::fromStdString(m_wallet->getWalletName());
 }
 
+QString WalletModel::getDisplayName() const
+{
+    const QString name = getWalletName();
+    return name.isEmpty() ? "["+tr("default wallet")+"]" : name;
+}
+
 bool WalletModel::isMultiwallet()
 {
     return m_node.getWallets().size() > 1;

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -203,6 +203,7 @@ public:
     interfaces::Wallet& wallet() const { return *m_wallet; }
 
     QString getWalletName() const;
+    QString getDisplayName() const;
 
     bool isMultiwallet();
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -208,6 +208,9 @@ public:
     bool isMultiwallet();
 
     AddressTableModel* getAddressTableModel() const { return addressTableModel; }
+
+    void requestUnload();
+
 private:
     std::unique_ptr<interfaces::Wallet> m_wallet;
     std::unique_ptr<interfaces::Handler> m_handler_unload;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2502,7 +2502,6 @@ static UniValue loadwallet(const JSONRPCRequest& request)
             + HelpExampleRpc("loadwallet", "\"test.dat\"")
         );
     std::string wallet_file = request.params[0].get_str();
-    std::string error;
 
     fs::path wallet_path = fs::absolute(wallet_file, GetWalletDir());
     if (fs::symlink_status(wallet_path).type() == fs::file_not_found) {
@@ -2515,18 +2514,11 @@ static UniValue loadwallet(const JSONRPCRequest& request)
         }
     }
 
-    std::string warning;
-    if (!CWallet::Verify(wallet_file, false, error, warning)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet file verification failed: " + error);
-    }
-
-    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(wallet_file, fs::absolute(wallet_file, GetWalletDir()));
+    std::string error, warning;
+    std::shared_ptr<CWallet> const wallet = LoadWallet(wallet_file, error, warning);
     if (!wallet) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet loading failed.");
+        throw JSONRPCError(RPC_WALLET_ERROR, error);
     }
-    AddWallet(wallet);
-
-    wallet->postInitProcess();
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());
@@ -2563,23 +2555,10 @@ static UniValue createwallet(const JSONRPCRequest& request)
         disable_privatekeys = request.params[1].get_bool();
     }
 
-    fs::path wallet_path = fs::absolute(wallet_name, GetWalletDir());
-    if (fs::symlink_status(wallet_path).type() != fs::file_not_found) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet " + wallet_name + " already exists.");
-    }
-
-    // Wallet::Verify will check if we're trying to create a wallet with a duplication name.
-    if (!CWallet::Verify(wallet_name, false, error, warning)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet file verification failed: " + error);
-    }
-
-    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(wallet_name, fs::absolute(wallet_name, GetWalletDir()), (disable_privatekeys ? (uint64_t)WALLET_FLAG_DISABLE_PRIVATE_KEYS : 0));
+    std::shared_ptr<CWallet> const wallet = CreateWallet(wallet_name, (disable_privatekeys ? (uint64_t)WALLET_FLAG_DISABLE_PRIVATE_KEYS : 0), error, warning);
     if (!wallet) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet creation failed.");
+        throw JSONRPCError(RPC_WALLET_ERROR, error);
     }
-    AddWallet(wallet);
-
-    wallet->postInitProcess();
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -85,10 +85,7 @@ static void GetWalletNameAndPath(const std::string& wallet_file, std::string& wa
     wallet_path = fs::absolute(wallet_file, GetWalletDir());
     fs::path name;
     fs::path parent = wallet_path;
-    while (!parent.empty()) {
-        if (parent == GetWalletDir()) {
-            break;
-        }
+    while (!parent.empty() && parent != GetWalletDir()) {
         name = parent.filename() / name;
         parent = parent.parent_path();
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -39,6 +39,10 @@ bool HasWallets();
 std::vector<std::shared_ptr<CWallet>> GetWallets();
 std::shared_ptr<CWallet> GetWallet(const std::string& name);
 
+std::shared_ptr<CWallet> CreateWallet(const std::string& wallet_file, uint64_t wallet_creation_flags, std::string& error, std::string& warning);
+std::shared_ptr<CWallet> LoadWallet(const std::string& wallet_file, std::string& error, std::string& warning);
+
+
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
@@ -1007,6 +1011,9 @@ public:
 
     //! Flush wallet (bitdb flush)
     void Flush(bool shutdown=false);
+
+    /** Wallet has loaded */
+    boost::signals2::signal<void ()> NotifyLoad;
 
     /** Wallet is about to be unloaded */
     boost::signals2::signal<void ()> NotifyUnload;


### PR DESCRIPTION
This PR adds a menu entry `Open Wallet` to support loading existing wallets in the UI.

Fixes #7675.