### PR TITLE
[0.16.2] Backports

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.7.1
-$(package)_download_path=http://download.qt.io/official_releases/qt/5.7/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/archive/qt/5.7/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -15,6 +15,7 @@
 #include <util.h>
 #include <utilstrencodings.h>
 
+#include <memory>
 #include <stdio.h>
 
 #include <event2/buffer.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -22,6 +22,7 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+#include <memory>
 #include <stdio.h>
 
 #include <boost/algorithm/string.hpp>

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -11,6 +11,7 @@
 #include <utilstrencodings.h>
 
 #include <assert.h>
+#include <memory>
 
 #include <chainparamsseeds.h>
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -9,6 +9,7 @@
 #include <util.h>
 
 #include <assert.h>
+#include <memory>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -4,6 +4,7 @@
 
 #include <dbwrapper.h>
 
+#include <memory>
 #include <random.h>
 
 #include <leveldb/cache.h>

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -17,6 +17,8 @@
 #include <crypto/hmac_sha256.h>
 #include <stdio.h>
 
+#include <memory>
+
 #include <boost/algorithm/string.hpp> // boost::trim
 
 /** WWW-Authenticate to present with 401 Unauthorized response */

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -13,6 +13,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <memory>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -283,6 +283,7 @@ void Shutdown()
  * The execution context the handler is invoked in is not guaranteed,
  * so we restrict handler operations to just touching variables:
  */
+#ifndef WIN32
 static void HandleSIGTERM(int)
 {
     fRequestShutdown = true;
@@ -292,6 +293,14 @@ static void HandleSIGHUP(int)
 {
     fReopenDebugLog = true;
 }
+#else
+static BOOL WINAPI consoleCtrlHandler(DWORD dwCtrlType)
+{
+    fRequestShutdown = true;
+    Sleep(INFINITE);
+    return true;
+}
+#endif
 
 #ifndef WIN32
 static void registerSignalHandler(int signal, void(*handler)(int))
@@ -880,6 +889,8 @@ bool AppInitBasicSetup()
 
     // Ignore SIGPIPE, otherwise it will bring the daemon down if the client closes unexpectedly
     signal(SIGPIPE, SIG_IGN);
+#else
+    SetConsoleCtrlHandler(consoleCtrlHandler, true);
 #endif
 
     std::set_new_handler(new_handler_terminate);

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 #include <unordered_map>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -27,6 +27,7 @@
 #include <validationinterface.h>
 
 #include <algorithm>
+#include <memory>
 #include <queue>
 #include <utility>
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -20,6 +20,7 @@
 #include <ui_interface.h>
 #include <utilstrencodings.h>
 
+#include <memory>
 #ifdef WIN32
 #include <string.h>
 #else

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,8 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+#include <memory>
+
 #if defined(NDEBUG)
 # error "Bitcoin cannot be compiled without assertions."
 #endif

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -12,6 +12,7 @@
 #include <sync.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -7,6 +7,8 @@
 
 #include <net.h>
 
+#include <memory>
+
 #include <QAbstractTableModel>
 #include <QStringList>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -36,6 +36,7 @@
 #include <wallet/wallet.h>
 #endif
 
+#include <memory>
 #include <stdint.h>
 
 #include <boost/thread.hpp>

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -16,6 +16,7 @@
 #include <wallet/wallet.h>
 
 #include <cstdlib>
+#include <memory>
 
 #include <openssl/x509_vfy.h>
 

--- a/src/qt/peertablemodel.h
+++ b/src/qt/peertablemodel.h
@@ -8,6 +8,8 @@
 #include <net_processing.h> // For CNodeStateStats
 #include <net.h>
 
+#include <memory>
+
 #include <QAbstractTableModel>
 #include <QStringList>
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -18,6 +18,8 @@
 #include <qt/recentrequeststablemodel.h>
 #include <qt/receiverequestdialog.h>
 
+#include <memory>
+
 #include <QAbstractButton>
 #include <QAction>
 #include <QApplication>

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -7,6 +7,8 @@
 
 #include <qt/walletmodel.h>
 
+#include <memory>
+
 #include <QObject>
 
 class SendCoinsRecipient;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -105,6 +105,7 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("nTx", (uint64_t)blockindex->nTx));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -150,6 +151,7 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("nTx", (uint64_t)blockindex->nTx));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -679,6 +681,7 @@ UniValue getblockheader(const JSONRPCRequest& request)
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
             "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
+            "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
             "}\n"
