### PR TITLE
[depends, zmq, doc] upgrade zeromq to 4.2.5 and avoid deprecated zeromq api functions

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.2.3
+$(package)_version=4.2.5
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0
+$(package)_sha256_hash=cc9090ba35713d59bb2f7d7965f877036c49c5558ea0c290b0dcc6f2a17e489f
 $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars

--- a/depends/patches/zeromq/0001-fix-build-with-older-mingw64.patch
+++ b/depends/patches/zeromq/0001-fix-build-with-older-mingw64.patch
@@ -1,6 +1,6 @@
-From 1a159c128c69a42d90819375c06a39994f3fbfc1 Mon Sep 17 00:00:00 2001
-From: Cory Fields <cory-nospam-@coryfields.com>
-Date: Tue, 28 Nov 2017 20:33:25 -0500
+From f6866b0f166ad168618aae64c7fbee8775d3eb23 Mon Sep 17 00:00:00 2001
+From: mruddy <6440430+mruddy@users.noreply.github.com>
+Date: Sat, 30 Jun 2018 09:44:58 -0400
 Subject: [PATCH] fix build with older mingw64
 
 ---
@@ -8,10 +8,10 @@ Subject: [PATCH] fix build with older mingw64
  1 file changed, 7 insertions(+)
 
 diff --git a/src/windows.hpp b/src/windows.hpp
-index 99e889d..e69038e 100644
+index 6c3839fd..2c32ec79 100644
 --- a/src/windows.hpp
 +++ b/src/windows.hpp
-@@ -55,6 +55,13 @@
+@@ -58,6 +58,13 @@
  #include <winsock2.h>
  #include <windows.h>
  #include <mswsock.h>
@@ -23,8 +23,8 @@ index 99e889d..e69038e 100644
 +#include <ws2ipdef.h>
 +#endif
  #include <iphlpapi.h>
-
+ 
  #if !defined __MINGW32__
---
-2.7.4
+-- 
+2.17.1
 

--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,6 +1,6 @@
-From 6e6b47d5ab381c3df3b30bb0b0a6cf210dfb1eba Mon Sep 17 00:00:00 2001
-From: Cory Fields <cory-nospam-@coryfields.com>
-Date: Mon, 5 Mar 2018 14:22:05 -0500
+From c9bbdd6581d07acfe8971e4bcebe278a3676cf03 Mon Sep 17 00:00:00 2001
+From: mruddy <6440430+mruddy@users.noreply.github.com>
+Date: Sat, 30 Jun 2018 09:57:18 -0400
 Subject: [PATCH] disable pthread_set_name_np
 
 pthread_set_name_np adds a Glibc requirement on >= 2.12.
@@ -9,21 +9,21 @@ pthread_set_name_np adds a Glibc requirement on >= 2.12.
  1 file changed, 3 insertions(+), 1 deletion(-)
 
 diff --git a/src/thread.cpp b/src/thread.cpp
-index 4fc59c3e..c3fdfd46 100644
+index a1086b0c..9943f354 100644
 --- a/src/thread.cpp
 +++ b/src/thread.cpp
-@@ -220,7 +220,7 @@ void zmq::thread_t::setThreadName(const char *name_)
+@@ -307,7 +307,7 @@ void zmq::thread_t::setThreadName (const char *name_)
   */
      if (!name_)
          return;
 -
 +#if 0
  #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
-     int rc = pthread_setname_np(name_);
-     if(rc) return;
-@@ -233,6 +233,8 @@ void zmq::thread_t::setThreadName(const char *name_)
+     int rc = pthread_setname_np (name_);
+     if (rc)
+@@ -323,6 +323,8 @@ void zmq::thread_t::setThreadName (const char *name_)
  #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
-     pthread_set_name_np(descriptor, name_);
+     pthread_set_name_np (descriptor, name_);
  #endif
 +#endif
 +    return;
@@ -31,5 +31,5 @@ index 4fc59c3e..c3fdfd46 100644
  
  #endif
 -- 
