### PR TITLE
logging: avoid nStart may be used uninitialized in AppInitMain warning

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1305,8 +1305,6 @@ bool AppInitMain()
             return InitError(_("Unable to start HTTP server. See debug log for details."));
     }
 
-    int64_t nStart;
-
     // ********************************************************* Step 5: verify wallet database integrity
     if (!g_wallet_init_interface.Verify()) return false;
 
@@ -1458,8 +1456,8 @@ bool AppInitMain()
 
         LOCK(cs_main);
 
-        nStart = GetTimeMillis();
         do {
+            const int64_t load_block_index_start_time = GetTimeMillis();
             try {
                 UnloadBlockIndex();
                 pcoinsTip.reset();
@@ -1582,6 +1580,7 @@ bool AppInitMain()
             }
 
             fLoaded = true;
+            LogPrintf(" block index %15dms\n", GetTimeMillis() - load_block_index_start_time);
         } while(false);
 
         if (!fLoaded && !fRequestShutdown) {
@@ -1611,9 +1610,6 @@ bool AppInitMain()
     {
         LogPrintf("Shutdown requested. Exiting.\n");
         return false;
-    }
-    if (fLoaded) {
-        LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
     }
 
     fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;


### PR DESCRIPTION
Was getting the following compiler warning:

```
init.cpp: In function ‘bool AppInitMain()’:
init.cpp:1616:60: warning: ‘nStart’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         LogPrintf(" block index %15dms\n", GetTimeMillis() - nStart);
```

It's ok without this PR, but this PR renames `nStart` to `load_block_index_start_time`, makes it `const`, and also reduces the scope of the variable.

The logging line is moved such that the the time spent will be logged even if a shutdown is requested while the index is being loaded.

Having the log message output even when a shutdown is requested may be how this was intended to work before anyways. That could explain the leading space, as such a log message now looks like:
```
2018-06-30T11:34:05Z [0%]...[16%]...[33%]...[50%]... block index           25750ms
2018-06-30T11:34:17Z Shutdown requested. Exiting.
```