### PR TITLE
Add more property based tests for basic bitcoin data structures

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -167,7 +167,7 @@ BITCOIN_TEST_SUITE += \
   test/gen/bloom_gen.h \
   test/gen/crypto_gen.cpp \
   test/gen/crypto_gen.h \
-  test/gen/merkle_block.h \
+  test/gen/merkleblock_gen.h \
   test/gen/script_gen.cpp \
   test/gen/script_gen.h \
   test/gen/transaction_gen.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -153,11 +153,25 @@ BITCOIN_TESTS =\
 
 if ENABLE_PROPERTY_TESTS
 BITCOIN_TESTS += \
-  test/key_properties.cpp
+  test/block_properties.cpp \
+  test/bloom_properties.cpp \
+  test/key_properties.cpp \
+  test/merkleblock_properties.cpp \
+  test/script_properties.cpp \
+  test/transaction_properties.cpp
 
 BITCOIN_TEST_SUITE += \
+  test/gen/block_gen.cpp \
+  test/gen/block_gen.h \
+  test/gen/bloom_gen.cpp \
+  test/gen/bloom_gen.h \
   test/gen/crypto_gen.cpp \
-  test/gen/crypto_gen.h
+  test/gen/crypto_gen.h \
+  test/gen/merkle_block.h \
+  test/gen/script_gen.cpp \
+  test/gen/script_gen.h \
+  test/gen/transaction_gen.cpp \
+  test/gen/transaction_gen.h
 endif
 
 if ENABLE_WALLET

--- a/src/test/block_properties.cpp
+++ b/src/test/block_properties.cpp
@@ -1,11 +1,15 @@
+// Copyright (c) 2018-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <boost/test/unit_test.hpp>
+#include <rapidcheck/Gen.h>
 #include <rapidcheck/boost_test.h>
 #include <rapidcheck/gen/Arbitrary.h>
-#include <rapidcheck/Gen.h>
 
-#include "test/test_bitcoin.h"
-#include "primitives/block.h"
-#include "test/gen/block_gen.h"
+#include <primitives/block.h>
+#include <streams.h>
+#include <test/gen/block_gen.h>
+#include <test/setup_common.h>
 
 
 BOOST_FIXTURE_TEST_SUITE(block_properties, BasicTestingSetup)

--- a/src/test/block_properties.cpp
+++ b/src/test/block_properties.cpp
@@ -1,0 +1,34 @@
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "test/test_bitcoin.h"
+#include "primitives/block.h"
+#include "test/gen/block_gen.h"
+
+
+BOOST_FIXTURE_TEST_SUITE(block_properties, BasicTestingSetup)
+
+RC_BOOST_PROP(blockheader_serialization_symmetry, (const CBlockHeader& header))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << header;
+    CBlockHeader header2;
+    ss >> header2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << header;
+    ss1 << header2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+
+RC_BOOST_PROP(block_serialization_symmetry, (const CBlock& block))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << block;
+    CBlock block2;
+    ss >> block2;
+    RC_ASSERT(block.GetHash() == block2.GetHash());
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/bloom_properties.cpp
+++ b/src/test/bloom_properties.cpp
@@ -1,16 +1,17 @@
-// Copyright (c) 2012-2016 The Bitcoin Core developers
+// Copyright (c) 2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include "test/gen/bloom_gen.h"
-#include "test/gen/crypto_gen.h"
+#include <test/gen/bloom_gen.h>
+#include <test/gen/crypto_gen.h>
 
-#include "test/test_bitcoin.h"
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+#include <rapidcheck/Gen.h>
 #include <rapidcheck/boost_test.h>
 #include <rapidcheck/gen/Arbitrary.h>
-#include <rapidcheck/Gen.h>
 
+#include <streams.h>
 
 BOOST_FIXTURE_TEST_SUITE(bloom_properties, BasicTestingSetup)
 

--- a/src/test/bloom_properties.cpp
+++ b/src/test/bloom_properties.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2012-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "test/gen/bloom_gen.h"
+#include "test/gen/crypto_gen.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+
+BOOST_FIXTURE_TEST_SUITE(bloom_properties, BasicTestingSetup)
+
+RC_BOOST_PROP(no_false_negatives, (CBloomFilter bloom_filter, const uint256& hash))
+{
+    bloom_filter.insert(hash);
+    bool result = bloom_filter.contains(hash);
+    RC_ASSERT(result);
+}
+
+RC_BOOST_PROP(serialization_symmetry, (const CBloomFilter& bloom_filter))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << bloom_filter;
+    CBloomFilter bloom_filter2;
+    ss >> bloom_filter2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << bloom_filter;
+    ss1 << bloom_filter2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/gen/block_gen.cpp
+++ b/src/test/gen/block_gen.cpp
@@ -1,4 +1,7 @@
-#include "test/gen/block_gen.h"
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <test/gen/block_gen.h>
 
 #include <rapidcheck/Gen.h>
 

--- a/src/test/gen/block_gen.cpp
+++ b/src/test/gen/block_gen.cpp
@@ -1,0 +1,12 @@
+#include "test/gen/block_gen.h"
+
+#include <rapidcheck/Gen.h>
+
+/** Generator for the primitives of a block header */
+rc::Gen<BlockHeaderTup> BlockHeaderPrimitives()
+{
+    return rc::gen::tuple(rc::gen::arbitrary<int32_t>(),
+        rc::gen::arbitrary<uint256>(), rc::gen::arbitrary<uint256>(),
+        rc::gen::arbitrary<uint32_t>(), rc::gen::arbitrary<uint32_t>(),
+        rc::gen::arbitrary<uint32_t>());
+}

--- a/src/test/gen/block_gen.h
+++ b/src/test/gen/block_gen.h
@@ -1,22 +1,24 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_BLOCK_GEN_H
 #define BITCOIN_TEST_GEN_BLOCK_GEN_H
 
-#include "test/gen/crypto_gen.h"
-#include "test/gen/transaction_gen.h"
-#include "uint256.h"
-#include "primitives/block.h"
+#include <primitives/block.h>
+#include <test/gen/crypto_gen.h>
+#include <test/gen/transaction_gen.h>
+#include <uint256.h>
 
-#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Arbitrary.h>
 
 
-typedef std::tuple<int32_t, uint256, uint256, uint32_t, uint32_t, uint32_t> BlockHeaderTup;
+using BlockHeaderTup = std::tuple<int32_t, uint256, uint256, uint32_t, uint32_t, uint32_t>;
 
 /** Generator for the primitives of a block header */
 rc::Gen<BlockHeaderTup> BlockHeaderPrimitives();
 
-namespace rc
-{
+namespace rc {
 /** Generator for a new CBlockHeader */
 template <>
 struct Arbitrary<CBlockHeader> {
@@ -54,5 +56,5 @@ struct Arbitrary<CBlock> {
         });
     }
 };
