### PR TITLE
[moveonly] Fix CConnman template methods to be fully-defined in net.h

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2809,11 +2809,6 @@ void CNode::AskFor(const CInv& inv)
     mapAskFor.insert(std::make_pair(nRequestTime, inv));
 }
 
-bool CConnman::NodeFullyConnected(const CNode* pnode)
-{
-    return pnode && pnode->fSuccessfullyConnected && !pnode->fDisconnect;
-}
-
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     size_t nMessageSize = msg.data.size();
@@ -2861,7 +2856,7 @@ bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)
             break;
         }
     }
-    return found != nullptr && NodeFullyConnected(found) && func(found);
+    return found != nullptr && found->FullyConnected() && func(found);
 }
 
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds) {

--- a/src/net.h
+++ b/src/net.h
@@ -322,6 +322,12 @@ public:
     CNode(const CNode&) = delete;
     CNode& operator=(const CNode&) = delete;
 
+    // Whether the node should be passed out in ForEach* callbacks
+    bool FullyConnected() const
+    {
+        return fSuccessfullyConnected && !fDisconnect;
+    }
+
 private:
     const NodeId id;
     const uint64_t nLocalHostNonce;
@@ -525,7 +531,7 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
+            if (node != nullptr && node->FullyConnected())
                 func(node);
         }
     };
@@ -535,7 +541,7 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
+            if (node != nullptr && node->FullyConnected())
                 func(node);
         }
     };
@@ -545,7 +551,7 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
+            if (node != nullptr && node->FullyConnected())
                 pre(node);
         }
         post();
@@ -556,7 +562,7 @@ public:
     {
         LOCK(cs_vNodes);
         for (auto&& node : vNodes) {
-            if (NodeFullyConnected(node))
+            if (node != nullptr && node->FullyConnected())
                 pre(node);
         }
         post();
@@ -699,9 +705,6 @@ private:
     // Network stats
     void RecordBytesRecv(uint64_t bytes);
     void RecordBytesSent(uint64_t bytes);
-
-    // Whether the node should be passed out in ForEach* callbacks
-    static bool NodeFullyConnected(const CNode* pnode);
 
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;

--- a/src/net.h
+++ b/src/net.h
@@ -35,7 +35,6 @@
 
 
 class CScheduler;
-class CNode;
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
@@ -93,7 +92,47 @@ struct AddedNodeInfo
     bool fInbound;
 };
 
-class CNodeStats;
+struct LocalServiceInfo {
+    int nScore;
+    int nPort;
+};
+
+extern CCriticalSection cs_mapLocalHost;
+extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
+typedef std::map<std::string, uint64_t> mapMsgCmdSize; //command, total bytes
+
+class CNodeStats
+{
+public:
+    NodeId nodeid;
+    ServiceFlags nServices;
+    bool fRelayTxes;
+    int64_t nLastSend;
+    int64_t nLastRecv;
+    int64_t nTimeConnected;
+    int64_t nTimeOffset;
+    std::string addrName;
+    int nVersion;
+    std::string cleanSubVer;
+    bool fInbound;
+    bool m_manual_connection;
+    int nStartingHeight;
+    uint64_t nSendBytes;
+    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    uint64_t nRecvBytes;
+    mapMsgCmdSize mapRecvBytesPerMsgCmd;
+    bool fWhitelisted;
+    double dPingTime;
+    double dPingWait;
+    double dMinPing;
+    // Our address, as reported by the peer
+    std::string addrLocal;
+    // Address of this peer
+    CAddress addr;
+    // Bind address of our side of the connection
+    CAddress addrBind;
+};
+
 class CClientUIInterface;
 
 struct CSerializedNetMsg
@@ -107,6 +146,307 @@ struct CSerializedNetMsg
 
     std::vector<unsigned char> data;
     std::string command;
