### PR TITLE
-masterdatadir for datadir bootstrapping

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -385,6 +385,7 @@ void SetupServerArgs()
     gArgs.AddArg("-feefilter", strprintf("Tell other nodes to filter invs to us by our mempool min fee (default: %u)", DEFAULT_FEEFILTER), true, OptionsCategory::OPTIONS);
     gArgs.AddArg("-includeconf=<file>", "Specify additional configuration file, relative to the -datadir path (only useable from configuration file, not command line)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-loadblock=<file>", "Imports blocks from external blk000??.dat file on startup", false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-masterdatadir=<dir>", "Specify a master data directory, from which the datadir is derived, reusing block files where possible", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxorphantx=<n>", strprintf("Keep at most <n> unconnectable transactions in memory (default: %u)", DEFAULT_MAX_ORPHAN_TRANSACTIONS), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY), false, OptionsCategory::OPTIONS);
@@ -1246,10 +1247,13 @@ bool AppInitMain(InitInterfaces& interfaces)
         }
     }
 
+    g_has_master_datadir = gArgs.IsArgSet("-masterdatadir");
+
     if (!LogInstance().m_log_timestamps)
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
+    if (g_has_master_datadir) LogPrintf("Using master data directory %s\n", GetMasterDataDir().string());
 
     // Only log conf file usage message if conf file actually exists.
     fs::path config_file_path = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1265,3 +1265,21 @@ std::pair<int, char**> WinCmdLineArgs::get()
 }
 #endif
 } // namespace util
+
+bool CopyDirectory(const fs::path& dest, const fs::path& source, const std::string& logprefix)
+{
+    if (fs::exists(source) && fs::is_directory(source)) {
+        if (!fs::is_directory(dest) && !fs::create_directory(dest)) {
+            return false;
+        }
+        LogPrintf("%s", logprefix); /* Continued */
+        for (fs::directory_iterator file(source); file != fs::directory_iterator(); ++file) {
+            fs::path current(file->path());
+            if (fs::is_directory(current)) continue;
+            fs::copy_file(current, dest / current.filename());
+            LogPrintf("."); /* Continued */
+        }
+        LogPrintf("\n");
+    }
+    return true;
+}

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -387,4 +387,13 @@ private:
 
 } // namespace util
 
+/**
+ * Copy all the files in the given directory to the destination path, log-printing
+ * "." for each file, and a "\n" after the copy operation completes, prefixed by
+ * logprefix (skipped if the source does not exist).
+ * Returns false if the destination path is not a directory and cannot be created.
+ * Note that true is returned, even if the source does not exist/is not a directory.
+ */
+bool CopyDirectory(const fs::path& dest, const fs::path& source, const std::string& logprefix);
+
 #endif // BITCOIN_UTIL_SYSTEM_H

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -83,6 +83,8 @@ fs::path GetDefaultDataDir();
 // The blocks directory is always net specific.
 const fs::path &GetBlocksDir();
 const fs::path &GetDataDir(bool fNetSpecific = true);
+const fs::path& GetMasterBlocksDir();
+const fs::path& GetMasterDataDir(bool net_specific = true);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string& confPath);
 #ifdef WIN32

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -69,6 +69,7 @@ bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
 bool RenameOver(fs::path src, fs::path dest);
+bool ObtainDirectoryLock(const fs::path& directory, const std::string lockfile_name, std::unique_ptr<fsbridge::FileLock>& lock);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name);
 bool DirIsWritable(const fs::path& directory);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -233,6 +233,8 @@ std::atomic_bool fImporting(false);
 std::atomic_bool fReindex(false);
 bool fHavePruned = false;
 bool fPruneMode = false;
+bool g_has_master_datadir = false;
+int g_master_endblock = -1;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 bool fRequireStandard = true;
 bool fCheckBlockIndex = false;

--- a/src/validation.h
+++ b/src/validation.h
@@ -189,6 +189,10 @@ static const uint64_t nMinDiskSpace = 52428800;
 extern bool fHavePruned;
 /** True if we're running in -prune mode. */
 extern bool fPruneMode;
+/** True if we have a master datadir from which we derive out own datadir. */
+extern bool g_has_master_datadir;
+/** Set to the block file index of the last block file that is shared with the master. */
+extern int g_master_endblock;
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */

--- a/src/validation.h
+++ b/src/validation.h
@@ -254,7 +254,7 @@ bool CheckDiskSpace(uint64_t nAdditionalBytes = 0, bool blocks_dir = false);
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
+fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix, bool readonly = false);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */

