### PR TITLE
Wallet/RPC: Add listsincetx method with a stateless (server-side) long polling option

### DIFF
--- a/contrib/push/example_walletnotify.py
+++ b/contrib/push/example_walletnotify.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Example code for wallet push notifications (similar to -walletnotify)
+# ./example_walletnotify.py -network=regtest -datadir=~/-.bitcoin/regtest
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+from __future__ import print_function
+import argparse
+import base64
+try: # Python 3
+    import http.client as httplib
+except ImportError: # Python 2
+    import httplib
+import json
+import os
+import os.path
+import sys
+
+settings = {}
+
+class BitcoinRPC:
+    def __init__(self, host, port, username, password):
+        authpair = "%s:%s" % (username, password)
+        authpair = authpair.encode('utf-8')
+        self.authhdr = b"Basic " + base64.b64encode(authpair)
+        self.conn = httplib.HTTPConnection(host, port=port, timeout=30)
+
+    def execute(self, obj):
+        try:
+            self.conn.request('POST', '/', json.dumps(obj),
+                { 'Authorization' : self.authhdr,
+                  'Content-type' : 'application/json' })
+        except ConnectionRefusedError:
+            print('RPC connection refused. Check RPC settings and the server status.',
+                  file=sys.stderr)
+            return None
+
+        resp = self.conn.getresponse()
+        if resp is None:
+            print("JSON-RPC: no response", file=sys.stderr)
+            return None
+
+        body = resp.read().decode('utf-8')
+        if len(body) == 0:
+            print("Invalid response, auth may failed")
+            return
+        resp_obj = json.loads(body)
+        return resp_obj
+
+    @staticmethod
+    def build_request(idx, method, params):
+        obj = { 'version' : '1.1',
+            'method' : method,
+            'id' : idx }
+        if params is None:
+            obj['params'] = []
+        else:
+            obj['params'] = params
+        return obj
+
+    @staticmethod
+    def response_is_error(resp_obj):
+        return 'error' in resp_obj and resp_obj['error'] is not None
+
+def get_rpc_cookie(datadir):
+    # Open the cookie file
+    with open(os.path.join(os.path.expanduser(datadir), '.cookie'), 'r') as f:
+        combined = f.readline()
+        combined_split = combined.split(":")
+        settings['rpcuser'] = combined_split[0]
+        settings['rpcpassword'] = combined_split[1]
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=
+                                     'WalletNotify push example that uses listsincetx under the hood (only works if there is already a transaction)'
+                                     '/example_walletnotify.py -network=regtest -datadir=~/-.bitcoin/regtest')
+    parser.add_argument('-network', default="regtest",
+                        help='Network to use (mainnet, testnet, regtest)')
+    parser.add_argument('-host', default="127.0.0.1",
+                        help='Host to access')
+    parser.add_argument('-rpcuser', default="user",
+                        help='RPC username')
+    parser.add_argument('-rpcpassword', default="pass",
+                        help='RPC password')
+    parser.add_argument('-datadir',
+                        help='Datadir to read the RPC cookie from (if set, rpcuser/rpcpassword is obsolete)')
+    args = parser.parse_args()
+    if not args.datadir:
+        parser.print_help()
+        exit()
+    settings['host'] = args.host
+    if args.network == "regtest":
+        settings['port'] =  18443
+    elif args.network == "mainnet":
+        settings['port'] =  8332
+    elif args.network == "testnet3" or args.network == "testnet" :
+        settings['port'] =  18332
+    settings['rpcuser'] = args.rpcuser
+    settings['rpcpassword'] = args.rpcpassword
+    if args.datadir:
+        get_rpc_cookie(args.datadir)
+
+    rpc = BitcoinRPC(settings['host'], settings['port'],
+             settings['rpcuser'], settings['rpcpassword'])
+    latest_wtx = rpc.execute(rpc.build_request(0, "listtransactions", ["*", 1]))['result'][-1]['txid']
+    while True:
+        res = rpc.execute(rpc.build_request(0, "listsincetx", [latest_wtx, 100]))
+        for tx in res['result']:
+            print("New txid"+tx['txid']+" with amount "+str(tx['amount']))
+        latest_wtx = res['result'][-1]['txid'] #update latest wtx

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -154,6 +154,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "echojson", 9, "arg9" },
     { "rescanblockchain", 0, "start_height"},
     { "rescanblockchain", 1, "stop_height"},
