### PR TITLE
[tests] Fix flake8 warnings in several wallet functional tests

### DIFF
--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -46,10 +46,10 @@ class Variant(collections.namedtuple("Variant", "call data rescan prune")):
         if self.call == Call.single:
             if self.data == Data.address:
                 response = self.try_rpc(self.node.importaddress, self.address["address"], self.label,
-                                               self.rescan == Rescan.yes)
+                                        self.rescan == Rescan.yes)
             elif self.data == Data.pub:
                 response = self.try_rpc(self.node.importpubkey, self.address["pubkey"], self.label,
-                                               self.rescan == Rescan.yes)
+                                        self.rescan == Rescan.yes)
             elif self.data == Data.priv:
                 response = self.try_rpc(self.node.importprivkey, self.key, self.label, self.rescan == Rescan.yes)
             assert_equal(response, None)

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -3,8 +3,13 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the importprunedfunds and removeprunedfunds RPCs."""
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
 
 class ImportPrunedFundsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -24,18 +29,18 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         address2 = self.nodes[0].getnewaddress()
         # privkey
         address3 = self.nodes[0].getnewaddress()
-        address3_privkey = self.nodes[0].dumpprivkey(address3)                              # Using privkey
+        address3_privkey = self.nodes[0].dumpprivkey(address3)  # Using privkey
 
-        #Check only one address
+        # Check only one address
         address_info = self.nodes[0].getaddressinfo(address1)
         assert_equal(address_info['ismine'], True)
 
         self.sync_all()
 
-        #Node 1 sync test
-        assert_equal(self.nodes[1].getblockcount(),101)
+        # Node 1 sync test
+        assert_equal(self.nodes[1].getblockcount(), 101)
 
-        #Address Test - before import
+        # Address Test - before import
         address_info = self.nodes[1].getaddressinfo(address1)
         assert_equal(address_info['iswatchonly'], False)
         assert_equal(address_info['ismine'], False)
@@ -48,7 +53,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['iswatchonly'], False)
         assert_equal(address_info['ismine'], False)
 
-        #Send funds to self
+        # Send funds to self
         txnid1 = self.nodes[0].sendtoaddress(address1, 0.1)
         self.nodes[0].generate(1)
         rawtxn1 = self.nodes[0].gettransaction(txnid1)['hex']
@@ -66,19 +71,19 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
 
         self.sync_all()
 
-        #Import with no affiliated address
+        # Import with no affiliated address
         assert_raises_rpc_error(-5, "No addresses", self.nodes[1].importprunedfunds, rawtxn1, proof1)
 
         balance1 = self.nodes[1].getbalance("", 0, True)
         assert_equal(balance1, Decimal(0))
 
-        #Import with affiliated address with no rescan
+        # Import with affiliated address with no rescan
         self.nodes[1].importaddress(address2, "add2", False)
         self.nodes[1].importprunedfunds(rawtxn2, proof2)
         balance2 = self.nodes[1].getbalance("add2", 0, True)
         assert_equal(balance2, Decimal('0.05'))
 
-        #Import with private key with no rescan
+        # Import with private key with no rescan
         self.nodes[1].importprivkey(privkey=address3_privkey, label="add3", rescan=False)
         self.nodes[1].importprunedfunds(rawtxn3, proof3)
         balance3 = self.nodes[1].getbalance("add3", 0, False)
@@ -86,7 +91,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         balance3 = self.nodes[1].getbalance("*", 0, True)
         assert_equal(balance3, Decimal('0.075'))
 
-        #Addresses Test - after import
+        # Addresses Test - after import
         address_info = self.nodes[1].getaddressinfo(address1)
         assert_equal(address_info['iswatchonly'], False)
         assert_equal(address_info['ismine'], False)
@@ -97,7 +102,7 @@ class ImportPrunedFundsTest(BitcoinTestFramework):
         assert_equal(address_info['iswatchonly'], False)
         assert_equal(address_info['ismine'], True)
 
-        #Remove transactions
+        # Remove transactions
         assert_raises_rpc_error(-8, "Transaction does not exist in wallet.", self.nodes[1].removeprunedfunds, txnid1)
 
         balance1 = self.nodes[1].getbalance("*", 0, True)

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -51,37 +51,37 @@ class ReceivedByTest(BitcoinTestFramework):
                             {"address": empty_addr},
                             {"address": empty_addr, "label": "", "amount": 0, "confirmations": 0, "txids": []})
 
-        #Test Address filtering
-        #Only on addr
-        expected = {"address":addr, "label":"", "amount":Decimal("0.1"), "confirmations":10, "txids":[txid,]}
+        # Test Address filtering
+        # Only on addr
+        expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 10, "txids": [txid, ]}
         res = self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True, include_watchonly=True, address_filter=addr)
-        assert_array_result(res, {"address":addr}, expected)
+        assert_array_result(res, {"address": addr}, expected)
         assert_equal(len(res), 1)
-        #Error on invalid address
+        # Error on invalid address
         assert_raises_rpc_error(-4, "address_filter parameter was invalid", self.nodes[1].listreceivedbyaddress, minconf=0, include_empty=True, include_watchonly=True, address_filter="bamboozling")
-        #Another address receive money
+        # Another address receive money
         res = self.nodes[1].listreceivedbyaddress(0, True, True)
-        assert_equal(len(res), 2) #Right now 2 entries
+        assert_equal(len(res), 2)  # Right now 2 entries
         other_addr = self.nodes[1].getnewaddress()
         txid2 = self.nodes[0].sendtoaddress(other_addr, 0.1)
         self.nodes[0].generate(1)
         self.sync_all()
-        #Same test as above should still pass
-        expected = {"address":addr, "label":"", "amount":Decimal("0.1"), "confirmations":11, "txids":[txid,]}
+        # Same test as above should still pass
+        expected = {"address": addr, "label": "", "amount": Decimal("0.1"), "confirmations": 11, "txids": [txid, ]}
         res = self.nodes[1].listreceivedbyaddress(0, True, True, addr)
-        assert_array_result(res, {"address":addr}, expected)
+        assert_array_result(res, {"address": addr}, expected)
         assert_equal(len(res), 1)
-        #Same test as above but with other_addr should still pass
-        expected = {"address":other_addr, "label":"", "amount":Decimal("0.1"), "confirmations":1, "txids":[txid2,]}
+        # Same test as above but with other_addr should still pass
+        expected = {"address": other_addr, "label": "", "amount": Decimal("0.1"), "confirmations": 1, "txids": [txid2, ]}
         res = self.nodes[1].listreceivedbyaddress(0, True, True, other_addr)
-        assert_array_result(res, {"address":other_addr}, expected)
+        assert_array_result(res, {"address": other_addr}, expected)
         assert_equal(len(res), 1)
-        #Should be two entries though without filter
+        # Should be two entries though without filter
         res = self.nodes[1].listreceivedbyaddress(0, True, True)
-        assert_equal(len(res), 3) #Became 3 entries
+        assert_equal(len(res), 3)  # Became 3 entries
 
-        #Not on random addr
-        other_addr = self.nodes[0].getnewaddress() # note on node[0]! just a random addr
+        # Not on random addr
+        other_addr = self.nodes[0].getnewaddress()  # note on node[0]! just a random addr
         res = self.nodes[1].listreceivedbyaddress(0, True, True, other_addr)
         assert_equal(len(res), 0)
 
@@ -112,8 +112,8 @@ class ReceivedByTest(BitcoinTestFramework):
         self.log.info("listreceivedbylabel + getreceivedbylabel Test")
 
         # set pre-state
-        addrArr = self.nodes[1].getnewaddress()
-        label = self.nodes[1].getaccount(addrArr)
+        address = self.nodes[1].getnewaddress()
+        label = self.nodes[1].getaccount(address)
         received_by_label_json = [r for r in self.nodes[1].listreceivedbylabel() if r["label"] == label][0]
         balance_by_label = self.nodes[1].getreceivedbylabel(label)
 

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -150,26 +150,26 @@ class ListSinceBlockTest (BitcoinTestFramework):
 
         # send from nodes[1] using utxo to nodes[0]
         change = '%.8f' % (float(utxo['amount']) - 1.0003)
-        recipientDict = {
+        recipient_dict = {
             self.nodes[0].getnewaddress(): 1,
             self.nodes[1].getnewaddress(): change,
         }
-        utxoDicts = [{
+        utxo_dicts = [{
             'txid': utxo['txid'],
             'vout': utxo['vout'],
         }]
         txid1 = self.nodes[1].sendrawtransaction(
             self.nodes[1].signrawtransactionwithwallet(
-                self.nodes[1].createrawtransaction(utxoDicts, recipientDict))['hex'])
+                self.nodes[1].createrawtransaction(utxo_dicts, recipient_dict))['hex'])
 
         # send from nodes[2] using utxo to nodes[3]
-        recipientDict2 = {
+        recipient_dict2 = {
             self.nodes[3].getnewaddress(): 1,
             self.nodes[2].getnewaddress(): change,
         }
         self.nodes[2].sendrawtransaction(
             self.nodes[2].signrawtransactionwithwallet(
-                self.nodes[2].createrawtransaction(utxoDicts, recipientDict2))['hex'])
+                self.nodes[2].createrawtransaction(utxo_dicts, recipient_dict2))['hex'])
 
         # generate on both sides
         lastblockhash = self.nodes[1].generate(3)[2]
@@ -225,16 +225,16 @@ class ListSinceBlockTest (BitcoinTestFramework):
         utxos = self.nodes[2].listunspent()
         utxo = utxos[0]
         change = '%.8f' % (float(utxo['amount']) - 1.0003)
-        recipientDict = {
+        recipient_dict = {
             self.nodes[0].getnewaddress(): 1,
             self.nodes[2].getnewaddress(): change,
         }
-        utxoDicts = [{
+        utxo_dicts = [{
             'txid': utxo['txid'],
             'vout': utxo['vout'],
         }]
         signedtxres = self.nodes[2].signrawtransactionwithwallet(
-                self.nodes[2].createrawtransaction(utxoDicts, recipientDict))
+            self.nodes[2].createrawtransaction(utxo_dicts, recipient_dict))
         assert signedtxres['complete']
 
         signedtx = signedtxres['hex']

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -3,13 +3,20 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test the listtransactions API."""
-
-from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
-from test_framework.mininode import CTransaction, COIN
+from decimal import Decimal
 from io import BytesIO
 
