### PR TITLE
Add aarch64 qt depends support for cross compiling bitcoin-qt

### DIFF
--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -3,9 +3,7 @@ packages:=boost openssl libevent zeromq
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib
 
-qt_x86_64_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
-qt_i686_linux_packages:=$(qt_x86_64_linux_packages)
-qt_arm_linux_packages:=$(qt_x86_64_linux_packages)
+qt_linux_packages:=qt expat dbus libxcb xcb_proto libXau xproto freetype fontconfig libX11 xextproto libXext xtrans
 
 qt_darwin_packages=qt
 qt_mingw32_packages=qt

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -92,6 +92,7 @@ $(package)_config_opts_linux += -no-opengl
 $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_x86_64_linux = -xplatform linux-g++-64
+$(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
 $(package)_build_env  = QT_RCC_TEST=1
 $(package)_build_env += QT_RCC_SOURCE_DATE_OVERRIDE=1

--- a/depends/packages/xextproto.mk
+++ b/depends/packages/xextproto.mk
@@ -4,6 +4,10 @@ $(package)_download_path=http://xorg.freedesktop.org/releases/individual/proto
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=f3f4b23ac8db9c3a9e0d8edb591713f3d70ef9c3b175970dd8823dfc92aa5bb0
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared
 endef


### PR DESCRIPTION
This also adds a generic qt linux target in packages.mk . I am a bit confused by the existing docs for the RISC addition. Are there boards that would support running bitcoin-qt, or at the very least forwarding X over ssh? Is everybody building depends with `NO_QT=1` when targeting RISC? If not, I will revert the change for a generic qt linux package definition back to the piecemeal solution. 

This pull request should close #13495 