### PR TITLE
[doc] qt: fixes broken link on readme

### DIFF
--- a/src/qt/README.md
+++ b/src/qt/README.md
@@ -16,7 +16,7 @@ To run:
 
 ### forms
 
-Contains [Designer UI](http://doc.qt.io/qt-5.9/designer-using-a-ui-file.html) files. They are created with [Qt Creator](#use-qt-Creator-as IDE), but can be edited using any text editor.
+Contains [Designer UI](http://doc.qt.io/qt-5.9/designer-using-a-ui-file.html) files. They are created with [Qt Creator](#using-qt-creator-as-ide), but can be edited using any text editor.
 
 ### locale
 


### PR DESCRIPTION
I was reading qt files and just fixed a trivial mistake on its readme file.
`#use-qt-Creator-as IDE` should be `#using-qt-creator-as-ide`