### PR TITLE
qa: Run more tests with wallet disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ jobs:
     - stage: test
       env: >-
         HOST=x86_64-unknown-linux-gnu
-        PACKAGES="python3"
+        PACKAGES="python3-zmq"
         DEP_OPTS="NO_WALLET=1"
         GOAL="install"
         BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -14,9 +14,6 @@ class ConfArgsTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def test_config_file_parser(self):
         # Assume node is stopped
 
@@ -68,13 +65,18 @@ class ConfArgsTest(BitcoinTestFramework):
         # Temporarily disabled, because this test would access the user's home dir (~/.bitcoin)
         #self.start_node(0, ['-conf='+conf_file, '-wallet=w1'])
         #self.stop_node(0)
+        #assert os.path.exists(os.path.join(new_data_dir, 'regtest', 'blocks'))
+        #if self.is_wallet_compiled():
         #assert os.path.exists(os.path.join(new_data_dir, 'regtest', 'wallets', 'w1'))
 
         # Ensure command line argument overrides datadir in conf
         os.mkdir(new_data_dir_2)
         self.nodes[0].datadir = new_data_dir_2
         self.start_node(0, ['-datadir='+new_data_dir_2, '-conf='+conf_file, '-wallet=w2'])
-        assert os.path.exists(os.path.join(new_data_dir_2, 'regtest', 'wallets', 'w2'))
+        assert os.path.exists(os.path.join(new_data_dir_2, 'regtest', 'blocks'))
+        if self.is_wallet_compiled():
+            assert os.path.exists(os.path.join(new_data_dir_2, 'regtest', 'wallets', 'w2'))
+
 
 if __name__ == '__main__':
     ConfArgsTest().main()

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -5,16 +5,15 @@
 """Test the -alertnotify, -blocknotify and -walletnotify options."""
 import os
 
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until, connect_nodes_bi
+
 
 class NotificationsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
 
     def setup_network(self):
         self.alertnotify_dir = os.path.join(self.options.tmpdir, "alertnotify")
@@ -25,7 +24,7 @@ class NotificationsTest(BitcoinTestFramework):
         os.mkdir(self.walletnotify_dir)
 
         # -alertnotify and -blocknotify on node0, walletnotify on node1
