### PR TITLE
Inline i64tostr and itostr

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1601,7 +1601,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 vRecv >> LIMITED_STRING(strMsg, CMessageHeader::COMMAND_SIZE) >> ccode >> LIMITED_STRING(strReason, MAX_REJECT_MESSAGE_LENGTH);
 
                 std::ostringstream ss;
-                ss << strMsg << " code " << itostr(ccode) << ": " << strReason;
+                ss << strMsg << strprintf(" code %u: ", ccode) << strReason;
 
                 if (strMsg == NetMsgType::BLOCK || strMsg == NetMsgType::TX)
                 {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -20,6 +20,7 @@
 #include <rpc/mining.h>
 #include <rpc/server.h>
 #include <shutdown.h>
+#include <tinyformat.h>
 #include <txmempool.h>
 #include <util.h>
 #include <utilstrencodings.h>
@@ -647,7 +648,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
-    result.pushKV("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
+    result.pushKV("longpollid", strprintf("%s%u", chainActive.Tip()->GetBlockHash().GetHex(), nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
     result.pushKV("mutable", aMutable);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -5,6 +5,7 @@
 #include <sync.h>
 
 #include <logging.h>
+#include <tinyformat.h>
 #include <utilstrencodings.h>
 
 #include <stdio.h>
@@ -47,7 +48,7 @@ struct CLockLocation {
 
     std::string ToString() const
     {
-        return mutexName + "  " + sourceFile + ":" + itostr(sourceLine) + (fTry ? " (TRY)" : "");
+        return strprintf("%s %s: %d%s", mutexName, sourceFile, sourceLine, (fTry ? " (TRY)" : ""));
     }
 
 private:

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -5,12 +5,12 @@
 
 #include <utilstrencodings.h>
 
-#include <tinyformat.h>
-
 #include <cstdlib>
 #include <cstring>
 #include <errno.h>
 #include <limits>
+#include <locale>
+#include <sstream>
 
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -392,16 +392,6 @@ std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
     return out.str();
 }
 
-std::string i64tostr(int64_t n)
-{
-    return strprintf("%d", n);
-}
-
-std::string itostr(int n)
-{
-    return strprintf("%d", n);
-}
-
 int64_t atoi64(const char* psz)
 {
 #ifdef _MSC_VER
@@ -543,4 +533,3 @@ bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
 
     return true;
 }
-

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -55,8 +55,6 @@ std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
-std::string i64tostr(int64_t n);
-std::string itostr(int n);
 int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -189,14 +189,6 @@ static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
     nOrderPos = atoi64(mapValue["n"].c_str());
 }
 
-
-static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
-{
-    if (nOrderPos == -1)
-        return;
-    mapValue["n"] = i64tostr(nOrderPos);
-}
-
 struct COutputEntry
 {
     CTxDestination destination;
@@ -402,7 +394,10 @@ public:
         mapValue_t mapValueCopy = mapValue;
 
         mapValueCopy["fromaccount"] = strFromAccount;
-        WriteOrderPos(nOrderPos, mapValueCopy);
+
+        if (nOrderPos != -1) {
+            mapValueCopy["n"] = strprintf("%d", nOrderPos);
+        }
         if (nTimeSmart) {
             mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
         }
@@ -601,7 +596,9 @@ public:
         s << nCreditDebit << nTime << strOtherAccount;
 
         mapValue_t mapValueCopy = mapValue;
-        WriteOrderPos(nOrderPos, mapValueCopy);
+        if (nOrderPos != -1) {
+            mapValueCopy["n"] = strprintf("%d", nOrderPos);
+        }
 
         std::string strCommentCopy = strComment;
         if (!mapValueCopy.empty() || !_ssExtra.empty()) {


### PR DESCRIPTION
These methods don't give us much, and removing them removes utilstrencodings's
dependence on tinyformat