### PR TITLE
Minimize vfExec counting in script handling

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -294,6 +294,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
     opcodetype opcode;
     valtype vchPushValue;
     std::vector<bool> vfExec;
+    bool fExec = true;
     std::vector<valtype> altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     if (script.size() > MAX_SCRIPT_SIZE)
@@ -305,8 +306,6 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
     {
         while (pc < pend)
         {
-            bool fExec = !count(vfExec.begin(), vfExec.end(), false);
-
             //
             // Read instruction
             //
@@ -485,6 +484,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                         if (opcode == OP_NOTIF)
                             fValue = !fValue;
                         popstack(stack);
+                        fExec = fValue;
                     }
                     vfExec.push_back(fValue);
                 }
@@ -495,6 +495,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     if (vfExec.empty())
                         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
                     vfExec.back() = !vfExec.back();
+                    fExec = fExec ? false : !count(vfExec.begin(), vfExec.end(), false);
                 }
                 break;
 
@@ -503,6 +504,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     if (vfExec.empty())
                         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
                     vfExec.pop_back();
+                    fExec = fExec ? true : !count(vfExec.begin(), vfExec.end(), false);
                 }
                 break;
 


### PR DESCRIPTION
@SergioDemianLerner described a potential attack vector by exploiting the way how `vfExec` is handled in script. Since the `vfExec` vector is scanned once for every opcode, a specially crafted script could scan up to 979K items, and it may take a couple seconds to validate a block packed with such scripts. Read more: https://bitslog.wordpress.com/2017/04/17/new-quadratic-delays-in-bitcoin-scripts/

The article suggested an O(1) algorithm to fix the problem. I'm trying to fix in a different way. Although it is not the optimal solution, the 5-line patch is very easy to review, and it can reduce the worst case from 979k to about 5k items to be scanned, a 99.49% reduction.

To make review easier, I'll make inline comments

EDIT: a regular block full of CHECKSIG might also take seconds to validate, so this consensus code fix may not be necessary. But anyway, review and comments are welcomed.