### PR TITLE
wallet: Prevent segfault when sending to unspendable witness

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -114,6 +114,7 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::v
             vSolutionsRet.push_back(std::move(witnessprogram));
             return true;
         }
+        typeRet = TX_NONSTANDARD;
         return false;
     }
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -726,6 +726,32 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK(!isInvalid);
     }
 
+    // witness unspendable
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(keys[0]);
+
+        scriptPubKey.clear();
+        scriptPubKey << OP_0 << ToByteVector(ParseHex("aabb"));
+
+        result = IsMine(keystore, scriptPubKey, isInvalid);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(!isInvalid);
+    }
+
+    // witness unknown
+    {
+        CBasicKeyStore keystore;
+        keystore.AddKey(keys[0]);
+
+        scriptPubKey.clear();
+        scriptPubKey << OP_16 << ToByteVector(ParseHex("aabb"));
+
+        result = IsMine(keystore, scriptPubKey, isInvalid);
+        BOOST_CHECK_EQUAL(result, ISMINE_NO);
+        BOOST_CHECK(!isInvalid);
+    }
+
     // Nonstandard
     {
         CBasicKeyStore keystore;


### PR DESCRIPTION
Previously we wouldn't care about the `txnouttype`, but after 4e91820531889e309dc4335fe0de8229c6426040 we `switch` on the type.