### PR TITLE
quit nicely with bitcoin-cli stop; use simple mode

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -12,11 +12,11 @@ Description=Bitcoin daemon
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
+ExecStart=/usr/bin/bitcoind -daemon=0 -conf=/etc/bitcoin/bitcoin.conf -pid=/run/bitcoind/bitcoind.pid
+ExecStop=/usr/bin/bitcoin-cli -conf=/etc/bitcoin/bitcoin.conf stop
 # Creates /run/bitcoind owned by bitcoin
 RuntimeDirectory=bitcoind
 User=bitcoin
-Type=forking
 PIDFile=/run/bitcoind/bitcoind.pid
 Restart=on-failure
 


### PR DESCRIPTION
- stop bitcoind with `bitcoin-cli stop`
(as I Googled around it seem to be the neater way to stop bitcoind)

- Put bitcoind to the foreground - Supervision services like systemd usually prefer daemons to be running in the foreground.

Tested on my production server, Debian 9.5.