### PR TITLE
wallet: Fix use of uninitialized value bnb_used in CWallet::CreateTransaction(...)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2844,6 +2844,8 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                             return false;
                         }
                     }
+                } else {
+                    bnb_used = false;
                 }
 
                 const CAmount nChange = nValueIn - nValueToSelect;


### PR DESCRIPTION
Avoid use of uninitialized value `bnb_used` in `CWallet::CreateTransaction(...)`.