### PR TITLE
Remove redundant run time assertions for locks already checked at compile time

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -9,7 +9,6 @@
 
 void CBasicKeyStore::ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey)
 {
-    AssertLockHeld(cs_KeyStore);
     CKeyID key_id = pubkey.GetID();
     // We must actually know about this key already.
     assert(HaveKey(key_id) || mapWatchKeys.count(key_id));

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -444,7 +444,6 @@ static void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash) EXCLUSIV
  */
 static void MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid, CConnman* connman) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    AssertLockHeld(cs_main);
     CNodeState* nodestate = State(nodeid);
     if (!nodestate || !nodestate->fSupportsDesiredCmpctVersion) {
         // Never ask from peers who can't provide witnesses.
@@ -480,7 +479,6 @@ static void MaybeSetPeerAsAnnouncingHeaderAndIDs(NodeId nodeid, CConnman* connma
 
 static bool TipMayBeStale(const Consensus::Params &consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    AssertLockHeld(cs_main);
     if (g_last_tip_update == 0) {
         g_last_tip_update = GetTime();
     }
@@ -833,7 +831,6 @@ void Misbehaving(NodeId pnode, int howmuch, const std::string& message) EXCLUSIV
 // we fully-validated them at some point.
 static bool BlockRequestAllowed(const CBlockIndex* pindex, const Consensus::Params& consensusParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    AssertLockHeld(cs_main);
     if (chainActive.Contains(pindex)) return true;
     return pindex->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != nullptr) &&
         (pindexBestHeader->GetBlockTime() - pindex->GetBlockTime() < STALE_RELAY_AGE_LIMIT) &&
@@ -2927,7 +2924,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
 
 static bool SendRejectsAndCheckIfBanned(CNode* pnode, CConnman* connman, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
-    AssertLockHeld(cs_main);
     CNodeState &state = *State(pnode->GetId());
 
     if (enable_bip61) {
@@ -3081,8 +3077,6 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
 
 void PeerLogicValidation::ConsiderEviction(CNode *pto, int64_t time_in_seconds)
 {
-    AssertLockHeld(cs_main);
-
     CNodeState &state = *State(pto->GetId());
     const CNetMsgMaker msgMaker(pto->GetSendVersion());
 

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -16,8 +16,6 @@ bool SignalsOptInRBF(const CTransaction &tx)
 
 RBFTransactionState IsRBFOptIn(const CTransaction &tx, CTxMemPool &pool)
 {
-    AssertLockHeld(pool.cs);
-
     CTxMemPool::setEntries setAncestors;
 
     // First check the transaction itself.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -387,8 +387,6 @@ static std::string EntryDescriptionString()
 
 static void entryToJSON(UniValue &info, const CTxMemPoolEntry &e) EXCLUSIVE_LOCKS_REQUIRED(::mempool.cs)
 {
-    AssertLockHeld(mempool.cs);
-
     UniValue fees(UniValue::VOBJ);
     fees.pushKV("base", ValueFromAmount(e.GetFee()));
     fees.pushKV("modified", ValueFromAmount(e.GetModifiedFee()));

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -529,7 +529,6 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
 void CTxMemPool::removeConflicts(const CTransaction &tx)
 {
     // Remove transactions which depend on inputs of tx, recursively
-    AssertLockHeld(cs);
     for (const CTxIn &txin : tx.vin) {
         auto it = mapNextTx.find(txin.prevout);
         if (it != mapNextTx.end()) {
@@ -753,8 +752,6 @@ public:
 std::vector<CTxMemPool::indexed_transaction_set::const_iterator> CTxMemPool::GetSortedDepthAndScore() const
 {
     std::vector<indexed_transaction_set::const_iterator> iters;
-    AssertLockHeld(cs);
-
     iters.reserve(mapTx.size());
 
     for (indexed_transaction_set::iterator mi = mapTx.begin(); mi != mapTx.end(); ++mi) {
@@ -915,7 +912,6 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
 }
 
 void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
-    AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);
     for (txiter it : stage) {
         removeUnchecked(it, reason);
@@ -1008,7 +1004,6 @@ CFeeRate CTxMemPool::GetMinFee(size_t sizelimit) const {
 }
 
 void CTxMemPool::trackPackageRemoved(const CFeeRate& rate) {
-    AssertLockHeld(cs);
     if (rate.GetFeePerK() > rollingMinimumFeeRate) {
         rollingMinimumFeeRate = rate.GetFeePerK();
         blockSinceLastRollingFeeBump = false;


### PR DESCRIPTION
Remove redundant run time assertions (`AssertLockHeld(foo)`) for locks already checked at compile time (`EXCLUSIVE_LOCKS_REQUIRED(foo)`, `-Wthread-safety`).

The redundancy can be verified by checking that the function that contains the removed run time assertion has the corresponding compile time check.

The relevant compile time checks can be listed using:

```
git grep -E -A3 '(ImplicitlyLearnRelatedKeyScripts|MaybeSetPeerAsAnnouncingHeaderAndIDs|TipMayBeStale|BlockRequestAllowed|SendRejectsAndCheckIfBanned|ConsiderEviction|IsRBFOptIn|entryToJSON|removeForReorg|GetSortedDepthAndScore|RemoveStaged|trackPackageRemoved|CheckFinalTx|TestLockPointValidity|IsCurrentForFeeEstimation|UpdateMempoolForReorg|CheckInputsFromMempoolAndCache|AcceptToMemoryPoolWorker|CheckForkWarningConditions|CheckForkWarningConditionsOnNewFork|CheckInputs|GetBlockScriptFlags|ConnectBlock|ActivateBestChainStep|InvalidateBlock|ResetBlockFailureFlags|AddToBlockIndex|AcceptBlockHeader|AcceptBlock|TestBlockValidity|InsertBlockIndex|GenerateNewKey|AddKeyPubKeyWithDB|LoadKeyMetadata|LoadScriptMetadata|UpdateTimeFirstKey|RemoveWatchOnly|HasWalletSpend|IncOrderPosNext|AvailableCoins|ListCoins|SignTransaction|ZapSelectTx|KeypoolCountExternalKeys|LoadKeyPool|GetAddressGroupings|MarkReserveKeysAsUsed|LockCoin|UnlockCoin|UnlockAllCoins|IsLockedCoin|ListLockedCoins)' | grep -B3 EXCLUSIVE_LOCKS_REQUIRED
```