### PR TITLE
[tests] Fix race in rpc_deprecated.py

### DIFF
--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -49,6 +49,7 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         #
         address0 = self.nodes[0].getnewaddress()
         self.nodes[0].generatetoaddress(101, address0)
+        self.sync_all()
         address1 = self.nodes[1].getnewaddress()
         self.nodes[1].generatetoaddress(101, address1)
 


### PR DESCRIPTION
Fixes a block generation race introduced in 3576ab1261.