### PR TITLE
Fix re-declared scoped enum as unscoped (Causes issues with some compilers)

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -33,7 +33,7 @@ enum class RetFormat {
 };
 
 static const struct {
-    enum RetFormat rf;
+    RetFormat rf;
     const char* name;
 } rf_names[] = {
       {RetFormat::UNDEF, ""},
@@ -68,7 +68,7 @@ static bool RESTERR(HTTPRequest* req, enum HTTPStatusCode status, std::string me
     return false;
 }
 
-static enum RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
+static RetFormat ParseDataFormat(std::string& param, const std::string& strReq)
 {
     const std::string::size_type pos = strReq.rfind('.');
     if (pos == std::string::npos)


### PR DESCRIPTION
MSVC fails to compile with the changes made in #10742 

The problem is enum types were changed to scoped (`enum class`) but in some places `enum` as an unscoped is used. 

This is a very simple fix and I've tested it.

Edit: Had to remove enum altogether - `enum class` doesn't compile on clang.