### PR TITLE
Allow descriptor imports with importmulti

### DIFF
--- a/doc/release-notes-14491.md
+++ b/doc/release-notes-14491.md
@@ -1,0 +1,5 @@
+Descriptor import support
+---------------------
+
+The `importmulti` RPC now supports importing of addresses from descriptors. A "desc" parameter can be provided instead of the "scriptPubKey" in a request, as well as an optional range for ranged descriptors to specify the start and end of the range to import. More information about
+descriptors can be found [here](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md).


### PR DESCRIPTION
~~Based on #14454 #14565, last two commits only are for review.~~

Best reviewed with `?w=1`

Allows a descriptor to be imported into the wallet using `importmulti` RPC. Start and end of range can be specified for ranged descriptors. The descriptor is implicitly converted to old structures on import.

Also adds a simple test of a P2SH-P2WPKH address being imported as a descriptor. More tests to come, as well as release notes.