### PR TITLE
ZMQ: Use C++ language bindings

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -34,8 +34,8 @@ buffering or reassembly.
 ## Prerequisites
 
 The ZeroMQ feature in Bitcoin Core requires ZeroMQ API version 4.x or
-newer. Typically, it is packaged by distributions as something like
-*libzmq3-dev*. The C++ wrapper for ZeroMQ is *not* needed.
+newer and the C++ language bindings.  Typically, it is packaged by
+distributions as something like *libzmq3-dev*.
 
 In order to run the example Python client scripts in contrib/ one must
 also install *python3-zmq*, though this is not necessary for daemon

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -7,6 +7,8 @@
 
 #include <zmq/zmqconfig.h>
 
+#include <memory>
+
 class CBlockIndex;
 class CZMQAbstractNotifier;
 
@@ -15,7 +17,7 @@ typedef CZMQAbstractNotifier* (*CZMQNotifierFactory)();
 class CZMQAbstractNotifier
 {
 public:
-    CZMQAbstractNotifier() : psocket(nullptr) { }
+    CZMQAbstractNotifier() = default;
     virtual ~CZMQAbstractNotifier();
 
     template <typename T>
@@ -29,14 +31,14 @@ public:
     std::string GetAddress() const { return address; }
     void SetAddress(const std::string &a) { address = a; }
 
-    virtual bool Initialize(void *pcontext) = 0;
+    virtual bool Initialize(zmq::context_t& context) = 0;
     virtual void Shutdown() = 0;
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransaction &transaction);
 
 protected:
-    void *psocket;
+    std::shared_ptr<zmq::socket_t> psocket;
     std::string type;
     std::string address;
 };

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -13,12 +13,12 @@
 #include <string>
 
 #if ENABLE_ZMQ
-#include <zmq.h>
+#include <zmq.hpp>
 #endif
 
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 
-void zmqError(const char *str);
+void zmqError(const char* msg, const zmq::error_t& exc);
 
 #endif // BITCOIN_ZMQ_ZMQCONFIG_H

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,6 +6,9 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
+
+#include <zmq.hpp>
+
 #include <string>
 #include <map>
 #include <list>
@@ -35,7 +38,7 @@ protected:
 private:
     CZMQNotificationInterface();
 
-    void *pcontext;
+    zmq::context_t context;
     std::list<CZMQAbstractNotifier*> notifiers;
 };
 

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -24,7 +24,7 @@ public:
     */
     bool SendMessage(const char *command, const void* data, size_t size);
 
-    bool Initialize(void *pcontext) override;
+    bool Initialize(zmq::context_t& context) override;
     void Shutdown() override;
 };
 


### PR DESCRIPTION
This changes the ZMQ code to use the C++ language bindings instead of the plain C interface.  This allows us to make use of RAII for initialisation and destruction, making the code easier to read and less error-prone.

See https://github.com/bitcoin/bitcoin/issues/13957.