+};
+
+class CNetMessage {
+private:
+    mutable CHash256 hasher;
+    mutable uint256 data_hash;
+public:
+    bool in_data;                   // parsing header (false) or data (true)
+
+    CDataStream hdrbuf;             // partially received header
+    CMessageHeader hdr;             // complete header
+    unsigned int nHdrPos;
+
+    CDataStream vRecv;              // received message data
+    unsigned int nDataPos;
+
+    int64_t nTime;                  // time (in microseconds) of message receipt.
+
+    CNetMessage(const CMessageHeader::MessageStartChars& pchMessageStartIn, int nTypeIn, int nVersionIn) : hdrbuf(nTypeIn, nVersionIn), hdr(pchMessageStartIn), vRecv(nTypeIn, nVersionIn) {
+        hdrbuf.resize(24);
+        in_data = false;
+        nHdrPos = 0;
+        nDataPos = 0;
+        nTime = 0;
+    }
+
+    bool complete() const
+    {
+        if (!in_data)
+            return false;
+        return (hdr.nMessageSize == nDataPos);
+    }
+
+    const uint256& GetMessageHash() const;
+
+    void SetVersion(int nVersionIn)
+    {
+        hdrbuf.SetVersion(nVersionIn);
+        vRecv.SetVersion(nVersionIn);
+    }
+
+    int readHeader(const char *pch, unsigned int nBytes);
+    int readData(const char *pch, unsigned int nBytes);
+};
+
+class CConnman;
+
+/** Information about a peer */
+class CNode
+{
+    friend class CConnman;
+public:
+    // socket
+    std::atomic<ServiceFlags> nServices;
+    SOCKET hSocket;
+    size_t nSendSize; // total size of all vSendMsg entries
+    size_t nSendOffset; // offset inside the first vSendMsg already sent
+    uint64_t nSendBytes;
+    std::deque<std::vector<unsigned char>> vSendMsg;
+    CCriticalSection cs_vSend;
+    CCriticalSection cs_hSocket;
+    CCriticalSection cs_vRecv;
+
+    CCriticalSection cs_vProcessMsg;
+    std::list<CNetMessage> vProcessMsg;
+    size_t nProcessQueueSize;
+
+    CCriticalSection cs_sendProcessing;
+
+    std::deque<CInv> vRecvGetData;
+    uint64_t nRecvBytes;
+    std::atomic<int> nRecvVersion;
+
+    std::atomic<int64_t> nLastSend;
+    std::atomic<int64_t> nLastRecv;
+    const int64_t nTimeConnected;
+    std::atomic<int64_t> nTimeOffset;
+    // Address of this peer
+    const CAddress addr;
+    // Bind address of our side of the connection
+    const CAddress addrBind;
+    std::atomic<int> nVersion;
+    // strSubVer is whatever byte array we read from the wire. However, this field is intended
+    // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
+    // store the sanitized version in cleanSubVer. The original should be used when dealing with
+    // the network or wire types and the cleaned string used when displayed or logged.
+    std::string strSubVer, cleanSubVer;
+    CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
+    bool fWhitelisted; // This peer can bypass DoS banning.
+    bool fFeeler; // If true this node is being used as a short lived feeler.
+    bool fOneShot;
+    bool m_manual_connection;
+    bool fClient;
+    bool m_limited_node; //after BIP159
+    const bool fInbound;
+    std::atomic_bool fSuccessfullyConnected;
+    std::atomic_bool fDisconnect;
+    // We use fRelayTxes for two purposes -
+    // a) it allows us to not relay tx invs before receiving the peer's version message
+    // b) the peer may tell us in its version message that we should not relay tx invs
+    //    unless it loads a bloom filter.
+    bool fRelayTxes; //protected by cs_filter
+    bool fSentAddr;
+    CSemaphoreGrant grantOutbound;
+    CCriticalSection cs_filter;
+    std::unique_ptr<CBloomFilter> pfilter;
+    std::atomic<int> nRefCount;
+
+    const uint64_t nKeyedNetGroup;
+    std::atomic_bool fPauseRecv;
+    std::atomic_bool fPauseSend;
+protected:
+
+    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    mapMsgCmdSize mapRecvBytesPerMsgCmd;
+
+public:
+    uint256 hashContinue;
+    std::atomic<int> nStartingHeight;
+
+    // flood relay
+    std::vector<CAddress> vAddrToSend;
+    CRollingBloomFilter addrKnown;
+    bool fGetAddr;
+    std::set<uint256> setKnown;
+    int64_t nNextAddrSend;
+    int64_t nNextLocalAddrSend;
+
+    // inventory based relay
+    CRollingBloomFilter filterInventoryKnown;
+    // Set of transaction ids we still have to announce.
+    // They are sorted by the mempool before relay, so the order is not important.
+    std::set<uint256> setInventoryTxToSend;
+    // List of block ids we still have announce.
+    // There is no final sorting before sending, as they are always sent immediately
+    // and in the order requested.
+    std::vector<uint256> vInventoryBlockToSend;
+    CCriticalSection cs_inventory;
+    std::set<uint256> setAskFor;
+    std::multimap<int64_t, CInv> mapAskFor;
+    int64_t nNextInvSend;
+    // Used for headers announcements - unfiltered blocks to relay
+    // Also protected by cs_inventory
+    std::vector<uint256> vBlockHashesToAnnounce;
+    // Used for BIP35 mempool sending, also protected by cs_inventory
+    bool fSendMempool;
+
+    // Last time a "MEMPOOL" request was serviced.
+    std::atomic<int64_t> timeLastMempoolReq;
+
+    // Block and TXN accept times
+    std::atomic<int64_t> nLastBlockTime;
+    std::atomic<int64_t> nLastTXTime;
+
+    // Ping time measurement:
+    // The pong reply we're expecting, or 0 if no pong expected.
+    std::atomic<uint64_t> nPingNonceSent;
+    // Time (in usec) the last ping was sent, or 0 if no ping was ever sent.
+    std::atomic<int64_t> nPingUsecStart;
+    // Last measured round-trip time.
+    std::atomic<int64_t> nPingUsecTime;
+    // Best measured round-trip time.
+    std::atomic<int64_t> nMinPingUsecTime;
+    // Whether a ping is requested.
+    std::atomic<bool> fPingQueued;
+    // Minimum fee rate with which to filter inv's to this node
+    CAmount minFeeFilter;
+    CCriticalSection cs_feeFilter;
+    CAmount lastSentFeeFilter;
+    int64_t nextSendTimeFeeFilter;
+
+    CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string &addrNameIn = "", bool fInboundIn = false);
+    ~CNode();
+    CNode(const CNode&) = delete;
+    CNode& operator=(const CNode&) = delete;
+
+private:
+    const NodeId id;
+    const uint64_t nLocalHostNonce;
+    // Services offered to this peer
+    const ServiceFlags nLocalServices;
+    const int nMyStartingHeight;
+    int nSendVersion;
+    std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
+
+    mutable CCriticalSection cs_addrName;
+    std::string addrName;
+
+    // Our address, as reported by the peer
+    CService addrLocal;
+    mutable CCriticalSection cs_addrLocal;
+public:
+
+    NodeId GetId() const {
+        return id;
+    }
+
+    uint64_t GetLocalNonce() const {
+        return nLocalHostNonce;
+    }
+
+    int GetMyStartingHeight() const {
+        return nMyStartingHeight;
+    }
+
+    int GetRefCount() const
+    {
+        assert(nRefCount >= 0);
+        return nRefCount;
+    }
+
+    bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
+
+    void SetRecvVersion(int nVersionIn)
+    {
+        nRecvVersion = nVersionIn;
+    }
+    int GetRecvVersion() const
+    {
+        return nRecvVersion;
+    }
+    void SetSendVersion(int nVersionIn);
+    int GetSendVersion() const;
+
+    CService GetAddrLocal() const;
+    //! May not be called more than once
+    void SetAddrLocal(const CService& addrLocalIn);
+
+    CNode* AddRef()
+    {
+        nRefCount++;
+        return this;
+    }
+
+    void Release()
+    {
+        nRefCount--;
+    }
+
+
+
+    void AddAddressKnown(const CAddress& _addr)
+    {
+        addrKnown.insert(_addr.GetKey());
+    }
+
+    void PushAddress(const CAddress& _addr, FastRandomContext &insecure_rand)
+    {
+        // Known checking here is only to save space from duplicates.
+        // SendMessages will filter it again for knowns that were added
+        // after addresses were pushed.
+        if (_addr.IsValid() && !addrKnown.contains(_addr.GetKey())) {
+            if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
+                vAddrToSend[insecure_rand.randrange(vAddrToSend.size())] = _addr;
+            } else {
+                vAddrToSend.push_back(_addr);
+            }
+        }
+    }
+
+
+    void AddInventoryKnown(const CInv& inv)
+    {
+        {
+            LOCK(cs_inventory);
+            filterInventoryKnown.insert(inv.hash);
+        }
+    }
+
+    void PushInventory(const CInv& inv)
+    {
+        LOCK(cs_inventory);
+        if (inv.type == MSG_TX) {
+            if (!filterInventoryKnown.contains(inv.hash)) {
+                setInventoryTxToSend.insert(inv.hash);
+            }
+        } else if (inv.type == MSG_BLOCK) {
+            vInventoryBlockToSend.push_back(inv.hash);
+        }
+    }
+
+    void PushBlockHash(const uint256 &hash)
+    {
+        LOCK(cs_inventory);
+        vBlockHashesToAnnounce.push_back(hash);
+    }
+
+    void AskFor(const CInv& inv);
+
+    void CloseSocketDisconnect();
+
+    void copyStats(CNodeStats &stats);
+
+    ServiceFlags GetLocalServices() const
+    {
+        return nLocalServices;
+    }
+
+    std::string GetAddrName() const;
+    //! Sets the addrName only if it was not previously set
+    void MaybeSetAddrName(const std::string& addrNameIn);
 };
 
 class NetEventsInterface;
