### PR TITLE
Make IS_TRIVIALLY_CONSTRUCTIBLE consistent on GCC < 5, don't patch clang

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -14,10 +14,10 @@
 
 // GCC 4.8 is missing some C++11 type_traits,
 // https://www.gnu.org/software/gcc/gcc-5/changes.html
-#if defined(__GNUC__) && __GNUC__ < 5
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivial
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+#define IS_TRIVIALLY_CONSTRUCTIBLE std::has_trivial_default_constructor
 #else
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivially_constructible
+#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivially_default_constructible
 #endif
 
 #ifdef WIN32


### PR DESCRIPTION
`std::is_trivially_constructible<T>` is equivalent to `std::is_trivially_default_constructible<T>`
`std::has_trivial_default_constructor<T>` is the GCC < 5 name for `std::is_trivially_default_constructible<T>`

https://en.cppreference.com/w/cpp/types/is_default_constructible
https://www.gnu.org/software/gcc/gcc-5/changes.html

`std::is_trivial` was also used when compiling with clang, due to clang's use of `__GNUC__`. Test `__clang__`  to target the intended implementations.
https://stackoverflow.com/a/28166605

All callers currently only pass one template argument to IS_TRIVIALLY_CONSTRUCTIBLE, with this change the build would fail if someone attempted passing more.