### PR TITLE
Fix path to doc/descriptors.md in 0.17 release notes

### DIFF
--- a/doc/release-notes/release-notes-0.17.0.md
+++ b/doc/release-notes/release-notes-0.17.0.md
@@ -270,7 +270,7 @@ Low-level RPC changes
 
 - The new RPC `scantxoutset` can be used to scan the UTXO set for entries
   that match certain output descriptors. Refer to the [output descriptors
-  reference documentation](doc/descriptors.md) for more details. This call
+  reference documentation](/doc/descriptors.md) for more details. This call
   is similar to `listunspent` but does not use a wallet, meaning that the
   wallet can be disabled at compile or run time. This call is experimental,
   as such, is subject to changes or removal in future releases.


### PR DESCRIPTION
Trivial fix for a missing slash in `0.17.0` release docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoin/bitcoin/14421)
<!-- Reviewable:end -->
