### PR TITLE
Fix incorrect shell quoting in FreeBSD build instructions.

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -17,7 +17,7 @@ pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgc
 For the wallet (optional):
 ```
 ./contrib/install_db4.sh `pwd`
-export BDB_PREFIX='$PWD/db4'
+export BDB_PREFIX="$PWD/db4"
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.


### PR DESCRIPTION
The current instructions suggest:

    BDB_PREFIX='$PWD/db4'

which results in BDB_PREFIX being set, literally, to '$PWD/db4'.
