### PR TITLE
Trivial: replace "Tor's control socket API" with "Tor's control protocol API"

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -88,7 +88,7 @@ for normal IPv4/IPv6 communication, use:
 
 ## 3. Automatically listen on Tor
 
-Starting with Tor version 0.2.7.1 it is possible, through Tor's control socket
+Starting with Tor version 0.2.7.1 it is possible, through Tor's control protocol 
 API, to create and destroy 'ephemeral' hidden services programmatically.
 Bitcoin Core has been updated to make use of this.
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -88,7 +88,7 @@ for normal IPv4/IPv6 communication, use:
 
 ## 3. Automatically listen on Tor
 
-Starting with Tor version 0.2.7.1 it is possible, through Tor's control protocol 
+Starting with Tor version 0.2.7.1 it is possible, through Tor's control protocol
 API, to create and destroy 'ephemeral' hidden services programmatically.
 Bitcoin Core has been updated to make use of this.
 


### PR DESCRIPTION
The use of control socket can create confusion as seen in https://github.com/bitcoin/bitcoin/issues/13397

control port is more appropriate in this instance
https://gitweb.torproject.org/torspec.git/tree/control-spec.txt