### PR TITLE
mempool: Fix unintended unsigned integer wraparound in CTxMemPool::UpdateAncestorsOf(bool add, …) when add is false

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -216,7 +216,7 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors
         UpdateChild(piter, it, add);
     }
     const int64_t updateCount = (add ? 1 : -1);
-    const int64_t updateSize = updateCount * it->GetTxSize();
+    const int64_t updateSize = updateCount * (int64_t)it->GetTxSize();
     const CAmount updateFee = updateCount * it->GetModifiedFee();
     for (txiter ancestorIt : setAncestors) {
         mapTx.modify(ancestorIt, update_descendant_state(updateSize, updateFee, updateCount));


### PR DESCRIPTION
Fix unintended unsigned integer wraparound in `CTxMemPool::UpdateAncestorsOf(bool add, …)` when `add` is `false`.

```
txmempool.cpp:219:44: runtime error: unsigned integer overflow: 18446744073709551615 * 155 cannot be represented in type 'unsigned long' !=
```
