### PR TITLE
tests: Stop node before removing the notification file

### DIFF
--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -51,12 +51,13 @@ class NotificationsTest(BitcoinTestFramework):
             # directory content should equal the generated transaction hashes
             txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
             assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
+            self.stop_node(1)
             for tx_file in os.listdir(self.walletnotify_dir):
                 os.remove(os.path.join(self.walletnotify_dir, tx_file))
 
             self.log.info("test -walletnotify after rescan")
             # restart node to rescan to force wallet notifications
-            self.restart_node(1)
+            self.start_node(1)
             connect_nodes_bi(self.nodes, 0, 1)
 
             wait_until(lambda: len(os.listdir(self.walletnotify_dir)) == block_count, timeout=10)


### PR DESCRIPTION
Stop node before removing the notification file to make sure the command has been terminated. After then we could removing those files safely and do not receive any permission error. (See #14446)

The permission error is Windows specific, documented in python doc:
>On Windows, attempting to remove a file that is in use causes an exception to be raised

See https://docs.python.org/3/library/os.html#os.remove