### PR TITLE
depends: fix qt determinism

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -8,7 +8,7 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
-$(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch fix_riscv64_arch.patch
+$(package)_patches=fix_qt_pkgconfig.patch mac-qmake.conf fix_configure_mac.patch fix_no_printer.patch fix_rcc_determinism.patch fix_riscv64_arch.patch xkb-default.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=9822084f8e2d2939ba39f4af4c0c2320e45d5996762a9423f833055607604ed8
@@ -83,7 +83,7 @@ $(package)_config_opts_darwin += -device-option MAC_TARGET=$(host)
 $(package)_config_opts_darwin += -device-option MAC_LD64_VERSION=$(LD64_VERSION)
 endif
 
-$(package)_config_opts_linux  = -qt-xkbcommon
+$(package)_config_opts_linux  = -qt-xkbcommon-x11
 $(package)_config_opts_linux += -qt-xcb
 $(package)_config_opts_linux += -system-freetype
 $(package)_config_opts_linux += -no-feature-sessionmanager
@@ -137,6 +137,7 @@ define $(package)_preprocess_cmds
   patch -p1 -i $($(package)_patch_dir)/fix_configure_mac.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_no_printer.patch &&\
   patch -p1 -i $($(package)_patch_dir)/fix_rcc_determinism.patch &&\
+  patch -p1 -i $($(package)_patch_dir)/xkb-default.patch &&\
   echo "!host_build: QMAKE_CFLAGS     += $($(package)_cflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_CXXFLAGS   += $($(package)_cxxflags) $($(package)_cppflags)" >> qtbase/mkspecs/common/gcc-base.conf && \
   echo "!host_build: QMAKE_LFLAGS     += $($(package)_ldflags)" >> qtbase/mkspecs/common/gcc-base.conf && \

--- a/depends/patches/qt/xkb-default.patch
+++ b/depends/patches/qt/xkb-default.patch
@@ -1,0 +1,26 @@
+--- old/qtbase/src/gui/configure.pri	2018-06-06 17:28:10.000000000 -0400
++++ new/qtbase/src/gui/configure.pri	2018-08-17 18:43:01.589384567 -0400
+@@ -43,18 +43,11 @@
+ }
+
+ defineTest(qtConfTest_xkbConfigRoot) {
+-    qtConfTest_getPkgConfigVariable($${1}): return(true)
+-
+-    for (dir, $$list("/usr/share/X11/xkb", "/usr/local/share/X11/xkb")) {
+-        exists($$dir) {
+-            $${1}.value = $$dir
+-            export($${1}.value)
+-            $${1}.cache += value
+-            export($${1}.cache)
+-            return(true)
+-        }
+-    }
+-    return(false)
++    $${1}.value = "/usr/share/X11/xkb"
++    export($${1}.value)
++    $${1}.cache += value
++    export($${1}.cache)
++    return(true)
+ }
+
+ defineTest(qtConfTest_qpaDefaultPlatform) {


### PR DESCRIPTION
Thanks to @MarcoFalke for pointing out the problem and the solution as well. I'm unsure if this takes care of all of the determinism issues with 0.17rc1, but it should fix at least one.

Qt's configure grabs the path to xkb's data root during configure, but the build changes in 5.8 apparently broke the handling for cross builds. As a result, the string embedded in the binary depends on whether or not some files are present in the builder's filesystem.

The "-xkb-config-root" configure setting is intended to allow manual overriding but it is also broken. See: https://bugreports.qt.io/browse/QTBUG-60005

This has since been fixed upstream, so just hard-code the path for now. We can drop this patch when we bump to a fixed Qt.

Also, fix the "-qt-xkbcommon-x11" config param which was renamed. This does not appear to affect build results, presumably because auto-detection is working, but it does not hurt to be explicit.

Edit: The hard-coded string matches the value from 0.16 builds, so nothing should be changing.