### PR TITLE
tests: Port usage of deprecated optparse module to argparse module

### DIFF
--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -20,9 +20,9 @@ class RPCBindTest(BitcoinTestFramework):
         self.add_nodes(self.num_nodes, None)
 
     def add_options(self, parser):
-        parser.add_option("--ipv4", action='store_true', dest="run_ipv4", help="Run ipv4 tests only", default=False)
-        parser.add_option("--ipv6", action='store_true', dest="run_ipv6", help="Run ipv6 tests only", default=False)
-        parser.add_option("--nonloopback", action='store_true', dest="run_nonloopback", help="Run non-loopback tests only", default=False)
+        parser.add_argument("--ipv4", action='store_true', dest="run_ipv4", help="Run ipv4 tests only", default=False)
+        parser.add_argument("--ipv6", action='store_true', dest="run_ipv6", help="Run ipv6 tests only", default=False)
+        parser.add_argument("--nonloopback", action='store_true', dest="run_nonloopback", help="Run non-loopback tests only", default=False)
 
     def run_bind_test(self, allow_ips, connect_to, addresses, expected):
         '''

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -35,13 +35,13 @@ class GetblockstatsTest(BitcoinTestFramework):
     ]
 
     def add_options(self, parser):
-        parser.add_option('--gen-test-data', dest='gen_test_data',
-                          default=False, action='store_true',
-                          help='Generate test data')
-        parser.add_option('--test-data', dest='test_data',
-                          default='data/rpc_getblockstats.json',
-                          action='store', metavar='FILE',
-                          help='Test data file')
+        parser.add_argument('--gen-test-data', dest='gen_test_data',
+                            default=False, action='store_true',
+                            help='Generate test data')
+        parser.add_argument('--test-data', dest='test_data',
+                            default='data/rpc_getblockstats.json',
+                            action='store', metavar='FILE',
+                            help='Test data file')
 
     def set_test_params(self):
         self.num_nodes = 2

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -7,7 +7,7 @@
 import configparser
 from enum import Enum
 import logging
-import optparse
+import argparse
 import os
 import pdb
 import shutil
@@ -96,31 +96,31 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     def main(self):
         """Main function. This should not be overridden by the subclass test scripts."""
 
-        parser = optparse.OptionParser(usage="%prog [options]")
-        parser.add_option("--nocleanup", dest="nocleanup", default=False, action="store_true",
-                          help="Leave bitcoinds and test.* datadir on exit or error")
-        parser.add_option("--noshutdown", dest="noshutdown", default=False, action="store_true",
-                          help="Don't stop bitcoinds after the test execution")
-        parser.add_option("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../cache"),
-                          help="Directory for caching pregenerated datadirs (default: %default)")
-        parser.add_option("--tmpdir", dest="tmpdir", help="Root directory for datadirs")
-        parser.add_option("-l", "--loglevel", dest="loglevel", default="INFO",
-                          help="log events at this level and higher to the console. Can be set to DEBUG, INFO, WARNING, ERROR or CRITICAL. Passing --loglevel DEBUG will output all logs to console. Note that logs at all levels are always written to the test_framework.log file in the temporary test directory.")
-        parser.add_option("--tracerpc", dest="trace_rpc", default=False, action="store_true",
-                          help="Print out all RPC calls as they are made")
-        parser.add_option("--portseed", dest="port_seed", default=os.getpid(), type='int',
-                          help="The seed to use for assigning port numbers (default: current process id)")
-        parser.add_option("--coveragedir", dest="coveragedir",
-                          help="Write tested RPC commands into this directory")
-        parser.add_option("--configfile", dest="configfile",
-                          default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../config.ini"),
-                          help="Location of the test framework config file (default: %default)")
-        parser.add_option("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
-                          help="Attach a python debugger if test fails")
-        parser.add_option("--usecli", dest="usecli", default=False, action="store_true",
-                          help="use bitcoin-cli instead of RPC for all commands")
+        parser = argparse.ArgumentParser(usage="%(prog)s [options]")
+        parser.add_argument("--nocleanup", dest="nocleanup", default=False, action="store_true",
+                            help="Leave bitcoinds and test.* datadir on exit or error")
+        parser.add_argument("--noshutdown", dest="noshutdown", default=False, action="store_true",
+                            help="Don't stop bitcoinds after the test execution")
+        parser.add_argument("--cachedir", dest="cachedir", default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../cache"),
+                            help="Directory for caching pregenerated datadirs (default: %(default)s)")
+        parser.add_argument("--tmpdir", dest="tmpdir", help="Root directory for datadirs")
+        parser.add_argument("-l", "--loglevel", dest="loglevel", default="INFO",
+                            help="log events at this level and higher to the console. Can be set to DEBUG, INFO, WARNING, ERROR or CRITICAL. Passing --loglevel DEBUG will output all logs to console. Note that logs at all levels are always written to the test_framework.log file in the temporary test directory.")
+        parser.add_argument("--tracerpc", dest="trace_rpc", default=False, action="store_true",
+                            help="Print out all RPC calls as they are made")
+        parser.add_argument("--portseed", dest="port_seed", default=os.getpid(), type=int,
+                            help="The seed to use for assigning port numbers (default: current process id)")
+        parser.add_argument("--coveragedir", dest="coveragedir",
+                            help="Write tested RPC commands into this directory")
+        parser.add_argument("--configfile", dest="configfile",
+                            default=os.path.abspath(os.path.dirname(os.path.realpath(__file__)) + "/../../config.ini"),
+                            help="Location of the test framework config file (default: %(default)s)")
+        parser.add_argument("--pdbonfailure", dest="pdbonfailure", default=False, action="store_true",
+                            help="Attach a python debugger if test fails")
+        parser.add_argument("--usecli", dest="usecli", default=False, action="store_true",
+                            help="use bitcoin-cli instead of RPC for all commands")
         self.add_options(parser)
-        (self.options, self.args) = parser.parse_args()
+        self.options = parser.parse_args()
 
         PortSeed.n = self.options.port_seed
 

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -17,10 +17,10 @@ class TxnMallTest(BitcoinTestFramework):
         self.num_nodes = 4
 
     def add_options(self, parser):
-        parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
-                          help="Test double-spend of 1-confirmed transaction")
-        parser.add_option("--segwit", dest="segwit", default=False, action="store_true",
-                          help="Test behaviour with SegWit txn (which should fail")
+        parser.add_argument("--mineblock", dest="mine_block", default=False, action="store_true",
+                            help="Test double-spend of 1-confirmed transaction")
+        parser.add_argument("--segwit", dest="segwit", default=False, action="store_true",
+                            help="Test behaviour with SegWit txn (which should fail")
 
     def setup_network(self):
         # Start with split network:

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -19,8 +19,8 @@ class TxnMallTest(BitcoinTestFramework):
         self.num_nodes = 4
 
     def add_options(self, parser):
-        parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
-                          help="Test double-spend of 1-confirmed transaction")
+        parser.add_argument("--mineblock", dest="mine_block", default=False, action="store_true",
+                            help="Test double-spend of 1-confirmed transaction")
 
     def setup_network(self):
         # Start with split network:


### PR DESCRIPTION
The optparse module is deprecated since Python 2.7/3.2 . Recommend usage of the argparse module which improves upon optparse.