### PR TITLE
Make sure all callers of LookupBlockIndex(...) check for nullptr before dereferencing (CBlockIndex*)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -880,7 +880,9 @@ static bool GetUTXOStats(CCoinsView *view, CCoinsStats &stats)
     stats.hashBlock = pcursor->GetBestBlock();
     {
         LOCK(cs_main);
-        stats.nHeight = LookupBlockIndex(stats.hashBlock)->nHeight;
+        const CBlockIndex* blockIndex = LookupBlockIndex(stats.hashBlock);
+        assert(blockIndex);
+        stats.nHeight = blockIndex->nHeight;
     }
     ss << stats.hashBlock;
     uint256 prevkey;
@@ -1064,6 +1066,7 @@ UniValue gettxout(const JSONRPCRequest& request)
     }
 
     const CBlockIndex* pindex = LookupBlockIndex(pcoinsTip->GetBestBlock());
+    assert(pindex);
     ret.pushKV("bestblock", pindex->GetBlockHash().GetHex());
     if (coin.nHeight == MEMPOOL_HEIGHT) {
         ret.pushKV("confirmations", 0);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1346,7 +1346,8 @@ bool CScriptCheck::operator()() {
 int GetSpendHeight(const CCoinsViewCache& inputs)
 {
     LOCK(cs_main);
-    CBlockIndex* pindexPrev = LookupBlockIndex(inputs.GetBestBlock());
+    const CBlockIndex* pindexPrev = LookupBlockIndex(inputs.GetBestBlock());
+    assert(pindexPrev);
     return pindexPrev->nHeight + 1;
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -99,7 +99,9 @@ static void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
     {
         entry.pushKV("blockhash", wtx.hashBlock.GetHex());
         entry.pushKV("blockindex", wtx.nIndex);
-        entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
+        const CBlockIndex* blockIndex = LookupBlockIndex(wtx.hashBlock);
+        assert(blockIndex);
+        entry.pushKV("blocktime", blockIndex->GetBlockTime());
     } else {
         entry.pushKV("trusted", wtx.IsTrusted());
     }
@@ -4009,6 +4011,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
     }
     UniValue response(UniValue::VOBJ);
     response.pushKV("start_height", pindexStart->nHeight);
+    assert(stopBlock);
     response.pushKV("stop_height", stopBlock->nHeight);
     return response;
 }


### PR DESCRIPTION
Make sure all callers of `LookupBlockIndex(...)` check for `nullptr` before dereferencing (`CBlockIndex*`).