### PR TITLE
Test rpc_help.py failed: Check whether ZMQ is enabled or not.

### DIFF
--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test RPC help output."""
 
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import BitcoinTestFramework, is_zmq_enabled
 from test_framework.util import assert_equal, assert_raises_rpc_error
 
 class HelpRpcTest(BitcoinTestFramework):
@@ -25,7 +25,13 @@ class HelpRpcTest(BitcoinTestFramework):
 
         # command titles
         titles = [line[3:-3] for line in node.help().splitlines() if line.startswith('==')]
-        assert_equal(titles, ['Blockchain', 'Control', 'Generating', 'Mining', 'Network', 'Rawtransactions', 'Util', 'Wallet', 'Zmq'])
+
+        components = ['Blockchain', 'Control', 'Generating', 'Mining', 'Network', 'Rawtransactions', 'Util', 'Wallet']
+
+        if is_zmq_enabled(self):
+            components.append('Zmq')
+
+        assert_equal(titles, components)
 
 if __name__ == '__main__':
     HelpRpcTest().main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -488,8 +488,13 @@ def skip_if_no_py3_zmq():
 
 def skip_if_no_bitcoind_zmq(test_instance):
     """Skip the running test if bitcoind has not been compiled with zmq support."""
+    if not is_zmq_enabled(test_instance):
+        raise SkipTest("bitcoind has not been built with zmq enabled.")
+
+
+def is_zmq_enabled(test_instance):
+    """Checks whether zmq is enabled or not."""
     config = configparser.ConfigParser()
     config.read_file(open(test_instance.options.configfile))
 
-    if not config["components"].getboolean("ENABLE_ZMQ"):
-        raise SkipTest("bitcoind has not been built with zmq enabled.")
+    return config["components"].getboolean("ENABLE_ZMQ")


### PR DESCRIPTION
/test/functional/rpc_help.py checks for the zmq-category even while zmq may be disabled (in /test/config.ini) , I have added a check function to test_framework.py that can be used whether to determine to include zmq in a test or not.