### PR TITLE
serialization: Don't invoke undefined behaviour when doing type punning

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -126,27 +126,31 @@ template<typename Stream> inline uint64_t ser_readdata64(Stream &s)
 }
 inline uint64_t ser_double_to_uint64(double x)
 {
-    union { double x; uint64_t y; } tmp;
-    tmp.x = x;
-    return tmp.y;
+    static_assert(sizeof(uint64_t) == sizeof(double), "Floating-point width assumption");
+    uint64_t y;
+    memcpy(&y, &x, sizeof(y));
+    return y;
 }
 inline uint32_t ser_float_to_uint32(float x)
 {
-    union { float x; uint32_t y; } tmp;
-    tmp.x = x;
-    return tmp.y;
+    static_assert(sizeof(uint32_t) == sizeof(float), "Floating-point width assumption");
+    uint32_t y;
+    memcpy(&y, &x, sizeof(y));
+    return y;
 }
 inline double ser_uint64_to_double(uint64_t y)
 {
-    union { double x; uint64_t y; } tmp;
-    tmp.y = y;
-    return tmp.x;
+    static_assert(sizeof(double) == sizeof(uint64_t), "Floating-point width assumption");
+    double x;
+    memcpy(&x, &y, sizeof(x));
+    return x;
 }
 inline float ser_uint32_to_float(uint32_t y)
 {
-    union { float x; uint32_t y; } tmp;
-    tmp.y = y;
-    return tmp.x;
+    static_assert(sizeof(float) == sizeof(uint32_t), "Floating-point width assumption");
+    float x;
+    memcpy(&x, &y, sizeof(x));
+    return x;
 }
 
 


### PR DESCRIPTION
Don't invoke undefined behaviour when doing type punning.

It is undefined behavior to read a union member with a different type from the one with which it was most recently written. (Even if GCC allows it as non-standard language extension.)

We should not invoke undefined behaviour.

Why should we not invoke undefined behaviour?

A well established result in compiler research is that invoking undefined behaviour means that we allow the compiler to make daemons fly out of our noses.

The causal link between invoking UB and the severe nose problem is called the "nasal daemon" effect in the literature.

Recent studies have shown that invoking undefined behaviour in cryptocurrency projects cause a certain subset of said nasal daemons to emerge: the privkey eating nasal deamons.

The privkey eating nasal deamons are special in that they scan your memory for private keys prior to the nose exit. Once they are outside of your nose they upload these keys to a remote server located in a foreign country (foreign in relation to the nose bearer).

That – ladies and gentlemen – is why we should not invoke undefined behaviour.
