### PR TITLE
txindex: Stop thread before calling base destructor

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -48,8 +48,6 @@ bool BaseIndex::DB::WriteBestBlock(const CBlockLocator& locator)
 
 BaseIndex::~BaseIndex()
 {
-    Interrupt();
-    Stop();
 }
 
 bool BaseIndex::Init()

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -75,7 +75,7 @@ protected:
     virtual const char* GetName() const = 0;
 
 public:
-    /// Destructor interrupts sync thread if running and blocks until it exits.
+    /// Derived destructor must interrupt sync thread if running and block until it exits.
     virtual ~BaseIndex();
 
     /// Blocks the current thread until the index is caught up to the current

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -227,7 +227,11 @@ TxIndex::TxIndex(size_t n_cache_size, bool f_memory, bool f_wipe)
     : m_db(MakeUnique<TxIndex::DB>(n_cache_size, f_memory, f_wipe))
 {}
 
-TxIndex::~TxIndex() {}
+TxIndex::~TxIndex()
+{
+    Interrupt();
+    Stop();
+}
 
 bool TxIndex::Init()
 {

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -36,7 +36,7 @@ public:
     /// Constructs the index, which becomes available to be queried.
     explicit TxIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
-    // Destructor is declared because this class contains a unique_ptr to an incomplete type.
+    /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~TxIndex() override;
 
     /// Look up a transaction by hash.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -211,9 +211,7 @@ void Shutdown()
     if (g_connman) g_connman->Stop();
     peerLogic.reset();
     g_connman.reset();
-    if (g_txindex) {
-        g_txindex.reset();
-    }
+    g_txindex.reset();
 
     StopTorControl();
 


### PR DESCRIPTION
Currently the thread would be stopped in the base destructor. Effectively leaving a race condition where the derived destructor is finished and the thread is still running, leading to segfaults.

Fix this by stopping the thread in the derived destructor.