### PR TITLE
Avoid triggering undefined behaviour in base_uint<BITS>::bits()

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -176,7 +176,7 @@ unsigned int base_uint<BITS>::bits() const
     for (int pos = WIDTH - 1; pos >= 0; pos--) {
         if (pn[pos]) {
             for (int nbits = 31; nbits > 0; nbits--) {
-                if (pn[pos] & 1 << nbits)
+                if (pn[pos] & 1U << nbits)
                     return 32 * pos + nbits + 1;
             }
             return 32 * pos + 1;


### PR DESCRIPTION
Avoid triggering undefined behaviour in `base_uint<BITS>::bits()`.

`1 << 31` is undefined behaviour in C++11.

Given the reasonable assumption of `sizeof(int) * CHAR_BIT == 32`.