### PR TITLE
contrib: correct version check

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -30,7 +30,7 @@ import signal
 import struct
 import sys
 
-if not (sys.version_info.major >= 3 and sys.version_info.minor >= 5):
+if (sys.version_info.major, sys.version_info.minor) < (3, 5):
     print("This example only works with Python 3.5 and greater")
     sys.exit(1)
 

--- a/contrib/zmq/zmq_sub3.4.py
+++ b/contrib/zmq/zmq_sub3.4.py
@@ -34,7 +34,7 @@ import signal
 import struct
 import sys
 
-if not (sys.version_info.major >= 3 and sys.version_info.minor >= 4):
+if (sys.version_info.major, sys.version_info.minor) < (3, 4):
     print("This example only works with Python 3.4 and greater")
     sys.exit(1)
 


### PR DESCRIPTION
[ not(major >= 3 and minor >= 4) ] fails for '4.0':

```Python
>>> major=4
>>> minor=0
>>> if not (major >= 3 and minor >= 5):
...     print('This example only works with Python 3.5 and greater')
...
This example only works with Python 3.5 and greater
```
