### PR TITLE
add secp256k1 bench flags

### DIFF
--- a/src/secp256k1/Makefile.am
+++ b/src/secp256k1/Makefile.am
@@ -86,7 +86,7 @@ bench_sign_SOURCES = src/bench_sign.c
 bench_sign_LDADD = libsecp256k1.la $(SECP_LIBS) $(SECP_TEST_LIBS) $(COMMON_LIB)
 bench_internal_SOURCES = src/bench_internal.c
 bench_internal_LDADD = $(SECP_LIBS) $(COMMON_LIB)
-bench_internal_CPPFLAGS = -DSECP256K1_BUILD $(SECP_INCLUDES)
+bench_internal_CPPFLAGS = -DSECP256K1_BUILD $(SECP_INCLUDES) -I$(top_srcdir)/src
 endif
 
 TESTS =


### PR DESCRIPTION
```
git clone https://github.com/bitcoin/bitcoin.git
cd bitcoin/src/secp256k1 && ./autogen.sh && mkdir build && cd build
../configure --enable-benchmark=yes && make
In file included from ../src/ecmult_gen_impl.h:15:0,
                 from ../src/secp256k1.c:16,
                 from ../src/bench_internal.c:19:
./src/ecmult_static_context.h:3:19: fatal error: group.h: No such file or directory
 #include "group.h"
```