-def txFromHex(hexstring):
+from test_framework.mininode import CTransaction, COIN
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    bytes_to_hex_str,
+    hex_str_to_bytes,
+    sync_mempools,
+)
+
+def tx_from_hex(hexstring):
     tx = CTransaction()
     f = BytesIO(hex_str_to_bytes(hexstring))
     tx.deserialize(f)
@@ -26,61 +33,61 @@ class ListTransactionsTest(BitcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid},
-                           {"category":"send","account":"","amount":Decimal("-0.1"),"confirmations":0})
+                            {"txid": txid},
+                            {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 0})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"txid":txid},
-                           {"category":"receive","account":"","amount":Decimal("0.1"),"confirmations":0})
+                            {"txid": txid},
+                            {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 0})
         # mine a block, confirmations should change:
         self.nodes[0].generate(1)
         self.sync_all()
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid},
-                           {"category":"send","account":"","amount":Decimal("-0.1"),"confirmations":1})
+                            {"txid": txid},
+                            {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 1})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"txid":txid},
-                           {"category":"receive","account":"","amount":Decimal("0.1"),"confirmations":1})
+                            {"txid": txid},
+                            {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 1})
 
         # send-to-self:
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.2)
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid, "category":"send"},
-                           {"amount":Decimal("-0.2")})
+                            {"txid": txid, "category": "send"},
+                            {"amount": Decimal("-0.2")})
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"txid":txid, "category":"receive"},
-                           {"amount":Decimal("0.2")})
+                            {"txid": txid, "category": "receive"},
+                            {"amount": Decimal("0.2")})
 
         # sendmany from node1: twice to self, twice to node2:
