### PR TITLE
qt: Fix QCompleter popup regression

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -536,6 +536,7 @@ bool RPCConsole::eventFilter(QObject* obj, QEvent *event)
             // forward these events to lineEdit
             if(obj == autoCompleter->popup()) {
                 QApplication::postEvent(ui->lineEdit, new QKeyEvent(*keyevt));
+                autoCompleter->popup()->hide();
                 return true;
             }
             break;


### PR DESCRIPTION
The PR #8129 has introduced a regression with the `QCompleter` popup in the Debug window.

How to reproduce:

1.  open the Debug window;
2.  go to the 'Console' tab;
3.  start writing some RPC command and try to pick it from the list using arrow keys, press Enter.

Note that the popup used to display completions is not being closed. To close it they should mouse click somewhere outside of the popup.

The wrong behaviour of the `QCompleter` popup is observed on Linux Mint 19 and Windows 10.
This PR fixes this regression.

Refs:

- #7613
- #7772
- #8129