### PR TITLE
Wallet: correctly deprecate accounts in getbalance, re-add minconf / include-watch-only

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -905,12 +905,11 @@ static UniValue getbalance(const JSONRPCRequest& request)
     int nMinDepth = 1;
     if (!minconf.isNull())
         nMinDepth = minconf.get_int();
-    isminefilter filter = ISMINE_SPENDABLE;
-    if(!include_watchonly.isNull())
-        if(include_watchonly.get_bool())
-            filter = filter | ISMINE_WATCH_ONLY;
-
     if (IsDeprecatedRPCEnabled("accounts")) {
+        isminefilter filter = ISMINE_SPENDABLE;
+        if(!include_watchonly.isNull())
+            if(include_watchonly.get_bool())
+                filter = filter | ISMINE_WATCH_ONLY;
         const UniValue& account_value = request.params[0];
 
         if (!account_value.isNull()) {
@@ -921,8 +920,8 @@ static UniValue getbalance(const JSONRPCRequest& request)
         return ValueFromAmount(pwallet->GetLegacyBalance(filter, nMinDepth, account));
     }
 
-    if (!minconf.isNull() || !include_watchonly.isNull() || account) {
-        return ValueFromAmount(pwallet->GetLegacyBalance(filter, nMinDepth, account));
+    if (!minconf.isNull() || !include_watchonly.isNull()) {
+        return ValueFromAmount(pwallet->GetWatchOnlyBalance(nMinDepth));
     }
     else {
         return ValueFromAmount(pwallet->GetBalance());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -849,8 +849,9 @@ static UniValue getbalance(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || (request.params.size() > 3 && IsDeprecatedRPCEnabled("accounts")) || (request.params.size() != 0 && !IsDeprecatedRPCEnabled("accounts")))
+    if (request.fHelp || request.params.size() > 3)
         throw std::runtime_error(
+            (IsDeprecatedRPCEnabled("accounts") ? std::string(
             "getbalance ( \"account\" minconf include_watchonly )\n"
             "\nIf account is not specified, returns the server's total available balance.\n"
             "The available balance is what the wallet considers currently spendable, and is\n"
@@ -871,9 +872,16 @@ static UniValue getbalance(const JSONRPCRequest& request)
             "                     the bumpfee command), temporarily resulting in low or even negative\n"
             "                     balances. In general, account balance calculation is not considered\n"
             "                     reliable and has resulted in confusing outcomes, so it is recommended to\n"
-            "                     avoid passing this argument.\n"
-            "2. minconf           (numeric, optional, default=1) DEPRECATED. Only valid when an account is specified. This argument will be removed in V0.18. To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. Only include transactions confirmed at least this many times.\n"
-            "3. include_watchonly (bool, optional, default=false) DEPRECATED. Only valid when an account is specified. This argument will be removed in V0.18. To use this deprecated argument, start bitcoind with -deprecatedrpc=accounts. Also include balance in watch-only addresses (see 'importaddress')\n"
+            "                     avoid passing this argument.\n")
+            : std::string(
+            "getbalance ( \"(dummy)\" minconf include_watchonly )\n"
+            "\nReturns the total available balance.\n"
+            "The available balance is what the wallet considers currently spendable, and is\n"
+            "thus affected by options which limit spendability such as -spendzeroconfchange.\n"
+            "\nArguments:\n"
+            "1. (dummy)           (string, optional) Ignored. Remains for backward compatibility.\n")) +
+            "2. minconf           (numeric, optional, default=1) Only include transactions confirmed at least this many times.\n"
+            "3. include_watchonly (bool, optional, default=false) Also include balance in watch-only addresses (see 'importaddress')\n"
             "\nResult:\n"
             "amount              (numeric) The total amount in " + CURRENCY_UNIT + " received for this account.\n"
             "\nExamples:\n"
@@ -891,38 +899,34 @@ static UniValue getbalance(const JSONRPCRequest& request)
 
     LOCK2(cs_main, pwallet->cs_wallet);
 
+    std::string* account = nullptr;
+    const UniValue& minconf = request.params[1];
+    const UniValue& include_watchonly = request.params[2];
+    int nMinDepth = 1;
+    if (!minconf.isNull())
+        nMinDepth = minconf.get_int();
+    isminefilter filter = ISMINE_SPENDABLE;
+    if(!include_watchonly.isNull())
+        if(include_watchonly.get_bool())
+            filter = filter | ISMINE_WATCH_ONLY;
+
     if (IsDeprecatedRPCEnabled("accounts")) {
         const UniValue& account_value = request.params[0];
-        const UniValue& minconf = request.params[1];
-        const UniValue& include_watchonly = request.params[2];
 
-        if (account_value.isNull()) {
-            if (!minconf.isNull()) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER,
-                    "getbalance minconf option is only currently supported if an account is specified");
-            }
-            if (!include_watchonly.isNull()) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER,
-                    "getbalance include_watchonly option is only currently supported if an account is specified");
-            }
-            return ValueFromAmount(pwallet->GetBalance());
+        if (!account_value.isNull()) {
+            const std::string& account_param = account_value.get_str();
+            account = account_param != "*" ? const_cast<std::string*>(&account_param) : nullptr;
         }
-
-        const std::string& account_param = account_value.get_str();
-        const std::string* account = account_param != "*" ? &account_param : nullptr;
-
-        int nMinDepth = 1;
-        if (!minconf.isNull())
-            nMinDepth = minconf.get_int();
-        isminefilter filter = ISMINE_SPENDABLE;
-        if(!include_watchonly.isNull())
-            if(include_watchonly.get_bool())
-                filter = filter | ISMINE_WATCH_ONLY;
 
         return ValueFromAmount(pwallet->GetLegacyBalance(filter, nMinDepth, account));
     }
 
-    return ValueFromAmount(pwallet->GetBalance());
+    if (!minconf.isNull() || !include_watchonly.isNull() || account) {
+        return ValueFromAmount(pwallet->GetLegacyBalance(filter, nMinDepth, account));
+    }
+    else {
+        return ValueFromAmount(pwallet->GetBalance());
+    }
 }
 
 static UniValue getunconfirmedbalance(const JSONRPCRequest &request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2186,7 +2186,7 @@ CAmount CWallet::GetImmatureBalance() const
     return nTotal;
 }
 
