### PR TITLE
Fix crash in fundrawtransaction when using non-solvable scripts

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2729,7 +2729,12 @@ bool CWallet::CreateTransaction(const std::vector<CRecipient>& vecSend, CTransac
                 if (pick_new_inputs) {
                     nValueIn = 0;
                     setCoins.clear();
-                    coin_selection_params.change_spend_size = CalculateMaximumSignedInputSize(change_prototype_txout, this);
+                    int max_signed_input_size = CalculateMaximumSignedInputSize(change_prototype_txout, this);
+                    if (max_signed_input_size < 0) {
+                        strFailReason = _("Fee calculation failed");
+                        return false;
+                    }
+                    coin_selection_params.change_spend_size = max_signed_input_size;
                     coin_selection_params.effective_fee = nFeeRateNeeded;
                     if (!SelectCoins(vAvailableCoins, nValueToSelect, setCoins, nValueIn, coin_control, coin_selection_params, bnb_used))
                     {


### PR DESCRIPTION
`CreateTransaction()` with non-solvable inputs (example: import a P2SH script) are leading to a crash.

`CalculateMaximumSignedInputSize(change_prototype_txout, this);` can return -1 in case of non-solvable input which gets directly loaded into a `size_t` container `CoinSelectionParams::change_spend_size` resulting to overflow back to `size_t::max`.

This should correctly detect the non-solvability and return an error.

A commit (to pull in here) with a function test is welcome.