### PR TITLE
p2p: Return a max of 1000 addrs from CAddrMan::GetAddr

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -471,7 +471,7 @@ int CAddrMan::Check_()
 }
 #endif
 
-void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr)
+void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr, const CRollingBloomFilter& addr_known)
 {
     unsigned int nNodes = ADDRMAN_GETADDR_MAX_PCT * vRandom.size() / 100;
     if (nNodes > ADDRMAN_GETADDR_MAX)
@@ -487,7 +487,7 @@ void CAddrMan::GetAddr_(std::vector<CAddress>& vAddr)
         assert(mapInfo.count(vRandom[n]) == 1);
 
         const CAddrInfo& ai = mapInfo[vRandom[n]];
-        if (!ai.IsTerrible())
+        if (!ai.IsTerrible() && !addr_known.contains(ai.GetKey()))
             vAddr.push_back(ai);
     }
 }

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -172,7 +172,7 @@ public:
 #define ADDRMAN_GETADDR_MAX_PCT 23
 
 //! the maximum number of nodes to return in a getaddr call
-#define ADDRMAN_GETADDR_MAX 2500
+#define ADDRMAN_GETADDR_MAX 1000
 
 //! Convenience
 #define ADDRMAN_TRIED_BUCKET_COUNT (1 << ADDRMAN_TRIED_BUCKET_COUNT_LOG2)

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_ADDRMAN_H
 #define BITCOIN_ADDRMAN_H
 
+#include <bloom.h>
 #include <netaddress.h>
 #include <protocol.h>
 #include <random.h>
@@ -274,7 +275,7 @@ protected:
 #endif
 
     //! Select several addresses at once.
-    void GetAddr_(std::vector<CAddress> &vAddr);
+    void GetAddr_(std::vector<CAddress> &vAddr, const CRollingBloomFilter& addr_known);
 
     //! Mark an entry as currently-connected-to.
     void Connected_(const CService &addr, int64_t nTime);
@@ -607,13 +608,13 @@ public:
     }
 
     //! Return a bunch of addresses, selected at random.
-    std::vector<CAddress> GetAddr()
+    std::vector<CAddress> GetAddr(const CRollingBloomFilter& addr_known)
     {
         Check();
         std::vector<CAddress> vAddr;
         {
             LOCK(cs);
-            GetAddr_(vAddr);
+            GetAddr_(vAddr, addr_known);
         }
         Check();
         return vAddr;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2499,9 +2499,9 @@ void CConnman::AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddres
     addrman.Add(vAddr, addrFrom, nTimePenalty);
 }
 
-std::vector<CAddress> CConnman::GetAddresses()
+std::vector<CAddress> CConnman::GetAddresses(const CRollingBloomFilter& addr_known)
 {
-    return addrman.GetAddr();
+    return addrman.GetAddr(addr_known);
 }
 
 bool CConnman::AddNode(const std::string& strNode)

--- a/src/net.h
+++ b/src/net.h
@@ -229,7 +229,7 @@ public:
     void SetServices(const CService &addr, ServiceFlags nServices);
     void MarkAddressGood(const CAddress& addr);
     void AddNewAddresses(const std::vector<CAddress>& vAddr, const CAddress& addrFrom, int64_t nTimePenalty = 0);
-    std::vector<CAddress> GetAddresses();
+    std::vector<CAddress> GetAddresses(const CRollingBloomFilter& addr_known);
 
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1757,7 +1757,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
 
             // Get recent addresses
-            if (pfrom->fOneShot || pfrom->nVersion >= CADDR_TIME_VERSION || connman->GetAddressCount() < 1000)
+            if (pfrom->fOneShot || pfrom->nVersion >= CADDR_TIME_VERSION || connman->GetAddressCount() < ADDRMAN_GETADDR_MAX)
             {
                 connman->PushMessage(pfrom, CNetMsgMaker(nSendVersion).Make(NetMsgType::GETADDR));
                 pfrom->fGetAddr = true;
@@ -1851,9 +1851,9 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         vRecv >> vAddr;
 
         // Don't want addr from older versions unless seeding
-        if (pfrom->nVersion < CADDR_TIME_VERSION && connman->GetAddressCount() > 1000)
+        if (pfrom->nVersion < CADDR_TIME_VERSION && connman->GetAddressCount() > ADDRMAN_GETADDR_MAX)
             return true;
-        if (vAddr.size() > 1000)
+        if (vAddr.size() > MAX_ADDR_TO_SEND)
         {
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message addr size() = %u", vAddr.size()));
@@ -1889,7 +1889,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 vAddrOk.push_back(addr);
         }
         connman->AddNewAddresses(vAddrOk, pfrom->addr, 2 * 60 * 60);
-        if (vAddr.size() < 1000)
+        if (vAddr.size() < ADDRMAN_GETADDR_MAX)
             pfrom->fGetAddr = false;
         if (pfrom->fOneShot)
             pfrom->fDisconnect = true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2744,9 +2744,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         pfrom->fSentAddr = true;
 
         pfrom->vAddrToSend.clear();
-        std::vector<CAddress> vAddr = connman->GetAddresses();
         FastRandomContext insecure_rand;
-        for (const CAddress &addr : vAddr)
+        for (const CAddress &addr : connman->GetAddresses(pfrom->addrKnown))
             pfrom->PushAddress(addr, insecure_rand);
         return true;
     }


### PR DESCRIPTION
This is the documented max size for an addr response, and was separately being
limited in PushAddress to 1000 via MAX_ADDR_TO_SEND. No point in selecting a
too-large random set then filtering it randomly down to a smaller set.