### PR TITLE
gui: Try shutdown also on failure

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -146,6 +146,8 @@ void BitcoinCore::handleRunawayException(const std::exception *e)
     PrintExceptionContinue(e, "Runaway exception");
     try {
         m_node.appShutdown();
+    } catch (const std::exception& e) {
+        PrintExceptionContinue(&e, __func__);
     } catch (...) {
     }
     Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings("gui")));
@@ -372,6 +374,8 @@ void BitcoinApplication::initializeResult(bool success)
     if (!success) {
         try {
             m_node.appShutdown();
+        } catch (const std::exception& e) {
+            PrintExceptionContinue(&e, __func__);
         } catch (...) {
         }
         Q_EMIT splashFinished(); // Make sure splash screen doesn't stick around during shutdown


### PR DESCRIPTION
The application would either `quit` or `std::exit` on failure and not even try a shutdown.

Note that bitcoind does a `Interrupt` and `Shutdown` in case the initialization fails or an exception is caught. So just do the same for the gui.