### PR TITLE
tests: Don't assert(...) with side effects

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -138,11 +138,13 @@ BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)
     // the callbacks should run in exactly the order in which they were enqueued
     for (int i = 0; i < 100; ++i) {
         queue1.AddToProcessQueue([i, &counter1]() {
-            assert(i == counter1++);
+            bool expectation = i == counter1++;
+            assert(expectation);
         });
 
         queue2.AddToProcessQueue([i, &counter2]() {
-            assert(i == counter2++);
+            bool expectation = i == counter2++;
+            assert(expectation);
         });
     }
 

--- a/test/lint/lint-assertions.sh
+++ b/test/lint/lint-assertions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for assertions with obvious side effects.
+
+export LC_ALL=C
+
+EXIT_CODE=0
+
+# PRE31-C (SEI CERT C Coding Standard):
+# "Assertions should not contain assignments, increment, or decrement operators."
+OUTPUT=$(git grep -E '[^_]assert\(.*(\+\+|\-\-|[^=!<>]=[^=!<>]).*\);' -- "*.cpp" "*.h")
+if [[ ${OUTPUT} != "" ]]; then
+    echo "Assertions should not have side effects:"
+    echo
+    echo "${OUTPUT}"
+    EXIT_CODE=1
+fi
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
Don't `assert(...)` with side effects.

From the developer notes:

> **Assertions should not have side-effects**
> 
> Rationale: Even though the source code is set to refuse to compile with assertions disabled, having side-effects in assertions is unexpected and makes the code harder to understand

These assertions were introduced quite recently (in #14069 which was merged two days ago) and since this is a recurring thing (see #13534 – "Don't assert(foo()) where foo() has side effects" from May) I added a simple regression test for the most obvious common side effect.