### PR TITLE
[0.15] backport depends: Update Qt download url

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -1,6 +1,6 @@
 PACKAGE=qt
 $(package)_version=5.7.1
-$(package)_download_path=http://download.qt.io/official_releases/qt/5.7/$($(package)_version)/submodules
+$(package)_download_path=https://download.qt.io/archive/qt/5.7/$($(package)_version)/submodules
 $(package)_suffix=opensource-src-$($(package)_version).tar.gz
 $(package)_file_name=qtbase-$($(package)_suffix)
 $(package)_sha256_hash=95f83e532d23b3ddbde7973f380ecae1bac13230340557276f75f2e37984e410


### PR DESCRIPTION
GitHub-Pull: #13544
Rebased-From: 2fca656