### PR TITLE
wallet: assert to ensure accuracy of CMerkleTx::GetBlocksToMaturity

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4397,7 +4397,9 @@ int CMerkleTx::GetBlocksToMaturity() const
 {
     if (!IsCoinBase())
         return 0;
-    return std::max(0, (COINBASE_MATURITY+1) - GetDepthInMainChain());
+    int chain_depth = GetDepthInMainChain();
+    assert(chain_depth >= 0); // coinbase tx should not be conflicted
+    return std::max(0, (COINBASE_MATURITY+1) - chain_depth);
 }
 
 


### PR DESCRIPTION
According to my understanding, it should not be possible for coinbase
transactions to be conflicting, thus it should not be possible for
GetDepthInMainChain to return a negative result. If it did, this would
also result in innacurate results for GetBlocksToMaturity due to the
math therein. asserting ensures accuracy.