### PR TITLE
[primitives, consensus] Make fChecked an atomic<bool>

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_PRIMITIVES_BLOCK_H
 #define BITCOIN_PRIMITIVES_BLOCK_H
 
+#include <atomic>
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -76,7 +77,7 @@ public:
     std::vector<CTransactionRef> vtx;
 
     // memory only
-    mutable bool fChecked;
+    mutable std::atomic<bool> fChecked;
 
     CBlock()
     {
@@ -87,6 +88,23 @@ public:
     {
         SetNull();
         *(static_cast<CBlockHeader*>(this)) = header;
+    }
+
+    CBlock(const CBlock &block)
+        :CBlock(static_cast<CBlockHeader>(block))
+    {
+        vtx = block.vtx;
+        fChecked = false;
+    }
+
+    CBlock& operator=(const CBlock& block)
+    {
+        fChecked = false;
+
+        *(static_cast<CBlockHeader*>(this)) = block;
+        vtx = block.vtx;
+
+        return *this;
     }
 
     ADD_SERIALIZE_METHODS;


### PR DESCRIPTION
This addresses a data race / thread sanitizer issue uncovered in #14058 

If there are alternate suggestions about how to effectuate this change in a more compact way without having to manually declare the copy constructor and copy assignment operator (because it is deleted for `std::atomic<bool>` that feedback would be welcome). 

CheckBlock can be invoked from multiple threads in parallel. To avoid
a data race, fChecked should be atomic. In practice, this would have
had limited effect currently since these paths are effectively
single-threaded in practice, except to maybe occasionally cause a
slight bit of redundant work to be performed in CheckBlock.