### PR TITLE
amount: Move CAmount CENT to unit test header

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -12,7 +12,6 @@
 typedef int64_t CAmount;
 
 static const CAmount COIN = 100000000;
-static const CAmount CENT = 1000000;
 
 /** No amount larger than this (in satoshi) is valid.
  *

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -12,8 +12,8 @@
 // FIXME: Dedup with SetupDummyInputs in test/transaction_tests.cpp.
 //
 // Helper: create two dummy transactions, each with
-// two outputs.  The first has 11 and 50 CENT outputs
-// paid to a TX_PUBKEY, the second 21 and 22 CENT outputs
+// two outputs.  The first has 11 and 50 COIN outputs
+// paid to a TX_PUBKEY, the second 21 and 22 COIN outputs
 // paid to a TX_PUBKEYHASH.
 //
 static std::vector<CMutableTransaction>
@@ -31,16 +31,16 @@ SetupDummyInputs(CBasicKeyStore& keystoreRet, CCoinsViewCache& coinsRet)
 
     // Create some dummy input transactions
     dummyTransactions[0].vout.resize(2);
-    dummyTransactions[0].vout[0].nValue = 11 * CENT;
+    dummyTransactions[0].vout[0].nValue = 11 * COIN;
     dummyTransactions[0].vout[0].scriptPubKey << ToByteVector(key[0].GetPubKey()) << OP_CHECKSIG;
-    dummyTransactions[0].vout[1].nValue = 50 * CENT;
+    dummyTransactions[0].vout[1].nValue = 50 * COIN;
     dummyTransactions[0].vout[1].scriptPubKey << ToByteVector(key[1].GetPubKey()) << OP_CHECKSIG;
     AddCoins(coinsRet, dummyTransactions[0], 0);
 
     dummyTransactions[1].vout.resize(2);
-    dummyTransactions[1].vout[0].nValue = 21 * CENT;
+    dummyTransactions[1].vout[0].nValue = 21 * COIN;
     dummyTransactions[1].vout[0].scriptPubKey = GetScriptForDestination(key[2].GetPubKey().GetID());
-    dummyTransactions[1].vout[1].nValue = 22 * CENT;
+    dummyTransactions[1].vout[1].nValue = 22 * COIN;
     dummyTransactions[1].vout[1].scriptPubKey = GetScriptForDestination(key[3].GetPubKey().GetID());
     AddCoins(coinsRet, dummyTransactions[1], 0);
 
@@ -72,7 +72,7 @@ static void CCoinsCaching(benchmark::State& state)
     t1.vin[2].prevout.n = 1;
     t1.vin[2].scriptSig << std::vector<unsigned char>(65, 0) << std::vector<unsigned char>(33, 4);
     t1.vout.resize(2);
-    t1.vout[0].nValue = 90 * CENT;
+    t1.vout[0].nValue = 90 * COIN;
     t1.vout[0].scriptPubKey << OP_1;
 
     // Benchmark.
@@ -80,7 +80,7 @@ static void CCoinsCaching(benchmark::State& state)
         bool success = AreInputsStandard(t1, coins);
         assert(success);
         CAmount value = coins.GetValueIn(t1);
-        assert(value == (50 + 21 + 22) * CENT);
+        assert(value == (50 + 21 + 22) * COIN);
     }
 }
 

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -37,6 +37,8 @@ static inline uint64_t InsecureRandBits(int bits) { return insecure_rand_ctx.ran
 static inline uint64_t InsecureRandRange(uint64_t range) { return insecure_rand_ctx.randrange(range); }
 static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
 
+static constexpr CAmount CENT{1000000};
+
 /** Basic testing setup.
  * This just configures logging and chain parameters.
  */

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -48,7 +48,7 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
         if (*p == '.')
         {
             p++;
-            int64_t nMult = CENT*10;
+            int64_t nMult = COIN / 10;
             while (isdigit(*p) && (nMult > 0))
             {
                 nUnits += nMult * (*p++ - '0');

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -10,7 +10,7 @@
 #include <random.h>
 
 //! target minimum change amount
-static const CAmount MIN_CHANGE = CENT;
+static constexpr CAmount MIN_CHANGE{COIN / 100};
 //! final minimum change amount after paying for fees
 static const CAmount MIN_FINAL_CHANGE = MIN_CHANGE/2;
 


### PR DESCRIPTION
`CAmount` is currently not type-safe. Exporting a constant (`CENT`) that is commonly not referred to by that name might be confusing. `CENT` is only used in two places prior to this commit (`ParseMoney` and `MIN_CHANGE`). So replace these with constants relative to `COIN` and move `CENT` to the unit test header.