### PR TITLE
Docs: corrected text to reflect new[er] process of specifying fingerprints

### DIFF
--- a/contrib/gitian-keys/README.md
+++ b/contrib/gitian-keys/README.md
@@ -1,9 +1,10 @@
 ## PGP keys of Gitian builders and Developers
 
-The keys.txt contains the public keys of Gitian builders and active developers.
+The file `keys.txt` contains fingerprints of the public keys of Gitian builders
+and active developers.
 
-The keys are mainly used to sign git commits or the build results of Gitian
-builds.
+The associated keys are mainly used to sign git commits or the build results
+of Gitian builds.
 
 The most recent version of each pgp key can be found on most pgp key servers.
 


### PR DESCRIPTION
More accurately reflects the contents of the directory and keys.txt (i.e., contains fingerprints of keys instead of actual keys).