### PR TITLE
tests: Make Travis linting output less verbose

### DIFF
--- a/.travis/lint_06_script.sh
+++ b/.travis/lint_06_script.sh
@@ -10,10 +10,12 @@ if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
   test/lint/commit-script-check.sh $TRAVIS_COMMIT_RANGE
 fi
 
-test/lint/git-subtree-check.sh src/crypto/ctaes
-test/lint/git-subtree-check.sh src/secp256k1
-test/lint/git-subtree-check.sh src/univalue
-test/lint/git-subtree-check.sh src/leveldb
+for SUBTREE in src/crypto/ctaes src/leveldb src/secp256k1 src/univalue; do
+    if ! SUBTREE_OUTPUT=$(test/lint/git-subtree-check.sh ${SUBTREE} 2>&1); then
+        echo "${SUBTREE_OUTPUT}"
+        exit 1
+    fi
+done
 test/lint/check-doc.py
 test/lint/check-rpc-mappings.py .
 test/lint/lint-all.sh

--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -6,8 +6,6 @@
 '''
 This checks if all command line args are documented.
 Return value is 0 to indicate no error.
-
-Author: @MarcoFalke
 '''
 
 from subprocess import check_output
@@ -34,15 +32,21 @@ def main():
     args_need_doc = args_used.difference(args_docd)
     args_unknown = args_docd.difference(args_used)
 
-    print("Args used        : {}".format(len(args_used)))
-    print("Args documented  : {}".format(len(args_docd)))
-    print("Args undocumented: {}".format(len(args_need_doc)))
-    print(args_need_doc)
-    print("Args unknown     : {}".format(len(args_unknown)))
-    print(args_unknown)
+    print("[info] {} arguments used. {} arguments documented.".format(len(args_used), len(args_docd)))
+
+    if args_need_doc:
+        print("")
+        print("The following arguments are undocumented:")
+        for undocumented_arg in sorted(args_need_doc):
+            print("* {}".format(undocumented_arg))
+
+    if args_unknown:
+        print("")
+        print("The following arguments are unknown:")
+        for unknown_arg in sorted(args_unknown):
+            print("* {}".format(unknown_arg))
 
     sys.exit(len(args_need_doc))
-
 
 if __name__ == "__main__":
     main()

--- a/test/lint/check-rpc-mappings.py
+++ b/test/lint/check-rpc-mappings.py
@@ -109,8 +109,6 @@ def main():
     client = SOURCE_CLIENT
     mapping = set(process_mapping(os.path.join(root, client)))
 
-    print('* Checking consistency between dispatch tables and vRPCConvertParams')
-
     # Check mapping consistency
     errors = 0
     for (cmdname, argidx, argname) in mapping:


### PR DESCRIPTION
Make Travis linting output less verbose and thereby significantly increase signal to noise :-)

Example before:

```
$ .travis/lint_06_script.sh
src/crypto/ctaes in HEAD currently refers to tree 1b6c31139a71f80245c09597c343936a8e41d021
src/crypto/ctaes in HEAD was last updated in commit 8501bedd7508ac514385806e191aec21ee978891 (tree 1b6c31139a71f80245c09597c343936a8e41d021)
subtree commit 003a4acfc273932ab8c2e276cde3b4f3541012dd unavailable: cannot compare
src/secp256k1 in HEAD currently refers to tree af619602c243e0d8fbd5934f375faa4aedb4ca6e
src/secp256k1 in HEAD was last updated in commit fd86f998fcfd25d823d67a2920814e22445655f9 (tree af619602c243e0d8fbd5934f375faa4aedb4ca6e)
subtree commit 0b7024185045a49a1a6a4c5615bf31c94f63d9c4 unavailable: cannot compare
src/univalue in HEAD currently refers to tree a2dbaf30021c0a31eecc213cd84d600273d333b6
src/univalue in HEAD was last updated in commit a570098021be6a7b9f4589300ea655ae4633628e (tree a2dbaf30021c0a31eecc213cd84d600273d333b6)
subtree commit 51d3ab34ba2857f0d03dc07250cb4a2b5e712e67 unavailable: cannot compare
src/leveldb in HEAD currently refers to tree f8cdc77167be86194f98d0412baf4b89d3d5abe6
src/leveldb in HEAD was last updated in commit ec749b1bcdf2483b642fb51d635800e272c68ba6 (tree f8cdc77167be86194f98d0412baf4b89d3d5abe6)
subtree commit 524b7e36a8e3bce6fcbcd1b5df09024283f325ba unavailable: cannot compare
Args used        : 181
Args documented  : 186
Args undocumented: 0
set()
Args unknown     : 5
{'-zmqpubrawtx', '-zmqpubhashtx', '-zmqpubhashblock', '-zmqpubrawblock', '-promiscuousmempoolflags'}
* Checking consistency between dispatch tables and vRPCConvertParams
```

Example after:

```
$ .travis/lint_06_script.sh
[info] 181 arguments used. 186 arguments documented.

The following arguments are unknown:
* -promiscuousmempoolflags
* -zmqpubhashblock
* -zmqpubhashtx
* -zmqpubrawblock
* -zmqpubrawtx
```

