### PR TITLE
Add datadir flag to bitcoind.service

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -12,7 +12,7 @@ Description=Bitcoin daemon
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
+ExecStart=/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid -datadir=/var/lib/bitcoind
 # Creates /run/bitcoind owned by bitcoin
 RuntimeDirectory=bitcoind
 User=bitcoin


### PR DESCRIPTION
I recently stood up an Ubuntu Bitcoin node, and I configured a systemd service using the example [file in the repo](https://github.com/bitcoin/bitcoin/blob/v0.16.0/contrib/init/bitcoind.service). While following the [instructions](https://github.com/bitcoin/bitcoin/blob/v0.16.0/doc/init.md) to set it up, I had to add the `-datadir` flag to set the data directory to `/var/lib/bitcoind`. This makes the service file more consistent with the [expectations](https://github.com/bitcoin/bitcoin/blob/v0.16.0/doc/init.md#linux) in the instructions.