### PR TITLE
[Logging] Only log "Using config file PATH_TO_bitcoin.conf" message on startup if conf file exists

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1243,7 +1243,19 @@ bool AppInitMain()
         LogPrintf("Startup time: %s\n", FormatISO8601DateTime(GetTime()));
     LogPrintf("Default data directory %s\n", GetDefaultDataDir().string());
     LogPrintf("Using data directory %s\n", GetDataDir().string());
-    LogPrintf("Using config file %s\n", GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
+
+    // Only log conf file usage message if conf file actually exists.
+    fs::path config_file_path = GetConfigFile(gArgs.GetArg("-conf", BITCOIN_CONF_FILENAME));
+    if (fs::exists(config_file_path)) {
+        LogPrintf("Config file: %s\n", config_file_path.string());
+    } else if (gArgs.IsArgSet("-conf")) {
+        // Warn if no conf file exists at path provided by user
+        InitWarning(strprintf(_("The specified config file %s does not exist\n"), config_file_path.string()));
+    } else {
+        // Not categorizing as "Warning" because it's the default behavior
+        LogPrintf("Config file: %s (not found, skipping)\n", config_file_path.string());
+    }
+
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);
 
     // Warn about relative -datadir path.


### PR DESCRIPTION
Currently we log a message indicating that a bitcoin.conf file is being used even if one does not exist. This PR changes the logic to:

**If config file does not exist and no -conf flag passed, log:**
`Config file: FILE_PATH (not found, skipping)`. Where `FILE_PATH` is the default or the path passed in with the `-conf` flag.

**If config file does not exist and -conf flag passed with incorrect path, log warning:**
`Warning: The specified config file FILE_PATH does not exist`

**If config file exists, log**:
`Config file: FILE_PATH` 

Note: This is a (modified) subset of changes introduced in https://github.com/bitcoin/bitcoin/pull/13761 which creates a default example config file. I think it makes sense to extract this small bit out into a separate PR.

