### PR TITLE
Don't close old debug log file handle prematurely when trying to re-open (on SIGHUP)

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -14,11 +14,6 @@ FILE *fopen(const fs::path& p, const char *mode)
     return ::fopen(p.string().c_str(), mode);
 }
 
-FILE *freopen(const fs::path& p, const char *mode, FILE *stream)
-{
-    return ::freopen(p.string().c_str(), mode, stream);
-}
-
 #ifndef WIN32
 
 static std::string GetErrorReason() {

--- a/src/fs.h
+++ b/src/fs.h
@@ -18,7 +18,6 @@ namespace fs = boost::filesystem;
 /** Bridge operations to C stdio */
 namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
-    FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
 
     class FileLock
     {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -219,13 +219,13 @@ void BCLog::Logger::LogPrintStr(const std::string &str)
             // reopen the log file, if requested
             if (m_reopen_file) {
                 m_reopen_file = false;
-                m_fileout = fsbridge::freopen(m_file_path, "a", m_fileout);
-                if (!m_fileout) {
-                    return;
+                FILE* new_fileout = fsbridge::fopen(m_file_path, "a");
+                if (new_fileout) {
+                    setbuf(new_fileout, nullptr); // unbuffered
+                    fclose(m_fileout);
+                    m_fileout = new_fileout;
                 }
-                setbuf(m_fileout, nullptr); // unbuffered
             }
-
             FileWriteStr(strTimestamped, m_fileout);
         }
     }


### PR DESCRIPTION
Don't close old debug log file handle prematurely when trying to re-open (on `SIGHUP`).

Context: https://github.com/bitcoin/bitcoin/pull/13148#issuecomment-386288606

Thanks @ajtowns!