### PR TITLE
Only allocate a LevelDB block cache if LevelDB will actually use it

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -72,7 +72,23 @@ public:
     }
 };
 
-static void SetMaxOpenFiles(leveldb::Options *options) {
+// Mmap is only used on 64-bit Unix systems.
+static constexpr bool LevelDBUsesMmap() {
+#ifdef WIN32
+    return false;
+#else
+    return sizeof(void*) >= 8;
+#endif
+}
+
+// Systems with mmap do not use the block cache.
+static constexpr bool LevelDBUsesBlockCache()
+{
+    return !LevelDBUsesMmap();
+}
+
+static void SetMaxOpenFiles(leveldb::Options *options)
+{
     // On most platforms the default setting of max_open_files (which is 1000)
     // is optimal. On Windows using a large file count is OK because the handles
     // do not interfere with select() loops. On 64-bit Unix hosts this value is
@@ -100,8 +116,20 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
 static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
-    options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
-    options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
+
+    // Only give LevelDB memory for the block cache if it will actually use it;
+    // on systems mmap this space is not used by LevelDB (as it's already in the
+    // page cache), so don't bother in that case.
+    //
+    // Up to two write buffers may be held in memory simultaneously, so set
+    // write_buffer_size for the worst case.
+    if (LevelDBUsesBlockCache()) {
+        options.write_buffer_size = nCacheSize / 4;
+        options.block_cache = leveldb::NewLRUCache(nCacheSize / 2);
+    } else {
+        options.write_buffer_size = nCacheSize / 2;
+    }
+
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
     options.info_log = new CBitcoinLevelDBLogger();


### PR DESCRIPTION
Rebased/squashed version of #12825.
Upstream discussion at https://github.com/google/leveldb/issues/561.

When snappy compression is disabled, LevelDB does not use a block cache. This PR avoids wasting memory reserved for the block cache in that situation, and gives it to the write buffer instead.

Unfortunately this behavior is not documented (I have filed a bug upstream already). You can see [here](https://github.com/bitcoin-core/leveldb/blob/bitcoin-fork/util/env_posix.cc#L202) that `PosixMmapReadableFile` takes a `scratch` argument that is unused. This isn't by accident; the return value of the method is compared against the supplied buffer [here](https://github.com/bitcoin-core/leveldb/blob/bitcoin-fork/table/format.cc#L109) to determine whether the block cache should be used.

Giving more memory to the write buffer is good for a number of reasons. Among them: LevelDB checks reads against the mem table holding current writes, so the write buffer acts as an LRU within LevelDB.