### PR TITLE
Fix FreeBSD build by including utilstrencodings.h

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -34,6 +34,7 @@
 #include <sys/random.h>
 #endif
 #ifdef HAVE_SYSCTL_ARND
+#include <utilstrencodings.h> // for ARRAYLEN
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
`random.cpp` needs to explicitly include `utilstrencodings.h` to get `ARRAYLEN`. This fixes the FreeBSD build.

This was broken in 84f41946b9026e8bf7bc44ed848dfb945394b693 (#13236).