### PR TITLE
Replace fs::relative call with custom GetRelativePath

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,5 +61,5 @@ test_script:
 - ps:  src\bench_bitcoin.exe -evals=1 -scaling=0
 - ps:  python test\util\bitcoin-util-test.py
 - cmd: python test\util\rpcauth-test.py
-- cmd: python test\functional\test_runner.py --force --quiet --combinedlogslen=4000 --exclude wallet_multiwallet
+- cmd: python test\functional\test_runner.py --force --quiet --combinedlogslen=4000
 deploy: off

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1217,6 +1217,25 @@ BOOST_AUTO_TEST_CASE(test_DirIsWritable)
     fs::remove(tmpdirname);
 }
 
+BOOST_AUTO_TEST_CASE(test_GetRelativePath)
+{
+    fs::path base = fs::temp_directory_path();
+    fs::path path;
+
+    BOOST_CHECK_EQUAL(GetRelativePath(path,  base / "foo/bar", "foo/bar"), false);
+    BOOST_CHECK_EQUAL(GetRelativePath(path, "foo/bar", base / "foo/bar"), false);
+    BOOST_CHECK_EQUAL(GetRelativePath(path, base, base / "foo"), false);
+
+    BOOST_CHECK_EQUAL(GetRelativePath(path, base, base), true);
+    BOOST_CHECK_EQUAL(path, "");
+
+    BOOST_CHECK_EQUAL(GetRelativePath(path, base / "bar", base), true);
+    BOOST_CHECK_EQUAL(path, "bar");
+
+    BOOST_CHECK_EQUAL(GetRelativePath(path, base / "foo/bar", base), true);
+    BOOST_CHECK_EQUAL(path, "foo/bar");
+}
+
 BOOST_AUTO_TEST_CASE(test_ToLower)
 {
     BOOST_CHECK_EQUAL(ToLower('@'), '@');

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -187,6 +187,20 @@ bool DirIsWritable(const fs::path& directory)
     return true;
 }
 
+bool GetRelativePath(fs::path& result, const fs::path& path, const fs::path& base)
+{
+    if (!path.is_absolute() || !base.is_absolute()) return false;
+    fs::path relative, parent = path;
+    boost::system::error_code ec;
+    while (!parent.empty() && parent != parent.root_path() && !fs::equivalent(parent, base, ec)) {
+        relative = parent.filename() / relative;
+        parent = parent.parent_path();
+    }
+    if (!fs::equivalent(parent, base, ec)) return false;
+    result = relative;
+    return true;
+}
+
 /**
  * Interpret a string argument as a boolean.
  *

--- a/src/util.h
+++ b/src/util.h
@@ -71,6 +71,13 @@ bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 bool DirIsWritable(const fs::path& directory);
 
+/**
+ * Returns path made relative to base. Does not resolve symlinks or normalizes
+ * paths, therefore boost::filesystem::relative (from version 1.67) is not a
+ * valid replacement.
+ */
+bool GetRelativePath(fs::path& result, const fs::path& path, const fs::path& base);
+
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.
  */

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -20,6 +20,7 @@
 #include <boost/thread.hpp>
 
 namespace {
+
 //! Make sure database has a unique fileid within the environment. If it
 //! doesn't, throw an error. BDB caches do not work properly when more than one
 //! open database has the same fileid (values written to one database may show
@@ -29,25 +30,19 @@ namespace {
 //! (https://docs.oracle.com/cd/E17275_01/html/programmer_reference/program_copy.html),
 //! so bitcoin should never create different databases with the same fileid, but
 //! this error can be triggered if users manually copy database files.
-void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filename, Db& db)
+void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filename, Db& db, BerkeleyFileid& fileid)
 {
     if (env.IsMock()) return;
 
-    u_int8_t fileid[DB_FILE_ID_LEN];
-    int ret = db.get_mpf()->get_fileid(fileid);
+    int ret = db.get_mpf()->get_fileid(fileid.value);
     if (ret != 0) {
         throw std::runtime_error(strprintf("BerkeleyBatch: Can't open database %s (get_fileid failed with %d)", filename, ret));
     }
 
-    for (const auto& item : env.mapDb) {
-        u_int8_t item_fileid[DB_FILE_ID_LEN];
-        if (item.second && item.second->get_mpf()->get_fileid(item_fileid) == 0 &&
-            memcmp(fileid, item_fileid, sizeof(fileid)) == 0) {
-            const char* item_filename = nullptr;
-            item.second->get_dbname(&item_filename, nullptr);
+    for (const auto& item : env.m_fileids) {
+        if (fileid == item.second && &fileid != &item.second) {
             throw std::runtime_error(strprintf("BerkeleyBatch: Can't open database %s (duplicates fileid %s from %s)", filename,
-                HexStr(std::begin(item_fileid), std::end(item_fileid)),
-                item_filename ? item_filename : "(unknown database)"));
+                HexStr(std::begin(item.second.value), std::end(item.second.value)), item.first));
         }
     }
 }
