### PR TITLE
Bugfix: ensure consistency of m_failed_blocks after reconsiderblock

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2834,6 +2834,7 @@ bool CChainState::ResetBlockFailureFlags(CBlockIndex *pindex) {
         if (pindex->nStatus & BLOCK_FAILED_MASK) {
             pindex->nStatus &= ~BLOCK_FAILED_MASK;
             setDirtyBlockIndex.insert(pindex);
+            m_failed_blocks.erase(pindex);
         }
         pindex = pindex->pprev;
     }


### PR DESCRIPTION
This was introduced in 015a5258adffb0cf394f387a95ac9c8afc34cfc3 and could cause a node to crash (due to assertion failure) when using the `reconsiderblock` rpc.