### PR TITLE
[qa] wallet_basic: Specify minimum required amount for listunspent

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -239,8 +239,8 @@ class WalletTest(BitcoinTestFramework):
         # 2. hex-changed one output to 0.0
         # 3. sign and send
         # 4. check if recipient (node0) can list the zero value tx
-        usp = self.nodes[1].listunspent()
-        inputs = [{"txid": usp[0]['txid'], "vout": usp[0]['vout']}]
+        usp = self.nodes[1].listunspent(query_options={'minimumAmount': '49.998'})[0]
+        inputs = [{"txid": usp['txid'], "vout": usp['vout']}]
         outputs = {self.nodes[1].getnewaddress(): 49.998, self.nodes[0].getnewaddress(): 11.11}
 
         raw_tx = self.nodes[1].createrawtransaction(inputs, outputs).replace("c0833842", "00000000")  # replace 11.11 with 0.0 (int32)


### PR DESCRIPTION
A value less than that would fail the tests later on anyway:

```
File "./test/functional/wallet_basic.py", line 250, in run_test
    self.nodes[1].sendrawtransaction(signed_raw_tx['hex'])

test_framework.authproxy.JSONRPCException: bad-txns-in-belowout, value in (1.00) < value out (49.998) (code 16) (-26)
