### PR TITLE
Relay ancestors of transactions

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,7 @@
 #include <utilstrencodings.h>
 
 #include <memory>
+#include <unordered_set>
 
 #if defined(NDEBUG)
 # error "Bitcoin cannot be compiled without assertions."
@@ -153,7 +154,12 @@ namespace {
     std::atomic<int64_t> g_last_tip_update(0);
 
     /** Relay map */
-    typedef std::map<uint256, CTransactionRef> MapRelay;
+    struct RelayEntry {
+        explicit RelayEntry(CTransactionRef &&tx) : m_txref(tx) {}
+        CTransactionRef m_txref;
+        std::unordered_set<NodeId> m_node_set;
+    };
+    typedef std::map<uint256, RelayEntry> MapRelay;
     MapRelay mapRelay GUARDED_BY(cs_main);
     /** Expiration-time ordered list of (expire time, relay map entry) pairs. */
     std::deque<std::pair<int64_t, MapRelay::iterator>> vRelayExpiration GUARDED_BY(cs_main);
@@ -1284,8 +1290,8 @@ void static ProcessGetData(CNode* pfrom, const CChainParams& chainparams, CConnm
             bool push = false;
             auto mi = mapRelay.find(inv.hash);
             int nSendFlags = (inv.type == MSG_TX ? SERIALIZE_TRANSACTION_NO_WITNESS : 0);
-            if (mi != mapRelay.end()) {
-                connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *mi->second));
+            if (mi != mapRelay.end() && mi->second.m_node_set.count(pfrom->GetId())) {
+                connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, *mi->second.m_txref));
                 push = true;
             } else if (pfrom->timeLastMempoolReq) {
                 auto txinfo = mempool.info(inv.hash);
@@ -3610,7 +3616,10 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                             vRelayExpiration.pop_front();
                         }
 
