### PR TITLE
Make tinyformat noexcept: Use default error handling (assert(0 && reason)) on incorrect format strings

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -145,14 +145,7 @@ template<typename T, typename... Args> static inline void MarkUsed(const T& t, c
 #else
 #define LogPrintf(...) do { \
     if (g_logger->Enabled()) { \
-        std::string _log_msg_; /* Unlikely name to avoid shadowing variables */ \
-        try { \
-            _log_msg_ = tfm::format(__VA_ARGS__); \
-        } catch (tinyformat::format_error &fmterr) { \
-            /* Original format string will have newline so don't add one here */ \
-            _log_msg_ = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + FormatStringFromLogArgs(__VA_ARGS__); \
-        } \
-        g_logger->LogPrintStr(_log_msg_); \
+        g_logger->LogPrintStr(tfm::format(__VA_ARGS__)); \
     } \
 } while(0)
 

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -122,13 +122,9 @@ namespace tinyformat {}
 // Namespace alias to encourage brevity
 namespace tfm = tinyformat;
 
-// Error handling; calls assert() by default.
-#define TINYFORMAT_ERROR(reasonString) throw tinyformat::format_error(reasonString)
-
 // Define for C++11 variadic templates which make the code shorter & more
 // general.  If you don't define this, C++11 support is autodetected below.
 #define TINYFORMAT_USE_VARIADIC_TEMPLATES
-
 
 //------------------------------------------------------------------------------
 // Implementation details.


### PR DESCRIPTION
Make tinyformat `noexcept`: Use tinyformat's default error handling (`assert(0 && reason);`) instead of throwing `tinyformat::format_error` on incorrect format strings.

The only place where `tinyformat::format_error` was handled was in `LogPrintf(...)` where it was handled to generate output which is equivalent to what `assert(0 && reason);` provides.

Incorrect format strings are best handled explicitly locally in a "fail fast" manner. No need for propagation.

Since tinyformat is used extensively via `strprintf(…)` large parts of the code base are switched from an implicit "might throw `tinyformat::format_error`" to "will not throw" from a compiler/static analyzer perspective with this change.

Reducing the number of unnecessary exceptions thrown increases the signal-to-noise for humans when analyzing potential issues introduced by uncaught exceptions.

These were the conditions that threw `tinyformat::format_error` prior to this commit:

```
$ git grep TINYFORMAT_ERROR
src/tinyformat.h:// Error handling: Define TINYFORMAT_ERROR to customize the error handling for
src/tinyformat.h:#define TINYFORMAT_ERROR(reasonString) throw tinyformat::format_error(reasonString)
src/tinyformat.h:#ifndef TINYFORMAT_ERROR
src/tinyformat.h:#   define TINYFORMAT_ERROR(reason) assert(0 && reason)
src/tinyformat.h:        TINYFORMAT_ERROR("tinyformat: Cannot convert from argument type to "
src/tinyformat.h:        TINYFORMAT_ERROR("tinyformat: Not enough conversion specifiers in format string");
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable width");
src/tinyformat.h:                TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable precision");
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: the %a and %A conversion specs "
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: %n conversion spec not supported");
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: Not enough format arguments");
src/tinyformat.h:        TINYFORMAT_ERROR("tinyformat: Too many conversion specifiers in format string");
```