### PR TITLE
[tests] Speed up knapsack_solver_test by not recreating wallet 100 times.

### DIFF
--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -452,14 +452,19 @@ BOOST_AUTO_TEST_CASE(knapsack_solver_test)
         BOOST_CHECK(testWallet.SelectCoinsMinConf(MIN_CHANGE * 9990 / 100, filter_confirmed, GroupCoins(vCoins), setCoinsRet, nValueRet, coin_selection_params, bnb_used));
         BOOST_CHECK_EQUAL(nValueRet, 101 * MIN_CHANGE);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 2U);
+      }
 
-        // test with many inputs
-        for (CAmount amt=1500; amt < COIN; amt*=10) {
-             empty_wallet();
-             // Create 676 inputs (=  (old MAX_STANDARD_TX_SIZE == 100000)  / 148 bytes per input)
-             for (uint16_t j = 0; j < 676; j++)
-                 add_coin(amt);
+      // test with many inputs
+      for (CAmount amt=1500; amt < COIN; amt*=10) {
+           empty_wallet();
+           // Create 676 inputs (=  (old MAX_STANDARD_TX_SIZE == 100000)  / 148 bytes per input)
+           for (uint16_t j = 0; j < 676; j++)
+               add_coin(amt);
+
+           // We only create the wallet once to save time, but we still run the coin selection RUN_TESTS times.
+           for (int i = 0; i < RUN_TESTS; i++) {
              BOOST_CHECK(testWallet.SelectCoinsMinConf(2000, filter_confirmed, GroupCoins(vCoins), setCoinsRet, nValueRet, coin_selection_params, bnb_used));
+
              if (amt - 2000 < MIN_CHANGE) {
                  // needs more than one input:
                  uint16_t returnSize = std::ceil((2000.0 + MIN_CHANGE)/amt);
@@ -471,14 +476,17 @@ BOOST_AUTO_TEST_CASE(knapsack_solver_test)
                  BOOST_CHECK_EQUAL(nValueRet, amt);
                  BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
              }
-        }
+           }
+      }
 
-        // test randomness
-        {
-            empty_wallet();
-            for (int i2 = 0; i2 < 100; i2++)
-                add_coin(COIN);
+      // test randomness
+      {
+          empty_wallet();
+          for (int i2 = 0; i2 < 100; i2++)
+              add_coin(COIN);
 
+          // Again, we only create the wallet once to save time, but we still run the coin selection RUN_TESTS times.
+          for (int i = 0; i < RUN_TESTS; i++) {
             // picking 50 from 100 coins doesn't depend on the shuffle,
             // but does depend on randomness in the stochastic approximation code
             BOOST_CHECK(testWallet.SelectCoinsMinConf(50 * COIN, filter_standard, GroupCoins(vCoins), setCoinsRet , nValueRet, coin_selection_params, bnb_used));
@@ -496,17 +504,19 @@ BOOST_AUTO_TEST_CASE(knapsack_solver_test)
                     fails++;
             }
             BOOST_CHECK_NE(fails, RANDOM_REPEATS);
+          }
 
-            // add 75 cents in small change.  not enough to make 90 cents,
-            // then try making 90 cents.  there are multiple competing "smallest bigger" coins,
-            // one of which should be picked at random
-            add_coin(5 * CENT);
-            add_coin(10 * CENT);
-            add_coin(15 * CENT);
-            add_coin(20 * CENT);
-            add_coin(25 * CENT);
+          // add 75 cents in small change.  not enough to make 90 cents,
+          // then try making 90 cents.  there are multiple competing "smallest bigger" coins,
+          // one of which should be picked at random
+          add_coin(5 * CENT);
+          add_coin(10 * CENT);
+          add_coin(15 * CENT);
+          add_coin(20 * CENT);
+          add_coin(25 * CENT);
 
-            fails = 0;
+          for (int i = 0; i < RUN_TESTS; i++) {
+            int fails = 0;
             for (int j = 0; j < RANDOM_REPEATS; j++)
             {
                 // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
@@ -517,8 +527,9 @@ BOOST_AUTO_TEST_CASE(knapsack_solver_test)
                     fails++;
             }
             BOOST_CHECK_NE(fails, RANDOM_REPEATS);
-        }
-    }
+          }
+      }
+
     empty_wallet();
 }
 


### PR DESCRIPTION
Optimization of `knapsack_solver_test`by moving an expensive wallet creation to outside a 100x for loop.

On my (slow) machine:

```
before:        9.8s
after:         6.2s
--------------------
saved:         3.6s (36%)
```

This PR was split from #13050. Also see #10026.