### PR TITLE
Trivial: update clang thread-safety docs url

### DIFF
--- a/src/threadsafety.h
+++ b/src/threadsafety.h
@@ -10,7 +10,7 @@
 // TL;DR Add GUARDED_BY(mutex) to member variables. The others are
 // rarely necessary. Ex: int nFoo GUARDED_BY(cs_foo);
 //
-// See http://clang.llvm.org/docs/LanguageExtensions.html#threadsafety
+// See https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
 // for documentation.  The clang compiler can do advanced static analysis
 // of locking when given the -Wthread-safety option.
 #define LOCKABLE __attribute__((lockable))


### PR DESCRIPTION
From the defunct http://clang.llvm.org/docs/LanguageExtensions.html#threadsafety to https://clang.llvm.org/docs/ThreadSafetyAnalysis.html