### PR TITLE
[WIP] Refactoring platform-specific code in util.h/util.cpp

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -372,7 +372,9 @@ libbitcoin_util_a_SOURCES = \
   support/cleanse.cpp \
   sync.cpp \
   threadinterrupt.cpp \
-  util.cpp \
+  util/platform_common.cpp \
+	util/platform_posix.cpp \
+	util/platform_windows.cpp \
   utilmoneystr.cpp \
   utilstrencodings.cpp \
   utiltime.cpp \

--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -12,7 +12,7 @@
 #include <random.h>
 #include <streams.h>
 #include <tinyformat.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 namespace {
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -11,7 +11,7 @@
 #include <random.h>
 #include <sync.h>
 #include <timedata.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <map>
 #include <set>

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -7,7 +7,7 @@
 #include <crypto/sha256.h>
 #include <key.h>
 #include <validation.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <random.h>
 
 #include <boost/lexical_cast.hpp>

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <validation.h>
 #include <checkqueue.h>
 #include <prevector.h>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -12,7 +12,7 @@
 #include <fs.h>
 #include <rpc/client.h>
 #include <rpc/protocol.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <memory>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -18,7 +18,7 @@
 #include <script/script.h>
 #include <script/sign.h>
 #include <univalue.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -14,7 +14,7 @@
 #include <rpc/server.h>
 #include <init.h>
 #include <noui.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <httpserver.h>
 #include <httprpc.h>
 #include <utilstrencodings.h>

--- a/src/blockencodings.cpp
+++ b/src/blockencodings.cpp
@@ -11,7 +11,7 @@
 #include <streams.h>
 #include <txmempool.h>
 #include <validation.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <unordered_map>
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -7,7 +7,7 @@
 #include <consensus/merkle.h>
 
 #include <tinyformat.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <assert.h>

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -6,7 +6,7 @@
 #include <chainparamsbase.h>
 
 #include <tinyformat.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <assert.h>
 

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -10,7 +10,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <version.h>
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -12,7 +12,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -9,7 +9,7 @@
 #include <fs.h>
 #include <serialize.h>
 #include <streams.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <version.h>
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -11,7 +11,7 @@
 #include <rpc/server.h>
 #include <random.h>
 #include <sync.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <ui_interface.h>
 #include <crypto/hmac_sha256.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -6,7 +6,7 @@
 
 #include <chainparamsbase.h>
 #include <compat.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <netbase.h>
 #include <rpc/protocol.h> // For HTTP status codes

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -7,7 +7,7 @@
 #include <init.h>
 #include <tinyformat.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <validation.h>
 #include <warnings.h>
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -40,7 +40,7 @@
 #include <txmempool.h>
 #include <torcontrol.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <validationinterface.h>
 #include <warnings.h>

--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -4,7 +4,7 @@
 
 #include <interfaces/handler.h>
 
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <boost/signals2/connection.hpp>
 #include <utility>

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -24,7 +24,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <validation.h>
 #include <warnings.h>
 

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -5,7 +5,7 @@
 
 #include <keystore.h>
 
