### PR TITLE
rpc: Early call once CWallet::MarkDirty in import calls

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -804,10 +804,10 @@ int64_t CWallet::IncOrderPosNext(WalletBatch *batch)
 
 void CWallet::MarkDirty()
 {
-    {
-        LOCK(cs_wallet);
-        for (std::pair<const uint256, CWalletTx>& item : mapWallet)
-            item.second.MarkDirty();
+    AssertLockHeld(cs_wallet);
+
+    for (std::pair<const uint256, CWalletTx>& item : mapWallet) {
+        item.second.MarkDirty();
     }
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -854,7 +854,7 @@ public:
     int64_t IncOrderPosNext(WalletBatch *batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     DBErrors ReorderTransactions();
 
-    void MarkDirty();
+    void MarkDirty() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
     void LoadToWallet(const CWalletTx& wtxIn);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;


### PR DESCRIPTION
This gives a small, but not relevant, performance improvement when calling `importmulti` RPC since `MarkDirty` is called only once.

Note that `ImportScript` is not atomic: https://github.com/bitcoin/bitcoin/blob/920c090f63f4990bf0f3b3d1a6d3d8a8bcd14ba0/src/wallet/rpcdump.cpp#L227-L242
ie something can fail after a successful `AddWatchOnly`, which could lead to invalid cached balances. That's why the `MarkDirty` call is done as early as possible.