### PR TITLE
qa: Fixups to "Run all tests even if wallet is not compiled"

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -44,12 +44,6 @@ class ZMQTest (BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def setup_nodes(self):
-        # Import keys
-        self.add_nodes(self.num_nodes)
-        self.start_nodes()
-        super().import_deterministic_coinbase_privkeys()
-        self.stop_nodes()
-
         import zmq
 
         # Initialize ZMQ context and socket.
@@ -69,11 +63,12 @@ class ZMQTest (BitcoinTestFramework):
         self.rawblock = ZMQSubscriber(socket, b"rawblock")
         self.rawtx = ZMQSubscriber(socket, b"rawtx")
 
-        self.nodes[0].extra_args = ["-zmqpub%s=%s" % (sub.topic.decode(), address) for sub in [self.hashblock, self.hashtx, self.rawblock, self.rawtx]]
+        self.extra_args = [
+            ["-zmqpub%s=%s" % (sub.topic.decode(), address) for sub in [self.hashblock, self.hashtx, self.rawblock, self.rawtx]],
+            [],
+        ]
+        self.add_nodes(self.num_nodes, self.extra_args)
         self.start_nodes()
-
-    def import_deterministic_coinbase_privkeys(self):
-        pass
 
     def run_test(self):
         try:

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -100,7 +100,7 @@ class TestNode():
     def get_deterministic_priv_key(self):
         """Return a deterministic priv key in base58, that only depends on the node's index"""
         PRIV_KEYS = [
-            # adress , privkey
+            # address , privkey
             ('mjTkW3DjgyZck4KbiRusZsqTgaYTxdSz6z', 'cVpF924EspNh8KjYsfhgY96mmxvT6DgdWiTYMtMjuM74hJaU5psW'),
             ('msX6jQXvxiNhx3Q62PKeLPrhrqZQdSimTg', 'cUxsWyKyZ9MAQTaAhUQWJmBbSvHMwSmuv59KgxQV7oZQU3PXN3KE'),
             ('mnonCMyH9TmAsSj3M59DsbH8H63U3RKoFP', 'cTrh7dkEAeJd6b3MRX9bZK8eRmNqVCMH3LSUkE3dSFDyzjU38QxK'),

--- a/test/functional/wallet_dump.py
+++ b/test/functional/wallet_dump.py
@@ -34,7 +34,11 @@ def read_dump(file_name, addrs, script_addrs, hd_master_addr_old):
                 # key = key_date_label[0]
                 date = key_date_label[1]
                 keytype = key_date_label[2]
-                if not len(comment) or date.startswith('1970'):
+
+                imported_key = date == '1970-01-01T00:00:01Z'
+                if imported_key:
+                    # Imported keys have multiple addresses, no label (keypath) and timestamp
+                    # Skip them
                     continue
 
                 addr_keypath = comment.split(" addr=")[1]

--- a/test/functional/wallet_import_rescan.py
+++ b/test/functional/wallet_import_rescan.py
@@ -120,7 +120,7 @@ class ImportRescanTest(BitcoinTestFramework):
 
         self.add_nodes(self.num_nodes, extra_args=extra_args)
 
-        # Import keys
+        # Import keys with pruning disabled
         self.start_nodes(extra_args=[[]] * self.num_nodes)
         super().import_deterministic_coinbase_privkeys()
         self.stop_nodes()

--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -9,7 +9,10 @@
 
 export LC_ALL=C
 
+EXIT_CODE=0
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt
 if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/qt/locale/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/"); then
     echo "^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in ${IGNORE_WORDS_FILE}"
+    EXIT_CODE=1
 fi
+exit ${EXIT_CODE}


### PR DESCRIPTION
Currently the functional tests require the wallet module to be compiled into the Bitcoin Core executable. For example the premine (or datadir cache) to speed up tests when run in parallel would mine a bunch of blocks and store the private keys to sign the coinbase tx outputs in a wallet. There is no need to have the overhead of the whole wallet module by using keys that are deterministic for all runs.

Note that this change most likely requires the `./test/cache/` to be cleared.