### PR TITLE
depends: fix bitcoin-qt back-compat with older freetype versions at runtime

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -120,6 +120,7 @@ define $(package)_extract_cmds
 endef
 
 define $(package)_preprocess_cmds
+  sed -i.old "s|FT_Get_Font_Format|FT_Get_X11_Font_Format|" qtbase/src/platformsupport/fontdatabases/freetype/qfontengine_ft.cpp && \
   sed -i.old "s|updateqm.commands = \$$$$\$$$$LRELEASE|updateqm.commands = $($(package)_extract_dir)/qttools/bin/lrelease|" qttranslations/translations/translations.pro && \
   sed -i.old "/updateqm.depends =/d" qttranslations/translations/translations.pro && \
   sed -i.old "s/src_plugins.depends = src_sql src_network/src_plugins.depends = src_network/" qtbase/src/src.pro && \


### PR DESCRIPTION
Fixes #14339. Thanks to @fanquake for confirming.

A few years ago, libfreetype introduced ```FT_Get_Font_Format()``` as an alias for ```FT_Get_X11_Font_Format()```, but ```FT_Get_X11_Font_Format()``` was kept for abi backwards-compatibility.

Our qt bump to 5.9 introduced a call to```FT_Get_Font_Format()```. Replace it with ```FT_Get_X11_Font_Format()``` in order to remain compatibile with older freetype, which is still used by e.g. Ubuntu Trusty.

Needs 0.17 backport.