### PR TITLE
crypto/sha256: Use pragmas to enforce necessary intrinsics for GCC and Clang

### DIFF
--- a/src/crypto/sha256_avx2.cpp
+++ b/src/crypto/sha256_avx2.cpp
@@ -9,6 +9,12 @@
 
 #include <crypto/common.h>
 
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((__target__("avx,avx2"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target ("avx,avx2")
+#endif
+
 namespace sha256d64_avx2 {
 namespace {
 
@@ -324,5 +330,9 @@ void Transform_8way(unsigned char* out, const unsigned char* in)
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 #endif

--- a/src/crypto/sha256_shani.cpp
+++ b/src/crypto/sha256_shani.cpp
@@ -11,6 +11,12 @@
 #include <stdint.h>
 #include <immintrin.h>
 
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((__target__("sse4,sha"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target ("sse4,sha")
+#endif
+
 namespace {
 
 alignas(__m128i) const uint8_t MASK[16] = {0x03, 0x02, 0x01, 0x00, 0x07, 0x06, 0x05, 0x04, 0x0b, 0x0a, 0x09, 0x08, 0x0f, 0x0e, 0x0d, 0x0c};
@@ -352,5 +358,9 @@ void Transform_2way(unsigned char* out, const unsigned char* in)
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 #endif

--- a/src/crypto/sha256_sse41.cpp
+++ b/src/crypto/sha256_sse41.cpp
@@ -9,6 +9,12 @@
 
 #include <crypto/common.h>
 
+#if defined(__clang__)
+#pragma clang attribute push(__attribute__((__target__("sse4.1"))), apply_to = function)
+#elif defined(__GNUC__)
+#pragma GCC target ("sse4.1")
+#endif
+
 namespace sha256d64_sse41 {
 namespace {
 
@@ -316,5 +322,9 @@ void Transform_4way(unsigned char* out, const unsigned char* in)
 }
 
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif
 
 #endif


### PR DESCRIPTION
This avoids problems when the user specifies CXXFLAGS explicitly disabling the relevant optimisations.

Partially fixes #13758, only for GCC/Clang.

NOTE: `src/leveldb/port/port_posix_sse.cc` has the same issue (only with our build system?), which is NOT addressed here.