### PR TITLE
[qa] Test inter-bucket privacy leakage

### DIFF
--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that we don't leak txs to inbound peers that we haven't yet announced to"""
+
+from test_framework.messages import msg_getdata, CInv
+from test_framework.mininode import mininode_lock, P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    wait_until,
+)
+
+
+class P2PLeakTxTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        gen_node = self.nodes[0]  # The block and tx generating node
+        gen_node.generate(1)
+        self.sync_all()
+
+        inbound_peer = self.nodes[0].add_p2p_connection(P2PDataStore())  # An "attacking" inbound peer
+        outbound_peer = self.nodes[1]  # Our outbound peer
+
+        # In an adversiarial setting we can generally assume that inbound peers
+        # are more likely to spy on us than outbound peers. Thus, on average,
+        # we announce transactions first to outbound peers, then to (all)
+        # inbound peers. Inbound peers must not be able to request the
+        # transaction they haven't yet received the announcement for it.
+        #
+        # With only one outbound peer, we expect that a tx is first announced
+        # to (all) inbound peers (and thus present a potential leak) in 28.5% of
+        # the cases.
+        #
+        # Probability( time_ann_inbound < time_ann_outbound )                 =
+        # ∫ f_in(x)                           * F_out(x)                   dx =
+        # ∫ (lambda_in * exp(-lambda_in * x)) * (1 - exp(-lambda_out * x)) dx =
+        # 0.285714
+        #
+        # Where,
+        # * f_in is the pdf of the exponential distribution for inbound peers,
+        #   with lambda_in = 1 / INVENTORY_BROADCAST_INTERVAL = 1/5
+        # * F_out is the cdf of the expon. distribuiton for outbound peers,
+        #   with lambda_out = 1 / (INVENTORY_BROADCAST_INTERVAL >> 1) = 1/2
+        #
+        # Due to measurement delays, the actual monte-carlo leak is a bit
+        # higher. Assume a total delay of 0.6 s (Includes network delays and
+        # rpc delay to poll the raw mempool)
+        #
+        # Probability( time_ann_inbound < time_ann_outbound + 0.6 )           =
+        # ∫ f_in(x)                           * F_out(x + 0.6)             dx =
+        # ∫ (lambda_in * exp(-lambda_in * x)) * (1 - exp(-lambda_out * (x+.6))) dx =
+        # 0.366485
+        EXPECTED_MEASURED_LEAK = .366485
+
+        REPEATS = 100
+        measured_leak = 0
+        self.log.info('Start simulation for {} repeats'.format(REPEATS))
+        for i in range(REPEATS):
+            self.log.debug('Run {}/{}'.format(i, REPEATS))
+            txid = gen_node.sendtoaddress(gen_node.getnewaddress(), 0.033)
+            want_tx = msg_getdata()
+            want_tx.inv.append(CInv(t=1, h=int(txid, 16)))
+
+            wait_until(lambda: txid in outbound_peer.getrawmempool(), lock=mininode_lock)
+            inbound_peer.send_message(want_tx)
+            inbound_peer.sync_with_ping()
+
+            if inbound_peer.last_message.get('notfound'):
+                assert_equal(inbound_peer.last_message['notfound'].vec[0].hash, int(txid, 16))
+                inbound_peer.last_message.pop('notfound')
+            else:
+                measured_leak += 1
+
+        measured_leak /= REPEATS
+        self.log.info('Measured leak of {}'.format(measured_leak))
+
+        assert_greater_than(EXPECTED_MEASURED_LEAK, measured_leak)
+
+
+if __name__ == '__main__':
+    P2PLeakTxTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1160,6 +1160,26 @@ class msg_mempool():
     def __repr__(self):
         return "msg_mempool()"
 
+
+class msg_notfound():
+    command = b"notfound"
+
+    def __init__(self, vec=None):
+        if vec is None:
+            self.vec = []
+        else:
+            self.vec = vec
+
+    def deserialize(self, f):
+        self.vec = deser_vector(f, CInv)
+
+    def serialize(self):
+        return ser_vector(self.vec)
+
+    def __repr__(self):
+        return "msg_notfound(vec=%s)" % (repr(self.vec))
+
+
 class msg_sendheaders():
     command = b"sendheaders"
 

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -21,7 +21,38 @@ import struct
 import sys
 import threading
 
-from test_framework.messages import CBlockHeader, MIN_VERSION_SUPPORTED, msg_addr, msg_block, MSG_BLOCK, msg_blocktxn, msg_cmpctblock, msg_feefilter, msg_getaddr, msg_getblocks, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_mempool, msg_ping, msg_pong, msg_reject, msg_sendcmpct, msg_sendheaders, msg_tx, MSG_TX, MSG_TYPE_MASK, msg_verack, msg_version, NODE_NETWORK, NODE_WITNESS, sha256
+from test_framework.messages import (
+    CBlockHeader,
+    MIN_VERSION_SUPPORTED,
+    msg_addr,
+    msg_block,
+    MSG_BLOCK,
+    msg_blocktxn,
+    msg_cmpctblock,
+    msg_feefilter,
+    msg_getaddr,
+    msg_getblocks,
+    msg_getblocktxn,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_mempool,
+    msg_notfound,
+    msg_ping,
+    msg_pong,
+    msg_reject,
+    msg_sendcmpct,
+    msg_sendheaders,
+    msg_tx,
+    MSG_TX,
+    MSG_TYPE_MASK,
+    msg_verack,
+    msg_version,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    sha256,
+)
 from test_framework.util import wait_until
 
 logger = logging.getLogger("TestFramework.mininode")
@@ -40,6 +71,7 @@ MESSAGEMAP = {
     b"headers": msg_headers,
     b"inv": msg_inv,
     b"mempool": msg_mempool,
+    b"notfound": msg_notfound,
     b"ping": msg_ping,
     b"pong": msg_pong,
     b"reject": msg_reject,
@@ -295,6 +327,7 @@ class P2PInterface(P2PConnection):
     def on_getheaders(self, message): pass
     def on_headers(self, message): pass
     def on_mempool(self, message): pass
+    def on_notfound(self, message): pass
     def on_pong(self, message): pass
     def on_reject(self, message): pass
     def on_sendcmpct(self, message): pass

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -122,6 +122,7 @@ BASE_SCRIPTS = [
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py',
+    'p2p_leak_tx.py',
     'rpc_zmq.py',
     'rpc_signmessage.py',
     'feature_nulldummy.py',


### PR DESCRIPTION
When sending transactions to peers, we announce them to different "buckets" at different times. Currently there is a bucket for each outgoing peer and one bucket for all incoming peers (see #13298)

This tests checks that we don't send transactions to peers in one bucket when they were never announced in that bucket. For simplicity, the test only considers one outbound peer and one inbound peer (two buckets).