### PR TITLE
Add address-based index (attempt 4?)

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -139,6 +139,7 @@ BITCOIN_CORE_H = \
   fs.h \
   httprpc.h \
   httpserver.h \
+  index/addrindex.h \
   index/base.h \
   index/blockfilterindex.h \
   index/disktxpos.h \
@@ -294,6 +295,7 @@ libbitcoin_server_a_SOURCES = \
   flatfile.cpp \
   httprpc.cpp \
   httpserver.cpp \
+  index/addrindex.cpp \
   index/base.cpp \
   index/blockfilterindex.cpp \
   index/txindex.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -204,6 +204,7 @@ FUZZ_SUITE_LD_COMMON = \
 
 # test_bitcoin binary #
 BITCOIN_TESTS =\
+  test/addrindex_tests.cpp \
   test/arith_uint256_tests.cpp \
   test/scriptnum10.h \
   test/addrman_tests.cpp \

--- a/src/index/addrindex.cpp
+++ b/src/index/addrindex.cpp
@@ -1,0 +1,279 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <dbwrapper.h>
+#include <hash.h>
+#include <index/addrindex.h>
+#include <index/disktxpos.h>
+#include <shutdown.h>
+#include <primitives/transaction.h>
+#include <random.h>
+#include <script/standard.h>
+#include <txdb.h>
+#include <validation.h>
+#include <vector>
+#include <uint256.h>
+
+std::unique_ptr<AddrIndex> g_addr_index;
+
+/*
+ * The address index stores two main types of objects that allow for
+ * script-based/address-based look-ups of all created outputs and all spent
+ * outputs in the Bitcoin blockchain. These are differentiated by their key_type
+ * as either DBKeyType::SPENT or DBKekyType::CREATED. The address index also
+ * stores one unique global value under the DBKeyType::SEED key that seeds the
+ * MurmurHash3 hasher used to create AddrIds.
+ *
+ * The DB keys are structured as follows: <addr_id, key_type, outpoint>
+ *
+ * addr_id is the hash of the script_pub_key computed using MurmurHash3, a short
+ * non-cryptographic hash function. It also functions as the search key, since
+ * LevelDB keys are iterated through in lexicograpical order. Collisions are
+ * resolved by storing the full script_pub_key in the DB value. This can be
+ * checked against the script used to make a look-up in the index.
+ *
+ * key_type is SPENT when the outpoint stored in the key is spent, i.e. it is
+ * used as a prevout in a transaction input.  It is CREATED when the outpoint is
+ * created as a new  COutpoint in that transaction.
+ *
+ * outpoints are stored in the key as opposed to in the DB value to preserve
+ * uniqueness and to support multiple values for a single addr_id and key_type
+ * combination. LevelDB only allows one value stored for each key.
+ *
+ *
+ * The DB values are simply: <CDiskTxPos, CScript>
+ *
+ * The tx_pos (CDiskTxPos) value is the transaction in which:
+ *  - the outpoint in the key was spent (for SPENT keys)
+ *  - OR where the outpoint was created (for CREATED keys)
+ *
+ * The CScript (the script_pub_key) is used for collision resolution.
+ */
+using AddrId = unsigned int;
+// DBKeyType is used by the address index to distinguish between the
+// different kinds of values stored.
+enum class DBKeyType : uint8_t {
+    SEED,    // Seed used for MurmurHash3 inside GetAddrId
+    SPENT,   // Used for values in the index indicating a spend
+    CREATED, // Used for values in the index indicating the creation of an input
+};
+
+
+namespace {
+
+struct DBKey {
+  AddrId m_addr_id;
+  DBKeyType m_key_type;
+  COutPoint m_outpoint;
+
+  DBKey() {}
+  explicit DBKey(DBKeyType key_type, AddrId addr_id, COutPoint outpoint) : m_addr_id(addr_id), m_key_type(key_type), m_outpoint(outpoint) {}
+
+  SERIALIZE_METHODS(DBKey, obj) {
+    uint8_t key_type;
+    SER_WRITE(obj, key_type = static_cast<uint8_t>(obj.m_key_type));
+
+    READWRITE(obj.m_addr_id, key_type, obj.m_outpoint);
+
+    SER_READ(obj, obj.m_key_type  = static_cast<DBKeyType>(key_type));
+    // Check if the key type is a valid key. SEED keys are excluded because they
+    // are never created with this type.
+    if ((obj.m_key_type != DBKeyType::SPENT) && (obj.m_key_type != DBKeyType::CREATED)) {
+      throw std::ios_base::failure("Invalid key type for address index DB key");
+    }
+  }
+};
+
+}; // namespace
+
+// The address index stores information needed to get relevant transactions,
+// and a copy of the CScript to double check against in case of hash collisions.
+using DBValue = std::pair<CDiskTxPos, CScript>;
+
+/** Access to the addr_index database (indexes/addr_index/)*/
+class AddrIndex::DB : public BaseIndex::DB
+{
+public:
+    explicit DB(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+
+    /** ReadAddrIndex returns the set of entries stored in the index for this addr_id. */
+    std::vector<std::pair<DBKey, DBValue>> ReadAddrIndex(const int max_count, const int skip, const unsigned int addr_id, const CScript& script);
+
+    /** WriteToIndex writes the input vector of database entries into the index.  */
+    bool WriteToIndex(const std::vector<std::pair<DBKey, DBValue>> &entries);
+
+    /** SetupHashSeed is used to create/backup/restore the seed used by the index for hashing. */
+    unsigned int SetupHashSeed();
+};
+
+AddrIndex::DB::DB(size_t n_cache_size, bool f_memory, bool f_wipe) :
+    BaseIndex::DB(GetDataDir() / "indexes" / "addr_index", n_cache_size, f_memory, f_wipe)
+{}
+
+BaseIndex::DB& AddrIndex::GetDB() const { return *m_db; }
+
+std::vector<std::pair<DBKey, DBValue>> AddrIndex::DB::ReadAddrIndex(const int max_count, const int skip, const unsigned int addr_id, const CScript& script)
+{
+    std::vector<std::pair<DBKey, DBValue>> result;
+    AddrId search_key = addr_id;
+
+    std::unique_ptr<CDBIterator> iter(NewIterator());
+    iter->Seek(search_key);
+    int i = 0;
+    while (iter->Valid() && i < max_count) {
+        DBKey key;
+        DBValue value;
+        if (!iter->GetKey(key) || key.m_addr_id != addr_id) break;
+        if (!iter->GetValue(value)) {
+            LogPrintf("%s: Failed to read value stored under key with addr_id:  %d\n", __func__, addr_id);
+            break;
+        }
+
+        // Check that the stored script matches the one we're searching for, in case of hash collisions.
+        if (value.second == script && i >= skip) {
+            result.emplace_back(std::make_pair(key, value));
+        }
+        iter->Next();
+        i++;
+    }
+
+    return result;
+}
+
+bool AddrIndex::Init() {
+        m_hash_seed = m_db->SetupHashSeed();
+        return BaseIndex::Init();
+}
+
+AddrIndex::AddrIndex(size_t n_cache_size, bool f_memory, bool f_wipe)
+    : m_db(MakeUnique<AddrIndex::DB>(n_cache_size, f_memory, f_wipe)) {}
+
+unsigned int AddrIndex::DB::SetupHashSeed() {
+    static const uint8_t seed_key =  static_cast<uint8_t>(DBKeyType::SEED);
+    unsigned int seed;
+
+    std::unique_ptr<CDBIterator> iter(NewIterator());
+    uint8_t key;
+
+    // If key is in the index already, read it and return.
+    iter->Seek(seed_key);
+    if (iter->Valid() && iter->GetKey(key) && key == seed_key) {
+        if (!iter->GetValue(seed)) {
+            return error("%s: Cannot read current %s seed key; index may be corrupted", __func__);
+        }
+        return seed;
+    }
+
+    // Generate a random key and write it to the index.
+    seed = GetRandInt(std::numeric_limits<int>::max());
+    Write(seed_key, seed);
+    return seed;
+}
+
+AddrIndex::~AddrIndex() {}
+
+unsigned int AddrIndex::GetAddrId(const CScript& script) {
+    std::vector<unsigned char> script_data;
+    for (auto it = script.begin(); it != script.end(); ++it) {
+        script_data.push_back(*it);
+    }
+    return MurmurHash3(m_hash_seed, script_data);
+}
+
+bool AddrIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+{
+    CBlockUndo block_undo;
+    CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
+    std::vector<std::pair<DBKey, DBValue>> entries;
+
+    const bool genesis_block = (pindex->nHeight == 0);
+    if (!genesis_block && !UndoReadFromDisk(block_undo, pindex)) {
+      return false;
+    }
+
+    for (size_t i = 0; i < block.vtx.size(); ++i) {
+        const CTransaction& tx = *(block.vtx[i]);
+        const uint256 tx_hash = tx.GetHash();
+        for (size_t j = 0; j < tx.vout.size(); ++j) {
+            CScript script_pub_key = tx.vout[j].scriptPubKey;
+            DBKey key(DBKeyType::CREATED, GetAddrId(script_pub_key), COutPoint(tx_hash, j));
+            entries.emplace_back(key, std::make_pair(pos, script_pub_key));
+        }
+
+        // Skip coinbase inputs.
+        if (!genesis_block && i > 0) {
+            const CTxUndo& tx_undo = block_undo.vtxundo[i-1];
+            for (size_t k = 0; k < tx.vin.size(); ++k) {
+                CScript spent_outputs_scriptpubkey = tx_undo.vprevout[k].out.scriptPubKey;
+                DBKey key(DBKeyType::SPENT, GetAddrId(spent_outputs_scriptpubkey), tx.vin[k].prevout);
+                entries.emplace_back(key, std::make_pair(pos, spent_outputs_scriptpubkey));
+            }
+        }
+        pos.nTxOffset += ::GetSerializeSize(tx, CLIENT_VERSION);
+    }
+
+    return m_db->WriteToIndex(entries);
+}
+
+bool AddrIndex::DB::WriteToIndex(const std::vector<std::pair<DBKey, DBValue>> &entries)
+{
+    CDBBatch batch(*this);
+    for (const auto& entry : entries) {
+        batch.Write(entry.first, entry.second);
+    }
+    return WriteBatch(batch);
+}
+
+// FindTxsByScript fills the spends_result vector with outpoints corresponding
+// to the output spent with the given script, and the transaction it was spent
+// in. creations_result is filled with outpoints for outputs created with this
+// script as their script pubkey, and the transactions they were created in.
+// max_count determines the maximum number of results returned. The skip
+// parameter sets the number of initial values skipped.
+bool AddrIndex::FindTxsByScript(const int max_count,
+                                const int skip,
+                                const CScript& script,
+                                std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> &spends_result,
+                                std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> &creations_result)
+{
+    auto db_entries = m_db->ReadAddrIndex(max_count, skip, GetAddrId(script), script);
+    if (db_entries.size() == 0) return false;
+
+    for (const auto& entry : db_entries) {
+        DBKey key = entry.first;
+        CDiskTxPos pos = entry.second.first;
+
+        CAutoFile file(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
+        if (file.IsNull()) {
+            return error("%s: OpenBlockFile failed", __func__);
+        }
+        CBlockHeader header;
+        CTransactionRef tx;
+        try {
+            file >> header;
+            if (fseek(file.Get(), pos.nTxOffset, SEEK_CUR)) {
+                return error("%s: fseek(...) failed", __func__);
+            }
+            file >> tx;
+        } catch (const std::exception& e) {
+            return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+        }
+        std::pair<CTransactionRef, uint256> result =  std::make_pair(tx, header.GetHash());
+
+        // Place entry into correct vector depending on its type.
+        switch (key.m_key_type) {
+            case DBKeyType::SPENT:
+                spends_result.emplace_back(std::make_pair(key.m_outpoint, result));
+                break;
+            case DBKeyType::CREATED:
+                creations_result.emplace_back(std::make_pair(key.m_outpoint, result));
+                break;
+            default:
+                LogPrintf("AddrIndex::DB returned value with unexpected key type.\n");
+                return false;
+        }
+    }
+
+    return true;
+}

--- a/src/index/addrindex.h
+++ b/src/index/addrindex.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_ADDRINDEX_H
+#define BITCOIN_INDEX_ADDRINDEX_H
+
+#include <chain.h>
+#include <index/base.h>
+#include <vector>
+#include <txdb.h>
+#include <uint256.h>
+#include <primitives/transaction.h>
+#include <script/standard.h>
+#include <script/script.h>
+#include <undo.h>
+
+/**
+ * AddrIndex is used to look up transactions included in the blockchain by script.
+ * The index is written to a LevelDB database and records the filesystem
+ * location of transactions by script.
+ */
+class AddrIndex final : public BaseIndex
+{
+protected:
+    class DB;
+
+private:
+    const std::unique_ptr<DB> m_db;
+
+    // m_hash_seed is used by GetAddrID in its calls to MurmurHash3.
+    // It is stored in the index, and restored from there on construction
+    // to maintain consistency.
+    unsigned int m_hash_seed;
+
+    unsigned int GetAddrId(const CScript& script);
+
+protected:
+    bool Init() override;
+
+    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+
+    BaseIndex::DB& GetDB() const override;
+
+    const char* GetName() const override { return "addr_index"; }
+
+public:
+    /// Constructs the index, which becomes available to be queried.
+    explicit AddrIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+
+    // Destructor is declared because this class contains a unique_ptr to an incomplete type.
+    ~AddrIndex() override;
+
+    bool FindTxsByScript(const int max_count,
+                         const int skip,
+                         const CScript& dest,
+                         std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> &spends_result,
+                         std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> &creations_result);
+};
+
+/// The global address index, used in FindTxsByScript. May be null.
+extern std::unique_ptr<AddrIndex> g_addr_index;
+
+#endif // BITCOIN_INDEX_ADDRINDEX_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -21,6 +21,7 @@
 #include <hash.h>
 #include <httprpc.h>
 #include <httpserver.h>
+#include <index/addrindex.h>
 #include <index/blockfilterindex.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
@@ -171,6 +172,9 @@ void Interrupt(NodeContext& node)
     if (g_txindex) {
         g_txindex->Interrupt();
     }
+    if (g_addr_index) {
+        g_addr_index->Interrupt();
+    }
     ForEachBlockFilterIndex([](BlockFilterIndex& index) { index.Interrupt(); });
 }
 
@@ -266,6 +270,12 @@ void Shutdown(NodeContext& node)
         g_txindex->Stop();
         g_txindex.reset();
     }
