### PR TITLE
gui: Don't access static members from class instances

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -720,9 +720,9 @@ int main(int argc, char *argv[])
 #if defined(Q_OS_WIN)
             WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("%1 didn't yet exit safely...").arg(QObject::tr(PACKAGE_NAME)), (HWND)app.getMainWinId());
 #endif
-            app.exec();
+            QApplication::exec();
             app.requestShutdown();
-            app.exec();
+            QApplication::exec();
             rv = app.getReturnValue();
         } else {
             // A dialog with detailed error will have been shown by InitError()

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1159,7 +1159,7 @@ void BitcoinGUI::detectShutdown()
     {
         if(rpcConsole)
             rpcConsole->hide();
-        qApp->quit();
+        QApplication::quit();
     }
 }
 

--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -42,7 +42,7 @@ Notificator::Notificator(const QString &_programName, QSystemTrayIcon *_trayIcon
     ,interface(0)
 #endif
 {
-    if(_trayIcon && _trayIcon->supportsMessages())
+    if(_trayIcon && QSystemTrayIcon::supportsMessages())
     {
         mode = QSystemTray;
     }

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests
     QApplication app(argc, argv);
-    app.setApplicationName("Bitcoin-Qt-test");
+    QApplication::setApplicationName("Bitcoin-Qt-test");
 
     SSL_library_init();
 


### PR DESCRIPTION
Don't access static members from class instances.

Be explicit about the fact that the members we're accessing are static.