### PR TITLE
[doc] nChainTx needs to become a 64-bit earlier due to SegWit

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -170,7 +170,7 @@ public:
 
     //! (memory only) Number of transactions in the chain up to and including this block.
     //! This value will be non-zero only if and only if transactions for this block and all its parents are available.
-    //! Change to 64-bit type when necessary; won't happen before 2030
+    //! Change to 64-bit type before 2024 (assuming worst case of 60 byte transactions).
     //!
     //! Note: this value is faked during use of a UTXO snapshot because we don't
     //! have the underlying block data available during snapshot load.


### PR DESCRIPTION
As of block 597,379 txcount is 460,596,047 (see `chainparams.cpp`), while `uint32` can handle up to 4,294,967,296. 

Pre segwit the [minimum transaction size](https://en.bitcoin.it/wiki/Maximum_transaction_rate) was 166 bytes, so the worst case number of transactions per block was ~6000. As the original source comment for `unsigned int  nChainTx` says, that should last until the year 2030.
 
With SegWit the smallest possible transaction is 60 bytes (potentially increased to 65 with a future soft fork, see #15482), without a witness:

```
4 bytes version
    1 byte input count
        36 bytes outpoint
        1 byte scriptSigLen (0x00)
        0 bytes scriptSig
        4 bytes sequence
    1 byte output count
        8 bytes value
        1 byte scriptPubKeyLen
        1 byte scriptPubKey (OP_TRUE)
    4 bytes locktime
```

That puts the maximum number of transactions per block at 16,666 so we might have to deal with this as early as a block 827,450 in early 2024.

Given that it's a memory-only thing and we want to allow users many years to upgrade, I would suggest fixing this in v0.20 and back-porting it.