### PR TITLE
Docs: Mention in release notes that regtest= and testnet= options must be outside of config sections

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -157,7 +157,8 @@ prefixing the option with the network, such as:
 
 The `addnode=`, `connect=`, `port=`, `bind=`, `rpcport=`, `rpcbind=`
 and `wallet=` options will only apply to mainnet when specified in the
-configuration file, unless a network is specified.
+configuration file, unless a network is specified. The options to choose a
+network (`regtest=` and `testnet=`) must be specified outside of sections.
 
 'label' and 'account' APIs for wallet
 -------------------------------------


### PR DESCRIPTION
My initial attempt to port regtest config files to 0.17 was to add `[regtest]` at the top of the file which resulted in `regtest=1` being ignored.