### PR TITLE
Typos in the install script

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -85,3 +85,5 @@ echo 'When compiling bitcoind, run `./configure` in the following way:'
 echo
 echo "  export BDB_PREFIX='${BDB_PREFIX}'"
 echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"'
+echo
+echo "In case additional flags are needed, append them to the command above."

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -84,4 +84,4 @@ echo
 echo 'When compiling bitcoind, run `./configure` in the following way:'
 echo
 echo "  export BDB_PREFIX='${BDB_PREFIX}'"
-echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...'
+echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"'


### PR DESCRIPTION
Removing kind-of-obvious three dots.

Here is the mindless output of the original command.

```./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...
configure: WARNING: you should use --build, --host, --target
checking build system type... Invalid configuration `...': machine `...' not recognized
configure: error: /bin/sh build-aux/config.sub ... failed```