### PR TITLE
Faster Input Deduplication Algorithm

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -18,6 +18,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/block_assemble.cpp \
   bench/checkblock.cpp \
   bench/checkqueue.cpp \
+  bench/duplicate_inputs.cpp \
   bench/examples.cpp \
   bench/rollingbloom.cpp \
   bench/crypto_hash.cpp \

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <chainparams.h>
+#include <coins.h>
+#include <consensus/merkle.h>
+#include <consensus/validation.h>
+#include <miner.h>
+#include <policy/policy.h>
+#include <pow.h>
+#include <scheduler.h>
+#include <txdb.h>
+#include <txmempool.h>
+#include <utiltime.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <boost/thread.hpp>
+
+#include <list>
+#include <vector>
+
+
+static void DuplicateInputs(benchmark::State& state)
+{
+    const std::vector<unsigned char> op_true{OP_TRUE};
+
+
+    const CScript SCRIPT_PUB{CScript(OP_TRUE)};
+
+    // Switch to regtest so we can mine faster
+    // Also segwit is active, so we can include witness transactions
+    SelectParams(CBaseChainParams::REGTEST);
+
+    InitScriptExecutionCache();
+
+    boost::thread_group thread_group;
+    CScheduler scheduler;
+    const CChainParams& chainparams = Params();
+    {
+        ::pblocktree.reset(new CBlockTreeDB(1 << 20, true));
+        ::pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));
+        ::pcoinsTip.reset(new CCoinsViewCache(pcoinsdbview.get()));
+
+        thread_group.create_thread(boost::bind(&CScheduler::serviceQueue, &scheduler));
+        GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+        LoadGenesisBlock(chainparams);
+        CValidationState state;
+        ActivateBestChain(state, chainparams);
+        assert(::chainActive.Tip() != nullptr);
+        const bool witness_enabled{IsWitnessEnabled(::chainActive.Tip(), chainparams.GetConsensus())};
+        assert(witness_enabled);
+    }
+
+    CBlock block{};
+    CMutableTransaction coinbaseTx{};
+    CMutableTransaction naughtyTx{};
+
+    CBlockIndex* pindexPrev = ::chainActive.Tip();
+    assert(pindexPrev != nullptr);
+    block.nBits = GetNextWorkRequired(pindexPrev, &block, chainparams.GetConsensus());
+    block.nNonce = 0;
+    auto nHeight = pindexPrev->nHeight + 1;
+    block.nTime = ::chainActive.Tip()->GetMedianTimePast() + 1;
+
+    // Make a coinbase TX
+    coinbaseTx.vin.resize(1);
+    coinbaseTx.vin[0].prevout.SetNull();
+    coinbaseTx.vout.resize(1);
+    coinbaseTx.vout[0].scriptPubKey = SCRIPT_PUB;
+    coinbaseTx.vout[0].nValue = GetBlockSubsidy(nHeight, chainparams.GetConsensus());
+    coinbaseTx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+
+
+    naughtyTx.vout.resize(1);
+    naughtyTx.vout[0].nValue = 0;
+    naughtyTx.vout[0].scriptPubKey = SCRIPT_PUB;
+
+    int n_inputs = (((MAX_BLOCK_SERIALIZED_SIZE / WITNESS_SCALE_FACTOR) - (CTransaction(coinbaseTx).GetTotalSize() + CTransaction(naughtyTx).GetTotalSize())) / 41) - 100;
+    for (int x = 0; x < (n_inputs - 1); ++x) {
+        naughtyTx.vin.emplace_back(GetRandHash(), 0, CScript(), 0);
+    }
+    naughtyTx.vin.emplace_back(naughtyTx.vin.back());
+
+    block.vtx.push_back(MakeTransactionRef(std::move(coinbaseTx)));
+    block.vtx.push_back(MakeTransactionRef(std::move(naughtyTx)));
+
+    block.hashMerkleRoot = BlockMerkleRoot(block);
+
+    while (state.KeepRunning()) {
+        CValidationState state{};
+        assert(!CheckBlock(block, state, chainparams.GetConsensus(), false, false));
+        assert(state.GetRejectReason() == "bad-txns-inputs-duplicate");
+    }
+
+    thread_group.interrupt_all();
+    thread_group.join_all();
+    GetMainSignals().FlushBackgroundCallbacks();
+    GetMainSignals().UnregisterBackgroundSignalScheduler();
+}
+
+BENCHMARK(DuplicateInputs, 10);

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -156,7 +156,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs, bool fCheckNullInputs)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
@@ -195,7 +195,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
         if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
     }
