### PR TITLE
qa: Remove redundant checkmempool/checkblockindex extra_args

### DIFF
--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -22,7 +22,7 @@ class ReindexTest(BitcoinTestFramework):
         self.nodes[0].generate(3)
         blockcount = self.nodes[0].getblockcount()
         self.stop_nodes()
-        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex", "-checkblockindex=1"]]
+        extra_args = [["-reindex-chainstate" if justchainstate else "-reindex"]]
         self.start_nodes(extra_args)
         wait_until(lambda: self.nodes[0].getblockcount() == blockcount)
         self.log.info("Success")

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -35,7 +35,6 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.extra_args = [[
-            '-checkmempool',
             '-txindex',
             '-reindex',  # Need reindex for txindex
             '-acceptnonstdtxn=0',  # Try to mimic main-net

--- a/test/functional/mempool_reorg.py
+++ b/test/functional/mempool_reorg.py
@@ -11,11 +11,10 @@ that spend (directly or indirectly) coinbase transactions.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-# Create one-input, one-output, no-fee transaction:
+
 class MempoolCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [["-checkmempool"]] * 2
 
     alert_filename = None  # Set by setup_network
 

--- a/test/functional/mempool_resurrect.py
+++ b/test/functional/mempool_resurrect.py
@@ -7,11 +7,10 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-# Create one-input, one-output, no-fee transaction:
+
 class MempoolCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [["-checkmempool"]]
 
     def run_test(self):
         node0_address = self.nodes[0].getnewaddress()

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -15,11 +15,10 @@ but less mature coinbase spends are NOT.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-# Create one-input, one-output, no-fee transaction:
+
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.extra_args = [["-checkmempool"]]
 
     def run_test(self):
         chain_height = self.nodes[0].getblockcount()


### PR DESCRIPTION
They are already enabled by default for regtest:

https://github.com/bitcoin/bitcoin/blob/df9f71274645a917e2578c52a1c59745bce8112d/src/init.cpp#L1002-L1007



Closes  #13912. CC #12138 