### PR TITLE
doc: Remove explicit storage requirement from README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -3,7 +3,7 @@ Bitcoin Core
 
 Setup
 ---------------------
-Bitcoin Core is the original Bitcoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions (which is currently more than 100 GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
+Bitcoin Core is the original Bitcoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions, which requires a few hundred gigabytes of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
 To download Bitcoin Core, visit [bitcoincore.org](https://bitcoincore.org/en/releases/).
 


### PR DESCRIPTION
Similarly discussed and fixed in the following bitcoin.org issue: https://github.com/bitcoin-dot-org/bitcoin.org/pull/2716

