### PR TITLE
[refactoring] Create common interface for CMutableTransaction and CTransaction with static polymorphism

### DIFF
--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -125,7 +125,7 @@ struct PrecomputedTransactionData
     bool ready = false;
 
     template <class T>
-    explicit PrecomputedTransactionData(const T& tx);
+    explicit PrecomputedTransactionData(const CBaseTransaction<T>& tx);
 };
 
 enum class SigVersion
@@ -139,7 +139,7 @@ static constexpr size_t WITNESS_V0_SCRIPTHASH_SIZE = 32;
 static constexpr size_t WITNESS_V0_KEYHASH_SIZE = 20;
 
 template <class T>
-uint256 SignatureHash(const CScript& scriptCode, const T& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);
+uint256 SignatureHash(const CScript& scriptCode, const CBaseTransaction<T>& txTo, unsigned int nIn, int nHashType, const CAmount& amount, SigVersion sigversion, const PrecomputedTransactionData* cache = nullptr);
 
 class BaseSignatureChecker
 {
@@ -166,7 +166,7 @@ template <class T>
 class GenericTransactionSignatureChecker : public BaseSignatureChecker
 {
 private:
-    const T* txTo;
+    const CBaseTransaction<T>* txTo;
     unsigned int nIn;
     const CAmount amount;
     const PrecomputedTransactionData* txdata;
@@ -175,8 +175,8 @@ protected:
     virtual bool VerifySignature(const std::vector<unsigned char>& vchSig, const CPubKey& vchPubKey, const uint256& sighash) const;
 
 public:
-    GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(nullptr) {}
-    GenericTransactionSignatureChecker(const T* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
+    GenericTransactionSignatureChecker(const CBaseTransaction<T>* txToIn, unsigned int nInIn, const CAmount& amountIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(nullptr) {}
+    GenericTransactionSignatureChecker(const CBaseTransaction<T>* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
     bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
     bool CheckLockTime(const CScriptNum& nLockTime) const override;
     bool CheckSequence(const CScriptNum& nSequence) const override;


### PR DESCRIPTION
This PR creates a common interface for `CMutableTransaction` and `CTransaction` as the template class `CBaseTransaction<T>`. This base class uses the CRTP (curiously recurring template pattern) in order to achieve static polymorphism. This way this change shouldn't have any effect on behaviour or runtime performance (though compilation performance is of course worse).

Rationale:
 - Creates a common, explicit interface type for `CTransaction` and `CMutableTransaction`.
 - Makes explicit common elements between two classes.
 - Functions that accept have a better option than accepting an unrestricted typename T.
 - Better than proliferating custom `static_assert` or `enable_if` with different, obscure error messages when the template is applied to the wrong types.

PS: This PR shouldn't affect performance or behaviour, but please review thoroughly as it touches consensus-sensitive code.