### PR TITLE
Disable wallet and address book Qt tests on macOS minimal platform

### DIFF
--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -17,6 +17,7 @@
 #include <key_io.h>
 #include <wallet/wallet.h>
 
+#include <QApplication>
 #include <QTimer>
 #include <QMessageBox>
 
@@ -139,5 +140,16 @@ void TestAddAddressesToSendBook()
 
 void AddressBookTests::addressBookTests()
 {
+#ifdef Q_OS_MAC
+    if (QApplication::platformName() == "minimal") {
+        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
+        // framework when it tries to look up unimplemented cocoa functions,
+        // and fails to handle returned nulls
+        // (https://bugreports.qt.io/browse/QTBUG-49686).
+        QWARN("Skipping AddressBookTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
+              "with 'test_bitcoin-qt -platform cocoa' on mac, or else use a linux or windows build.");
+        return;
+    }
+#endif
     TestAddAddressesToSendBook();
 }

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -243,5 +243,16 @@ void TestGUI()
 
 void WalletTests::walletTests()
 {
+#ifdef Q_OS_MAC
+    if (QApplication::platformName() == "minimal") {
+        // Disable for mac on "minimal" platform to avoid crashes inside the Qt
+        // framework when it tries to look up unimplemented cocoa functions,
+        // and fails to handle returned nulls
+        // (https://bugreports.qt.io/browse/QTBUG-49686).
+        QWARN("Skipping WalletTests on mac build with 'minimal' platform set due to Qt bugs. To run AppTests, invoke "
+              "with 'test_bitcoin-qt -platform cocoa' on mac, or else use a linux or windows build.");
+        return;
+    }
+#endif
     TestGUI();
 }


### PR DESCRIPTION
macOS minimal platform is frequently broken, and these are currently failing with Qt 5.11.1.

The tests do pass when run on the full cocoa platform (with `test_bitcoin-qt -platform cocoa`).

Stack trace from test crash: https://gist.github.com/ryanofsky/3401fb63c52d13d5585e7fc777361f1e