### PR TITLE
Initialize m_next_send_inv_to_incoming

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -441,7 +441,7 @@ private:
      *  This takes the place of a feeler connection */
     std::atomic_bool m_try_another_outbound_peer;
 
-    std::atomic<int64_t> m_next_send_inv_to_incoming;
+    std::atomic<int64_t> m_next_send_inv_to_incoming{0};
 
     friend struct CConnmanTest;
 };


### PR DESCRIPTION
This fixes an uninitialized variable introduced in #13298.