@@ -55,6 +50,11 @@ void CheckUniqueFileid(const BerkeleyEnvironment& env, const std::string& filena
 CCriticalSection cs_db;
 std::map<std::string, BerkeleyEnvironment> g_dbenvs GUARDED_BY(cs_db); //!< Map from directory name to open db environment.
 } // namespace
+
+bool BerkeleyFileid::operator==(const BerkeleyFileid& rhs) const
+{
+    return memcmp(value, &rhs.value, sizeof(value)) == 0;
+}
 
 BerkeleyEnvironment* GetWalletEnv(const fs::path& wallet_path, std::string& database_filename)
 {
@@ -504,7 +504,7 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
             // versions of BDB have an set_lk_exclusive method for this
             // purpose, but the older version we use does not.)
             for (const auto& env : g_dbenvs) {
-                CheckUniqueFileid(env.second, strFilename, *pdb_temp);
+                CheckUniqueFileid(env.second, strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
             }
 
             pdb = pdb_temp.release();
@@ -826,6 +826,10 @@ void BerkeleyDatabase::Flush(bool shutdown)
             LOCK(cs_db);
             g_dbenvs.erase(env->Directory().string());
             env = nullptr;
+        } else {
+            // To avoid accessing a map that has already deconstructed, do not call this when shutdown is true. g_dbenvs.erase would also erase this value.
+            // TODO: get rid of wild pointers
+            env->m_fileids.erase(strFile);
         }
     }
 }

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -18,12 +18,18 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <db_cxx.h>
 
 static const unsigned int DEFAULT_WALLET_DBLOGSIZE = 100;
 static const bool DEFAULT_WALLET_PRIVDB = true;
