### PR TITLE
[WIP] support new multisig template in wallet for Solver, signing, and signature combining

### DIFF
--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -35,6 +35,87 @@ const char* GetTxnOutputType(txnouttype t)
     return nullptr;
 }
 
+static bool IsSmallishInteger(const opcodetype& opcode, const valtype& data, unsigned int& value)
+{
+    if (opcode >= OP_1 && opcode <= OP_16) {
+        value = CScript::DecodeOP_N(opcode);
+        return true;
+    }
+    if (opcode == 1 && data[0] >= 17 && data[0] <= 67) {
+        value = data[0];
+        return true;
+    }
+    return false;
+}
+
+/* Script of the form:
+ *
+ * <pubkey1> OP_CHECKSIG
+ * OP_SWAP <pubkey2> OP_CHECKSIG OP_ADD
+ * OP_SWAP <pubkey3> OP_CHECKSIG OP_ADD
+ * ...
+ * OP_SWAP <pubkey67> OP_CHECKSIG OP_ADD
+ * <m> OP_NUMEQUAL
+ */
+bool IsLargeMultisig(const CScript& script, std::vector<std::vector<unsigned char> >& solutions) {
+    opcodetype opcode;
+    std::vector<unsigned char> vch;
+    CScript::const_iterator pc = script.begin();
+
+    // First pubkey/checksig/swap
+    if (!script.GetOp(pc, opcode, vch) || vch.size() != 33) {
+        return false;
+    }
+    solutions.push_back(vch);
+    if (!script.GetOp(pc, opcode, vch) || opcode != OP_CHECKSIG) {
+        return false;
+    }
+
+    // Repeated pubkey/checksig/op_add/swaps
+    while (true) {
+
+        if (!script.GetOp(pc, opcode, vch)) {
+            return false;
+        }
+
+        // Might just be <m>, break
+        if (opcode != OP_SWAP) {
+            break;
+        }
+
+        if (!script.GetOp(pc, opcode, vch) || vch.size() != 33) {
+            return false;
+        }
+        solutions.push_back(vch);
+
+        if (!script.GetOp(pc, opcode, vch) || opcode != OP_CHECKSIG) {
+            return false;
+        }
+
+        if (!script.GetOp(pc, opcode, vch) || opcode != OP_ADD) {
+            return false;
+        }
+
+    }
+
+    unsigned int value;
+    if (!IsSmallishInteger(opcode, vch, value)) {
+         return false;
+    }
+
+    if (value > solutions.size()) {
+        return false;
+    }
+
+    solutions.push_back({static_cast<unsigned char>(value)});
+
+    if (!script.GetOp(pc, opcode, vch) || opcode != OP_NUMEQUAL) {
+        return false;
+    }
+
+    return true;
+}
+
 static bool MatchPayToPubkey(const CScript& script, valtype& pubkey)
 {
     if (script.size() == CPubKey::PUBLIC_KEY_SIZE + 2 && script[0] == CPubKey::PUBLIC_KEY_SIZE && script.back() == OP_CHECKSIG) {
@@ -84,6 +165,11 @@ static bool MatchMultisig(const CScript& script, unsigned int& required, std::ve
 bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, std::vector<std::vector<unsigned char> >& vSolutionsRet)
 {
     vSolutionsRet.clear();
+
+    if (IsLargeMultisig(scriptPubKey, vSolutionsRet)) {
+        typeRet = TX_LARGE_MULTISIG;
+        return true;
+    }
 
     // Shortcut for pay-to-script-hash, which are more constrained than the other types:
     // it is always OP_HASH160 20 [20 byte hash] OP_EQUAL

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -61,6 +61,7 @@ enum txnouttype
     TX_PUBKEYHASH,
     TX_SCRIPTHASH,
     TX_MULTISIG,
+    TX_LARGE_MULTISIG,
     TX_NULL_DATA, //!< unspendable OP_RETURN script that carries data
     TX_WITNESS_V0_SCRIPTHASH,
     TX_WITNESS_V0_KEYHASH,


### PR DESCRIPTION
…ature combining

Currently the wallet can only sign/understand up to n-of-16 checkmultisig templates. Some efforts are being taken to expand this to n-of-20: #13348 . Rather than try to increase the number of possible signatures marginally this template is based on https://bitcoin.stackexchange.com/a/51653 which allows signing/combining of up to n-of-67, constrained by the non-push opcode limit.

```
+/* Script of the form:
+ *
+ * <pubkey1> OP_CHECKSIG
+ * OP_SWAP <pubkey2> OP_CHECKSIG OP_ADD
+ * OP_SWAP <pubkey3> OP_CHECKSIG OP_ADD
+ * ...
+ * OP_SWAP <pubkey67> OP_CHECKSIG OP_ADD
+ * <m> OP_NUMEQUAL
+ */
```

Wallet code currently disallows import of any redeem/witnessscript beyond 520 bytes(n-of-15), so no safety is lost due to the possible mixture of segwit/non-segwit scripts.

Looking for concept ACKs before I go write tests and attempt code de-duplication, but manual testing worked.