### PR TITLE
Set default CFLAGS, CXXFLAGS to empty

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,8 @@ if test "x${CXXFLAGS+set}" = "xset"; then
 else
   CXXFLAGS_overridden=no
 fi
+: ${CXXFLAGS=""}
+: ${CFLAGS=""}
 AC_PROG_CXX
 
 dnl By default, libtool for mingw refuses to link static libs into a dll for


### PR DESCRIPTION
Fix  #13432 

Remove default `-g -O2` flags