### PR TITLE
Warn (don't fail!) on spelling errors. Fix typos reported by codespell.

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -6,4 +6,5 @@
 
 export LC_ALL=C
 
+travis_retry pip install codespell
 travis_retry pip install flake8

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -96,7 +96,7 @@ Comment: Site: https://bitcointalk.org/?topic=1756.0
 Files: src/qt/res/icons/proxy.png
        src/qt/res/src/proxy.svg
 Copyright: Cristian Mircea Messel
-Licese: public-domain
+License: public-domain
 
 
 License: Expat

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -170,7 +170,7 @@ def main():
 
     args.sign_prog = 'true' if args.detach_sign else 'gpg --detach-sign'
 
-    # Set enviroment variable USE_LXC or USE_DOCKER, let gitian-builder know that we use lxc or docker
+    # Set environment variable USE_LXC or USE_DOCKER, let gitian-builder know that we use lxc or docker
     if args.docker:
         os.environ['USE_DOCKER'] = '1'
     elif not args.kvm:

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -78,7 +78,7 @@ static void SetMaxOpenFiles(leveldb::Options *options) {
     // do not interfere with select() loops. On 64-bit Unix hosts this value is
     // also OK, because up to that amount LevelDB will use an mmap
     // implementation that does not use extra file descriptors (the fds are
-    // closed after being mmaped).
+    // closed after being mmap'ed).
     //
     // Increasing the value beyond the default is dangerous because LevelDB will
     // fall back to a non-mmap implementation when the file count is too large.

--- a/src/qt/test/util.h
+++ b/src/qt/test/util.h
@@ -5,7 +5,7 @@
  * Press "Ok" button in message box dialog.
  *
  * @param text - Optionally store dialog text.
- * @param msec - Number of miliseconds to pause before triggering the callback.
+ * @param msec - Number of milliseconds to pause before triggering the callback.
  */
 void ConfirmMessage(QString* text = nullptr, int msec = 0);
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1740,7 +1740,7 @@ UniValue converttopsbt(const JSONRPCRequest& request)
                             "                              will continue. If false, RPC will fail if any signatures are present.\n"
                             "3. iswitness               (boolean, optional) Whether the transaction hex is a serialized witness transaction.\n"
                             "                              If iswitness is not present, heuristic tests will be used in decoding. If true, only witness deserializaion\n"
-                            "                              will be tried. If false, only non-witness deserialization wil be tried. Only has an effect if\n"
+                            "                              will be tried. If false, only non-witness deserialization will be tried. Only has an effect if\n"
                             "                              permitsigdata is true.\n"
                             "\nResult:\n"
                             "  \"psbt\"        (string)  The resulting raw transaction (base64-encoded string)\n"

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -111,7 +111,7 @@ public:
     /**
      * Add a callback to be executed. Callbacks are executed serially
      * and memory is release-acquire consistent between callback executions.
-     * Practially, this means that callbacks can behave as if they are executed
+     * Practically, this means that callbacks can behave as if they are executed
      * in order by a single thread.
      */
     void AddToProcessQueue(std::function<void (void)> func);

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -373,7 +373,7 @@ enum class ParseScriptContext {
     P2WSH,
 };
 
-/** Parse a constant. If succesful, sp is updated to skip the constant and return true. */
+/** Parse a constant. If successful, sp is updated to skip the constant and return true. */
 bool Const(const std::string& str, Span<const char>& sp)
 {
     if ((size_t)sp.size() >= str.size() && std::equal(str.begin(), str.end(), sp.begin())) {
@@ -383,7 +383,7 @@ bool Const(const std::string& str, Span<const char>& sp)
     return false;
 }
 
-/** Parse a function call. If succesful, sp is updated to be the function's argument(s). */
+/** Parse a function call. If successful, sp is updated to be the function's argument(s). */
 bool Func(const std::string& str, Span<const char>& sp)
 {
     if ((size_t)sp.size() >= str.size() + 2 && sp[str.size()] == '(' && sp[sp.size() - 1] == ')' && std::equal(str.begin(), str.end(), sp.begin())) {

--- a/src/streams.h
+++ b/src/streams.h
@@ -529,7 +529,7 @@ public:
     explicit BitStreamReader(IStream& istream) : m_istream(istream) {}
 
     /** Read the specified number of bits from the stream. The data is returned
-     * in the nbits least signficant bits of a 64-bit uint.
+     * in the nbits least significant bits of a 64-bit uint.
      */
     uint64_t Read(int nbits) {
         if (nbits < 0 || nbits > 64) {

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -75,7 +75,7 @@ void* Arena::alloc(size_t size)
 
     // Create the used-chunk, taking its space from the end of the free-chunk
     const size_t size_remaining = size_ptr_it->first - size;
-    auto alloced = chunks_used.emplace(size_ptr_it->second + size_remaining, size).first;
+    auto allocated = chunks_used.emplace(size_ptr_it->second + size_remaining, size).first;
     chunks_free_end.erase(size_ptr_it->second + size_ptr_it->first);
     if (size_ptr_it->first == size) {
         // whole chunk is used up
@@ -88,7 +88,7 @@ void* Arena::alloc(size_t size)
     }
     size_to_free_chunk.erase(size_ptr_it);
 
-    return reinterpret_cast<void*>(alloced->first);
+    return reinterpret_cast<void*>(allocated->first);
 }
 
 void Arena::free(void *ptr)

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -72,7 +72,7 @@ BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& data
         database_filename = "wallet.dat";
     }
     LOCK(cs_db);
-    // Note: An ununsed temporary BerkeleyEnvironment object may be created inside the
+    // Note: An unused temporary BerkeleyEnvironment object may be created inside the
     // emplace function if the key already exists. This is a little inefficient,
     // but not a big concern since the map will be changed in the future to hold
     // pointers instead of objects, anyway.

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -76,7 +76,7 @@ class ExampleTest(BitcoinTestFramework):
     def set_test_params(self):
         """Override test parameters for your individual test.
 
-        This method must be overridden and num_nodes must be exlicitly set."""
+        This method must be overridden and num_nodes must be explicitly set."""
         self.setup_clean_chain = True
         self.num_nodes = 3
         # Use self.extra_args to change command-line arguments for the nodes

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -989,7 +989,7 @@ class FullBlockTest(BitcoinTestFramework):
         assert_equal(get_legacy_sigopcount_block(b73), MAX_BLOCK_SIGOPS + 1)
         self.sync_blocks([b73], success=False, reject_code=16, reject_reason=b'bad-blk-sigops', reconnect=True)
 
-        # b74/75 - if we push an invalid script element, all prevous sigops are counted,
+        # b74/75 - if we push an invalid script element, all previous sigops are counted,
         #          but sigops after the element are not counted.
         #
         #       The invalid script element is that the push_data indicates that

--- a/test/functional/mining_getblocktemplate_longpoll.py
+++ b/test/functional/mining_getblocktemplate_longpoll.py
@@ -15,8 +15,8 @@ class LongpollThread(threading.Thread):
     def __init__(self, node):
         threading.Thread.__init__(self)
         # query current longpollid
-        templat = node.getblocktemplate()
-        self.longpollid = templat['longpollid']
+        template = node.getblocktemplate()
+        self.longpollid = template['longpollid']
         # create a new connection to the node, we can't use the same
         # connection from two threads
         self.node = get_rpc_proxy(node.url, 1, timeout=600, coveragedir=node.coverage_dir)
@@ -31,11 +31,11 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)
-        templat = self.nodes[0].getblocktemplate()
-        longpollid = templat['longpollid']
+        template = self.nodes[0].getblocktemplate()
+        longpollid = template['longpollid']
         # longpollid should not change between successive invocations if nothing else happens
-        templat2 = self.nodes[0].getblocktemplate()
-        assert(templat2['longpollid'] == longpollid)
+        template2 = self.nodes[0].getblocktemplate()
+        assert(template2['longpollid'] == longpollid)
 
         # Test 1: test that the longpolling wait if we do nothing
         thr = LongpollThread(self.nodes[0])

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -76,7 +76,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.reconnect_p2p(num_connections=2)
 
         self.log.info('Test orphan transaction handling ... ')
-        # Create a root transaction that we withhold until all dependend transactions
+        # Create a root transaction that we withhold until all dependent transactions
         # are sent out and in the orphan cache
         SCRIPT_PUB_KEY_OP_TRUE = b'\x51\x75' * 15 + b'\x51'
         tx_withhold = CTransaction()

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -89,7 +89,7 @@ class NodeNetworkLimitedTest(BitcoinTestFramework):
             sync_blocks([self.nodes[0], self.nodes[2]], timeout=5)
         except:
             pass
-        # node2 must remain at heigh 0
+        # node2 must remain at height 0
         assert_equal(self.nodes[2].getblockheader(self.nodes[2].getbestblockhash())['height'], 0)
 
         # now connect also to node 1 (non pruned)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -471,7 +471,7 @@ class SegWitTest(BitcoinTestFramework):
         blocks are permitted to contain witnesses)."""
 
         # node2 doesn't need to be connected for this test.
-        # (If it's connected, node0 may propogate an invalid block to it over
+        # (If it's connected, node0 may propagate an invalid block to it over
         # compact blocks and the nodes would have inconsistent tips.)
         disconnect_nodes(self.nodes[0], 2)
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -105,7 +105,7 @@ class PSBTTest(BitcoinTestFramework):
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'])
         assert_raises_rpc_error(-22, "TX decode failed", self.nodes[0].converttopsbt, signedtx['hex'])
 
-        # Explicilty allow converting non-empty txs
+        # Explicitly allow converting non-empty txs
         new_psbt = self.nodes[0].converttopsbt(rawtx['hex'])
         self.nodes[0].decodepsbt(new_psbt)
 

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -122,7 +122,7 @@ def create_tx_with_script(prevtx, n, script_sig=b"", *, amount, script_pub_key=C
     """Return one-input, one-output transaction object
        spending the prevtx's n-th output with the given amount.
 
-       Can optionally pass scriptPubKey and scriptSig, default is anyone-can-spend ouput.
+       Can optionally pass scriptPubKey and scriptSig, default is anyone-can-spend output.
     """
     tx = CTransaction()
     assert(n < len(prevtx.vout))

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -1,0 +1,5 @@
+cas
+hights
+mor
+objext
+useable

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -2,4 +2,5 @@ cas
 hights
 mor
 objext
+unselect
 useable

--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Warn in case of spelling errors.
+# Note: Will exit successfully regardless of spelling errors.
+
+export LC_ALL=C
+
+IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt
+if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/qt/locale/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/"); then
+    echo "^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in ${IGNORE_WORDS_FILE}"
+fi


### PR DESCRIPTION
* Check for common misspellings using `codespell`.
* Fix recently introduced typos reported by `codespell`.
