### PR TITLE
Remove redundancies: redundant forward declaration, redundant namespace, redundant copying, redundant conditionals

### DIFF
--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -52,7 +52,7 @@ static CTxIn MineBlock(const CScript& coinbase_scriptPubKey)
 }
 
 
-static void AssembleBlock(benchmark::State& state)
+static void AssembleBlock(benchmark::State& benchmarkState)
 {
     const std::vector<unsigned char> op_true{OP_TRUE};
     CScriptWitness witness;
@@ -102,13 +102,13 @@ static void AssembleBlock(benchmark::State& state)
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
 
         for (const auto& txr : txs) {
-            CValidationState state;
-            bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
+            CValidationState validationState;
+            bool ret{::AcceptToMemoryPool(::mempool, validationState, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
             assert(ret);
         }
     }
 
-    while (state.KeepRunning()) {
+    while (benchmarkState.KeepRunning()) {
         PrepareBlock(SCRIPT_PUB);
     }
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -37,12 +37,9 @@
 #include <boost/thread/thread.hpp>
 #include <univalue.h>
 
-class CWallet;
 std::vector<std::shared_ptr<CWallet>> GetWallets();
 
 namespace interfaces {
-
-class Wallet;
 
 namespace {
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1271,8 +1271,8 @@ int ScheduleBatchPriority()
 #endif
 }
 
-namespace util {
 #ifdef WIN32
+namespace util {
 WinCmdLineArgs::WinCmdLineArgs()
 {
     wchar_t** wargv = CommandLineToArgvW(GetCommandLineW(), &argc);
@@ -1295,5 +1295,5 @@ std::pair<int, char**> WinCmdLineArgs::get()
 {
     return std::make_pair(argc, argv);
 }
-#endif
 } // namespace util
+#endif

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2836,7 +2836,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
     return results;
 }
 
-void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, UniValue options)
+void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& fee_out, int& change_position, const UniValue& options)
 {
     // Make sure the results are valid at least up to the most recent block
     // the user could have gotten from another RPC command prior to now


### PR DESCRIPTION
* Remove redundant forward declaration
* Remove confusing variable shadowing
* Remove empty namespace
* Remove unnecessary copying: pass large object by `const` reference instead
* ~~Remove redundant condition: `nBytes < 0` is always `true`~~
* ~~Remove redundant condition: `iter < 2` is always `true`~~

Rationale:
* Less is more