### PR TITLE
streams: Fix broken streams_vector_reader test. Remove unused seek(size_t).

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -126,12 +126,6 @@ class CVectorWriter
     {
         return nType;
     }
-    void seek(size_t nSize)
-    {
-        nPos += nSize;
-        if(nPos > vchData.size())
-            vchData.resize(nPos);
-    }
 private:
     const int nType;
     const int nVersion;
@@ -158,9 +152,11 @@ public:
      * @param[in]  pos Starting position. Vector index where reads should start.
      */
     VectorReader(int type, int version, const std::vector<unsigned char>& data, size_t pos)
-        : m_type(type), m_version(version), m_data(data)
+        : m_type(type), m_version(version), m_data(data), m_pos(pos)
     {
-        seek(pos);
+        if (m_pos > m_data.size()) {
+            throw std::ios_base::failure("VectorReader(...): end of data (m_pos > m_data.size())");
+        }
     }
 
     /*
@@ -202,14 +198,6 @@ public:
         }
         memcpy(dst, m_data.data() + m_pos, n);
         m_pos = pos_next;
-    }
-
-    void seek(size_t n)
-    {
-        m_pos += n;
-        if (m_pos > m_data.size()) {
-            throw std::ios_base::failure("VectorReader::seek(): end of data");
-        }
     }
 };
 

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -102,15 +102,15 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     BOOST_CHECK_THROW(reader >> d, std::ios_base::failure);
 
     // Read a 4 bytes as a signed int from the beginning of the buffer.
-    reader.seek(-6);
-    reader >> d;
+    VectorReader new_reader(SER_NETWORK, INIT_PROTO_VERSION, vch, 0);
+    new_reader >> d;
     BOOST_CHECK_EQUAL(d, 67370753); // 1,255,3,4 in little-endian base-256
-    BOOST_CHECK_EQUAL(reader.size(), 2);
-    BOOST_CHECK(!reader.empty());
+    BOOST_CHECK_EQUAL(new_reader.size(), 2);
+    BOOST_CHECK(!new_reader.empty());
 
     // Reading after end of byte vector throws an error even if the reader is
     // not totally empty.
-    BOOST_CHECK_THROW(reader >> d, std::ios_base::failure);
+    BOOST_CHECK_THROW(new_reader >> d, std::ios_base::failure);
 }
 
 BOOST_AUTO_TEST_CASE(bitstream_reader_writer)

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -29,7 +29,6 @@ unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
-unsigned-integer-overflow:streams.h
 unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp


### PR DESCRIPTION
Fix broken `streams_vector_reader` test. Remove unused `seek(size_t)`.

Before this change the test `streams_vector_reader` triggered an unintended unsigned integer wraparound. It tried so seek using a negative value in `reader.seek(-6)`.

Changes in this PR:
* Fix broken `VectorReader::seek(size_t)` test case
* Remove unused `seek(size_t)`