### PR TITLE
Remove unneeded start parameter of zero from Python range function

### DIFF
--- a/contrib/seeds/makeseeds.py
+++ b/contrib/seeds/makeseeds.py
@@ -59,7 +59,7 @@ def parseline(line):
     else:
         # Do IPv4 sanity check
         ip = 0
-        for i in range(0,4):
+        for i in range(4):
             if int(m.group(i+2)) < 0 or int(m.group(i+2)) > 255:
                 return None
             ip = ip + (int(m.group(i+2)) << (8*(3-i)))

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -540,7 +540,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        for i in range(0,20):
+        for i in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
         self.nodes[0].generate(1)
         self.sync_all()
@@ -570,7 +570,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        for i in range(0,20):
+        for i in range(20):
             self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
         self.nodes[0].generate(1)
         self.sync_all()

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -99,7 +99,7 @@ class WalletDumpTest(BitcoinTestFramework):
         # wallet, we will expect 21 addresses in the dump
         test_addr_count = 20
         addrs = []
-        for i in range(0,test_addr_count):
+        for i in range(test_addr_count):
             addr = self.nodes[0].getnewaddress()
             vaddr= self.nodes[0].getaddressinfo(addr) #required to get hd keypath
             addrs.append(vaddr)


### PR DESCRIPTION
This removes the default first parameter of zero from Python range functions when it's not needed.

https://docs.python.org/3.5/library/stdtypes.html#range

The majority of the codebase uses the range without the zero as the first parameter.

I used a regex in PyCharm to just search through Python files for the range functions that I changed in this PR.  Regex was ->  range *\\( *0

The only other results are the range functions that use all three parameters, start - stop - step.
