### PR TITLE
doc: Split depends installation instructions per arch

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -30,21 +30,34 @@ Common `host-platform-triplets` for cross compilation are:
 
 No other options are needed, the paths are automatically configured.
 
-Install the required dependencies: Ubuntu & Debian
---------------------------------------------------
+### Install the required dependencies: Ubuntu & Debian
 
-For macOS cross compilation:
+First, install the common dependencies:
 
-    sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
+    sudo apt-get install autoconf automake cmake bsdmainutils ca-certificates curl faketime g++ libtool pkg-config
 
-For Win32/Win64 cross compilation:
+#### For macOS cross compilation:
+
+    sudo apt-get install librsvg2-bin libtiff-tools imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
+
+#### For Win32/Win64 cross compilation:
 
 - see [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)
 
-For linux (including i386, ARM) cross compilation:
+#### For linux (including i386, ARM) cross compilation:
 
-    sudo apt-get install curl g++-aarch64-linux-gnu g++-4.8-aarch64-linux-gnu gcc-4.8-aarch64-linux-gnu binutils-aarch64-linux-gnu g++-arm-linux-gnueabihf g++-4.8-arm-linux-gnueabihf gcc-4.8-arm-linux-gnueabihf binutils-arm-linux-gnueabihf g++-4.8-multilib gcc-4.8-multilib binutils-gold bsdmainutils
+Common linux dependencies:
 
+    sudo apt-get install g++-multilib binutils-gold bsdmainutils
+
+For linux ARM cross compilation:
+
+    sudo apt-get install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
+For linux AARCH64 cross compilation:
+
+    sudo apt-get install g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
+    
 For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 
     sudo apt-get install curl g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
@@ -52,7 +65,7 @@ For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 RISC-V known issue: gcc-7.3.0 and gcc-7.3.1 result in a broken `test_bitcoin` executable (see https://github.com/bitcoin/bitcoin/pull/13543),
 this is apparently fixed in gcc-8.1.0.
 
-Dependency Options:
+### Dependency Options
 The following can be set when running make: make FOO=bar
 
     SOURCES_PATH: downloaded sources will be placed here
@@ -70,7 +83,7 @@ The following can be set when running make: make FOO=bar
 If some packages are not built, for example `make NO_WALLET=1`, the appropriate
 options will be passed to bitcoin's configure. In this case, `--disable-wallet`.
 
-Additional targets:
+### Additional targets
 
     download: run 'make download' to fetch all sources without building them
     download-osx: run 'make download-osx' to fetch all sources needed for macOS builds

--- a/depends/README.md
+++ b/depends/README.md
@@ -32,35 +32,31 @@ No other options are needed, the paths are automatically configured.
 
 ### Install the required dependencies: Ubuntu & Debian
 
-First, install the common dependencies:
+#### For macOS cross compilation
 
-    sudo apt-get install autoconf automake cmake bsdmainutils ca-certificates curl faketime g++ libtool pkg-config
+    sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
 
-#### For macOS cross compilation:
-
-    sudo apt-get install librsvg2-bin libtiff-tools imagemagick libcap-dev libz-dev libbz2-dev python-setuptools
-
-#### For Win32/Win64 cross compilation:
+#### For Win32/Win64 cross compilation
 
 - see [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)
 
-#### For linux (including i386, ARM) cross compilation:
+#### For linux (including i386, ARM) cross compilation
 
 Common linux dependencies:
 
-    sudo apt-get install g++-multilib binutils-gold bsdmainutils
+    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3
 
 For linux ARM cross compilation:
 
-    sudo apt-get install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+    sudo apt-get install g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
 
 For linux AARCH64 cross compilation:
 
-    sudo apt-get install g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
-    
+    sudo apt-get install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
 For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 
-    sudo apt-get install curl g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
+    sudo apt-get install g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
 
 RISC-V known issue: gcc-7.3.0 and gcc-7.3.1 result in a broken `test_bitcoin` executable (see https://github.com/bitcoin/bitcoin/pull/13543),
 this is apparently fixed in gcc-8.1.0.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -70,7 +70,11 @@ tuned to conserve memory with additional CXXFLAGS:
 
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils python3 libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
+
+Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
+
+    sudo apt-get libssl-dev libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
 
 BerkeleyDB is required for the wallet.
 
@@ -97,7 +101,7 @@ ZMQ dependencies (provides ZMQ API):
 
     sudo apt-get install libzmq3-dev
 
-#### Dependencies for the GUI
+GUI dependencies:
 
 If you want to build bitcoin-qt, make sure that the required packages for Qt development
 are installed. Qt 5 is necessary to build the GUI.


### PR DESCRIPTION
The current depends installation instructions fail on bionic with

```
E: Unable to locate package g++-4.8-aarch64-linux-gnu
E: Unable to locate package gcc-4.8-aarch64-linux-gnu
E: Unable to locate package g++-4.8-arm-linux-gnueabihf
E: Unable to locate package gcc-4.8-arm-linux-gnueabihf
```

Also, they fail due to missing dependencies `make automake cmake pkg-config python3`

Fix this by removing the explicit version and splitting them into common instructions and instructions per linux architecture.