### PR TITLE
zmq: update to avoid deprecated zeromq api functions and log zmq version used

### DIFF
--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -72,10 +72,14 @@ CZMQNotificationInterface* CZMQNotificationInterface::Create()
 // Called at startup to conditionally set up ZMQ socket(s)
 bool CZMQNotificationInterface::Initialize()
 {
+    int major = 0, minor = 0, patch = 0;
+    zmq_version(&major, &minor, &patch);
+    LogPrint(BCLog::ZMQ, "zmq: version %d.%d.%d\n", major, minor, patch);
+
     LogPrint(BCLog::ZMQ, "zmq: Initialize notification interface\n");
     assert(!pcontext);
 
-    pcontext = zmq_init(1);
+    pcontext = zmq_ctx_new();
 
     if (!pcontext)
     {
@@ -118,7 +122,7 @@ void CZMQNotificationInterface::Shutdown()
             LogPrint(BCLog::ZMQ, "   Shutdown notifier %s at %s\n", notifier->GetType(), notifier->GetAddress());
             notifier->Shutdown();
         }
-        zmq_ctx_destroy(pcontext);
+        zmq_ctx_term(pcontext);
 
         pcontext = nullptr;
     }


### PR DESCRIPTION
According to the libzmq API docs for version 4.2.3 (the version that we currently depend on) and later:
http://api.zeromq.org/master:zmq-init is deprecated by http://api.zeromq.org/master:zmq-ctx-new
http://api.zeromq.org/master:zmq-ctx-destroy is deprecated by http://api.zeromq.org/master:zmq-ctx-term

The one I/O thread set on `zmq_init` is the default for `zmq_ctx_new`, so no further change is necessary.
I don't believe anything is changing beyond function naming with `zmq_ctx_new` and `zmq_ctx_term` -- the API docs read basically the same for the before and after functions.

I also added a log message to output the exact version of ZMQ being used by the node.