### PR TITLE
Fix Windows locale problem

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_64_0
 $(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_patches=make-windows-use-utf8-encoding.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,6 +26,7 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/make-windows-use-utf8-encoding.patch && \
   echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
 endef
 

--- a/depends/patches/boost/make-windows-use-utf8-encoding.patch
+++ b/depends/patches/boost/make-windows-use-utf8-encoding.patch
@@ -1,0 +1,23 @@
+diff --git a/libs/filesystem/src/windows_file_codecvt.cpp b/libs/filesystem/src/windows_file_codecvt.cpp
+index 6b8e745..8f19f61 100644
+--- a/libs/filesystem/src/windows_file_codecvt.cpp
++++ b/libs/filesystem/src/windows_file_codecvt.cpp
+@@ -36,7 +36,7 @@
+     const char* from, const char* from_end, const char*& from_next,
+     wchar_t* to, wchar_t* to_end, wchar_t*& to_next) const
+   {
+-    UINT codepage = AreFileApisANSI() ? CP_ACP : CP_OEMCP;
++    UINT codepage = CP_UTF8;
+
+     int count;
+     if ((count = ::MultiByteToWideChar(codepage, MB_PRECOMPOSED, from,
+@@ -56,7 +56,7 @@
+     const wchar_t* from, const wchar_t* from_end, const wchar_t*  & from_next,
+     char* to, char* to_end, char* & to_next) const
+   {
+-    UINT codepage = AreFileApisANSI() ? CP_ACP : CP_OEMCP;
++    UINT codepage = CP_UTF8;
+
+     int count;
+     if ((count = ::WideCharToMultiByte(codepage, WC_NO_BEST_FIT_CHARS, from,
+

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -403,6 +403,11 @@ static int CommandLineRPC(int argc, char *argv[])
             gArgs.ForceSetArg("-rpcpassword", rpcPass);
         }
         std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+#ifdef WIN32
+        for (auto it = args.begin(); it != args.end(); it++) {
+            *it = LocalToUtf8(*it);
+        }
+#endif
         if (gArgs.GetBoolArg("-stdin", false)) {
             // Read one arg per line from stdin and append
             std::string line;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -130,13 +130,13 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
     } else {
         if (fWipe) {
             LogPrintf("Wiping LevelDB in %s\n", path.string());
-            leveldb::Status result = leveldb::DestroyDB(path.string(), options);
+            leveldb::Status result = leveldb::DestroyDB(Utf8ToLocal(path.string()), options);
             dbwrapper_private::HandleError(result);
         }
         TryCreateDirectories(path);
         LogPrintf("Opening LevelDB in %s\n", path.string());
     }
-    leveldb::Status status = leveldb::DB::Open(options, path.string(), &pdb);
+    leveldb::Status status = leveldb::DB::Open(options, Utf8ToLocal(path.string()), &pdb);
     dbwrapper_private::HandleError(status);
     LogPrintf("Opened LevelDB successfully\n");
 

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -1,15 +1,16 @@
 #include <fs.h>
+#include <utilstrencodings.cpp>
 
 namespace fsbridge {
 
 FILE *fopen(const fs::path& p, const char *mode)
 {
-    return ::fopen(p.string().c_str(), mode);
+    return ::fopen(Utf8ToLocal(p.string()).c_str(), mode);
 }
 
 FILE *freopen(const fs::path& p, const char *mode, FILE *stream)
 {
-    return ::freopen(p.string().c_str(), mode, stream);
+    return ::freopen(Utf8ToLocal(p.string()).c_str(), mode, stream);
 }
 
 } // fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -12,6 +12,8 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 
+#include <utilstrencodings.h>
+
 /** Filesystem operations and types */
 namespace fs = boost::filesystem;
 
@@ -19,6 +21,58 @@ namespace fs = boost::filesystem;
 namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
     FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
+
+    class ifstream : public std::ifstream
+    {
+    public:
+        ifstream() {}
+
+        virtual ~ifstream() {}
+
+        explicit ifstream(const fs::path& p) : std::ifstream(Utf8ToLocal(p.string())) {}
+
+        ifstream(const fs::path& p, std::ios::openmode mode) : std::ifstream(Utf8ToLocal(p.string()), mode) {}
+
+        void open(const fs::path& p)
+        {
+            std::ifstream::open(Utf8ToLocal(p.string()));
+        }
+
+        void open(const fs::path& p, std::ios::openmode mode)
+        {
+            std::ifstream::open(Utf8ToLocal(p.string()), mode);
+        }
+
+    private:
+        ifstream(const ifstream&) = delete;
+        const ifstream& operator=(const ifstream&) = delete;
+    };
+
+    class ofstream : public std::ofstream
+    {
+    public:
+        ofstream() {}
+
+        virtual ~ofstream() {}
+
+        explicit ofstream(const fs::path& p) : std::ofstream(Utf8ToLocal(p.string())) {}
+
+        ofstream(const fs::path& p, std::ios::openmode mode) : std::ofstream(Utf8ToLocal(p.string()), mode) {}
+
+        void open(const fs::path& p)
+        {
+            std::ofstream::open(Utf8ToLocal(p.string()));
+        }
+
+        void open(const fs::path& p, std::ios::openmode mode)
+        {
+            std::ofstream::open(Utf8ToLocal(p.string()), mode);
+        }
+
+    private:
+        ofstream(const ofstream&) = delete;
+        const ofstream& operator=(const ofstream&) = delete;
+    };
 };
 
 #endif // BITCOIN_FS_H

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -664,11 +664,8 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             hres = psl->QueryInterface(IID_IPersistFile, reinterpret_cast<void**>(&ppf));
             if (SUCCEEDED(hres))
             {
-                WCHAR pwsz[MAX_PATH];
-                // Ensure that the string is ANSI.
-                MultiByteToWideChar(CP_ACP, 0, StartupShortcutPath().string().c_str(), -1, pwsz, MAX_PATH);
                 // Save the link by calling IPersistFile::Save.
-                hres = ppf->Save(pwsz, TRUE);
+                hres = ppf->Save(StartupShortcutPath().wstring().c_str(), TRUE);
                 ppf->Release();
                 psl->Release();
                 CoUninitialize();

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -406,8 +406,8 @@ bool openBitcoinConf()
     boost::filesystem::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
 
     /* Create the file */
-    boost::filesystem::ofstream configFile(pathConfig, std::ios_base::app);
-    
+    fsbridge::ofstream configFile(pathConfig, std::ios_base::app);
+
     if (!configFile.good())
         return false;
     
@@ -705,7 +705,7 @@ fs::path static GetAutostartFilePath()
 
 bool GetStartOnSystemStartup()
 {
-    fs::ifstream optionFile(GetAutostartFilePath());
+    fsbridge::ifstream optionFile(GetAutostartFilePath());
     if (!optionFile.good())
         return false;
     // Scan through file for "Hidden=true":
@@ -736,7 +736,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 
         fs::create_directories(GetAutostartDir());
 
-        fs::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
+        fsbridge::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out | std::ios_base::trunc);
         if (!optionFile.good())
             return false;
         std::string chain = gArgs.GetChainName();

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -5,14 +5,13 @@
 
 #include <rpc/protocol.h>
 
+#include <fs.h>
 #include <random.h>
 #include <tinyformat.h>
 #include <util.h>
 #include <utilstrencodings.h>
 #include <utiltime.h>
 #include <version.h>
-
-#include <fstream>
 
 /**
  * JSON-RPC protocol.  Bitcoin speaks version 1.0 for maximum compatibility,
@@ -85,9 +84,9 @@ bool GenerateAuthCookie(std::string *cookie_out)
     /** the umask determines what permissions are used to create this file -
      * these are set to 077 in init.cpp unless overridden with -sysperms.
      */
-    std::ofstream file;
+    fsbridge::ofstream file;
     fs::path filepath_tmp = GetAuthCookieFile(true);
-    file.open(filepath_tmp.string().c_str());
+    file.open(filepath_tmp);
     if (!file.is_open()) {
         LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath_tmp.string());
         return false;
@@ -109,10 +108,10 @@ bool GenerateAuthCookie(std::string *cookie_out)
 
 bool GetAuthCookie(std::string *cookie_out)
 {
-    std::ifstream file;
+    fsbridge::ifstream file;
     std::string cookie;
     fs::path filepath = GetAuthCookieFile();
-    file.open(filepath.string().c_str());
+    file.open(filepath);
     if (!file.is_open())
         return false;
     std::getline(file, cookie);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -161,7 +161,7 @@ bool LockDirectory(const fs::path& directory, const std::string lockfile_name, b
     if (file) fclose(file);
 
     try {
-        auto lock = MakeUnique<boost::interprocess::file_lock>(pathLockFile.string().c_str());
+        auto lock = MakeUnique<boost::interprocess::file_lock>(Utf8ToLocal(pathLockFile.string()).c_str());
         if (!lock->try_lock()) {
             return false;
         }
@@ -419,6 +419,7 @@ void ArgsManager::ParseParameters(int argc, const char* const argv[])
 
     for (int i = 1; i < argc; i++) {
         std::string key(argv[i]);
+        key = LocalToUtf8(key);
         std::string val;
         size_t is_index = key.find('=');
         if (is_index != std::string::npos) {
@@ -861,8 +862,8 @@ void CreatePidFile(const fs::path &path, pid_t pid)
 bool RenameOver(fs::path src, fs::path dest)
 {
 #ifdef WIN32
-    return MoveFileExA(src.string().c_str(), dest.string().c_str(),
-                       MOVEFILE_REPLACE_EXISTING) != 0;
+    return MoveFileExA(Utf8ToLocal(src.string()).c_str(), Utf8ToLocal(dest.string()).c_str(),
+               MOVEFILE_REPLACE_EXISTING) != 0;
 #else
     int rc = std::rename(src.string().c_str(), dest.string().c_str());
     return (rc == 0);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1004,9 +1004,9 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
 {
-    char pszPath[MAX_PATH] = "";
+    wchar_t pszPath[MAX_PATH] = L"";
 
-    if(SHGetSpecialFolderPathA(nullptr, pszPath, nFolder, fCreate))
+    if(SHGetSpecialFolderPathW(nullptr, pszPath, nFolder, fCreate))
     {
         return fs::path(pszPath);
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -775,7 +775,7 @@ void ArgsManager::ReadConfigFiles()
     }
 
     const std::string confPath = GetArg("-conf", BITCOIN_CONF_FILENAME);
-    fs::ifstream stream(GetConfigFile(confPath));
+    fsbridge::ifstream stream(GetConfigFile(confPath));
 
     // ok to not have a config file
     if (stream.good()) {
@@ -800,7 +800,7 @@ void ArgsManager::ReadConfigFiles()
             }
 
             for (const std::string& to_include : includeconf) {
-                fs::ifstream include_config(GetConfigFile(to_include));
+                fsbridge::ifstream include_config(GetConfigFile(to_include));
                 if (include_config.good()) {
                     ReadConfigStream(include_config);
                     LogPrintf("Included configuration file %s\n", to_include.c_str());

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -12,6 +12,10 @@
 #include <errno.h>
 #include <limits>
 
+#ifdef WIN32
+#include <stringapiset.h>
+#endif
+
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 static const std::string SAFE_CHARS[] =
@@ -544,3 +548,36 @@ bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
     return true;
 }
 
+#ifdef WIN32
+std::string LocalToUtf8(const std::string& local_string)
+{
+    if (local_string.size() == 0) return local_string;
+    int size = MultiByteToWideChar(CP_ACP, 0, local_string.c_str(), local_string.size(), nullptr, 0);
+    assert(size);
+    std::wstring wide_string(size, L'\0');
+    size = MultiByteToWideChar(CP_ACP, 0, local_string.c_str(), local_string.size(), &wide_string[0], size);
+    assert(size == wide_string.size());
+    size = WideCharToMultiByte(CP_UTF8, 0, wide_string.c_str(), wide_string.size(), nullptr, 0, nullptr, nullptr);
+    assert(size);
+    std::string utf8_string(size, '\0');
+    size = WideCharToMultiByte(CP_UTF8, 0, wide_string.c_str(), wide_string.size(), &utf8_string[0], size, nullptr, nullptr);
+    assert(size == utf8_string.size());
+    return utf8_string;
+}
+
+std::string Utf8ToLocal(const std::string& utf8_string)
+{
+    if (utf8_string.size() == 0) return utf8_string;
+    int size = MultiByteToWideChar(CP_UTF8, 0, utf8_string.c_str(), utf8_string.size(), nullptr, 0);
+    assert(size);
+    std::wstring wide_string(size, L'\0');
+    size = MultiByteToWideChar(CP_UTF8, 0, utf8_string.c_str(), utf8_string.size(), &wide_string[0], size);
+    assert(size == wide_string.size());
+    size = WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), wide_string.size(), nullptr, 0, nullptr, nullptr);
+    assert(size);
+    std::string local_string(size, '\0');
+    size = WideCharToMultiByte(CP_ACP, 0, wide_string.c_str(), wide_string.size(), &local_string[0], size, nullptr, nullptr);
+    assert(size == local_string.size());
+    return local_string;
+}
+#endif

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -173,4 +173,11 @@ bool ConvertBits(const O& outfn, I it, I end) {
     return true;
 }
 
+#ifdef WIN32
+std::string LocalToUtf8(const std::string& local_string);
+std::string Utf8ToLocal(const std::string& utf8_string);
+#else
+#define LocalToUtf8(x) (x)
+#define Utf8ToLocal(x) (x)
+#endif
 #endif // BITCOIN_UTILSTRENCODINGS_H

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/filesystem/path.hpp>
 
 #include <univalue.h>
 
@@ -541,8 +542,9 @@ UniValue importwallet(const JSONRPCRequest& request)
 
         EnsureWalletIsUnlocked(pwallet);
 
-        std::ifstream file;
-        file.open(request.params[0].get_str().c_str(), std::ios::in | std::ios::ate);
+        fsbridge::ifstream file;
+        fs::path path = request.params[0].get_str();
+        file.open(path, std::ios::in | std::ios::ate);
         if (!file.is_open()) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
         }
@@ -722,8 +724,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.string() + " already exists. If you are sure this is what you want, move it out of the way first");
     }
 
-    std::ofstream file;
-    file.open(filepath.string().c_str());
+    fsbridge::ofstream file;
+    file.open(filepath);
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 


### PR DESCRIPTION
Fixes #13103
This PR make internal strings of Windows always be utf8-encoded
-  Add UTF8 <-> localized string conversion function
-  Use localized string on Berkeley DB
-  Use localized string on LevelDB
-  Use localized string on fstream::open
-  Use std::fstream instead of fs::fstream

Patched the boost library to convert `fs::path::string()` to be UTF8 encoded. Add two functions that convert between UTF8 and Local encodes. 

To those who want to test this, adding `-datadir=(some non-ASCII characters)` option make every file that Bitcoin Core use contain non-ASCII characters

Defect: If the user's codepage does not support the filename, it will be encoded to `?`
I don't known how to solve this. Leveldb and Berkeley DB don't support wide char.