### PR TITLE
wallet: -avoidreuse with destination filters

### DIFF
--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -13,6 +13,7 @@ void CCoinControl::SetNull()
     fAllowOtherInputs = false;
     fAllowWatchOnly = false;
     m_avoid_partial_spends = gArgs.GetBoolArg("-avoidpartialspends", DEFAULT_AVOIDPARTIALSPENDS);
+    m_dest_filter = DeriveDestinationFilter();
     setSelected.clear();
     m_feerate.reset();
     fOverrideFeeRate = false;
@@ -20,4 +21,3 @@ void CCoinControl::SetNull()
     m_signal_bip125_rbf.reset();
     m_fee_mode = FeeEstimateMode::UNSET;
 }
-

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -34,6 +34,8 @@ public:
     boost::optional<bool> m_signal_bip125_rbf;
     //! Avoid partial use of funds sent to a given address
     bool m_avoid_partial_spends;
+    //! Destination filter (allow all, or allow only clean, or allow only dirty outputs)
+    DestinationFilter m_dest_filter;
     //! Fee estimation mode to control arguments to estimateSmartFee
     FeeEstimateMode m_fee_mode;
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -324,3 +324,26 @@ bool OutputGroup::EligibleForSpending(const CoinEligibilityFilter& eligibility_f
         && m_ancestors <= eligibility_filter.max_ancestors
         && m_descendants <= eligibility_filter.max_descendants;
 }
+
+static const std::string DESTINATION_FILTER_STRING_MIXED = "mixed";
+static const std::string DESTINATION_FILTER_STRING_CLEAN = "clean";
+static const std::string DESTINATION_FILTER_STRING_DIRTY = "dirty";
+
+bool ParseDestinationFilter(const std::string& type, DestinationFilter& dest_filter)
+{
+    if      (type == DESTINATION_FILTER_STRING_MIXED) dest_filter = DestinationFilter::DestinationMixed;
+    else if (type == DESTINATION_FILTER_STRING_CLEAN) dest_filter = DestinationFilter::DestinationOnlyClean;
+    else if (type == DESTINATION_FILTER_STRING_DIRTY) dest_filter = DestinationFilter::DestinationOnlyDirty;
+    else return false;
+    return true;
+}
+
+const std::string& FormatDestinationFilter(DestinationFilter type)
+{
+    switch (type) {
+    case DestinationFilter::DestinationMixed:     return DESTINATION_FILTER_STRING_MIXED;
+    case DestinationFilter::DestinationOnlyClean: return DESTINATION_FILTER_STRING_CLEAN;
+    case DestinationFilter::DestinationOnlyDirty: return DESTINATION_FILTER_STRING_DIRTY;
+    default: assert(false);
+    }
+}

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -53,6 +53,21 @@ public:
     }
 };
 