-} //namespace rc
+} // namespace rc
 #endif

--- a/src/test/gen/block_gen.h
+++ b/src/test/gen/block_gen.h
@@ -1,0 +1,58 @@
+#ifndef BITCOIN_TEST_GEN_BLOCK_GEN_H
+#define BITCOIN_TEST_GEN_BLOCK_GEN_H
+
+#include "test/gen/crypto_gen.h"
+#include "test/gen/transaction_gen.h"
+#include "uint256.h"
+#include "primitives/block.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+
+typedef std::tuple<int32_t, uint256, uint256, uint32_t, uint32_t, uint32_t> BlockHeaderTup;
+
+/** Generator for the primitives of a block header */
+rc::Gen<BlockHeaderTup> BlockHeaderPrimitives();
+
+namespace rc
+{
+/** Generator for a new CBlockHeader */
+template <>
+struct Arbitrary<CBlockHeader> {
+    static Gen<CBlockHeader> arbitrary()
+    {
+        return gen::map(BlockHeaderPrimitives(), [](const BlockHeaderTup& primitives) {
+            int32_t nVersion;
+            uint256 hashPrevBlock;
+            uint256 hashMerkleRoot;
+            uint32_t nTime;
+            uint32_t nBits;
+            uint32_t nNonce;
+            std::tie(nVersion, hashPrevBlock, hashMerkleRoot, nTime, nBits, nNonce) = primitives;
+            CBlockHeader header;
+            header.nVersion = nVersion;
+            header.hashPrevBlock = hashPrevBlock;
+            header.hashMerkleRoot = hashMerkleRoot;
+            header.nTime = nTime;
+            header.nBits = nBits;
+            header.nNonce = nNonce;
+            return header;
+        });
+    };
+};
+
+/** Generator for a new CBlock */
+template <>
+struct Arbitrary<CBlock> {
+    static Gen<CBlock> arbitrary()
+    {
+        return gen::map(gen::nonEmpty<std::vector<CTransactionRef>>(), [](const std::vector<CTransactionRef>& refs) {
+            CBlock block;
+            block.vtx = refs;
+            return block;
+        });
+    }
+};
+} //namespace rc
+#endif

--- a/src/test/gen/bloom_gen.cpp
+++ b/src/test/gen/bloom_gen.cpp
@@ -1,15 +1,18 @@
-#include "test/gen/bloom_gen.h"
-#include "test/gen/crypto_gen.h"
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <test/gen/bloom_gen.h>
+#include <test/gen/crypto_gen.h>
 
-#include "bloom.h"
+#include <bloom.h>
 #include <math.h>
 
-#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
-#include <rapidcheck/gen/Tuple.h>
-#include <rapidcheck/gen/Predicate.h>
-#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/gen/Container.h>
+#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Tuple.h>
 
 /** Generates a double between [0,1) */
 rc::Gen<double> BetweenZeroAndOne()

--- a/src/test/gen/bloom_gen.cpp
+++ b/src/test/gen/bloom_gen.cpp
@@ -1,0 +1,59 @@
+#include "test/gen/bloom_gen.h"
+#include "test/gen/crypto_gen.h"
+
+#include "bloom.h"
+#include <math.h>
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Tuple.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Container.h>
+
+/** Generates a double between [0,1) */
+rc::Gen<double> BetweenZeroAndOne()
+{
+    return rc::gen::map(rc::gen::arbitrary<double>(), [](double x) {
+        double result = abs(fmod(x, 1));
+        assert(result >= 0 && result < 1);
+        return result;
+    });
+}
+
+rc::Gen<unsigned int> Between1And100()
+{
+    return rc::gen::inRange<unsigned int>(1, 100);
+}
+/** Generates the C++ primitives used to create a bloom filter */
+rc::Gen<std::tuple<unsigned int, double, unsigned int, unsigned int>> BloomFilterPrimitives()
+{
+    return rc::gen::tuple(Between1And100(),
+        BetweenZeroAndOne(), rc::gen::arbitrary<unsigned int>(),
+        rc::gen::inRange<unsigned int>(0, 3));
+}
+
+/** Returns a bloom filter loaded with the given uint256s */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadedBloomFilter()
+{
+    return rc::gen::map(rc::gen::pair(rc::gen::arbitrary<CBloomFilter>(), rc::gen::arbitrary<std::vector<uint256>>()),
+        [](const std::pair<CBloomFilter, const std::vector<uint256>&>& primitives) {
+            CBloomFilter bloomFilter = primitives.first;
+            std::vector<uint256> hashes = primitives.second;
+            for (unsigned int i = 0; i < hashes.size(); i++) {
+                bloomFilter.insert(hashes[i]);
+            }
+            return std::make_pair(bloomFilter, hashes);
+        });
+}
+
+/** Loads an arbitrary bloom filter with the given hashes */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadBloomFilter(const std::vector<uint256>& hashes)
+{
+    return rc::gen::map(rc::gen::arbitrary<CBloomFilter>(), [&hashes](CBloomFilter bloomFilter) {
+        for (unsigned int i = 0; i < hashes.size(); i++) {
+            bloomFilter.insert(hashes[i]);
+        }
+        return std::make_pair(bloomFilter, hashes);
+    });
+}

--- a/src/test/gen/bloom_gen.h
+++ b/src/test/gen/bloom_gen.h
@@ -1,8 +1,11 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_BLOOM_GEN_H
 #define BITCOIN_TEST_GEN_BLOOM_GEN_H
 
-#include "bloom.h"
-#include "merkleblock.h"
+#include <bloom.h>
+#include <merkleblock.h>
 
 #include <math.h>
 
@@ -14,8 +17,7 @@ rc::Gen<double> BetweenZeroAndOne();
 
 rc::Gen<std::tuple<unsigned int, double, unsigned int, unsigned int>> BloomFilterPrimitives();
 
