### PR TITLE
Disallow extended encoding for non-witness transactions

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -220,6 +220,10 @@ inline void UnserializeTransaction(TxType& tx, Stream& s) {
         for (size_t i = 0; i < tx.vin.size(); i++) {
             s >> tx.vin[i].scriptWitness.stack;
         }
+        if (!tx.HasWitness()) {
+            /* It's illegal to encode witnesses when all witness stacks are empty. */
+            throw std::ios_base::failure("Superfluous witness record");
+        }
     }
     if (flags) {
         /* Unknown flag in the serialization */


### PR DESCRIPTION
BIP144 specifies that transactions without witness should use the legacy encoding, which is currently not enforced.

This rule was present in the original SegWit implementation (https://github.com/bitcoin/bitcoin/pull/8149), but was subsequently dropped (https://github.com/bitcoin/bitcoin/pull/8589).

As all hashes, txids, and weights are always computed over a reserialized version of a transaction, it is mostly harmless to permit extended encoding for non-segwit transactions, but I'd rather strictly follow the BIP.