+    { "listsincetx", 1, "polltime"},
 };
 
 class CRPCConvertTable

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1180,6 +1180,11 @@ public:
 
     /** Whether a given output is spendable by this wallet */
     bool OutputEligibleForSpending(const COutput& output, const CoinEligibilityFilter& eligibility_filter) const;
+
+    /** mutex, container and condition variable for updating the latest transaction id */
+    std::mutex m_cs_txadd;
+    std::condition_variable m_cond_txadd;
+    uint256 m_latest_wtxid;
 };
 
 /** A key allocated from the key pool. */

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -127,6 +127,7 @@ BASE_SCRIPTS = [
     'wallet_bumpfee.py',
     'rpc_named_arguments.py',
     'wallet_listsinceblock.py',
+    'wallet_listsincetx.py',
     'p2p_leak.py',
     'wallet_encryption.py',
     'feature_dersig.py',

--- a/test/functional/wallet_listsincetx.py
+++ b/test/functional/wallet_listsincetx.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the listsincetx RPC including longpoll."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+import threading
+import time
+
+class LongpollThread(threading.Thread):
+    def __init__(self, node, txid):
+        threading.Thread.__init__(self)
+        self.txid = txid
+        self.node = node
+        self.txlist = []
+
+    def run(self):
+        self.txlist = self.node.listsincetx(self.txid, 10)
+
+
+class ListSinceTxTest (BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        self.nodes[0].generate(101)
+        self.sync_all()
+        newest_txid         = self.nodes[0].listtransactions()[-1]['txid']
+        second_newest_txid  = self.nodes[0].listtransactions()[-2]['txid']
+        listsinceoldest     = self.nodes[0].listsincetx(self.nodes[0].listtransactions("*", 101)[0]['txid'])
+        self.log.info("Testing synchronous listtxsince behaviour")
+        assert_equal(len(listsinceoldest), 100) #all follow up transactions
+        assert_equal(listsinceoldest[-1]['txid'], newest_txid)
+        assert_equal(listsinceoldest[-2]['txid'], second_newest_txid)
+        assert_equal(self.nodes[0].listsincetx(second_newest_txid)[0]['txid'], newest_txid)
+        assert_equal(len(self.nodes[0].listsincetx(newest_txid)), 0) #no transaction will follow the newest one
+        assert_equal(len(self.nodes[0].listsincetx(newest_txid, 1)), 0) #poll with no result
+        txid_n1_1 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
+        txid_n1_2 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 2)
+        self.sync_all()
+        assert_equal(self.nodes[1].listsincetx(txid_n1_1)[0]['txid'], txid_n1_2)
+        assert_equal(len(self.nodes[1].listsincetx(txid_n1_2, 1)), 0) #poll with no result
+
+        self.log.info("Start long polling thread")
+        new_addr_n1 = self.nodes[1].getnewaddress()
+        thr = LongpollThread(self.nodes[1], txid_n1_2)
+        thr.start()
+        self.log.info("Sending transaction from other node on main thread")
+        txid_n1_3 = self.nodes[0].sendtoaddress(new_addr_n1, 3)
+        cnt = 0
+        while True: #need to loop since sync_all won't work with an active RPC connection
+            if len(thr.txlist) > 0:
+                self.log.info("Lonpoll thread received transaction")
+                break
+            time.sleep(1)
+            cnt+=1
+            assert(cnt < 10) #timeout of 10 seconds
+        thr.join(5)
+        assert_equal(thr.txlist[0]['txid'], txid_n1_3)
+
+if __name__ == '__main__':
+    ListSinceTxTest().main()


### PR DESCRIPTION
This adds a new wallet RPC call `listsincetx` that allows to list follow-up transactions (in order / `wtxOrdered`) from a specified transaction.

If the latest transaction was used as base-point for finding follow-up transactions and the long-polling timeout if set greater then zero, it will wait until new transactions has been found or the timeout has been expired (http push channel). Used together with a https proxy, one can build a very robust wallet transaction push channel (that can bypass NATs, proxys, etc.)

This does allow to build a wallet-notify push channel without keeping client-states on the server side.
It does also allow clients to effectively sync the transaction list.

A client can simply loop over `listsincetx(<newest_known_txid>, 30/*timeout*/)` and will immediately get new txns once they arrive.

Mitigates #13237 
Related #7949

This (or a similar) approach was once discussed during an IRC meeting (can't find it anymore in the logs).

* [ ] Needs release notes
* [x] Needs wallet notify example python script