### PR TITLE
wallet: Remove trailing separators from -walletdir arg

### DIFF
--- a/build_msvc/test_bitcoin/test_bitcoin.vcxproj
+++ b/build_msvc/test_bitcoin/test_bitcoin.vcxproj
@@ -24,7 +24,7 @@
     <ClCompile Include="..\..\src\wallet\test\*_tests.cpp" />
     <ClCompile Include="..\..\src\test\test_bitcoin.cpp" />
     <ClCompile Include="..\..\src\test\test_bitcoin_main.cpp" />
-    <ClCompile Include="..\..\src\wallet\test\wallet_test_fixture.cpp" />
+    <ClCompile Include="..\..\src\wallet\test\*_fixture.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -110,11 +110,14 @@ BITCOIN_TESTS += \
   wallet/test/psbt_wallet_tests.cpp \
   wallet/test/wallet_tests.cpp \
   wallet/test/wallet_crypto_tests.cpp \
-  wallet/test/coinselector_tests.cpp
+  wallet/test/coinselector_tests.cpp \
+  wallet/test/init_tests.cpp
 
 BITCOIN_TEST_SUITE += \
   wallet/test/wallet_test_fixture.cpp \
-  wallet/test/wallet_test_fixture.h
+  wallet/test/wallet_test_fixture.h \
+  wallet/test/init_test_fixture.cpp \
+  wallet/test/init_test_fixture.h
 endif
 
 test_test_bitcoin_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <fs.h>
+
+#include <wallet/test/init_test_fixture.h>
+
+InitWalletDirTestingSetup::InitWalletDirTestingSetup(const std::string& chainName): BasicTestingSetup(chainName)
+{
+    std::string sep;
+    sep += fs::path::preferred_separator;
+
+    m_datadir = SetDataDir("tempdir");
+    m_cwd = fs::current_path();
+
+    m_walletdir_path_cases["default"] = m_datadir / "wallets";
+    m_walletdir_path_cases["custom"] = m_datadir / "my_wallets";
+    m_walletdir_path_cases["nonexistent"] = m_datadir / "path_does_not_exist";
+    m_walletdir_path_cases["file"] = m_datadir / "not_a_directory.dat";
+    m_walletdir_path_cases["trailing"] = m_datadir / "wallets" / sep;
+    m_walletdir_path_cases["trailing2"] = m_datadir / "wallets" / sep / sep;
+
+    fs::current_path(m_datadir);
+    m_walletdir_path_cases["relative"] = "wallets";
+
+    fs::create_directories(m_walletdir_path_cases["default"]);
+    fs::create_directories(m_walletdir_path_cases["custom"]);
+    fs::create_directories(m_walletdir_path_cases["relative"]);
+    std::ofstream f(m_walletdir_path_cases["file"].BOOST_FILESYSTEM_C_STR);
+    f.close();
+}
+
+InitWalletDirTestingSetup::~InitWalletDirTestingSetup()
+{
+    fs::current_path(m_cwd);
+}
+
+void InitWalletDirTestingSetup::SetWalletDir(const fs::path& walletdir_path)
+{
+    gArgs.ForceSetArg("-walletdir", walletdir_path.string());
+}

--- a/src/wallet/test/init_test_fixture.h
+++ b/src/wallet/test/init_test_fixture.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WALLET_TEST_INIT_TEST_FIXTURE_H
+#define BITCOIN_WALLET_TEST_INIT_TEST_FIXTURE_H
+
+#include <test/test_bitcoin.h>
+
+
+struct InitWalletDirTestingSetup: public BasicTestingSetup {
+    explicit InitWalletDirTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    ~InitWalletDirTestingSetup();
+    void SetWalletDir(const fs::path& walletdir_path);
+
+    fs::path m_datadir;
+    fs::path m_cwd;
+    std::map<std::string, fs::path> m_walletdir_path_cases;
+};
+
+#endif // BITCOIN_WALLET_TEST_INIT_TEST_FIXTURE_H

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -55,4 +55,24 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_relative)
     BOOST_CHECK(result == false);
 }
 
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing)
+{
+    SetWalletDir(m_walletdir_path_cases["trailing"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == true);
+    fs::path walletdir = gArgs.GetArg("-walletdir", "");
+    fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
+    BOOST_CHECK(walletdir == expected_path);
+}
+
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_no_trailing2)
+{
+    SetWalletDir(m_walletdir_path_cases["trailing2"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == true);
+    fs::path walletdir = gArgs.GetArg("-walletdir", "");
+    fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
+    BOOST_CHECK(walletdir == expected_path);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include <test/test_bitcoin.h>
+#include <wallet/test/init_test_fixture.h>
+
+#include <init.h>
+#include <walletinitinterface.h>
+#include <wallet/wallet.h>
+
+
+BOOST_FIXTURE_TEST_SUITE(init_tests, InitWalletDirTestingSetup)
+
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_default)
+{
+    SetWalletDir(m_walletdir_path_cases["default"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == true);
+    fs::path walletdir = gArgs.GetArg("-walletdir", "");
+    fs::path expected_path = fs::canonical(m_walletdir_path_cases["default"]);
+    BOOST_CHECK(walletdir == expected_path);
+}
+
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_custom)
+{
+    SetWalletDir(m_walletdir_path_cases["custom"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == true);
+    fs::path walletdir = gArgs.GetArg("-walletdir", "");
+    fs::path expected_path = fs::canonical(m_walletdir_path_cases["custom"]);
+    BOOST_CHECK(walletdir == expected_path);
+}
+
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_does_not_exist)
+{
+    SetWalletDir(m_walletdir_path_cases["nonexistent"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == false);
+}
+
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_directory)
+{
+    SetWalletDir(m_walletdir_path_cases["file"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == false);
+}
+
+BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_relative)
+{
+    SetWalletDir(m_walletdir_path_cases["relative"]);
+    bool result = g_wallet_init_interface.Verify();
+    BOOST_CHECK(result == false);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
If a user passes in a path with a trailing separator as the `walletdir`, multiple BerkeleyEnvironments may be created in the same directory which can lead to data corruption.

Discovered while reviewing https://github.com/bitcoin/bitcoin/pull/12493#issuecomment-417147646