-    else
+    else if (fCheckNullInputs)
     {
         for (const auto& txin : tx.vin)
             if (txin.prevout.IsNull())

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -13,10 +13,6 @@
 #include <chain.h>
 #include <coins.h>
 #include <utilmoneystr.h>
-#include <utilmemory.h>
-#include <random.h>
-
-#include <functional>
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {
@@ -160,7 +156,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs, std::bitset<1ull<<21>* table)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
@@ -185,170 +181,25 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     }
 
     // Check for duplicate inputs - note that this check is slow so we skip it in CheckBlock
-    if (tx.IsCoinBase() ) {
+    if (fCheckDuplicateInputs) {
+        std::set<COutPoint> vInOutPoints;
+        for (const auto& txin : tx.vin)
+        {
+            if (!vInOutPoints.insert(txin.prevout).second)
+                return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
+        }
+    }
+
+    if (tx.IsCoinBase())
+    {
         if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
-    } else if (!fCheckDuplicateInputs || tx.vin.size() == 1){
-        for (const auto& txin : tx.vin) {
-            if (txin.prevout.IsNull()) {
+    }
+    else
+    {
+        for (const auto& txin : tx.vin)
+            if (txin.prevout.IsNull())
                 return state.DoS(10, false, REJECT_INVALID, "bad-txns-prevout-null");
-            }
-        }
-    } else{
-        // This duplication checking algorithm uses a probabilistic filter
-        // to check for collisions efficiently.
-        //
-        // This is faster than the naive construction, using a set, which
-        // requires more allocation and comparison of uint256s.
-        //
-        // First we create a bitset table with 1<<21 elements. This
-        // is around 300 KB, so we construct it on the heap.
-        //
-        // We also allow reusing a 'dirty' table because zeroing 300 KB
-        // can be expensive, and the table will operate acceptably for all of the
-        // transactions in a given block.
-        //
-        // Then, we iterate through the elements one by one, generated 8 salted
-        // 21-bit hashes (which can be quickly generated using siphash) based on
-        // each prevout.
-        //
-        // We then check if all 8 hashes are set in the table yet. If they are,
-        // we do a linear scan through the inputs to see if it was a true
-        // collision, and reject the txn.
-        //
-        // Otherwise, we set the 8 bits corresponding to the hashes and
-        // continue.
-        //
-        // From the perspective of the N+1st prevout, assuming the transaction
-        // does not double spend:
-        //
-        // Up to N*8 hashes have been set in the table already (potentially
-        // fewer if collisions)
-        //
-        // For each of the 8 hashes h_1...h_8, P(bit set in table for h_i) =
-        // (N*8)/1<<21
-        //
-        // Each of these probabilities is independent
-        //
-        // Therefore the total probability of a false collision on all bits is:
-        // ((N*8)/2**21)**8
-        //
-        // The cost of a false collision is to do N comparisons.
-        //
-        // Therefore, the expression for the expected number of comparisons is:
-        //
-        // Sum from i = 0 to M [ i*( i*8 / 2**21)**8 ]
-        //
-        // Based on an input being at least 41 bytes, and a block being 1M bytes
-        // max, there are a maximum of 24390 inputs, so M = 24390
-        //
-        // The total expected number of direct comparisons for M=24930 is
-        // therefore 0.33 with this algorithm.
-        //
-        // As a bonus, we also get "free" null checking by manually inserting
-        // the null element into the table so it always generates a conflict
-        // check. We remove this null-check before terminating so that we avoid
-        // doubling the bloat on the table.
-        //
-        // If a dirty table is used, the algorithms worst-case
-        // runtime is still better because of three key reasons:
-        //
-        // 1) the linear searches complexity is limited to each transaction's
-        // subset of inputs
-        // 2) The total number of inputs in the block still does not exceed
-        // 24930
-        // 3) less initialization of the table
-        //
-        //
-        // The worst case for this algorithm from a denial of service
-        // perspective with an invalid transaction would be to do a transaction
-        // where the last two elements are a collision. In this case, the scan
-        // would require to scan all N elements.
-        //
-        //
-        //
-        // N.B. When the table is dirty, the bits set in the table
-        // are meaningless because the hash was salted separately.
-        //
-        uint64_t k1 = GetRand(std::numeric_limits<uint64_t>::max());
-        uint64_t k2 = GetRand(std::numeric_limits<uint64_t>::max());
-        // If we haven't been given a table, make one now.
-        std::unique_ptr<std::bitset<1<<21>> upTable = table ? std::unique_ptr<std::bitset<1<<21>>(nullptr) :
-                                                      MakeUnique<std::bitset<1<<21>>();
-        table = table ? table : upTable.get();
-        struct pos {
-            uint64_t a : 21;
-            uint64_t b : 21;
-            uint64_t c : 21;
-            bool empty_1 : 1;
-            uint64_t d : 21;
-            uint64_t e : 21;
-            uint64_t f : 21;
-            bool empty_2 : 1;
-            uint64_t g : 21;
-            uint64_t h : 21;
-            uint64_t unused : 22;
-            void set(std::bitset<1<<21>& t) {
-                t.set(a);
-                t.set(b); 
-                t.set(c); 
-                t.set(d); 
-                t.set(e); 
-                t.set(f); 
-                t.set(g); 
-                t.set(h);
-            };
-        };
-        struct packed_hash {
-            uint64_t a;
-            uint64_t b;
-            uint64_t c;
-        };
-        union convert {
-            packed_hash ph;
-            pos p;
-        };
-        auto hasher = [k1, k2](const COutPoint& out){
-            auto h = SipHashUint256Extra192(k1, k2, out.hash, out.n);
-            convert v = {std::get<0>(h), std::get<1>(h), std::get<2>(h)};
-            return v.p;
-        };
-        auto nil_hash = hasher(COutPoint{});
-        nil_hash.set(*table);
-        std::unique_ptr<void, std::function<void(void*)>>
-            cleanupNilEntryGuard((void*)1, [&](void*) { 
-                    table->flip(nil_hash.a);
-                    table->flip(nil_hash.b);
-                    table->flip(nil_hash.c);
-                    table->flip(nil_hash.d);
-                    table->flip(nil_hash.e);
-                    table->flip(nil_hash.f);
-                    table->flip(nil_hash.g);
-                    table->flip(nil_hash.h);
-                    });
-        for (auto txinit =  tx.vin.cbegin(); txinit != tx.vin.cend(); ++txinit) {
-            auto hash = hasher(txinit->prevout);
-            if (table->test(hash.a) &&
-                table->test(hash.b) &&
-                table->test(hash.c) &&
-                table->test(hash.d) &&
-                table->test(hash.e) &&
-                table->test(hash.f) &&
-                table->test(hash.g) &&
-                table->test(hash.h)) {
-                if (txinit->prevout.IsNull()) {
-                    return state.DoS(10, false, REJECT_INVALID, "bad-txns-prevout-null");
-                }
-                // If we have a potential collision, then scan through the set up to here for the colliding element
-                auto elem = std::find_if(tx.vin.begin(), txinit, [txinit](CTxIn x){return x.prevout == txinit->prevout;});
-                // If the iterator outputs anything except for txinit, then we have found a conflict
-                if  (elem != txinit) {
-                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
-                }
-            } else {
-                hash.set(*table);
-            }
-        }
     }
 
     return true;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -13,6 +13,10 @@
 #include <chain.h>
 #include <coins.h>
 #include <utilmoneystr.h>
+#include <utilmemory.h>
+#include <random.h>
+
+#include <functional>
 
 bool IsFinalTx(const CTransaction &tx, int nBlockHeight, int64_t nBlockTime)
 {
@@ -156,7 +160,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
+bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs, uint64_t table[])
 {
     // Basic checks that don't depend on any context
     if (tx.vin.empty())
@@ -181,25 +185,167 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     }
 
     // Check for duplicate inputs - note that this check is slow so we skip it in CheckBlock
-    if (fCheckDuplicateInputs) {
-        std::set<COutPoint> vInOutPoints;
-        for (const auto& txin : tx.vin)
-        {
-            if (!vInOutPoints.insert(txin.prevout).second)
-                return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
-        }
-    }
-
-    if (tx.IsCoinBase())
-    {
+    if (tx.IsCoinBase() ) {
         if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-length");
-    }
-    else
-    {
-        for (const auto& txin : tx.vin)
-            if (txin.prevout.IsNull())
+    } else if (!fCheckDuplicateInputs || tx.vin.size() == 1){
+        for (const auto& txin : tx.vin) {
+            if (txin.prevout.IsNull()) {
                 return state.DoS(10, false, REJECT_INVALID, "bad-txns-prevout-null");
+            }
+        }
+    } else{
+        // This duplication checking algorithm uses a probabilistic filter
+        // to check for collisions efficiently.
+        //
+        // This is faster than the naive construction, using a set, which
+        // requires more allocation and comparison of uint256s.
+        //
+        // First we create a bitset table with 1<<21 elements. This
+        // is around 300 KB, so we construct it on the heap.
+        //
+        // We also allow reusing a 'dirty' table because zeroing 300 KB
+        // can be expensive, and the table will operate acceptably for all of the
+        // transactions in a given block.
+        //
+        // Then, we iterate through the elements one by one, generated 8 salted
+        // 21-bit hashes (which can be quickly generated using siphash) based on
+        // each prevout.
+        //
+        // We then check if all 8 hashes are set in the table yet. If they are,
+        // we do a linear scan through the inputs to see if it was a true
+        // collision, and reject the txn.
+        //
+        // Otherwise, we set the 8 bits corresponding to the hashes and
+        // continue.
+        //
+        // From the perspective of the N+1st prevout, assuming the transaction
+        // does not double spend:
+        //
+        // Up to N*8 hashes have been set in the table already (potentially
+        // fewer if collisions)
+        //
+        // For each of the 8 hashes h_1...h_8, P(bit set in table for h_i) =
+        // (N*8)/1<<21
+        //
+        // Each of these probabilities is independent
+        //
+        // Therefore the total probability of a false collision on all bits is:
+        // ((N*8)/2**21)**8
+        //
+        // The cost of a false collision is to do N comparisons.
+        //
+        // Therefore, the expression for the expected number of comparisons is:
+        //
+        // Sum from i = 0 to M [ i*( i*8 / 2**21)**8 ]
+        //
+        // Based on an input being at least 41 bytes, and a block being 1M bytes
+        // max, there are a maximum of 24390 inputs, so M = 24390
+        //
+        // The total expected number of direct comparisons for M=24930 is
+        // therefore 0.33 with this algorithm.
+        //
+        // As a bonus, we also get "free" null checking by manually inserting
+        // the null element into the table so it always generates a conflict
+        // check. We remove this null-check before terminating so that we avoid
+        // doubling the bloat on the table.
+        //
+        // If a dirty table is used, the algorithms worst-case
+        // runtime is still better because of three key reasons:
+        //
+        // 1) the linear searches complexity is limited to each transaction's
+        // subset of inputs
+        // 2) The total number of inputs in the block still does not exceed
+        // 24930
+        // 3) less initialization of the table
+        //
+        //
+        // The worst case for this algorithm from a denial of service
+        // perspective with an invalid transaction would be to do a transaction
+        // where the last two elements are a collision. In this case, the scan
+        // would require to scan all N elements.
+        //
+        //
+        //
+        // N.B. When the table is dirty, the bits set in the table
+        // are meaningless because the hash was salted separately.
+        //
+        uint64_t k1 = GetRand(std::numeric_limits<uint64_t>::max());
+        uint64_t k2 = GetRand(std::numeric_limits<uint64_t>::max());
+        auto hasher = [k1, k2](const COutPoint& out){return SipHashUint256Extra192(k1, k2, out.hash, out.n);};
+        // If we haven't been given a table, make one now.
+        std::unique_ptr<uint64_t[]> upTable = table ? std::unique_ptr<uint64_t[]>(nullptr) :
+                                                      std::unique_ptr<uint64_t[]>(new uint64_t[1<<15]());
+        table = table ? table : upTable.get();
+#define HASH(h, a) \
+uint64_t bit1 = 1<<(std::get<0>(h) & 63);\
+uint64_t bit2 = 1<<(std::get<0>(h)>>6 & 63);\
+uint64_t bit3 = 1<<(std::get<0>(h)>>12 & 63);\
+uint64_t bit4 = 1<<(std::get<0>(h)>>18 & 63);\
+uint64_t bit5 = 1<<(std::get<0>(h)>>24 & 63);\
+uint64_t bit6 = 1<<(std::get<0>(h)>>24 & 63);\
+uint64_t bit7 = 1<<(std::get<0>(h)>>24 & 63);\
+uint64_t bit8 = 1<<(std::get<0>(h)>>24 & 63);\
+uint64_t pos1 = (std::get<1>(h)     & 0x07FFF);\
+uint64_t pos2 = (std::get<1>(h)>>15 & 0x07FFF);\
+uint64_t pos3 = (std::get<1>(h)>>30 & 0x07FFF);\
+uint64_t pos4 = (std::get<1>(h)>>45 & 0x07FFF);\
+uint64_t pos5 = (std::get<2>(h)     & 0x07FFF);\
+uint64_t pos6 = (std::get<2>(h)>>15 & 0x07FFF);\
+uint64_t pos7 = (std::get<2>(h)>>30 & 0x07FFF);\
+uint64_t pos8 = (std::get<2>(h)>>45 & 0x07FFF);\
+        a;
+#define SET_BITS \
+        table[pos1] |= bit1;\
+        table[pos2] |= bit2;\
+        table[pos3] |= bit3;\
+        table[pos4] |= bit4;\
+        table[pos5] |= bit5;\
+        table[pos6] |= bit6;\
+        table[pos7] |= bit7;\
+        table[pos8] |= bit8;
+
+#define TOGGLE_BITS \
+        table[pos1] ^= bit1;\
+        table[pos2] ^= bit2;\
+        table[pos3] ^= bit3;\
+        table[pos4] ^= bit4;\
+        table[pos5] ^= bit5;\
+        table[pos6] ^= bit6;\
+        table[pos7] ^= bit7;\
+        table[pos8] ^= bit8;
+#define DONT_SET_BITS
+
+
+        auto nil_hash = hasher(COutPoint{});
+        HASH(nil_hash, SET_BITS);
+        std::unique_ptr<void, std::function<void(void*)>>
+            cleanupNilEntryGuard((void*)1, [&](void*) { TOGGLE_BITS; });
+        for (auto txinit =  tx.vin.cbegin(); txinit != tx.vin.cend(); ++txinit) {
+            auto hash = hasher(txinit->prevout);
+            HASH(hash, DONT_SET_BITS)
+            if (
+            (table[pos1] & bit1) &&
+            (table[pos2] & bit2) &&
+            (table[pos3] & bit3) &&
+            (table[pos4] & bit4) &&
+            (table[pos5] & bit5) &&
+            (table[pos6] & bit6) &&
+            (table[pos7] & bit7) &&
+            (table[pos8] & bit8)) {
+                if (txinit->prevout.IsNull()) {
+                    return state.DoS(10, false, REJECT_INVALID, "bad-txns-prevout-null");
+                }
+                // If we have a potential collision, then scan through the set up to here for the colliding element
+                auto elem = std::find_if(tx.vin.begin(), txinit, [txinit](CTxIn x){return x.prevout == txinit->prevout;});
+                // If the iterator outputs anything except for txinit, then we have found a conflict
+                if  (elem != txinit) {
+                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputs-duplicate");
+                }
+            } else {
+                SET_BITS;
+            }
+        }
     }
 
     return true;

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -278,22 +278,22 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
                                                       std::unique_ptr<uint64_t[]>(new uint64_t[1<<15]());
         table = table ? table : upTable.get();
 #define HASH(h, a) \
-uint64_t bit1 = 1<<(std::get<0>(h) & 63);\
-uint64_t bit2 = 1<<(std::get<0>(h)>>6 & 63);\
-uint64_t bit3 = 1<<(std::get<0>(h)>>12 & 63);\
-uint64_t bit4 = 1<<(std::get<0>(h)>>18 & 63);\
-uint64_t bit5 = 1<<(std::get<0>(h)>>24 & 63);\
-uint64_t bit6 = 1<<(std::get<0>(h)>>24 & 63);\
-uint64_t bit7 = 1<<(std::get<0>(h)>>24 & 63);\
-uint64_t bit8 = 1<<(std::get<0>(h)>>24 & 63);\
+uint64_t bit1 = 1<<((std::get<0>(h)) & 63);\
+uint64_t bit2 = 1<<((std::get<0>(h)>>6) & 63);\
+uint64_t bit3 = 1<<((std::get<0>(h)>>12) & 63);\
+uint64_t bit4 = 1<<((std::get<0>(h)>>18) & 63);\
+uint64_t bit5 = 1<<((std::get<0>(h)>>24) & 63);\
+uint64_t bit6 = 1<<((std::get<0>(h)>>30) & 63);\
+uint64_t bit7 = 1<<((std::get<0>(h)>>36) & 63);\
+uint64_t bit8 = 1<<((std::get<0>(h)>>42) & 63);\
 uint64_t pos1 = (std::get<1>(h)     & 0x07FFF);\
-uint64_t pos2 = (std::get<1>(h)>>15 & 0x07FFF);\
-uint64_t pos3 = (std::get<1>(h)>>30 & 0x07FFF);\
-uint64_t pos4 = (std::get<1>(h)>>45 & 0x07FFF);\
+uint64_t pos2 = ((std::get<1>(h)>>15) & 0x07FFF);\
+uint64_t pos3 = ((std::get<1>(h)>>30) & 0x07FFF);\
+uint64_t pos4 = ((std::get<1>(h)>>45) & 0x07FFF);\
 uint64_t pos5 = (std::get<2>(h)     & 0x07FFF);\
-uint64_t pos6 = (std::get<2>(h)>>15 & 0x07FFF);\
-uint64_t pos7 = (std::get<2>(h)>>30 & 0x07FFF);\
-uint64_t pos8 = (std::get<2>(h)>>45 & 0x07FFF);\
+uint64_t pos6 = ((std::get<2>(h)>>15) & 0x07FFF);\
+uint64_t pos7 = ((std::get<2>(h)>>30) & 0x07FFF);\
+uint64_t pos8 = ((std::get<2>(h)>>45) & 0x07FFF);\
         a;
 #define SET_BITS \
         table[pos1] |= bit1;\

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -18,7 +18,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true, uint64_t table[]=nullptr);
 
 namespace Consensus {
 /**

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <bitset>
 
 class CBlockIndex;
 class CCoinsViewCache;
@@ -18,7 +19,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true, uint64_t table[]=nullptr);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true, std::bitset<1ull<<21>* table=nullptr);
 
 namespace Consensus {
 /**

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -18,7 +18,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true, bool fCheckNullInputs=true);
 
 namespace Consensus {
 /**

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -9,7 +9,6 @@
 
 #include <stdint.h>
 #include <vector>
-#include <bitset>
 
 class CBlockIndex;
 class CCoinsViewCache;
@@ -19,7 +18,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true, std::bitset<1ull<<21>* table=nullptr);
+bool CheckTransaction(const CTransaction& tx, CValidationState& state, bool fCheckDuplicateInputs=true);
 
 namespace Consensus {
 /**

--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -245,3 +245,63 @@ uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint3
     SIPROUND;
     return v0 ^ v1 ^ v2 ^ v3;
 }
+
+std::tuple<uint64_t, uint64_t, uint64_t> SipHashUint256Extra192(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra)
+{
+    /* Specialized implementation for efficiency */
+    uint64_t d = val.GetUint64(0);
+
+    uint64_t v0 = 0x736f6d6570736575ULL ^ k0;
+    uint64_t v1 = 0x646f72616e646f6dULL ^ k1;
+    uint64_t v2 = 0x6c7967656e657261ULL ^ k0;
+    uint64_t v3 = 0x7465646279746573ULL ^ k1 ^ d;
+
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = val.GetUint64(1);
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = val.GetUint64(2);
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = val.GetUint64(3);
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    d = (((uint64_t)36) << 56) | extra;
+    v3 ^= d;
+    SIPROUND;
+    SIPROUND;
+    v0 ^= d;
+    v2 ^= 0xEE;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+
+    uint64_t res1 = v0 ^ v1 ^ v2 ^ v3;
+
+    v1 ^= 0xDD;
+
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+
+    uint64_t res2 = v0 ^ v1 ^ v2 ^ v3;
+
+    v1 ^= 0xAA;
+
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+    SIPROUND;
+
+    return std::make_tuple(res1, res2, v0 ^ v1 ^ v2 ^ v3);
+}

--- a/src/hash.h
+++ b/src/hash.h
@@ -229,4 +229,5 @@ public:
 uint64_t SipHashUint256(uint64_t k0, uint64_t k1, const uint256& val);
 uint64_t SipHashUint256Extra(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
 
+std::tuple<uint64_t, uint64_t, uint64_t> SipHashUint256Extra192(uint64_t k0, uint64_t k1, const uint256& val, uint32_t extra);
 #endif // BITCOIN_HASH_H

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3122,7 +3122,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     //
-    std::unique_ptr<uint64_t[]> table = std::unique_ptr<uint64_t[]>(new uint64_t[1<<15]());
+    std::unique_ptr<std::bitset<1<<21>> table = MakeUnique<std::bitset<1<<21>>();
     for (const auto& tx : block.vtx)
         if (!CheckTransaction(*tx, state, true, table.get()))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3121,8 +3121,10 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
             return state.DoS(100, false, REJECT_INVALID, "bad-cb-multiple", false, "more than one coinbase");
 
     // Check transactions
+    //
+    std::unique_ptr<uint64_t[]> table = std::unique_ptr<uint64_t[]>(new uint64_t[1<<15]());
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, true))
+        if (!CheckTransaction(*tx, state, true, table.get()))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
This PR introduces a faster input deduplication algorithm.

In the first commit, I introduce a worst case duplicate input benchmark.

The existing code achieves the following performance.

DuplicateInputs, 5, 10, 0.710982, 0.0140756, 0.0143986, 0.0141852

In the next commit, I introduce a probabilistic checker which is much faster. It's analysis and use is documented extensively in the code comments. It achieves the following performance on the same benchmark.

DuplicateInputs, 5, 10, 0.166576, 0.00329314, 0.0034048, 0.0033221

This is about 4.3X faster.


Future work can further improve this by back-grounding the checks and hashing to another thread.


This does introduce one behavior change in which DoS error gets reported for transactions which have both duplicates and null inputs; the first error found will be the one reported.