### PR TITLE
Free keystore.h from file scope level type aliases

### DIFF
--- a/src/keystore.h
+++ b/src/keystore.h
@@ -38,16 +38,16 @@ public:
     virtual bool HaveWatchOnly() const =0;
 };
 
-typedef std::map<CKeyID, CKey> KeyMap;
-typedef std::map<CKeyID, CPubKey> WatchKeyMap;
-typedef std::map<CScriptID, CScript > ScriptMap;
-typedef std::set<CScript> WatchOnlySet;
-
 /** Basic key store, that keeps keys in an address->secret map */
 class CBasicKeyStore : public CKeyStore
 {
 protected:
     mutable CCriticalSection cs_KeyStore;
+
+    using KeyMap = std::map<CKeyID, CKey>;
+    using WatchKeyMap = std::map<CKeyID, CPubKey>;
+    using ScriptMap = std::map<CScriptID, CScript>;
+    using WatchOnlySet = std::set<CScript>;
 
     KeyMap mapKeys GUARDED_BY(cs_KeyStore);
     WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
@@ -73,9 +73,6 @@ public:
     bool HaveWatchOnly(const CScript &dest) const override;
     bool HaveWatchOnly() const override;
 };
-
-typedef std::vector<unsigned char, secure_allocator<unsigned char> > CKeyingMaterial;
-typedef std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char> > > CryptedKeyMap;
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */
 CKeyID GetKeyForDestination(const CKeyStore& store, const CTxDestination& dest);

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -126,6 +126,8 @@ private:
     bool fDecryptionThoroughlyChecked;
 
 protected:
+    using CryptedKeyMap = std::map<CKeyID, std::pair<CPubKey, std::vector<unsigned char>>>;
+
     bool SetCrypted();
 
     //! will encrypt previously unencrypted keys


### PR DESCRIPTION
This pull request frees `keystore.h` from type alias declarations that have been declared at file scope level.

`keystore.h` has various type aliases that have been declared ~3 - 6 years ago at file scope level, which can either be encapsulated or removed.

Where type alias declarations are encapsulated at the appropriate scope and access level, C++11's `using` notation is used in favor of the `typedef` notation.
