### PR TITLE
build: Make lint-locale-dependence.sh work with BSD grep (avoid empty subexpressions)

### DIFF
--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -199,11 +199,11 @@ REGEXP_IGNORE_KNOWN_VIOLATIONS=$(join_array "|" "${KNOWN_VIOLATIONS[@]}")
 
 # Invoke "git grep" only once in order to minimize run-time
 REGEXP_LOCALE_DEPENDENT_FUNCTIONS=$(join_array "|" "${LOCALE_DEPENDENT_FUNCTIONS[@]}")
-GIT_GREP_OUTPUT=$(git grep -E "[^a-zA-Z0-9_\`'\"<>](${REGEXP_LOCALE_DEPENDENT_FUNCTIONS}(|_r|_s))[^a-zA-Z0-9_\`'\"<>]" -- "*.cpp" "*.h")
+GIT_GREP_OUTPUT=$(git grep -E "[^a-zA-Z0-9_\`'\"<>](${REGEXP_LOCALE_DEPENDENT_FUNCTIONS}(_r|_s)?)[^a-zA-Z0-9_\`'\"<>]" -- "*.cpp" "*.h")
 
 EXIT_CODE=0
 for LOCALE_DEPENDENT_FUNCTION in "${LOCALE_DEPENDENT_FUNCTIONS[@]}"; do
-    MATCHES=$(grep -E "[^a-zA-Z0-9_\`'\"<>]${LOCALE_DEPENDENT_FUNCTION}(|_r|_s)[^a-zA-Z0-9_\`'\"<>]" <<< "${GIT_GREP_OUTPUT}" | \
+    MATCHES=$(grep -E "[^a-zA-Z0-9_\`'\"<>]${LOCALE_DEPENDENT_FUNCTION}(_r|_s)?[^a-zA-Z0-9_\`'\"<>]" <<< "${GIT_GREP_OUTPUT}" | \
         grep -vE "\.(c|cpp|h):\s*(//|\*|/\*|\").*${LOCALE_DEPENDENT_FUNCTION}" | \
         grep -vE 'fprintf\(.*(stdout|stderr)')
     if [[ ${REGEXP_IGNORE_EXTERNAL_DEPENDENCIES} != "" ]]; then

--- a/test/lint/lint-shell-bsd-compat.sh
+++ b/test/lint/lint-shell-bsd-compat.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Make sure we don't depend on GNU specific functionality in commands called
+# from shell scripts.
+
+export LC_ALL=C
+
+EXIT_CODE=0
+
+# BSD grep does not support empty subexpressions
+#
+# macOS High Sierra:
+#
+# $ grep --version
+# grep (BSD grep) 2.5.1-FreeBSD
+# $ echo foo | grep -E '^foo(_r|_s)?$'
+# foo
+# $ echo foo | grep -E '^foo(|_r|_s)$'
+# grep: empty (sub)expression
+#
+# Ubuntu 18.04 LTS:
+#
+# $ grep --version
+# grep (GNU grep) 3.1
+# $ echo foo | grep -E '^foo(_r|_s)?$'
+# foo
+# $ echo foo | grep -E '^foo(|_r|_s)$'
+# foo
+
+if git grep -E 'grep .*(\([^)]*\|\)|\(\|[^)]*\)|\([^)]*\|\|[^)]*\))' -- "*.sh" ":!test/lint/lint-shell-bsd-compat.sh"; then
+    echo "^ BSD grep does not support empty subexpressions. Please reformulate the regexp."
+    EXIT_CODE=1
+fi
+
+exit ${EXIT_CODE}

--- a/test/lint/lint-shell-locale.sh
+++ b/test/lint/lint-shell-locale.sh
@@ -15,7 +15,7 @@ for SHELL_SCRIPT in $(git ls-files -- "*.sh" | grep -vE "src/(secp256k1|univalue
     if grep -q "# This script is intentionally locale dependent by not setting \"export LC_ALL=C\"" "${SHELL_SCRIPT}"; then
         continue
     fi
-    FIRST_NON_COMMENT_LINE=$(grep -vE '^(#.*|)$' "${SHELL_SCRIPT}" | head -1)
+    FIRST_NON_COMMENT_LINE=$(grep -vE '^(#.*)?$' "${SHELL_SCRIPT}" | head -1)
     if [[ ${FIRST_NON_COMMENT_LINE} != "export LC_ALL=C" ]]; then
         echo "Missing \"export LC_ALL=C\" (to avoid locale dependence) as first non-comment non-empty line in ${SHELL_SCRIPT}"
         EXIT_CODE=1


### PR DESCRIPTION
Make `lint-locale-dependence.sh` work with BSD `grep` by avoiding empty subexpressions.

macOS High Sierra:

```
$ grep --version
grep (BSD grep) 2.5.1-FreeBSD
$ echo foo | grep -E '^foo(_r|_s)?$'
foo
$ echo foo | grep -E '^foo(|_r|_s)$'
grep: empty (sub)expression
```

Ubuntu 18.04 LTS:

```
$ grep --version
grep (GNU grep) 3.1
$ echo foo | grep -E '^foo(_r|_s)?$'
foo
$ echo foo | grep -E '^foo(|_r|_s)$'
foo
```

Reported by @masonicboom in https://github.com/bitcoin/bitcoin/pull/13708#discussion_r203791916. Thanks!