### PR TITLE
Utils and libraries: Drops the boost/algorithm/string/split.hpp dependency

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -212,6 +212,7 @@ BITCOIN_CORE_H = \
   util/moneystr.h \
   util/rbf.h \
   util/threadnames.h \
+  util/splitstring.h \
   util/time.h \
   util/translation.h \
   util/url.h \
@@ -298,6 +299,7 @@ libbitcoin_server_a_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   ui_interface.cpp \
+  util/splitstring.cpp \
   validation.cpp \
   validationinterface.cpp \
   versionbits.cpp \
@@ -468,6 +470,7 @@ libbitcoin_common_a_SOURCES = \
   script/sign.cpp \
   script/signingprovider.cpp \
   script/standard.cpp \
+  util/splitstring.cpp \
   versionbitsinfo.cpp \
   warnings.cpp \
   $(BITCOIN_CORE_H)
@@ -500,6 +503,7 @@ libbitcoin_util_a_SOURCES = \
   util/moneystr.cpp \
   util/rbf.cpp \
   util/threadnames.cpp \
+  util/splitstring.cpp \
   util/strencodings.cpp \
   util/time.cpp \
   util/url.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -147,6 +147,7 @@ BITCOIN_TESTS =\
   test/txvalidation_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/uint256_tests.cpp \
+  test/utilsplitstring_tests.cpp \
   test/util_tests.cpp \
   test/validation_block_tests.cpp \
   test/versionbits_tests.cpp

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -20,6 +20,7 @@
 #include <univalue.h>
 #include <util/moneystr.h>
 #include <util/rbf.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
@@ -27,8 +28,6 @@
 #include <functional>
 #include <memory>
 #include <stdio.h>
-
-#include <boost/algorithm/string.hpp>
 
 static bool fCreateBlank;
 static std::map<std::string,UniValue> registers;
