### PR TITLE
More intuitive GUI settings behavior when -proxy is set

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -61,9 +61,15 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->proxyPortTor->setEnabled(false);
     ui->proxyPortTor->setValidator(new QIntValidator(1, 65535, this));
 
-    connect(ui->connectSocks, &QPushButton::toggled, ui->proxyIp, &QWidget::setEnabled);
-    connect(ui->connectSocks, &QPushButton::toggled, ui->proxyPort, &QWidget::setEnabled);
-    connect(ui->connectSocks, &QPushButton::toggled, this, &OptionsDialog::updateProxyValidationState);
+    // Disable and don't connect proxy checkbox interaction if proxy= is set by
+    // a param, to make it clear that removing the param / config is prerequisite to disabling.
+    if (!gArgs.GetArg("-proxy", "").empty()) {
+        ui->connectSocks->setEnabled(false);
+    } else {
+        connect(ui->connectSocks, &QPushButton::toggled, ui->proxyIp, &QWidget::setEnabled);
+        connect(ui->connectSocks, &QPushButton::toggled, ui->proxyPort, &QWidget::setEnabled);
+        connect(ui->connectSocks, &QPushButton::toggled, this, &OptionsDialog::updateProxyValidationState);
+    }
 
     connect(ui->connectSocksTor, &QPushButton::toggled, ui->proxyIpTor, &QWidget::setEnabled);
     connect(ui->connectSocksTor, &QPushButton::toggled, ui->proxyPortTor, &QWidget::setEnabled);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -130,15 +130,25 @@ void OptionsModel::Init(bool resetSettings)
     if (!m_node.softSetBoolArg("-listen", settings.value("fListen").toBool()))
         addOverriddenOption("-listen");
 
-    if (!settings.contains("fUseProxy"))
-        settings.setValue("fUseProxy", false);
-    if (!settings.contains("addrProxy"))
-        settings.setValue("addrProxy", GetDefaultProxyAddress());
+    if (!settings.contains("addrProxy")) {
+        QString addrProxy = QString::fromStdString(gArgs.GetArg("-proxy", ""));
+        if (!addrProxy.isEmpty()) {
+            // If a proxy is configured, enable it in the UI:
+            if (!settings.contains("fUseProxy")) {
+                settings.setValue("fUseProxy", true);
+            }
+        } else {
+            addrProxy = GetDefaultProxyAddress();
+        }
+        settings.setValue("addrProxy", addrProxy);
+    }
     // Only try to set -proxy, if user has enabled fUseProxy
     if (settings.value("fUseProxy").toBool() && !m_node.softSetArg("-proxy", settings.value("addrProxy").toString().toStdString()))
         addOverriddenOption("-proxy");
     else if(!settings.value("fUseProxy").toBool() && !gArgs.GetArg("-proxy", "").empty())
         addOverriddenOption("-proxy");
+    if (!settings.contains("fUseProxy"))
+        settings.setValue("fUseProxy", false);
 
     if (!settings.contains("fUseSeparateProxyTor"))
         settings.setValue("fUseSeparateProxyTor", false);


### PR DESCRIPTION
Given `proxy=127.0.0.1:9051` bitcoin.conf (or using `-proxy`):

Before:
<img width="615" alt="schermafbeelding 2018-07-31 om 16 07 37" src="https://user-images.githubusercontent.com/10217/43464643-e6b07ebc-94db-11e8-99d3-8f64e7149fd0.png">

There are number of confusing aspects to this:

1. it shows the default proxy URL, rather than the one in `bitcoin.conf`
2. the check box is unchecked, even though the proxy is enabled. If the user checks it themselves (for aesthetic reasons?), that leads to problem (4) and (5). 
3. the phrase "options that override above options" (it sometimes confuses me if that means anything)
4. if the user wants to turn off the proxy by unchecking it, that won't actually work
5. if the user tries to change the IP or port that won't do anything

So I changed the behavior to check the box and populate the initial setting (only done at first launch or after you reset QT settings) if `-proxy` is set (perhaps it's even to always do this?).

In addition the user can no longer disable the check box or edit the settings when `-proxy` is set. They have to remove the entry from `bitcoin.conf` first.

After:
<img width="612" alt="after" src="https://user-images.githubusercontent.com/10217/43464512-97121e92-94db-11e8-9cfa-dd74981b6b50.png">


#11082 and #12833 are a more rigorous solution, but there's some overlap. E.g. if a setting exists in the read-only `bitcoin.conf` it should be similarly disabled in the GUI, along with an instruction to remove it from `bitcoin.conf` if the user wishes to edit it (using the read-write `bitcoin-rw.conf`).

This UX pattern can be applied to a few other settings as well. I found `proxy` particularly useful because it's used with Tor where confusion is really not a good thing.

I'm guessing that a separate Tor proxy through `-onion` is less common, so I didn't touch that (yet). I find that setting confusing in general.