### PR TITLE
doc: Remove outdated net comment

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1798,7 +1798,6 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
         CAddress addrConnect;
 
         // Only connect out to one peer per network group (/16 for IPv4).
-        // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
         int nOutbound = 0;
         std::set<std::vector<unsigned char> > setConnected;
         {


### PR DESCRIPTION
`mapAddresses` and the corresponding "critsect" has been removed in 5fee401fe14aa6459428a26a82f764db70a6a0b9 more than 6 years ago. Now is probably a good time to remove this confusing comment.