### PR TITLE
contrib: Clone core repo in gitian-build

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -7,7 +7,7 @@ import sys
 
 def setup():
     global args, workdir
-    programs = ['ruby', 'git', 'apt-cacher-ng']
+    programs = ['ruby', 'git', 'apt-cacher-ng', 'make', 'wget']
     if args.kvm:
         programs += ['python-vm-builder', 'qemu-kvm', 'qemu-utils']
     elif args.docker:
@@ -21,6 +21,8 @@ def setup():
         subprocess.check_call(['git', 'clone', 'https://github.com/bitcoin-core/bitcoin-detached-sigs.git'])
     if not os.path.isdir('gitian-builder'):
         subprocess.check_call(['git', 'clone', 'https://github.com/devrandom/gitian-builder.git'])
+    if not os.path.isdir('bitcoin'):
+        subprocess.check_call(['git', 'clone', 'https://github.com/bitcoin/bitcoin.git'])
     os.chdir('gitian-builder')
     make_image_prog = ['bin/make-base-vm', '--suite', 'bionic', '--arch', 'amd64']
     if args.docker:
@@ -70,7 +72,7 @@ def build():
         subprocess.check_call(['git', 'add', args.version+'-linux/'+args.signer])
         subprocess.check_call(['git', 'add', args.version+'-win-unsigned/'+args.signer])
         subprocess.check_call(['git', 'add', args.version+'-osx-unsigned/'+args.signer])
-        subprocess.check_call(['git', 'commit', '-a', '-m', 'Add '+args.version+' unsigned sigs for '+args.signer])
+        subprocess.check_call(['git', 'commit', '-m', 'Add '+args.version+' unsigned sigs for '+args.signer])
         os.chdir(workdir)
 
 def sign():

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -157,7 +157,7 @@ Commit your signature to gitian.sigs:
     git add ${VERSION}-linux/"${SIGNER}"
     git add ${VERSION}-win-unsigned/"${SIGNER}"
     git add ${VERSION}-osx-unsigned/"${SIGNER}"
-    git commit -a
+    git commit -m "Add ${VERSION} unsigned sigs for ${SIGNER}"
     git push  # Assuming you can push to the gitian.sigs tree
     popd
 


### PR DESCRIPTION
Cloning the core repo is mentioned in https://github.com/bitcoin/bitcoin/blob/master/doc/release-process.md#first-time--new-builders and required later on in the script.

Also, remove a redundant `-a` option to `git commit` when commiting the signatures.

Also, install missing commands, which are required later on in the script.