### PR TITLE
test: Default to running -checkblockindex in test_framework (TheBlueMatt)

### DIFF
--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -22,7 +22,7 @@ class ReindexTest(BitcoinTestFramework):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
-        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
         self.start_nodes(extra_args)
         wait_until(lambda: self.nodes[0].getblockcount() == blockcount)
         self.log.info("Success")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -302,6 +302,7 @@ def initialize_datadir(dirname, n):
         f.write("discover=0\n")
         f.write("listenonion=0\n")
         f.write("printtoconsole=0\n")
+        f.write("checkblockindex=1\n")
         os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
         os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir


### PR DESCRIPTION
Salvaged from #12138, and adjusted to current test framework conventions.

> Block index inconsistencies are one of the most critical types of
> bugs we could see. Making sure we get good coverage of
> CheckBlockIndex() is pretty important (and there is minimal, if any
> performance difference in a default run).

Test suite on master takes 928-988 seconds on my machine, with this change it takes 901-1045 seconds (n=2, and not a perfect experimental setup).