### PR TITLE
Build: during 'make clean', remove some files that are currently missed.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -294,5 +294,5 @@ clean-docs:
 
 clean-local: clean-docs
 	rm -rf coverage_percent.txt test_bitcoin.coverage/ total.coverage/ test/tmp/ cache/ $(OSX_APP)
-	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache
+	rm -rf test/functional/__pycache__ test/functional/test_framework/__pycache__ test/cache share/rpcauth/__pycache__
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -161,7 +161,7 @@ nodist_test_test_bitcoin_SOURCES = $(GENERATED_TEST_FILES)
 
 $(BITCOIN_TESTS): $(GENERATED_TEST_FILES)
 
-CLEAN_BITCOIN_TEST = test/*.gcda test/*.gcno $(GENERATED_TEST_FILES)
+CLEAN_BITCOIN_TEST = test/*.gcda test/*.gcno $(GENERATED_TEST_FILES) $(BITCOIN_TESTS:.cpp=.cpp.log)
 
 CLEANFILES += $(CLEAN_BITCOIN_TEST)
 


### PR DESCRIPTION
`make clean` currently leaves behind some cache and test log files that should be removed.
