### PR TITLE
Use explicit captures in lambda expressions

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3156,7 +3156,7 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
 
         LOCK(cs_main);
 
-        connman->ForEachNode([&](CNode* pnode) {
+        connman->ForEachNode([&worst_peer, &oldest_block_announcement](CNode* pnode) {
             AssertLockHeld(cs_main);
 
             // Ignore non-outbound peers, or nodes marked for disconnect already
@@ -3171,7 +3171,7 @@ void PeerLogicValidation::EvictExtraOutboundPeers(int64_t time_in_seconds)
             }
         });
         if (worst_peer != -1) {
-            bool disconnected = connman->ForNode(worst_peer, [&](CNode *pnode) {
+            bool disconnected = connman->ForNode(worst_peer, [&time_in_seconds, &oldest_block_announcement](CNode *pnode) {
                 AssertLockHeld(cs_main);
 
                 // Only disconnect a peer that has been connected to us for

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -174,7 +174,7 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
     size_t filter_begin_pos = 0, chpos;
     std::vector<std::pair<size_t, size_t>> filter_ranges;
 
-    auto add_to_current_stack = [&](const std::string& strArg) {
+    auto add_to_current_stack = [&stack, &nDepthInsideSensitive, &filter_begin_pos, &chpos](const std::string& strArg) {
         if (stack.back().empty() && (!nDepthInsideSensitive) && historyFilter.contains(QString::fromStdString(strArg), Qt::CaseInsensitive)) {
             nDepthInsideSensitive = 1;
             filter_begin_pos = chpos;
@@ -186,7 +186,7 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
         stack.back().push_back(strArg);
     };
 
-    auto close_out_params = [&]() {
+    auto close_out_params = [&nDepthInsideSensitive, &filter_begin_pos, &filter_ranges, &chpos, &stack]() {
         if (nDepthInsideSensitive) {
             if (!--nDepthInsideSensitive) {
                 assert(filter_begin_pos);

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -232,7 +232,7 @@ static void test_cache_erase_parallel(size_t megabytes)
     for (uint32_t x = 0; x < 3; ++x)
         /** Each thread is emplaced with x copy-by-value
         */
-        threads.emplace_back([&, x] {
+        threads.emplace_back([&hashes, &mtx, &n_insert, x, &set] {
             boost::shared_lock<boost::shared_mutex> l(mtx);
             size_t ntodo = (n_insert/4)/3;
             size_t start = ntodo*x;


### PR DESCRIPTION
Use explicit captures in lambda expressions.

Rationale:
* Explicit is better than implicit.
* Help avoid the lambda dangling reference problem (UB) by being explicit with what objects we use. Makes it easier to reason about their lifetimes.
