### PR TITLE
qa: quote path in authproxy for external multiwallets

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -15,6 +15,7 @@ import re
 import subprocess
 import tempfile
 import time
+import urllib.parse
 
 from .authproxy import JSONRPCException
 from .util import (
@@ -184,7 +185,7 @@ class TestNode():
             return self.cli("-rpcwallet={}".format(wallet_name))
         else:
             assert self.rpc_connected and self.rpc, self._node_msg("RPC not connected")
-            wallet_path = "wallet/%s" % wallet_name
+            wallet_path = "wallet/{}".format(urllib.parse.quote(wallet_name))
             return self.rpc / wallet_path
 
     def stop_node(self, expected_stderr=''):


### PR DESCRIPTION
When using external multiwallets they are specified by their full path which might contain non-ascii characters (e.g. umlauts or emojis).

Fix this by url-quoting the path.