-CAmount CWallet::GetWatchOnlyBalance() const
+CAmount CWallet::GetWatchOnlyBalance(int min_depth, int max_depth) const
 {
     CAmount nTotal = 0;
     {
@@ -2194,8 +2194,13 @@ CAmount CWallet::GetWatchOnlyBalance() const
         for (const auto& entry : mapWallet)
         {
             const CWalletTx* pcoin = &entry.second;
-            if (pcoin->IsTrusted())
+            int depth = pcoin->GetDepthInMainChain();
+            if ( (min_depth == 0 && !pcoin->IsTrusted() && depth == 0 && pcoin->InMempool()) /* either 0 conf... */
+                ||
+                 (pcoin->IsTrusted() && (min_depth == 1 || depth >= min_depth) && (max_depth < 0 || depth <= max_depth)) /*... or within depth limits (if set) */
+               ) {
                 nTotal += pcoin->GetAvailableWatchOnlyCredit();
+            }
         }
     }
 
@@ -2204,17 +2209,7 @@ CAmount CWallet::GetWatchOnlyBalance() const
 
 CAmount CWallet::GetUnconfirmedWatchOnlyBalance() const
 {
-    CAmount nTotal = 0;
-    {
-        LOCK2(cs_main, cs_wallet);
-        for (const auto& entry : mapWallet)
-        {
-            const CWalletTx* pcoin = &entry.second;
-            if (!pcoin->IsTrusted() && pcoin->GetDepthInMainChain() == 0 && pcoin->InMempool())
-                nTotal += pcoin->GetAvailableWatchOnlyCredit();
-        }
-    }
-    return nTotal;
+    return GetWatchOnlyBalance(0, 0);
 }
 
 CAmount CWallet::GetImmatureWatchOnlyBalance() const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -946,7 +946,7 @@ public:
     CAmount GetBalance() const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
-    CAmount GetWatchOnlyBalance() const;
+    CAmount GetWatchOnlyBalance(int min_depth = 1, int max_depth = -1 /* unlimited */) const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;
     CAmount GetImmatureWatchOnlyBalance() const;
     CAmount GetLegacyBalance(const isminefilter& filter, int minDepth, const std::string* account) const;


### PR DESCRIPTION
It looks like that #9614 accidentally(?) dropped support for `min-conf` and `watch_only` in `getbalance()`.

This PR tries to correctly deprecate accounts in `getbalance()` following the dummy-argument approach. 