### PR TITLE
bench: fix incorrect behaviour in prevector.cpp

### DIFF
--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -42,7 +42,7 @@ static void PrevectorClear(benchmark::State& state)
             t0.resize(28);
             t0.clear();
             t1.resize(29);
-            t0.clear();
+            t1.clear();
         }
     }
 }
@@ -64,11 +64,11 @@ static void PrevectorResize(benchmark::State& state)
 
 #define PREVECTOR_TEST(name, nontrivops, trivops)                       \
     static void Prevector ## name ## Nontrivial(benchmark::State& state) { \
-        PrevectorResize<nontrivial_t>(state);                           \
+        Prevector ## name<nontrivial_t>(state);                         \
     }                                                                   \
     BENCHMARK(Prevector ## name ## Nontrivial, nontrivops);             \
     static void Prevector ## name ## Trivial(benchmark::State& state) { \
-        PrevectorResize<trivial_t>(state);                              \
+        Prevector ## name<trivial_t>(state);                            \
     }                                                                   \
     BENCHMARK(Prevector ## name ## Trivial, trivops);
 


### PR DESCRIPTION
This patch intends to fix some incorrect action of bench/prevector.cpp.

1. PrevectorClear()
2nd call of ```clear()``` should to operate t1 instead of t0.
This patch changes t0 to t1.

2. PREVECTOR_TEST()
PREVECTOR_TEST macro should to call both
```PrevectorXX<nontrivial_t>(state)``` and ```PrevectorXX<trivial_t>(state)```
by specific ```"name"``` which given by parameter instead of calling
```PrevectorResize<>()``` regardless of ```"name"```.
This patch changes ```"PrevectorResize<"``` of this macro to
```"Prevector ## name<"```.
