### PR TITLE
qa: Use assert not BOOST_CHECK_* from multithreaded tests

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -138,11 +138,11 @@ BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)
     // the callbacks should run in exactly the order in which they were enqueued
     for (int i = 0; i < 100; ++i) {
         queue1.AddToProcessQueue([i, &counter1]() {
-            BOOST_CHECK_EQUAL(i, counter1++);
+            assert(i == counter1++);
         });
 
         queue2.AddToProcessQueue([i, &counter2]() {
-            BOOST_CHECK_EQUAL(i, counter2++);
+            assert(i == counter2++);
         });
     }
 


### PR DESCRIPTION
Resolves thread sanitizer failure @MarcoFalke found in #14058 