### PR TITLE
Trivial / Doc: Update mac os build instructions

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](https://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent qrencode
+    brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf260 python qt libevent qrencode
 
 See [dependencies.md](dependencies.md) for a complete overview.
 


### PR DESCRIPTION
I changed `protobuf` brew dependancy to `protobuf260` because on mac os high sierra `brew install protobuf` will install `protobuf 3.6.0` which is incompatible resulting in
```  
In file included from ./qt/paymentrequestplus.h:10:
./qt/paymentrequest.pb.h:17:2: error: This file was generated by an older version of protoc which is
#error This file was generated by an older version of protoc which is
 ^
```
while running `make`

Sorry it is my first PR to bitcoin so I hope I followed your guidlines correctly (: 