### PR TITLE
bench: Add missing pow.h header

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -9,6 +9,7 @@
 #include <consensus/validation.h>
 #include <miner.h>
 #include <policy/policy.h>
+#include <pow.h>
 #include <scheduler.h>
 #include <txdb.h>
 #include <txmempool.h>


### PR DESCRIPTION
Fix a build error introduced in #13219.

```
.../bitcoin/src/bench/block_assemble.cpp:42:13:error: use of undeclared identifier 'CheckProofOfWork'
    while (!CheckProofOfWork(block->GetHash(), block->nBits, Params().GetConsensus())) {
```