### PR TITLE
[refactor] Fix the chainparamsbase -> util circular dependency

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -31,9 +31,6 @@ static const int CONTINUE_EXECUTION=-1;
 
 static void SetupCliArgs()
 {
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
-    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
-
     gArgs.AddArg("-?", "This help message", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-version", "Print version and exit", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), false, OptionsCategory::OPTIONS);
@@ -45,7 +42,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcconnect=<ip>", strprintf("Send commands to node running on <ip> (default: %s)", DEFAULT_RPCCONNECT), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpccookiefile=<loc>", _("Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)"), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u or testnet: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-rpcport=<port>", strprintf("Connect to JSON-RPC on <port> (default: %u or testnet: %u)", GetRPCPort(CBaseChainParams::MAIN), GetRPCPort(CBaseChainParams::TESTNET)), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwait", "Wait for RPC server to start", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to bitcoind)", false, OptionsCategory::OPTIONS);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -130,9 +130,9 @@ static int AppInitRPC(int argc, char* argv[])
         fprintf(stderr, "Error reading configuration file: %s\n", error.c_str());
         return EXIT_FAILURE;
     }
-    // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
+    // Check for -testnet or -regtest parameter (gArgs.ConfigNetwork() calls are only valid after this clause)
     try {
-        SelectBaseParams(gArgs.GetChainName());
+        gArgs.SelectConfigNetwork(gArgs.GetChainName());
     } catch (const std::exception& e) {
         fprintf(stderr, "Error: %s\n", e.what());
         return EXIT_FAILURE;
@@ -311,7 +311,7 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
     //     1. -rpcport
     //     2. port in -rpcconnect (ie following : in ipv4 or ]: in ipv6)
     //     3. default port for chain
-    int port = BaseParams().RPCPort();
+    int port = GetRPCPort(gArgs.ConfigNetwork());
     SplitHostPort(gArgs.GetArg("-rpcconnect", DEFAULT_RPCCONNECT), port, host);
     port = gArgs.GetArg("-rpcport", port);
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -375,7 +375,7 @@ std::unique_ptr<CChainParams> CreateChainParams(const std::string& chain)
 
 void SelectParams(const std::string& network)
 {
-    SelectBaseParams(network);
+    gArgs.SelectConfigNetwork(network);
     globalChainParams = CreateChainParams(network);
 }
 

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -22,12 +22,30 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-testnet", "Use the test chain", false, OptionsCategory::CHAINPARAMS);
 }
 
-static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
-
-const CBaseChainParams& BaseParams()
+std::string GetDataDir(const std::string& chain)
 {
-    assert(globalChainBaseParams);
-    return *globalChainBaseParams;
+    if (chain == CBaseChainParams::MAIN) {
+        return "";
+    } else if (chain == CBaseChainParams::TESTNET) {
+        return "testnet3";
+    } else if (chain == CBaseChainParams::REGTEST) {
+        return "regtest";
+    } else {
+        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+    }
+}
+
+int GetRPCPort(const std::string& chain)
+{
+    if (chain == CBaseChainParams::MAIN) {
+        return 8332;
+    } else if (chain == CBaseChainParams::TESTNET) {
+        return 18332;
+    } else if (chain == CBaseChainParams::REGTEST) {
+        return 18443;
+    } else {
+        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+    }
 }
 
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
@@ -40,10 +58,4 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         return MakeUnique<CBaseChainParams>("regtest", 18443);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
-}
-
-void SelectBaseParams(const std::string& chain)
-{
-    globalChainBaseParams = CreateBaseChainParams(chain);
-    gArgs.SelectConfigNetwork(chain);
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -7,9 +7,6 @@
 
 #include <tinyformat.h>
 #include <util.h>
-#include <utilmemory.h>
-
-#include <assert.h>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
@@ -46,16 +43,4 @@ int GetRPCPort(const std::string& chain)
     } else {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
     }
-}
-
-std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
-{
-    if (chain == CBaseChainParams::MAIN)
-        return MakeUnique<CBaseChainParams>("", 8332);
-    else if (chain == CBaseChainParams::TESTNET)
-        return MakeUnique<CBaseChainParams>("testnet3", 18332);
-    else if (chain == CBaseChainParams::REGTEST)
-        return MakeUnique<CBaseChainParams>("regtest", 18443);
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -6,18 +6,10 @@
 #include <chainparamsbase.h>
 
 #include <tinyformat.h>
-#include <util.h>
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
-
-void SetupChainParamsBaseOptions()
-{
-    gArgs.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
-                                   "This is intended for regression testing tools and app development.", true, OptionsCategory::CHAINPARAMS);
-    gArgs.AddArg("-testnet", "Use the test chain", false, OptionsCategory::CHAINPARAMS);
-}
 
 std::string GetDataDir(const std::string& chain)
 {

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_CHAINPARAMSBASE_H
 #define BITCOIN_CHAINPARAMSBASE_H
 
-#include <memory>
 #include <string>
-#include <vector>
 
 /**
  * CBaseChainParams defines the base parameters (shared between bitcoin-cli and bitcoind)
@@ -20,24 +18,7 @@ public:
     static const std::string MAIN;
     static const std::string TESTNET;
     static const std::string REGTEST;
-
-    const std::string& DataDir() const { return strDataDir; }
-    int RPCPort() const { return nRPCPort; }
-
-    CBaseChainParams() = delete;
-    CBaseChainParams(const std::string& data_dir, int rpc_port) : nRPCPort(rpc_port), strDataDir(data_dir) {}
-
-private:
-    int nRPCPort;
-    std::string strDataDir;
 };
-
-/**
- * Creates and returns a std::unique_ptr<CBaseChainParams> of the chosen chain.
- * @returns a CBaseChainParams* of the chosen chain.
- * @throws a std::runtime_error if the chain is not supported.
- */
-std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain);
 
 /**
  *Set the arguments for chainparams

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -44,13 +44,10 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
  */
 void SetupChainParamsBaseOptions();
 
