### PR TITLE
util: Implement boolean conversion and !operator for uint*

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -18,6 +18,8 @@ class uint256;
 class uint_error : public std::runtime_error {
 public:
     explicit uint_error(const std::string& str) : std::runtime_error(str) {}
+    explicit uint_error(const char* str) : std::runtime_error(str) {}
+    uint_error() = delete;
 };
 
 /** Template base class for unsigned big integers. */

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -35,7 +35,7 @@ public:
     {
         static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
 
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             pn[i] = 0;
     }
 
@@ -43,13 +43,13 @@ public:
     {
         static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
 
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             pn[i] = b.pn[i];
     }
 
     base_uint& operator=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             pn[i] = b.pn[i];
         return *this;
     }
@@ -68,16 +68,23 @@ public:
 
     bool operator!() const
     {
-        for (int i = 0; i < WIDTH; i++)
-            if (pn[i] != 0)
-                return false;
-        return true;
+	return !(operator bool());
+    }
+
+    explicit operator bool() const
+    {
+	for (unsigned int i = 0; i < WIDTH; ++i) {
+            if (pn[i]) {
+                return true;
+	    }
+	}
+        return false;
     }
 
     const base_uint operator~() const
     {
         base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             ret.pn[i] = ~pn[i];
         return ret;
     }
@@ -85,7 +92,7 @@ public:
     const base_uint operator-() const
     {
         base_uint ret;
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             ret.pn[i] = ~pn[i];
         ++ret;
         return ret;
@@ -97,28 +104,28 @@ public:
     {
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
-        for (int i = 2; i < WIDTH; i++)
+        for (unsigned int i = 2; i < WIDTH; ++i)
             pn[i] = 0;
         return *this;
     }
 
     base_uint& operator^=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             pn[i] ^= b.pn[i];
         return *this;
     }
 
     base_uint& operator&=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             pn[i] &= b.pn[i];
         return *this;
     }
 
     base_uint& operator|=(const base_uint& b)
     {
-        for (int i = 0; i < WIDTH; i++)
+        for (unsigned int i = 0; i < WIDTH; ++i)
             pn[i] |= b.pn[i];
         return *this;
     }
