### PR TITLE
RPC: Improve error messages on RPC endpoints that use GetTransaction

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -352,14 +352,13 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
     if (!ParseHashStr(hashStr, hash))
         return RESTERR(req, HTTP_BAD_REQUEST, "Invalid hash: " + hashStr);
 
-    if (g_txindex) {
-        g_txindex->BlockUntilSyncedToCurrentChain();
-    }
-
     CTransactionRef tx;
     uint256 hashBlock = uint256();
-    if (!GetTransaction(hash, tx, hashBlock, true))
-        return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
+    int error_code;
+    std::string errmsg;
+    if (!GetTransaction(hash, tx, hashBlock, error_code, errmsg, true)) {
+        return RESTERR(req, HTTP_NOT_FOUND, errmsg);
+    }
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
     ssTx << tx;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -12,6 +12,7 @@
 #include <validation.h>
 #include <httpserver.h>
 #include <rpc/blockchain.h>
+#include <rpc/rawtransaction.h>
 #include <rpc/server.h>
 #include <streams.h>
 #include <sync.h>
@@ -357,7 +358,7 @@ static bool rest_tx(HTTPRequest* req, const std::string& strURIPart)
 
     CTransactionRef tx;
     uint256 hashBlock = uint256();
-    if (!GetTransaction(hash, tx, Params().GetConsensus(), hashBlock, true))
+    if (!GetTransaction(hash, tx, hashBlock, true))
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -16,6 +16,7 @@
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>
+#include <rpc/rawtransaction.h>
 #include <rpc/server.h>
 #include <streams.h>
 #include <sync.h>