@@ -513,350 +853,6 @@ extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 
 /** Subversion as sent to the P2P network in `version` messages */
 extern std::string strSubVersion;
-
-struct LocalServiceInfo {
-    int nScore;
-    int nPort;
-};
-
-extern CCriticalSection cs_mapLocalHost;
-extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
-typedef std::map<std::string, uint64_t> mapMsgCmdSize; //command, total bytes
-
-class CNodeStats
-{
-public:
-    NodeId nodeid;
-    ServiceFlags nServices;
-    bool fRelayTxes;
-    int64_t nLastSend;
-    int64_t nLastRecv;
-    int64_t nTimeConnected;
-    int64_t nTimeOffset;
-    std::string addrName;
-    int nVersion;
-    std::string cleanSubVer;
-    bool fInbound;
-    bool m_manual_connection;
-    int nStartingHeight;
-    uint64_t nSendBytes;
-    mapMsgCmdSize mapSendBytesPerMsgCmd;
-    uint64_t nRecvBytes;
-    mapMsgCmdSize mapRecvBytesPerMsgCmd;
-    bool fWhitelisted;
-    double dPingTime;
-    double dPingWait;
-    double dMinPing;
-    // Our address, as reported by the peer
-    std::string addrLocal;
-    // Address of this peer
-    CAddress addr;
-    // Bind address of our side of the connection
-    CAddress addrBind;
-};
-
-
-
-
-class CNetMessage {
-private:
-    mutable CHash256 hasher;
-    mutable uint256 data_hash;
-public:
-    bool in_data;                   // parsing header (false) or data (true)
-
-    CDataStream hdrbuf;             // partially received header
-    CMessageHeader hdr;             // complete header
-    unsigned int nHdrPos;
-
-    CDataStream vRecv;              // received message data
-    unsigned int nDataPos;
-
-    int64_t nTime;                  // time (in microseconds) of message receipt.
-
-    CNetMessage(const CMessageHeader::MessageStartChars& pchMessageStartIn, int nTypeIn, int nVersionIn) : hdrbuf(nTypeIn, nVersionIn), hdr(pchMessageStartIn), vRecv(nTypeIn, nVersionIn) {
-        hdrbuf.resize(24);
-        in_data = false;
-        nHdrPos = 0;
-        nDataPos = 0;
-        nTime = 0;
-    }
-
-    bool complete() const
-    {
-        if (!in_data)
-            return false;
-        return (hdr.nMessageSize == nDataPos);
-    }
-
-    const uint256& GetMessageHash() const;
-
-    void SetVersion(int nVersionIn)
-    {
-        hdrbuf.SetVersion(nVersionIn);
-        vRecv.SetVersion(nVersionIn);
-    }
-
-    int readHeader(const char *pch, unsigned int nBytes);
-    int readData(const char *pch, unsigned int nBytes);
-};
-
-
-/** Information about a peer */
-class CNode
-{
-    friend class CConnman;
-public:
-    // socket
-    std::atomic<ServiceFlags> nServices;
-    SOCKET hSocket;
-    size_t nSendSize; // total size of all vSendMsg entries
-    size_t nSendOffset; // offset inside the first vSendMsg already sent
-    uint64_t nSendBytes;
-    std::deque<std::vector<unsigned char>> vSendMsg;
-    CCriticalSection cs_vSend;
-    CCriticalSection cs_hSocket;
-    CCriticalSection cs_vRecv;
-
-    CCriticalSection cs_vProcessMsg;
-    std::list<CNetMessage> vProcessMsg;
-    size_t nProcessQueueSize;
-
-    CCriticalSection cs_sendProcessing;
-
-    std::deque<CInv> vRecvGetData;
-    uint64_t nRecvBytes;
-    std::atomic<int> nRecvVersion;
-
-    std::atomic<int64_t> nLastSend;
-    std::atomic<int64_t> nLastRecv;
-    const int64_t nTimeConnected;
-    std::atomic<int64_t> nTimeOffset;
-    // Address of this peer
-    const CAddress addr;
-    // Bind address of our side of the connection
-    const CAddress addrBind;
-    std::atomic<int> nVersion;
-    // strSubVer is whatever byte array we read from the wire. However, this field is intended
-    // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
-    // store the sanitized version in cleanSubVer. The original should be used when dealing with
-    // the network or wire types and the cleaned string used when displayed or logged.
-    std::string strSubVer, cleanSubVer;
-    CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
-    bool fWhitelisted; // This peer can bypass DoS banning.
-    bool fFeeler; // If true this node is being used as a short lived feeler.
-    bool fOneShot;
-    bool m_manual_connection;
-    bool fClient;
-    bool m_limited_node; //after BIP159
-    const bool fInbound;
-    std::atomic_bool fSuccessfullyConnected;
-    std::atomic_bool fDisconnect;
-    // We use fRelayTxes for two purposes -
-    // a) it allows us to not relay tx invs before receiving the peer's version message
-    // b) the peer may tell us in its version message that we should not relay tx invs
-    //    unless it loads a bloom filter.
-    bool fRelayTxes; //protected by cs_filter
-    bool fSentAddr;
-    CSemaphoreGrant grantOutbound;
-    CCriticalSection cs_filter;
-    std::unique_ptr<CBloomFilter> pfilter;
-    std::atomic<int> nRefCount;
-
-    const uint64_t nKeyedNetGroup;
-    std::atomic_bool fPauseRecv;
-    std::atomic_bool fPauseSend;
-protected:
-
-    mapMsgCmdSize mapSendBytesPerMsgCmd;
-    mapMsgCmdSize mapRecvBytesPerMsgCmd;
-
-public:
-    uint256 hashContinue;
-    std::atomic<int> nStartingHeight;
-
-    // flood relay
-    std::vector<CAddress> vAddrToSend;
-    CRollingBloomFilter addrKnown;
-    bool fGetAddr;
-    std::set<uint256> setKnown;
-    int64_t nNextAddrSend;
-    int64_t nNextLocalAddrSend;
-
-    // inventory based relay
-    CRollingBloomFilter filterInventoryKnown;
-    // Set of transaction ids we still have to announce.
-    // They are sorted by the mempool before relay, so the order is not important.
-    std::set<uint256> setInventoryTxToSend;
-    // List of block ids we still have announce.
-    // There is no final sorting before sending, as they are always sent immediately
-    // and in the order requested.
-    std::vector<uint256> vInventoryBlockToSend;
-    CCriticalSection cs_inventory;
-    std::set<uint256> setAskFor;
-    std::multimap<int64_t, CInv> mapAskFor;
-    int64_t nNextInvSend;
-    // Used for headers announcements - unfiltered blocks to relay
-    // Also protected by cs_inventory
-    std::vector<uint256> vBlockHashesToAnnounce;
-    // Used for BIP35 mempool sending, also protected by cs_inventory
-    bool fSendMempool;
-
-    // Last time a "MEMPOOL" request was serviced.
-    std::atomic<int64_t> timeLastMempoolReq;
-
-    // Block and TXN accept times
-    std::atomic<int64_t> nLastBlockTime;
-    std::atomic<int64_t> nLastTXTime;
-
-    // Ping time measurement:
-    // The pong reply we're expecting, or 0 if no pong expected.
-    std::atomic<uint64_t> nPingNonceSent;
-    // Time (in usec) the last ping was sent, or 0 if no ping was ever sent.
-    std::atomic<int64_t> nPingUsecStart;
-    // Last measured round-trip time.
-    std::atomic<int64_t> nPingUsecTime;
-    // Best measured round-trip time.
-    std::atomic<int64_t> nMinPingUsecTime;
-    // Whether a ping is requested.
-    std::atomic<bool> fPingQueued;
-    // Minimum fee rate with which to filter inv's to this node
-    CAmount minFeeFilter;
-    CCriticalSection cs_feeFilter;
-    CAmount lastSentFeeFilter;
-    int64_t nextSendTimeFeeFilter;
-
-    CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string &addrNameIn = "", bool fInboundIn = false);
-    ~CNode();
-    CNode(const CNode&) = delete;
-    CNode& operator=(const CNode&) = delete;
-
-private:
-    const NodeId id;
-    const uint64_t nLocalHostNonce;
-    // Services offered to this peer
-    const ServiceFlags nLocalServices;
-    const int nMyStartingHeight;
-    int nSendVersion;
-    std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
-
-    mutable CCriticalSection cs_addrName;
-    std::string addrName;
-
-    // Our address, as reported by the peer
-    CService addrLocal;
-    mutable CCriticalSection cs_addrLocal;
-public:
-
-    NodeId GetId() const {
-        return id;
-    }
-
-    uint64_t GetLocalNonce() const {
-        return nLocalHostNonce;
-    }
-
-    int GetMyStartingHeight() const {
-        return nMyStartingHeight;
-    }
-
-    int GetRefCount() const
-    {
-        assert(nRefCount >= 0);
-        return nRefCount;
-    }
-
-    bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
-
-    void SetRecvVersion(int nVersionIn)
-    {
-        nRecvVersion = nVersionIn;
-    }
-    int GetRecvVersion() const
-    {
-        return nRecvVersion;
-    }
-    void SetSendVersion(int nVersionIn);
-    int GetSendVersion() const;
-
-    CService GetAddrLocal() const;
-    //! May not be called more than once
-    void SetAddrLocal(const CService& addrLocalIn);
-
-    CNode* AddRef()
-    {
-        nRefCount++;
-        return this;
-    }
-
-    void Release()
-    {
-        nRefCount--;
-    }
-
-
-
-    void AddAddressKnown(const CAddress& _addr)
-    {
-        addrKnown.insert(_addr.GetKey());
-    }
-
-    void PushAddress(const CAddress& _addr, FastRandomContext &insecure_rand)
-    {
-        // Known checking here is only to save space from duplicates.
-        // SendMessages will filter it again for knowns that were added
-        // after addresses were pushed.
-        if (_addr.IsValid() && !addrKnown.contains(_addr.GetKey())) {
-            if (vAddrToSend.size() >= MAX_ADDR_TO_SEND) {
-                vAddrToSend[insecure_rand.randrange(vAddrToSend.size())] = _addr;
-            } else {
-                vAddrToSend.push_back(_addr);
-            }
-        }
-    }
-
-
-    void AddInventoryKnown(const CInv& inv)
-    {
-        {
-            LOCK(cs_inventory);
-            filterInventoryKnown.insert(inv.hash);
-        }
-    }
-
-    void PushInventory(const CInv& inv)
-    {
-        LOCK(cs_inventory);
-        if (inv.type == MSG_TX) {
-            if (!filterInventoryKnown.contains(inv.hash)) {
-                setInventoryTxToSend.insert(inv.hash);
-            }
-        } else if (inv.type == MSG_BLOCK) {
-            vInventoryBlockToSend.push_back(inv.hash);
-        }
-    }
-
-    void PushBlockHash(const uint256 &hash)
-    {
-        LOCK(cs_inventory);
-        vBlockHashesToAnnounce.push_back(hash);
-    }
-
-    void AskFor(const CInv& inv);
-
-    void CloseSocketDisconnect();
-
-    void copyStats(CNodeStats &stats);
-
-    ServiceFlags GetLocalServices() const
-    {
-        return nLocalServices;
-    }
-
-    std::string GetAddrName() const;
-    //! Sets the addrName only if it was not previously set
-    void MaybeSetAddrName(const std::string& addrNameIn);
-};
 
 
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3200,7 +3200,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
     const Consensus::Params& consensusParams = Params().GetConsensus();
     {
         // Don't send anything until the version handshake is complete
-        if (!pto->fSuccessfullyConnected || pto->fDisconnect)
+        if (!pto->FullyConnected())
             return true;
 
         // If we get here, the outgoing message serialization version is set and can't change.


### PR DESCRIPTION
Currently template methods `CConnman::ForEachNode` and `CConnman::ForEachNodeThen` rely on `CConnman::NodeFullyConnected`, which is defined in net.cpp. This can result in linker errors like so:
https://travis-ci.org/bitcoin/bitcoin/jobs/379011082

The fix is to move `CNode`'s declaration above` CConnman` in net.h, so that `CConnman` can make use of `CNode` members in the method implementations, and move `NodeFullyConnected` from net.cpp to net.h.