### PR TITLE
Scripts and tools: fix gitian build related to Debian/MacOSX-SDK/curl

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -8,7 +8,7 @@ import shutil
 
 def setup():
     global args, workdir
-    programs = ['ruby', 'git', 'apt-cacher-ng', 'make', 'wget']
+    programs = ['ruby', 'git', 'apt-cacher-ng', 'make', 'wget', 'curl']
     if args.kvm:
         programs += ['python-vm-builder', 'qemu-kvm', 'qemu-utils']
     elif args.docker:


### PR DESCRIPTION
The [documentation](https://github.com/bitcoin-core/docs/blob/master/gitian-building.md) suggest to use debian 8.x, but the script bin/make-base-vm is invoked with '--suite bionic’ that on debian rises an error (not easy to understand for a newby). It is solved detecting automatically the distro and the suite-codename invoking lsb_release.

The [documentation](https://github.com/bitcoin-core/docs/blob/master/gitian-building/gitian-building-mac-os-sdk.md) instruct to create the directory ‘gitian-builder/inputs’ with the MacOSX  SDK inside. The presence of this path does not consent to clone the gitian-builder repos and rises a subsequent error not clearly related to the issue. It is solved checking the presence of the ‘.git’ inside and moving the SDK temporary outside, relocating at his place after cloning.

The curl package is required for the build process as described [here](https://github.com/bitcoin/bitcoin/blob/master/depends/README.md).