### PR TITLE
Implement sighash cache in CHECKMULTISIG

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -144,7 +144,7 @@ uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn
 class BaseSignatureChecker
 {
 public:
-    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256* sighash_copy, int* sighash_copy_type) const
     {
         return false;
     }
@@ -177,7 +177,7 @@ protected:
 public:
     GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(nullptr) {}
     GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256* sighash_copy, int* sighash_copy_type) const override;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
     bool CheckSequence(const CScriptNum& nSequence) const override;
 };

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -282,12 +282,12 @@ private:
 
 public:
     SignatureExtractorChecker(SignatureData& sigdata, BaseSignatureChecker& checker) : sigdata(sigdata), checker(checker) {}
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256* sighash_copy, int* sighash_copy_type) const override;
 };
 
-bool SignatureExtractorChecker::CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+bool SignatureExtractorChecker::CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256* sighash_copy, int* sighash_copy_type) const
 {
-    if (checker.CheckSig(scriptSig, vchPubKey, scriptCode, sigversion)) {
+    if (checker.CheckSig(scriptSig, vchPubKey, scriptCode, sigversion, nullptr, nullptr)) {
         CPubKey pubkey(vchPubKey);
         sigdata.signatures.emplace(pubkey.GetID(), SigPair(pubkey, scriptSig));
         return true;
@@ -365,7 +365,7 @@ SignatureData DataFromTransaction(const CMutableTransaction& tx, unsigned int nI
             for (unsigned int i = last_success_key; i < num_pubkeys; ++i) {
                 const valtype& pubkey = solutions[i+1];
                 // We either have a signature for this pubkey, or we have found a signature and it is valid
-                if (data.signatures.count(CPubKey(pubkey).GetID()) || extractor_checker.CheckSig(sig, pubkey, next_script, sigversion)) {
+                if (data.signatures.count(CPubKey(pubkey).GetID()) || extractor_checker.CheckSig(sig, pubkey, next_script, sigversion, nullptr, nullptr)) {
                     last_success_key = i + 1;
                     break;
                 }
@@ -426,7 +426,7 @@ class DummySignatureChecker final : public BaseSignatureChecker
 {
 public:
     DummySignatureChecker() {}
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override { return true; }
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, uint256* sighash_copy, int* sighash_copy_type) const override { return true; }
 };
 const DummySignatureChecker DUMMY_CHECKER;
 


### PR DESCRIPTION
Currently `CHECKMULTISIG` recalculates the sighash every time it verifies a key-signature pair. It is not necessary because sighash for the same `nHashType` is always the same _inside_ a `CHECKMULTISIG`. Therefore, we could reuse a sighash as long as the `nHashType` is not changed.

Note that in `CHECKMULTISIG`, the trimming of `scriptCode` (with `CODESEPARATOR` and `FindAndDelete()`) is done before the signature checking loop. So the `scriptCode` is always a constant in the same `CHECKMULTISIG` operation. However, this is not guaranteed across different `CHECKSIG` or `CHECKMULTISIG` so a cross-opcode sighash cache could not be done in the same way.