### PR TITLE
test: Add testing of value_ret for SelectCoinsBnB

### DIFF
--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -150,6 +150,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(1 * CENT, 1, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));
     BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
     actual_selection.clear();
     selection.clear();
 
@@ -157,6 +158,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(2 * CENT, 2, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 2 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));
     BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK_EQUAL(value_ret, 2 * CENT);
     actual_selection.clear();
     selection.clear();
 
@@ -165,6 +167,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(2 * CENT, 2, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 5 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));
     BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK_EQUAL(value_ret, 5 * CENT);
     actual_selection.clear();
     selection.clear();
 
@@ -181,6 +184,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(1 * CENT, 1, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));
     BOOST_CHECK(equal_sets(selection, actual_selection));
+    BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
     actual_selection.clear();
     selection.clear();
 
@@ -190,6 +194,9 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     add_coin(3 * CENT, 3, actual_selection);
     add_coin(2 * CENT, 2, actual_selection);
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 10 * CENT, 5000, selection, value_ret, not_input_fees));
+    BOOST_CHECK_EQUAL(value_ret, 10 * CENT);
+    // FIXME: this test is redundant with the above, because 1 Cent is selected, not "too small"
+    // BOOST_CHECK(equal_sets(selection, actual_selection));
 
     // Select 0.25 Cent, not possible
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.25 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));
@@ -203,6 +210,7 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), target, 0, selection, value_ret, not_input_fees)); // Should not exhaust
 
     // Test same value early bailout optimization
+    utxo_pool.clear();
     add_coin(7 * CENT, 7, actual_selection);
     add_coin(7 * CENT, 7, actual_selection);
     add_coin(7 * CENT, 7, actual_selection);
@@ -217,6 +225,8 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
         add_coin(5 * CENT, 7, utxo_pool);
     }
     BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 30 * CENT, 5000, selection, value_ret, not_input_fees));
+    BOOST_CHECK_EQUAL(value_ret, 30 * CENT);
+    BOOST_CHECK(equal_sets(selection, actual_selection));
 
     ////////////////////
     // Behavior tests //


### PR DESCRIPTION
Fix that the early bailout optimization tests did not test the intended
selection because their utxo pool was polluted by the make_hard_case test
preceding. Note the code was tested, just not with the constructed case.