### PR TITLE
Use non-throwing type-safe ChainType where possible

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -65,7 +65,7 @@ static void AssembleBlock(benchmark::State& state)
 
     // Switch to regtest so we can mine faster
     // Also segwit is active, so we can include witness transactions
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(ChainType::REGTEST);
 
     InitScriptExecutionCache();
 

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -41,7 +41,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
 
     while (state.KeepRunning()) {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -33,9 +33,9 @@ static const int CONTINUE_EXECUTION=-1;
 
 static void SetupCliArgs()
 {
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
-    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
-    const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
+    const auto defaultBaseParams = CreateBaseChainParams(ChainType::MAIN);
+    const auto testnetBaseParams = CreateBaseChainParams(ChainType::TESTNET);
+    const auto regtestBaseParams = CreateBaseChainParams(ChainType::REGTEST);
 
     gArgs.AddArg("-?", "This help message", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-version", "Print version and exit", false, OptionsCategory::OPTIONS);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -133,12 +133,12 @@ static int AppInitRPC(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     // Check for -testnet or -regtest parameter (BaseParams() calls are only valid after this clause)
-    try {
-        SelectBaseParams(gArgs.GetChainName());
-    } catch (const std::exception& e) {
-        fprintf(stderr, "Error: %s\n", e.what());
+    const auto chain = gArgs.GetChainType(error);
+    if (!chain) {
+        fprintf(stderr, "Error: %s\n", error.c_str());
         return EXIT_FAILURE;
     }
+    SelectBaseParams(*chain);
     return CONTINUE_EXECUTION;
 }
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -89,12 +89,12 @@ static int AppInitRawTx(int argc, char* argv[])
     }
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    try {
-        SelectParams(gArgs.GetChainName());
-    } catch (const std::exception& e) {
-        fprintf(stderr, "Error: %s\n", e.what());
+    const auto chain = gArgs.GetChainType(error);
+    if (!chain) {
+        fprintf(stderr, "Error: %s\n", error.c_str());
         return EXIT_FAILURE;
     }
+    SelectParams(*chain);
 
     fCreateBlank = gArgs.GetBoolArg("-create", false);
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -101,12 +101,12 @@ static bool AppInit(int argc, char* argv[])
             return false;
         }
         // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-        try {
-            SelectParams(gArgs.GetChainName());
-        } catch (const std::exception& e) {
-            fprintf(stderr, "Error: %s\n", e.what());
+        const auto chain = gArgs.GetChainType(error);
+        if (!chain) {
+            fprintf(stderr, "Error: %s\n", error.c_str());
             return false;
         }
+        SelectParams(*chain);
 
         // Error out when loose non-argument tokens are encountered on command line
         for (int i = 1; i < argc; i++) {

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -394,17 +394,6 @@ const CChainParams &Params() {
     return *globalChainParams;
 }
 
-std::unique_ptr<const CChainParams> CreateChainParams(const std::string& chain)
-{
-    if (chain == CBaseChainParams::MAIN)
-        return std::unique_ptr<CChainParams>(new CMainParams());
-    else if (chain == CBaseChainParams::TESTNET)
-        return std::unique_ptr<CChainParams>(new CTestNetParams());
-    else if (chain == CBaseChainParams::REGTEST)
-        return std::unique_ptr<CChainParams>(new CRegTestParams(gArgs));
-    throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
-}
-
 std::unique_ptr<const CChainParams> CreateChainParams(const ChainType& chain)
 {
     switch (chain) {
@@ -417,12 +406,6 @@ std::unique_ptr<const CChainParams> CreateChainParams(const ChainType& chain)
         // no default case, so the compiler can warn about missing cases
     }
     assert(false);
-}
-
-void SelectParams(const std::string& network)
-{
-    SelectBaseParams(network);
-    globalChainParams = CreateChainParams(network);
 }
 
 void SelectParams(const ChainType& network)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -405,7 +405,27 @@ std::unique_ptr<const CChainParams> CreateChainParams(const std::string& chain)
     throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 
+std::unique_ptr<const CChainParams> CreateChainParams(const ChainType& chain)
+{
+    switch (chain) {
+    case ChainType::MAIN:
+        return MakeUnique<CMainParams>();
+    case ChainType::TESTNET:
+        return MakeUnique<CTestNetParams>();
+    case ChainType::REGTEST:
+        return MakeUnique<CRegTestParams>(gArgs);
+        // no default case, so the compiler can warn about missing cases
+    }
+    assert(false);
+}
+
 void SelectParams(const std::string& network)
+{
+    SelectBaseParams(network);
+    globalChainParams = CreateChainParams(network);
+}
+
+void SelectParams(const ChainType& network)
 {
     SelectBaseParams(network);
     globalChainParams = CreateChainParams(network);

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -107,6 +107,7 @@ protected:
  * @throws a std::runtime_error if the chain is not supported.
  */
 std::unique_ptr<const CChainParams> CreateChainParams(const std::string& chain);
+std::unique_ptr<const CChainParams> CreateChainParams(const ChainType& chain);
 
 /**
  * Return the currently selected parameters. This won't change after app
@@ -119,5 +120,6 @@ const CChainParams &Params();
  * @throws std::runtime_error when the chain is not supported.
  */
 void SelectParams(const std::string& chain);
+void SelectParams(const ChainType& chain);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -104,9 +104,7 @@ protected:
 /**
  * Creates and returns a std::unique_ptr<CChainParams> of the chosen chain.
  * @returns a CChainParams* of the chosen chain.
- * @throws a std::runtime_error if the chain is not supported.
  */
-std::unique_ptr<const CChainParams> CreateChainParams(const std::string& chain);
 std::unique_ptr<const CChainParams> CreateChainParams(const ChainType& chain);
 
 /**
@@ -117,9 +115,7 @@ const CChainParams &Params();
 
 /**
  * Sets the params returned by Params() to those for the given BIP70 chain name.
- * @throws std::runtime_error when the chain is not supported.
  */
-void SelectParams(const std::string& chain);
 void SelectParams(const ChainType& chain);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -15,6 +15,23 @@ const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
+bool ParseChainType(const std::string& str, ChainType& chain)
+{
+    if (str == CBaseChainParams::MAIN) {
+        chain = ChainType::MAIN;
+        return true;
+    }
+    if (str == CBaseChainParams::TESTNET) {
+        chain = ChainType::TESTNET;
+        return true;
+    }
+    if (str == CBaseChainParams::REGTEST) {
+        chain = ChainType::REGTEST;
+        return true;
+    }
+    return false;
+}
+
 const std::string& FormatChainType(const ChainType& chain)
 {
     switch (chain) {
@@ -45,18 +62,6 @@ const CBaseChainParams& BaseParams()
     return *globalChainBaseParams;
 }
 
-std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const std::string& chain)
-{
-    if (chain == CBaseChainParams::MAIN)
-        return MakeUnique<CBaseChainParams>("", 8332);
-    else if (chain == CBaseChainParams::TESTNET)
-        return MakeUnique<CBaseChainParams>("testnet3", 18332);
-    else if (chain == CBaseChainParams::REGTEST)
-        return MakeUnique<CBaseChainParams>("regtest", 18443);
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
-}
-
 std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const ChainType& chain)
 {
     switch (chain) {
@@ -69,12 +74,6 @@ std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const ChainType& c
         // no default case, so the compiler can warn about missing cases
     }
     assert(false);
-}
-
-void SelectBaseParams(const std::string& chain)
-{
-    globalChainBaseParams = CreateBaseChainParams(chain);
-    gArgs.SelectConfigNetwork(chain);
 }
 
 void SelectBaseParams(const ChainType& chain)

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -39,14 +39,13 @@ enum class ChainType {
     REGTEST,
 };
 
+bool ParseChainType(const std::string& str, ChainType& chain);
 const std::string& FormatChainType(const ChainType& chain);
 
 /**
  * Creates and returns a std::unique_ptr<CBaseChainParams> of the chosen chain.
  * @returns a CBaseChainParams* of the chosen chain.
- * @throws a std::runtime_error if the chain is not supported.
  */
-std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const std::string& chain);
 std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const ChainType& chain);
 
 /**
@@ -61,7 +60,6 @@ void SetupChainParamsBaseOptions();
 const CBaseChainParams& BaseParams();
 
 /** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(const std::string& chain);
 void SelectBaseParams(const ChainType& chain);
 
 #endif // BITCOIN_CHAINPARAMSBASE_H

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -32,12 +32,22 @@ private:
     std::string strDataDir;
 };
 
+/** Enumeration of all chains (with potentially different consensus rules) we understand */
+enum class ChainType {
+    MAIN,
+    TESTNET,
+    REGTEST,
+};
+
+const std::string& FormatChainType(const ChainType& chain);
+
 /**
  * Creates and returns a std::unique_ptr<CBaseChainParams> of the chosen chain.
  * @returns a CBaseChainParams* of the chosen chain.
  * @throws a std::runtime_error if the chain is not supported.
  */
-std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain);
+std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const std::string& chain);
+std::unique_ptr<const CBaseChainParams> CreateBaseChainParams(const ChainType& chain);
 
 /**
  *Set the arguments for chainparams
@@ -52,5 +62,6 @@ const CBaseChainParams& BaseParams();
 
 /** Sets the params returned by Params() to those for the given network. */
 void SelectBaseParams(const std::string& chain);
