### PR TITLE
rpc: Use pushKV in some new PSBT RPCs

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1662,12 +1662,12 @@ UniValue finalizepsbt(const JSONRPCRequest& request)
             mtx.vin[i].scriptWitness = psbtx.inputs[i].final_script_witness;
         }
         ssTx << mtx;
-        result.push_back(Pair("hex", HexStr(ssTx.begin(), ssTx.end())));
+        result.pushKV("hex", HexStr(ssTx.begin(), ssTx.end()));
     } else {
         ssTx << psbtx;
-        result.push_back(Pair("psbt", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size())));
+        result.pushKV("psbt", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size()));
     }
-    result.push_back(Pair("complete", complete));
+    result.pushKV("complete", complete);
 
     return result;
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4630,8 +4630,8 @@ UniValue walletprocesspsbt(const JSONRPCRequest& request)
     UniValue result(UniValue::VOBJ);
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
     ssTx << psbtx;
-    result.push_back(Pair("psbt", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size())));
-    result.push_back(Pair("complete", complete));
+    result.pushKV("psbt", EncodeBase64((unsigned char*)ssTx.data(), ssTx.size()));
+    result.pushKV("complete", complete);
 
     return result;
 }


### PR DESCRIPTION
Most of the code uses `UniValue::pushKV` where appropriate, but some new RPC code related to PSBTs did not.  This fixes those places - after this change, there are no remaining source files I could find that contain `push_back(Pair(`.