### PR TITLE
[doc] getblocktemplate: use SegWit in example

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -362,8 +362,8 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
             "}\n"
 
             "\nExamples:\n"
-            + HelpExampleCli("getblocktemplate", "")
-            + HelpExampleRpc("getblocktemplate", "")
+            + HelpExampleCli("getblocktemplate", "{\"rules\": [\"segwit\"]}")
+            + HelpExampleRpc("getblocktemplate", "{\"rules\": [\"segwit\"]}")
          );
 
     LOCK(cs_main);


### PR DESCRIPTION
Make it less likely for new miners to accidentally mine non-SegWit blocks.

Suggest backport to 0.17 so the docs on bitcoincore.org get updated at the next minor release.