### PR TITLE
util: Make strprintf noexcept. Improve error message on format string error.

### DIFF
--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1052,17 +1052,20 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 
 #endif
 
-// Added for Bitcoin Core
-template<typename... Args>
-std::string format(const std::string &fmt, const Args&... args)
-{
-    std::ostringstream oss;
-    format(oss, fmt.c_str(), args...);
-    return oss.str();
-}
-
 } // namespace tinyformat
 
-#define strprintf tfm::format
+// Added for Bitcoin Core
+template<typename... Args>
+std::string strprintf(const std::string& fmt, const Args&... args) noexcept
+{
+    std::ostringstream oss;
+    try {
+        tfm::format(oss, fmt.c_str(), args...);
+    } catch (const tinyformat::format_error& fmterr) {
+        fprintf(stderr, "Format error: %s (fmt=\"%s\")\n", fmterr.what(), fmt.c_str());
+        std::terminate();
+    }
+    return oss.str();
+}
 
 #endif // TINYFORMAT_H_INCLUDED


### PR DESCRIPTION
Make `strprintf` `noexcept`. Improve the error message given on format string errors.

With this change large parts of the code base (`strprintf` callers directly or indirectly) are switched from an implicit "might throw `tinyformat::format_error`" to "will not throw" from a compiler/static analyzer perspective.

Also, reducing the number of unnecessary exceptions thrown increases the signal-to-noise for humans when analyzing potential issues introduced by uncaught exceptions.

These were the conditions that could make `strprintf(…)` throw `tinyformat::format_error` prior to this commit:

```
$ git grep TINYFORMAT_ERROR
src/tinyformat.h:// Error handling: Define TINYFORMAT_ERROR to customize the error handling for
src/tinyformat.h:#define TINYFORMAT_ERROR(reasonString) throw tinyformat::format_error(reasonString)
src/tinyformat.h:#ifndef TINYFORMAT_ERROR
src/tinyformat.h:#   define TINYFORMAT_ERROR(reason) assert(0 && reason)
src/tinyformat.h:        TINYFORMAT_ERROR("tinyformat: Cannot convert from argument type to "
src/tinyformat.h:        TINYFORMAT_ERROR("tinyformat: Not enough conversion specifiers in format string");
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable width");
src/tinyformat.h:                TINYFORMAT_ERROR("tinyformat: Not enough arguments to read variable precision");
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: the %a and %A conversion specs "
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: %n conversion spec not supported");
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
src/tinyformat.h:            TINYFORMAT_ERROR("tinyformat: Not enough format arguments");
src/tinyformat.h:        TINYFORMAT_ERROR("tinyformat: Too many conversion specifiers in format string");
```