### PR TITLE
shutdown: Stop threads before resetting ptrs

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -209,11 +209,7 @@ void Shutdown()
     // using the other before destroying them.
     if (peerLogic) UnregisterValidationInterface(peerLogic.get());
     if (g_connman) g_connman->Stop();
-    peerLogic.reset();
-    g_connman.reset();
-    if (g_txindex) {
-        g_txindex.reset();
-    }
+    if (g_txindex) g_txindex->Stop();
 
     StopTorControl();
 
@@ -221,6 +217,12 @@ void Shutdown()
     // CScheduler/checkqueue threadGroup
     threadGroup.interrupt_all();
     threadGroup.join_all();
+
+    // After the threads that potentially access these pointers have been stopped,
+    // destruct and reset all to nullptr.
+    peerLogic.reset();
+    g_connman.reset();
+    g_txindex.reset();
 
     if (g_is_mempool_loaded && gArgs.GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         DumpMempool();


### PR DESCRIPTION
On shutdown some threads would continue to run after or during a pointer reset. This leads to occasional segfaults on shutdown.

Fix this by resetting the smart pointers after all threads that might read from them have been stopped.

This should fix:
* A segfault in the txindex thread, that occurs when the txindex destructor is done, but the thread was not yet stopped (as this is done in the base index destructor)
* A segfault in the scheduler thread, which dereferences conman. (e.g. CheckForStaleTipAndEvictPeers)