### PR TITLE
tests: Add usage note to check-rpc-mappings.py

### DIFF
--- a/test/lint/check-rpc-mappings.py
+++ b/test/lint/check-rpc-mappings.py
@@ -90,6 +90,10 @@ def process_mapping(fname):
     return cmds
 
 def main():
+    if len(sys.argv) != 2:
+        print('Usage: {} ROOT-DIR'.format(sys.argv[0]), file=sys.stderr)
+        sys.exit(1)
+
     root = sys.argv[1]
 
     # Get all commands from dispatch tables


### PR DESCRIPTION
This test would previously fail without a user-friendly warning message, if invoked with no arguments.

Test plan:
```
bitcoin @_@$ python3 test/lint/check-rpc-mappings.py
Usage: test/lint/check-rpc-mappings.py ROOT-DIR
bitcoin @_@$ echo $?
1
bitcoin @_@$ python3 test/lint/check-rpc-mappings.py .
* Checking consistency between dispatch tables and vRPCConvertParams
bitcoin @_@$ echo $?
0
```