### PR TITLE
Refactoring: Clarify code using encrypted_batch in CWallet

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -757,6 +757,11 @@ private:
     std::mutex mutexScanning;
     friend class WalletRescanReserver;
 
+    /**
+     * The current wallet batch for encrypted keys; only set temporarily while
+     * certain member functions are executing.  The memory is not owned by the
+     * CWallet instance.
+     */
     WalletBatch *encrypted_batch GUARDED_BY(cs_wallet) = nullptr;
 
     //! the current wallet version: clients below this version are not able to load the wallet
@@ -933,8 +938,6 @@ public:
     {
         // Should not have slots connected at this point.
         assert(NotifyUnload.empty());
-        delete encrypted_batch;
-        encrypted_batch = nullptr;
     }
 
     bool IsCrypted() const { return fUseCrypto; }


### PR DESCRIPTION
This is a pure refactoring (no functional changes) that clarifies the use of `CWallet::encrypted_batch` as well as the code using it according to my proposal in #14139.  (A more detailed description and rationale can be [found there](https://github.com/bitcoin/bitcoin/issues/14139#issue-356554677).)

The change is split in two commits that correspond to logical units (matching the description in the [proposal](https://github.com/bitcoin/bitcoin/issues/14139#issue-356554677)):  A general cleanup of the code and the use of RAII (as also recommended in the developer guidelines) for setting/resetting `encrypted_batch` temporarily.  In case the second commit is seen as overengineering, I'm happy to change the PR to include just the first commit.

The second commit (using RAII) obsoletes #14138.