### PR TITLE
RPC: Add new 'clearmempool' method

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1924,6 +1924,38 @@ static UniValue savemempool(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
+static UniValue clearmempool(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0) {
+        throw std::runtime_error(
+            "clearmempool\n"
+            "\nRemoves all transactions from the mempool.\n"
+            "It will fail if a previous dump is still being loaded.\n"
+            "\nResult:\n"
+            "{                               (json object)\n"
+            "  \"transactions_removed\": n,    (numeric) The number of evicted transactions\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("clearmempool", "")
+            + HelpExampleRpc("clearmempool", "")
+        );
+    }
+
+    if (!g_is_mempool_loaded) {
+        throw JSONRPCError(RPC_MISC_ERROR, "The mempool was not loaded yet");
+    }
+
+    LOCK2(cs_main, mempool.cs);
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("transactions_removed", mempool.size());
+
+    mempool.clear();
+    mempool.check(pcoinsTip.get());
+
+    return result;
+}
+
 //! Search for a given set of pubkey scripts
 bool FindScriptPubKey(std::atomic<int>& scan_progress, const std::atomic<bool>& should_abort, int64_t& count, CCoinsViewCursor* cursor, const std::set<CScript>& needles, std::map<COutPoint, Coin>& out_results) {
     scan_progress = 0;
@@ -2230,6 +2262,7 @@ static const CRPCCommand commands[] =
     { "blockchain",         "gettxoutsetinfo",        &gettxoutsetinfo,        {} },
     { "blockchain",         "pruneblockchain",        &pruneblockchain,        {"height"} },
     { "blockchain",         "savemempool",            &savemempool,            {} },
+    { "blockchain",         "clearmempool",           &clearmempool,           {} },
     { "blockchain",         "verifychain",            &verifychain,            {"checklevel","nblocks"} },
 
     { "blockchain",         "preciousblock",          &preciousblock,          {"blockhash"} },

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -588,6 +588,7 @@ void CTxMemPool::_clear()
     mapLinks.clear();
     mapTx.clear();
     mapNextTx.clear();
+    mapDeltas.clear();
     totalTxSize = 0;
     cachedInnerUsage = 0;
     lastRollingFeeUpdate = GetTime();
@@ -726,6 +727,9 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         const CTransaction& tx = it2->GetTx();
         assert(it2 != mapTx.end());
         assert(&tx == it->second);
+    }
+    for (const auto& entry : mapDeltas) {
+        assert(mapTx.count(entry.first) > 0);
     }
 
     assert(totalTxSize == checkTotal);

--- a/test/functional/mempool_clear.py
+++ b/test/functional/mempool_clear.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test explicit clearing of the mempool."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+from decimal import Decimal
+
+
+class MempoolClearTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        address = self.nodes[0].getnewaddress()
+        txid = self.nodes[0].sendtoaddress(address, Decimal('1'))
+        assert_equal(self.nodes[0].getrawmempool(), [txid])
+
+        # Add a fee delta to make the mempool more complicated before we
+        # clear it.
+        self.nodes[0].prioritisetransaction(txid, None, 1000)
+
+        assert_equal(self.nodes[0].clearmempool(), {"transactions_removed": 1})
+        assert_equal(self.nodes[0].getrawmempool(), [])
+        assert_equal(self.nodes[0].clearmempool(), {"transactions_removed": 0})
+        assert_equal(self.nodes[0].getrawmempool(), [])
+
+        # Mine a block, it should not confirm the wallet transaction.
+        self.nodes[0].generate(1)
+        assert_equal(self.nodes[0].gettransaction(txid)['confirmations'], 0)
+
+
+if __name__ == '__main__':
+    MempoolClearTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -119,6 +119,7 @@ BASE_SCRIPTS = [
     'p2p_invalid_tx.py',
     'rpc_createmultisig.py',
     'feature_versionbits_warning.py',
+    'mempool_clear.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py',
     'rpc_zmq.py',


### PR DESCRIPTION
The new `clearmempool` RPC method removes all transactions in the mempool.  This can be useful for testing, and might be useful also in some other situations.