### PR TITLE
depends: Update Qt download url

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.7.1
-$(package)_download_path=http://download.qt.io/official_releases/qt/5.7/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/archive/qt/5.7/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410


### PR DESCRIPTION
Qt has moved the 5.7.1 downloads from the [official_releases](https://download.qt.io/official_releases/qt/) directory to it's [archive](https://download.qt.io/archive/qt/).

```
Fetching qtbase-opensource-src-5.7.1.tar.gz from http://download.qt.io/official_releases/qt/5.7/5.7.1/submodules
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
curl: (22) The requested URL returned error: 404 Not Found
```

This updates the qt download url in depends so we aren't always falling back on [bitcoincore.org/depends-sources](https://bitcoincore.org/depends-sources).