### PR TITLE
[trivial] Fix typo in CDiskBlockPos struct's ToString

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -117,7 +117,7 @@ struct CDiskBlockPos
 
     std::string ToString() const
     {
-        return strprintf("CBlockDiskPos(nFile=%i, nPos=%i)", nFile, nPos);
+        return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
     }
 
 };


### PR DESCRIPTION
(Logging)