### PR TITLE
util: Replace boost::signals2 with std::function

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -13,6 +13,8 @@
 
 #include <memory>
 
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 static const int64_t DEFAULT_BENCH_EVALUATIONS = 5;
 static const char* DEFAULT_BENCH_FILTER = ".*";
 static const char* DEFAULT_BENCH_SCALING = "1.0";

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -24,6 +24,8 @@
 
 #include <univalue.h>
 
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 static const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 static const bool DEFAULT_NAMED=false;

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -31,6 +31,8 @@ static bool fCreateBlank;
 static std::map<std::string,UniValue> registers;
 static const int CONTINUE_EXECUTION=-1;
 
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 static void SetupBitcoinTxArgs()
 {
     gArgs.AddArg("-?", "This help message", false, OptionsCategory::OPTIONS);

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -23,6 +23,8 @@
 
 #include <stdio.h>
 
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
+
 /* Introduction text for doxygen: */
 
 /*! \mainpage Developer documentation

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -12,6 +12,8 @@
 #include <stdint.h>
 #include <string>
 
+#include <boost/signals2/connection.hpp>
+
 static bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)
 {
     bool fSecure = style & CClientUIInterface::SECURE;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -76,13 +76,10 @@ static void InitMessage(const std::string &message)
     LogPrintf("init message: %s\n", message);
 }
 
-/*
-   Translate string to current locale using Qt.
- */
-static std::string Translate(const char* psz)
-{
+/** Translate string to current locale using Qt. */
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = [](const char* psz) {
     return QCoreApplication::translate("bitcoin-core", psz).toStdString();
-}
+};
 
 static QString GetLangTerritory()
 {
@@ -619,7 +616,6 @@ int main(int argc, char *argv[])
     // Now that QSettings are accessible, initialize translations
     QTranslator qtTranslatorBase, qtTranslator, translatorBase, translator;
     initTranslations(qtTranslatorBase, qtTranslator, translatorBase, translator);
-    translationInterface.Translate.connect(Translate);
 
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -57,6 +57,8 @@
 #include <QUrlQuery>
 #include <QVBoxLayout>
 
+#include <boost/bind.hpp>
+
 const std::string BitcoinGUI::DEFAULT_UIPLATFORM =
 #if defined(Q_OS_MAC)
         "macosx"

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -14,8 +14,8 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
-#include <util.h>
 #include <ui_interface.h>
+#include <util.h>
 #include <version.h>
 
 #include <QApplication>
@@ -23,6 +23,8 @@
 #include <QDesktopWidget>
 #include <QPainter>
 #include <QRadialGradient>
+
+#include <boost/bind.hpp>
 
 SplashScreen::SplashScreen(interfaces::Node& node, Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0), m_node(node)

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -16,16 +16,18 @@
 #include <core_io.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
-#include <validation.h>
 #include <sync.h>
 #include <uint256.h>
 #include <util.h>
+#include <validation.h>
 
 #include <QColor>
 #include <QDateTime>
 #include <QDebug>
 #include <QIcon>
 #include <QList>
+
+#include <boost/bind.hpp>
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -8,15 +8,17 @@
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
-#include <validation.h>
 #include <miner.h>
 #include <net_processing.h>
 #include <pow.h>
-#include <ui_interface.h>
-#include <streams.h>
-#include <rpc/server.h>
 #include <rpc/register.h>
+#include <rpc/server.h>
 #include <script/sigcache.h>
+#include <streams.h>
+#include <ui_interface.h>
+#include <validation.h>
+
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
 void CConnmanTest::AddNode(CNode& node)
 {

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -6,20 +6,20 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <consensus/merkle.h>
-#include <primitives/block.h>
-#include <script/script.h>
 #include <addrman.h>
+#include <blockencodings.h>
 #include <chain.h>
 #include <coins.h>
 #include <compressor.h>
+#include <consensus/merkle.h>
 #include <net.h>
+#include <primitives/block.h>
 #include <protocol.h>
+#include <pubkey.h>
+#include <script/script.h>
 #include <streams.h>
 #include <undo.h>
 #include <version.h>
-#include <pubkey.h>
-#include <blockencodings.h>
 
 #include <stdint.h>
 #include <unistd.h>
@@ -27,6 +27,8 @@
 #include <algorithm>
 #include <memory>
 #include <vector>
+
+const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
 enum TEST_ID {
     CBLOCK_DESERIALIZE=0,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -86,8 +86,6 @@ const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";
 
 ArgsManager gArgs;
 
-CTranslationInterface translationInterface;
-
 /** Init OpenSSL library multithreading support */
 static std::unique_ptr<CCriticalSection[]> ppmutexOpenSSL;
 void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS

--- a/src/util.h
+++ b/src/util.h
@@ -19,8 +19,8 @@
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <utiltime.h>
 #include <utilmemory.h>
+#include <utiltime.h>
 
 #include <atomic>
 #include <exception>
@@ -31,33 +31,24 @@
 #include <unordered_set>
 #include <vector>
 
-#include <boost/signals2/signal.hpp>
 #include <boost/thread/condition_variable.hpp> // for boost::thread_interrupted
 
 // Application startup time (used for uptime calculation)
 int64_t GetStartupTime();
 
-/** Signals for translation. */
-class CTranslationInterface
-{
-public:
-    /** Translate a message to the native language of the user. */
-    boost::signals2::signal<std::string (const char* psz)> Translate;
-};
-
-extern CTranslationInterface translationInterface;
-
 extern const char * const BITCOIN_CONF_FILENAME;
 extern const char * const BITCOIN_PID_FILENAME;
 
+/** Translate a message to the native language of the user. */
+const extern std::function<std::string(const char*)> G_TRANSLATION_FUN;
+
 /**
- * Translation function: Call Translate signal on UI interface, which returns a boost::optional result.
- * If no translation slot is registered, nothing is returned, and simply return the input.
+ * Translation function.
+ * If no translation function is set, simply return the input.
  */
 inline std::string _(const char* psz)
 {
-    boost::optional<std::string> rv = translationInterface.Translate(psz);
-    return rv ? (*rv) : psz;
+    return G_TRANSLATION_FUN ? (G_TRANSLATION_FUN)(psz) : psz;
 }
 
 void SetupEnvironment();

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -3,8 +3,11 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <wallet/coinselection.h>
+
 #include <util.h>
 #include <utilmoneystr.h>
+
+#include <boost/optional.hpp>
 
 // Descending order comparator
 struct {


### PR DESCRIPTION
This removes the `#include <boost/signals2/signal.hpp>` from `util.h` (hopefully speeding up the build time and reducing the memory usage further after  #13634)

The whole translation interface is replaced by a function `G_TRANSLATION_FUN` that is set to nullptr in units that don't need translation. (Thus only set in the gui)