### PR TITLE
Thread names in logs and deadlock debug tools (take 2)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -775,8 +775,23 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   }
   ])],
   [
-    AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
-    AC_MSG_RESULT(yes)
+   case $host in
+     *mingw*)
+        # mingw32's implementation of thread_local has also been shown to behave
+        # erroneously under concurrent usage; see:
+        # https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
+        AC_MSG_RESULT(no)
+        ;;
+      *darwin*)
+        # TODO enable thread_local on later versions of Darwin where it is
+        # supported (per https://stackoverflow.com/a/29929949)
+        AC_MSG_RESULT(no)
+        ;;
+      *)
+        AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
+        AC_MSG_RESULT(yes)
+        ;;
+    esac
   ],
   [
     AC_MSG_RESULT(no)

--- a/doc/release-notes-pr13168.md
+++ b/doc/release-notes-pr13168.md
@@ -1,0 +1,6 @@
+Thread names in logs
+--------------------
+
+On platforms supporting `thread_local`, log lines are now prefixed by default
+with the name of the thread that caused the log. To disable this behavior,
+specify `-logthreadnames=0`.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -169,6 +169,7 @@ BITCOIN_CORE_H = \
   support/events.h \
   support/lockedpool.h \
   sync.h \
+  threadutil.h \
   threadsafety.h \
   threadinterrupt.h \
   timedata.h \
@@ -409,6 +410,7 @@ libbitcoin_util_a_SOURCES = \
   rpc/protocol.cpp \
   support/cleanse.cpp \
   sync.cpp \
+  threadutil.cpp \
   threadinterrupt.cpp \
   util.cpp \
   utilmoneystr.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -80,6 +80,7 @@ BITCOIN_TESTS =\
   test/sigopcount_tests.cpp \
   test/skiplist_tests.cpp \
   test/streams_tests.cpp \
+  test/threadutil_tests.cpp \
   test/timedata_tests.cpp \
   test/torcontrol_tests.cpp \
   test/transaction_tests.cpp \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -18,6 +18,7 @@
 #include <util.h>
 #include <httpserver.h>
 #include <httprpc.h>
+#include <threadutil.h>
 #include <utilstrencodings.h>
 #include <walletinitinterface.h>
 
@@ -57,6 +58,8 @@ static void WaitForShutdown()
 static bool AppInit(int argc, char* argv[])
 {
     bool fRet = false;
+
+    thread_util::Rename("init");
 
     //
     // Parameters

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -36,6 +36,7 @@
 #include <script/sigcache.h>
 #include <scheduler.h>
 #include <shutdown.h>
+#include <threadutil.h>
 #include <timedata.h>
 #include <txdb.h>
 #include <txmempool.h>
@@ -195,7 +196,7 @@ void Shutdown()
     /// for example if the data directory was found to be locked.
     /// Be sure that anything that writes files or flushes caches only does this if the respective
     /// module was initialized.
-    RenameThread("bitcoin-shutoff");
+    thread_util::Rename("shutoff");
     mempool.AddTransactionsUpdated(1);
 
     StopHTTPRPC();
@@ -631,7 +632,7 @@ static void CleanupBlockRevFiles()
 static void ThreadImport(std::vector<fs::path> vImportFiles)
 {
     const CChainParams& chainparams = Params();
-    RenameThread("bitcoin-loadblk");
+    thread_util::Rename("loadblk");
     ScheduleBatchPriority();
 
     {
@@ -1264,7 +1265,7 @@ bool AppInitMain()
     LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
     if (nScriptCheckThreads) {
         for (int i=0; i<nScriptCheckThreads-1; i++)
-            threadGroup.create_thread(&ThreadScriptCheck);
+            threadGroup.create_thread([i]() { return ThreadScriptCheck(i); });
     }
 
     // Start the lightweight task scheduler thread

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -470,6 +470,7 @@ void SetupServerArgs()
     gArgs.AddArg("-help-debug", "Show all debugging options (usage: --help -help-debug)", false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-logips", strprintf("Include IP addresses in debug output (default: %u)", DEFAULT_LOGIPS), false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-logtimestamps", strprintf("Prepend debug output with timestamp (default: %u)", DEFAULT_LOGTIMESTAMPS), false, OptionsCategory::DEBUG_TEST);
+    gArgs.AddArg("-logthreadnames", strprintf("Prepend debug output with name of the originating thread (only available on platforms supporting thread_local) (default: %u)", DEFAULT_LOGTHREADNAMES), false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS), true, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-mocktime=<n>", "Replace actual time with <n> seconds since epoch (default: 0)", true, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-maxsigcachesize=<n>", strprintf("Limit sum of signature cache and script execution cache sizes to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE), true, OptionsCategory::DEBUG_TEST);
@@ -836,6 +837,7 @@ void InitLogging()
     g_logger->m_print_to_console = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
     g_logger->m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     g_logger->m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);
+    g_logger->m_log_threadnames = gArgs.GetBoolArg("-logthreadnames", DEFAULT_LOGTHREADNAMES);
 
     fLogIPs = gArgs.GetBoolArg("-logips", DEFAULT_LOGIPS);
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -5,6 +5,11 @@
 
 #include <logging.h>
 #include <utiltime.h>
+#include <utilstrencodings.h>
+#include <threadutil.h>
+
+#include <list>
+#include <mutex>
 
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
@@ -168,7 +173,7 @@ std::vector<CLogCategoryActive> ListActiveLogCategories()
     return ret;
 }
 
-std::string BCLog::Logger::LogTimestampStr(const std::string &str)
+std::string BCLog::Logger::LogTimestampStr(std::string str)
 {
     std::string strStamped;
 
@@ -178,6 +183,7 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
     if (m_started_new_line) {
         int64_t nTimeMicros = GetTimeMicros();
         strStamped = FormatISO8601DateTime(nTimeMicros/1000000);
+
         if (m_log_time_micros) {
             strStamped.pop_back();
             strStamped += strprintf(".%06dZ", nTimeMicros%1000000);
@@ -190,21 +196,27 @@ std::string BCLog::Logger::LogTimestampStr(const std::string &str)
     } else
         strStamped = str;
 
-    if (!str.empty() && str[str.size()-1] == '\n')
-        m_started_new_line = true;
-    else
-        m_started_new_line = false;
-
     return strStamped;
+}
+
+std::string BCLog::Logger::LogThreadnameStr(const std::string& str)
+{
+    if (!m_log_threadnames || !m_started_new_line) {
+        return str;
+    }
+    std::string thread_name = thread_util::GetInternalName();
+    return "[" + std::move(thread_name) + "] " + str;
 }
 
 void BCLog::Logger::LogPrintStr(const std::string &str)
 {
-    std::string strTimestamped = LogTimestampStr(str);
+    std::string strPrefixed = LogTimestampStr(LogThreadnameStr(str));
+
+    m_started_new_line = (!str.empty() && str[str.size()-1] == '\n');
 
     if (m_print_to_console) {
         // print to console
-        fwrite(strTimestamped.data(), 1, strTimestamped.size(), stdout);
+        fwrite(strPrefixed.data(), 1, strPrefixed.size(), stdout);
         fflush(stdout);
     }
     if (m_print_to_file) {
@@ -212,7 +224,7 @@ void BCLog::Logger::LogPrintStr(const std::string &str)
 
         // buffer if we haven't opened the log yet
         if (m_fileout == nullptr) {
-            m_msgs_before_open.push_back(strTimestamped);
+            m_msgs_before_open.push_back(strPrefixed);
         }
         else
         {
@@ -226,7 +238,7 @@ void BCLog::Logger::LogPrintStr(const std::string &str)
                 setbuf(m_fileout, nullptr); // unbuffered
             }
 
-            FileWriteStr(strTimestamped, m_fileout);
+            FileWriteStr(strPrefixed, m_fileout);
         }
     }
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -19,6 +19,7 @@
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
+static const bool DEFAULT_LOGTHREADNAMES = true;
 extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
@@ -73,7 +74,8 @@ namespace BCLog {
         /** Log categories bitfield. */
         std::atomic<uint32_t> m_categories{0};
 
-        std::string LogTimestampStr(const std::string& str);
+        std::string LogTimestampStr(std::string str);
+        std::string LogThreadnameStr(const std::string& str);
 
     public:
         bool m_print_to_console = false;
@@ -81,6 +83,7 @@ namespace BCLog {
 
         bool m_log_timestamps = DEFAULT_LOGTIMESTAMPS;
         bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
+        bool m_log_threadnames = DEFAULT_LOGTHREADNAMES;
 
         fs::path m_file_path;
         std::atomic<bool> m_reopen_file{false};

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -28,6 +28,7 @@
 
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <threadutil.h>
 #include <rpc/server.h>
 #include <ui_interface.h>
 #include <uint256.h>
@@ -259,6 +260,7 @@ void BitcoinCore::initialize()
     try
     {
         qDebug() << __func__ << ": Running initialization in thread";
+        thread_util::Rename("qt-init");
         bool rv = m_node.appInitMain();
         Q_EMIT initializeResult(rv);
     } catch (const std::exception& e) {
@@ -556,6 +558,7 @@ static void SetupUIArgs()
 int main(int argc, char *argv[])
 {
     SetupEnvironment();
+    thread_util::Rename("main");
 
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -3,8 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <sync.h>
+#include <tinyformat.h>
 
 #include <logging.h>
+#include <threadutil.h>
 #include <utilstrencodings.h>
 
 #include <stdio.h>
@@ -37,23 +39,23 @@ void PrintLockContention(const char* pszName, const char* pszFile, int nLine)
 //
 
 struct CLockLocation {
-    CLockLocation(const char* pszName, const char* pszFile, int nLine, bool fTryIn)
-    {
-        mutexName = pszName;
-        sourceFile = pszFile;
-        sourceLine = nLine;
-        fTry = fTryIn;
-    }
+    CLockLocation(
+        const char* pszName, const char* pszFile, int nLine, bool fTryIn, std::string thread_name_) :
+            mutexName(pszName), sourceFile(pszFile), sourceLine(nLine), fTry(fTryIn),
+            thread_name(std::move(thread_name_)) { }
 
     std::string ToString() const
     {
-        return mutexName + "  " + sourceFile + ":" + itostr(sourceLine) + (fTry ? " (TRY)" : "");
+        return tfm::format(
+            "%s %s:%s%s (in thread %s)",
+            mutexName, sourceFile, itostr(sourceLine), (fTry ? " (TRY)" : ""), thread_name);
     }
 
 private:
     bool fTry;
     std::string mutexName;
     std::string sourceFile;
+    std::string thread_name;
     int sourceLine;
 };
 
@@ -132,7 +134,7 @@ static void pop_lock()
 
 void EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry)
 {
-    push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry));
+    push_lock(cs, CLockLocation(pszName, pszFile, nLine, fTry, thread_util::GetInternalName()));
 }
 
 void LeaveCritical()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -96,7 +96,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         }
         nScriptCheckThreads = 3;
         for (int i=0; i < nScriptCheckThreads-1; i++)
-            threadGroup.create_thread(&ThreadScriptCheck);
+            threadGroup.create_thread([i]() { return ThreadScriptCheck(i); });
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
         connman = g_connman.get();
         peerLogic.reset(new PeerLogicValidation(connman, scheduler));

--- a/src/test/threadutil_tests.cpp
+++ b/src/test/threadutil_tests.cpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <threadutil.h>
+#include <test/test_bitcoin.h>
+
+#include <thread>
+#include <vector>
+#include <set>
+#include <mutex>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(threadutil_tests, BasicTestingSetup)
+
+std::string TEST_THREAD_NAME_BASE = "test_thread.";
+
+/**
+ * Run a bunch of threads to all call thread_util::rename.
+ *
+ * @return the set of name each thread has after attempted renaming.
+ */
+std::set<std::string> RenameEnMasse(int num_threads)
+{
+    std::vector<std::thread> threads;
+    std::set<std::string> names;
+    std::mutex lock;
+
+    auto RenameThisThread = [&](int i) {
+        thread_util::Rename(TEST_THREAD_NAME_BASE + std::to_string(i));
+        std::lock_guard<std::mutex> guard(lock);
+        names.insert(thread_util::GetInternalName());
+    };
+
+    for (int i = 0; i < num_threads; ++i) {
+        threads.push_back(std::thread(RenameThisThread, i));
+    }
+
+    for (std::thread& thread : threads) thread.join();
+
+    return names;
+}
+
+/**
+ * Rename a bunch of threads with the same basename (expect_multiple=true), ensuring suffixes are
+ * applied properly.
+ */
+BOOST_AUTO_TEST_CASE(threadutil_test_rename_threaded)
+{
+    BOOST_CHECK_EQUAL(thread_util::GetInternalName(), "");
+
+#if !defined(HAVE_THREAD_LOCAL)
+    // This test doesn't apply to platforms where we don't have thread_local.
+    return;
+#endif
+
+    std::set<std::string> names = RenameEnMasse(100);
+
+    BOOST_CHECK_EQUAL(names.size(), 100);
+
+    // Names "test_thread.[n]" should exist for n = [0, 99]
+    for (int i = 0; i < 100; ++i) {
+        BOOST_CHECK(names.find(TEST_THREAD_NAME_BASE + std::to_string(i)) != names.end());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/threadutil.cpp
+++ b/src/threadutil.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <atomic>
+#include <thread>
+
+#include <threadutil.h>
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h> // For prctl, PR_SET_NAME, PR_GET_NAME
+#endif
+
+/**
+ * Set the thread's name at the process level. Does not affect the
+ * internal name.
+ */
+static void SetThreadName(const char* name)
+{
+#if defined(PR_SET_NAME)
+    // Only the first 15 characters are used (16 - NUL terminator)
+    ::prctl(PR_SET_NAME, name, 0, 0, 0);
+#elif (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+    pthread_set_name_np(pthread_self(), name);
+#elif defined(MAC_OSX)
+    pthread_setname_np(name);
+#else
+    // Prevent warnings for unused parameters...
+    (void)name;
+#endif
+}
+
+/*
+ * If we have thread_local, just keep thread ID and name in a thread_local
+ * global.
+ */
+#if defined(HAVE_THREAD_LOCAL)
+
+static thread_local std::string g_thread_name;
+
+std::string thread_util::GetInternalName() {
+    return g_thread_name;
+}
+
+/**
+ * Set the in-memory internal name for this thread. Does not affect the process
+ * name.
+ */
+static void SetInternalName(const std::string& name)
+{
+    g_thread_name = name;
+}
+
+/**
+ * Without thread_local available, don't handle internal name at all.
+ */
+#else
+
+std::string thread_util::GetInternalName()
+{
+    return "";
+}
+
+static void SetInternalName(const std::string& name) { }
+
+#endif
+
+void thread_util::Rename(const std::string& name)
+{
+    SetThreadName(("bitcoin-" + name).c_str());
+    SetInternalName(name);
+}

--- a/src/threadutil.h
+++ b/src/threadutil.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_THREADUTIL_H
+#define BITCOIN_THREADUTIL_H
+
+#include <string>
+
+namespace thread_util
+{
+    /**
+     * Rename a thread both in terms of an internal (in-memory) name as well
+     * as its system thread name.
+     */
+    void Rename(const std::string&);
+
+    /**
+     * Get the thread's internal (in-memory) name; used e.g. for identification in
+     * logging.
+     */
+    std::string GetInternalName();
+
+} // namespace thread_util
+
+#endif // BITCOIN_THREADUTIL_H

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,10 +63,6 @@
 #include <shlobj.h>
 #endif
 
-#ifdef HAVE_SYS_PRCTL_H
-#include <sys/prctl.h>
-#endif
-
 #ifdef HAVE_MALLOPT_ARENA_MAX
 #include <malloc.h>
 #endif
@@ -1107,22 +1103,6 @@ void runCommand(const std::string& strCommand)
     int nErr = ::system(strCommand.c_str());
     if (nErr)
         LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
-}
-
-void RenameThread(const char* name)
-{
-#if defined(PR_SET_NAME)
-    // Only the first 15 characters are used (16 - NUL terminator)
-    ::prctl(PR_SET_NAME, name, 0, 0, 0);
-#elif (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
-    pthread_set_name_np(pthread_self(), name);
-
-#elif defined(MAC_OSX)
-    pthread_setname_np(name);
-#else
-    // Prevent warnings for unused parameters...
-    (void)name;
-#endif
 }
 
 void SetupEnvironment()

--- a/src/util.h
+++ b/src/util.h
@@ -18,6 +18,7 @@
 #include <fs.h>
 #include <logging.h>
 #include <sync.h>
+#include <threadutil.h>
 #include <tinyformat.h>
 #include <utiltime.h>
 
@@ -314,15 +315,12 @@ std::string HelpMessageOpt(const std::string& option, const std::string& message
  */
 int GetNumCores();
 
-void RenameThread(const char* name);
-
 /**
  * .. and a wrapper that just calls func once
  */
 template <typename Callable> void TraceThread(const char* name,  Callable func)
 {
-    std::string s = strprintf("bitcoin-%s", name);
-    RenameThread(s.c_str());
+    thread_util::Rename(name);
     try
     {
         LogPrintf("%s thread start\n", name);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -43,6 +43,7 @@
 
 #include <future>
 #include <sstream>
+#include <string>
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -1702,8 +1703,8 @@ static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, CValidationState&
 
 static CCheckQueue<CScriptCheck> scriptcheckqueue(128);
 
-void ThreadScriptCheck() {
-    RenameThread("bitcoin-scriptch");
+void ThreadScriptCheck(int worker_num) {
+    thread_util::Rename(strprintf("scriptch.%i", worker_num));
     scriptcheckqueue.Thread();
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -221,7 +221,7 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
-/** 
+/**
  * Process an incoming block. This only returns after the best known valid
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
@@ -232,7 +232,7 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  *
  * Note that we guarantee that either the proof-of-work is valid on pblock, or
  * (and possibly also) BlockChecked will have been called.
- * 
+ *
  * May not be called in a
  * validationinterface callback.
  *
@@ -275,7 +275,7 @@ bool LoadChainTip(const CChainParams& chainparams);
 /** Unload database information */
 void UnloadBlockIndex();
 /** Run an instance of the script checking thread */
-void ThreadScriptCheck();
+void ThreadScriptCheck(int worker_num);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */
@@ -365,7 +365,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = null
 
 /**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {


### PR DESCRIPTION
Replaces #13099.

The goal here is the same as the previous PR, but this approach only includes threadnames in logs when we can make use of `thread_local`. We specifically disable `HAVE_THREAD_LOCAL` for platforms where its presence or implementation is questionable (Darwin, mingw32).

Instead of using a mutex-protected map to generate numeric suffixes (e.g. `httpworker.2`) we explicitly pass in suffixes during thread creation.

Under this changeset, logs look like this:
```
2018-06-13T21:43:28Z [bitcoin-qt-init] init message: Starting network threads...
2018-06-13T21:43:28Z [net] net thread start
2018-06-13T21:43:28Z [bitcoin-qt-init] init message: Done loading
2018-06-13T21:43:28Z [opencon] opencon thread start
2018-06-13T21:43:28Z [msghand] msghand thread start
2018-06-13T21:43:28Z [dnsseed] dnsseed thread start
2018-06-13T21:43:28Z [dnsseed] Loading addresses from DNS seeds (could take a while)
2018-06-13T21:43:28Z [dnsseed] 0 addresses found from DNS seeds
2018-06-13T21:43:28Z [dnsseed] dnsseed thread exit
2018-06-13T21:43:28Z [addcon] addcon thread start
2018-06-13T21:43:28Z [bitcoin-qt] GUI: Platform customization: "other"
2018-06-13T21:43:28Z [bitcoin-qt] GUI: PaymentServer::LoadRootCAs: Loaded  146  root certificates
2018-06-13T21:43:28Z [loadblk] Loaded 1 blocks from external file in 147ms
2018-06-13T21:43:28Z [loadblk] Reindexing finished
2018-06-13T21:43:28Z [loadblk] Imported mempool transactions from disk: 0 succeeded, 0 failed, 0 expired, 0 already there

```