### PR TITLE
scheduler: Add Clang thread safety annotations for variables guarded by m_cs_callbacks_pending

### DIFF
--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -95,8 +95,8 @@ private:
     CScheduler *m_pscheduler;
 
     CCriticalSection m_cs_callbacks_pending;
-    std::list<std::function<void (void)>> m_callbacks_pending;
-    bool m_are_callbacks_running = false;
+    std::list<std::function<void (void)>> m_callbacks_pending GUARDED_BY(m_cs_callbacks_pending);
+    bool m_are_callbacks_running GUARDED_BY(m_cs_callbacks_pending) = false;
 
     void MaybeScheduleProcessQueue();
     void ProcessQueue();


### PR DESCRIPTION
Add Clang thread safety annotations for variables guarded by `m_cs_callbacks_pending`.