### PR TITLE
WIP [bench] CCoinsView(Cache): measure various scenarios

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -116,7 +116,7 @@ void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double
         if (0 == num_iters) {
             num_iters = 1;
         }
-        State state(p.first, num_evals, num_iters, printer);
+        State state(p.first, num_evals, num_iters, scaling, printer);
         if (!is_list_only) {
             p.second.func(state);
         }


### PR DESCRIPTION
`src/bench/bench_bitcoin -printer=plot -filter=CCoinsView.* > plot.html`:

![unknown](https://user-images.githubusercontent.com/10217/41417011-78430530-6fec-11e8-80a8-0cfc93eee8e7.png)

Tested scenarios (plus ideas that could be added later):

- [x] access a cached coin
- [x] add 200.000 coins to cache (plot shows average time per coin) 
- [x] flush cache (plot shows average time per coin)
- [ ] load cache from disk
- [ ] access coins that are not cached
- [ ] access coins that are cached but dirty
- [ ] flush dirty coins

The flush test creates a temporary directory on disk.

I normalized the cache access benchmark to take about the same speed as the existing benches do on my machine.

I disabled scaling iterations for the cache addition and flush bench. It doesn't make sense to have more than 1 iteration per eval, because the speed per coin as part of a large flush is a more relevant metric then how often you can flush 1 coin. At the same time I didn't want the benches to use up too much  RAM if someone sets `-scaling` to high number.

To test a bigger cache increase `N_CACHE_SCALE=1`. The cache is about 40 MB by default, try `N_CACHE_SCALE=100` for more realistic scenarios, but note that test needs ~3x RAM.

I'm doing a few things the bench framework doesn't seem designed for. Would like some feedback before I refactor it in the wrong direction:

- [ ] share code with test framework (should support `--disable-test`?)
- [ ] clean up stuff between evals; e.g. I need to reset the coin cache for `CCoinsViewCacheAddCoinFresh` and `CCoinsViewCacheFlush`
- [ ] disable scaling iterations
- [ ] add a memory-scaling argument
- [ ] allow pausing the clock between iterations; e.g. to generate test coins on the fly rather in bulk before the run 