### PR TITLE
docs: release process: RPC documentation

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -296,6 +296,8 @@ bitcoin.org (see below for bitcoin.org update instructions).
 
   - bitcoincore.org blog post
 
+  - bitcoincore.org RPC documentation update
+
   - Update title of #bitcoin on Freenode IRC
 
   - Optionally twitter, reddit /r/Bitcoin, ... but this will usually sort out itself


### PR DESCRIPTION
The auto-generated RPC docs seem to work so far ( https://bitcoincore.org/en/doc/ + 0.17.0 https://github.com/bitcoin-core/bitcoincore.org/pull/618 ). There are some problems (the design of the list on the right is not ideal, and apparently the huge list of pages slows down jekyll), but that can be fixed later; people are already linking to the docs now and looking for them there

So I am adding the RPC docs to the release process.

The script is here and it is written in golang, since I am most confident in the language; if necessary, I can try to rewrite to python, which is more common in bitcoin tooling

https://github.com/bitcoin-core/bitcoincore.org/tree/master/contrib/doc-gen

