### PR TITLE
Avoid 1 << 31 (UB) in calculation of SEQUENCE_LOCKTIME_DISABLE_FLAG

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -73,7 +73,7 @@ public:
     /* Below flags apply in the context of BIP 68*/
     /* If this flag set, CTxIn::nSequence is NOT interpreted as a
      * relative lock-time. */
-    static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1 << 31);
+    static const uint32_t SEQUENCE_LOCKTIME_DISABLE_FLAG = (1U << 31);
 
     /* If CTxIn::nSequence encodes a relative lock-time and this flag
      * is set, the relative lock-time has units of 512 seconds,


### PR DESCRIPTION
Avoid `1 << 31` (UB) in calculation of `SEQUENCE_LOCKTIME_DISABLE_FLAG`.

Context: https://github.com/bitcoin/bitcoin/pull/14510#issuecomment-431153707