### PR TITLE
[net,mempool] Call AcceptToMemoryPool() asynchronously in p2p

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,7 @@ BITCOIN_CORE_H = \
   compressor.h \
   consensus/consensus.h \
   consensus/tx_verify.h \
+  core/async_layer.h \
   core/consumerthread.h \
   core/producerconsumerqueue.h \
   core_io.h \
@@ -216,6 +217,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   consensus/tx_verify.cpp \
+  core/async_layer.cpp \
   httprpc.cpp \
   httpserver.cpp \
   index/base.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -178,6 +178,7 @@ BITCOIN_CORE_H = \
   utilmoneystr.h \
   utiltime.h \
   validation.h \
+  validation_layer.h \
   validationinterface.h \
   versionbits.h \
   walletinitinterface.h \
@@ -244,6 +245,7 @@ libbitcoin_server_a_SOURCES = \
   txmempool.cpp \
   ui_interface.cpp \
   validation.cpp \
+  validation_layer.cpp \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -140,6 +140,7 @@ BITCOIN_CORE_H = \
   policy/policy.h \
   policy/rbf.h \
   pow.h \
+  core/producerconsumerqueue.h \
   protocol.h \
   random.h \
   reverse_iterator.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -130,6 +130,7 @@ BITCOIN_CORE_H = \
   limitedmap.h \
   logging.h \
   memusage.h \
+  mempool_layer.h \
   merkleblock.h \
   miner.h \
   net.h \
@@ -224,6 +225,7 @@ libbitcoin_server_a_SOURCES = \
   index/txindex.cpp \
   init.cpp \
   dbwrapper.cpp \
+  mempool_layer.cpp \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,8 @@ BITCOIN_CORE_H = \
   compressor.h \
   consensus/consensus.h \
   consensus/tx_verify.h \
+  core/consumerthread.h \
+  core/producerconsumerqueue.h \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
@@ -140,7 +142,6 @@ BITCOIN_CORE_H = \
   policy/policy.h \
   policy/rbf.h \
   pow.h \
-  core/producerconsumerqueue.h \
   protocol.h \
   random.h \
   reverse_iterator.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -65,6 +65,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
+  test/producerconsumerqueue_tests.cpp \
   test/raii_event_tests.cpp \
   test/random_tests.cpp \
   test/reverselock_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -44,6 +44,7 @@ BITCOIN_TESTS =\
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \
   test/compress_tests.cpp \
+  test/consumerthread_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \
   test/denialofservice_tests.cpp \

--- a/src/core/async_layer.cpp
+++ b/src/core/async_layer.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <core/async_layer.h>
+
+void AsyncLayer::Start()
+{
+    assert(!m_thread || !m_thread->IsActive());
+    m_thread = std::unique_ptr<WorkerThread>(new WorkerThread(m_request_queue));
+}
+
+void AsyncLayer::Stop()
+{
+    assert(m_thread && m_thread->IsActive());
+    m_thread->Terminate();
+}

--- a/src/core/async_layer.h
+++ b/src/core/async_layer.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_ASYNC_LAYER_H
+#define BITCOIN_CORE_ASYNC_LAYER_H
+
+#include <future>
+
+#include <chainparams.h>
+#include <core/async_layer.h>
+#include <core/consumerthread.h>
+#include <core/producerconsumerqueue.h>
+#include <util.h>
+
+/**
+ * Encapsulates a request to validate an object
+ *
+ * @see AsyncLayer
+ */
+template <typename RESPONSE>
+class AsyncRequest : public WorkItem<WorkerMode::BLOCKING>
+{
+    friend class AsyncLayer;
+
+public:
+    //! Returns a string identifier (for logging)
+    virtual std::string GetId() const = 0;
+
+protected:
+    //! Guts of the validation
+    virtual void operator()() = 0;
+
+    //! Promise that will deliver the validation result to the caller who generated this request
+    std::promise<RESPONSE> m_promise;
+};
+
+class AsyncLayer
+{
+    typedef WorkQueue<WorkerMode::BLOCKING> RequestQueue;
+    typedef ConsumerThread<WorkerMode::BLOCKING> WorkerThread;
+
+public:
+    AsyncLayer(unsigned int capacity) : m_request_queue(std::make_shared<RequestQueue>(capacity)) {}
+
+    void Start();
+    void Stop();
+
+protected:
+    //! Internal utility method that wraps a request in a unique pointer and deposits it on the validation queue
+    template <typename REQUEST, typename RESPONSE>
+    std::future<RESPONSE> AddToQueue(REQUEST* request)
+    {
+        LogPrint(BCLog::ASYNC, "%s<%s>: submitting request=%s\n", __func__, typeid(RESPONSE).name(), request->GetId());
+
+        auto ret = request->m_promise.get_future();
+        m_request_queue->Push(std::unique_ptr<REQUEST>(request));
+        return ret;
+    };
+
+private:
+    //! a queue that holds validation requests that are sequentially processed by m_thread
+    const std::shared_ptr<RequestQueue> m_request_queue;
+
+    //! the validation thread - sequentially processes validation requests from m_validation_queue
+    std::unique_ptr<WorkerThread> m_thread;
+};
+
+#endif // BITCOIN_CORE_ASYNC_LAYER_H

--- a/src/core/consumerthread.h
+++ b/src/core/consumerthread.h
@@ -1,0 +1,197 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_CONSUMERTHREAD_H
+#define BITCOIN_CORE_CONSUMERTHREAD_H
+
+#include <future>
+#include <thread>
+
+#include <core/producerconsumerqueue.h>
+#include <util.h>
+
+template <WorkerMode MODE>
+class ConsumerThread;
+
+//! A WorkItem() encapsulates a task that can be processed by a ConsumerThread()
+//! @see ConsumerThread()
+template <WorkerMode MODE>
+class WorkItem
+{
+    friend ConsumerThread<MODE>; //<! only a consumer thread can execute a WorkItem
+
+protected:
+    WorkItem(){};
+    virtual void operator()(){};
+};
+
+template <WorkerMode MODE>
+class GenericWorkItem : public WorkItem<MODE>
+{
+    friend ConsumerThread<MODE>;
+
+public:
+    GenericWorkItem(std::function<void()> f) : m_f(f) {}
+
+protected:
+    void operator()() override
+    {
+        m_f();
+    }
+
+    std::function<void()> m_f;
+};
+
+//! A special WorkItem() that is used to interrupt a blocked ConsumerThread() so that it can terminate
+template <WorkerMode MODE>
+class ShutdownPill : public WorkItem<MODE>
+{
+    friend ConsumerThread<MODE>;
+
+private:
+    ShutdownPill(ConsumerThread<MODE>& consumer) : m_consumer(consumer){};
+    void operator()()
+    {
+        std::thread::id id = m_consumer.m_thread.get_id();
+        if (std::this_thread::get_id() != id) {
+            // this ShutdownPill was intended for another thread
+
+            // we haven't seen this pill before
+            if (!m_threads_observed.count(id)) {
+                m_threads_observed.insert(std::this_thread::get_id());
+
+                // resubmit it so that it gets a chance to get to the right thread
+                // when resubmitting, do not block and do not care about failures
+                // theres a potential deadlock where we try to push this to a queue thats
+                // full and there are no other threads still consuming
+                // since the only purpose of reinjecting this is to terminate threads that
+                // may be blocking on an empty queue when the queue is full we do not need to do this
+                m_consumer.m_queue->Push(MakeUnique<ShutdownPill<MODE>>(std::move(*this)), WorkerMode::NONBLOCKING);
+            }
+
+            // if the same pill has been seen by the same thread previously then it can safely be discarded
+            // the intended thread has either terminated or is currently processing a work item and will terminate
+            // after completing that item and before blocking on the queue
+        }
+    };
+
+    ConsumerThread<MODE>& m_consumer;
+    std::set<std::thread::id> m_threads_observed;
+};
+
+template <WorkerMode PRODUCER_MODE>
+class WorkQueue : public BlockingConsumerQueue<std::unique_ptr<WorkItem<PRODUCER_MODE>>, PRODUCER_MODE>
+{
+public:
+    WorkQueue(int capacity) :BlockingConsumerQueue<std::unique_ptr<WorkItem<PRODUCER_MODE>>, PRODUCER_MODE>(capacity) {}
+
+    //! Blocks until everything pushed to the queue prior to this call has been dequeued by a worker
+    void Sync()
+    {
+        std::promise<void> barrier;
+        this->Push(MakeUnique<GenericWorkItem<PRODUCER_MODE>>([&barrier](){ barrier.set_value(); }), WorkerMode::BLOCKING);
+        barrier.get_future().wait();
+    }
+};
+
+/**
+ * A worker thread that interoperates with a BlockingConsumerQueue
+ *
+ * Blocks on the queue, pulls WorkItem() tasks and executes them
+ * No assumptions are made about number of threads operating on this queue
+ *
+ * @see WorkItem
+ * @see WorkQueue
+ * @see BlockingConsumerQueue
+ * @see ProducerConsumerQueue
+ */
+template <WorkerMode PRODUCER_POLICY>
+class ConsumerThread
+{
+    friend ShutdownPill<PRODUCER_POLICY>; //<! needs to introspect in order to cleanly terminate this thread
+
+public:
+    //! Default constructor: not a valid thread
+    ConsumerThread() : m_active(false){};
+
+    //! Constructs a ConsumerThread: RAII
+    //! @param queue the queue from which this thread will pull work
+    ConsumerThread(std::shared_ptr<WorkQueue<PRODUCER_POLICY>> queue, const std::string id = "worker")
+        : m_id(id), m_queue(queue), m_active(true)
+    {
+        m_thread = std::thread(&TraceThread<std::function<void()>>, id.c_str(), std::function<void()>(std::bind(&ConsumerThread<PRODUCER_POLICY>::Loop, this)));
+    };
+
+    //! Terminates a running consumer thread
+    //! Blocks until the thread joins
+    //! Repeated calls are no-ops
+    void Terminate()
+    {
+        RequestTermination();
+        Join();
+    }
+
+    //! Requests termination of a running consumer thread
+    //! Does not wait for the thread to terminate
+    //! Repeated calls are no-ops
+    void RequestTermination()
+    {
+        // locked only so that repeated calls do not push extra ShutdownPills
+        std::unique_lock<CWaitableCriticalSection> l(m_cs_shutdown);
+        if (m_active) {
+            m_active = false;
+
+            // push an empty WorkItem so that we wake the thread up if it is blocking on an empty queue
+            // there is no easy way to determine if this consumer is blocked on the queue without introducing
+            // additional synchronization, but there is little downside to pushing this unnecessarily:
+            // either this is the last active thread on the queue in which case this will be destroyed if/when
+            // the queue (and any other work that may remain is destroyed)
+            // or there are other threads on the queue - in which case this pill will be discarded after any
+            // of the other threads observe it more than once
+            m_queue->Push(std::unique_ptr<ShutdownPill<PRODUCER_POLICY>>(new ShutdownPill<PRODUCER_POLICY>(*this)), WorkerMode::NONBLOCKING);
+        }
+    }
+
+    //! Waits until this thread terminates
+    //! RequestTerminate() must have been previously called or be called by a different thread
+    void Join()
+    {
+        m_thread.join();
+    }
+
+    bool IsActive() const { std::unique_lock<CWaitableCriticalSection> l(m_cs_shutdown); return m_active; }
+
+    const std::string m_id;
+
+private:
+    //! the queue of work that this thread should consume from
+    const std::shared_ptr<WorkQueue<PRODUCER_POLICY>> m_queue;
+
+    //! the thread that this class wraps
+    std::thread m_thread;
+
+    //! whether this thread should continue running: behaves like a latch
+    //! initialized to true in the constructor
+    //! can be set to false by calling Terminate()
+    volatile bool m_active;
+
+    //! protects Terminate()
+    mutable CWaitableCriticalSection m_cs_shutdown;
+
+    //! the body of this thread
+    //! Receives WorkItem() elements from m_queue and executes them until Terminate() is called
+    void Loop()
+    {
+        while (m_active) {
+            Process(m_queue->Pop());
+        }
+    }
+
+    void Process(const std::unique_ptr<WorkItem<PRODUCER_POLICY>> work) const
+    {
+        (*work)();
+    }
+};
+
+#endif // BITCOIN_CORE_CONSUMERTHREAD_H

