### PR TITLE
test: Add linter to make sure single parameter constructors are marked explicit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ cache:
 stages:
   - lint
   - test
+  - extended-lint
 env:
   global:
     - MAKEJOBS=-j3
@@ -84,6 +85,19 @@ jobs:
         - set -o errexit; source .travis/lint_05_before_script.sh
       script:
         - set -o errexit; source .travis/lint_06_script.sh
+
+    - stage: extended-lint
+      name: 'extended lint [runtime >= 60 seconds]'
+      env:
+      cache: false
+      language: python
+      python: '3.5'
+      install:
+        - set -o errexit; source .travis/extended_lint_04_install.sh
+      before_script:
+        - set -o errexit; source .travis/lint_05_before_script.sh
+      script:
+        - set -o errexit; source .travis/extended_lint_06_script.sh
 
     - stage: test
       name: 'ARM  [GOAL: install]  [no unit or functional tests]'

--- a/.travis/extended_lint_04_install.sh
+++ b/.travis/extended_lint_04_install.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+CPPCHECK_VERSION=1.86
+curl -s https://codeload.github.com/danmar/cppcheck/tar.gz/${CPPCHECK_VERSION} | tar -zxf - --directory /tmp/
+(cd /tmp/cppcheck-${CPPCHECK_VERSION}/ && make CFGDIR=/tmp/cppcheck-${CPPCHECK_VERSION}/cfg/ > /dev/null)
+export PATH="$PATH:/tmp/cppcheck-${CPPCHECK_VERSION}/"

