### PR TITLE
Tests: Ignore RemoteDisconnected and BadStatusLine when stopping node

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -196,6 +196,8 @@ class TestNode():
             self.stop()
         except http.client.CannotSendRequest:
             self.log.exception("Unable to stop node.")
+        except (http.client.RemoteDisconnected, http.client.BadStatusLine):
+            pass
 
         # Check that stderr is as expected
         self.stderr.seek(0)


### PR DESCRIPTION
Close #11777 
If the HTTP server stopped before it response, then the tests would fail. I think we can just ignore the response error and check if the node has stopped at `is_node_stopped`.