-        send_to = { self.nodes[0].getnewaddress() : 0.11,
-                    self.nodes[1].getnewaddress() : 0.22,
-                    self.nodes[0].getaccountaddress("from1") : 0.33,
-                    self.nodes[1].getaccountaddress("toself") : 0.44 }
+        send_to = {self.nodes[0].getnewaddress(): 0.11,
+                   self.nodes[1].getnewaddress(): 0.22,
+                   self.nodes[0].getaccountaddress("from1"): 0.33,
+                   self.nodes[1].getaccountaddress("toself"): 0.44}
         txid = self.nodes[1].sendmany("", send_to)
         self.sync_all()
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.11")},
-                           {"txid":txid} )
+                            {"category": "send", "amount": Decimal("-0.11")},
+                            {"txid": txid})
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.11")},
-                           {"txid":txid} )
+                            {"category": "receive", "amount": Decimal("0.11")},
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.22")},
-                           {"txid":txid} )
+                            {"category": "send", "amount": Decimal("-0.22")},
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.22")},
-                           {"txid":txid} )
+                            {"category": "receive", "amount": Decimal("0.22")},
+                            {"txid": txid})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.33")},
-                           {"txid":txid} )
+                            {"category": "send", "amount": Decimal("-0.33")},
+                            {"txid": txid})
         assert_array_result(self.nodes[0].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.33")},
-                           {"txid":txid, "account" : "from1"} )
+                            {"category": "receive", "amount": Decimal("0.33")},
+                            {"txid": txid, "account": "from1"})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"send","amount":Decimal("-0.44")},
-                           {"txid":txid, "account" : ""} )
+                            {"category": "send", "amount": Decimal("-0.44")},
+                            {"txid": txid, "account": ""})
         assert_array_result(self.nodes[1].listtransactions(),
-                           {"category":"receive","amount":Decimal("0.44")},
-                           {"txid":txid, "account" : "toself"} )
+                            {"category": "receive", "amount": Decimal("0.44")},
+                            {"txid": txid, "account": "toself"})
 
         pubkey = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress())['pubkey']
         multisig = self.nodes[1].createmultisig(1, [pubkey])
