### PR TITLE
util: Don't throw in GetTime{Millis,Micros}(). Mark as noexcept.

### DIFF
--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -37,18 +37,20 @@ int64_t GetMockTime()
     return nMockTime.load(std::memory_order_relaxed);
 }
 
-int64_t GetTimeMillis()
+int64_t GetTimeMillis() noexcept
 {
+    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
-                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+                   epoch).total_milliseconds();
     assert(now > 0);
     return now;
 }
 
-int64_t GetTimeMicros()
+int64_t GetTimeMicros() noexcept
 {
+    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
-                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
+                   epoch).total_microseconds();
     assert(now > 0);
     return now;
 }

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -20,8 +20,8 @@
  */
 
 int64_t GetTime();
-int64_t GetTimeMillis();
-int64_t GetTimeMicros();
+int64_t GetTimeMillis() noexcept;
+int64_t GetTimeMicros() noexcept;
 int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 void SetMockTime(int64_t nMockTimeIn);
 int64_t GetMockTime();


### PR DESCRIPTION
* `boost::posix_time::ptime(boost::gregorian::date(1970,1,1)` throws `bad_year`, `bad_day_of_month`, or `bad_day_month` (derivatives of `std::out_of_range`) if the year, month or day are out of range. It is obvious to us that it won't throw at run-time for `1970-01-01`, but that is not obvious for the compiler or static analyzers. From a static analyzer perspective it will look like these exceptions can reach all the way up to `NodeImpl::appInitMain()` where they are unhandled.
* `boost::posix_time::from_time_t(0)` is simpler and doesn't throw. 
* Re-use the result of `boost::posix_time::from_time_t(0)` like we're doing in `DecodeDumpTime(…)`.
* Mark `GetTimeMillis()` and `GetTimeMicros()` as `noexcept`.