### PR TITLE
~~Correctly~~ terminate HTTP server

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -480,6 +480,9 @@ void StopHTTPServer()
     }
     {
         LogPrint(BCLog::HTTP, "Disabling reading on current connections\n");
+        // Workers completed their job but there can be events to process
+        // related to their response in the event loop. For now just disable
+        // reading on each connection, keep writes enabled.
         LOCK(g_http_connections_mutex);
         for (evhttp_connection* conn : g_http_connections) {
             bufferevent* bev = evhttp_connection_get_bufferevent(conn);

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -486,7 +486,7 @@ void StopHTTPServer()
         LOCK(g_http_connections_mutex);
         for (evhttp_connection* conn : g_http_connections) {
             bufferevent* bev = evhttp_connection_get_bufferevent(conn);
-            if (bev) bufferevent_disable(bev, EV_READ);
+            bufferevent_disable(bev, EV_READ);
         }
         g_http_connections.clear();
     }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -226,6 +226,9 @@ static void http_request_cb(struct evhttp_request* req, void* /* arg */)
     {
         LOCK(g_http_connections_mutex);
         evhttp_connection* conn = evhttp_request_get_connection(req);
+        // One connection can be used for multiple requests (HTTP 1.1 or
+        // Connection: Keep-Alive header) so set the close callback on the first
+        // request only.
         if (g_http_connections.insert(conn).second) {
             evhttp_connection_set_closecb(conn, http_connection_close_cb, nullptr);
         }


### PR DESCRIPTION
Fixes #11777. Replaces #13492.

This PR tracks current HTTP connections in order to disable reading on shutdown while allowing all remaining events to process. This allows the event loop to exit gracefully.

This happens in the test framework because the RPC client never closes the connection to the node — the same connection is used for all RPC to that node — even when `stop` is called.