### PR TITLE
logging: Fix potential use-after-free in LogPrintStr(...)

### DIFF
--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -222,8 +222,11 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
             // reopen the log file, if requested
             if (m_reopen_file) {
                 m_reopen_file = false;
-                if (fsbridge::freopen(m_file_path,"a",m_fileout) != nullptr)
-                    setbuf(m_fileout, nullptr); // unbuffered
+                m_fileout = fsbridge::freopen(m_file_path, "a", m_fileout);
+                if (!m_fileout) {
+                    return ret;
+                }
+                setbuf(m_fileout, nullptr); // unbuffered
             }
 
             ret = FileWriteStr(strTimestamped, m_fileout);

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -198,15 +198,13 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
     return strStamped;
 }
 
-int BCLog::Logger::LogPrintStr(const std::string &str)
+void BCLog::Logger::LogPrintStr(const std::string &str)
 {
-    int ret = 0; // Returns total number of characters written
-
     std::string strTimestamped = LogTimestampStr(str);
 
     if (m_print_to_console) {
         // print to console
-        ret = fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
+        fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
         fflush(stdout);
     }
     if (m_print_to_file) {
@@ -214,7 +212,6 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
 
         // buffer if we haven't opened the log yet
         if (m_fileout == nullptr) {
-            ret = strTimestamped.length();
             m_msgs_before_open.push_back(strTimestamped);
         }
         else
@@ -224,15 +221,14 @@ int BCLog::Logger::LogPrintStr(const std::string &str)
                 m_reopen_file = false;
                 m_fileout = fsbridge::freopen(m_file_path, "a", m_fileout);
                 if (!m_fileout) {
-                    return ret;
+                    return;
                 }
                 setbuf(m_fileout, nullptr); // unbuffered
             }
 
-            ret = FileWriteStr(strTimestamped, m_fileout);
+            FileWriteStr(strTimestamped, m_fileout);
         }
     }
-    return ret;
 }
 
 void BCLog::Logger::ShrinkDebugFile()

--- a/src/logging.h
+++ b/src/logging.h
@@ -86,7 +86,7 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
-        int LogPrintStr(const std::string &str);
+        void LogPrintStr(const std::string &str);
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return m_print_to_console || m_print_to_file; }


### PR DESCRIPTION
Fix potential use-after-free in `LogPrintStr(...)`.

`freopen(…)` frees `m_fileout`.
