### PR TITLE
Docs: reflow some markdown text files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,39 +1,45 @@
 Contributing to Bitcoin Core
 ============================
 
-The Bitcoin Core project operates an open contributor model where anyone is
-welcome to contribute towards development in the form of peer review, testing
-and patches. This document explains the practical process and guidelines for
-contributing.
+The Bitcoin Core project operates an open contributor model where anyone
+is welcome to contribute towards development in the form of peer review,
+testing and patches. This document explains the practical process and
+guidelines for contributing.
 
 Firstly in terms of structure, there is no particular concept of "Core
 developers" in the sense of privileged people. Open source often naturally
-revolves around meritocracy where longer term contributors gain more trust from
-the developer community. However, some hierarchy is necessary for practical
-purposes. As such there are repository "maintainers" who are responsible for
-merging pull requests as well as a "lead maintainer" who is responsible for the
-release cycle, overall merging, moderation and appointment of maintainers.
+revolves around meritocracy where longer term contributors gain more
+trust from the developer community. However, some hierarchy is necessary
+for practical purposes. As such there are repository "maintainers" who
+are responsible for merging pull requests as well as a "lead maintainer"
+who is responsible for the release cycle, overall merging, moderation
+and appointment of maintainers.
 
 If you're looking for somewhere to start contributing, check out the
