### PR TITLE
Switch to NSIS 3.03 to avoid DLL hijacking

### DIFF
--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -256,12 +256,12 @@ if [[ $build = true ]]
 then
     # Make output folder
     mkdir -p ./bitcoin-binaries/${VERSION}
-    
+
     # Build Dependencies
     echo ""
     echo "Building Dependencies"
     echo ""
-    pushd ./gitian-builder    
+    pushd ./gitian-builder
     mkdir -p inputs
     wget -N -P inputs $osslPatchUrl
     wget -N -P inputs $osslTarUrl
@@ -348,10 +348,10 @@ then
     echo "Verifying v${VERSION} Windows"
     echo ""
     ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-    # Mac OSX    
+    # Mac OSX
     echo ""
     echo "Verifying v${VERSION} Mac OSX"
-    echo ""    
+    echo ""
     ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
     # Signed Windows
     echo ""
@@ -362,15 +362,14 @@ then
     echo ""
     echo "Verifying v${VERSION} Signed Mac OSX"
     echo ""
-    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml    
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
     popd
 fi
 
 # Sign binaries
 if [[ $sign = true ]]
 then
-    
-        pushd ./gitian-builder
+    pushd ./gitian-builder
     # Sign Windows
     if [[ $windows = true ]]
     then

--- a/contrib/gitian-build.sh
+++ b/contrib/gitian-build.sh
@@ -36,23 +36,23 @@ Run this script from the directory containing the bitcoin, gitian-builder, gitia
 
 Arguments:
 signer          GPG signer to sign each build assert file
-version		Version number, commit, or branch to build. If building a commit or branch, the -c option must be specified
+version        Version number, commit, or branch to build. If building a commit or branch, the -c option must be specified
 
 Options:
--c|--commit	Indicate that the version argument is for a commit or branch
--u|--url	Specify the URL of the repository. Default is https://github.com/bitcoin/bitcoin
--v|--verify 	Verify the Gitian build
--b|--build	Do a Gitian build
--s|--sign	Make signed binaries for Windows and Mac OSX
--B|--buildsign	Build both signed and unsigned binaries
--o|--os		Specify which Operating Systems the build is for. Default is lwx. l for linux, w for windows, x for osx
--j		Number of processes to use. Default 2
--m		Memory to allocate in MiB. Default 2000
+-c|--commit     Indicate that the version argument is for a commit or branch
+-u|--url        Specify the URL of the repository. Default is https://github.com/bitcoin/bitcoin
+-v|--verify     Verify the Gitian build
+-b|--build      Do a Gitian build
+-s|--sign       Make signed binaries for Windows and Mac OSX
+-B|--buildsign  Build both signed and unsigned binaries
+-o|--os         Specify which Operating Systems the build is for. Default is lwx. l for linux, w for windows, x for osx
+-j        Number of processes to use. Default 2
+-m        Memory to allocate in MiB. Default 2000
 --kvm           Use KVM instead of LXC
 --setup         Set up the Gitian building environment. Uses LXC. If you want to use KVM, use the --kvm option. Only works on Debian-based systems (Ubuntu, Debian)
 --detach-sign   Create the assert file for detached signing. Will not commit anything.
 --no-commit     Do not commit anything to git
--h|--help	Print this help message
+-h|--help       Print this help message
 EOF
 
 # Get options and arguments
@@ -60,99 +60,99 @@ while :; do
     case $1 in
         # Verify
         -v|--verify)
-	    verify=true
+        verify=true
             ;;
         # Build
         -b|--build)
-	    build=true
+        build=true
             ;;
         # Sign binaries
         -s|--sign)
-	    sign=true
+        sign=true
             ;;
         # Build then Sign
         -B|--buildsign)
-	    sign=true
-	    build=true
+        sign=true
+        build=true
             ;;
         # PGP Signer
         -S|--signer)
-	    if [ -n "$2" ]
-	    then
-		SIGNER="$2"
-		shift
-	    else
-		echo 'Error: "--signer" requires a non-empty argument.'
-		exit 1
-	    fi
+        if [ -n "$2" ]
+        then
+        SIGNER="$2"
+        shift
+        else
+        echo 'Error: "--signer" requires a non-empty argument.'
+        exit 1
+        fi
            ;;
         # Operating Systems
         -o|--os)
