### PR TITLE
Fix for test runner UnicodeDecodeError when utf-8 is not supported

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -226,7 +226,12 @@ def main():
     logging.basicConfig(format='%(message)s', level=logging_level)
 
     # Create base test directory
-    tmpdir = "%s/test_runner_₿_🏃_%s" % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+    try:
+        tmpdir_name = "/test_runner_₿_🏃_"
+        tmpdir_name.encode(sys.getfilesystemencoding())
+    except UnicodeEncodeError:
+        tmpdir_name = "/test_runner_"
+    tmpdir = ("%s" + tmpdir_name + "%s") % (args.tmpdirprefix, datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
     os.makedirs(tmpdir)
 
     logging.debug("Temporary test directory at %s" % tmpdir)


### PR DESCRIPTION
When attempting to create a directory using "/test_runner_₿_🏃_", the following error is created.

  `File "test/functional/test_runner.py", line 611, in <module>`
  	`    main()`
`File "test/functional/test_runner.py", line 230, in main`
  	`    os.makedirs(tmpdir)`
`File "/usr/lib/python3.6/os.py", line 220, in makedirs`
	`    mkdir(name, mode)` 
`UnicodeEncodeError: 'ascii' codec can't encode character '\u20bf' in position 17: ordinal not in range(128)`

Since, the code already checks for UTF-8 encoding/decoding at a previous place, it makes sense to check for this string too. 

I am using docker container for testing bitcoin and it comes with a default `sys.getfilesystemencoding() = ascii`, which is how I stumbled into this. 

If this code will bloat the file, it might be better to use simple characters for directory name.