### PR TITLE
Refactoring: optimize SelectCoinsBnB

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -105,4 +105,4 @@ static void BnBExhaustion(benchmark::State& state)
 }
 
 BENCHMARK(CoinSelection, 650);
-BENCHMARK(BnBExhaustion, 650);
+BENCHMARK(BnBExhaustion, 2300);

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -64,7 +64,7 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
     out_set.clear();
     CAmount curr_value = 0;
 
-    std::vector<bool> curr_selection; // select the utxo at this index
+    std::vector<char> curr_selection; // select the utxo at this index
     curr_selection.reserve(utxo_pool.size());
     CAmount actual_target = not_input_fees + target_value;
 
@@ -83,7 +83,7 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
     std::sort(utxo_pool.begin(), utxo_pool.end(), descending);
 
     CAmount curr_waste = 0;
-    std::vector<bool> best_selection;
+    std::vector<char> best_selection;
     CAmount best_waste = MAX_MONEY;
 
     // Depth First search loop for choosing the UTXOs

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -64,8 +64,8 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
     out_set.clear();
     CAmount curr_value = 0;
 
-    std::vector<char> curr_selection; // select the utxo at this index
-    curr_selection.reserve(utxo_pool.size());
+    std::vector<char> curr_selection(utxo_pool.size(), false); // select the utxo at this index
+    size_t curr_selection_size = 0;
     CAmount actual_target = not_input_fees + target_value;
 
     // Calculate curr_available_value
@@ -102,7 +102,6 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
             // explore any more UTXOs to avoid burning money like that.
             if (curr_waste <= best_waste) {
                 best_selection = curr_selection;
-                best_selection.resize(utxo_pool.size());
                 best_waste = curr_waste;
             }
             curr_waste -= (curr_value - actual_target); // Remove the excess value as we will be selecting different coins now
