### PR TITLE
build: Pin to specific versions of Python packages we install from PyPI in Travis

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -7,4 +7,4 @@
 export LC_ALL=C
 
 travis_retry pip install codespell==1.13.0
-travis_retry pip install flake8
+travis_retry pip install flake8==3.5.0


### PR DESCRIPTION
Pin to specific versions of Python packages we install from PyPI in Travis.

To avoid the possibility of surprise build failures when a new version of a PyPI dependency is released.