### PR TITLE
[trivial] Updates the ADD_SERIALIZE_METHODS documentation

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -174,7 +174,7 @@ template<typename X> const X& ReadWriteAsHelper(const X& x) { return x; }
 #define READWRITEAS(type, obj) (::SerReadWriteMany(s, ser_action, ReadWriteAsHelper<type>(obj)))
 
 /**
- * Implement three methods for serializable objects. These are actually wrappers over
+ * Implement two methods for serializable objects. These are actually wrappers over
  * "SerializationOp" template, which implements the body of each class' serialization
  * code. Adding "ADD_SERIALIZE_METHODS" in the body of the class causes these wrappers to be
  * added as members.


### PR DESCRIPTION
This pull request fixes a small error in the `ADD_SERIALIZE_METHODS` documentation.

At the moment the `ADD_SERIALIZE_METHODS` macro adds two methods to a class:

```c++
template<typename Stream>void Serialize(Stream& s) const { ... }
template<typename Stream>void Unserialize(Stream& s) { ... }
```

`ADD_SERIALIZE_METHODS` used to add three methods to a class:

```c++
size_t GetSerializeSize(int nType, int nVersion) const {...}
template<typename Stream>void Serialize(Stream& s, int nType, int nVersion) const  {...}
template<typename Stream>void Unserialize(Stream& s, int nType, int nVersion)  {...}
```

`size_t GetSerializeSize(int nType, int nVersion) const` was removed from the `ADD_SERIALIZE_METHODS` macro in  657e05ab2e87ff725723fe8a375fc3f8aad02126, but the documentation was not updated accordingly at the time.

This pull request corrects this mistake.