### PR TITLE
build: Move rpc/util.cpp from libbitcoin-util to libbitcoin-server

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -235,6 +235,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/net.cpp \
   rpc/rawtransaction.cpp \
   rpc/server.cpp \
+  rpc/util.cpp \
   script/sigcache.cpp \
   timedata.cpp \
   torcontrol.cpp \
@@ -392,7 +393,6 @@ libbitcoin_util_a_SOURCES = \
   logging.cpp \
   random.cpp \
   rpc/protocol.cpp \
-  rpc/util.cpp \
   support/cleanse.cpp \
   sync.cpp \
   threadinterrupt.cpp \


### PR DESCRIPTION
The functions in `rpc/util.cpp` would call functions in `script/standard.cpp` which in libbitcoin-common. This could cause problem if the linker does not strip out unused function while linking `bitcoin-cli`.