### PR TITLE
Drop redundant private class access specifiers

### DIFF
--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -79,7 +79,6 @@ typedef std::map<CSubNet, CBanEntry> banmap_t;
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB
 {
-private:
     fs::path pathAddr;
 public:
     CAddrDB();
@@ -91,7 +90,6 @@ public:
 /** Access to the banlist database (banlist.dat) */
 class CBanDB
 {
-private:
     fs::path pathBanlist;
 public:
     CBanDB();

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -187,7 +187,6 @@ public:
  */
 class CAddrMan
 {
-private:
     //! critical section to protect the inner data structures
     mutable CCriticalSection cs;
 

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -129,7 +129,6 @@ typedef enum ReadStatus_t
 } ReadStatus;
 
 class CBlockHeaderAndShortTxIDs {
-private:
     mutable uint64_t shorttxidk0, shorttxidk1;
     uint64_t nonce;
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -87,7 +87,6 @@ enum BlockFilterType : uint8_t
  */
 class BlockFilter
 {
-private:
     BlockFilterType m_filter_type;
     uint256 m_block_hash;
     GCSFilter m_filter;

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -43,7 +43,6 @@ enum bloomflags
  */
 class CBloomFilter
 {
-private:
     std::vector<unsigned char> vData;
     bool isFull;
     bool isEmpty;

--- a/src/chain.h
+++ b/src/chain.h
@@ -433,7 +433,6 @@ public:
 
 /** An in-memory indexed chain of blocks. */
 class CChain {
-private:
     std::vector<CBlockIndex*> vChain;
 
 public:

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -29,7 +29,6 @@ class CCheckQueueControl;
 template <typename T>
 class CCheckQueue
 {
-private:
     //! Mutex to protect the inner state
     boost::mutex mutex;
 
@@ -170,7 +169,6 @@ public:
 template <typename T>
 class CCheckQueueControl
 {
-private:
     CCheckQueue<T> * const pqueue;
     bool fDone;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -83,7 +83,6 @@ public:
 
 class SaltedOutpointHasher
 {
-private:
     /** Salt */
     const uint64_t k0, k1;
 

--- a/src/compressor.h
+++ b/src/compressor.h
@@ -35,7 +35,6 @@ uint64_t DecompressAmount(uint64_t nAmount);
  */
 class CScriptCompressor
 {
-private:
     /**
      * make this static for now (there are only 6 special scripts defined)
      * this can potentially be extended together with a new nVersion for
@@ -85,7 +84,6 @@ public:
 /** wrapper for CTxOut that provides a more compact serialization */
 class CTxOutCompressor
 {
-private:
     CTxOut &txout;
 
 public:

--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -24,7 +24,6 @@ static const unsigned char REJECT_CHECKPOINT = 0x43;
 
 /** Capture information about block/transaction validation */
 class CValidationState {
-private:
     enum mode_state {
         MODE_VALID,   //!< everything ok
         MODE_INVALID, //!< network rule violation (DoS value may be set)

--- a/src/crypto/aes.h
+++ b/src/crypto/aes.h
@@ -18,7 +18,6 @@ static const int AES256_KEYSIZE = 32;
 /** An encryption class for AES-128. */
 class AES128Encrypt
 {
-private:
     AES128_ctx ctx;
 
 public:
@@ -30,7 +29,6 @@ public:
 /** A decryption class for AES-128. */
 class AES128Decrypt
 {
-private:
     AES128_ctx ctx;
 
 public:
@@ -42,7 +40,6 @@ public:
 /** An encryption class for AES-256. */
 class AES256Encrypt
 {
-private:
     AES256_ctx ctx;
 
 public:
@@ -54,7 +51,6 @@ public:
 /** A decryption class for AES-256. */
 class AES256Decrypt
 {
-private:
     AES256_ctx ctx;
 
 public:

--- a/src/crypto/chacha20.h
+++ b/src/crypto/chacha20.h
@@ -11,7 +11,6 @@
 /** A PRNG class for ChaCha20. */
 class ChaCha20
 {
-private:
     uint32_t input[16];
 
 public:

--- a/src/crypto/hmac_sha256.h
+++ b/src/crypto/hmac_sha256.h
@@ -13,7 +13,6 @@
 /** A hasher class for HMAC-SHA-256. */
 class CHMAC_SHA256
 {
-private:
     CSHA256 outer;
     CSHA256 inner;
 

--- a/src/crypto/hmac_sha512.h
+++ b/src/crypto/hmac_sha512.h
@@ -13,7 +13,6 @@
 /** A hasher class for HMAC-SHA-512. */
 class CHMAC_SHA512
 {
-private:
     CSHA512 outer;
     CSHA512 inner;
 

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -11,7 +11,6 @@
 /** A hasher class for RIPEMD-160. */
 class CRIPEMD160
 {
-private:
     uint32_t s[5];
     unsigned char buf[64];
     uint64_t bytes;

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -11,7 +11,6 @@
 /** A hasher class for SHA1. */
 class CSHA1
 {
-private:
     uint32_t s[5];
     unsigned char buf[64];
     uint64_t bytes;

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -12,7 +12,6 @@
 /** A hasher class for SHA-256. */
 class CSHA256
 {
-private:
     uint32_t s[8];
     unsigned char buf[64];
     uint64_t bytes;

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -11,7 +11,6 @@
 /** A hasher class for SHA-512. */
 class CSHA512
 {
-private:
     uint64_t s[8];
     unsigned char buf[128];
     uint64_t bytes;

--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -159,7 +159,6 @@ public:
 template <typename Element, typename Hash>
 class cache
 {
-private:
     /** table stores all the elements */
     std::vector<Element> table;
 

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -48,7 +48,6 @@ class CDBBatch
 {
     friend class CDBWrapper;
 
-private:
     const CDBWrapper &parent;
     leveldb::WriteBatch batch;
 
@@ -116,7 +115,6 @@ public:
 
 class CDBIterator
 {
-private:
     const CDBWrapper &parent;
     leveldb::Iterator *piter;
 
@@ -176,7 +174,6 @@ public:
 class CDBWrapper
 {
     friend const std::vector<unsigned char>& dbwrapper_private::GetObfuscateKey(const CDBWrapper &w);
-private:
     //! custom environment this database is using (may be nullptr in case of default environment)
     leveldb::Env* penv;
 

--- a/src/hash.h
+++ b/src/hash.h
@@ -19,7 +19,6 @@ typedef uint256 ChainCode;
 
 /** A hasher class for Bitcoin's 256-bit hash (double SHA-256). */
 class CHash256 {
-private:
     CSHA256 sha;
 public:
     static const size_t OUTPUT_SIZE = CSHA256::OUTPUT_SIZE;
@@ -43,7 +42,6 @@ public:
 
 /** A hasher class for Bitcoin's 160-bit hash (SHA-256 + RIPEMD-160). */
 class CHash160 {
-private:
     CSHA256 sha;
 public:
     static const size_t OUTPUT_SIZE = CRIPEMD160::OUTPUT_SIZE;
@@ -115,7 +113,6 @@ inline uint160 Hash160(const prevector<N, unsigned char>& vch)
 /** A writer stream (for serialization) that computes a 256-bit hash. */
 class CHashWriter
 {
-private:
     CHash256 ctx;
 
     const int nType;
@@ -150,7 +147,6 @@ public:
 template<typename Source>
 class CHashVerifier : public CHashWriter
 {
-private:
     Source* source;
 
 public:
@@ -197,7 +193,6 @@ void BIP32Hash(const ChainCode &chainCode, unsigned int nChild, unsigned char he
 /** SipHash-2-4 */
 class CSipHasher
 {
-private:
     uint64_t v[4];
     uint64_t tmp;
     int count;

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -67,7 +67,6 @@ private:
 template <typename WorkItem>
 class WorkQueue
 {
-private:
     /** Mutex protects entire object */
     Mutex cs;
     std::condition_variable cond;

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -56,7 +56,6 @@ struct event_base* EventBase();
  */
 class HTTPRequest
 {
-private:
     struct evhttp_request* req;
     bool replySent;
 

--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -20,7 +20,6 @@ struct DereferencingComparator { bool operator()(const T a, const T b) const { r
  */
 template <class K, class T>
 class indirectmap {
-private:
     typedef std::map<const K*, T, DereferencingComparator<const K*> > base;
     base m;
 public:

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -20,7 +20,6 @@ namespace
 {
 class DestinationEncoder : public boost::static_visitor<std::string>
 {
-private:
     const CChainParams& m_params;
 
 public:

--- a/src/logging.h
+++ b/src/logging.h
@@ -58,7 +58,6 @@ namespace BCLog {
 
     class Logger
     {
-    private:
         FILE* m_fileout = nullptr;
         std::mutex m_file_mutex;
         std::list<std::string> m_msgs_before_open;

--- a/src/miner.h
+++ b/src/miner.h
@@ -123,7 +123,6 @@ struct update_for_parent_inclusion
 /** Generate a new block, without valid proof-of-work */
 class BlockAssembler
 {
-private:
     // The constructed block template
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     // A convenience pointer that always refers to the CBlock in pblocktemplate

--- a/src/net.h
+++ b/src/net.h
@@ -571,7 +571,6 @@ public:
 
 
 class CNetMessage {
-private:
     mutable CHash256 hasher;
     mutable uint256 data_hash;
 public:

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -18,7 +18,6 @@ static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static constexpr bool DEFAULT_ENABLE_BIP61{false};
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
-private:
     CConnman* const connman;
 
 public:

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -18,7 +18,6 @@ extern const std::string CURRENCY_UNIT;
  */
 class CFeeRate
 {
-private:
     CAmount nSatoshisPerK; // unit is satoshis-per-1,000-bytes
 
 public:

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -71,7 +71,6 @@ bool FeeModeFromString(const std::string& mode_string, FeeEstimateMode& fee_esti
  */
 class TxConfirmStats
 {
-private:
     //Define the buckets we will group transactions into
     const std::vector<double>& buckets;              // The upper-bound of the range for the bucket (inclusive)
     const std::map<double, unsigned int>& bucketMap; // Map of bucket upper-bound to index into all vectors by bucket

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -135,7 +135,6 @@ struct FeeCalculation
  */
 class CBlockPolicyEstimator
 {
-private:
     /** Track confirm delays up to 12 blocks for short horizon */
     static constexpr unsigned int SHORT_BLOCK_PERIODS = 12;
     static constexpr unsigned int SHORT_SCALE = 1;
@@ -273,7 +272,6 @@ private:
 
 class FeeFilterRounder
 {
-private:
     static constexpr double MAX_FILTER_FEERATE = 1e7;
     /** FEE_FILTER_SPACING is just used to provide some quantization of fee
      * filter results.  Historically it reused FEE_SPACING, but it is completely

--- a/src/random.h
+++ b/src/random.h
@@ -43,7 +43,6 @@ void GetStrongRandBytes(unsigned char* buf, int num);
  * This class is not thread-safe.
  */
 class FastRandomContext {
-private:
     bool requires_seed;
     ChaCha20 rng;
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2011,7 +2011,6 @@ static std::atomic<bool> g_scan_in_progress;
 static std::atomic<bool> g_should_abort_scan;
 class CoinsViewScanReserver
 {
-private:
     bool m_could_reserve;
 public:
     explicit CoinsViewScanReserver() : m_could_reserve(false) {}

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -169,7 +169,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
 
 class CRPCConvertTable
 {
-private:
     std::set<std::pair<std::string, int>> members;
     std::set<std::pair<std::string, std::string>> membersByName;
 

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -142,7 +142,6 @@ public:
  */
 class CRPCTable
 {
-private:
     std::map<std::string, const CRPCCommand*> mapCommands;
 public:
     CRPCTable();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -95,7 +95,6 @@ private:
  * before it.
  */
 class SingleThreadedSchedulerClient {
-private:
     CScheduler *m_pscheduler;
 
     CCriticalSection m_cs_callbacks_pending;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1092,7 +1092,6 @@ namespace {
 template <class T>
 class CTransactionSignatureSerializer
 {
-private:
     const T& txTo;             //!< reference to the spending transaction (the one being serialized)
     const CScript& scriptCode; //!< output script being consumed
     const unsigned int nIn;    //!< input index of txTo being signed

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -165,7 +165,6 @@ public:
 template <class T>
 class GenericTransactionSignatureChecker : public BaseSignatureChecker
 {
-private:
     const T* txTo;
     unsigned int nIn;
     const CAmount amount;

--- a/src/script/sigcache.cpp
+++ b/src/script/sigcache.cpp
@@ -22,7 +22,6 @@ namespace {
  */
 class CSignatureCache
 {
-private:
      //! Entries are SHA256(nonce || signature hash || public key || signature):
     uint256 nonce;
     typedef CuckooCache::cache<uint256, SignatureCacheHasher> map_type;

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -42,7 +42,6 @@ public:
 
 class CachingTransactionSignatureChecker : public TransactionSignatureChecker
 {
-private:
     bool store;
 
 public:

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -291,7 +291,6 @@ bool SignPSBTInput(const SigningProvider& provider, const CMutableTransaction& t
 
 class SignatureExtractorChecker final : public BaseSignatureChecker
 {
-private:
     SignatureData& sigdata;
     BaseSignatureChecker& checker;
 
@@ -446,7 +445,6 @@ public:
 const DummySignatureChecker DUMMY_CHECKER;
 
 class DummySignatureCreator final : public BaseSignatureCreator {
-private:
     char m_r_len = 32;
     char m_s_len = 32;
 public:

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -41,7 +41,6 @@ extern const SigningProvider& DUMMY_SIGNING_PROVIDER;
 
 class HidingSigningProvider : public SigningProvider
 {
-private:
     const bool m_hide_secret;
     const bool m_hide_origin;
     const SigningProvider* m_provider;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -240,7 +240,6 @@ namespace
 {
 class CScriptVisitor : public boost::static_visitor<bool>
 {
-private:
     CScript *script;
 public:
     explicit CScriptVisitor(CScript *scriptin) { script = scriptin; }

--- a/src/streams.h
+++ b/src/streams.h
@@ -143,7 +143,6 @@ private:
  */
 class VectorReader
 {
-private:
     const int m_type;
     const int m_version;
     const std::vector<unsigned char>& m_data;
@@ -513,7 +512,6 @@ public:
 template <typename IStream>
 class BitStreamReader
 {
-private:
     IStream& m_istream;
 
     /// Buffered byte read in from the input stream. A new byte is read into the
@@ -556,7 +554,6 @@ public:
 template <typename OStream>
 class BitStreamWriter
 {
-private:
     OStream& m_ostream;
 
     /// Buffered byte waiting to be written to the output stream. The byte is
@@ -620,7 +617,6 @@ public:
  */
 class CAutoFile
 {
-private:
     const int nType;
     const int nVersion;
 
@@ -729,7 +725,6 @@ public:
  */
 class CBufferedFile
 {
-private:
     const int nType;
     const int nVersion;
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -117,7 +117,6 @@ void PrintLockContention(const char* pszName, const char* pszFile, int nLine);
 template <typename Mutex, typename Base = typename Mutex::UniqueLock>
 class SCOPED_LOCKABLE UniqueLock : public Base
 {
-private:
     void Enter(const char* pszName, const char* pszFile, int nLine)
     {
         EnterCritical(pszName, pszFile, nLine, (void*)(Base::mutex()));
@@ -199,7 +198,6 @@ using DebugLock = UniqueLock<typename std::remove_reference<typename std::remove
 
 class CSemaphore
 {
-private:
     std::condition_variable condition;
     std::mutex mutex;
     int value;
@@ -236,7 +234,6 @@ public:
 /** RAII-style semaphore lock */
 class CSemaphoreGrant
 {
-private:
     CSemaphore* sem;
     bool fHaveGrant;
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -277,7 +277,6 @@ enum class WitnessMode {
 
 class TestBuilder
 {
-private:
     //! Actually executed script
     CScript script;
     //! The P2SH redeemscript

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -18,7 +18,6 @@ static const Consensus::Params paramsDummy = Consensus::Params();
 
 class TestConditionChecker : public AbstractThresholdConditionChecker
 {
-private:
     mutable ThresholdConditionCache cache;
 
 public:

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -21,7 +21,6 @@ class CNetAddr;
 template <typename T>
 class CMedianFilter
 {
-private:
     std::vector<T> vValues;
     std::vector<T> vSorted;
     unsigned int nSize;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -64,7 +64,6 @@ class CTxMemPool;
 
 class CTxMemPoolEntry
 {
-private:
     const CTransactionRef tx;
     const CAmount nFee;             //!< Cached to avoid expensive parent-transaction lookups
     const size_t nTxWeight;         //!< ... and avoid recomputing tx weight (also used for GetTxSize())
@@ -354,7 +353,6 @@ enum class MemPoolRemovalReason {
 
 class SaltedTxidHasher
 {
-private:
     /** Salt */
     const uint64_t k0, k1;
 
@@ -440,7 +438,6 @@ public:
  */
 class CTxMemPool
 {
-private:
     uint32_t nCheckFrequency GUARDED_BY(cs); //!< Value n means that n times in 2^32 we check.
     unsigned int nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
     CBlockPolicyEstimator* minerPolicyEstimator;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -104,7 +104,6 @@ class ConnectTrace;
  * functions (eventually this will also be via callbacks).
  */
 class CChainState {
-private:
     /**
      * The set of all CBlockIndex entries with BLOCK_VALID_TRANSACTIONS (for itself and all ancestors) and
      * as good as our current tip or better. Entries may be failed, though, and pruning nodes may be
@@ -1703,7 +1702,6 @@ int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Para
  */
 class WarningBitsConditionChecker : public AbstractThresholdConditionChecker
 {
-private:
     int bit;
 
 public:
@@ -2365,7 +2363,6 @@ struct PerBlockConnectTrace {
  * it away and make a new one.
  */
 class ConnectTrace {
-private:
     std::vector<PerBlockConnectTrace> blocksConnected;
     CTxMemPool &pool;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -355,7 +355,6 @@ bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = null
  */
 class CScriptCheck
 {
-private:
     CTxOut m_tx_out;
     const CTransaction *ptxTo;
     unsigned int nIn;

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -154,7 +154,6 @@ protected:
 
 struct MainSignalsInstance;
 class CMainSignals {
-private:
     std::unique_ptr<MainSignalsInstance> m_internals;
 
     friend void ::RegisterValidationInterface(CValidationInterface*);

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -165,7 +165,6 @@ namespace
  * Class to implement versionbits logic.
  */
 class VersionBitsConditionChecker : public AbstractThresholdConditionChecker {
-private:
     const Consensus::DeploymentPos id;
 
 protected:

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -76,7 +76,6 @@ namespace wallet_crypto_tests
 class CCrypter
 {
 friend class wallet_crypto_tests::TestCrypter; // for test access to chKey/chIV
-private:
     std::vector<unsigned char, secure_allocator<unsigned char>> vchKey;
     std::vector<unsigned char, secure_allocator<unsigned char>> vchIV;
     bool fKeySet;
@@ -114,8 +113,6 @@ public:
  */
 class CCryptoKeyStore : public CBasicKeyStore
 {
-private:
-
     CKeyingMaterial vMasterKey GUARDED_BY(cs_KeyStore);
 
     //! if fUseCrypto is true, mapKeys must be empty

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -27,7 +27,6 @@ static const bool DEFAULT_WALLET_PRIVDB = true;
 
 class BerkeleyEnvironment
 {
-private:
     bool fDbEnvInit;
     bool fMockDb;
     // Don't change into fs::path, as that can result in

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -106,7 +106,6 @@ std::string COutput::ToString() const
 
 /** A class to identify which pubkeys a script and a keystore have in common. */
 class CAffectedKeysVisitor : public boost::static_visitor<void> {
-private:
     const CKeyStore &keystore;
     std::vector<CKeyID> &vKeys;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -207,7 +207,6 @@ struct COutputEntry
 /** A transaction with a merkle branch linking it to the block chain. */
 class CMerkleTx
 {
-private:
   /** Constant used in hashBlock to indicate tx has been abandoned */
     static const uint256 ABANDON_HASH;
 
@@ -291,7 +290,6 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* pwallet,
  */
 class CWalletTx : public CMerkleTx
 {
-private:
     const CWallet* pwallet;
 
 public:
@@ -585,7 +583,6 @@ class WalletRescanReserver; //forward declarations for ScanForWalletTransactions
  */
 class CWallet final : public CCryptoKeyStore, public CValidationInterface
 {
-private:
     std::atomic<bool> fAbortRescan{false};
     std::atomic<bool> fScanningWallet{false}; // controlled by WalletRescanReserver
     std::mutex mutexScanning;
@@ -1162,7 +1159,6 @@ public:
 /** RAII object to check and reserve a wallet rescan */
 class WalletRescanReserver
 {
-private:
     CWallet* m_wallet;
     bool m_could_reserve;
 public:

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -138,7 +138,6 @@ public:
  */
 class WalletBatch
 {
-private:
     template <typename K, typename T>
     bool WriteIC(const K& key, const T& value, bool fOverwrite = true)
     {

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -11,7 +11,6 @@ class CBlockIndex;
 
 class CZMQAbstractPublishNotifier : public CZMQAbstractNotifier
 {
-private:
     uint32_t nSequence; //!< upcounting per message sequence number
 
 public:


### PR DESCRIPTION
This pull request drops redundant `private` access specifiers from `class` definitions where the `class` members are private by default.

This pull request does not rearrange class members.