### PR TITLE
[test] Add coverage to estimaterawfee and estimatesmartfee

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -99,8 +99,20 @@ def split_inputs(from_node, txins, txouts, initial_split=False):
     txouts.append({"txid": txid, "vout": 0, "amount": half_change})
     txouts.append({"txid": txid, "vout": 1, "amount": rem_change})
 
+def check_raw_estimates(node, fees_seen):
+    """Call estimaterawfee and verify that the estimates meet certain invariants."""
 
-def check_estimates(node, fees_seen):
+    delta = 1.0e-6  # account for rounding error
+    for i in range(1, 26):
+        for _, e in node.estimaterawfee(i).items():
+            feerate = float(e["feerate"])
+            assert_greater_than(feerate, 0)
+
+            if feerate + delta < min(fees_seen) or feerate - delta > max(fees_seen):
+                raise AssertionError("Estimated fee (%f) out of range (%f,%f)"
+                                     % (feerate, min(fees_seen), max(fees_seen)))
+
+def check_smart_estimates(node, fees_seen):
     """Call estimatesmartfee and verify that the estimates meet certain invariants."""
 
     delta = 1.0e-6  # account for rounding error
@@ -123,6 +135,9 @@ def check_estimates(node, fees_seen):
         else:
             assert_greater_than_or_equal(i + 1, e["blocks"])
 
+def check_estimates(node, fees_seen):
+    check_raw_estimates(node, fees_seen)
+    check_smart_estimates(node, fees_seen)
 
 class EstimateFeeTest(BitcoinTestFramework):
     def set_test_params(self):

--- a/test/functional/rpc_estimatefee.py
+++ b/test/functional/rpc_estimatefee.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the estimatefee RPCs.
+
+Test the following RPCs:
+   - estimatesmartfee
+   - estimaterawfee
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+class EstimateFeeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def run_test(self):
+        # missing required params
+        assert_raises_rpc_error(-1, "estimatesmartfee", self.nodes[0].estimatesmartfee)
+        assert_raises_rpc_error(-1, "estimaterawfee", self.nodes[0].estimaterawfee)
+
+        # wrong type for conf_target
+        assert_raises_rpc_error(-3, "Expected type number, got string", self.nodes[0].estimatesmartfee, 'foo')
+        assert_raises_rpc_error(-3, "Expected type number, got string", self.nodes[0].estimaterawfee, 'foo')
+
+        # wrong type for estimatesmartfee(estimate_mode)
+        assert_raises_rpc_error(-3, "Expected type string, got number", self.nodes[0].estimatesmartfee, 1, 1)
+        assert_raises_rpc_error(-8, "Invalid estimate_mode parameter", self.nodes[0].estimatesmartfee, 1, 'foo')
+
+        # wrong type for estimaterawfee(threshold)
+        assert_raises_rpc_error(-3, "Expected type number, got string", self.nodes[0].estimaterawfee, 1, 'foo')
+
+        # extra params
+        assert_raises_rpc_error(-1, "estimatesmartfee", self.nodes[0].estimatesmartfee, 1, 'ECONOMICAL', 1)
+        assert_raises_rpc_error(-1, "estimaterawfee", self.nodes[0].estimaterawfee, 1, 1, 1)
+
+        # valid calls
+        self.nodes[0].estimatesmartfee(1)
+        # self.nodes[0].estimatesmartfee(1, None)
+        self.nodes[0].estimatesmartfee(1, 'ECONOMICAL')
+
+        self.nodes[0].estimaterawfee(1)
+        self.nodes[0].estimaterawfee(1, None)
+        self.nodes[0].estimaterawfee(1, 1)
+
+
+if __name__ == '__main__':
+    EstimateFeeTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -191,6 +191,7 @@ BASE_SCRIPTS = [
     'wallet_resendwallettransactions.py',
     'wallet_fallbackfee.py',
     'feature_minchainwork.py',
+    'rpc_estimatefee.py',
     'rpc_getblockstats.py',
     'wallet_create_tx.py',
     'p2p_fingerprint.py',


### PR DESCRIPTION
This adds light functional coverage to estimaterawfee - a subset of
the testing applied to estimatesmartfee, and argument validation
testing to both estimaterawfee and estimatesmartfee.

One valid estimatesmartfee signature test is commented out because it
fails currently.

Extracted from #12940