### PR TITLE
rpcauth: Make it possible to provide a custom password

### DIFF
--- a/share/rpcauth/README.md
+++ b/share/rpcauth/README.md
@@ -8,3 +8,7 @@ Create login credentials for a JSON-RPC user.
 Usage:
 
     ./rpcauth.py <username>
+
+in which case the script will generate a password. To specify a custom password do:
+
+    ./rpcauth.py <username> <password>

--- a/test/util/rpcauth-test.py
+++ b/test/util/rpcauth-test.py
@@ -28,16 +28,15 @@ class TestRPCAuth(unittest.TestCase):
         self.assertGreaterEqual(len(self.rpcauth.generate_salt()), 16)
 
     def test_generate_password(self):
-        salt = self.rpcauth.generate_salt()
-        password, password_hmac = self.rpcauth.generate_password(salt)
-
+        password = self.rpcauth.generate_password()
         expected_password = base64.urlsafe_b64encode(
             base64.urlsafe_b64decode(password)).decode('utf-8')
         self.assertEqual(expected_password, password)
 
     def test_check_password_hmac(self):
         salt = self.rpcauth.generate_salt()
-        password, password_hmac = self.rpcauth.generate_password(salt)
+        password = self.rpcauth.generate_password()
+        password_hmac = self.rpcauth.password_to_hmac(salt, password)
 
         m = hmac.new(bytearray(salt, 'utf-8'),
             bytearray(password, 'utf-8'), 'SHA256')


### PR DESCRIPTION
This adds the functionality to specify a custom password to `rpcauth.py`, as well as makes the code (IMO) easier to understand.