+enum DestinationFilter
+{
+    DestinationMixed     = 0,
+    DestinationOnlyClean = 1,
+    DestinationOnlyDirty = 2,
+};
+
+bool ParseDestinationFilter(const std::string& str, DestinationFilter& dest_filter);
+const std::string& FormatDestinationFilter(DestinationFilter dest_filter);
+inline bool DestinationFilterApplies(DestinationFilter dest_filter, bool is_dirty) {
+    return
+        (dest_filter == DestinationFilter::DestinationMixed) ||
+        ((dest_filter == DestinationOnlyDirty) == is_dirty);
+}
+
 struct CoinEligibilityFilter
 {
     const int conf_mine;

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -55,6 +55,7 @@ void WalletInit::AddWalletOptions() const
 {
     gArgs.AddArg("-addresstype", strprintf("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")", FormatOutputType(DEFAULT_ADDRESS_TYPE)), false, OptionsCategory::WALLET);
     gArgs.AddArg("-avoidpartialspends", strprintf(_("Group outputs by address, selecting all or none, instead of selecting on a per-output basis. Privacy is improved as an address is only used once (unless someone sends to it after spending from it), but may result in slightly higher fees as suboptimal coin selection may result due to the added limitation (default: %u)"), DEFAULT_AVOIDPARTIALSPENDS), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-avoidreuse", "Mark addresses which have been used to fund transactions in the past, and avoid reusing these in future funding, except when explicitly requested " + strprintf(_("(default: %u)"), DEFAULT_AVOIDREUSE), false, OptionsCategory::WALLET);
     gArgs.AddArg("-changetype", "What type of change to use (\"legacy\", \"p2sh-segwit\", or \"bech32\"). Default is same as -addresstype, except when -addresstype=p2sh-segwit a native segwit output is used when sending to a native segwit address)", false, OptionsCategory::WALLET);
     gArgs.AddArg("-disablewallet", "Do not load the wallet and disable wallet RPC calls", false, OptionsCategory::WALLET);
     gArgs.AddArg("-discardfee=<amt>", strprintf("The fee rate (in %s/kB) that indicates your tolerance for discarding change by adding it to the fee (default: %s). "

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -521,9 +521,9 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    if (request.fHelp || request.params.size() < 2 || request.params.size() > 8)
+    if (request.fHelp || request.params.size() < 2 || request.params.size() > 9)
         throw std::runtime_error(
-            "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount replaceable conf_target \"estimate_mode\")\n"
+            "sendtoaddress \"address\" amount ( \"comment\" \"comment_to\" subtractfeefromamount replaceable conf_target \"estimate_mode\" dest_filter )\n"
             "\nSend an amount to a given address.\n"
             + HelpRequiringPassphrase(pwallet) +
             "\nArguments:\n"
@@ -542,12 +542,17 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
             "       \"UNSET\"\n"
             "       \"ECONOMICAL\"\n"
             "       \"CONSERVATIVE\"\n"
+            "9. dest_filter              (string, optional) Destination filter (only applicable if -avoidreuse is enabled), one of 'mixed', 'clean', or 'dirty'\n"
+            "                            'mixed' will include both clean and dirty outputs (default if -avoidreuse=false)\n"
+            "                            'clean' will include clean outputs only (default if -avoidreuse=true)\n"
+            "                            'dirty' will include dirty outputs only\n"
             "\nResult:\n"
             "\"txid\"                  (string) The transaction id.\n"
             "\nExamples:\n"
             + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1")
             + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"donation\" \"seans outpost\"")
             + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" true")
+            + HelpExampleCli("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\" 0.1 \"\" \"\" false true 0 UNSET dirty")
             + HelpExampleRpc("sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\"")
         );
 
@@ -594,6 +599,7 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
         }
     }
 
+    if (!request.params[8].isNull()) coin_control.m_dest_filter = DestinationFilterFromValue(request.params[8]);
 
     EnsureWalletIsUnlocked(pwallet);
 
@@ -4821,7 +4827,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "loadwallet",                       &loadwallet,                    {"filename"} },
     { "wallet",             "lockunspent",                      &lockunspent,                   {"unlock","transactions"} },
     { "wallet",             "sendmany",                         &sendmany,                      {"fromaccount|dummy","amounts","minconf","comment","subtractfeefrom","replaceable","conf_target","estimate_mode"} },
-    { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode"} },
+    { "wallet",             "sendtoaddress",                    &sendtoaddress,                 {"address","amount","comment","comment_to","subtractfeefromamount","replaceable","conf_target","estimate_mode","dest_filter"} },
     { "wallet",             "settxfee",                         &settxfee,                      {"amount"} },
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },
     { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype"} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -40,6 +40,16 @@
 
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 
+inline DestinationFilter DestinationFilterFromValue(const UniValue& value)
+{
+    DestinationFilter dest_filter;
+    if (value.isNull()) return DeriveDestinationFilter();
+    if (!ParseDestinationFilter(value.get_str(), dest_filter)) {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "dest_filter must be one of 'mixed', 'clean', or 'dirty'");
+    }
+    return dest_filter;
+}
+
 bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string& wallet_name)
 {
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
@@ -464,7 +474,7 @@ static UniValue getaddressesbyaccount(const JSONRPCRequest& request)
 
 static CTransactionRef SendMoney(CWallet * const pwallet, const CTxDestination &address, CAmount nValue, bool fSubtractFeeFromAmount, const CCoinControl& coin_control, mapValue_t mapValue, std::string fromAccount)
 {
-    CAmount curBalance = pwallet->GetBalance();
+    CAmount curBalance = pwallet->GetBalance(ISMINE_SPENDABLE, 0, coin_control.m_dest_filter);
 
     // Check amount
     if (nValue <= 0)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4454,3 +4454,11 @@ std::vector<OutputGroup> CWallet::GroupOutputs(const std::vector<COutput>& outpu
     }
     return groups;
 }
+
+DestinationFilter DeriveDestinationFilter(const CCoinControl* potential_coin_control)
+{
+    if (potential_coin_control) return potential_coin_control->m_dest_filter;
+    return gArgs.GetBoolArg("-avoidreuse", DEFAULT_AVOIDREUSE)
+            ? DestinationFilter::DestinationOnlyClean
+            : DestinationFilter::DestinationMixed;
+}

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -64,6 +64,9 @@ static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 
+//! if set, addresses will be marked dirty once spent from, and will be excluded from future coin selects
+static const bool DEFAULT_AVOIDREUSE = false;
+
 class CBlockIndex;
 class CCoinControl;
 class COutput;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -78,6 +78,8 @@ class CWalletTx;
 struct FeeCalculation;
 enum class FeeEstimateMode;
 
+DestinationFilter DeriveDestinationFilter(const CCoinControl* potential_coin_control=nullptr);
+
 /** (client) version numbers for particular wallet features */
 enum WalletFeature
 {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -284,6 +284,25 @@ public:
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet);
 
 /**
+ * A cached balance entry, for the three cases
+ * (1) mixed clean and dirty outputs,
+ * (2) clean outputs only,
+ * (3) dirty outputs only.
+ */
+struct CachedBalance {
+    bool valid[3]; ///< whether the cached value is applicable
+    CAmount value[3];
+    CachedBalance() : valid{false, false, false} {}
+    inline void Select(DestinationFilter dest_filter, bool** valid_ptr, CAmount** value_ptr) const {
+        *valid_ptr = const_cast<bool*>(&valid[dest_filter]);
+        *value_ptr = const_cast<CAmount*>(&value[dest_filter]);
+    }
+    inline void Reset() {
+        memset(valid, 0, sizeof(valid));
+    }
+};
+
+/**
  * A transaction with a bunch of additional info that only the owner cares about.
  * It includes any unrecorded transactions needed to link it back to the block chain.
  */
@@ -346,21 +365,19 @@ public:
     mutable bool fDebitCached;
     mutable bool fCreditCached;
     mutable bool fImmatureCreditCached;
-    mutable bool fAvailableCreditCached;
+    CachedBalance available_credit;
+    CachedBalance available_watch_credit;
     mutable bool fWatchDebitCached;
     mutable bool fWatchCreditCached;
     mutable bool fImmatureWatchCreditCached;
-    mutable bool fAvailableWatchCreditCached;
     mutable bool fChangeCached;
     mutable bool fInMempool;
     mutable CAmount nDebitCached;
     mutable CAmount nCreditCached;
     mutable CAmount nImmatureCreditCached;
-    mutable CAmount nAvailableCreditCached;
     mutable CAmount nWatchDebitCached;
     mutable CAmount nWatchCreditCached;
     mutable CAmount nImmatureWatchCreditCached;
-    mutable CAmount nAvailableWatchCreditCached;
     mutable CAmount nChangeCached;
 
     CWalletTx(const CWallet* pwalletIn, CTransactionRef arg) : CMerkleTx(std::move(arg))
@@ -381,23 +398,21 @@ public:
         fDebitCached = false;
         fCreditCached = false;
         fImmatureCreditCached = false;
-        fAvailableCreditCached = false;
         fWatchDebitCached = false;
         fWatchCreditCached = false;
         fImmatureWatchCreditCached = false;
-        fAvailableWatchCreditCached = false;
         fChangeCached = false;
         fInMempool = false;
         nDebitCached = 0;
         nCreditCached = 0;
         nImmatureCreditCached = 0;
-        nAvailableCreditCached = 0;
         nWatchDebitCached = 0;
         nWatchCreditCached = 0;
-        nAvailableWatchCreditCached = 0;
         nImmatureWatchCreditCached = 0;
         nChangeCached = 0;
         nOrderPos = -1;
+        available_credit.Reset();
+        available_watch_credit.Reset();
     }
 
     template<typename Stream>
