### PR TITLE
qa: Fix bench/block_assemble assert failure

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -97,10 +97,14 @@ static void AssembleBlock(benchmark::State& state)
         if (NUM_BLOCKS - b >= COINBASE_MATURITY)
             txs.at(b) = MakeTransactionRef(tx);
     }
-    for (const auto& txr : txs) {
-        CValidationState state;
-        bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
-        assert(ret);
+    {
+        LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
+
+        for (const auto& txr : txs) {
+            CValidationState state;
+            bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
+            assert(ret);
+        }
     }
 
     while (state.KeepRunning()) {


### PR DESCRIPTION
Calling `bench_bitcoin` currently fails due to calling ATMP without acquiring cs_main first in the recently added block_assemble bench (https://github.com/bitcoin/bitcoin/pull/13219).

```
$ cat <(uname -a) <(gcc --version)

Linux james 4.4.0-119-generic #143+jamesob SMP Mon Apr 16 21:47:24 EDT 2018 x86_64 x86_64 x86_64 GNU/Linux
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.9) 5.4.0 20160609

$ ./src/bench/bench_bitcoin

WARNING: This is a debug build - may result in slower benchmarks.
# Benchmark, evals, iterations, total, min, max, median
Assertion failed: lock cs_main not held in validation.cpp:566; locks held:
[1]    19323 abort (core dumped)  ./src/bench/bench_bitcoin
```

```
(gdb) bt
#0  0x00007fbdc9cf5428 in __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:54
#1  0x00007fbdc9cf702a in __GI_abort () at abort.c:89
#2  0x0000555a19580dc5 in AssertLockHeldInternal (pszName=pszName@entry=0x555a19834549 "cs_main",
    pszFile=pszFile@entry=0x555a1988a001 "validation.cpp", nLine=nLine@entry=566, cs=cs@entry=0x555a19ba55c0 <cs_main>) at sync.cpp:157
#3  0x0000555a194b395f in AcceptToMemoryPoolWorker (chainparams=..., pool=..., state=...,
    ptx=std::shared_ptr (count 1, weak 0) 0x555a1bb819b0, pfMissingInputs=pfMissingInputs@entry=0x0, nAcceptTime=1532964079,
    plTxnReplaced=0x0, bypass_limits=false, nAbsurdFee=@0x7ffcbc1719d8: 0, coins_to_uncache=std::vector of length 0, capacity 0,
    test_accept=false) at validation.cpp:566
#4  0x0000555a194ba661 in AcceptToMemoryPoolWithTime (chainparams=..., pool=..., state=...,
    tx=std::shared_ptr (count 1, weak 0) 0x555a1bb819b0, pfMissingInputs=pfMissingInputs@entry=0x0, nAcceptTime=<optimized out>,
    plTxnReplaced=0x0, bypass_limits=false, nAbsurdFee=0, test_accept=false) at validation.cpp:998
#5  0x0000555a194ba7ce in AcceptToMemoryPool (pool=..., state=..., tx=std::shared_ptr (count 1, weak 0) 0x555a1bb819b0,
    pfMissingInputs=pfMissingInputs@entry=0x0, plTxnReplaced=plTxnReplaced@entry=0x0, bypass_limits=bypass_limits@entry=false, nAbsurdFee=0,
    test_accept=false) at validation.cpp:1014
#6  0x0000555a19363fbe in AssembleBlock (state=...) at bench/block_assemble.cpp:102
#7  0x0000555a193654d3 in std::_Function_handler<void (benchmark::State&), void (*)(benchmark::State&)>::_M_invoke(std::_Any_data const&, benchmark::State&) (__functor=..., __args#0=...) at /usr/include/c++/5/functional:1871
#8  0x0000555a193501d7 in std::function<void (benchmark::State&)>::operator()(benchmark::State&) const (this=this@entry=0x555a1ba2cda0,
    __args#0=...) at /usr/include/c++/5/functional:2267
#9  0x0000555a1934ec4c in benchmark::BenchRunner::RunAll (printer=..., num_evals=5, scaling=<optimized out>, filter=..., is_list_only=false)
    at bench/bench.cpp:121
#10 0x0000555a1934ade9 in main (argc=<optimized out>, argv=<optimized out>) at bench/bench_bitcoin.cpp:92
```