### PR TITLE
Add explicit cast to base58 and bech32 string constants in order to silence GCC warning

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -11,7 +11,7 @@
 #include <string.h>
 
 /** All alphanumeric characters except for "0", "I", "O", and "l" */
-static const char* pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+static const char* pszBase58 = const_cast<char*>("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz");
 static const int8_t mapBase58[256] = {
     -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
     -1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,

--- a/src/bech32.cpp
+++ b/src/bech32.cpp
@@ -10,7 +10,7 @@ namespace
 typedef std::vector<uint8_t> data;
 
 /** The Bech32 character set for encoding. */
-const char* CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+const char* CHARSET = const_cast<char*>("qpzry9x8gf2tvdw0s3jn54khce6mua7l");
 
 /** The Bech32 character set for decoding. */
 const int8_t CHARSET_REV[128] = {


### PR DESCRIPTION
May I also constexprize them in this Pull Request?