@@ -748,6 +751,7 @@ UniValue getblock(const JSONRPCRequest& request)
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
             "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
+            "  \"nTx\" : n,             (numeric) The number of transactions in the block.\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -33,6 +33,7 @@
 
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
 
+#include <memory>
 #include <mutex>
 #include <condition_variable>
 

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -27,6 +27,7 @@
 #endif
 
 #include <algorithm>
+#include <memory>
 
 LockedPoolManager* LockedPoolManager::_instance = nullptr;
 std::once_flag LockedPoolManager::init_flag;

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -4,6 +4,7 @@
 
 #include <sync.h>
 
+#include <memory>
 #include <set>
 #include <util.h>
 #include <utilstrencodings.h>

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -7,6 +7,8 @@
 #include <support/allocators/secure.h>
 #include <test/test_bitcoin.h>
 
+#include <memory>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(allocator_tests, BasicTestingSetup)

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -7,6 +7,8 @@
 #include <random.h>
 #include <test/test_bitcoin.h>
 
+#include <memory>
+
 #include <boost/test/unit_test.hpp>
 
 // Test if a string consists entirely of null characters

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -13,6 +13,8 @@
 #include <chainparams.h>
 #include <util.h>
 
+#include <memory>
+
 class CAddrManSerializationMock : public CAddrMan
 {
 public:

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -14,6 +14,8 @@
 #include <txdb.h>
 #include <txmempool.h>
 
+#include <memory>
+
 #include <boost/thread.hpp>
 
 extern uint256 insecure_rand_seed;

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -25,6 +25,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <memory>
 #include <vector>
 
 enum TEST_ID {

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -6,6 +6,8 @@
 
 #include <net.h>
 
+#include <memory>
+
 #include <boost/test/unit_test.hpp>
 
 std::unique_ptr<CConnman> g_connman;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,6 +11,7 @@
 #include <chain.h>
 
 #include <map>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <exception>
 #include <map>
+#include <memory>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <exception>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdint.h>
 #include <string>

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -432,7 +432,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 1 || request.params.size() > 4)
+    if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
         throw std::runtime_error(
             "importpubkey \"pubkey\" ( \"label\" rescan )\n"
             "\nAdds a public key (in hex) that can be watched as if it were in your wallet but cannot be used to spend. Requires a new wallet backup.\n"

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -9,6 +9,8 @@
 
 #include <wallet/wallet.h>
 
+#include <memory>
+
 /** Testing setup and teardown for wallet.
  */
 struct WalletTestingSetup: public TestingSetup {

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/wallet.h>
 
+#include <memory>
 #include <set>
 #include <stdint.h>
 #include <utility>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <atomic>
 #include <map>
+#include <memory>
 #include <set>
 #include <stdexcept>
 #include <stdint.h>

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -260,9 +260,16 @@ class PruneTest(BitcoinTestFramework):
         # should not prune because chain tip of node 3 (995) < PruneAfterHeight (1000)
         assert_raises_rpc_error(-1, "Blockchain is too short for pruning", node.pruneblockchain, height(500))
 
+        # Save block transaction count before pruning, assert value
+        block1_details = node.getblock(node.getblockhash(1))
+        assert_equal(block1_details["nTx"], len(block1_details["tx"]))
+
         # mine 6 blocks so we are at height 1001 (i.e., above PruneAfterHeight)
         node.generate(6)
         assert_equal(node.getblockchaininfo()["blocks"], 1001)
+
+        # Pruned block should still know the number of transactions
+        assert_equal(node.getblockheader(node.getblockhash(1))["nTx"], block1_details["nTx"])
 
         # negative heights should raise an exception
         assert_raises_rpc_error(-8, "Negative", node.pruneblockchain, -10)

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -185,6 +185,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(header['confirmations'], 1)
         assert_equal(header['previousblockhash'], secondbesthash)
         assert_is_hex_string(header['chainwork'])
+        assert_equal(header['nTx'], 1)
         assert_is_hash_string(header['hash'])
         assert_is_hash_string(header['previousblockhash'])
         assert_is_hash_string(header['merkleroot'])


### PR DESCRIPTION
Backports:
* #12859 Bugfix: Include <memory> for std::unique_ptr
* #13131 Add Windows shutdown handler
* #13451 rpc: expose CBlockIndex::nTx in getblock(header)
* #13507 RPC: Fix parameter count check for importpubkey
* #13544 depends: Update Qt download url

to the 0.16 branch.
