### PR TITLE
Qt: Fix for bitcoin-qt becoming unresponsive during shutdown (issue #13217)

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -161,6 +161,7 @@ private:
     RPCConsole* rpcConsole = nullptr;
     HelpMessageDialog* helpMessageDialog = nullptr;
     ModalOverlay* modalOverlay = nullptr;
+    bool closeEventRegistered = false;
 
 #ifdef Q_OS_MAC
     CAppNapInhibitor* m_app_nap_inhibitor = nullptr;
@@ -220,6 +221,7 @@ public Q_SLOTS:
        @param[in] ret       pointer to a bool that will be modified to whether Ok was clicked (modal only)
     */
     void message(const QString &title, const QString &message, unsigned int style, bool *ret = nullptr);
+    void clearChildModels();
 
 #ifdef ENABLE_WALLET
     void setCurrentWallet(WalletModel* wallet_model);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -686,8 +686,8 @@ void RPCConsole::setClientModel(ClientModel *model)
     }
     if (!model) {
         // Client model is being set to 0, this means shutdown() is about to be called.
+        connect(&thread, &QThread::finished, this, &RPCConsole::executorThreadFinished);
         thread.quit();
-        thread.wait();
     }
 }
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -133,6 +133,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     // For RPC command executor
     void cmdRequest(const QString &command, const WalletModel* wallet_model);
+    void executorThreadFinished();
 
 private:
     void startExecutor();


### PR DESCRIPTION
This pull request contains a fix for the issue #13217, where bitcoin-qt becomes unresponsive during shutdown after a long running call (like gettxoutsetinfo) in the QT console.
The problem occurs because, during shutdown, waiting for the RPCExecutor thread to finish happens in the main thread.