### PR TITLE
gui: Also log and print messages or questions like bitcoind

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/signals2/connection.hpp>
 
-static bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)
+bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)
 {
     bool fSecure = style & CClientUIInterface::SECURE;
     style &= ~CClientUIInterface::SECURE;
@@ -41,19 +41,18 @@ static bool noui_ThreadSafeMessageBox(const std::string& message, const std::str
     return false;
 }
 
-static bool noui_ThreadSafeQuestion(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
+bool noui_ThreadSafeQuestion(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
 {
     return noui_ThreadSafeMessageBox(message, caption, style);
 }
 
-static void noui_InitMessage(const std::string& message)
+void noui_InitMessage(const std::string& message)
 {
     LogPrintf("init message: %s\n", message);
 }
 
 void noui_connect()
 {
-    // Connect bitcoind signal handlers
     uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
     uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
     uiInterface.InitMessage_connect(noui_InitMessage);

--- a/src/noui.h
+++ b/src/noui.h
@@ -5,6 +5,16 @@
 #ifndef BITCOIN_NOUI_H
 #define BITCOIN_NOUI_H
 
-extern void noui_connect();
+#include <string>
+
+/** Non-GUI handler, which logs and prints messages. */
+bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style);
+/** Non-GUI handler, which logs and prints questions. */
+bool noui_ThreadSafeQuestion(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style);
+/** Non-GUI handler, which only logs a message. */
+void noui_InitMessage(const std::string& message);
+
+/** Connect all bitcoind signal handlers */
+void noui_connect();
 
 #endif // BITCOIN_NOUI_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -28,6 +28,7 @@
 
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <noui.h>
 #include <rpc/server.h>
 #include <ui_interface.h>
 #include <uint256.h>
@@ -71,9 +72,9 @@ Q_DECLARE_METATYPE(bool*)
 Q_DECLARE_METATYPE(CAmount)
 Q_DECLARE_METATYPE(uint256)
 
-static void InitMessage(const std::string &message)
+static void InitMessage(const std::string& message)
 {
-    LogPrintf("init message: %s\n", message);
+    noui_InitMessage(message);
 }
 
 /** Translate string to current locale using Qt. */

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -31,6 +31,7 @@
 #include <chainparams.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
+#include <noui.h>
 #include <ui_interface.h>
 #include <util.h>
 
@@ -1217,8 +1218,11 @@ void BitcoinGUI::showModalOverlay()
         modalOverlay->toggleVisibility();
 }
 
-static bool ThreadSafeMessageBox(BitcoinGUI *gui, const std::string& message, const std::string& caption, unsigned int style)
+static bool ThreadSafeMessageBox(BitcoinGUI* gui, const std::string& message, const std::string& caption, unsigned int style)
 {
+    // Redundantly log and print message in non-gui fashion
+    noui_ThreadSafeMessageBox(message, caption, style);
+
     bool modal = (style & CClientUIInterface::MODAL);
     // The SECURE flag has no effect in the Qt GUI.
     // bool secure = (style & CClientUIInterface::SECURE);


### PR DESCRIPTION
Testing and debugging after shutdown are harder if the node was run through the gui, because errors and warnings would not be logged to the debug.log or written to the stderr (as is the case for bitcoind).