### PR TITLE
use IsBlockPruned() where appropriate

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2040,8 +2040,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // If pruning, don't inv blocks unless we have on disk and are likely to still have
             // for some reasonable time window (1 hour) that block relay might require.
             const int nPrunedBlocksLikelyToHave = MIN_BLOCKS_TO_KEEP - 3600 / chainparams.GetConsensus().nPowTargetSpacing;
-            if (fPruneMode && (!(pindex->nStatus & BLOCK_HAVE_DATA) || pindex->nHeight <= chainActive.Tip()->nHeight - nPrunedBlocksLikelyToHave))
-            {
+            if (IsBlockPruned(pindex) || pindex->nHeight <= chainActive.Tip()->nHeight - nPrunedBlocksLikelyToHave) {
                 LogPrint(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1244,7 +1244,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     if (fPruneMode) {
         CBlockIndex* block = chainActive.Tip();
         assert(block);
-        while (block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA)) {
+        while (block->pprev && !IsBlockPruned(block->pprev)) {
             block = block->pprev;
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4002,7 +4002,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         uiInterface.ShowProgress(_("Verifying blocks..."), percentageDone, false);
         if (pindex->nHeight <= chainActive.Height()-nCheckDepth)
             break;
-        if (fPruneMode && !(pindex->nStatus & BLOCK_HAVE_DATA)) {
+        if (IsBlockPruned(pindex)) {
             // If pruning, only go back as far as we have data.
             LogPrintf("VerifyDB(): block verification stopping at height %d (pruning, no data)\n", pindex->nHeight);
             break;
@@ -4177,7 +4177,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
     CValidationState state;
     CBlockIndex* pindex = chainActive.Tip();
     while (chainActive.Height() >= nHeight) {
-        if (fPruneMode && !(chainActive.Tip()->nStatus & BLOCK_HAVE_DATA)) {
+        if (IsBlockPruned(chainActive.Tip())) {
             // If pruning, don't try rewinding past the HAVE_DATA point;
             // since older blocks can't be served anyway, there's
             // no need to walk further, and trying to DisconnectTip()

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3891,7 +3891,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
         LOCK(cs_main);
         CBlockIndex *block = pindexStop ? pindexStop : pChainTip;
         while (block && block->nHeight >= pindexStart->nHeight) {
-            if (!(block->nStatus & BLOCK_HAVE_DATA)) {
+            if (IsBlockPruned(block)) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Can't rescan beyond pruned data. Use RPC call getblockchaininfo to determine your pruned height.");
             }
             block = block->pprev;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4281,11 +4281,11 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         //We can't rescan beyond non-pruned blocks, stop and throw an error
         //this might happen if a user uses an old wallet within a pruned node
         // or if he ran -disablewallet for a longer time, then decided to re-enable
-        if (fPruneMode)
-        {
+        if (fPruneMode) {
             CBlockIndex *block = chainActive.Tip();
-            while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA) && block->pprev->nTx > 0 && pindexRescan != block)
+            while (block->pprev && !IsBlockPruned(block->pprev) && pindexRescan != block) {
                 block = block->pprev;
+            }
 
             if (pindexRescan != block) {
                 InitError(_("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)"));


### PR DESCRIPTION
There are cases where a "full" check for block pruning is not done (`fHavePruned` and `nTx > 0` checks), but where the context indicates that pruning is always the reason. This makes the checks more explicit and straightforward, and separates them more from the cases where we are simply checking whether we have a block or not vs whether we had it at one point and it was pruned.

Note that `nTx > 0` is supposed to always be equivalent to `(pindex->nStatus & BLOCK_HAVE_DATA)`. (Edit: got this backwards; this is true for the true case, but for pruned nodes, `nTx > 0` while `(pindex->nStatus & BLOCK_HAVE_DATA) is 0`.)