### PR TITLE
depends: qt: avoid system harfbuzz and bz2

### DIFF
--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4aa82f88
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-zlib --without-png --disable-static
+  $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -64,6 +64,7 @@ $(package)_config_opts += -prefix $(host_prefix)
 $(package)_config_opts += -qt-libpng
 $(package)_config_opts += -qt-libjpeg
 $(package)_config_opts += -qt-pcre
+$(package)_config_opts += -qt-harfbuzz
 $(package)_config_opts += -system-zlib
 $(package)_config_opts += -static
 $(package)_config_opts += -silent


### PR DESCRIPTION
Should fix #14367.

Gitian builds end up with this config implicitly due to missing harfbuzz system lib, this change explicitly disables the use of the lib completely, even if present.

We may eventually want to break out harfbuzz and build it in depends, but for now just ensure that runtime dependencies don't depend on whether or not harfbuzz was present on the builder.

@real-or-random Can you confirm that this fixes your issue?