--- a/src/core/producerconsumerqueue.h
+++ b/src/core/producerconsumerqueue.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_PRODUCERCONSUMERQUEUE_H
+#define BITCOIN_CORE_PRODUCERCONSUMERQUEUE_H
+
+#include <assert.h>
+#include <deque>
+#include <sync.h>
+#include <type_traits>
+
+/**
+ * The mode in which the queue operates
+ * Modes may be specified for both producers and consumers
+ */
+enum class WorkerMode {
+    BLOCKING,   //!< cv_wait until the action may proceed
+    NONBLOCKING //!< do not block, immediately return failure if the action is not possible
+};
+
+/**
+ * A FIFO thread safe producer consumer queue with two operations Push() and Pop()
+ * Producers Push() and Consumers Pop()
+ *
+ * @param T the type of the data contained
+ * @param m_producer_mode queue behavior when calling Push() on a full queue (block till space becomes available, or immediately fail)
+ * @param m_consumer_mode queue behavior when calling Pop() on an empty queue (block until there is data, or immediately fail)
+ *
+ * @see WorkerMode
+ */
+template <typename T, WorkerMode m_producer_mode = WorkerMode::BLOCKING, WorkerMode m_consumer_mode = WorkerMode::BLOCKING>
+class ProducerConsumerQueue
+{
+public:
+    /**
+     * Constructs a ProducerConsumerQueue()
+     * @param[in] capacity the maximum size of this queue
+     */
+    ProducerConsumerQueue(int capacity)
+        : m_capacity(capacity)
+    {
+        assert(m_capacity > 0);
+    };
+
+    /**
+     * Constructs an empty ProducerConsumerQueue with capacity 0
+     * In nonblocking mode all operations will immediately fail
+     * In blocking mode all operations will fail an assertion to avoid blocking forever
+     */
+    ProducerConsumerQueue()
+        : m_capacity(0){};
+    ~ProducerConsumerQueue(){};
+
+    /**
+     * Push an element to the back of the queue
+     * Blocking producer mode: will always eventually succeed
+     * Non-blocking producer mode: Push() returns failure when the queue is at capacity
+     * @param[in] data the data to be pushed
+     * @return the success of the operation
+     * @see WorkerMode
+     */
+    template <typename TT>
+    bool Push(TT&& data, WorkerMode mode = m_producer_mode)
+    {
+        // TT needed for perfect forwarding to vector::push_back
+
+        // attempting a push to a queue of capacity 0 is likely unintended
+        assert(m_capacity > 0);
+
+        {
+            std::unique_lock<std::mutex> l(m_queue_lock);
+            if (m_data.size() >= m_capacity) {
+                if (mode == WorkerMode::NONBLOCKING) {
+                    return false;
+                }
+
+                m_producer_cv.wait(l, [&]() { return m_data.size() < m_capacity; });
+            }
+
+            m_data.push_back(std::forward<TT>(data));
+        }
+        m_consumer_cv.notify_one();
+        return true;
+    };
+
+    /**
+     * Try to pop the oldest element from the front of the queue, if present
+     * Blocking consumer mode: will always eventually succeed
+     * Nonblocking consumer mode: Pop() returns failure when the queue is empty
+     * @param[out] the data popped, if the operation was successful
+     * @return the success of the operation
+     * @see WorkerMode
+     */
+    bool Pop(T& data, WorkerMode mode = m_consumer_mode)
+    {
+        // attempting a pop from a queue of capacity 0 is likely unintended
+        assert(m_capacity > 0);
+
+        {
+            std::unique_lock<std::mutex> l(m_queue_lock);
+            if (m_data.size() <= 0) {
+                if (mode == WorkerMode::NONBLOCKING) {
+                    return false;
+                }
+
+                m_consumer_cv.wait(l, [&]() { return m_data.size() > 0; });
+            }
+
+            data = std::move(m_data.front());
+            m_data.pop_front();
+        }
+        m_producer_cv.notify_one();
+        return true;
+    }
+
+    /**
+     * Shortcut for bool Pop(T&) when consumer mode is blocking
+     * This must always succeed and thus may only be called in producer blocking mode
+     * @return the element popped
+     */
+    T Pop()
+    {
+        static_assert(m_consumer_mode == WorkerMode::BLOCKING, "");
+
+        T ret;
+
+        // use a temporary so theres no side effecting code inside an assert which could be disabled
+        bool success = Pop(ret);
+        assert(success);
+
+        return ret;
+    }
+
+    typename std::deque<T>::size_type size()
+    {
+        std::unique_lock<std::mutex> l(m_queue_lock);
+        return m_data.size();
+    }
+    unsigned int GetCapacity() const { return m_capacity; }
+    static constexpr WorkerMode GetProducerMode() { return m_producer_mode; }
+    static constexpr WorkerMode GetConsumerMode() { return m_consumer_mode; }
+
+private:
+    unsigned int m_capacity; //!< maximum capacity the queue can hold above which pushes will block or fail
+    std::deque<T> m_data;    //!< the data currently in the queue
+
+    std::mutex m_queue_lock;          //!< synchronizes access to m_data
+    CConditionVariable m_consumer_cv; //!< consumers waiting for m_data to become non-empty
+    CConditionVariable m_producer_cv; //!< producers waiting for available space in m_data
+};
+
+template <typename T, WorkerMode consumer_mode>
+using BlockingConsumerQueue = ProducerConsumerQueue<T, WorkerMode::BLOCKING, consumer_mode>;
+
+#endif // BITCOIN_CORE_PRODUCERCONSUMERQUEUE_H

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -120,6 +120,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::VALIDATION, "validation"},
+    {BCLog::ASYNC, "async"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -119,6 +119,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::COINDB, "coindb"},
     {BCLog::QT, "qt"},
     {BCLog::LEVELDB, "leveldb"},
