### PR TITLE
Add tests for RPC help

### DIFF
--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test RPC help output."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_rpc_error
+
+class HelpRpcTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # wrong argument count
+        assert_raises_rpc_error(-1, 'help', node.help, 'foo', 'bar')
+
+        # invalid argument
+        assert_raises_rpc_error(-1, 'JSON value is not a string as expected', node.help, 0)
+
+        # help of unknown command
+        assert_equal(node.help('foo'), 'help: unknown command: foo')
+
+        # command titles
+        titles = [line[3:-3] for line in node.help().splitlines() if line.startswith('==')]
+        assert_equal(titles, ['Blockchain', 'Control', 'Generating', 'Mining', 'Network', 'Rawtransactions', 'Util', 'Wallet', 'Zmq'])
+
+if __name__ == '__main__':
+    HelpRpcTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -152,6 +152,7 @@ BASE_SCRIPTS = [
     'p2p_node_network_limited.py',
     'feature_blocksdir.py',
     'feature_config_args.py',
+    'rpc_help.py',
     'feature_help.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time


### PR DESCRIPTION
At the moment the new test checks for:
 - invalid usages
 - expected output for unknown command
 - current RPC command titles (derived from command categories) — this prevents adding wrong RPC categories and new categories must be added to the test