### PR TITLE
[devtools translations] catch invalid specifiers

### DIFF
--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -52,6 +52,10 @@ def find_format_specifiers(s):
         percent = s.find('%', pos)
         if percent < 0:
             break
+        try:
+            specifiers.append(s[percent+1])
+        except:
+            print('Failed to get specifier')
         specifiers.append(s[percent+1])
         pos = percent+2
     return specifiers


### PR DESCRIPTION
While being careful in the source code, during translation a "%" can easily sneak init the wrong position, especially when dealing with percentages (how comes?). 
Instead of giving up, catching that can make life easier.