+
+struct BerkeleyFileid {
+    u_int8_t value[DB_FILE_ID_LEN];
+    bool operator==(const BerkeleyFileid& rhs) const;
+};
 
 class BerkeleyEnvironment
 {
@@ -38,6 +44,7 @@ public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, int> mapFileUseCount;
     std::map<std::string, Db*> mapDb;
+    std::unordered_map<std::string, BerkeleyFileid> m_fileids;
     std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -229,6 +229,10 @@ class MultiWalletTest(BitcoinTestFramework):
         # Fail to load if one wallet is a copy of another
         assert_raises_rpc_error(-1, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
 
+        # Fail to load if one wallet is a copy of another, test this twice to make sure that we don't re-introduce #14304
+        assert_raises_rpc_error(-1, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
+
+
         # Fail to load if wallet file is a symlink
         if os.name != 'nt':
             assert_raises_rpc_error(-4, "Wallet file verification failed: Invalid -wallet path 'w8_symlink'", self.nodes[0].loadwallet, 'w8_symlink')

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -46,9 +46,8 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # create symlink to verify wallet directory path can be referenced
         # through symlink
-        if os.name != 'nt':
-            os.mkdir(wallet_dir('w7'))
-            os.symlink('w7', wallet_dir('w7_symlink'))
+        os.mkdir(wallet_dir('w7'))
+        os.symlink('w7', wallet_dir('w7_symlink'))
 
         # rename wallet.dat to make sure plain wallet file paths (as opposed to
         # directory paths) can be loaded
@@ -69,11 +68,9 @@ class MultiWalletTest(BitcoinTestFramework):
         #   w8         - to verify existing wallet file is loaded correctly
         #   ''         - to verify default wallet file is created correctly
         wallet_names = ['w1', 'w2', 'w3', 'w', 'sub/w5', os.path.join(self.options.tmpdir, 'extern/w6'), 'w7_symlink', 'w8', '']
-        if os.name == 'nt':
-            wallet_names.remove('w7_symlink')
         extra_args = ['-wallet={}'.format(n) for n in wallet_names]
         self.start_node(0, extra_args)
-        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', 'sub/w5', 'w7', 'w7', 'w1', 'w8', 'w']))
+        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', os.path.join('sub', 'w5'), 'w7', 'w7', 'w1', 'w8', 'w']))
 
         assert_equal(set(node.listwallets()), set(wallet_names))
 
@@ -99,9 +96,8 @@ class MultiWalletTest(BitcoinTestFramework):
         self.nodes[0].assert_start_raises_init_error(['-wallet=w8', '-wallet=w8_copy'], exp_stderr, match=ErrorMatch.PARTIAL_REGEX)
 
         # should not initialize if wallet file is a symlink
-        if os.name != 'nt':
-            os.symlink('w8', wallet_dir('w8_symlink'))
-            self.nodes[0].assert_start_raises_init_error(['-wallet=w8_symlink'], 'Error: Invalid -wallet path \'w8_symlink\'\. .*', match=ErrorMatch.FULL_REGEX)
+        os.symlink('w8', wallet_dir('w8_symlink'))
+        self.nodes[0].assert_start_raises_init_error(['-wallet=w8_symlink'], 'Error: Invalid -wallet path \'w8_symlink\'\. .*', match=ErrorMatch.FULL_REGEX)
 
         # should not initialize if the specified walletdir does not exist
         self.nodes[0].assert_start_raises_init_error(['-walletdir=bad'], 'Error: Specified -walletdir "bad" does not exist')
@@ -147,7 +143,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         self.restart_node(0, extra_args)
 
-        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', 'sub/w5', 'w7', 'w7', 'w8_copy', 'w1', 'w8', 'w']))
+        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', os.path.join('sub', 'w5'), 'w7', 'w7', 'w8_copy', 'w1', 'w8', 'w']))
 
         wallets = [wallet(w) for w in wallet_names]
         wallet_bad = wallet("bad")
@@ -234,8 +230,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
 
         # Fail to load if wallet file is a symlink
-        if os.name != 'nt':
-            assert_raises_rpc_error(-4, "Wallet file verification failed: Invalid -wallet path 'w8_symlink'", self.nodes[0].loadwallet, 'w8_symlink')
+        assert_raises_rpc_error(-4, "Wallet file verification failed: Invalid -wallet path 'w8_symlink'", self.nodes[0].loadwallet, 'w8_symlink')
 
         # Fail to load if a directory is specified that doesn't contain a wallet
         os.mkdir(wallet_dir('empty_wallet_dir'))
@@ -291,7 +286,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].listwallets(), ['w1'])
         assert_equal(w1.getwalletinfo()['walletname'], 'w1')
 
-        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', 'sub/w5', 'w7', 'w9', 'w7', 'w8_copy', 'w1', 'w8', 'w']))
+        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', os.path.join('sub', 'w5'), 'w7', 'w9', 'w7', 'w8_copy', 'w1', 'w8', 'w']))
 
         # Test backing up and restoring wallets
         self.log.info("Test wallet backup")

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -70,7 +70,7 @@ class MultiWalletTest(BitcoinTestFramework):
         wallet_names = ['w1', 'w2', 'w3', 'w', 'sub/w5', os.path.join(self.options.tmpdir, 'extern/w6'), 'w7_symlink', 'w8', '']
         extra_args = ['-wallet={}'.format(n) for n in wallet_names]
         self.start_node(0, extra_args)
-        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', os.path.join('sub', 'w5'), 'w7', 'w7', 'w1', 'w8', 'w']))
+        assert_equal(sorted(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), ['', os.path.join('sub', 'w5'), 'w', 'w1', 'w2', 'w3', 'w7', 'w7_symlink', 'w8'])
 
         assert_equal(set(node.listwallets()), set(wallet_names))
 
@@ -143,7 +143,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         self.restart_node(0, extra_args)
 
-        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', os.path.join('sub', 'w5'), 'w7', 'w7', 'w8_copy', 'w1', 'w8', 'w']))
+        assert_equal(sorted(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), ['', os.path.join('sub', 'w5'), 'w', 'w1', 'w2', 'w3', 'w7', 'w7_symlink', 'w8', 'w8_copy'])
 
         wallets = [wallet(w) for w in wallet_names]
         wallet_bad = wallet("bad")
@@ -286,7 +286,7 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].listwallets(), ['w1'])
         assert_equal(w1.getwalletinfo()['walletname'], 'w1')
 
-        assert_equal(set(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), set(['', 'w3', 'w2', os.path.join('sub', 'w5'), 'w7', 'w9', 'w7', 'w8_copy', 'w1', 'w8', 'w']))
+        assert_equal(sorted(map(lambda w: w['name'], self.nodes[0].listwalletdir()['wallets'])), ['', os.path.join('sub', 'w5'), 'w', 'w1', 'w2', 'w3', 'w7', 'w7_symlink', 'w8', 'w8_copy', 'w9'])
 
         # Test backing up and restoring wallets
         self.log.info("Test wallet backup")


### PR DESCRIPTION
The implementation of `fs::relative` resolves symlinks which is not intended
in ListWalletDir. The replacement does what is required, and `listwalletdir` RPC
tests are fixed accordingly.

Also, `fs::recursive_directory_iterator` iteration is fixed to build with boost 1.47.