### PR TITLE
qa: Fix wallet_listreceivedby race

### DIFF
--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -6,10 +6,13 @@
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import (assert_array_result,
-                                 assert_equal,
-                                 assert_raises_rpc_error,
-                                 )
+from test_framework.util import (
+    assert_array_result,
+    assert_equal,
+    assert_raises_rpc_error,
+    sync_blocks,
+)
+
 
 class ReceivedByTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -18,6 +21,7 @@ class ReceivedByTest(BitcoinTestFramework):
     def run_test(self):
         # Generate block to get out of IBD
         self.nodes[0].generate(1)
+        sync_blocks(self.nodes)
 
         self.log.info("listreceivedbyaddress Test")
 


### PR DESCRIPTION
Generating a block on node 0 will only get node 0 out of IBD and not node 1. So the inv for the `txid` is dropped by node 1 and the call to `sync_all` fails.

Solve it by a call to `sync_blocks` after `generate`.