### PR TITLE
Fix UpdateTip log error typo

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2289,7 +2289,7 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
             DoWarning(strWarning);
         }
     }
-    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
+    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%dutxo)", __func__, /* Continued */
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
       log(pindexNew->nChainWork.getdouble())/log(2.0), (unsigned long)pindexNew->nChainTx,
       FormatISO8601DateTime(pindexNew->GetBlockTime()),


### PR DESCRIPTION
The following is correct:
`2018-07-07 14:58:31 UpdateTip: new best=00000000000038230e39621092289313f5b7ec7f16e05a44a05ed5c670385936 height=631644 version=0x00000004 log2_work=66.837168 tx=8733448 date='2016-01-05 21:50:05' progress=0.437787 cache=6.8MiB(52427utxo)`

Not:
`2018-07-07 14:58:31 UpdateTip: new best=00000000000038230e39621092289313f5b7ec7f16e05a44a05ed5c670385936 height=631644 version=0x00000004 log2_work=66.837168 tx=8733448 date='2016-01-05 21:50:05' progress=0.437787 cache=6.8MiB(52427txo)`