### PR TITLE
WIP: Transaction Pool Layer

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -310,8 +310,8 @@ public:
         auto limit_descendant_size = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
         std::string unused_error_string;
         LOCK(::mempool.cs);
-        return ::mempool.CalculateMemPoolAncestors(entry, ancestors, limit_ancestor_count, limit_ancestor_size,
-            limit_descendant_count, limit_descendant_size, unused_error_string);
+        return ::mempool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, ancestors, limit_ancestor_count, limit_ancestor_size,
+            limit_descendant_count, limit_descendant_size, unused_error_string, /* search_parents_for_entry */ &entry);
     }
     CFeeRate estimateSmartFee(int num_blocks, bool conservative, FeeCalculation* calc) override
     {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -391,7 +391,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         CTxMemPool::setEntries ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        mempool.CalculateMemPoolAncestors(*iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        mempool.CalculateMemPoolAncestors(iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
 
         onlyUnconfirmed(ancestors);
         ancestors.insert(iter);

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -12,7 +12,7 @@ void FindCoins(std::map<COutPoint, Coin>& coins)
     LOCK2(cs_main, ::mempool.cs);
     assert(pcoinsTip);
     CCoinsViewCache& chain_view = *::pcoinsTip;
-    CCoinsViewMemPool mempool_view(&chain_view, ::mempool);
+    CoinsViewMemPool<CTxMemPool> mempool_view(&chain_view, ::mempool);
     for (auto& coin : coins) {
         if (!mempool_view.GetCoin(coin.first, coin.second)) {
             // Either the coin is not in the CCoinsViewCache or is spent. Clear it.

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -26,8 +26,8 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
     // signaled for RBF if any unconfirmed parents have signaled.
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    CTxMemPoolEntry entry = *pool.mapTx.find(tx.GetHash());
-    pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    auto it_tx = pool.mapTx.find(tx.GetHash());
+    pool.CalculateMemPoolAncestors(it_tx, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy);
 
     for (CTxMemPool::txiter it : setAncestors) {
         if (SignalsOptInRBF(it->GetTx())) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -504,7 +504,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
             // use db+mempool as cache backend in case user likes to query mempool
             LOCK2(cs_main, mempool.cs);
             CCoinsViewCache& viewChain = *pcoinsTip;
-            CCoinsViewMemPool viewMempool(&viewChain, mempool);
+            CoinsViewMemPool<CTxMemPool> viewMempool(&viewChain, mempool);
             process_utxos(viewMempool, mempool);
         } else {
             LOCK(cs_main);  // no need to lock mempool!

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -566,7 +566,7 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
     CTxMemPool::setEntries setAncestors;
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    mempool.CalculateMemPoolAncestors(*it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    mempool.CalculateMemPoolAncestors(it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy);
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1128,7 +1128,7 @@ UniValue gettxout(const JSONRPCRequest& request)
     Coin coin;
     if (fMempool) {
         LOCK(mempool.cs);
-        CCoinsViewMemPool view(pcoinsTip.get(), mempool);
+        CoinsViewMemPool<CTxMemPool> view(pcoinsTip.get(), mempool);
         if (!view.GetCoin(out, coin) || mempool.isSpent(out)) {
             return NullUniValue;
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -633,7 +633,7 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
         LOCK(cs_main);
         LOCK(mempool.cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CoinsViewMemPool<CTxMemPool> viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         for (const CTxIn& txin : mergedTx.vin) {
@@ -1495,7 +1495,7 @@ UniValue utxoupdatepsbt(const JSONRPCRequest& request)
     {
         LOCK2(cs_main, mempool.cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CoinsViewMemPool<CTxMemPool> viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         for (const CTxIn& txin : psbtx.tx->vin) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -863,19 +863,21 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Array must contain exactly one raw transaction for now");
     }
 
-    CMutableTransaction mtx;
-    if (!DecodeHexTx(mtx, request.params[0].get_array()[0].get_str())) {
-        throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+    std::vector<CTransactionRef> txs;
+    for (const auto& tx : request.params[0].get_array().getValues()) {
+        CMutableTransaction mtx;
+        if (!DecodeHexTx(mtx, tx.get_str())) {
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
+        }
+        txs.push_back(MakeTransactionRef(std::move(mtx)));
     }
-    CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
-    const uint256& tx_hash = tx->GetHash();
 
     CAmount max_raw_tx_fee = DEFAULT_MAX_RAW_TX_FEE;
     // TODO: temporary migration code for old clients. Remove in v0.20
     if (request.params[1].isBool()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Second argument must be numeric (maxfeerate) and no longer supports a boolean. To allow a transaction with high fees, set maxfeerate to 0.");
     } else if (!request.params[1].isNull()) {
-        size_t weight = GetTransactionWeight(*tx);
+        size_t weight = /* TODO fix */ 4000; //GetTransactionWeight(*tx);
         CFeeRate fr(AmountFromValue(request.params[1]));
         // the +3/4 part rounds the value up, and is the same formula used when
         // calculating the fee for a transaction
@@ -884,29 +886,33 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
     }
 
     UniValue result(UniValue::VARR);
-    UniValue result_0(UniValue::VOBJ);
-    result_0.pushKV("txid", tx_hash.GetHex());
 
-    CValidationState state;
-    bool missing_inputs;
-    bool test_accept_res;
-    {
-        LOCK(cs_main);
-        test_accept_res = AcceptToMemoryPool(mempool, state, std::move(tx), &missing_inputs,
-            nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, /* test_accept */ true);
-    }
-    result_0.pushKV("allowed", test_accept_res);
-    if (!test_accept_res) {
-        if (state.IsInvalid()) {
-            result_0.pushKV("reject-reason", strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
-        } else if (missing_inputs) {
-            result_0.pushKV("reject-reason", "missing-inputs");
-        } else {
-            result_0.pushKV("reject-reason", state.GetRejectReason());
+    LOCK2(cs_main, ::mempool.cs);
+    TxPoolLayer pool_layer{::mempool};
+    for (const auto& tx : txs) {
+        UniValue result_i(UniValue::VOBJ);
+        result_i.pushKV("txid", tx->GetHash().GetHex());
+
+        CValidationState state;
+        bool missing_inputs;
+        bool test_accept_res;
+        {
+            test_accept_res = AcceptToMemoryPool(pool_layer, state, tx, &missing_inputs,
+                nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, /* test_accept */ false);
         }
-    }
+        result_i.pushKV("allowed", test_accept_res);
+        if (!test_accept_res) {
+            if (state.IsInvalid()) {
+                result_i.pushKV("reject-reason", strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
+            } else if (missing_inputs) {
+                result_i.pushKV("reject-reason", "missing-inputs");
+            } else {
+                result_i.pushKV("reject-reason", state.GetRejectReason());
+            }
+        }
 
-    result.push_back(std::move(result_0));
+        result.push_back(std::move(result_i));
+    }
     return result;
 }
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -193,9 +193,10 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx7.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx7.vout[1].nValue = 1 * COIN;
 
+    const CTxMemPoolEntry& search_parents_for_entry_1 = entry.Fee(2000000LL).FromTx(tx7);
     CTxMemPool::setEntries setAncestorsCalculated;
     std::string dummy;
-    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(2000000LL).FromTx(tx7), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy, &search_parents_for_entry_1), true);
     BOOST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(entry.FromTx(tx7), setAncestors);
@@ -252,8 +253,9 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx10.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx10.vout[0].nValue = 10 * COIN;
 
+    const CTxMemPoolEntry& search_parents_for_entry_2 = entry.Fee(200000LL).Time(4).FromTx(tx10);
     setAncestorsCalculated.clear();
-    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(4).FromTx(tx10), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy, &search_parents_for_entry_2), true);
     BOOST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(entry.FromTx(tx10), setAncestors);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -145,9 +145,10 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     }
 }
 
-static bool CalculateMemPoolAncestors(const CTxMemPool& pool, CTxMemPool::txiter it, CTxMemPool::setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename P>
+static bool CalculateMemPoolAncestors(const P& pool, typename P::txiter it, typename P::setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
-    CTxMemPool::setEntries parentHashes;
+    typename P::setEntries parentHashes;
     const CTxMemPoolEntry& entry = search_parents_for_entry ? *search_parents_for_entry : pool.GetEntry(it);
     const CTransaction &tx = entry.GetTx();
 
@@ -156,7 +157,7 @@ static bool CalculateMemPoolAncestors(const CTxMemPool& pool, CTxMemPool::txiter
         // GetMemPoolParents() is only valid for entries in the mempool, so we
         // iterate mapTx to find parents.
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            boost::optional<CTxMemPool::txiter> piter = pool.GetIter(tx.vin[i].prevout.hash);
+            boost::optional<typename P::txiter> piter = pool.GetIter(tx.vin[i].prevout.hash);
             if (piter) {
                 parentHashes.insert(*piter);
                 if (parentHashes.size() + 1 > limitAncestorCount) {
@@ -212,7 +213,13 @@ bool CTxMemPool::CalculateMemPoolAncestors(txiter it, setEntries& setAncestors, 
     return ::CalculateMemPoolAncestors(*this, it, setAncestors, limitAncestorCount, limitAncestorSize, limitDescendantCount, limitDescendantSize, errString, search_parents_for_entry);
 }
 
-static void UpdateAncestorsOf(CTxMemPool& pool, bool add, CTxMemPool::txiter it, const CTxMemPool::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+bool TxPoolLayer::CalculateMemPoolAncestors(txiter it, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry)
+{
+    return ::CalculateMemPoolAncestors(*this, it, setAncestors, limitAncestorCount, limitAncestorSize, limitDescendantCount, limitDescendantSize, errString, search_parents_for_entry);
+}
+
+template <typename P>
+static void UpdateAncestorsOf(P& pool, bool add, typename P::txiter it, const typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     auto parentIters = pool.GetMemPoolParents(it);
     // add or remove this tx as a child of each parent
@@ -231,8 +238,13 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, const setEntries& setAnc
 {
     return ::UpdateAncestorsOf(*this, add, it, setAncestors);
 }
+void TxPoolLayer::UpdateAncestorsOf(bool add, const TxPoolLayer::txiter& it, const setEntries& setAncestors)
+{
+    return ::UpdateAncestorsOf(*this, add, it, setAncestors);
+}
 
-static void UpdateEntryForAncestors(CTxMemPool& pool, CTxMemPool::txiter it, const CTxMemPool::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename P>
+static void UpdateEntryForAncestors(P& pool, typename P::txiter it, const typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     int64_t updateCount = setAncestors.size();
     int64_t updateSize = 0;
@@ -250,8 +262,13 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries& setAncesto
 {
     return ::UpdateEntryForAncestors(*this, it, setAncestors);
 }
+void TxPoolLayer::UpdateEntryForAncestors(const TxPoolLayer::txiter& it, const setEntries& setAncestors)
+{
+    return ::UpdateEntryForAncestors(*this, it, setAncestors);
+}
 
-static void UpdateChildrenForRemoval(CTxMemPool& pool, CTxMemPool::txiter it) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename P>
+static void UpdateChildrenForRemoval(P& pool, typename P::txiter it) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     const auto& setMemPoolChildren = pool.GetMemPoolChildren(it);
     for (const auto& updateIt : setMemPoolChildren) {
@@ -264,7 +281,13 @@ void CTxMemPool::UpdateChildrenForRemoval(txiter it)
     return ::UpdateChildrenForRemoval(*this, it);
 }
 
-static void UpdateForRemoveFromMempool(CTxMemPool& pool, const CTxMemPool::setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+void TxPoolLayer::UpdateChildrenForRemoval(txiter it)
+{
+    return ::UpdateChildrenForRemoval(*this, it);
+}
+
+template <typename P>
+static void UpdateForRemoveFromMempool(P& pool, const typename P::setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     // For each entry, walk back all ancestors and decrement size associated with this
     // transaction
@@ -277,7 +300,7 @@ static void UpdateForRemoveFromMempool(CTxMemPool& pool, const CTxMemPool::setEn
         // we need to preserve until we're finished with all operations that
         // need to traverse the mempool).
         for (const auto& removeIt : entriesToRemove) {
-            CTxMemPool::setEntries setDescendants;
+            typename P::setEntries setDescendants;
             pool.CalculateDescendants(removeIt, setDescendants);
             setDescendants.erase(removeIt); // don't update state for self
             int64_t modifySize = -((int64_t)pool.GetEntry(removeIt).GetTxSize());
@@ -289,7 +312,7 @@ static void UpdateForRemoveFromMempool(CTxMemPool& pool, const CTxMemPool::setEn
         }
     }
     for (const auto& removeIt : entriesToRemove) {
-        CTxMemPool::setEntries setAncestors;
+        typename P::setEntries setAncestors;
         std::string dummy;
         // Since this is a tx that is already in the mempool, we can call CMPA
         // with fSearchForParents = false.  If the mempool is in a consistent
@@ -325,6 +348,10 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries& entriesToRemove, b
     return ::UpdateForRemoveFromMempool(*this, entriesToRemove, updateDescendants);
 }
 
+void TxPoolLayer::UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants)
+{
+    return ::UpdateForRemoveFromMempool(*this, entriesToRemove, updateDescendants);
+}
 void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
 {
     nSizeWithDescendants += modifySize;
@@ -372,7 +399,8 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
     nTransactionsUpdated += n;
 }
 
-static CTxMemPool::txiter addUnchecked(CTxMemPool& pool, const CTxMemPoolEntry& entry, const CTxMemPool::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename P>
+static typename P::txiter addUnchecked(P& pool, const CTxMemPoolEntry& entry, const typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     // Add to memory pool without checking anything.
     // Used by AcceptToMemoryPool(), which DOES do
@@ -432,7 +460,13 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, const setEntries& se
     newit->vTxHashesIdx = vTxHashes.size() - 1;
 }
 
-static void removeUnchecked(CTxMemPool& pool, CTxMemPool::txiter it, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+void TxPoolLayer::addUnchecked(const CTxMemPoolEntry& entry, const TxPoolLayer::setEntries& setAncestors, bool /* validFeeEstimate */)
+{
+    ::addUnchecked(*this, entry, setAncestors);
+}
+
+template <typename P>
+static void removeUnchecked(P& pool, typename P::txiter it, MemPoolRemovalReason) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     for (const CTxIn& txin : pool.GetEntry(it).GetTx().vin)
         pool.EraseNextTx(txin.prevout);
@@ -465,15 +499,22 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     if (minerPolicyEstimator) {minerPolicyEstimator->removeTx(hash, false);}
 }
 
+void TxPoolLayer::removeUnchecked(txiter it, MemPoolRemovalReason reason)
+{
+    ::removeUnchecked(*this, it, reason);
+}
+
+
 // Calculates descendants of entry that are not already in setDescendants, and adds to
 // setDescendants. Assumes entryit is already a tx in the mempool and setMemPoolChildren
 // is correct for tx and all descendants.
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-static void CalculateDescendants(const CTxMemPool& pool, const CTxMemPool::txiter& entryit, CTxMemPool::setEntries& setDescendants) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename P>
+static void CalculateDescendants(const P& pool, const typename P::txiter& entryit, typename P::setEntries& setDescendants) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
-    CTxMemPool::setEntries stage;
+    typename P::setEntries stage;
     if (setDescendants.count(entryit) == 0) {
         stage.insert(entryit);
     }
@@ -498,6 +539,12 @@ void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants
 {
     return ::CalculateDescendants(*this, entryit, setDescendants);
 }
+
+void TxPoolLayer::CalculateDescendants(const TxPoolLayer::txiter& entryit, TxPoolLayer::setEntries& setDescendants)
+{
+    return ::CalculateDescendants(*this, entryit, setDescendants);
+}
+
 
 void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReason reason)
 {
@@ -844,6 +891,14 @@ CTransactionRef CTxMemPool::get(const uint256& hash) const
     return i->GetSharedTx();
 }
 
+CTransactionRef TxPoolLayer::get(const uint256& hash) const
+{
+    auto it = m_cache_added.find(hash);
+    if (it != m_cache_added.end()) return it->GetSharedTx();
+    if (m_cache_removed.find(hash) != m_cache_removed.end()) return nullptr;
+    return m_tx_pool.get(hash);
+}
+
 TxMempoolInfo CTxMemPool::info(const uint256& hash) const
 {
     LOCK(cs);
@@ -851,6 +906,33 @@ TxMempoolInfo CTxMemPool::info(const uint256& hash) const
     if (i == mapTx.end())
         return TxMempoolInfo();
     return GetInfo(i);
+}
+
+bool TxPoolLayer::exists(const uint256& hash) const
+{
+    if (m_cache_added.find(hash) != m_cache_added.end()) return true;
+    if (m_cache_removed.find(hash) != m_cache_removed.end()) return false;
+    return m_tx_pool.exists(hash);
+}
+
+const CTxMemPoolEntry& TxPoolLayer::GetEntry(const TxPoolLayer::txiter& it)
+{
+    if (it.which() == 0) return *boost::get<txiter_nested>(it)._i;
+    return CTxMemPool::GetEntry(boost::get<CTxMemPool::txiter>(it));
+}
+
+void TxPoolLayer::EraseTx(TxPoolLayer::txiter it)
+{
+    if (it.which() == 0) {
+        const uint256& hash{GetEntry(it).GetTx().GetHash()};
+        if (m_tx_pool.exists(hash)) {
+            // likely the tx exists in both layers because of modified fees, so mark it erased in the outer layer
+            m_cache_removed.emplace(hash);
+        }
+        m_cache_added.erase(boost::get<txiter_nested>(it)._i);
+    } else {
+        m_cache_removed.emplace(GetEntry(it).GetTx().GetHash());
+    }
 }
 
 void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeDelta)
@@ -892,6 +974,10 @@ void CTxMemPool::ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const
     const CAmount &delta = pos->second;
     nFeeDelta += delta;
 }
+void TxPoolLayer::ApplyDelta(const uint256& hash, CAmount& fee_delta) const
+{
+    return m_tx_pool.ApplyDelta(hash, fee_delta);
+}
 
 void CTxMemPool::ClearPrioritisation(const uint256 hash)
 {
@@ -905,6 +991,15 @@ const CTransaction* CTxMemPool::GetConflictTx(const COutPoint& prevout) const
     return it == mapNextTx.end() ? nullptr : it->second;
 }
 
+const CTransaction* TxPoolLayer::GetConflictTx(const COutPoint& prevout) const
+{
+    auto it_add = m_map_next_tx_added.find(prevout);
+    if (it_add != m_map_next_tx_added.end()) return it_add->second;
+    if (m_map_next_tx_removed.find(prevout) != m_map_next_tx_removed.end()) return nullptr;
+
+    return m_tx_pool.GetConflictTx(prevout);
+}
+
 boost::optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) const
 {
     auto it = mapTx.find(txid);
@@ -912,9 +1007,26 @@ boost::optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) con
     return boost::optional<txiter>{};
 }
 
-static CTxMemPool::setEntries GetIterSet(const CTxMemPool& pool, const std::set<uint256>& hashes) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+boost::optional<TxPoolLayer::txiter> TxPoolLayer::GetIter(const uint256& txid) const
 {
-    CTxMemPool::setEntries ret;
+    const auto& it_cache = m_cache_added.find(txid);
+    if (it_cache != m_cache_added.end()) {
+        return TxPoolLayer::txiter{it_cache};
+    }
+    if (m_cache_removed.find(txid) != m_cache_removed.end()) {
+        return boost::optional<TxPoolLayer::txiter>{};
+    }
+
+    // Nothing found in the cache, fall back to the inner layer:
+    const auto it_inner = m_tx_pool.GetIter(txid);
+    if (it_inner) return TxPoolLayer::txiter{*it_inner};
+    return boost::optional<TxPoolLayer::txiter>{};
+}
+
+template <typename P>
+static typename P::setEntries GetIterSet(const P& pool, const std::set<uint256>& hashes) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+{
+    typename P::setEntries ret;
     for (const auto& h : hashes) {
         const auto mi = pool.GetIter(h);
         if (mi) ret.insert(*mi);
@@ -926,6 +1038,10 @@ CTxMemPool::setEntries CTxMemPool::GetIterSet(const std::set<uint256>& hashes) c
 {
     return ::GetIterSet(*this, hashes);
 }
+TxPoolLayer::setEntries TxPoolLayer::GetIterSet(const std::set<uint256>& hashes) const
+{
+    return ::GetIterSet(*this, hashes);
+}
 
 template <typename UpdateStruct>
 void CTxMemPool::Modify(txiter it, const UpdateStruct& update_object)
@@ -933,7 +1049,20 @@ void CTxMemPool::Modify(txiter it, const UpdateStruct& update_object)
     mapTx.modify(it, update_object);
 }
 
-static bool HasNoInputsOf(const CTxMemPool& pool, const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename UpdateStruct>
+void TxPoolLayer::Modify(txiter it, const UpdateStruct& update_object)
+{
+    if (it.which() == 0) {
+        m_cache_added.modify(boost::get<txiter_nested>(it)._i, update_object);
+    } else {
+        const CTxMemPoolEntry& e{*boost::get<CTxMemPool::txiter>(it)};
+        txiter it_added = Insert(e).first;
+        m_cache_added.modify(boost::get<txiter_nested>(it_added)._i, update_object);
+    }
+}
+
+template <typename P>
+static bool HasNoInputsOf(const P& pool, const CTransaction& tx) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     for (unsigned int i = 0; i < tx.vin.size(); i++)
         if (pool.exists(tx.vin[i].prevout.hash))
@@ -942,6 +1071,11 @@ static bool HasNoInputsOf(const CTxMemPool& pool, const CTransaction& tx) EXCLUS
 }
 
 bool CTxMemPool::HasNoInputsOf(const CTransaction& tx) const
+{
+    return ::HasNoInputsOf(*this, tx);
+}
+
+bool TxPoolLayer::HasNoInputsOf(const CTransaction& tx) const
 {
     return ::HasNoInputsOf(*this, tx);
 }
@@ -964,6 +1098,7 @@ bool CoinsViewMemPool<P>::GetCoin(const COutPoint& outpoint, Coin& coin) const
     return base->GetCoin(outpoint, coin);
 }
 template bool CoinsViewMemPool<CTxMemPool>::GetCoin(const COutPoint& outpoint, Coin& coin) const;
+template bool CoinsViewMemPool<TxPoolLayer>::GetCoin(const COutPoint& outpoint, Coin& coin) const;
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
@@ -971,7 +1106,8 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-static void RemoveStaged(CTxMemPool& pool, CTxMemPool::setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(pool.cs) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+template <typename P>
+static void RemoveStaged(P& pool, typename P::setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     AssertLockHeld(pool.cs);
     pool.UpdateForRemoveFromMempool(stage, updateDescendants);
@@ -981,6 +1117,10 @@ static void RemoveStaged(CTxMemPool& pool, CTxMemPool::setEntries& stage, bool u
 }
 
 void CTxMemPool::RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason)
+{
+    return ::RemoveStaged(*this, stage, updateDescendants, reason);
+}
+void TxPoolLayer::RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason)
 {
     return ::RemoveStaged(*this, stage, updateDescendants, reason);
 }
@@ -1000,17 +1140,29 @@ int CTxMemPool::Expire(int64_t time) {
     RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
     return stage.size();
 }
-
-static void addUnchecked(CTxMemPool& pool, const CTxMemPoolEntry& entry, bool validFeeEstimate) EXCLUSIVE_LOCKS_REQUIRED(pool.cs, cs_main)
+int TxPoolLayer::Expire(int64_t /* time */)
 {
-    CTxMemPool::setEntries setAncestors;
+    // The Layer is currently assumed to be very short lived (see comment on Layer::cs)
+    // So assume this would very rarely have an effect and skip it
+    return 0;
+}
+
+template <typename P>
+static void addUnchecked(P& pool, const CTxMemPoolEntry& entry, bool validFeeEstimate) EXCLUSIVE_LOCKS_REQUIRED(pool.cs, cs_main)
+{
+    typename P::setEntries setAncestors;
     uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, /* search_parents_for_entry */ &entry);
+    pool.CalculateMemPoolAncestors(typename P::txiter{}, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, /* search_parents_for_entry */ &entry);
     return pool.addUnchecked(entry, setAncestors, validFeeEstimate);
 }
 
 void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate)
+{
+    return ::addUnchecked(*this, entry, validFeeEstimate);
+}
+
+void TxPoolLayer::addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate)
 {
     return ::addUnchecked(*this, entry, validFeeEstimate);
 }
@@ -1025,6 +1177,15 @@ void CTxMemPool::UpdateChild(txiter entry, txiter child, bool add)
     }
 }
 
+void TxPoolLayer::UpdateChild(const TxPoolLayer::txiter& entry, const TxPoolLayer::txiter& child, bool add)
+{
+    if (add) {
+        m_cache_map_links[entry].children.insert(child);
+    } else {
+        m_cache_map_links[entry].children.erase(child);
+    }
+}
+
 void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
 {
     setEntries s;
@@ -1032,6 +1193,15 @@ void CTxMemPool::UpdateParent(txiter entry, txiter parent, bool add)
         cachedInnerUsage += memusage::IncrementalDynamicUsage(s);
     } else if (!add && mapLinks[entry].parents.erase(parent)) {
         cachedInnerUsage -= memusage::IncrementalDynamicUsage(s);
+    }
+}
+
+void TxPoolLayer::UpdateParent(const TxPoolLayer::txiter& entry, const TxPoolLayer::txiter& parent, bool add)
+{
+    if (add) {
+        m_cache_map_links[entry].parents.insert(parent);
+    } else {
+        m_cache_map_links[entry].parents.erase(parent);
     }
 }
 
@@ -1043,12 +1213,36 @@ const CTxMemPool::setEntries & CTxMemPool::GetMemPoolParents(txiter entry) const
     return it->second.parents;
 }
 
+TxPoolLayer::setEntries TxPoolLayer::GetMemPoolParents(const TxPoolLayer::txiter& entry) const
+{
+    const auto it = m_cache_map_links.find(entry);
+    if (it != m_cache_map_links.end()) return it->second.parents;
+
+    TxPoolLayer::setEntries ret;
+    for (const auto& parent : m_tx_pool.GetMemPoolParents(boost::get<CTxMemPool::txiter>(entry))) {
+        ret.emplace(parent);
+    }
+    return ret;
+}
+
 const CTxMemPool::setEntries & CTxMemPool::GetMemPoolChildren(txiter entry) const
 {
     assert (entry != mapTx.end());
     txlinksMap::const_iterator it = mapLinks.find(entry);
     assert(it != mapLinks.end());
     return it->second.children;
+}
+
+TxPoolLayer::setEntries TxPoolLayer::GetMemPoolChildren(const txiter& entry) const
+{
+    auto it = m_cache_map_links.find(entry);
+    if (it != m_cache_map_links.end()) return it->second.children;
+
+    TxPoolLayer::setEntries ret;
+    for (const auto& child: m_tx_pool.GetMemPoolChildren(boost::get<CTxMemPool::txiter>(entry))) {
+        ret.emplace(child);
+    }
+    return ret;
 }
 
 CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
@@ -1073,6 +1267,11 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
         }
     }
     return std::max(CFeeRate(llround(rollingMinimumFeeRate)), incrementalRelayFee);
+}
+
+CFeeRate TxPoolLayer::GetMinFee(size_t sizelimit) const
+{
+    return m_tx_pool.GetMinFee(sizelimit);
 }
 
 void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {
@@ -1125,6 +1324,13 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         LogPrint(BCLog::MEMPOOL, "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
     }
 }
+
+void TxPoolLayer::TrimToSize(size_t /* sizelimit */, std::vector<COutPoint>* /* pvNoSpendsRemaining */)
+{
+    // The Layer has no strict size limit for now, it is the responsibility of the caller to not exceed any limits
+    return;
+}
+
 
 uint64_t CTxMemPool::CalculateDescendantMaximum(txiter entry) const {
     // find parent with highest descendant count

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -884,13 +884,13 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
     return true;
 }
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
-
-bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
+template <typename P>
+bool CoinsViewMemPool<P>::GetCoin(const COutPoint& outpoint, Coin& coin) const
+{
     // If an entry in the mempool exists, always return that one, as it's guaranteed to never
     // conflict with the underlying cache, and it cannot have pruned entries (as it contains full)
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
-    CTransactionRef ptx = mempool.get(outpoint.hash);
+    CTransactionRef ptx = m_tx_pool.get(outpoint.hash);
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
             coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);
@@ -901,6 +901,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     }
     return base->GetCoin(outpoint, coin);
 }
+template bool CoinsViewMemPool<CTxMemPool>::GetCoin(const COutPoint& outpoint, Coin& coin) const;
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -148,7 +148,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
 static bool CalculateMemPoolAncestors(const CTxMemPool& pool, CTxMemPool::txiter it, CTxMemPool::setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     CTxMemPool::setEntries parentHashes;
-    const CTxMemPoolEntry& entry = search_parents_for_entry ? *search_parents_for_entry : *it;
+    const CTxMemPoolEntry& entry = search_parents_for_entry ? *search_parents_for_entry : pool.GetEntry(it);
     const CTransaction &tx = entry.GetTx();
 
     if (search_parents_for_entry) {
@@ -174,17 +174,17 @@ static bool CalculateMemPoolAncestors(const CTxMemPool& pool, CTxMemPool::txiter
     size_t totalSizeWithAncestors = entry.GetTxSize();
 
     while (!parentHashes.empty()) {
-        CTxMemPool::txiter stageit = *parentHashes.begin();
+        auto stageit = *parentHashes.begin();
 
         setAncestors.insert(stageit);
         parentHashes.erase(stageit);
-        totalSizeWithAncestors += stageit->GetTxSize();
+        totalSizeWithAncestors += pool.GetEntry(stageit).GetTxSize();
 
-        if (stageit->GetSizeWithDescendants() + entry.GetTxSize() > limitDescendantSize) {
-            errString = strprintf("exceeds descendant size limit for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString(), limitDescendantSize);
+        if (pool.GetEntry(stageit).GetSizeWithDescendants() + entry.GetTxSize() > limitDescendantSize) {
+            errString = strprintf("exceeds descendant size limit for tx %s [limit: %u]", pool.GetEntry(stageit).GetTx().GetHash().ToString(), limitDescendantSize);
             return false;
-        } else if (stageit->GetCountWithDescendants() + 1 > limitDescendantCount) {
-            errString = strprintf("too many descendants for tx %s [limit: %u]", stageit->GetTx().GetHash().ToString(), limitDescendantCount);
+        } else if (pool.GetEntry(stageit).GetCountWithDescendants() + 1 > limitDescendantCount) {
+            errString = strprintf("too many descendants for tx %s [limit: %u]", pool.GetEntry(stageit).GetTx().GetHash().ToString(), limitDescendantCount);
             return false;
         } else if (totalSizeWithAncestors > limitAncestorSize) {
             errString = strprintf("exceeds ancestor size limit [limit: %u]", limitAncestorSize);
@@ -220,9 +220,9 @@ static void UpdateAncestorsOf(CTxMemPool& pool, bool add, CTxMemPool::txiter it,
         pool.UpdateChild(piter, it, add);
     }
     const int64_t updateCount = (add ? 1 : -1);
-    const int64_t updateSize = updateCount * it->GetTxSize();
-    const CAmount updateFee = updateCount * it->GetModifiedFee();
-    for (CTxMemPool::txiter ancestorIt : setAncestors) {
+    const int64_t updateSize = updateCount * pool.GetEntry(it).GetTxSize();
+    const CAmount updateFee = updateCount * pool.GetEntry(it).GetModifiedFee();
+    for (const auto& ancestorIt : setAncestors) {
         pool.Modify(ancestorIt, update_descendant_state(updateSize, updateFee, updateCount));
     }
 }
@@ -238,10 +238,10 @@ static void UpdateEntryForAncestors(CTxMemPool& pool, CTxMemPool::txiter it, con
     int64_t updateSize = 0;
     CAmount updateFee = 0;
     int64_t updateSigOpsCost = 0;
-    for (CTxMemPool::txiter ancestorIt : setAncestors) {
-        updateSize += ancestorIt->GetTxSize();
-        updateFee += ancestorIt->GetModifiedFee();
-        updateSigOpsCost += ancestorIt->GetSigOpCost();
+    for (const auto& ancestorIt : setAncestors) {
+        updateSize += pool.GetEntry(ancestorIt).GetTxSize();
+        updateFee += pool.GetEntry(ancestorIt).GetModifiedFee();
+        updateSigOpsCost += pool.GetEntry(ancestorIt).GetSigOpCost();
     }
     pool.Modify(it, update_ancestor_state(updateSize, updateFee, updateCount, updateSigOpsCost));
 }
@@ -254,7 +254,7 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries& setAncesto
 static void UpdateChildrenForRemoval(CTxMemPool& pool, CTxMemPool::txiter it) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     const auto& setMemPoolChildren = pool.GetMemPoolChildren(it);
-    for (CTxMemPool::txiter updateIt : setMemPoolChildren) {
+    for (const auto& updateIt : setMemPoolChildren) {
         pool.UpdateParent(updateIt, it, false);
     }
 }
@@ -276,19 +276,19 @@ static void UpdateForRemoveFromMempool(CTxMemPool& pool, const CTxMemPool::setEn
         // Here we only update statistics and not data in mapLinks (which
         // we need to preserve until we're finished with all operations that
         // need to traverse the mempool).
-        for (CTxMemPool::txiter removeIt : entriesToRemove) {
+        for (const auto& removeIt : entriesToRemove) {
             CTxMemPool::setEntries setDescendants;
             pool.CalculateDescendants(removeIt, setDescendants);
             setDescendants.erase(removeIt); // don't update state for self
-            int64_t modifySize = -((int64_t)removeIt->GetTxSize());
-            CAmount modifyFee = -removeIt->GetModifiedFee();
-            int modifySigOps = -removeIt->GetSigOpCost();
-            for (CTxMemPool::txiter dit : setDescendants) {
+            int64_t modifySize = -((int64_t)pool.GetEntry(removeIt).GetTxSize());
+            CAmount modifyFee = -pool.GetEntry(removeIt).GetModifiedFee();
+            int modifySigOps = -pool.GetEntry(removeIt).GetSigOpCost();
+            for (const auto& dit : setDescendants) {
                 pool.Modify(dit, update_ancestor_state(modifySize, modifyFee, -1, modifySigOps));
             }
         }
     }
-    for (CTxMemPool::txiter removeIt : entriesToRemove) {
+    for (const auto& removeIt : entriesToRemove) {
         CTxMemPool::setEntries setAncestors;
         std::string dummy;
         // Since this is a tx that is already in the mempool, we can call CMPA
@@ -316,7 +316,7 @@ static void UpdateForRemoveFromMempool(CTxMemPool& pool, const CTxMemPool::setEn
     // After updating all the ancestor sizes, we can now sever the link between each
     // transaction being removed and any mempool children (ie, update setMemPoolParents
     // for each direct child of a transaction being removed).
-    for (CTxMemPool::txiter removeIt : entriesToRemove) {
+    for (const auto& removeIt : entriesToRemove) {
         pool.UpdateChildrenForRemoval(removeIt);
     }
 }
@@ -391,7 +391,7 @@ static CTxMemPool::txiter addUnchecked(CTxMemPool& pool, const CTxMemPoolEntry& 
     // (When we update the entry for in-mempool parents, memory usage will be
     // further updated.)
 
-    const CTransaction& tx = newit->GetTx();
+    const CTransaction& tx = pool.GetEntry(newit).GetTx();
     std::set<uint256> setParentTransactions;
     for (unsigned int i = 0; i < tx.vin.size(); i++) {
         pool.InsertNextTx(std::make_pair(&tx.vin[i].prevout, &tx));
@@ -434,7 +434,7 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, const setEntries& se
 
 static void removeUnchecked(CTxMemPool& pool, CTxMemPool::txiter it, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
-    for (const CTxIn& txin : it->GetTx().vin)
+    for (const CTxIn& txin : pool.GetEntry(it).GetTx().vin)
         pool.EraseNextTx(txin.prevout);
 
     pool.EraseLinks(it);
@@ -481,7 +481,7 @@ static void CalculateDescendants(const CTxMemPool& pool, const CTxMemPool::txite
     // accounted for in setDescendants already (because those children have either
     // already been walked, or will be walked in this iteration).
     while (!stage.empty()) {
-        CTxMemPool::txiter it = *stage.begin();
+        const auto it = *stage.begin();
         setDescendants.insert(it);
         stage.erase(it);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -751,14 +751,17 @@ private:
  * signrawtransactionwithkey and signrawtransactionwithwallet,
  * as long as the conflicting transaction is not yet confirmed.
  */
-class CCoinsViewMemPool : public CCoinsViewBacked
+template <class P>
+class CoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
-    const CTxMemPool& mempool;
+    const P& m_tx_pool;
 
 public:
-    CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    CoinsViewMemPool(CCoinsView* baseIn, const P& mempoolIn)
+        : CCoinsViewBacked(baseIn), m_tx_pool(mempoolIn) {}
+
+    bool GetCoin(const COutPoint& outpoint, Coin& coin) const override EXCLUSIVE_LOCKS_REQUIRED(m_tx_pool.cs);
 };
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -626,17 +626,18 @@ public:
      */
     void UpdateTransactionsFromBlock(const std::vector<uint256>& vHashesToUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
-    /** Try to calculate all in-mempool ancestors of entry.
+    /** Try to calculate all in-mempool ancestors of the passed iterator.
      *  (these are all calculated including the tx itself)
      *  limitAncestorCount = max number of ancestors
      *  limitAncestorSize = max size of ancestors
      *  limitDescendantCount = max number of descendants any ancestor can have
      *  limitDescendantSize = max size of descendants any ancestor can have
      *  errString = populated with error reason if any limits are hit
-     *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
-     *    look up parents from mapLinks. Must be true for entries not in the mempool
+     *  search_parents_for_entry = Use this entry's tx's vin to search for in-mempool parents.
+     *    Only needed when there is no mapTx iterator to this entry, which could be
+     *    used to look up parents from mapLinks.
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(txiter it, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -752,6 +752,108 @@ public:
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN) EXCLUSIVE_LOCKS_REQUIRED(cs);
 };
 
+class TxPoolLayer
+{
+public:
+    mutable RecursiveMutex cs; //!< Dummy mutex
+    struct txiter_nested {
+        CTxMemPool::txiter _i;
+        explicit txiter_nested(CTxMemPool::txiter val) : _i(val) {}
+        txiter_nested() : _i() {}
+    };
+    /**
+     * The txiter of this layer is a pair.
+     * The first element is a const iterator of this layer's m_cache_added,
+     * the second element is a fallback to the underlying txiter (only present when first is missing)
+     */
+    using txiter = boost::variant<
+        txiter_nested, // Can always use this one, since all entries might be created in the cache??
+        CTxMemPool::txiter>;
+
+    struct CompareIteratorByHash {
+        bool operator()(const txiter& a, const txiter& b) const
+        {
+            return GetEntry(a).GetTx().GetHash() < GetEntry(b).GetTx().GetHash();
+        }
+    };
+
+    using setEntries = std::set<TxPoolLayer::txiter, CompareIteratorByHash>;
+
+    struct TxLinks {
+        TxPoolLayer::setEntries parents;
+        TxPoolLayer::setEntries children;
+    };
+    using txlinksMap = std::map<TxPoolLayer::txiter, TxPoolLayer::TxLinks, CompareIteratorByHash>;
+    /**
+         * Construct a Layer based on an existing tx pool.
+         * The caller must acquire the lock for the whole life-time of this layer.
+         */
+    explicit TxPoolLayer(const CTxMemPool& p) EXCLUSIVE_LOCKS_REQUIRED(p.cs)
+        : m_tx_pool(p) { AssertLockHeld(p.cs); }
+
+    /// Methods that have identical signatures in the underlying tx pool:
+    bool exists(const uint256& hash) const NO_THREAD_SAFETY_ANALYSIS;
+    boost::optional<txiter> GetIter(const uint256& txid) const NO_THREAD_SAFETY_ANALYSIS;
+    TxPoolLayer::setEntries GetIterSet(const std::set<uint256>& hashes) const NO_THREAD_SAFETY_ANALYSIS;
+    template <typename UpdateStruct>
+    void Modify(txiter it, const UpdateStruct& update_object) NO_THREAD_SAFETY_ANALYSIS;
+    std::pair<txiter, bool> Insert(const CTxMemPoolEntry& entry) NO_THREAD_SAFETY_ANALYSIS
+    {
+        auto ins = m_cache_added.insert(entry);
+        assert(ins.second);
+        return {txiter_nested{ins.first}, ins.second};
+    }
+    void EraseTx(TxPoolLayer::txiter it) NO_THREAD_SAFETY_ANALYSIS;
+    void InsertLinks(txiter newit) NO_THREAD_SAFETY_ANALYSIS { m_cache_map_links.emplace(newit, TxLinks{}); }
+    void EraseLinks(txiter it) NO_THREAD_SAFETY_ANALYSIS { m_cache_map_links.erase(it); }
+    void InsertNextTx(std::pair<const COutPoint*, const CTransaction*> next_tx) NO_THREAD_SAFETY_ANALYSIS { m_map_next_tx_added.insert(next_tx); }
+    void EraseNextTx(const COutPoint& out) NO_THREAD_SAFETY_ANALYSIS
+    {
+        m_map_next_tx_added.erase(out);
+        m_map_next_tx_removed.emplace(out);
+    }
+    static const CTxMemPoolEntry& GetEntry(const TxPoolLayer::txiter& it);
+    const CTransaction* GetConflictTx(const COutPoint& prevout) const NO_THREAD_SAFETY_ANALYSIS;
+    CTransactionRef get(const uint256& hash) const;
+    void ApplyDelta(const uint256& hash, CAmount& fee_delta) const NO_THREAD_SAFETY_ANALYSIS;
+    CFeeRate GetMinFee(size_t sizelimit) const NO_THREAD_SAFETY_ANALYSIS;
+    bool CalculateMemPoolAncestors(txiter it, TxPoolLayer::setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry = nullptr) NO_THREAD_SAFETY_ANALYSIS;
+    void CalculateDescendants(const TxPoolLayer::txiter& it, TxPoolLayer::setEntries& setDescendants) NO_THREAD_SAFETY_ANALYSIS;
+    void RemoveStaged(TxPoolLayer::setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN) NO_THREAD_SAFETY_ANALYSIS;
+    bool HasNoInputsOf(const CTransaction& tx) const NO_THREAD_SAFETY_ANALYSIS;
+    void addUnchecked(const CTxMemPoolEntry& entry, bool /* validFeeEstimate */ ignore) NO_THREAD_SAFETY_ANALYSIS;
+    TxPoolLayer::setEntries GetMemPoolParents(const TxPoolLayer::txiter& entry) const NO_THREAD_SAFETY_ANALYSIS;
+    int Expire(int64_t time) NO_THREAD_SAFETY_ANALYSIS;
+    void TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining = nullptr) NO_THREAD_SAFETY_ANALYSIS;
+
+    void addUnchecked(const CTxMemPoolEntry& entry, const TxPoolLayer::setEntries& setAncestors, bool /* validFeeEstimate */ ignore) NO_THREAD_SAFETY_ANALYSIS;
+    void UpdateAncestorsOf(bool add, const TxPoolLayer::txiter& it, const setEntries& setAncestors) NO_THREAD_SAFETY_ANALYSIS;
+    void UpdateParent(const TxPoolLayer::txiter& entry, const TxPoolLayer::txiter& parent, bool add) NO_THREAD_SAFETY_ANALYSIS;
+    void UpdateChild(const TxPoolLayer::txiter& entry, const TxPoolLayer::txiter& child, bool add) NO_THREAD_SAFETY_ANALYSIS;
+    void UpdateEntryForAncestors(const TxPoolLayer::txiter& it, const setEntries& setAncestors) NO_THREAD_SAFETY_ANALYSIS;
+    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) NO_THREAD_SAFETY_ANALYSIS;
+    void UpdateChildrenForRemoval(txiter it) NO_THREAD_SAFETY_ANALYSIS;
+    setEntries GetMemPoolChildren(const txiter& entry) const NO_THREAD_SAFETY_ANALYSIS;
+    void removeUnchecked(txiter it, MemPoolRemovalReason reason) NO_THREAD_SAFETY_ANALYSIS;
+
+private:
+    /** The underlying tx pool */
+    const CTxMemPool& m_tx_pool;
+
+    /* The txs this layer is adding */
+    CTxMemPool::indexed_transaction_set m_cache_added;
+    /* The txs this layer is removing */
+    std::set<uint256> m_cache_removed;
+
+    /* Tx links for txs that got their links modified */
+    TxPoolLayer::txlinksMap m_cache_map_links;
+
+    /* Next txs that were added */
+    indirectmap<COutPoint, const CTransaction*> m_map_next_tx_added;
+    /* Next txs that were removed */
+    std::set<COutPoint> m_map_next_tx_removed;
+};
+
 /**
  * CCoinsView that brings transactions from a mempool into view.
  * It does not check for spendings by memory pool transactions.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -445,7 +445,7 @@ class CTxMemPool
 private:
     uint32_t nCheckFrequency GUARDED_BY(cs); //!< Value n means that n times in 2^32 we check.
     std::atomic<unsigned int> nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* minerPolicyEstimator;
+    CBlockPolicyEstimator* const minerPolicyEstimator;
 
     uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
@@ -606,6 +606,9 @@ public:
     /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups */
     setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /** Dereference the txiter */
+    static const CTxMemPoolEntry& GetEntry(txiter it) { return *it; }
+
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must
      *  also be in the set, unless this transaction is being removed for being
@@ -725,16 +728,16 @@ public:
      *  same transaction again, if encountered in another transaction chain.
      */
     void UpdateForDescendants(txiter updateIt,
-            cacheMap &cachedDescendants,
-            const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
+        cacheMap& cachedDescendants,
+        const std::set<uint256>& setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, const setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
-    void UpdateEntryForAncestors(txiter it, const setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateEntryForAncestors(txiter it, const setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
-    void UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -610,7 +610,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         size_t nLimitDescendants = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
         size_t nLimitDescendantSize = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT)*1000;
         std::string errString;
-        if (!pool.CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString)) {
+        if (!pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString, /* search_parents_for_entry */ &entry)) {
             return state.Invalid(ValidationInvalidReason::TX_MEMPOOL_POLICY, false, REJECT_NONSTANDARD, "too-long-mempool-chain", errString);
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -255,7 +255,7 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
     }
     else {
         // pcoinsTip contains the UTXO set for ::ChainActive().Tip()
-        CCoinsViewMemPool viewMemPool(pcoinsTip.get(), pool);
+        CoinsViewMemPool<CTxMemPool> viewMemPool(pcoinsTip.get(), pool);
         std::vector<int> prevheights;
         prevheights.resize(tx.vin.size());
         for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++) {
@@ -508,7 +508,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         CCoinsViewCache view(&dummy);
 
         LockPoints lp;
-        CCoinsViewMemPool viewMemPool(pcoinsTip.get(), pool);
+        CoinsViewMemPool<CTxMemPool> viewMemPool(pcoinsTip.get(), pool);
         view.SetBackend(viewMemPool);
 
         // do all inputs exist?

--- a/src/validation.h
+++ b/src/validation.h
@@ -279,7 +279,8 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
+template<typename P>
+bool AcceptToMemoryPool(P& pool, CValidationState& state, const CTransactionRef& tx,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
                         bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -323,7 +324,8 @@ bool TestLockPointValidity(const LockPoints* lp) EXCLUSIVE_LOCKS_REQUIRED(cs_mai
  *
  * See consensus/consensus.h for flag definitions.
  */
-bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+template <typename P>
+bool CheckSequenceLocks(const P& pool, const CTransaction& tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs);
 
 /**
  * Closure representing one script verification


### PR DESCRIPTION
This implements a layer around an immutable tx pool. The layer can be seen as a temporary throw-away shell that provides the same interface as `CTxMemPool`. Its primary purpose right now is to be passed into ATMP while testing acceptance of several (potentially depending) transaction and then to be discarded.

One use case could be to determine if smart contracts that are set up with multiple txs would be accepted by current consensus and policy rules.

In the future it could be extended to support recursive wrapping of layers or a way to commit changes that happened in the layer to the underlying pool or layer. Furthermore, it could be extended to be revivable after changes to the underlying layer happened. (As opposed to be single-use)