### PR TITLE
uint256: Remove unnecessary crypto/common.h use

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -10,6 +10,11 @@
 #include <netbase.h>
 #include <random.h>
 
+bool littleendian = (CHashWriter(SER_GETHASH, 0) << 1).GetHash().GetCheapHash() == 10162316372170307393ULL;
+
+// to test big endian output on a little endian machine, temporarily change
+// GetCheapHash() in uint256.h to return ReadBE64(data)
+
 class CAddrManTest : public CAddrMan
 {
     uint64_t state;
@@ -222,7 +227,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
 
     // Test: Select pulls from new and tried regardless of port number.
     std::set<uint16_t> ports;
-    for (int i = 0; i < 20; ++i) {
+    for (int i = 0; i < 50; ++i) {
         ports.insert(addrman.Select().GetPort());
     }
     BOOST_CHECK_EQUAL(ports.size(), 3U);
@@ -236,7 +241,12 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    for (unsigned int i = 1; i < 18; i++) {
+    // Collision at:
+    //  littleendian: 18
+    //  bigendian:    11
+    unsigned int first_collision = littleendian ? 18 : 11;
+    size_t expected_size = first_collision - 1;
+    for (unsigned int i = 1; i < first_collision; i++) {
         CService addr = ResolveService("250.1.1." + std::to_string(i));
         addrman.Add(CAddress(addr, NODE_NONE), source);
 
@@ -245,13 +255,14 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
     }
 
     //Test: new table collision!
-    CService addr1 = ResolveService("250.1.1.18");
+    CService addr1 = ResolveService(littleendian ? "250.1.1.18" : "250.1.1.11");
     addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK_EQUAL(addrman.size(), 17U);
+    BOOST_CHECK_EQUAL(addrman.size(), expected_size);
 
     CService addr2 = ResolveService("250.1.1.19");
     addrman.Add(CAddress(addr2, NODE_NONE), source);
-    BOOST_CHECK_EQUAL(addrman.size(), 18U);
+    expected_size++;
+    BOOST_CHECK_EQUAL(addrman.size(), expected_size);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
@@ -262,23 +273,23 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     BOOST_CHECK_EQUAL(addrman.size(), 0U);
 
-    for (unsigned int i = 1; i < 80; i++) {
+    // First collision:
+    //  little endian: 80
+    //  big endian:    50
+    unsigned int first_collision = littleendian ? 80 : 50;
+    unsigned int expected_size = first_collision - 1;
+    for (unsigned int i = 1; i < first_collision; i++) {
         CService addr = ResolveService("250.1.1." + std::to_string(i));
         addrman.Add(CAddress(addr, NODE_NONE), source);
         addrman.Good(CAddress(addr, NODE_NONE));
 
-        //Test: No collision in tried table yet.
         BOOST_CHECK_EQUAL(addrman.size(), i);
     }
 
-    //Test: tried table collision!
-    CService addr1 = ResolveService("250.1.1.80");
-    addrman.Add(CAddress(addr1, NODE_NONE), source);
-    BOOST_CHECK_EQUAL(addrman.size(), 79U);
-
     CService addr2 = ResolveService("250.1.1.81");
     addrman.Add(CAddress(addr2, NODE_NONE), source);
-    BOOST_CHECK_EQUAL(addrman.size(), 80U);
+    expected_size++;
+    BOOST_CHECK_EQUAL(addrman.size(), expected_size);
 }
 
 BOOST_AUTO_TEST_CASE(addrman_find)
@@ -409,9 +420,9 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
 
     size_t percent23 = (addrman.size() * 23) / 100;
     BOOST_CHECK_EQUAL(vAddr.size(), percent23);
-    BOOST_CHECK_EQUAL(vAddr.size(), 461U);
+    BOOST_CHECK_EQUAL(vAddr.size(), littleendian ? 461U : 460U);
     // (Addrman.size() < number of addresses added) due to address collisions.
-    BOOST_CHECK_EQUAL(addrman.size(), 2006U);
+    BOOST_CHECK_EQUAL(addrman.size(), littleendian ? 2006U : 2003U);
 }
 
 
@@ -431,7 +442,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     uint256 nKey2 = (uint256)(CHashWriter(SER_GETHASH, 0) << 2).GetHash();
 
 
-    BOOST_CHECK_EQUAL(info1.GetTriedBucket(nKey1), 40);
+    BOOST_CHECK_EQUAL(info1.GetTriedBucket(nKey1), littleendian ? 40 : 215);
 
     // Test: Make sure key actually randomizes bucket placement. A fail on
     //  this test could be a security issue.
@@ -466,7 +477,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     }
     // Test: IP addresses in the different groups should map to more than
     //  8 buckets.
-    BOOST_CHECK_EQUAL(buckets.size(), 160U);
+    BOOST_CHECK_EQUAL(buckets.size(), littleendian ? 160U : 152U);
 }
 
 BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
@@ -484,8 +495,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     uint256 nKey2 = (uint256)(CHashWriter(SER_GETHASH, 0) << 2).GetHash();
 
     // Test: Make sure the buckets are what we expect
-    BOOST_CHECK_EQUAL(info1.GetNewBucket(nKey1), 786);
-    BOOST_CHECK_EQUAL(info1.GetNewBucket(nKey1, source1), 786);
+    BOOST_CHECK_EQUAL(info1.GetNewBucket(nKey1), littleendian ? 786 : 606);
+    BOOST_CHECK_EQUAL(info1.GetNewBucket(nKey1, source1), littleendian ? 786 : 606);
 
     // Test: Make sure key actually randomizes bucket placement. A fail on
     //  this test could be a security issue.
@@ -589,15 +600,19 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
         BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
     }
 
