### PR TITLE
docs: Add config file docs to '-help' messages

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -77,12 +77,13 @@ static bool AppInit(int argc, char* argv[])
 
         if (gArgs.IsArgSet("-version"))
         {
-            strUsage += FormatParagraph(LicenseInfo());
+            strUsage += FormatParagraph(LicenseInfo()) + "\n";
         }
         else
         {
             strUsage += "\nUsage:  bitcoind [options]                     Start " PACKAGE_NAME " Daemon\n";
             strUsage += "\n" + gArgs.GetHelpMessage();
+            strUsage += "\n" + FormatParagraph(ConfigHelp("bitcoind")) + "\n";
         }
 
         fprintf(stdout, "%s", strUsage.c_str());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -528,6 +528,22 @@ std::string LicenseInfo()
            "\n";
 }
 
+std::string ConfigHelp(const std::string& strBitcoinClient)
+{
+    return strprintf(_("All command-line options (except for '%s') may be specified in a configuration file, and all configuration file options may also be specified on the command line. "
+                       "Command-line options override values set in the configuration file."),
+               "-conf") +
+           "\n" +
+           "\n" +
+           strprintf(_("The configuration file is a list of 'setting=value' pairs, one per line, with optional comments starting with the '%s' character."), "#") +
+           "\n" +
+           "\n" +
+           strprintf(_("The configuration file is not automatically created; you can create it using your favorite plain-text editor. "
+                       "By default, %s will look for a file named '%s' in the %s data directory, but both the data directory and the configuration file path may be changed using the '%s' and '%s' command-line arguments."),
+               strBitcoinClient, BITCOIN_CONF_FILENAME, PACKAGE_NAME, "-datadir", "-conf") +
+           "\n";
+}
+
 static void BlockNotifyCallback(bool initialSync, const CBlockIndex *pBlockIndex)
 {
     if (initialSync || !pBlockIndex)

--- a/src/init.h
+++ b/src/init.h
@@ -64,4 +64,7 @@ void SetupServerArgs();
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();
 
+/** Returns configuration file help (for -help) */
+std::string ConfigHelp(const std::string& strBitcoinClient);
+
 #endif // BITCOIN_INIT_H

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -21,6 +21,7 @@
 #include <init.h>
 #include <interfaces/node.h>
 #include <util.h>
+#include <utilstrencodings.h>
 
 #include <stdio.h>
 
@@ -52,9 +53,9 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
     {
         setWindowTitle(tr("About %1").arg(tr(PACKAGE_NAME)));
 
+        std::string licenseInfo = LicenseInfo();
         /// HTML-format the license message from the core
-        QString licenseInfo = QString::fromStdString(LicenseInfo());
-        QString licenseInfoHTML = licenseInfo;
+        QString licenseInfoHTML = QString::fromStdString(LicenseInfo());
         // Make URLs clickable
         QRegExp uri("<(.*)>", Qt::CaseSensitive, QRegExp::RegExp2);
         uri.setMinimal(true); // use non-greedy matching
@@ -64,7 +65,7 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
 
         ui->aboutMessage->setTextFormat(Qt::RichText);
         ui->scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-        text = version + "\n" + licenseInfo;
+        text = version + "\n" + QString::fromStdString(FormatParagraph(licenseInfo));
         ui->aboutMessage->setText(version + "<br><br>" + licenseInfoHTML);
         ui->aboutMessage->setWordWrap(true);
         ui->helpMessage->setVisible(false);
@@ -78,8 +79,9 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
         cursor.insertBlock();
 
         std::string strUsage = gArgs.GetHelpMessage();
+        std::string configHelp = ConfigHelp("bitcoin-qt");
         QString coreOptions = QString::fromStdString(strUsage);
-        text = version + "\n\n" + header + "\n" + coreOptions;
+        text = version + "\n\n" + header + "\n" + coreOptions + "\n" + QString::fromStdString(FormatParagraph(configHelp));
 
         QTextTableFormat tf;
         tf.setBorderStyle(QTextFrameFormat::BorderStyle_None);
@@ -111,6 +113,12 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
                 cursor.insertTable(1, 2, tf);
             }
         }
+
+        cursor.movePosition(QTextCursor::End);
+        cursor.insertBlock();
+        cursor.insertBlock();
+        cursor.insertBlock();
+        cursor.insertText(QString::fromStdString(configHelp));
 
         ui->helpMessage->moveCursor(QTextCursor::Start);
         ui->scrollArea->setVisible(false);


### PR DESCRIPTION
This adds a suitable user documentation about configuration file.

The `bitcoin-qt -version` output formatting has been fixed as well.

Refs:

- https://github.com/bitcoin/bitcoin/pull/14370#issuecomment-426509475

- #9944

Some small modifications made outputs of `bitcoind` and `bitcoin-qt` the same:
```
cd ~/github/bitcoin/
./src/bitcoind -help > ~/bitcoind-help
./src/qt/bitcoin-qt -help > ~/bitcoinqt-help
diff ~/bitcoind-help ~/bitcoinqt-help 
1c1
< Bitcoin Core Daemon version v0.17.99.0-6ca88a670
---
> Bitcoin Core version v0.17.99.0-6ca88a670 (64-bit)
3c3
< Usage:  bitcoind [options]                     Start Bitcoin Core Daemon
---
> Usage:  bitcoin-qt [command-line options]                     
466a467,486
> UI Options:
> 
>   -choosedatadir
>        Choose data directory on startup (default: 0)
> 
>   -lang=<lang>
>        Set language, for example "de_DE" (default: system locale)
> 
>   -min
>        Start minimized
> 
>   -resetguisettings
>        Reset all settings changed in the GUI
> 
>   -rootcertificates=<file>
>        Set SSL root certificates for payment request (default: -system-)
> 
>   -splash
>        Show splash screen on startup (default: 1)
> 
477c497
< your favorite plain-text editor. By default, bitcoind will look for a file
---
> your favorite plain-text editor. By default, bitcoin-qt will look for a file
```

```
cd ~/github/bitcoin/
./src/bitcoind -version > ~/bitcoind-version
./src/qt/bitcoin-qt -version > ~/bitcoinqt-version
diff ~/bitcoind-version ~/bitcoinqt-version
1c1
< Bitcoin Core Daemon version v0.17.99.0-6ca88a670
---
> Bitcoin Core version v0.17.99.0-6ca88a670 (64-bit)
```

And the output on GUI (menu -> `Help` -> `Command-line options`):
![screenshot from 2018-10-07 20-00-03](https://user-images.githubusercontent.com/32963518/46584609-160d8c00-ca6e-11e8-800d-091a3e573dc8.png)
