### PR TITLE
Directly operate with CMutableTransaction

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -93,8 +93,10 @@ public:
 // using only serialization with and without witness data. As witness_size
 // is equal to total_size - stripped_size, this formula is identical to:
 // weight = (stripped_size * 3) + total_size.
-static inline int64_t GetTransactionWeight(const CTransaction& tx)
+template <typename T>
+static inline int64_t GetTransactionWeight(const T& tx)
 {
+    static_assert(std::is_same<T, CTransaction>::value || std::is_same<T, CMutableTransaction>::value, "no need to allow other types");
     return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 }
 static inline int64_t GetBlockWeight(const CBlock& block)

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -33,7 +33,8 @@ int ParseSighashString(const UniValue& sighash);
 // core_write.cpp
 UniValue ValueFromAmount(const CAmount& amount);
 std::string FormatScript(const CScript& script);
-std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
+template <typename T>
+std::string EncodeHexTx(const T& tx, const int serializeFlags = 0);
 std::string SighashToStr(unsigned char sighash_type);
 void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -128,12 +128,15 @@ std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDeco
     return str;
 }
 
-std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags)
+template <typename T>
+std::string EncodeHexTx(const T& tx, const int serializeFlags)
 {
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION | serializeFlags);
     ssTx << tx;
     return HexStr(ssTx.begin(), ssTx.end());
 }
+template std::string EncodeHexTx(const CTransaction&, const int);
+template std::string EncodeHexTx(const CMutableTransaction&, const int);
 
 void ScriptToUniv(const CScript& script, UniValue& out, bool include_address)
 {

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -253,6 +253,11 @@ int64_t GetVirtualTransactionSize(const CTransaction& tx, int64_t nSigOpCost)
     return GetVirtualTransactionSize(GetTransactionWeight(tx), nSigOpCost);
 }
 
+int64_t GetVirtualTransactionSize(const CMutableTransaction& tx, int64_t nSigOpCost)
+{
+    return GetVirtualTransactionSize(GetTransactionWeight(tx), nSigOpCost);
+}
+
 int64_t GetVirtualTransactionInputSize(const CTxIn& txin, int64_t nSigOpCost)
 {
     return GetVirtualTransactionSize(GetTransactionInputWeight(txin), nSigOpCost);

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -105,6 +105,7 @@ extern unsigned int nBytesPerSigOp;
 /** Compute the virtual transaction size (weight reinterpreted as bytes). */
 int64_t GetVirtualTransactionSize(int64_t nWeight, int64_t nSigOpCost);
 int64_t GetVirtualTransactionSize(const CTransaction& tx, int64_t nSigOpCost = 0);
+int64_t GetVirtualTransactionSize(const CMutableTransaction& tx, int64_t nSigOpCost = 0);
 int64_t GetVirtualTransactionInputSize(const CTxIn& tx, int64_t nSigOpCost = 0);
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -4,15 +4,18 @@
 
 #include <policy/rbf.h>
 
-bool SignalsOptInRBF(const CTransaction &tx)
+template <typename T>
+bool SignalsOptInRBF(const T& tx)
 {
-    for (const CTxIn &txin : tx.vin) {
+    for (const CTxIn& txin : tx.vin) {
         if (txin.nSequence < std::numeric_limits<unsigned int>::max()-1) {
             return true;
         }
     }
     return false;
 }
+template bool SignalsOptInRBF(const CTransaction&);
+template bool SignalsOptInRBF(const CMutableTransaction&);
 
 RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool)
 {

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -15,9 +15,12 @@ enum class RBFTransactionState {
     FINAL
 };
 
-// Check whether the sequence numbers on this transaction are signaling
-// opt-in to replace-by-fee, according to BIP 125
-bool SignalsOptInRBF(const CTransaction &tx);
+/**
+ * Check whether the sequence numbers on this transaction are signaling
+ * opt-in to replace-by-fee, according to BIP 125
+ */
+template <typename T>
+bool SignalsOptInRBF(const T& tx);
 
 // Determine whether an in-mempool transaction is signaling opt-in to RBF
 // according to BIP 125

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1478,7 +1478,8 @@ bool CWallet::DummySignTx(CMutableTransaction &txNew, const std::vector<CTxOut> 
     return true;
 }
 
-int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, bool use_max_sig)
+template <typename T>
+int64_t CalculateMaximumSignedTxSize(const T& tx, const CWallet* wallet, bool use_max_sig)
 {
     std::vector<CTxOut> txouts;
     // Look up the inputs.  We should have already checked that this transaction
@@ -1492,12 +1493,8 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wall
         assert(input.prevout.n < mi->second.tx->vout.size());
         txouts.emplace_back(mi->second.tx->vout[input.prevout.n]);
     }
-    return CalculateMaximumSignedTxSize(tx, wallet, txouts, use_max_sig);
-}
 
-// txouts needs to be in the order of tx.vin
-int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, const std::vector<CTxOut>& txouts, bool use_max_sig)
-{
+    // txouts needs to be in the order of tx.vin
     CMutableTransaction txNew(tx);
     if (!wallet->DummySignTx(txNew, txouts, use_max_sig)) {
         // This should never happen, because IsAllFromMe(ISMINE_SPENDABLE)
@@ -1506,6 +1503,8 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wall
     }
     return GetVirtualTransactionSize(txNew);
 }
+template int64_t CalculateMaximumSignedTxSize(const CTransaction&, const CWallet*, bool);
+template int64_t CalculateMaximumSignedTxSize(const CMutableTransaction&, const CWallet*, bool);
 
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* wallet, bool use_max_sig)
 {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1198,6 +1198,6 @@ public:
 // Use DummySignatureCreator, which inserts 71 byte signatures everywhere.
 // NOTE: this requires that all inputs must be in mapWallet (eg the tx should
 // be IsAllFromMe).
-int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, bool use_max_sig = false);
-int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wallet, const std::vector<CTxOut>& txouts, bool use_max_sig = false);
+template <typename T>
+int64_t CalculateMaximumSignedTxSize(const T& tx, const CWallet* wallet, bool use_max_sig = false);
 #endif // BITCOIN_WALLET_WALLET_H


### PR DESCRIPTION
When serializing a transaction for the wallet or rpc, it shouldn't matter if the type is `CTransaction` or `CMutableTransaction`. (See the code for `SerializeTransaction`, which is a template on `TxType`)

Thus, we can avoid a call to a `CTransaction` constructor by templating various helper methods similar to #13309 (Directly operate with CMutableTransaction in SignSignature)