### PR TITLE
refactor: Make globals easier to identify by prefixing them g_. Avoid declaring variable and type in the same statement.

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -29,7 +29,8 @@ private:
         MODE_VALID,   //!< everything ok
         MODE_INVALID, //!< network rule violation (DoS value may be set)
         MODE_ERROR,   //!< run-time error
-    } mode;
+    };
+    mode_state mode;
     int nDoS;
     std::string strRejectReason;
     unsigned int chRejectCode;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2393,8 +2393,8 @@ public:
         WSACleanup();
 #endif
     }
-}
-instance_of_cnetcleanup;
+};
+CNetCleanup g_instance_of_cnetcleanup;
 
 void CConnman::Interrupt()
 {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3784,4 +3784,5 @@ public:
         mapOrphanTransactions.clear();
         mapOrphanTransactionsByPrev.clear();
     }
-} instance_of_cnetprocessingcleanup;
+};
+CNetProcessingCleanup g_instance_of_cnetprocessingcleanup;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -167,7 +167,8 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
         STATE_ESCAPE_DOUBLEQUOTED,
         STATE_COMMAND_EXECUTED,
         STATE_COMMAND_EXECUTED_INNER
-    } state = STATE_EATING_SPACES;
+    };
+    CmdParseState state = STATE_EATING_SPACES;
     std::string curarg;
     UniValue lastResult;
     unsigned nDepthInsideSensitive = 0;

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -32,12 +32,13 @@ static RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */
 static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
 
-static struct CRPCSignals
+struct CRPCSignals
 {
     boost::signals2::signal<void ()> Started;
     boost::signals2::signal<void ()> Stopped;
     boost::signals2::signal<void (const CRPCCommand&)> PreCommand;
-} g_rpcSignals;
+};
+static CRPCSignals g_rpcSignals;
 
 void RPCServer::OnStarted(std::function<void ()> slot)
 {

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -182,7 +182,8 @@ void SingleThreadedSchedulerClient::ProcessQueue() {
             }
             instance->MaybeScheduleProcessQueue();
         }
-    } raiicallbacksrunning(this);
+    };
+    RAIICallbacksRunning raiicallbacksrunning(this);
 
     callback();
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -133,8 +133,8 @@ public:
         // Clear the set of locks now to maintain symmetry with the constructor.
         ppmutexOpenSSL.reset();
     }
-}
-instance_of_cinit;
+};
+CInit g_instance_of_cinit;
 
 /** A map that contains all the currently held directory locks. After
  * successful locking, these will be held here until the global destructor

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -208,10 +208,8 @@ private:
 
 
     bool RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& inputs, const CChainParams& params) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-} g_chainstate;
-
-
-
+};
+CChainState g_chainstate;
 CCriticalSection cs_main;
 
 BlockMap& mapBlockIndex = g_chainstate.mapBlockIndex;
@@ -4846,4 +4844,5 @@ public:
             delete (*it1).second;
         mapBlockIndex.clear();
     }
-} instance_of_cmaincleanup;
+};
+CMainCleanup g_instance_of_cmaincleanup;


### PR DESCRIPTION
* Make globals easier to identify by prefixing them `g_` (see developer notes).
* Make globals easier to identify by avoiding declaring variable and type in the same merged statement. (Some of the cases are not globals but included them for completeness.)