### PR TITLE
doc: correct GetDifficulty doc after #13288

### DIFF
--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -16,8 +16,7 @@ class UniValue;
 static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
 
 /**
- * Get the difficulty of the net wrt to the given block index, or the chain tip if
- * not provided.
+ * Get the difficulty of the net wrt to the given block index.
  *
  * @return A floating point number that is a multiple of the main net minimum
  * difficulty (4295032833 hashes).


### PR DESCRIPTION
`chain` is no longer passed to GetDifficulty, and we just return `1.0` if no `blockindex`.