### PR TITLE
refactor: Extract BnB-specific data from CInputCoin 

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -65,15 +65,15 @@ static void CoinSelection(benchmark::State& state)
 typedef std::set<CInputCoin> CoinSet;
 
 // Copied from src/wallet/test/coinselector_tests.cpp
-static void add_coin(const CAmount& nValue, int nInput, std::vector<CInputCoin>& set)
+static void add_coin(const CAmount& nValue, int nInput, std::vector<InputCoinWithFee>& set)
 {
     CMutableTransaction tx;
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
-    set.emplace_back(MakeTransactionRef(tx), nInput);
+    set.emplace_back(CInputCoin(MakeTransactionRef(tx), nInput), 0, 0);
 }
 // Copied from src/wallet/test/coinselector_tests.cpp
-static CAmount make_hard_case(int utxos, std::vector<CInputCoin>& utxo_pool)
+static CAmount make_hard_case(int utxos, std::vector<InputCoinWithFee>& utxo_pool)
 {
     utxo_pool.clear();
     CAmount target = 0;
@@ -88,7 +88,7 @@ static CAmount make_hard_case(int utxos, std::vector<CInputCoin>& utxo_pool)
 static void BnBExhaustion(benchmark::State& state)
 {
     // Setup
-    std::vector<CInputCoin> utxo_pool;
+    std::vector<InputCoinWithFee> utxo_pool;
     CoinSet selection;
     CAmount value_ret = 0;
     CAmount not_input_fees = 0;

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -36,12 +36,12 @@ CoinEligibilityFilter filter_confirmed(1, 1, 0);
 CoinEligibilityFilter filter_standard_extra(6, 6, 0);
 CoinSelectionParams coin_selection_params(false, 0, 0, CFeeRate(0), 0);
 
-static void add_coin(const CAmount& nValue, int nInput, std::vector<CInputCoin>& set)
+static void add_coin(const CAmount& nValue, int nInput, std::vector<InputCoinWithFee>& set)
 {
     CMutableTransaction tx;
     tx.vout.resize(nInput + 1);
     tx.vout[nInput].nValue = nValue;
-    set.emplace_back(MakeTransactionRef(tx), nInput);
+    set.emplace_back(CInputCoin(MakeTransactionRef(tx), nInput), 0, 0);
 }
 
 static void add_coin(const CAmount& nValue, int nInput, CoinSet& set)
@@ -90,7 +90,7 @@ static bool equal_sets(CoinSet a, CoinSet b)
     return ret.first == a.end() && ret.second == b.end();
 }
 
-static CAmount make_hard_case(int utxos, std::vector<CInputCoin>& utxo_pool)
+static CAmount make_hard_case(int utxos, std::vector<InputCoinWithFee>& utxo_pool)
 {
     utxo_pool.clear();
     CAmount target = 0;
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     LOCK(testWallet.cs_wallet);
 
     // Setup
-    std::vector<CInputCoin> utxo_pool;
+    std::vector<InputCoinWithFee> utxo_pool;
     CoinSet selection;
     CoinSet actual_selection;
     CAmount value_ret = 0;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2475,7 +2475,6 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibil
     setCoinsRet.clear();
     nValueRet = 0;
 
-    std::vector<CInputCoin> utxo_pool;
     if (coin_selection_params.use_bnb) {
 
         // Get long term estimate
@@ -2487,19 +2486,19 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibil
         // Calculate cost of change
         CAmount cost_of_change = GetDiscardRate(*this, ::feeEstimator).GetFee(coin_selection_params.change_spend_size) + coin_selection_params.effective_fee.GetFee(coin_selection_params.change_output_size);
 
+        std::vector<InputCoinWithFee> utxo_pool;
         // Filter by the min conf specs and add to utxo_pool and calculate effective value
         for (const COutput &output : vCoins)
         {
             if (!OutputEligibleForSpending(output, eligibility_filter))
                 continue;
 
+            CAmount fee = (output.nInputBytes < 0 ? 0 : coin_selection_params.effective_fee.GetFee(output.nInputBytes));
             CInputCoin coin(output.tx->tx, output.i);
-            coin.effective_value = coin.txout.nValue - (output.nInputBytes < 0 ? 0 : coin_selection_params.effective_fee.GetFee(output.nInputBytes));
             // Only include outputs that are positive effective value (i.e. not dust)
-            if (coin.effective_value > 0) {
-                coin.fee = output.nInputBytes < 0 ? 0 : coin_selection_params.effective_fee.GetFee(output.nInputBytes);
-                coin.long_term_fee = output.nInputBytes < 0 ? 0 : long_term_feerate.GetFee(output.nInputBytes);
-                utxo_pool.push_back(coin);
+            if (coin.txout.nValue > fee) {
+                CAmount long_term_fee = output.nInputBytes < 0 ? 0 : long_term_feerate.GetFee(output.nInputBytes);
+                utxo_pool.push_back(InputCoinWithFee(std::move(coin), fee, long_term_fee));
             }
         }
         // Calculate the fees for things that aren't inputs
@@ -2507,13 +2506,14 @@ bool CWallet::SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibil
         bnb_used = true;
         return SelectCoinsBnB(utxo_pool, nTargetValue, cost_of_change, setCoinsRet, nValueRet, not_input_fees);
     } else {
+        std::vector<CInputCoin> utxo_pool;
         // Filter by the min conf specs and add to utxo_pool
         for (const COutput &output : vCoins)
         {
             if (!OutputEligibleForSpending(output, eligibility_filter))
                 continue;
 
-            CInputCoin coin = CInputCoin(output.tx->tx, output.i);
+            CInputCoin coin(output.tx->tx, output.i);
             utxo_pool.push_back(coin);
         }
         bnb_used = false;


### PR DESCRIPTION
This separates the fee-specific info of CInputCoin that are only used by
SelectCoinsBnB into a separate wrapper class. This makes CInputCoin small and
allows for isolation and expression of BnB-specific concepts like waste.

This also calls attention to the fact that there is no fee-specific testing of
SelectCoinsBnB currently. Could be worthy to visit for greater coverage.