### PR TITLE
[wip] depends: native_protobuf 3.6.1

### DIFF
--- a/depends/packages/native_protobuf.mk
+++ b/depends/packages/native_protobuf.mk
@@ -1,8 +1,8 @@
 package=native_protobuf
-$(package)_version=2.6.1
+$(package)_version=3.6.1
 $(package)_download_path=https://github.com/google/protobuf/releases/download/v$($(package)_version)
-$(package)_file_name=protobuf-$($(package)_version).tar.bz2
-$(package)_sha256_hash=ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
+$(package)_file_name=protobuf-cpp-$($(package)_version).tar.gz
+$(package)_sha256_hash=b3732e471a9bb7950f090fd0457ebd2536a9ba0891b7f3785919c654fe2a2529
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -20,7 +20,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | MiniUPnPc | [2.0.20180203](http://miniupnp.free.fr/files) |  | No |  |  |
 | OpenSSL | [1.0.1k](https://www.openssl.org/source) |  | Yes |  |  |
 | PCRE |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L66) |
-| protobuf | [2.6.1](https://github.com/google/protobuf/releases) |  | No |  |  |
+| protobuf | [3.6.1](https://github.com/google/protobuf/releases) |  | No |  |  |
 | Python (tests) |  | [3.4](https://www.python.org/downloads) |  |  |  |
 | qrencode | [3.4.4](https://fukuchi.org/works/qrencode) |  | No |  |  |
 | Qt | [5.9.6](https://download.qt.io/official_releases/qt/) | 5.x | No |  |  |


### PR DESCRIPTION
From [3.6.0](https://github.com/google/protobuf/releases/tag/v3.6.0) onwards, Protobuf requires C++11. See discussion in https://github.com/google/protobuf/issues/2780. 
This updates depends to that release, and swaps to the cpp specific download.

TODO:
- [ ] Do we still need to explicitly pass `-std=c++11` to cxxflags in our [protobuf package](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/protobuf.mk#L7)?
- [ ] Needs more testing/depends builds done on platforms other than macOS.

Protobuf 3.6.1 (C++) release notes:
  * Introduced workaround for Windows issue with std::atomic and std::once_flag
    initialization.

Protobuf 3.6.0 (C++) release notes:
* Starting from this release, we now require C++11. For those we cannot yet upgrade to C++11, we will try to keep the 3.5.x branch updated with critical bug fixes only. If you have any concerns about this, please comment on issue #2780.
* Moved to C++11 types like std::atomic and std::unique_ptr and away from our old custom-built equivalents.
* Added support for repeated message fields in lite protos using implicit weak fields. This is an experimental feature that allows the linker to strip out more unused messages than previously was possible.
* Fixed SourceCodeInfo for interpreted options and extension range options.
* Fixed always_print_enums_as_ints option for JSON serialization.
* Added support for ignoring unknown enum values when parsing JSON.
* Create std::string in Arena memory.
* Fixed ValidateDateTime to correctly check the day.
* Fixed bug in ZeroCopyStreamByteSink.
* Various other cleanups and fixes.