-#include <util.h>
+#include <util/platform_common.h>
 
 void CBasicKeyStore::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey)
 {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -22,7 +22,7 @@
 #include <primitives/transaction.h>
 #include <script/standard.h>
 #include <timedata.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <validationinterface.h>
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -26,7 +26,7 @@
 #include <tinyformat.h>
 #include <txmempool.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -10,7 +10,7 @@
 #include <uint256.h>
 #include <random.h>
 #include <tinyformat.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <atomic>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -6,7 +6,7 @@
 #include <noui.h>
 
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <cstdio>
 #include <stdint.h>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -10,7 +10,7 @@
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <txmempool.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 static constexpr double INF_FEERATE = 1e99;
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -11,7 +11,7 @@
 #include <validation.h>
 #include <coins.h>
 #include <tinyformat.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -5,7 +5,7 @@
 
 #include <protocol.h>
 
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #ifndef WIN32

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -32,7 +32,7 @@
 #include <rpc/server.h>
 #include <ui_interface.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <warnings.h>
 
 #include <walletinitinterface.h>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -33,7 +33,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <iostream>
 

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -19,7 +19,7 @@
 #include <net.h>
 #include <txmempool.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <warnings.h>
 
 #include <stdint.h>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -18,7 +18,7 @@
 #include <protocol.h>
 #include <script/script.h>
 #include <script/standard.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #ifdef WIN32
 #ifdef _WIN32_WINNT

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -13,7 +13,7 @@
 #include <qt/guiutil.h>
 
 #include <interfaces/node.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <QFileDialog>
 #include <QSettings>

--- a/src/qt/paymentrequestplus.cpp
+++ b/src/qt/paymentrequestplus.cpp
@@ -9,7 +9,7 @@
 
 #include <qt/paymentrequestplus.h>
 
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <stdexcept>
 

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -13,7 +13,7 @@
 #include <policy/policy.h>
 #include <key_io.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <wallet/wallet.h>
 
 #include <cstdlib>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -18,7 +18,7 @@
 #include <netbase.h>
 #include <rpc/server.h>
 #include <rpc/client.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <openssl/crypto.h>
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -15,7 +15,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <ui_interface.h>
 #include <version.h>
 

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -13,7 +13,7 @@
 #include <random.h>
 #include <script/script.h>
 #include <script/standard.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <openssl/x509.h>

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -14,7 +14,7 @@
 #include <qt/rpcconsole.h>
 #include <test/test_bitcoin.h>
 #include <univalue.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <QDir>
 #include <QtGlobal>

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -8,7 +8,7 @@
 
 #include <chainparams.h>
 #include <qt/test/rpcnestedtests.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <qt/test/uritests.h>
 #include <qt/test/compattests.h>
 

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -15,7 +15,7 @@
 #include <validation.h>
 #include <script/script.h>
 #include <timedata.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <wallet/db.h>
 #include <wallet/wallet.h>
 #include <policy/policy.h>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -19,7 +19,7 @@
 #include <validation.h>
 #include <sync.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <QColor>
 #include <QDateTime>

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -20,7 +20,7 @@
 #include <clientversion.h>
 #include <init.h>
 #include <interfaces/node.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <stdio.h>
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -16,7 +16,7 @@
 #include <interfaces/node.h>
 #include <key_io.h>
 #include <ui_interface.h>
-#include <util.h> // for GetBoolArg
+#include <util/platform_common.h> // for GetBoolArg
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -6,7 +6,7 @@
 
 #if defined(Q_OS_WIN) && QT_VERSION >= 0x050000
 #include <init.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <windows.h>
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -11,7 +11,7 @@
 #include <compat.h> // for Windows API
 #include <wincrypt.h>
 #endif
-#include <util.h>             // for LogPrint()
+#include <util/platform_common.h>             // for LogPrint()
 #include <utilstrencodings.h> // for GetTime()
 
 #include <stdlib.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -21,7 +21,7 @@
 #include <sync.h>
 #include <txdb.h>
 #include <txmempool.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <hash.h>
 #include <validationinterface.h>

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -5,7 +5,7 @@
 
 #include <rpc/client.h>
 #include <rpc/protocol.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <set>
 #include <stdint.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -21,7 +21,7 @@
 #include <rpc/mining.h>
 #include <rpc/server.h>
 #include <txmempool.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <validationinterface.h>
 #include <warnings.h>

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -17,7 +17,7 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <timedata.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #ifdef ENABLE_WALLET
 #include <wallet/rpcwallet.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -16,7 +16,7 @@
 #include <sync.h>
 #include <timedata.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <version.h>
 #include <warnings.h>

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -7,7 +7,7 @@
 
 #include <random.h>
 #include <tinyformat.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <utiltime.h>
 #include <version.h>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -11,7 +11,7 @@
 #include <random.h>
 #include <sync.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <boost/bind.hpp>

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -9,7 +9,7 @@
 #include <pubkey.h>
 #include <random.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <cuckoocache.h>
 #include <boost/thread.hpp>

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -7,7 +7,7 @@
 
 #include <pubkey.h>
 #include <script/script.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <set>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <stdio.h>

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -11,7 +11,7 @@
 #include <pow.h>
 #include <script/sign.h>
 #include <serialize.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <validation.h>
 
 #include <test/test_bitcoin.h>

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <support/allocators/secure.h>
 #include <test/test_bitcoin.h>

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -7,7 +7,7 @@
 #include <key.h>
 #include <key_io.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <test/test_bitcoin.h>
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -13,7 +13,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <test/test_bitcoin.h>
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util.h>
+#include <util/platform_common.h>
 #include <utiltime.h>
 #include <validation.h>
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compressor.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <test/test_bitcoin.h>
 
 #include <stdint.h>

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util.h>
+#include <util/platform_common.h>
 #include <test/test_bitcoin.h>
 
 #include <string>

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -7,7 +7,7 @@
 #include <key_io.h>
 #include <script/script.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <test/test_bitcoin.h>
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -4,7 +4,7 @@
 
 #include <policy/policy.h>
 #include <txmempool.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <test/test_bitcoin.h>
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -15,7 +15,7 @@
 #include <script/standard.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 
 #include <test/test_bitcoin.h>

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -11,7 +11,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <chainparams.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <memory>
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -6,7 +6,7 @@
 #include <policy/fees.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <test/test_bitcoin.h>
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -6,7 +6,7 @@
 #include <chainparams.h>
 #include <pow.h>
 #include <random.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <test/test_bitcoin.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -10,7 +10,7 @@
 #include <script/script.h>
 #include <script/script_error.h>
 #include <script/sign.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <test/test_bitcoin.h>
 #include <rpc/server.h>

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -11,7 +11,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <test/test_bitcoin.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <version.h>
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <test/test_bitcoin.h>
 
 #include <vector>

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -5,7 +5,7 @@
 #include <index/txindex.h>
 #include <script/standard.h>
 #include <test/test_bitcoin.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utiltime.h>
 #include <validation.h>
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <clientversion.h>
 #include <primitives/transaction.h>

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -11,7 +11,7 @@
 #include <netaddress.h>
 #include <sync.h>
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilstrencodings.h>
 #include <warnings.h>
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -7,7 +7,7 @@
 #include <utilstrencodings.h>
 #include <netbase.h>
 #include <net.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <crypto/hmac_sha256.h>
 
 #include <vector>

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -10,7 +10,7 @@
 #include <random.h>
 #include <pow.h>
 #include <uint256.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <ui_interface.h>
 #include <init.h>
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -14,7 +14,7 @@
 #include <reverse_iterator.h>
 #include <streams.h>
 #include <timedata.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <utiltime.h>
 

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <ui_interface.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 CClientUIInterface uiInterface;
 

--- a/src/util/platform_common.h
+++ b/src/util/platform_common.h
@@ -7,8 +7,8 @@
  * Server/client environment: argument handling, config file parsing,
  * thread wrappers, startup time
  */
-#ifndef BITCOIN_UTIL_H
-#define BITCOIN_UTIL_H
+#ifndef BITCOIN_UTIL_PLATFORM_COMMON_H
+#define BITCOIN_UTIL_PLATFORM_COMMON_H
 
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>
@@ -90,6 +90,7 @@ const fs::path &GetBlocksDir(bool fNetSpecific = true);
 const fs::path &GetDataDir(bool fNetSpecific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string& confPath);
+
 #ifndef WIN32
 fs::path GetPidFile();
 void CreatePidFile(const fs::path &path, pid_t pid);
@@ -97,6 +98,7 @@ void CreatePidFile(const fs::path &path, pid_t pid);
 #ifdef WIN32
 fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif
+
 void runCommand(const std::string& strCommand);
 
 /**
@@ -109,14 +111,7 @@ void runCommand(const std::string& strCommand);
  */
 fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific = true);
 
