### PR TITLE
gui: Add leading 0 to QT_VERSION check for QFontDatabase

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -49,6 +49,7 @@
 #include <QDoubleValidator>
 #include <QFileDialog>
 #include <QFont>
+#include <QFontDatabase>
 #include <QLineEdit>
 #include <QSettings>
 #include <QTextDocument> // for Qt::mightBeRichText
@@ -59,10 +60,6 @@
 #include <QUrl>
 #else
 #include <QUrlQuery>
-#endif
-
-#if QT_VERSION >= 0x50200
-#include <QFontDatabase>
 #endif
 
 static fs::detail::utf8_codecvt_facet utf8;
@@ -91,7 +88,7 @@ QString dateTimeStr(qint64 nTime)
 
 QFont fixedPitchFont()
 {
-#if QT_VERSION >= 0x50200
+#if QT_VERSION >= 0x050200
     return QFontDatabase::systemFont(QFontDatabase::FixedFont);
 #else
     QFont font("Monospace");


### PR DESCRIPTION
Also removes the QT_VERSION check around the QFontDatabase #include. 
QFontDatabase has existed since at least Qt 4.2.

This can go in after #13458.