### PR TITLE
qt: Remove redundant stopThread() and stopExecutor() signals

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -212,7 +212,7 @@ BitcoinApplication::~BitcoinApplication()
     if(coreThread)
     {
         qDebug() << __func__ << ": Stopping thread";
-        Q_EMIT stopThread();
+        coreThread->quit();
         coreThread->wait();
         qDebug() << __func__ << ": Stopped thread";
     }
@@ -279,8 +279,7 @@ void BitcoinApplication::startThread()
     connect(this, &BitcoinApplication::requestedInitialize, executor, &BitcoinCore::initialize);
     connect(this, &BitcoinApplication::requestedShutdown, executor, &BitcoinCore::shutdown);
     /*  make sure executor object is deleted in its own thread */
-    connect(this, &BitcoinApplication::stopThread, executor, &QObject::deleteLater);
-    connect(this, &BitcoinApplication::stopThread, coreThread, &QThread::quit);
+    connect(coreThread, &QThread::finished, executor, &QObject::deleteLater);
 
     coreThread->start();
 }

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -99,7 +99,6 @@ public Q_SLOTS:
 Q_SIGNALS:
     void requestedInitialize();
     void requestedShutdown();
-    void stopThread();
     void splashFinished();
     void windowShown(BitcoinGUI* window);
 

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -158,7 +158,7 @@ Intro::~Intro()
 {
     delete ui;
     /* Ensure thread is finished before it is deleted */
-    Q_EMIT stopThread();
+    thread->quit();
     thread->wait();
 }
 
@@ -306,8 +306,7 @@ void Intro::startThread()
     connect(executor, &FreespaceChecker::reply, this, &Intro::setStatus);
     connect(this, &Intro::requestCheck, executor, &FreespaceChecker::check);
     /*  make sure executor object is deleted in its own thread */
-    connect(this, &Intro::stopThread, executor, &QObject::deleteLater);
-    connect(this, &Intro::stopThread, thread, &QThread::quit);
+    connect(thread, &QThread::finished, executor, &QObject::deleteLater);
 
     thread->start();
 }

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -54,7 +54,6 @@ public:
 
 Q_SIGNALS:
     void requestCheck();
-    void stopThread();
 
 public Q_SLOTS:
     void setStatus(int status, const QString &message, quint64 bytesAvailable);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -132,7 +132,6 @@ public Q_SLOTS:
 
 Q_SIGNALS:
     // For RPC command executor
-    void stopExecutor();
     void cmdRequest(const QString &command, const WalletModel* wallet_model);
 
 private:


### PR DESCRIPTION
The `QThread::finished` signal do this work.