### PR TITLE
refactor: Fix the chainparamsbase -> util circular dependency

### DIFF
--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -15,14 +15,6 @@ const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
-void SetupChainParamsBaseOptions()
-{
-    gArgs.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
-                                   "This is intended for regression testing tools and app development.", true, OptionsCategory::CHAINPARAMS);
-    gArgs.AddArg("-testnet", "Use the test chain", false, OptionsCategory::CHAINPARAMS);
-    gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", true, OptionsCategory::CHAINPARAMS);
-}
-
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -6,7 +6,6 @@
 #include <chainparamsbase.h>
 
 #include <tinyformat.h>
-#include <util/system.h>
 #include <util/memory.h>
 
 #include <assert.h>
@@ -26,17 +25,26 @@ const CBaseChainParams& BaseParams()
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain)
 {
     if (chain == CBaseChainParams::MAIN)
-        return MakeUnique<CBaseChainParams>("", 8332);
+        return MakeUnique<CBaseChainParams>(chain, "", 8332);
     else if (chain == CBaseChainParams::TESTNET)
-        return MakeUnique<CBaseChainParams>("testnet3", 18332);
+        return MakeUnique<CBaseChainParams>(chain, "testnet3", 18332);
     else if (chain == CBaseChainParams::REGTEST)
-        return MakeUnique<CBaseChainParams>("regtest", 18443);
+        return MakeUnique<CBaseChainParams>(chain, "regtest", 18443);
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+}
+
+bool BaseParamsSelected()
+{
+    return globalChainBaseParams != nullptr;
 }
 
 void SelectBaseParams(const std::string& chain)
 {
     globalChainBaseParams = CreateBaseChainParams(chain);
-    gArgs.SelectConfigNetwork(chain);
+}
+
+void UnselectBaseParams()
+{
+    globalChainBaseParams.reset();
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -40,11 +40,6 @@ private:
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain);
 
 /**
- *Set the arguments for chainparams
- */
-void SetupChainParamsBaseOptions();
-
-/**
  * Return the currently selected parameters. This won't change after app
  * startup, except for unit tests.
  */

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -21,13 +21,16 @@ public:
     static const std::string TESTNET;
     static const std::string REGTEST;
 
+    const std::string& ChainName() const { return m_chain_name; }
     const std::string& DataDir() const { return strDataDir; }
     int RPCPort() const { return nRPCPort; }
 
     CBaseChainParams() = delete;
-    CBaseChainParams(const std::string& data_dir, int rpc_port) : nRPCPort(rpc_port), strDataDir(data_dir) {}
+    CBaseChainParams(const std::string& chain_name, const std::string& data_dir, int rpc_port)
+        : m_chain_name(chain_name), nRPCPort(rpc_port), strDataDir(data_dir) {}
 
 private:
+    std::string m_chain_name;
     int nRPCPort;
     std::string strDataDir;
 };
@@ -38,6 +41,11 @@ private:
  * @throws a std::runtime_error if the chain is not supported.
  */
 std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain);
+
+/**
+ * @return true if BaseParams have been selected, false if not
+ */
+bool BaseParamsSelected();
 
 /**
  * Return the currently selected parameters. This won't change after app

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -629,6 +629,14 @@ std::string ArgsManager::GetHelpMessage() const
     return usage;
 }
 
+void SetupChainParamsBaseOptions()
+{
+    gArgs.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
+                                   "This is intended for regression testing tools and app development.", true, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-testnet", "Use the test chain", false, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", true, OptionsCategory::CHAINPARAMS);
+}
+
 bool HelpRequested(const ArgsManager& args)
 {
     return args.IsArgSet("-?") || args.IsArgSet("-h") || args.IsArgSet("-help") || args.IsArgSet("-help-debug");

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -163,11 +163,6 @@ protected:
 public:
     ArgsManager();
 
-    /**
-     * Select the network in use
-     */
-    void SelectConfigNetwork(const std::string& network);
-
     NODISCARD bool ParseParameters(int argc, const char* const argv[], std::string& error);
     NODISCARD bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -296,6 +296,11 @@ public:
 extern ArgsManager gArgs;
 
 /**
+ * Set the chain name arguments for ArgsManager::GetChainName
+ */
+void SetupChainParamsBaseOptions();
+
+/**
  * @return true if help has been requested via a command-line arg
  */
 bool HelpRequested(const ArgsManager& args);

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -9,7 +9,6 @@
 export LC_ALL=C
 
 EXPECTED_CIRCULAR_DEPENDENCIES=(
-    "chainparamsbase -> util/system -> chainparamsbase"
     "index/txindex -> validation -> index/txindex"
     "policy/fees -> txmempool -> policy/fees"
     "policy/policy -> policy/settings -> policy/policy"


### PR DESCRIPTION
By making `BaseParams()` responsible for holding the current chain name, and layering
`ArgsManager` atop it. 

Without this both `m_network` of `ArgsManager` and `globalChainBaseParams` track the current chain, leading to circular dependencies between them.