### PR TITLE
Audit stdlib inclusion

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -11,6 +11,7 @@
 #include <utilstrencodings.h>
 #include <validation.h>
 
+#include <cstdlib> // EXIT_FAILURE, EXIT_SUCCESS
 #include <memory>
 
 static const int64_t DEFAULT_BENCH_EVALUATIONS = 5;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -24,6 +24,8 @@
 
 #include <univalue.h>
 
+#include <cstdlib> // EXIT_FAILURE, EXIT_SUCCESS, free, abs
+
 static const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 static const bool DEFAULT_NAMED=false;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -22,6 +22,7 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+#include <cstdlib> // EXIT_FAILURE, EXIT_SUCCESS, atoi
 #include <memory>
 #include <stdio.h>
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/thread.hpp>
 
+#include <cstdlib> // EXIT_FAILURE, EXIT_SUCCESS
 #include <stdio.h>
 
 /* Introduction text for doxygen: */

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -11,8 +11,8 @@
 #include <random.h>
 #include <streams.h>
 
+#include <cstddef> // size_t
 #include <math.h>
-#include <stdlib.h>
 
 
 #define LN2SQUARED 0.4804530139182014246671025263266649717305529515945455

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-#include <stdlib.h>
+#include <cstddef> // size_t
 #include <stdint.h>
 
 /** The maximum allowed size for a serialized block, in bytes (only for buffer size limits) */

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_CHACHA20_H
 #define BITCOIN_CRYPTO_CHACHA20_H
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A PRNG class for ChaCha20. */
 class ChaCha20

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -7,8 +7,8 @@
 
 #include <crypto/sha256.h>
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -7,8 +7,8 @@
 
 #include <crypto/sha512.h>
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for HMAC-SHA-512. */
 class CHMAC_SHA512

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_RIPEMD160_H
 #define BITCOIN_CRYPTO_RIPEMD160_H
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA1_H
 #define BITCOIN_CRYPTO_SHA1_H
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for SHA1. */
 class CSHA1

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA256_H
 #define BITCOIN_CRYPTO_SHA256_H
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 #include <string>
 
 /** A hasher class for SHA-256. */

--- a/src/crypto/sha256_sse4.cpp
+++ b/src/crypto/sha256_sse4.cpp
@@ -5,8 +5,8 @@
 // This is a translation to GCC extended asm syntax from YASM code by Intel
 // (available at the bottom of this file).
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 #if defined(__x86_64__) || defined(__amd64__)
 

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_CRYPTO_SHA512_H
 #define BITCOIN_CRYPTO_SHA512_H
 
+#include <cstddef> // size_t
 #include <stdint.h>
-#include <stdlib.h>
 
 /** A hasher class for SHA-512. */
 class CSHA512

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -13,9 +13,9 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <cstdlib> // free, size_t
 #include <memory>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
 #include <sys/types.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -64,6 +64,8 @@
 #include <zmq/zmqnotificationinterface.h>
 #endif
 
+#include <cstdlib> // abort, atoi, size_t
+
 bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -7,8 +7,7 @@
 
 #include <indirectmap.h>
 
-#include <stdlib.h>
-
+#include <cstddef> // size_t
 #include <map>
 #include <memory>
 #include <set>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -6,7 +6,7 @@
 #define BITCOIN_PREVECTOR_H
 
 #include <assert.h>
-#include <stdlib.h>
+#include <cstdlib> // malloc, realloc, free, size_t
 #include <stdint.h>
 #include <string.h>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -37,6 +37,7 @@
 
 #include <walletinitinterface.h>
 
+#include <cstdlib> // EXIT_FAILURE, EXIT_SUCCESS, exit
 #include <memory>
 #include <stdint.h>
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -20,6 +20,8 @@
 #include <script/standard.h>
 #include <util.h>
 
+#include <cstdlib> // getenv
+
 #ifdef WIN32
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -16,7 +16,6 @@
 #include <util.h>
 #include <wallet/wallet.h>
 
-#include <cstdlib>
 #include <memory>
 
 #include <openssl/x509_vfy.h>

--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -11,6 +11,8 @@
 #include <QImage>
 #include <QPalette>
 
