### PR TITLE
Utils: Refactor ArgsManager a little

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -446,7 +446,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
 
         // Check that the arg is known
         if (!(IsSwitchChar(key[0]) && key.size() == 1)) {
-            if (!IsArgKnown(key, error)) {
+            if (!IsArgKnown(key)) {
                 error = strprintf("Invalid parameter %s", key.c_str());
                 return false;
             }
@@ -466,7 +466,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     return true;
 }
 
-bool ArgsManager::IsArgKnown(const std::string& key, std::string& error)
+bool ArgsManager::IsArgKnown(const std::string& key) const
 {
     size_t option_index = key.find('.');
     std::string arg_no_net;
@@ -591,7 +591,7 @@ void ArgsManager::AddHiddenArgs(const std::vector<std::string>& names)
     }
 }
 
-std::string ArgsManager::GetHelpMessage()
+std::string ArgsManager::GetHelpMessage() const
 {
     const bool show_debug = gArgs.GetBoolArg("-help-debug", false);
 
@@ -859,7 +859,7 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, std::string& error, boo
         }
 
         // Check that the arg is known
-        if (!IsArgKnown(strKey, error) && !ignore_invalid_keys) {
+        if (!IsArgKnown(strKey) && !ignore_invalid_keys) {
             error = strprintf("Invalid configuration value %s", option.first.c_str());
             return false;
         }

--- a/src/util.h
+++ b/src/util.h
@@ -276,12 +276,12 @@ public:
     /**
      * Get the help string
      */
-    std::string GetHelpMessage();
+    std::string GetHelpMessage() const;
 
     /**
      * Check whether we know of this arg
      */
-    bool IsArgKnown(const std::string& key, std::string& error);
+    bool IsArgKnown(const std::string& key) const;
 };
 
 extern ArgsManager gArgs;


### PR DESCRIPTION
This PR contains some small refactors for `ArgsManager`.

1. Mark `const` on member function if it possible.
2. Remove unused `error` argument from `ArgsManager::IsArgKnown`.

I'm not sure whether these refactors should be separated into another PR. If so, I will do that.