### PR TITLE
[Net] Switch nPrevNodeCount to vNodesSize

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1227,7 +1227,7 @@ void CConnman::ThreadSocketHandler()
         if(vNodesSize != nPrevNodeCount) {
             nPrevNodeCount = vNodesSize;
             if(clientInterface)
-                clientInterface->NotifyNumConnectionsChanged(nPrevNodeCount);
+                clientInterface->NotifyNumConnectionsChanged(vNodesSize);
         }
 
         //


### PR DESCRIPTION
These both have the same value, but the variable naming is confusing.