### PR TITLE
doc: Clarify that mempool txiter is const_iterator

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -486,7 +486,7 @@ public:
     mutable CCriticalSection cs;
     indexed_transaction_set mapTx GUARDED_BY(cs);
 
-    typedef indexed_transaction_set::nth_index<0>::type::iterator txiter;
+    using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
     std::vector<std::pair<uint256, txiter> > vTxHashes; //!< All tx witness hashes/entries in mapTx, in random order
 
     struct CompareIteratorByHash {


### PR DESCRIPTION
`iterator` and `const_iterator` are the same type for multi indexed transaction sets, but `const_iterator` should be preferred for documentation purposes.