+    {BCLog::VALIDATION, "validation"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -54,6 +54,7 @@ namespace BCLog {
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
         VALIDATION  = (1 << 21),
+        ASYNC       = (1 << 22),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/logging.h
+++ b/src/logging.h
@@ -53,6 +53,7 @@ namespace BCLog {
         COINDB      = (1 << 18),
         QT          = (1 << 19),
         LEVELDB     = (1 << 20),
+        VALIDATION  = (1 << 21),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/mempool_layer.cpp
+++ b/src/mempool_layer.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <mempool_layer.h>
+#include <validation.h>
+
+void TransactionSubmissionRequest::operator()()
+{
+    LogPrint(BCLog::ASYNC, "%s: validating request=%s\n", __func__, GetId());
+    auto res = m_mempool_layer.ValidateInternal(m_transaction, m_bypass_limits, m_absurd_fee, m_test_only);
+    LogPrint(BCLog::ASYNC, "%s: validation result request=%s accepted=%d\n",
+        __func__, GetId(), res.accepted);
+
+    m_promise.set_value(res);
+    if (m_on_ready) {
+        m_on_ready();
+    }
+}
+
+std::string TransactionSubmissionRequest::GetId() const
+{
+    return strprintf("TransactionRequest[%s]", m_transaction->GetWitnessHash().ToString());
+}
+
+std::future<TransactionSubmissionResponse> MempoolLayer::SubmitForValidation(
+    const CTransactionRef& transaction,
+    const bool bypass_limits,
+    const CAmount absurd_fee,
+    const bool test_only,
+    std::function<void()> on_ready)
+{
+    TransactionSubmissionRequest* req = new TransactionSubmissionRequest(*this, transaction,
+        bypass_limits, absurd_fee, test_only,
+        on_ready);
+    return AddToQueue<TransactionSubmissionRequest, TransactionSubmissionResponse>(req);
+}
+
+TransactionSubmissionResponse MempoolLayer::Validate(
+    const CTransactionRef& transaction,
+    const bool bypass_limits,
+    const CAmount absurd_fee,
+    const bool test_only)
+{
+    return SubmitForValidation(transaction, bypass_limits, absurd_fee, test_only).get();
+}
+
+TransactionSubmissionResponse MempoolLayer::ValidateInternal(const CTransactionRef& tx, bool bypass_limits, CAmount absurd_fee, bool test_only) const
+{
+    bool missing;
+    CValidationState state{};
+    std::list<CTransactionRef> removed;
+
+    LOCK(cs_main);
+    bool accepted = AcceptToMemoryPool(m_mempool, state, tx, &missing, &removed, bypass_limits, absurd_fee, test_only);
+
+    return TransactionSubmissionResponse{accepted, missing, std::move(removed), state};
+};

--- a/src/mempool_layer.h
+++ b/src/mempool_layer.h
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MEMPOOL_LAYER_H
+#define BITCOIN_MEMPOOL_LAYER_H
+
+#include <consensus/validation.h>
+#include <core/async_layer.h>
+#include <txmempool.h>
+
+class MempoolLayer;
+
+struct TransactionSubmissionResponse {
+    const bool accepted;
+    const bool missing_inputs;
+    const std::list<CTransactionRef> removed_transactions;
+    CValidationState status;
+};
+
+class TransactionSubmissionRequest : public AsyncRequest<TransactionSubmissionResponse>
+{
+    friend MempoolLayer;
+
+public:
+    //! Returns a transaction witness hash
+    std::string GetId() const override;
+
+protected:
+    //! Adds this transaction to the mempool
+    void operator()() override;
+
+private:
+    TransactionSubmissionRequest(MempoolLayer& mempool_layer, const CTransactionRef transaction, const bool bypass_limits, const CAmount absurd_fee, const bool test_only, const std::function<void()> on_ready)
+        : m_mempool_layer(mempool_layer), m_transaction(transaction),
+          m_bypass_limits(bypass_limits), m_absurd_fee(absurd_fee), m_test_only(test_only),
+          m_on_ready(on_ready){};
+
+    //! The mempool
+    const MempoolLayer& m_mempool_layer;
+
+    //! Parameters for AcceptToMemoryPool()
+    const CTransactionRef m_transaction;
+    const bool m_bypass_limits;
+    const CAmount m_absurd_fee;
+    const bool m_test_only;
+
+    //! A callback to invoke when ready
+    //! This is a workaround because c++11 does not support multiplexed waiting on futures
+    //! In a move to subsequent standards when this behavior is supported this can probably be removed
+    const std::function<void()> m_on_ready;
+};
+
+class MempoolLayer : public AsyncLayer
+{
+    friend TransactionSubmissionRequest;
+
+public:
+    MempoolLayer(CTxMemPool& mempool)
+        : AsyncLayer(1000), m_mempool(mempool) {}
+
+    //! Submit a transaction for asynchronous validation
+    std::future<TransactionSubmissionResponse> SubmitForValidation(
+        const CTransactionRef& transaction,
+        const bool bypass_limits,
+        const CAmount absurd_fee,
+        const bool test_only,
+        std::function<void()> on_ready = []() {});
+
+    //! Submit a transaction for asynchronous validation
+    TransactionSubmissionResponse Validate(
+        const CTransactionRef& transaction,
+        const bool bypass_limits,
+        const CAmount absurd_fee,
+        const bool test_only);
+
+private:
+    //! Internal utility method - sets up and calls AcceptToMemoryPool
+    TransactionSubmissionResponse ValidateInternal(
+        const CTransactionRef& transaction,
+        const bool bypass_limits,
+        const CAmount absurd_fee,
+        const bool test_only) const;
+
+    CTxMemPool& m_mempool;
+};
+
+#endif

--- a/src/mempool_layer.h
+++ b/src/mempool_layer.h
@@ -10,11 +10,19 @@
 #include <txmempool.h>
 
 class MempoolLayer;
+extern std::unique_ptr<MempoolLayer> g_mempool_layer;
 
 struct TransactionSubmissionResponse {
+    //! was the transaction accepted
     const bool accepted;
+
+    //! if rejected, was it rejected because it was missing inputs
     const bool missing_inputs;
+
+    //! if accepted, a list of transactions evicted
     const std::list<CTransactionRef> removed_transactions;
+
+    //! validation state, contains reject reason
     CValidationState status;
 };
 
@@ -67,7 +75,7 @@ public:
         const bool test_only,
         std::function<void()> on_ready = []() {});
 
-    //! Submit a transaction for asynchronous validation
+    //! Submit a transaction for synchronous validation
     TransactionSubmissionResponse Validate(
         const CTransactionRef& transaction,
         const bool bypass_limits,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -59,6 +59,11 @@ static CCriticalSection g_cs_orphans;
 std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(g_cs_orphans);
 std::map<COutPoint, std::set<std::map<uint256, COrphanTx>::iterator, IteratorComparator>> mapOrphanTransactionsByPrev GUARDED_BY(g_cs_orphans);
 void EraseOrphansFor(NodeId peer);
+static void ProcessMempoolAccept(CConnman *, CNode *, const CTransaction&, std::list<CTransactionRef>&) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans);
+static void ProcessMempoolReject(CConnman * connman, CNode * pfrom,
+                                 const CNetMsgMaker msgMaker, const std::string& strCommand,
+                                 const CTransactionRef& ptx, const CValidationState& state, bool missing_inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans);
+static void ProcessMempoolMissingInputs(CNode * pfrom, const CTransactionRef& ptx) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans);
 
 static size_t vExtraTxnForCompactIt GUARDED_BY(g_cs_orphans) = 0;
 static std::vector<std::pair<uint256, CTransactionRef>> vExtraTxnForCompact GUARDED_BY(g_cs_orphans);
@@ -2189,8 +2194,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             return true;
         }
 
-        std::deque<COutPoint> vWorkQueue;
-        std::vector<uint256> vEraseQueue;
         CTransactionRef ptx;
         vRecv >> ptx;
         const CTransaction& tx = *ptx;
@@ -2208,160 +2211,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
         std::list<CTransactionRef> lRemovedTxn;
 
