### PR TITLE
tests: Use MAX_SCRIPT_ELEMENT_SIZE from script.py

### DIFF
--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -46,6 +46,7 @@ from test_framework.script import (
     CScript,
     CScriptNum,
     CScriptOp,
+    MAX_SCRIPT_ELEMENT_SIZE,
     OP_0,
     OP_1,
     OP_16,
@@ -1136,8 +1137,6 @@ class SegWitTest(BitcoinTestFramework):
     @subtest
     def test_max_witness_push_length(self):
         """Test that witness stack can only allow up to 520 byte pushes."""
-
-        MAX_SCRIPT_ELEMENT_SIZE = 520
 
         block = self.build_next_block()
 


### PR DESCRIPTION
`p2p_segwit.py` and `test_framework/script.py` both define a constant for `MAX_SCRIPT_ELEMENT_SIZE` (=520 bytes), which is redundant.  This change uses the constant defined in the `script.py` module for `p2p_segwit.py`.