### PR TITLE
fix converttopsbt permitsigdata arg, add basic test

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1669,7 +1669,7 @@ UniValue converttopsbt(const JSONRPCRequest& request)
 
     // Remove all scriptSigs and scriptWitnesses from inputs
     for (CTxIn& input : tx.vin) {
-        if ((!input.scriptSig.empty() || !input.scriptWitness.IsNull()) && (request.params[1].isNull() || (!request.params[1].isNull() && request.params[1].get_bool()))) {
+        if ((!input.scriptSig.empty() || !input.scriptWitness.IsNull()) && !permitsigdata) {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Inputs must not have scriptSigs and scriptWitnesses");
         }
         input.scriptSig.clear();

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -107,6 +107,9 @@ class PSBTTest(BitcoinTestFramework):
         # Make sure that a psbt with signatures cannot be converted
         signedtx = self.nodes[0].signrawtransactionwithwallet(rawtx['hex'])
         assert_raises_rpc_error(-22, "TX decode failed", self.nodes[0].converttopsbt, signedtx['hex'])
+        assert_raises_rpc_error(-22, "TX decode failed", self.nodes[0].converttopsbt, signedtx['hex'], False)
+        # Unless we allow it to convert and strip signatures
+        self.nodes[0].converttopsbt(signedtx['hex'], True)
 
         # Explicitly allow converting non-empty txs
         new_psbt = self.nodes[0].converttopsbt(rawtx['hex'])


### PR DESCRIPTION
The final check for extraneous sigdata has a flipped boolean, resulting in incorrect behavior.

Resolves https://github.com/bitcoin/bitcoin/issues/14355