### PR TITLE
depends: use MacOS friendly sed syntax in qt.mk

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -129,7 +129,7 @@ define $(package)_preprocess_cmds
   cp -f qtbase/mkspecs/macx-clang/qplatformdefs.h qtbase/mkspecs/macx-clang-linux/ &&\
   cp -f $($(package)_patch_dir)/mac-qmake.conf qtbase/mkspecs/macx-clang-linux/qmake.conf && \
   cp -r qtbase/mkspecs/linux-arm-gnueabi-g++ qtbase/mkspecs/bitcoin-linux-g++ && \
-  sed -i s/arm-linux-gnueabi-/$(host)-/g qtbase/mkspecs/bitcoin-linux-g++/qmake.conf && \
+  sed -i.old "s/arm-linux-gnueabi-/$(host)-/g" qtbase/mkspecs/bitcoin-linux-g++/qmake.conf && \
   patch -p1 -i $($(package)_patch_dir)/fix_qt_pkgconfig.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_configure_mac.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_no_printer.patch &&\


### PR DESCRIPTION
I just got this error on master:
```
make clean-all
make -j5
[...]
/bitcoin/depends/sources/qttools-opensource-src-5.9.6.tar.xz: OK
Preprocessing qt...
sed: 1: "qtbase/mkspecs/bitcoin- ...": extra characters at the end of q command
make: *** /bitcoin/depends/work/build/x86_64-apple-darwin17.7.0/qt/5.9.6-b48df1b490b/.stamp_preprocessed] Error 1
```