### PR TITLE
Add Clang thread safety annotations for variables guarded by cs_{rpcWarmup,nTimeOffset,warnings}

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -23,10 +23,10 @@
 #include <memory> // for unique_ptr
 #include <unordered_map>
 
-static bool fRPCRunning = false;
-static bool fRPCInWarmup = true;
-static std::string rpcWarmupStatus("RPC server started");
 static CCriticalSection cs_rpcWarmup;
+static bool fRPCRunning = false;
+static bool fRPCInWarmup GUARDED_BY(cs_rpcWarmup) = true;
+static std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";
 /* Timer-creating functions */
 static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -17,7 +17,7 @@
 
 
 static CCriticalSection cs_nTimeOffset;
-static int64_t nTimeOffset = 0;
+static int64_t nTimeOffset GUARDED_BY(cs_nTimeOffset) = 0;
 
 /**
  * "Never go to sea with two chronometers; take one or three."

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -9,9 +9,9 @@
 #include <warnings.h>
 
 CCriticalSection cs_warnings;
-std::string strMiscWarning;
-bool fLargeWorkForkFound = false;
-bool fLargeWorkInvalidChainFound = false;
+std::string strMiscWarning GUARDED_BY(cs_warnings);
+bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
+bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
 
 void SetMiscWarning(const std::string& strWarning)
 {


### PR DESCRIPTION
Add Clang thread safety annotations for variables guarded by `cs_{rpcWarmup,nTimeOffset,warnings}`.