### PR TITLE
doc: Remove misleading checkpoints comment in CMainParams

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -4,15 +4,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
-#include <consensus/merkle.h>
 
+#include <chainparamsseeds.h>
+#include <consensus/merkle.h>
 #include <tinyformat.h>
 #include <util.h>
 #include <utilstrencodings.h>
 
 #include <assert.h>
-
-#include <chainparamsseeds.h>
 
 static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
@@ -62,14 +61,6 @@ void CChainParams::UpdateVersionBitsParameters(Consensus::DeploymentPos d, int64
 /**
  * Main network
  */
-/**
- * What makes a good checkpoint block?
- * + Is surrounded by blocks with reasonable timestamps
- *   (no blocks before with a timestamp after, none after with
- *    timestamp before)
- * + Contains no strange transactions
- */
-
 class CMainParams : public CChainParams {
 public:
     CMainParams() {


### PR DESCRIPTION
This removes the checkpoints comment because it is misleading for two reasons:

* It shows up in the doxygen documentation of `CMainParams` https://dev.visucore.com/bitcoin/doxygen/class_c_main_params.html
* The comment refers to "strange transactions" in a block, which are not specified further. Transactions in blocks are always consensus-valid or rejected as consensus-invalid.

Also sort the includes with `clang-format`, as the file is touched anyway.