### PR TITLE
index: Create IndexRunner class for activing indexes.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -132,7 +132,9 @@ BITCOIN_CORE_H = \
   httprpc.h \
   httpserver.h \
   index/base.h \
+  index/error.h \
   index/txindex.h \
+  index/runner.h \
   indirectmap.h \
   init.h \
   interfaces/chain.h \
@@ -250,6 +252,7 @@ libbitcoin_server_a_SOURCES = \
   httprpc.cpp \
   httpserver.cpp \
   index/base.cpp \
+  index/runner.cpp \
   index/txindex.cpp \
   interfaces/chain.cpp \
   interfaces/handler.cpp \

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -8,11 +8,11 @@
 #include <dbwrapper.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <threadinterrupt.h>
 #include <uint256.h>
 #include <validationinterface.h>
 
 class CBlockIndex;
+class CThreadInterrupt;
 
 /**
  * Base class for indices of blockchain data. This implements
@@ -21,6 +21,8 @@ class CBlockIndex;
  */
 class BaseIndex : public CValidationInterface
 {
+    friend class IndexRunner;
+
 protected:
     class DB : public CDBWrapper
     {
@@ -44,15 +46,12 @@ private:
     /// The last block in the chain that the index is in sync with.
     std::atomic<const CBlockIndex*> m_best_block_index{nullptr};
 
-    std::thread m_thread_sync;
-    CThreadInterrupt m_interrupt;
-
     /// Sync the index with the block index starting from the current best block.
     /// Intended to be run in its own thread, m_thread_sync, and can be
-    /// interrupted with m_interrupt. Once the index gets in sync, the m_synced
-    /// flag is set and the BlockConnected ValidationInterface callback takes
-    /// over and the sync thread exits.
-    void ThreadSync();
+    /// interrupted with the interrupt parameter. Once the index gets in sync,
+    /// the m_synced flag is set and the BlockConnected ValidationInterface
+    /// callback takes over and the sync thread exits.
+    void ThreadSync(CThreadInterrupt* interrupt);
 
     /// Write the current chain block locator to the DB.
     bool WriteBestBlock(const CBlockIndex* block_index);
@@ -75,8 +74,7 @@ protected:
     virtual const char* GetName() const = 0;
 
 public:
-    /// Destructor interrupts sync thread if running and blocks until it exits.
-    virtual ~BaseIndex();
+    virtual ~BaseIndex() = default;
 
     /// Blocks the current thread until the index is caught up to the current
     /// state of the block chain. This only blocks if the index has gotten in
@@ -84,15 +82,6 @@ public:
     /// queue. If the index is catching up from far behind, this method does
     /// not block and immediately returns false.
     bool BlockUntilSyncedToCurrentChain();
-
-    void Interrupt();
-
-    /// Start initializes the sync state and registers the instance as a
-    /// ValidationInterface so that it stays in sync with blockchain updates.
-    void Start();
-
-    /// Stops the instance from staying in sync with blockchain updates.
-    void Stop();
 };
 
 #endif // BITCOIN_INDEX_BASE_H

--- a/src/index/error.h
+++ b/src/index/error.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2017-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_ERROR_H
+#define BITCOIN_INDEX_ERROR_H
+
+#include <string>
+
+#include <logging.h>
+#include <shutdown.h>
+#include <tinyformat.h>
+#include <ui_interface.h>
+#include <warnings.h>
+
+template<typename... Args>
+static void FatalError(const char* fmt, const Args&... args)
+{
+    std::string strMessage = tfm::format(fmt, args...);
+    SetMiscWarning(strMessage);
+    LogPrintf("*** %s\n", strMessage);
+    uiInterface.ThreadSafeMessageBox(
+        "Error: A fatal internal error occurred, see debug.log for details",
+        "", CClientUIInterface::MSG_ERROR);
+    StartShutdown();
+}
+
+#endif // BITCOIN_INDEX_ERROR_H

--- a/src/index/runner.cpp
+++ b/src/index/runner.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <map>
+
+#include <index/base.h>
+#include <index/error.h>
+#include <index/runner.h>
+#include <validationinterface.h>
+
+static std::map<BaseIndex*, IndexRunner> g_running_indexes;
+
+IndexRunner::IndexRunner(BaseIndex* index) : m_index(index)
+{
+    // Need to register this ValidationInterface before running Init(), so that
+    // callbacks are not missed if Init sets m_synced to true.
+    RegisterValidationInterface(m_index);
+    if (!m_index->Init()) {
+        FatalError("%s: %s failed to initialize", __func__, m_index->GetName());
+        return;
+    }
+
+    m_thread_sync = std::thread(&TraceThread<std::function<void()>>, m_index->GetName(),
+                                std::bind(&BaseIndex::ThreadSync, m_index, &m_interrupt));
+}
+
+IndexRunner::~IndexRunner()
+{
+    UnregisterValidationInterface(m_index);
+
+    Interrupt();
+    if (m_thread_sync.joinable()) {
+        m_thread_sync.join();
+    }
+}
+
+void IndexRunner::Interrupt()
+{
+    m_interrupt();
+}
+
+bool StartIndex(BaseIndex* index)
+{
+    if (!index) return false;
+    auto result = g_running_indexes.emplace(std::piecewise_construct,
+                                            std::forward_as_tuple(index),
+                                            std::forward_as_tuple(index));
+    return result.second;
+}
+
+bool InterruptIndex(BaseIndex* index)
+{
+    if (!index) return false;
+
+    auto it = g_running_indexes.find(index);
+    if (it == g_running_indexes.end()) return false;
+
+    it->second.Interrupt();
+    return true;
+}
+
+bool StopIndex(BaseIndex* index)
+{
+    if (!index) return false;
+    return g_running_indexes.erase(index);
+}

--- a/src/index/runner.h
+++ b/src/index/runner.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_RUNNER_H
+#define BITCOIN_INDEX_RUNNER_H
+
+#include <thread>
+
+#include <threadinterrupt.h>
+
+class BaseIndex;
+
+/**
+ * RAII interface for activating indexes to stay in sync with blockchain updates.
+ */
+class IndexRunner
+{
+private:
+    BaseIndex* m_index;
+
+    std::thread m_thread_sync;
+    CThreadInterrupt m_interrupt;
+
+public:
+
+    /**
+     * Start initializes the sync state and registers the index as a ValidationInterface so that it
+     * stays in sync with blockchain updates.
+     */
+    explicit IndexRunner(BaseIndex* index);
+
+    /** Stops the instance from staying in sync with blockchain updates. */
+    ~IndexRunner();
+
+    /** Interrupts the sync thread if it is running. */
+    void Interrupt();
+};
+
+bool StartIndex(BaseIndex* index);
+bool InterruptIndex(BaseIndex* index);
+bool StopIndex(BaseIndex* index);
+
+#endif // BITCOIN_INDEX_RUNNER_H

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -4,6 +4,7 @@
 
 #include <index/txindex.h>
 #include <shutdown.h>
+#include <txdb.h>
 #include <ui_interface.h>
 #include <util/system.h>
 #include <validation.h>

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -7,7 +7,6 @@
 
 #include <chain.h>
 #include <index/base.h>
-#include <txdb.h>
 
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -22,6 +22,7 @@
 #include <httprpc.h>
 #include <interfaces/chain.h>
 #include <index/txindex.h>
+#include <index/runner.h>
 #include <key.h>
 #include <validation.h>
 #include <miner.h>
@@ -184,9 +185,7 @@ void Interrupt()
     InterruptMapPort();
     if (g_connman)
         g_connman->Interrupt();
-    if (g_txindex) {
-        g_txindex->Interrupt();
-    }
+    InterruptIndex(g_txindex.get());
 }
 
 void Shutdown(InitInterfaces& interfaces)
