### PR TITLE
doc: remove leftover check-doc documentation

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -2,12 +2,6 @@ Contents
 ========
 This directory contains tools for developers working on this repository.
 
-check-doc.py
-============
-
-Check if all command line args are documented. The return value indicates the
-number of undocumented args.
-
 clang-format-diff.py
 ===================
 


### PR DESCRIPTION
Remove leftover check-doc.py documentation. Mentioned [here](https://github.com/bitcoin/bitcoin/pull/13281#issuecomment-392010168), it's now [here](https://github.com/bitcoin/bitcoin/tree/master/test/lint#check-docpy).