### PR TITLE
bench: Make CoinSelection output groups pass eligibility filter

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -21,7 +21,7 @@ static void addCoin(const CAmount& nValue, const CWallet& wallet, std::vector<Ou
 
     int nAge = 6 * 24;
     COutput output(wtx, nInput, nAge, true /* spendable */, true /* solvable */, true /* safe */);
-    groups.emplace_back(output.GetInputCoin(), 0, false, 0, 0);
+    groups.emplace_back(output.GetInputCoin(), 6, false, 0, 0);
 }
 
 // Simple benchmark for wallet coin selection. Note that it maybe be necessary


### PR DESCRIPTION
Set the depth of the output groups used in the CoinSelection benchmark to be 6 in order to pass the eligibility filter for the benchmark.

Fixes #13813