### PR TITLE
test: Fix AreInputsStandard test to reference the proper scriptPubKey

### DIFF
--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     // vout[5/6] are non-standard because they exceed MAX_P2SH_SIGOPS
     CScript sixteenSigops; sixteenSigops << OP_16 << OP_CHECKMULTISIG;
     keystore.AddCScript(sixteenSigops);
-    txFrom.vout[5].scriptPubKey = GetScriptForDestination(CScriptID(fifteenSigops));
+    txFrom.vout[5].scriptPubKey = GetScriptForDestination(CScriptID(sixteenSigops));
     txFrom.vout[5].nValue = 5000;
     CScript twentySigops; twentySigops << OP_CHECKMULTISIG;
     keystore.AddCScript(twentySigops);


### PR DESCRIPTION
This value doesn't affect the outcome of the test, because the values are
properly set on line 351 (https://github.com/bitcoin/bitcoin/pull/13565/files#diff-b7061098b41bd31ef5db043705441133R351), but this makes the test values internally coherent.