### PR TITLE
refactor: make checkqueue manage the threads by itself (also removed some boost dependencies)

### DIFF
--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -37,10 +37,7 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
         void swap(PrevectorJob& x){p.swap(x.p);};
     };
     CCheckQueue<PrevectorJob> queue {QUEUE_BATCH_SIZE};
-    boost::thread_group tg;
-    for (auto x = 0; x < std::max(MIN_CORES, GetNumCores()); ++x) {
-       tg.create_thread([&]{queue.Thread();});
-    }
+    queue.Start(std::max(MIN_CORES, GetNumCores()));
     while (state.KeepRunning()) {
         // Make insecure_rand here so that each iteration is identical.
         FastRandomContext insecure_rand(true);
@@ -57,6 +54,6 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
         control.Wait();
     }
     queue.Interrupt();
-    tg.join_all();
+    queue.Stop();
 }
 BENCHMARK(CCheckQueueSpeedPrevectorJob, 1400);

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -56,7 +56,7 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
         // it is done explicitly here for clarity
         control.Wait();
     }
-    tg.interrupt_all();
+    queue.Interrupt();
     tg.join_all();
 }
 BENCHMARK(CCheckQueueSpeedPrevectorJob, 1400);

--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -10,9 +10,6 @@
 #include <algorithm>
 #include <vector>
 
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/mutex.hpp>
-
 template <typename T>
 class CCheckQueueControl;
 
@@ -31,51 +28,51 @@ class CCheckQueue
 {
 private:
     //! Mutex to protect the inner state
-    boost::mutex mutex;
+    Mutex mutex;
 
     //! Worker threads block on this when out of work
-    boost::condition_variable condWorker;
+    std::condition_variable condWorker;
 
     //! Master thread blocks on this when out of work
-    boost::condition_variable condMaster;
+    std::condition_variable condMaster;
 
     //! The queue of elements to be processed.
     //! As the order of booleans doesn't matter, it is used as a LIFO (stack)
-    std::vector<T> queue;
+    std::vector<T> queue GUARDED_BY(mutex);
 
     //! The number of workers (including the master) that are idle.
-    int nIdle;
+    int nIdle GUARDED_BY(mutex) = 0;
 
     //! The total number of workers (including the master).
-    int nTotal;
+    int nTotal GUARDED_BY(mutex) = 0;
 
     //! The temporary evaluation result.
-    bool fAllOk;
+    bool fAllOk GUARDED_BY(mutex) = true;
 
     //! The interrupt flag.
-    bool interrupted;
+    bool interrupted GUARDED_BY(mutex) = false;
 
     /**
      * Number of verifications that haven't completed yet.
      * This includes elements that are no longer queued, but still in the
      * worker's own batches.
      */
-    unsigned int nTodo;
+    unsigned int nTodo GUARDED_BY(mutex) = 0;
 
     //! The maximum number of elements to be processed in one batch
-    unsigned int nBatchSize;
+    const unsigned int nBatchSize;
 
     /** Internal function that does bulk of the verification work. */
-    bool Loop(bool fMaster = false)
+    bool Loop(const bool fMaster = false)
     {
-        boost::condition_variable& cond = fMaster ? condMaster : condWorker;
+        std::condition_variable& cond = fMaster ? condMaster : condWorker;
         std::vector<T> vChecks;
         vChecks.reserve(nBatchSize);
         unsigned int nNow = 0;
         bool fOk = true;
         do {
             {
-                boost::unique_lock<boost::mutex> lock(mutex);
+                WAIT_LOCK(mutex, lock);
                 // first do the clean-up of the previous loop run (allowing us to do it in the same critsect)
                 if (nNow) {
                     fAllOk &= fOk;
@@ -131,10 +128,10 @@ private:
 
 public:
     //! Mutex to ensure only one concurrent CCheckQueueControl
-    boost::mutex ControlMutex;
+    Mutex ControlMutex;
 
     //! Create a new check queue
-    explicit CCheckQueue(unsigned int nBatchSizeIn) : nIdle(0), nTotal(0), fAllOk(true), nTodo(0), nBatchSize(nBatchSizeIn) {}
+    explicit CCheckQueue(unsigned int nBatchSizeIn) : nBatchSize(nBatchSizeIn) {}
 
     //! Worker thread
     void Thread()
@@ -151,7 +148,7 @@ public:
     //! Add a batch of checks to the queue
     void Add(std::vector<T>& vChecks)
     {
-        boost::unique_lock<boost::mutex> lock(mutex);
+        LOCK(mutex);
         for (T& check : vChecks) {
             queue.push_back(T());
             check.swap(queue.back());
@@ -166,8 +163,7 @@ public:
     void Interrupt()
     {
         {
-            boost::unique_lock<boost::mutex>(ControlMutex);
-            boost::unique_lock<boost::mutex>(mutex);
+            LOCK2(ControlMutex, mutex);
             interrupted = true;
         }
         condWorker.notify_all();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1273,7 +1273,6 @@ bool AppInitMain(InitInterfaces& interfaces)
     InitSignatureCache();
     InitScriptExecutionCache();
 
-    LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
     StartScriptCheck();
 
     // Start the lightweight task scheduler thread

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -178,6 +178,7 @@ static CScheduler scheduler;
 
 void Interrupt()
 {
+    InterruptScriptCheck();
     InterruptHTTPServer();
     InterruptHTTPRPC();
     InterruptRPC();
@@ -206,6 +207,7 @@ void Shutdown(InitInterfaces& interfaces)
     RenameThread("bitcoin-shutoff");
     mempool.AddTransactionsUpdated(1);
 
+    StopScriptCheck();
     StopHTTPRPC();
     StopREST();
     StopRPC();
@@ -1272,10 +1274,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     InitScriptExecutionCache();
 
     LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
-    if (nScriptCheckThreads) {
-        for (int i=0; i<nScriptCheckThreads-1; i++)
-            threadGroup.create_thread(&ThreadScriptCheck);
-    }
+    StartScriptCheck();
 
     // Start the lightweight task scheduler thread
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -170,7 +170,7 @@ static void Correct_Queue_range(std::vector<size_t> range)
             BOOST_TEST_MESSAGE("Failure on trial " << i << " expected, got " << FakeCheckCheckCompletion::n_calls);
         }
     }
-    tg.interrupt_all();
+    small_queue->Interrupt();
     tg.join_all();
 }
 
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Catches_Failure)
             BOOST_REQUIRE(success);
         }
     }
-    tg.interrupt_all();
+    fail_queue->Interrupt();
     tg.join_all();
 }
 // Test that a block validation which fails does not interfere with
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Recovers_From_Failure)
             BOOST_REQUIRE(r != end_fails);
         }
     }
