### PR TITLE
[depends] Add riscv qt depends support for cross compiling bitcoin-qt

### DIFF
--- a/depends/packages/libX11.mk
+++ b/depends/packages/libX11.mk
@@ -10,6 +10,10 @@ $(package)_config_opts=--disable-xkb --disable-static
 $(package)_config_opts_linux=--with-pic
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -10,6 +10,10 @@ define $(package)_set_vars
   $(package)_config_opts_linux=--with-pic
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/libXext.mk
+++ b/depends/packages/libXext.mk
@@ -9,6 +9,10 @@ define $(package)_set_vars
   $(package)_config_opts=--disable-static
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -10,6 +10,7 @@ $(package)_config_opts=--disable-static
 endef
 
 define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub build-aux &&\
   sed "s/pthread-stubs//" -i configure
 endef
 

--- a/depends/packages/protobuf.mk
+++ b/depends/packages/protobuf.mk
@@ -11,6 +11,11 @@ define $(package)_set_vars
   $(package)_config_opts_linux=--with-pic
 endef
 
+define $(package)_preprocess_cmds
+   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub . &&\
+   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub gtest/build-aux
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -9,6 +9,10 @@ $(package)_config_opts=--disable-shared -without-tools --disable-sdltest
 $(package)_config_opts_linux=--with-pic
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub use
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -8,7 +8,7 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
-$(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch
+$(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch fix_riscv64_arch.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=9822084f8e2d2939ba39f4af4c0c2320e45d5996762a9423f833055607604ed8
@@ -93,6 +93,7 @@ $(package)_config_opts_arm_linux += -platform linux-g++ -xplatform bitcoin-linux
 $(package)_config_opts_i686_linux  = -xplatform linux-g++-32
 $(package)_config_opts_x86_64_linux = -xplatform linux-g++-64
 $(package)_config_opts_aarch64_linux = -xplatform linux-aarch64-gnu-g++
+$(package)_config_opts_riscv64_linux = -platform linux-g++ -xplatform bitcoin-linux-g++
 $(package)_config_opts_mingw32  = -no-opengl -xplatform win32-g++ -device-option CROSS_COMPILE="$(host)-"
 $(package)_build_env  = QT_RCC_TEST=1
 $(package)_build_env += QT_RCC_SOURCE_DATE_OVERRIDE=1
@@ -139,6 +140,7 @@ define $(package)_preprocess_cmds
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
+  patch -p1 -i $($(package)_patch_dir)/fix_riscv64_arch.patch &&\
   echo "QMAKE_LINK_OBJECT_MAX = 10" >> qtbase/mkspecs/win32-g++/qmake.conf &&\
   echo "QMAKE_LINK_OBJECT_SCRIPT = object_script" >> qtbase/mkspecs/win32-g++/qmake.conf &&\
   sed -i.old "s|QMAKE_CFLAGS            = |!host_build: QMAKE_CFLAGS            = $($(package)_cflags) $($(package)_cppflags) |" qtbase/mkspecs/win32-g++/qmake.conf && \

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -8,6 +8,10 @@ define $(package)_set_vars
 $(package)_config_opts=--disable-shared
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/packages/xtrans.mk
+++ b/depends/packages/xtrans.mk
@@ -9,6 +9,10 @@ define $(package)_set_vars
 $(package)_config_opts_linux=--with-pic --disable-static
 endef
 
+define $(package)_preprocess_cmds
+  cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub .
+endef
+
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef

--- a/depends/patches/qt/fix_riscv64_arch.patch
+++ b/depends/patches/qt/fix_riscv64_arch.patch
@@ -1,0 +1,14 @@
+diff --git a/qtbase/src/3rdparty/double-conversion/include/double-conversion/utils.h b/qtbase/src/3rdparty/double-conversion/include/double-conversion/utils.h
+index 20bfd36..93729fa 100644
+--- a/qtbase/src/3rdparty/double-conversion/include/double-conversion/utils.h
++++ b/qtbase/src/3rdparty/double-conversion/include/double-conversion/utils.h
+@@ -65,7 +65,8 @@
+     defined(__sparc__) || defined(__sparc) || defined(__s390__) || \
+     defined(__SH4__) || defined(__alpha__) || \
+     defined(_MIPS_ARCH_MIPS32R2) || \
+-    defined(__AARCH64EL__)
++    defined(__AARCH64EL__) || defined(__aarch64__) || \
++    defined(__riscv)
+ #define DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS 1
+ #elif defined(_M_IX86) || defined(__i386__) || defined(__i386)
+ #if defined(_WIN32)


### PR DESCRIPTION
Based on #13696 , patched a bunch of config.guess and config.sub that does not support riscv
Also patched double-convension from [here](https://github.com/google/double-conversion/blob/master/double-conversion/utils.h)