### PR TITLE
wallet: Exit SyncMetaData if there are no transactions to sync

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -549,7 +549,9 @@ void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> ran
         }
     }
 
-    assert(copyFrom);
+    if (!copyFrom) {
+        return;
+    }
 
     // Now copy data from copyFrom to rest:
     for (TxSpends::iterator it = range.first; it != range.second; ++it)


### PR DESCRIPTION
Instead of crash with an assertion error, simply exit the function `SyncMetaData` if there is no metadata to sync.

Fixes #13110.