### PR TITLE
Use a semaphore or pipe for shutdown notification (skeees, laanwj)

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -42,10 +42,7 @@
 
 static void WaitForShutdown()
 {
-    while (!ShutdownRequested())
-    {
-        MilliSleep(200);
-    }
+    BlockUntilShutdownRequested();
     Interrupt();
 }
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -467,8 +467,6 @@ void StopHTTPServer()
     }
     if (eventBase) {
         LogPrint(BCLog::HTTP, "Waiting for HTTP event thread to exit\n");
-        // Exit the event loop as soon as there are no active events.
-        event_base_loopexit(eventBase, nullptr);
         // Give event loop a few seconds to exit (to send back last RPC responses), then break it
         // Before this was solved with event_base_loopexit, but that didn't work as expected in
         // at least libevent 2.0.21 and always introduced a delay. In libevent

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -131,14 +131,59 @@ static const char* FEE_ESTIMATES_FILENAME="fee_estimates.dat";
 //
 
 std::atomic<bool> fRequestShutdown(false);
+#ifdef WIN32
+CSemaphore shutdown_barrier(0);
+#else
+// On POSIX systems use a pipe to be notified of shutdown - this is the only method
+// that is safe with signal handling.
+int g_shutdown_pipe[2] = {-1,-1};
+#endif
 
 void StartShutdown()
 {
+    if (fRequestShutdown) // Avoid writing to pipe multiple times for multiple signals
+        return;
     fRequestShutdown = true;
+#ifdef WIN32
+    shutdown_barrier.post();
+#else
+    static const char ch = 0;
+    (void)write(g_shutdown_pipe[1], &ch, 1);
+#endif
 }
+
 bool ShutdownRequested()
 {
     return fRequestShutdown;
+}
+
+void BlockUntilShutdownRequested()
+{
+#ifdef WIN32
+    shutdown_barrier.wait();
+#else
+    char ch;
+    (void)read(g_shutdown_pipe[0], &ch, 1);
+#endif
+}
+
+bool StartShutdownNotification()
+{
+#ifdef WIN32
+    // Nothing to do, shutdown_barrier is pre-initialized
+    return true;
+#else
+    return pipe(g_shutdown_pipe) == 0;
+#endif
+}
+
+void StopShutdownNotification()
+{
+#ifndef WIN32
+    close(g_shutdown_pipe[0]);
+    close(g_shutdown_pipe[1]);
+    g_shutdown_pipe[0] = g_shutdown_pipe[1] = -1;
+#endif
 }
 
 /**
@@ -290,6 +335,7 @@ void Shutdown()
     g_wallet_init_interface.Close();
     globalVerifyHandle.reset();
     ECC_Stop();
+    StopShutdownNotification();
     LogPrintf("%s: done\n", __func__);
 }
 
@@ -301,7 +347,7 @@ void Shutdown()
 #ifndef WIN32
 static void HandleSIGTERM(int)
 {
-    fRequestShutdown = true;
+    StartShutdown();
 }
 
 static void HandleSIGHUP(int)
@@ -311,7 +357,7 @@ static void HandleSIGHUP(int)
 #else
 static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
 {
-    fRequestShutdown = true;
+    StartShutdown();
     Sleep(INFINITE);
     return true;
 }
@@ -1205,6 +1251,9 @@ bool AppInitMain()
 #ifndef WIN32
     CreatePidFile(GetPidFile(), getpid());
 #endif
+    if (!StartShutdownNotification()) {
+        return InitError("Unable to create shutdown notification.");
+    }
     if (g_logger->m_print_to_file) {
         if (gArgs.GetBoolArg("-shrinkdebugfile", g_logger->DefaultShrinkDebugFile())) {
             // Do this first since it both loads a bunch of debug.log into memory,

--- a/src/init.h
+++ b/src/init.h
@@ -23,6 +23,8 @@ class thread_group;
 
 void StartShutdown();
 bool ShutdownRequested();
+/* Block until shutdown requested - this can only be called from one thread. */
+void BlockUntilShutdownRequested();
 /** Interrupt threads */
 void Interrupt();
 void Shutdown();


### PR DESCRIPTION
Instead of polling, use a semaphore (on WIN32) or a pipe (on POSIX) for shutdown notification. This avoids the need for a polling loop in bitcoind.

Extends #13186.

This does not change the polilng of `ShutdownRequested()` in the GUI. This is more complicated: on POSIX it would be possible to import the `pipe[0]` handle into the event loop, and call a handler when a character is detected, on Windows the `StartShutdown()` could make a callback that queues a qt signal at the GUI side. But I think that is better left for a later PR.