### PR TITLE
index: Fix for indexers skipping genesis block.

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -60,7 +60,11 @@ bool BaseIndex::Init()
     }
 
     LOCK(cs_main);
-    m_best_block_index = FindForkInGlobalIndex(chainActive, locator);
+    if (locator.IsNull()) {
+        m_best_block_index = nullptr;
+    } else {
+        m_best_block_index = FindForkInGlobalIndex(chainActive, locator);
+    }
     m_synced = m_best_block_index.load() == chainActive.Tip();
     return true;
 }

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -245,6 +245,9 @@ bool TxIndex::Init()
 
 bool TxIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
 {
+    // Exclude genesis block transaction because outputs are not spendable.
+    if (pindex->nHeight == 0) return true;
+
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     std::vector<std::pair<uint256, CDiskTxPos>> vPos;
     vPos.reserve(block.vtx.size());

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <chainparams.h>
 #include <index/txindex.h>
 #include <script/standard.h>
 #include <test/test_bitcoin.h>
@@ -36,6 +37,12 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     while (!txindex.BlockUntilSyncedToCurrentChain()) {
         BOOST_REQUIRE(time_start + timeout_ms > GetTimeMillis());
         MilliSleep(100);
+    }
+
+    // Check that txindex excludes genesis block transactions.
+    const CBlock& genesis_block = Params().GenesisBlock();
+    for (const auto& txn : genesis_block.vtx) {
+        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
     }
 
     // Check that txindex has all txs that were in the chain before it started.


### PR DESCRIPTION
This fixes a bug where indexers would skip processing of the genesis block. Preserves the current behavior of omitting genesis block transaction from the index.