### PR TITLE
Prevent copying of in/outputs for SignSignature

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -57,6 +57,15 @@ std::string CTxOut::ToString() const
 CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}
 CMutableTransaction::CMutableTransaction(const CTransaction& tx) : vin(tx.vin), vout(tx.vout), nVersion(tx.nVersion), nLockTime(tx.nLockTime) {}
 
+CMutableTransaction& CMutableTransaction::operator=(CTransaction&& tx) {
+    // ugly const cast - but since tx can be consumed, it's ok to move the data out.
+    vin = std::move(const_cast<std::vector<CTxIn>&>(tx.vin));
+    vout = std::move(const_cast<std::vector<CTxOut>&>(tx.vout));
+    nVersion = tx.nVersion;
+    nLockTime = tx.nLockTime;
+    return *this;
+}
+
 uint256 CMutableTransaction::GetHash() const
 {
     return SerializeHash(*this, SER_GETHASH, SERIALIZE_TRANSACTION_NO_WITNESS);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -369,6 +369,8 @@ struct CMutableTransaction
     CMutableTransaction();
     CMutableTransaction(const CTransaction& tx);
 
+    CMutableTransaction& operator=(CTransaction&&);
+
     template <typename Stream>
     inline void Serialize(Stream& s) const {
         SerializeTransaction(*this, s);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -209,11 +209,15 @@ bool SignSignature(const SigningProvider &provider, const CScript& fromPubKey, C
 {
     assert(nIn < txTo.vin.size());
 
-    CTransaction txToConst(txTo);
+    // moves txTo's in & outputs so they are not copied - txTo not needed here
+    CTransaction txToConst(std::move(txTo));
     TransactionSignatureCreator creator(&txToConst, nIn, amount, nHashType);
 
     SignatureData sigdata;
     bool ret = ProduceSignature(provider, creator, fromPubKey, sigdata);
+    
+    // txToConst not needed any more - move the data back
+    txTo = std::move(txToConst);
     UpdateTransaction(txTo, nIn, sigdata);
     return ret;
 }


### PR DESCRIPTION
Instead of copying data from a `CMutableTransaction` into a `CTransaction`,
the data is temporarily moved and then moved back after it's use. This speeds up
the slowest unit test `transaction_tests/test_big_witness_transaction`:

24.351 sec for all unit tests before
21.187 sec for all unit tests after this change

The change is somewhat ugly since a `const_cast` is necessary.

Relates to  #10026. It should also speed up any use of `SignSignature`, especially for machines where  allocating memory is slow.
