### PR TITLE
Document intentional and unintentional unsigned integer overflows (wraparounds) using annotations

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -444,6 +444,14 @@ General C++
   - *Rationale*: `MakeUnique` is concise and ensures exception safety in complex expressions.
     `MakeUnique` is a temporary project local implementation of `std::make_unique` (C++14).
 
+- Do not rely on unsigned wrap-around semantics unless there are good reasons for doing so (e.g. hash functions).
+  Functions that intentionally rely on unsigned wrap-around semantics should be annotated using `ALLOW_WRAPAROUND`.
+  Functions that unintentionally trigger unsigned wrap-arounds should be annotated using
+  `WARNING_UNINTENTIONAL_WRAPAROUND` while awaiting being fixed.
+
+  - *Rationale*: Intentional use of modular arithmetic needs to be annotated because unintended wraps are often bugs
+  and we use instrumentation (e.g. `-fsanitize`) to look for those bugs.
+
 C++ data structures
 --------------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -95,6 +95,7 @@ endif
 BITCOIN_CORE_H = \
   addrdb.h \
   addrman.h \
+  attributes.h \
   base58.h \
   bech32.h \
   bloom.h \

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
+#include <attributes.h>
 #include <assert.h>
 #include <cstring>
 #include <stdexcept>
@@ -168,7 +169,7 @@ public:
     base_uint& operator*=(const base_uint& b);
     base_uint& operator/=(const base_uint& b);
 