@@ -143,8 +150,7 @@ public:
     base_uint& operator+=(const base_uint& b)
     {
         uint64_t carry = 0;
-        for (int i = 0; i < WIDTH; i++)
-        {
+        for (unsigned int i = 0; i < WIDTH; ++i) {
             uint64_t n = carry + pn[i] + b.pn[i];
             pn[i] = n & 0xffffffff;
             carry = n >> 32;

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -68,16 +68,16 @@ public:
 
     bool operator!() const
     {
-	return !(operator bool());
+        return !(operator bool());
     }
 
     explicit operator bool() const
     {
-	for (unsigned int i = 0; i < WIDTH; ++i) {
+        for (unsigned int i = 0; i < WIDTH; ++i) {
             if (pn[i]) {
                 return true;
-	    }
-	}
+            }
+        }
         return false;
     }
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -83,6 +83,12 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(~MaxL == ZeroL);
     BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
 
+    // truthiness
+    BOOST_CHECK(static_cast<bool>(OneL));
+    BOOST_CHECK(!static_cast<bool>(ZeroL));
+    BOOST_CHECK(OneL);
+    BOOST_CHECK(!ZeroL);
+
     uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
     for (unsigned int i = 0; i < 256; ++i)
     {

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -83,12 +83,6 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(~MaxL == ZeroL);
     BOOST_CHECK( ((R1L ^ R2L) ^ R1L) == R2L);
 
-    // truthiness
-    BOOST_CHECK(static_cast<bool>(OneL));
-    BOOST_CHECK(!static_cast<bool>(ZeroL));
-    BOOST_CHECK(OneL);
-    BOOST_CHECK(!ZeroL);
-
     uint64_t Tmp64 = 0xc4dab720d9c7acaaULL;
     for (unsigned int i = 0; i < 256; ++i)
     {
@@ -210,6 +204,9 @@ BOOST_AUTO_TEST_CASE( unaryOperators ) // !    ~    -
         BOOST_CHECK(!(!(OneL<<i)));
     BOOST_CHECK(!(!R1L));
     BOOST_CHECK(!(!MaxL));
+
+    BOOST_CHECK(static_cast<bool>(OneL));
+    BOOST_CHECK(!static_cast<bool>(ZeroL));
 
     BOOST_CHECK(~ZeroL == MaxL);
 

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -95,6 +95,16 @@ BOOST_AUTO_TEST_CASE( basics ) // constructors, equality, inequality
     BOOST_CHECK(OneL != ZeroL && OneS != ZeroS);
     BOOST_CHECK(MaxL != ZeroL && MaxS != ZeroS);
 
+    // truthiness
+    BOOST_CHECK(!ZeroL);
+    BOOST_CHECK(!ZeroS);
+    BOOST_CHECK(OneL);
+    BOOST_CHECK(OneS);
+    BOOST_CHECK(static_cast<bool>(OneS));
+    BOOST_CHECK(static_cast<bool>(OneL));
+    BOOST_CHECK(!static_cast<bool>(ZeroS));
+    BOOST_CHECK(!static_cast<bool>(ZeroL));
+
     // String Constructor and Copy Constructor
     BOOST_CHECK(uint256S("0x"+R1L.ToString()) == R1L);
     BOOST_CHECK(uint256S("0x"+R2L.ToString()) == R2L);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -48,6 +48,21 @@ public:
     friend inline bool operator!=(const base_blob& a, const base_blob& b) { return a.Compare(b) != 0; }
     friend inline bool operator<(const base_blob& a, const base_blob& b) { return a.Compare(b) < 0; }
 
+    bool operator!() const
+    {
+	return !(operator bool());
+    }
+
+    explicit operator bool() const
+    {
+	for (unsigned int i = 0; i < WIDTH; ++i) {
+	    if (data[i]) {
+		return true;
+	    }
+	}
+	return false;
+    }
+
     std::string GetHex() const;
     void SetHex(const char* psz);
     void SetHex(const std::string& str);

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -31,9 +31,11 @@ public:
 
     bool IsNull() const
     {
-        for (int i = 0; i < WIDTH; i++)
-            if (data[i] != 0)
+        for (unsigned int i = 0; i < WIDTH; ++i) {
+            if (data[i] != 0) {
                 return false;
+	    }
+	}
         return true;
     }
 
@@ -55,12 +57,7 @@ public:
 
     explicit operator bool() const
     {
-        for (unsigned int i = 0; i < WIDTH; ++i) {
-            if (data[i]) {
-                return true;
-            }
-        }
-        return false;
+        return !IsNull();
     }
 
     std::string GetHex() const;

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -50,17 +50,17 @@ public:
 
     bool operator!() const
     {
-	return !(operator bool());
+        return !(operator bool());
     }
 
     explicit operator bool() const
     {
-	for (unsigned int i = 0; i < WIDTH; ++i) {
-	    if (data[i]) {
-		return true;
-	    }
-	}
-	return false;
+        for (unsigned int i = 0; i < WIDTH; ++i) {
+            if (data[i]) {
+                return true;
+            }
+        }
+        return false;
     }
 
     std::string GetHex() const;

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -34,8 +34,8 @@ public:
         for (unsigned int i = 0; i < WIDTH; ++i) {
             if (data[i] != 0) {
                 return false;
-	    }
-	}
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
_First time contributor_

1. Implement boolean conversion and `operator!()` for uint160/uint256 to be consistent with https://github.com/bitcoin/bitcoin/blob/master/src/arith_uint256.h#L67

2. Implement boolean conversion operator for `arith_uint256`

3. Add unit tests for (1) and (2)