-inline bool IsSwitchChar(char c)
-{
-#ifdef WIN32
-    return c == '-' || c == '/';
-#else
-    return c == '-';
-#endif
-}
+bool IsSwitchChar(char c);
 
 enum class OptionsCategory
 {
@@ -337,4 +332,4 @@ std::unique_ptr<T> MakeUnique(Args&&... args)
  */
 int ScheduleBatchPriority(void);
 
-#endif // BITCOIN_UTIL_H
+#endif // BITCOIN_UTIL_PLATFORM_COMMON_H

--- a/src/util/platform_posix.cpp
+++ b/src/util/platform_posix.cpp
@@ -1,0 +1,184 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "platform_common.h"
+
+#include <chainparamsbase.h>
+#include <random.h>
+#include <serialize.h>
+#include <utilstrencodings.h>
+
+#include <stdarg.h>
+
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+#include <pthread.h>
+#include <pthread_np.h>
+#endif
+
+#ifndef WIN32
+// for posix_fallocate
+#ifdef __linux__
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+
+#define _POSIX_C_SOURCE 200112L
+
+#endif // __linux__
+
+#include <algorithm>
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+
+#else
+
+#ifdef _MSC_VER
+#pragma warning(disable:4786)
+#pragma warning(disable:4804)
+#pragma warning(disable:4805)
+#pragma warning(disable:4717)
+#endif
+
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+#define _WIN32_WINNT 0x0501
+
+#ifdef _WIN32_IE
+#undef _WIN32_IE
+#endif
+#define _WIN32_IE 0x0501
+
+#define WIN32_LEAN_AND_MEAN 1
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <io.h> /* for _commit */
+#include <shlobj.h>
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+
+#ifdef HAVE_MALLOPT_ARENA_MAX
+#include <malloc.h>
+#endif
+
+#include <boost/interprocess/sync/file_lock.hpp>
+#include <boost/program_options/detail/config_file.hpp>
+#include <boost/thread.hpp>
+#include <openssl/crypto.h>
+#include <openssl/rand.h>
+#include <openssl/conf.h>
+#include <thread>
+
+bool IsSwitchChar(char c)
+{
+  return c == '-';
+}
+
+bool RenameOver(fs::path src, fs::path dest)
+{
+  int rc = std::rename(src.string().c_str(), dest.string().c_str());
+  return (rc == 0);
+}
+
+bool FileCommit(FILE *file)
+{
+  // This is now repeated in platform_windows.cpp
+  if (fflush(file) != 0) { // harmless if redundantly called
+      LogPrintf("%s: fflush failed: %d\n", __func__, errno);
+      return false;
+  }
+  //--
+
+  #if defined(__linux__) || defined(__NetBSD__)
+  if (fdatasync(fileno(file)) != 0 && errno != EINVAL) { // Ignore EINVAL for filesystems that don't support sync
+      LogPrintf("%s: fdatasync failed: %d\n", __func__, errno);
+      return false;
+  }
+  #elif defined(__APPLE__) && defined(F_FULLFSYNC)
+  if (fcntl(fileno(file), F_FULLFSYNC, 0) == -1) { // Manpage says "value other than -1" is returned on success
+      LogPrintf("%s: fcntl F_FULLFSYNC failed: %d\n", __func__, errno);
+      return false;
+  }
+  #else
+  if (fsync(fileno(file)) != 0 && errno != EINVAL) {
+      LogPrintf("%s: fsync failed: %d\n", __func__, errno);
+      return false;
+  }
+  #endif
+
+  return true;
+}
+
+bool TruncateFile(FILE *file, unsigned int length) {
+  return ftruncate(fileno(file), length) == 0;
+}
+
+int RaiseFileDescriptorLimit(int nMinFD) {
+  struct rlimit limitFD;
+  if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1) {
+      if (limitFD.rlim_cur < (rlim_t)nMinFD) {
+          limitFD.rlim_cur = nMinFD;
+          if (limitFD.rlim_cur > limitFD.rlim_max)
+              limitFD.rlim_cur = limitFD.rlim_max;
+          setrlimit(RLIMIT_NOFILE, &limitFD);
+          getrlimit(RLIMIT_NOFILE, &limitFD);
+      }
+      return limitFD.rlim_cur;
+  }
+  return nMinFD; // getrlimit failed, assume it's fine
+}
+
+/**
+ * this function tries to make a particular range of a file allocated (corresponding to disk space)
+ * it is advisory, and the range specified in the arguments will never contain live data
+ */
+void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
+// TODO: We need to combine the MAC OSX, Linux, and Fallback
+#if defined(MAC_OSX)
+    // OSX specific version
+    fstore_t fst;
+    fst.fst_flags = F_ALLOCATECONTIG;
+    fst.fst_posmode = F_PEOFPOSMODE;
+    fst.fst_offset = 0;
+    fst.fst_length = (off_t)offset + length;
+    fst.fst_bytesalloc = 0;
+    if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
+        fst.fst_flags = F_ALLOCATEALL;
+        fcntl(fileno(file), F_PREALLOCATE, &fst);
+    }
+    ftruncate(fileno(file), fst.fst_length);
+#elif defined(__linux__)
+    // Version using posix_fallocate
+    off_t nEndPos = (off_t)offset + length;
+    posix_fallocate(fileno(file), 0, nEndPos);
+#else
+    // Fallback version
+    // TODO: just write one byte per block
+    static const char buf[65536] = {};
+    if (fseek(file, offset, SEEK_SET)) {
+        return;
+    }
+    while (length > 0) {
+        unsigned int now = 65536;
+        if (length < now)
+            now = length;
+        fwrite(buf, 1, now, file); // allowed to fail; this function is advisory anyway
+        length -= now;
+    }
+#endif
+}
+
+bool SetupNetworking()
+{
+  return true;
+}

