### PR TITLE
[trivial] Qt: Add testnet chainsize constants and switch for intro

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -55,7 +55,9 @@ static const int MAX_URI_LENGTH = 255;
 
 /* Minimum free space (in GB) needed for data directory */
 static const uint64_t BLOCK_CHAIN_SIZE = 200;
+static const uint64_t BLOCK_CHAIN_SIZE_TESTNET = 20;
 /* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
 static const uint64_t CHAIN_STATE_SIZE = 3;
+static const uint64_t CHAIN_STATE_SIZE_TESTNET = 2;
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -53,4 +53,9 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
 
+/* Minimum free space (in GB) needed for data directory */
+static const uint64_t BLOCK_CHAIN_SIZE = 200;
+/* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
+static const uint64_t CHAIN_STATE_SIZE = 3;
+
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -10,6 +10,7 @@
 #include <qt/intro.h>
 #include <qt/forms/ui_intro.h>
 
+#include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 
 #include <interfaces/node.h>
@@ -22,10 +23,6 @@
 #include <cmath>
 
 static const uint64_t GB_BYTES = 1000000000LL;
-/* Minimum free space (in GB) needed for data directory */
-static const uint64_t BLOCK_CHAIN_SIZE = 200;
-/* Minimum free space (in GB) needed for data directory when pruned; Does not include prune target */
-static const uint64_t CHAIN_STATE_SIZE = 3;
 /* Total required space (in GB) depending on user choice (prune, not prune) */
 static uint64_t requiredSpace;
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -13,6 +13,7 @@
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 
+#include <chainparamsbase.h>
 #include <interfaces/node.h>
 #include <util.h>
 
@@ -130,7 +131,7 @@ Intro::Intro(QWidget *parent) :
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(tr(PACKAGE_NAME)));
 
     uint64_t pruneTarget = std::max<int64_t>(0, gArgs.GetArg("-prune", 0));
-    requiredSpace = BLOCK_CHAIN_SIZE;
+    requiredSpace = gArgs.GetChainName() == CBaseChainParams::MAIN ? BLOCK_CHAIN_SIZE : BLOCK_CHAIN_SIZE_TESTNET;
     QString storageRequiresMsg = tr("At least %1 GB of data will be stored in this directory, and it will grow over time.");
     if (pruneTarget) {
         uint64_t prunedGBs = std::ceil(pruneTarget * 1024 * 1024.0 / GB_BYTES);
@@ -142,7 +143,7 @@ Intro::Intro(QWidget *parent) :
     } else {
         ui->lblExplanation3->setVisible(false);
     }
-    requiredSpace += CHAIN_STATE_SIZE;
+    requiredSpace += gArgs.GetChainName() == CBaseChainParams::MAIN ? CHAIN_STATE_SIZE : CHAIN_STATE_SIZE_TESTNET;
     ui->sizeWarningLabel->setText(
         tr("%1 will download and store a copy of the Bitcoin block chain.").arg(tr(PACKAGE_NAME)) + " " +
         storageRequiresMsg.arg(requiredSpace) + " " +


### PR DESCRIPTION
Fixes #13213.

The current GUI intro screen (datadir picker) requires 202 GB free disk space for testnet due to not being able to switch between test/mainnet.

This adds size constants for testnet (20GB chain size [It's actually not even 15GB, but keep some room] and 1GB chain state size which is pretty accurate).