### PR TITLE
gui: fix visual "overflow" of amount input.

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -197,7 +197,7 @@ BitcoinAmountField::BitcoinAmountField(QWidget *parent) :
     amount = new AmountSpinBox(this);
     amount->setLocale(QLocale::c());
     amount->installEventFilter(this);
-    amount->setMaximumWidth(170);
+    amount->setMaximumWidth(240);
 
     QHBoxLayout *layout = new QHBoxLayout(this);
     layout->addWidget(amount);


### PR DESCRIPTION
Fixes #13231. 

I was able to reproduce this bug within my own Fedora 27 VM. Following @jonasschnelli's advice, I first tried to change `setAlignment(Qt::AlignRight);` to `setAlignment(Qt::AlignLeft);`, however, I realized that this wouldn't fix the underlying overflow problem, as it would only make it easier to see the most significant digits under certain scenarios. The reason for the overflow is that Fedora uses plus and minus buttons on the Qt spin box class, rather than up and down arrows, which is what happens on **most** other operating systems. These plus and minus buttons take up more width, and therefore provide less space for text.

The solution I went with was the second suggestion by @jonasschnelli, which was to just increase the maximum width of the amount box. After some experimentation, 240 seemed to be the smallest max width that would allow as many digits as one would want in the amount box without overflow, even with the plus and minus buttons in Fedora.

Please let me know if there are any issues with this PR and I will work to fix them. Thank you!
