### PR TITLE
autoconf: add 'test' alias for 'tests' to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -120,10 +120,15 @@ AC_ARG_ENABLE([upnp-default],
   [use_upnp_default=$enableval],
   [use_upnp_default=no])
 
-AC_ARG_ENABLE(tests,
-    AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
+# This is a simple alias for test_s_ below; note that the default case goes here
+AC_ARG_ENABLE(test,
+    AS_HELP_STRING([--disable-test,]),
     [use_tests=$enableval],
     [use_tests=yes])
+
+AC_ARG_ENABLE(tests,
+    AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
+    [use_tests=$enableval],)
 
 AC_ARG_ENABLE(gui-tests,
     AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),

--- a/configure.ac
+++ b/configure.ac
@@ -120,15 +120,18 @@ AC_ARG_ENABLE([upnp-default],
   [use_upnp_default=$enableval],
   [use_upnp_default=no])
 
-# This is a simple alias for test_s_ below; note that the default case goes here
+# These 4 make up combinations for --without-test(s) and --disable-test(s)
 AC_ARG_ENABLE(test,
     AS_HELP_STRING([--disable-test,]),
     [use_tests=$enableval],
     [use_tests=yes])
-
 AC_ARG_ENABLE(tests,
     AS_HELP_STRING([--disable-tests],[do not compile tests (default is to compile)]),
     [use_tests=$enableval],)
+AC_ARG_WITH(test, AS_HELP_STRING([--without-test,]), [use_tests=$withval],)
+AC_ARG_WITH(tests,
+    AS_HELP_STRING([--without-tests],[alias for --disable-tests]),
+    [use_tests=$withval],)
 
 AC_ARG_ENABLE(gui-tests,
     AS_HELP_STRING([--disable-gui-tests],[do not compile GUI tests (default is to compile if GUI and tests enabled)]),


### PR DESCRIPTION
I often get `--disable-test` and `--disable-tests` mixed up. This PR makes both do the same thing and in addition allows `--without-test[s]` as well (i.e. it adds 3 aliases to the `use_tests` variable in `configure.ac`).

The help output:
```
./configure --help
[...]
  --enable-upnp-default   if UPNP is enabled, turn it on at startup (default
                          is no)
  --disable-test,
  --disable-tests         do not compile tests (default is to compile)
  --disable-gui-tests     do not compile GUI tests (default is to compile if
                          GUI and tests enabled)
[...]
  --with-miniupnpc        enable UPNP (default is yes if libminiupnpc is
                          found)
  --without-test,
  --without-tests         alias for --disable-tests
  --with-rapidcheck       enable RapidCheck property based tests (default is
                          yes if librapidcheck is found)
[...]
```

These commands:
```
./configure
./configure --enable-test
./configure --enable-tests
./configure --with-test
./configure --with-tests
```

all result in
```
  with test     = yes
```

while these:
```
./configure --disable-test
./configure --disable-tests
./configure --without-test
./configure --without-tests
```
give
```
  with test     = no
```

Combining these (e.g. `--enable-tests --without-test`) does not break anything, but some of them take precedence over the others, so the outcome depends on which one you are specifying. There's no reason to ever mix them, so this should not be an issue.