### PR TITLE
Prefer initialization to assignment in constructors. Prefer in-class initializers to member initializers in constructors for constant initializers.

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -476,6 +476,21 @@ class A
 }
 ```
 
+- Prefer initialization to assignment in constructors.
+
+  - An initialization explicitly states that initialization, rather than
+    assignment, is done and can be more elegant and efficient. Prevents
+    "use before set" errors. (C.49 in the C++ Core Guidelines)
+
+```
+class A {
+    std::string s;
+public:
+    A(std::string sIn) : s(sIn) { } // Good
+    // A(std::string sIn) { s = sIn; } // Bad
+};
+```
+
 - By default, declare single-argument constructors `explicit`.
 
   - *Rationale*: This is a precaution to avoid unintended conversions that might

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2701,6 +2701,7 @@ int CConnman::GetBestHeight() const
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string& addrNameIn, bool fInboundIn) :
+    hSocket(hSocketIn),
     nTimeConnected(GetSystemTimeInSeconds()),
     addr(addrIn),
     addrBind(addrBindIn),
@@ -2715,7 +2716,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nSendVersion(0)
 {
     nServices = NODE_NONE;
-    hSocket = hSocketIn;
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;
     nLastRecv = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2707,60 +2707,13 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     addrBind(addrBindIn),
     fInbound(fInboundIn),
     nKeyedNetGroup(nKeyedNetGroupIn),
-    addrKnown(5000, 0.001),
-    filterInventoryKnown(50000, 0.000001),
     id(idIn),
     nLocalHostNonce(nLocalHostNonceIn),
     nLocalServices(nLocalServicesIn),
-    nMyStartingHeight(nMyStartingHeightIn),
-    nSendVersion(0)
+    nMyStartingHeight(nMyStartingHeightIn)
 {
-    nServices = NODE_NONE;
-    nRecvVersion = INIT_PROTO_VERSION;
-    nLastSend = 0;
-    nLastRecv = 0;
-    nSendBytes = 0;
-    nRecvBytes = 0;
-    nTimeOffset = 0;
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
-    nVersion = 0;
-    strSubVer = "";
-    fWhitelisted = false;
-    fOneShot = false;
-    m_manual_connection = false;
-    fClient = false; // set by version message
-    m_limited_node = false; // set by version message
-    fFeeler = false;
-    fSuccessfullyConnected = false;
-    fDisconnect = false;
-    nRefCount = 0;
-    nSendSize = 0;
-    nSendOffset = 0;
-    hashContinue = uint256();
-    nStartingHeight = -1;
     filterInventoryKnown.reset();
-    fSendMempool = false;
-    fGetAddr = false;
-    nNextLocalAddrSend = 0;
-    nNextAddrSend = 0;
-    nNextInvSend = 0;
-    fRelayTxes = false;
-    fSentAddr = false;
-    pfilter = MakeUnique<CBloomFilter>();
-    timeLastMempoolReq = 0;
-    nLastBlockTime = 0;
-    nLastTXTime = 0;
-    nPingNonceSent = 0;
-    nPingUsecStart = 0;
-    nPingUsecTime = 0;
-    fPingQueued = false;
-    nMinPingUsecTime = std::numeric_limits<int64_t>::max();
-    minFeeFilter = 0;
-    lastSentFeeFilter = 0;
-    nextSendTimeFeeFilter = 0;
-    fPauseRecv = false;
-    fPauseSend = false;
-    nProcessQueueSize = 0;
 
     for (const std::string &msg : getAllNetMessageTypes())
         mapRecvBytesPerMsgCmd[msg] = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2713,7 +2713,6 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nMyStartingHeight(nMyStartingHeightIn)
 {
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
-    filterInventoryKnown.reset();
 
     for (const std::string &msg : getAllNetMessageTypes())
         mapRecvBytesPerMsgCmd[msg] = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -620,11 +620,11 @@ class CNode
     friend class CConnman;
 public:
     // socket
-    std::atomic<ServiceFlags> nServices;
+    std::atomic<ServiceFlags> nServices{NODE_NONE};
     SOCKET hSocket;
-    size_t nSendSize; // total size of all vSendMsg entries
-    size_t nSendOffset; // offset inside the first vSendMsg already sent
-    uint64_t nSendBytes;
+    size_t nSendSize = 0; // total size of all vSendMsg entries
+    size_t nSendOffset = 0; // offset inside the first vSendMsg already sent
+    uint64_t nSendBytes = 0;
     std::deque<std::vector<unsigned char>> vSendMsg;
     CCriticalSection cs_vSend;
     CCriticalSection cs_hSocket;
@@ -632,71 +632,71 @@ public:
 
     CCriticalSection cs_vProcessMsg;
     std::list<CNetMessage> vProcessMsg;
-    size_t nProcessQueueSize;
+    size_t nProcessQueueSize = 0;
 
     CCriticalSection cs_sendProcessing;
 
     std::deque<CInv> vRecvGetData;
-    uint64_t nRecvBytes;
-    std::atomic<int> nRecvVersion;
+    uint64_t nRecvBytes = 0;
+    std::atomic<int> nRecvVersion{INIT_PROTO_VERSION};
 
-    std::atomic<int64_t> nLastSend;
-    std::atomic<int64_t> nLastRecv;
+    std::atomic<int64_t> nLastSend{0};
+    std::atomic<int64_t> nLastRecv{0};
     const int64_t nTimeConnected;
-    std::atomic<int64_t> nTimeOffset;
+    std::atomic<int64_t> nTimeOffset{0};
     // Address of this peer
     const CAddress addr;
     // Bind address of our side of the connection
     const CAddress addrBind;
-    std::atomic<int> nVersion;
+    std::atomic<int> nVersion{0};
     // strSubVer is whatever byte array we read from the wire. However, this field is intended
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
     // store the sanitized version in cleanSubVer. The original should be used when dealing with
     // the network or wire types and the cleaned string used when displayed or logged.
     std::string strSubVer, cleanSubVer;
     CCriticalSection cs_SubVer; // used for both cleanSubVer and strSubVer
-    bool fWhitelisted; // This peer can bypass DoS banning.
-    bool fFeeler; // If true this node is being used as a short lived feeler.
-    bool fOneShot;
-    bool m_manual_connection;
-    bool fClient;
-    bool m_limited_node; //after BIP159
+    bool fWhitelisted = false; // This peer can bypass DoS banning.
+    bool fFeeler = false; // If true this node is being used as a short lived feeler.
+    bool fOneShot = false;
+    bool m_manual_connection = false;
+    bool fClient = false;
+    bool m_limited_node = false; //after BIP159
     const bool fInbound;
-    std::atomic_bool fSuccessfullyConnected;
-    std::atomic_bool fDisconnect;
+    std::atomic_bool fSuccessfullyConnected{false};
+    std::atomic_bool fDisconnect{false};
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs
     //    unless it loads a bloom filter.
-    bool fRelayTxes; //protected by cs_filter
-    bool fSentAddr;
+    bool fRelayTxes = false; //protected by cs_filter
+    bool fSentAddr = false;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
-    std::unique_ptr<CBloomFilter> pfilter;
-    std::atomic<int> nRefCount;
+    std::unique_ptr<CBloomFilter> pfilter{MakeUnique<CBloomFilter>()};
+    std::atomic<int> nRefCount{0};
 
     const uint64_t nKeyedNetGroup;
-    std::atomic_bool fPauseRecv;
-    std::atomic_bool fPauseSend;
+    std::atomic_bool fPauseRecv{false};
+    std::atomic_bool fPauseSend{false};
 protected:
 
     mapMsgCmdSize mapSendBytesPerMsgCmd;
     mapMsgCmdSize mapRecvBytesPerMsgCmd;
 
 public:
-    uint256 hashContinue;
-    std::atomic<int> nStartingHeight;
+    uint256 hashContinue{};
+    std::atomic<int> nStartingHeight{-1};
 
     // flood relay
     std::vector<CAddress> vAddrToSend;
-    CRollingBloomFilter addrKnown;
-    bool fGetAddr;
+    CRollingBloomFilter addrKnown{5000, 0.001};
+    bool fGetAddr = false;
     std::set<uint256> setKnown;
-    int64_t nNextAddrSend;
-    int64_t nNextLocalAddrSend;
+    int64_t nNextAddrSend = 0;
+    int64_t nNextLocalAddrSend = 0;
 
     // inventory based relay
-    CRollingBloomFilter filterInventoryKnown;
+    CRollingBloomFilter filterInventoryKnown{50000, 0.000001};
     // Set of transaction ids we still have to announce.
     // They are sorted by the mempool before relay, so the order is not important.
     std::set<uint256> setInventoryTxToSend;
@@ -707,36 +707,36 @@ public:
     CCriticalSection cs_inventory;
     std::set<uint256> setAskFor;
     std::multimap<int64_t, CInv> mapAskFor;
-    int64_t nNextInvSend;
+    int64_t nNextInvSend = 0;
     // Used for headers announcements - unfiltered blocks to relay
     // Also protected by cs_inventory
     std::vector<uint256> vBlockHashesToAnnounce;
     // Used for BIP35 mempool sending, also protected by cs_inventory
-    bool fSendMempool;
+    bool fSendMempool = false;
 
     // Last time a "MEMPOOL" request was serviced.
-    std::atomic<int64_t> timeLastMempoolReq;
+    std::atomic<int64_t> timeLastMempoolReq{0};
 
     // Block and TXN accept times
-    std::atomic<int64_t> nLastBlockTime;
-    std::atomic<int64_t> nLastTXTime;
+    std::atomic<int64_t> nLastBlockTime{0};
+    std::atomic<int64_t> nLastTXTime{0};
 
     // Ping time measurement:
     // The pong reply we're expecting, or 0 if no pong expected.
-    std::atomic<uint64_t> nPingNonceSent;
+    std::atomic<uint64_t> nPingNonceSent{0};
     // Time (in usec) the last ping was sent, or 0 if no ping was ever sent.
-    std::atomic<int64_t> nPingUsecStart;
+    std::atomic<int64_t> nPingUsecStart{0};
     // Last measured round-trip time.
-    std::atomic<int64_t> nPingUsecTime;
+    std::atomic<int64_t> nPingUsecTime{0};
     // Best measured round-trip time.
-    std::atomic<int64_t> nMinPingUsecTime;
+    std::atomic<int64_t> nMinPingUsecTime{std::numeric_limits<int64_t>::max()};
     // Whether a ping is requested.
-    std::atomic<bool> fPingQueued;
+    std::atomic<bool> fPingQueued{false};
     // Minimum fee rate with which to filter inv's to this node
-    CAmount minFeeFilter;
+    CAmount minFeeFilter = 0;
     CCriticalSection cs_feeFilter;
-    CAmount lastSentFeeFilter;
-    int64_t nextSendTimeFeeFilter;
+    CAmount lastSentFeeFilter = 0;
+    int64_t nextSendTimeFeeFilter = 0;
 
     CNode(NodeId id, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress &addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string &addrNameIn = "", bool fInboundIn = false);
     ~CNode();
@@ -749,7 +749,7 @@ private:
     // Services offered to this peer
     const ServiceFlags nLocalServices;
     const int nMyStartingHeight;
-    int nSendVersion;
+    int nSendVersion = 0;
     std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
 
     mutable CCriticalSection cs_addrName;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3218,10 +3218,7 @@ class CompareInvMempoolOrder
 {
     CTxMemPool *mp;
 public:
-    explicit CompareInvMempoolOrder(CTxMemPool *_mempool)
-    {
-        mp = _mempool;
-    }
+    explicit CompareInvMempoolOrder(CTxMemPool *_mempool) : mp(_mempool) {}
 
     bool operator()(std::set<uint256>::iterator a, std::set<uint256>::iterator b)
     {

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -72,10 +72,9 @@ CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
     SetRaw(NET_IPV4, (const uint8_t*)&ipv4Addr);
 }
 
-CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
+CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope) : scopeId(scope)
 {
     SetRaw(NET_IPV6, (const uint8_t*)&ipv6Addr);
-    scopeId = scope;
 }
 
 unsigned int CNetAddr::GetByte(int n) const
@@ -576,16 +575,13 @@ std::string CService::ToString() const
     return ToStringIPPort();
 }
 
-CSubNet::CSubNet():
-    valid(false)
+CSubNet::CSubNet() : valid(false)
 {
     memset(netmask, 0, sizeof(netmask));
 }
 
-CSubNet::CSubNet(const CNetAddr &addr, int32_t mask)
+CSubNet::CSubNet(const CNetAddr &addr, int32_t mask) : network(addr), valid(true)
 {
-    valid = true;
-    network = addr;
     // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
     memset(netmask, 255, sizeof(netmask));
 
@@ -607,10 +603,8 @@ CSubNet::CSubNet(const CNetAddr &addr, int32_t mask)
         network.ip[x] &= netmask[x];
 }
 
-CSubNet::CSubNet(const CNetAddr &addr, const CNetAddr &mask)
+CSubNet::CSubNet(const CNetAddr &addr, const CNetAddr &mask) : network(addr), valid(true)
 {
-    valid = true;
-    network = addr;
     // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
     memset(netmask, 255, sizeof(netmask));
 
@@ -625,11 +619,9 @@ CSubNet::CSubNet(const CNetAddr &addr, const CNetAddr &mask)
         network.ip[x] &= netmask[x];
 }
 
-CSubNet::CSubNet(const CNetAddr &addr):
-    valid(addr.IsValid())
+CSubNet::CSubNet(const CNetAddr &addr) : network(addr), valid(addr.IsValid())
 {
     memset(netmask, 255, sizeof(netmask));
-    network = addr;
 }
 
 bool CSubNet::Match(const CNetAddr &addr) const

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -175,11 +175,9 @@ public:
 TxConfirmStats::TxConfirmStats(const std::vector<double>& defaultBuckets,
                                 const std::map<double, unsigned int>& defaultBucketMap,
                                unsigned int maxPeriods, double _decay, unsigned int _scale)
-    : buckets(defaultBuckets), bucketMap(defaultBucketMap)
+    : buckets(defaultBuckets), bucketMap(defaultBucketMap), decay(_decay), scale(_scale)
 {
-    decay = _decay;
     assert(_scale != 0 && "_scale must be non-zero");
-    scale = _scale;
     confAvg.resize(maxPeriods);
     for (unsigned int i = 0; i < maxPeriods; i++) {
         confAvg[i].resize(buckets.size());

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -17,7 +17,7 @@ std::string COutPoint::ToString() const
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)
     : prevout(prevoutIn), scriptSig(scriptSigIn), nSequence(nSequenceIn) {}
 
-CTxIn::CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
+CTxIn::CTxIn(const uint256& hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
     : prevout(COutPoint(hashPrevTx, nOut)), scriptSig(scriptSigIn), nSequence(nSequenceIn) {}
 
 std::string CTxIn::ToString() const

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -15,18 +15,10 @@ std::string COutPoint::ToString() const
 }
 
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)
-{
-    prevout = prevoutIn;
-    scriptSig = scriptSigIn;
-    nSequence = nSequenceIn;
-}
+    : prevout(prevoutIn), scriptSig(scriptSigIn), nSequence(nSequenceIn) {}
 
 CTxIn::CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn, uint32_t nSequenceIn)
-{
-    prevout = COutPoint(hashPrevTx, nOut);
-    scriptSig = scriptSigIn;
-    nSequence = nSequenceIn;
-}
+    : prevout(COutPoint(hashPrevTx, nOut)), scriptSig(scriptSigIn), nSequence(nSequenceIn) {}
 
 std::string CTxIn::ToString() const
 {
@@ -43,11 +35,7 @@ std::string CTxIn::ToString() const
     return str;
 }
 
-CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn)
-{
-    nValue = nValueIn;
-    scriptPubKey = scriptPubKeyIn;
-}
+CTxOut::CTxOut(const CAmount& nValueIn, CScript scriptPubKeyIn) : nValue(nValueIn), scriptPubKey(scriptPubKeyIn) {}
 
 std::string CTxOut::ToString() const
 {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -99,7 +99,7 @@ public:
     }
 
     explicit CTxIn(COutPoint prevoutIn, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
-    CTxIn(uint256 hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
+    CTxIn(const uint256& hashPrevTx, uint32_t nOut, CScript scriptSigIn=CScript(), uint32_t nSequenceIn=SEQUENCE_FINAL);
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -85,11 +85,11 @@ CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 }
 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
+    : nMessageSize(nMessageSizeIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
     memset(pchCommand, 0, sizeof(pchCommand));
     strncpy(pchCommand, pszCommand, COMMAND_SIZE);
-    nMessageSize = nMessageSizeIn;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -63,10 +63,7 @@ private:
 
 #include <qt/intro.moc>
 
-FreespaceChecker::FreespaceChecker(Intro *_intro)
-{
-    this->intro = _intro;
-}
+FreespaceChecker::FreespaceChecker(Intro *_intro) : intro(_intro) {}
 
 void FreespaceChecker::check()
 {

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -243,7 +243,7 @@ class CScriptVisitor : public boost::static_visitor<bool>
 private:
     CScript *script;
 public:
-    explicit CScriptVisitor(CScript *scriptin) { script = scriptin; }
+    explicit CScriptVisitor(CScript *scriptin) : script(scriptin) {}
 
     bool operator()(const CNoDestination &dest) const {
         script->clear();

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -443,11 +443,10 @@ void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
 }
 
 
-BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr)
+BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn)
+   : pdb(nullptr), activeTxn(nullptr), fFlushOnClose(fFlushOnCloseIn), env(database.env)
 {
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
-    fFlushOnClose = fFlushOnCloseIn;
-    env = database.env;
     if (database.IsDummy()) {
         return;
     }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -444,7 +444,7 @@ void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
 
 
 BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn)
-   : pdb(nullptr), activeTxn(nullptr), fFlushOnClose(fFlushOnCloseIn), env(database.env)
+   : fFlushOnClose(fFlushOnCloseIn), env(database.env)
 {
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     if (database.IsDummy()) {

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -167,9 +167,9 @@ private:
 class BerkeleyBatch
 {
 protected:
-    Db* pdb;
+    Db* pdb = nullptr;
     std::string strFile;
-    DbTxn* activeTxn;
+    DbTxn* activeTxn = nullptr;
     bool fReadOnly;
     bool fFlushOnClose;
     BerkeleyEnvironment *env;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4204,26 +4204,12 @@ bool CWallet::BackupWallet(const std::string& strDest)
     return database->Backup(strDest);
 }
 
-CKeyPool::CKeyPool()
-{
-    nTime = GetTime();
-    fInternal = false;
-    m_pre_split = false;
-}
+CKeyPool::CKeyPool() : nTime(GetTime()), fInternal(false), m_pre_split(false) {}
 
 CKeyPool::CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn)
-{
-    nTime = GetTime();
-    vchPubKey = vchPubKeyIn;
-    fInternal = internalIn;
-    m_pre_split = false;
-}
+    : nTime(GetTime()), vchPubKey(vchPubKeyIn), fInternal(internalIn), m_pre_split(false) {}
 
-CWalletKey::CWalletKey(int64_t nExpires)
-{
-    nTimeCreated = (nExpires ? GetTime() : 0);
-    nTimeExpires = nExpires;
-}
+CWalletKey::CWalletKey(int64_t nExpires) : nTimeCreated(nExpires ? GetTime() : 0), nTimeExpires(nExpires) {}
 
 void CMerkleTx::SetMerkleBranch(const CBlockIndex* pindex, int posInBlock)
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4204,10 +4204,9 @@ bool CWallet::BackupWallet(const std::string& strDest)
     return database->Backup(strDest);
 }
 
-CKeyPool::CKeyPool() : nTime(GetTime()), fInternal(false), m_pre_split(false) {}
+CKeyPool::CKeyPool() : nTime(GetTime()), fInternal(false) {}
 
-CKeyPool::CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn)
-    : nTime(GetTime()), vchPubKey(vchPubKeyIn), fInternal(internalIn), m_pre_split(false) {}
+CKeyPool::CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn) : nTime(GetTime()), vchPubKey(vchPubKeyIn), fInternal(internalIn) {}
 
 CWalletKey::CWalletKey(int64_t nExpires) : nTimeCreated(nExpires ? GetTime() : 0), nTimeExpires(nExpires) {}
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -117,7 +117,7 @@ public:
     int64_t nTime;
     CPubKey vchPubKey;
     bool fInternal; // for change outputs
-    bool m_pre_split; // For keys generated before keypool split upgrade
+    bool m_pre_split = false; // For keys generated before keypool split upgrade
 
     CKeyPool();
     CKeyPool(const CPubKey& vchPubKeyIn, bool internalIn);


### PR DESCRIPTION
Initialize members in initialization lists. Prefer in-class initializers to member initializers in constructors for constant initializers.

Rationale:
* [C.49: Prefer initialization to assignment in constructors ](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c49-prefer-initialization-to-assignment-in-constructors)
* [C.48: Prefer in-class initializers to member initializers in constructors for constant initializers](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-in-class-initializer)