### PR TITLE
Move urlDecode to wallet/rpcwallet.cpp, where it's used

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -16,7 +16,6 @@
 #include <noui.h>
 #include <shutdown.h>
 #include <util.h>
-#include <httpserver.h>
 #include <httprpc.h>
 #include <utilstrencodings.h>
 #include <walletinitinterface.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -665,15 +665,3 @@ void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch)
         pathHandlers.erase(i);
     }
 }
-
-std::string urlDecode(const std::string &urlEncoded) {
-    std::string res;
-    if (!urlEncoded.empty()) {
-        char *decoded = evhttp_uridecode(urlEncoded.c_str(), false, nullptr);
-        if (decoded) {
-            res = std::string(decoded);
-            free(decoded);
-        }
-    }
-    return res;
-}

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -148,6 +148,4 @@ private:
     struct event* ev;
 };
 
-std::string urlDecode(const std::string &urlEncoded);
-
 #endif // BITCOIN_HTTPSERVER_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -7,7 +7,6 @@
 #include <chain.h>
 #include <consensus/validation.h>
 #include <core_io.h>
-#include <httpserver.h>
 #include <validation.h>
 #include <key_io.h>
 #include <net.h>
@@ -32,15 +31,27 @@
 #include <wallet/walletdb.h>
 #include <wallet/walletutil.h>
 
-#include <stdint.h>
-
+#include <event2/http.h> // for evhttp_uridecode
 #include <univalue.h>
 
 #include <functional>
+#include <stdint.h>
+
+static std::string urlDecode(const std::string &urlEncoded) {
+    std::string res;
+    if (!urlEncoded.empty()) {
+        char *decoded = evhttp_uridecode(urlEncoded.c_str(), 0, nullptr);
+        if (decoded) {
+            res = std::string(decoded);
+            free(decoded);
+        }
+    }
+    return res;
+}
 
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 
-bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string& wallet_name)
+static bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string& wallet_name)
 {
     if (request.URI.substr(0, WALLET_ENDPOINT_BASE.size()) == WALLET_ENDPOINT_BASE) {
         // wallet endpoint was used


### PR DESCRIPTION
Remove now-unnecessary includes of httpserver.h from bitcoind.cpp and
wallet/rpcwallet.cpp.

Pass decode_plus arg as an int rather than bool, as documented here:
http://www.wangafu.net/~nickm/libevent-2.0/doxygen/html/http_8h.html#ac2914389616f04199aded10444fd8e42
https://github.com/libevent/libevent/blob/29cc8386a2f7911eaa9336692a2c5544d8b4734f/http.c#L3182