### PR TITLE
refactor: Optimize bech32::Encode

### DIFF
--- a/src/bech32.h
+++ b/src/bech32.h
@@ -19,7 +19,11 @@
 namespace bech32
 {
 
-/** Encode a Bech32 string. Returns the empty string in case of failure. */
+/**
+ * Encode a Bech32 string.
+ * @return a Bech32 string representing the inputs
+ * @throws std::length_error if the result would exceed the allowed length of 90 chars
+ */
 std::string Encode(const std::string& hrp, const std::vector<uint8_t>& values);
 
 /** Decode a Bech32 string. Returns (hrp, data). Empty hrp means failure. */


### PR DESCRIPTION
This is my treatment of @kallewoof's #13586

I got another big win out of not catting together the values and checksum for iteration, and a small win from using pre-increment.

This results in a ~40% speed-up in calls to Encode()

Before:
```
  #Benchmark, evals, iterations, total, min, max, median
  Bech32Encode, 5, 800000, 5.98941, 1.46948e-06, 1.56082e-06, 1.49065e-06
```
After:
```
  #Benchmark, evals, iterations, total, min, max, median
  Bech32Encode, 5, 800000, 3.60337, 8.82574e-07, 9.23948e-07, 8.93568e-07
```

Also throwing a `std::length_error` on length error, rather than asserting, for easier error handling.

This PR brought to you by insomnia.