### PR TITLE
[depends] Don't build Qt dependencies if it doesn't support Qt

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -89,14 +89,14 @@ $(host_arch)_$(host_os)_id_string+=$(shell $(host_CXX) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_RANLIB) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
 
-qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
+qt_packages_$(NO_QT) = $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
 
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
-ifneq ($(qt_packages_),)
+ifneq ($(strip $(qt_packages_)),)
 native_packages += $(qt_native_packages)
 endif
 

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,14 +1,13 @@
 packages:=boost openssl libevent zeromq
 
 qt_native_packages = native_protobuf
-qt_packages = qrencode protobuf zlib
 
-qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
+qt_x86_64_linux_packages:=qt qrencode protobuf zlib expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
 qt_arm_linux_packages:=$(qt_x86_64_linux_packages)
 
-qt_darwin_packages=qt
-qt_mingw32_packages=qt
+qt_darwin_packages=qt qrencode protobuf zlib
+qt_mingw32_packages=qt qrencode protobuf zlib
 
 wallet_packages=bdb
 


### PR DESCRIPTION
Take ARM in gitian for example:
This PR

    copying packages: boost openssl libevent zeromq bdb miniupnpc

master

    copying packages: native_protobuf boost openssl libevent zeromq qrencode protobuf zlib bdb miniupnpc

This would be helpful to add risc-v support into gitian