### PR TITLE
[moveonly] Extract MakeUnique into utilmemory.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -179,6 +179,7 @@ BITCOIN_CORE_H = \
   ui_interface.h \
   undo.h \
   util.h \
+  utilmemory.h \
   utilmoneystr.h \
   utiltime.h \
   validation.h \

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -7,6 +7,7 @@
 
 #include <tinyformat.h>
 #include <util.h>
+#include <utilmemory.h>
 
 #include <assert.h>
 

--- a/src/interfaces/handler.cpp
+++ b/src/interfaces/handler.cpp
@@ -4,7 +4,7 @@
 
 #include <interfaces/handler.h>
 
-#include <util.h>
+#include <utilmemory.h>
 
 #include <boost/signals2/connection.hpp>
 #include <utility>

--- a/src/util.h
+++ b/src/util.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2017 The Bitcoin Core developers
+// Copyright (c) 2009-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -20,11 +20,11 @@
 #include <sync.h>
 #include <tinyformat.h>
 #include <utiltime.h>
+#include <utilmemory.h>
 
 #include <atomic>
 #include <exception>
 #include <map>
-#include <memory>
 #include <set>
 #include <stdint.h>
 #include <string>
@@ -345,13 +345,6 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
 }
 
 std::string CopyrightHolders(const std::string& strPrefix);
-
-//! Substitute for C++14 std::make_unique.
-template <typename T, typename... Args>
-std::unique_ptr<T> MakeUnique(Args&&... args)
-{
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
 
 /**
  * On platforms that support it, tell the kernel the calling thread is

--- a/src/utilmemory.h
+++ b/src/utilmemory.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTILMEMORY_H
+#define BITCOIN_UTILMEMORY_H
+
+#include <memory>
+#include <utility>
+
+//! Substitute for C++14 std::make_unique.
+template <typename T, typename... Args>
+std::unique_ptr<T> MakeUnique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+#endif


### PR DESCRIPTION
And use it to reduce chainparamsbase.cpp's and remove interfaces/handler.cpp's reliance on util.h
This is a step toward fixing the chainparamsbase -> util circular dependency.

Confirmed no need for the util.h include via iwyu and visual inspection.
Extracted from #13639 for easier review.