-    tg.interrupt_all();
+    fail_queue->Interrupt();
     tg.join_all();
 }
 
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_UniqueCheck)
     for (size_t i = 0; i < COUNT; ++i)
         r = r && UniqueCheck::results.count(i) == 1;
     BOOST_REQUIRE(r);
-    tg.interrupt_all();
+    queue->Interrupt();
     tg.join_all();
 }
 
@@ -333,7 +333,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Memory)
         }
         BOOST_REQUIRE_EQUAL(MemoryCheck::fake_allocated_memory, 0U);
     }
-    tg.interrupt_all();
+    queue->Interrupt();
     tg.join_all();
 }
 
@@ -376,7 +376,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_FrozenCleanup)
     FrozenCleanupCheck::cv.notify_one();
     // Wait for control to finish
     t0.join();
-    tg.interrupt_all();
+    queue->Interrupt();
     tg.join_all();
     BOOST_REQUIRE(!fails);
 }

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -149,10 +149,7 @@ typedef CCheckQueue<FrozenCleanupCheck> FrozenCleanup_Queue;
 static void Correct_Queue_range(std::vector<size_t> range)
 {
     auto small_queue = MakeUnique<Correct_Queue>(QUEUE_BATCH_SIZE);
-    boost::thread_group tg;
-    for (auto x = 0; x < nScriptCheckThreads; ++x) {
-       tg.create_thread([&]{small_queue->Thread();});
-    }
+    small_queue->Start(nScriptCheckThreads);
     // Make vChecks here to save on malloc (this test can be slow...)
     std::vector<FakeCheckCheckCompletion> vChecks;
     for (const size_t i : range) {
@@ -171,7 +168,7 @@ static void Correct_Queue_range(std::vector<size_t> range)
         }
     }
     small_queue->Interrupt();
