### PR TITLE
Trivial: Remove sstream.h include from univalue.h

### DIFF
--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -14,8 +14,6 @@
 #include <map>
 #include <cassert>
 
-#include <sstream>        // .get_int64()
-
 class UniValue {
 public:
     enum VType { VNULL, VOBJ, VARR, VSTR, VNUM, VBOOL, };

--- a/src/univalue/lib/univalue_get.cpp
+++ b/src/univalue/lib/univalue_get.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <limits>
 #include <string>
+#include <sstream>
 
 #include "univalue.h"
 


### PR DESCRIPTION
Including sstream.h in the univalue.h is not needed and makes C++ preprocessing of files including univalue.h file slower. 
