### PR TITLE
wallet: Introduce assertion to document the assumption that cache and cache_used are always set in tandem

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1947,6 +1947,7 @@ CAmount CWalletTx::GetAvailableCredit(bool fUseCache, const isminefilter& filter
 
     if (cache) {
         *cache = nCredit;
+        assert(cache_used);
         *cache_used = true;
     }
     return nCredit;


### PR DESCRIPTION
Avoid potential null pointer dereference in `CWalletTx::GetAvailableCredit(...)`.

Introduced in 4279da47855ec776f8d57c6579fe89afc9cbe8c1.