### PR TITLE
fix various uses of inline

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -230,7 +230,7 @@ CRollingBloomFilter::CRollingBloomFilter(const unsigned int nElements, const dou
 }
 
 /* Similar to CBloomFilter::Hash */
-static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, const std::vector<unsigned char>& vDataToHash) {
+static uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, const std::vector<unsigned char>& vDataToHash) {
     return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash);
 }
 
@@ -238,7 +238,7 @@ static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, 
 // A replacement for x % n. This assumes that x and n are 32bit integers, and x is a uniformly random distributed 32bit value
 // which should be the case for a good hash.
 // See https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-static inline uint32_t FastMod(uint32_t x, size_t n) {
+static uint32_t FastMod(uint32_t x, size_t n) {
     return ((uint64_t)x * (uint64_t)n) >> 32;
 }
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -67,10 +67,10 @@ CBlockIndex* CChain::FindEarliestAtLeast(int64_t nTime) const
 }
 
 /** Turn the lowest '1' bit in the binary representation of a number into a '0'. */
-int static inline InvertLowestOne(int n) { return n & (n - 1); }
+int static InvertLowestOne(int n) { return n & (n - 1); }
 
 /** Compute what height to jump back to with the CBlockIndex::pskip pointer. */
-int static inline GetSkipHeight(int height) {
+int static GetSkipHeight(int height) {
     if (height < 2)
         return 0;
 

--- a/src/compat.h
+++ b/src/compat.h
@@ -102,7 +102,7 @@ typedef void* sockopt_arg_type;
 typedef char* sockopt_arg_type;
 #endif
 
-bool static inline IsSelectableSocket(const SOCKET& s) {
+bool inline IsSelectableSocket(const SOCKET& s) {
 #ifdef WIN32
     return true;
 #else

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -93,15 +93,15 @@ public:
 // using only serialization with and without witness data. As witness_size
 // is equal to total_size - stripped_size, this formula is identical to:
 // weight = (stripped_size * 3) + total_size.
-static inline int64_t GetTransactionWeight(const CTransaction& tx)
+inline int64_t GetTransactionWeight(const CTransaction& tx)
 {
     return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 }
-static inline int64_t GetBlockWeight(const CBlock& block)
+inline int64_t GetBlockWeight(const CBlock& block)
 {
     return ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
 }
-static inline int64_t GetTransactionInputWeight(const CTxIn& txin)
+inline int64_t GetTransactionInputWeight(const CTxIn& txin)
 {
     // scriptWitness size is added here because witnesses and txins are split up in segwit serialization.
     return ::GetSerializeSize(txin, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txin, SER_NETWORK, PROTOCOL_VERSION) + ::GetSerializeSize(txin.scriptWitness.stack, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -64,7 +64,7 @@ inline size_t RecursiveDynamicUsage(const CBlockLocator& locator) {
 }
 
 template<typename X>
-inline size_t RecursiveDynamicUsage(const std::shared_ptr<X>& p) {
+size_t RecursiveDynamicUsage(const std::shared_ptr<X>& p) {
     return p ? memusage::DynamicUsage(p) + RecursiveDynamicUsage(*p) : 0;
 }
 

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -9,15 +9,15 @@
 #include <primitives/block.h>
 #include <memusage.h>
 
-static inline size_t RecursiveDynamicUsage(const CScript& script) {
+inline size_t RecursiveDynamicUsage(const CScript& script) {
     return memusage::DynamicUsage(script);
 }
 
-static inline size_t RecursiveDynamicUsage(const COutPoint& out) {
+inline size_t RecursiveDynamicUsage(const COutPoint& out) {
     return 0;
 }
 
-static inline size_t RecursiveDynamicUsage(const CTxIn& in) {
+inline size_t RecursiveDynamicUsage(const CTxIn& in) {
     size_t mem = RecursiveDynamicUsage(in.scriptSig) + RecursiveDynamicUsage(in.prevout) + memusage::DynamicUsage(in.scriptWitness.stack);
     for (std::vector<std::vector<unsigned char> >::const_iterator it = in.scriptWitness.stack.begin(); it != in.scriptWitness.stack.end(); it++) {
          mem += memusage::DynamicUsage(*it);
@@ -25,11 +25,11 @@ static inline size_t RecursiveDynamicUsage(const CTxIn& in) {
     return mem;
 }
 
-static inline size_t RecursiveDynamicUsage(const CTxOut& out) {
+inline size_t RecursiveDynamicUsage(const CTxOut& out) {
     return RecursiveDynamicUsage(out.scriptPubKey);
 }
 
-static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
+inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     size_t mem = memusage::DynamicUsage(tx.vin) + memusage::DynamicUsage(tx.vout);
     for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
         mem += RecursiveDynamicUsage(*it);
@@ -40,7 +40,7 @@ static inline size_t RecursiveDynamicUsage(const CTransaction& tx) {
     return mem;
 }
 
-static inline size_t RecursiveDynamicUsage(const CMutableTransaction& tx) {
+inline size_t RecursiveDynamicUsage(const CMutableTransaction& tx) {
     size_t mem = memusage::DynamicUsage(tx.vin) + memusage::DynamicUsage(tx.vout);
     for (std::vector<CTxIn>::const_iterator it = tx.vin.begin(); it != tx.vin.end(); it++) {
         mem += RecursiveDynamicUsage(*it);
@@ -51,7 +51,7 @@ static inline size_t RecursiveDynamicUsage(const CMutableTransaction& tx) {
     return mem;
 }
 
-static inline size_t RecursiveDynamicUsage(const CBlock& block) {
+inline size_t RecursiveDynamicUsage(const CBlock& block) {
     size_t mem = memusage::DynamicUsage(block.vtx);
     for (const auto& tx : block.vtx) {
         mem += memusage::DynamicUsage(tx) + RecursiveDynamicUsage(*tx);
@@ -59,12 +59,12 @@ static inline size_t RecursiveDynamicUsage(const CBlock& block) {
     return mem;
 }
 
-static inline size_t RecursiveDynamicUsage(const CBlockLocator& locator) {
+inline size_t RecursiveDynamicUsage(const CBlockLocator& locator) {
     return memusage::DynamicUsage(locator.vHave);
 }
 
 template<typename X>
-static inline size_t RecursiveDynamicUsage(const std::shared_ptr<X>& p) {
+inline size_t RecursiveDynamicUsage(const std::shared_ptr<X>& p) {
     return p ? memusage::DynamicUsage(p) + RecursiveDynamicUsage(*p) : 0;
 }
 

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -10,7 +10,7 @@
 
 #include <string.h>
 
-constexpr static inline uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
+constexpr static uint32_t rotl32(uint32_t v, int c) { return (v << c) | (v >> (32 - c)); }
 
 #define QUARTERROUND(a,b,c,d) \
   a += b; d = rotl32(d ^ a, 16); \

--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -14,73 +14,73 @@
 
 #include <compat/endian.h>
 
-uint16_t static inline ReadLE16(const unsigned char* ptr)
+uint16_t inline ReadLE16(const unsigned char* ptr)
 {
     uint16_t x;
     memcpy((char*)&x, ptr, 2);
     return le16toh(x);
 }
 
-uint32_t static inline ReadLE32(const unsigned char* ptr)
+uint32_t inline ReadLE32(const unsigned char* ptr)
 {
     uint32_t x;
     memcpy((char*)&x, ptr, 4);
     return le32toh(x);
 }
 
-uint64_t static inline ReadLE64(const unsigned char* ptr)
+uint64_t inline ReadLE64(const unsigned char* ptr)
 {
     uint64_t x;
     memcpy((char*)&x, ptr, 8);
     return le64toh(x);
 }
 
-void static inline WriteLE16(unsigned char* ptr, uint16_t x)
+void inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
     uint16_t v = htole16(x);
     memcpy(ptr, (char*)&v, 2);
 }
 
-void static inline WriteLE32(unsigned char* ptr, uint32_t x)
+void inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htole32(x);
     memcpy(ptr, (char*)&v, 4);
 }
 
-void static inline WriteLE64(unsigned char* ptr, uint64_t x)
+void inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htole64(x);
     memcpy(ptr, (char*)&v, 8);
 }
 
-uint32_t static inline ReadBE32(const unsigned char* ptr)
+uint32_t inline ReadBE32(const unsigned char* ptr)
 {
     uint32_t x;
     memcpy((char*)&x, ptr, 4);
     return be32toh(x);
 }
 
-uint64_t static inline ReadBE64(const unsigned char* ptr)
+uint64_t inline ReadBE64(const unsigned char* ptr)
 {
     uint64_t x;
     memcpy((char*)&x, ptr, 8);
     return be64toh(x);
 }
 
-void static inline WriteBE32(unsigned char* ptr, uint32_t x)
+void inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
     uint32_t v = htobe32(x);
     memcpy(ptr, (char*)&v, 4);
 }
 
-void static inline WriteBE64(unsigned char* ptr, uint64_t x)
+void inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
     uint64_t v = htobe64(x);
     memcpy(ptr, (char*)&v, 8);
 }
 
 /** Return the smallest number n such that (x >> n) == 0 (or 64 if the highest bit in x is set. */
-uint64_t static inline CountBits(uint64_t x)
+uint64_t inline CountBits(uint64_t x)
 {
 #if HAVE_DECL___BUILTIN_CLZL
     if (sizeof(unsigned long) >= sizeof(uint64_t)) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -129,7 +129,7 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
 
 inline void MarkUsed() {}
-template<typename T, typename... Args> inline void MarkUsed(const T& t, const Args&... args)
+template<typename T, typename... Args> void MarkUsed(const T& t, const Args&... args)
 {
     (void)t;
     MarkUsed(args...);

--- a/src/logging.h
+++ b/src/logging.h
@@ -111,7 +111,7 @@ namespace BCLog {
 extern BCLog::Logger* const g_logger;
 
 /** Return true if log accepts specified category */
-static inline bool LogAcceptCategory(BCLog::LogFlags category)
+inline bool LogAcceptCategory(BCLog::LogFlags category)
 {
     return g_logger->WillLogCategory(category);
 }
@@ -128,8 +128,8 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 /** Get format string from VA_ARGS for error reporting */
 template<typename... Args> std::string FormatStringFromLogArgs(const char *fmt, const Args&... args) { return fmt; }
 
-static inline void MarkUsed() {}
-template<typename T, typename... Args> static inline void MarkUsed(const T& t, const Args&... args)
+inline void MarkUsed() {}
+template<typename T, typename... Args> inline void MarkUsed(const T& t, const Args&... args)
 {
     (void)t;
     MarkUsed(args...);

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -34,8 +34,8 @@ inline size_t DynamicUsage(const int64_t& v) { return 0; }
 inline size_t DynamicUsage(const uint64_t& v) { return 0; }
 inline size_t DynamicUsage(const float& v) { return 0; }
 inline size_t DynamicUsage(const double& v) { return 0; }
-template<typename X> inline size_t DynamicUsage(X * const &v) { return 0; }
-template<typename X> inline size_t DynamicUsage(const X * const &v) { return 0; }
+template<typename X> size_t DynamicUsage(X * const &v) { return 0; }
+template<typename X> size_t DynamicUsage(const X * const &v) { return 0; }
 
 /** Compute the memory used for dynamically allocated but owned data structures.
  *  For generic data types, this is *not* recursive. DynamicUsage(vector<vector<int> >)
@@ -82,37 +82,37 @@ struct stl_shared_counter
 };
 
 template<typename X>
-inline size_t DynamicUsage(const std::vector<X>& v)
+size_t DynamicUsage(const std::vector<X>& v)
 {
     return MallocUsage(v.capacity() * sizeof(X));
 }
 
 template<unsigned int N, typename X, typename S, typename D>
-inline size_t DynamicUsage(const prevector<N, X, S, D>& v)
+size_t DynamicUsage(const prevector<N, X, S, D>& v)
 {
     return MallocUsage(v.allocated_memory());
 }
 
 template<typename X, typename Y>
-inline size_t DynamicUsage(const std::set<X, Y>& s)
+size_t DynamicUsage(const std::set<X, Y>& s)
 {
     return MallocUsage(sizeof(stl_tree_node<X>)) * s.size();
 }
 
 template<typename X, typename Y>
-inline size_t IncrementalDynamicUsage(const std::set<X, Y>& s)
+size_t IncrementalDynamicUsage(const std::set<X, Y>& s)
 {
     return MallocUsage(sizeof(stl_tree_node<X>));
 }
 
 template<typename X, typename Y, typename Z>
-inline size_t DynamicUsage(const std::map<X, Y, Z>& m)
+size_t DynamicUsage(const std::map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >)) * m.size();
 }
 
 template<typename X, typename Y, typename Z>
-inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
+size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >));
 }
@@ -120,25 +120,25 @@ inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
 // indirectmap has underlying map with pointer as key
 
 template<typename X, typename Y>
-inline size_t DynamicUsage(const indirectmap<X, Y>& m)
+size_t DynamicUsage(const indirectmap<X, Y>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >)) * m.size();
 }
 
 template<typename X, typename Y>
-inline size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
+size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
 }
 
 template<typename X>
-inline size_t DynamicUsage(const std::unique_ptr<X>& p)
+size_t DynamicUsage(const std::unique_ptr<X>& p)
 {
     return p ? MallocUsage(sizeof(X)) : 0;
 }
 
 template<typename X>
-inline size_t DynamicUsage(const std::shared_ptr<X>& p)
+size_t DynamicUsage(const std::shared_ptr<X>& p)
 {
     // A shared_ptr can either use a single continuous memory block for both
     // the counter and the storage (when using std::make_shared), or separate.
@@ -154,13 +154,13 @@ private:
 };
 
 template<typename X, typename Y>
-inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
+size_t DynamicUsage(const std::unordered_set<X, Y>& s)
 {
     return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
 }
 
 template<typename X, typename Y, typename Z>
-inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
+size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -24,18 +24,18 @@ namespace memusage
 static size_t MallocUsage(size_t alloc);
 
 /** Dynamic memory usage for built-in types is zero. */
-static inline size_t DynamicUsage(const int8_t& v) { return 0; }
-static inline size_t DynamicUsage(const uint8_t& v) { return 0; }
-static inline size_t DynamicUsage(const int16_t& v) { return 0; }
-static inline size_t DynamicUsage(const uint16_t& v) { return 0; }
-static inline size_t DynamicUsage(const int32_t& v) { return 0; }
-static inline size_t DynamicUsage(const uint32_t& v) { return 0; }
-static inline size_t DynamicUsage(const int64_t& v) { return 0; }
-static inline size_t DynamicUsage(const uint64_t& v) { return 0; }
-static inline size_t DynamicUsage(const float& v) { return 0; }
-static inline size_t DynamicUsage(const double& v) { return 0; }
-template<typename X> static inline size_t DynamicUsage(X * const &v) { return 0; }
-template<typename X> static inline size_t DynamicUsage(const X * const &v) { return 0; }
+inline size_t DynamicUsage(const int8_t& v) { return 0; }
+inline size_t DynamicUsage(const uint8_t& v) { return 0; }
+inline size_t DynamicUsage(const int16_t& v) { return 0; }
+inline size_t DynamicUsage(const uint16_t& v) { return 0; }
+inline size_t DynamicUsage(const int32_t& v) { return 0; }
+inline size_t DynamicUsage(const uint32_t& v) { return 0; }
+inline size_t DynamicUsage(const int64_t& v) { return 0; }
+inline size_t DynamicUsage(const uint64_t& v) { return 0; }
+inline size_t DynamicUsage(const float& v) { return 0; }
+inline size_t DynamicUsage(const double& v) { return 0; }
+template<typename X> inline size_t DynamicUsage(X * const &v) { return 0; }
+template<typename X> inline size_t DynamicUsage(const X * const &v) { return 0; }
 
 /** Compute the memory used for dynamically allocated but owned data structures.
  *  For generic data types, this is *not* recursive. DynamicUsage(vector<vector<int> >)
@@ -45,7 +45,7 @@ template<typename X> static inline size_t DynamicUsage(const X * const &v) { ret
  *  iterate themselves, or use more efficient caching + updating on modification.
  */
 
-static inline size_t MallocUsage(size_t alloc)
+inline size_t MallocUsage(size_t alloc)
 {
     // Measured on libc6 2.19 on Linux.
     if (alloc == 0) {
@@ -82,37 +82,37 @@ struct stl_shared_counter
 };
 
 template<typename X>
-static inline size_t DynamicUsage(const std::vector<X>& v)
+inline size_t DynamicUsage(const std::vector<X>& v)
 {
     return MallocUsage(v.capacity() * sizeof(X));
 }
 
 template<unsigned int N, typename X, typename S, typename D>
-static inline size_t DynamicUsage(const prevector<N, X, S, D>& v)
+inline size_t DynamicUsage(const prevector<N, X, S, D>& v)
 {
     return MallocUsage(v.allocated_memory());
 }
 
 template<typename X, typename Y>
-static inline size_t DynamicUsage(const std::set<X, Y>& s)
+inline size_t DynamicUsage(const std::set<X, Y>& s)
 {
     return MallocUsage(sizeof(stl_tree_node<X>)) * s.size();
 }
 
 template<typename X, typename Y>
-static inline size_t IncrementalDynamicUsage(const std::set<X, Y>& s)
+inline size_t IncrementalDynamicUsage(const std::set<X, Y>& s)
 {
     return MallocUsage(sizeof(stl_tree_node<X>));
 }
 
 template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const std::map<X, Y, Z>& m)
+inline size_t DynamicUsage(const std::map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >)) * m.size();
 }
 
 template<typename X, typename Y, typename Z>
-static inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
+inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X, Y> >));
 }
@@ -120,25 +120,25 @@ static inline size_t IncrementalDynamicUsage(const std::map<X, Y, Z>& m)
 // indirectmap has underlying map with pointer as key
 
 template<typename X, typename Y>
-static inline size_t DynamicUsage(const indirectmap<X, Y>& m)
+inline size_t DynamicUsage(const indirectmap<X, Y>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >)) * m.size();
 }
 
 template<typename X, typename Y>
-static inline size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
+inline size_t IncrementalDynamicUsage(const indirectmap<X, Y>& m)
 {
     return MallocUsage(sizeof(stl_tree_node<std::pair<const X*, Y> >));
 }
 
 template<typename X>
-static inline size_t DynamicUsage(const std::unique_ptr<X>& p)
+inline size_t DynamicUsage(const std::unique_ptr<X>& p)
 {
     return p ? MallocUsage(sizeof(X)) : 0;
 }
 
 template<typename X>
-static inline size_t DynamicUsage(const std::shared_ptr<X>& p)
+inline size_t DynamicUsage(const std::shared_ptr<X>& p)
 {
     // A shared_ptr can either use a single continuous memory block for both
     // the counter and the storage (when using std::make_shared), or separate.
@@ -154,13 +154,13 @@ private:
 };
 
 template<typename X, typename Y>
-static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
+inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
 {
     return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
 }
 
 template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
+inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
 {
     return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -642,7 +642,7 @@ bool CSubNet::Match(const CNetAddr &addr) const
     return true;
 }
 
-static inline int NetmaskBits(uint8_t x)
+static int NetmaskBits(uint8_t x)
 {
     switch(x) {
     case 0x00: return 0;

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -27,7 +27,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(hash);
         READWRITE(n);
     }
@@ -104,7 +104,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(prevout);
         READWRITE(scriptSig);
         READWRITE(nSequence);
@@ -144,7 +144,7 @@ public:
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(nValue);
         READWRITE(scriptPubKey);
     }
@@ -194,7 +194,7 @@ struct CMutableTransaction;
  * - uint32_t nLockTime
  */
 template<typename Stream, typename TxType>
-inline void UnserializeTransaction(TxType& tx, Stream& s) {
+void UnserializeTransaction(TxType& tx, Stream& s) {
     const bool fAllowWitness = !(s.GetVersion() & SERIALIZE_TRANSACTION_NO_WITNESS);
 
     s >> tx.nVersion;
@@ -229,7 +229,7 @@ inline void UnserializeTransaction(TxType& tx, Stream& s) {
 }
 
 template<typename Stream, typename TxType>
-inline void SerializeTransaction(const TxType& tx, Stream& s) {
+void SerializeTransaction(const TxType& tx, Stream& s) {
     const bool fAllowWitness = !(s.GetVersion() & SERIALIZE_TRANSACTION_NO_WITNESS);
 
     s << tx.nVersion;
@@ -300,7 +300,7 @@ public:
     CTransaction(CMutableTransaction &&tx);
 
     template <typename Stream>
-    inline void Serialize(Stream& s) const {
+    void Serialize(Stream& s) const {
         SerializeTransaction(*this, s);
     }
 
@@ -368,13 +368,13 @@ struct CMutableTransaction
     explicit CMutableTransaction(const CTransaction& tx);
 
     template <typename Stream>
-    inline void Serialize(Stream& s) const {
+    void Serialize(Stream& s) const {
         SerializeTransaction(*this, s);
     }
 
 
     template <typename Stream>
-    inline void Unserialize(Stream& s) {
+    void Unserialize(Stream& s) {
         UnserializeTransaction(*this, s);
     }
 
@@ -401,6 +401,6 @@ struct CMutableTransaction
 
 typedef std::shared_ptr<const CTransaction> CTransactionRef;
 inline CTransactionRef MakeTransactionRef() { return std::make_shared<const CTransaction>(); }
-template <typename Tx> inline CTransactionRef MakeTransactionRef(Tx&& txIn) { return std::make_shared<const CTransaction>(std::forward<Tx>(txIn)); }
+template <typename Tx> CTransactionRef MakeTransactionRef(Tx&& txIn) { return std::make_shared<const CTransaction>(std::forward<Tx>(txIn)); }
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -400,7 +400,7 @@ struct CMutableTransaction
 };
 
 typedef std::shared_ptr<const CTransaction> CTransactionRef;
-static inline CTransactionRef MakeTransactionRef() { return std::make_shared<const CTransaction>(); }
-template <typename Tx> static inline CTransactionRef MakeTransactionRef(Tx&& txIn) { return std::make_shared<const CTransaction>(std::forward<Tx>(txIn)); }
+inline CTransactionRef MakeTransactionRef() { return std::make_shared<const CTransaction>(); }
+template <typename Tx> inline CTransactionRef MakeTransactionRef(Tx&& txIn) { return std::make_shared<const CTransaction>(std::forward<Tx>(txIn)); }
 
 #endif // BITCOIN_PRIMITIVES_TRANSACTION_H

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -312,7 +312,7 @@ void SetServiceFlagsIBDCache(bool status);
  * == GetDesirableServiceFlags(services), ie determines whether the given
  * set of service flags are sufficient for a peer to be "relevant".
  */
-static inline bool HasAllDesirableServiceFlags(ServiceFlags services) {
+inline bool HasAllDesirableServiceFlags(ServiceFlags services) {
     return !(GetDesirableServiceFlags(services) & (~services));
 }
 
@@ -320,7 +320,7 @@ static inline bool HasAllDesirableServiceFlags(ServiceFlags services) {
  * Checks if a peer with the given service flags may be capable of having a
  * robust address-storage DB.
  */
-static inline bool MayHaveUsefulAddressDB(ServiceFlags services) {
+inline bool MayHaveUsefulAddressDB(ServiceFlags services) {
     return (services & NODE_NETWORK) || (services & NODE_NETWORK_LIMITED);
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -54,7 +54,7 @@
     std::abort();
 }
 
-static inline int64_t GetPerformanceCounter()
+static int64_t GetPerformanceCounter()
 {
     // Read the hardware time stamp counter when available.
     // See https://en.wikipedia.org/wiki/Time_Stamp_Counter for more information.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1683,9 +1683,9 @@ void CalculatePercentilesByWeight(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES],
 }
 
 template<typename T>
-static inline bool SetHasKeys(const std::set<T>& set) {return false;}
+static bool SetHasKeys(const std::set<T>& set) {return false;}
 template<typename T, typename Tk, typename... Args>
-static inline bool SetHasKeys(const std::set<T>& set, const Tk& key, const Args&... args)
+static bool SetHasKeys(const std::set<T>& set, const Tk& key, const Args&... args)
 {
     return (set.count(key) != 0) || SetHasKeys(set, args...);
 }

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -20,7 +20,7 @@ void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 /** Register raw transaction RPC commands */
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
 
-static inline void RegisterAllCoreRPCCommands(CRPCTable &t)
+inline void RegisterAllCoreRPCCommands(CRPCTable &t)
 {
     RegisterBlockchainRPCCommands(t);
     RegisterNetRPCCommands(t);

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -422,7 +422,7 @@ std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq)
  * Process named arguments into a vector of positional arguments, based on the
  * passed-in specification for the RPC call's arguments.
  */
-static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, const std::vector<std::string>& argNames)
+static JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, const std::vector<std::string>& argNames)
 {
     JSONRPCRequest out = in;
     out.params = UniValue(UniValue::VARR);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -53,7 +53,7 @@ bool CastToBool(const valtype& vch)
  */
 #define stacktop(i)  (stack.at(stack.size()+(i)))
 #define altstacktop(i)  (altstack.at(altstack.size()+(i)))
-static inline void popstack(std::vector<valtype>& stack)
+static void popstack(std::vector<valtype>& stack)
 {
     if (stack.empty())
         throw std::runtime_error("popstack(): stack empty");

--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -35,7 +35,7 @@ std::once_flag LockedPoolManager::init_flag;
 // Utilities
 //
 /** Align up to power of 2 */
-static inline size_t align_up(size_t x, size_t align)
+static size_t align_up(size_t x, size_t align)
 {
     return (x + align - 1) & ~(align - 1);
 }

--- a/src/sync.h
+++ b/src/sync.h
@@ -61,11 +61,11 @@ void DeleteLock(void* cs);
  */
 extern bool g_debug_lockorder_abort;
 #else
-void static inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
-void static inline LeaveCritical() {}
-void static inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) ASSERT_EXCLUSIVE_LOCK(cs) {}
-void static inline AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
-void static inline DeleteLock(void* cs) {}
+void inline EnterCritical(const char* pszName, const char* pszFile, int nLine, void* cs, bool fTry = false) {}
+void inline LeaveCritical() {}
+void inline AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) ASSERT_EXCLUSIVE_LOCK(cs) {}
+void inline AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs) {}
+void inline DeleteLock(void* cs) {}
 #endif
 #define AssertLockHeld(cs) AssertLockHeldInternal(#cs, __FILE__, __LINE__, &cs)
 #define AssertLockNotHeld(cs) AssertLockNotHeldInternal(#cs, __FILE__, __LINE__, &cs)

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -17,7 +17,7 @@
 BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
 
 /// Convert vector to arith_uint256, via uint256 blob
-static inline arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)
+static arith_uint256 arith_uint256V(const std::vector<unsigned char>& vch)
 {
     return UintToArith256(uint256(vch));
 }

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -170,7 +170,7 @@ static std::vector<uint256> BlockGetMerkleBranch(const CBlock& block, const std:
     return vMerkleBranch;
 }
 
-static inline int ctz(uint32_t i) {
+static int ctz(uint32_t i) {
     if (i == 0) return 0;
     int j = 0;
     while (!(i & 1)) {

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -21,7 +21,7 @@
 extern uint256 insecure_rand_seed;
 extern FastRandomContext insecure_rand_ctx;
 
-static inline void SeedInsecureRand(bool fDeterministic = false)
+inline void SeedInsecureRand(bool fDeterministic = false)
 {
     if (fDeterministic) {
         insecure_rand_seed = uint256();
@@ -31,11 +31,11 @@ static inline void SeedInsecureRand(bool fDeterministic = false)
     insecure_rand_ctx = FastRandomContext(insecure_rand_seed);
 }
 
-static inline uint32_t InsecureRand32() { return insecure_rand_ctx.rand32(); }
-static inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }
-static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.randbits(bits); }
-static inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
-static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
+inline uint32_t InsecureRand32() { return insecure_rand_ctx.rand32(); }
+inline uint256 InsecureRand256() { return insecure_rand_ctx.rand256(); }
+inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.randbits(bits); }
+inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
+inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
 
 /** Basic testing setup.
  * This just configures logging and chain parameters.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -216,20 +216,20 @@ public:
 
     /** Determine whether to use config settings in the default section,
      *  See also comments around ArgsManager::ArgsManager() below. */
-    static inline bool UseDefaultSection(const ArgsManager& am, const std::string& arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
+    static bool UseDefaultSection(const ArgsManager& am, const std::string& arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
     {
         return (am.m_network == CBaseChainParams::MAIN || am.m_network_only_args.count(arg) == 0);
     }
 
     /** Convert regular argument into the network-specific setting */
-    static inline std::string NetworkArg(const ArgsManager& am, const std::string& arg)
+    static std::string NetworkArg(const ArgsManager& am, const std::string& arg)
     {
         assert(arg.length() > 1 && arg[0] == '-');
         return "-" + am.m_network + "." + arg.substr(1);
     }
 
     /** Find arguments in a map and add them to a vector */
-    static inline void AddArgs(std::vector<std::string>& res, const MapArgs& map_args, const std::string& arg)
+    static void AddArgs(std::vector<std::string>& res, const MapArgs& map_args, const std::string& arg)
     {
         auto it = map_args.find(arg);
         if (it != map_args.end()) {
@@ -240,7 +240,7 @@ public:
     /** Return true/false if an argument is set in a map, and also
      *  return the first (or last) of the possibly multiple values it has
      */
-    static inline std::pair<bool,std::string> GetArgHelper(const MapArgs& map_args, const std::string& arg, bool getLast = false)
+    static std::pair<bool,std::string> GetArgHelper(const MapArgs& map_args, const std::string& arg, bool getLast = false)
     {
         auto it = map_args.find(arg);
 
@@ -259,7 +259,7 @@ public:
      * indicating the argument was found, and the value for the argument
      * if it was found (or the empty string if not found).
      */
-    static inline std::pair<bool,std::string> GetArg(const ArgsManager &am, const std::string& arg)
+    static std::pair<bool,std::string> GetArg(const ArgsManager &am, const std::string& arg)
     {
         LOCK(am.cs_args);
         std::pair<bool,std::string> found_result(false, std::string());
@@ -295,7 +295,7 @@ public:
     /* Special test for -testnet and -regtest args, because we
      * don't want to be confused by craziness like "[regtest] testnet=1"
      */
-    static inline bool GetNetBoolArg(const ArgsManager &am, const std::string& net_arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
+    static bool GetNetBoolArg(const ArgsManager &am, const std::string& net_arg) EXCLUSIVE_LOCKS_REQUIRED(am.cs_args)
     {
         std::pair<bool,std::string> found_result(false,std::string());
         found_result = GetArgHelper(am.m_override_args, net_arg, true);

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -437,7 +437,7 @@ int atoi(const std::string& str)
 static const int64_t UPPER_BOUND = 1000000000000000000LL - 1LL;
 
 /** Helper function for ParseFixedPoint */
-static inline bool ProcessMantissaDigit(char ch, int64_t &mantissa, int &mantissa_tzeros)
+static bool ProcessMantissaDigit(char ch, int64_t &mantissa, int &mantissa_tzeros)
 {
     if(ch == '0')
         ++mantissa_tzeros;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -179,7 +179,7 @@ struct CRecipient
 typedef std::map<std::string, std::string> mapValue_t;
 
 
-static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
+inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (!mapValue.count("n"))
     {
@@ -190,7 +190,7 @@ static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 }
 
 
-static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
+inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (nOrderPos == -1)
         return;


### PR DESCRIPTION
This is C++, inline functions in a headers do not need to be `static`. Making it so is a pessimization as it will generate functions with internal linkage in every translation unit including the header. (Note that `inline` in C is different from `inline` in C++).

Furthermore, a static function in a cpp file already has internal linkage, making it `inline` has no effect.

Templates already have an inline-like property of being allowed to be defined multiple times, and having the linker deal with it. Making them `inline` is also redundant.

This change does 3 things:
1. removes `static` from all inlined functions in header files
2. removes `inline` from all `static inline` functions in .cpp files
3. removes `inline` from templates