### PR TITLE
Increase maximum mmaps() used by each LevelDB instance from 1000 to 4096 on 64 bit systems.

### DIFF
--- a/src/leveldb/util/env_posix.cc
+++ b/src/leveldb/util/env_posix.cc
@@ -585,8 +585,8 @@ static int MaxMmaps() {
   if (mmap_limit >= 0) {
     return mmap_limit;
   }
-  // Up to 1000 mmaps for 64-bit binaries; none for smaller pointer sizes.
-  mmap_limit = sizeof(void*) >= 8 ? 1000 : 0;
+  // Up to 4096 mmaps for 64-bit binaries; none for smaller pointer sizes.
+  mmap_limit = sizeof(void*) >= 8 ? 4096 : 0;
   return mmap_limit;
 }
 


### PR DESCRIPTION
By default LevelDB will only mmap() up to 1000 ldb files for reading, this default is arbitrarily small.

Once the first 1000 files are mmap()ed, it falls back to using file descriptor based IO which eventually
causes problems for handling new sockets due to the use of select(). Increasing the number of mmaps() used will hold off running into the 1024 file descriptor (default) limit for select().