### PR TITLE
Fix reply not sent when event loop terminates prematurely

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -283,8 +283,8 @@ static bool ThreadHTTP(struct event_base* base, struct evhttp* http)
 {
     RenameThread("bitcoin-http");
     LogPrint(BCLog::HTTP, "Entering http event loop\n");
-    event_base_dispatch(base);
-    // Event loop will be interrupted by InterruptHTTPServer()
+    event_base_loop(base, EVLOOP_NO_EXIT_ON_EMPTY);
+    // Event loop will be interrupted by StopHTTPServer()
     LogPrint(BCLog::HTTP, "Exited http event loop\n");
     return event_base_got_break(base) == 0;
 }


### PR DESCRIPTION
Fixes #11777. Closes #13485.

When calling RPC `stop`, there is a race when the event loop terminates before `HTTPRequest::WriteReply` and so the reply event fails to process. This happens because `event_base_dispatch` returns when there are no active or pending events, which is the case between `InterruptHTTPServer` and `HTTPRequest::WriteReply`.