--- a/.travis/extended_lint_06_script.sh
+++ b/.travis/extended_lint_06_script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+test/lint/extended-lint-all.sh

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -53,7 +53,7 @@ struct DBHeightKey {
     int height;
 
     DBHeightKey() : height(0) {}
-    DBHeightKey(int height_in) : height(height_in) {}
+    explicit DBHeightKey(int height_in) : height(height_in) {}
 
     template<typename Stream>
     void Serialize(Stream& s) const
@@ -76,7 +76,7 @@ struct DBHeightKey {
 struct DBHashKey {
     uint256 hash;
 
-    DBHashKey(const uint256& hash_in) : hash(hash_in) {}
+    explicit DBHashKey(const uint256& hash_in) : hash(hash_in) {}
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -205,7 +205,7 @@ public:
 class RpcHandlerImpl : public Handler
 {
 public:
-    RpcHandlerImpl(const CRPCCommand& command) : m_command(command), m_wrapped_command(&command)
+    explicit RpcHandlerImpl(const CRPCCommand& command) : m_command(command), m_wrapped_command(&command)
     {
         m_command.actor = [this](const JSONRPCRequest& request, UniValue& result, bool last_handler) {
             if (!m_wrapped_command) return false;

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -221,7 +221,7 @@ struct RPCResults {
 
 struct RPCExamples {
     const std::string m_examples;
-    RPCExamples(
+    explicit RPCExamples(
         std::string examples)
         : m_examples(std::move(examples))
     {

--- a/test/lint/extended-lint-all.sh
+++ b/test/lint/extended-lint-all.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script runs all contrib/devtools/extended-lint-*.sh files, and fails if
+# any exit with a non-zero status code.
+
+# This script is intentionally locale dependent by not setting "export LC_ALL=C"
+# in order to allow for the executed lint scripts to opt in or opt out of locale
+# dependence themselves.
+
+set -u
+
+SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
+LINTALL=$(basename "${BASH_SOURCE[0]}")
+
+for f in "${SCRIPTDIR}"/extended-lint-*.sh; do
+  if [ "$(basename "$f")" != "$LINTALL" ]; then
+    if ! "$f"; then
+      echo "^---- failure generated from $f"
+      exit 1
+    fi
+  fi
+done

--- a/test/lint/extended-lint-cppcheck.sh
+++ b/test/lint/extended-lint-cppcheck.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+
+export LC_ALL=C
+
+ENABLED_CHECKS=(
+    "Class '.*' has a constructor with 1 argument that is not explicit."
+    "Struct '.*' has a constructor with 1 argument that is not explicit."
+)
+
+IGNORED_WARNINGS=(
+    "src/arith_uint256.h:.* Class 'arith_uint256' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint < 256 >' has a constructor with 1 argument that is not explicit."
+    "src/arith_uint256.h:.* Class 'base_uint' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewBacked' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCache' has a constructor with 1 argument that is not explicit."
+    "src/coins.h:.* Class 'CCoinsViewCursor' has a constructor with 1 argument that is not explicit."
+    "src/net.h:.* Class 'CNetMessage' has a constructor with 1 argument that is not explicit."
+    "src/policy/feerate.h:.* Class 'CFeeRate' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'const_reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'iterator' has a constructor with 1 argument that is not explicit."
+    "src/prevector.h:.* Class 'reverse_iterator' has a constructor with 1 argument that is not explicit."
+    "src/primitives/block.h:.* Class 'CBlock' has a constructor with 1 argument that is not explicit."
+    "src/primitives/transaction.h:.* Class 'CTransaction' has a constructor with 1 argument that is not explicit."
+    "src/protocol.h:.* Class 'CMessageHeader' has a constructor with 1 argument that is not explicit."
+    "src/qt/guiutil.h:.* Class 'ItemDelegate' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* Struct 'RPCResults' has a constructor with 1 argument that is not explicit."
+    "src/rpc/util.h:.* style: Struct 'UniValueType' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'AddressDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'ComboDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'ConstPubkeyProvider' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'PKDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'PKHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'RawDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'SHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'WPKHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/descriptor.cpp:.* Class 'WSHDescriptor' has a constructor with 1 argument that is not explicit."
+    "src/script/script.h:.* Class 'CScript' has a constructor with 1 argument that is not explicit."
+    "src/script/standard.h:.* Class 'CScriptID' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < RNGState >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/secure.h:.* Struct 'secure_allocator < unsigned char >' has a constructor with 1 argument that is not explicit."
+    "src/support/allocators/zeroafterfree.h:.* Struct 'zero_after_free_allocator < char >' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'FailingCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'MemoryCheck' has a constructor with 1 argument that is not explicit."
+    "src/test/checkqueue_tests.cpp:.* Struct 'UniqueCheck' has a constructor with 1 argument that is not explicit."
+    "src/wallet/db.h:.* Class 'BerkeleyEnvironment' has a constructor with 1 argument that is not explicit."
+)
+
+if ! command -v cppcheck > /dev/null; then
+    echo "Skipping cppcheck linting since cppcheck is not installed. Install by running \"apt install cppcheck\""
+    exit 0
+fi
+
+function join_array {
+    local IFS="$1"
+    shift
+    echo "$*"
+}
+
+ENABLED_CHECKS_REGEXP=$(join_array "|" "${ENABLED_CHECKS[@]}")
+IGNORED_WARNINGS_REGEXP=$(join_array "|" "${IGNORED_WARNINGS[@]}")
+WARNINGS=$(git ls-files -- "*.cpp" "*.h" ":(exclude)src/leveldb/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/" | \
+    xargs cppcheck --enable=all -j "$(getconf _NPROCESSORS_ONLN)" --language=c++ --std=c++11 --template=gcc -D__cplusplus -DCLIENT_VERSION_BUILD -DCLIENT_VERSION_IS_RELEASE -DCLIENT_VERSION_MAJOR -DCLIENT_VERSION_MINOR -DCLIENT_VERSION_REVISION -DCOPYRIGHT_YEAR -DDEBUG -DHAVE_WORKING_BOOST_SLEEP_FOR -I src/ -q 2>&1 | sort -u | \
+    grep -E "${ENABLED_CHECKS_REGEXP}" | \
+    grep -vE "${IGNORED_WARNINGS_REGEXP}")
+if [[ ${WARNINGS} != "" ]]; then
+    echo "${WARNINGS}"
+    echo
+    echo "Advice not applicable in this specific case? Add an exception by updating"
+    echo "IGNORED_WARNINGS in $0"
+    # Uncomment to enforce the developer note policy "By default, declare single-argument constructors `explicit`"
+    # exit 1
+fi
+exit 0


### PR DESCRIPTION
Make single parameter constructors `explicit` (C++11).

Rationale from the developer notes:

> - By default, declare single-argument constructors `explicit`.
>   - *Rationale*: This is a precaution to avoid unintended conversions that might
>   arise when single-argument constructors are used as implicit conversion
>   functions.