-[good first issue](https://github.com/bitcoin/bitcoin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
-list.
+[good first issue] list.
+
+[good first issue]: https://github.com/bitcoin/bitcoin/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22
+
 
 Communication Channels
 ----------------------
 
-Most communication about Bitcoin Core development happens on IRC, in the
-#bitcoin-core-dev channel on Freenode. The easiest way to participate on IRC is
-with the web client, [webchat.freenode.net](https://webchat.freenode.net/). Chat
-history logs can be found
-on [botbot.me](https://botbot.me/freenode/bitcoin-core-dev/).
+Most communication about Bitcoin Core development happens
+on IRC, in the #bitcoin-core-dev channel on Freenode.
+The easiest way to participate on IRC is with the web client,
+[webchat.freenode.net].
+Chat history logs can be found on [botbot.me].
 
-Discussion about code base improvements happens in GitHub issues and on pull
-requests.
+[webchat.freenode.net]: https://webchat.freenode.net/
+[botbot.me]: https://botbot.me/freenode/bitcoin-core-dev/
 
-The developer
-[mailing list](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev)
-should be used to discuss complicated or controversial changes before working on
-a patch set.
+Discussion about code base improvements happens in GitHub issues and on
+pull requests.
+
+The developer [mailing list] should be used to discuss complicated or
+controversial changes before working on a patch set.
+
+[mailing list]: https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev
 
 
 Contributor Workflow
@@ -49,32 +55,41 @@ To contribute a patch, the workflow is as follows:
   1. Create topic branch
   1. Commit patches
 
-The project coding conventions in the [developer notes](doc/developer-notes.md)
-must be adhered to.
+The project coding conventions in the [developer notes] must
+be adhered to.
 
-In general [commits should be atomic](https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention)
-and diffs should be easy to read. For this reason do not mix any formatting
-fixes or code moves with actual code changes.
+[developer notes]: doc/developer-notes.md
 
-Commit messages should be verbose by default consisting of a short subject line
-(50 chars max), a blank line and detailed explanatory text as separate
-paragraph(s), unless the title alone is self-explanatory (like "Corrected typo
-in init.cpp") in which case a single title line is sufficient. Commit messages should be
-helpful to people reading your code in the future, so explain the reasoning for
-your decisions. Further explanation [here](http://chris.beams.io/posts/git-commit/).
+In general [commits should be atomic][c] and diffs should be easy
+to read. For this reason do not mix any formatting fixes or code moves
+with actual code changes.
 
-If a particular commit references another issue, please add the reference. For
-example: `refs #1234` or `fixes #4321`. Using the `fixes` or `closes` keywords
-will cause the corresponding issue to be closed when the pull request is merged.
+[c]: https://en.wikipedia.org/wiki/Atomic_commit#Atomic_commit_convention
 
-Please refer to the [Git manual](https://git-scm.com/doc) for more information
-about Git.
+Commit messages should be verbose by default consisting of a short
+subject line (50 chars max), a blank line and detailed explanatory text
+as separate paragraph(s), unless the title alone is self-explanatory
+(like "Corrected typo in init.cpp") in which case a single title line
+is sufficient. Commit messages should be helpful to people reading your
+code in the future, so explain the reasoning for your decisions. Further
+explanation [here].
+
+[here]: https://chris.beams.io/posts/git-commit/
+
+If a particular commit references another issue, please add the
+reference. For example: `refs #1234` or `fixes #4321`. Using the `fixes`
+or `closes` keywords will cause the corresponding issue to be closed
+when the pull request is merged.
+
+Please refer to the [Git manual] for more information about Git.
+
+[Git manual]: https://git-scm.com/doc
 
   - Push changes to your fork
   - Create pull request
 
-The title of the pull request should be prefixed by the component or area that
-the pull request affects. Valid areas as:
+The title of the pull request should be prefixed by the component or
+area that the pull request affects. Valid areas as:
 
   - *Consensus* for changes to consensus critical code
   - *Docs* for changes to the documentation
@@ -102,28 +117,36 @@ Examples:
     Qt: Add feed bump button
     Trivial: Fix typo in init.cpp
 
-Note that translations should not be submitted as pull requests, please see
-[Translation Process](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md) 
-for more information on helping with translations.
+Note that translations should not be submitted as pull requests,
+please see [Translation Process] for more information on helping with
+translations.
+
+[Translation Process]: doc/translation_process.md
 
 If a pull request is not to be considered for merging (yet), please
-prefix the title with [WIP] or use [Tasks Lists](https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists)
-in the body of the pull request to indicate tasks are pending.
+prefix the title with [WIP] or use [Tasks Lists] in the body of the pull
+request to indicate tasks are pending.
 
-The body of the pull request should contain enough description about what the
-patch does together with any justification/reasoning. You should include
-references to any discussions (for example other tickets or mailing list
-discussions).
+[Tasks Lists]: https://help.github.com/articles/basic-writing-and-formatting-syntax/#task-lists
 
-At this stage one should expect comments and review from other contributors. You
-can add more commits to your pull request by committing them locally and pushing
-to your fork until you have satisfied all feedback.
+The body of the pull request should contain enough description about what
+the patch does together with any justification/reasoning. You should
+include references to any discussions (for example other tickets or
+mailing list discussions).
+
+At this stage one should expect comments and review from other
+contributors. You can add more commits to your pull request by committing
+them locally and pushing to your fork until you have satisfied all
+feedback.
+
 
 Squashing Commits
 ---------------------------
-If your pull request is accepted for merging, you may be asked by a maintainer
-to squash and or [rebase](https://git-scm.com/docs/git-rebase) your commits
-before it will be merged. The basic squashing workflow is shown below.
+If your pull request is accepted for merging, you may be asked by a
+maintainer to squash and or [rebase] your commits before it will be
+merged. The basic squashing workflow is shown below.
+
+[rebase]: https://git-scm.com/docs/git-rebase
 
     git checkout your_branch_name
     git rebase -i HEAD~n
@@ -133,35 +156,36 @@ before it will be merged. The basic squashing workflow is shown below.
     # Save and quit.
     git push -f # (force push to GitHub)
 
-If you have problems with squashing (or other workflows with `git`), you can
-alternatively enable "Allow edits from maintainers" in the right GitHub
-sidebar and ask for help in the pull request.
+If you have problems with squashing (or other workflows with `git`),
+you can alternatively enable "Allow edits from maintainers" in the right
+GitHub sidebar and ask for help in the pull request.
 
 Please refrain from creating several pull requests for the same change.
-Use the pull request that is already open (or was created earlier) to amend
-changes. This preserves the discussion and review that happened earlier for
-the respective change set.
+Use the pull request that is already open (or was created earlier) to
+amend changes. This preserves the discussion and review that happened
+earlier for the respective change set.
 
-The length of time required for peer review is unpredictable and will vary from
-pull request to pull request.
+The length of time required for peer review is unpredictable and will
+vary from pull request to pull request.
 
 
 Pull Request Philosophy
 -----------------------
 
-Patchsets should always be focused. For example, a pull request could add a
-feature, fix a bug, or refactor code; but not a mixture. Please also avoid super
-pull requests which attempt to do too much, are overly large, or overly complex
-as this makes review difficult.
+Patchsets should always be focused. For example, a pull request could
+add a feature, fix a bug, or refactor code; but not a mixture. Please
+also avoid super pull requests which attempt to do too much, are overly
+large, or overly complex as this makes review difficult.
 
 
 ### Features
 
-When adding a new feature, thought must be given to the long term technical debt
-and maintenance that feature may require after inclusion. Before proposing a new
-feature that will require maintenance, please consider if you are willing to
-maintain it (including bug fixing). If features get orphaned with no maintainer
-in the future, they may be removed by the Repository Maintainer.
+When adding a new feature, thought must be given to the long
+term technical debt and maintenance that feature may require after
+inclusion. Before proposing a new feature that will require maintenance,
+please consider if you are willing to maintain it (including bug
+fixing). If features get orphaned with no maintainer in the future,
+they may be removed by the Repository Maintainer.
 
 
 ### Refactoring
@@ -169,125 +193,144 @@ in the future, they may be removed by the Repository Maintainer.
 Refactoring is a necessary part of any software project's evolution. The
 following guidelines cover refactoring pull requests for the project.
 
-There are three categories of refactoring, code only moves, code style fixes,
-code refactoring. In general refactoring pull requests should not mix these
-three kinds of activity in order to make refactoring pull requests easy to
-review and uncontroversial. In all cases, refactoring PRs must not change the
-behaviour of code within the pull request (bugs must be preserved as is).
+There are three categories of refactoring, code only moves, code style
+fixes, code refactoring. In general refactoring pull requests should
+not mix these three kinds of activity in order to make refactoring pull
+requests easy to review and uncontroversial. In all cases, refactoring
+PRs must not change the behaviour of code within the pull request (bugs
+must be preserved as is).
 
-Project maintainers aim for a quick turnaround on refactoring pull requests, so
-where possible keep them short, uncomplex and easy to verify.
+Project maintainers aim for a quick turnaround on refactoring pull
+requests, so where possible keep them short, uncomplex and easy to verify.
 
-Pull requests that refactor the code should not be made by new contributors. It
-requires a certain level of experience to know where the code belongs to and to
-understand the full ramification (including rebase effort of open pull requests).
+Pull requests that refactor the code should not be made by new
+contributors. It requires a certain level of experience to know where
+the code belongs to and to understand the full ramification (including
+rebase effort of open pull requests).
 
-Trivial pull requests or pull requests that refactor the code with no clear
-benefits may be immediately closed by the maintainers to reduce unnecessary
-workload on reviewing.
+Trivial pull requests or pull requests that refactor the code with no
+clear benefits may be immediately closed by the maintainers to reduce
+unnecessary workload on reviewing.
 
 
 "Decision Making" Process
 -------------------------
 
-The following applies to code changes to the Bitcoin Core project (and related
-projects such as libsecp256k1), and is not to be confused with overall Bitcoin
-Network Protocol consensus changes.
+The following applies to code changes to the Bitcoin Core project (and
+related projects such as libsecp256k1), and is not to be confused with
+overall Bitcoin Network Protocol consensus changes.
 
-Whether a pull request is merged into Bitcoin Core rests with the project merge
-maintainers and ultimately the project lead.
+Whether a pull request is merged into Bitcoin Core rests with the project
+merge maintainers and ultimately the project lead.
 
-Maintainers will take into consideration if a patch is in line with the general
-principles of the project; meets the minimum standards for inclusion; and will
-judge the general consensus of contributors.
+Maintainers will take into consideration if a patch is in line with
+the general principles of the project; meets the minimum standards for
+inclusion; and will judge the general consensus of contributors.
 
 In general, all pull requests must:
 
-  - Have a clear use case, fix a demonstrable bug or serve the greater good of
-    the project (for example refactoring for modularisation);
+  - Have a clear use case, fix a demonstrable bug or serve the greater
+    good of the project (for example refactoring for modularisation);
   - Be well peer reviewed;
   - Have unit tests and functional tests where appropriate;
-  - Follow code style guidelines ([C++](doc/developer-notes.md), [functional tests](test/functional/README.md));
+  - Follow code style guidelines ([C++], [functional tests]);
   - Not break the existing test suite;
   - Where bugs are fixed, where possible, there should be unit tests
-    demonstrating the bug and also proving the fix. This helps prevent regression.
+    demonstrating the bug and also proving the fix. This helps prevent
+    regression.
 
-Patches that change Bitcoin consensus rules are considerably more involved than
-normal because they affect the entire ecosystem and so must be preceded by
-extensive mailing list discussions and have a numbered BIP. While each case will
-be different, one should be prepared to expend more time and effort than for
-other kinds of patches because of increased peer review and consensus building
-requirements.
+[C++]: doc/developer-notes.md
+[functional tests]: test/functional/README.md
+
+Patches that change Bitcoin consensus rules are considerably more
+involved than normal because they affect the entire ecosystem and so must
+be preceded by extensive mailing list discussions and have a numbered
+BIP. While each case will be different, one should be prepared to expend
+more time and effort than for other kinds of patches because of increased
+peer review and consensus building requirements.
 
 
 ### Peer Review
 
-Anyone may participate in peer review which is expressed by comments in the pull
-request. Typically reviewers will review the code for obvious errors, as well as
-test out the patch set and opine on the technical merits of the patch. Project
-maintainers take into account the peer review when determining if there is
-consensus to merge a pull request (remember that discussions may have been
-spread out over GitHub, mailing list and IRC discussions). The following
-language is used within pull-request comments:
+Anyone may participate in peer review which is expressed by comments
+in the pull request. Typically reviewers will review the code for
+obvious errors, as well as test out the patch set and opine on the
+technical merits of the patch. Project maintainers take into account
+the peer review when determining if there is consensus to merge a pull
+request (remember that discussions may have been spread out over GitHub,
+mailing list and IRC discussions). The following language is used within
+pull-request comments:
 
   - ACK means "I have tested the code and I agree it should be merged";
-  - NACK means "I disagree this should be merged", and must be accompanied by
-    sound technical justification (or in certain cases of copyright/patent/licensing
-    issues, legal justification). NACKs without accompanying reasoning may be
-    disregarded;
-  - utACK means "I have not tested the code, but I have reviewed it and it looks
-    OK, I agree it can be merged";
-  - Concept ACK means "I agree in the general principle of this pull request";
+  - NACK means "I disagree this should be merged", and must be
+    accompanied by sound technical justification (or in certain cases
+    of copyright/patent/licensing issues, legal justification). NACKs
+    without accompanying reasoning may be disregarded;
+  - utACK means "I have not tested the code, but I have reviewed it and
+    it looks OK, I agree it can be merged";
+  - Concept ACK means "I agree in the general principle of this pull
+    request";
   - Nit refers to trivial, often non-blocking issues.
 
-Reviewers should include the commit hash which they reviewed in their comments.
+Reviewers should include the commit hash which they reviewed in their
+comments.
 
-Project maintainers reserve the right to weigh the opinions of peer reviewers
-using common sense judgement and also may weight based on meritocracy: Those
-that have demonstrated a deeper commitment and understanding towards the project
-(over time) or have clear domain expertise may naturally have more weight, as
-one would expect in all walks of life.
+Project maintainers reserve the right to weigh the opinions of peer
+reviewers using common sense judgement and also may weight based on
+meritocracy: Those that have demonstrated a deeper commitment and
+understanding towards the project (over time) or have clear domain
+expertise may naturally have more weight, as one would expect in all
+walks of life.
 
-Where a patch set affects consensus critical code, the bar will be set much
-higher in terms of discussion and peer review requirements, keeping in mind that
-mistakes could be very costly to the wider community. This includes refactoring
-of consensus critical code.
+Where a patch set affects consensus critical code, the bar will be set
+much higher in terms of discussion and peer review requirements, keeping
+in mind that mistakes could be very costly to the wider community. This
+includes refactoring of consensus critical code.
 
-Where a patch set proposes to change the Bitcoin consensus, it must have been
-discussed extensively on the mailing list and IRC, be accompanied by a widely
-discussed BIP and have a generally widely perceived technical consensus of being
-a worthwhile change based on the judgement of the maintainers.
+Where a patch set proposes to change the Bitcoin consensus, it must have
+been discussed extensively on the mailing list and IRC, be accompanied by
+a widely discussed BIP and have a generally widely perceived technical
+consensus of being a worthwhile change based on the judgement of the
+maintainers.
 
 ### Finding Reviewers
 
-As most reviewers are themselves developers with their own projects, the review
-process can be quite lengthy, and some amount of patience is required. If you find
-that you've been waiting for a pull request to be given attention for several
-months, there may be a number of reasons for this, some of which you can do something
-about:
+As most reviewers are themselves developers with their own projects,
+the review process can be quite lengthy, and some amount of patience
+is required. If you find that you've been waiting for a pull request to
+be given attention for several months, there may be a number of reasons
+for this, some of which you can do something about:
 
-  - It may be because of a feature freeze due to an upcoming release. During this time,
-    only bug fixes are taken into consideration. If your pull request is a new feature,
-    it will not be prioritized until the release is over. Wait for release.
-  - It may be because the changes you are suggesting do not appeal to people. Rather than
-    nits and critique, which require effort and means they care enough to spend time on your
-    contribution, thundering silence is a good sign of widespread (mild) dislike of a given change
-    (because people don't assume *others* won't actually like the proposal). Don't take
-    that personally, though! Instead, take another critical look at what you are suggesting
-    and see if it: changes too much, is too broad, doesn't adhere to the
-    [developer notes](doc/developer-notes.md), is dangerous or insecure, is messily written, etc.
-    Identify and address any of the issues you find. Then ask e.g. on IRC if someone could give
-    their opinion on the concept itself.
-  - It may be because your code is too complex for all but a few people. And those people
-    may not have realized your pull request even exists. A great way to find people who
-    are qualified and care about the code you are touching is the
-    [Git Blame feature](https://help.github.com/articles/tracing-changes-in-a-file/). Simply
-    find the person touching the code you are touching before you and see if you can find
-    them and give them a nudge. Don't be incessant about the nudging though.
-  - Finally, if all else fails, ask on IRC or elsewhere for someone to give your pull request
-    a look. If you think you've been waiting an unreasonably long amount of time (month+) for
-    no particular reason (few lines changed, etc), this is totally fine. Try to return the favor
-    when someone else is asking for feedback on their code, and universe balances out.
+  - It may be because of a feature freeze due to an upcoming
+    release. During this time, only bug fixes are taken into
+    consideration. If your pull request is a new feature, it will not
+    be prioritized until the release is over. Wait for release.
+  - It may be because the changes you are suggesting do not appeal
+    to people. Rather than nits and critique, which require effort
+    and means they care enough to spend time on your contribution,
+    thundering silence is a good sign of widespread (mild) dislike of a
+    given change (because people don't assume *others* won't actually
+    like the proposal). Don't take that personally, though! Instead,
+    take another critical look at what you are suggesting and see if it:
+    changes too much, is too broad, doesn't adhere to the [developer
+    notes](doc/developer-notes.md), is dangerous or insecure, is messily
+    written, etc.  Identify and address any of the issues you find. Then
+    ask e.g. on IRC if someone could give their opinion on the concept
+    itself.
+  - It may be because your code is too complex for all but a few
+    people. And those people may not have realized your pull request
+    even exists. A great way to find people who are qualified
+    and care about the code you are touching is the [Git Blame
+    feature](https://help.github.com/articles/tracing-changes-in-a-file/).
+    Simply find the person touching the code you are touching before
+    you and see if you can find them and give them a nudge. Don't be
+    incessant about the nudging though.
+  - Finally, if all else fails, ask on IRC or elsewhere for someone to
+    give your pull request a look. If you think you've been waiting an
+    unreasonably long amount of time (month+) for no particular reason
+    (few lines changed, etc), this is totally fine. Try to return the
+    favor when someone else is asking for feedback on their code, and
+    universe balances out.
 
 
 Release Policy
@@ -298,7 +341,8 @@ The project leader is the release manager for each Bitcoin Core release.
 Copyright
 ---------
 
-By contributing to this repository, you agree to license your work under the 
-MIT license unless specified otherwise in `contrib/debian/copyright` or at 
-the top of the file itself. Any work contributed where you are not the original 
-author must contain its license header with the original author(s) and source.
+By contributing to this repository, you agree to license your work under
+the MIT license unless specified otherwise in `contrib/debian/copyright`
+or at the top of the file itself. Any work contributed where you are not
+the original author must contain its license header with the original
+author(s) and source.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,5 @@
 Building Bitcoin
 ================
 
-See doc/build-*.md for instructions on building the various
+See `doc/build-*.md` for instructions on building the various
 elements of the Bitcoin Core reference implementation of Bitcoin.

--- a/README.md
+++ b/README.md
@@ -1,76 +1,96 @@
 Bitcoin Core integration/staging tree
 =====================================
 
-[![Build Status](https://travis-ci.org/bitcoin/bitcoin.svg?branch=master)](https://travis-ci.org/bitcoin/bitcoin)
+[![Build Status][ci-travis-icon]][ci-travis]
+
+[ci-travis-icon]: https://travis-ci.org/bitcoin/bitcoin.svg?branch=master
+[ci-travis]: https://travis-ci.org/bitcoin/bitcoin
 
 https://bitcoincore.org
 
 What is Bitcoin?
 ----------------
 
-Bitcoin is an experimental digital currency that enables instant payments to
-anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
-with no central authority: managing transactions and issuing money are carried
-out collectively by the network. Bitcoin Core is the name of open source
-software which enables the use of this currency.
+Bitcoin is an experimental digital currency that enables instant payments
+to anyone, anywhere in the world.
+Bitcoin uses peer-to-peer technology to operate with no central authority:
+managing transactions and issuing money are carried out collectively by
+the network.
+Bitcoin Core is the name of open source software which enables the use
+of this currency.
 
-For more information, as well as an immediately useable, binary version of
-the Bitcoin Core software, see https://bitcoincore.org/en/download/, or read the
-[original whitepaper](https://bitcoincore.org/bitcoin.pdf).
+For more information, as well as an immediately useable, binary version
+of the Bitcoin Core software, see https://bitcoincore.org/en/download/,
+or read the [original whitepaper](https://bitcoincore.org/bitcoin.pdf).
 
 License
 -------
 
-Bitcoin Core is released under the terms of the MIT license. See [COPYING](COPYING) for more
-information or see https://opensource.org/licenses/MIT.
+Bitcoin Core is released under the terms of the MIT
+license. See [COPYING](COPYING) for more information or see
+https://opensource.org/licenses/MIT.
 
 Development Process
 -------------------
 
-The `master` branch is regularly built and tested, but is not guaranteed to be
-completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
-regularly to indicate new official, stable release versions of Bitcoin Core.
+The `master` branch is regularly built and tested, but is not guaranteed
+to be completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags)
+are created regularly to indicate new official, stable release versions
+of Bitcoin Core.
 
-The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
+The contribution workflow is described in
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 Testing
 -------
 
-Testing and code review is the bottleneck for development; we get more pull
-requests than we can review and test on short notice. Please be patient and help out by testing
-other people's pull requests, and remember this is a security-critical project where any mistake might cost people
-lots of money.
+Testing and code review is the bottleneck for development; we get more
+pull requests than we can review and test on short notice.
+Please be patient and help out by testing other people's pull requests,
+and remember this is a security-critical project where any mistake might
+cost people lots of money.
 
 ### Automated Testing
 
-Developers are strongly encouraged to write [unit tests](src/test/README.md) for new code, and to
-submit new unit tests for old code. Unit tests can be compiled and run
-(assuming they weren't disabled in configure) with: `make check`. Further details on running
-and extending unit tests can be found in [/src/test/README.md](/src/test/README.md).
+Developers are strongly encouraged to write [unit
+tests](src/test/README.md) for new code, and to submit new unit tests
+for old code.
+Unit tests can be compiled and run (assuming they weren't disabled in
+configure) with: `make check`.
+Further details on running and extending unit tests can be found in
+[/src/test/README.md](/src/test/README.md).
 
 There are also [regression and integration tests](/test), written
 in Python, that are run automatically on the build server.
-These tests can be run (if the [test dependencies](/test) are installed) with: `test/functional/test_runner.py`
+These tests can be run (if the [test dependencies](/test) are installed)
+with: `test/functional/test_runner.py`
 
-The Travis CI system makes sure that every pull request is built for Windows, Linux, and macOS, and that unit/sanity tests are run automatically.
+The Travis CI system makes sure that every pull request is built
+for Windows, Linux, and macOS, and that unit/sanity tests are run
+automatically.
 
 ### Manual Quality Assurance (QA) Testing
 
-Changes should be tested by somebody other than the developer who wrote the
-code. This is especially important for large or high-risk changes. It is useful
-to add a test plan to the pull request description if testing the changes is
-not straightforward.
+Changes should be tested by somebody other than the developer who wrote
+the code. This is especially important for large or high-risk changes.
+It is useful to add a test plan to the pull request description if testing
+the changes is not straightforward.
 
 Translations
 ------------
 
-Changes to translations as well as new translations can be submitted to
-[Bitcoin Core's Transifex page](https://www.transifex.com/projects/p/bitcoin/).
+Changes to translations as well as new translations
+can be submitted to [Bitcoin Core's Transifex
+page](https://www.transifex.com/projects/p/bitcoin/).
 
-Translations are periodically pulled from Transifex and merged into the git repository. See the
-[translation process](doc/translation_process.md) for details on how this works.
+Translations are periodically pulled from Transifex and merged into the
+git repository.
+See the [translation process](doc/translation_process.md)
+for details on how this works.
 
-**Important**: We do not accept translation changes as GitHub pull requests because the next
-pull from Transifex would automatically overwrite them again.
+**Important**: We do not accept translation changes as GitHub pull
+requests because the next pull from Transifex would automatically
+overwrite them again.
 
-Translators should also subscribe to the [mailing list](https://groups.google.com/forum/#!forum/bitcoin-translators).
+Translators should also subscribe to the [mailing
+list](https://groups.google.com/forum/#!forum/bitcoin-translators).

--- a/contrib/qos/README.md
+++ b/contrib/qos/README.md
@@ -1,5 +1,10 @@
 ### QoS (Quality of service) ###
 
-This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN.
+This is a Linux bash script that will set up tc to limit the outgoing
+bandwidth for connections to the Bitcoin network. It limits outbound
+TCP traffic with a source or destination port of 8333, but not if the
+destination IP is within a LAN.
 
-This means one can have an always-on bitcoind instance running, and another local bitcoind/bitcoin-qt instance which connects to this node and receives blocks from it.
+This means one can have an always-on bitcoind instance running, and
+another local bitcoind/bitcoin-qt instance which connects to this node
+and receives blocks from it.

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -1,60 +1,64 @@
 Each recipe consists of 3 main parts: defining identifiers, setting build
 variables, and defining build commands.
 
-The package "mylib" will be used here as an example
+The package `mylib` will be used here as an example
 
 General tips:
-- mylib_foo is written as $(package)_foo in order to make recipes more similar.
+
+- `mylib_foo` is written as `$(package)_foo` in order to make recipes
+  more similar.
 
 ## Identifiers
 Each package is required to define at least these variables:
 
-    $(package)_version:
-    Version of the upstream library or program. If there is no version, a
-    placeholder such as 1.0 can be used.
+### `$(package)_version`
+Version of the upstream library or program. If there is no version, a
+placeholder such as 1.0 can be used.
 
-    $(package)_download_path:
-    Location of the upstream source, without the file-name. Usually http or
-    ftp.
+### `$(package)_download_path`
+Location of the upstream source, without the file-name. Usually http or
+ftp.
 
-    $(package)_file_name:
-    The upstream source filename available at the download path.
+### `$(package)_file_name`
+The upstream source filename available at the download path.
 
-    $(package)_sha256_hash:
-    The sha256 hash of the upstream file
+### `$(package)_sha256_hash`
+The sha256 hash of the upstream file
 
-These variables are optional:
 
-    $(package)_build_subdir:
-    cd to this dir before running configure/build/stage commands.
+## Optional Identifiers
+Following variables are optional:
+
+### `$(package)_build_subdir`
+`cd` to this dir before running `configure/build/stage` commands.
     
-    $(package)_download_file:
-    The file-name of the upstream source if it differs from how it should be
-    stored locally. This can be used to avoid storing file-names with strange
-    characters.
+### `$(package)_download_file`
+The file-name of the upstream source if it differs from how it should be
+stored locally. This can be used to avoid storing file-names with strange
+characters.
     
-    $(package)_dependencies:
-    Names of any other packages that this one depends on.
+### `$(package)_dependencies`
+Names of any other packages that this one depends on.
     
-    $(package)_patches:
-    Filenames of any patches needed to build the package
+### `$(package)_patches`
+Filenames of any patches needed to build the package
 
-    $(package)_extra_sources:
-    Any extra files that will be fetched via $(package)_fetch_cmds. These are
-    specified so that they can be fetched and verified via 'make download'.
+### `$(package)_extra_sources`
+Any extra files that will be fetched via $(package)_fetch_cmds. These are
+specified so that they can be fetched and verified via 'make download'.
 
 
 ## Build Variables:
-After defining the main identifiers, build variables may be added or customized
-before running the build commands. They should be added to a function called
-$(package)_set_vars. For example:
+After defining the main identifiers, build variables may be added or
+customized before running the build commands. They should be added to
+a function called `$(package)_set_vars`. For example:
 
     define $(package)_set_vars
     ...
     endef
 
-Most variables can be prefixed with the host, architecture, or both, to make
-the modifications specific to that case. For example:
+Most variables can be prefixed with the host, architecture, or both,
+to make the modifications specific to that case. For example:
 
     Universal:     $(package)_cc=gcc
     Linux only:    $(package)_linux_cc=gcc
@@ -81,66 +85,74 @@ These variables may be set to override or append their default values.
     $(package)_build_opts
     $(package)_config_opts
 
-The *_env variables are used to add environment variables to the respective
-commands.
+The `*_env` variables are used to add environment variables to the
+respective commands.
 
-Many variables respect a debug/release suffix as well, in order to use them for
-only the appropriate build config. For example:
+Many variables respect a `debug/release suffix` as well, in order to
+use them for only the appropriate build config. For example:
 
     $(package)_cflags_release = -O3
     $(package)_cflags_i686_debug = -g
     $(package)_config_opts_release = --disable-debug
 
 These will be used in addition to the options that do not specify
-debug/release. All builds are considered to be release unless DEBUG=1 is set by
-the user. Other variables may be defined as needed.
+`debug/release`. All builds are considered to be release unless `DEBUG=1`
+is set by the user. Other variables may be defined as needed.
 
 ## Build commands:
 
-  For each build, a unique build dir and staging dir are created. For example,
-  `work/build/mylib/1.0-1adac830f6e` and `work/staging/mylib/1.0-1adac830f6e`.
+For each build, a unique build dir and staging dir are
+created. For example, `work/build/mylib/1.0-1adac830f6e` and
+`work/staging/mylib/1.0-1adac830f6e`.
 
-  The following build commands are available for each recipe:
+The following build commands are available for each recipe:
 
-    $(package)_fetch_cmds:
-    Runs from: build dir
-    Fetch the source file. If undefined, it will be fetched and verified
-    against its hash.
+### `$(package)_fetch_cmds`
+Runs from: build dir
 
-    $(package)_extract_cmds:
-    Runs from: build dir
-    Verify the source file against its hash and extract it. If undefined, the
-    source is assumed to be a tarball.
+Fetch the source file. If undefined, it will be fetched and verified
+against its hash.
 
-    $(package)_preprocess_cmds:
-    Runs from: build dir/$(package)_build_subdir
-    Preprocess the source as necessary. If undefined, does nothing.
+### `$(package)_extract_cmds`
+Runs from: build dir
 
-    $(package)_config_cmds:
-    Runs from: build dir/$(package)_build_subdir
-    Configure the source. If undefined, does nothing.
+Verify the source file against its hash and extract it. If undefined, the
+source is assumed to be a tarball.
 
-    $(package)_build_cmds:
-    Runs from: build dir/$(package)_build_subdir
-    Build the source. If undefined, does nothing.
+### `$(package)_preprocess_cmds`
+Runs from: build dir/$(package)_build_subdir
 
-    $(package)_stage_cmds:
-    Runs from: build dir/$(package)_build_subdir
-    Stage the build results. If undefined, does nothing.
+Preprocess the source as necessary. If undefined, does nothing.
 
-  The following variables are available for each recipe:
+### `$(package)_config_cmds`
+Runs from: build dir/$(package)_build_subdir
+
+Configure the source. If undefined, does nothing.
+
+### `$(package)_build_cmds`
+Runs from: build dir/$(package)_build_subdir
+
+Build the source. If undefined, does nothing.
+
+### `$(package)_stage_cmds`
+Runs from: build dir/$(package)_build_subdir
+
+Stage the build results. If undefined, does nothing.
+
+## Build Variables
+The following variables are available for each recipe:
     
-    $(1)_staging_dir: package's destination sysroot path
-    $(1)_staging_prefix_dir: prefix path inside of the package's staging dir
-    $(1)_extract_dir: path to the package's extracted sources
-    $(1)_build_dir: path where configure/build/stage commands will be run
-    $(1)_patch_dir: path where the package's patches (if any) are found
+  1. `$(1)_staging_dir`: package's destination sysroot path
+  1. `$(1)_staging_prefix_dir`: prefix path inside of the package's staging dir
+  1. `$(1)_extract_dir`: path to the package's extracted sources
+  1. `$(1)_build_dir`: path where configure/build/stage commands will be run
+  1. `$(1)_patch_dir`: path where the package's patches (if any) are found
 
-Notes on build commands:
+## Notes on build commands:
 
-For packages built with autotools, $($(package)_autoconf) can be used in the
-configure step to (usually) correctly configure automatically. Any
-$($(package)_config_opts) will be appended.
+For packages built with autotools, `$($(package)_autoconf)` can be used
+in the configure step to (usually) correctly configure automatically. Any
+`$($(package)_config_opts)` will be appended.
 
 Most autotools projects can be properly staged using:
 

--- a/doc/init.md
+++ b/doc/init.md
@@ -13,27 +13,32 @@ can be found in the contrib/init folder.
 Service User
 ---------------------------------
 
-All three Linux startup configurations assume the existence of a "bitcoin" user
-and group.  They must be created before attempting to use these scripts.
-The macOS configuration assumes bitcoind will be set up for the current user.
+All three Linux startup configurations assume the existence of a "bitcoin"
+user and group.
+They must be created before attempting to use these scripts.
+The macOS configuration assumes bitcoind will be set up for
+the current user.
 
 Configuration
 ---------------------------------
 
-At a bare minimum, bitcoind requires that the rpcpassword setting be set
-when running as a daemon.  If the configuration file does not exist or this
-setting is not set, bitcoind will shutdown promptly after startup.
+At a bare minimum, bitcoind requires that the rpcpassword setting be
+set when running as a daemon.
+If the configuration file does not exist or this setting is not set,
+bitcoind will shutdown promptly after startup.
 
-This password does not have to be remembered or typed as it is mostly used
-as a fixed token that bitcoind and client programs read from the configuration
-file, however it is recommended that a strong and secure password be used
-as this password is security critical to securing the wallet should the
-wallet be enabled.
+This password does not have to be remembered or typed as it is mostly
+used as a fixed token that bitcoind and client programs read from the
+configuration file, however it is recommended that a strong and secure
+password be used as this password is security critical to securing the
+wallet should the wallet be enabled.
 
-If bitcoind is run with the "-server" flag (set by default), and no rpcpassword is set,
-it will use a special cookie file for authentication. The cookie is generated with random
-content when the daemon starts, and deleted when it exits. Read access to this file
-controls who can access it through RPC.
+If bitcoind is run with the "-server" flag (set by default),
+and no rpcpassword is set, it will use a special cookie file for
+authentication.
+The cookie is generated with random content when the daemon starts,
+and deleted when it exits.
+Read access to this file controls who can access it through RPC.
 
 By default the cookie is stored in the data directory, but it's location can be overridden
 with the option '-rpccookiefile'.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,12 +1,12 @@
-(note: this is a temporary file, to be added-to by anybody, and moved to
-release-notes at release time)
+(note: this is a temporary file, to be added-to by anybody, and moved
+to release-notes at release time)
 
 Bitcoin Core version *version* is now available from:
 
   <https://bitcoincore.org/bin/bitcoin-core-*version*/>
 
-This is a new major version release, including new features, various bugfixes
-and performance improvements, as well as updated translations.
+This is a new major version release, including new features, various
+bugfixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
 
@@ -19,27 +19,29 @@ To receive security and update notifications, please subscribe to:
 How to Upgrade
 ==============
 
-If you are running an older version, shut it down. Wait until it has completely
-shut down (which might take a few minutes for older versions), then run the
-installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
-or `bitcoind`/`bitcoin-qt` (on Linux).
+If you are running an older version, shut it down. Wait until it
+has completely shut down (which might take a few minutes for older
+versions), then run the installer (on Windows) or just copy over
+`/Applications/Bitcoin-Qt` (on Mac) or `bitcoind`/`bitcoin-qt` (on Linux).
 
-The first time you run version 0.15.0, your chainstate database will be converted to a
-new format, which will take anywhere from a few minutes to half an hour,
-depending on the speed of your machine.
+The first time you run version 0.15.0, your chainstate database will be
+converted to a new format, which will take anywhere from a few minutes
+to half an hour, depending on the speed of your machine.
 
-Note that the block database format also changed in version 0.8.0 and there is no
-automatic upgrade code from before version 0.8 to version 0.15.0. Upgrading
-directly from 0.7.x and earlier without redownloading the blockchain is not supported.
-However, as usual, old wallet versions are still supported.
+Note that the block database format also changed in version 0.8.0 and
+there is no automatic upgrade code from before version 0.8 to version
+0.15.0. Upgrading directly from 0.7.x and earlier without redownloading
+the blockchain is not supported.  However, as usual, old wallet versions
+are still supported.
 
 Downgrading warning
 -------------------
 
-The chainstate database for this release is not compatible with previous
-releases, so if you run 0.15 and then decide to switch back to any
-older version, you will need to run the old release with the `-reindex-chainstate`
-option to rebuild the chainstate data structures in the old format.
+The chainstate database for this release is not compatible with
+previous releases, so if you run 0.15 and then decide to switch back
+to any older version, you will need to run the old release with the
+`-reindex-chainstate` option to rebuild the chainstate data structures
+in the old format.
 
 If your node has pruning enabled, this will entail re-downloading and
 processing the entire blockchain.
@@ -48,10 +50,11 @@ Compatibility
 ==============
 
 Bitcoin Core is extensively tested on multiple operating systems using
-the Linux kernel, macOS 10.10+, and Windows 7 and newer (Windows XP is not supported).
+the Linux kernel, macOS 10.10+, and Windows 7 and newer (Windows XP is
+not supported).
 
-Bitcoin Core should also work on most other Unix-like systems but is not
-frequently tested on them.
+Bitcoin Core should also work on most other Unix-like systems but is
+not frequently tested on them.
 
 From 0.17.0 onwards macOS <10.10 is no longer supported. 0.17.0 is built using Qt 5.9.x, which doesn't
 support versions of macOS older than 10.10.
@@ -158,4 +161,5 @@ Credits
 Thanks to everyone who directly contributed to this release:
 
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on
+[Transifex](https://www.transifex.com/projects/p/bitcoin/).


### PR DESCRIPTION
Though the plain text was pretty good (mostly 80-char lines),
this makes it even more readable for terminal monks. The fancy
HTML5 markdown output on GitHub is the same (checked with rendering
original and changed file with `commonmarker` and normalizing both
with HTML `tidy`, the only change being the simplified in-tree doc
path for Translation Process).

One more little change is that http://chris.beams.io was changed
to https as suggested by @fanquake.

    commonmarker CONTRIBUTING.md | tidy > /tmp/aoeui.html
    git checkout master
    commonmarker CONTRIBUTING.md | tidy | diff -u - /tmp/aoeui.html

 - INSTALL.md: Add monospace markup to file name
 - CONTRIBUTING.md - reflow the text - no change in wording
 - contrib/qos/README.md - fmt (reflow and wrap long lines)
 - reflow release-notes.md
 - README.md reflow
 - depends/packages.md - reflow

Ref: https://github.com/ElementsProject/lightning/pull/1137

This is yet another take on before-unmerged https://github.com/bitcoin/bitcoin/pull/11759