@@ -90,8 +97,8 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         assert(len(self.nodes[0].listtransactions("watchonly", 100, 0, False)) == 0)
         assert_array_result(self.nodes[0].listtransactions("watchonly", 100, 0, True),
-                           {"category":"receive","amount":Decimal("0.1")},
-                           {"txid":txid, "account" : "watchonly"} )
+                            {"category": "receive", "amount": Decimal("0.1")},
+                            {"txid": txid, "account": "watchonly"})
 
         self.run_rbf_opt_in_test()
 
@@ -117,9 +124,9 @@ class ListTransactionsTest(BitcoinTestFramework):
         # 1. Chain a few transactions that don't opt-in.
         txid_1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         assert(not is_opt_in(self.nodes[0], txid_1))
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_1}, {"bip125-replaceable":"no"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_1}, {"bip125-replaceable": "no"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_1}, {"bip125-replaceable":"no"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_1}, {"bip125-replaceable": "no"})
 
         # Tx2 will build off txid_1, still not opting in to RBF.
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_1)
@@ -129,7 +136,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         assert_equal(utxo_to_use["safe"], False)
 
         # Create tx2 using createrawtransaction
-        inputs = [{"txid":utxo_to_use["txid"], "vout":utxo_to_use["vout"]}]
+        inputs = [{"txid": utxo_to_use["txid"], "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[0].getnewaddress(): 0.999}
         tx2 = self.nodes[1].createrawtransaction(inputs, outputs)
         tx2_signed = self.nodes[1].signrawtransactionwithwallet(tx2)["hex"]
@@ -137,51 +144,51 @@ class ListTransactionsTest(BitcoinTestFramework):
 
         # ...and check the result
         assert(not is_opt_in(self.nodes[1], txid_2))
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_2}, {"bip125-replaceable":"no"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_2}, {"bip125-replaceable": "no"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_2}, {"bip125-replaceable":"no"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_2}, {"bip125-replaceable": "no"})
 
         # Tx3 will opt-in to RBF
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[0], txid_2)
-        inputs = [{"txid": txid_2, "vout":utxo_to_use["vout"]}]
+        inputs = [{"txid": txid_2, "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[1].getnewaddress(): 0.998}
         tx3 = self.nodes[0].createrawtransaction(inputs, outputs)
-        tx3_modified = txFromHex(tx3)
+        tx3_modified = tx_from_hex(tx3)
         tx3_modified.vin[0].nSequence = 0
         tx3 = bytes_to_hex_str(tx3_modified.serialize())
         tx3_signed = self.nodes[0].signrawtransactionwithwallet(tx3)['hex']
         txid_3 = self.nodes[0].sendrawtransaction(tx3_signed)
 
         assert(is_opt_in(self.nodes[0], txid_3))
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_3}, {"bip125-replaceable":"yes"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_3}, {"bip125-replaceable": "yes"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_3}, {"bip125-replaceable":"yes"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_3}, {"bip125-replaceable": "yes"})
 
         # Tx4 will chain off tx3.  Doesn't signal itself, but depends on one
         # that does.
         utxo_to_use = get_unconfirmed_utxo_entry(self.nodes[1], txid_3)
