### PR TITLE
[qt] CoinControlDialog amount header display unit

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -127,8 +127,8 @@ CoinControlDialog::CoinControlDialog(const PlatformStyle *_platformStyle, QWidge
     ui->treeWidget->headerItem()->setText(COLUMN_CHECKBOX, QString());
 
     ui->treeWidget->setColumnWidth(COLUMN_CHECKBOX, 84);
-    ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 110);
-    ui->treeWidget->setColumnWidth(COLUMN_LABEL, 190);
+    ui->treeWidget->setColumnWidth(COLUMN_AMOUNT, 130);
+    ui->treeWidget->setColumnWidth(COLUMN_LABEL, 170);
     ui->treeWidget->setColumnWidth(COLUMN_ADDRESS, 320);
     ui->treeWidget->setColumnWidth(COLUMN_DATE, 130);
     ui->treeWidget->setColumnWidth(COLUMN_CONFIRMATIONS, 110);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -165,6 +165,7 @@ void CoinControlDialog::setModel(WalletModel *_model)
         updateView();
         updateLabelLocked();
         CoinControlDialog::updateLabels(_model, this);
+        UpdateAmountHeader(_model);
     }
 }
 
@@ -736,4 +737,10 @@ void CoinControlDialog::updateView()
     // sort view
     sortView(sortColumn, sortOrder);
     ui->treeWidget->setEnabled(true);
+}
+
+// updates the text of the amount header to show the correct display unit
+void CoinControlDialog::UpdateAmountHeader(WalletModel* model)
+{
+    ui->treeWidget->headerItem()->setText(COLUMN_AMOUNT, BitcoinUnits::getAmountColumnTitle(model->getOptionsModel()->getDisplayUnit()));
 }

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -107,6 +107,7 @@ private Q_SLOTS:
     void buttonBoxClicked(QAbstractButton*);
     void buttonSelectAllClicked();
     void updateLabelLocked();
+    void UpdateAmountHeader(WalletModel* model);
 };
 
 #endif // BITCOIN_QT_COINCONTROLDIALOG_H

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -417,7 +417,7 @@
      </column>
      <column>
       <property name="text">
-       <string>Amount</string>
+       <string/>
       </property>
      </column>
      <column>


### PR DESCRIPTION
The coin control table currently only says "Amount". This makes it more consistent with other tables by showing the current display unit like "Amount (BTC)".