### PR TITLE
tests: Add missing locking annotations and locks (g_cs_orphans)

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -70,7 +70,7 @@ struct COrphanTx {
     NodeId fromPeer;
     int64_t nTimeExpire;
 };
-static CCriticalSection g_cs_orphans;
+CCriticalSection g_cs_orphans;
 std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(g_cs_orphans);
 
 void EraseOrphansFor(NodeId peer);


### PR DESCRIPTION
Add missing locking annotations and locks.

`mapOrphanTransactions` is guarded by `g_cs_orphans`.
