### PR TITLE
Make sure LC_ALL=C is set in all shell scripts

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"

--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export LC_ALL=C
 TOPDIR=${TOPDIR:-$(git rev-parse --show-toplevel)}
 BUILDDIR=${BUILDDIR:-$TOPDIR}
 

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 # What to do
 sign=false
 verify=false

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -2,6 +2,7 @@
 
 # Install libdb4.8 (Berkeley DB).
 
+export LC_ALL=C
 set -e
 
 if [ -z "${1}" ]; then

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 set -e
 
 UNSIGNED="$1"

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 set -e
 
 ROOTDIR=dist

--- a/contrib/macdeploy/extract-osx-sdk.sh
+++ b/contrib/macdeploy/extract-osx-sdk.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 set -e
 
 INPUTFILE="Xcode_7.3.1.dmg"

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -2,6 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 #network interface on which to limit traffic
 IF="eth0"
 #limit of the network interface in question

--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 INPUT=$(cat /dev/stdin)
 VALID=false
 REVSIG=false

--- a/contrib/verify-commits/pre-push-hook.sh
+++ b/contrib/verify-commits/pre-push-hook.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 if ! [[ "$2" =~ ^(git@)?(www.)?github.com(:|/)bitcoin/bitcoin(.git)?$ ]]; then
     exit 0
 fi

--- a/contrib/verifybinaries/verify.sh
+++ b/contrib/verifybinaries/verify.sh
@@ -11,6 +11,7 @@
 ###   The script returns 0 if everything passes the checks. It returns 1 if either the
 ###   signature check or the hash check doesn't pass. If an error occurs the return value is 2
 
