### PR TITLE
tests: Avoid read/write to default datadir

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -38,6 +38,14 @@ static void SetupBenchArgs()
     gArgs.AddArg("-help", "", false, OptionsCategory::HIDDEN);
 }
 
+static fs::path SetDataDir()
+{
+    fs::path ret = fs::temp_directory_path() / "bench_bitcoin" / fs::unique_path();
+    fs::create_directories(ret);
+    gArgs.ForceSetArg("-datadir", ret.string());
+    return ret;
+}
+
 int main(int argc, char** argv)
 {
     SetupBenchArgs();
@@ -52,6 +60,9 @@ int main(int argc, char** argv)
 
         return EXIT_SUCCESS;
     }
+
+    // Set the datadir after parsing the bench options
+    const fs::path bench_datadir{SetDataDir()};
 
     SHA256AutoDetect();
     RandomInit();
@@ -79,6 +90,8 @@ int main(int argc, char** argv)
     }
 
     benchmark::BenchRunner::RunAll(*printer, evaluations, scaling_factor, regex_filter, is_list_only);
+
+    fs::remove_all(bench_datadir);
 
     ECC_Stop();
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -89,6 +89,7 @@ BOOST_AUTO_TEST_CASE(cnode_listen_port)
 
 BOOST_AUTO_TEST_CASE(caddrdb_read)
 {
+    SetDataDir("caddrdb_read");
     CAddrManUncorrupted addrmanUncorrupted;
     addrmanUncorrupted.MakeDeterministic();
 
@@ -134,6 +135,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
 
 BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
 {
+    SetDataDir("caddrdb_read_corrupted");
     CAddrManCorrupted addrmanCorrupted;
     addrmanCorrupted.MakeDeterministic();
 


### PR DESCRIPTION
tests should never read or write and potentially corrupt the default datadir, so try to avoid it.