### PR TITLE
qt: Revert "Force TLS1.0+ for SSL connections"

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -51,7 +51,6 @@
 #include <QThread>
 #include <QTimer>
 #include <QTranslator>
-#include <QSslConfiguration>
 
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
@@ -572,13 +571,6 @@ int main(int argc, char *argv[])
 #endif
 #ifdef Q_OS_MAC
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
-#endif
-#if QT_VERSION >= 0x050500
-    // Because of the POODLE attack it is recommended to disable SSLv3 (https://disablessl3.com/),
-    // so set SSL protocols to TLS1.0+.
-    QSslConfiguration sslconf = QSslConfiguration::defaultConfiguration();
-    sslconf.setProtocol(QSsl::TlsV1_0OrLater);
-    QSslConfiguration::setDefaultConfiguration(sslconf);
 #endif
 
     // Register meta types used for QMetaObject::invokeMethod


### PR DESCRIPTION
This reverts commit 15e26a6a9afe299b9ca6fced73b876644365879b, whose
purpose was to tweak the Qt configuration to force TLS, i.e., to
disable SSLv3, in Qt versions >= 5.5. However, the default behavior
of Qt >= 5.4 is to disable SSLv3 anyway [1], so the configuration
tweak is redundant.

With Qt 5.11.2, the configuration tweak is not only redundant but in
fact provokes a deadlock due to a bug in Qt 5.11.2. Since the deadlock
occurs at the early startup stage of bitcoin-qt, it renders bitcoin-qt
entirely non-functional when compiled against Qt 5.11.2 (and maybe
other Qt versions).

Fixes #14359.

[1] https://code.qt.io/cgit/qt/qtbase.git/commit/?id=3fd2d9eff8c1f948306ee5fbfe364ccded1c4b84