### PR TITLE
Refactor: encapsulate mapBlockIndex within validation.cpp

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1473,7 +1473,7 @@ bool AppInitMain()
                 }
 
                 // At this point we're either in reindex or we've loaded a useful
-                // block tree into mapBlockIndex!
+                // block tree into the index!
 
                 pcoinsdbview.reset(new CCoinsViewDB(nCoinDBCache, false, fReset || fReindexChainState));
                 pcoinscatcher.reset(new CCoinsViewErrorCatcher(pcoinsdbview.get()));
@@ -1507,7 +1507,7 @@ bool AppInitMain()
                 if (!fReset) {
                     // Note that RewindBlockIndex MUST run even if we're about to -reindex-chainstate.
                     // It both disconnects blocks based on chainActive, and drops block data in
-                    // mapBlockIndex based on lack of available witness data.
+                    // the index based on lack of available witness data.
                     uiInterface.InitMessage(_("Rewinding blocks..."));
                     if (!RewindBlockIndex(chainparams)) {
                         strLoadError = _("Unable to rewind the database to a pre-fork state. You will need to redownload the blockchain");
@@ -1663,7 +1663,7 @@ bool AppInitMain()
     //// debug print
     {
         LOCK(cs_main);
-        LogPrintf("mapBlockIndex.size() = %u\n", GetBlockIndexCount());
+        LogPrintf("GetBlockIndexCount() = %u\n", GetBlockIndexCount());
         chain_active_height = chainActive.Height();
     }
     LogPrintf("nBestHeight = %d\n", chain_active_height);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1452,7 +1452,7 @@ bool AppInitMain()
 
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
-                if (!mapBlockIndex.empty() && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
+                if (GetBlockIndexCount() > 0 && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
                 }
 
@@ -1663,7 +1663,7 @@ bool AppInitMain()
     //// debug print
     {
         LOCK(cs_main);
-        LogPrintf("mapBlockIndex.size() = %u\n", mapBlockIndex.size());
+        LogPrintf("mapBlockIndex.size() = %u\n", GetBlockIndexCount());
         chain_active_height = chainActive.Height();
     }
     LogPrintf("nBestHeight = %d\n", chain_active_height);

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -88,8 +88,7 @@ WalletTx MakeWalletTx(CWallet& wallet, const CWalletTx& wtx)
 WalletTxStatus MakeWalletTxStatus(const CWalletTx& wtx)
 {
     WalletTxStatus result;
-    auto mi = ::mapBlockIndex.find(wtx.hashBlock);
-    CBlockIndex* block = mi != ::mapBlockIndex.end() ? mi->second : nullptr;
+    const CBlockIndex* block = ::LookupBlockIndex(wtx.hashBlock);
     result.block_height = (block ? block->nHeight : std::numeric_limits<int>::max()),
     result.blocks_to_maturity = wtx.GetBlocksToMaturity();
     result.depth_in_main_chain = wtx.GetDepthInMainChain();

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1384,13 +1384,13 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
                 // under BIP 152).
                 // Here, we try to detect the narrow situation that we have a
                 // valid block header (ie it was valid at the time the header
-                // was received, and hence stored in mapBlockIndex) but know the
+                // was received, and hence stored in the index) but know the
                 // block is invalid, and that a peer has announced that same
                 // block as being on its active chain.
                 // Disconnect the peer in such a situation.
                 //
                 // Note: if the header that is invalid was not accepted to our
-                // mapBlockIndex at all, that may also be grounds for
+                // block index at all, that may also be grounds for
                 // disconnecting the peer, as the chain they are on is likely
                 // to be incompatible. However, there is a circumstance where
                 // that does not hold: if the header's timestamp is more than

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -266,7 +266,6 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
 
     pcursor->Seek(std::make_pair(DB_BLOCK_INDEX, uint256()));
 
-    // Load mapBlockIndex
     while (pcursor->Valid()) {
         boost::this_thread::interruption_point();
         std::pair<char, uint256> key;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -55,6 +55,8 @@
 #define MICRO 0.000001
 #define MILLI 0.001
 
+typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
+
 /**
  * Global state
  */
@@ -274,6 +276,13 @@ namespace {
     /** Dirty block file entries. */
     std::set<int> setDirtyFileInfo;
 } // anon namespace
+
+CBlockIndex* LookupBlockIndex(const uint256& hash)
+{
+    AssertLockHeld(cs_main);
+    BlockMap::const_iterator it = mapBlockIndex.find(hash);
+    return it == mapBlockIndex.end() ? nullptr : it->second;
+}
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -294,6 +294,12 @@ CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& loc
     return chain.Genesis();
 }
 
+size_t GetBlockIndexCount()
+{
+    LOCK(cs_main);
+    return mapBlockIndex.size();
+}
+
 std::vector<const CBlockIndex*> GetChainTips()
 {
     LOCK(cs_main);

--- a/src/validation.h
+++ b/src/validation.h
@@ -443,6 +443,12 @@ inline CBlockIndex* LookupBlockIndex(const uint256& hash)
 /** Find the last common block between the parameter chain and a locator. */
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
 
+/*
+ * The set of chain tips consists of the tip of the active chain plus any stale blocks which do not
+ * have another stale block building off of them.
+ */
+std::vector<const CBlockIndex*> GetChainTips();
+
 /** Mark a block as precious and reorganize. */
 bool PreciousBlock(CValidationState& state, const CChainParams& params, CBlockIndex *pindex);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -443,6 +443,9 @@ inline CBlockIndex* LookupBlockIndex(const uint256& hash)
 /** Find the last common block between the parameter chain and a locator. */
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);
 
+/** Get the number of block index entries. */
+size_t GetBlockIndexCount();
+
 /*
  * The set of chain tips consists of the tip of the active chain plus any stale blocks which do not
  * have another stale block building off of them.

--- a/src/validation.h
+++ b/src/validation.h
@@ -160,8 +160,6 @@ extern CCriticalSection cs_main;
 extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
 extern std::atomic_bool g_is_mempool_loaded;
-typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
-extern BlockMap& mapBlockIndex;
 extern uint64_t nLastBlockTx;
 extern uint64_t nLastBlockWeight;
 extern const std::string strMessageMagic;
@@ -433,12 +431,7 @@ public:
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
-inline CBlockIndex* LookupBlockIndex(const uint256& hash)
-{
-    AssertLockHeld(cs_main);
-    BlockMap::const_iterator it = mapBlockIndex.find(hash);
-    return it == mapBlockIndex.end() ? nullptr : it->second;
-}
+CBlockIndex* LookupBlockIndex(const uint256& hash);
 
 /** Find the last common block between the parameter chain and a locator. */
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator);


### PR DESCRIPTION
This is part of an effort to remove global variables and use more well-defined interfaces. Continued effort in this direction should make it easier to create a shared library for Bitcoin consensus rules.