-        if (!AlreadyHave(inv) &&
-            AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
-            mempool.check(pcoinsTip.get());
-            RelayTransaction(tx, connman);
-            for (unsigned int i = 0; i < tx.vout.size(); i++) {
-                vWorkQueue.emplace_back(inv.hash, i);
-            }
-
-            pfrom->nLastTXTime = GetTime();
-
-            LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
-                pfrom->GetId(),
-                tx.GetHash().ToString(),
-                mempool.size(), mempool.DynamicMemoryUsage() / 1000);
-
-            // Recursively process any orphan transactions that depended on this one
-            std::set<NodeId> setMisbehaving;
-            while (!vWorkQueue.empty()) {
-                auto itByPrev = mapOrphanTransactionsByPrev.find(vWorkQueue.front());
-                vWorkQueue.pop_front();
-                if (itByPrev == mapOrphanTransactionsByPrev.end())
-                    continue;
-                for (auto mi = itByPrev->second.begin();
-                     mi != itByPrev->second.end();
-                     ++mi)
-                {
-                    const CTransactionRef& porphanTx = (*mi)->second.tx;
-                    const CTransaction& orphanTx = *porphanTx;
-                    const uint256& orphanHash = orphanTx.GetHash();
-                    NodeId fromPeer = (*mi)->second.fromPeer;
-                    bool fMissingInputs2 = false;
-                    // Use a dummy CValidationState so someone can't setup nodes to counter-DoS based on orphan
-                    // resolution (that is, feeding people an invalid transaction based on LegitTxX in order to get
-                    // anyone relaying LegitTxX banned)
-                    CValidationState stateDummy;
-
-
-                    if (setMisbehaving.count(fromPeer))
-                        continue;
-                    if (AcceptToMemoryPool(mempool, stateDummy, porphanTx, &fMissingInputs2, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
-                        LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
-                        RelayTransaction(orphanTx, connman);
-                        for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {
-                            vWorkQueue.emplace_back(orphanHash, i);
-                        }
-                        vEraseQueue.push_back(orphanHash);
-                    }
-                    else if (!fMissingInputs2)
-                    {
-                        int nDos = 0;
-                        if (stateDummy.IsInvalid(nDos) && nDos > 0)
-                        {
-                            // Punish peer that gave us an invalid orphan tx
-                            Misbehaving(fromPeer, nDos);
-                            setMisbehaving.insert(fromPeer);
-                            LogPrint(BCLog::MEMPOOL, "   invalid orphan tx %s\n", orphanHash.ToString());
-                        }
-                        // Has inputs but not accepted to mempool
-                        // Probably non-standard or insufficient fee
-                        LogPrint(BCLog::MEMPOOL, "   removed orphan tx %s\n", orphanHash.ToString());
-                        vEraseQueue.push_back(orphanHash);
-                        if (!orphanTx.HasWitness() && !stateDummy.CorruptionPossible()) {
-                            // Do not use rejection cache for witness transactions or
-                            // witness-stripped transactions, as they can have been malleated.
-                            // See https://github.com/bitcoin/bitcoin/issues/8279 for details.
-                            assert(recentRejects);
-                            recentRejects->insert(orphanHash);
-                        }
-                    }
-                    mempool.check(pcoinsTip.get());
-                }
-            }
-
-            for (uint256 hash : vEraseQueue)
-                EraseOrphanTx(hash);
-        }
-        else if (fMissingInputs)
-        {
-            bool fRejectedParents = false; // It may be the case that the orphans parents have all been rejected
-            for (const CTxIn& txin : tx.vin) {
-                if (recentRejects->contains(txin.prevout.hash)) {
-                    fRejectedParents = true;
-                    break;
-                }
-            }
-            if (!fRejectedParents) {
-                uint32_t nFetchFlags = GetFetchFlags(pfrom);
-                for (const CTxIn& txin : tx.vin) {
-                    CInv _inv(MSG_TX | nFetchFlags, txin.prevout.hash);
-                    pfrom->AddInventoryKnown(_inv);
-                    if (!AlreadyHave(_inv)) pfrom->AskFor(_inv);
-                }
-                AddOrphanTx(ptx, pfrom->GetId());
-
-                // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
-                unsigned int nMaxOrphanTx = (unsigned int)std::max((int64_t)0, gArgs.GetArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
-                unsigned int nEvicted = LimitOrphanTxSize(nMaxOrphanTx);
-                if (nEvicted > 0) {
-                    LogPrint(BCLog::MEMPOOL, "mapOrphan overflow, removed %u tx\n", nEvicted);
-                }
+        if (!AlreadyHave(inv)) {
+            if(AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
+                assert(!state.IsInvalid());
+                ProcessMempoolAccept(connman, pfrom, tx, lRemovedTxn);
             } else {
-                LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
-                // We will continue to reject this tx since it has rejected
-                // parents so avoid re-requesting it from other peers.
-                recentRejects->insert(tx.GetHash());
-            }
-        } else {
-            if (!tx.HasWitness() && !state.CorruptionPossible()) {
-                // Do not use rejection cache for witness transactions or
-                // witness-stripped transactions, as they can have been malleated.
-                // See https://github.com/bitcoin/bitcoin/issues/8279 for details.
-                assert(recentRejects);
-                recentRejects->insert(tx.GetHash());
-                if (RecursiveDynamicUsage(*ptx) < 100000) {
-                    AddToCompactExtraTransactions(ptx);
-                }
-            } else if (tx.HasWitness() && RecursiveDynamicUsage(*ptx) < 100000) {
-                AddToCompactExtraTransactions(ptx);
-            }
-
-            if (pfrom->fWhitelisted && gArgs.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY)) {
-                // Always relay transactions received from whitelisted peers, even
-                // if they were already in the mempool or rejected from it due
-                // to policy, allowing the node to function as a gateway for
-                // nodes hidden behind it.
-                //
-                // Never relay transactions that we would assign a non-zero DoS
-                // score for, as we expect peers to do the same with us in that
-                // case.
-                int nDoS = 0;
-                if (!state.IsInvalid(nDoS) || nDoS == 0) {
-                    LogPrintf("Force relaying tx %s from whitelisted peer=%d\n", tx.GetHash().ToString(), pfrom->GetId());
-                    RelayTransaction(tx, connman);
-                } else {
-                    LogPrintf("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n", tx.GetHash().ToString(), pfrom->GetId(), FormatStateMessage(state));
-                }
-            }
-        }
-
-        for (const CTransactionRef& removedTx : lRemovedTxn)
-            AddToCompactExtraTransactions(removedTx);
-
-        int nDoS = 0;
-        if (state.IsInvalid(nDoS))
-        {
-            LogPrint(BCLog::MEMPOOLREJ, "%s from peer=%d was not accepted: %s\n", tx.GetHash().ToString(),
-                pfrom->GetId(),
-                FormatStateMessage(state));
-            if (g_enable_bip61 && state.GetRejectCode() > 0 && state.GetRejectCode() < REJECT_INTERNAL) { // Never send AcceptToMemoryPool's internal codes over P2P
-                connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, strCommand, (unsigned char)state.GetRejectCode(),
-                                   state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash));
-            }
-            if (nDoS > 0) {
-                Misbehaving(pfrom->GetId(), nDoS);
+                assert(lRemovedTxn.empty());
+                ProcessMempoolReject(connman, pfrom, msgMaker, strCommand, ptx, state, fMissingInputs);
             }
         }
     }