-        inputs = [{"txid": txid_3, "vout":utxo_to_use["vout"]}]
+        inputs = [{"txid": txid_3, "vout": utxo_to_use["vout"]}]
         outputs = {self.nodes[0].getnewaddress(): 0.997}
         tx4 = self.nodes[1].createrawtransaction(inputs, outputs)
         tx4_signed = self.nodes[1].signrawtransactionwithwallet(tx4)["hex"]
         txid_4 = self.nodes[1].sendrawtransaction(tx4_signed)
 
         assert(not is_opt_in(self.nodes[1], txid_4))
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"yes"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "yes"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"yes"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "yes"})
 
         # Replace tx3, and check that tx4 becomes unknown
         tx3_b = tx3_modified
-        tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN) # bump the fee
+        tx3_b.vout[0].nValue -= int(Decimal("0.004") * COIN)  # bump the fee
         tx3_b = bytes_to_hex_str(tx3_b.serialize())
         tx3_b_signed = self.nodes[0].signrawtransactionwithwallet(tx3_b)['hex']
         txid_3b = self.nodes[0].sendrawtransaction(tx3_b_signed, True)
         assert(is_opt_in(self.nodes[0], txid_3b))
 
-        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"unknown"})
+        assert_array_result(self.nodes[0].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "unknown"})
         sync_mempools(self.nodes)
-        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable":"unknown"})
+        assert_array_result(self.nodes[1].listtransactions(), {"txid": txid_4}, {"bip125-replaceable": "unknown"})
 
         # Check gettransaction as well:
         for n in self.nodes[0:2]:
@@ -197,7 +204,5 @@ class ListTransactionsTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].gettransaction(txid_3b)["bip125-replaceable"], "no")
         assert_equal(self.nodes[0].gettransaction(txid_4)["bip125-replaceable"], "unknown")
 
-
 if __name__ == '__main__':
     ListTransactionsTest().main()
