### PR TITLE
[WIP] depends: Add native_nsis to support unicode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,15 +71,16 @@ jobs:
         HOST=i686-w64-mingw32
         DPKG_ADD_ARCH="i386"
         DEP_OPTS="NO_QT=1"
-        PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
+        PACKAGES="python3 scons g++-mingw-w64-i686 wine-binfmt wine32"
         GOAL="install"
         BITCOIN_CONFIG="--enable-reduce-exports"
 # Win64
     - stage: test
       env: >-
         HOST=x86_64-w64-mingw32
+        DPKG_ADD_ARCH="i386"
         DEP_OPTS="NO_QT=1"
-        PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
+        PACKAGES="python3 scons g++-mingw-w64-i686 g++-mingw-w64-x86-64 wine-binfmt wine64"
         GOAL="install"
         BITCOIN_CONFIG="--enable-reduce-exports"
 # 32-bit + dash

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -17,7 +17,7 @@ packages:
 - "bsdmainutils"
 - "mingw-w64"
 - "g++-mingw-w64"
-- "nsis"
+- "scons"
 - "zip"
 - "ca-certificates"
 - "python"
@@ -30,8 +30,8 @@ script: |
   WRAP_DIR=$HOME/wrapped
   HOSTS="i686-w64-mingw32 x86_64-w64-mingw32"
   CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
-  FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
-  FAKETIME_PROGS="date makensis zip"
+  FAKETIME_HOST_PROGS="ar as ranlib nm windres strip objcopy"
+  FAKETIME_PROGS="date scons zip"
   HOST_CFLAGS="-O2 -g"
   HOST_CXXFLAGS="-O2 -g"
 
@@ -54,7 +54,7 @@ script: |
     echo "REAL=\`which -a ${prog} | grep -v ${WRAP_DIR}/${prog} | head -1\`" >> ${WRAP_DIR}/${prog}
     echo 'export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/faketime/libfaketime.so.1' >> ${WRAP_DIR}/${prog}
     echo "export FAKETIME=\"$1\"" >> ${WRAP_DIR}/${prog}
-    echo "\$REAL \$@" >> $WRAP_DIR/${prog}
+    echo "\$REAL \"\$@\"" >> $WRAP_DIR/${prog}
     chmod +x ${WRAP_DIR}/${prog}
   done
   }

--- a/depends/packages/native_nsis.mk
+++ b/depends/packages/native_nsis.mk
@@ -1,0 +1,26 @@
+package=native_nsis
+$(package)_version=3.03
+$(package)_download_path=https://sourceforge.net/projects/nsis/files/NSIS%203/$($(package)_version)
+$(package)_file_name=nsis-$($(package)_version)-src.tar.bz2
+$(package)_sha256_hash=abae7f4488bc6de7a4dd760d5f0e7cd3aad7747d4d7cd85786697c8991695eaa
+$(package)_dependencies=native_zlib
+
+define $(package)_set_vars
+$(package)_build_opts  = PREFIX=$(build_prefix)
+$(package)_build_opts += PREFIX_DEST=$($(package)_staging_dir)
+$(package)_build_opts += APPEND_CPPPATH=$(build_prefix)/include
+$(package)_build_opts += APPEND_LIBPATH=$(build_prefix)/lib
+$(package)_build_opts += SKIPDOC=COPYING
+$(package)_build_opts += SKIPSTUBS=bzip2
+$(package)_build_opts += SKIPPLUGINS=AdvSplash,Banner,BgImage,Dialer,InstallOptions,LangDLL,Library/TypeLib,Math,nsExec,NSISdl,Splash,UserInfo,VPatch/Source/Plugin
+$(package)_build_opts += SKIPUTILS=Library/LibraryLocal,Library/RegTool,MakeLangId,Makensisw,'NSIS Menu',SubStart,VPatch/Source/GenPat,zip2exe
+$(package)_build_opts += SKIPMISC=MultiUser,'Modern UI',VPatch
+endef
+
+define $(package)_build_cmds
+  scons $($(package)_build_opts)
+endef
+
+define $(package)_stage_cmds
+  scons $($(package)_build_opts) install-bin install-data
+endef

--- a/depends/packages/native_zlib.mk
+++ b/depends/packages/native_zlib.mk
@@ -1,0 +1,18 @@
+package=native_zlib
+$(package)_version=1.2.11
+$(package)_download_path=http://www.zlib.net
+$(package)_file_name=zlib-$($(package)_version).tar.gz
+$(package)_sha256_hash=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+
+define $(package)_config_cmds
+  ./configure --prefix=$(build_prefix)
+endef
+
+define $(package)_build_cmds
+  $(MAKE)
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
+endef
+

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -13,6 +13,7 @@ wallet_packages=bdb
 upnp_packages=miniupnpc
 
 darwin_native_packages = native_biplist native_ds_store native_mac_alias
+mingw32_native_packages = native_nsis native_zlib
 
 ifneq ($(build_os),darwin)
 darwin_native_packages += native_cctools native_cdrkit native_libdmg-hfsplus

--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -1,4 +1,6 @@
 Name "@PACKAGE_NAME@ (@WINDOWS_BITS@-bit)"
+Unicode true
+SetDateSave off
 
 RequestExecutionLevel highest
 SetCompressor /SOLID lzma


### PR DESCRIPTION
Since version 3.0, nsis start to support unicode. However, Bionic still use 2.51. So, it might be a good reason to add nsis into dependency list to support unicode.

Fix #13817 
Close #8825

TODO:
- [ ] Gitian build should be deterministic