### PR TITLE
qt, docs: Fix `bitcoin-qt -version` output formatting

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -77,7 +77,7 @@ static bool AppInit(int argc, char* argv[])
 
         if (gArgs.IsArgSet("-version"))
         {
-            strUsage += FormatParagraph(LicenseInfo());
+            strUsage += FormatParagraph(LicenseInfo()) + "\n";
         }
         else
         {

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -23,6 +23,7 @@
 #include <init.h>
 #include <interfaces/node.h>
 #include <util/system.h>
+#include <util/strencodings.h>
 
 #include <stdio.h>
 
@@ -54,9 +55,9 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
     {
         setWindowTitle(tr("About %1").arg(tr(PACKAGE_NAME)));
 
+        std::string licenseInfo = LicenseInfo();
         /// HTML-format the license message from the core
-        QString licenseInfo = QString::fromStdString(LicenseInfo());
-        QString licenseInfoHTML = licenseInfo;
+        QString licenseInfoHTML = QString::fromStdString(LicenseInfo());
         // Make URLs clickable
         QRegExp uri("<(.*)>", Qt::CaseSensitive, QRegExp::RegExp2);
         uri.setMinimal(true); // use non-greedy matching
@@ -66,7 +67,7 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
 
         ui->aboutMessage->setTextFormat(Qt::RichText);
         ui->scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
-        text = version + "\n" + licenseInfo;
+        text = version + "\n" + QString::fromStdString(FormatParagraph(licenseInfo));
         ui->aboutMessage->setText(version + "<br><br>" + licenseInfoHTML);
         ui->aboutMessage->setWordWrap(true);
         ui->helpMessage->setVisible(false);


### PR DESCRIPTION
This PR makes command line output of `bitcoin-qt -version` formatted in the same way as `bitcoind -version` output.

Before:
![screenshot from 2018-10-19 20-16-42](https://user-images.githubusercontent.com/32963518/47233718-434a2a80-d3dc-11e8-90d4-84dd23e8ac3b.png)

After:
![screenshot from 2018-10-19 20-22-09](https://user-images.githubusercontent.com/32963518/47233888-b653a100-d3dc-11e8-9155-000b517a8e7b.png)

