### PR TITLE
Introduce MempoolObserver interface to break "policy/fees -> txmempool -> policy/fees" circular dependency

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ BITCOIN_CORE_H = \
   init.h \
   interfaces/chain.h \
   interfaces/handler.h \
+  interfaces/mempool_observer.h \
   interfaces/node.h \
   interfaces/wallet.h \
   key.h \

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -14,4 +14,6 @@ The following interfaces are defined here:
 
 * [`Init`](init.h) — used by multiprocess code to access interfaces above on startup. Added in [#10102](https://github.com/bitcoin/bitcoin/pull/10102).
 
+* [`MempoolObserver`](mempool_observer.h) — used by fee estimation to be notified on mempool events. Added in [#13949](https://github.com/bitcoin/bitcoin/pull/13949).
+
 The interfaces above define boundaries between major components of bitcoin code (node, wallet, and gui), making it possible for them to run in different processes, and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.

--- a/src/interfaces/mempool_observer.h
+++ b/src/interfaces/mempool_observer.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_MEMPOOL_OBSERVER_H
+#define BITCOIN_INTERFACES_MEMPOOL_OBSERVER_H
+
+#include <uint256.h>
+
+#include <vector>
+
+class CTxMemPoolEntry;
+
+namespace interfaces {
+
+//! Observer interface for mempool operation.
+class MempoolObserver
+{
+public:
+    virtual ~MempoolObserver() {}
+
+    /** Called when a block is attached to the chain
+      * @param[in] nBlockHeight height of the new block
+      * @param[in] entries mempool entries included in the block
+      */
+    virtual void processBlock(unsigned int nBlockHeight, std::vector<const CTxMemPoolEntry*>& entries) = 0;
+
+    /** Called when a transaction is added to the mempool
+     * @param[in] entry entry added to the mempool
+     * @param[in] validFeeEstimate whether this entry is a valid basis for estimating fees
+     */
+    virtual void processTransaction(const CTxMemPoolEntry& entry, bool validFeeEstimate) = 0;
+
+    /** Called when a transaction is removed from the mempool, for reasons other than the tx being in a block
+     * @param[in] hash the txid of the removed transaction
+     */
+    virtual void removeTx(const uint256& hash) = 0;
+};
+
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_MEMPOOL_OBSERVER_H

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -474,7 +474,13 @@ void TxConfirmStats::removeTx(unsigned int entryHeight, unsigned int nBestSeenHe
 // tracked. Txs that were part of a block have already been removed in
 // processBlockTx to ensure they are never double tracked, but it is
 // of no harm to try to remove them again.
-bool CBlockPolicyEstimator::removeTx(uint256 hash, bool inBlock)
+void CBlockPolicyEstimator::removeTx(const uint256& hash)
+{
+    removeTx(hash, false);
+}
+
+// Private interface to removeTx which allows inBlock removals
+bool CBlockPolicyEstimator::removeTx(const uint256& hash, bool inBlock)
 {
     LOCK(m_cs_fee_estimator);
     std::map<uint256, TxStatsInfo>::iterator pos = mapMemPoolTxs.find(hash);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -17,6 +17,7 @@
 #include <coins.h>
 #include <crypto/siphash.h>
 #include <indirectmap.h>
+#include <interfaces/mempool_observer.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <sync.h>
@@ -320,8 +321,6 @@ struct descendant_score {};
 struct entry_time {};
 struct ancestor_score {};
 
-class CBlockPolicyEstimator;
-
 /**
  * Information about a mempool transaction.
  */
@@ -444,7 +443,7 @@ class CTxMemPool
 private:
     uint32_t nCheckFrequency GUARDED_BY(cs); //!< Value n means that n times in 2^32 we check.
     unsigned int nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* minerPolicyEstimator;
+    interfaces::MempoolObserver* m_observer;
 
     uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
@@ -561,7 +560,7 @@ public:
 
     /** Create a new CTxMemPool.
      */
-    explicit CTxMemPool(CBlockPolicyEstimator* estimator = nullptr);
+    explicit CTxMemPool(interfaces::MempoolObserver* observer = nullptr);
 
     /**
      * If sanity-checking is turned on, check makes sure the pool is

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -11,7 +11,6 @@ export LC_ALL=C
 EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chainparamsbase -> util/system -> chainparamsbase"
     "index/txindex -> validation -> index/txindex"
-    "policy/fees -> txmempool -> policy/fees"
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"
     "qt/bantablemodel -> qt/clientmodel -> qt/bantablemodel"
     "qt/bitcoingui -> qt/utilitydialog -> qt/bitcoingui"


### PR DESCRIPTION
A simple interface which make the implementations independent of one another.

Note I also removed the `inBlock` argument to the public `CBlockPolicyEstimator::removeTx`, as all block-related removal calls are internal to the class. This simplifies the extracted interface and reduces CBlockPolicyEstimator surface area.