### PR TITLE
Fix osslsigncode compile issue in gitian-build

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -5,7 +5,8 @@ suites:
 architectures:
 - "amd64"
 packages:
-- "libssl-dev"
+# Once osslsigncode supports openssl 1.1, we can change this back to libssl-dev
+- "libssl1.0-dev"
 - "autoconf"
 remotes:
 - "url": "https://github.com/bitcoin-core/bitcoin-detached-sigs.git"


### PR DESCRIPTION
Install libssl1.0-dev that is compatible with osslsigncode.

Fixes #13762 

Verifed that this gitian descriptor file can sign 0.16.2rc2.