### PR TITLE
write to log file when rescanning is finished

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1183,6 +1183,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
             nLowestTimestamp = chainActive.Tip()->GetBlockTime();
         } else {
             fRescan = false;
+            LogPrintf("Rescan completed\n");
         }
 
         for (const UniValue& data : requests.getValues()) {


### PR DESCRIPTION
I need it to add bitcoind backend to electrum. Grepping the source, I couldn't find an RPC call to find rescan status to find when rescanning is done. Logging it would be perfect, and only needs 1 line of code.