@@ -441,14 +456,14 @@ public:
     void MarkDirty()
     {
         fCreditCached = false;
-        fAvailableCreditCached = false;
         fImmatureCreditCached = false;
         fWatchDebitCached = false;
         fWatchCreditCached = false;
-        fAvailableWatchCreditCached = false;
         fImmatureWatchCreditCached = false;
         fDebitCached = false;
         fChangeCached = false;
+        available_credit.Reset();
+        available_watch_credit.Reset();
     }
 
     void BindWallet(CWallet *pwalletIn)
@@ -461,7 +476,7 @@ public:
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
-    CAmount GetAvailableCredit(bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE) const;
+    CAmount GetAvailableCredit(bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE, DestinationFilter dest_filter=DeriveDestinationFilter()) const;
     CAmount GetImmatureWatchOnlyCredit(const bool fUseCache=true) const;
     CAmount GetChange() const;
 
@@ -864,6 +879,9 @@ public:
         std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
 
     bool IsSpent(const uint256& hash, unsigned int n) const;
+    bool IsDirty(const uint256& hash, unsigned int n) const;
+    void SetDirtyState(const uint256& hash, unsigned int n, bool dirty);
+
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, bool single_coin) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
@@ -952,7 +970,7 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override;
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
-    CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
+    CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0, DestinationFilter dest_filter=DeriveDestinationFilter()) const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;

