### PR TITLE
lint: Run the CI lint stage on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,28 @@ jobs:
       script:
         - set -o errexit; source ./ci/extended_lint/06_script.sh
 
+    - stage: extended-lint
+      name: 'lint macOS 10.12 (compat)'
+      os: osx
+      # Use the earliest macOS that can build our lint dependencies:
+      # Xcode 8.3.3, macOS 10.12, JDK 1.8.0_112-b16
+      # https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+      osx_image: xcode8.3
+      # TODO: if you're updating osx_image, try using "rvm:" to supply the
+      # version of ruby required by homebrew. Despite this "rvm:" declaration,
+      # brew update installs ruby 2.3.7 as its first action.
+      language: ruby
+      rvm:
+        - 2.3.7
+      env:
+      cache: false
+      install:
+        - set -o errexit; source ./ci/lint/04_install.sh
+      before_script:
+        - set -o errexit; source ./ci/lint/05_before_script.sh
+      script:
+        - set -o errexit; source ./ci/lint/06_script.sh
+
     - stage: test
       name: 'ARM  [GOAL: install]  [no unit or functional tests]'
       env: >-

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -11,11 +11,13 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   travis_retry brew update
   travis_retry brew install shellcheck
   travis_retry brew upgrade python
-  export PATH="$(brew --prefix python)/bin:$PATH"
+  PATH="$(brew --prefix python)/bin:$PATH"
+  export PATH
 else
   SHELLCHECK_VERSION=v0.6.0
   travis_retry curl --silent "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
-  export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
+  PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
+  export PATH
 fi
 
 travis_retry pip3 install codespell==1.15.0

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -6,9 +6,17 @@
 
 export LC_ALL=C
 
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  # update first to install required ruby dependency
+  travis_retry brew update
+  travis_retry brew install shellcheck
+  travis_retry brew upgrade python
+  export PATH="$(brew --prefix python)/bin:$PATH"
+else
+  SHELLCHECK_VERSION=v0.6.0
+  travis_retry curl --silent "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
+  export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
+fi
+
 travis_retry pip3 install codespell==1.15.0
 travis_retry pip3 install flake8==3.7.8
-
-SHELLCHECK_VERSION=v0.6.0
-curl -s "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
-export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -9,6 +9,9 @@ export LC_ALL=C
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   # update first to install required ruby dependency
   travis_retry brew update
+  travis_retry brew reinstall git -- --with-pcre2 # for  --perl-regexp
+  travis_retry brew install grep # gnu grep for --perl-regexp support
+  PATH="$(brew --prefix grep)/libexec/gnubin:$PATH"
   travis_retry brew install shellcheck
   travis_retry brew upgrade python
   PATH="$(brew --prefix python)/bin:$PATH"


### PR DESCRIPTION
This helps ensure ongoing compatibility with macOS-distributed version of GNU bash.