-

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -5,7 +5,12 @@
 """Test the wallet accounts properly when there are cloned transactions with malleated scriptsigs."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import *
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    sync_blocks,
+)
 
 class TxnMallTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -26,9 +31,9 @@ class TxnMallTest(BitcoinTestFramework):
 
     def run_test(self):
         if self.options.segwit:
-            output_type="p2sh-segwit"
+            output_type = "p2sh-segwit"
         else:
-            output_type="legacy"
+            output_type = "legacy"
 
         # All nodes should start with 1,250 BTC:
         starting_balance = 1250
@@ -53,28 +58,27 @@ class TxnMallTest(BitcoinTestFramework):
         # Coins are sent to node1_address
         node1_address = self.nodes[1].getnewaddress("from0")
 
-        # Send tx1, and another transaction tx2 that won't be cloned 
+        # Send tx1, and another transaction tx2 that won't be cloned
         txid1 = self.nodes[0].sendfrom("foo", node1_address, 40, 0)
         txid2 = self.nodes[0].sendfrom("bar", node1_address, 20, 0)
 
-        # Construct a clone of tx1, to be malleated 
-        rawtx1 = self.nodes[0].getrawtransaction(txid1,1)
-        clone_inputs = [{"txid":rawtx1["vin"][0]["txid"],"vout":rawtx1["vin"][0]["vout"]}]
-        clone_outputs = {rawtx1["vout"][0]["scriptPubKey"]["addresses"][0]:rawtx1["vout"][0]["value"],
-                         rawtx1["vout"][1]["scriptPubKey"]["addresses"][0]:rawtx1["vout"][1]["value"]}
+        # Construct a clone of tx1, to be malleated
+        rawtx1 = self.nodes[0].getrawtransaction(txid1, 1)
+        clone_inputs = [{"txid": rawtx1["vin"][0]["txid"], "vout": rawtx1["vin"][0]["vout"]}]
+        clone_outputs = {rawtx1["vout"][0]["scriptPubKey"]["addresses"][0]: rawtx1["vout"][0]["value"],
+                         rawtx1["vout"][1]["scriptPubKey"]["addresses"][0]: rawtx1["vout"][1]["value"]}
         clone_locktime = rawtx1["locktime"]
         clone_raw = self.nodes[0].createrawtransaction(clone_inputs, clone_outputs, clone_locktime)
 
         # createrawtransaction randomizes the order of its outputs, so swap them if necessary.
         # output 0 is at version+#inputs+input+sigstub+sequence+#outputs
         # 40 BTC serialized is 00286bee00000000
-        pos0 = 2*(4+1+36+1+4+1)
+        pos0 = 2 * (4 + 1 + 36 + 1 + 4 + 1)
         hex40 = "00286bee00000000"
-        output_len = 16 + 2 + 2 * int("0x" + clone_raw[pos0 + 16 : pos0 + 16 + 2], 0)
-        if (rawtx1["vout"][0]["value"] == 40 and clone_raw[pos0 : pos0 + 16] != hex40 or
-            rawtx1["vout"][0]["value"] != 40 and clone_raw[pos0 : pos0 + 16] == hex40):
-            output0 = clone_raw[pos0 : pos0 + output_len]
-            output1 = clone_raw[pos0 + output_len : pos0 + 2 * output_len]
+        output_len = 16 + 2 + 2 * int("0x" + clone_raw[pos0 + 16:pos0 + 16 + 2], 0)
+        if (rawtx1["vout"][0]["value"] == 40 and clone_raw[pos0:pos0 + 16] != hex40 or rawtx1["vout"][0]["value"] != 40 and clone_raw[pos0:pos0 + 16] == hex40):
+            output0 = clone_raw[pos0:pos0 + output_len]
+            output1 = clone_raw[pos0 + output_len:pos0 + 2 * output_len]
             clone_raw = clone_raw[:pos0] + output1 + output0 + clone_raw[pos0 + 2 * output_len:]
 
         # Use a different signature hash type to sign.  This creates an equivalent but malleated clone.
@@ -142,7 +146,7 @@ class TxnMallTest(BitcoinTestFramework):
         # Check node0's total balance; should be same as before the clone, + 100 BTC for 2 matured,
         # less possible orphaned matured subsidy
         expected += 100
-        if (self.options.mine_block): 
+        if (self.options.mine_block):
             expected -= 50
         assert_equal(self.nodes[0].getbalance(), expected)
         assert_equal(self.nodes[0].getbalance("*", 0), expected)
@@ -153,16 +157,11 @@ class TxnMallTest(BitcoinTestFramework):
         # "bar" should have been debited by (possibly unconfirmed) tx2
         assert_equal(self.nodes[0].getbalance("bar", 0), 29 + tx2["amount"] + tx2["fee"])
         # "" should have starting balance, less funding txes, plus subsidies
-        assert_equal(self.nodes[0].getbalance("", 0), starting_balance
-                                                                - 1219
-                                                                + fund_foo_tx["fee"]
-                                                                -   29
-                                                                + fund_bar_tx["fee"]
-                                                                +  100)
+        assert_equal(self.nodes[0].getbalance("", 0),
+                     starting_balance - 1219 + fund_foo_tx["fee"] - 29 + fund_bar_tx["fee"] + 100)
 
         # Node1's "from0" account balance
         assert_equal(self.nodes[1].getbalance("from0", 0), -(tx1["amount"] + tx2["amount"]))
 
 if __name__ == '__main__':
     TxnMallTest().main()
-


### PR DESCRIPTION
Fixes flake8 warnings in several wallet functional tests.

Several wallet functional tests need rewrite to remove the accounts API (#13075). To prepare for that, I fixed all the flake8 warnings in those tests.

#13075 is blocked on a bitcoind bug. This PR is just the flake8 fixes so we're not completely blocked.