### PR TITLE
Handle unsuccessful fseek(...):s

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -268,7 +268,9 @@ bool TxIndex::FindTx(const uint256& tx_hash, uint256& block_hash, CTransactionRe
     CBlockHeader header;
     try {
         file >> header;
-        fseek(file.Get(), postx.nTxOffset, SEEK_CUR);
+        if (fseek(file.Get(), postx.nTxOffset, SEEK_CUR)) {
+            return error("%s: fseek(...) failed", __func__);
+        }
         file >> tx;
     } catch (const std::exception& e) {
         return error("%s: Deserialize or I/O error - %s", __func__, e.what());

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -255,6 +255,7 @@ void BCLog::Logger::ShrinkDebugFile()
         // Restart the file with some of the end
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
         if (fseek(file, -((long)vch.size()), SEEK_END)) {
+            LogPrintf("Failed to shrink debug log file: fseek(...) failed\n");
             fclose(file);
             return;
         }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -254,7 +254,10 @@ void BCLog::Logger::ShrinkDebugFile()
     {
         // Restart the file with some of the end
         std::vector<char> vch(RECENT_DEBUG_HISTORY_SIZE, 0);
-        fseek(file, -((long)vch.size()), SEEK_END);
+        if (fseek(file, -((long)vch.size()), SEEK_END)) {
+            fclose(file);
+            return;
+        }
         int nBytes = fread(vch.data(), 1, vch.size(), file);
         fclose(file);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -887,7 +887,9 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
     // Fallback version
     // TODO: just write one byte per block
     static const char buf[65536] = {};
-    fseek(file, offset, SEEK_SET);
+    if (fseek(file, offset, SEEK_SET)) {
+        return;
+    }
     while (length > 0) {
         unsigned int now = 65536;
         if (length < now)


### PR DESCRIPTION
Handle unsuccessful `fseek(...)`:s.

**Note to reviewers:** What is the most appropriate course of actions for each of these unsuccessful `fseek(...)`:s?