### PR TITLE
[Qt] Re-setup args after translator setup to translate help text

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -623,6 +623,11 @@ int main(int argc, char *argv[])
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
     translationInterface.Translate.connect(Translate);
 
+    // Re-setup help text so that they are translated
+    gArgs.ClearArgs();
+    node->setupServerArgs();
+    SetupUIArgs();
+
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {

--- a/src/util.h
+++ b/src/util.h
@@ -249,6 +249,11 @@ public:
     std::string GetChainName() const;
 
     /**
+     * Clear available arguments
+     */
+    void ClearArgs() { m_available_args.clear(); }
+
+    /**
      * Add argument
      */
     void AddArg(const std::string& name, const std::string& help, const bool debug_only, const OptionsCategory& cat);


### PR DESCRIPTION
`tr()` requires a `QTranslator` to be installed for it to translate, but we can't setup the args after setting up the `QTranslator` as setting that up requires looking up a command line argument. So instead we setup the arguments with the default text (`tr()` will resort to the default), then get the language to setup with and create the `QTranslator`, then clear the arguments and lastly setup the arguments again. The second arguments setup will allow the arguments to be translated with the `QTranslator`.

Note that the contexts for some of the translations changed after #13190 so translations are not available for some strings where translations were previously available. Fixing that requires a translation resource update.

Fixes #13287