### PR TITLE
build: Reset default -g -O2 flags when enable debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,10 @@ AC_LANG_PUSH([C++])
 AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 if test "x$enable_debug" = xyes; then
+  # Clear default -g -O2 flags
+  if test "x$CXXFLAGS_overridden" = xno; then
+	CXXFLAGS=""
+  fi
   # Prefer -Og, fall back to -O0 if that is unavailable.
   AX_CHECK_COMPILE_FLAG(
     [-Og],


### PR DESCRIPTION
The default CXXFLAGS is -g -O2, this should not appear when enable debug.
fixes #13432 