### PR TITLE
build: make 'depends' output less spammy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,5 @@ test/cache/*
 
 libbitcoinconsensus.pc
 contrib/devtools/split-debug.sh
+
+depends/.built-*


### PR DESCRIPTION
This PR changes the tremendously spammy 'make depends' output to only print actual output if something breaks. As it stands, travis truncates the logs because it is too long, and I doubt anyone has any use for a million lines of build logs unless something actually doesn't compile.

Need to verify: 
* [x] I am not sure if my `|| cat outputfile` approach will signal the exit code to automake or if automake will continue puffing along.
