### PR TITLE
build: Add missing [[noreturn]] to handleRunawayException(...). Enable -Wsuggest-attribute=noreturn if available.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -303,6 +303,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wformat-security],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wformat-security"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wthread-safety-analysis],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wthread-safety-analysis"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wrange-loop-analysis],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wrange-loop-analysis"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wsuggest-attribute=noreturn],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wsuggest-attribute=noreturn"],,[[$CXXFLAG_WERROR]])
 
   ## Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   ## unknown options if any other warning is produced. Test the -Wfoo case, and

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -168,7 +168,7 @@ Q_SIGNALS:
 
 private:
     /// Pass fatal exception message to UI thread
-    void handleRunawayException(const std::exception *e);
+    [[noreturn]] void handleRunawayException(const std::exception *e);
 
     interfaces::Node& m_node;
 };
@@ -212,7 +212,7 @@ public Q_SLOTS:
     void initializeResult(bool success);
     void shutdownResult();
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
-    void handleRunawayException(const QString &message);
+    [[noreturn]] void handleRunawayException(const QString &message);
     void addWallet(WalletModel* walletModel);
     void removeWallet();
 
@@ -248,7 +248,7 @@ BitcoinCore::BitcoinCore(interfaces::Node& node) :
 {
 }
 
-void BitcoinCore::handleRunawayException(const std::exception *e)
+[[noreturn]] void BitcoinCore::handleRunawayException(const std::exception *e)
 {
     PrintExceptionContinue(e, "Runaway exception");
     Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings("gui")));
@@ -524,7 +524,7 @@ void BitcoinApplication::shutdownResult()
     quit(); // Exit second main loop invocation after shutdown finished
 }
 
-void BitcoinApplication::handleRunawayException(const QString &message)
+[[noreturn]] void BitcoinApplication::handleRunawayException(const QString &message)
 {
     QMessageBox::critical(0, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. Bitcoin can no longer continue safely and will quit.") + QString("\n\n") + message);
     ::exit(EXIT_FAILURE);


### PR DESCRIPTION
* Add missing `[[noreturn]]` to `handleRunawayException(…)`
* Enable `-Wsuggest-attribute=noreturn` if available