+export LC_ALL=C
 function clean_up {
    for file in $*
    do

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 if [ -z "$OSSLSIGNCODE" ]; then
   OSSLSIGNCODE=osslsigncode
 fi

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 if [ $# -gt 1 ]; then
     cd "$2" || exit 1
 fi

--- a/src/qt/res/movies/makespinner.sh
+++ b/src/qt/res/movies/makespinner.sh
@@ -2,6 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 FRAMEDIR=$(dirname $0)
 for i in {0..35}
 do

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -11,6 +11,7 @@
 # The resulting script should exactly transform the previous commit into the current
 # one. Any remaining diff signals an error.
 
+export LC_ALL=C
 if test "x$1" = "x"; then
     echo "Usage: $0 <commit>..."
     exit 1

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+export LC_ALL=C
 DIR="$1"
 COMMIT="$2"
 if [ -z "$COMMIT" ]; then

--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -7,6 +7,10 @@
 # This script runs all contrib/devtools/lint-*.sh files, and fails if any exit
 # with a non-zero status code.
 
+# This script is intentionally locale dependent by not setting "export LC_ALL=C"
+# in order to allow for the executed lint scripts to opt in or opt out of locale
+# dependence themselves.
+
 set -u
 
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -6,6 +6,7 @@
 #
 # Check include guards.
 
+export LC_ALL=C
 HEADER_ID_PREFIX="BITCOIN_"
 HEADER_ID_SUFFIX="_H"
 

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -8,6 +8,7 @@
 # Guard against accidental introduction of new Boost dependencies.
 # Check includes: Check for duplicate includes. Enforce bracket syntax includes.
 
+export LC_ALL=C
 IGNORE_REGEXP="/(leveldb|secp256k1|univalue)/"
 
 filter_suffix() {

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export LC_ALL=C
 KNOWN_VIOLATIONS=(
     "src/base58.cpp:.*isspace"
     "src/bitcoin-tx.cpp.*stoul"

--- a/test/lint/lint-logs.sh
+++ b/test/lint/lint-logs.sh
@@ -12,7 +12,7 @@
 # There are some instances of LogPrintf() in comments. Those can be
 # ignored
 
-
+export LC_ALL=C
 UNTERMINATED_LOGS=$(git grep --extended-regexp "LogPrintf?\(" -- "*.cpp" | \
     grep -v '\\n"' | \
     grep -v "/\* Continued \*/" | \

--- a/test/lint/lint-python-shebang.sh
+++ b/test/lint/lint-python-shebang.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # Shebang must use python3 (not python or python2)
+
+export LC_ALL=C
 EXIT_CODE=0
 for PYTHON_FILE in $(git ls-files -- "*.py"); do
     if [[ $(head -c 2 "${PYTHON_FILE}") == "#!" &&

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -6,6 +6,8 @@
 #
 # Check for specified flake8 warnings in python files.
 
+export LC_ALL=C
+
 # E101 indentation contains mixed spaces and tabs
 # E112 expected an indented block
 # E113 unexpected indentation

--- a/test/lint/lint-shell-locale.sh
+++ b/test/lint/lint-shell-locale.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Make sure all shell scripts:
+# a.) explicitly opt out of locale dependence using "export LC_ALL=C", or
+# b.) explicitly opt in to locale dependence using the annotation below.
+
+export LC_ALL=C
+
+EXIT_CODE=0
+for SHELL_SCRIPT in $(git ls-files -- "*.sh" | grep -vE "src/(secp256k1|univalue)/"); do
+    if grep -q "# This script is intentionally locale dependent by not setting \"export LC_ALL=C\"" "${SHELL_SCRIPT}"; then
+        continue
+    fi
+    FIRST_NON_COMMENT_LINE=$(grep -vE '^(#.*|)$' "${SHELL_SCRIPT}" | head -1)
+    if [[ ${FIRST_NON_COMMENT_LINE} != "export LC_ALL=C" ]]; then
+        echo "Missing \"export LC_ALL=C\" (to avoid locale dependence) as first non-comment non-empty line in ${SHELL_SCRIPT}"
+        EXIT_CODE=1
+    fi
+done
+exit ${EXIT_CODE}

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -6,6 +6,10 @@
 #
 # Check for shellcheck warnings in shell scripts.
 
+# This script is intentionally locale dependent by not setting "export LC_ALL=C"
+# to allow running certain versions of shellcheck that core dump when LC_ALL=C
+# is set.
+
 # Disabled warnings:
 # SC2001: See if you can use ${variable//search/replace} instead.
 # SC2004: $/${} is unnecessary on arithmetic variables.

--- a/test/lint/lint-tests.sh
+++ b/test/lint/lint-tests.sh
@@ -6,6 +6,7 @@
 #
 # Check the test suite naming conventions
 
+export LC_ALL=C
 EXIT_CODE=0
 
 NAMING_INCONSISTENCIES=$(git grep -E '^BOOST_FIXTURE_TEST_SUITE\(' -- \

--- a/test/lint/lint-whitespace.sh
+++ b/test/lint/lint-whitespace.sh
@@ -8,6 +8,7 @@
 
 # We can't run this check unless we know the commit range for the PR.
 
+export LC_ALL=C
 while getopts "?" opt; do
   case $opt in
     ?)


### PR DESCRIPTION
~~Make sure `LC_ALL=C` is set when using `grep` range expressions.~~

Make sure `LC_ALL=C` is set in all shell scripts.

From the `grep(1)` documentation:

> Within a bracket expression, a range expression consists of two characters separated by a hyphen. It matches any single character that sorts between the two characters, inclusive, using the locale's collating sequence and character set. For example, in the default C locale, `[a-d]` is equivalent to `[abcd]`. Many  locales sort characters in dictionary order, and in these locales `[a-d]` is typically not equivalent to `[abcd]`; it might be equivalent to `[aBbCcDd]`, for example. To obtain the traditional interpretation of bracket expressions, you can use the C locale by setting the `LC_ALL` environment variable to the value C.

Context: [Locale issue found when reviewing #13450](https://github.com/bitcoin/bitcoin/pull/13450/files#r194877736)
