### PR TITLE
Audit string.h inclusion

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -14,6 +14,8 @@
 #include <tinyformat.h>
 #include <util.h>
 
+#include <cstring> // memcmp
+
 namespace {
 
 template <typename Stream, typename Data>

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -10,7 +10,6 @@
 #include <crypto/common.h>
 
 #include <stdio.h>
-#include <string.h>
 
 template <unsigned int BITS>
 base_uint<BITS>::base_uint(const std::string& str)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -7,7 +7,7 @@
 #define BITCOIN_ARITH_UINT256_H
 
 #include <assert.h>
-#include <cstring>
+#include <cstring> // memcmp
 #include <stdexcept>
 #include <stdint.h>
 #include <string>

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -8,7 +8,7 @@
 #include <uint256.h>
 
 #include <assert.h>
-#include <string.h>
+#include <cstring> // strlen, memcmp
 
 /** All alphanumeric characters except for "0", "I", "O", and "l" */
 static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -22,6 +22,7 @@
 
 #include <boost/thread.hpp>
 
+#include <cstring> // strerror
 #include <stdio.h>
 
 /* Introduction text for doxygen: */

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -14,6 +14,8 @@
 
 #include <chainparamsseeds.h>
 
+#include <cstring> // strlen
+
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     CMutableTransaction txNew;

--- a/src/compat/glibc_compat.cpp
+++ b/src/compat/glibc_compat.cpp
@@ -6,7 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <cstddef>
+#include <cstring> // memmove, memcpy, size_t
 
 #if defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>

--- a/src/compat/glibc_sanity.cpp
+++ b/src/compat/glibc_sanity.cpp
@@ -6,7 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <cstddef>
+#include <cstring> // memcpy, size_t
 
 #if defined(HAVE_SYS_SELECT_H)
 #include <sys/select.h>

--- a/src/compat/strnlen.cpp
+++ b/src/compat/strnlen.cpp
@@ -6,7 +6,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <cstring>
+#include <cstring> // memchr
 
 #if HAVE_DECL_STRNLEN == 0
 size_t strnlen( const char *start, size_t max_len)

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -9,6 +9,8 @@
 #include <pubkey.h>
 #include <script/standard.h>
 
+#include <cstring> // memcpy
+
 /*
  * These check for scripts for which a special case with a shorter encoding is defined.
  * They are implemented separately from the CScript test, as these test for exact byte

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -19,6 +19,8 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
 
+#include <cstring> // strcmp
+
 CScript ParseScript(const std::string& s)
 {
     CScript result;

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -6,7 +6,7 @@
 #include <crypto/common.h>
 
 #include <assert.h>
-#include <string.h>
+#include <cstring> // memset, memcpy
 
 extern "C" {
 #include <crypto/ctaes/ctaes.c>

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -8,7 +8,7 @@
 #include <crypto/common.h>
 #include <crypto/chacha20.h>
 
-#include <string.h>
+#include <cstring> // memset
 
 constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
 

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -9,8 +9,8 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <cstring> // memcpy
 #include <stdint.h>
-#include <string.h>
 
 #include <compat/endian.h>
 

--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -4,7 +4,7 @@
 
 #include <crypto/hmac_sha256.h>
 
-#include <string.h>
+#include <cstring> // memcpy, memset
 
 CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
 {

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -4,7 +4,7 @@
 
 #include <crypto/hmac_sha512.h>
 
-#include <string.h>
+#include <cstring> // memcpy, memset
 
 CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
 {

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -6,7 +6,7 @@
 
 #include <crypto/common.h>
 
-#include <string.h>
+#include <cstring> // memset
 
 // Internal implementation code.
 namespace

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -6,7 +6,7 @@
 
 #include <crypto/common.h>
 
-#include <string.h>
+#include <cstring> // memcpy
 
 // Internal implementation code.
 namespace

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -6,8 +6,8 @@
 #include <crypto/common.h>
 
 #include <assert.h>
-#include <string.h>
 #include <atomic>
+#include <cstring> // memcpy
 
 #if defined(__x86_64__) || defined(__amd64__)
 #if defined(USE_ASM)

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -6,7 +6,7 @@
 
 #include <crypto/common.h>
 
-#include <string.h>
+#include <cstring> // memcpy
 
 // Internal implementation code.
 namespace

--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -8,8 +8,8 @@
 #include <array>
 #include <algorithm>
 #include <atomic>
-#include <cstring>
 #include <cmath>
+#include <cstddef> // size_t
 #include <memory>
 #include <vector>
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -13,10 +13,10 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <cstddef> // size_t
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/key.h
+++ b/src/key.h
@@ -12,6 +12,7 @@
 #include <support/allocators/secure.h>
 #include <uint256.h>
 
+#include <cstring> // memset, memcpy, memcmp
 #include <stdexcept>
 #include <vector>
 

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -13,8 +13,8 @@
 #include <boost/variant/static_visitor.hpp>
 
 #include <assert.h>
-#include <string.h>
 #include <algorithm>
+#include <cstddef> // size_t
 
 namespace
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -25,6 +25,7 @@
 #else
 #include <fcntl.h>
 #endif
+#include <cstring> // memcpy, strcmp
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniupnpc.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,7 @@
 #include <utilmoneystr.h>
 #include <utilstrencodings.h>
 
+#include <cstring> // memcmp, strstr
 #include <memory>
 
 #if defined(NDEBUG)

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -8,6 +8,8 @@
 #include <utilstrencodings.h>
 #include <tinyformat.h>
 
+#include <cstring> // memset, memcpy, memcmp
+
 static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
 static const unsigned char pchOnionCat[] = {0xFD,0x87,0xD8,0x7E,0xEB,0x43};
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -14,6 +14,7 @@
 #include <utilstrencodings.h>
 
 #include <atomic>
+#include <cstring> // memset
 
 #ifndef WIN32
 #include <fcntl.h>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -6,9 +6,9 @@
 #define BITCOIN_PREVECTOR_H
 
 #include <assert.h>
+#include <cstring> // memcpy, memset, memmove
 #include <stdlib.h>
 #include <stdint.h>
-#include <string.h>
 
 #include <cstddef>
 #include <iterator>

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -12,6 +12,8 @@
 # include <arpa/inet.h>
 #endif
 
+#include <cstring> // memcpy, memset, strncmp, memcmp
+
 static std::atomic<bool> g_initial_block_download_completed(false);
 
 namespace NetMsgType {

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -8,6 +8,8 @@
 #include <secp256k1.h>
 #include <secp256k1_recovery.h>
 
+#include <cstring> // memcpy, memset
+
 namespace
 {
 /* Global secp256k1_context object used for verification. */

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -11,6 +11,7 @@
 #include <serialize.h>
 #include <uint256.h>
 
+#include <cstring> // memcpy, memcmp
 #include <stdexcept>
 #include <vector>
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -14,6 +14,7 @@
 #include <logging.h>  // for LogPrint()
 #include <utiltime.h> // for GetTime()
 
+#include <cstring> // memcpy, memset
 #include <stdlib.h>
 #include <chrono>
 #include <thread>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -23,6 +23,8 @@
 
 #include <univalue.h>
 
+#include <cstring> // strlen, size_t
+
 static const size_t MAX_GETUTXOS_OUTPOINTS = 15; //allow a max of 15 outpoints to be queried at once
 
 enum class RetFormat {

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -10,6 +10,8 @@
 #include <script/interpreter.h>
 #include <version.h>
 
+#include <cstring> // memcpy, size_t
+
 namespace {
 
 /** A class that deserializes a single CTransaction one time. */

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -12,6 +12,8 @@
 #include <script/script.h>
 #include <uint256.h>
 
+#include <cstring> // memcmp, size_t
+
 typedef std::vector<unsigned char> valtype;
 
 namespace {

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -12,10 +12,10 @@
 
 #include <assert.h>
 #include <climits>
+#include <cstddef> // size_t
 #include <limits>
 #include <stdexcept>
 #include <stdint.h>
-#include <string.h>
 #include <string>
 #include <vector>
 

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -8,6 +8,7 @@
 
 #include <script/interpreter.h>
 
+#include <cstring> // memcpy
 #include <vector>
 
 // DoS prevention: limit cache size to 32MB (over 1000000 entries on 64-bit

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <cstddef> // size_t
 #include <ios>
 #include <limits>
 #include <map>
@@ -17,7 +18,6 @@
 #include <set>
 #include <stdint.h>
 #include <string>
-#include <string.h>
 #include <utility>
 #include <vector>
 

--- a/src/streams.h
+++ b/src/streams.h
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <cstring> // memcpy
 #include <ios>
 #include <limits>
 #include <map>
@@ -18,7 +19,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <string>
-#include <string.h>
 #include <utility>
 #include <vector>
 

--- a/src/support/cleanse.cpp
+++ b/src/support/cleanse.cpp
@@ -5,7 +5,7 @@
 
 #include <support/cleanse.h>
 
-#include <cstring>
+#include <cstring> // memset
 
 #if defined(_MSC_VER)
 #include <Windows.h> // For SecureZeroMemory.

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -17,6 +17,7 @@
 #include <utilstrencodings.h>
 #include <test/test_bitcoin.h>
 
+#include <cstring> // memset
 #include <vector>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -14,6 +14,7 @@
 #include <utilstrencodings.h>
 #include <test/test_bitcoin.h>
 
+#include <cstring> // memcmp
 #include <vector>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -7,6 +7,7 @@
 #include <hash.h>
 #include <test/test_bitcoin.h>
 
+#include <cstring> // memcpy, strcmp
 #include <stdint.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -21,6 +21,7 @@
 #include <pubkey.h>
 #include <blockencodings.h>
 
+#include <cstring> // memcpy
 #include <stdint.h>
 #include <unistd.h>
 

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -7,6 +7,8 @@
 #include <test/test_bitcoin.h>
 
 #include <boost/test/unit_test.hpp>
+
+#include <cstring> // memcmp
 #include <stdint.h>
 #include <sstream>
 #include <iomanip>

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -8,7 +8,6 @@
 #include <utilstrencodings.h>
 
 #include <stdio.h>
-#include <string.h>
 
 template <unsigned int BITS>
 base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -7,7 +7,7 @@
 #define BITCOIN_UINT256_H
 
 #include <assert.h>
-#include <cstring>
+#include <cstring> // memcpy, memset, memcmp
 #include <stdexcept>
 #include <stdint.h>
 #include <string>

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -10,6 +10,7 @@
 #include <serialize.h>
 #include <utilstrencodings.h>
 
+#include <cstring> // strlen, strerror
 #include <stdarg.h>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -8,7 +8,7 @@
 #include <tinyformat.h>
 
 #include <cstdlib>
-#include <cstring>
+#include <cstring> // strlen
 #include <errno.h>
 #include <limits>
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -41,6 +41,7 @@
 #include <validationinterface.h>
 #include <warnings.h>
 
+#include <cstring> // memcmp, memcpy
 #include <future>
 #include <sstream>
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -10,6 +10,7 @@
 #include <script/standard.h>
 #include <util.h>
 
+#include <cstring> // memcpy
 #include <string>
 #include <vector>
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -11,6 +11,7 @@
 #include <utilstrencodings.h>
 #include <wallet/walletutil.h>
 
+#include <cstring> // memcmp, strchr, strncmp, strlen
 #include <stdint.h>
 
 #ifndef WIN32

--- a/src/wallet/test/wallet_crypto_tests.cpp
+++ b/src/wallet/test/wallet_crypto_tests.cpp
@@ -6,6 +6,7 @@
 #include <utilstrencodings.h>
 #include <wallet/crypter.h>
 
+#include <cstring> // memcmp
 #include <vector>
 
 #include <boost/test/unit_test.hpp>

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -10,6 +10,8 @@
 #include <util.h>
 #include <rpc/server.h>
 
+#include <cstring> // memcpy, strlen
+
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
 static const char *MSG_HASHBLOCK = "hashblock";


### PR DESCRIPTION
* Prefer cstddef over cstring for size_t definition - fewer overall definitions
* Include cstring where used, and note which definitions are used

Fixes #13581