### PR TITLE
bitcoin-cli: -stdinwalletpassphrase and non-echo stdin passwords

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -520,6 +520,8 @@ endif
 libbitcoin_cli_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_cli_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_cli_a_SOURCES = \
+  compat/stdin.h \
+  compat/stdin.cpp \
   rpc/client.cpp \
   $(BITCOIN_CORE_H)
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -421,6 +421,9 @@ static int CommandLineRPC(int argc, char *argv[])
             if (!std::getline(std::cin, rpcPass)) {
                 throw std::runtime_error("-stdinrpcpass specified but failed to read from standard input");
             }
+            if (StdinTerminal()) {
+                fputc('\n', stdout);
+            }
             gArgs.ForceSetArg("-rpcpassword", rpcPass);
         }
         std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
@@ -437,6 +440,9 @@ static int CommandLineRPC(int argc, char *argv[])
             if (!std::getline(std::cin, walletPass)) {
                 throw std::runtime_error("-stdinwalletpassphrase specified but failed to read from standard input");
             }
+            if (StdinTerminal()) {
+                fputc('\n', stdout);
+            }
             args.insert(args.begin() + 1, walletPass);
         }
         if (gArgs.GetBoolArg("-stdin", false)) {
@@ -444,6 +450,9 @@ static int CommandLineRPC(int argc, char *argv[])
             std::string line;
             while (std::getline(std::cin, line)) {
                 args.push_back(line);
+            }
+            if (StdinTerminal()) {
+                fputc('\n', stdout);
             }
         }
         std::unique_ptr<BaseRequestHandler> rh;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -27,6 +27,7 @@
 #include <support/events.h>
 
 #include <univalue.h>
+#include <compat/stdin.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
@@ -58,7 +59,8 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcwait", "Wait for RPC server to start", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to bitcoind). This changes the RPC endpoint used, e.g. http://127.0.0.1:8332/wallet/<walletname>", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-stdin", "Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases). When combined with -stdinrpcpass, the first line from standard input is used for the RPC password.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-stdinrpcpass", "Read RPC password from standard input as a single line. When combined with -stdin, the first line from standard input is used for the RPC password.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stdinrpcpass", "Read RPC password from standard input as a single line. When combined with -stdin, the first line from standard input is used for the RPC password. When combined with -stdinwalletpassphrase, -stdinrpcpass consumes the first line, and -stdinwalletpassphrase consumes the second.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stdinwalletpassphrase", "Read wallet passphrase from standard input as a single line. When combined with -stdin, the first line from standard input is used for the wallet passphrase.", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 }
 
 /** libevent event log callback */
@@ -411,12 +413,32 @@ static int CommandLineRPC(int argc, char *argv[])
         }
         std::string rpcPass;
         if (gArgs.GetBoolArg("-stdinrpcpass", false)) {
+            NO_STDIN_ECHO();
+            if (!StdinReady()) {
+                fputs("RPC password> ", stderr);
+                fflush(stderr);
+            }
             if (!std::getline(std::cin, rpcPass)) {
                 throw std::runtime_error("-stdinrpcpass specified but failed to read from standard input");
             }
             gArgs.ForceSetArg("-rpcpassword", rpcPass);
         }
         std::vector<std::string> args = std::vector<std::string>(&argv[1], &argv[argc]);
+        if (gArgs.GetBoolArg("-stdinwalletpassphrase", false)) {
+            NO_STDIN_ECHO();
+            std::string walletPass;
+            if (args.size() < 1 || args[0].substr(0, 16) != "walletpassphrase") {
+                throw std::runtime_error("-stdinwalletpassphrase is only applicable for walletpassphrase(change)");
+            }
+            if (!StdinReady()) {
+                fputs("Wallet passphrase> ", stderr);
+                fflush(stderr);
+            }
+            if (!std::getline(std::cin, walletPass)) {
+                throw std::runtime_error("-stdinwalletpassphrase specified but failed to read from standard input");
+            }
+            args.insert(args.begin() + 1, walletPass);
+        }
         if (gArgs.GetBoolArg("-stdin", false)) {
             // Read one arg per line from stdin and append
             std::string line;

--- a/src/compat/stdin.cpp
+++ b/src/compat/stdin.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <cstdio>       // for fileno(), stdin
+
+#ifdef WIN32
+#include <windows.h>    // for SetStdinEcho()
+#include <io.h>         // for isatty()
+#else
+#include <termios.h>    // for SetStdinEcho()
+#include <unistd.h>     // for SetStdinEcho(), isatty()
+#include <sys/poll.h>   // for StdinReady()
+#endif
+
+#include <compat/stdin.h>
+
+// https://stackoverflow.com/questions/1413445/reading-a-password-from-stdcin
+void SetStdinEcho(bool enable)
+{
+#ifdef WIN32
+    HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD mode;
+    GetConsoleMode(hStdin, &mode);
+    if (!enable) {
+        mode &= ~ENABLE_ECHO_INPUT;
+    } else {
+        mode |= ENABLE_ECHO_INPUT;
+    }
+    SetConsoleMode(hStdin, mode);
+#else
+    struct termios tty;
+    tcgetattr(STDIN_FILENO, &tty);
+    if (!enable) {
+        tty.c_lflag &= ~ECHO;
+    } else {
+        tty.c_lflag |= ECHO;
+    }
+    (void)tcsetattr(STDIN_FILENO, TCSANOW, &tty);
+#endif
+}
+
+bool StdinTerminal()
+{
+#ifdef WIN32
+    return _isatty(_fileno(stdin));
+#else
+    return isatty(fileno(stdin));
+#endif
+}
+
+bool StdinReady()
+{
+    if (!StdinTerminal()) {
+        return true;
+    }
+#ifdef WIN32
+    return false;
+#else
+    struct pollfd fds;
+    fds.fd = 0; /* this is STDIN */
+    fds.events = POLLIN;
+    return poll(&fds, 1, 0) == 1;
+#endif
+}
+
+NoechoInst::NoechoInst() { SetStdinEcho(false); }
+NoechoInst::~NoechoInst() { SetStdinEcho(true); }

--- a/src/compat/stdin.h
+++ b/src/compat/stdin.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_STDIN_H
+#define BITCOIN_COMPAT_STDIN_H
+
+struct NoechoInst {
+    NoechoInst();
+    ~NoechoInst();
+};
+
+#define NO_STDIN_ECHO() NoechoInst _no_echo
+
+bool StdinTerminal();
+bool StdinReady();
+
+#endif // BITCOIN_COMPAT_STDIN_H


### PR DESCRIPTION
This PR
* adds `-stdinwalletpassphrase` for use with `walletpasshprase(change)`
* adds no-echo for passwords (`-stdinrpcpass` and above)

It may not be ideal, but it's better than having to clear the screen whenever you unlock the wallet.
