### PR TITLE
Remind developers that disablewallet=1 should always work

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -434,6 +434,8 @@ void SetupServerArgs()
     gArgs.AddArg("-whitelist=<IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times."
         " Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway", false, OptionsCategory::CONNECTION);
 
+    // DummyWalletInit::AddWalletOptions() is called if wallet is not compiled.
+    // If this behavior is changed, "disablewallet" should be added to hidden options.
     g_wallet_init_interface.AddWalletOptions();
 
 #if ENABLE_ZMQ


### PR DESCRIPTION
A user may configure `disablewallet=1` for instance to prevent a wallet from accidentally being created (which could lead to confusion as to what to backup).

Since #13059 a user might also use that option to prevent someone with RPC access from dynamically loading a wallet there're not supposed to.

The most rigorous way to do the above is to compile with `--disable-wallet`.

As of #13112 unknown config arguments throw an error. So the user in the above scenario would have to remove this line. But then later if they download a new binary with wallet support compiled, they might forget to add it back. For that reason I believe `disablewallet=1` should always be allowed.

Although unknown config arguments throw an error, the wallet interface added in #10762 includes a dummy wallet to handle `--disable-wallet`. Part of this dummy wallets adds `disablewallet` and other wallet parameters to the list of hidden params; those aren't shown in help, but their presence won't throw an error. This might change in the some future refactor though

So I added a comment that hopefully  prevents a future refactor from causing `disablewallet=1` to throw when compiled with `--disable-wallet`.