### PR TITLE
utils and libraries: Allow values quoting in config files

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -839,6 +839,9 @@ static bool GetConfigOptions(std::istream& stream, std::string& error, std::vect
             } else if ((pos = str.find('=')) != std::string::npos) {
                 std::string name = prefix + TrimString(str.substr(0, pos), pattern);
                 std::string value = TrimString(str.substr(pos + 1), pattern);
+                if (*value.begin() == '"' && *value.rbegin() == '"') {
+                    value = value.substr(1, value.size() - 2);
+                }
                 options.emplace_back(name, value);
             } else {
                 error = strprintf("parse error on line %i: %s", linenr, str);


### PR DESCRIPTION
~The using double quotes to quote command line option values with spaces
(e.g. paths) is allowed on all platforms. Options in config files are
handled in the same way now.~
The config file values can be surrounded by quotation marks. This allows
for explicit using of whitespaces (e.g. in paths).