### PR TITLE
Qt/Bugfix: fix handling default wallet with no name

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -312,7 +312,7 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                             std::string method = stack.back()[0];
                             std::string uri;
 #ifdef ENABLE_WALLET
-                            if (walletID && !walletID->empty()) {
+                            if (walletID) {
                                 QByteArray encodedName = QUrl::toPercentEncoding(QString::fromStdString(*walletID));
                                 uri = "/wallet/"+std::string(encodedName.constData(), encodedName.length());
                             }
@@ -425,7 +425,7 @@ void RPCExecutor::request(const QString &command, const QString &walletID)
             return;
         }
         std::string wallet_id = walletID.toStdString();
-        if(!RPCConsole::RPCExecuteCommandLine(m_node, result, executableCommand, nullptr, &wallet_id))
+        if (!RPCConsole::RPCExecuteCommandLine(m_node, result, executableCommand, nullptr, walletID.isNull() ? nullptr : &wallet_id))
         {
             Q_EMIT reply(RPCConsole::CMD_ERROR, QString("Parse error: unbalanced ' or \""));
             return;
@@ -909,7 +909,7 @@ void RPCConsole::on_lineEdit_returnPressed()
         }
 
         if (m_last_wallet_id != walletID) {
-            if (walletID.isEmpty()) {
+            if (walletID.isNull()) {
                 message(CMD_REQUEST, tr("Executing command without any wallet"));
             } else {
                 message(CMD_REQUEST, tr("Executing command using \"%1\" wallet").arg(walletID));


### PR DESCRIPTION
If one loads a wallet via RPC (`loadwallet w2`), then select w2, select back to the default wallet (which is an empty string), that default wallet cannot be access through the RPC console because the current code only points to the wallet endpoint if the wallet name is not empty.

This is a quick fix that reenables accessing the default wallet in case an additional wallet has been loaded.

Using "" for the default wallet may not be ideal in other cases and it may make more sense to change it at a deeper level (wallet.cpp). See discussion here which where the reasons for the current behaviour in master:
https://github.com/bitcoin/bitcoin/pull/11687#issuecomment-370862718

@jnewbery @promag @ryanofsky 