### PR TITLE
Update cross compilation dependencies for Bionic, clarify depends usage

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -33,6 +33,8 @@ No other options are needed, the paths are automatically configured.
 Install the required dependencies: Ubuntu & Debian
 --------------------------------------------------
 
+These instructions assume Ubuntu 18.04 or newer. For Ubuntu 16.04 see [v0.16 version](https://github.com/bitcoin/bitcoin/blob/0.16/depends/README.md#install-the-required-dependencies-ubuntu--debian) of this document.
+
 For macOS cross compilation:
 
     sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
@@ -43,7 +45,9 @@ For Win32/Win64 cross compilation:
 
 For linux (including i386, ARM) cross compilation:
 
-    sudo apt-get install curl g++-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu gcc-4.8-aarch64-linux-gnu binutils-aarch64-linux-gnu g++-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf gcc-4.8-arm-linux-gnueabihf binutils-arm-linux-gnueabihf g++-4.8-multilib gcc-4.8-multilib binutils-gold bsdmainutils
+    sudo apt-get install curl g++-arm-linux-gnueabihf g++-aarch64-linux-gnu \
+    binutils-arm-linux-gnueabihf binutils-aarch64-linux-gnu \
+    g++-4.8-multilib gcc-4.8-multilib binutils-gold
 
 For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 
@@ -80,4 +84,3 @@ Additional targets:
 
 - [description.md](description.md): General description of the depends system
 - [packages.md](packages.md): Steps for adding packages
-

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -72,6 +72,10 @@ Build requirements:
 
     sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev
 
+Build requirements if you use the [depends system](/depends/README.md):
+
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config python3 bsdmainutils
+
 BerkeleyDB is required for the wallet.
 
 **For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
@@ -279,9 +283,9 @@ To build executables for ARM:
     cd depends
     make HOST=arm-linux-gnueabihf NO_QT=1
     cd ..
+    ./autogen.sh
     ./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
     make
 
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-


### PR DESCRIPTION
Bionic `apt-get install` can't find the `g++-4.8*` packages.

When using the depends system for your own host, you don't need to install: `libssl-dev libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-program-options-dev libboost-test-dev libboost-thread-dev`.