### PR TITLE
travis: Avoid unnecessarily setting env variables on the lint build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,6 @@ jobs:
         apt:
           packages:
             - python3-pip
-            - shellcheck
       install:
         - travis_retry pip3 install flake8 --user
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ after_script:
 jobs:
   include:
     - stage: lint
+      env:
       sudo: false
       cache: false
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,12 +84,10 @@ jobs:
       env:
       sudo: false
       cache: false
-      addons:
-        apt:
-          packages:
-            - python3-pip
+      language: python
+      python: '3.6'
       install:
-        - travis_retry pip3 install flake8 --user
+        - travis_retry pip install flake8
       before_script:
         - git fetch --unshallow
       script:


### PR DESCRIPTION
The relevent env variables are set for the matrix builds, and are irrelevant
to the lint build. By default the first matrix entry is applied.

"Each job included in jobs.include inherits the first value of the array that defines a matrix dimension."
https://docs.travis-ci.com/user/build-stages/#Build-Stages-and-Build-Matrix-Expansion

Note the global env variables are still applied, just the matrix are excluded:
https://travis-ci.org/bitcoin/bitcoin/jobs/406455565#L558

Before:
<img width="755" alt="screen shot 2018-07-20 at 19 16 45" src="https://user-images.githubusercontent.com/5470/43029041-81e5fd14-8c51-11e8-9e2a-6c4bcbb36d2c.png">

After:
<img width="702" alt="screen shot 2018-07-20 at 19 23 05" src="https://user-images.githubusercontent.com/5470/43029187-5ec76b28-8c52-11e8-8b03-5bee859c0d96.png">