-    // Collision between 23 and 19.
-    CService addr23 = ResolveService("250.1.1.23");
-    addrman.Add(CAddress(addr23, NODE_NONE), source);
-    addrman.Good(addr23);
+    // Collision between
+    //  little endian: 23 and 19
+    //  big endian:    38 and 6
+    std::string addrcoll_str = littleendian ? "250.1.1.23" : "250.1.1.38";
+    std::string evicted_str = littleendian ? "250.1.1.19:0" : "250.1.1.6:0";
+    CService addrcoll = ResolveService(addrcoll_str);
+    addrman.Add(CAddress(addrcoll, NODE_NONE), source);
+    addrman.Good(addrcoll);
 
-    BOOST_CHECK(addrman.size() == 23);
-    BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "250.1.1.19:0");
+    BOOST_CHECK_EQUAL(addrman.size(), 23U);
+    BOOST_CHECK_EQUAL(addrman.SelectTriedCollision().ToString(), evicted_str);
 
-    // 23 should be discarded and 19 not evicted.
+    // 23/38 should be discarded and 19/6 not evicted.
     addrman.ResolveCollisions();
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
 
@@ -612,16 +627,18 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
     }
 
     // Cause a collision.
-    CService addr33 = ResolveService("250.1.1.33");
-    addrman.Add(CAddress(addr33, NODE_NONE), source);
-    addrman.Good(addr33);
+    std::string addrcoll2_str = littleendian ? "250.1.1.33" : "250.1.1.53";
+    std::string evicted2_str = littleendian ? "250.1.1.27:0" : "250.1.1.2:0";
+    CService addrcoll2 = ResolveService(addrcoll2_str);
+    addrman.Add(CAddress(addrcoll2, NODE_NONE), source);
+    addrman.Good(addrcoll2);
     BOOST_CHECK(addrman.size() == 33);
 
-    BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "250.1.1.27:0");
+    BOOST_CHECK_EQUAL(addrman.SelectTriedCollision().ToString(), evicted2_str);
 
     // Cause a second collision.
-    addrman.Add(CAddress(addr23, NODE_NONE), source);
-    addrman.Good(addr23);
+    addrman.Add(CAddress(addrcoll, NODE_NONE), source);
+    addrman.Good(addrcoll);
     BOOST_CHECK(addrman.size() == 33);
 
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() != "[::]:0");
@@ -653,34 +670,38 @@ BOOST_AUTO_TEST_CASE(addrman_evictionworks)
         BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
     }
 
-    // Collision between 23 and 19.
-    CService addr = ResolveService("250.1.1.23");
+    // Collision between
+    //  little endian: 23 and 19
+    //  big endian:    38 and 6
+    std::string addrcoll_str = littleendian ? "250.1.1.23" : "250.1.1.38";
+    std::string evicted_str = littleendian ? "250.1.1.19" : "250.1.1.6";
+    CService addr = ResolveService(addrcoll_str);
     addrman.Add(CAddress(addr, NODE_NONE), source);
     addrman.Good(addr);
 
     BOOST_CHECK(addrman.size() == 23);
     CAddrInfo info = addrman.SelectTriedCollision();
-    BOOST_CHECK(info.ToString() == "250.1.1.19:0");
+    BOOST_CHECK_EQUAL(info.ToString(), evicted_str + ":0");
 
     // Ensure test of address fails, so that it is evicted.
     addrman.SimConnFail(info);
 
-    // Should swap 23 for 19.
+    // Should swap 23/38 for 19/6.
     addrman.ResolveCollisions();
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
 
-    // If 23 was swapped for 19, then this should cause no collisions.
+    // If 23/38 was swapped for 19/6, then this should cause no collisions.
     addrman.Add(CAddress(addr, NODE_NONE), source);
     addrman.Good(addr);
 
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
 
-    // If we insert 19 is should collide with 23.
-    CService addr19 = ResolveService("250.1.1.19");
-    addrman.Add(CAddress(addr19, NODE_NONE), source);
-    addrman.Good(addr19);
+    // If we insert 19/6 it should collide with 23/38.
+    CService addr_evicted = ResolveService(evicted_str);
+    addrman.Add(CAddress(addr_evicted, NODE_NONE), source);
+    addrman.Good(addr_evicted);
 
-    BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "250.1.1.23:0");
+    BOOST_CHECK_EQUAL(addrman.SelectTriedCollision().ToString(), addrcoll_str + ":0");
 
     addrman.ResolveCollisions();
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -12,7 +12,6 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
-#include <crypto/common.h>
 
 /** Template base class for fixed-sized opaque blobs. */
 template<unsigned int BITS>
@@ -131,7 +130,9 @@ public:
      */
     uint64_t GetCheapHash() const
     {
-        return ReadLE64(data);
+        uint64_t r;
+        memcpy(&r, data, sizeof(r));
+        return r;
     }
 };
 


### PR DESCRIPTION
Alternative approach: #13258.

There is no reason for `uint256::GetCheapHash()` to support multi-platform endian-ness, since the cheap hash is never used outside of the internal system (it is used in `CAddrInfo` bucket stuff, and that's it). We can remove an entire `#include` and probably some overhead as well. This will remove a number of chained dependencies from `uint256` (`crypto/common.h`, `compat/endian.h`, and `compat/byteswap.h`).

Edit: due to the dependency on little endian in the *tests* for the address manager, #7078 switched to the `ReadLE64()` function. This test reverts that decision and updates the tests instead to work with big and little endian. These tests need to be rethought, possibly removed, as they test basically nothing right now*, but in the meantime, this will address the test errors for big endian.

(* they test that after adding a, b, and c to a bucket, adding d will cause a collision, but adding e will not...)