### PR TITLE
build: avoid getifaddrs when unavailable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -727,6 +727,10 @@ fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
 
+AC_CHECK_DECLS([getifaddrs, freeifaddrs],,,
+    [#include <sys/types.h>
+    #include <ifaddrs.h>]
+)
 AC_CHECK_DECLS([strnlen])
 
 # Check for daemon(3), unrelated to --with-daemon (although used by it)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2167,7 +2167,7 @@ void Discover()
             }
         }
     }
-#else
+#elif (HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS)
     // Get local host ip
     struct ifaddrs* myaddrs;
     if (getifaddrs(&myaddrs) == 0)


### PR DESCRIPTION
These changes from @theuni help building when targeting platforms that don't always have getifaddrs available like Android < 24