### PR TITLE
travis: set codespell version to avoid breakage

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -6,5 +6,5 @@
 
 export LC_ALL=C
 
-travis_retry pip install codespell
+travis_retry pip install codespell==1.13.0
 travis_retry pip install flake8


### PR DESCRIPTION
codespell changes the behaviour across version, so just hardcode the version to avoid warnings when they bump the version.