### PR TITLE
bench: Use non-throwing ParseDouble(...) instead of throwing boost::lexical_cast<double>(...)

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -6,11 +6,10 @@
 
 #include <crypto/sha256.h>
 #include <key.h>
-#include <validation.h>
-#include <util.h>
 #include <random.h>
-
-#include <boost/lexical_cast.hpp>
+#include <util.h>
+#include <utilstrencodings.h>
+#include <validation.h>
 
 #include <memory>
 
@@ -64,8 +63,11 @@ int main(int argc, char** argv)
     std::string scaling_str = gArgs.GetArg("-scaling", DEFAULT_BENCH_SCALING);
     bool is_list_only = gArgs.GetBoolArg("-list", false);
 
-    double scaling_factor = boost::lexical_cast<double>(scaling_str);
-
+    double scaling_factor;
+    if (!ParseDouble(scaling_str, &scaling_factor)) {
+        fprintf(stderr, "Error parsing scaling factor as double: %s\n", scaling_str.c_str());
+        return EXIT_FAILURE;
+    }
 
     std::unique_ptr<benchmark::Printer> printer(new benchmark::ConsolePrinter());
     std::string printer_arg = gArgs.GetArg("-printer", DEFAULT_BENCH_PRINTER);


### PR DESCRIPTION
* Non-Boost is better than Boost.
* Non-throwing is better than throwing.
* Explicit error handling is better than implicit error handling.
* `ParseDouble(…)` deserves to be used outside of its unit tests :-)