-2.11.1
+2.17.1
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -47,7 +47,7 @@ Optional dependencies:
  protobuf    | Payments in GUI  | Data interchange format used for payment protocol (only needed when GUI enabled)
  libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
  univalue    | Utility          | JSON parsing and encoding (bundled version will be used unless --with-system-univalue passed to configure)
- libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.x)
+ libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.0.0)
 
 For the versions used, see [dependencies.md](dependencies.md)
 
@@ -93,7 +93,7 @@ Optional (see --with-miniupnpc and --enable-upnp-default):
 
     sudo apt-get install libminiupnpc-dev
 
-ZMQ dependencies (provides ZMQ API 4.x):
+ZMQ dependencies (provides ZMQ API):
 
     sudo apt-get install libzmq3-dev
 

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -26,5 +26,5 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | Qt | [5.9.6](https://download.qt.io/official_releases/qt/) | 5.x | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L87) (Linux only) |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L86) (Linux only) |
-| ZeroMQ | [4.2.3](https://github.com/zeromq/libzmq/releases) |  | No |  |  |
+| ZeroMQ | [4.2.5](https://github.com/zeromq/libzmq/releases) | 4.0.0 | No |  |  |
 | zlib | [1.2.11](https://zlib.net/) |  |  |  | No |

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -33,8 +33,10 @@ buffering or reassembly.
 
 ## Prerequisites
 
-The ZeroMQ feature in Bitcoin Core requires ZeroMQ API version 4.x or
-newer. Typically, it is packaged by distributions as something like
+The ZeroMQ feature in Bitcoin Core requires the ZeroMQ API >= 4.0.0
+[libzmq](https://github.com/zeromq/libzmq/releases).
+For version information, see [dependencies.md](dependencies.md).
+Typically, it is packaged by distributions as something like
 *libzmq3-dev*. The C++ wrapper for ZeroMQ is *not* needed.
 
 In order to run the example Python client scripts in contrib/ one must

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -81,10 +81,14 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
 // Called at startup to conditionally set up ZMQ socket(s)
 bool CZMQNotificationInterface::Initialize()
 {
+    int major = 0, minor = 0, patch = 0;
+    zmq_version(&major, &minor, &patch);
+    LogPrint(BCLog::ZMQ, "zmq: version %d.%d.%d\n", major, minor, patch);
+
     LogPrint(BCLog::ZMQ, "zmq: Initialize notification interface\n");
     assert(!pcontext);
 
-    pcontext = zmq_init(1);
+    pcontext = zmq_ctx_new();
 
     if (!pcontext)
     {
@@ -127,7 +131,7 @@ void CZMQNotificationInterface::Shutdown()
             LogPrint(BCLog::ZMQ, "   Shutdown notifier %s at %s\n", notifier->GetType(), notifier->GetAddress());
             notifier->Shutdown();
         }
-        zmq_ctx_destroy(pcontext);
+        zmq_ctx_term(pcontext);
 
         pcontext = nullptr;
     }


### PR DESCRIPTION
Upgrade the ZeroMQ dependency from version 4.2.3 to the latest stable version 4.2.5.

This PR Follows the lead of https://github.com/bitcoin/bitcoin/pull/11986.

I upgraded both patch files to correspond to the version `4.2.5` libzmq files.
I assume doing so is still necessary and correct.

Without updating the patch line numbers, things appear to work, but you get extra log messages while building `depends` because things don't exactly match, e.g.:
```
/bitcoin/depends> make zeromq
Extracting zeromq...
/bitcoin/depends/sources/zeromq-4.2.5.tar.gz: OK
Preprocessing zeromq...
patching file src/windows.hpp
Hunk #1 succeeded at 58 (offset 3 lines).
patching file src/thread.cpp
Hunk #1 succeeded at 307 with fuzz 2 (offset 87 lines).
Hunk #2 succeeded at 323 with fuzz 2 (offset 90 lines).
```
Updating the patches seemed cleaner, so I did it. Note that libzmq had some whitespace changes, so that's why the updated patches do too.

More info: https://github.com/zeromq/libzmq/releases/tag/v4.2.5

tags: libzmq, zmq, 0mq