### PR TITLE
lint: Check for use of NULL instead of nullptr

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4007,7 +4007,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(const std::string& name, 
     } else if (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) {
         // Make it impossible to disable private keys after creation
         InitError(strprintf(_("Error loading %s: Private keys can only be disabled during creation"), walletFile));
-        return NULL;
+        return nullptr;
     } else if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         LOCK(walletInstance->cs_KeyStore);
         if (!walletInstance->mapKeys.empty() || !walletInstance->mapCryptedKeys.empty()) {

--- a/test/lint/lint-cpp.sh
+++ b/test/lint/lint-cpp.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check for common C++ issues.
+
+export LC_ALL=C
+
+EXIT_CODE=0
+
+# Check for use of NULL instead of nullptr.
+#
+# The POSIX regular expression [^abc] matches any character except a, b and c.
+OUTPUT=$(git grep -E "[^A-Za-z0-9_\"]NULL[^A-Za-z0-9_\"]" -- "*.cpp" "*.h" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" ":(exclude)src/torcontrol.cpp" | grep -vE "//.*NULL")
+if [[ ${OUTPUT} != "" ]]; then
+    echo "Use nullptr instead of NULL:"
+    echo
+    echo "${OUTPUT}"
+    EXIT_CODE=1
+fi
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
Add linter: Check for use of `NULL` instead of `nullptr`.

As suggested by @HashUnlimited in #14203 :-)

Technical rationale:

`nullptr` cannot be confused with an `int`. `nullptr` also has a well-specified (very restrictive) type, and thus works in more scenarios where type deduction might do the wrong thing on `NULL` or `0`.

Thus: using `nullptr` instead of `NULL` consistently will avoid a certain class of bugs.

