### PR TITLE
Docs: Create default bitcoin.conf file on startup

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   compat/endian.h \
   compat/sanity.h \
   compressor.h \
+  conf_file.h \
   consensus/consensus.h \
   consensus/tx_verify.h \
   core_io.h \

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -11,13 +11,13 @@
 #include <clientversion.h>
 #include <compat.h>
 #include <fs.h>
-#include <httprpc.h>
-#include <httpserver.h>
+#include <rpc/server.h>
 #include <init.h>
 #include <noui.h>
-#include <rpc/server.h>
 #include <shutdown.h>
 #include <util.h>
+#include <httpserver.h>
+#include <httprpc.h>
 #include <utilstrencodings.h>
 #include <walletinitinterface.h>
 
@@ -96,7 +96,6 @@ static bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "").c_str());
             return false;
         }
-
         if (!gArgs.ReadConfigFiles(error)) {
             fprintf(stderr, "Error reading configuration file: %s\n", error.c_str());
             return false;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -10,7 +10,6 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <compat.h>
-#include <conf_file.h>
 #include <fs.h>
 #include <httprpc.h>
 #include <httpserver.h>
@@ -96,19 +95,6 @@ static bool AppInit(int argc, char* argv[])
         {
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "").c_str());
             return false;
-        }
-
-        // Create bitcoin.conf template in datadir if -conf flag is not set and there is no existing bitcoin.conf file in the datadir
-        if (!gArgs.IsArgSet("-conf") && !fs::exists(GetConfigFile(BITCOIN_CONF_FILENAME))) {
-            try {
-                // write default bitcoin.conf template
-                std::ofstream conf_file(GetConfigFile(BITCOIN_CONF_FILENAME).string().c_str());
-                conf_file << DEFAULT_BITCOIN_CONF_TEXT;
-
-                // fail gracefully
-            } catch (std::ofstream::failure& writeErr) {
-                LogPrintf("Failed to write bitcoin.conf file template to %s\n", GetConfigFile(BITCOIN_CONF_FILENAME).string());
-            }
         }
 
         if (!gArgs.ReadConfigFiles(error)) {

--- a/src/conf_file.h
+++ b/src/conf_file.h
@@ -26,28 +26,26 @@ static const char* DEFAULT_BITCOIN_CONF_TEXT = R"(##
 # Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6
 #whitebind=<addr>
 
-##############################################################
-##            Quick Primer on addnode vs connect            ##
-##  Let's say for instance you use addnode=4.2.2.4          ##
-##  addnode will connect you to and tell you about the      ##
-##    nodes connected to 4.2.2.4.  In addition it will tell ##
-##    the other nodes connected to it that you exist so     ##
-##    they can connect to you.                              ##
-##  connect will not do the above when you 'connect' to it. ##
-##    It will *only* connect you to 4.2.2.4 and no one else.##
-##                                                          ##
-##  So if you're behind a firewall, or have other problems  ##
-##  finding nodes, add some using 'addnode'.                ##
-##                                                          ##
-##  If you want to stay private, use 'connect' to only      ##
-##  connect to "trusted" nodes.                             ##
-##                                                          ##
-##  If you run multiple nodes on a LAN, there's no need for ##
-##  all of them to open lots of connections.  Instead       ##
-##  'connect' them all to one node that is port forwarded   ##
-##  and has lots of connections.                            ##
-##       Thanks goes to [Noodle] on Freenode.               ##
-##############################################################
+    #############################################################################
+    ##            Quick Primer on addnode vs connect                           ##
+    ##  Let's say for instance you use addnode=4.2.2.4 addnode will connect    ##
+    ##  you to and tell you about the nodes connected to 4.2.2.4. In addition  ##
+    ##  it will tell the other nodes connected to it that you exist so         ##
+    ##  they can connect to you.                                               ##
+    ##                                                                         ##
+    ##  connect will not do the above when you 'connect' to it. It will        ##
+    ##  *only* connect you to 4.2.2.4 and no one else.                         ##
+    ##                                                                         ##
+    ##  So if you're behind a firewall, or have other problems finding nodes,  ##
+    ##  add some using 'addnode'.                                              ##
+    ##                                                                         ##
+    ##  If you want to stay private, use 'connect' to only connect to          ##
+    ##  "trusted" nodes.                                                       ##
+    ##                                                                         ##
+    ##  If you run multiple nodes on a LAN, there's no need for all of them    ##
+    ##  to open lots of connections.  Instead 'connect' them all to one node   ##
+    ##  that is port forwarded and has lots of connections.                    ##
+    #############################################################################
 
 # Use as many addnode= settings as you like to connect to specific peers
 #addnode=69.164.218.197
@@ -81,7 +79,7 @@ static const char* DEFAULT_BITCOIN_CONF_TEXT = R"(##
 # If not, you must set rpcuser and rpcpassword to secure the JSON-RPC api. The first
 # method(DEPRECATED) is to set this pair for the server and client:
 #rpcuser=Ulysseys
-#rpcpassword=YourSuperGreatPasswordNumber_DO_NOT_USE_THIS_OR_YOU_WILL_GET_ROBBED_385593
+#rpcpassword=YourSuperGreatPassword_DO_NOT_USE_THIS_OR_YOU_WILL_GET_ROBBED_385593
 #
 # The second method `rpcauth` can be added to server startup argument. It is set at initialization time
 # using the output from the script in share/rpcauth/rpcauth.py after providing a username:

--- a/src/conf_file.h
+++ b/src/conf_file.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CONF_FILE_H
+#define BITCOIN_CONF_FILE_H
+
+static const char* DEFAULT_BITCOIN_CONF_TEXT = R"(##
+## bitcoin.conf configuration file. Lines beginning with # are comments.
+##
+
+# Network-related settings:
+
+# Run on the test network instead of the real bitcoin network.
+#testnet=0
+
+# Run a regression test network
+#regtest=0
+
+# Connect via a SOCKS5 proxy
+#proxy=127.0.0.1:9050
+
+# Bind to given address and always listen on it. Use [host]:port notation for IPv6
+#bind=<addr>
+
+# Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6
+#whitebind=<addr>
+
+##############################################################
+##            Quick Primer on addnode vs connect            ##
+##  Let's say for instance you use addnode=4.2.2.4          ##
+##  addnode will connect you to and tell you about the      ##
+##    nodes connected to 4.2.2.4.  In addition it will tell ##
+##    the other nodes connected to it that you exist so     ##
+##    they can connect to you.                              ##
+##  connect will not do the above when you 'connect' to it. ##
+##    It will *only* connect you to 4.2.2.4 and no one else.##
+##                                                          ##
+##  So if you're behind a firewall, or have other problems  ##
+##  finding nodes, add some using 'addnode'.                ##
+##                                                          ##
+##  If you want to stay private, use 'connect' to only      ##
+##  connect to "trusted" nodes.                             ##
+##                                                          ##
+##  If you run multiple nodes on a LAN, there's no need for ##
+##  all of them to open lots of connections.  Instead       ##
+##  'connect' them all to one node that is port forwarded   ##
+##  and has lots of connections.                            ##
+##       Thanks goes to [Noodle] on Freenode.               ##
+##############################################################
+
+# Use as many addnode= settings as you like to connect to specific peers
+#addnode=69.164.218.197
+#addnode=10.0.0.2:8333
+
+# Alternatively use as many connect= settings as you like to connect ONLY to specific peers
+#connect=69.164.218.197
+#connect=10.0.0.1:8333
+
+# Listening mode, enabled by default except when 'connect' is being used
+#listen=1
+
+# Maximum number of inbound+outbound connections.
+#maxconnections=
+
+#
+# JSON-RPC options (for controlling a running Bitcoin/bitcoind process)
+#
+
+# server=1 tells Bitcoin-Qt and bitcoind to accept JSON-RPC commands
+#server=0
+
+# Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6.
+# This option can be specified multiple times (default: bind to all interfaces)
+#rpcbind=<addr>
+
+# If no rpcpassword is set, rpc cookie auth is sought. The default `-rpccookiefile` name
+# is .cookie and found in the `-datadir` being used for bitcoind. This option is typically used
+# when the server and client are run as the same user.
+#
+# If not, you must set rpcuser and rpcpassword to secure the JSON-RPC api. The first
+# method(DEPRECATED) is to set this pair for the server and client:
+#rpcuser=Ulysseys
+#rpcpassword=YourSuperGreatPasswordNumber_DO_NOT_USE_THIS_OR_YOU_WILL_GET_ROBBED_385593
+#
+# The second method `rpcauth` can be added to server startup argument. It is set at initialization time
+# using the output from the script in share/rpcauth/rpcauth.py after providing a username:
+#
+# ./share/rpcauth/rpcauth.py alice
+# String to be appended to bitcoin.conf:
+# rpcauth=alice:f7efda5c189b999524f151318c0c86$d5b51b3beffbc02b724e5d095828e0bc8b2456e9ac8757ae3211a5d9b16a22ae
+# Your password:
+# DONT_USE_THIS_YOU_WILL_GET_ROBBED_8ak1gI25KFTvjovL3gAM967mies3E=
+#
+# On client-side, you add the normal user/password pair to send commands:
+#rpcuser=alice
+#rpcpassword=DONT_USE_THIS_YOU_WILL_GET_ROBBED_8ak1gI25KFTvjovL3gAM967mies3E=
+#
+# You can even add multiple entries of these to the server conf file, and client can use any of them:
+# rpcauth=bob:b2dd077cb54591a2f3139e69a897ac$4e71f08d48b4347cf8eff3815c0e25ae2e9a4340474079f55705f40574f4ec99
+
+# How many seconds bitcoin will wait for a complete RPC HTTP request.
+# after the HTTP connection is established.
+#rpcclienttimeout=30
+
+# By default, only RPC connections from localhost are allowed.
+# Specify as many rpcallowip= settings as you like to allow connections from other hosts,
+# either as a single IPv4/IPv6 or with a subnet specification.
+
+# NOTE: opening up the RPC port to hosts outside your local trusted network is NOT RECOMMENDED,
+# because the rpcpassword is transmitted over the network unencrypted.
+
+# server=1 tells Bitcoin-Qt to accept JSON-RPC commands.
+# it is also read by bitcoind to determine if RPC should be enabled
+#rpcallowip=10.1.1.34/255.255.255.0
+#rpcallowip=1.2.3.4/24
+#rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
+
+# Listen for RPC connections on this TCP port:
+#rpcport=8332
+
+# You can use Bitcoin or bitcoind to send commands to Bitcoin/bitcoind
+# running on another host using this option:
+#rpcconnect=127.0.0.1
+
+# Create transactions that have enough fees so they are likely to begin confirmation within n blocks (default: 6).
+# This setting is over-ridden by the -paytxfee option.
+#txconfirmtarget=n
+
+# Miscellaneous options
+
+# Pre-generate this many public/private key pairs, so wallet backups will be valid for
+# both prior transactions and several dozen future transactions.
+#keypool=100
+
+# Pay an optional transaction fee every time you send bitcoins.  Transactions with fees
+# are more likely than free transactions to be included in generated blocks, so may
+# be validated sooner.
+#paytxfee=0.00
+
+# Enable pruning to reduce storage requirements by deleting old blocks.
+# This mode is incompatible with -txindex and -rescan.
+# 0 = default (no pruning).
+# 1 = allows manual pruning via RPC.
+# >=550 = target to stay under in MiB.
+#prune=550
+
+# User interface options
+
+# Start Bitcoin minimized
+#min=1
+
+# Minimize to the system tray
+#minimizetotray=1)";
+
+#endif // BITCOIN_CONF_FILE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1244,7 +1244,12 @@ bool AppInitMain()
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
-    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
+
+    // Only log conf file usage message if conf file actually exists
+    fs::path config_file_path = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+    if(fs::exists(config_file_path))
+        LogPrintf("Using config file %s\n", config_file_path.string());
+
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     // Warn about relative -datadir path.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1247,7 +1247,7 @@ bool AppInitMain()
 
     // Only log conf file usage message if conf file actually exists
     fs::path config_file_path = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
-    if(fs::exists(config_file_path))
+    if (fs::exists(config_file_path))
         LogPrintf("Using config file %s\n", config_file_path.string());
 
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -6,6 +6,7 @@
 #include <util.h>
 
 #include <chainparamsbase.h>
+#include <conf_file.h>
 #include <random.h>
 #include <serialize.h>
 #include <utilstrencodings.h>
@@ -788,11 +789,21 @@ const fs::path &GetDataDir(bool fNetSpecific)
         path /= BaseParams().DataDir();
 
     if (fs::create_directories(path)) {
-        // This is the first run, create wallets subdirectory too
-        fs::create_directories(path / "wallets");
+        // This is the first run, setup datadir
+        SetupDatadir(path);
     }
 
     return path;
+}
+
+void SetupDatadir(fs::path path)
+{
+    // create "wallets" subdirectory
+    fs::create_directories(path / "wallets");
+
+    // write default bitcoin.conf template to datadir
+    std::ofstream conf_file((path / BITCOIN_CONF_FILENAME).string().c_str());
+    conf_file << DEFAULT_BITCOIN_CONF_TEXT << std::endl;
 }
 
 void ClearDatadirCache()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -802,7 +802,9 @@ void SetupDatadir(fs::path path)
     fs::create_directories(path / "wallets");
 
     // write default bitcoin.conf template to datadir
