### PR TITLE
utils: Make fs::path::string() always return utf-8 string on Windows

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -10,7 +10,6 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/detail/utf8_codecvt_facet.hpp>
 
 /** Filesystem operations and types */
 namespace fs = boost::filesystem;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -60,8 +60,6 @@
 #include <QFontDatabase>
 #endif
 
-static fs::detail::utf8_codecvt_facet utf8;
-
 namespace GUIUtil {
 
 QString dateTimeStr(const QDateTime &date)
@@ -764,12 +762,12 @@ void setClipboard(const QString& str)
 
 fs::path qstringToBoostPath(const QString &path)
 {
-    return fs::path(path.toStdString(), utf8);
+    return fs::path(path.toStdString());
 }
 
 QString boostPathToQString(const fs::path &path)
 {
-    return QString::fromStdString(path.string(utf8));
+    return QString::fromStdString(path.string());
 }
 
 QString formatDurationStr(int secs)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1206,7 +1206,11 @@ void SetupEnvironment()
     // A dummy locale is used to extract the internal default locale, used by
     // fs::path, which is then used to explicitly imbue the path.
     std::locale loc = fs::path::imbue(std::locale::classic());
+#ifndef WIN32
     fs::path::imbue(loc);
+#else
+    fs::path::imbue(std::locale(loc, new std::codecvt_utf8_utf16<wchar_t>()));
+#endif
 }
 
 bool SetupNetworking()

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -54,7 +54,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/chrono/chrono.hpp
     boost/date_time/posix_time/posix_time.hpp
     boost/filesystem.hpp
-    boost/filesystem/detail/utf8_codecvt_facet.hpp
     boost/filesystem/fstream.hpp
     boost/multi_index/hashed_index.hpp
     boost/multi_index/ordered_index.hpp


### PR DESCRIPTION
Imbue `fs::path` with `std::codecvt_utf8_utf16` at `SetupEnvironment()`, so that default string encoding will be utf-8 inside `fs::path`.