### PR TITLE
doc: Remove newlines from error message 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -927,7 +927,7 @@ bool AppInitParameterInteraction()
     // also see: InitParameterInteraction()
 
     if (!fs::is_directory(GetBlocksDir(false))) {
-        return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist.\n"), gArgs.GetArg("-blocksdir", "").c_str()));
+        return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist."), gArgs.GetArg("-blocksdir", "").c_str()));
     }
 
     // if using block pruning, then disallow txindex

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4109,7 +4109,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
         // Regenerate the keypool if upgraded to HD
         if (hd_upgrade) {
             if (!walletInstance->TopUpKeyPool()) {
-                InitError(_("Unable to generate keys") += "\n");
+                InitError(_("Unable to generate keys"));
                 return nullptr;
             }
         }
@@ -4137,7 +4137,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
 
         // Top up the keypool
         if (!walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && !walletInstance->TopUpKeyPool()) {
-            InitError(_("Unable to generate initial keys") += "\n");
+            InitError(_("Unable to generate initial keys"));
             return nullptr;
         }
 


### PR DESCRIPTION
Fix accidental use of the addition assignment operator (`+=`).

_Note to reviewers:_ Perhaps the `\n`:s should be removed too?