### PR TITLE
Qt: Fix restoration of minimized to tray window

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1147,14 +1147,14 @@ void BitcoinGUI::showNormalIfMinimized(bool fToggleHidden)
         return;
 
     // activateWindow() (sometimes) helps with keyboard focus on Windows
-    if (isHidden())
-    {
-        show();
-        activateWindow();
-    }
-    else if (isMinimized())
+    if (isMinimized())
     {
         showNormal();
+        activateWindow();
+    }
+    else if (isHidden())
+    {
+        show();
         activateWindow();
     }
     else if (GUIUtil::isObscured(this))


### PR DESCRIPTION
Fix UX bug on Windows. Steps to reproduce (tested on Windows 10):

1. In Options->Window enable "Minimize to the tray instead of the taskbar".
2. Minimize the main window.
3. Select Show/Hide on the tray icon menu (or just click on the tray icon).

The normal size window is expected.

Actually the main window is restored minimized to the taskbar.

Rationale: minimizing the window with `fMinimizeToTray==true` actually do both `showMinimized()` and `hide()`. During restoration `isMinimized()` should be checked first. Otherwise, the restored window will be minimized.

The logic is broken both on Windows and Linux, but on my Linux (Mint 19 + Cinnamon 3.8.9) the window manager renders the main window as if all is correct. Nevertheless, other Linux systems may be affected by this bug.

Ref:
- #8225
- #11859