### PR TITLE
[WIP] RPC: Add Method To Retrieve HTTP Server Metrics

### DIFF
--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -150,4 +150,17 @@ private:
 
 std::string urlDecode(const std::string &urlEncoded);
 
+/** RPC server related metrics.
+ */
+class RPCServerStats
+{
+public:
+    int64_t start_time_micros;
+    uint64_t num_http_requests;
+};
+
+/** Compute and return RPC metrics.
+ */
+RPCServerStats GetRPCServerStats();
+
 #endif // BITCOIN_HTTPSERVER_H

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -8,6 +8,7 @@
 #include <clientversion.h>
 #include <core_io.h>
 #include <validation.h>
+#include <httpserver.h>
 #include <net.h>
 #include <net_processing.h>
 #include <netbase.h>
@@ -491,6 +492,33 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
     return obj;
 }
 
+static UniValue getnetworkrpcinfo(const JSONRPCRequest& request)
+{
+    if (request.fHelp || request.params.size() != 0)
+        throw std::runtime_error(
+            "getnetworkrpcinfo\n"
+            "Returns an object containing various state info regarding RPC service.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"total_requests\": xxxxx,  (numeric) Lifetime total number of RPC requests processed.\n"
+            "  \"uptime_micros\": xxxxx,   (numeric) Uptime of RPC server in microseconds.\n"
+            "}\n"
+            "\nExamples:\n"
+            + HelpExampleCli("getnetworkrpcinfo", "")
+            + HelpExampleRpc("getnetworkrpcinfo", "")
+        );
+
+    RPCServerStats rpc_stats = GetRPCServerStats();
+
+    int64_t uptime_micros = GetTimeMicros() - rpc_stats.start_time_micros;
+
+    UniValue obj(UniValue::VOBJ);
+    obj.pushKV("total_requests", rpc_stats.num_http_requests);
+    obj.pushKV("uptime_micros", uptime_micros);
+
+    return obj;
+}
+
 static UniValue setban(const JSONRPCRequest& request)
 {
     std::string strCommand;
@@ -638,6 +666,7 @@ static const CRPCCommand commands[] =
     { "network",            "getaddednodeinfo",       &getaddednodeinfo,       {"node"} },
     { "network",            "getnettotals",           &getnettotals,           {} },
     { "network",            "getnetworkinfo",         &getnetworkinfo,         {} },
+    { "network",            "getnetworkrpcinfo",      &getnetworkrpcinfo,      {} },
     { "network",            "setban",                 &setban,                 {"subnet", "command", "bantime", "absolute"} },
     { "network",            "listbanned",             &listbanned,             {} },
     { "network",            "clearbanned",            &clearbanned,            {} },

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -12,6 +12,7 @@ from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
     connect_nodes_bi,
@@ -31,6 +32,7 @@ class NetTest(BitcoinTestFramework):
         self._test_getnetworkinginfo()
         self._test_getaddednodeinfo()
         self._test_getpeerinfo()
+        self._test_getnetworkrpcinfo()
 
     def _test_connection_count(self):
         # connect_nodes_bi connects each node to the other
@@ -100,6 +102,13 @@ class NetTest(BitcoinTestFramework):
         assert_equal(peer_info[1][0]['addrbind'], peer_info[0][0]['addr'])
         assert_equal(peer_info[0][0]['minfeefilter'], Decimal("0.00000500"))
         assert_equal(peer_info[1][0]['minfeefilter'], Decimal("0.00001000"))
+
+    def _test_getnetworkrpcinfo(self):
+        first_result = self.nodes[0].getnetworkrpcinfo()
+        second_result = self.nodes[0].getnetworkrpcinfo()
+
+        assert_greater_than(second_result['uptime_micros'], first_result['uptime_micros'])
+        assert_greater_than(second_result['total_requests'], first_result['total_requests'])
 
 if __name__ == '__main__':
     NetTest().main()


### PR DESCRIPTION
This is a work in progress, all comments and review are welcome and appreciated.

**TL;DR:** We add a new network RPC call, `getnetworkrpcinfo`, that returns metrics about JSON RPC HTTP server.

## INTRODUCTION
As part of constructing Service Level Agreements (SLAs) around the uptime of Bitcoin nodes, it is useful to measure such things as requests processed per second or average request processing time. While the `getnetworkinfo` RPC call provides a lot information and many useful metrics about the P2P layer of Bitcoin, it does not provide any metrics about the JSON RPC layer. Since many services interact with Bitcoin almost entirely through its JSON RPC interface, it would be useful to collect and provide metrics about this interface.

## OVERVIEW OF CHANGES
This PR contains two major changes: Collecting HTTP server metrics and Adding a new RPC method.

### Collect HTTP Server Metrics (`httpserver.h`, `httpserver.cpp`)
This change is the first part of adding a new RPC call to report stats from the HTTP server. It modifies the HTTP server functionality to collect and report the gathered statistics.

`httpserver.h`:
  * Add private member variable `receivedAtTimeMicros` to `HTTPRequest` to record the time at which the request was started.
  * Add data-type, `RPCServerStats`, that holds all gathered HTTP server stats.
  * Add function, `GetRPCServerStats`, that returns the current RPC server stats via the provider pointer.

`httpserver.cpp`:
  * Add static global `g_rpcserverstats` to hold HTTP server stats across all requests.
  * Add static global `g_rpcserverstats_mutex` to serialize writes to `g_rpcserverstats`.
  * Modify several functions to collect the RPC server stats.
  * Implement `GetRPCServerStats`.

### Add getnetworkrpcinfo RPC Method (`rpc/net.cpp`)
Add a new RPC command, `getnetworkrpcinfo`, that returns an object containing various state information about the HTTP server providing a JSON RPC interface. This information can be used to derive information such as requests per second and average request processing time.

The information is provided in a raw form leaving the clients to derive such useful metrics, this is intentional and allows this RPC call to avoid issues around floating point accuracy and floating point error accumulation. Instead, these issues are left to the consumers of the response object to handle in whatever fashion they like.