-    base_uint& operator++()
+    WARNING_UNINTENTIONAL_WRAPAROUND base_uint& operator++()
     {
         // prefix operator
         int i = 0;

--- a/src/attributes.h
+++ b/src/attributes.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ATTRIBUTES_H
+#define BITCOIN_ATTRIBUTES_H
+
+// Use ALLOW_WRAPAROUND to annotate functions that are known to cause unsigned integer
+// wraparounds where the modular arithmetic is intentional (e.g. hash functions).
+#if defined(__clang__)
+#  define ALLOW_WRAPAROUND __attribute__((no_sanitize("unsigned-integer-overflow")))
+#else
+#  define ALLOW_WRAPAROUND
+#endif
+
+// Use WARNING_UNINTENTIONAL_WRAPAROUND to annotate existing functions that are known to cause
+// unsigned integer wraparounds where the modular arithmetic is unintentional.
+//
+// Do not add new code with functions annotated WARNING_UNINTENTIONAL_WRAPAROUND. Newly introduced
+// code should not trigger unintentional integer wraparounds.
+#if defined(__clang__)
+#  define WARNING_UNINTENTIONAL_WRAPAROUND __attribute__((no_sanitize("unsigned-integer-overflow")))
+#else
+#  define WARNING_UNINTENTIONAL_WRAPAROUND
+#endif
+
+#endif // BITCOIN_ATTRIBUTES_H

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -5,12 +5,14 @@
 #ifndef BITCOIN_BENCH_BENCH_H
 #define BITCOIN_BENCH_BENCH_H
 
+#include <attributes.h>
+
+#include <chrono>
 #include <functional>
 #include <limits>
 #include <map>
 #include <string>
 #include <vector>
-#include <chrono>
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
@@ -67,7 +69,7 @@ public:
     {
     }
 
-    inline bool KeepRunning()
+    WARNING_UNINTENTIONAL_WRAPAROUND inline bool KeepRunning()
     {
         if (m_num_iters_left--) {
             return true;

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <attributes.h>
 #include <bloom.h>
-
-#include <primitives/transaction.h>
 #include <hash.h>
+#include <primitives/transaction.h>
+#include <random.h>
 #include <script/script.h>
 #include <script/standard.h>
-#include <random.h>
 #include <streams.h>
 
 #include <math.h>
@@ -230,7 +230,7 @@ CRollingBloomFilter::CRollingBloomFilter(const unsigned int nElements, const dou
 }
 
 /* Similar to CBloomFilter::Hash */
-static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, const std::vector<unsigned char>& vDataToHash) {
+ALLOW_WRAPAROUND static inline uint32_t RollingBloomHash(unsigned int nHashNum, uint32_t nTweak, const std::vector<unsigned char>& vDataToHash) {
     return MurmurHash3(nHashNum * 0xFBA4C795 + nTweak, vDataToHash);
 }
 

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <attributes.h>
 #include <chain.h>
 
 /**
@@ -133,7 +134,7 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
     return (~bnTarget / (bnTarget + 1)) + 1;
 }
 
-int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params& params)
+WARNING_UNINTENTIONAL_WRAPAROUND int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params& params)
 {
     arith_uint256 r;
     int sign = 1;

--- a/src/chain.h
+++ b/src/chain.h
@@ -7,6 +7,7 @@
 #define BITCOIN_CHAIN_H
 
 #include <arith_uint256.h>
+#include <attributes.h>
 #include <consensus/params.h>
 #include <primitives/block.h>
 #include <tinyformat.h>
@@ -474,7 +475,7 @@ public:
     }
 
     /** Return the maximal height in the chain. Is equal to chain.Tip() ? chain.Tip()->nHeight : -1. */
-    int Height() const {
+    WARNING_UNINTENTIONAL_WRAPAROUND int Height() const {
         return vChain.size() - 1;
     }
 

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <core_io.h>
-
+#include <attributes.h>
 #include <consensus/consensus.h>
 #include <consensus/validation.h>
+#include <core_io.h>
 #include <key_io.h>
 #include <script/script.h>
 #include <script/standard.h>
@@ -26,7 +26,7 @@ UniValue ValueFromAmount(const CAmount& amount)
             strprintf("%s%d.%08d", sign ? "-" : "", quotient, remainder));
 }
 
-std::string FormatScript(const CScript& script)
+WARNING_UNINTENTIONAL_WRAPAROUND std::string FormatScript(const CScript& script)
 {
     std::string ret;
     CScript::const_iterator it = script.begin();

--- a/src/crypto/chacha20.cpp
+++ b/src/crypto/chacha20.cpp
@@ -5,8 +5,9 @@
 // Based on the public domain implementation 'merged' by D. J. Bernstein
 // See https://cr.yp.to/chacha.html.
 
-#include <crypto/common.h>
+#include <attributes.h>
 #include <crypto/chacha20.h>
+#include <crypto/common.h>
 
 #include <string.h>
 
@@ -71,7 +72,7 @@ void ChaCha20::Seek(uint64_t pos)
     input[13] = pos >> 32;
 }
 
-void ChaCha20::Output(unsigned char* c, size_t bytes)
+ALLOW_WRAPAROUND void ChaCha20::Output(unsigned char* c, size_t bytes)
 {
     uint32_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
     uint32_t j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;

--- a/src/crypto/ripemd160.cpp
+++ b/src/crypto/ripemd160.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/ripemd160.h>
-
+#include <attributes.h>
 #include <crypto/common.h>
+#include <crypto/ripemd160.h>
 
 #include <string.h>
 
@@ -32,7 +32,7 @@ void inline Initialize(uint32_t* s)
 
 uint32_t inline rol(uint32_t x, int i) { return (x << i) | (x >> (32 - i)); }
 
-void inline Round(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t f, uint32_t x, uint32_t k, int r)
+ALLOW_WRAPAROUND void inline Round(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t f, uint32_t x, uint32_t k, int r)
 {
     a = rol(a + f + x + k, r) + e;
     c = rol(c, 10);
@@ -51,7 +51,7 @@ void inline R42(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, ui
 void inline R52(uint32_t& a, uint32_t b, uint32_t& c, uint32_t d, uint32_t e, uint32_t x, int r) { Round(a, b, c, d, e, f1(b, c, d), x, 0, r); }
 
 /** Perform a RIPEMD-160 transformation, processing a 64-byte chunk. */
-void Transform(uint32_t* s, const unsigned char* chunk)
+ALLOW_WRAPAROUND void Transform(uint32_t* s, const unsigned char* chunk)
 {
     uint32_t a1 = s[0], b1 = s[1], c1 = s[2], d1 = s[3], e1 = s[4];
     uint32_t a2 = a1, b2 = b1, c2 = c1, d2 = d1, e2 = e1;

--- a/src/crypto/sha1.cpp
+++ b/src/crypto/sha1.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/sha1.h>
-
+#include <attributes.h>
 #include <crypto/common.h>
+#include <crypto/sha1.h>
 
 #include <string.h>
 
@@ -15,7 +15,7 @@ namespace
 namespace sha1
 {
 /** One round of SHA-1. */
-void inline Round(uint32_t a, uint32_t& b, uint32_t c, uint32_t d, uint32_t& e, uint32_t f, uint32_t k, uint32_t w)
+ALLOW_WRAPAROUND void inline Round(uint32_t a, uint32_t& b, uint32_t c, uint32_t d, uint32_t& e, uint32_t f, uint32_t k, uint32_t w)
 {
     e += ((a << 5) | (a >> 27)) + f + k + w;
     b = (b << 30) | (b >> 2);
@@ -43,7 +43,7 @@ const uint32_t k3 = 0x8F1BBCDCul;
 const uint32_t k4 = 0xCA62C1D6ul;
 
 /** Perform a SHA-1 transformation, processing a 64-byte chunk. */
-void Transform(uint32_t* s, const unsigned char* chunk)
+ALLOW_WRAPAROUND void Transform(uint32_t* s, const unsigned char* chunk)
 {
     uint32_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4];
     uint32_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/sha256.h>
+#include <attributes.h>
 #include <crypto/common.h>
+#include <crypto/sha256.h>
 
 #include <assert.h>
 #include <string.h>
@@ -53,7 +54,7 @@ uint32_t inline sigma0(uint32_t x) { return (x >> 7 | x << 25) ^ (x >> 18 | x <<
 uint32_t inline sigma1(uint32_t x) { return (x >> 17 | x << 15) ^ (x >> 19 | x << 13) ^ (x >> 10); }
 
 /** One round of SHA-256. */
-void inline Round(uint32_t a, uint32_t b, uint32_t c, uint32_t& d, uint32_t e, uint32_t f, uint32_t g, uint32_t& h, uint32_t k)
+ALLOW_WRAPAROUND void inline Round(uint32_t a, uint32_t b, uint32_t c, uint32_t& d, uint32_t e, uint32_t f, uint32_t g, uint32_t& h, uint32_t k)
 {
     uint32_t t1 = h + Sigma1(e) + Ch(e, f, g) + k;
     uint32_t t2 = Sigma0(a) + Maj(a, b, c);
@@ -75,7 +76,7 @@ void inline Initialize(uint32_t* s)
 }
 
 /** Perform a number of SHA-256 transformations, processing 64-byte chunks. */
-void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
+ALLOW_WRAPAROUND void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks)
 {
     while (blocks--) {
         uint32_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];

--- a/src/crypto/sha512.cpp
+++ b/src/crypto/sha512.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/sha512.h>
-
+#include <attributes.h>
 #include <crypto/common.h>
+#include <crypto/sha512.h>
 
 #include <string.h>
 
@@ -22,7 +22,7 @@ uint64_t inline sigma0(uint64_t x) { return (x >> 1 | x << 63) ^ (x >> 8 | x << 
 uint64_t inline sigma1(uint64_t x) { return (x >> 19 | x << 45) ^ (x >> 61 | x << 3) ^ (x >> 6); }
 
 /** One round of SHA-512. */
-void inline Round(uint64_t a, uint64_t b, uint64_t c, uint64_t& d, uint64_t e, uint64_t f, uint64_t g, uint64_t& h, uint64_t k, uint64_t w)
+ALLOW_WRAPAROUND void inline Round(uint64_t a, uint64_t b, uint64_t c, uint64_t& d, uint64_t e, uint64_t f, uint64_t g, uint64_t& h, uint64_t k, uint64_t w)
 {
     uint64_t t1 = h + Sigma1(e) + Ch(e, f, g) + k + w;
     uint64_t t2 = Sigma0(a) + Maj(a, b, c);
@@ -44,7 +44,7 @@ void inline Initialize(uint64_t* s)
 }
 
 /** Perform one SHA-512 transformation, processing a 128-byte chunk. */
-void Transform(uint64_t* s, const unsigned char* chunk)
+ALLOW_WRAPAROUND void Transform(uint64_t* s, const unsigned char* chunk)
 {
     uint64_t a = s[0], b = s[1], c = s[2], d = s[3], e = s[4], f = s[5], g = s[6], h = s[7];
     uint64_t w0, w1, w2, w3, w4, w5, w6, w7, w8, w9, w10, w11, w12, w13, w14, w15;

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -2,17 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <hash.h>
+#include <attributes.h>
 #include <crypto/common.h>
 #include <crypto/hmac_sha512.h>
-
+#include <hash.h>
 
 inline uint32_t ROTL32(uint32_t x, int8_t r)
 {
     return (x << r) | (x >> (32 - r));
 }
 
-unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char>& vDataToHash)
+ALLOW_WRAPAROUND unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char>& vDataToHash)
 {
     // The following is MurmurHash3 (x86_32), see http://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
     uint32_t h1 = nHashSeed;

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -3,10 +3,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <attributes.h>
+#include <clientversion.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
-
-#include <clientversion.h>
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <txmempool.h>
@@ -241,7 +241,7 @@ void TxConfirmStats::UpdateMovingAverages()
 }
 
 // returns -1 on error conditions
-double TxConfirmStats::EstimateMedianVal(int confTarget, double sufficientTxVal,
+WARNING_UNINTENTIONAL_WRAPAROUND double TxConfirmStats::EstimateMedianVal(int confTarget, double sufficientTxVal,
                                          double successBreakPoint, bool requireGreater,
                                          unsigned int nBlockHeight, EstimationResult *result) const
 {

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -5,17 +5,17 @@
 #ifndef BITCOIN_PREVECTOR_H
 #define BITCOIN_PREVECTOR_H
 
-#include <assert.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <string.h>
+#include <attributes.h>
+#include <compat.h>
 
 #include <algorithm>
+#include <assert.h>
 #include <cstddef>
 #include <iterator>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 #include <type_traits>
-
-#include <compat.h>
 
 #pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
@@ -293,8 +293,8 @@ public:
     iterator end() { return iterator(item_ptr(size())); }
     const_iterator end() const { return const_iterator(item_ptr(size())); }
 
-    reverse_iterator rbegin() { return reverse_iterator(item_ptr(size() - 1)); }
-    const_reverse_iterator rbegin() const { return const_reverse_iterator(item_ptr(size() - 1)); }
+    WARNING_UNINTENTIONAL_WRAPAROUND reverse_iterator rbegin() { return reverse_iterator(item_ptr(size() - 1)); }
+    WARNING_UNINTENTIONAL_WRAPAROUND const_reverse_iterator rbegin() const { return const_reverse_iterator(item_ptr(size() - 1)); }
     reverse_iterator rend() { return reverse_iterator(item_ptr(-1)); }
     const_reverse_iterator rend() const { return const_reverse_iterator(item_ptr(-1)); }
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -3,12 +3,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <script/interpreter.h>
-
+#include <attributes.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
 #include <pubkey.h>
+#include <script/interpreter.h>
 #include <script/script.h>
 #include <uint256.h>
 
@@ -278,7 +278,7 @@ int FindAndDelete(CScript& script, const CScript& b)
     return nFound;
 }
 
-bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
+WARNING_UNINTENTIONAL_WRAPAROUND bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& script, unsigned int flags, const BaseSignatureChecker& checker, SigVersion sigversion, ScriptError* serror)
 {
     static const CScriptNum bnZero(0);
     static const CScriptNum bnOne(1);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -3,20 +3,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <txmempool.h>
-
+#include <attributes.h>
 #include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <validation.h>
-#include <policy/policy.h>
 #include <policy/fees.h>
+#include <policy/policy.h>
 #include <reverse_iterator.h>
 #include <streams.h>
 #include <timedata.h>
+#include <txmempool.h>
 #include <util/system.h>
 #include <util/moneystr.h>
 #include <util/time.h>
+#include <validation.h>
 
 CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFee,
                                  int64_t _nTime, unsigned int _entryHeight,
@@ -208,7 +208,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
     return true;
 }
 
-void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors)
+WARNING_UNINTENTIONAL_WRAPAROUND void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors)
 {
     setEntries parentIters = GetMemPoolParents(it);
     // add or remove this tx as a child of each parent
@@ -303,7 +303,7 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
     }
 }
 
-void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
+WARNING_UNINTENTIONAL_WRAPAROUND void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
 {
     nSizeWithDescendants += modifySize;
     assert(int64_t(nSizeWithDescendants) > 0);
@@ -312,7 +312,7 @@ void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFe
     assert(int64_t(nCountWithDescendants) > 0);
 }
 
-void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
+WARNING_UNINTENTIONAL_WRAPAROUND void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
 {
     nSizeWithAncestors += modifySize;
     assert(int64_t(nSizeWithAncestors) > 0);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <attributes.h>
 #include <util/strencodings.h>
 
 #include <tinyformat.h>
@@ -106,7 +107,7 @@ std::vector<unsigned char> ParseHex(const std::string& str)
     return ParseHex(str.c_str());
 }
 
-void SplitHostPort(std::string in, int &portOut, std::string &hostOut) {
+WARNING_UNINTENTIONAL_WRAPAROUND void SplitHostPort(std::string in, int &portOut, std::string &hostOut) {
     size_t colon = in.find_last_of(':');
     // if a : is found, and it either follows a [...], or no other : is in the string, treat it as port separator
     bool fHaveColon = colon != in.npos;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3,9 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <validation.h>
-
 #include <arith_uint256.h>
+#include <attributes.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <checkpoints.h>
@@ -39,6 +38,7 @@
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <validationinterface.h>
+#include <validation.h>
 #include <warnings.h>
 
 #include <future>
@@ -1567,7 +1567,7 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
-DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
+WARNING_UNINTENTIONAL_WRAPAROUND DisconnectResult CChainState::DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
 {
     bool fClean = true;
 
@@ -3445,7 +3445,7 @@ static CDiskBlockPos SaveBlockToDisk(const CBlock& block, int nHeight, const CCh
 }
 
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
+WARNING_UNINTENTIONAL_WRAPAROUND bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const CDiskBlockPos* dbp, bool* fNewBlock)
 {
     const CBlock& block = *pblock;
 
@@ -4682,7 +4682,7 @@ int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::D
 
 static const uint64_t MEMPOOL_DUMP_VERSION = 1;
 
-bool LoadMempool()
+WARNING_UNINTENTIONAL_WRAPAROUND bool LoadMempool()
 {
     const CChainParams& chainparams = Params();
     int64_t nExpiryTimeout = gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60;


### PR DESCRIPTION
* ~~Add `-fsanitize=integer` Travis job~~
* Document unsigned integer overflows (wraparounds) using annotation `ALLOW_WRAPAROUND` (intentional) or `WARNING_UNINTENTIONAL_WRAPAROUND` (unintentional).