-        self.extra_args = [["-blockversion=2",
+        self.extra_args = [[
                             "-alertnotify=echo > {}".format(os.path.join(self.alertnotify_dir, '%s')),
                             "-blocknotify=echo > {}".format(os.path.join(self.blocknotify_dir, '%s'))],
                            ["-blockversion=211",
@@ -36,7 +35,7 @@ class NotificationsTest(BitcoinTestFramework):
     def run_test(self):
         self.log.info("test -blocknotify")
         block_count = 10
-        blocks = self.nodes[1].generate(block_count)
+        blocks = self.nodes[1].generatetoaddress(block_count, self.nodes[1].getnewaddress() if self.is_wallet_compiled() else ADDRESS_BCRT1_UNSPENDABLE)
 
         # wait at most 10 seconds for expected number of files before reading the content
         wait_until(lambda: len(os.listdir(self.blocknotify_dir)) == block_count, timeout=10)
@@ -44,30 +43,31 @@ class NotificationsTest(BitcoinTestFramework):
         # directory content should equal the generated blocks hashes
         assert_equal(sorted(blocks), sorted(os.listdir(self.blocknotify_dir)))
 
-        self.log.info("test -walletnotify")
-        # wait at most 10 seconds for expected number of files before reading the content
-        wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
+        if self.is_wallet_compiled():
+            self.log.info("test -walletnotify")
+            # wait at most 10 seconds for expected number of files before reading the content
+            wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
-        # directory content should equal the generated transaction hashes
-        txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
-        assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
-        for tx_file in os.listdir(self.walletnotify_dir):
-            os.remove(os.path.join(self.walletnotify_dir, tx_file))
+            # directory content should equal the generated transaction hashes
+            txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
+            assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
+            for tx_file in os.listdir(self.walletnotify_dir):
+                os.remove(os.path.join(self.walletnotify_dir, tx_file))
 
-        self.log.info("test -walletnotify after rescan")
-        # restart node to rescan to force wallet notifications
-        self.restart_node(1)
-        connect_nodes_bi(self.nodes, 0, 1)
+            self.log.info("test -walletnotify after rescan")
+            # restart node to rescan to force wallet notifications
+            self.restart_node(1)
+            connect_nodes_bi(self.nodes, 0, 1)
 
-        wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
+            wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)
 
-        # directory content should equal the generated transaction hashes
-        txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
-        assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
+            # directory content should equal the generated transaction hashes
+            txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
+            assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
 
         # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
         self.log.info("test -alertnotify")
-        self.nodes[1].generate(41)
+        self.nodes[1].generatetoaddress(41, ADDRESS_BCRT1_UNSPENDABLE)
         self.sync_all()
 
         # Give bitcoind 10 seconds to write the alert notification
@@ -77,7 +77,7 @@ class NotificationsTest(BitcoinTestFramework):
             os.remove(os.path.join(self.alertnotify_dir, notify_file))
 
         # Mine more up-version blocks, should not get more alerts:
-        self.nodes[1].generate(2)
+        self.nodes[1].generatetoaddress(2, ADDRESS_BCRT1_UNSPENDABLE)
         self.sync_all()
 
         self.log.info("-alertnotify should not continue notifying for more unknown version blocks")

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -12,9 +12,6 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.num_nodes = 1
 
-    def skip_test_if_missing_module(self):
-        self.skip_if_no_wallet()
-
     def run_test(self):
         """Main test logic"""
 
@@ -22,9 +19,10 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert("Bitcoin Core RPC client version" in cli_response)
 
         self.log.info("Compare responses from gewalletinfo RPC and `bitcoin-cli getwalletinfo`")
-        cli_response = self.nodes[0].cli.getwalletinfo()
-        rpc_response = self.nodes[0].getwalletinfo()
-        assert_equal(cli_response, rpc_response)
+        if self.is_wallet_compiled():
+            cli_response = self.nodes[0].cli.getwalletinfo()
+            rpc_response = self.nodes[0].getwalletinfo()
+            assert_equal(cli_response, rpc_response)
 
         self.log.info("Compare responses from getblockchaininfo RPC and `bitcoin-cli getblockchaininfo`")
         cli_response = self.nodes[0].cli.getblockchaininfo()
@@ -52,26 +50,30 @@ class TestBitcoinCli(BitcoinTestFramework):
 
         self.log.info("Compare responses from `bitcoin-cli -getinfo` and the RPCs data is retrieved from.")
         cli_get_info = self.nodes[0].cli('-getinfo').send_cli()
-        wallet_info = self.nodes[0].getwalletinfo()
+        if self.is_wallet_compiled():
+            wallet_info = self.nodes[0].getwalletinfo()
         network_info = self.nodes[0].getnetworkinfo()
         blockchain_info = self.nodes[0].getblockchaininfo()
 
         assert_equal(cli_get_info['version'], network_info['version'])
         assert_equal(cli_get_info['protocolversion'], network_info['protocolversion'])
-        assert_equal(cli_get_info['walletversion'], wallet_info['walletversion'])
-        assert_equal(cli_get_info['balance'], wallet_info['balance'])
+        if self.is_wallet_compiled():
+            assert_equal(cli_get_info['walletversion'], wallet_info['walletversion'])
+            assert_equal(cli_get_info['balance'], wallet_info['balance'])
         assert_equal(cli_get_info['blocks'], blockchain_info['blocks'])
         assert_equal(cli_get_info['timeoffset'], network_info['timeoffset'])
         assert_equal(cli_get_info['connections'], network_info['connections'])
         assert_equal(cli_get_info['proxy'], network_info['networks'][0]['proxy'])
         assert_equal(cli_get_info['difficulty'], blockchain_info['difficulty'])
         assert_equal(cli_get_info['testnet'], blockchain_info['chain'] == "test")
-        assert_equal(cli_get_info['balance'], wallet_info['balance'])
-        assert_equal(cli_get_info['keypoololdest'], wallet_info['keypoololdest'])
-        assert_equal(cli_get_info['keypoolsize'], wallet_info['keypoolsize'])
-        assert_equal(cli_get_info['paytxfee'], wallet_info['paytxfee'])
-        assert_equal(cli_get_info['relayfee'], network_info['relayfee'])
-        # unlocked_until is not tested because the wallet is not encrypted
+        if self.is_wallet_compiled():
+            assert_equal(cli_get_info['balance'], wallet_info['balance'])
+            assert_equal(cli_get_info['keypoololdest'], wallet_info['keypoololdest'])
+            assert_equal(cli_get_info['keypoolsize'], wallet_info['keypoolsize'])
+            assert_equal(cli_get_info['paytxfee'], wallet_info['paytxfee'])
+            assert_equal(cli_get_info['relayfee'], network_info['relayfee'])
+            # unlocked_until is not tested because the wallet is not encrypted
+
 
 if __name__ == '__main__':
     TestBitcoinCli().main()

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -5,6 +5,7 @@
 """Test the ZMQ notification interface."""
 import struct
 
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import CTransaction
 from test_framework.util import (
@@ -41,7 +42,6 @@ class ZMQTest (BitcoinTestFramework):
     def skip_test_if_missing_module(self):
         self.skip_if_no_py3_zmq()
         self.skip_if_no_bitcoind_zmq()
-        self.skip_if_no_wallet()
 
     def setup_nodes(self):
         import zmq
@@ -81,7 +81,7 @@ class ZMQTest (BitcoinTestFramework):
     def _zmq_test(self):
         num_blocks = 5
         self.log.info("Generate %(n)d blocks (and %(n)d coinbase txes)" % {"n": num_blocks})
-        genhashes = self.nodes[0].generate(num_blocks)
+        genhashes = self.nodes[0].generatetoaddress(num_blocks, ADDRESS_BCRT1_UNSPENDABLE)
         self.sync_all()
 
         for x in range(num_blocks):
@@ -105,17 +105,19 @@ class ZMQTest (BitcoinTestFramework):
             block = self.rawblock.receive()
             assert_equal(genhashes[x], bytes_to_hex_str(hash256(block[:80])))
 
-        self.log.info("Wait for tx from second node")
-        payment_txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
-        self.sync_all()
+        if self.is_wallet_compiled():
+            self.log.info("Wait for tx from second node")
+            payment_txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1.0)
+            self.sync_all()
 
-        # Should receive the broadcasted txid.
-        txid = self.hashtx.receive()
-        assert_equal(payment_txid, bytes_to_hex_str(txid))
+            # Should receive the broadcasted txid.
+            txid = self.hashtx.receive()
+            assert_equal(payment_txid, bytes_to_hex_str(txid))
 
-        # Should receive the broadcasted raw transaction.
-        hex = self.rawtx.receive()
-        assert_equal(payment_txid, bytes_to_hex_str(hash256(hex)))
+            # Should receive the broadcasted raw transaction.
+            hex = self.rawtx.receive()
+            assert_equal(payment_txid, bytes_to_hex_str(hash256(hex)))
+
 
 if __name__ == '__main__':
     ZMQTest().main()

--- a/test/functional/test_framework/address.py
+++ b/test/functional/test_framework/address.py
@@ -9,7 +9,10 @@ from .util import bytes_to_hex_str, hex_str_to_bytes
 
 from . import segwit_addr
 
+ADDRESS_BCRT1_UNSPENDABLE = 'bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj'
+
 chars = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
 
 def byte_to_base58(b, version):
     result = ''


### PR DESCRIPTION
Instead of skipping the whole test, only skip the wallet specific section of a test if the wallet is not compiled in. This is mostly an indentation change, so can be reviewed with `--ignore-all-space`.