### PR TITLE
net: Avoid using the value of a potentially invalid pointer (hSocket after close)

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -693,7 +693,7 @@ bool CloseSocket(SOCKET& hSocket)
     int ret = close(hSocket);
 #endif
     if (ret) {
-        LogPrintf("Socket close failed: %d. Error: %s\n", hSocket, NetworkErrorString(WSAGetLastError()));
+        LogPrintf("Socket close failed with error: %s\n", NetworkErrorString(WSAGetLastError()));
     }
     hSocket = INVALID_SOCKET;
     return ret != SOCKET_ERROR;


### PR DESCRIPTION
Avoid using the value of a potentially invalid pointer: `hSocket` after close.