### PR TITLE
utils: Use _wfopen and _wfreopen on Windows

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -11,7 +11,12 @@ namespace fsbridge {
 
 FILE *fopen(const fs::path& p, const char *mode)
 {
+#ifndef WIN32
     return ::fopen(p.string().c_str(), mode);
+#else
+    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t> utf8_cvt;
+    return ::_wfopen(p.wstring().c_str(), utf8_cvt.from_bytes(mode).c_str());
+#endif
 }
 
 #ifndef WIN32


### PR DESCRIPTION
The fopen function does not support unicode filename on Windows, so use Windows specific function do deal with it.