### PR TITLE
fix locale for lint-shell

### DIFF
--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -6,9 +6,15 @@
 #
 # Check for shellcheck warnings in shell scripts.
 
-# This script is intentionally locale dependent by not setting "export LC_ALL=C"
-# to allow running certain versions of shellcheck that core dump when LC_ALL=C
-# is set.
+export LC_ALL=C
+
+# The shellcheck binary segfault/coredumps in Travis with LC_ALL=C
+# It does not do so in Ubuntu 14.04, 16.04, 18.04 in versions 0.3.3, 0.3.7, 0.4.6
+# respectively. So export LC_ALL=C is set as required by lint-shell-locale.sh
+# but unset here in case of running in Travis.
+if [ "$TRAVIS" = "true" ]; then
+  unset LC_ALL
+fi
 
 # Disabled warnings:
 # SC2001: See if you can use ${variable//search/replace} instead.


### PR DESCRIPTION
A piece of code from https://github.com/bitcoin/bitcoin/pull/13816 which I am hereby splitting into smaller PRs.

The `shellcheck` executable shipped with travis's trusty linux environment (contains shellcheck `0.3.1` in `/usr/local/bin` as opposed to the distros `0.3.3` in `/usr/bin`) segfaults when `LC_ALL=C`.

This makes sure that in travis, no matter from where the script is called, `LC_ALL` is left unset. Comment changed accordingly.