### PR TITLE
Trivial: fix comparison of integers of different signs

### DIFF
--- a/src/leveldb/util/logging.cc
+++ b/src/leveldb/util/logging.cc
@@ -52,7 +52,7 @@ bool ConsumeDecimalNumber(Slice* in, uint64_t* val) {
     unsigned char c = (*in)[0];
     if (c >= '0' && c <= '9') {
       ++digits;
-      const int delta = (c - '0');
+      const uint32_t delta = (c - '0');
       static const uint64_t kMaxUint64 = ~static_cast<uint64_t>(0);
       if (v > kMaxUint64/10 ||
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {


### PR DESCRIPTION
Fixes a sign comparison warning during compilation: 

leveldb/util/logging.cc:58:40: warning: comparison of integers of different signs: 'const int' and 'unsigned long long' [-Wsign-compare] (v == kMaxUint64/10 && delta > kMaxUint64%10)) {