-    tg.join_all();
+    small_queue->Stop();
 }
 
 /** Test that 0 checks is correct
@@ -215,10 +212,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Catches_Failure)
 {
     auto fail_queue = MakeUnique<Failing_Queue>(QUEUE_BATCH_SIZE);
 
-    boost::thread_group tg;
-    for (auto x = 0; x < nScriptCheckThreads; ++x) {
-       tg.create_thread([&]{fail_queue->Thread();});
-    }
+    fail_queue->Start(nScriptCheckThreads);
 
     for (size_t i = 0; i < 1001; ++i) {
         CCheckQueueControl<FailingCheck> control(fail_queue.get());
@@ -240,17 +234,14 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Catches_Failure)
         }
     }
     fail_queue->Interrupt();
-    tg.join_all();
+    fail_queue->Stop();
 }
 // Test that a block validation which fails does not interfere with
 // future blocks, ie, the bad state is cleared.
 BOOST_AUTO_TEST_CASE(test_CheckQueue_Recovers_From_Failure)
 {
     auto fail_queue = MakeUnique<Failing_Queue>(QUEUE_BATCH_SIZE);
-    boost::thread_group tg;
-    for (auto x = 0; x < nScriptCheckThreads; ++x) {
-       tg.create_thread([&]{fail_queue->Thread();});
-    }
+    fail_queue->Start(nScriptCheckThreads);
 
     for (auto times = 0; times < 10; ++times) {
         for (const bool end_fails : {true, false}) {
@@ -266,7 +257,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Recovers_From_Failure)
         }
     }
     fail_queue->Interrupt();
-    tg.join_all();
+    fail_queue->Stop();
 }
 
 // Test that unique checks are actually all called individually, rather than
@@ -275,11 +266,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Recovers_From_Failure)
 BOOST_AUTO_TEST_CASE(test_CheckQueue_UniqueCheck)
 {
     auto queue = MakeUnique<Unique_Queue>(QUEUE_BATCH_SIZE);
-    boost::thread_group tg;
-    for (auto x = 0; x < nScriptCheckThreads; ++x) {
-       tg.create_thread([&]{queue->Thread();});
-
-    }
+    queue->Start(nScriptCheckThreads);
 
     size_t COUNT = 100000;
     size_t total = COUNT;
@@ -299,7 +286,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_UniqueCheck)
         r = r && UniqueCheck::results.count(i) == 1;
     BOOST_REQUIRE(r);
     queue->Interrupt();
-    tg.join_all();
+    queue->Stop();
 }
 
 
@@ -311,10 +298,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_UniqueCheck)
 BOOST_AUTO_TEST_CASE(test_CheckQueue_Memory)
 {
     auto queue = MakeUnique<Memory_Queue>(QUEUE_BATCH_SIZE);
-    boost::thread_group tg;
-    for (auto x = 0; x < nScriptCheckThreads; ++x) {
-       tg.create_thread([&]{queue->Thread();});
-    }
+    queue->Start(nScriptCheckThreads);
     for (size_t i = 0; i < 1000; ++i) {
         size_t total = i;
         {
@@ -334,7 +318,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Memory)
         BOOST_REQUIRE_EQUAL(MemoryCheck::fake_allocated_memory, 0U);
     }
     queue->Interrupt();
-    tg.join_all();
+    queue->Stop();
 }
 
 // Test that a new verification cannot occur until all checks
@@ -342,11 +326,8 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_Memory)
 BOOST_AUTO_TEST_CASE(test_CheckQueue_FrozenCleanup)
 {
     auto queue = MakeUnique<FrozenCleanup_Queue>(QUEUE_BATCH_SIZE);
-    boost::thread_group tg;
+    queue->Start(nScriptCheckThreads);
     bool fails = false;
-    for (auto x = 0; x < nScriptCheckThreads; ++x) {
-        tg.create_thread([&]{queue->Thread();});
-    }
     std::thread t0([&]() {
         CCheckQueueControl<FrozenCleanupCheck> control(queue.get());
         std::vector<FrozenCleanupCheck> vChecks(1);
@@ -377,7 +358,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_FrozenCleanup)
     // Wait for control to finish
     t0.join();
     queue->Interrupt();
-    tg.join_all();
+    queue->Stop();
     BOOST_REQUIRE(!fails);
 }
 
@@ -441,6 +422,26 @@ BOOST_AUTO_TEST_CASE(test_CheckQueueControl_Locks)
         }
         tg.join_all();
     }
+}
+
+BOOST_AUTO_TEST_CASE(test_CheckQueue_threads_count)
+{
+    CCheckQueue<FakeCheck> queue(QUEUE_BATCH_SIZE);
+
+    // Test for positive number
+    queue.Start(GetNumCores());
+    queue.Interrupt();
+    queue.Stop();
+
+    // Test for zero
+    queue.Start(0);
+    queue.Interrupt();
+    queue.Stop();
+
+    // Test for negtive value
+    queue.Start(-5);
+    queue.Interrupt();
+    queue.Stop();
 }
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -91,15 +91,15 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
     }
 
     nScriptCheckThreads = 3;
-    for (int i = 0; i < nScriptCheckThreads - 1; i++)
-        threadGroup.create_thread(&ThreadScriptCheck);
-
+    StartScriptCheck();
     g_banman = MakeUnique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     g_connman = MakeUnique<CConnman>(0x1337, 0x1337); // Deterministic randomness for tests.
 }
 
 TestingSetup::~TestingSetup()
 {
+    InterruptScriptCheck();
+    StopScriptCheck();
     threadGroup.interrupt_all();
     threadGroup.join_all();
     GetMainSignals().FlushBackgroundCallbacks();

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -462,14 +462,10 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
 
     // check all inputs concurrently, with the cache
     PrecomputedTransactionData txdata(tx);
-    boost::thread_group threadGroup;
     CCheckQueue<CScriptCheck> scriptcheckqueue(128);
     {
         CCheckQueueControl<CScriptCheck> control(&scriptcheckqueue);
-
-        for (int i = 0; i < 20; i++)
-            threadGroup.create_thread(std::bind(&CCheckQueue<CScriptCheck>::Thread, std::ref(scriptcheckqueue)));
-
+        scriptcheckqueue.Start(20);
         std::vector<Coin> coins;
         for (uint32_t i = 0; i < mtx.vin.size(); i++) {
             Coin coin;
@@ -493,7 +489,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     }
 
     scriptcheckqueue.Interrupt();
-    threadGroup.join_all();
+    scriptcheckqueue.Stop();
 }
 
 SignatureData CombineSignatures(const CMutableTransaction& input1, const CMutableTransaction& input2, const CTransactionRef tx)

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -464,33 +464,35 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
     PrecomputedTransactionData txdata(tx);
     boost::thread_group threadGroup;
     CCheckQueue<CScriptCheck> scriptcheckqueue(128);
-    CCheckQueueControl<CScriptCheck> control(&scriptcheckqueue);
+    {
+        CCheckQueueControl<CScriptCheck> control(&scriptcheckqueue);
 
-    for (int i=0; i<20; i++)
-        threadGroup.create_thread(std::bind(&CCheckQueue<CScriptCheck>::Thread, std::ref(scriptcheckqueue)));
+        for (int i = 0; i < 20; i++)
+            threadGroup.create_thread(std::bind(&CCheckQueue<CScriptCheck>::Thread, std::ref(scriptcheckqueue)));
 
-    std::vector<Coin> coins;
-    for(uint32_t i = 0; i < mtx.vin.size(); i++) {
-        Coin coin;
-        coin.nHeight = 1;
-        coin.fCoinBase = false;
-        coin.out.nValue = 1000;
-        coin.out.scriptPubKey = scriptPubKey;
-        coins.emplace_back(std::move(coin));
+        std::vector<Coin> coins;
+        for (uint32_t i = 0; i < mtx.vin.size(); i++) {
+            Coin coin;
+            coin.nHeight = 1;
+            coin.fCoinBase = false;
+            coin.out.nValue = 1000;
+            coin.out.scriptPubKey = scriptPubKey;
+            coins.emplace_back(std::move(coin));
+        }
+
+        for (uint32_t i = 0; i < mtx.vin.size(); i++) {
+            std::vector<CScriptCheck> vChecks;
+            CScriptCheck check(coins[tx.vin[i].prevout.n].out, tx, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
+            vChecks.push_back(CScriptCheck());
+            check.swap(vChecks.back());
+            control.Add(vChecks);
+        }
+
+        bool controlCheck = control.Wait();
+        assert(controlCheck);
     }
 
-    for(uint32_t i = 0; i < mtx.vin.size(); i++) {
-        std::vector<CScriptCheck> vChecks;
-        CScriptCheck check(coins[tx.vin[i].prevout.n].out, tx, i, SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_WITNESS, false, &txdata);
-        vChecks.push_back(CScriptCheck());
-        check.swap(vChecks.back());
-        control.Add(vChecks);
-    }
-
-    bool controlCheck = control.Wait();
-    assert(controlCheck);
-
-    threadGroup.interrupt_all();
+    scriptcheckqueue.Interrupt();
     threadGroup.join_all();
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1664,22 +1664,10 @@ static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, CValidationState&
 
 static CCheckQueue<CScriptCheck> scriptcheckqueue(128);
 
-static std::vector<std::thread> g_thread_scriptcheck_workers;
-
-static void ThreadScriptCheck()
-{
-    RenameThread("bitcoin-scriptch");
-    scriptcheckqueue.Thread();
-}
-
 void StartScriptCheck()
 {
     LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
-    if (nScriptCheckThreads) {
-        for (int i = 0; i < nScriptCheckThreads - 1; i++) {
-            g_thread_scriptcheck_workers.emplace_back(ThreadScriptCheck);
-        }
-    }
+    scriptcheckqueue.Start(nScriptCheckThreads - 1, "bitcoin-scriptch");
 }
 
 void InterruptScriptCheck()
@@ -1689,10 +1677,7 @@ void InterruptScriptCheck()
 
 void StopScriptCheck()
 {
-    for (auto& th : g_thread_scriptcheck_workers) {
-        th.join();
-    }
-    g_thread_scriptcheck_workers.clear();
+    scriptcheckqueue.Stop();
 }
 
 // Protected by cs_main

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1664,11 +1664,38 @@ static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, CValidationState&
 
 static CCheckQueue<CScriptCheck> scriptcheckqueue(128);
 
-void ThreadScriptCheck() {
+static std::vector<std::thread> g_thread_scriptcheck_workers;
+
+static void ThreadScriptCheck()
+{
     RenameThread("bitcoin-scriptch");
     scriptcheckqueue.Thread();
 }
 
+void StartScriptCheck()
+{
+    LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
+    if (nScriptCheckThreads) {
+        for (int i = 0; i < nScriptCheckThreads - 1; i++) {
+            g_thread_scriptcheck_workers.emplace_back(ThreadScriptCheck);
+        }
+    }
+}
+
+void InterruptScriptCheck()
+{
+    scriptcheckqueue.Interrupt();
+}
+
+void StopScriptCheck()
+{
+    for (auto& th : g_thread_scriptcheck_workers) {
+        th.join();
+    }
+    g_thread_scriptcheck_workers.clear();
+}
+
+// Protected by cs_main
 VersionBitsCache versionbitscache GUARDED_BY(cs_main);
 
 int32_t ComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params)

--- a/src/validation.h
+++ b/src/validation.h
@@ -257,8 +257,12 @@ bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs
 bool LoadChainTip(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 /** Unload database information */
 void UnloadBlockIndex();
-/** Run an instance of the script checking thread */
-void ThreadScriptCheck();
+/** Start script checking threads */
+void StartScriptCheck();
+/** Interrupt script checking threads */
+void InterruptScriptCheck();
+/** Stop script checking threads */
+void StopScriptCheck();
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -67,7 +67,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/test/unit_test.hpp
     boost/thread.hpp
     boost/thread/condition_variable.hpp
-    boost/thread/mutex.hpp
     boost/thread/thread.hpp
     boost/variant.hpp
     boost/variant/apply_visitor.hpp


### PR DESCRIPTION
This PR removes use of the following object in checkqueue
- `boost::condition_variable`
- `boost::mutex`
- `boost::unique_lock`

Instead of using `boost::thread_group::interrupt_all` to trigger `boost::thread_interrupted` exception, it should call `InterruptScriptCheck()` or `scriptcheckqueue.Interrupt()` to interrupt the checkqueue thread.

Also, it adds three functions:
- `StartScriptCheck()`
- `InterruptScriptCheck()`
- `StopScriptCheck()`

for clearer logic for script check threads.