### PR TITLE
depends: set LANG=C in Makefile

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,5 +1,7 @@
 .NOTPARALLEL :
 
+LANG=C
+
 SOURCES_PATH ?= $(BASEDIR)/sources
 WORK_PATH = $(BASEDIR)/work
 BASE_CACHE ?= $(BASEDIR)/built

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -59,7 +59,8 @@ endef
 
 define $(package)_preprocess_cmds
   sed -i.old "/define DATE/d" util/mkbuildinf.pl && \
-  sed -i.old "s|engines apps test|engines|" Makefile.org
+  sed -i.old "s|engines apps test|engines|" Makefile.org && \
+  sed -i.old "s/-isysroot.*(CROSS_SDK)//" Configure
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
While testing some of @theuni's work for iOS cross builds in depends, I found a locale related issue that appears when preprocessing OpenSSL's `Configure`. This is on macOS 10.13.5.

7ac0c67 (a subset of the iOS related build changes) is included to show the issue. 
When doing a depends build with master (6579d80) + that commit I see:
```
cd depends
make -j5
<snip>
Extracting openssl...
bitcoin/depends/sources/openssl-1.0.1k.tar.gz: OK
Preprocessing openssl...
sed: RE error: illegal byte sequence
make: *** [bitcoin/depends/work/build/x86_64-apple-darwin17.6.0/openssl/1.0.1k-b6eae8817ad/.stamp_preprocessed] Error 1
```

It seems like the issue could be related to embedded double quotes.

I did try setting other [locale related variables](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables):
`LANGUAGE=C`
`LC_ALL=C`
`LC_CTYPE=C`
etc, however `LANG=C` was the only one that actually seemed to work.

This is the output of `locale` on my machine:
```
$ locale
LANG="en_AU.UTF-8"
LC_COLLATE="en_AU.UTF-8"
LC_CTYPE="en_AU.UTF-8"
LC_MESSAGES="en_AU.UTF-8"
LC_MONETARY="en_AU.UTF-8"
LC_NUMERIC="en_AU.UTF-8"
LC_TIME="en_AU.UTF-8"
LC_ALL=
```

Todo:
- [ ] Confirm this isn't a local issue.
- [ ] Should we also set other locale related vars?
- [ ] Followup other uses of `sed` in `/depends/packages`.