### PR TITLE
Transaction relay privacy bugfix

### DIFF
--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -5,12 +5,10 @@
 """Test that we don't leak txs to inbound peers that we haven't yet announced to"""
 
 from test_framework.messages import msg_getdata, CInv
-from test_framework.mininode import mininode_lock, P2PDataStore
+from test_framework.mininode import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    assert_greater_than,
-    wait_until,
 )
 
 import time

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that we don't leak txs to inbound peers that we haven't yet announced to"""
+
+from test_framework.messages import msg_getdata, CInv
+from test_framework.mininode import mininode_lock, P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    wait_until,
+)
+
+import time
+
+
+class P2PNode(P2PDataStore):
+    def on_inv(self, msg):
+        pass
+
+
+class P2PLeakTxTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        gen_node = self.nodes[0]  # The block and tx generating node
+        gen_node.generate(1)
+        self.sync_all()
+
+        inbound_peer = self.nodes[0].add_p2p_connection(P2PNode())  # An "attacking" inbound peer
+
+        REPEATS = 10
+        self.log.info('Start test for {} repeats'.format(REPEATS))
+        for i in range(REPEATS):
+            self.log.debug('Run {}/{}'.format(i, REPEATS))
+            txid = gen_node.sendtoaddress(gen_node.getnewaddress(), 0.033)
+
+            time.sleep(5)
+
+            want_tx = msg_getdata()
+            want_tx.inv.append(CInv(t=1, h=int(txid, 16)))
+            inbound_peer.send_message(want_tx)
+            inbound_peer.sync_with_ping()
+
+            if inbound_peer.last_message.get('notfound'):
+                self.log.debug('tx {} was not yet announced to us.'.format(txid))
+                assert_equal(inbound_peer.last_message['notfound'].vec[0].hash, int(txid, 16))
+                inbound_peer.last_message.pop('notfound')
+            else:
+                self.log.debug('tx {} was announced to us.'.format(txid))
+                assert int(txid, 16) in [inv.hash for inv in inbound_peer.last_message['inv'].inv]
+
+
+if __name__ == '__main__':
+    P2PLeakTxTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1232,6 +1232,26 @@ class msg_mempool:
         return "msg_mempool()"
 
 
+class msg_notfound:
+    __slots__ = ("vec")
+    command = b"notfound"
+
+    def __init__(self, vec=None):
+        if vec is None:
+            self.vec = []
+        else:
+            self.vec = vec
+
+    def deserialize(self, f):
+        self.vec = deser_vector(f, CInv)
+
+    def serialize(self):
+        return ser_vector(self.vec)
+
+    def __repr__(self):
+        return "msg_notfound(vec=%s)" % (repr(self.vec))
+
+
 class msg_sendheaders:
     __slots__ = ()
     command = b"sendheaders"

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -21,7 +21,38 @@ import struct
 import sys
 import threading
 
-from test_framework.messages import CBlockHeader, MIN_VERSION_SUPPORTED, msg_addr, msg_block, MSG_BLOCK, msg_blocktxn, msg_cmpctblock, msg_feefilter, msg_getaddr, msg_getblocks, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_mempool, msg_ping, msg_pong, msg_reject, msg_sendcmpct, msg_sendheaders, msg_tx, MSG_TX, MSG_TYPE_MASK, msg_verack, msg_version, NODE_NETWORK, NODE_WITNESS, sha256
+from test_framework.messages import (
+    CBlockHeader,
+    MIN_VERSION_SUPPORTED,
+    msg_addr,
+    msg_block,
+    MSG_BLOCK,
+    msg_blocktxn,
+    msg_cmpctblock,
+    msg_feefilter,
+    msg_getaddr,
+    msg_getblocks,
+    msg_getblocktxn,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_mempool,
+    msg_notfound,
+    msg_ping,
+    msg_pong,
+    msg_reject,
+    msg_sendcmpct,
+    msg_sendheaders,
+    msg_tx,
+    MSG_TX,
+    MSG_TYPE_MASK,
+    msg_verack,
+    msg_version,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    sha256,
+)
 from test_framework.util import wait_until
 
 logger = logging.getLogger("TestFramework.mininode")
@@ -40,6 +71,7 @@ MESSAGEMAP = {
     b"headers": msg_headers,
     b"inv": msg_inv,
     b"mempool": msg_mempool,
+    b"notfound": msg_notfound,
     b"ping": msg_ping,
     b"pong": msg_pong,
     b"reject": msg_reject,
@@ -295,6 +327,7 @@ class P2PInterface(P2PConnection):
     def on_getheaders(self, message): pass
     def on_headers(self, message): pass
     def on_mempool(self, message): pass
+    def on_notfound(self, message): pass
     def on_pong(self, message): pass
     def on_reject(self, message): pass
     def on_sendcmpct(self, message): pass

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -152,6 +152,7 @@ BASE_SCRIPTS = [
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py',
+    'p2p_leak_tx.py',
     'rpc_signmessage.py',
     'feature_nulldummy.py',
     'mempool_accept.py',


### PR DESCRIPTION
This PR does ~~two~~ one thing~~s~~:

* Fixes a privacy issue where if we relay a transaction to peer A (but not peer B), peer B can request the transaction and we'll provide it.  Instead, we should wait until we announce to peer B before providing the transaction.

~~* Respond to getdata requests for transactions that are ancestors of newly-announced transactions.  Currently, our software will request the parents of an orphan transaction from the peer who announced the orphan, but if our peer is running a recent Bitcoin Core version, the request would typically be dropped.  So this should improve propagation for transaction chains, particularly for nodes that are just starting up.~~

~~This PR also includes a test that transaction chains relay to peers that weren't connected when a parent was broadcast.~~