### PR TITLE
p2p: Disable BIP 61 by default

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -59,6 +59,16 @@ support versions of macOS older than 10.10.
 Notable changes
 ===============
 
+Command line option changes
+---------------------------
+
+The `-enablebip61` command line option (introduced in Bitcoin Core 0.17.0) is
+used to toggle sending of BIP 61 reject messages. Reject messages have no use
+case on the P2P network and are only logged for debugging by most network
+nodes. The option will now by default be off for improved privacy and security
+as well as reduced upload usage. The option can explicitly be turned on for
+local-network debugging purposes.
+
 Example item
 ------------
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -15,7 +15,7 @@ static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 /** Default for BIP61 (sending reject messages) */
-static constexpr bool DEFAULT_ENABLE_BIP61 = true;
+static constexpr bool DEFAULT_ENABLE_BIP61{false};
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:


### PR DESCRIPTION
The live p2p network should not be used for debugging or as development aid when implementing the p2p protocol. Instead, applications should be tested locally (e.g. by inspecting the debug log of a validating node on the local network)

Using the p2p network for this purpose seems wasteful and even dangerous, as peers can not be trusted to send the correct reject messages or a reject message at all.