### PR TITLE
Remove 16 bits from versionbits signalling system (BIP320)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -76,7 +76,7 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 12;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
 
@@ -193,7 +193,7 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 12;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
 
@@ -288,7 +288,7 @@ public:
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
         consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 12;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2270,7 +2270,7 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
         for (int i = 0; i < 100 && pindex != nullptr; i++)
         {
             int32_t nExpectedVersion = ComputeBlockVersion(pindex->pprev, chainParams.GetConsensus());
-            if (pindex->nVersion > VERSIONBITS_LAST_OLD_BLOCK_VERSION && (pindex->nVersion & ~nExpectedVersion) != 0)
+            if (pindex->nVersion > VERSIONBITS_LAST_OLD_BLOCK_VERSION && (pindex->nVersion & ~nExpectedVersion & VERSIONBITS_IGNORE_MASK) != 0)
                 ++nUpgraded;
             pindex = pindex->pprev;
         }

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -15,7 +15,9 @@ static const int32_t VERSIONBITS_TOP_BITS = 0x20000000UL;
 /** What bitmask determines whether versionbits is in use */
 static const int32_t VERSIONBITS_TOP_MASK = 0xE0000000UL;
 /** Total bits available for versionbits */
-static const int32_t VERSIONBITS_NUM_BITS = 29;
+static const int32_t VERSIONBITS_NUM_BITS = 13;
+/** Bitmask for ignored versionbits. It should match VERSIONBITS_NUM_BITS (BIPxxx) */
+static const int32_t VERSIONBITS_IGNORE_MASK = 0xE0001FFFUL;
 
 enum class ThresholdState {
     DEFINED,

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -13,7 +13,7 @@ from time import sleep
 
 from test_framework.blocktools import create_block, create_coinbase
 from test_framework.messages import msg_block
-from test_framework.mininode import P2PInterface, mininode_lock
+from test_framework.mininode import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import wait_until
 


### PR DESCRIPTION
Over 5% of the hashpower is currently using version-rolling which consumes bits from the nVersion in the blockheader. Miners are generally using the the bits within the range 0x1fffe000 as per recommendation in the [reserved bits](https://github.com/bitcoin/bips/pull/661/files) proposal as well as the [BIP 310 stratum-extension](https://github.com/bitcoin/bips/pull/709/files) for version-rolling.

Before this pull request the BIP9/versionbits system will emit false warnings for unknown softforks when version-rolling is used. This pull request removes the bits in the range 0x1fffe000 so version-rolling, or other miner use of those bits, will not falsely trigger the warning system or interfere with soft forks.

False positive warnings are toxic because it leads to node operators ignoring warning messages, thus defeating the purpose of a warning system.