### PR TITLE
refactor: remove superfluous boost::thread_interrupted catch

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -494,9 +494,6 @@ static int CommandLineRPC(int argc, char *argv[])
             }
         } while (fWait);
     }
-    catch (const boost::thread_interrupted&) {
-        throw;
-    }
     catch (const std::exception& e) {
         strPrint = std::string("error: ") + e.what();
         nRet = EXIT_FAILURE;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -816,10 +816,6 @@ static int CommandLineRawTx(int argc, char* argv[])
 
         OutputTx(tx);
     }
-
-    catch (const boost::thread_interrupted&) {
-        throw;
-    }
     catch (const std::exception& e) {
         strPrint = std::string("error: ") + e.what();
         nRet = EXIT_FAILURE;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -18,8 +18,6 @@
 
 #include <atomic>
 
-#include <boost/thread.hpp>
-
 //
 // WalletBatch
 //
@@ -595,9 +593,6 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         }
         pcursor->close();
     }
-    catch (const boost::thread_interrupted&) {
-        throw;
-    }
     catch (...) {
         result = DBErrors::CORRUPT;
     }
@@ -689,9 +684,6 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CW
             }
         }
         pcursor->close();
-    }
-    catch (const boost::thread_interrupted&) {
-        throw;
     }
     catch (...) {
         result = DBErrors::CORRUPT;


### PR DESCRIPTION
No point in catching exception just to re-throw it