### PR TITLE
Report minfeefilter value in getpeerinfo rpc

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -715,6 +715,7 @@ void CNode::copyStats(CNodeStats &stats)
         X(nRecvBytes);
     }
     X(fWhitelisted);
+    X(minFeeFilter);
 
     // It is common for nodes with good ping times to suddenly become lagged,
     // due to a new block arriving or other large transfer.

--- a/src/net.h
+++ b/src/net.h
@@ -558,6 +558,7 @@ public:
     double dPingTime;
     double dPingWait;
     double dMinPing;
+    CAmount minFeeFilter;
     // Our address, as reported by the peer
     std::string addrLocal;
     // Address of this peer

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -102,6 +102,7 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             "       ...\n"
             "    ],\n"
             "    \"whitelisted\": true|false, (boolean) Whether the peer is whitelisted\n"
+            "    \"minfeefilter\": n,         (numeric) The minimum fee rate for transactions this peer accepts\n"
             "    \"bytessent_per_msg\": {\n"
             "       \"addr\": n,              (numeric) The total bytes sent aggregated by message type\n"
             "       ...\n"
@@ -169,6 +170,7 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             obj.pushKV("inflight", heights);
         }
         obj.pushKV("whitelisted", stats.fWhitelisted);
+        obj.pushKV("minfeefilter", ValueFromAmount(stats.minFeeFilter));
 
         UniValue sendPerMsgCmd(UniValue::VOBJ);
         for (const mapMsgCmdSize::value_type &i : stats.mapSendBytesPerMsgCmd) {

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -7,6 +7,8 @@
 Tests correspond to code in rpc/net.cpp.
 """
 
+from decimal import Decimal
+
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -21,6 +23,7 @@ class NetTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
+        self.extra_args = [["-minrelaytxfee=0.00001000"],["-minrelaytxfee=0.00000500"]]
 
     def run_test(self):
         self._test_connection_count()
@@ -95,6 +98,8 @@ class NetTest(BitcoinTestFramework):
         # the address bound to on one side will be the source address for the other node
         assert_equal(peer_info[0][0]['addrbind'], peer_info[1][0]['addr'])
         assert_equal(peer_info[1][0]['addrbind'], peer_info[0][0]['addr'])
+        assert_equal(peer_info[0][0]['minfeefilter'], Decimal("0.00000500"))
+        assert_equal(peer_info[1][0]['minfeefilter'], Decimal("0.00001000"))
 
 if __name__ == '__main__':
     NetTest().main()


### PR DESCRIPTION
Lowering the minimum relay fee is only useful when many nodes in the p2p network also lower the fee, so to make it easier to understand progress on that front, this includes the value of the minfeefilter in getpeerinfo, so you at least have visibility to what fees your neighbours are currently accepting.