### PR TITLE
build: Move interfaces/* to libbitcoin_server

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -228,6 +228,8 @@ libbitcoin_server_a_SOURCES = \
   httpserver.cpp \
   index/base.cpp \
   index/txindex.cpp \
+  interfaces/handler.cpp \
+  interfaces/node.cpp \
   init.cpp \
   dbwrapper.cpp \
   merkleblock.cpp \
@@ -414,8 +416,6 @@ libbitcoin_util_a_SOURCES = \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
   fs.cpp \
-  interfaces/handler.cpp \
-  interfaces/node.cpp \
   logging.cpp \
   random.cpp \
   rpc/protocol.cpp \


### PR DESCRIPTION
Move interfaces/* from libbitcoin_util to libbitcoin_server.

Usage of these is shared between `bitcoind` and `bitcoin-qt`. It is unnecessary for them to be linked against the other utilities. Also semantically they belong with the server/node, I think.