### PR TITLE
qt: Fix start with the `-min` option

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -487,14 +487,13 @@ void BitcoinApplication::initializeResult(bool success)
         }
 #endif
 
-        // If -min option passed, start window minimized.
-        if(gArgs.GetBoolArg("-min", false))
-        {
-            window->showMinimized();
-        }
-        else
-        {
+        // If -min option passed, start window minimized (iconified) or minimized to tray
+        if (!gArgs.GetBoolArg("-min", false)) {
             window->show();
+        } else if (clientModel->getOptionsModel()->getMinimizeToTray() && window->hasTrayIcon()) {
+            // do nothing as the window is managed by the tray icon
+        } else {
+            window->showMinimized();
         }
         Q_EMIT splashFinished(window);
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -82,6 +82,11 @@ public:
 #endif // ENABLE_WALLET
     bool enableWallet = false;
 
+    /** Get the tray icon status.
+        Some systems have not "system tray" or "notification area" available.
+    */
+    bool hasTrayIcon() const { return trayIcon; }
+
 protected:
     void changeEvent(QEvent *e);
     void closeEvent(QCloseEvent *event);


### PR DESCRIPTION
From IRC:

> 2018-10-17T12:36:38  \<Drakon\> The option to minimize to system tray instead of the taskbar ist available, but doesn't have an effect if it is started with the -min option. If I start it via that option, I have to click on the program symbil on the taskbar and then minimize it again in order to get it minimized to system tray.
> 2018-10-17T12:37:28  \<Drakon\> That's annoying.
> 2018-10-17T13:51:19  \<wumpus\> can you open an issue for that please? https://github.com/bitcoin/bitcoin/issues/new
> 2018-10-17T13:53:24  \<wumpus\> (if there isn't one yet-)

This PR fixes this bug.