### PR TITLE
gui: don't disable the sync overlay when wallet is disabled

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -196,11 +196,11 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     connect(connectionsControl, SIGNAL(clicked(QPoint)), this, SLOT(toggleNetworkActive()));
 
     modalOverlay = new ModalOverlay(this->centralWidget());
+    connect(labelBlocksIcon, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
+    connect(progressBar, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
 #ifdef ENABLE_WALLET
     if(enableWallet) {
         connect(walletFrame, SIGNAL(requestedSyncWarningInfo()), this, SLOT(showModalOverlay()));
-        connect(labelBlocksIcon, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
-        connect(progressBar, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));
     }
 #endif
 }


### PR DESCRIPTION
When running with `-disablewallet` the sync modal is now available by clicking on the progress bar or `syncing` icon.

<img width="853" alt="screenshot 2018-08-02 at 4 21 57 pm" src="https://user-images.githubusercontent.com/863730/43571756-56a8105a-9670-11e8-8c72-39ead02663b5.png">

Fixes #13828.