### PR TITLE
travis: WIP - build and run tests on os: osx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,15 @@ jobs:
         - set -o errexit; source .travis/lint_05_before_script.sh
       script:
         - set -o errexit; source .travis/lint_06_script.sh
+# macOS native
+    - stage: test
+      os: osx
+      osx_image: xcode9.4
+      env: >
+        HOST=osx
+        PACKAGES="berkeley-db4 libtool boost miniupnpc pkg-config protobuf qt libevent librsvg"
+        GOAL=install
+        BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror"
 # ARM
     - stage: test
       env: >-
@@ -133,3 +142,4 @@ jobs:
         RUN_FUNCTIONAL_TESTS=false
         GOAL="all deploy"
         BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror"
+

--- a/.travis/test_04_install.sh
+++ b/.travis/test_04_install.sh
@@ -6,6 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
+# linux build - uses docker
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+
 travis_retry docker pull "$DOCKER_NAME_TAG"
 env | grep -E '^(CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL)' | tee /tmp/env
 if [[ $HOST = *-mingw32 ]]; then
@@ -23,4 +26,13 @@ fi
 
 travis_retry DOCKER_EXEC apt-get update
 travis_retry DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES $DOCKER_PACKAGES
+
+# macOS build - does not use docker, but might require some packages
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+
+for package in $PACKAGES; do
+  brew install $package || true # brew fails if the package is already available
+done
+
+fi
 

--- a/.travis/test_05_before_script.sh
+++ b/.travis/test_05_before_script.sh
@@ -6,9 +6,12 @@
 
 export LC_ALL=C.UTF-8
 
-DOCKER_EXEC echo \> \$HOME/.bitcoin  # Make sure default datadir does not exist and is never read by creating a dummy file
-
 mkdir -p depends/SDKs depends/sdk-sources
+
+
+if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+
+DOCKER_EXEC echo \> \$HOME/.bitcoin  # Make sure default datadir does not exist and is never read by creating a dummy file
 
 if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
   curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
@@ -22,4 +25,6 @@ fi
 if [ -z "$NO_DEPENDS" ]; then
   DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
 fi
+
+fi # end if os name
 


### PR DESCRIPTION
This pull requests enables building and running the project with `os: osx`, sort of natively on os x instead of cross-compiling and not running the tests.

To achieve that the `before_install`, `install`, `before_script`, and `script` parts were externalized into `.travis/before_install` etc. These scripts exist for both `linux` (which runs everything in docker) and `osx` (which runs everything directly).

Having the steps externalized in individual scripts makes them more readable and subject to `shellcheck` (`lint-shell.sh`).

The `shellcheck` executable segfaults on me, which is why it's now being run via docker. This has a nice side effect, namely that a more recent version of shellcheck can be used. The runtime of the lint step is not affected to much by it (it's still around 1 minute as it was before).

The newer shellcheck also comes with more lint rules of which I disabled some as I did not want to touch too much stuff in this single pull request, which is primarily about a reorganization of the travis build.