### PR TITLE
RPCAuth Detection in Logs

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -215,7 +215,7 @@ static bool InitRPCAuthentication()
 {
     if (gArgs.GetArg("-rpcpassword", "") == "")
     {
-        LogPrintf("No rpcpassword set - using random cookie authentication\n");
+        LogPrintf("No rpcpassword set - using random cookie authentication.\n");
         if (!GenerateAuthCookie(&strRPCUserColonPass)) {
             uiInterface.ThreadSafeMessageBox(
                 _("Error: A fatal internal error occurred, see debug.log for details"), // Same message as AbortNode
@@ -225,6 +225,10 @@ static bool InitRPCAuthentication()
     } else {
         LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcuser for rpcauth auth generation.\n");
         strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");
+    }
+    if (gArgs.GetArg("-rpcauth","") != "")
+    {
+        LogPrintf("Using rpcauth authentication.\n");
     }
     return true;
 }


### PR DESCRIPTION
This adds a log entry for when RPCAuth is detected.
This keeps everything working as it currently is. I suppose it could be added as a nested if to also stop the creation of the cookie file if this would be wanted.