+    if (g_addr_index) {
+        g_addr_index->Stop();
+        g_addr_index.reset();
+    }
+
+
     ForEachBlockFilterIndex([](BlockFilterIndex& index) { index.Stop(); });
     DestroyAllBlockFilterIndexes();
 
@@ -433,6 +443,7 @@ void SetupServerArgs(NodeContext& node)
     hidden_args.emplace_back("-sysperms");
 #endif
     argsman.AddArg("-txindex", strprintf("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)", DEFAULT_TXINDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    argsman.AddArg("-addrindex", strprintf("Maintain a full address index, used by the searchrawtransactions rpc call (default: %u)", DEFAULT_ADDR_INDEX), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     argsman.AddArg("-blockfilterindex=<type>",
                  strprintf("Maintain an index of compact filters by block (default: %s, values: %s).", DEFAULT_BLOCKFILTERINDEX, ListBlockFilterTypes()) +
                  " If <type> is not supplied or if <type> = 1, indexes for all known types are enabled.",
@@ -1017,6 +1028,8 @@ bool AppInitParameterInteraction(const ArgsManager& args)
     if (args.GetArg("-prune", 0)) {
         if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX))
             return InitError(_("Prune mode is incompatible with -txindex."));
+        if (gArgs.GetBoolArg("-addrindex", DEFAULT_ADDR_INDEX))
+            return InitError(_("Prune mode is incompatible with -addrindex."));
         if (!g_enabled_filter_types.empty()) {
             return InitError(_("Prune mode is incompatible with -blockfilterindex."));
         }
@@ -1548,6 +1561,8 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
         filter_index_cache = max_cache / n_indexes;
         nTotalCache -= filter_index_cache * n_indexes;
     }
+    int64_t addr_index_cache = std::min(nTotalCache / 8, gArgs.GetBoolArg("-addrindex", DEFAULT_TXINDEX) ? max_addr_index_cache << 20 : 0);
+    nTotalCache -= addr_index_cache;
     int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23)); // use 25%-50% of the remainder for disk cache
     nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
     nTotalCache -= nCoinDBCache;