@@ -3070,6 +2926,180 @@ void PeerLogicValidation::ProcessBlockValidationResponse(CNode* pfrom, const std
         pfrom->nLastBlockTime = GetTime();
     } else {
         mapBlockSource.erase(pblock->GetHash());
+    }
+}
+
+static void ProcessMempoolAccept(CConnman * connman, CNode * pfrom, const CTransaction& tx, std::list<CTransactionRef>& lRemovedTxn) EXCLUSIVE_LOCKS_REQUIRED(g_cs_orphans)
+{
+    std::deque<COutPoint> vWorkQueue;
+    std::vector<uint256> vEraseQueue;
+
+    mempool.check(pcoinsTip.get());
+    RelayTransaction(tx, connman);
+    for (unsigned int i = 0; i < tx.vout.size(); i++) {
+        vWorkQueue.emplace_back(tx.GetHash(), i);
+    }
+
+    pfrom->nLastTXTime = GetTime();
+
+    LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: peer=%d: accepted %s (poolsz %u txn, %u kB)\n",
+             pfrom->GetId(),
+             tx.GetHash().ToString(),
+             mempool.size(), mempool.DynamicMemoryUsage() / 1000);
+
+    // Recursively process any orphan transactions that depended on this one
+    std::set<NodeId> setMisbehaving;
+    while (!vWorkQueue.empty()) {
+        auto itByPrev = mapOrphanTransactionsByPrev.find(vWorkQueue.front());
+        vWorkQueue.pop_front();
+        if (itByPrev == mapOrphanTransactionsByPrev.end())
+            continue;
+        for (auto mi = itByPrev->second.begin();
+             mi != itByPrev->second.end();
+             ++mi)
+        {
+            const CTransactionRef& porphanTx = (*mi)->second.tx;
+            const CTransaction& orphanTx = *porphanTx;
+            const uint256& orphanHash = orphanTx.GetHash();
+            NodeId fromPeer = (*mi)->second.fromPeer;
+            bool fMissingInputs2 = false;
+            // Use a dummy CValidationState so someone can't setup nodes to counter-DoS based on orphan
+            // resolution (that is, feeding people an invalid transaction based on LegitTxX in order to get
+            // anyone relaying LegitTxX banned)
+            CValidationState stateDummy;
+
+
+            if (setMisbehaving.count(fromPeer))
+                continue;
+            if (AcceptToMemoryPool(mempool, stateDummy, porphanTx, &fMissingInputs2, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
+                LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
+                RelayTransaction(orphanTx, connman);
+                for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {
+                    vWorkQueue.emplace_back(orphanHash, i);
+                }
+                vEraseQueue.push_back(orphanHash);
+            }
+            else if (!fMissingInputs2)
+            {
+                int nDos = 0;
+                if (stateDummy.IsInvalid(nDos) && nDos > 0)
+                {
+                    // Punish peer that gave us an invalid orphan tx
+                    Misbehaving(fromPeer, nDos);
+                    setMisbehaving.insert(fromPeer);
+                    LogPrint(BCLog::MEMPOOL, "   invalid orphan tx %s\n", orphanHash.ToString());
+                }
+                // Has inputs but not accepted to mempool
+                // Probably non-standard or insufficient fee
+                LogPrint(BCLog::MEMPOOL, "   removed orphan tx %s\n", orphanHash.ToString());
+                vEraseQueue.push_back(orphanHash);
+                if (!orphanTx.HasWitness() && !stateDummy.CorruptionPossible()) {
+                    // Do not use rejection cache for witness transactions or
+                    // witness-stripped transactions, as they can have been malleated.
+                    // See https://github.com/bitcoin/bitcoin/issues/8279 for details.
+                    assert(recentRejects);
+                    recentRejects->insert(orphanHash);
+                }
+            }
+            mempool.check(pcoinsTip.get());
+        }
+    }
+
+    for (uint256 hash : vEraseQueue)
+        EraseOrphanTx(hash);
+
+    for (const CTransactionRef& removedTx : lRemovedTxn)
+        AddToCompactExtraTransactions(removedTx);
+}
+
+static void ProcessMempoolReject(CConnman * connman, CNode * pfrom,
+                                 const CNetMsgMaker msgMaker, const std::string& strCommand,
+                                 const CTransactionRef& ptx, const CValidationState& state, bool missing_inputs) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans)
+{
+    const CTransaction& tx = *ptx;
+
+    if (missing_inputs) {
+        ProcessMempoolMissingInputs(pfrom, ptx);
+    } else {
+        if (!tx.HasWitness() && !state.CorruptionPossible()) {
+            // Do not use rejection cache for witness transactions or
+            // witness-stripped transactions, as they can have been malleated.
+            // See https://github.com/bitcoin/bitcoin/issues/8279 for details.
+            assert(recentRejects);
+            recentRejects->insert(tx.GetHash());
+            if (RecursiveDynamicUsage(*ptx) < 100000) {
+                AddToCompactExtraTransactions(ptx);
+            }
+        } else if (tx.HasWitness() && RecursiveDynamicUsage(*ptx) < 100000) {
+            AddToCompactExtraTransactions(ptx);
+        }
+
+        if (pfrom->fWhitelisted && gArgs.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY)) {
+            // Always relay transactions received from whitelisted peers, even
+            // if they were already in the mempool or rejected from it due
+            // to policy, allowing the node to function as a gateway for
+            // nodes hidden behind it.
+            //
+            // Never relay transactions that we would assign a non-zero DoS
+            // score for, as we expect peers to do the same with us in that
+            // case.
+            int nDoS = 0;
+            if (!state.IsInvalid(nDoS) || nDoS == 0) {
+                LogPrintf("Force relaying tx %s from whitelisted peer=%d\n", tx.GetHash().ToString(), pfrom->GetId());
+                RelayTransaction(tx, connman);
+            } else {
+                LogPrintf("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n", tx.GetHash().ToString(), pfrom->GetId(), FormatStateMessage(state));
+            }
+        }
+    }
+
+    int nDoS = 0;
+    if (state.IsInvalid(nDoS))
+    {
+        LogPrint(BCLog::MEMPOOLREJ, "%s from peer=%d was not accepted: %s\n", tx.GetHash().ToString(),
+                 pfrom->GetId(),
+                 FormatStateMessage(state));
+        if (g_enable_bip61 && state.GetRejectCode() > 0 && state.GetRejectCode() < REJECT_INTERNAL) { // Never send AcceptToMemoryPool's internal codes over P2P
+            connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::REJECT, strCommand, (unsigned char)state.GetRejectCode(),
+                                                      state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), tx.GetHash()));
+        }
+        if (nDoS > 0) {
+            Misbehaving(pfrom->GetId(), nDoS);
+        }
+    }
+}
+
+static void ProcessMempoolMissingInputs(CNode * pfrom, const CTransactionRef& ptx) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans)
+{
+    const CTransaction& tx = *ptx;
+
+    bool fRejectedParents = false; // It may be the case that the orphans parents have all been rejected
+    for (const CTxIn& txin : tx.vin) {
+        if (recentRejects->contains(txin.prevout.hash)) {
+            fRejectedParents = true;
+            break;
+        }
+    }
+    if (!fRejectedParents) {
+        uint32_t nFetchFlags = GetFetchFlags(pfrom);
+        for (const CTxIn& txin : tx.vin) {
+            CInv _inv(MSG_TX | nFetchFlags, txin.prevout.hash);
+            pfrom->AddInventoryKnown(_inv);
+            if (!AlreadyHave(_inv)) pfrom->AskFor(_inv);
+        }
+        AddOrphanTx(ptx, pfrom->GetId());
+
+        // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
+        unsigned int nMaxOrphanTx = (unsigned int)std::max((int64_t)0, gArgs.GetArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
+        unsigned int nEvicted = LimitOrphanTxSize(nMaxOrphanTx);
+        if (nEvicted > 0) {
+            LogPrint(BCLog::MEMPOOL, "mapOrphan overflow, removed %u tx\n", nEvicted);
+        }
+    } else {
+        LogPrint(BCLog::MEMPOOL, "not keeping orphan with rejected parents %s\n",tx.GetHash().ToString());
+        // We will continue to reject this tx since it has rejected
+        // parents so avoid re-requesting it from other peers.
+        recentRejects->insert(tx.GetHash());
     }
 }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -11,6 +11,7 @@
 #include <consensus/params.h>
 
 struct BlockValidationResponse;
+class MempoolLayer;
 class ValidationLayer;
 
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
@@ -47,9 +48,10 @@ class PeerLogicValidation final : public CValidationInterface, public NetEventsI
 private:
     CConnman* const connman;
     ValidationLayer& m_validation_layer;
+    MempoolLayer& m_mempool_layer;
 
 public:
-    explicit PeerLogicValidation(CConnman* connman, ValidationLayer& validation_layer, CScheduler& scheduler);
+    explicit PeerLogicValidation(CConnman* connman, ValidationLayer& validation_layer, MempoolLayer& mempool_layer, CScheduler& scheduler);
 
     /**
      * Overridden from CValidationInterface.
@@ -91,6 +93,7 @@ public:
     void EvictExtraOutboundPeers(int64_t time_in_seconds);
 
     void ProcessBlockValidationResponse(CNode*, std::shared_ptr<const CBlock>, const CBlockIndex*, const BlockValidationResponse&) override;
+    void ProcessMempoolValidationResponse(CConnman* connman, CNode* pfrom, const CTransactionRef& transaction, const TransactionSubmissionResponse& response) override;
 
 private:
     int64_t m_stale_tip_check_time; //! Next time to check for stale tip

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -10,6 +10,9 @@
 #include <validationinterface.h>
 #include <consensus/params.h>
 
+struct BlockValidationResponse;
+class ValidationLayer;
+
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Expiration time for orphan transactions in seconds */
@@ -43,9 +46,10 @@ extern bool g_enable_bip61;
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:
     CConnman* const connman;
+    ValidationLayer& m_validation_layer;
 
 public:
-    explicit PeerLogicValidation(CConnman* connman, CScheduler &scheduler);
+    explicit PeerLogicValidation(CConnman* connman, ValidationLayer& validation_layer, CScheduler& scheduler);
 
     /**
      * Overridden from CValidationInterface.
@@ -85,6 +89,8 @@ public:
     void CheckForStaleTipAndEvictPeers(const Consensus::Params &consensusParams);
     /** If we have extra outbound peers, try to disconnect the one with the oldest block announcement */
     void EvictExtraOutboundPeers(int64_t time_in_seconds);
+
+    void ProcessBlockValidationResponse(CNode*, std::shared_ptr<const CBlock>, const CBlockIndex*, const BlockValidationResponse&) override;
 
 private:
     int64_t m_stale_tip_check_time; //! Next time to check for stale tip

--- a/src/test/consumerthread_tests.cpp
+++ b/src/test/consumerthread_tests.cpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <atomic>
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <test/test_bitcoin.h>
+
+#include <core/consumerthread.h>
+#include <core/producerconsumerqueue.h>
+
+BOOST_FIXTURE_TEST_SUITE(consumerthread_tests, BasicTestingSetup)
+
+class TestWorkItem : public WorkItem<WorkerMode::BLOCKING>
+{
+public:
+    TestWorkItem(int& i) : m_i(i){};
+    void operator()()
+    {
+        // yield to make unit tests somewhat more unpredictable
+        std::this_thread::yield();
+        ++m_i;
+        std::this_thread::yield();
+        ++m_i;
+    }
+
+private:
+    int& m_i;
+};
+
+void ConsumerThreadTest(int n_elements, int n_threads)
+{
+    std::vector<int> work(n_elements);
+    auto queue = std::shared_ptr<WorkQueue<WorkerMode::BLOCKING>>(new WorkQueue<WorkerMode::BLOCKING>(n_elements + 1));
+
+    std::vector<std::unique_ptr<ConsumerThread<WorkerMode::BLOCKING>>> threads;
+    for (int i = 0; i < n_threads; i++) {
+        threads.emplace_back(std::unique_ptr<ConsumerThread<WorkerMode::BLOCKING>>(new ConsumerThread<WorkerMode::BLOCKING>(queue, std::to_string(i))));
+    }
+
+    for (int i = 0; i < n_elements; i++) {
+        work[i] = i;
+        queue->Push(std::unique_ptr<TestWorkItem>(new TestWorkItem(work[i])));
+    }
+
+    while (queue->size() > 0) {
+        std::this_thread::yield();
+    }
+    queue->Sync();
+
+    for (int i = 0; i < n_threads / 2; i++) {
+        threads[i]->Terminate();
+    }
+
+    BOOST_CHECK_LT(queue->size(), n_threads + 1);
+    for (int i = 0; i < n_elements; i++) {
+        BOOST_CHECK_EQUAL(work[i], i + 2);
+    }
+
+    for (int i = 0; i < n_elements; i++) {
+        queue->Push(std::unique_ptr<TestWorkItem>(new TestWorkItem(work[i])));
+    }
+
+    while (queue->size() > 0) {
+        std::this_thread::yield();
+    }
+    queue->Sync();
+
+    for (int i = n_threads / 2; i < n_threads; i++) {
+        threads[i]->Terminate();
+    }
+
+    BOOST_CHECK_LT(queue->size(), n_threads + 1);
+    for (int i = 0; i < n_elements; i++) {
+        BOOST_CHECK_EQUAL(work[i], i + 4);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(foo)
+{
+    ConsumerThreadTest(100, 1);
+    ConsumerThreadTest(100, 10);
+    ConsumerThreadTest(0, 10);
+    ConsumerThreadTest(3, 10);
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -17,6 +17,7 @@
 #include <uint256.h>
 #include <util.h>
 #include <utilstrencodings.h>
+#include <validation_layer.h>
 
 #include <test/test_bitcoin.h>
 
@@ -207,6 +208,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Note that by default, these tests run with size accounting enabled.
     const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     const CChainParams& chainparams = *chainParams;
+
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     CMutableTransaction tx,tx2;
@@ -248,7 +250,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        BOOST_CHECK(g_validation_layer->Validate(shared_pblock, true).block_valid);
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/producerconsumerqueue_tests.cpp
+++ b/src/test/producerconsumerqueue_tests.cpp
@@ -1,0 +1,178 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <test/test_bitcoin.h>
+
+#include <core/producerconsumerqueue.h>
+
+BOOST_FIXTURE_TEST_SUITE(producerconsumerqueue_tests, BasicTestingSetup)
+
+typedef ProducerConsumerQueue<int, WorkerMode::BLOCKING, WorkerMode::BLOCKING> QueueBB;
+typedef ProducerConsumerQueue<int, WorkerMode::BLOCKING, WorkerMode::NONBLOCKING> QueueBN;
+typedef ProducerConsumerQueue<int, WorkerMode::NONBLOCKING, WorkerMode::BLOCKING> QueueNB;
+typedef ProducerConsumerQueue<int, WorkerMode::NONBLOCKING, WorkerMode::NONBLOCKING> QueueNN;
+
+typedef boost::mpl::list<QueueBB, QueueBN, QueueNB, QueueNN> queue_types;
+
+template <typename Q>
+void Producer(Q& push, Q& recv, int id, int elements_to_push)
+{
+    // push all of these elements to one queue
+    int elements_pushed = 0;
+    while (elements_pushed < elements_to_push) {
+        if (push.Push(id * elements_to_push + elements_pushed)) {
+            elements_pushed++;
+        } else if (push.GetProducerMode() == WorkerMode::BLOCKING) {
+            BOOST_FAIL("a blocking push should always succeed");
+        } else {
+            std::this_thread::yield();
+        }
+    }
+
+    std::set<int> received;
+    while (received.size() < (unsigned)elements_to_push) {
+        int e;
+        if (recv.Pop(e)) {
+            assert(!received.count(e));
+            received.insert(e);
+        } else if (recv.GetConsumerMode() == WorkerMode::BLOCKING) {
+            BOOST_FAIL("a blocking pop should always succeed");
+        } else {
+            std::this_thread::yield();
+        }
+    }
+
+    for (int i = 0; i < elements_to_push; i++) {
+        assert(received.count(-i));
+    }
+}
+
+template <typename Q>
+void Consumer(Q& work, std::vector<Q*> push, int id, int n_producers, int bucket_size, int elements_to_receive)
+{
+    int elements_received = 0;
+    std::vector<int> latest(n_producers, -1);
+
+    while (elements_received != elements_to_receive) {
+        int w;
+        if (work.Pop(w)) {
+            int producer_id = w / bucket_size;
+            int i = w % bucket_size;
+
+            assert(producer_id < n_producers);
+            assert(i > latest[producer_id]);
+            latest[producer_id] = i;
+
+            while (!push[producer_id]->Push(-i)) {
+                if (push[producer_id]->GetProducerMode() == WorkerMode::BLOCKING) {
+                    BOOST_FAIL("a blocking push should always succeed");
+                }
+                std::this_thread::yield();
+            }
+            elements_received++;
+        } else if (work.GetConsumerMode() == WorkerMode::BLOCKING) {
+            BOOST_FAIL("a blocking pop should always succeed");
+        } else {
+            std::this_thread::yield();
+        }
+    }
+}
+
+template <typename Q>
+void QueueTest(int capacity, int n_elements, int n_producers, int n_consumers)
+{
+    int bucket_size = n_elements / n_producers;
+
+    Q push(capacity);
+    std::vector<Q*> pull;
+    for (int i = 0; i < n_producers; i++)
+        pull.push_back(new Q(bucket_size));
+
+    boost::thread_group test_threads;
+
+    for (int i = 0; i < n_producers; i++) {
+        test_threads.create_thread([&, i] { Producer(push, *(pull[i]), i, bucket_size); });
+    }
+
+    for (int i = 0; i < n_consumers; i++) {
+        test_threads.create_thread([&, i] { Consumer(push, pull, i, n_producers, bucket_size, n_elements / n_consumers); });
+    }
+
+    test_threads.join_all();
+
+    // queue should be empty
+    BOOST_CHECK_EQUAL(push.size(), 0);
+    for (int i = 0; i < n_producers; i++) {
+        BOOST_CHECK_EQUAL(pull[i]->size(), 0);
+        delete pull[i];
+    }
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(invalid_queue, Q, queue_types)
+{
+    Q q;
+    BOOST_CHECK(q.GetCapacity() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(basic_operation)
+{
+    int n = 10;
+    QueueBB qBB(n);
+    QueueBN qBN(n);
+    QueueNB qNB(n);
+    QueueNN qNN(n);
+
+    BOOST_CHECK((int)qBB.GetCapacity() == n);
+    for (int i = 0; i < n; i++) {
+        BOOST_CHECK(qBB.Push(i));
+        BOOST_CHECK(qBN.Push(i));
+        BOOST_CHECK(qNB.Push(i));
+        BOOST_CHECK(qNN.Push(i));
+    }
+
+    BOOST_CHECK(!qNB.Push(0));
+    BOOST_CHECK(!qNN.Push(0));
+
+    int t;
+    for (int i = 0; i < n; i++) {
+        BOOST_CHECK_EQUAL(qBB.Pop(), i);
+
+        BOOST_CHECK(qBN.Pop(t));
+        BOOST_CHECK_EQUAL(t, i);
+
+        BOOST_CHECK_EQUAL(qNB.Pop(), i);
+
+        BOOST_CHECK(qNN.Pop(t));
+        BOOST_CHECK_EQUAL(t, i);
+    }
+
+    int ret;
+    BOOST_CHECK(!qBN.Pop(ret));
+    BOOST_CHECK(!qNN.Pop(ret));
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(multithreaded_operation, Q, queue_types)
+{
+    QueueTest<Q>(1000, 100, 1, 1);
+    QueueTest<Q>(100, 1000, 1, 1);
+
+    QueueTest<Q>(1000, 100, 1, 10);
+    QueueTest<Q>(100, 1000, 1, 10);
+
+    QueueTest<Q>(1000, 100, 10, 1);
+    QueueTest<Q>(100, 1000, 10, 1);
+
+    QueueTest<Q>(1000, 100, 10, 10);
+    QueueTest<Q>(100, 1000, 10, 10);
+
+    QueueTest<Q>(1000, 100, 10, 5);
+    QueueTest<Q>(100, 1000, 10, 5);
+
+    QueueTest<Q>(1000, 100, 5, 10);
+    QueueTest<Q>(100, 1000, 5, 10);
+};
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -17,6 +17,7 @@
 #include <rpc/server.h>
 #include <rpc/register.h>
 #include <script/sigcache.h>
+#include <validation_layer.h>
 
 void CConnmanTest::AddNode(CNode& node)
 {
@@ -99,7 +100,11 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
             threadGroup.create_thread(&ThreadScriptCheck);
         g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
         connman = g_connman.get();
-        peerLogic.reset(new PeerLogicValidation(connman, scheduler));
+
+        g_validation_layer.reset(new ValidationLayer(Params()));
+        g_validation_layer->Start();
+
+        peerLogic.reset(new PeerLogicValidation(connman, *g_validation_layer, scheduler));
 }
 
 TestingSetup::~TestingSetup()
@@ -110,6 +115,8 @@ TestingSetup::~TestingSetup()
         GetMainSignals().UnregisterBackgroundSignalScheduler();
         g_connman.reset();
         peerLogic.reset();
+        if (g_validation_layer) g_validation_layer->Stop();
+        g_validation_layer.reset();
         UnloadBlockIndex();
         pcoinsTip.reset();
         pcoinsdbview.reset();
@@ -119,6 +126,7 @@ TestingSetup::~TestingSetup()
 
 TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
 {
+
     // CreateAndProcessBlock() does not support building SegWit blocks, so don't activate in these tests.
     // TODO: fix the code to support SegWit blocks.
     UpdateVersionBitsParameters(Consensus::DEPLOYMENT_SEGWIT, 0, Consensus::BIP9Deployment::NO_TIMEOUT);
@@ -158,7 +166,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    g_validation_layer->Validate(shared_pblock, true);
 
     CBlock result = block;
     return result;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -10,6 +10,7 @@
 #include <crypto/sha256.h>
 #include <validation.h>
 #include <miner.h>
+#include <mempool_layer.h>
 #include <net_processing.h>
 #include <pow.h>
 #include <ui_interface.h>
@@ -105,7 +106,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
     g_validation_layer.reset(new ValidationLayer(Params()));
     g_validation_layer->Start();
 
-    peerLogic.reset(new PeerLogicValidation(connman, *g_validation_layer, scheduler));
+    peerLogic.reset(new PeerLogicValidation(connman, *g_validation_layer, *g_mempool_layer, scheduler));
 }
 
 TestingSetup::~TestingSetup()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -48,80 +48,81 @@ std::ostream& operator<<(std::ostream& os, const uint256& num)
 
 BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 {
-        SHA256AutoDetect();
-        RandomInit();
-        ECC_Start();
-        SetupEnvironment();
-        SetupNetworking();
-        InitSignatureCache();
-        InitScriptExecutionCache();
-        fCheckBlockIndex = true;
-        SelectParams(chainName);
-        noui_connect();
+    SHA256AutoDetect();
+    RandomInit();
+    ECC_Start();
+    SetupEnvironment();
+    SetupNetworking();
+    InitSignatureCache();
+    InitScriptExecutionCache();
+    fCheckBlockIndex = true;
+    SelectParams(chainName);
+    noui_connect();
 }
 
 BasicTestingSetup::~BasicTestingSetup()
 {
-        ECC_Stop();
+    ECC_Stop();
 }
 
 TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
 {
     const CChainParams& chainparams = Params();
-        // Ideally we'd move all the RPC tests to the functional testing framework
-        // instead of unit tests, but for now we need these here.
 
-        RegisterAllCoreRPCCommands(tableRPC);
-        ClearDatadirCache();
-        pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30)));
-        fs::create_directories(pathTemp);
-        gArgs.ForceSetArg("-datadir", pathTemp.string());
+    // Ideally we'd move all the RPC tests to the functional testing framework
+    // instead of unit tests, but for now we need these here.
 
-        // We have to run a scheduler thread to prevent ActivateBestChain
-        // from blocking due to queue overrun.
-        threadGroup.create_thread(boost::bind(&CScheduler::serviceQueue, &scheduler));
-        GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+    RegisterAllCoreRPCCommands(tableRPC);
+    ClearDatadirCache();
+    pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin_%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30)));
+    fs::create_directories(pathTemp);
+    gArgs.ForceSetArg("-datadir", pathTemp.string());
 
-        mempool.setSanityCheck(1.0);
-        pblocktree.reset(new CBlockTreeDB(1 << 20, true));
-        pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
-        pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
-        if (!LoadGenesisBlock(chainparams)) {
-            throw std::runtime_error("LoadGenesisBlock failed.");
+    // We have to run a scheduler thread to prevent ActivateBestChain
+    // from blocking due to queue overrun.
+    threadGroup.create_thread(boost::bind(&CScheduler::serviceQueue, &scheduler));
+    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+
+    mempool.setSanityCheck(1.0);
+    pblocktree.reset(new CBlockTreeDB(1 << 20, true));
+    pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
+    pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
+    if (!LoadGenesisBlock(chainparams)) {
+        throw std::runtime_error("LoadGenesisBlock failed.");
+    }
+    {
+        CValidationState state;
+        if (!ActivateBestChain(state, chainparams)) {
+            throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", FormatStateMessage(state)));
         }
-        {
-            CValidationState state;
-            if (!ActivateBestChain(state, chainparams)) {
-                throw std::runtime_error(strprintf("ActivateBestChain failed. (%s)", FormatStateMessage(state)));
-            }
-        }
-        nScriptCheckThreads = 3;
-        for (int i=0; i < nScriptCheckThreads-1; i++)
-            threadGroup.create_thread(&ThreadScriptCheck);
-        g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
-        connman = g_connman.get();
+    }
+    nScriptCheckThreads = 3;
+    for (int i=0; i < nScriptCheckThreads-1; i++)
+        threadGroup.create_thread(&ThreadScriptCheck);
+    g_connman = std::unique_ptr<CConnman>(new CConnman(0x1337, 0x1337)); // Deterministic randomness for tests.
+    connman = g_connman.get();
 
-        g_validation_layer.reset(new ValidationLayer(Params()));
-        g_validation_layer->Start();
+    g_validation_layer.reset(new ValidationLayer(Params()));
+    g_validation_layer->Start();
 
-        peerLogic.reset(new PeerLogicValidation(connman, *g_validation_layer, scheduler));
+    peerLogic.reset(new PeerLogicValidation(connman, *g_validation_layer, scheduler));
 }
 
 TestingSetup::~TestingSetup()
 {
-        threadGroup.interrupt_all();
-        threadGroup.join_all();
-        GetMainSignals().FlushBackgroundCallbacks();
-        GetMainSignals().UnregisterBackgroundSignalScheduler();
-        g_connman.reset();
-        peerLogic.reset();
-        if (g_validation_layer) g_validation_layer->Stop();
-        g_validation_layer.reset();
-        UnloadBlockIndex();
-        pcoinsTip.reset();
-        pcoinsdbview.reset();
-        pblocktree.reset();
-        fs::remove_all(pathTemp);
+    threadGroup.interrupt_all();
+    threadGroup.join_all();
+    GetMainSignals().FlushBackgroundCallbacks();
+    GetMainSignals().UnregisterBackgroundSignalScheduler();
+    g_connman.reset();
+    peerLogic.reset();
+    if (g_validation_layer) g_validation_layer->Stop();
+    g_validation_layer.reset();
+    UnloadBlockIndex();
+    pcoinsTip.reset();
+    pcoinsdbview.reset();
+    pblocktree.reset();
+    fs::remove_all(pathTemp);
 }
 
 TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -18,6 +18,8 @@
 
 #include <boost/thread.hpp>
 
+class ValidationLayer;
+
 extern uint256 insecure_rand_seed;
 extern FastRandomContext insecure_rand_ctx;
 

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -5,12 +5,14 @@
 #define BOOST_TEST_MODULE Bitcoin Test Suite
 
 #include <net.h>
+#include <validation_layer.h>
 
 #include <memory>
 
 #include <boost/test/unit_test.hpp>
 
 std::unique_ptr<CConnman> g_connman;
+std::unique_ptr<ValidationLayer> g_validation_layer;
 
 [[noreturn]] void Shutdown(void* parg)
 {

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -13,6 +13,7 @@
 
 std::unique_ptr<CConnman> g_connman;
 std::unique_ptr<ValidationLayer> g_validation_layer;
+std::unique_ptr<ValidationLayer> g_mempool_layer;
 
 [[noreturn]] void Shutdown(void* parg)
 {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -947,6 +947,10 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                         __func__, hash.ToString(), FormatStateMessage(state));
                 } else {
                     LogPrintf("Warning: -promiscuousmempool flags set to not include currently enforced soft forks, this may break mining or otherwise cause instability!\n");
+
+                    // reset the validation state here as it was made invalid by the failure of CheckInputsFromMempoolAndCache
+                    // but we're choosing to ignore/override this validation failure
+                    state = CValidationState();
                 }
             }
         }

--- a/src/validation.h
+++ b/src/validation.h
@@ -221,28 +221,6 @@ static const unsigned int DEFAULT_CHECKLEVEL = 3;
 // Setting the target to > than 550MB will make it likely we can respect the target.
 static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
 
-/** 
- * Process an incoming block. This only returns after the best known valid
- * block is made active. Note that it does not, however, guarantee that the
- * specific block passed to it has been checked for validity!
- *
- * If you want to *possibly* get feedback on whether pblock is valid, you must
- * install a CValidationInterface (see validationinterface.h) - this will have
- * its BlockChecked method called whenever *any* block completes validation.
- *
- * Note that we guarantee that either the proof-of-work is valid on pblock, or
- * (and possibly also) BlockChecked will have been called.
- * 
- * May not be called with cs_main held. May not be called in a
- * validationinterface callback.
- *
- * @param[in]   pblock  The block we want to process.
- * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
- * @return True if state.IsValid()
- */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
-
 /**
  * Process incoming block headers.
  *
@@ -365,7 +343,7 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = null
 
 /**
  * Closure representing one script verification
- * Note that this stores references to the spending transaction 
+ * Note that this stores references to the spending transaction
  */
 class CScriptCheck
 {

--- a/src/validation_layer.cpp
+++ b/src/validation_layer.cpp
@@ -10,7 +10,7 @@ void BlockValidationRequest::operator()()
     LogPrint(BCLog::VALIDATION, "%s: validating request=%s\n", __func__, GetId());
     auto res = m_validation_layer.ValidateInternal(m_block, m_force_processing);
     LogPrint(BCLog::VALIDATION, "%s: validation result request=%s block_valid=%d is_new=%d\n",
-        __func__, GetId(), res.block_valid, res.is_new);
+             __func__, GetId(), res.block_valid, res.is_new);
 
     m_promise.set_value(res);
     if (m_on_ready) {

--- a/src/validation_layer.cpp
+++ b/src/validation_layer.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <validation_layer.h>
+#include <validation.h>
+
+void BlockValidationRequest::operator()()
+{
+    LogPrint(BCLog::VALIDATION, "%s: validating request=%s\n", __func__, GetId());
+    auto res = m_validation_layer.ValidateInternal(m_block, m_force_processing);
+    LogPrint(BCLog::VALIDATION, "%s: validation result request=%s block_valid=%d is_new=%d\n",
+        __func__, GetId(), res.block_valid, res.is_new);
+
+    m_promise.set_value(res);
+    if (m_on_ready) {
+        m_on_ready();
+    }
+}
+
+std::string BlockValidationRequest::GetId() const
+{
+    return strprintf("BlockValidationRequest[%s]", m_block->GetHash().ToString());
+}
+
+void ValidationLayer::Start()
+{
+    assert(!m_thread || !m_thread->IsActive());
+    m_thread = std::unique_ptr<ValidationThread>(new ValidationThread(m_validation_queue));
+}
+
+void ValidationLayer::Stop()
+{
+    assert(m_thread && m_thread->IsActive());
+    m_thread->Terminate();
+}
+
+std::future<BlockValidationResponse> ValidationLayer::SubmitForValidation(const std::shared_ptr<const CBlock> block, bool force_processing, std::function<void()> on_ready)
+{
+    BlockValidationRequest* req = new BlockValidationRequest(*this, block, force_processing, on_ready);
+    return SubmitForValidation<BlockValidationResponse>(req);
+}
+
+BlockValidationResponse ValidationLayer::Validate(const std::shared_ptr<const CBlock> block, bool force_processing)
+{
+    return SubmitForValidation(block, force_processing).get();
+}
+
+BlockValidationResponse ValidationLayer::ValidateInternal(const std::shared_ptr<const CBlock> block, bool force_processing) const
+{
+    bool is_new = false;
+    bool block_valid = ProcessNewBlock(m_chainparams, block, force_processing, &is_new);
+    return BlockValidationResponse(block_valid, is_new);
+};

--- a/src/validation_layer.cpp
+++ b/src/validation_layer.cpp
@@ -3,7 +3,27 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <validation_layer.h>
-#include <validation.h>
+
+/**
+ * Process an incoming block. This only returns after the best known valid
+ * block is made active. Note that it does not, however, guarantee that the
+ * specific block passed to it has been checked for validity!
+ *
+ * If you want to *possibly* get feedback on whether pblock is valid, you must
+ * install a CValidationInterface (see validationinterface.h) - this will have
+ * its BlockChecked method called whenever *any* block completes validation.
+ *
+ * Note that we guarantee that either the proof-of-work is valid on pblock, or
+ * (and possibly also) BlockChecked will have been called.
+ *
+ * Call without cs_main held.
+ *
+ * @param[in]   pblock  The block we want to process.
+ * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
+ * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
+ * @return True if state.IsValid()
+ */
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock);
 
 void BlockValidationRequest::operator()()
 {

--- a/src/validation_layer.h
+++ b/src/validation_layer.h
@@ -1,0 +1,144 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_VALIDATION_LAYER_H
+#define BITCOIN_VALIDATION_LAYER_H
+
+#include <future>
+
+#include <chainparams.h>
+#include <core/consumerthread.h>
+#include <core/producerconsumerqueue.h>
+#include <util.h>
+
+class ValidationLayer;
+extern std::unique_ptr<ValidationLayer> g_validation_layer;
+
+/**
+ * Encapsulates a request to validate an object (currently only a block)
+ * Submitted to ValidationLayer for asynchronous validation
+ *
+ * @see ValidationLayer
+ */
+template <typename RESPONSE>
+class ValidationRequest : public WorkItem<WorkerMode::BLOCKING>
+{
+    friend ValidationLayer;
+
+private:
+    //! Guts of the validation
+    virtual void operator()() = 0;
+
+    //! Returns a string identifier (for logging)
+    virtual std::string GetId() const = 0;
+
+protected:
+    //! Promise that will deliver the validation result to the caller who generated this request
+    std::promise<RESPONSE> m_promise;
+};
+
+/**
+ * Holds the results of asynchronous block validation
+ */
+struct BlockValidationResponse {
+    //! Is this the first time this block has been validated
+    const bool is_new;
+
+    //! Did initial validation pass (a block can still pass initial validation but then later fail to connect to an active chain)
+    const bool block_valid;
+
+    BlockValidationResponse(bool _block_valid, bool _is_new)
+        : is_new(_is_new), block_valid(_block_valid){};
+};
+
+/**
+ * Encapsulates a request to validate a block
+ */
+class BlockValidationRequest : public ValidationRequest<BlockValidationResponse>
+{
+    friend ValidationLayer;
+
+private:
+    BlockValidationRequest(ValidationLayer& validation_layer, const std::shared_ptr<const CBlock> block, bool force_processing, const std::function<void()> on_ready)
+        : m_validation_layer(validation_layer), m_block(block), m_force_processing(force_processing), m_on_ready(on_ready){};
+
+    //! Does the validation
+    void operator()() override;
+
+    //! Returns a block hash
+    std::string GetId() const override;
+
+    const ValidationLayer& m_validation_layer;
+
+    //! The block to be validated
+    const std::shared_ptr<const CBlock> m_block;
+
+    //! Was this block explicitly requested (currently required by ProcessNewBlock)
+    const bool m_force_processing;
+
+    //! A callback to invoke when ready
+    //! This is a workaround because c++11 does not support multiplexed waiting on futures
+    //! In a move to subsequent standards when this behavior is supported this can probably be removed
+    const std::function<void()> m_on_ready;
+};
+
+/**
+ * Public interface to block validation
+ *
+ * Two apis:
+ *  - asynchronous: SubmitForValidation(object) -> future<Response>
+ *  - synchronous:  Validate(object) -> Response (just calls SubmitForValidation and blocks on the response)
+ *
+ * Internally, a validation thread pulls validations requests from a queue, processes them and satisfies the promise
+ * with the result of validation.
+ */
+class ValidationLayer
+{
+    friend BlockValidationRequest;
+
+    typedef WorkQueue<WorkerMode::BLOCKING> ValidationQueue;
+    typedef ConsumerThread<WorkerMode::BLOCKING> ValidationThread;
+
+public:
+    ValidationLayer(const CChainParams& chainparams)
+        : m_chainparams(chainparams), m_validation_queue(std::make_shared<ValidationQueue>(100)) {}
+    ~ValidationLayer(){};
+
+    //! Starts the validation layer (creating the validation thread)
+    void Start();
+
+    //! Stops the validation layer (stopping the validation thread)
+    void Stop();
+
+    //! Submit a block for asynchronous validation
+    std::future<BlockValidationResponse> SubmitForValidation(const std::shared_ptr<const CBlock> block, bool force_processing, std::function<void()> on_ready = []() {});
+
+    //! Submit a block for validation and block on the response
+    BlockValidationResponse Validate(const std::shared_ptr<const CBlock> block, bool force_processing);
+
+private:
+    //! Internal utility method - sets up and calls ProcessNewBlock
+    BlockValidationResponse ValidateInternal(const std::shared_ptr<const CBlock> block, bool force_processing) const;
+
+    //! Internal utility method that wraps a request in a unique pointer and deposits it on the validation queue
+    template <typename RESPONSE>
+    std::future<RESPONSE> SubmitForValidation(ValidationRequest<RESPONSE>* request)
+    {
+        LogPrint(BCLog::VALIDATION, "%s<%s>: submitting request=%s\n", __func__, typeid(RESPONSE).name(), request->GetId());
+
+        auto ret = request->m_promise.get_future();
+        m_validation_queue->Push(std::unique_ptr<ValidationRequest<RESPONSE>>(request));
+        return ret;
+    };
+
+    const CChainParams& m_chainparams;
+
+    //! a queue that holds validation requests that are sequentially processed by m_thread
+    const std::shared_ptr<ValidationQueue> m_validation_queue;
+
+    //! the validation thread - sequentially processes validation requests from m_validation_queue
+    std::unique_ptr<ValidationThread> m_thread;
+};
+
+#endif


### PR DESCRIPTION
This depends on #12934 and #13407: review those first

As a follow up to #12934 which introduces some armature code to make message passing based communication a bit easier and moves ProcessNewBlock into its own thread, this does similar for AcceptToMemoryPool() in p2p

If this approach seems reasonable, I think logical next steps are (in forthcoming prs) to try to reduce dependency on cs_main in p2p so that the benefits of this parallelism can be better realized