### PR TITLE
validation: Log FormatStateMessage on ConnectBlock error in ConnectTip

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2448,7 +2448,7 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
-            return error("ConnectTip(): ConnectBlock %s failed", pindexNew->GetBlockHash().ToString());
+            return error("%s: ConnectBlock %s failed, %s", __func__, pindexNew->GetBlockHash().ToString(), FormatStateMessage(state));
         }
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint(BCLog::BENCH, "  - Connect total: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime3 - nTime2) * MILLI, nTimeConnectTotal * MICRO, nTimeConnectTotal * MILLI / nBlocksTotal);


### PR DESCRIPTION
This change additionally logs the validation state on error, which is not logged at all on current master.

Before:
```
ERROR: ConnectTip(): ConnectBlock ffffff.... failed
```

After:
```
ERROR: ConnectTip: ConnectBlock ffffff.... failed, bad-cb-amount (code 16)
```