-namespace rc
-{
+namespace rc {
 /** Generator for a new CBloomFilter*/
 template <>
 struct Arbitrary<CBloomFilter> {

--- a/src/test/gen/bloom_gen.h
+++ b/src/test/gen/bloom_gen.h
@@ -1,0 +1,42 @@
+#ifndef BITCOIN_TEST_GEN_BLOOM_GEN_H
+#define BITCOIN_TEST_GEN_BLOOM_GEN_H
+
+#include "bloom.h"
+#include "merkleblock.h"
+
+#include <math.h>
+
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Arbitrary.h>
+
+/** Generates a double between [0,1) */
+rc::Gen<double> BetweenZeroAndOne();
+
+rc::Gen<std::tuple<unsigned int, double, unsigned int, unsigned int>> BloomFilterPrimitives();
+
+namespace rc
+{
+/** Generator for a new CBloomFilter*/
+template <>
+struct Arbitrary<CBloomFilter> {
+    static Gen<CBloomFilter> arbitrary()
+    {
+        return gen::map(BloomFilterPrimitives(), [](const std::tuple<unsigned int, double, unsigned int, unsigned int>& primitives) {
+            unsigned int num_elements;
+            double fp_rate;
+            unsigned int n_tweak_in;
+            unsigned int bloom_flag;
+            std::tie(num_elements, fp_rate, n_tweak_in, bloom_flag) = primitives;
+            return CBloomFilter(num_elements, fp_rate, n_tweak_in, bloom_flag);
+        });
+    };
+};
+} //namespace rc
+
+/** Returns a bloom filter loaded with the returned uint256s */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadedBloomFilter();
+
+/** Loads an arbitrary bloom filter with the given hashes */
+rc::Gen<std::pair<CBloomFilter, std::vector<uint256>>> LoadBloomFilter(const std::vector<uint256>& hashes);
+
+#endif

--- a/src/test/gen/crypto_gen.cpp
+++ b/src/test/gen/crypto_gen.cpp
@@ -1,6 +1,9 @@
-#include "test/gen/crypto_gen.h"
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <test/gen/crypto_gen.h>
 
-#include "key.h"
+#include <key.h>
 
 #include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>

--- a/src/test/gen/crypto_gen.cpp
+++ b/src/test/gen/crypto_gen.cpp
@@ -1,9 +1,6 @@
-// Copyright (c) 2018 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#include <test/gen/crypto_gen.h>
+#include "test/gen/crypto_gen.h"
 
-#include <key.h>
+#include "key.h"
 
 #include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
@@ -14,6 +11,13 @@
 rc::Gen<std::vector<CKey>> MultisigKeys()
 {
     return rc::gen::suchThat(rc::gen::arbitrary<std::vector<CKey>>(), [](const std::vector<CKey>& keys) {
+        //TODO: Investigate why we can only allow 15 keys. Consensus rules
+        // dictate we can up to 20 keys
+        //https://github.com/bitcoin/bitcoin/blob/10bee0dd4f37eb6cb7a0f1d565fa0fecf8109c35/src/script/script.h#L29
+        //needs to be <= 16 keys because this assertion fails
+        //https://github.com/bitcoin/bitcoin/blob/10bee0dd4f37eb6cb7a0f1d565fa0fecf8109c35/src/script/script.h#L585
+        //ProduceSignature() fails for p2sh(multisig) if there are >= 16 keys
+        //this is why we are currently limited to the range >= 1 && <= 15
         return keys.size() >= 1 && keys.size() <= 15;
     });
 };

--- a/src/test/gen/crypto_gen.h
+++ b/src/test/gen/crypto_gen.h
@@ -1,9 +1,12 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_CRYPTO_GEN_H
 #define BITCOIN_TEST_GEN_CRYPTO_GEN_H
 
-#include "key.h"
-#include "random.h"
-#include "uint256.h"
+#include <key.h>
+#include <random.h>
+#include <uint256.h>
 #include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
 #include <rapidcheck/gen/Create.h>
@@ -56,5 +59,5 @@ struct Arbitrary<uint256> {
         return rc::gen::just(GetRandHash());
     };
 };
-} //namespace rc
+} // namespace rc
 #endif

--- a/src/test/gen/crypto_gen.h
+++ b/src/test/gen/crypto_gen.h
@@ -1,12 +1,9 @@
-// Copyright (c) 2018 The Bitcoin Core developers
-// Distributed under the MIT software license, see the accompanying
-// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_CRYPTO_GEN_H
 #define BITCOIN_TEST_GEN_CRYPTO_GEN_H
 
-#include <key.h>
-#include <random.h>
-#include <uint256.h>
+#include "key.h"
+#include "random.h"
+#include "uint256.h"
 #include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
 #include <rapidcheck/gen/Create.h>

--- a/src/test/gen/merkleblock_gen.h
+++ b/src/test/gen/merkleblock_gen.h
@@ -1,15 +1,17 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_MERKLEBLOCK_GEN_H
 #define BITCOIN_TEST_GEN_MERKLEBLOCK_GEN_H
 
-#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Arbitrary.h>
 
-#include "merkleblock.h"
-#include "test/gen/block_gen.h"
+#include <merkleblock.h>
+#include <test/gen/block_gen.h>
 
 #include <iostream>
-namespace rc
-{
+namespace rc {
 /** Returns a CMerkleblock with the hashes that match inside of the CPartialMerkleTree */
 template <>
 struct Arbitrary<std::pair<CMerkleBlock, std::set<uint256>>> {
@@ -89,5 +91,5 @@ struct Arbitrary<CPartialMerkleTree> {
             });
     };
 };
-} //namespace rc
+} // namespace rc
 #endif