-	    if [ -n "$2" ]
-	    then
-		linux=false
-		windows=false
-		osx=false
-		if [[ "$2" = *"l"* ]]
-		then
-		    linux=true
-		fi
-		if [[ "$2" = *"w"* ]]
-		then
-		    windows=true
-		fi
-		if [[ "$2" = *"x"* ]]
-		then
-		    osx=true
-		fi
-		shift
-	    else
-		echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)'
-		exit 1
-	    fi
-	    ;;
-	# Help message
-	-h|--help)
-	    echo "$usage"
-	    exit 0
-	    ;;
-	# Commit or branch
-	-c|--commit)
-	    commit=true
-	    ;;
-	# Number of Processes
-	-j)
-	    if [ -n "$2" ]
-	    then
-		proc=$2
-		shift
-	    else
-		echo 'Error: "-j" requires an argument'
-		exit 1
-	    fi
-	    ;;
-	# Memory to allocate
-	-m)
-	    if [ -n "$2" ]
-	    then
-		mem=$2
-		shift
-	    else
-		echo 'Error: "-m" requires an argument'
-		exit 1
-	    fi
-	    ;;
-	# URL
-	-u)
-	    if [ -n "$2" ]
-	    then
-		url=$2
-		shift
-	    else
-		echo 'Error: "-u" requires an argument'
-		exit 1
-	    fi
-	    ;;
+        if [ -n "$2" ]
+        then
+        linux=false
+        windows=false
+        osx=false
+        if [[ "$2" = *"l"* ]]
+        then
+            linux=true
+        fi
+        if [[ "$2" = *"w"* ]]
+        then
+            windows=true
+        fi
+        if [[ "$2" = *"x"* ]]
+        then
+            osx=true
+        fi
+        shift
+        else
+        echo 'Error: "--os" requires an argument containing an l (for linux), w (for windows), or x (for Mac OSX)'
+        exit 1
+        fi
+        ;;
+    # Help message
+    -h|--help)
+        echo "$usage"
+        exit 0
+        ;;
+    # Commit or branch
+    -c|--commit)
+        commit=true
+        ;;
+    # Number of Processes
+    -j)
+        if [ -n "$2" ]
+        then
+        proc=$2
+        shift
+        else
+        echo 'Error: "-j" requires an argument'
+        exit 1
+        fi
+        ;;
+    # Memory to allocate
+    -m)
+        if [ -n "$2" ]
+        then
+        mem=$2
+        shift
+        else
+        echo 'Error: "-m" requires an argument'
+        exit 1
+        fi
+        ;;
+    # URL
+    -u)
+        if [ -n "$2" ]
+        then
+        url=$2
+        shift
+        else
+        echo 'Error: "-u" requires an argument'
+        exit 1
+        fi
+        ;;
         # kvm
         --kvm)
             lxc=false
@@ -170,7 +170,7 @@ while :; do
         --setup)
             setup=true
             ;;
-	*)               # Default case: If no more options then break out of the loop.
+    *)               # Default case: If no more options then break out of the loop.
              break
     esac
     shift
@@ -223,7 +223,7 @@ fi
 # Add a "v" if no -c
 if [[ $commit = false ]]
 then
-	COMMIT="v${VERSION}"
+    COMMIT="v${VERSION}"
 fi
 echo ${COMMIT}
 
@@ -254,56 +254,74 @@ popd
 # Build
 if [[ $build = true ]]
 then
-	# Make output folder
-	mkdir -p ./bitcoin-binaries/${VERSION}
-	
-	# Build Dependencies
-	echo ""
-	echo "Building Dependencies"
-	echo ""
-	pushd ./gitian-builder	
-	mkdir -p inputs
-	wget -N -P inputs $osslPatchUrl
-	wget -N -P inputs $osslTarUrl
-	make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common
+    # Make output folder
+    mkdir -p ./bitcoin-binaries/${VERSION}
+    
+    # Build Dependencies
+    echo ""
+    echo "Building Dependencies"
+    echo ""
+    pushd ./gitian-builder    
+    mkdir -p inputs
+    wget -N -P inputs $osslPatchUrl
+    wget -N -P inputs $osslTarUrl
+    make -C ../bitcoin/depends download SOURCES_PATH=`pwd`/cache/common
 
-	# Linux
-	if [[ $linux = true ]]
-	then
+    # Linux
+    if [[ $linux = true ]]
+    then
+        echo ""
+        echo "Compiling ${VERSION} Linux"
+        echo ""
+        ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+        ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+        mv build/out/bitcoin-*.tar.gz build/out/src/bitcoin-*.tar.gz ../bitcoin-binaries/${VERSION}
+    fi
+    # Windows
+    if [[ $windows = true ]]
+    then
+        if [ ! -f inputs/nsis-win32-utils.zip ];
+        then
             echo ""
