### PR TITLE
Enable libsecp256k1 ecdh module, add ECDH function to CKey

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1432,7 +1432,7 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --enable-experimental --enable-module-ecdh --disable-jni"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -11,6 +11,7 @@
 #include <random.h>
 
 #include <secp256k1.h>
+#include <secp256k1_ecdh.h>
 #include <secp256k1_recovery.h>
 
 static secp256k1_context* secp256k1_context_sign = nullptr;
@@ -283,6 +284,17 @@ bool CKey::Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const
     keyChild.fCompressed = true;
     keyChild.fValid = ret;
     return ret;
+}
+
+bool CKey::ComputeECDHSecret(const CPubKey& pubkey, CPrivKey& secret_out) const
+{
+    secp256k1_pubkey pubkey_internal;
+    if (!secp256k1_ec_pubkey_parse(secp256k1_context_sign, &pubkey_internal, pubkey.data(), pubkey.size())) {
+        return false;
+    }
+
+    secret_out.resize(32);
+    return secp256k1_ecdh(secp256k1_context_sign, &secret_out[0], &pubkey_internal, keydata.data()) == 1;
 }
 
 bool CExtKey::Derive(CExtKey &out, unsigned int _nChild) const {

--- a/src/key.h
+++ b/src/key.h
@@ -128,6 +128,9 @@ public:
     //! Derive BIP32 child key.
     bool Derive(CKey& keyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode& cc) const;
 
+    // computes an EC Diffie-Hellman 256bit secret
+    bool ComputeECDHSecret(const CPubKey& pubkey, CPrivKey& secret_out) const;
+
     /**
      * Verify thoroughly whether a private key and a public key match.
      * This is done using a different mechanism than just regenerating it.

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -150,6 +150,26 @@ BOOST_AUTO_TEST_CASE(key_test1)
     BOOST_CHECK(key2C.SignCompact(hashMsg, detsigc));
     BOOST_CHECK(detsig == ParseHex("1c52d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
     BOOST_CHECK(detsigc == ParseHex("2052d8a32079c11e79db95af63bb9600c5b04f21a9ca33dc129c2bfa8ac9dc1cd561d8ae5e0f6c1a16bde3719c64c2fd70e404b6428ab9a69566962e8771b5944d"));
+
+    // test EC Diffie-Hellman secret computation
+    CPrivKey secret1;
+    CPrivKey secret2;
+    BOOST_CHECK(key1C.ComputeECDHSecret(pubkey2, secret1));
+    BOOST_CHECK(key2C.ComputeECDHSecret(pubkey1, secret2));
+    BOOST_CHECK(secret1.size() == 32);
+    BOOST_CHECK(secret1 == secret2);
+    // invalid pubkey test
+    std::vector<unsigned char> pubkeydata;
+    pubkeydata.insert(pubkeydata.end(), pubkey1C.begin(), pubkey1C.end());
+    pubkeydata[0] = 0xFF;
+    CPubKey pubkey1_invalid(pubkeydata);
+    BOOST_CHECK(key2.ComputeECDHSecret(pubkey1_invalid, secret2) == false);
+    pubkeydata[0] = 0x03;
+    CPubKey pubkey2_invalid(pubkeydata);
+    BOOST_CHECK(key2.ComputeECDHSecret(pubkey2_invalid, secret2) == true);
+    pubkeydata[9] = 0xFF;
+    CPubKey pubkey3_invalid(pubkeydata);
+    BOOST_CHECK(key2.ComputeECDHSecret(pubkey3_invalid, secret2) == false);
 }
 
 BOOST_AUTO_TEST_CASE(key_signature_tests)


### PR DESCRIPTION
This add `ComputeECDHSecret(const CPubKey& pubkey, CPrivKey& secret_out)`  to `CKey` (including a test).

This is a subset of #14032 and a pre-requirement for BIP324.