### PR TITLE
Fix listreceivedbyaddress not taking address as a string

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -45,7 +45,6 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listreceivedbyaddress", 0, "minconf" },
     { "listreceivedbyaddress", 1, "include_empty" },
     { "listreceivedbyaddress", 2, "include_watchonly" },
-    { "listreceivedbyaddress", 3, "address_filter" },
     { "listreceivedbylabel", 0, "minconf" },
     { "listreceivedbylabel", 1, "include_empty" },
     { "listreceivedbylabel", 2, "include_watchonly" },

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -68,6 +68,10 @@ class ReceivedByTest(BitcoinTestFramework):
         res = self.nodes[1].listreceivedbyaddress(minconf=0, include_empty=True, include_watchonly=True, address_filter=addr)
         assert_array_result(res, {"address": addr}, expected)
         assert_equal(len(res), 1)
+        # Test for regression on CLI calls with address string (#14173)
+        cli_res = self.nodes[1].cli.listreceivedbyaddress(0, True, True, addr)
+        assert_array_result(cli_res, {"address": addr}, expected)
+        assert_equal(len(cli_res), 1)
         # Error on invalid address
         assert_raises_rpc_error(-4, "address_filter parameter was invalid", self.nodes[1].listreceivedbyaddress, minconf=0, include_empty=True, include_watchonly=True, address_filter="bamboozling")
         # Another address receive money


### PR DESCRIPTION
Fixes #14173. Add the patch in #14173 and include a regression test.