--- a/test/functional/feature_masterdatadir.py
+++ b/test/functional/feature_masterdatadir.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the master datadir feature.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    get_datadir_path,
+    mine_large_block,
+)
+import os
+
+# Copied from feature_pruning.py; should probably be moved into util.py
+def calc_usage(blockdir):
+    return sum(os.path.getsize(blockdir+f) for f in os.listdir(blockdir) if os.path.isfile(os.path.join(blockdir, f))) / (1024. * 1024.)
+
+class MasterDatadirTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_nodes(self):
+        self.masterdatadir = get_datadir_path(self.options.tmpdir, 0)
+        # Create node 0 to mine.
+        # Create node 1 to test -masterdatadir.
+        self.extra_args = [[],
+                           ["-masterdatadir=" + self.masterdatadir]]
+        self.add_nodes(2, self.extra_args)
+        self.start_node(0)
+
+        self.blocks0 = os.path.join(self.nodes[0].datadir, 'regtest', 'blocks', '')
+        self.blocks1 = os.path.join(self.nodes[1].datadir, 'regtest', 'blocks', '')
+
+    def setup_network(self):
+        self.setup_nodes()
+
+    def run_test(self):
+        self.log.info("Mining large blocks until we have more than one blk file")
+        # Make stuff
+        self.nodes[0].generate(150)
+        assert_equal(150, self.nodes[0].getblockcount())
+        # We want more than one block file, so make a few large blocks
+        for i in range(150):
+            mine_large_block(self.nodes[0])
+            if i % 50 == 0:
+                self.log.info("... %s / 150", str(i))
+        assert_equal(300, self.nodes[0].getblockcount())
+        # Check datadir space use
+        node0use = calc_usage(self.blocks0)
+        self.log.info("Node uses %s MB", str(node0use))
+        assert 140. < node0use < 160.
+        self.log.info("Basic setup test")
+        # Shutdown
+        self.stop_node(0)
+        # Start up with master dir
+        self.start_node(1, ["-masterdatadir=" + self.masterdatadir])
+        # Get block count
+        assert_equal(300, self.nodes[1].getblockcount())
+        # Check datadir space use
+        node1use = calc_usage(self.blocks1)
+        assert node1use < 20.
+        # Generate blocks
+        self.nodes[1].generate(100)
+        assert_equal(400, self.nodes[1].getblockcount())
+        # Check datadir space use
+        node1use = calc_usage(self.blocks1)
+        assert node1use < 20.
+        # Go back to node 0
+        self.stop_node(1)
+        self.start_node(0)
+        assert_equal(300, self.nodes[0].getblockcount())
+        # Get both online and synced up
+        self.start_node(1, ["-masterdatadir=" + self.masterdatadir])
+        connect_nodes(self.nodes[0], 1)
+        self.sync_all()
+        assert_equal(400, self.nodes[0].getblockcount())
+        assert_equal(400, self.nodes[1].getblockcount())
+        node0use = calc_usage(self.blocks0)
+        node1use = calc_usage(self.blocks1)
+        assert 140. < node0use < 160.
+        assert node1use < 20.
+
+        # Test case where master mines an additional block file while slave is
+        # offline - slave should never reference new master blocks file
+        self.log.info("Post-init master block file increase test")
+
+        # Shut down node 1
+        self.stop_node(1)
+        # Make more large blocks
+        for i in range(150):
+            mine_large_block(self.nodes[0])
+            if i % 50 == 0:
+                self.log.info("... %s / 150", str(i))
+        node0use = calc_usage(self.blocks0)
+        self.log.info("Node uses %s MB", str(node0use))
+        for f in os.listdir(self.blocks0):
+            print(f)
+        # Start node 1 back up
+        self.start_node(1, ["-masterdatadir=" + self.masterdatadir])
+        connect_nodes(self.nodes[0], 1)
+        self.sync_all()
+        assert_equal(self.nodes[0].getblockcount(), self.nodes[1].getblockcount())
+        node1use = calc_usage(self.blocks1)
+        assert node1use < 180.
+
+        # Reindex the blockchain as node 1; it should directly refer to master
+        # blocks and its own blocks as appropriate
+        self.stop_node(1)
+        self.start_node(1, ["-masterdatadir=" + self.masterdatadir, "-reindex", "-reindex-chainstate"])
+        connect_nodes(self.nodes[0], 1)
+        self.sync_all()
+        node1use = calc_usage(self.blocks1)
+        assert node1use < 180.
+
+if __name__ == '__main__':
+    MasterDatadirTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -199,6 +199,7 @@ EXTENDED_SCRIPTS = [
     # Longest test should go first, to favor running tests in parallel
     'feature_pruning.py',
     'feature_dbcrash.py',
+    'feature_masterdatadir.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -9,6 +9,7 @@ KNOWN_VIOLATIONS=(
     "src/httprpc.cpp.*trim"
     "src/init.cpp:.*atoi"
     "src/init.cpp:.*fprintf"
+    "src/init.cpp:.*stoull"
     "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"


### PR DESCRIPTION
This PR adds the ability to bootstrap another node from an existing datadir.

To fire up a new node with access to an existing node's datadir `y`, you would simply do

```bash
$ bitcoind -datadir=x -masterdatadir=y
```

(presumably permanently in `bitcoin.conf`) and it would use the blocks files from the former up until it needed to change something, at which point it would copy. (See accompanying test.)

It currently only supports `blocks/blk*` caching, which is implemented as copy-on-write. Due to limitations in LevelDB, the `chainstate` and `blocks/index` dirs are copied to `-datadir` on first launch. Latter is only ~75 MB, but former is ~4 GB, so this is sad but better than nothing.

Note: the `feature_masterdatadir.py` test makes ~150 MB of block data. May want to combine this with the pruning tests to not redo the work of mining, but it is in its own test for now. Also may wanna move it to extended, but keeping it in base while this PR is ongoing.
