### PR TITLE
fix deprecation in bitcoin-util-test.py

### DIFF
--- a/test/util/bitcoin-util-test.py
+++ b/test/util/bitcoin-util-test.py
@@ -28,7 +28,7 @@ import sys
 def main():
     config = configparser.ConfigParser()
     config.optionxform = str
-    config.readfp(open(os.path.join(os.path.dirname(__file__), "../config.ini"), encoding="utf8"))
+    config.read_file(open(os.path.join(os.path.dirname(__file__), "../config.ini"), encoding="utf8"))
     env_conf = dict(config.items('environment'))
 
     parser = argparse.ArgumentParser(description=__doc__)


### PR DESCRIPTION
To avoid:

$ make check
{…omissis…}
Running test/util/bitcoin-util-test.py...
/usr/local/bin/python3.7 ../test/util/bitcoin-util-test.py
../test/util/bitcoin-util-test.py:31: DeprecationWarning: This method will be removed in future versions.  Use 'parser.read_file()' instead.
config.readfp(open(os.path.join(os.path.dirname(__file__), "../config.ini"), encoding="utf8"))

$ python3 --version
Python 3.7.0