### PR TITLE
utils: Convert fs::filesystem_error messages from local multibyte to utf-8 on Windows

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -92,4 +92,20 @@ bool FileLock::TryLock()
 }
 #endif
 
+std::string get_filesystem_error_message(const fs::filesystem_error& e)
+{
+#ifndef WIN32
+    return e.what();
+#else
+    // Convert from Multi Byte to utf-16
+    std::string mb_string(e.what());
+    int size = MultiByteToWideChar(CP_ACP, 0, mb_string.c_str(), mb_string.size(), nullptr, 0);
+
+    std::wstring utf16_string(size, L'\0');
+    MultiByteToWideChar(CP_ACP, 0, mb_string.c_str(), mb_string.size(), &*utf16_string.begin(), size);
+    // Convert from utf-16 to utf-8
+    return std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t>().to_bytes(utf16_string);
+#endif
+}
+
 } // fsbridge

--- a/src/fs.h
+++ b/src/fs.h
@@ -38,6 +38,8 @@ namespace fsbridge {
         void* hFile = (void*)-1; // INVALID_HANDLE_VALUE
 #endif
     };
+
+    std::string get_filesystem_error_message(const fs::filesystem_error& e);
 };
 
 #endif // BITCOIN_FS_H

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -128,7 +128,7 @@ void DeleteAuthCookie()
     try {
         fs::remove(GetAuthCookieFile());
     } catch (const fs::filesystem_error& e) {
-        LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, e.what());
+        LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, fsbridge::get_filesystem_error_message(e));
     }
 }
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -783,7 +783,7 @@ bool BerkeleyDatabase::Backup(const std::string& strDest)
                     LogPrintf("copied %s to %s\n", strFile, pathDest.string());
                     return true;
                 } catch (const fs::filesystem_error& e) {
-                    LogPrintf("error copying %s to %s - %s\n", strFile, pathDest.string(), e.what());
+                    LogPrintf("error copying %s to %s - %s\n", strFile, pathDest.string(), fsbridge::get_filesystem_error_message(e));
                     return false;
                 }
             }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3849,7 +3849,7 @@ bool CWallet::Verify(std::string wallet_file, bool salvage_wallet, std::string& 
             return false;
         }
     } catch (const fs::filesystem_error& e) {
-        error_string = strprintf("Error loading wallet %s. %s", wallet_file, e.what());
+        error_string = strprintf("Error loading wallet %s. %s", wallet_file, fsbridge::get_filesystem_error_message(e));
         return false;
     }
 


### PR DESCRIPTION
Before:
![default](https://user-images.githubusercontent.com/11154118/45318798-8d83f480-b570-11e8-8cbb-c729a54f6b9e.png)
After:
![2](https://user-images.githubusercontent.com/11154118/45318806-91177b80-b570-11e8-9474-a62342c92dbd.png)
