### PR TITLE
Add tests and error handling to DecodeExtPubKey/DecodeExtKey. Add [[nodiscard]]. 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,6 +92,7 @@ endif
 BITCOIN_CORE_H = \
   addrdb.h \
   addrman.h \
+  attributes.h \
   base58.h \
   bech32.h \
   bloom.h \

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ATTRIBUTES_H
+#define BITCOIN_ATTRIBUTES_H
+
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(nodiscard)
+#  define NODISCARD [[nodiscard]]
+#elif defined(_MSC_VER) && _MSC_VER >= 1700
+#  define NODISCARD _Check_return_
+#else
+#  define NODISCARD __attribute__((warn_unused_result))
+#endif
+
+#endif // BITCOIN_ATTRIBUTES_H

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -159,17 +159,17 @@ std::string EncodeSecret(const CKey& key)
     return ret;
 }
 
-CExtPubKey DecodeExtPubKey(const std::string& str)
+bool DecodeExtPubKey(const std::string& str, CExtPubKey& extpubkey)
 {
-    CExtPubKey key;
     std::vector<unsigned char> data;
     if (DecodeBase58Check(str, data)) {
         const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_PUBLIC_KEY);
         if (data.size() == BIP32_EXTKEY_SIZE + prefix.size() && std::equal(prefix.begin(), prefix.end(), data.begin())) {
-            key.Decode(data.data() + prefix.size());
+            extpubkey.Decode(data.data() + prefix.size());
+            return extpubkey.pubkey.IsValid();
         }
     }
-    return key;
+    return false;
 }
 
 std::string EncodeExtPubKey(const CExtPubKey& key)
@@ -182,17 +182,17 @@ std::string EncodeExtPubKey(const CExtPubKey& key)
     return ret;
 }
 
-CExtKey DecodeExtKey(const std::string& str)
+bool DecodeExtKey(const std::string& str, CExtKey& extkey)
 {
-    CExtKey key;
     std::vector<unsigned char> data;
     if (DecodeBase58Check(str, data)) {
         const std::vector<unsigned char>& prefix = Params().Base58Prefix(CChainParams::EXT_SECRET_KEY);
         if (data.size() == BIP32_EXTKEY_SIZE + prefix.size() && std::equal(prefix.begin(), prefix.end(), data.begin())) {
-            key.Decode(data.data() + prefix.size());
+            extkey.Decode(data.data() + prefix.size());
+            return extkey.key.IsValid();
         }
     }
-    return key;
+    return false;
 }
 
 std::string EncodeExtKey(const CExtKey& key)

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_KEY_IO_H
 #define BITCOIN_KEY_IO_H
 
+#include <attributes.h>
 #include <chainparams.h>
 #include <key.h>
 #include <pubkey.h>
@@ -17,10 +18,10 @@ CKey DecodeSecret(const std::string& str);
 std::string EncodeSecret(const CKey& key);
 
 //! Returns true if and only if extkey is valid (extkey.key.IsValid()) when the function returns.
-bool DecodeExtKey(const std::string& str, CExtKey& extkey);
+NODISCARD bool DecodeExtKey(const std::string& str, CExtKey& extkey);
 std::string EncodeExtKey(const CExtKey& extkey);
 //! Returns true if and only if extpubkey is valid (extpubkey.pubkey.IsValid()) when the function returns.
-bool DecodeExtPubKey(const std::string& str, CExtPubKey& extpubkey);
+NODISCARD bool DecodeExtPubKey(const std::string& str, CExtPubKey& extpubkey);
 std::string EncodeExtPubKey(const CExtPubKey& extpubkey);
 
 std::string EncodeDestination(const CTxDestination& dest);

--- a/src/key_io.h
+++ b/src/key_io.h
@@ -16,9 +16,11 @@
 CKey DecodeSecret(const std::string& str);
 std::string EncodeSecret(const CKey& key);
 
-CExtKey DecodeExtKey(const std::string& str);
+//! Returns true if and only if extkey is valid (extkey.key.IsValid()) when the function returns.
+bool DecodeExtKey(const std::string& str, CExtKey& extkey);
 std::string EncodeExtKey(const CExtKey& extkey);
-CExtPubKey DecodeExtPubKey(const std::string& str);
+//! Returns true if and only if extpubkey is valid (extpubkey.pubkey.IsValid()) when the function returns.
+bool DecodeExtPubKey(const std::string& str, CExtPubKey& extpubkey);
 std::string EncodeExtPubKey(const CExtPubKey& extpubkey);
 
 std::string EncodeDestination(const CTxDestination& dest);

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -464,9 +464,11 @@ std::unique_ptr<PubkeyProvider> ParsePubkey(const Span<const char>& sp, bool per
             return MakeUnique<ConstPubkeyProvider>(pubkey);
         }
     }
