### PR TITLE
doc: mention that macOS system headers now require manual installation

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -11,6 +11,12 @@ Install the macOS command line tools:
 
 When the popup appears, click `Install`.
 
+If you're running macOS 10.14/Xcode 10.0 or later, and want to use the `depends` system,
+you'll also need to use the following script to install the macOS system headers into `/usr/include`.
+```
+open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+```
+
 Then install [Homebrew](https://brew.sh).
 
 Dependencies


### PR DESCRIPTION
Starting with [Xcode 10.0](https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes), installing the macOS Command Line Tools no longer installs the macOS system headers into `/usr/include/` (this behaviour is seemingly deprecated). 

This means that building some dependencies using `depends` will fail like:
```
fatal error: 'unistd.h' file not found
```

`/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg` is provided as a work around to install the system headers into `/usr/include/`. This has come up [once already](https://github.com/bitcoin/bitcoin/issues/14327), so probably worth documenting in the macOS build notes.
