### PR TITLE
Use a semaphore to trigger shutdown procedures

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -42,10 +42,7 @@
 
 static void WaitForShutdown()
 {
-    while (!ShutdownRequested())
-    {
-        MilliSleep(200);
-    }
+    BlockUntilShutdown();
     Interrupt();
 }
 

--- a/src/init.h
+++ b/src/init.h
@@ -22,6 +22,7 @@ class thread_group;
 
 void StartShutdown();
 bool ShutdownRequested();
+void BlockUntilShutdown();
 /** Interrupt threads */
 void Interrupt();
 void Shutdown();


### PR DESCRIPTION
Very simple cleanup to avoid sleep waiting on the `fShutdownRequested` flag