-    std::ofstream conf_file((path / BITCOIN_CONF_FILENAME).string().c_str());
+    std::string conf_filename(BITCOIN_CONF_FILENAME);
+    std::string example_conf_filename = conf_filename + ".example";
+    std::ofstream conf_file((path / example_conf_filename).string().c_str());
     conf_file << DEFAULT_BITCOIN_CONF_TEXT << std::endl;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -88,6 +88,7 @@ bool TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();
 const fs::path &GetBlocksDir(bool fNetSpecific = true);
 const fs::path &GetDataDir(bool fNetSpecific = true);
+void SetupDatadir(fs::path path);
 void ClearDatadirCache();
 fs::path GetConfigFile(const std::string& confPath);
 #ifndef WIN32


### PR DESCRIPTION
Fixes #10746. If no -conf flag is passed and no bitcoin.conf file exists in the datadir, then a bitcoin.conf template will be created in the datadir. This conf file will have no configurations set, only explanatory comments. The default bitcoin.conf template was copied from contrib/debian/examples/bitcoin.conf.

The lack of a default config file historically causes a lot of confusion for new users because bitcoind will print `Using config file 
 $DATADIR/bitcoin.conf` on startup even if no file exists.

Curious if error handling is being done properly here or if file permissions need to be considered. I don't think a failure to create this file should terminate the process.