-                        auto ret = mapRelay.insert(std::make_pair(hash, std::move(txinfo.tx)));
+                        auto ret = mapRelay.emplace(hash, RelayEntry(std::move(txinfo.tx)));
+                        // Add this peer to the node map indicating which peers
+                        // we will allow to download the transaction
+                        ret.first->second.m_node_set.insert(pto->GetId());
                         if (ret.second) {
                             vRelayExpiration.push_back(std::make_pair(nNow + 15 * 60 * 1000000, ret.first));
                         }

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test that we don't leak txs to inbound peers that we haven't yet announced to"""
+
+from test_framework.messages import msg_getdata, CInv
+from test_framework.mininode import mininode_lock, P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    wait_until,
+)
+
+
+class P2PLeakTxTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        gen_node = self.nodes[0]  # The block and tx generating node
+        gen_node.generate(1)
+        self.sync_all()
+
+        inbound_peer = self.nodes[0].add_p2p_connection(P2PDataStore())  # An "attacking" inbound peer
+        outbound_peer = self.nodes[1]  # Our outbound peer
+
+        # In an adversiarial setting we can generally assume that inbound peers
+        # are more likely to spy on us than outbound peers. Thus, on average,
+        # we announce transactions first to outbound peers, then to (all)
+        # inbound peers. Inbound peers must not be able to request the
+        # transaction they haven't yet received the announcement for it.
+        #
+        # With only one outbound peer, we expect that a tx is first announced
+        # to (all) inbound peers (and thus present a potential leak) in 28.5% of
+        # the cases.
+        #
+        # Probability( time_ann_inbound < time_ann_outbound )                 =
+        # ∫ f_in(x)                           * F_out(x)                   dx =
+        # ∫ (lambda_in * exp(-lambda_in * x)) * (1 - exp(-lambda_out * x)) dx =
+        # 0.285714
+        #
+        # Where,
+        # * f_in is the pdf of the exponential distribution for inbound peers,
+        #   with lambda_in = 1 / INVENTORY_BROADCAST_INTERVAL = 1/5
+        # * F_out is the cdf of the expon. distribuiton for outbound peers,
+        #   with lambda_out = 1 / (INVENTORY_BROADCAST_INTERVAL >> 1) = 1/2
+        #
+        # Due to measurement delays, the actual monte-carlo leak is a bit
+        # higher. Assume a total delay of 0.6 s (Includes network delays and
+        # rpc delay to poll the raw mempool)
+        #
+        # Probability( time_ann_inbound < time_ann_outbound + 0.6 )           =
+        # ∫ f_in(x)                           * F_out(x + 0.6)             dx =
+        # ∫ (lambda_in * exp(-lambda_in * x)) * (1 - exp(-lambda_out * (x+.6))) dx =
+        # 0.366485
+        EXPECTED_MEASURED_LEAK = .366485
+
+        REPEATS = 100
+        measured_leak = 0
+        self.log.info('Start simulation for {} repeats'.format(REPEATS))
+        for i in range(REPEATS):
+            self.log.debug('Run {}/{}'.format(i, REPEATS))
+            txid = gen_node.sendtoaddress(gen_node.getnewaddress(), 0.033)
+            want_tx = msg_getdata()
+            want_tx.inv.append(CInv(t=1, h=int(txid, 16)))
+
+            wait_until(lambda: txid in outbound_peer.getrawmempool(), lock=mininode_lock)
+            inbound_peer.send_message(want_tx)
+            inbound_peer.sync_with_ping()
+
+            if inbound_peer.last_message.get('notfound'):
+                assert_equal(inbound_peer.last_message['notfound'].vec[0].hash, int(txid, 16))
+                inbound_peer.last_message.pop('notfound')
+            else:
+                measured_leak += 1
+
+        measured_leak /= REPEATS
+        self.log.info('Measured leak of {}'.format(measured_leak))
+
+        assert_greater_than(EXPECTED_MEASURED_LEAK, measured_leak)
+
+
+if __name__ == '__main__':
+    P2PLeakTxTest().main()

--- a/test/functional/p2p_txchain_relay.py
+++ b/test/functional/p2p_txchain_relay.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test relay of transaction chains.
+
+Ensure that if bitcoind announces a transaction it will also respond
+to getdata requests for parents of the transaction.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    sync_blocks
+)
+
+class ChainRelayTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.log.info("Generating one utxo for node0")
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+        self.nodes[1].generate(100)
+        self.sync_all()
+
+        # Node0 should now have 1 utxo.
+        assert_equal(len(self.nodes[0].listunspent()), 1)
+
+        assert self.nodes[0].getbalance() > 10 # Should be 50, but doesn't matter
+
+        self.log.info("Disconnect node0 from node1")
+        disconnect_nodes(self.nodes[0], 1)
+        disconnect_nodes(self.nodes[1], 0)
+
+        assert_equal(len(self.nodes[0].getpeerinfo()), 0)
+
+        # This next part is sort of a hack -- we're going to reconnect the
+        # nodes after generating a transaction on node0, and we'll need a way
+        # to test that the p2p connections are fully up before generating the
+        # child transaction. To do that we will just test whether a block generated
+        # on node1 makes it over to node0. Perhaps there's a status field in
+        # getpeerinfo() that might be sufficient as well (synced_headers or
+        # something?).
+        self.log.info("Mine a block on node1")
+        self.nodes[1].generate(1)
+
+        self.log.info("Generating new transaction on node0")
+        self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1, "", "", False)
+        assert_equal(len(self.nodes[0].getrawmempool()), 1)
+
+        self.log.info("Reconnect node0 to node1")
+        connect_nodes(self.nodes[0], 1)
+
+        sync_blocks(self.nodes)
+        # Check that node1's mempool is still empty
+        assert_equal(len(self.nodes[1].getrawmempool()), 0)
+
+        self.log.info("Generating child transaction on node0")
+        txid2 = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 2, "", "", False)
+        assert_equal(self.nodes[0].getmempoolentry(txid2)['ancestorcount'], 2)
+
+        self.log.info("Check that both transactions end up on node1")
+        self.sync_all()
+
+        # sync_all ensures the mempool's are synced, but for avoidance of doubt
+        # just verify that the child transaction made it to node1
+        assert txid2 in self.nodes[1].getrawmempool()
+
+        self.log.info("Node1 successfully synced")
+
+if __name__ == '__main__':
+    ChainRelayTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1160,6 +1160,26 @@ class msg_mempool():
     def __repr__(self):
         return "msg_mempool()"
 
+
+class msg_notfound():
+    command = b"notfound"
+
+    def __init__(self, vec=None):
+        if vec is None:
+            self.vec = []
+        else:
+            self.vec = vec
+
+    def deserialize(self, f):
+        self.vec = deser_vector(f, CInv)
+
+    def serialize(self):
+        return ser_vector(self.vec)
+
+    def __repr__(self):
+        return "msg_notfound(vec=%s)" % (repr(self.vec))
+
+
 class msg_sendheaders():
     command = b"sendheaders"
 

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -21,7 +21,38 @@ import struct
 import sys
 import threading
 
-from test_framework.messages import CBlockHeader, MIN_VERSION_SUPPORTED, msg_addr, msg_block, MSG_BLOCK, msg_blocktxn, msg_cmpctblock, msg_feefilter, msg_getaddr, msg_getblocks, msg_getblocktxn, msg_getdata, msg_getheaders, msg_headers, msg_inv, msg_mempool, msg_ping, msg_pong, msg_reject, msg_sendcmpct, msg_sendheaders, msg_tx, MSG_TX, MSG_TYPE_MASK, msg_verack, msg_version, NODE_NETWORK, NODE_WITNESS, sha256
+from test_framework.messages import (
+    CBlockHeader,
+    MIN_VERSION_SUPPORTED,
+    msg_addr,
+    msg_block,
+    MSG_BLOCK,
+    msg_blocktxn,
+    msg_cmpctblock,
+    msg_feefilter,
+    msg_getaddr,
+    msg_getblocks,
+    msg_getblocktxn,
+    msg_getdata,
+    msg_getheaders,
+    msg_headers,
+    msg_inv,
+    msg_mempool,
+    msg_notfound,
+    msg_ping,
+    msg_pong,
+    msg_reject,
+    msg_sendcmpct,
+    msg_sendheaders,
+    msg_tx,
+    MSG_TX,
+    MSG_TYPE_MASK,
+    msg_verack,
+    msg_version,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    sha256,
+)
 from test_framework.util import wait_until
 
 logger = logging.getLogger("TestFramework.mininode")
@@ -40,6 +71,7 @@ MESSAGEMAP = {
     b"headers": msg_headers,
     b"inv": msg_inv,
     b"mempool": msg_mempool,
+    b"notfound": msg_notfound,
     b"ping": msg_ping,
     b"pong": msg_pong,
     b"reject": msg_reject,
@@ -295,6 +327,7 @@ class P2PInterface(P2PConnection):
     def on_getheaders(self, message): pass
     def on_headers(self, message): pass
     def on_mempool(self, message): pass
+    def on_notfound(self, message): pass
     def on_pong(self, message): pass
     def on_reject(self, message): pass
     def on_sendcmpct(self, message): pass

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -122,6 +122,7 @@ BASE_SCRIPTS = [
     'feature_versionbits_warning.py',
     'rpc_preciousblock.py',
     'wallet_importprunedfunds.py',
+    'p2p_leak_tx.py',
     'rpc_zmq.py',
     'rpc_signmessage.py',
     'feature_nulldummy.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -110,6 +110,7 @@ BASE_SCRIPTS = [
     'rpc_decodescript.py',
     'rpc_blockchain.py',
     'rpc_deprecated.py',
+    'p2p_txchain_relay.py',
     'wallet_disable.py',
     'rpc_net.py',
     'wallet_keypool.py',


### PR DESCRIPTION
Respond to getdata requests for transactions that are ancestors of newly-announced transactions.  Currently, our software will request the parents of an orphan transaction from the peer who announced the orphan, but if our peer is running a recent Bitcoin Core version, the request would typically be dropped.  So this should improve propagation for transaction chains, particularly for nodes that are just starting up.

(continued from #14220, which is now just a bugfix PR)

Depends on:
 - [ ] #14220
