### PR TITLE
Docs: Add disable-wallet section to OSX build instructions, update line in Unix instructions

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -73,8 +73,7 @@ disable-wallet mode with:
 
 In this case there is no dependency on Berkeley DB 4.8.
 
-Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
-call not `getwork`.
+Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
 
 Running
 -------

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -64,6 +64,18 @@ Build Bitcoin Core
 
         make deploy
 
+Disable-wallet mode
+--------------------
+When the intention is to run only a P2P node without a wallet, Bitcoin Core may be compiled in
+disable-wallet mode with:
+
+    ./configure --disable-wallet
+
+In this case there is no dependency on Berkeley DB 4.8.
+
+Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
+call not `getwork`.
+
 Running
 -------
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -234,8 +234,7 @@ disable-wallet mode with:
 
 In this case there is no dependency on Berkeley DB 4.8.
 
-Mining is also possible in disable-wallet mode, but only using the `getblocktemplate` RPC
-call not `getwork`.
+Mining is also possible in disable-wallet mode using the `getblocktemplate` RPC call.
 
 Additional Configure Flags
 --------------------------
@@ -284,4 +283,3 @@ To build executables for ARM:
 
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-


### PR DESCRIPTION
The `disable-wallet` section was mentioned in the `Berkeley DB` section of the OSX build instructions, but the section did not actually exist. This PR ports the section from the Unix build instructions.