+#include <cstdlib> // abs
+
 static const struct {
     const char *platformId;
     /** Show images on push buttons */

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -40,6 +40,8 @@
 #include <QTimer>
 #include <QStringList>
 
+#include <cstdlib> // atoi, size_t
+
 // TODO: add a scrollback limit, as there is currently none
 // TODO: make it possible to filter out categories (esp debug messages when implemented)
 // TODO: receive errors and debug messages through ClientModel

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -7,7 +7,7 @@
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionrecord.h>
 
-#include <cstdlib>
+#include <cstdlib> // llabs
 
 // Earliest date that can be represented (far in the past)
 const QDateTime TransactionFilterProxy::MIN_DATE = QDateTime::fromTime_t(0);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -14,7 +14,7 @@
 #include <logging.h>  // for LogPrint()
 #include <utiltime.h> // for GetTime()
 
-#include <stdlib.h>
+#include <cstdlib> // abort, size_t
 #include <chrono>
 #include <thread>
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -23,6 +23,8 @@
 
 #include <univalue.h>
 
+#include <cstdlib> // strtol, size_t
+
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 
 enum class RetFormat {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -26,6 +26,7 @@
 #endif
 #include <warnings.h>
 
+#include <cstdlib> // free, size_t
 #include <stdint.h>
 #ifdef HAVE_MALLOC_INFO
 #include <malloc.h>

--- a/src/support/cleanse.h
+++ b/src/support/cleanse.h
@@ -6,7 +6,7 @@
 #ifndef BITCOIN_SUPPORT_CLEANSE_H
 #define BITCOIN_SUPPORT_CLEANSE_H
 
-#include <stdlib.h>
+#include <cstddef> // size_t
 
 // Attempt to overwrite data in the specified memory span.
 void memory_cleanse(void *ptr, size_t len);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -9,6 +9,7 @@
 
 #include <stdio.h>
 
+#include <cstdlib> // abort
 #include <map>
 #include <memory>
 #include <set>

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -1,6 +1,6 @@
 #include <boost/test/unit_test.hpp>
 
-#include <stdlib.h>
+#include <cstdlib> // abs
 
 #include <rpc/blockchain.h>
 #include <test/test_bitcoin.h>

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -8,7 +8,7 @@
 // It would probably be ideal to define dummy test(s) that report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
 
 #include <map>
-#include <stdlib.h>
+#include <cstdlib> // malloc, free, size_t
 
 #include <support/events.h>
 

--- a/src/test/test_bitcoin_main.cpp
+++ b/src/test/test_bitcoin_main.cpp
@@ -6,6 +6,7 @@
 
 #include <net.h>
 
+#include <cstdlib> // exit, EXIT_SUCCESS, EXIT_FAILURE
 #include <memory>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -11,6 +11,7 @@
 #include <utilmoneystr.h>
 #include <test/test_bitcoin.h>
 
+#include <cstdlib> // exit, EXIT_SUCCESS
 #include <stdint.h>
 #include <vector>
 #ifndef WIN32
@@ -1090,7 +1091,7 @@ static void TestOtherProcess(fs::path dirname, std::string lockname, int fd)
             break;
         case ExitCommand:
             close(fd);
-            exit(0);
+            exit(EXIT_SUCCESS);
         default:
             assert(0);
         }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 #include <deque>
 #include <set>
-#include <stdlib.h>
+#include <cstdlib> // free, atoi, strtol, size_t
 
 #include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -14,6 +14,7 @@
 #include <ui_interface.h>
 #include <init.h>
 
+#include <cstdlib> // _Exit, EXIT_SUCCESS
 #include <stdint.h>
 
 #include <boost/thread.hpp>
@@ -125,7 +126,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
                 static FastRandomContext rng;
                 if (rng.randrange(crash_simulate) == 0) {
                     LogPrintf("Simulating a crash. Goodbye.\n");
-                    _Exit(0);
+                    _Exit(EXIT_SUCCESS);
                 }
             }
         }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,6 +11,7 @@
 #include <chain.h>
 #include <primitives/block.h>
 
+#include <cstddef> // size_t
 #include <map>
 #include <memory>
 #include <string>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -77,6 +77,8 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/conf.h>
+
+#include <cstdlib> // atoi, getenv, system, size_t
 #include <thread>
 
 // Application startup time (used for uptime calculation)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -7,7 +7,7 @@
 
 #include <tinyformat.h>
 
-#include <cstdlib>
+#include <cstdlib> // strto*, atoi, size_t
 #include <cstring>
 #include <errno.h>
 #include <limits>

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -15,6 +15,7 @@
 #include <version.h>
 
 #include <atomic>
+#include <cstdlib> // free
 #include <map>
 #include <memory>
 #include <string>

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_WARNINGS_H
 #define BITCOIN_WARNINGS_H
 
-#include <stdlib.h>
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);


### PR DESCRIPTION
* Prefer cstddef over cstdlib for size_t definition - fewer overall definitions
* Include cstdlib where used, and note which definitions are used

I used iwyu and the following regex to check for usage:
```regexp
stdlib\.h|\bEXIT_SUCCESS\b|\bEXIT_FAILURE\b|\bMB_CUR_MAX\b|\bRAND_MAX\b|\bdiv_t\b|\bldiv_t\b|\blldiv_t\b|\babort\(|[^.]exit\(|\bquick_exit\(|\b_Exit\(|\batexit\(|\bat_quick_exit\(|\bsystem\(|[^.]getenv\(|\bmalloc\(|\bcalloc\(|\brealloc\(|[^.]free\(|\batof\(|\batoi\(|\batol\(|\batoll\(|\bstrtol\(|\bstrtoll\(|\bstrtoul\(|\bstrtoull\(|\bstrtof\(|\bstrtod\(|\bstrtold\(|\bmblen\(|\bmbtowc\(|\bwctomb\(|\bmbstowcs\(|\bwcstombs\(|\brand\(|\bsrand\(|\bqsort\(|\bbsearch\(|\babs\(|\blabs\(|\bllabs\(|\bdiv\(|\bldiv\(|\blldiv\(
```

Prompted by initial look at include-what-you-use tool.