--- a/src/util/platform_windows.cpp
+++ b/src/util/platform_windows.cpp
@@ -1,0 +1,161 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "platform_common.h"
+
+#include <chainparamsbase.h>
+#include <random.h>
+#include <serialize.h>
+#include <utilstrencodings.h>
+
+#include <stdarg.h>
+
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+#include <pthread.h>
+#include <pthread_np.h>
+#endif
+
+#ifndef WIN32
+// for posix_fallocate
+#ifdef __linux__
+
+#ifdef _POSIX_C_SOURCE
+#undef _POSIX_C_SOURCE
+#endif
+
+#define _POSIX_C_SOURCE 200112L
+
+#endif // __linux__
+
+#include <algorithm>
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+
+#else
+
+#ifdef _MSC_VER
+#pragma warning(disable:4786)
+#pragma warning(disable:4804)
+#pragma warning(disable:4805)
+#pragma warning(disable:4717)
+#endif
+
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+#define _WIN32_WINNT 0x0501
+
+#ifdef _WIN32_IE
+#undef _WIN32_IE
+#endif
+#define _WIN32_IE 0x0501
+
+#define WIN32_LEAN_AND_MEAN 1
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+
+#include <io.h> /* for _commit */
+#include <shlobj.h>
+#endif
+
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+
+#ifdef HAVE_MALLOPT_ARENA_MAX
+#include <malloc.h>
+#endif
+
+#include <boost/interprocess/sync/file_lock.hpp>
+#include <boost/program_options/detail/config_file.hpp>
+#include <boost/thread.hpp>
+#include <openssl/crypto.h>
+#include <openssl/rand.h>
+#include <openssl/conf.h>
+#include <thread>
+
+#ifdef WIN32
+
+fs::path GetPidFile();
+void CreatePidFile(const fs::path &path, pid_t pid);
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+
+bool IsSwitchChar(char c)
+{
+  return c == '-' || c == '/';
+}
+
+bool RenameOver(fs::path src, fs::path dest)
+{
+  return MoveFileExA(src.string().c_str(), dest.string().c_str(),
+                     MOVEFILE_REPLACE_EXISTING) != 0;
+}
+
+bool FileCommit(FILE *file)
+{
+  //-- This is now repeated in platform_posix.cpp
+  if (fflush(file) != 0) { // harmless if redundantly called
+      LogPrintf("%s: fflush failed: %d\n", __func__, errno);
+      return false;
+  }
+  //--
+
+  HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+  if (FlushFileBuffers(hFile) == 0) {
+      LogPrintf("%s: FlushFileBuffers failed: %d\n", __func__, GetLastError());
+      return false;
+  }
+  return true;
+}
+
+bool TruncateFile(FILE *file, unsigned int length) {
+  return _chsize(_fileno(file), length) == 0;
+}
+
+int RaiseFileDescriptorLimit(int nMinFD) {
+  return 2048;
+}
+
+/**
+ * this function tries to make a particular range of a file allocated (corresponding to disk space)
+ * it is advisory, and the range specified in the arguments will never contain live data
+ */
+void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
+  // Windows-specific version
+  HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(file));
+  LARGE_INTEGER nFileSize;
+  int64_t nEndPos = (int64_t)offset + length;
+  nFileSize.u.LowPart = nEndPos & 0xFFFFFFFF;
+  nFileSize.u.HighPart = nEndPos >> 32;
+  SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
+  SetEndOfFile(hFile);
+}
+
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate)
+{
+  char pszPath[MAX_PATH] = "";
+
+  if(SHGetSpecialFolderPathA(nullptr, pszPath, nFolder, fCreate))
+  {
+      return fs::path(pszPath);
+  }
+
+  LogPrintf("SHGetSpecialFolderPathA() failed, could not obtain requested path.\n");
+  return fs::path("");
+}
+
+bool SetupNetworking()
+{
+  // Initialize Windows Sockets
+  WSADATA wsadata;
+  int ret = WSAStartup(MAKEWORD(2,2), &wsadata);
+  if (ret != NO_ERROR || LOBYTE(wsadata.wVersion ) != 2 || HIBYTE(wsadata.wVersion) != 2)
+      return false;
+  return true;
+}
+#endif

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -35,7 +35,7 @@
 #include <txmempool.h>
 #include <ui_interface.h>
 #include <undo.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 #include <validationinterface.h>

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -10,7 +10,7 @@
 #include <scheduler.h>
 #include <sync.h>
 #include <txmempool.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <validation.h>
 
 #include <list>

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <wallet/coinselection.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 
 // Descending order comparator

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -8,7 +8,7 @@
 #include <crypto/sha512.h>
 #include <script/script.h>
 #include <script/standard.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 #include <string>
 #include <vector>

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -11,7 +11,7 @@
 #include <serialize.h>
 #include <streams.h>
 #include <sync.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <version.h>
 
 #include <atomic>

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -13,7 +13,7 @@
 #include <validation.h> //for mempool access
 #include <txmempool.h>
 #include <utilmoneystr.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <net.h>
 
 //! Check whether transaction has descendant in wallet or mempool, or has been

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -7,7 +7,7 @@
 
 #include <policy/policy.h>
 #include <txmempool.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -6,7 +6,7 @@
 #include <chainparams.h>
 #include <init.h>
 #include <net.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <validation.h>
 #include <walletinitinterface.h>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -9,7 +9,7 @@
 #include <script/script.h>
 #include <script/standard.h>
 #include <sync.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utiltime.h>
 #include <wallet/wallet.h>
 #include <merkleblock.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -21,7 +21,7 @@
 #include <rpc/util.h>
 #include <script/sign.h>
 #include <timedata.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utilmoneystr.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -15,7 +15,7 @@
 #include <validationinterface.h>
 #include <script/ismine.h>
 #include <script/sign.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <wallet/crypter.h>
 #include <wallet/coinselection.h>
 #include <wallet/walletdb.h>

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -12,7 +12,7 @@
 #include <protocol.h>
 #include <serialize.h>
 #include <sync.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <utiltime.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -6,7 +6,7 @@
 #define BITCOIN_WALLET_WALLETUTIL_H
 
 #include <chainparamsbase.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 //! Get the path of the wallet directory.
 fs::path GetWalletDir();

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -5,7 +5,7 @@
 
 #include <sync.h>
 #include <clientversion.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <warnings.h>
 
 CCriticalSection cs_warnings;

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <zmq/zmqabstractnotifier.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 
 CZMQAbstractNotifier::~CZMQAbstractNotifier()

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -8,7 +8,7 @@
 #include <version.h>
 #include <validation.h>
 #include <streams.h>
