### PR TITLE
Avoid concurrency issue when make multiple target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -95,9 +95,9 @@ $(OSX_APP)/Contents/Resources/bitcoin.icns: $(OSX_INSTALLER_ICONS)
 	$(MKDIR_P) $(@D)
 	$(INSTALL_DATA) $< $@
 
-$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(BITCOIN_QT_BIN)
+$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: all-recursive
 	$(MKDIR_P) $(@D)
-	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM)  $< $@
+	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM)  $(BITCOIN_QT_BIN) $@
 
 $(OSX_APP)/Contents/Resources/Base.lproj/InfoPlist.strings:
 	$(MKDIR_P) $(@D)


### PR DESCRIPTION
From #13406, changed travis job target for Mac to `all deploy`, but this could cause a race condition.
Simply add `.NOTPARALLEL` to avoid it.
Related jobs:
https://travis-ci.org/bitcoin/bitcoin/jobs/391863281
https://travis-ci.org/bitcoin/bitcoin/jobs/391907335
Close #13469