### PR TITLE
doc: fixed bitcoin-cli --help output to compatibility with help2man

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -50,7 +50,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-rpcwait", "Wait for RPC server to start", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcwallet=<walletname>", "Send RPC for non-default wallet on RPC server (needs to exactly match corresponding -wallet option passed to bitcoind)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-stdin", "Read extra arguments from standard input, one per line until EOF/Ctrl-D (recommended for sensitive information such as passphrases).  When combined with -stdinrpcpass, the first line from standard input is used for the RPC password.", false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-stdinrpcpass", strprintf("Read RPC password from standard input as a single line.  When combined with -stdin, the first line from standard input is used for the RPC password."), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-stdinrpcpass", strprintf("Read RPC password from standard input as a single line. When combined with -stdin, the first line from standard input is used for the RPC password."), false, OptionsCategory::OPTIONS);
 
     // Hidden
     gArgs.AddArg("-h", "", false, OptionsCategory::HIDDEN);
@@ -108,7 +108,7 @@ static int AppInitRPC(int argc, char* argv[])
         if (!gArgs.IsArgSet("-version")) {
             strUsage += "\nUsage:\n"
                   "  bitcoin-cli [options] <command> [params]  " + strprintf("Send command to %s", PACKAGE_NAME) + "\n" +
-                  "  bitcoin-cli [options] -named <command> [name=value] ... " + strprintf("Send command to %s (with named arguments)", PACKAGE_NAME) + "\n" +
+                  "  bitcoin-cli [options] -named <command> [name=value]...  " + strprintf("Send command to %s (with named arguments)", PACKAGE_NAME) + "\n" +
                   "  bitcoin-cli [options] help                List commands\n" +
                   "  bitcoin-cli [options] help <command>      Get help for a command\n";
 


### PR DESCRIPTION
Currently help2man produces some unexpected commands in the manual page file bitcoin-cli.1:
- .TP + .IP for 'Usage' in DESCRIPTION section. Should be all .TP;
- .TP + .IP for '-stdinrpcpass' in OPTIONS section. Should be only an .IP