@@ -217,7 +216,7 @@ void Shutdown(InitInterfaces& interfaces)
     // using the other before destroying them.
     if (peerLogic) UnregisterValidationInterface(peerLogic.get());
     if (g_connman) g_connman->Stop();
-    if (g_txindex) g_txindex->Stop();
+    StopIndex(g_txindex.get());
 
     StopTorControl();
 
@@ -1641,7 +1640,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     // ********************************************************* Step 8: start indexers
     if (gArgs.GetBoolArg("-txindex", DEFAULT_TXINDEX)) {
         g_txindex = MakeUnique<TxIndex>(nTxIndexCache, false, fReindex);
-        g_txindex->Start();
+        StartIndex(g_txindex.get());
     }
 
     // ********************************************************* Step 9: load wallet

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <index/runner.h>
 #include <index/txindex.h>
 #include <script/standard.h>
 #include <test/test_bitcoin.h>
@@ -29,7 +30,7 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
     BOOST_CHECK(!txindex.BlockUntilSyncedToCurrentChain());
 
-    txindex.Start();
+    IndexRunner runner(&txindex);
 
     // Allow tx index to catch up with the block index.
     constexpr int64_t timeout_ms = 10 * 1000;
@@ -68,14 +69,6 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
             BOOST_ERROR("Read incorrect tx");
         }
     }
-
-    // shutdown sequence (c.f. Shutdown() in init.cpp)
-    txindex.Stop();
-
-    threadGroup.interrupt_all();
-    threadGroup.join_all();
-
-    // Rest of shutdown sequence and destructors happen in ~TestingSetup()
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/lint/lint-format-strings.py
+++ b/test/lint/lint-format-strings.py
@@ -14,7 +14,7 @@ import sys
 
 FALSE_POSITIVES = [
     ("src/dbwrapper.cpp", "vsnprintf(p, limit - p, format, backup_ap)"),
-    ("src/index/base.cpp", "FatalError(const char* fmt, const Args&... args)"),
+    ("src/index/error.h", "FatalError(const char* fmt, const Args&... args)"),
     ("src/netbase.cpp", "LogConnectFailure(bool manual_connection, const char* fmt, const Args&... args)"),
     ("src/util/system.cpp", "strprintf(_(COPYRIGHT_HOLDERS), _(COPYRIGHT_HOLDERS_SUBSTITUTION))"),
     ("src/util/system.cpp", "strprintf(COPYRIGHT_HOLDERS, COPYRIGHT_HOLDERS_SUBSTITUTION)"),


### PR DESCRIPTION
As noted by @ryanofsky and mitigated in #13894 and #14071, the index destructor previously had a memory violation by accessing its own address in call to UnregisterValidationInterface. This is problematic even if `Start` is never called on the index. The new runner class is an RAII-style interface for sync thread management and validation interface registration.

I'm not sure if this is a good idea or an unnecessary abstraction since the `init` module still has responsibility for starting/stopping via global pointers. I do think it's a better separation of concerns though. Looking for feedback before polishing up the PR.