### PR TITLE
Document assumptions made in PeerLogicValidation::SendMessages(...) and rescanblockchain(...)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3414,6 +3414,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto, std::atomic<bool>& interruptM
                     bool fGotBlockFromCache = false;
                     {
                         LOCK(cs_most_recent_block);
+                        assert(pBestIndex);
                         if (most_recent_block_hash == pBestIndex->GetBlockHash()) {
                             if (state.fWantsCmpctWitness || !fWitnessesPresentInMostRecentCompactBlock)
                                 connman->PushMessage(pto, msgMaker.Make(nSendFlags, NetMsgType::CMPCTBLOCK, *most_recent_compact_block));

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3972,6 +3972,8 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
     else {
         throw JSONRPCError(RPC_MISC_ERROR, "Rescan failed. Potentially corrupted data files.");
     }
+    assert(stopBlock);
+
     UniValue response(UniValue::VOBJ);
     response.pushKV("start_height", pindexStart->nHeight);
     response.pushKV("stop_height", stopBlock->nHeight);


### PR DESCRIPTION
Document assumptions made in `PeerLogicValidation::SendMessages(...)` and `rescanblockchain(...)` via assertions.

The fact that `pBestIndex != nullptr` and `stopBlock != nullptr` in these contexts is not immediately obvious. Explicit is better than implicit.