### PR TITLE
appveyor: script improvement

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -6,12 +6,11 @@ platform: x64
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   CLCACHE_SERVER: 1
-  PACKAGES: boost-filesystem boost-signals2 boost-interprocess boost-test libevent openssl zeromq berkeleydb secp256k1 leveldb
+  PACKAGES: boost-filesystem boost-signals2 boost-test libevent openssl zeromq berkeleydb secp256k1 leveldb
   PYTHONIOENCODING: utf-8
 cache:
 - C:\tools\vcpkg\installed
 - C:\Users\appveyor\clcache
-- build_msvc\cache
 init:
 - cmd: set PATH=C:\Python36-x64;C:\Python36-x64\Scripts;%PATH%
 install:
@@ -23,32 +22,39 @@ install:
            $env:ALL_PACKAGES += $packages[$i] + ":" + $env:PLATFORM + "-windows-static "
        }
 - cmd: git -C C:\Tools\vcpkg pull # This is a temporary fix, can be removed after appveyor update its image to include Microsoft/vcpkg#4046
+- cmd: C:\Tools\vcpkg\bootstrap-vcpkg.bat
+- cmd: vcpkg remove --recurse --outdated
 - cmd: vcpkg install %ALL_PACKAGES%
-- cmd: vcpkg upgrade --no-dry-run
 - cmd: del /s /q C:\Tools\vcpkg\installed\%PLATFORM%-windows-static\debug # Remove unused debug library
 before_build:
-- cmd: if not exist build_msvc\cache\ (del build_msvc\cache & mkdir build_msvc\cache)
-- cmd: if not exist build_msvc\%PLATFORM%\%CONFIGURATION%\ (mkdir build_msvc\%PLATFORM%\%CONFIGURATION%)
-- cmd: if exist build_msvc\cache\*.iobj (move build_msvc\cache\* build_msvc\%PLATFORM%\%CONFIGURATION%\)
-- cmd: clcache -M 2147483648
+- ps:  clcache -M 536870912
 - cmd: python build_msvc\msvc-autogen.py
 - ps:  $files = (Get-ChildItem -Recurse | where {$_.extension -eq ".vcxproj"}).FullName
-- ps:  for ($i = 0; $i -lt $files.length; $i++) {
-           (Get-Content $files[$i]).Replace("</RuntimeLibrary>", "</RuntimeLibrary><DebugInformationFormat>None</DebugInformationFormat>").Replace("NDEBUG;", "") | Set-Content $files[$i]
+- ps:  for (${i} = 0; ${i} -lt ${files}.length; ${i}++) {
+           ${content} = (Get-Content ${files}[${i}]);
+           ${content} = ${content}.Replace("</RuntimeLibrary>", "</RuntimeLibrary><DebugInformationFormat>None</DebugInformationFormat>");
+           ${content} = ${content}.Replace("<WholeProgramOptimization>true", "<WholeProgramOptimization>false");
+           ${content} = ${content}.Replace("NDEBUG;", "");
+           Set-Content ${files}[${i}] ${content};
        }
 - ps:  Start-Process clcache-server
+- ps:  fsutil behavior set disablelastaccess 0 # Enable Access time feature on Windows (for clcache)
 build_script:
 - cmd: msbuild /p:TrackFileAccess=false /p:CLToolExe=clcache.exe build_msvc\bitcoin.sln /m /v:q /nowarn:C4244;C4267;C4715 /nologo
 after_build:
-- cmd: move build_msvc\%PLATFORM%\%CONFIGURATION%\*.iobj build_msvc\cache\
-- cmd: move build_msvc\%PLATFORM%\%CONFIGURATION%\*.ipdb build_msvc\cache\
-- cmd: del C:\Users\appveyor\clcache\stats.txt
+- ps:  fsutil behavior set disablelastaccess 0 # Disable Access time feature on Windows (better performance)
+- ps:  clcache -z
 before_test:
 - ps:  ${conf_ini} = (Get-Content([IO.Path]::Combine(${env:APPVEYOR_BUILD_FOLDER}, "test", "config.ini.in")))
-- ps:  ${conf_ini} = $conf_ini.Replace("@abs_top_srcdir@", ${env:APPVEYOR_BUILD_FOLDER}).Replace("@abs_top_builddir@", ${env:APPVEYOR_BUILD_FOLDER}).Replace("@EXEEXT@", ".exe")
-- ps:  ${conf_ini} = $conf_ini.Replace("@ENABLE_WALLET_TRUE@", "").Replace("@BUILD_BITCOIN_CLI_TRUE@", "").Replace("@BUILD_BITCOIND_TRUE@", "").Replace("@ENABLE_ZMQ_TRUE@", "")
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@abs_top_srcdir@", ${env:APPVEYOR_BUILD_FOLDER})
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@abs_top_builddir@", ${env:APPVEYOR_BUILD_FOLDER})
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@EXEEXT@", ".exe")
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@ENABLE_WALLET_TRUE@", "")
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@BUILD_BITCOIN_CLI_TRUE@", "")
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@BUILD_BITCOIND_TRUE@", "")
+- ps:  ${conf_ini} = ${conf_ini}.Replace("@ENABLE_ZMQ_TRUE@", "")
 - ps:  ${utf8} = New-Object System.Text.UTF8Encoding ${false}
-- ps:  '[IO.File]::WriteAllLines([IO.Path]::Combine(${env:APPVEYOR_BUILD_FOLDER}, "test", "config.ini"), $conf_ini, ${utf8})'
+- ps:  '[IO.File]::WriteAllLines([IO.Path]::Combine(${env:APPVEYOR_BUILD_FOLDER}, "test", "config.ini"), ${conf_ini}, ${utf8})'
 - ps:  move "build_msvc\${env:PLATFORM}\${env:CONFIGURATION}\*.exe" src
 test_script:
 - cmd: src\test_bitcoin.exe


### PR DESCRIPTION
- Reduce cache size from 1.55GB to 170MB by disabling whole program optimization.
- The `*.iobj` `*.ipdb` cache is no longer required because of above change.
- Clearing cache hit stats instead of deleting clcache stats.txt file
- Enable access time on Windows so clcache would work correctly
- Reduce max cache size from 2GB to 512MB (Uncompressed)
- Remove unnecessary `boost-interprocess` vcpkg package
- Split some command into multiple lines to make it easier to know what commands do.