--- a/test/functional/feature_avoidreuse.py
+++ b/test/functional/feature_avoidreuse.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the -avoidreuse config option."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+# TODO: Copied from wallet_groups.py -- should perhaps move into util.py
+def assert_approx(v, vexp, vspan=0.00001):
+    if v < vexp - vspan:
+        raise AssertionError("%s < [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
+    if v > vexp + vspan:
+        raise AssertionError("%s > [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
+
+class AvoidReuseTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 2
+        self.extra_args = [[], ['-avoidreuse=1']]
+
+    def reset_balance(self, node, discardaddr):
+        '''
+        Throw away all owned coins by the node so it gets a balance of 0.
+        '''
+        balance = node.getbalance(dest_filter='mixed')
+        if balance > 0.5:
+            node.sendtoaddress(address=discardaddr, amount=balance, subtractfeefromamount=True, dest_filter='mixed')
+
+    def run_test(self):
+        '''
+        Set up initial chain and run tests defined below
+        '''
+
+        self.nodes[0].generate(110)
+        self.sync_all()
+        self.reset_balance(self.nodes[1], self.nodes[0].getnewaddress())
+        self.test_fund_send_fund_send()
+        self.reset_balance(self.nodes[1], self.nodes[0].getnewaddress())
+        self.test_fund_send_fund_senddirty()
+
+    def test_fund_send_fund_send(self):
+        '''
+        Test the simple case where [1] generates a new address A, then
+        [0] sends 10 BTC to A.
+        [1] spends 5 BTC from A. (leaving roughly 4 BTC useable)
+        [0] sends 10 BTC to A again.
+        [1] tries to spend 10 BTC (fails; dirty).
+        [1] tries to spend 4 BTC (succeeds; change address sufficient)
+        '''
+
+        fundaddr = self.nodes[1].getnewaddress()
+        retaddr = self.nodes[0].getnewaddress()
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        self.nodes[1].sendtoaddress(retaddr, 5)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        # node 1 should now have a balance of 5 (no dirty) or 15 (including dirty)
+        assert_approx(self.nodes[1].getbalance(), 5, 0.001)
+        assert_approx(self.nodes[1].getbalance(dest_filter='mixed'), 15, 0.001)
+
+        assert_raises_rpc_error(-6, "Insufficient funds", self.nodes[1].sendtoaddress, retaddr, 10)
+
+        self.nodes[1].sendtoaddress(retaddr, 4)
+
+    def test_fund_send_fund_senddirty(self):
+        '''
+        Test the same as above, except send the 10 BTC with the allow_dirty flag
+        set. This means the 10 BTC send should succeed, where it fails above.
+        '''
+
+        fundaddr = self.nodes[1].getnewaddress()
+        retaddr = self.nodes[0].getnewaddress()
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        self.nodes[1].sendtoaddress(retaddr, 5)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        self.nodes[0].sendtoaddress(fundaddr, 10)
+        self.sync_all()
+        self.nodes[0].generate(1)
+
+        self.nodes[1].sendtoaddress(address=retaddr, amount=10, dest_filter='mixed')
+
+if __name__ == '__main__':
+    AvoidReuseTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -94,6 +94,7 @@ BASE_SCRIPTS = [
     'rpc_getchaintips.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
+    'feature_avoidreuse.py',
     'mempool_reorg.py',
     'mempool_persist.py',
     'wallet_multiwallet.py',


### PR DESCRIPTION
This is an alternative to #13756, which includes destination filters.

A destination filter is one of `mixed` (default for `-avoidreuse=false`), `clean` (default for `-avoidreuse=true`), or `dirty`.

* `mixed` will do coin select without caring about dirty/clean state of outputs
* `clean` will ignore dirty outputs in coin select
* `dirty` will ignore clean outputs in coin select

Pros with this alternative is that it more precisely allows the user to deal with different cases, and gives them a safe(ish) approach to getting rid of dirty UTXO's.

Cons is (1) increased complexity/learning curve for users, and (2) larger diff for reviewers.

I will close one or the other based on feedback.

A PR will be made based on https://github.com/kallewoof/bitcoin/tree/feature-avoidreuse-destfilter-rpc once/if this PR is merged.