### PR TITLE
Implement pinentry wrapper to unlock bitcoin wallet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/bitcoin
 src/bitcoind
 src/bitcoin-cli
 src/bitcoin-tx
+src/bitcoin-wallet-unlock
 src/test/test_bitcoin
 src/test/test_bitcoin_fuzzy
 src/qt/test/test_bitcoin-qt

--- a/configure.ac
+++ b/configure.ac
@@ -170,6 +170,12 @@ AC_ARG_ENABLE([lcov],
   [use_lcov=$enableval],
   [use_lcov=no])
 
+AC_ARG_ENABLE([pinentry],
+  [AS_HELP_STRING([--disable-pinentry],
+  [disable bitcoin-wallet-unlock pinentry wrapper (enabled by default)])],
+  [enable_pinentry=$enableval],
+  [enable_pinentry=yes])
+
 AC_ARG_ENABLE([lcov-branch-coverage],
   [AS_HELP_STRING([--enable-lcov-branch-coverage],
   [enable lcov testing branch coverage (default is no)])],
@@ -1235,6 +1241,8 @@ if test x$use_reduce_exports = xyes; then
 else
   AC_MSG_RESULT([no])
 fi
+
+AM_CONDITIONAL([ENABLE_PINENTRY], [test x$enable_pinentry = xyes && test x$TARGET_OS != xwindows])
 
 if test x$build_bitcoin_utils$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests = xnononononono; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,6 +71,9 @@ endif
 
 if BUILD_BITCOIN_UTILS
   bin_PROGRAMS += bitcoin-cli bitcoin-tx
+if ENABLE_PINENTRY
+  bin_PROGRAMS += bitcoin-wallet-unlock
+endif
 endif
 
 .PHONY: FORCE check-symbols check-security
@@ -456,6 +459,15 @@ bitcoin_tx_LDADD = \
   $(LIBSECP256K1)
 
 bitcoin_tx_LDADD += $(BOOST_LIBS) $(CRYPTO_LIBS)
+#
+
+# bitcoin-wallet-unlock binary #
+if ENABLE_PINENTRY
+bitcoin_wallet_unlock_SOURCES = bitcoin-wallet-unlock.cpp
+bitcoin_wallet_unlock_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+bitcoin_wallet_unlock_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+bitcoin_wallet_unlock_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+endif
 #
 
 # bitcoinconsensus library #

--- a/src/bitcoin-wallet-unlock.cpp
+++ b/src/bitcoin-wallet-unlock.cpp
@@ -1,0 +1,361 @@
+// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <errno.h>
+#include <getopt.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <iostream>
+#include <sstream>
+
+void xclose(int fd)
+{
+    if (close(fd) == -1) {
+        std::ostringstream os;
+        os << "close(): " << strerror(errno);
+        throw std::runtime_error(os.str());
+    }
+}
+
+void xdup2(int oldfd, int newfd)
+{
+    if (dup2(oldfd, newfd) == -1) {
+        std::ostringstream os;
+        os << "dup2(): " << strerror(errno);
+        throw std::runtime_error(os.str());
+    }
+}
+
+void xpipe(int pipefd[2])
+{
+    if (pipe(pipefd) == -1) {
+        std::ostringstream os;
+        os << "pipe(): " << strerror(errno);
+        throw std::runtime_error(os.str());
+    }
+}
+
+pid_t xfork()
+{
+    pid_t pid = fork();
+    if (pid == -1) {
+        std::ostringstream os;
+        os << "fork(): " << strerror(errno);
+        throw std::runtime_error(os.str());
+    }
+    return pid;
+}
+
+// Pinentry is a simple wrapper for pinentry, which communicates with its parent
+// process using a simplified subset of the assuan protcol over stdin/stdout.
+// The relevant aspects of the pinentry protocol are documented at
+// http://info2html.sourceforge.net/cgi-bin/info2html-demo/info2html?%28pinentry%29Protocol
+class Pinentry
+{
+public:
+    Pinentry() = delete;
+    Pinentry(const Pinentry& other) = delete;
+    Pinentry(int read, int write)
+        : read_(fdopen(read, "r")), write_(fdopen(write, "w")), line_(nullptr), line_sz_(0) {}
+    ~Pinentry()
+    {
+        fclose(read_);
+        fclose(write_);
+        free(line_);
+    }
+
+    void CheckOK()
+    {
+        ReadLine();
+        if (strncmp(line_, "OK", 2) != 0) {
+            throw std::runtime_error("pinentry protocol failure");
+        }
+    }
+
+    std::string ReadData()
+    {
+        size_t sz = ReadLine();
+        if (strncmp(line_, "D ", 2) != 0) {
+            throw std::runtime_error("pinentry protocol failure");
+        }
+        return {&line_[2], sz - 3};
+    }
+
+    void Command(const std::string& cmd)
+    {
+        fprintf(write_, "%s\n", cmd.c_str());
+        fflush(write_);
+    }
+
+private:
+    FILE* read_;
+    FILE* write_;
+    char* line_;
+    size_t line_sz_;
+
+    ssize_t ReadLine()
+    {
+        ssize_t nread = getline(&line_, &line_sz_, read_);
+        if (nread < 0) {
+            throw std::runtime_error("failed to read data from pinentry");
+        }
+        return nread;
+    }
+};
+
+// GetPinentryPassphrase invokes pinentry to get the wallet passphrase.
+//
+// If there were extra parameters not parsed by getopt_long() they will be
+// forwarded to pinentry. Consider the following invocation:
+//
+//   bitcoin-wallet-unlock 300 -- -D :0
+//
+// This would cause pinentry to be invoked as:
+//
+//   pinentry -D :0
+//
+// Ordinarily this is not needed, but this can be useful in contexts where
+// pinentry has to be explicitly told where to prompt for inputs (e.g. to force
+// pinentry to use a TTY, or the opposite). In most cases they will need to be
+// separated using -- as in the example above to prevent getopt_long() to
+// interpret these arguments as program flags.
+//
+// These extra arguments are forwarded directly to execvp(), so there are no
+// shell expansion or escaping issues to be aware of.
+static std::string GetPinentryPassphrase(
+    const std::string& pinentry_program,
+    bool force_tty,
+    int argc,
+    char** argv)
+{
+    int read_pipe[2];
+    xpipe(read_pipe);
+    int parent_read = read_pipe[0];
+    int child_write = read_pipe[1];
+
+    int write_pipe[2];
+    xpipe(write_pipe);
+    int child_read = write_pipe[0];
+    int parent_write = write_pipe[1];
+
+    pid_t pid = xfork();
+    if (pid > 0) {
+        // parent process
+        xclose(child_read);
+        xclose(child_write);
+
+        Pinentry pinentry(parent_read, parent_write);
+        pinentry.CheckOK();
+
+        if (force_tty) {
+            std::ostringstream os;
+            os << "OPTION ttyname=" << ttyname(STDIN_FILENO);
+            pinentry.Command(os.str());
+            pinentry.CheckOK();
+
+            char* envvar;
+            if ((envvar = getenv("TERM"))) {
+                os.str("");
+                os << "OPTION ttytype=" << envvar;
+                pinentry.Command(os.str());
+                pinentry.CheckOK();
+            }
+
+            if ((envvar = getenv("LC_ALL"))) {
+                os.str("");
+                os << "OPTION lc-ctype=" << envvar;
+                pinentry.Command(os.str());
+                pinentry.CheckOK();
+            } else if ((envvar = getenv("LANG"))) {
+                os.str("");
+                os << "OPTION lc-ctype=" << envvar;
+                pinentry.Command(os.str());
+                pinentry.CheckOK();
+            }
+        }
+
+        pinentry.Command("SETDESC Enter your Bitcoin wallet passphrase.");
+        pinentry.CheckOK();
+
+        pinentry.Command("SETPROMPT Passphrase:");
+        pinentry.CheckOK();
+
+        pinentry.Command("SETTITLE Unlock Bitcoin wallet");
+        pinentry.CheckOK();
+
+        pinentry.Command("GETPIN");
+        std::string passphrase = pinentry.ReadData();
+        pinentry.CheckOK();
+        return passphrase;
+    } else {
+        // child process
+        xclose(parent_read);
+        xclose(parent_write);
+        xdup2(child_read, STDIN_FILENO);
+        xdup2(child_write, STDOUT_FILENO);
+        xclose(child_read);
+        xclose(child_write);
+
+        // build an arg array for execvp
+        size_t argcount = argc + 2;
+        char** pinentry_args = new char*[argcount];
+        pinentry_args[0] = strdup(pinentry_program.c_str());
+        pinentry_args[argcount - 1] = nullptr;
+        for (int i = 0; i < argc; i++) {
+            pinentry_args[i + 1] = argv[i];
+        }
+        execvp(pinentry_args[0], pinentry_args);
+        perror("failed to exec pinentry");
+        exit(EXIT_FAILURE);
+    }
+    return 0;
+}
+
+// InvokeBitcoinCLI calls bitcoin-cli with the wallet passphrase and timeout.
+static void InvokeBitcoinCLI(
+    const std::string& bitcoin_cli_program,
+    const std::string& passphrase,
+    int timeout)
+{
+    int read_pipe[2];
+    xpipe(read_pipe);
+    int parent_read = read_pipe[0];
+    int child_write = read_pipe[1];
+
+    int write_pipe[2];
+    xpipe(write_pipe);
+    int child_read = write_pipe[0];
+    int parent_write = write_pipe[1];
+
+    pid_t pid = xfork();
+    if (pid > 0) {
+        // parent process
+        xclose(child_read);
+        xclose(child_write);
+
+        FILE* child_stdin = fdopen(parent_write, "w");
+        fprintf(child_stdin, "%s\n%d\n", passphrase.c_str(), timeout);
+        fclose(child_stdin);
+
+        int wstatus;
+        if (waitpid(pid, &wstatus, 0) == -1) {
+            std::ostringstream os;
+            os << "waitpid(): " << strerror(errno);
+            throw std::runtime_error(os.str());
+        }
+        int exit_status = WEXITSTATUS(wstatus);
+        if (exit_status != 0) {
+            std::ostringstream os;
+            os << "bitcoin-cli exited with status " << exit_status;
+            throw std::runtime_error(os.str());
+        }
+        xclose(parent_read);
+    } else {
+        // child process
+        xclose(parent_read);
+        xclose(parent_write);
+        xdup2(child_read, STDIN_FILENO);
+        xdup2(child_write, STDOUT_FILENO);
+        xclose(child_read);
+        xclose(child_write);
+        const char* cli_args[] = {
+            bitcoin_cli_program.c_str(),
+            "-stdin",
+            "walletpassphrase",
+            nullptr};
+        execvp(cli_args[0], (char* const*)cli_args);
+        perror("Failed to exec bitcoin-cli");
+        exit(EXIT_FAILURE);
+    }
+}
+
+static void PrintUsage()
+{
+    std::cerr << "Usage: bitcoin-wallet-unlock [options] TIMEOUT\n";
+    std::cerr << "       bitcoin-wallet-unlock [options] TIMEOUT -- pinentry_arg1 pinentry_arg2...\n";
+    std::cerr << "\n";
+    std::cerr << "Options:\n";
+    std::cerr << "  -h, --help                         Show help\n";
+    std::cerr << "  -c, --bitcoin-cli PROGRAM          Set the bitcoin-cli program (default: bitcoin-cli)\n";
+    std::cerr << "  -p, --pinentry-program PROGRAM     Set the pinentry program (default: pinentry)\n";
+    std::cerr << "  -t, --tty                          Force pinentry into TTY mode\n";
+}
+
+int main(int argc, char** argv)
+{
+    bool force_tty = false;
+    std::string pinentry_program = "";
+    std::string bitcoin_cli_program = "bitcoin-cli";
+    static const char short_opts[] = "c:hp:t";
+    static struct option long_opts[] = {
+        {"help", no_argument, 0, 'h'},
+        {"bitcoin-cli", required_argument, 0, 'c'},
+        {"pinentry-program", required_argument, 0, 'p'},
+        {"tty", no_argument, 0, 't'},
+        {0, 0, 0, 0}};
+
+    for (;;) {
+        int c = getopt_long(argc, argv, short_opts, long_opts, nullptr);
+        if (c == -1) {
+            break;
+        }
+        switch (c) {
+        case 'h':
+            PrintUsage();
+            return 0;
+            break;
+        case 'c':
+            bitcoin_cli_program = optarg;
+            break;
+        case 'p':
+            pinentry_program = optarg;
+            break;
+        case 't':
+            force_tty = true;
+            break;
+        case '?':
+            // getopt_long should already have printed an error message
+            break;
+        default:
+            std::cerr << "Unrecognized command line flag: " << optarg << "\n";
+            abort();
+        }
+    }
+    if (pinentry_program.empty()) {
+        pinentry_program = force_tty ? "pinentry-curses" : "pinentry";
+    }
+    if (optind >= argc) {
+        std::cerr << "Error: no TIMEOUT argument was supplied.\n\n";
+        PrintUsage();
+        return 1;
+    }
+
+    int unlocktime;
+    try {
+        unlocktime = std::stod(argv[optind]);
+    } catch (const std::invalid_argument&) {
+        std::cerr << "Error: invalid timeout value " << argv[optind] << "\n";
+        return 1;
+    }
+    if (unlocktime <= 0) {
+        std::cerr << "Error: invalid timeout value " << argv[optind] << "\n";
+        return 1;
+    }
+
+    try {
+        const std::string passphrase = GetPinentryPassphrase(
+            pinentry_program,
+            force_tty,
+            argc - optind - 1,
+            &argv[optind + 1]);
+        InvokeBitcoinCLI(bitcoin_cli_program, passphrase, unlocktime);
+    } catch (const std::exception& exc) {
+        std::cerr << "Fatal exception: " << exc.what() << "\n";
+    }
+    return 0;
+}


### PR DESCRIPTION
This adds a new optional build executable called `bitcoin-wallet-unlock`. This program invokes [Pinentry](https://www.gnupg.org/related_software/pinentry/index.en.html) (part of GnuPG) to securely read the user's wallet passphrase. This is intended to be used by users of `bitcion-cli`, as `bitcoin-qt` already reads wallet passphrases securely.

### Details

Normally parameters to Bitcoin RPC methods are passed as program arguments to `bitcoin-cli`. This is insecure for `walletpassphrase` for two reasons:
 * The passphrase will be leaked to other processes via the command name, e.g. another user running `top` or `ps` might see the passphrase in the clear.
 * In all likelihood the command invocation will end up in the user's shell history.

A commonly cited workaround is to use `bitcoin-cli -stdin walletpassphrase`. In this mode the command arguments are provided to `bitcoin-cli` over stdin, and this allows the user to enter a passphrase (and timeout) without the issues described above. However, it is still not perfect, as `bitcoin-cli` keeps stdin in `ICANON` mode. This means that if you literally type `bitcoin-cli -stdin walletpassphrase` and enter a passphrase and timeout value, the passphrase you type will be echoed on the terminal in the clear. Another person shoulder-surfing will be able to see the cleartext passphrase, as can any process doing a screen capture.

Pinentry solves this problem and a few others. When reading from the TTY, Pinentry disables echoing to the console, which means that shoulder-surfers can't see the passphrase. Pinentry has some other nifty features. For example, if you invoke pinentry from a terminal emulator in a graphical session in most cases it can automatically upgrade to a graphical input method, e.g. using GTK. This is what input looks like by default for me in GNOME when running `bitcoin-wallet-unlock` from a terminal: https://monad.io/bwemqwkg.png

This implementation of `bitcoin-wallet-unlock` allows using `-p` to force a particular pinentry backend, and `-t` to force TTY input. Extra arguments passed to `bitcoin-wallet-unlock` will be forwarded to the underlying pinentry program; there's an example of this in the comment for `GetPinentryPassphrase()`. Communication with Pinentry is done using a limited subset of the assuan protocol, which is described [here](http://info2html.sourceforge.net/cgi-bin/info2html-demo/info2html?(pinentry)Protocol).

These are the caveats I know of with this PR:
 * Since the HTTP client code in `bitcoin-cli` isn't well factored, I am just execing `bitcoin-cli`, rather than actually making the RPC request from the `bitcoin-wallet-unlock` program. This feels a little bit hacky, but minimizes code churn.
 * The default behavior is to use a relative path for `bitcoin-cli` and `pinentry` when calling `execvp()`. This could potentially cause a malicious program to be invoked if an attacker can put bad things in the users PATH. This can be mitigated by invoking `bitcoin-wallet-unlock` with absolute paths, e.g. `bitcoin-wallet-unlock -c /usr/bin/bitcoin-cli -p /usr/bin/pinentry`.
 * Graphical pinentry methods can delegate to a desktop password manager (e.g. with `gnome-keyring-daemon` on GNOME) when pinentry is linked with libsecret. That is a cool feautre, but I don't enable this because I don't think it's secure (it's trivial to dump the plaintext passwords with these once you're logged in as a user).
 * This code is not portable to Windows as it uses `pipe()` and `exec()` (although I suspect most Windows users are using `bitcoin-qt`).