### PR TITLE
qa: Re-enable test for unknown arg in conf file

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -126,7 +126,7 @@ static int AppInitRPC(int argc, char* argv[])
         fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "").c_str());
         return EXIT_FAILURE;
     }
-    if (!gArgs.ReadConfigFiles(error, true)) {
+    if (!gArgs.ReadConfigFiles(error, /* ignore_invalid_keys */ true)) {
         fprintf(stderr, "Error reading configuration file: %s\n", error.c_str());
         return EXIT_FAILURE;
     }

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -96,7 +96,7 @@ static bool AppInit(int argc, char* argv[])
             fprintf(stderr, "Error: Specified data directory \"%s\" does not exist.\n", gArgs.GetArg("-datadir", "").c_str());
             return false;
         }
-        if (!gArgs.ReadConfigFiles(error, true)) {
+        if (!gArgs.ReadConfigFiles(error, /* ignore_invalid_keys */ true)) {
             fprintf(stderr, "Error reading configuration file: %s\n", error.c_str());
             return false;
         }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -864,7 +864,7 @@ bool ArgsManager::ReadConfigStream(std::istream& stream, std::string& error, boo
                 error = strprintf("Invalid configuration value %s", option.first.c_str());
                 return false;
             } else {
-                LogPrintf("Ignoring unknown configuration value %s\n", option.first);
+                fprintf(stderr, "Ignoring unknown configuration value %s\n", option.first.c_str());
             }
         }
     }

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -56,10 +56,10 @@ class IncludeConfTest(BitcoinTestFramework):
 
         self.log.info("-includeconf cannot contain invalid arg")
 
-        # Commented out as long as we ignore invalid arguments in configuration files
-        #with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
-        #    f.write("foo=bar\n")
-        #self.nodes[0].assert_start_raises_init_error(expected_msg="Error reading configuration file: Invalid configuration value foo")
+        with open(os.path.join(self.options.tmpdir, "node0", "relative.conf"), "w", encoding="utf8") as f:
+            f.write("foo=bar\n")
+        self.start_node(0)
+        self.stop_node(0, expected_stderr="Ignoring unknown configuration value foo")
 
         self.log.info("-includeconf cannot be invalid path")
         os.remove(os.path.join(self.options.tmpdir, "node0", "relative.conf"))


### PR DESCRIPTION
I believe we can't currently write to the debug.log at the time the conf files are parsed. So just write to stderr for now.

Also re-enable the test that was disabled in #13799