### PR TITLE
Include cstring alongside select in compat/glib_sanity.cpp

### DIFF
--- a/src/compat/glibc_sanity.cpp
+++ b/src/compat/glibc_sanity.cpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 
 #if defined(HAVE_SYS_SELECT_H)
+#include <cstring>
 #include <sys/select.h>
 #endif
 


### PR DESCRIPTION
At least SmartOS implements FD_ZERO relative to memset but does not
ensure its availability. Including cstring fixes that.