### PR TITLE
tests: fixes mininode's P2PConnection sending messages on closing transport

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -179,7 +179,7 @@ class P2PConnection(asyncio.Protocol):
             raise IOError('Not connected')
         self._log_message("send", message)
         tmsg = self._build_message(message)
-        NetworkThread.network_event_loop.call_soon_threadsafe(lambda: self._transport and self._transport.write(tmsg))
+        NetworkThread.network_event_loop.call_soon_threadsafe(lambda: self._transport and not self._transport.is_closing() and self._transport.write(tmsg))
 
     # Class utility methods
 


### PR DESCRIPTION
Fixes #13579.
I think one possible solution is to check for [`_transport.is_closing()`](https://docs.python.org/3.4/library/asyncio-protocol.html#asyncio.BaseTransport.is_closing) in the lambda before sending a message (compatible with Python 3.4 too). Let me know if I missed any side effects this introduces.