### PR TITLE
Bugfix: NSIS: Exclude Makefile* from docs

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -80,7 +80,7 @@ Section -Main SEC0000
     File @abs_top_srcdir@/release/@BITCOIN_DAEMON_NAME@@EXEEXT@
     File @abs_top_srcdir@/release/@BITCOIN_CLI_NAME@@EXEEXT@
     SetOutPath $INSTDIR\doc
-    File /r @abs_top_srcdir@/doc\*.*
+    File /r /x Makefile* @abs_top_srcdir@/doc\*.*
     SetOutPath $INSTDIR
     WriteRegStr HKCU "${REGKEY}\Components" Main 1
 SectionEnd


### PR DESCRIPTION
Otherwise, the generated Makefile is included in the NSIS-installed documentation, which can lead to non-determinism (eg, if gawk is installed on some build VMs, but others only have mawk)

(gawk is part of the standard Ubuntu bionic server install, but for some reason missing on many other developers' build VMs.)

(Branch is safe to merge cleanly into 0.14-0.17 branches also)

Testing requested. I have a separate `fix_nsis_makefile` branch directly on the `v0.17.0rc1` tag, which produces for me (with gawk installed):

```
f2f0e81e053f6bb59f3007a182e3e8b5cc4ccd374cfee29c80861d00c508a798  bitcoin-0.17.0-win-unsigned.tar.gz
935d4ef25e9602352833bbd594003a7b07ef9e2281fa9a2258c0f71167bdaaca  bitcoin-0.17.0-win32-debug.zip
37a789993f4fef6007633a988614f8008389463ded6807c1beaaf3c04212d5f9  bitcoin-0.17.0-win32-setup-unsigned.exe
8b04d4d7de3d4308bff5f2e61bb771926dd66fa815fcea1eadc8d627f0f8970a  bitcoin-0.17.0-win32.zip
8883dad775c2b97085b2217175e9916a9aa894ff97fbdc9b7ca74b4e8206298d  bitcoin-0.17.0-win64-debug.zip
cd30d3eb2b739f6e4956c768ea4fb0230fb23e01dcad094d2fbf4efa6c7dad52  bitcoin-0.17.0-win64-setup-unsigned.exe
817d5b9df4cc3f7fd323e134ed8670787aa9cafc921e883bbbb9cdfb439b03da  bitcoin-0.17.0-win64.zip
e3ed7f2d4a5993e4c343e967cfa838c6314fa98900c43519572a31b96d3e00ca  src/bitcoin-0.17.0.tar.gz
38d2f92cf2c9823ea3c52aaa9c42f7cb38a87a12896a89379bfc4315a04d2e92  bitcoin-win-0.17-res.yml
```