--- a/src/test/gen/merkleblock_gen.h
+++ b/src/test/gen/merkleblock_gen.h
@@ -1,0 +1,93 @@
+#ifndef BITCOIN_TEST_GEN_MERKLEBLOCK_GEN_H
+#define BITCOIN_TEST_GEN_MERKLEBLOCK_GEN_H
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "merkleblock.h"
+#include "test/gen/block_gen.h"
+
+#include <iostream>
+namespace rc
+{
+/** Returns a CMerkleblock with the hashes that match inside of the CPartialMerkleTree */
+template <>
+struct Arbitrary<std::pair<CMerkleBlock, std::set<uint256>>> {
+    static Gen<std::pair<CMerkleBlock, std::set<uint256>>> arbitrary()
+    {
+        return gen::map(gen::arbitrary<CBlock>(), [](const CBlock& block) {
+            std::set<uint256> hashes;
+            for (unsigned int i = 0; i < block.vtx.size(); i++) {
+                //pretty naive to include every other txid in the merkle block
+                //but this will work for now.
+                if (i % 2 == 0) {
+                    hashes.insert(block.vtx[i]->GetHash());
+                }
+            }
+            return std::make_pair(CMerkleBlock(block, hashes), hashes);
+        });
+    };
+};
+
+/** Returns [0,100) uint256s */
+Gen<std::vector<uint256>> BetweenZeroAnd100()
+{
+    return gen::suchThat<std::vector<uint256>>([](const std::vector<uint256>& hashes) {
+        return hashes.size() <= 100;
+    });
+}
+/** Returns [1,100) uint256s */
+Gen<std::vector<uint256>> Between1And100()
+{
+    return gen::suchThat(BetweenZeroAnd100(), [](const std::vector<uint256>& hashes) {
+        return hashes.size() > 0 && hashes.size() <= 100;
+    });
+}
+
+/** Returns an arbitrary CMerkleBlock */
+template <>
+struct Arbitrary<CMerkleBlock> {
+    static Gen<CMerkleBlock> arbitrary()
+    {
+        return gen::map(gen::arbitrary<std::pair<CMerkleBlock, std::set<uint256>>>(),
+            [](const std::pair<const CMerkleBlock&, const std::set<uint256>&>& mb_with_txids) {
+                const CMerkleBlock& mb = mb_with_txids.first;
+                return mb;
+            });
+    };
+};
+
+/** Generates a CPartialMerkleTree and returns the PartialMerkleTree along
+   * with the txids that should be matched inside of it */
+template <>
+struct Arbitrary<std::pair<CPartialMerkleTree, std::vector<uint256>>> {
+    static Gen<std::pair<CPartialMerkleTree, std::vector<uint256>>> arbitrary()
+    {
+        return gen::map(Between1And100(), [](const std::vector<uint256>& txids) {
+            std::vector<bool> matches;
+            std::vector<uint256> matched_txs;
+            for (unsigned int i = 0; i < txids.size(); i++) {
+                //pretty naive to include every other txid in the merkle block
+                //but this will work for now.
+                matches.push_back(i % 2 == 1);
+                if (i % 2 == 1) {
+                    matched_txs.push_back(txids[i]);
+                }
+            }
+            return std::make_pair(CPartialMerkleTree(txids, matches), matched_txs);
+        });
+    };
+};
+
+template <>
+struct Arbitrary<CPartialMerkleTree> {
+    static Gen<CPartialMerkleTree> arbitrary()
+    {
+        return gen::map(gen::arbitrary<std::pair<CPartialMerkleTree, std::vector<uint256>>>(),
+            [](const std::pair<const CPartialMerkleTree&, const std::vector<uint256>&>& p) {
+                return p.first;
+            });
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/gen/script_gen.cpp
+++ b/src/test/gen/script_gen.cpp
@@ -1,14 +1,17 @@
-#include "test/gen/script_gen.h"
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <test/gen/script_gen.h>
 
-#include "test/gen/crypto_gen.h"
-#include "script/script.h"
-#include "script/standard.h"
-#include "base58.h"
-#include "core_io.h"
-#include <rapidcheck/gen/Arbitrary.h>
+#include <base58.h>
+#include <core_io.h>
 #include <rapidcheck/Gen.h>
-#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <script/script.h>
+#include <script/standard.h>
+#include <test/gen/crypto_gen.h>
 
 /** Generates a P2PK/CKey pair */
 rc::Gen<SPKCKeyPair> P2PKSPK()
@@ -24,7 +27,7 @@ rc::Gen<SPKCKeyPair> P2PKSPK()
 rc::Gen<SPKCKeyPair> P2PKHSPK()
 {
     return rc::gen::map(rc::gen::arbitrary<CKey>(), [](const CKey& key) {
-        CKeyID id = key.GetPubKey().GetID();
+        PKHash id = PKHash(key.GetPubKey());
         std::vector<CKey> keys;
         keys.push_back(key);
         const CScript& s = GetScriptForDestination(id);
@@ -59,7 +62,7 @@ rc::Gen<SPKCKeyPair> P2SHSPK()
     return rc::gen::map(RawSPK(), [](const SPKCKeyPair& spk_keys) {
         const CScript& redeemScript = spk_keys.first;
         const std::vector<CKey>& keys = spk_keys.second;
-        const CScript& p2sh = GetScriptForDestination(CScriptID(redeemScript));
+        const CScript& p2sh = GetScriptForDestination(ScriptHash(redeemScript));
         return std::make_pair(redeemScript, keys);
     });
 }

--- a/src/test/gen/script_gen.cpp
+++ b/src/test/gen/script_gen.cpp
@@ -1,0 +1,88 @@
+#include "test/gen/script_gen.h"
+
+#include "test/gen/crypto_gen.h"
+#include "script/script.h"
+#include "script/standard.h"
+#include "base58.h"
+#include "core_io.h"
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Numeric.h>
+
+/** Generates a P2PK/CKey pair */
+rc::Gen<SPKCKeyPair> P2PKSPK()
+{
+    return rc::gen::map(rc::gen::arbitrary<CKey>(), [](const CKey& key) {
+        const CScript& s = GetScriptForRawPubKey(key.GetPubKey());
+        std::vector<CKey> keys;
+        keys.push_back(key);
+        return std::make_pair(s, keys);
+    });
+}
+/** Generates a P2PKH/CKey pair */
+rc::Gen<SPKCKeyPair> P2PKHSPK()
+{
+    return rc::gen::map(rc::gen::arbitrary<CKey>(), [](const CKey& key) {
+        CKeyID id = key.GetPubKey().GetID();
+        std::vector<CKey> keys;
+        keys.push_back(key);
+        const CScript& s = GetScriptForDestination(id);
+        return std::make_pair(s, keys);
+    });
+}
+
+/** Generates a MultiSigSPK/CKey(s) pair */
+rc::Gen<SPKCKeyPair> MultisigSPK()
+{
+    return rc::gen::mapcat(MultisigKeys(), [](const std::vector<CKey>& keys) {
+        return rc::gen::map(rc::gen::inRange<int>(1, keys.size()), [keys](int required_sigs) {
+            std::vector<CPubKey> pub_keys;
+            for (unsigned int i = 0; i < keys.size(); i++) {
+                pub_keys.push_back(keys[i].GetPubKey());
+            }
+            const CScript& s = GetScriptForMultisig(required_sigs, pub_keys);
+            return std::make_pair(s, keys);
+        });
+    });
+}
+
+rc::Gen<SPKCKeyPair> RawSPK()
+{
+    return rc::gen::oneOf(P2PKSPK(), P2PKHSPK(), MultisigSPK(),
+        P2WPKHSPK());
+}
+
+/** Generates a P2SHSPK/CKey(s) */
+rc::Gen<SPKCKeyPair> P2SHSPK()
+{
+    return rc::gen::map(RawSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& redeemScript = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript& p2sh = GetScriptForDestination(CScriptID(redeemScript));
+        return std::make_pair(redeemScript, keys);
+    });
+}
+
+//witness SPKs
+
+rc::Gen<SPKCKeyPair> P2WPKHSPK()
+{
+    rc::Gen<SPKCKeyPair> spks = rc::gen::oneOf(P2PKSPK(), P2PKHSPK());
+    return rc::gen::map(spks, [](const SPKCKeyPair& spk_keys) {
+        const CScript& p2pk = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript& wit_spk = GetScriptForWitness(p2pk);
+        return std::make_pair(wit_spk, keys);
+    });
+}
+
+rc::Gen<SPKCKeyPair> P2WSHSPK()
+{
+    return rc::gen::map(MultisigSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& p2pk = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript& wit_spk = GetScriptForWitness(p2pk);
+        return std::make_pair(wit_spk, keys);
+    });
+}

--- a/src/test/gen/script_gen.h
+++ b/src/test/gen/script_gen.h
@@ -1,15 +1,18 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_SCRIPT_GEN_H
 #define BITCOIN_TEST_GEN_SCRIPT_GEN_H
 
-#include "script/script.h"
-#include "key.h"
-#include <rapidcheck/gen/Arbitrary.h>
+#include <key.h>
 #include <rapidcheck/Gen.h>
-#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/gen/Container.h>
+#include <rapidcheck/gen/Numeric.h>
 #include <rapidcheck/gen/Select.h>
+#include <script/script.h>
 
-typedef std::pair<CScript, std::vector<CKey>> SPKCKeyPair;
+using SPKCKeyPair = std::pair<CScript, std::vector<CKey>>;
 
 //non witness SPKs
 rc::Gen<SPKCKeyPair> P2PKSPK();
@@ -29,16 +32,15 @@ rc::Gen<SPKCKeyPair> P2WPKHSPK();
 
 rc::Gen<SPKCKeyPair> P2WSHSPK();
 
-namespace rc
-{
+namespace rc {
 template <>
 struct Arbitrary<CScript> {
     static Gen<CScript> arbitrary()
     {
         return gen::map(gen::arbitrary<std::vector<unsigned char>>(), [](std::vector<unsigned char> script) {
-            return CScript(script);
+            return CScript(script.begin(), script.end());
         });
     };
 };
-} //namespace rc
+} // namespace rc
 #endif

--- a/src/test/gen/script_gen.h
+++ b/src/test/gen/script_gen.h
@@ -1,0 +1,44 @@
+#ifndef BITCOIN_TEST_GEN_SCRIPT_GEN_H
+#define BITCOIN_TEST_GEN_SCRIPT_GEN_H
+
+#include "script/script.h"
+#include "key.h"
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Numeric.h>
+#include <rapidcheck/gen/Container.h>
+#include <rapidcheck/gen/Select.h>
+
+typedef std::pair<CScript, std::vector<CKey>> SPKCKeyPair;
+
+//non witness SPKs
+rc::Gen<SPKCKeyPair> P2PKSPK();
+
+rc::Gen<SPKCKeyPair> P2PKHSPK();
+
+rc::Gen<SPKCKeyPair> MultisigSPK();
+
+/** Generates a non-P2SH/P2WSH spk */
+rc::Gen<SPKCKeyPair> RawSPK();
+
+rc::Gen<SPKCKeyPair> P2SHSPK();
+
+//witness spks
+
+rc::Gen<SPKCKeyPair> P2WPKHSPK();
+
+rc::Gen<SPKCKeyPair> P2WSHSPK();
+
+namespace rc
+{
+template <>
+struct Arbitrary<CScript> {
+    static Gen<CScript> arbitrary()
+    {
+        return gen::map(gen::arbitrary<std::vector<unsigned char>>(), [](std::vector<unsigned char> script) {
+            return CScript(script);
+        });
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/gen/transaction_gen.cpp
+++ b/src/test/gen/transaction_gen.cpp
@@ -1,16 +1,19 @@
-#include "test/gen/transaction_gen.h"
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <test/gen/transaction_gen.h>
 
-#include "test/gen/crypto_gen.h"
-#include "test/gen/script_gen.h"
+#include <test/gen/crypto_gen.h>
+#include <test/gen/script_gen.h>
 
-#include "script/sign.h"
-#include "script/script.h"
-#include "primitives/transaction.h"
-#include "core_io.h"
-#include "keystore.h"
+#include <core_io.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <wallet/wallet.h>
 
-#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/gen/Predicate.h>
 #include <rapidcheck/gen/Select.h>
 
@@ -55,7 +58,7 @@ SpendingInfo sign(const SPKCKeyPair& spk_keys, const CScript& redeemScript = CSc
     const CAmount nValue = 0;
     const CScript& spk = spk_keys.first;
     const std::vector<CKey>& keys = spk_keys.second;
-    CBasicKeyStore store;
+    FillableSigningProvider store;
     for (const auto k : keys) {
         store.AddKey(k);
     }
@@ -102,7 +105,7 @@ rc::Gen<SpendingInfo> SignedP2SHTx()
         const CScript& redeemScript = spk_keys.first;
         const std::vector<CKey>& keys = spk_keys.second;
         //hash the spk
-        const CScript& p2sh = GetScriptForDestination(CScriptID(redeemScript));
+        const CScript& p2sh = GetScriptForDestination(ScriptHash(redeemScript));
         return sign(std::make_pair(p2sh, keys), redeemScript);
     });
 }

--- a/src/test/gen/transaction_gen.cpp
+++ b/src/test/gen/transaction_gen.cpp
@@ -1,0 +1,133 @@
+#include "test/gen/transaction_gen.h"
+
+#include "test/gen/crypto_gen.h"
+#include "test/gen/script_gen.h"
+
+#include "script/sign.h"
+#include "script/script.h"
+#include "primitives/transaction.h"
+#include "core_io.h"
+#include "keystore.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+#include <rapidcheck/gen/Select.h>
+
+CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue = 0)
+{
+    CMutableTransaction txCredit;
+    txCredit.nVersion = 1;
+    txCredit.nLockTime = 0;
+    txCredit.vin.resize(1);
+    txCredit.vout.resize(1);
+    txCredit.vin[0].prevout.SetNull();
+    txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
+    txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txCredit.vout[0].scriptPubKey = scriptPubKey;
+    txCredit.vout[0].nValue = nValue;
+
+    return txCredit;
+}
+
+CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CScriptWitness& scriptWitness, const CMutableTransaction& txCredit)
+{
+    CMutableTransaction txSpend;
+    txSpend.nVersion = 1;
+    txSpend.nLockTime = 0;
+    txSpend.vin.resize(1);
+    txSpend.vin[0].scriptWitness = scriptWitness;
+    txSpend.vin[0].prevout.hash = txCredit.GetHash();
+    txSpend.vin[0].prevout.n = 0;
+    txSpend.vin[0].scriptSig = scriptSig;
+    txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txSpend.vout.resize(1);
+    txSpend.vout[0].scriptPubKey = CScript();
+    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
+
+    return txSpend;
+}
+
+/** Helper function to generate a tx that spends a spk */
+SpendingInfo sign(const SPKCKeyPair& spk_keys, const CScript& redeemScript = CScript())
+{
+    const unsigned int inputIndex = 0;
+    const CAmount nValue = 0;
+    const CScript& spk = spk_keys.first;
+    const std::vector<CKey>& keys = spk_keys.second;
+    CBasicKeyStore store;
+    for (const auto k : keys) {
+        store.AddKey(k);
+    }
+    //add redeem script
+    store.AddCScript(redeemScript);
+    CMutableTransaction creditingTx = BuildCreditingTransaction(spk, nValue);
+    CMutableTransaction spendingTx = BuildSpendingTransaction(CScript(), CScriptWitness(), creditingTx);
+    SignatureData sigdata;
+    MutableTransactionSignatureCreator creator(&spendingTx, inputIndex, 0);
+    const SigningProvider& sp = store;
+    assert(ProduceSignature(sp, creator, spk, sigdata));
+    UpdateInput(spendingTx.vin[0], sigdata);
+    const CTxOut& output = creditingTx.vout[0];
+    const CTransaction finalTx = CTransaction(spendingTx);
+    SpendingInfo tup = std::make_tuple(output, finalTx, inputIndex);
+    return tup;
+}
+
+/** A signed tx that validly spends a P2PKSPK */
+rc::Gen<SpendingInfo> SignedP2PKTx()
+{
+    return rc::gen::map(P2PKSPK(), [](const SPKCKeyPair& spk_key) {
+        return sign(spk_key);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2PKHTx()
+{
+    return rc::gen::map(P2PKHSPK(), [](const SPKCKeyPair& spk_key) {
+        return sign(spk_key);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedMultisigTx()
+{
+    return rc::gen::map(MultisigSPK(), [](const SPKCKeyPair& spk_key) {
+        return sign(spk_key);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2SHTx()
+{
+    return rc::gen::map(RawSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& redeemScript = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        //hash the spk
+        const CScript& p2sh = GetScriptForDestination(CScriptID(redeemScript));
+        return sign(std::make_pair(p2sh, keys), redeemScript);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2WPKHTx()
+{
+    return rc::gen::map(P2WPKHSPK(), [](const SPKCKeyPair& spk_keys) {
+        return sign(spk_keys);
+    });
+}
+
+rc::Gen<SpendingInfo> SignedP2WSHTx()
+{
+    return rc::gen::map(MultisigSPK(), [](const SPKCKeyPair& spk_keys) {
+        const CScript& redeemScript = spk_keys.first;
+        const std::vector<CKey>& keys = spk_keys.second;
+        const CScript p2wsh = GetScriptForWitness(redeemScript);
+        return sign(std::make_pair(p2wsh, keys), redeemScript);
+    });
+}
+
+/** Generates an arbitrary validly signed tx */
+rc::Gen<SpendingInfo> SignedTx()
+{
+    return rc::gen::oneOf(SignedP2PKTx(), SignedP2PKHTx(),
+        SignedMultisigTx(), SignedP2SHTx(), SignedP2WPKHTx(),
+        SignedP2WSHTx());
+}

--- a/src/test/gen/transaction_gen.h
+++ b/src/test/gen/transaction_gen.h
@@ -1,18 +1,22 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #ifndef BITCOIN_TEST_GEN_TRANSACTION_GEN_H
 #define BITCOIN_TEST_GEN_TRANSACTION_GEN_H
 
-#include "test/gen/crypto_gen.h"
-#include "test/gen/script_gen.h"
+#include <test/gen/crypto_gen.h>
+#include <test/gen/script_gen.h>
 
-#include "script/script.h"
-#include "primitives/transaction.h"
-#include "amount.h"
+#include <amount.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
 
-#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/gen/Predicate.h>
 
-typedef std::tuple<const CTxOut, const CTransaction, const int> SpendingInfo;
+using SpendingInfo = std::tuple<const CTxOut, const CTransaction, const int>;
+
 /** A signed tx that validly spends a P2PKSPK and the input index */
 rc::Gen<SpendingInfo> SignedP2PKTx();
 
@@ -34,8 +38,7 @@ rc::Gen<SpendingInfo> SignedP2WSHTx();
 /** Generates a arbitrary validly signed tx */
 rc::Gen<SpendingInfo> SignedTx();
 
-namespace rc
-{
+namespace rc {
 /** Generator for a COutPoint */
 template <>
 struct Arbitrary<COutPoint> {
@@ -120,5 +123,5 @@ struct Arbitrary<CTransactionRef> {
         });
     };
 };
-} //namespace rc
+} // namespace rc
 #endif

--- a/src/test/gen/transaction_gen.h
+++ b/src/test/gen/transaction_gen.h
@@ -1,0 +1,124 @@
+#ifndef BITCOIN_TEST_GEN_TRANSACTION_GEN_H
+#define BITCOIN_TEST_GEN_TRANSACTION_GEN_H
+
+#include "test/gen/crypto_gen.h"
+#include "test/gen/script_gen.h"
+
+#include "script/script.h"
+#include "primitives/transaction.h"
+#include "amount.h"
+
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+#include <rapidcheck/gen/Predicate.h>
+
+typedef std::tuple<const CTxOut, const CTransaction, const int> SpendingInfo;
+/** A signed tx that validly spends a P2PKSPK and the input index */
+rc::Gen<SpendingInfo> SignedP2PKTx();
+
+/** A signed tx that validly spends a P2PKHSPK and the input index */
+rc::Gen<SpendingInfo> SignedP2PKHTx();
+
+/** A signed tx that validly spends a MultisigSPK and the input index */
+rc::Gen<SpendingInfo> SignedMultisigTx();
+
+/** A signed tx that validly spends a P2SHSPK and the input index */
+rc::Gen<SpendingInfo> SignedP2SHTx();
+
+/** A signed tx that validly spends a P2WPKH and the input index */
+rc::Gen<SpendingInfo> SignedP2WPKHTx();
+
+/** A signed tx that validly spends a P2WSH output and the input index */
+rc::Gen<SpendingInfo> SignedP2WSHTx();
+
+/** Generates a arbitrary validly signed tx */
+rc::Gen<SpendingInfo> SignedTx();
+
+namespace rc
+{
+/** Generator for a COutPoint */
+template <>
+struct Arbitrary<COutPoint> {
+    static Gen<COutPoint> arbitrary()
+    {
+        return gen::map(gen::tuple(gen::arbitrary<uint256>(), gen::arbitrary<uint32_t>()), [](std::tuple<uint256, uint32_t> outPointPrimitives) {
+            uint32_t nIn;
+            uint256 nHashIn;
+            std::tie(nHashIn, nIn) = outPointPrimitives;
+            return COutPoint(nHashIn, nIn);
+        });
+    };
+};
+
+/** Generator for a CTxIn */
+template <>
+struct Arbitrary<CTxIn> {
+    static Gen<CTxIn> arbitrary()
+    {
+        return gen::map(gen::tuple(gen::arbitrary<COutPoint>(), gen::arbitrary<CScript>(), gen::arbitrary<uint32_t>()), [](const std::tuple<const COutPoint&, const CScript&, uint32_t>& primitives) {
+            COutPoint outpoint;
+            CScript script;
+            uint32_t sequence;
+            std::tie(outpoint, script, sequence) = primitives;
+            return CTxIn(outpoint, script, sequence);
+        });
+    };
+};
+
+/** Generator for a CAmount */
+template <>
+struct Arbitrary<CAmount> {
+    static Gen<CAmount> arbitrary()
+    {
+        //why doesn't this generator call work? It seems to cause an infinite loop.
+        //return gen::arbitrary<int64_t>();
+        return gen::inRange<int64_t>(std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max());
+    };
+};
+
+/** Generator for CTxOut */
+template <>
+struct Arbitrary<CTxOut> {
+    static Gen<CTxOut> arbitrary()
+    {
+        return gen::map(gen::pair(gen::arbitrary<CAmount>(), gen::arbitrary<CScript>()), [](const std::pair<CAmount, CScript>& primitives) {
+            return CTxOut(primitives.first, primitives.second);
+        });
+    };
+};
+
+/** Generator for a CTransaction */
+template <>
+struct Arbitrary<CTransaction> {
+    static Gen<CTransaction> arbitrary()
+    {
+        return gen::map(gen::tuple(gen::arbitrary<int32_t>(),
+                            gen::nonEmpty<std::vector<CTxIn>>(), gen::nonEmpty<std::vector<CTxOut>>(), gen::arbitrary<uint32_t>()),
+            [](const std::tuple<int32_t, const std::vector<CTxIn>&, const std::vector<CTxOut>&, uint32_t>& primitives) {
+                CMutableTransaction tx;
+                int32_t nVersion;
+                std::vector<CTxIn> vin;
+                std::vector<CTxOut> vout;
+                uint32_t locktime;
+                std::tie(nVersion, vin, vout, locktime) = primitives;
+                tx.nVersion = nVersion;
+                tx.vin = vin;
+                tx.vout = vout;
+                tx.nLockTime = locktime;
+                return CTransaction(tx);
+            });
+    };
+};
+
+/** Generator for a CTransactionRef */
+template <>
+struct Arbitrary<CTransactionRef> {
+    static Gen<CTransactionRef> arbitrary()
+    {
+        return gen::map(gen::arbitrary<CTransaction>(), [](const CTransaction& tx) {
+            return MakeTransactionRef(tx);
+        });
+    };
+};
+} //namespace rc
+#endif

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -14,7 +14,7 @@
 
 
 #include <key_io.h>
-#include "test/gen/crypto_gen.h"
+#include <test/gen/crypto_gen.h>
 
 BOOST_FIXTURE_TEST_SUITE(key_properties, BasicTestingSetup)
 

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -7,13 +7,14 @@
 #include <util/system.h>
 #include <test/setup_common.h>
 #include <vector>
-
 #include <boost/test/unit_test.hpp>
 #include <rapidcheck/boost_test.h>
 #include <rapidcheck/gen/Arbitrary.h>
 #include <rapidcheck/Gen.h>
 
-#include <test/gen/crypto_gen.h>
+
+#include <key_io.h>
+#include "test/gen/crypto_gen.h"
 
 BOOST_FIXTURE_TEST_SUITE(key_properties, BasicTestingSetup)
 
@@ -28,6 +29,14 @@ RC_BOOST_PROP(key_generates_correct_pubkey, (const CKey& key))
 {
     CPubKey pubKey = key.GetPubKey();
     RC_ASSERT(key.VerifyPubKey(pubKey));
+}
+
+/** Serialization symmetry CKey -> CBitcoinSecret -> CKey */
+RC_BOOST_PROP(key_bitcoinsecret_symmetry, (const CKey& key))
+{
+    std::string secret = EncodeSecret(key);
+    CKey decode = DecodeSecret(secret);
+    RC_ASSERT(decode == key);
 }
 
 /** Create a CKey using the 'Set' function must give us the same key */

--- a/src/test/merkleblock_properties.cpp
+++ b/src/test/merkleblock_properties.cpp
@@ -1,14 +1,15 @@
-#include "test/test_bitcoin.h"
+#include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
+#include <rapidcheck/Gen.h>
 #include <rapidcheck/boost_test.h>
 #include <rapidcheck/gen/Arbitrary.h>
-#include <rapidcheck/Gen.h>
 
-#include "merkleblock.h"
-#include "test/gen/merkleblock_gen.h"
+#include <merkleblock.h>
+#include <test/gen/merkleblock_gen.h>
 
 #include <iostream>
+#include <streams.h>
 BOOST_FIXTURE_TEST_SUITE(merkleblock_properties, BasicTestingSetup)
 
 RC_BOOST_PROP(merkleblock_serialization_symmetry, (const CMerkleBlock& mb))

--- a/src/test/merkleblock_properties.cpp
+++ b/src/test/merkleblock_properties.cpp
@@ -1,0 +1,61 @@
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "merkleblock.h"
+#include "test/gen/merkleblock_gen.h"
+
+#include <iostream>
+BOOST_FIXTURE_TEST_SUITE(merkleblock_properties, BasicTestingSetup)
+
+RC_BOOST_PROP(merkleblock_serialization_symmetry, (const CMerkleBlock& mb))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mb;
+    CMerkleBlock mb2;
+    ss >> mb2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << mb;
+    ss1 << mb2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+
+/** Should find all txids we inserted in the merkle block */
+RC_BOOST_PROP(merkle_block_match_symmetry, (std::pair<CMerkleBlock, std::set<uint256>> p))
+{
+    const CMerkleBlock& mb = p.first;
+    const std::set<uint256>& inserted_hashes = p.second;
+    for (unsigned int i = 0; i < mb.vMatchedTxn.size(); i++) {
+        const auto& h = mb.vMatchedTxn[i].second;
+        RC_ASSERT(inserted_hashes.find(h) != inserted_hashes.end());
+    }
+}
+
+RC_BOOST_PROP(partialmerkletree_serialization_symmetry, (const CPartialMerkleTree& tree))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << tree;
+    CPartialMerkleTree tree2;
+    ss >> tree2;
+    CDataStream ss1(SER_NETWORK, PROTOCOL_VERSION);
+    ss << tree;
+    ss1 << tree2;
+    RC_ASSERT(ss.str() == ss1.str());
+}
+
+
+/** Should find all txids we inserted in the PartialMerkleTree */
+RC_BOOST_PROP(partialmerkletree_extract_matches_symmetry, (std::pair<CPartialMerkleTree, std::vector<uint256>> p))
+{
+    CPartialMerkleTree& tree = p.first;
+    const std::vector<uint256>& expectedMatches = p.second;
+    std::vector<uint256> matches;
+    std::vector<unsigned int> indices;
+    tree.ExtractMatches(matches, indices);
+    RC_ASSERT(matches == expectedMatches);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_properties.cpp
+++ b/src/test/script_properties.cpp
@@ -2,13 +2,15 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <rapidcheck/Gen.h>
 #include <rapidcheck/boost_test.h>
 #include <rapidcheck/gen/Arbitrary.h>
-#include <rapidcheck/Gen.h>
 
-#include "script/script.h"
-#include "test/test_bitcoin.h"
-#include "test/gen/script_gen.h"
+#include <script/script.h>
+#include <test/gen/script_gen.h>
+#include <test/setup_common.h>
+
+#include <streams.h>
 
 BOOST_FIXTURE_TEST_SUITE(script_properties, BasicTestingSetup)
 

--- a/src/test/script_properties.cpp
+++ b/src/test/script_properties.cpp
@@ -1,0 +1,26 @@
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+#include "script/script.h"
+#include "test/test_bitcoin.h"
+#include "test/gen/script_gen.h"
+
+BOOST_FIXTURE_TEST_SUITE(script_properties, BasicTestingSetup)
+
+/** Check CScript serialization symmetry */
+RC_BOOST_PROP(cscript_serialization_symmetry, (const CScript& script))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << static_cast<const CScriptBase&>(script);
+    std::vector<unsigned char> deserialized;
+    ss >> deserialized;
+    CScript script2 = CScript(deserialized.begin(), deserialized.end());
+    RC_ASSERT(script == script2);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_properties.cpp
+++ b/src/test/transaction_properties.cpp
@@ -1,23 +1,22 @@
 
-#include "test/gen/transaction_gen.h"
+#include <test/gen/transaction_gen.h>
 
-#include "key.h"
-#include "base58.h"
-#include "script/script.h"
-#include "policy/policy.h"
-#include "primitives/transaction.h"
-#include "uint256.h"
-#include "util.h"
-#include "utilstrencodings.h"
-#include "test/test_bitcoin.h"
-#include "streams.h"
+#include <base58.h>
+#include <key.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <script/script.h>
+#include <streams.h>
 #include <string>
+#include <test/setup_common.h>
+#include <uint256.h>
+#include <util/strencodings.h>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+#include <rapidcheck/Gen.h>
 #include <rapidcheck/boost_test.h>
 #include <rapidcheck/gen/Arbitrary.h>
-#include <rapidcheck/Gen.h>
 
 BOOST_FIXTURE_TEST_SUITE(transaction_properties, BasicTestingSetup)
 /** Helper function to run a SpendingInfo through the interpreter to check

--- a/src/test/transaction_properties.cpp
+++ b/src/test/transaction_properties.cpp
@@ -1,0 +1,116 @@
+
+#include "test/gen/transaction_gen.h"
+
+#include "key.h"
+#include "base58.h"
+#include "script/script.h"
+#include "policy/policy.h"
+#include "primitives/transaction.h"
+#include "uint256.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include "test/test_bitcoin.h"
+#include "streams.h"
+#include <string>
+#include <vector>
+
+#include <boost/test/unit_test.hpp>
+#include <rapidcheck/boost_test.h>
+#include <rapidcheck/gen/Arbitrary.h>
+#include <rapidcheck/Gen.h>
+
+BOOST_FIXTURE_TEST_SUITE(transaction_properties, BasicTestingSetup)
+/** Helper function to run a SpendingInfo through the interpreter to check
+  * validity of the transaction spending a spk */
+bool run(SpendingInfo info)
+{
+    const CTxOut output = std::get<0>(info);
+    const CTransaction tx = std::get<1>(info);
+    const int input_idx = std::get<2>(info);
+    const CTxIn input = tx.vin[input_idx];
+    const CScript scriptSig = input.scriptSig;
+    TransactionSignatureChecker checker(&tx, input_idx, output.nValue);
+    const CScriptWitness wit = input.scriptWitness;
+    //run it through the interpreter
+    bool result = VerifyScript(scriptSig, output.scriptPubKey,
+        &wit, STANDARD_SCRIPT_VERIFY_FLAGS, checker);
+    return result;
+}
+/** Check COutpoint serialization symmetry */
+RC_BOOST_PROP(outpoint_serialization_symmetry, (const COutPoint& outpoint))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << outpoint;
+    COutPoint outpoint2;
+    ss >> outpoint2;
+    RC_ASSERT(outpoint2 == outpoint);
+}
+/** Check CTxIn serialization symmetry */
+RC_BOOST_PROP(ctxin_serialization_symmetry, (const CTxIn& txin))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << txin;
+    CTxIn txin2;
+    ss >> txin2;
+    RC_ASSERT(txin == txin2);
+}
+
+/** Check CTxOut serialization symmetry */
+RC_BOOST_PROP(ctxout_serialization_symmetry, (const CTxOut& txout))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << txout;
+    CTxOut txout2;
+    ss >> txout2;
+    RC_ASSERT(txout == txout2);
+}
+
+/** Check CTransaction serialization symmetry */
+RC_BOOST_PROP(ctransaction_serialization_symmetry, (const CTransaction& tx))
+{
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss << tx;
+    CTransaction tx2(deserialize, ss);
+    RC_ASSERT(tx == tx2);
+}
+
+/** Check that we can spend a p2pk tx that ProduceSignature created */
+RC_BOOST_PROP(spend_p2pk_tx, ())
+{
+    const SpendingInfo& info = *SignedP2PKTx();
+    RC_ASSERT(run(info));
+}
+
+/** Check that we can spend a p2pkh tx that ProduceSignature created */
+RC_BOOST_PROP(spend_p2pkh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2PKHTx();
+    RC_ASSERT(run(info));
+}
+
+/** Check that we can spend a multisig tx that ProduceSignature created */
+RC_BOOST_PROP(spend_multisig_tx, ())
+{
+    const SpendingInfo& info = *SignedMultisigTx();
+    RC_ASSERT(run(info));
+}
+/** Check that we can spend a p2sh tx that ProduceSignature created */
+RC_BOOST_PROP(spend_p2sh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2SHTx();
+    RC_ASSERT(run(info));
+}
+
+RC_BOOST_PROP(spend_p2wpkh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2WPKHTx();
+    RC_ASSERT(run(info));
+}
+
+RC_BOOST_PROP(spend_p2wsh_tx, ())
+{
+    const SpendingInfo& info = *SignedP2WSHTx();
+    RC_ASSERT(run(info));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is the second half of #12775. 

In general property based testing is a great testing idiom for making sure invariants that you believe about your code hold true under a range of "valid" values. 

This PR includes basic properties for  

1. [Keys](https://github.com/bitcoin/bitcoin/blob/adeb5e7b8757c71b25f32d4278fed4218b1d5851/src/test/key_properties.cpp)
2. [Blocks](https://github.com/bitcoin/bitcoin/blob/adeb5e7b8757c71b25f32d4278fed4218b1d5851/src/test/block_properties.cpp)
3. [Bloom Filters](https://github.com/bitcoin/bitcoin/blob/adeb5e7b8757c71b25f32d4278fed4218b1d5851/src/test/bloom_properties.cpp)
4. [Merkleblocks](https://github.com/bitcoin/bitcoin/blob/adeb5e7b8757c71b25f32d4278fed4218b1d5851/src/test/merkleblock_properties.cpp)
5. [Scripts](https://github.com/bitcoin/bitcoin/blob/adeb5e7b8757c71b25f32d4278fed4218b1d5851/src/test/script_properties.cpp)
6. [Transactions](https://github.com/bitcoin/bitcoin/blob/adeb5e7b8757c71b25f32d4278fed4218b1d5851/src/test/transaction_properties.cpp)

Currently rapidcheck is not enabled by default on travis -- work has been done to enable in #14171 there appears to be a memory access violation in one of the environments. 
