### PR TITLE
Qt: Only call tryGetBalances in pollBalanceChanged if the result will be used.

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -345,16 +345,24 @@ public:
         }
         return result;
     }
-    bool tryGetBalances(WalletBalances& balances, int& num_blocks) override
+    bool tryGetBalances(WalletBalances& balances, bool skip_height_check, int cached_blocks, int& num_blocks) override
     {
         TRY_LOCK(cs_main, locked_chain);
-        if (!locked_chain) return false;
+        if (!locked_chain) {
+            return false;
+        }
+
+        num_blocks = ::chainActive.Height();
+        if (!skip_height_check && num_blocks == cached_blocks) {
+            return false;
+        }
+
         TRY_LOCK(m_wallet.cs_wallet, locked_wallet);
         if (!locked_wallet) {
             return false;
         }
         balances = getBalances();
-        num_blocks = ::chainActive.Height();
+
         return true;
     }
     CAmount getBalance() override { return m_wallet.GetBalance(); }

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -192,8 +192,8 @@ public:
     //! Get balances.
     virtual WalletBalances getBalances() = 0;
 
-    //! Get balances if possible without blocking.
-    virtual bool tryGetBalances(WalletBalances& balances, int& num_blocks) = 0;
+    //! Get balances if cached_blocks != num_blocks and if possible without blocking.
+    virtual bool tryGetBalances(WalletBalances& balances, bool skip_height_check, int cached_blocks, int& num_blocks) = 0;
 
     //! Get balance.
     virtual CAmount getBalance() = 0;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -66,18 +66,17 @@ void WalletModel::updateStatus()
 
 void WalletModel::pollBalanceChanged()
 {
-    // Try to get balances and return early if locks can't be acquired. This
-    // avoids the GUI from getting stuck on periodical polls if the core is
-    // holding the locks for a longer time - for example, during a wallet
-    // rescan.
-    interfaces::WalletBalances new_balances;
-    int numBlocks = -1;
-    if (!m_wallet->tryGetBalances(new_balances, numBlocks)) {
-        return;
-    }
+    if (fForceCheckBalanceChanged || m_node.getNumBlocks() != cachedNumBlocks) {
+        // Try to get balances and return early if locks can't be acquired. This
+        // avoids the GUI from getting stuck on periodical polls if the core is
+        // holding the locks for a longer time - for example, during a wallet
+        // rescan.
+        interfaces::WalletBalances new_balances;
+        int numBlocks = -1;
+        if (!m_wallet->tryGetBalances(new_balances, numBlocks)) {
+            return;
+        }
 
-    if(fForceCheckBalanceChanged || m_node.getNumBlocks() != cachedNumBlocks)
-    {
         fForceCheckBalanceChanged = false;
 
         // Balance and number of transactions might have changed

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -66,25 +66,22 @@ void WalletModel::updateStatus()
 
 void WalletModel::pollBalanceChanged()
 {
-    if (fForceCheckBalanceChanged || m_node.getNumBlocks() != cachedNumBlocks) {
-        // Try to get balances and return early if locks can't be acquired. This
-        // avoids the GUI from getting stuck on periodical polls if the core is
-        // holding the locks for a longer time - for example, during a wallet
-        // rescan.
-        interfaces::WalletBalances new_balances;
-        int numBlocks = -1;
-        if (!m_wallet->tryGetBalances(new_balances, numBlocks)) {
-            return;
-        }
+    interfaces::WalletBalances new_balances;
+    int numBlocks = -1;
 
-        fForceCheckBalanceChanged = false;
+    // Try to get balances and return early if locks can't be acquired. This
+    // avoids the GUI from getting stuck on periodical polls if the core is
+    // holding the locks for a longer time - for example, during a wallet
+    // rescan.
+    if (!m_wallet->tryGetBalances(new_balances, fForceCheckBalanceChanged, cachedNumBlocks, numBlocks)) {
+        return;
+    }
+    fForceCheckBalanceChanged = false;
 
-        // Balance and number of transactions might have changed
-        cachedNumBlocks = m_node.getNumBlocks();
-
-        checkBalanceChanged(new_balances);
-        if(transactionTableModel)
-            transactionTableModel->updateConfirmations();
+    checkBalanceChanged(new_balances);
+    cachedNumBlocks = numBlocks;
+    if (transactionTableModel) {
+        transactionTableModel->updateConfirmations();
     }
 }
 


### PR DESCRIPTION
getBalances takes significant processing if the wallet has many transactions.