### PR TITLE
net: Add missing verification of IPv6 address in CNetAddr::GetIn6Addr(...)

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -300,6 +300,9 @@ bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const
 
 bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
 {
+    if (!IsIPv6()) {
+        return false;
+    }
     memcpy(pipv6Addr, ip, 16);
     return true;
 }


### PR DESCRIPTION
Add missing verification of IPv6 address in `CNetAddr::GetIn6Addr(...)`.