-#include <util.h>
+#include <util/platform_common.h>
 
 void zmqError(const char *str)
 {

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -7,7 +7,7 @@
 #include <streams.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <validation.h>
-#include <util.h>
+#include <util/platform_common.h>
 #include <rpc/server.h>
 
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;


### PR DESCRIPTION
Take all of the functions that are specific to Windows or Unix, and create a common set of methods in a new header file, all combined in the `src/util/` folder.

The goal of this PR is to break `src/util.cpp` and `src/util.h` into the following files:

**For Across Platform:**
* `src/util/platform_common.h`
* `src/util/platform_common.cpp`

**For Windows:**
* `src/util/platform_windows.cpp`

**For Mac & Linux:**
* `src/util/platform_posix.cpp`

Issue Reference: https://github.com/bitcoin/bitcoin/issues/12697

## Discussion
1. How should we handle "duplicate codes"? For example: [this](https://github.com/bitcoin/bitcoin/pull/13209/files#diff-2da22387097e9ac5c565ab65b73cf151R95) & [this](https://github.com/bitcoin/bitcoin/pull/13209/files#diff-705e6c45222827fdee5fdf9891982ba4R101)
2. Certain things seems to be "very specific to a certain posix platform". How do we want to handle this? For example: [this](https://github.com/bitcoin/bitcoin/pull/13209/files#diff-2da22387097e9ac5c565ab65b73cf151R15) & [this](https://github.com/glaksmono/bitcoin/blob/da361f0410149d085a89a7492eaa5261c41221dd/src/util/platform_common.cpp#L890)