-/**
- * Return the currently selected parameters. This won't change after app
- * startup, except for unit tests.
- */
-const CBaseChainParams& BaseParams();
+/** @return the data dir for the named chain */
+std::string GetDataDir(const std::string& chain);
 
-/** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(const std::string& chain);
+/** @return the rpc port for the named chain */
+int GetRPCPort(const std::string& chain);
 
 #endif // BITCOIN_CHAINPARAMSBASE_H

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -20,11 +20,6 @@ public:
     static const std::string REGTEST;
 };
 
-/**
- *Set the arguments for chainparams
- */
-void SetupChainParamsBaseOptions();
-
 /** @return the data dir for the named chain */
 std::string GetDataDir(const std::string& chain);
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -292,7 +292,7 @@ static bool ThreadHTTP(struct event_base* base, struct evhttp* http)
 /** Bind HTTP server to specified addresses */
 static bool HTTPBindAddresses(struct evhttp* http)
 {
-    int defaultPort = gArgs.GetArg("-rpcport", BaseParams().RPCPort());
+    int defaultPort = gArgs.GetArg("-rpcport", GetRPCPort(gArgs.ConfigNetwork()));
     std::vector<std::pair<std::string, uint16_t> > endpoints;
 
     // Determine what addresses to bind to

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -339,8 +339,6 @@ static void OnRPCStopped()
 
 void SetupServerArgs()
 {
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
-    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
     const auto defaultChainParams = CreateChainParams(CBaseChainParams::MAIN);
     const auto testnetChainParams = CreateChainParams(CBaseChainParams::TESTNET);
 
@@ -505,7 +503,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcbind=<addr>[:port]", "Bind to given address to listen for JSON-RPC connections. This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost, or if -rpcallowip has been specified, 0.0.0.0 and :: i.e., all addresses)", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcpassword=<pw>", "Password for JSON-RPC connections", false, OptionsCategory::RPC);
-    gArgs.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)", defaultBaseParams->RPCPort(), testnetBaseParams->RPCPort()), false, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcport=<port>", strprintf("Listen for JSON-RPC connections on <port> (default: %u or testnet: %u)", GetRPCPort(CBaseChainParams::MAIN), GetRPCPort(CBaseChainParams::TESTNET)), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcserialversion", strprintf("Sets the serialization of raw transaction or block hex returned in non-verbose mode, non-segwit(0) or segwit(1) (default: %d)", DEFAULT_RPC_SERIALIZE_VERSION), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT), true, OptionsCategory::RPC);
     gArgs.AddArg("-rpcthreads=<n>", strprintf("Set the number of threads to service RPC calls (default: %d)", DEFAULT_HTTP_THREADS), false, OptionsCategory::RPC);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -961,6 +961,14 @@ std::string ArgsManager::GetChainName() const
     return CBaseChainParams::MAIN;
 }
 
+void SetupChainParamsBaseOptions()
+{
+    gArgs.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
+                            "This is intended for regression testing tools and app development.",
+        true, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-testnet", "Use the test chain", false, OptionsCategory::CHAINPARAMS);
+}
+
 #ifndef WIN32
 fs::path GetPidFile()
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -411,6 +411,11 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
     m_network = network;
 }
 
+const std::string& ArgsManager::ConfigNetwork() const
+{
+    return m_network;
+}
+
 bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::string& error)
 {
     LOCK(cs_args);
@@ -756,7 +761,7 @@ const fs::path &GetBlocksDir(bool fNetSpecific)
         path = GetDataDir(false);
     }
     if (fNetSpecific)
-        path /= BaseParams().DataDir();
+        path /= ::GetDataDir(gArgs.ConfigNetwork());
 
     path /= "blocks";
     fs::create_directories(path);
@@ -785,7 +790,7 @@ const fs::path &GetDataDir(bool fNetSpecific)
         path = GetDefaultDataDir();
     }
     if (fNetSpecific)
-        path /= BaseParams().DataDir();
+        path /= ::GetDataDir(gArgs.ConfigNetwork());
 
     if (fs::create_directories(path)) {
         // This is the first run, create wallets subdirectory too

--- a/src/util.h
+++ b/src/util.h
@@ -167,6 +167,9 @@ public:
      */
     void SelectConfigNetwork(const std::string& network);
 
+    /** @return the network in use */
+    const std::string& ConfigNetwork() const;
+
     bool ParseParameters(int argc, const char* const argv[], std::string& error);
     bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);
 

--- a/src/util.h
+++ b/src/util.h
@@ -290,6 +290,11 @@ public:
 extern ArgsManager gArgs;
 
 /**
+ * Set the chain name arguments for ArgsManager::GetChainName
+ */
+void SetupChainParamsBaseOptions();
+
+/**
  * @return true if help has been requested via a command-line arg
  */
 bool HelpRequested(const ArgsManager& args);

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -9,7 +9,6 @@
 export LC_ALL=C
 
 EXPECTED_CIRCULAR_DEPENDENCIES=(
-    "chainparamsbase -> util -> chainparamsbase"
     "checkpoints -> validation -> checkpoints"
     "index/txindex -> validation -> index/txindex"
     "policy/fees -> txmempool -> policy/fees"


### PR DESCRIPTION
By moving gArgs references out of chainparamsbase.cpp.

Note both chainparams.cpp, bitcoin-cli.cpp, and all callers of
SetupChainParamsBaseOptions include util.h