### PR TITLE
depends: disable Werror when building zmq

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb2
 $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-docs --disable-shared --without-libsodium --disable-curve --disable-curve-keygen --disable-perf
+  $(package)_config_opts=--without-docs --disable-shared --without-libsodium --disable-curve --disable-curve-keygen --disable-perf --disable-Werror
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
 endef


### PR DESCRIPTION
This PR ~~backports this libzmq commit https://github.com/zeromq/libzmq/pull/3140/commits/58d13395ece1fa0dd9b0583d736af4ac342c1267 from this merged upstream PR (but unreleased as of today) https://github.com/zeromq/libzmq/pull/3140 as a patch to our zmq 4.2.3 version.~~ passes --disable-Werror when we build zmq.

For reference see https://github.com/bitcoin/bitcoin/issues/11844#issuecomment-398406988

~~This patch~~ A similar patch is already in use in abcore/bitcoin_ndk and needed to build bitcoind for android using NDK or some versions of clang 6+ during cross compilation.

This patch won't be necessary once zmqlib releases a 4.2.6+ version including the fix and bitcoin core updates to it but it may be good to [have](https://github.com/bitcoin/bitcoin/pull/13689#issuecomment-405644394)

~~It also reintroduces autogen.sh as it is necessary for the patch to work, otherwise you'll have aclocal issues (see https://travis-ci.org/greenaddress/bitcoin/jobs/404902106). autogen,sh was removed in master only https://github.com/bitcoin/bitcoin/pull/11986 as non-necessary but otherwise unreleased.~~

In the likely case https://github.com/bitcoin/bitcoin/pull/13578 is merged first I rebased the patch for the newer zmq version (4.2.5) in https://github.com/greenaddress/bitcoin/tree/zmq-upgrade-mruddy-patched and i can update the PR accordingly or close and open a new one.