### PR TITLE
wallet: Add GetBalances to calculate all balances

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -333,15 +333,14 @@ public:
     WalletBalances getBalances() override
     {
         WalletBalances result;
-        result.balance = m_wallet.GetBalance();
-        result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance();
-        result.immature_balance = m_wallet.GetImmatureBalance();
-        result.have_watch_only = m_wallet.HaveWatchOnly();
-        if (result.have_watch_only) {
-            result.watch_only_balance = m_wallet.GetWatchOnlyBalance();
-            result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
-            result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
-        }
+        m_wallet.GetBalances(
+          result.balance,
+          result.unconfirmed_balance,
+          result.immature_balance,
+          result.have_watch_only,
+          result.watch_only_balance,
+          result.unconfirmed_watch_only_balance,
+          result.immature_watch_only_balance);
         return result;
     }
     bool tryGetBalances(WalletBalances& balances, int& num_blocks) override

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -942,6 +942,7 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
+    void GetBalances(CAmount& balance, CAmount& unconfirmed_balance, CAmount& immature_balance, bool& have_watch_only, CAmount& watch_only_balance, CAmount& unconfirmed_watch_only_balance, CAmount& immature_watch_only_balance) const;
     CAmount GetBalance() const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;


### PR DESCRIPTION
The new method `CWallet::GetBalances` computes all balances in one iteration.
It also avoids repetitive lock/unlock for each wallet transaction.