-    CExtKey extkey = DecodeExtKey(str);
-    CExtPubKey extpubkey = DecodeExtPubKey(str);
-    if (!extkey.key.IsValid() && !extpubkey.pubkey.IsValid()) return nullptr;
+    CExtKey extkey;
+    const bool validExtKey = DecodeExtKey(str, extkey);
+    CExtPubKey extpubkey;
+    const bool validExtPubKey = DecodeExtPubKey(str, extpubkey);
+    if (!validExtKey && !validExtPubKey) return nullptr;
     KeyPath path;
     DeriveType type = DeriveType::NO;
     if (split.back() == MakeSpan("*").first(1)) {

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -100,11 +100,15 @@ static void RunTest(const TestVector &test) {
 
         // Test private key
         BOOST_CHECK(EncodeExtKey(key) == derive.prv);
-        BOOST_CHECK(DecodeExtKey(derive.prv) == key); //ensure a base58 decoded key also matches
+        CExtKey extkey;
+        BOOST_CHECK(DecodeExtKey(derive.prv, extkey));
+        BOOST_CHECK(extkey == key); // ensure a base58 decoded key also matches
 
         // Test public key
         BOOST_CHECK(EncodeExtPubKey(pubkey) == derive.pub);
-        BOOST_CHECK(DecodeExtPubKey(derive.pub) == pubkey); //ensure a base58 decoded pubkey also matches
+        CExtPubKey extpubkey;
+        BOOST_CHECK(DecodeExtPubKey(derive.pub, extpubkey));
+        BOOST_CHECK(extpubkey == pubkey); // ensure a base58 decoded pubkey also matches
 
         // Derive new keys
         CExtKey keyNew;

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -104,11 +104,55 @@ static void RunTest(const TestVector &test) {
         BOOST_CHECK(DecodeExtKey(derive.prv, extkey));
         BOOST_CHECK(extkey == key); // ensure a base58 decoded key also matches
 
+        // Test DecodeExtKey with some valid and some invalid private keys
+        CExtKey extkeyTmp;
+        BOOST_CHECK(DecodeExtKey(" " + derive.prv, extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey("_" + derive.prv, extkeyTmp));
+        BOOST_CHECK(DecodeExtKey(derive.prv + " ", extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey(derive.prv + "A", extkeyTmp));
+        BOOST_CHECK(DecodeExtKey("\n" + derive.prv, extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey("A" + derive.prv, extkeyTmp));
+        BOOST_CHECK(DecodeExtKey("\n\n\n\n" + derive.prv + "\n\n\n\n", extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey("invalid" + derive.prv, extkeyTmp));
+        BOOST_CHECK(DecodeExtKey(" \r\t\n" + derive.prv + " \n\t\r", extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey(derive.prv + derive.prv, extkeyTmp));
+        BOOST_CHECK(DecodeExtKey("\r" + derive.prv, extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey("\r\a" + derive.prv, extkeyTmp));
+        BOOST_CHECK(DecodeExtKey("\t" + derive.prv, extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey("\a\t" + derive.prv, extkeyTmp));
+        BOOST_CHECK(DecodeExtKey(derive.prv + "\n", extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey(derive.prv + "\a\n", extkeyTmp));
+        BOOST_CHECK(DecodeExtKey(derive.prv + "\r", extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey(derive.prv + "\r\a", extkeyTmp));
+        BOOST_CHECK(!DecodeExtKey(derive.pub, extkeyTmp));
+
         // Test public key
         BOOST_CHECK(EncodeExtPubKey(pubkey) == derive.pub);
         CExtPubKey extpubkey;
         BOOST_CHECK(DecodeExtPubKey(derive.pub, extpubkey));
         BOOST_CHECK(extpubkey == pubkey); // ensure a base58 decoded pubkey also matches
+
+        // Test DecodeExtPubKey with some valid and some invalid public keys
+        CExtPubKey extpubkeyTmp;
+        BOOST_CHECK(DecodeExtPubKey(" " + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey("_" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey(derive.pub + " ", extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey(derive.pub + "A", extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey("\n" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey("A" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey("\n\n\n\n" + derive.pub + "\n\n\n\n", extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey("invalid" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey(" \r\t\n" + derive.pub + " \n\t\r", extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey(derive.pub + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey("\r" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey("\r\a" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey("\t" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey("\a\t" + derive.pub, extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey(derive.pub + "\n", extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey(derive.pub + "\a\n", extpubkeyTmp));
+        BOOST_CHECK(DecodeExtPubKey(derive.pub + "\r", extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey(derive.pub + "\r\a", extpubkeyTmp));
+        BOOST_CHECK(!DecodeExtPubKey(derive.prv, extpubkeyTmp));
 
         // Derive new keys
         CExtKey keyNew;


### PR DESCRIPTION
Add error handling to `DecodeExtPubKey`/`DecodeExtKey` and make sure return value is checked (via `[[nodiscard]]`).

Prior to this commit:

```
$ cat > test.cpp
…
int main(void) {
  CExtPubKey key = DecodeExtPubKey("foo");
  std::cout << key.nChild << "\n";
}
^D
$ g++ -o test test.cpp
$ ./test
109452364
$ ./test
-1789494196
$ ./test
-1568076724
$ ./test
1483189324
$ ./test
-1168606132
```