### PR TITLE
integer division instead of implicit double conversion

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -53,9 +53,9 @@ static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 //! -maxtxfee default
-static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
+static const CAmount DEFAULT_TRANSACTION_MAXFEE = COIN / 10;
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
-static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN;
+static const CAmount HIGH_TX_FEE_PER_KB = COIN / 100;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */


### PR DESCRIPTION
use integer division instead of double conversion and multiplication for computing amounts. This will most likely generate identical code.

My main argument in favour of this change is one of purity, that we should not rely on implicit conversion from `CAmount` -> `double` and back again. Today this implicit conversion can happen because `CAmount` is just a typedef to `int64_t`. However, I envision a future where `CAmount` is a proper type that does not allow suspicious implicit conversions like these.