### PR TITLE
[WIP] Wrap C++17 std::filesystem::path to solve encoding issue on Windows.

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -45,12 +45,12 @@ bool SerializeFileDB(const std::string& prefix, const fsbridge::Path& path, cons
     FILE *file = fsbridge::fopen(pathTmp, "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull())
-        return error("%s: Failed to open file %s", __func__, pathTmp.string());
+        return error("%s: Failed to open file %s", __func__, pathTmp.u8string());
 
     // Serialize
     if (!SerializeDB(fileout, data)) return false;
     if (!FileCommit(fileout.Get()))
-        return error("%s: Failed to flush file %s", __func__, pathTmp.string());
+        return error("%s: Failed to flush file %s", __func__, pathTmp.u8string());
     fileout.fclose();
 
     // replace existing file, if any, with new file
@@ -98,7 +98,7 @@ bool DeserializeFileDB(const fsbridge::Path& path, Data& data)
     FILE *file = fsbridge::fopen(path, "rb");
     CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
     if (filein.IsNull())
-        return error("%s: Failed to open file %s", __func__, path.string());
+        return error("%s: Failed to open file %s", __func__, path.u8string());
 
     return DeserializeDB(filein, data);
 }

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -33,7 +33,7 @@ bool SerializeDB(Stream& stream, const Data& data)
 }
 
 template <typename Data>
-bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data& data)
+bool SerializeFileDB(const std::string& prefix, const fsbridge::Path& path, const Data& data)
 {
     // Generate random temporary filename
     unsigned short randv = 0;
@@ -41,7 +41,7 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     std::string tmpfn = strprintf("%s.%04x", prefix, randv);
 
     // open temp output file, and associate with CAutoFile
-    fs::path pathTmp = GetDataDir() / tmpfn;
+    fsbridge::Path pathTmp = GetDataDir() / tmpfn;
     FILE *file = fsbridge::fopen(pathTmp, "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
     if (fileout.IsNull())
@@ -92,7 +92,7 @@ bool DeserializeDB(Stream& stream, Data& data, bool fCheckSum = true)
 }
 
 template <typename Data>
-bool DeserializeFileDB(const fs::path& path, Data& data)
+bool DeserializeFileDB(const fsbridge::Path& path, Data& data)
 {
     // open input file, and associate with CAutoFile
     FILE *file = fsbridge::fopen(path, "rb");

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -80,7 +80,7 @@ typedef std::map<CSubNet, CBanEntry> banmap_t;
 class CAddrDB
 {
 private:
-    fs::path pathAddr;
+    fsbridge::Path pathAddr;
 public:
     CAddrDB();
     bool Write(const CAddrMan& addr);
@@ -92,7 +92,7 @@ public:
 class CBanDB
 {
 private:
-    fs::path pathBanlist;
+    fsbridge::Path pathBanlist;
 public:
     CBanDB();
     bool Write(const banmap_t& banSet);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -404,7 +404,10 @@ static int CommandLineRPC(int argc, char *argv[])
             }
             gArgs.ForceSetArg("-rpcpassword", rpcPass);
         }
-        std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+        std::vector<std::string> args;
+        for(char ** i = &argv[1]; i != &argv[argc]; i++) {
+            args.push_back(NativeToUtf8(*i));
+        }
         if (gArgs.GetBoolArg("-stdin", false)) {
             // Read one arg per line from stdin and append
             std::string line;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -367,7 +367,7 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
         if (failedToGetAuthCookie) {
             throw std::runtime_error(strprintf(
                 _("Could not locate RPC credentials. No authentication cookie could be found, and RPC password is not set.  See -rpcpassword and -stdinrpcpass.  Configuration file: (%s)"),
-                GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string().c_str()));
+                GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).u8string().c_str()));
         } else {
             throw std::runtime_error("Authorization failed: Incorrect rpcuser or rpcpassword");
         }

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -114,7 +114,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     return options;
 }
 
-CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
+CDBWrapper::CDBWrapper(const fsbridge::Path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
     : m_name(fs::basename(path))
 {
     penv = nullptr;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -129,21 +129,21 @@ CDBWrapper::CDBWrapper(const fsbridge::Path& path, size_t nCacheSize, bool fMemo
         options.env = penv;
     } else {
         if (fWipe) {
-            LogPrintf("Wiping LevelDB in %s\n", path.string());
-            leveldb::Status result = leveldb::DestroyDB(path.string(), options);
+            LogPrintf("Wiping LevelDB in %s\n", path.u8string());
+            leveldb::Status result = leveldb::DestroyDB(path.u8string(), options);
             dbwrapper_private::HandleError(result);
         }
         TryCreateDirectories(path);
-        LogPrintf("Opening LevelDB in %s\n", path.string());
+        LogPrintf("Opening LevelDB in %s\n", path.u8string());
     }
-    leveldb::Status status = leveldb::DB::Open(options, path.string(), &pdb);
+    leveldb::Status status = leveldb::DB::Open(options, path.u8string(), &pdb);
     dbwrapper_private::HandleError(status);
     LogPrintf("Opened LevelDB successfully\n");
 
     if (gArgs.GetBoolArg("-forcecompactdb", false)) {
-        LogPrintf("Starting database compaction of %s\n", path.string());
+        LogPrintf("Starting database compaction of %s\n", path.u8string());
         pdb->CompactRange(nullptr, nullptr);
-        LogPrintf("Finished database compaction of %s\n", path.string());
+        LogPrintf("Finished database compaction of %s\n", path.u8string());
     }
 
     // The base-case obfuscation key, which is a noop.
@@ -160,10 +160,10 @@ CDBWrapper::CDBWrapper(const fsbridge::Path& path, size_t nCacheSize, bool fMemo
         Write(OBFUSCATE_KEY_KEY, new_key);
         obfuscate_key = new_key;
 
-        LogPrintf("Wrote new obfuscate key for %s: %s\n", path.string(), HexStr(obfuscate_key));
+        LogPrintf("Wrote new obfuscate key for %s: %s\n", path.u8string(), HexStr(obfuscate_key));
     }
 
-    LogPrintf("Using obfuscation key for %s: %s\n", path.string(), HexStr(obfuscate_key));
+    LogPrintf("Using obfuscation key for %s: %s\n", path.u8string(), HexStr(obfuscate_key));
 }
 
 CDBWrapper::~CDBWrapper()

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -221,7 +221,7 @@ public:
      * @param[in] obfuscate   If true, store data obfuscated via simple XOR. If false, XOR
      *                        with a zero'd byte array.
      */
-    CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
+    CDBWrapper(const fsbridge::Path& path, size_t nCacheSize, bool fMemory = false, bool fWipe = false, bool obfuscate = false);
     ~CDBWrapper();
 
     CDBWrapper(const CDBWrapper&) = delete;

--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -1,4 +1,5 @@
 #include <fs.h>
+#include <utilstrencodings.h>
 
 namespace fsbridge {
 
@@ -12,4 +13,17 @@ FILE *freopen(const fs::path& p, const char *mode, FILE *stream)
     return ::freopen(p.string().c_str(), mode, stream);
 }
 
+Path::Path() : fs::path(){}
+
+Path::Path(const fs::path& p) : fs::path(p) {}
+
+std::string Path::u8string() const
+{
+    return NativeToUtf8(boost::filesystem::path::string());
+}
+
+Path U8Path(const std::string& source)
+{
+    return Utf8ToNative(source);
+}
 } // fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -19,6 +19,20 @@ namespace fs = boost::filesystem;
 namespace fsbridge {
     FILE *fopen(const fs::path& p, const char *mode);
     FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
+
+    class Path : public fs::path
+    {
+    public:
+        Path();
+        template<typename Source>
+        Path(const Source & source) : fs::path(source){}
+        template<typename Source>
+        Path(const Source & source, const codecvt_type& cvt) : fs::path(source, cvt){}
+        Path(const fs::path& p);
+        std::string u8string() const;
+    };
+
+    Path U8Path(const std::string& source);
 };
 
 #endif // BITCOIN_FS_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -233,7 +233,7 @@ void Shutdown()
     if (fFeeEstimatesInitialized)
     {
         ::feeEstimator.FlushUnconfirmed();
-        fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
+        fsbridge::Path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
         CAutoFile est_fileout(fsbridge::fopen(est_path, "wb"), SER_DISK, CLIENT_VERSION);
         if (!est_fileout.IsNull())
             ::feeEstimator.Write(est_fileout);
@@ -606,13 +606,13 @@ struct CImportingNow
 // works correctly.
 static void CleanupBlockRevFiles()
 {
-    std::map<std::string, fs::path> mapBlockFiles;
+    std::map<std::string, fsbridge::Path> mapBlockFiles;
 
     // Glob all blk?????.dat and rev?????.dat files from the blocks directory.
     // Remove the rev files immediately and insert the blk file paths into an
     // ordered map keyed by block file index.
     LogPrintf("Removing unusable blk?????.dat and rev?????.dat files for -reindex with -prune\n");
-    fs::path blocksdir = GetBlocksDir();
+    fsbridge::Path blocksdir = GetBlocksDir();
     for (fs::directory_iterator it(blocksdir); it != fs::directory_iterator(); it++) {
         if (fs::is_regular_file(*it) &&
             it->path().filename().string().length() == 12 &&
@@ -630,7 +630,7 @@ static void CleanupBlockRevFiles()
     // keeping a separate counter.  Once we hit a gap (or if 0 doesn't exist)
     // start removing block files.
     int nContigCounter = 0;
-    for (const std::pair<std::string, fs::path>& item : mapBlockFiles) {
+    for (const std::pair<std::string, fsbridge::Path>& item : mapBlockFiles) {
         if (atoi(item.first) == nContigCounter) {
             nContigCounter++;
             continue;
@@ -639,7 +639,7 @@ static void CleanupBlockRevFiles()
     }
 }
 
-static void ThreadImport(std::vector<fs::path> vImportFiles)
+static void ThreadImport(std::vector<fsbridge::Path> vImportFiles)
 {
     const CChainParams& chainparams = Params();
     RenameThread("bitcoin-loadblk");
@@ -670,11 +670,11 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
     }
 
     // hardcoded $DATADIR/bootstrap.dat
-    fs::path pathBootstrap = GetDataDir() / "bootstrap.dat";
+    fsbridge::Path pathBootstrap = GetDataDir() / "bootstrap.dat";
     if (fs::exists(pathBootstrap)) {
         FILE *file = fsbridge::fopen(pathBootstrap, "rb");
         if (file) {
-            fs::path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";
+            fsbridge::Path pathBootstrapOld = GetDataDir() / "bootstrap.dat.old";
             LogPrintf("Importing bootstrap.dat...\n");
             LoadExternalBlockFile(chainparams, file);
             RenameOver(pathBootstrap, pathBootstrapOld);
@@ -684,7 +684,7 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
     }
 
     // -loadblock=
-    for (const fs::path& path : vImportFiles) {
+    for (const fsbridge::Path& path : vImportFiles) {
         FILE *file = fsbridge::fopen(path, "rb");
         if (file) {
             LogPrintf("Importing blocks file %s...\n", path.string());
@@ -1188,7 +1188,7 @@ bool AppInitParameterInteraction()
 static bool LockDataDirectory(bool probeOnly)
 {
     // Make sure only a single Bitcoin process is using the data directory.
-    fs::path datadir = GetDataDir();
+    fsbridge::Path datadir = GetDataDir();
     if (!DirIsWritable(datadir)) {
         return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), datadir.string()));
     }
@@ -1258,7 +1258,7 @@ bool AppInitMain()
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     // Warn about relative -datadir path.
-    if (gArgs.IsArgSet("-datadir") && !fs::path(gArgs.GetArg("-datadir", "")).is_absolute()) {
+    if (gArgs.IsArgSet("-datadir") && !fsbridge::Path(gArgs.GetArg("-datadir", "")).is_absolute()) {
         LogPrintf("Warning: relative datadir option '%s' specified, which will be interpreted relative to the " /* Continued */
                   "current working directory '%s'. This is fragile, because if bitcoin is started in the future "
                   "from a different location, it will be unable to locate the current data files. There could "
@@ -1611,7 +1611,7 @@ bool AppInitMain()
         LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
     }
 
-    fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
+    fsbridge::Path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fsbridge::fopen(est_path, "rb"), SER_DISK, CLIENT_VERSION);
     // Allowed to fail as this file IS missing on first startup.
     if (!est_filein.IsNull())
@@ -1666,7 +1666,7 @@ bool AppInitMain()
     if (gArgs.IsArgSet("-blocknotify"))
         uiInterface.NotifyBlockTip.connect(BlockNotifyCallback);
 
-    std::vector<fs::path> vImportFiles;
+    std::vector<fsbridge::Path> vImportFiles;
     for (const std::string& strFile : gArgs.GetArgs("-loadblock")) {
         vImportFiles.push_back(strFile);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -836,7 +836,7 @@ static std::string ResolveErrMsg(const char * const optname, const std::string& 
 void InitLogging()
 {
     g_logger->m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
-    g_logger->m_file_path = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
+    g_logger->m_file_path = AbsPathForConfigVal(fsbridge::U8Path(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE)));
 
     // Add newlines to the logfile to distinguish this execution from the last
     // one; called before console logging is set up, so this is only sent to
@@ -1668,7 +1668,7 @@ bool AppInitMain()
 
     std::vector<fsbridge::Path> vImportFiles;
     for (const std::string& strFile : gArgs.GetArgs("-loadblock")) {
-        vImportFiles.push_back(strFile);
+        vImportFiles.push_back(fsbridge::U8Path(strFile));
     }
 
     threadGroup.create_thread(boost::bind(&ThreadImport, vImportFiles));

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -238,7 +238,7 @@ void Shutdown()
         if (!est_fileout.IsNull())
             ::feeEstimator.Write(est_fileout);
         else
-            LogPrintf("%s: Failed to write fee estimates to %s\n", __func__, est_path.string());
+            LogPrintf("%s: Failed to write fee estimates to %s\n", __func__, est_path.u8string());
         fFeeEstimatesInitialized = false;
     }
 
@@ -615,12 +615,12 @@ static void CleanupBlockRevFiles()
     fsbridge::Path blocksdir = GetBlocksDir();
     for (fs::directory_iterator it(blocksdir); it != fs::directory_iterator(); it++) {
         if (fs::is_regular_file(*it) &&
-            it->path().filename().string().length() == 12 &&
-            it->path().filename().string().substr(8,4) == ".dat")
+            it->path().filename().u8string().length() == 12 &&
+            it->path().filename().u8string().substr(8,4) == ".dat")
         {
-            if (it->path().filename().string().substr(0,3) == "blk")
-                mapBlockFiles[it->path().filename().string().substr(3,5)] = it->path();
-            else if (it->path().filename().string().substr(0,3) == "rev")
+            if (it->path().filename().u8string().substr(0,3) == "blk")
+                mapBlockFiles[it->path().filename().u8string().substr(3,5)] = it->path();
+            else if (it->path().filename().u8string().substr(0,3) == "rev")
                 remove(it->path());
         }
     }
@@ -679,7 +679,7 @@ static void ThreadImport(std::vector<fsbridge::Path> vImportFiles)
             LoadExternalBlockFile(chainparams, file);
             RenameOver(pathBootstrap, pathBootstrapOld);
         } else {
-            LogPrintf("Warning: Could not open bootstrap file %s\n", pathBootstrap.string());
+            LogPrintf("Warning: Could not open bootstrap file %s\n", pathBootstrap.u8string());
         }
     }
 
@@ -687,10 +687,10 @@ static void ThreadImport(std::vector<fsbridge::Path> vImportFiles)
     for (const fsbridge::Path& path : vImportFiles) {
         FILE *file = fsbridge::fopen(path, "rb");
         if (file) {
-            LogPrintf("Importing blocks file %s...\n", path.string());
+            LogPrintf("Importing blocks file %s...\n", path.u8string());
             LoadExternalBlockFile(chainparams, file);
         } else {
-            LogPrintf("Warning: Could not open blocks file %s\n", path.string());
+            LogPrintf("Warning: Could not open blocks file %s\n", path.u8string());
         }
     }
 
@@ -1190,10 +1190,10 @@ static bool LockDataDirectory(bool probeOnly)
     // Make sure only a single Bitcoin process is using the data directory.
     fsbridge::Path datadir = GetDataDir();
     if (!DirIsWritable(datadir)) {
-        return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), datadir.string()));
+        return InitError(strprintf(_("Cannot write to data directory '%s'; check permissions."), datadir.u8string()));
     }
     if (!LockDirectory(datadir, ".lock", probeOnly)) {
-        return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), datadir.string(), _(PACKAGE_NAME)));
+        return InitError(strprintf(_("Cannot obtain a lock on data directory %s. %s is probably already running."), datadir.u8string(), _(PACKAGE_NAME)));
     }
     return true;
 }
