### PR TITLE
Qt: Remove unnecessary image buffer for Mac dock icon

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -429,6 +429,9 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
   m4_ifdef([PKG_CHECK_MODULES],[
     QT_LIB_PREFIX=Qt5
     qt5_modules="Qt5Core Qt5Gui Qt5Network Qt5Widgets"
+    if test "x$TARGET_OS" = xdarwin; then
+      qt5_modules="$qt5_modules Qt5MacExtras"
+    fi
     BITCOIN_QT_CHECK([
       PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" have_qt=yes],[have_qt=no])
 

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -429,9 +429,6 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
   m4_ifdef([PKG_CHECK_MODULES],[
     QT_LIB_PREFIX=Qt5
     qt5_modules="Qt5Core Qt5Gui Qt5Network Qt5Widgets"
-    if test "x$TARGET_OS" = xdarwin; then
-      qt5_modules="$qt5_modules Qt5MacExtras"
-    fi
     BITCOIN_QT_CHECK([
       PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" have_qt=yes],[have_qt=no])
 

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -8,6 +8,7 @@
 #include <QMenu>
 #include <QBuffer>
 #include <QWidget>
+#include <QtMac>
 
 #undef slots
 #include <Cocoa/Cocoa.h>
@@ -80,18 +81,7 @@ void MacDockIconHandler::setIcon(const QIcon &icon)
     else {
         // generate NSImage from QIcon and use this as dock icon.
         QSize size = icon.actualSize(QSize(128, 128));
-        QPixmap pixmap = icon.pixmap(size);
-
-        // Write image into a R/W buffer from raw pixmap, then save the image.
-        QBuffer notificationBuffer;
-        if (!pixmap.isNull() && notificationBuffer.open(QIODevice::ReadWrite)) {
-            QImageWriter writer(&notificationBuffer, "PNG");
-            if (writer.write(pixmap.toImage())) {
-                NSData* macImgData = [NSData dataWithBytes:notificationBuffer.buffer().data()
-                                             length:notificationBuffer.buffer().size()];
-                image =  [[NSImage alloc] initWithData:macImgData];
-            }
-        }
+        image = QtMac::toNSImage(icon.pixmap(size));
 
         if(!image) {
             // if testnet image could not be created, load std. app icon

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -8,7 +8,6 @@
 #include <QMenu>
 #include <QBuffer>
 #include <QWidget>
-#include <QtMac>
 
 #undef slots
 #include <Cocoa/Cocoa.h>
@@ -51,9 +50,7 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
     this->setMainWindow(nullptr);
-#if QT_VERSION >= 0x050200
     this->m_dockMenu->setAsDockMenu();
-#endif
     [pool release];
 }
 
@@ -81,7 +78,12 @@ void MacDockIconHandler::setIcon(const QIcon &icon)
     else {
         // generate NSImage from QIcon and use this as dock icon.
         QSize size = icon.actualSize(QSize(128, 128));
-        image = QtMac::toNSImage(icon.pixmap(size));
+        CGImageRef cgimage = toCGImageRef(icon.pixmap(size));
+        NSBitmapImageRep *bitmapRep = [[NSBitmapImageRep alloc] initWithCGImage:cgimage];
+        image = [[NSImage alloc] init];
+        [image addRepresentation:bitmapRep];
+        [bitmapRep release];
+        CFRelease(cgimage);
 
         if(!image) {
             // if testnet image could not be created, load std. app icon


### PR DESCRIPTION
The code curently writes the Mac dock icon to a buffer and then sets the final image data from the buffer. This was presumably done to satisfy Qt 4. Now that Qt 5 is mandatory, remove the buffer and write the data directly to the image.

Note that this patch will force the bitcoin-qt binary to have a minimum of Qt 5.2 on Macs due to usage of QtMacExtras (https://wiki.qt.io/New_Features_in_Qt_5.2). While this needs to be discussed before accepting the patch, Qt 5.2 is almost five years old. It's arguable that a Mac with Qt 5 but staying below 5.2 is an improbable corner case.