### PR TITLE
Remove unused qt nullptr args

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -350,7 +350,7 @@ void BitcoinApplication::createOptionsModel(bool resetSettings)
 
 void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 {
-    window = new BitcoinGUI(m_node, platformStyle, networkStyle, 0);
+    window = new BitcoinGUI(m_node, platformStyle, networkStyle);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, SIGNAL(timeout()), window, SLOT(detectShutdown()));
@@ -358,7 +358,7 @@ void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 
 void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)
 {
-    SplashScreen *splash = new SplashScreen(m_node, 0, networkStyle);
+    SplashScreen* splash = new SplashScreen(m_node, networkStyle);
     // We don't hold a direct pointer to the splash screen after creation, but the splash
     // screen will take care of deleting itself when slotFinish happens.
     splash->show();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -67,8 +67,7 @@ const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #endif
         ;
 
-BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformStyle, const NetworkStyle *networkStyle, QWidget *parent) :
-    QMainWindow(parent),
+BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle* _platformStyle, const NetworkStyle* networkStyle) :
     m_node(node),
     platformStyle(_platformStyle)
 {

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -56,7 +56,7 @@ class BitcoinGUI : public QMainWindow
 public:
     static const std::string DEFAULT_UIPLATFORM;
 
-    explicit BitcoinGUI(interfaces::Node& node, const PlatformStyle *platformStyle, const NetworkStyle *networkStyle, QWidget *parent = 0);
+    explicit BitcoinGUI(interfaces::Node& node, const PlatformStyle* platformStyle, const NetworkStyle* networkStyle);
     ~BitcoinGUI();
 
     /** Set the client model.

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -24,8 +24,8 @@
 #include <QPainter>
 #include <QRadialGradient>
 
-SplashScreen::SplashScreen(interfaces::Node& node, Qt::WindowFlags f, const NetworkStyle *networkStyle) :
-    QWidget(0, f), curAlignment(0), m_node(node)
+SplashScreen::SplashScreen(interfaces::Node& node, const NetworkStyle* networkStyle) :
+    curAlignment(0), m_node(node)
 {
     // set reference point, paddings
     int paddingRight            = 50;

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -29,7 +29,7 @@ class SplashScreen : public QWidget
     Q_OBJECT
 
 public:
-    explicit SplashScreen(interfaces::Node& node, Qt::WindowFlags f, const NetworkStyle *networkStyle);
+    explicit SplashScreen(interfaces::Node& node, const NetworkStyle* networkStyle);
     ~SplashScreen();
 
 protected:

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -148,8 +148,7 @@ void HelpMessageDialog::on_okButton_accepted()
 
 
 /** "Shutdown" window */
-ShutdownWindow::ShutdownWindow(QWidget *parent, Qt::WindowFlags f):
-    QWidget(parent, f)
+ShutdownWindow::ShutdownWindow()
 {
     QVBoxLayout *layout = new QVBoxLayout();
     layout->addWidget(new QLabel(

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -45,7 +45,7 @@ class ShutdownWindow : public QWidget
     Q_OBJECT
 
 public:
-    explicit ShutdownWindow(QWidget *parent=0, Qt::WindowFlags f=0);
+    explicit ShutdownWindow();
     static QWidget *showShutdownWindow(BitcoinGUI *window);
 
 protected:


### PR DESCRIPTION
In all cases these were either unreferenced or equal to the default value of
the base class's constructor. I.e.:
http://doc.qt.io/qt-5/qwidget.html#QWidget
http://doc.qt.io/qt-5/qmainwindow.html#QMainWindow

Found via `zero-as-null-ptr-constant` warnings.