### PR TITLE
Update boost.mk

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -19,7 +19,7 @@ $(package)_toolset_$(host_os)=gcc
 $(package)_archiver_$(host_os)=$($(package)_ar)
 $(package)_toolset_darwin=darwin
 $(package)_archiver_darwin=$($(package)_libtool)
-$(package)_config_libraries=chrono,filesystem,system,thread,test
+$(package)_config_libraries=chrono,filesystem,system,thread,test,program_options
 $(package)_cxxflags=-std=c++11 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 endef


### PR DESCRIPTION
In my case, it solved this error during configure:
configure: error: Could not find a version of the boost_program_options library!
ubuntu 18.04 without native boost installed