### PR TITLE
gui: Favor macOS show / hide action in dock menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -614,8 +614,11 @@ void BitcoinGUI::createTrayIconMenu()
 #endif
 
     // Configuration of the tray icon (or dock icon) icon menu
+#ifndef Q_OS_MAC
+    // Note: On Mac, the dock icon's menu already has show / hide action.
     trayIconMenu->addAction(toggleHideAction);
     trayIconMenu->addSeparator();
+#endif
     trayIconMenu->addAction(sendCoinsMenuAction);
     trayIconMenu->addAction(receiveCoinsMenuAction);
     trayIconMenu->addSeparator();


### PR DESCRIPTION
Before:

<img width="188" alt="screen shot 2018-09-02 at 19 10 02" src="https://user-images.githubusercontent.com/3534524/44959393-5a44c400-aee5-11e8-90f4-9a30f67f7ee2.png">

After:

<img width="200" alt="screen shot 2018-09-02 at 19 19 01" src="https://user-images.githubusercontent.com/3534524/44959395-60d33b80-aee5-11e8-9773-1d04d3482115.png">

Note that macOS toggles between `Hide` and `Show`.