@@ -233,7 +232,7 @@ static void MutateTxRBFOptIn(CMutableTransaction& tx, const std::string& strInId
 static void MutateTxAddInput(CMutableTransaction& tx, const std::string& strInput)
 {
     std::vector<std::string> vStrInputParts;
-    boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
+    Split(vStrInputParts, strInput, IsAnyOf(":"));
 
     // separate TXID:VOUT in string
     if (vStrInputParts.size()<2)
@@ -268,7 +267,7 @@ static void MutateTxAddOutAddr(CMutableTransaction& tx, const std::string& strIn
 {
     // Separate into VALUE:ADDRESS
     std::vector<std::string> vStrInputParts;
-    boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
+    Split(vStrInputParts, strInput, IsAnyOf(":"));
 
     if (vStrInputParts.size() != 2)
         throw std::runtime_error("TX output missing or too many separators");
@@ -293,7 +292,7 @@ static void MutateTxAddOutPubKey(CMutableTransaction& tx, const std::string& str
 {
     // Separate into VALUE:PUBKEY[:FLAGS]
     std::vector<std::string> vStrInputParts;
-    boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
+    Split(vStrInputParts, strInput, IsAnyOf(":"));
 
     if (vStrInputParts.size() < 2 || vStrInputParts.size() > 3)
         throw std::runtime_error("TX output missing or too many separators");
@@ -337,7 +336,7 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
 {
     // Separate into VALUE:REQUIRED:NUMKEYS:PUBKEY1:PUBKEY2:....[:FLAGS]
     std::vector<std::string> vStrInputParts;
-    boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
+    Split(vStrInputParts, strInput, IsAnyOf(":"));
 
     // Check that there are enough parameters
     if (vStrInputParts.size()<3)
@@ -438,7 +437,7 @@ static void MutateTxAddOutScript(CMutableTransaction& tx, const std::string& str
 {
     // separate VALUE:SCRIPT[:FLAGS]
     std::vector<std::string> vStrInputParts;
-    boost::split(vStrInputParts, strInput, boost::is_any_of(":"));
+    Split(vStrInputParts, strInput, IsAnyOf(":"));
     if (vStrInputParts.size() < 2)
         throw std::runtime_error("TX output missing separator");
 
@@ -767,7 +766,7 @@ static std::string readStdin()
     if (ferror(stdin))
         throw std::runtime_error("error reading stdin");
 
-    boost::algorithm::trim_right(ret);
+    ret.erase(ret.find_last_not_of(" \t\n\v\f\r") + 1);
 
     return ret;
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -9,13 +9,11 @@
 #include <consensus/merkle.h>
 #include <tinyformat.h>
 #include <util/system.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <versionbitsinfo.h>
 
 #include <assert.h>
-
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
@@ -350,7 +348,7 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
 
     for (const std::string& strDeployment : args.GetArgs("-vbparams")) {
         std::vector<std::string> vDeploymentParams;
-        boost::split(vDeploymentParams, strDeployment, boost::is_any_of(":"));
+        Split(vDeploymentParams, strDeployment, IsAnyOf(":"));
         if (vDeploymentParams.size() != 3) {
             throw std::runtime_error("Version bits parameters malformed, expecting deployment:start:end");
         }

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -11,12 +11,12 @@
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <version.h>
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 #include <algorithm>
 
@@ -46,13 +46,13 @@ CScript ParseScript(const std::string& s)
     }
 
     std::vector<std::string> words;
-    boost::algorithm::split(words, s, boost::algorithm::is_any_of(" \t\n"), boost::algorithm::token_compress_on);
+    Split(words, s, IsAnyOf(" \t\n"), true);
 
     for (std::vector<std::string>::const_iterator w = words.begin(); w != words.end(); ++w)
     {
         if (w->empty())
         {
-            // Empty string, ignore. (boost::split given '' will return one word)
+            // Empty string, ignore. (Split given '' will return one word)
         }
         else if (std::all_of(w->begin(), w->end(), ::IsDigit) ||
             (w->front() == '-' && w->size() > 1 && std::all_of(w->begin()+1, w->end(), ::IsDigit)))

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -12,6 +12,7 @@
 #include <rpc/server.h>
 #include <sync.h>
 #include <ui_interface.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
@@ -97,7 +98,7 @@ static bool multiUserAuthorized(std::string strUserPass)
     for (const std::string& strRPCAuth : gArgs.GetArgs("-rpcauth")) {
         //Search for multi-user login/pass "rpcauth" from config
         std::vector<std::string> vFields;
-        boost::split(vFields, strRPCAuth, boost::is_any_of(":$"));
+        Split(vFields, strRPCAuth, IsAnyOf(":$"));
         if (vFields.size() != 3) {
             //Incorrect formatting in config file
             continue;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -47,6 +47,7 @@
 #include <txmempool.h>
 #include <ui_interface.h>
 #include <util/moneystr.h>
+#include <util/splitstring.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -67,7 +68,6 @@
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/thread.hpp>
 
 #if ENABLE_ZMQ

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -17,11 +17,10 @@
 #include <streams.h>
 #include <sync.h>
 #include <txmempool.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <validation.h>
 #include <version.h>
-
-#include <boost/algorithm/string.hpp>
 
 #include <univalue.h>
 
@@ -123,7 +122,7 @@ static bool rest_headers(HTTPRequest* req,
     std::string param;
     const RetFormat rf = ParseDataFormat(param, strURIPart);
     std::vector<std::string> path;
-    boost::split(path, param, boost::is_any_of("/"));
+    Split(path, param, IsAnyOf("/"));
 
     if (path.size() != 2)
         return RESTERR(req, HTTP_BAD_REQUEST, "No header count specified. Use /rest/headers/<count>/<hash>.<ext>.");
@@ -403,7 +402,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     if (param.length() > 1)
     {
         std::string strUriParams = param.substr(1);
-        boost::split(uriParts, strUriParams, boost::is_any_of("/"));
+        Split(uriParts, strUriParams, IsAnyOf("/"));
     }
 
     // throw exception in case of an empty request

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -10,12 +10,12 @@
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 
 #include <boost/signals2/signal.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 
 #include <memory> // for unique_ptr
 #include <unordered_map>
@@ -387,7 +387,7 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
     int hole = 0;
     for (const std::string &argNamePattern: argNames) {
         std::vector<std::string> vargNames;
-        boost::algorithm::split(vargNames, argNamePattern, boost::algorithm::is_any_of("|"));
+        Split(vargNames, argNamePattern, IsAnyOf("|"));
         auto fr = argsIn.end();
         for (const std::string & argName : vargNames) {
             fr = argsIn.find(argName);

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <util/strencodings.h>
+#include <util/splitstring.h>
 #include <util/system.h>
 #include <test/setup_common.h>
 
@@ -10,7 +11,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
@@ -19,7 +19,7 @@ static void ResetArgs(const std::string& strArg)
 {
     std::vector<std::string> vecArg;
     if (strArg.size())
-      boost::split(vecArg, strArg, IsSpace, boost::token_compress_on);
+      Split(vecArg, strArg, IsSpace, true);
 
     // Insert dummy executable name:
     vecArg.insert(vecArg.begin(), "testbitcoin");

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -10,9 +10,9 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <test/setup_common.h>
+#include <util/splitstring.h>
 #include <util/time.h>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <univalue.h>
@@ -22,7 +22,7 @@
 UniValue CallRPC(std::string args)
 {
     std::vector<std::string> vArgs;
-    boost::split(vArgs, args, boost::is_any_of(" \t"));
+    Split(vArgs, args, IsAnyOf(" \t"));
     std::string strMethod = vArgs[0];
     vArgs.erase(vArgs.begin());
     JSONRPCRequest request;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -21,13 +21,13 @@
 #include <script/script_error.h>
 #include <script/standard.h>
 #include <streams.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 
 #include <map>
 #include <string>
 
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <univalue.h>
@@ -65,7 +65,7 @@ unsigned int ParseScriptFlags(std::string strFlags)
     }
     unsigned int flags = 0;
     std::vector<std::string> words;
-    boost::algorithm::split(words, strFlags, boost::algorithm::is_any_of(","));
+    Split(words, strFlags, IsAnyOf(","));
 
     for (const std::string& word : words)
     {

--- a/src/test/utilsplitstring_tests.cpp
+++ b/src/test/utilsplitstring_tests.cpp
@@ -1,0 +1,165 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/splitstring.h>
+#include <util/strencodings.h>
+
+#include <string>
+#include <vector>
+
+#include <test/setup_common.h>
+#include <boost/test/unit_test.hpp>
+
+//
+// To validate the implementation of Split against `boost::split`:
+//
+// [1] Comment out `#include <util/splitstring.h>` above and use the includes below:
+//
+// #include <boost/algorithm/string/classification.hpp>
+// #include <boost/algorithm/string/split.hpp>
+//
+// [2] Replace the Split implementation in `util/splitstring.h` with the implementation below:
+//
+// template<typename ContainerT>
+// void Split(ContainerT& tokens, const std::string& str, const std::function<bool(char)>& predicate, bool merge_empty = false)
+// {
+//     boost::split(tokens, str, predicate, merge_empty ? boost::token_compress_on : boost::token_compress_off);
+// }
+//
+// The unit tests should yield the same result.
+//
+
+BOOST_FIXTURE_TEST_SUITE(utilsplitstring_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(urlsplitstring_test)
+{
+    {
+        std::vector<std::string> result;
+        Split(result, "", IsAnyOf(","));
+        std::vector<std::string> expected = {""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, "", IsAnyOf(","), true);
+        std::vector<std::string> expected = {""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",", IsAnyOf(","));
+        std::vector<std::string> expected = {"", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",", IsAnyOf(","), true);
+        std::vector<std::string> expected = {"", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",,", IsAnyOf(","));
+        std::vector<std::string> expected = {"", "", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",,", IsAnyOf(","), true);
+        std::vector<std::string> expected = {"", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",,,", IsAnyOf(","));
+        std::vector<std::string> expected = {"", "", "", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",,,", IsAnyOf(","), true);
+        std::vector<std::string> expected = {"", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, "Satoshi,Nakamoto", IsAnyOf(","));
+        std::vector<std::string> expected = {"Satoshi", "Nakamoto"};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, "Satoshi,Nakamoto", IsAnyOf(","), true);
+        std::vector<std::string> expected = {"Satoshi", "Nakamoto"};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",,Satoshi,,,,,,Nakamoto,,", IsAnyOf(","));
+        std::vector<std::string> expected = {"", "", "Satoshi", "", "", "", "", "", "Nakamoto", "", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, ",,Satoshi,,,,,,Nakamoto,,", IsAnyOf(","), true);
+        std::vector<std::string> expected = {"", "Satoshi", "Nakamoto", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::set<std::string> result;
+        Split(result, "#reckless", IsAnyOf(""), false);
+        BOOST_CHECK_EQUAL(result.count("#reckless"), 1);
+    }
+
+    {
+        std::set<std::string> result;
+        Split(result, "#reckless", IsAnyOf(""), true);
+        BOOST_CHECK_EQUAL(result.count("#reckless"), 1);
+    }
+
+    {
+        std::set<std::string> result;
+        Split(result, "#reckless", IsAnyOf(",#$"), false);
+        BOOST_CHECK_EQUAL(result.count(""), 1);
+        BOOST_CHECK_EQUAL(result.count("reckless"), 1);
+    }
+
+    {
+        std::set<std::string> result;
+        Split(result, "#reckless|hodl bitcoin ", IsAnyOf(" |"), true);
+        BOOST_CHECK_EQUAL(result.count("#reckless"), 1);
+        BOOST_CHECK_EQUAL(result.count("hodl"), 1);
+        BOOST_CHECK_EQUAL(result.count("bitcoin"), 1);
+        BOOST_CHECK_EQUAL(result.count(""), 1);
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, "  Satoshi \f\n\r\t\vNakamoto  ", IsSpace);
+        std::vector<std::string> expected = {"", "", "Satoshi", "", "", "", "", "", "Nakamoto", "", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+    {
+        std::vector<std::string> result;
+        Split(result, "  Satoshi \f\n\r\t\vNakamoto  ", IsSpace, true);
+        std::vector<std::string> expected = {"", "Satoshi", "Nakamoto", ""};
+        BOOST_CHECK_EQUAL_COLLECTIONS(result.begin(), result.end(), expected.begin(), expected.end());
+    }
+
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -5,6 +5,7 @@
 
 #include <chainparams.h>
 #include <torcontrol.h>
+#include <util/splitstring.h>
 #include <util/strencodings.h>
 #include <netbase.h>
 #include <net.h>
@@ -17,7 +18,6 @@
 #include <stdlib.h>
 
 #include <boost/signals2/signal.hpp>
-#include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/replace.hpp>
 
@@ -621,7 +621,7 @@ void TorController::protocolinfo_cb(TorControlConnection& _conn, const TorContro
                 std::map<std::string,std::string> m = ParseTorReplyMapping(l.second);
                 std::map<std::string,std::string>::iterator i;
                 if ((i = m.find("METHODS")) != m.end())
-                    boost::split(methods, i->second, boost::is_any_of(","));
+                    Split(methods, i->second, IsAnyOf(","));
                 if ((i = m.find("COOKIEFILE")) != m.end())
                     cookiefile = i->second;
             } else if (l.first == "VERSION") {

--- a/src/util/splitstring.cpp
+++ b/src/util/splitstring.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/splitstring.h>
+
+std::function<bool(char)> IsAnyOf(const std::string& any_of_separator)
+{
+    auto predicate = [&](char c) {
+        return (any_of_separator.find(c) != std::string::npos);
+    };
+
+    return predicate;
+}

--- a/src/util/splitstring.h
+++ b/src/util/splitstring.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <functional>
+#include <iterator>
+#include <set>
+#include <string>
+#include <vector>
+#include <type_traits>
+
+#ifndef BITCOIN_UTIL_SPLITSTRING_H
+#define BITCOIN_UTIL_SPLITSTRING_H
+
+/**
+ * Returns a predicate function that tests if a character is in the `any_of_separator` string argument.
+ * @param[in] any_of_string     A string with valid separators.
+ */
+std::function<bool(char)> IsAnyOf(const std::string& any_of_separator);
+
+/**
+ * Tokenizes a string by any of the given separators.
+ * @param[in] tokens            The container (either an instance of std::vector<std::string>
+ *                              or std::set<std::string>) to add tokenized string parts to.
+ * @param[in] str               The string to tokenize.
+ * @param[in] predicate         A function predicate that identifies separators.
+ * @param[in] merge_empty       Set to true to merge adjacent separators (empty tokens); otherwise false (default).
+ */
+template<typename ContainerT>
+void Split(ContainerT& tokens, const std::string& str, const std::function<bool(char)>& predicate, bool merge_empty=false)
+{
+    static_assert(
+        std::is_same<std::vector<std::string>, ContainerT>::value ||
+        std::is_same<std::set<std::string>, ContainerT>::value,
+        "`Split` has only been tested with template arguments of type `std::vector<std::string>` and `std::set<std::string>`");
+
+    auto insertIt = std::inserter(tokens, tokens.end());
+    if (str.empty()) {
+        *insertIt = "";
+        return;
+    }
+
+    const auto begin = str.cbegin();
+    const auto end = str.cend();
+
+    for (auto it = begin; it < end; ++it) {
+        bool foundSeparator{false};
+        auto start = it;
+
+        for (; it < end; ++it) {
+            foundSeparator = predicate(*it);
+            if (foundSeparator) break;
+        }
+
+        if (it != begin && (!merge_empty || start != it)) {
+            *insertIt = std::string(start, it);
+        }
+
+        if (foundSeparator) {
+            if (it == begin) {
+                *insertIt = "";
+            }
+            if (it == end - 1) {
+                *insertIt = "";
+            }
+        }
+    }
+}
+
+#endif // BITCOIN_UTIL_SPLITSTRING_H

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -14,6 +14,7 @@
 #include <script/standard.h>
 #include <sync.h>
 #include <util/bip32.h>
+#include <util/splitstring.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
@@ -23,7 +24,6 @@
 #include <stdint.h>
 #include <tuple>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <univalue.h>
@@ -595,7 +595,7 @@ UniValue importwallet(const JSONRPCRequest& request)
                 continue;
 
             std::vector<std::string> vstr;
-            boost::split(vstr, line, boost::is_any_of(" "));
+            Split(vstr, line, IsAnyOf(" "));
             if (vstr.size() < 2)
                 continue;
             CKey key = DecodeSecret(vstr[0]);

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -49,7 +49,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/algorithm/string.hpp
     boost/algorithm/string/classification.hpp
     boost/algorithm/string/replace.hpp
-    boost/algorithm/string/split.hpp
     boost/chrono/chrono.hpp
     boost/date_time/posix_time/posix_time.hpp
     boost/filesystem.hpp


### PR DESCRIPTION
This pull request drops the `boost/algorithm/string/split.hpp` dependency from the project. It replaces `boost::split` with a custom template function `Split` that has a similar API and returns exactly the same results as `boost::split`.

In addition this pull request refactors an instance of `boost::algorithm::trim_right`, which was implicitly made available via the `boost/algorithm/string.hpp` dependency to prevent having to introduce a new dependency `boost/algorithm/string/trim.hpp`.

The `#include <boost/algorithm/string/predicate.hpp>` in `src/wallet/rpcdump.cpp` will be addressed in #13656 if that PR is merged after this one; or in this PR should #13656 be merged first.

The test vectors in the accompanying unit test have been validated against `boost::split`.