@@ -112,38 +111,39 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
         // Backtracking, moving backwards
         if (backtrack) {
             // Walk backwards to find the last included UTXO that still needs to have its omission branch traversed.
-            while (!curr_selection.empty() && !curr_selection.back()) {
-                curr_selection.pop_back();
-                curr_available_value += utxo_pool.at(curr_selection.size()).effective_value;
+            while (curr_selection_size > 0 && !curr_selection[curr_selection_size - 1]) {
+                --curr_selection_size;
+                curr_available_value += utxo_pool.at(curr_selection_size).effective_value;
             };
 
-            if (curr_selection.empty()) { // We have walked back to the first utxo and no branch is untraversed. All solutions searched
+            if (curr_selection_size == 0) { // We have walked back to the first utxo and no branch is untraversed. All solutions searched
                 break;
             }
 
             // Output was included on previous iterations, try excluding now.
-            curr_selection.back() = false;
-            CInputCoin& utxo = utxo_pool.at(curr_selection.size() - 1);
+            curr_selection[curr_selection_size - 1] = false;
+            CInputCoin& utxo = utxo_pool.at(curr_selection_size - 1);
             curr_value -= utxo.effective_value;
             curr_waste -= utxo.fee - utxo.long_term_fee;
         } else { // Moving forwards, continuing down this branch
-            CInputCoin& utxo = utxo_pool.at(curr_selection.size());
+            CInputCoin& utxo = utxo_pool.at(curr_selection_size);
 
             // Remove this utxo from the curr_available_value utxo amount
             curr_available_value -= utxo.effective_value;
 
             // Avoid searching a branch if the previous UTXO has the same value and same waste and was excluded. Since the ratio of fee to
             // long term fee is the same, we only need to check if one of those values match in order to know that the waste is the same.
-            if (!curr_selection.empty() && !curr_selection.back() &&
-                utxo.effective_value == utxo_pool.at(curr_selection.size() - 1).effective_value &&
-                utxo.fee == utxo_pool.at(curr_selection.size() - 1).fee) {
-                curr_selection.push_back(false);
+            if (curr_selection_size > 0 && !curr_selection[curr_selection_size - 1] &&
+                utxo.effective_value == utxo_pool.at(curr_selection_size - 1).effective_value &&
+                utxo.fee == utxo_pool.at(curr_selection_size - 1).fee) {
+                curr_selection[curr_selection_size] = false;
             } else {
                 // Inclusion branch first (Largest First Exploration)
-                curr_selection.push_back(true);
+                curr_selection[curr_selection_size] = true;
                 curr_value += utxo.effective_value;
                 curr_waste += utxo.fee - utxo.long_term_fee;
             }
+            ++curr_selection_size;
         }
     }
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -92,7 +92,7 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
         bool backtrack = false;
         if (curr_value + curr_available_value < actual_target ||                // Cannot possibly reach target with the amount remaining in the curr_available_value.
             curr_value > actual_target + cost_of_change ||    // Selected value is out of range, go back and try other branch
-            (curr_waste > best_waste && (utxo_pool.at(0).fee - utxo_pool.at(0).long_term_fee) > 0)) { // Don't select things which we know will be more wasteful if the waste is increasing
+            (curr_waste > best_waste && (utxo_pool[0].fee - utxo_pool[0].long_term_fee) > 0)) { // Don't select things which we know will be more wasteful if the waste is increasing
             backtrack = true;
         } else if (curr_value >= actual_target) {       // Selected value is within range
             curr_waste += (curr_value - actual_target); // This is the excess value which is added to the waste for the below comparison
@@ -113,7 +113,7 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
             // Walk backwards to find the last included UTXO that still needs to have its omission branch traversed.
             while (curr_selection_size > 0 && !curr_selection[curr_selection_size - 1]) {
                 --curr_selection_size;
-                curr_available_value += utxo_pool.at(curr_selection_size).effective_value;
+                curr_available_value += utxo_pool[curr_selection_size].effective_value;
             };
 
             if (curr_selection_size == 0) { // We have walked back to the first utxo and no branch is untraversed. All solutions searched
@@ -122,11 +122,11 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
 
             // Output was included on previous iterations, try excluding now.
             curr_selection[curr_selection_size - 1] = false;
-            CInputCoin& utxo = utxo_pool.at(curr_selection_size - 1);
+            CInputCoin& utxo = utxo_pool[curr_selection_size - 1];
             curr_value -= utxo.effective_value;
             curr_waste -= utxo.fee - utxo.long_term_fee;
         } else { // Moving forwards, continuing down this branch
-            CInputCoin& utxo = utxo_pool.at(curr_selection_size);
+            CInputCoin& utxo = utxo_pool[curr_selection_size];
 
             // Remove this utxo from the curr_available_value utxo amount
             curr_available_value -= utxo.effective_value;
@@ -134,8 +134,8 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
             // Avoid searching a branch if the previous UTXO has the same value and same waste and was excluded. Since the ratio of fee to
             // long term fee is the same, we only need to check if one of those values match in order to know that the waste is the same.
             if (curr_selection_size > 0 && !curr_selection[curr_selection_size - 1] &&
-                utxo.effective_value == utxo_pool.at(curr_selection_size - 1).effective_value &&
-                utxo.fee == utxo_pool.at(curr_selection_size - 1).fee) {
+                utxo.effective_value == utxo_pool[curr_selection_size - 1].effective_value &&
+                utxo.fee == utxo_pool[curr_selection_size - 1].fee) {
                 curr_selection[curr_selection_size] = false;
             } else {
                 // Inclusion branch first (Largest First Exploration)
@@ -155,9 +155,9 @@ bool SelectCoinsBnB(std::vector<CInputCoin>& utxo_pool, const CAmount& target_va
     // Set output set
     value_ret = 0;
     for (size_t i = 0; i < best_selection.size(); ++i) {
-        if (best_selection.at(i)) {
-            out_set.insert(utxo_pool.at(i));
-            value_ret += utxo_pool.at(i).txout.nValue;
+        if (best_selection[i]) {
+            out_set.insert(utxo_pool[i]);
+            value_ret += utxo_pool[i].txout.nValue;
         }
     }
 


### PR DESCRIPTION
Some simple optimizations to `SelectCoinsBnB`. In total these changes sum up to a speedup of a factor of about 2.4 on my machine:

```
BnBExhaustion, 5, 650, 2.08837, 0.000634196, 0.000660664, 0.000638457  # before
BnBExhaustion, 5, 2300, 4.89576, 0.000422629, 0.000429628, 0.000424571 # std::vector<char>
BnBExhaustion, 5, 2300, 3.48065, 0.000299667, 0.000308361, 0.000301751 # with curr_selection_size
BnBExhaustion, 5, 2300, 3.08375, 0.000266867, 0.000270109, 0.00026751  # [] instead of .at
```

![image](https://user-images.githubusercontent.com/14386/39637940-d8273ae0-4fc4-11e8-8f44-4b42772efc7d.png)

These changes are minor code refactoring that should not change the behaviour of the algorithm in any way.