### PR TITLE
[Docs] Add version footnote to tor.md (Willtech)

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -39,7 +39,8 @@ In a typical situation, this suffices to run behind a Tor proxy:
 
 If you configure your Tor system accordingly, it is possible to make your node also
 reachable from the Tor network. Add these lines to your /etc/tor/torrc (or equivalent
-config file):
+config file): *Needed for Tor version 0.2.7.0 and older versions of Tor only. For newer
++versions of Tor the [onion listener can be configured automatically](#3-automatically-listen-on-tor).*
 
 	HiddenServiceDir /var/lib/tor/bitcoin-service/
 	HiddenServicePort 8333 127.0.0.1:8333


### PR DESCRIPTION
Added note to section 2, part -edits to `/etc/tor/torrc`- indicating this is only required for Tor version 0.2.7.0 and older, since section 3 states it is valid for Tor version 0.2.7.1 and newer. Added ref link from section 2 version footnote to section 3. Re-styled headings to work on GitHub -alternate heading style markup creation issue with numbered headings and thus headings and automatic heading links are broken- Ref: [Issue# 12376](https://github.com/bitcoin/bitcoin/issues/12376)

Signed-off-by: Damian Williamson <willtech@live.com.au>