@@ -1822,7 +1823,7 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             for (const CTxIn& in : tx->vin) {
                 CTransactionRef tx_in;
                 uint256 hashBlock;
-                if (!GetTransaction(in.prevout.hash, tx_in, Params().GetConsensus(), hashBlock, false)) {
+                if (!GetTransaction(in.prevout.hash, tx_in, hashBlock, false)) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Unexpected internal error (tx index seems corrupt)"));
                 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1823,7 +1823,9 @@ static UniValue getblockstats(const JSONRPCRequest& request)
             for (const CTxIn& in : tx->vin) {
                 CTransactionRef tx_in;
                 uint256 hashBlock;
-                if (!GetTransaction(in.prevout.hash, tx_in, hashBlock, false)) {
+                int dummy_error_code;
+                std::string dummy_errmsg;
+                if (!GetTransaction(in.prevout.hash, tx_in, hashBlock, dummy_error_code, dummy_errmsg, false)) {
                     throw JSONRPCError(RPC_INTERNAL_ERROR, std::string("Unexpected internal error (tx index seems corrupt)"));
                 }
 

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -57,6 +57,7 @@ enum RPCErrorCode
     RPC_VERIFY_ALREADY_IN_CHAIN     = -27, //!< Transaction already in chain
     RPC_IN_WARMUP                   = -28, //!< Client still warming up
     RPC_METHOD_DEPRECATED           = -32, //!< RPC method is deprecated
+    RPC_DATA_UNAVAILABLE            = -33, //!< Requested data is unavailable due to application configuration or state
 
     //! Aliases for backward compatibility
     RPC_TRANSACTION_ERROR           = RPC_VERIFY_ERROR,

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -5,11 +5,18 @@
 #ifndef BITCOIN_RPC_RAWTRANSACTION_H
 #define BITCOIN_RPC_RAWTRANSACTION_H
 
+#include <primitives/transaction.h>
+#include <uint256.h>
+
 class CBasicKeyStore;
+class CBlockIndex;
 struct CMutableTransaction;
 class UniValue;
 
 /** Sign a transaction with the given keystore and previous transactions */
 UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxs, CBasicKeyStore *keystore, bool tempKeystore, const UniValue& hashType);
+
+/** Retrieve a transaction (from memory pool, or from disk, if possible) */
+bool GetTransaction(const uint256& hash, CTransactionRef& tx, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
 
 #endif // BITCOIN_RPC_RAWTRANSACTION_H

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -24,11 +24,13 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxs, CBas
  * @param[in]   tx_hash  The hash of the transaction to be returned.
  * @param[out]  tx  The transaction itself.
  * @param[out]  block_hash  The hash of the block the transaction is found in.
+ * @param[out]  error_code  RPC code explaining why transaction could not be found.
+ * @param[out]  errmsg  Reason why transaction could not be found.
  * @param[in]   allow_slow  An option to search a slow, unreliable source for transactions.
  * @return  true if transaction is found, false otherwise
  */
 bool GetTransaction(const uint256& tx_hash, CTransactionRef& tx, uint256& block_hash,
-                    bool allow_slow);
+                    int& error_code, std::string& errmsg, bool allow_slow);
 
 /**
  * Look up a raw transaction by hash within a specified block. This loads the

--- a/src/rpc/rawtransaction.h
+++ b/src/rpc/rawtransaction.h
@@ -16,7 +16,31 @@ class UniValue;
 /** Sign a transaction with the given keystore and previous transactions */
 UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxs, CBasicKeyStore *keystore, bool tempKeystore, const UniValue& hashType);
 
-/** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256& hash, CTransactionRef& tx, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
+/**
+ * Look up a transaction by hash. This checks for transactions in the mempool,
+ * the tx index if enabled, and the UTXO set cache on a best-effort basis. If
+ * the transaction is not found, this returns false.
+ *
+ * @param[in]   tx_hash  The hash of the transaction to be returned.
+ * @param[out]  tx  The transaction itself.
+ * @param[out]  block_hash  The hash of the block the transaction is found in.
+ * @param[in]   allow_slow  An option to search a slow, unreliable source for transactions.
+ * @return  true if transaction is found, false otherwise
+ */
+bool GetTransaction(const uint256& tx_hash, CTransactionRef& tx, uint256& block_hash,
+                    bool allow_slow);
+
+/**
+ * Look up a raw transaction by hash within a specified block. This loads the
+ * block itself from disk and return true if the transaction is contained within
+ * it.
+ *
+ * @param[in]   tx_hash  The hash of the transaction to be returned.
+ * @param[in]   block_index  The block index of the block to search.
+ * @param[out]  tx  The raw transaction itself.
+ * @return  true if transaction is found, false otherwise
+ */
+bool GetTransactionInBlock(const uint256& tx_hash, const CBlockIndex* block_index,
+                           CTransactionRef& tx);
 
 #endif // BITCOIN_RPC_RAWTRANSACTION_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -278,8 +278,6 @@ void UnloadBlockIndex();
 void ThreadScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
-/** Retrieve a transaction (from memory pool, or from disk, if possible) */
-bool GetTransaction(const uint256& hash, CTransactionRef& tx, const Consensus::Params& params, uint256& hashBlock, bool fAllowSlow = false, CBlockIndex* blockIndex = nullptr);
 /**
  * Find the best known block, and make it the tip of the block chain
  *

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -40,7 +40,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         tx2 = self.nodes[0].createrawtransaction([node0utxos.pop()], {self.nodes[1].getnewaddress(): 49.99})
         txid2 = self.nodes[0].sendrawtransaction(self.nodes[0].signrawtransactionwithwallet(tx2)["hex"])
         # This will raise an exception because the transaction is not yet in a block
-        assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[0].gettxoutproof, [txid1])
+        assert_raises_rpc_error(-5, "Transaction not found in block", self.nodes[3].gettxoutproof, [txid1])
 
         self.nodes[0].generate(1)
         blockhash = self.nodes[0].getblockhash(chain_height + 1)
@@ -64,8 +64,8 @@ class MerkleBlockTest(BitcoinTestFramework):
         txid_spent = txin_spent["txid"]
         txid_unspent = txid1 if txin_spent["txid"] != txid1 else txid2
 
-        # We can't find the block from a fully-spent tx
-        assert_raises_rpc_error(-5, "Transaction not yet in block", self.nodes[2].gettxoutproof, [txid_spent])
+        # We can't find the block from a fully-spent tx without txindex
+        assert_raises_rpc_error(-33, "Use -txindex to enable blockchain transaction queries", self.nodes[2].gettxoutproof, [txid_spent])
         # We can get the proof if we specify the block
         assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid_spent], blockhash)), [txid_spent])
         # We can't get the proof if we specify a non-existent block


### PR DESCRIPTION
This contains some follow up items from #13033.

The PR refactors the GetTransaction function and moves it from validation to rpc/rawtransaction. This breaks a cyclic dependency between validation and index/txindex pointed out by @sipa. Also, the REST transaction API and gettxoutproof RPC now have more clear error messages when the txindex is not available, as requested by @TheBlueMatt.

This would also be a good opportunity to drop the slow tx lookup through the unspent coins view if people are for it, as proposed in https://github.com/bitcoin/bitcoin/issues/3220.