### PR TITLE
Utils and libraries: Fix #13371 - move umask operation earlier in AppInit()

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -85,13 +85,6 @@ static bool AppInit(int argc, char* argv[])
 
     util::Ref context{node};
 
-#ifndef WIN32
-    // set umask before any filesystem writes occur
-    if (!gArgs.GetBoolArg("-sysperms", false)) {
-        umask(077);
-    }
-#endif
-
     try
     {
         if (!CheckDataDirOption()) {
@@ -116,6 +109,13 @@ static bool AppInit(int argc, char* argv[])
 
         // -server defaults to true for bitcoind but not for the GUI so do this here
         gArgs.SoftSetBoolArg("-server", true);
+
+#ifndef WIN32
+    // set umask before any filesystem writes occur
+    if (!gArgs.GetBoolArg("-sysperms", false)) {
+        umask(077);
+    }
+#endif
         // Set this early so that parameter interactions go to console
         InitLogging();
         InitParameterInteraction();

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -25,6 +25,10 @@
 
 #include <functional>
 
+#ifndef WIN32
+#include <sys/stat.h>
+#endif
+
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 UrlDecodeFn* const URL_DECODE = urlDecode;
 
@@ -78,7 +82,16 @@ static bool AppInit(int argc, char* argv[])
         return true;
     }
 
+
     util::Ref context{node};
+
+#ifndef WIN32
+    // set umask before any filesystem writes occur
+    if (!gArgs.GetBoolArg("-sysperms", false)) {
+        umask(077);
+    }
+#endif
+
     try
     {
         if (!CheckDataDirOption()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -935,10 +935,6 @@ bool AppInitBasicSetup()
     }
 
 #ifndef WIN32
-    if (!gArgs.GetBoolArg("-sysperms", false)) {
-        umask(077);
-    }
-
     // Clean shutdown on SIGTERM
     registerSignalHandler(SIGTERM, HandleSIGTERM);
     registerSignalHandler(SIGINT, HandleSIGTERM);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -491,13 +491,6 @@ int GuiMain(int argc, char* argv[])
         return EXIT_SUCCESS;
     }
 
-#ifndef WIN32
-    // set umask before any filesystem writes occur
-    if (!gArgs.GetBoolArg("-sysperms", false)) {
-        umask(077);
-    }
-#endif
-
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory
     bool did_show_intro = false;
@@ -519,6 +512,13 @@ int GuiMain(int argc, char* argv[])
             QObject::tr("Error: Cannot parse configuration file: %1.").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
     }
+
+#ifndef WIN32
+    // set umask before any filesystem writes occur
+    if (!gArgs.GetBoolArg("-sysperms", false)) {
+        umask(077);
+    }
+#endif
 
     /// 7. Determine network (and switch to network specific options)
     // - Do not call Params() before this step

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -37,6 +37,13 @@
 #include <validation.h>
 
 #include <memory>
+#include <stdint.h>
+
+#ifndef WIN32
+#include <sys/stat.h>
+#endif
+
+#include <boost/thread.hpp>
 
 #include <QApplication>
 #include <QDebug>
@@ -483,6 +490,13 @@ int GuiMain(int argc, char* argv[])
         help.showOrPrint();
         return EXIT_SUCCESS;
     }
+
+#ifndef WIN32
+    // set umask before any filesystem writes occur
+    if (!gArgs.GetBoolArg("-sysperms", false)) {
+        umask(077);
+    }
+#endif
 
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory

--- a/test/functional/feature_sysperms.py
+++ b/test/functional/feature_sysperms.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Verify -sysperms=false (default) works as expected."""
+
+import os
+import platform
+import stat
+
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
+
+
+class SyspermsTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def check_nosysperms_pathname(self, fullpathname):
+        self.log.info('{}  {}'.format(stat.filemode(os.stat(fullpathname).st_mode), fullpathname))
+        return (os.stat(fullpathname).st_mode & (stat.S_IRWXO | stat.S_IRWXG)) == 0
+
+    def check_nosysperms_dir(self, regtest_dirpath):
+        result = []
+        for path, dirs, files in os.walk(regtest_dirpath):
+            for dirname in dirs:
+                result.append(self.check_nosysperms_pathname(os.path.join(path, dirname)))
+
+            for filename in files:
+                result.append(self.check_nosysperms_pathname(os.path.join(path, filename)))
+        return result
+
+    def run_test(self):
+        self.log.info("Check for valid platform")
+        if platform.system() == 'Windows':
+            raise SkipTest("This test does not run on Windows.")
+
+        self.restart_node(0)
+        datadir = self.nodes[0].datadir
+
+        self.log.info("Running test without -sysperms option - assuming umask of '077'")
+        self.log.info('-datadir: {}'.format(datadir))
+
+        self.log.info('Checking permissions... ')
+        # check regtest dir and its contents
+        regtest_dirpath = os.path.join(datadir, 'regtest')
+        assert self.check_nosysperms_pathname(regtest_dirpath)
+        assert any(self.check_nosysperms_dir(regtest_dirpath))
+        self.log.info('Pass.')
+
+        # Run test again with -sysperms
+        self.stop_node(1)
+        # Now retry an confirm node starts as expected
+        self.log.info("Running test with -sysperms -disablewallet options")
+        self.start_node(1, extra_args=["-sysperms", "-disablewallet"])
+        self.log.info('Pass.')
+
+
+if __name__ == '__main__':
+    SyspermsTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -180,6 +180,7 @@ BASE_SCRIPTS = [
     'rpc_getblockfilter.py',
     'rpc_invalidateblock.py',
     'feature_rbf.py',
+    'feature_sysperms.py',
     'mempool_packages.py',
     'mempool_package_onemore.py',
     'rpc_createmultisig.py',


### PR DESCRIPTION
When the option -sysperms=false (default) is enabled, the created datadirs doesn't take into account the default umask setting of '077'.
The fix moves the umask operation to just after parameters are parsed during AppInit()