### PR TITLE
Qt: load wallet in UI after possible init aborts

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4095,8 +4095,6 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         }
     }
 
-    uiInterface.LoadWallet(walletInstance);
-
     int prev_version = walletInstance->nWalletVersion;
     if (gArgs.GetBoolArg("-upgradewallet", fFirstRun))
     {
@@ -4345,6 +4343,8 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
             }
         }
     }
+
+    uiInterface.LoadWallet(walletInstance);
 
     // Register with the validation interface. It's ok to do this after rescan since we're still holding cs_main.
     RegisterValidationInterface(walletInstance.get());


### PR DESCRIPTION
Bug was introduced in #13063 (80b4910f7d87983f50047074c3c2397b0a5c4e92) where #13097 made possible to get "hit" by that bug. Reported by @ken2812221 (https://github.com/bitcoin/bitcoin/pull/13097#issuecomment-398445833).

Dynamically loading a wallet informs the UI (and therefore makes the instance accessible) about the new wallet before all possible error cases where handled.

Easy to reproduce by starting `bitcoin-qt --regtest --nowallet -usehd=0` then in the console enter `loadwallet wallet.dat`.

This PR will make sure only correctly initialised (loaded) wallets will appear in the UI.