### PR TITLE
 tests: Add Python dead code linter (vulture) to Travis

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -8,3 +8,4 @@ export LC_ALL=C
 
 travis_retry pip install codespell==1.13.0
 travis_retry pip install flake8==3.5.0
+travis_retry pip install vulture==0.29

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -25,7 +25,6 @@ CLTV_HEIGHT = 1351
 
 # Reject codes that we might receive in this test
 REJECT_INVALID = 16
-REJECT_OBSOLETE = 17
 REJECT_NONSTANDARD = 64
 
 def cltv_invalidate(tx):

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -22,7 +22,6 @@ DERSIG_HEIGHT = 1251
 
 # Reject codes that we might receive in this test
 REJECT_INVALID = 16
-REJECT_OBSOLETE = 17
 REJECT_NONSTANDARD = 64
 
 # A canonical signature consists of:

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -35,7 +35,6 @@ MY_VERSION = 70014  # past bip-31 for ping/pong
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version messages (BIP37)
 
-MAX_INV_SZ = 50000
 MAX_LOCATOR_SZ = 101
 MAX_BLOCK_BASE_SIZE = 1000000
 
@@ -57,9 +56,6 @@ MSG_TYPE_MASK = 0xffffffff >> 2
 # Serialization/deserialization tools
 def sha256(s):
     return hashlib.new('sha256', s).digest()
-
-def ripemd160(s):
-    return hashlib.new('ripemd160', s).digest()
 
 def hash256(s):
     return sha256(sha256(s))
@@ -887,13 +883,12 @@ class BlockTransactions:
 
 
 class CPartialMerkleTree:
-    __slots__ = ("fBad", "nTransactions", "vBits", "vHash")
+    __slots__ = ("nTransactions", "vBits", "vHash")
 
     def __init__(self):
         self.nTransactions = 0
         self.vHash = []
         self.vBits = []
-        self.fBad = False
 
     def deserialize(self, f):
         self.nTransactions = struct.unpack("<i", f.read(4))[0]

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -349,7 +349,7 @@ class P2PInterface(P2PConnection):
         self.send_message(msg_pong(message.nonce))
 
     def on_verack(self, message):
-        self.verack_received = True
+        pass
 
     def on_version(self, message):
         assert message.nVersion >= MIN_VERSION_SUPPORTED, "Version {} received. Test framework only supports versions greater than {}".format(message.nVersion, MIN_VERSION_SUPPORTED)

--- a/test/functional/test_framework/socks5.py
+++ b/test/functional/test_framework/socks5.py
@@ -54,10 +54,9 @@ class Socks5Command():
         return 'Socks5Command(%s,%s,%s,%s,%s,%s)' % (self.cmd, self.atyp, self.addr, self.port, self.username, self.password)
 
 class Socks5Connection():
-    def __init__(self, serv, conn, peer):
+    def __init__(self, serv, conn):
         self.serv = serv
         self.conn = conn
-        self.peer = peer
 
     def handle(self):
         """Handle socks5 request according to RFC192."""
@@ -137,9 +136,9 @@ class Socks5Server():
 
     def run(self):
         while self.running:
-            (sockconn, peer) = self.s.accept()
+            (sockconn, _) = self.s.accept()
             if self.running:
-                conn = Socks5Connection(self, sockconn, peer)
+                conn = Socks5Connection(self, sockconn)
                 thread = threading.Thread(None, conn.handle)
                 thread.daemon = True
                 thread.start()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -635,7 +635,7 @@ class RPCCoverage():
         with open(coverage_ref_filename, 'r', encoding="utf8") as coverage_ref_file:
             all_cmds.update([line.strip() for line in coverage_ref_file.readlines()])
 
-        for root, dirs, files in os.walk(self.dir):
+        for root, _, files in os.walk(self.dir):
             for filename in files:
                 if filename.startswith(coverage_file_prefix):
                     coverage_filenames.add(os.path.join(root, filename))

--- a/test/lint/lint-python-dead-code.sh
+++ b/test/lint/lint-python-dead-code.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Find dead Python code.
+
+export LC_ALL=C
+
+if ! command -v vulture > /dev/null; then
+    echo "Skipping Python dead code linting since vulture is not installed. Install by running \"pip3 install vulture\""
+    exit 0
+fi
+
+vulture \
+    --min-confidence 60 \
+    --ignore-names "argtypes,connection_lost,connection_made,converter,data_received,daemon,errcheck,get_ecdh_key,get_privkey,is_compressed,is_fullyvalid,msg_generic,on_*,optionxform,restype,set_privkey" \
+    $(git ls-files -- "*.py" ":(exclude)contrib/")


### PR DESCRIPTION
Add Python dead code linter (`vulture`) to Travis.

Rationale for allowing dead code only after explicit opt-in (via `--ignore-names`):
* Less is more :-)
* Unused code is by definition "untested"
* Unused code can be an indication of bugs/logical errors. By making the contributor aware of newly introduced unused code it gives him/her an opportunity to investigate if the unused code they introduce is malignant or benign :-)
* Unused code is hard to spot for humans and is thus often missed during manual review
* [YAGNI](https://en.wikipedia.org/wiki/You_aren%27t_gonna_need_it)

Based on #14312 to make linter job pass.