### PR TITLE
Remove 2nd mapTx lookup in CTxMemPool::removeForBlock

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -910,7 +910,7 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(const setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) {
     AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);
     for (const txiter& it : stage) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -573,7 +573,7 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
-    void RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(const setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
      *  new mempool entries may have children in the mempool (which is generally


### PR DESCRIPTION
`CTxMemPool::removeForBlock` has 2 loops over the block transactions:
 - the first determines which block transactions are in the mempool (required for `minerPolicyEstimator`);
 - the second removes from the mempool transactions that conflict with the block transactions.

With this PR the second loop is optimized because `mapTx` lookup is removed and `CTxMemPool::RemoveStaged` is called only once (since it supports batch removal).