### PR TITLE
Add README.md to linux release tarballs

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -184,6 +184,7 @@ script: |
     rm -rf ${DISTNAME}/lib/pkgconfig
     find ${DISTNAME}/bin -type f -executable -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
     find ${DISTNAME}/lib -type f -exec ../contrib/devtools/split-debug.sh {} {} {}.dbg \;
+    cp ../doc/README.md ${DISTNAME}/
     find ${DISTNAME} -not -name "*.dbg" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     find ${DISTNAME} -name "*.dbg" | sort | tar --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}-debug.tar.gz
     cd ../../


### PR DESCRIPTION
fix #8160

Gitian building report for 0.17.0rc2:
```
7d89d7dc3488915ec2380253a69fb3b8f8065592e24c5b2a99a91da30f2142cc  bitcoin-0.17.0-aarch64-linux-gnu-debug.tar.gz
fcb292fd2c4fca88e5cc5a97ee7fa3390d3c7221aada166fe7822d64a2ee9dfa  bitcoin-0.17.0-aarch64-linux-gnu.tar.gz
0ec6f979a823a6b6084d2e80605dffd3ccdda359e8459cebec25092c1087348f  bitcoin-0.17.0-arm-linux-gnueabihf-debug.tar.gz
45af8757a2315125afe2f4d4f276d9b9cf616b8ab814284ce2f82b9a345971d8  bitcoin-0.17.0-arm-linux-gnueabihf.tar.gz
b37b6d9bda864af968dfab6eebb245e75ecc56eb18b139b946270933381ea288  bitcoin-0.17.0-i686-pc-linux-gnu-debug.tar.gz
20c96a5509eeb3e8ec505f18914ef9231beef1fec5e9e1c4b33ec6c6b613d146  bitcoin-0.17.0-i686-pc-linux-gnu.tar.gz
d505888594a04dab2b34ccd6863b8f25eb97d9cb76650e39d93f4d6c09d4c55a  bitcoin-0.17.0-x86_64-linux-gnu-debug.tar.gz
f55b16716c3295e309c816e170911380a5a26e9be3a336b213f2f412f0b159b3  bitcoin-0.17.0-x86_64-linux-gnu.tar.gz
01c6b5ce15b9f3fcdcce96baae14eb04ab2605f2294d333e96b66e004594eea6  src/bitcoin-0.17.0.tar.gz
```
Release tarball content:
```
$ tar -tf bitcoin-binaries/0.17.0rc2/bitcoin-0.17.0-x86_64-linux-gnu.tar.gz 
bitcoin-0.17.0/
bitcoin-0.17.0/bin/
bitcoin-0.17.0/bin/bitcoin-cli
bitcoin-0.17.0/bin/bitcoind
bitcoin-0.17.0/bin/bitcoin-qt
bitcoin-0.17.0/bin/bitcoin-tx
bitcoin-0.17.0/bin/test_bitcoin
bitcoin-0.17.0/include/
bitcoin-0.17.0/include/bitcoinconsensus.h
bitcoin-0.17.0/lib/
bitcoin-0.17.0/lib/libbitcoinconsensus.so
bitcoin-0.17.0/lib/libbitcoinconsensus.so.0
bitcoin-0.17.0/lib/libbitcoinconsensus.so.0.0.0
bitcoin-0.17.0/README.md
bitcoin-0.17.0/share/
bitcoin-0.17.0/share/man/
bitcoin-0.17.0/share/man/man1/
bitcoin-0.17.0/share/man/man1/bitcoin-cli.1
bitcoin-0.17.0/share/man/man1/bitcoind.1
bitcoin-0.17.0/share/man/man1/bitcoin-qt.1
bitcoin-0.17.0/share/man/man1/bitcoin-tx.1
```