### PR TITLE
Significantly reduce GetTransaction cs_main locking (TheBlueMatt)

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -179,6 +179,7 @@ UniValue getrawtransaction(const JSONRPCRequest& request)
     if (!GetTransaction(hash, tx, Params().GetConsensus(), hash_block, true, blockindex)) {
         std::string errmsg;
         if (blockindex) {
+            LOCK(cs_main);
             if (!(blockindex->nStatus & BLOCK_HAVE_DATA)) {
                 throw JSONRPCError(RPC_MISC_ERROR, "Block not available");
             }
@@ -266,13 +267,12 @@ UniValue gettxoutproof(const JSONRPCRequest& request)
         g_txindex->BlockUntilSyncedToCurrentChain();
     }
 
-    LOCK(cs_main);
-
     if (pblockindex == nullptr)
     {
         CTransactionRef tx;
         if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock, false) || hashBlock.IsNull())
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not yet in block");
+        LOCK(cs_main);
         pblockindex = LookupBlockIndex(hashBlock);
         if (!pblockindex) {
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Transaction index corrupt");

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1019,8 +1019,6 @@ bool GetTransaction(const uint256& hash, CTransactionRef& txOut, const Consensus
 {
     CBlockIndex* pindexSlow = blockIndex;
 
-    LOCK(cs_main);
-
     if (!blockIndex) {
         CTransactionRef ptx = mempool.get(hash);
         if (ptx) {
@@ -1032,6 +1030,7 @@ bool GetTransaction(const uint256& hash, CTransactionRef& txOut, const Consensus
             return g_txindex->FindTx(hash, hashBlock, txOut);
         }
 
+        LOCK(cs_main);
         if (fAllowSlow) { // use coin database to locate block that contains transaction, and scan it
             const Coin& coin = AccessByTxid(*pcoinsTip, hash);
             if (!coin.IsSpent()) pindexSlow = chainActive[coin.nHeight];


### PR DESCRIPTION
Reading a block from disk does not require `cs_main`, so it can be removed or held shorter in functions that read from disk.

This is the first commit stolen from #11913 without rebase or otherwise touching it.