### PR TITLE
Removed unused == operator from CMutableTransaction.

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -388,11 +388,6 @@ struct CMutableTransaction
      */
     uint256 GetHash() const;
 
-    friend bool operator==(const CMutableTransaction& a, const CMutableTransaction& b)
-    {
-        return a.GetHash() == b.GetHash();
-    }
-
     bool HasWitness() const
     {
         for (size_t i = 0; i < vin.size(); i++) {


### PR DESCRIPTION
This removes the unused == operator from `CMutableTransaction`.

The motivation is that unused code has a cost but offers no benefit (in general), while also adding the risk of introducing silent bugs. On top of that this particular code is quite inefficient, unnecessarily calculating the hash (it could, say, compare serializations). So if anyone ever needs to use a == comparison on `CMutableTransaction`, they'd be better of having to reimplement it (and add tests) than relying on code that's not being maintained.

Note: after this, trying to use the == operator on CMutableTransactions results in a compilation error: 
```
./primitives/transaction.h:405:15: error: invalid operands to binary expression ('CMutableTransaction' and
      'CMutableTransaction')
```