### PR TITLE
[0.17][psbt] always drop the unnecessary utxo and convert non-witness utxo to witness when necessary

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4525,8 +4525,8 @@ bool FillPSBT(const CWallet* pwallet, PartiallySignedTransaction& psbtx, const C
             complete &= SignPSBTInput(PublicOnlySigningProvider(pwallet), *psbtx.tx, input, sigdata, i, sighash_type);
         }
 
-        if (it != pwallet->mapWallet.end()) {
-            // Drop the unnecessary UTXO if we added both from the wallet.
+        // If both UTXO types are present, drop the unnecessary one.
+        if (input.non_witness_utxo && !input.witness_utxo.IsNull()) {
             if (sigdata.witness) {
                 input.non_witness_utxo = nullptr;
             } else {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4525,6 +4525,13 @@ bool FillPSBT(const CWallet* pwallet, PartiallySignedTransaction& psbtx, const C
             complete &= SignPSBTInput(PublicOnlySigningProvider(pwallet), *psbtx.tx, input, sigdata, i, sighash_type);
         }
 
+        if (sigdata.witness) {
+            // Convert the non-witness utxo to witness
+            if (input.witness_utxo.IsNull() && input.non_witness_utxo) {
+                input.witness_utxo = input.non_witness_utxo->vout[txin.prevout.n];
+            }
+        }
+
         // If both UTXO types are present, drop the unnecessary one.
         if (input.non_witness_utxo && !input.witness_utxo.IsNull()) {
             if (sigdata.witness) {


### PR DESCRIPTION
When we sign an input in a psbt that has a non-witness utxo but a witness signature is produced, we will now replace the non-witness utxo with the corresponding witness utxo. Furthermore, we should make sure that the correct UTXO type is used based on what UTXOs are there, not based on earlier wallet behavior.

Note that this is PR'd to the 0.17 branch because the code here no longer exists in master.