-	    echo "Compiling ${VERSION} Linux"
-	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-linux --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	    mv build/out/bitcoin-*.tar.gz build/out/src/bitcoin-*.tar.gz ../bitcoin-binaries/${VERSION}
-	fi
-	# Windows
-	if [[ $windows = true ]]
-	then
-	    echo ""
-	    echo "Compiling ${VERSION} Windows"
-	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	    mv build/out/bitcoin-*-win-unsigned.tar.gz inputs/bitcoin-win-unsigned.tar.gz
-	    mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../bitcoin-binaries/${VERSION}
-	fi
-	# Mac OSX
-	if [[ $osx = true ]]
-	then
-	    echo ""
-	    echo "Compiling ${VERSION} Mac OSX"
-	    echo ""
-	    ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
-	    mv build/out/bitcoin-*-osx-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
-	    mv build/out/bitcoin-*.tar.gz build/out/bitcoin-*.dmg ../bitcoin-binaries/${VERSION}
-	fi
-	popd
+            echo "Starting Utilities build for Windows"
+            echo ""
+            ./bin/gbuild -j ${proc} -m ${mem} --allow-sudo ../bitcoin/contrib/gitian-descriptors/gitian-win-utils.yml
+            if [ $? -ne 0 ];
+            then
+                echo ""
+                echo "FAILED to build Utilities for Windows"
+                echo ""
+                exit 1
+            fi
+            pushd inputs
+            cp -a ../build/out/*-utils.zip .
+            mv nsis-*-win32-utils.zip nsis-win32-utils.zip
+            popd ..
+        fi
+        echo ""
+        echo "Compiling ${VERSION} Windows"
+        echo ""
+        ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+        ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+        mv build/out/bitcoin-*-win-unsigned.tar.gz inputs/bitcoin-win-unsigned.tar.gz
+        mv build/out/bitcoin-*.zip build/out/bitcoin-*.exe ../bitcoin-binaries/${VERSION}
+    fi
+    # Mac OSX
+    if [[ $osx = true ]]
+    then
+        echo ""
+        echo "Compiling ${VERSION} Mac OSX"
+        echo ""
+        ./bin/gbuild -j ${proc} -m ${mem} --commit bitcoin=${COMMIT} --url bitcoin=${url} ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+        ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-unsigned --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+        mv build/out/bitcoin-*-osx-unsigned.tar.gz inputs/bitcoin-osx-unsigned.tar.gz
+        mv build/out/bitcoin-*.tar.gz build/out/bitcoin-*.dmg ../bitcoin-binaries/${VERSION}
+    fi
+    popd
 
         if [[ $commitFiles = true ]]
         then
-	    # Commit to gitian.sigs repo
+        # Commit to gitian.sigs repo
             echo ""
             echo "Committing ${VERSION} Unsigned Sigs"
             echo ""
@@ -319,62 +337,62 @@ fi
 # Verify the build
 if [[ $verify = true ]]
 then
-	# Linux
-	pushd ./gitian-builder
-	echo ""
-	echo "Verifying v${VERSION} Linux"
-	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-linux ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
-	# Windows
-	echo ""
-	echo "Verifying v${VERSION} Windows"
-	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
-	# Mac OSX	
-	echo ""
-	echo "Verifying v${VERSION} Mac OSX"
-	echo ""	
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
-	# Signed Windows
-	echo ""
-	echo "Verifying v${VERSION} Signed Windows"
-	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
-	# Signed Mac OSX
-	echo ""
-	echo "Verifying v${VERSION} Signed Mac OSX"
-	echo ""
-	./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml	
-	popd
+    # Linux
+    pushd ./gitian-builder
+    echo ""
+    echo "Verifying v${VERSION} Linux"
+    echo ""
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-linux ../bitcoin/contrib/gitian-descriptors/gitian-linux.yml
+    # Windows
+    echo ""
+    echo "Verifying v${VERSION} Windows"
+    echo ""
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-win-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-win.yml
+    # Mac OSX    
+    echo ""
+    echo "Verifying v${VERSION} Mac OSX"
+    echo ""    
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-unsigned ../bitcoin/contrib/gitian-descriptors/gitian-osx.yml
+    # Signed Windows
+    echo ""
+    echo "Verifying v${VERSION} Signed Windows"
+    echo ""
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+    # Signed Mac OSX
+    echo ""
+    echo "Verifying v${VERSION} Signed Mac OSX"
+    echo ""
+    ./bin/gverify -v -d ../gitian.sigs/ -r ${VERSION}-osx-signed ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml    
+    popd
 fi
 
 # Sign binaries
 if [[ $sign = true ]]
 then
-	
+    
         pushd ./gitian-builder
-	# Sign Windows
-	if [[ $windows = true ]]
-	then
-	    echo ""
-	    echo "Signing ${VERSION} Windows"
-	    echo ""
-	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
-	    mv build/out/bitcoin-*win64-setup.exe ../bitcoin-binaries/${VERSION}
-	    mv build/out/bitcoin-*win32-setup.exe ../bitcoin-binaries/${VERSION}
-	fi
-	# Sign Mac OSX
-	if [[ $osx = true ]]
-	then
-	    echo ""
-	    echo "Signing ${VERSION} Mac OSX"
-	    echo ""
-	    ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
-	    ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
-	    mv build/out/bitcoin-osx-signed.dmg ../bitcoin-binaries/${VERSION}/bitcoin-${VERSION}-osx.dmg
-	fi
-	popd
+    # Sign Windows
+    if [[ $windows = true ]]
+    then
+        echo ""
+        echo "Signing ${VERSION} Windows"
+        echo ""
+        ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+        ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-win-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-win-signer.yml
+        mv build/out/bitcoin-*win64-setup.exe ../bitcoin-binaries/${VERSION}
+        mv build/out/bitcoin-*win32-setup.exe ../bitcoin-binaries/${VERSION}
+    fi
+    # Sign Mac OSX
+    if [[ $osx = true ]]
+    then
+        echo ""
+        echo "Signing ${VERSION} Mac OSX"
+        echo ""
+        ./bin/gbuild -i --commit signature=${COMMIT} ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+        ./bin/gsign -p "$signProg" --signer "$SIGNER" --release ${VERSION}-osx-signed --destination ../gitian.sigs/ ../bitcoin/contrib/gitian-descriptors/gitian-osx-signer.yml
+        mv build/out/bitcoin-osx-signed.dmg ../bitcoin-binaries/${VERSION}/bitcoin-${VERSION}-osx.dmg
+    fi
+    popd
 
         if [[ $commitFiles = true ]]
         then

--- a/contrib/gitian-descriptors/gitian-win-utils.yml
+++ b/contrib/gitian-descriptors/gitian-win-utils.yml
@@ -1,0 +1,97 @@
+---
+name: "utils-windows"
+sudo: true
+suites:
+- "trusty"
+architectures:
+- "amd64"
+packages:
+- "libtool"
+- "automake"
+- "libfaketime"
+- "mingw-w64"
+- "g++-mingw-w64"
+- "zip"
+- "unzip"
+# Needed for compiling nsis.
+- "scons"
+- "libcppunit-dev"
+- "zlib1g"
+- "zlib1g-dev"
+reference_datetime: "2016-01-01 00:00:00"
+remotes: []
+files: []
+script: |
+  WRAP_DIR="$HOME/wrapped"
+  INSTDIR="$HOME/install"
+
+  NSIS_VER=3.03
+  NSIS_PACKAGE=nsis-${NSIS_VER}-src.tar.bz2
+  NSIS_DEBIAN_PACKAGE=nsis_${NSIS_VER}-2.debian.tar.xz
+  NSIS_HASH=abae7f4488bc6de7a4dd760d5f0e7cd3aad7747d4d7cd85786697c8991695eaa
+  NSIS_DEBIAN_HASH=b12956c561d7ad2e078561684a8a06c95c583c14c4d904ec93d252e2d2c2d75c
+  NSIS_URL=http://downloads.sourceforge.net/nsis/${NSIS_PACKAGE}
+  NSIS_DEBIAN_URL=http://http.debian.net/debian/pool/main/n/nsis/${NSIS_DEBIAN_PACKAGE}
+
+  echo "${REFERENCE_DATETIME}" | sudo tee --append /etc/faketimerc
+  echo "/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1" | sudo tee --append /etc/ld.so.preload
+
+  export GZIP="-9n"
+  export TAR_OPTIONS="--mtime="$REFERENCE_DATE\\\ $REFERENCE_TIME""
+  export TZ="UTC"
+  export BUILD_DIR=`pwd`
+  mkdir -p ${WRAP_DIR}
+
+  get() {
+    local file="$1"; shift
+    local url="$1"; shift
+
+    if ! wget --no-check-certificate -U "" -N "$url"; then
+      echo >&2 "Error: Cannot download $url"
+      mv "${file}" "${file}.DLFAILED"
+      exit 1
+    fi
+  }
+
+  dzip() {
+    export LC_ALL=C
+    
+    ZIPFILE=${1:?}
+    shift
+    
+    if [ -n "$REFERENCE_DATETIME" ]; then
+      find "$@" -exec touch --date="$REFERENCE_DATETIME" -- {} +
+    fi
+    find "$@"   -executable -exec chmod 700 {} +
+    find "$@" ! -executable -exec chmod 600 {} +
+    find "$@" | sort | zip $ZIPOPTS -X -@ "$ZIPFILE"
+  }
+
+  for i in NSIS NSIS_DEBIAN
+  do
+    URL="${i}_URL"
+    PACKAGE="${i}_PACKAGE"
+    get "${!PACKAGE}" "${!URL}"
+
+    HASH="${i}_HASH"
+    if ! echo "${!HASH}  ${!PACKAGE}" | sha256sum -c -; then
+      echo "Package hash for ${!PACKAGE} differs from our locally stored sha256!"
+      exit 1
+    fi
+  done
+  
+  get Zlib-1.2.7-win32-x86.zip http://nsis.sourceforge.net/mediawiki/images/c/ca/Zlib-1.2.7-win32-x86.zip
+  unzip -d Zlib-1.2.7 Zlib-1.2.7-win32-x86.zip
+
+  # Building nsis
+  tar xf $NSIS_PACKAGE
+  cd nsis-${NSIS_VER}-src
+  tar xf ../$NSIS_DEBIAN_PACKAGE
+  scons VERSION=${NSIS_VER} SKIPUTILS='NSIS Menu' XGCC_W32_PREFIX=i686-w64-mingw32- ZLIB_W32=${HOME}/build/Zlib-1.2.7 PREFIX=$INSTDIR/nsis
+  scons VERSION=${NSIS_VER} SKIPUTILS='NSIS Menu' XGCC_W32_PREFIX=i686-w64-mingw32- ZLIB_W32=${HOME}/build/Zlib-1.2.7 PREFIX=$INSTDIR/nsis install
+  cd ..
+
+  # Grabbing the remaining results
+  cd $INSTDIR
+  dzip nsis-$NSIS_VER-win32-utils.zip nsis
+  cp nsis-$NSIS_VER-win32-utils.zip $OUTDIR/

--- a/contrib/gitian-descriptors/gitian-win-utils.yml
+++ b/contrib/gitian-descriptors/gitian-win-utils.yml
@@ -55,10 +55,10 @@ script: |
 
   dzip() {
     export LC_ALL=C
-    
+
     ZIPFILE=${1:?}
     shift
-    
+
     if [ -n "$REFERENCE_DATETIME" ]; then
       find "$@" -exec touch --date="$REFERENCE_DATETIME" -- {} +
     fi
@@ -79,7 +79,7 @@ script: |
       exit 1
     fi
   done
-  
+
   get Zlib-1.2.7-win32-x86.zip http://nsis.sourceforge.net/mediawiki/images/c/ca/Zlib-1.2.7-win32-x86.zip
   unzip -d Zlib-1.2.7 Zlib-1.2.7-win32-x86.zip
 

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -17,14 +17,15 @@ packages:
 - "bsdmainutils"
 - "mingw-w64"
 - "g++-mingw-w64"
-- "nsis"
 - "zip"
+- "unzip"
 - "ca-certificates"
 - "python"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"
-files: []
+files:
+- "nsis-win32-utils.zip"
 script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
@@ -93,6 +94,10 @@ script: |
     done
   done
   }
+
+  # Extract nsis
+  unzip -d $HOME/install ${BUILD_DIR}/nsis-win32-utils.zip
+  export PATH=$HOME/install/nsis/bin:$PATH
 
   # Faketime for depends so intermediate results are comparable
   export PATH_orig=${PATH}


### PR DESCRIPTION
Early version of NSIS searches its DLL from the same directory of the executable. If a hacker can place some DLL files in the same directory of the bitcoin installer, the installer will load and run it with admin permission.

Gitian is still in trusty. It shipped with NSIS 2.46, which is vulnerable to this issue. So in this fix, we instead build the latest NSIS by Gitian.

Thanks to @wilsonmeier from Bitcoin Gold team for the fix. Borrowed some code from TOR project.

Details: https://trac.torproject.org/projects/tor/ticket/17895