### PR TITLE
validation: Pass chainparams in AcceptToMemoryPoolWorker(...)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -918,7 +918,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         // There is a similar check in CreateNewBlock() to prevent creating
         // invalid blocks (using TestBlockValidity), however allowing such
         // transactions into the mempool can be exploited as a DoS attack.
-        unsigned int currentBlockScriptVerifyFlags = GetBlockScriptFlags(chainActive.Tip(), Params().GetConsensus());
+        unsigned int currentBlockScriptVerifyFlags = GetBlockScriptFlags(chainActive.Tip(), chainparams.GetConsensus());
         if (!CheckInputsFromMempoolAndCache(tx, state, view, pool, currentBlockScriptVerifyFlags, true, txdata)) {
             return error("%s: BUG! PLEASE REPORT THIS! CheckInputs failed against latest-block but not STANDARD flags %s, %s",
                     __func__, hash.ToString(), FormatStateMessage(state));


### PR DESCRIPTION
Remove unused `CChainParams` argument in `AcceptToMemoryPoolWorker(...)`.

After the merge of #13527 ("policy: Remove promiscuousmempoolflags") yesterday the `CChainParams` argument is no longer used in `AcceptToMemoryPoolWorker(...)`.