+void SelectBaseParams(const ChainType& chain);
 
 #endif // BITCOIN_CHAINPARAMSBASE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -314,12 +314,12 @@ static void OnRPCStopped()
 
 void SetupServerArgs()
 {
-    const auto defaultBaseParams = CreateBaseChainParams(CBaseChainParams::MAIN);
-    const auto testnetBaseParams = CreateBaseChainParams(CBaseChainParams::TESTNET);
-    const auto regtestBaseParams = CreateBaseChainParams(CBaseChainParams::REGTEST);
-    const auto defaultChainParams = CreateChainParams(CBaseChainParams::MAIN);
-    const auto testnetChainParams = CreateChainParams(CBaseChainParams::TESTNET);
-    const auto regtestChainParams = CreateChainParams(CBaseChainParams::REGTEST);
+    const auto defaultBaseParams = CreateBaseChainParams(ChainType::MAIN);
+    const auto testnetBaseParams = CreateBaseChainParams(ChainType::TESTNET);
+    const auto regtestBaseParams = CreateBaseChainParams(ChainType::REGTEST);
+    const auto defaultChainParams = CreateChainParams(ChainType::MAIN);
+    const auto testnetChainParams = CreateChainParams(ChainType::TESTNET);
+    const auto regtestChainParams = CreateChainParams(ChainType::REGTEST);
 
     // Hidden Options
     std::vector<std::string> hidden_args = {"-h", "-help",

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -56,6 +56,7 @@ class NodeImpl : public Node
     bool softSetArg(const std::string& arg, const std::string& value) override { return gArgs.SoftSetArg(arg, value); }
     bool softSetBoolArg(const std::string& arg, bool value) override { return gArgs.SoftSetBoolArg(arg, value); }
     void selectParams(const std::string& network) override { SelectParams(network); }
+    void selectParams(const ChainType& network) override { SelectParams(network); }
     std::string getNetwork() override { return Params().NetworkIDString(); }
     void initLogging() override { InitLogging(); }
     void initParameterInteraction() override { InitParameterInteraction(); }

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -55,7 +55,6 @@ class NodeImpl : public Node
     bool readConfigFiles(std::string& error) override { return gArgs.ReadConfigFiles(error, true); }
     bool softSetArg(const std::string& arg, const std::string& value) override { return gArgs.SoftSetArg(arg, value); }
     bool softSetBoolArg(const std::string& arg, bool value) override { return gArgs.SoftSetBoolArg(arg, value); }
-    void selectParams(const std::string& network) override { SelectParams(network); }
     void selectParams(const ChainType& network) override { SelectParams(network); }
     std::string getNetwork() override { return Params().NetworkIDString(); }
     void initLogging() override { InitLogging(); }

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -50,7 +50,6 @@ public:
     virtual bool readConfigFiles(std::string& error) = 0;
 
     //! Choose network parameters.
-    virtual void selectParams(const std::string& network) = 0;
     virtual void selectParams(const ChainType& network) = 0;
 
     //! Get network name.

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -51,6 +51,7 @@ public:
 
     //! Choose network parameters.
     virtual void selectParams(const std::string& network) = 0;
+    virtual void selectParams(const ChainType& network) = 0;
 
     //! Get network name.
     virtual std::string getNetwork() = 0;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -651,12 +651,13 @@ int main(int argc, char *argv[])
     // - Needs to be done before createOptionsModel
 
     // Check for -testnet or -regtest parameter (Params() calls are only valid after this clause)
-    try {
-        node->selectParams(gArgs.GetChainName());
-    } catch(std::exception &e) {
-        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME), QObject::tr("Error: %1").arg(e.what()));
+    const auto chain = gArgs.GetChainType(error);
+    if (!chain) {
+        fprintf(stderr, "Error: %s\n", error.c_str());
+        QMessageBox::critical(0, QObject::tr(PACKAGE_NAME), QObject::tr("Error: %1").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
     }
+    node->selectParams(*chain);
 #ifdef ENABLE_WALLET
     // Parse URIs on command line -- this can affect Params()
     PaymentServer::ipcParseCommandLine(*node, argc, argv);

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -522,12 +522,14 @@ TableViewLastColumnResizingFixer::TableViewLastColumnResizingFixer(QTableView* t
 #ifdef WIN32
 fs::path static StartupShortcutPath()
 {
-    std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
+    std::string error;
+    const auto chain = gArgs.GetChainName(error);
+    if (!chain) throw std::runtime_error(error);
+    if (*chain == CBaseChainParams::MAIN)
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin.lnk";
-    if (chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
+    if (*chain == CBaseChainParams::TESTNET) // Remove this special case when CBaseChainParams::TESTNET = "testnet4"
         return GetSpecialFolderPath(CSIDL_STARTUP) / "Bitcoin (testnet).lnk";
-    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", chain);
+    return GetSpecialFolderPath(CSIDL_STARTUP) / strprintf("Bitcoin (%s).lnk", *chain);
 }
 
 bool GetStartOnSystemStartup()
@@ -605,10 +607,12 @@ fs::path static GetAutostartDir()
 
 fs::path static GetAutostartFilePath()
 {
-    std::string chain = gArgs.GetChainName();
-    if (chain == CBaseChainParams::MAIN)
+    std::string error;
+    const auto chain = gArgs.GetChainName(error);
+    if (!chain) throw std::runtime_error(error);
+    if (*chain == CBaseChainParams::MAIN)
         return GetAutostartDir() / "bitcoin.desktop";
-    return GetAutostartDir() / strprintf("bitcoin-%s.lnk", chain);
+    return GetAutostartDir() / strprintf("bitcoin-%s.lnk", *chain);
 }
 
 bool GetStartOnSystemStartup()
@@ -647,14 +651,16 @@ bool SetStartOnSystemStartup(bool fAutoStart)
         fs::ofstream optionFile(GetAutostartFilePath(), std::ios_base::out|std::ios_base::trunc);
         if (!optionFile.good())
             return false;
-        std::string chain = gArgs.GetChainName();
+        std::string error;
+        const auto chain = gArgs.GetChainName(error);
+        if (!chain) throw std::runtime_error(error);
         // Write a bitcoin.desktop file to the autostart directory:
         optionFile << "[Desktop Entry]\n";
         optionFile << "Type=Application\n";
-        if (chain == CBaseChainParams::MAIN)
+        if (*chain == CBaseChainParams::MAIN)
             optionFile << "Name=Bitcoin\n";
         else
-            optionFile << strprintf("Name=Bitcoin (%s)\n", chain);
+            optionFile << strprintf("Name=Bitcoin (%s)\n", *chain);
         optionFile << "Exec=" << pszExePath << strprintf(" -min -testnet=%d -regtest=%d\n", gArgs.GetBoolArg("-testnet", false), gArgs.GetBoolArg("-regtest", false));
         optionFile << "Terminal=false\n";
         optionFile << "Hidden=false\n";

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -209,14 +209,14 @@ void PaymentServer::ipcParseCommandLine(interfaces::Node& node, int argc, char* 
             SendCoinsRecipient r;
             if (GUIUtil::parseBitcoinURI(arg, &r) && !r.address.isEmpty())
             {
-                auto tempChainParams = CreateChainParams(CBaseChainParams::MAIN);
+                auto tempChainParams = CreateChainParams(ChainType::MAIN);
 
                 if (IsValidDestinationString(r.address.toStdString(), *tempChainParams)) {
-                    node.selectParams(CBaseChainParams::MAIN);
+                    node.selectParams(ChainType::MAIN);
                 } else {
-                    tempChainParams = CreateChainParams(CBaseChainParams::TESTNET);
+                    tempChainParams = CreateChainParams(ChainType::TESTNET);
                     if (IsValidDestinationString(r.address.toStdString(), *tempChainParams)) {
-                        node.selectParams(CBaseChainParams::TESTNET);
+                        node.selectParams(ChainType::TESTNET);
                     }
                 }
             }
@@ -230,11 +230,11 @@ void PaymentServer::ipcParseCommandLine(interfaces::Node& node, int argc, char* 
             {
                 if (request.getDetails().network() == "main")
                 {
-                    node.selectParams(CBaseChainParams::MAIN);
+                    node.selectParams(ChainType::MAIN);
                 }
                 else if (request.getDetails().network() == "test")
                 {
-                    node.selectParams(CBaseChainParams::TESTNET);
+                    node.selectParams(ChainType::TESTNET);
                 }
             }
         }

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -66,7 +66,7 @@ static SendCoinsRecipient handleRequest(PaymentServer* server, std::vector<unsig
 
 void PaymentServerTests::paymentServerTests()
 {
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(ChainType::MAIN);
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);
     PaymentServer* server = new PaymentServer(nullptr, false);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 {
     SetupEnvironment();
     SetupNetworking();
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(ChainType::MAIN);
     noui_connect();
     ClearDatadirCache();
     fs::path pathTemp = fs::temp_directory_path() / strprintf("test_bitcoin-qt_%lu_%i", (unsigned long)GetTime(), (int)GetRand(100000));

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -15,7 +15,7 @@
 std::vector<std::pair<uint256, CTransactionRef>> extra_txn;
 
 struct RegtestingSetup : public TestingSetup {
-    RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
+    RegtestingSetup() : TestingSetup(ChainType::REGTEST) {}
 };
 
 BOOST_FIXTURE_TEST_SUITE(blockencodings_tests, RegtestingSetup)

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -36,9 +36,11 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
         }
         std::string exp_base58string = test[0].get_str();
         std::vector<unsigned char> exp_payload = ParseHex(test[1].get_str());
-        const UniValue &metadata = test[2].get_obj();
+        const UniValue& metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
-        SelectParams(find_value(metadata, "chain").get_str());
+        ChainType chain;
+        BOOST_CHECK(ParseChainType(find_value(metadata, "chain").get_str(), chain));
+        SelectParams(chain);
         bool try_case_flip = find_value(metadata, "tryCaseFlip").isNull() ? false : find_value(metadata, "tryCaseFlip").get_bool();
         if (isPrivkey) {
             bool isCompressed = find_value(metadata, "isCompressed").get_bool();
@@ -95,9 +97,11 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
         }
         std::string exp_base58string = test[0].get_str();
         std::vector<unsigned char> exp_payload = ParseHex(test[1].get_str());
-        const UniValue &metadata = test[2].get_obj();
+        const UniValue& metadata = test[2].get_obj();
         bool isPrivkey = find_value(metadata, "isPrivkey").get_bool();
-        SelectParams(find_value(metadata, "chain").get_str());
+        ChainType chain;
+        BOOST_CHECK(ParseChainType(find_value(metadata, "chain").get_str(), chain));
+        SelectParams(chain);
         if (isPrivkey) {
             bool isCompressed = find_value(metadata, "isCompressed").get_bool();
             CKey key;
@@ -136,7 +140,7 @@ BOOST_AUTO_TEST_CASE(key_io_invalid)
         std::string exp_base58string = test[0].get_str();
 
         // must be invalid as public and as private key
-        for (const auto& chain : { CBaseChainParams::MAIN, CBaseChainParams::TESTNET, CBaseChainParams::REGTEST }) {
+        for (const auto& chain : {ChainType::MAIN, ChainType::TESTNET, ChainType::REGTEST}) {
             SelectParams(chain);
             destination = DecodeDestination(exp_base58string);
             BOOST_CHECK_MESSAGE(!IsValidDestination(destination), "IsValid pubkey in mainnet:" + strTest);

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -25,7 +25,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
     UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
     CKey privkey;
     CTxDestination destination;
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(ChainType::MAIN);
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
         }
     }
 
-    SelectParams(CBaseChainParams::MAIN);
+    SelectParams(ChainType::MAIN);
 }
 
 

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -39,7 +39,7 @@ static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
 
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     TestBlockSubsidyHalvings(chainParams->GetConsensus()); // As in main
     TestBlockSubsidyHalvings(150); // As in regtest
     TestBlockSubsidyHalvings(1000); // Just another interval
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
 
 BOOST_AUTO_TEST_CASE(subsidy_limit_test)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     CAmount nSum = 0;
     for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
         CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -205,7 +205,7 @@ static void TestPackageSelection(const CChainParams& chainparams, const CScript&
 BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 {
     // Note that by default, these tests run with size accounting enabled.
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     const CChainParams& chainparams = *chainParams;
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     std::unique_ptr<CBlockTemplate> pblocktemplate;

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -16,7 +16,7 @@ BOOST_FIXTURE_TEST_SUITE(pow_tests, BasicTestingSetup)
 /* Test calculation of next difficulty target with no constraints applying */
 BOOST_AUTO_TEST_CASE(get_next_work)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     int64_t nLastRetargetTime = 1261130161; // Block #30240
     CBlockIndex pindexLast;
     pindexLast.nHeight = 32255;
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(get_next_work)
 /* Test the constraint on the upper bound for next work */
 BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     int64_t nLastRetargetTime = 1231006505; // Block #0
     CBlockIndex pindexLast;
     pindexLast.nHeight = 2015;
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
 /* Test the constraint on the lower bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     int64_t nLastRetargetTime = 1279008237; // Block #66528
     CBlockIndex pindexLast;
     pindexLast.nHeight = 68543;
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_lower_limit_actual)
 /* Test the constraint on the upper bound for actual time taken */
 BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     int64_t nLastRetargetTime = 1263163443; // NOTE: Not an actual block time
     CBlockIndex pindexLast;
     pindexLast.nHeight = 46367;
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_upper_limit_actual)
 
 BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 {
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     std::vector<CBlockIndex> blocks(10000);
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -48,7 +48,7 @@ std::ostream& operator<<(std::ostream& os, const uint256& num)
     return os;
 }
 
-BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
+BasicTestingSetup::BasicTestingSetup(const ChainType& chain)
     : m_path_root(fs::temp_directory_path() / "test_bitcoin" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
 {
     SHA256AutoDetect();
@@ -62,7 +62,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     // CreateAndProcessBlock() does not support building SegWit blocks, so don't activate in these tests.
     // TODO: fix the code to support SegWit blocks.
     gArgs.ForceSetArg("-vbparams", strprintf("segwit:0:%d", (int64_t)Consensus::BIP9Deployment::NO_TIMEOUT));
-    SelectParams(chainName);
+    SelectParams(chain);
     noui_connect();
 }
 
@@ -80,7 +80,7 @@ fs::path BasicTestingSetup::SetDataDir(const std::string& name)
     return ret;
 }
 
-TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(chainName)
+TestingSetup::TestingSetup(const ChainType& chain) : BasicTestingSetup(chain)
 {
     SetDataDir("tempdir");
     const CChainParams& chainparams = Params();
@@ -130,7 +130,7 @@ TestingSetup::~TestingSetup()
         pblocktree.reset();
 }
 
-TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
+TestChain100Setup::TestChain100Setup() : TestingSetup(ChainType::REGTEST)
 {
     // Generate a 100-block chain:
     coinbaseKey.MakeNewKey(true);

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -43,7 +43,7 @@ static inline bool InsecureRandBool() { return insecure_rand_ctx.randbool(); }
 struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
 
-    explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit BasicTestingSetup(const ChainType& chain = ChainType::MAIN);
     ~BasicTestingSetup();
 
     fs::path SetDataDir(const std::string& name);
@@ -69,7 +69,7 @@ struct TestingSetup: public BasicTestingSetup {
     CScheduler scheduler;
     std::unique_ptr<PeerLogicValidation> peerLogic;
 
-    explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+    explicit TestingSetup(const ChainType& chain = ChainType::MAIN);
     ~TestingSetup();
 };
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -558,39 +558,39 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
     std::string error;
 
     test_args.ParseParameters(0, (char**)argv_testnet, error);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "main");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "main");
 
     test_args.ParseParameters(2, (char**)argv_testnet, error);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(2, (char**)argv_regtest, error);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "regtest");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "regtest");
 
     test_args.ParseParameters(3, (char**)argv_test_no_reg, error);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(3, (char**)argv_both, error);
-    BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
+    BOOST_CHECK(!test_args.GetChainName(error));
 
     test_args.ParseParameters(0, (char**)argv_testnet, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(2, (char**)argv_testnet, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(2, (char**)argv_regtest, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
+    BOOST_CHECK(!test_args.GetChainName(error));
 
     test_args.ParseParameters(3, (char**)argv_test_no_reg, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(3, (char**)argv_both, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
+    BOOST_CHECK(!test_args.GetChainName(error));
 
     // check setting the network to test (and thus making
     // [test] regtest=1 potentially relevant) doesn't break things
@@ -598,23 +598,23 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
 
     test_args.ParseParameters(0, (char**)argv_testnet, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(2, (char**)argv_testnet, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(2, (char**)argv_regtest, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
+    BOOST_CHECK(!test_args.GetChainName(error));
 
     test_args.ParseParameters(2, (char**)argv_test_no_reg, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_EQUAL(test_args.GetChainName(), "test");
+    BOOST_CHECK_EQUAL(*test_args.GetChainName(error), "test");
 
     test_args.ParseParameters(3, (char**)argv_both, error);
     test_args.ReadConfigString(testnetconf);
-    BOOST_CHECK_THROW(test_args.GetChainName(), std::runtime_error);
+    BOOST_CHECK(!test_args.GetChainName(error));
 }
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -15,7 +15,7 @@
 #include <validationinterface.h>
 
 struct RegtestingSetup : public TestingSetup {
-    RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
+    RegtestingSetup() : TestingSetup(ChainType::REGTEST) {}
 };
 
 BOOST_FIXTURE_TEST_SUITE(validation_block_tests, RegtestingSetup)

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -223,7 +223,7 @@ BOOST_AUTO_TEST_CASE(versionbits_test)
     }
 
     // Sanity checks of version bit deployments
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     const Consensus::Params &mainnetParams = chainParams->GetConsensus();
     for (int i=0; i<(int) Consensus::MAX_VERSION_BITS_DEPLOYMENTS; i++) {
         uint32_t bitmask = VersionBitsMask(mainnetParams, static_cast<Consensus::DeploymentPos>(i));
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
 {
     // Check that ComputeBlockVersion will set the appropriate bit correctly
     // on mainnet.
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
+    const auto chainParams = CreateChainParams(ChainType::MAIN);
     const Consensus::Params &mainnetParams = chainParams->GetConsensus();
 
     // Use the TESTDUMMY deployment for testing purposes.

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -407,6 +407,12 @@ void ArgsManager::SelectConfigNetwork(const std::string& network)
     m_network = network;
 }
 
+void ArgsManager::SelectConfigNetwork(const ChainType& network)
+{
+    LOCK(cs_args);
+    m_network = FormatChainType(network);
+}
+
 bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::string& error)
 {
     LOCK(cs_args);

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include <boost/optional.hpp>
 #include <boost/thread/condition_variable.hpp> // for boost::thread_interrupted
 
 enum class ChainType;
@@ -248,9 +249,11 @@ public:
 
     /**
      * Looks for -regtest, -testnet and returns the appropriate BIP70 chain name.
-     * @return CBaseChainParams::MAIN by default; raises runtime error if an invalid combination is given.
+     * @return CBaseChainParams::MAIN by default, none if error is set
      */
-    std::string GetChainName() const;
+    boost::optional<std::string> GetChainName(std::string& error) const;
+
+    boost::optional<ChainType> GetChainType(std::string& error) const;
 
     /**
      * Add argument

--- a/src/util.h
+++ b/src/util.h
@@ -33,6 +33,8 @@
 
 #include <boost/thread/condition_variable.hpp> // for boost::thread_interrupted
 
+enum class ChainType;
+
 // Application startup time (used for uptime calculation)
 int64_t GetStartupTime();
 
@@ -157,6 +159,7 @@ public:
      * Select the network in use
      */
     void SelectConfigNetwork(const std::string& network);
+    void SelectConfigNetwork(const ChainType& network);
 
     bool ParseParameters(int argc, const char* const argv[], std::string& error);
     bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -7,8 +7,8 @@
 #include <rpc/server.h>
 #include <wallet/db.h>
 
-WalletTestingSetup::WalletTestingSetup(const std::string& chainName):
-    TestingSetup(chainName), m_wallet("mock", WalletDatabase::CreateMock())
+WalletTestingSetup::WalletTestingSetup(const ChainType& chain)
+    : TestingSetup(chain), m_wallet("mock", WalletDatabase::CreateMock())
 {
     bool fFirstRun;
     m_wallet.LoadWallet(fFirstRun);

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -13,8 +13,8 @@
 
 /** Testing setup and teardown for wallet.
  */
-struct WalletTestingSetup: public TestingSetup {
-    explicit WalletTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
+struct WalletTestingSetup : public TestingSetup {
+    explicit WalletTestingSetup(const ChainType& chain = ChainType::MAIN);
     ~WalletTestingSetup();
 
     CWallet m_wallet;

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -7,6 +7,7 @@
 import os
 
 from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_node import ErrorMatch
 
 
 class ConfArgsTest(BitcoinTestFramework):
@@ -31,6 +32,14 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('nono\n')
         self.nodes[0].assert_start_raises_init_error(expected_msg='Error reading configuration file: parse error on line 1: nono, if you intended to specify a negated option, use nono=1 instead')
+
+        with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
+            conf.write('vbparams=a:b\n')
+        self.nodes[0].assert_start_raises_init_error(expected_msg='Version bits parameters malformed, expecting deployment:start:end', match=ErrorMatch.PARTIAL_REGEX)
+
+        with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
+            conf.write('testnet=1\n')
+        self.nodes[0].assert_start_raises_init_error(expected_msg='Invalid combination of -regtest and -testnet.', match=ErrorMatch.PARTIAL_REGEX)
 
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear

--- a/test/util/data/bitcoin-util-test.json
+++ b/test/util/data/bitcoin-util-test.json
@@ -1,5 +1,65 @@
 [
   { "exec": "./bitcoin-tx",
+    "args": ["-regtest", "-testnet"],
+    "return_code": 1,
+    "error_txt": "Invalid combination of -regtest and -testnet.",
+    "description": "Tests for invalid chain selection"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": ["-regtest", "-vbparams=a:b"],
+    "return_code": 1,
+    "error_txt": "Version bits parameters malformed, expecting deployment:start:end",
+    "description": "Tests for invalid vbparams"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": ["-regtest", "-vbparams=a:b:c"],
+    "return_code": 1,
+    "error_txt": "Invalid nStartTime (b)",
+    "description": "Tests for invalid vbparams"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": ["-regtest", "-vbparams=a:0:c"],
+    "return_code": 1,
+    "error_txt": "Invalid nTimeout (c)",
+    "description": "Tests for invalid vbparams"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": ["-regtest", "-vbparams=a:0:0"],
+    "return_code": 1,
+    "error_txt": "Invalid deployment (a)",
+    "description": "Tests for invalid vbparams"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": ["-unknown_arg"],
+    "return_code": 1,
+    "error_txt": "Error parsing command line arguments: Invalid parameter -unknown_arg",
+    "description": "Tests for invalid arg"
+  },
+  { "exec": "./bitcoin-tx",
+    "args": [],
+    "return_code": 1,
+    "error_txt": "Error: too few parameters",
+    "description": "Tests for too few parameters"
+  },
+  { "exec": "./bitcoin-cli",
+    "args": ["-unknown_arg"],
+    "return_code": 1,
+    "error_txt": "Error parsing command line arguments: Invalid parameter -unknown_arg",
+    "description": "Tests for invalid arg"
+  },
+  { "exec": "./bitcoin-cli",
+    "args": [],
+    "return_code": 1,
+    "error_txt": "Error: too few parameters",
+    "description": "Tests for too few parameters"
+  },
+  { "exec": "./bitcoin-cli",
+    "args": ["-datadir=/tmp/does/not/exist/"],
+    "return_code": 1,
+    "error_txt": "Error: Specified data directory \"/tmp/does/not/exist/\" does not exist.",
+    "description": "Tests for wrong datadir"
+  },
+  { "exec": "./bitcoin-tx",
     "args": ["-create", "nversion=1"],
     "output_cmp": "blanktxv1.hex",
     "description": "Creates a blank v1 transaction"


### PR DESCRIPTION
Currently we use string constants to select different chain rules (e.g "main" or "test"). The obvious downsides are that any function that accepts such a string needs to check if it is one of the known ones and return a runtime error when not found.

This check can be done at compile time by using a `switch` statement on an `enum class`.

To not refactor all the existing code, this first introduces the type-safe `enum class ChainType` and then runs a scripted diff on all instances where we can benefit from the new class. I intend to remove the throwing and now deprecated methods that pass around the string in a future patch.