### PR TITLE
Process logs in a separate thread

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -457,6 +457,7 @@ void SetupServerArgs()
     gArgs.AddArg("-logips", strprintf(_("Include IP addresses in debug output (default: %u)"), DEFAULT_LOGIPS), false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-logtimestamps", strprintf(_("Prepend debug output with timestamp (default: %u)"), DEFAULT_LOGTIMESTAMPS), false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-logtimemicros", strprintf("Add microsecond precision to debug timestamps (default: %u)", DEFAULT_LOGTIMEMICROS), true, OptionsCategory::DEBUG_TEST);
+    gArgs.AddArg("-logasync", strprintf(_("Buffer debug output and flush it to file asynchronously (default: %u)"), DEFAULT_LOGASYNC), false, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-mocktime=<n>", "Replace actual time with <n> seconds since epoch (default: 0)", true, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-maxsigcachesize=<n>", strprintf("Limit sum of signature cache and script execution cache sizes to <n> MiB (default: %u)", DEFAULT_MAX_SIG_CACHE_SIZE), true, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-maxtipage=<n>", strprintf("Maximum tip age in seconds to consider node in initial block download (default: %u)", DEFAULT_MAX_TIP_AGE), true, OptionsCategory::DEBUG_TEST);
@@ -808,7 +809,7 @@ void InitLogging()
     // Add newlines to the logfile to distinguish this execution from the last
     // one; called before console logging is set up, so this is only sent to
     // debug.log.
-    LogPrintf("\n\n\n\n\n");
+    g_logger->LogPrintStr("\n\n\n\n\n");
 
     g_logger->m_print_to_console = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
     g_logger->m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
@@ -1214,6 +1215,10 @@ bool AppInitMain()
         if (!g_logger->OpenDebugLog()) {
             return InitError(strprintf("Could not open debug log file %s",
                                        g_logger->m_file_path.string()));
+        }
+
+        if (gArgs.GetBoolArg("-logasync", DEFAULT_LOGASYNC)) {
+            async_logging::Init();
         }
     }
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -19,6 +19,7 @@
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = false;
 static const bool DEFAULT_LOGTIMESTAMPS = true;
+static const bool DEFAULT_LOGASYNC      = true;
 extern const char * const DEFAULT_DEBUGLOGFILE;
 
 extern bool fLogIPs;
@@ -93,6 +94,7 @@ namespace BCLog {
 
         bool OpenDebugLog();
         void ShrinkDebugFile();
+        void FlushFile();
 
         uint32_t GetCategoryMask() const { return m_categories.load(); }
 
@@ -152,7 +154,7 @@ template<typename T, typename... Args> static inline void MarkUsed(const T& t, c
             /* Original format string will have newline so don't add one here */ \
             _log_msg_ = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
         } \
-        g_logger->LogPrintStr(_log_msg_); \
+        async_logging::Queue(std::move(_log_msg_));     \
     } \
 } while(0)
 
@@ -162,5 +164,12 @@ template<typename T, typename... Args> static inline void MarkUsed(const T& t, c
     } \
 } while(0)
 #endif
+
+namespace async_logging {
+    void Init(void);
+
+    /** Queue a log message to be written. */
+    void Queue(std::string&& str);
+}
 
 #endif // BITCOIN_LOGGING_H


### PR DESCRIPTION
This changeset renders and flushes log messages in a dedicated thread, preventing the originating thread from blocking (or failing) on fwrite, fflush, or the various string manipulations done on log messages. Originating threads push log messages into a buffer that is continually flushed. 

Benchmarks live in the comments below.

Open questions:
- Do we want this behavior by default? I think so, given that it seems safer and more performant than doing log processing synchronously with Important Stuff.
- Do we want to allow an opt-out configuration option that makes log processing synchronous again?
- The ring buffer implementation allows either overwriting existing data or blocking when at full capacity. In the case of logging, I've set it to block and wait for capacity instead of dropping messages. Does this seem right?

Future work:
- Reconcile this change with https://github.com/bitcoin/bitcoin/pull/13168 in case that's merged first (I have a patch)
- Even when logging is disabled, buffer debug logs without flushing and then handle SIGSEGV et al by flushing the log buffer (idea being to give the user crash diagnostics).
