### PR TITLE
tests: Write the notification message to different files to avoid race condition in feature_notifications.py

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,5 +55,5 @@ test_script:
 - ps:  src\bench_bitcoin.exe -evals=1 -scaling=0
 - ps:  python test\util\bitcoin-util-test.py
 - cmd: python test\util\rpcauth-test.py
-- cmd: python test\functional\test_runner.py --force --quiet --combinedlogslen=4000 --exclude "feature_notifications,wallet_multiwallet,wallet_multiwallet.py --usecli"
+- cmd: python test\functional\test_runner.py --force --quiet --combinedlogslen=4000 --exclude "wallet_multiwallet,wallet_multiwallet.py --usecli"
 deploy: off

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -17,17 +17,20 @@ class NotificationsTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def setup_network(self):
-        self.alert_filename = os.path.join(self.options.tmpdir, "alert.txt")
-        self.block_filename = os.path.join(self.options.tmpdir, "blocks.txt")
-        self.tx_filename = os.path.join(self.options.tmpdir, "transactions.txt")
+        self.alertnotify_dir = os.path.join(self.options.tmpdir, "alertnotify")
+        self.blocknotify_dir = os.path.join(self.options.tmpdir, "blocknotify")
+        self.walletnotify_dir = os.path.join(self.options.tmpdir, "walletnotify")
+        os.mkdir(self.alertnotify_dir)
+        os.mkdir(self.blocknotify_dir)
+        os.mkdir(self.walletnotify_dir)
 
         # -alertnotify and -blocknotify on node0, walletnotify on node1
         self.extra_args = [["-blockversion=2",
-                            "-alertnotify=echo %%s >> %s" % self.alert_filename,
-                            "-blocknotify=echo %%s >> %s" % self.block_filename],
+                            "-alertnotify=echo > {}".format(os.path.join(self.alertnotify_dir, '%s')),
+                            "-blocknotify=echo > {}".format(os.path.join(self.blocknotify_dir, '%s'))],
                            ["-blockversion=211",
                             "-rescan",
-                            "-walletnotify=echo %%s >> %s" % self.tx_filename]]
+                            "-walletnotify=echo > {}".format(os.path.join(self.walletnotify_dir, '%s'))]]
         super().setup_network()
 
     def run_test(self):
@@ -35,34 +38,32 @@ class NotificationsTest(BitcoinTestFramework):
         block_count = 10
         blocks = self.nodes[1].generate(block_count)
 
-        # wait at most 10 seconds for expected file size before reading the content
-        wait_until(lambda: os.path.isfile(self.block_filename) and os.stat(self.block_filename).st_size >= (block_count * 65), timeout=10)
+        # wait at most 10 seconds for expected number of files before reading the content
+        wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
 
-        # file content should equal the generated blocks hashes
-        with open(self.block_filename, 'r', encoding="utf-8") as f:
-            assert_equal(sorted(blocks), sorted(l.strip() for l in f.read().splitlines()))
+        # directory content should equal the generated blocks hashes
+        assert_equal(sorted(blocks), sorted(os.listdir(self.blocknotify_dir)))
 
         self.log.info("test -walletnotify")
-        # wait at most 10 seconds for expected file size before reading the content
-        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+        # wait at most 10 seconds for expected number of files before reading the content
+        wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
-        # file content should equal the generated transaction hashes
+        # directory content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
-        with open(self.tx_filename, 'r', encoding="ascii") as f:
-            assert_equal(sorted(txids_rpc), sorted(l.strip() for l in f.read().splitlines()))
-        os.remove(self.tx_filename)
+        assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
+        for tx_file in os.listdir(self.walletnotify_dir):
+            os.remove(os.path.join(self.walletnotify_dir, tx_file))
 
         self.log.info("test -walletnotify after rescan")
         # restart node to rescan to force wallet notifications
         self.restart_node(1)
         connect_nodes_bi(self.nodes, 0, 1)
 
-        wait_until(lambda: os.path.isfile(self.tx_filename) and os.stat(self.tx_filename).st_size >= (block_count * 65), timeout=10)
+        wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
-        # file content should equal the generated transaction hashes
+        # directory content should equal the generated transaction hashes
         txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
-        with open(self.tx_filename, 'r', encoding="ascii") as f:
-            assert_equal(sorted(txids_rpc), sorted(l.strip() for l in f.read().splitlines()))
+        assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
 
         # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
         self.log.info("test -alertnotify")
@@ -70,20 +71,17 @@ class NotificationsTest(BitcoinTestFramework):
         self.sync_all()
 
         # Give bitcoind 10 seconds to write the alert notification
-        wait_until(lambda: os.path.isfile(self.alert_filename) and os.path.getsize(self.alert_filename), timeout=10)
+        wait_until(lambda: len(os.listdir(self.alertnotify_dir)), timeout=10)
 
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text = f.read()
+        for notify_file in os.listdir(self.alertnotify_dir):
+            os.remove(os.path.join(self.alertnotify_dir, notify_file))
 
         # Mine more up-version blocks, should not get more alerts:
         self.nodes[1].generate(2)
         self.sync_all()
 
-        with open(self.alert_filename, 'r', encoding='utf8') as f:
-            alert_text2 = f.read()
-
         self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
-        assert_equal(alert_text, alert_text2)
+        assert_equal(len(os.listdir(self.alertnotify_dir)), 0)
 
 if __name__ == '__main__':
     NotificationsTest().main()


### PR DESCRIPTION
This PR change the behavior that `feature_notifications.py` would write to different files instead of writing to  the same file to avoid race condition.