### PR TITLE
travis: Rename the build stage "check_doc" to "lint"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   - depends/sdk-sources
   - $HOME/.ccache
 stages:
-  - check_doc
+  - lint
   - test
 env:
   global:
@@ -77,7 +77,7 @@ after_script:
 
 jobs:
   include:
-    - stage: check_doc
+    - stage: lint
       sudo: false
       addons:
         apt:


### PR DESCRIPTION
Rename the Travis build stage from `check_doc` to `lint`.

When `check_doc` was introduced back in fa1b80db889307f5259961ae22128b88b9437b03 it was used to make sure `contrib/devtools/check-doc.py` was run only once.

Nowadays `check_docs` is used to trigger various linting type jobs which makes the name `check_doc` a bit misleading.