@@ -1246,15 +1246,15 @@ bool AppInitMain()
         }
         if (!g_logger->OpenDebugLog()) {
             return InitError(strprintf("Could not open debug log file %s",
-                                       g_logger->m_file_path.string()));
+                                       g_logger->m_file_path.u8string()));
         }
     }
 
     if (!g_logger->m_log_timestamps)
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
-    LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
-    LogPrintf("Using data directory %s\n", GetDataDir().string());
-    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
+    LogPrintf("Default data directory %s\n", GetDefaultDataDir().u8string());
+    LogPrintf("Using data directory %s\n", GetDataDir().u8string());
+    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).u8string());
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     // Warn about relative -datadir path.
@@ -1263,7 +1263,7 @@ bool AppInitMain()
                   "current working directory '%s'. This is fragile, because if bitcoin is started in the future "
                   "from a different location, it will be unable to locate the current data files. There could "
                   "also be data loss if bitcoin is started while in a temporary directory.\n",
-            gArgs.GetArg("-datadir", ""), fs::current_path().string());
+            gArgs.GetArg("-datadir", ""), fs::current_path().u8string());
     }
 
     InitSignatureCache();

--- a/src/logging.h
+++ b/src/logging.h
@@ -82,7 +82,7 @@ namespace BCLog {
         bool m_log_timestamps = DEFAULT_LOGTIMESTAMPS;
         bool m_log_time_micros = DEFAULT_LOGTIMEMICROS;
 
-        fs::path m_file_path;
+        fsbridge::Path m_file_path;
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -394,7 +394,7 @@ bool isObscured(QWidget *w)
 
 void openDebugLogfile()
 {
-    fs::path pathDebug = GetDataDir() / "debug.log";
+    fsbridge::Path pathDebug = GetDataDir() / "debug.log";
 
     /* Open debug.log with the associated application */
     if (fs::exists(pathDebug))
@@ -403,7 +403,7 @@ void openDebugLogfile()
 
 bool openBitcoinConf()
 {
-    boost::filesystem::path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+    fsbridge::Path pathConfig = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
 
     /* Create the file */
     boost::filesystem::ofstream configFile(pathConfig, std::ios_base::app);
@@ -597,7 +597,7 @@ TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* t
 }
 
 #ifdef WIN32
-fs::path static StartupShortcutPath()
+fsbridge::Path static StartupShortcutPath()
 {
     std::string chain = gArgs.GetChainName();
     if (chain == CBaseChainParams::MAIN)
@@ -686,16 +686,16 @@ bool SetStartOnSystemStartup(bool fAutoStart)
 // Follow the Desktop Application Autostart Spec:
 // http://standards.freedesktop.org/autostart-spec/autostart-spec-latest.html
 
-fs::path static GetAutostartDir()
+fsbridge::Path static GetAutostartDir()
 {
     char* pszConfigHome = getenv("XDG_CONFIG_HOME");
-    if (pszConfigHome) return fs::path(pszConfigHome) / "autostart";
+    if (pszConfigHome) return fsbridge::Path(pszConfigHome) / "autostart";
     char* pszHome = getenv("HOME");
-    if (pszHome) return fs::path(pszHome) / ".config" / "autostart";
-    return fs::path();
+    if (pszHome) return fsbridge::Path(pszHome) / ".config" / "autostart";
+    return fsbridge::Path();
 }
 
-fs::path static GetAutostartFilePath()
+fsbridge::Path static GetAutostartFilePath()
 {
     std::string chain = gArgs.GetChainName();
     if (chain == CBaseChainParams::MAIN)
@@ -854,12 +854,12 @@ void setClipboard(const QString& str)
     QApplication::clipboard()->setText(str, QClipboard::Selection);
 }
 
-fs::path qstringToBoostPath(const QString &path)
+fsbridge::Path qstringToBoostPath(const QString &path)
 {
-    return fs::path(path.toStdString(), utf8);
+    return fsbridge::Path(path.toStdString(), utf8);
 }
 
-QString boostPathToQString(const fs::path &path)
+QString boostPathToQString(const fsbridge::Path &path)
 {
     return QString::fromStdString(path.string(utf8));
 }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -666,7 +666,7 @@ bool SetStartOnSystemStartup(bool fAutoStart)
             {
                 WCHAR pwsz[MAX_PATH];
                 // Ensure that the string is ANSI.
-                MultiByteToWideChar(CP_ACP, 0, StartupShortcutPath().string().c_str(), -1, pwsz, MAX_PATH);
+                MultiByteToWideChar(CP_ACP, 0, StartupShortcutPath().u8string().c_str(), -1, pwsz, MAX_PATH);
                 // Save the link by calling IPersistFile::Save.
                 hres = ppf->Save(pwsz, TRUE);
                 ppf->Release();

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -184,10 +184,10 @@ namespace GUIUtil
     bool SetStartOnSystemStartup(bool fAutoStart);
 
     /* Convert QString to OS specific boost path through UTF-8 */
-    fs::path qstringToBoostPath(const QString &path);
+    fsbridge::Path qstringToBoostPath(const QString &path);
 
     /* Convert OS specific boost path to QString through UTF-8 */
-    QString boostPathToQString(const fs::path &path);
+    QString boostPathToQString(const fsbridge::Path &path);
 
     /* Convert seconds into a QString with days, hours, mins, secs */
     QString formatDurationStr(int secs);

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -235,7 +235,7 @@ bool Intro::pickDataDirectory(interfaces::Node& node)
      * (to be consistent with bitcoind behavior)
      */
     if(dataDir != getDefaultDataDirectory()) {
-        node.softSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).string()); // use OS locale for path setting
+        node.softSetArg("-datadir", GUIUtil::qstringToBoostPath(dataDir).u8string()); // use OS locale for path setting
     }
     return true;
 }

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -71,14 +71,14 @@ FreespaceChecker::FreespaceChecker(Intro *_intro)
 void FreespaceChecker::check()
 {
     QString dataDirStr = intro->getPathToCheck();
-    fs::path dataDir = GUIUtil::qstringToBoostPath(dataDirStr);
+    fsbridge::Path dataDir = GUIUtil::qstringToBoostPath(dataDirStr);
     uint64_t freeBytesAvailable = 0;
     int replyStatus = ST_OK;
     QString replyMessage = tr("A new data directory will be created.");
 
     /* Find first parent that exists, so that fs::space does not fail */
-    fs::path parentDir = dataDir;
-    fs::path parentDirOld = fs::path();
+    fsbridge::Path parentDir = dataDir;
+    fsbridge::Path parentDirOld = fsbridge::Path();
     while(parentDir.has_parent_path() && !fs::exists(parentDir))
     {
         parentDir = parentDir.parent_path();

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -160,7 +160,7 @@ static void CopySettings(QSettings& dst, const QSettings& src)
 }
 
 /** Back up a QSettings to an ini-formatted file. */
-static void BackupSettings(const fs::path& filename, const QSettings& src)
+static void BackupSettings(const fsbridge::Path& filename, const QSettings& src)
 {
     qWarning() << "Backing up GUI settings to" << GUIUtil::boostPathToQString(filename);
     QSettings dst(GUIUtil::boostPathToQString(filename), QSettings::IniFormat);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
     SelectParams(CBaseChainParams::MAIN);
     noui_connect();
     ClearDatadirCache();
-    fs::path pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin-qt_%lu_%i", (unsigned long)GetTime(), (int)GetRand(100000));
+    fsbridge::Path pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin-qt_%lu_%i", (unsigned long)GetTime(), (int)GetRand(100000));
     fs::create_directories(pathTemp);
     gArgs.ForceSetArg("-datadir", pathTemp.string());
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char *argv[])
     ClearDatadirCache();
     fsbridge::Path pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin-qt_%lu_%i", (unsigned long)GetTime(), (int)GetRand(100000));
     fs::create_directories(pathTemp);
-    gArgs.ForceSetArg("-datadir", pathTemp.string());
+    gArgs.ForceSetArg("-datadir", pathTemp.u8string());
 
     bool fInvalid = false;
 

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -66,13 +66,13 @@ static const std::string COOKIEAUTH_USER = "__cookie__";
 static const std::string COOKIEAUTH_FILE = ".cookie";
 
 /** Get name of RPC authentication cookie file */
-static fs::path GetAuthCookieFile(bool temp=false)
+static fsbridge::Path GetAuthCookieFile(bool temp=false)
 {
     std::string arg = gArgs.GetArg("-rpccookiefile", COOKIEAUTH_FILE);
     if (temp) {
         arg += ".tmp";
     }
-    return AbsPathForConfigVal(fs::path(arg));
+    return AbsPathForConfigVal(fsbridge::Path(arg));
 }
 
 bool GenerateAuthCookie(std::string *cookie_out)
@@ -86,7 +86,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
      * these are set to 077 in init.cpp unless overridden with -sysperms.
      */
     std::ofstream file;
-    fs::path filepath_tmp = GetAuthCookieFile(true);
+    fsbridge::Path filepath_tmp = GetAuthCookieFile(true);
     file.open(filepath_tmp.string().c_str());
     if (!file.is_open()) {
         LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath_tmp.string());
@@ -95,7 +95,7 @@ bool GenerateAuthCookie(std::string *cookie_out)
     file << cookie;
     file.close();
 
-    fs::path filepath = GetAuthCookieFile(false);
+    fsbridge::Path filepath = GetAuthCookieFile(false);
     if (!RenameOver(filepath_tmp, filepath)) {
         LogPrintf("Unable to rename cookie authentication file %s to %s\n", filepath_tmp.string(), filepath.string());
         return false;
@@ -111,7 +111,7 @@ bool GetAuthCookie(std::string *cookie_out)
 {
     std::ifstream file;
     std::string cookie;
-    fs::path filepath = GetAuthCookieFile();
+    fsbridge::Path filepath = GetAuthCookieFile();
     file.open(filepath.string().c_str());
     if (!file.is_open())
         return false;

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -87,9 +87,9 @@ bool GenerateAuthCookie(std::string *cookie_out)
      */
     std::ofstream file;
     fsbridge::Path filepath_tmp = GetAuthCookieFile(true);
-    file.open(filepath_tmp.string().c_str());
+    file.open(filepath_tmp.u8string().c_str());
     if (!file.is_open()) {
-        LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath_tmp.string());
+        LogPrintf("Unable to open cookie authentication file %s for writing\n", filepath_tmp.u8string());
         return false;
     }
     file << cookie;
@@ -97,10 +97,10 @@ bool GenerateAuthCookie(std::string *cookie_out)
 
     fsbridge::Path filepath = GetAuthCookieFile(false);
     if (!RenameOver(filepath_tmp, filepath)) {
-        LogPrintf("Unable to rename cookie authentication file %s to %s\n", filepath_tmp.string(), filepath.string());
+        LogPrintf("Unable to rename cookie authentication file %s to %s\n", filepath_tmp.u8string(), filepath.u8string());
         return false;
     }
-    LogPrintf("Generated RPC authentication cookie %s\n", filepath.string());
+    LogPrintf("Generated RPC authentication cookie %s\n", filepath.u8string());
 
     if (cookie_out)
         *cookie_out = cookie;
@@ -112,7 +112,7 @@ bool GetAuthCookie(std::string *cookie_out)
     std::ifstream file;
     std::string cookie;
     fsbridge::Path filepath = GetAuthCookieFile();
-    file.open(filepath.string().c_str());
+    file.open(filepath.u8string().c_str());
     if (!file.is_open())
         return false;
     std::getline(file, cookie);

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -27,7 +27,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
         char key = 'k';
         uint256 in = InsecureRand256();
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         char key = 'i';
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 {
     // Perform tests both obfuscated and non-obfuscated.
     for (bool obfuscate : {false, true}) {
-        fs::path ph = fs::temp_directory_path() / fs::unique_path();
+        fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
         CDBWrapper dbw(ph, (1 << 20), true, false, obfuscate);
 
         // The two keys are intentionally chosen for ordering
@@ -122,8 +122,8 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
 // Test that we do not obfuscation if there is existing data.
 BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 {
-    // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    // We're going to share this fsbridge::Path between two wrappers
+    fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -163,8 +163,8 @@ BOOST_AUTO_TEST_CASE(existing_data_no_obfuscate)
 // Ensure that we start obfuscating during a reindex.
 BOOST_AUTO_TEST_CASE(existing_data_reindex)
 {
-    // We're going to share this fs::path between two wrappers
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    // We're going to share this fsbridge::Path between two wrappers
+    fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
     create_directories(ph);
 
     // Set up a non-obfuscated wrapper to write some initial data.
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(existing_data_reindex)
 
 BOOST_AUTO_TEST_CASE(iterator_ordering)
 {
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<256; ++x) {
         uint8_t key = x;
@@ -277,7 +277,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
     char buf[10];
 
-    fs::path ph = fs::temp_directory_path() / fs::unique_path();
+    fsbridge::Path ph = fs::temp_directory_path() / fs::unique_path();
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -67,7 +67,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         ClearDatadirCache();
         pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30)));
         fs::create_directories(pathTemp);
-        gArgs.ForceSetArg("-datadir", pathTemp.string());
+        gArgs.ForceSetArg("-datadir", pathTemp.u8string());
 
         // We have to run a scheduler thread to prevent ActivateBestChain
         // from blocking due to queue overrun.

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -59,7 +59,7 @@ struct CConnmanTest {
 
 class PeerLogicValidation;
 struct TestingSetup: public BasicTestingSetup {
-    fs::path pathTemp;
+    fsbridge::Path pathTemp;
     boost::thread_group threadGroup;
     CConnman* connman;
     CScheduler scheduler;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1039,7 +1039,7 @@ BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)
     BOOST_CHECK(!ParseFixedPoint("1.", 8, &amount));
 }
 
-static void TestOtherThread(fs::path dirname, std::string lockname, bool *result)
+static void TestOtherThread(fsbridge::Path dirname, std::string lockname, bool *result)
 {
     *result = LockDirectory(dirname, lockname);
 }
@@ -1049,7 +1049,7 @@ static constexpr char LockCommand = 'L';
 static constexpr char UnlockCommand = 'U';
 static constexpr char ExitCommand = 'X';
 
-static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
+static void TestOtherProcess(fsbridge::Path dirname, std::string lockname, int fd)
 {
     char ch;
     while (true) {
@@ -1078,7 +1078,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
 
 BOOST_AUTO_TEST_CASE(test_LockDirectory)
 {
-    fs::path dirname = fs::temp_directory_path() / fs::unique_path();
+    fsbridge::Path dirname = fs::temp_directory_path() / fs::unique_path();
     const std::string lockname = ".lock";
 #ifndef WIN32
     // Revert SIGCHLD to default, otherwise boost.test will catch and fail on
@@ -1167,7 +1167,7 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
 BOOST_AUTO_TEST_CASE(test_DirIsWritable)
 {
     // Should be able to write to the system tmp dir.
-    fs::path tmpdirname = fs::temp_directory_path();
+    fsbridge::Path tmpdirname = fs::temp_directory_path();
     BOOST_CHECK_EQUAL(DirIsWritable(tmpdirname), true);
 
     // Should not be able to write to a non-existent dir.

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -467,7 +467,7 @@ TorController::TorController(struct event_base* _base, const std::string& _targe
     // Read service private key if cached
     std::pair<bool,std::string> pkf = ReadBinaryFile(GetPrivateKeyFile());
     if (pkf.first) {
-        LogPrint(BCLog::TOR, "tor: Reading cached private key from %s\n", GetPrivateKeyFile().string());
+        LogPrint(BCLog::TOR, "tor: Reading cached private key from %s\n", GetPrivateKeyFile().u8string());
         private_key = pkf.second;
     }
 }
@@ -505,9 +505,9 @@ void TorController::add_onion_cb(TorControlConnection& _conn, const TorControlRe
         service = LookupNumeric(std::string(service_id+".onion").c_str(), GetListenPort());
         LogPrintf("tor: Got service ID %s, advertising service %s\n", service_id, service.ToString());
         if (WriteBinaryFile(GetPrivateKeyFile(), private_key)) {
-            LogPrint(BCLog::TOR, "tor: Cached service private key to %s\n", GetPrivateKeyFile().string());
+            LogPrint(BCLog::TOR, "tor: Cached service private key to %s\n", GetPrivateKeyFile().u8string());
         } else {
-            LogPrintf("tor: Error writing service private key to %s\n", GetPrivateKeyFile().string());
+            LogPrintf("tor: Error writing service private key to %s\n", GetPrivateKeyFile().u8string());
         }
         AddLocal(service, LOCAL_MANUAL);
         // ... onion requested - keep connection open

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -657,7 +657,7 @@ void TorController::protocolinfo_cb(TorControlConnection& _conn, const TorContro
         } else if (methods.count("SAFECOOKIE")) {
             // Cookie: hexdump -e '32/1 "%02x""\n"'  ~/.tor/control_auth_cookie
             LogPrint(BCLog::TOR, "tor: Using SAFECOOKIE authentication, reading cookie authentication from %s\n", cookiefile);
-            std::pair<bool,std::string> status_cookie = ReadBinaryFile(cookiefile, TOR_COOKIE_SIZE);
+            std::pair<bool,std::string> status_cookie = ReadBinaryFile(fsbridge::U8Path(cookiefile), TOR_COOKIE_SIZE);
             if (status_cookie.first && status_cookie.second.size() == TOR_COOKIE_SIZE) {
                 // _conn.Command("AUTHENTICATE " + HexStr(status_cookie.second), boost::bind(&TorController::auth_cb, this, _1, _2));
                 cookie = std::vector<uint8_t>(status_cookie.second.begin(), status_cookie.second.end());

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -364,7 +364,7 @@ static std::map<std::string,std::string> ParseTorReplyMapping(const std::string 
  * @param maxsize Puts a maximum size limit on the file that is read. If the file is larger than this, truncated data
  *         (with len > maxsize) will be returned.
  */
-static std::pair<bool,std::string> ReadBinaryFile(const fs::path &filename, size_t maxsize=std::numeric_limits<size_t>::max())
+static std::pair<bool,std::string> ReadBinaryFile(const fsbridge::Path &filename, size_t maxsize=std::numeric_limits<size_t>::max())
 {
     FILE *f = fsbridge::fopen(filename, "rb");
     if (f == nullptr)
@@ -390,7 +390,7 @@ static std::pair<bool,std::string> ReadBinaryFile(const fs::path &filename, size
 /** Write contents of std::string to a file.
  * @return true on success.
  */
-static bool WriteBinaryFile(const fs::path &filename, const std::string &data)
+static bool WriteBinaryFile(const fsbridge::Path &filename, const std::string &data)
 {
     FILE *f = fsbridge::fopen(filename, "wb");
     if (f == nullptr)
@@ -415,7 +415,7 @@ public:
     ~TorController();
 
     /** Get name fo file to store private key in */
-    fs::path GetPrivateKeyFile();
+    fsbridge::Path GetPrivateKeyFile();
 
     /** Reconnect, after getting disconnected */
     void Reconnect();
@@ -718,7 +718,7 @@ void TorController::Reconnect()
     }
 }
 
-fs::path TorController::GetPrivateKeyFile()
+fsbridge::Path TorController::GetPrivateKeyFile()
 {
     return GetDataDir() / "onion_private_key";
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -152,7 +152,7 @@ bool LockDirectory(const fsbridge::Path& directory, const std::string lockfile_n
     fsbridge::Path pathLockFile = directory / lockfile_name;
 
     // If a lock for this directory already exists in the map, don't try to re-lock it
-    if (dir_locks.count(pathLockFile.string())) {
+    if (dir_locks.count(pathLockFile.u8string())) {
         return true;
     }
 
@@ -161,16 +161,16 @@ bool LockDirectory(const fsbridge::Path& directory, const std::string lockfile_n
     if (file) fclose(file);
 
     try {
-        auto lock = MakeUnique<boost::interprocess::file_lock>(pathLockFile.string().c_str());
+        auto lock = MakeUnique<boost::interprocess::file_lock>(pathLockFile.u8string().c_str());
         if (!lock->try_lock()) {
             return false;
         }
         if (!probe_only) {
             // Lock successful and we're not just probing, put it into the map
-            dir_locks.emplace(pathLockFile.string(), std::move(lock));
+            dir_locks.emplace(pathLockFile.u8string(), std::move(lock));
         }
     } catch (const boost::interprocess::interprocess_exception& e) {
-        return error("Error while attempting to lock directory %s: %s", directory.string(), e.what());
+        return error("Error while attempting to lock directory %s: %s", directory.u8string(), e.what());
     }
     return true;
 }
@@ -761,10 +761,10 @@ void CreatePidFile(const fsbridge::Path &path, pid_t pid)
 bool RenameOver(fsbridge::Path src, fsbridge::Path dest)
 {
 #ifdef WIN32
-    return MoveFileExA(src.string().c_str(), dest.string().c_str(),
+    return MoveFileExA(src.u8string().c_str(), dest.u8string().c_str(),
                        MOVEFILE_REPLACE_EXISTING) != 0;
 #else
-    int rc = std::rename(src.string().c_str(), dest.string().c_str());
+    int rc = std::rename(src.u8string().c_str(), dest.u8string().c_str());
     return (rc == 0);
 #endif /* WIN32 */
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -418,7 +418,7 @@ void ArgsManager::ParseParameters(int argc, const char* const argv[])
     m_override_args.clear();
 
     for (int i = 1; i < argc; i++) {
-        std::string key(argv[i]);
+        std::string key(NativeToUtf8(argv[i]));
         std::string val;
         size_t is_index = key.find('=');
         if (is_index != std::string::npos) {

--- a/src/util.h
+++ b/src/util.h
@@ -75,27 +75,27 @@ bool FileCommit(FILE *file);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
-bool RenameOver(fs::path src, fs::path dest);
-bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
-bool DirIsWritable(const fs::path& directory);
+bool RenameOver(fsbridge::Path src, fsbridge::Path dest);
+bool LockDirectory(const fsbridge::Path& directory, const std::string lockfile_name, bool probe_only=false);
+bool DirIsWritable(const fsbridge::Path& directory);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.
  */
 void ReleaseDirectoryLocks();
 
-bool TryCreateDirectories(const fs::path& p);
-fs::path GetDefaultDataDir();
-const fs::path &GetBlocksDir(bool fNetSpecific = true);
-const fs::path &GetDataDir(bool fNetSpecific = true);
+bool TryCreateDirectories(const fsbridge::Path& p);
+fsbridge::Path GetDefaultDataDir();
+const fsbridge::Path &GetBlocksDir(bool fNetSpecific = true);
+const fsbridge::Path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
-fs::path GetConfigFile(const std::string& confPath);
+fsbridge::Path GetConfigFile(const std::string& confPath);
 #ifndef WIN32
-fs::path GetPidFile();
-void CreatePidFile(const fs::path &path, pid_t pid);
+fsbridge::Path GetPidFile();
+void CreatePidFile(const fsbridge::Path &path, pid_t pid);
 #endif
 #ifdef WIN32
-fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+fsbridge::Path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
 void runCommand(const std::string& strCommand);
 
@@ -107,7 +107,7 @@ void runCommand(const std::string& strCommand);
  * @param net_specific Forwarded to GetDataDir().
  * @return The normalized path.
  */
-fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
+fsbridge::Path AbsPathForConfigVal(const fsbridge::Path& path, bool net_specific = true);
 
 inline bool IsSwitchChar(char c)
 {

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -12,6 +12,10 @@
 #include <errno.h>
 #include <limits>
 
+#ifdef WIN32
+#include <stringapiset.h>
+#endif
+
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 static const std::string SAFE_CHARS[] =
@@ -544,3 +548,34 @@ bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
     return true;
 }
 
+std::string NativeToUtf8(const std::string& source)
+{
+#ifdef WIN32
+    wchar_t wide[MAX_PATH];
+    char utf8[MAX_PATH];
+    if (source.size() == 0) return source;
+    int size = MultiByteToWideChar(CP_ACP, 0, source.c_str(), source.size(), wide, MAX_PATH);
+    assert(size);
+    size = WideCharToMultiByte(CP_UTF8, 0, wide, size, utf8, MAX_PATH, nullptr, nullptr);
+    assert(size);
+    return std::string(utf8, 0, size);
+#else
+    return source;
+#endif
+}
+
+std::string Utf8ToNative(const std::string& source)
+{
+#ifdef WIN32
+    wchar_t wide[MAX_PATH];
+    char native[MAX_PATH];
+    if (source.size() == 0) return source;
+    int size = MultiByteToWideChar(CP_UTF8, 0, source.c_str(), source.size(), wide, MAX_PATH);
+    assert(size);
+    size = WideCharToMultiByte(CP_ACP, 0, wide, size, native, MAX_PATH, nullptr, nullptr);
+    assert(size);
+    return std::string(native, 0, size);
+#else
+    return source;
+#endif
+}

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -173,4 +173,8 @@ bool ConvertBits(const O& outfn, I it, I end) {
     return true;
 }
 
+std::string NativeToUtf8(const std::string& source);
+
+std::string Utf8ToNative(const std::string& source);
+
 #endif // BITCOIN_UTILSTRENCODINGS_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3701,7 +3701,7 @@ static FILE* OpenDiskFile(const CDiskBlockPos &pos, const char *prefix, bool fRe
 {
     if (pos.IsNull())
         return nullptr;
-    fs::path path = GetBlockPosFilename(pos, prefix);
+    fsbridge::Path path = GetBlockPosFilename(pos, prefix);
     fs::create_directories(path.parent_path());
     FILE* file = fsbridge::fopen(path, fReadOnly ? "rb": "rb+");
     if (!file && !fReadOnly)
@@ -3729,7 +3729,7 @@ static FILE* OpenUndoFile(const CDiskBlockPos &pos, bool fReadOnly) {
     return OpenDiskFile(pos, "rev", fReadOnly);
 }
 
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix)
+fsbridge::Path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix)
 {
     return GetBlocksDir() / strprintf("%s%05u.dat", prefix, pos.nFile);
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3707,12 +3707,12 @@ static FILE* OpenDiskFile(const CDiskBlockPos &pos, const char *prefix, bool fRe
     if (!file && !fReadOnly)
         file = fsbridge::fopen(path, "wb+");
     if (!file) {
-        LogPrintf("Unable to open file %s\n", path.string());
+        LogPrintf("Unable to open file %s\n", path.u8string());
         return nullptr;
     }
     if (pos.nPos) {
         if (fseek(file, pos.nPos, SEEK_SET)) {
-            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
+            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.u8string());
             fclose(file);
             return nullptr;
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -260,7 +260,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes = 0, bool blocks_dir = false);
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
+fsbridge::Path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -30,7 +30,7 @@ class BerkeleyEnvironment
 private:
     bool fDbEnvInit;
     bool fMockDb;
-    // Don't change into fs::path, as that can result in
+    // Don't change into fsbridge::Path, as that can result in
     // shutdown problems/crashes caused by a static initialized internal pointer.
     std::string strPath;
 
@@ -39,14 +39,14 @@ public:
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
 
-    BerkeleyEnvironment(const fs::path& env_directory);
+    BerkeleyEnvironment(const fsbridge::Path& env_directory);
     ~BerkeleyEnvironment();
     void Reset();
 
     void MakeMock();
     bool IsMock() const { return fMockDb; }
     bool IsInitialized() const { return fDbEnvInit; }
-    fs::path Directory() const { return strPath; }
+    fsbridge::Path Directory() const { return strPath; }
 
     /**
      * Verify that database file strFile is OK. If it is not,
@@ -57,7 +57,7 @@ public:
     enum class VerifyResult { VERIFY_OK,
                         RECOVER_OK,
                         RECOVER_FAIL };
-    typedef bool (*recoverFunc_type)(const fs::path& file_path, std::string& out_backup_filename);
+    typedef bool (*recoverFunc_type)(const fsbridge::Path& file_path, std::string& out_backup_filename);
     VerifyResult Verify(const std::string& strFile, recoverFunc_type recoverFunc, std::string& out_backup_filename);
     /**
      * Salvage data from a file that Verify says is bad.
@@ -87,7 +87,7 @@ public:
 };
 
 /** Get BerkeleyEnvironment and database filename given a wallet path. */
-BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename);
+BerkeleyEnvironment* GetWalletEnv(const fsbridge::Path& wallet_path, std::string& database_filename);
 
 /** An instance of this class represents one database.
  * For BerkeleyDB this is just a (env, strFile) tuple.
@@ -102,7 +102,7 @@ public:
     }
 
     /** Create DB handle to real database */
-    BerkeleyDatabase(const fs::path& wallet_path, bool mock = false) :
+    BerkeleyDatabase(const fsbridge::Path& wallet_path, bool mock = false) :
         nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0)
     {
         env = GetWalletEnv(wallet_path, strFile);
@@ -114,7 +114,7 @@ public:
     }
 
     /** Return object for accessing database at specified path. */
-    static std::unique_ptr<BerkeleyDatabase> Create(const fs::path& path)
+    static std::unique_ptr<BerkeleyDatabase> Create(const fsbridge::Path& path)
     {
         return MakeUnique<BerkeleyDatabase>(path);
     }
@@ -183,15 +183,15 @@ public:
 
     void Flush();
     void Close();
-    static bool Recover(const fs::path& file_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename);
+    static bool Recover(const fsbridge::Path& file_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename);
 
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
     static bool PeriodicFlush(BerkeleyDatabase& database);
     /* verifies the database environment */
-    static bool VerifyEnvironment(const fs::path& file_path, std::string& errorStr);
+    static bool VerifyEnvironment(const fsbridge::Path& file_path, std::string& errorStr);
     /* verifies the database file */
-    static bool VerifyDatabaseFile(const fs::path& file_path, std::string& warningStr, std::string& errorStr, BerkeleyEnvironment::recoverFunc_type recoverFunc);
+    static bool VerifyDatabaseFile(const fsbridge::Path& file_path, std::string& warningStr, std::string& errorStr, BerkeleyEnvironment::recoverFunc_type recoverFunc);
 
 public:
     template <typename K, typename T>

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -185,15 +185,15 @@ bool WalletInit::Verify() const
     if (gArgs.IsArgSet("-walletdir")) {
         fsbridge::Path wallet_dir = gArgs.GetArg("-walletdir", "");
         if (!fs::exists(wallet_dir)) {
-            return InitError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
+            return InitError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.u8string()));
         } else if (!fs::is_directory(wallet_dir)) {
-            return InitError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), wallet_dir.string()));
+            return InitError(strprintf(_("Specified -walletdir \"%s\" is not a directory"), wallet_dir.u8string()));
         } else if (!wallet_dir.is_absolute()) {
-            return InitError(strprintf(_("Specified -walletdir \"%s\" is a relative path"), wallet_dir.string()));
+            return InitError(strprintf(_("Specified -walletdir \"%s\" is a relative path"), wallet_dir.u8string()));
         }
     }
 
-    LogPrintf("Using wallet directory %s\n", GetWalletDir().string());
+    LogPrintf("Using wallet directory %s\n", GetWalletDir().u8string());
 
     uiInterface.InitMessage(_("Verifying wallet(s)..."));
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -183,7 +183,7 @@ bool WalletInit::Verify() const
     }
 
     if (gArgs.IsArgSet("-walletdir")) {
-        fs::path wallet_dir = gArgs.GetArg("-walletdir", "");
+        fsbridge::Path wallet_dir = gArgs.GetArg("-walletdir", "");
         if (!fs::exists(wallet_dir)) {
             return InitError(strprintf(_("Specified -walletdir \"%s\" does not exist"), wallet_dir.string()));
         } else if (!fs::is_directory(wallet_dir)) {
@@ -198,7 +198,7 @@ bool WalletInit::Verify() const
     uiInterface.InitMessage(_("Verifying wallet(s)..."));
 
     // Keep track of each wallet absolute path to detect duplicates.
-    std::set<fs::path> wallet_paths;
+    std::set<fsbridge::Path> wallet_paths;
 
     for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
         // Do some checking on wallet path. It should be either a:
@@ -207,11 +207,11 @@ bool WalletInit::Verify() const
         // 2. Path to an existing directory.
         // 3. Path to a symlink to a directory.
         // 4. For backwards compatibility, the name of a data file in -walletdir.
-        fs::path wallet_path = fs::absolute(walletFile, GetWalletDir());
+        fsbridge::Path wallet_path = fs::absolute(walletFile, GetWalletDir());
         fs::file_type path_type = fs::symlink_status(wallet_path).type();
         if (!(path_type == fs::file_not_found || path_type == fs::directory_file ||
               (path_type == fs::symlink_file && fs::is_directory(wallet_path)) ||
-              (path_type == fs::regular_file && fs::path(walletFile).filename() == walletFile))) {
+              (path_type == fs::regular_file && fsbridge::Path(walletFile).filename() == walletFile))) {
             return InitError(strprintf(
                 _("Invalid -wallet path '%s'. -wallet path should point to a directory where wallet.dat and "
                   "database/log.?????????? files can be stored, a location where such a directory could be created, "

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -710,7 +710,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(pwallet);
 
-    boost::filesystem::path filepath = request.params[0].get_str();
+    fsbridge::Path filepath = request.params[0].get_str();
     filepath = boost::filesystem::absolute(filepath);
 
     /* Prevent arbitrary files from being overwritten. There have been reports

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -719,11 +719,11 @@ UniValue dumpwallet(const JSONRPCRequest& request)
      * It may also avoid other security issues.
      */
     if (boost::filesystem::exists(filepath)) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.string() + " already exists. If you are sure this is what you want, move it out of the way first");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.u8string() + " already exists. If you are sure this is what you want, move it out of the way first");
     }
 
     std::ofstream file;
-    file.open(filepath.string().c_str());
+    file.open(filepath.u8string().c_str());
     if (!file.is_open())
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot open wallet dump file");
 
@@ -805,7 +805,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
     file.close();
 
     UniValue reply(UniValue::VOBJ);
-    reply.pushKV("filename", filepath.string());
+    reply.pushKV("filename", filepath.u8string());
 
     return reply;
 }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -139,7 +139,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back((pathTemp / "wallet.backup").u8string());
         AddWallet(&wallet);
         ::dumpwallet(request);
         RemoveWallet(&wallet);
@@ -152,7 +152,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
 
         JSONRPCRequest request;
         request.params.setArray();
-        request.params.push_back((pathTemp / "wallet.backup").string());
+        request.params.push_back((pathTemp / "wallet.backup").u8string());
         AddWallet(&wallet);
         ::importwallet(request);
         RemoveWallet(&wallet);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3955,7 +3955,7 @@ std::vector<std::string> CWallet::GetDestValues(const std::string& prefix) const
     return values;
 }
 
-CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fs::path& path)
+CWallet* CWallet::CreateWalletFromFile(const std::string& name, const fsbridge::Path& path)
 {
     const std::string& walletFile = name;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1107,7 +1107,7 @@ public:
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
     /* Initializes the wallet, returns a new CWallet instance or a null pointer in case of an error */
-    static CWallet* CreateWalletFromFile(const std::string& name, const fs::path& path);
+    static CWallet* CreateWalletFromFile(const std::string& name, const fsbridge::Path& path);
 
     /**
      * Wallet post-init setup

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -779,12 +779,12 @@ void MaybeCompactWalletDB()
 //
 // Try to (very carefully!) recover wallet file if there is a problem.
 //
-bool WalletBatch::Recover(const fs::path& wallet_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename)
+bool WalletBatch::Recover(const fsbridge::Path& wallet_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename)
 {
     return BerkeleyBatch::Recover(wallet_path, callbackDataIn, recoverKVcallback, out_backup_filename);
 }
 
-bool WalletBatch::Recover(const fs::path& wallet_path, std::string& out_backup_filename)
+bool WalletBatch::Recover(const fsbridge::Path& wallet_path, std::string& out_backup_filename)
 {
     // recover without a key filter callback
     // results in recovering all record types
@@ -814,12 +814,12 @@ bool WalletBatch::RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, C
     return true;
 }
 
-bool WalletBatch::VerifyEnvironment(const fs::path& wallet_path, std::string& errorStr)
+bool WalletBatch::VerifyEnvironment(const fsbridge::Path& wallet_path, std::string& errorStr)
 {
     return BerkeleyBatch::VerifyEnvironment(wallet_path, errorStr);
 }
 
-bool WalletBatch::VerifyDatabaseFile(const fs::path& wallet_path, std::string& warningStr, std::string& errorStr)
+bool WalletBatch::VerifyDatabaseFile(const fsbridge::Path& wallet_path, std::string& warningStr, std::string& errorStr)
 {
     return BerkeleyBatch::VerifyDatabaseFile(wallet_path, warningStr, errorStr, WalletBatch::Recover);
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -219,17 +219,17 @@ public:
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut);
     /* Try to (very carefully!) recover wallet database (with a possible key type filter) */
-    static bool Recover(const fs::path& wallet_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename);
+    static bool Recover(const fsbridge::Path& wallet_path, void *callbackDataIn, bool (*recoverKVcallback)(void* callbackData, CDataStream ssKey, CDataStream ssValue), std::string& out_backup_filename);
     /* Recover convenience-function to bypass the key filter callback, called when verify fails, recovers everything */
-    static bool Recover(const fs::path& wallet_path, std::string& out_backup_filename);
+    static bool Recover(const fsbridge::Path& wallet_path, std::string& out_backup_filename);
     /* Recover filter (used as callback), will only let keys (cryptographical keys) as KV/key-type pass through */
     static bool RecoverKeysOnlyFilter(void *callbackData, CDataStream ssKey, CDataStream ssValue);
     /* Function to determine if a certain KV/key-type is a key (cryptographical key) type */
     static bool IsKeyType(const std::string& strType);
     /* verifies the database environment */
-    static bool VerifyEnvironment(const fs::path& wallet_path, std::string& errorStr);
+    static bool VerifyEnvironment(const fsbridge::Path& wallet_path, std::string& errorStr);
     /* verifies the database file */
-    static bool VerifyDatabaseFile(const fs::path& wallet_path, std::string& warningStr, std::string& errorStr);
+    static bool VerifyDatabaseFile(const fsbridge::Path& wallet_path, std::string& warningStr, std::string& errorStr);
 
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -4,9 +4,9 @@
 
 #include <wallet/walletutil.h>
 
-fs::path GetWalletDir()
+fsbridge::Path GetWalletDir()
 {
-    fs::path path;
+    fsbridge::Path path;
 
     if (gArgs.IsArgSet("-walletdir")) {
         path = gArgs.GetArg("-walletdir", "");

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -9,6 +9,6 @@
 #include <util.h>
 
 //! Get the path of the wallet directory.
-fs::path GetWalletDir();
+fsbridge::Path GetWalletDir();
 
 #endif // BITCOIN_WALLET_WALLETUTIL_H


### PR DESCRIPTION
Fix #13103
We can call `.u8string()` everywhere and call `.string()` when we need to use native-encoded path. 