### PR TITLE
doxygen: Fix member comments

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -68,7 +68,7 @@ public:
     void EvictExtraOutboundPeers(int64_t time_in_seconds);
 
 private:
-    int64_t m_stale_tip_check_time; //! Next time to check for stale tip
+    int64_t m_stale_tip_check_time; //!< Next time to check for stale tip
 
     /** Enable BIP61 (sending reject messages) */
     const bool m_enable_bip61;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -191,10 +191,10 @@ enum SOCKSVersion: uint8_t {
 
 /** Values defined for METHOD in RFC1928 */
 enum SOCKS5Method: uint8_t {
-    NOAUTH = 0x00,        //! No authentication required
-    GSSAPI = 0x01,        //! GSSAPI
-    USER_PASS = 0x02,     //! Username/password
-    NO_ACCEPTABLE = 0xff, //! No acceptable methods
+    NOAUTH = 0x00,        //!< No authentication required
+    GSSAPI = 0x01,        //!< GSSAPI
+    USER_PASS = 0x02,     //!< Username/password
+    NO_ACCEPTABLE = 0xff, //!< No acceptable methods
 };
 
 /** Values defined for CMD in RFC1928 */
@@ -206,15 +206,15 @@ enum SOCKS5Command: uint8_t {
 
 /** Values defined for REP in RFC1928 */
 enum SOCKS5Reply: uint8_t {
-    SUCCEEDED = 0x00,        //! Succeeded
-    GENFAILURE = 0x01,       //! General failure
-    NOTALLOWED = 0x02,       //! Connection not allowed by ruleset
-    NETUNREACHABLE = 0x03,   //! Network unreachable
-    HOSTUNREACHABLE = 0x04,  //! Network unreachable
-    CONNREFUSED = 0x05,      //! Connection refused
-    TTLEXPIRED = 0x06,       //! TTL expired
-    CMDUNSUPPORTED = 0x07,   //! Command not supported
-    ATYPEUNSUPPORTED = 0x08, //! Address type not supported
+    SUCCEEDED = 0x00,        //!< Succeeded
+    GENFAILURE = 0x01,       //!< General failure
+    NOTALLOWED = 0x02,       //!< Connection not allowed by ruleset
+    NETUNREACHABLE = 0x03,   //!< Network unreachable
+    HOSTUNREACHABLE = 0x04,  //!< Network unreachable
+    CONNREFUSED = 0x05,      //!< Connection refused
+    TTLEXPIRED = 0x06,       //!< TTL expired
+    CMDUNSUPPORTED = 0x07,   //!< Command not supported
+    ATYPEUNSUPPORTED = 0x08, //!< Address type not supported
 };
 
 /** Values defined for ATYPE in RFC1928 */

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -50,9 +50,9 @@ std::string StringForFeeReason(FeeReason reason);
 
 /* Used to determine type of fee estimation requested */
 enum class FeeEstimateMode {
-    UNSET,        //! Use default settings based on other criteria
-    ECONOMICAL,   //! Force estimateSmartFee to use non-conservative estimates
-    CONSERVATIVE, //! Force estimateSmartFee to use conservative estimates
+    UNSET,        //!< Use default settings based on other criteria
+    ECONOMICAL,   //!< Force estimateSmartFee to use non-conservative estimates
+    CONSERVATIVE, //!< Force estimateSmartFee to use conservative estimates
 };
 
 bool FeeModeFromString(const std::string& mode_string, FeeEstimateMode& fee_estimate_mode);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -64,7 +64,7 @@ public:
     COutPoint prevout;
     CScript scriptSig;
     uint32_t nSequence;
-    CScriptWitness scriptWitness; //! Only serialized through CTransaction
+    CScriptWitness scriptWitness; //!< Only serialized through CTransaction
 
     /* Setting nSequence to this value for every input in a transaction
      * disables nLockTime. */

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -23,9 +23,9 @@ namespace {
  */
 enum class IsMineSigVersion
 {
-    TOP = 0,        //! scriptPubKey execution
-    P2SH = 1,       //! P2SH redeemScript
-    WITNESS_V0 = 2  //! P2WSH witness script execution
+    TOP = 0,        //!< scriptPubKey execution
+    P2SH = 1,       //!< P2SH redeemScript
+    WITNESS_V0 = 2, //!< P2WSH witness script execution
 };
 
 /**
@@ -35,10 +35,10 @@ enum class IsMineSigVersion
  */
 enum class IsMineResult
 {
-    NO = 0,          //! Not ours
-    WATCH_ONLY = 1,  //! Included in watch-only balance
-    SPENDABLE = 2,   //! Included in all balances
-    INVALID = 3,     //! Not spendable by anyone (uncompressed pubkey in segwit, P2SH inside P2SH or witness, witness inside witness)
+    NO = 0,         //!< Not ours
+    WATCH_ONLY = 1, //!< Included in watch-only balance
+    SPENDABLE = 2,  //!< Included in all balances
+    INVALID = 3,    //!< Not spendable by anyone (uncompressed pubkey in segwit, P2SH inside P2SH or witness, witness inside witness)
 };
 
 bool PermitsUncompressed(IsMineSigVersion sigversion)

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -343,13 +343,13 @@ struct TxMempoolInfo
  * this is passed to the notification signal.
  */
 enum class MemPoolRemovalReason {
-    UNKNOWN = 0, //! Manually removed or unknown reason
-    EXPIRY,      //! Expired from mempool
-    SIZELIMIT,   //! Removed in size limiting
-    REORG,       //! Removed for reorganization
-    BLOCK,       //! Removed for block
-    CONFLICT,    //! Removed for conflict with in-block transaction
-    REPLACED     //! Removed for replacement
+    UNKNOWN = 0, //!< Manually removed or unknown reason
+    EXPIRY,      //!< Expired from mempool
+    SIZELIMIT,   //!< Removed in size limiting
+    REORG,       //!< Removed for reorganization
+    BLOCK,       //!< Removed for block
+    CONFLICT,    //!< Removed for conflict with in-block transaction
+    REPLACED,    //!< Removed for replacement
 };
 
 class SaltedTxidHasher


### PR DESCRIPTION
Trailing comments must be indicted with the caret `//!<`.

Not all places do this right now, see for example https://dev.visucore.com/bitcoin/doxygen/txmempool_8h.html#a2bc6653552b5871101b6cbefdbaf251f, but they can be fixed with an almost-scripted-diff:

```
sed -i --regexp-extended -e 's/((,|;) *\/\/!) /\1< /g' $(git grep --extended-regexp -l  '(,|;)\s*//!\s')
```

(Same as  [doxygen] Fix member comments #7793)