### PR TITLE
travis: Increase travis_wait time while verifying commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -104,5 +104,5 @@ jobs:
         - test/lint/lint-all.sh
         - if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_EVENT_TYPE" = "cron" ]; then
               while read LINE; do travis_retry gpg --keyserver hkp://subset.pool.sks-keyservers.net --recv-keys $LINE; done < contrib/verify-commits/trusted-keys &&
-              travis_wait 30 contrib/verify-commits/verify-commits.py;
+              travis_wait 50 contrib/verify-commits/verify-commits.py;
           fi


### PR DESCRIPTION
From https://travis-ci.org/ken2812221/bitcoin-verify-commits/builds
I have run vecify-commits.py nightly on travis, as you can see that 30 minutes is not enough, it took 30-50 minutes to run the script with no extra options. So change it to 50 minutes would be better. Forgot to change this at #13066