### PR TITLE
build: Warn (don't fail!) on spelling errors

### DIFF
--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -1,6 +1,7 @@
 cas
 hights
 mor
+mut
 objext
 unselect
 useable

--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -9,10 +9,7 @@
 
 export LC_ALL=C
 
-EXIT_CODE=0
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt
 if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/qt/locale/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/"); then
     echo "^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in ${IGNORE_WORDS_FILE}"
-    EXIT_CODE=1
 fi
-exit ${EXIT_CODE}


### PR DESCRIPTION
Revert `codespell` policy change introduced in #14179.

Context: https://github.com/bitcoin/bitcoin/pull/13954#issuecomment-430200183