@@ -1564,6 +1579,25 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     }
     LogPrintf("* Using %.1f MiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
     LogPrintf("* Using %.1f MiB for in-memory UTXO set (plus up to %.1f MiB of unused mempool space)\n", nCoinCacheUsage * (1.0 / 1024 / 1024), nMempoolSizeMax * (1.0 / 1024 / 1024));
+
+    if (gArgs.GetBoolArg("-addrindex", DEFAULT_ADDR_INDEX)) {
+        LogPrintf("* Using %.1f MiB for address index database\n", addr_index_cache * (1.0 / 1024 / 1024));
+
+        LogPrintf("Built-in address index is enabled! Address " /* Continued */
+          "indexing is going to become less scalable as transaction history "
+          "increases, and will eventually need to be removed from %s and "
+          "replaced by a dedicated external index. Users relying on the address"
+          " index for accounting purposes are advised to track metadata in real"
+          " time so relying on a historical index is not necessary.\n",
+          PACKAGE_NAME);
+
+        if (g_wallet_init_interface.HasWalletSupport()) {
+          LogPrintf("If using the address index to work around lack" /* Continued */
+           " of tagging or notifications from the built-in %s wallet, "
+           " please file wallet feature requests: %s\n",
+           PACKAGE_NAME, PACKAGE_BUGREPORT);
+        }
+    }
 
     bool fLoaded = false;
     while (!fLoaded && !ShutdownRequested()) {
@@ -1799,6 +1833,11 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
     if (args.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
         g_txindex = MakeUnique<TxIndex>(nTxIndexCache, false, fReindex);
         g_txindex->Start();
+    }
+
+    if (gArgs.GetBoolArg("-addrindex", DEFAULT_ADDR_INDEX)) {
+        g_addr_index = MakeUnique<AddrIndex>(addr_index_cache, false, fReindex);
+        g_addr_index->Start();
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -150,6 +150,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },
     { "prioritisetransaction", 2, "fee_delta" },
+    { "searchrawtransactions", 1, "verbose" },
+    { "searchrawtransactions", 2, "count" },
     { "setban", 2, "bantime" },
     { "setban", 3, "absolute" },
     { "setnetworkactive", 0, "state" },

--- a/src/test/addrindex_tests.cpp
+++ b/src/test/addrindex_tests.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+#include <chainparams.h>
+#include <index/addrindex.h>
+#include <index/txindex.h>
+#include <script/standard.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(addr_index_tests)
+
+BOOST_FIXTURE_TEST_CASE(addr_index_initial_sync_and_spends, TestChain100Setup)
+{
+    AddrIndex addr_index(1 << 20, true);
+    CScript coinbase_script_pub_key = CScript() <<  ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    const int max_count = 500; // Use a max count of 500, which is much higher than the number of results in the test.
+    const int skip = 0;
+
+    // Transactions should not be found in the index before it is started.
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends;
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations;
+    BOOST_CHECK(!addr_index.FindTxsByScript(max_count, skip, coinbase_script_pub_key, spends, creations));
+
+    // BlockUntilSyncedToCurrentChain should return false before addr_index is started.
+    BOOST_CHECK(!addr_index.BlockUntilSyncedToCurrentChain());
+    addr_index.Start();
+
+    // Mine blocks for coinbase maturity, so we can spend some coinbase outputs in the test.
+    for (int i = 0; i < 20; i++) {
+        std::vector<CMutableTransaction> no_txns;
+        CreateAndProcessBlock(no_txns, coinbase_script_pub_key);
+    }
+
+    // Allow addr_index to catch up with the block index.
+    constexpr int64_t timeout_ms = 10 * 1000;
+    int64_t time_start = GetTimeMillis();
+    while (!addr_index.BlockUntilSyncedToCurrentChain()) {
+        BOOST_REQUIRE(time_start + timeout_ms > GetTimeMillis());
+        UninterruptibleSleep(std::chrono::milliseconds{100});
+    }
+
+    // Check that addr_index has all coinbase outputs indexed.
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends2;
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations2;
+    if (!addr_index.FindTxsByScript(max_count, skip, coinbase_script_pub_key, spends2, creations2)) {
+            BOOST_ERROR("FindTxsByScript failed");
+    }
+    // The coinbase transactions have the same scriptPubKey in their output.
+    BOOST_CHECK_EQUAL(spends2.size(), 0u);
+    BOOST_CHECK_EQUAL(creations2.size(), 120u);
+
+    // Create several new key pairs to test sending to many different addresses in the same block.
+    std::vector<CKey> priv_keys(10);
+    std::vector<CScript> script_pub_keys(10);
+    for (int i = 0; i < 10; i++) {
+        priv_keys[i].MakeNewKey(true);
+        script_pub_keys[i] = CScript() <<  ToByteVector(priv_keys[i].GetPubKey()) << OP_CHECKSIG;
+    }
+
+    // Create a transaction sending to each of the new addresses.
+    std::vector<CMutableTransaction> spend_txns(10);
+    CreateSpendingTxs(0, script_pub_keys, spend_txns, coinbase_script_pub_key);
+
+    const CBlock& block = CreateAndProcessBlock(spend_txns, coinbase_script_pub_key);
+    const uint256 block_hash = block.GetHash();
+    BOOST_CHECK(addr_index.BlockUntilSyncedToCurrentChain()); // Let the address index catch up.
+    BOOST_CHECK(::ChainActive().Tip()->GetBlockHash() == block_hash); // Sanity check to make sure this block is actually being used.
+
+    // Now check that all the addresses we sent to are present in the index.
+    for (int i = 0; i < 10; i++) {
+        std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends3;
+        std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations3;
+        if (!addr_index.FindTxsByScript(max_count, skip, script_pub_keys[i], spends3, creations3)) {
+            BOOST_ERROR("FindTxsByScript failed");
+        }
+
+        // The coinbase transactions have the same scriptPubKey in their output.
+        BOOST_CHECK_EQUAL(spends3.size(), 0u);
+        BOOST_CHECK_EQUAL(creations3.size(), 1u);
+
+        // Confirm that the transaction's destination is in the index.
+        bool found_tx = false;
+        for (const auto& creation : creations3) {
+            if (creation.second.first->GetHash() == spend_txns[i].GetHash()) {
+                found_tx = true;
+                break;
+            }
+        }
+
+        if (!found_tx) BOOST_ERROR("Transaction not found by destination");
+    }
+
+    // Now we'll create transaction that only send to the first 5 addresses we made.
+    // Then we can check that the number of txs for those addresses increases, while
+    // the number of txs for the other address remains the same.
+    std::vector<CMutableTransaction> spend_txns2(5);
+    CreateSpendingTxs(10, script_pub_keys, spend_txns2, coinbase_script_pub_key);
+
+    const CBlock& block2 = CreateAndProcessBlock(spend_txns2, coinbase_script_pub_key);
+    const uint256 block_hash2 = block2.GetHash();
+    BOOST_CHECK(addr_index.BlockUntilSyncedToCurrentChain());
+    BOOST_CHECK(::ChainActive().Tip()->GetBlockHash() == block_hash2);
+
+    for (int i = 0; i < 10; i++) {
+        std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends4;
+        std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations4;
+
+        if (!addr_index.FindTxsByScript(max_count, skip, script_pub_keys[i], spends4, creations4)) {
+            BOOST_ERROR("FindTxsByScript failed");
+        }
+
+        // The coinbase transactions have the same scriptPubKey in their output.
+        BOOST_CHECK_EQUAL(spends4.size(), 0u);
+
+        // Expect 2 transactions for those sent to twice, 1 for the rest.
+        if (i >= 5) {
+            BOOST_CHECK_EQUAL(creations4.size(), 1u);
+        } else {
+            BOOST_CHECK_EQUAL(creations4.size(), 2u);
+        }
+
+        // Confirm that the transaction's destination is in the index.
+        bool found_tx = false;
+        for (const auto& creation :creations4) {
+            if (i >= 5) {
+                if (creation.second.first->GetHash() == spend_txns[i].GetHash()) {
+                    found_tx = true;
+                    break;
+                }
+            } else {
+                if (creation.second.first->GetHash() == spend_txns2[i].GetHash()) {
+                    found_tx = true;
+                    break;
+                }
+            }
+        }
+        if (!found_tx) BOOST_ERROR("Transaction not found by destination");
+    }
+
+    // Check the results for the coinbase_script_pub_key again.
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends5;
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations5;
+    if (!addr_index.FindTxsByScript(max_count, skip, coinbase_script_pub_key, spends5, creations5)) {
+        BOOST_ERROR("FindTxsByScript failed");
+    }
+    BOOST_CHECK_EQUAL(spends5.size(), 10u + 5u);
+    BOOST_CHECK_EQUAL(creations5.size(), 100u + 20u + 2u);
+
+    // Check that max_count is respected by setting a low max_count of 22.
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends6;
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations6;
+    if (!addr_index.FindTxsByScript(22, skip, coinbase_script_pub_key, spends6, creations6)) {
+            BOOST_ERROR("FindTxsByScript failed");
+    }
+    BOOST_CHECK_EQUAL(spends6.size()+creations6.size(), 22u);
+
+    // Check that the skip parameter is respected by setting a skip of 40.
+    const unsigned int skip_test_val = 40;
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> spends7;
+    std::vector<std::pair<COutPoint, std::pair<CTransactionRef, uint256>>> creations7;
+    if (!addr_index.FindTxsByScript(max_count, skip_test_val, coinbase_script_pub_key, spends7, creations7)) {
+            BOOST_ERROR("FindTxsByScript failed");
+    }
+    BOOST_CHECK_EQUAL(spends7.size()+creations7.size(), spends5.size()+creations5.size()-skip_test_val);
+
+    addr_index.Stop();
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -227,6 +227,26 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     return block;
 }
 
+void TestChain100Setup::CreateSpendingTxs(int coinbase_spent_offset, std::vector<CScript>& script_pub_keys, std::vector<CMutableTransaction> &spends, const CScript& coinbase_script_pub_key) {
+    for (unsigned int i = 0; i < spends.size(); i++) {
+        spends[i].nVersion = 1;
+        spends[i].vin.resize(1);
+        spends[i].vin[0].prevout.hash = m_coinbase_txns[i + coinbase_spent_offset]->GetHash();
+        spends[i].vin[0].prevout.n = 0;
+        spends[i].vout.resize(1);
+        spends[i].vout[0].nValue = 11*CENT;
+        spends[i].vout[0].scriptPubKey = script_pub_keys[i];
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        const uint256 hash = SignatureHash(coinbase_script_pub_key, spends[i], 0, SIGHASH_ALL, 0, SigVersion::BASE);
+        coinbaseKey.Sign(hash, vchSig);
+        vchSig.push_back((unsigned char)SIGHASH_ALL);
+        spends[i].vin[0].scriptSig << vchSig;
+    }
+}
+
+
 TestChain100Setup::~TestChain100Setup()
 {
     gArgs.ForceSetArg("-segwitheight", "0");

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -115,6 +115,10 @@ struct TestChain100Setup : public RegTestingSetup {
     CBlock CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns,
                                  const CScript& scriptPubKey);
 
+    // Fill spends with spending transaction using coinbase_spent_offset to
+    // choose which m_coinbase_txns to spend from.
+    void CreateSpendingTxs(int coinbase_spent_offset, std::vector<CScript>& script_pub_keys, std::vector<CMutableTransaction> &spends, const CScript& coinbase_script_pub_key);
+
     ~TestChain100Setup();
 
     std::vector<CTransactionRef> m_coinbase_txns; // For convenience, coinbase transactions

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -36,6 +36,8 @@ static const int64_t nMaxBlockDBCache = 2;
 static const int64_t nMaxTxIndexCache = 1024;
 //! Max memory allocated to all block filter index caches combined in MiB.
 static const int64_t max_filter_index_cache = 1024;
+//! Max memory allocated to the address index cache.
+static const int64_t max_addr_index_cache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -74,6 +74,8 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
+static const bool DEFAULT_ADDR_INDEX = false;
+static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
 /** Default for using fee filter */


### PR DESCRIPTION
Adds index to transactions by scriptPubKey. Based off of #2802. Stores hashes of scripts (hashed using Murmurhash3, with a hash seed that is stored in the index database), along with the `COutPoint` for the output which was spent/created, and the `CDiskTxPos` for the transaction in which this happened.