### PR TITLE
util: Add Clang thread safety annotations for variables guarded by cs_args

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -372,6 +372,8 @@ ArgsManager::ArgsManager() :
 
 void ArgsManager::WarnForSectionOnlyArgs()
 {
+    LOCK(cs_args);
+
     // if there's no section selected, don't worry
     if (m_network.empty()) return;
 
@@ -400,6 +402,7 @@ void ArgsManager::WarnForSectionOnlyArgs()
 
 void ArgsManager::SelectConfigNetwork(const std::string& network)
 {
+    LOCK(cs_args);
     m_network = network;
 }
 
@@ -468,6 +471,7 @@ bool ArgsManager::IsArgKnown(const std::string& key) const
         arg_no_net = std::string("-") + key.substr(option_index + 1, std::string::npos);
     }
 
+    LOCK(cs_args);
     for (const auto& arg_map : m_available_args) {
         if (arg_map.second.count(arg_no_net)) return true;
     }
@@ -571,6 +575,7 @@ void ArgsManager::AddArg(const std::string& name, const std::string& help, const
         eq_index = name.size();
     }
 
+    LOCK(cs_args);
     std::map<std::string, Arg>& arg_map = m_available_args[cat];
     auto ret = arg_map.emplace(name.substr(0, eq_index), Arg(name.substr(eq_index, name.size() - eq_index), help, debug_only));
     assert(ret.second); // Make sure an insertion actually happened
@@ -588,6 +593,7 @@ std::string ArgsManager::GetHelpMessage() const
     const bool show_debug = gArgs.GetBoolArg("-help-debug", false);
 
     std::string usage = "";
+    LOCK(cs_args);
     for (const auto& arg_map : m_available_args) {
         switch(arg_map.first) {
             case OptionsCategory::OPTIONS:
@@ -865,10 +871,8 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, std::string& error, boo
 
 bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
 {
-    {
-        LOCK(cs_args);
-        m_config_args.clear();
-    }
+    LOCK(cs_args);
+    m_config_args.clear();
 
     const std::string confPath = GetArg("-conf", BITCOIN_CONF_FILENAME);
     fs::ifstream stream(GetConfigFile(confPath));
@@ -892,11 +896,8 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
 
             // Remove -includeconf from configuration, so we can warn about recursion
             // later
-            {
-                LOCK(cs_args);
-                m_config_args.erase("-includeconf");
-                m_config_args.erase(std::string("-") + chain_id + ".includeconf");
-            }
+            m_config_args.erase("-includeconf");
+            m_config_args.erase(std::string("-") + chain_id + ".includeconf");
 
             for (const std::string& to_include : includeconf) {
                 fs::ifstream include_config(GetConfigFile(to_include));
@@ -940,6 +941,7 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
 
 std::string ArgsManager::GetChainName() const
 {
+    LOCK(cs_args);
     bool fRegTest = ArgsManagerHelper::GetNetBoolArg(*this, "-regtest");
     bool fTestNet = ArgsManagerHelper::GetNetBoolArg(*this, "-testnet");
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -871,8 +871,10 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, std::string& error, boo
 
 bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
 {
-    LOCK(cs_args);
-    m_config_args.clear();
+    {
+        LOCK(cs_args);
+        m_config_args.clear();
+    }
 
     const std::string confPath = GetArg("-conf", BITCOIN_CONF_FILENAME);
     fs::ifstream stream(GetConfigFile(confPath));
@@ -884,7 +886,12 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
         }
         // if there is an -includeconf in the override args, but it is empty, that means the user
         // passed '-noincludeconf' on the command line, in which case we should not include anything
-        if (m_override_args.count("-includeconf") == 0) {
+        bool emptyIncludeConf;
+        {
+            LOCK(cs_args);
+            emptyIncludeConf = m_override_args.count("-includeconf") == 0;
+        }
+        if (emptyIncludeConf) {
             std::string chain_id = GetChainName();
             std::vector<std::string> includeconf(GetArgs("-includeconf"));
             {
@@ -896,8 +903,11 @@ bool ArgsManager::ReadConfigFiles(std::string& error, bool ignore_invalid_keys)
 
             // Remove -includeconf from configuration, so we can warn about recursion
             // later
-            m_config_args.erase("-includeconf");
-            m_config_args.erase(std::string("-") + chain_id + ".includeconf");
+            {
+                LOCK(cs_args);
+                m_config_args.erase("-includeconf");
+                m_config_args.erase(std::string("-") + chain_id + ".includeconf");
+            }
 
             for (const std::string& to_include : includeconf) {
                 fs::ifstream include_config(GetConfigFile(to_include));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -216,7 +216,7 @@ public:
 
     /** Determine whether to use config settings in the default section,
      *  See also comments around ArgsManager::ArgsManager() below. */
-    static inline bool UseDefaultSection(const ArgsManager& am, const std::string& arg)
+    static inline bool UseDefaultSection(const ArgsManager& am, const std::string& arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
     {
         return (am.m_network == CBaseChainParams::MAIN || am.m_network_only_args.count(arg) == 0);
     }
@@ -295,7 +295,7 @@ public:
     /* Special test for -testnet and -regtest args, because we
      * don't want to be confused by craziness like "[regtest] testnet=1"
      */
-    static inline bool GetNetBoolArg(const ArgsManager &am, const std::string& net_arg)
+    static inline bool GetNetBoolArg(const ArgsManager &am, const std::string& net_arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
     {
         std::pair<bool,std::string> found_result(false,std::string());
         found_result = GetArgHelper(am.m_override_args, net_arg, true);

--- a/src/util.h
+++ b/src/util.h
@@ -262,7 +262,10 @@ public:
     /**
      * Clear available arguments
      */
-    void ClearArgs() { m_available_args.clear(); }
+    void ClearArgs() {
+        LOCK(cs_args);
+        m_available_args.clear();
+    }
 
     /**
      * Get the help string

--- a/src/util.h
+++ b/src/util.h
@@ -142,11 +142,11 @@ protected:
     };
 
     mutable CCriticalSection cs_args;
-    std::map<std::string, std::vector<std::string>> m_override_args;
-    std::map<std::string, std::vector<std::string>> m_config_args;
-    std::string m_network;
-    std::set<std::string> m_network_only_args;
-    std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args;
+    std::map<std::string, std::vector<std::string>> m_override_args GUARDED_BY(cs_args);
+    std::map<std::string, std::vector<std::string>> m_config_args GUARDED_BY(cs_args);
+    std::string m_network GUARDED_BY(cs_args);
+    std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
+    std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
 
     bool ReadConfigStream(std::istream& stream, std::string& error, bool ignore_invalid_keys = false);
 


### PR DESCRIPTION
* Add missing `cs_args` locks
* Add Clang thread safety annotations for variables guarded by `cs_args`