### PR TITLE
[WIP] wallet: ensure wallet files are not reused across chains

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -49,6 +49,7 @@ void DummyWalletInit::AddWalletOptions() const
         "-flushwallet",
         "-privdb",
         "-walletrejectlongchains",
+        "-walletcrosschain",
     });
 }
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -39,6 +39,7 @@ const WalletInitInterface& g_wallet_init_interface = WalletInit();
 void WalletInit::AddWalletOptions() const
 {
     gArgs.AddArg("-addresstype", strprintf("What type of addresses to use (\"legacy\", \"p2sh-segwit\", or \"bech32\", default: \"%s\")", FormatOutputType(DEFAULT_ADDRESS_TYPE)), false, OptionsCategory::WALLET);
+    gArgs.AddArg("-walletcrosschain", strprintf("Allow reusing wallet files across chains (default: %u)", DEFAULT_WALLETCROSSCHAIN), false, OptionsCategory::WALLET);
     gArgs.AddArg("-avoidpartialspends", strprintf("Group outputs by address, selecting all or none, instead of selecting on a per-output basis. Privacy is improved as an address is only used once (unless someone sends to it after spending from it), but may result in slightly higher fees as suboptimal coin selection may result due to the added limitation (default: %u)", DEFAULT_AVOIDPARTIALSPENDS), false, OptionsCategory::WALLET);
     gArgs.AddArg("-changetype", "What type of change to use (\"legacy\", \"p2sh-segwit\", or \"bech32\"). Default is same as -addresstype, except when -addresstype=p2sh-segwit a native segwit output is used when sending to a native segwit address)", false, OptionsCategory::WALLET);
     gArgs.AddArg("-disablewallet", "Do not load the wallet and disable wallet RPC calls", false, OptionsCategory::WALLET);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -73,6 +73,7 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
+static const bool DEFAULT_WALLETCROSSCHAIN = false;
 //! -maxtxfee default
 constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{COIN / 10};
 //! Discourage users to set fees higher than this amount (in satoshis) per kB

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -200,6 +200,7 @@ BASE_SCRIPTS = [
     'rpc_help.py',
     'feature_help.py',
     'feature_shutdown.py',
+    'wallet_crosschain.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, \
+    assert_raises_rpc_error, assert_raises_process_error, \
+    connect_nodes, sync_blocks, sync_mempools
+
+
+class WalletCrossChain(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def setup_network(self, split=False):
+        self.setup_nodes()
+        connect_nodes(self.nodes[1], 2)
+
+    def run_test(self):
+        self.log.info("Generating initial blockchains")
+        # Separate blockchain.
+        self.nodes[0].generate(10)
+
+        # Create wallet below allowed height difference (5 blocks).
+        self.nodes[1].generate(5)
+        ok_path = os.path.join(self.nodes[1].datadir, 'ok-wallet')
+        self.nodes[1].createwallet(ok_path)
+        self.nodes[1].unloadwallet(ok_path)
+
+        # Create wallet at allowed height difference (6 blocks).
+        self.nodes[1].generate(1)
+        edge_path = os.path.join(self.nodes[1].datadir, 'edge-wallet')
+        self.nodes[1].createwallet(edge_path)
+        self.nodes[1].unloadwallet(edge_path)
+
+        # Create wallet outside allowed height difference (7 blocks).
+        self.nodes[1].generate(1)
+        not_ok_path = os.path.join(self.nodes[1].datadir, 'not-ok-wallet')
+        self.nodes[1].createwallet(not_ok_path)
+        self.nodes[1].unloadwallet(not_ok_path)
+
+        self.log.info("Loading reorg wallet within allowed height difference")
+        self.nodes[0].loadwallet(ok_path)
+
+        self.log.info("Loading reorg wallet exactly at allowed height difference")
+        self.nodes[0].loadwallet(edge_path)
+
+        self.log.info("Loading reorg wallet outside allowed height difference")
+        assert_raises_rpc_error(-4, 'Wallet loading failed.', self.nodes[0].loadwallet, not_ok_path)
+        self.stop_node(0, expected_stderr='Error: Wallet files should not be reused across chains')
+
+        self.sync_blocks(self.nodes[1:3])
+
+        # Create wallet below allowed height difference (5 blocks).
+        self.nodes[2].generate(5)
+        ok_path = os.path.join(self.nodes[2].datadir, 'ok-wallet')
+        self.nodes[2].createwallet(ok_path)
+        self.nodes[2].unloadwallet(ok_path)
+
+        # Create wallet exactly at allowed height difference (6 blocks).
+        self.nodes[2].generate(1)
+        edge_path = os.path.join(self.nodes[2].datadir, 'edge-wallet')
+        self.nodes[2].createwallet(edge_path)
+        self.nodes[2].unloadwallet(edge_path)
+
+        # Create wallet outside allowed height difference (7 blocks).
+        self.nodes[2].generate(1)
+        not_ok_path = os.path.join(self.nodes[2].datadir, 'not-ok-wallet')
+        self.nodes[2].createwallet(not_ok_path)
+        self.nodes[2].unloadwallet(not_ok_path)
+
+        self.log.info("Loading no-reorg wallet within allowed height difference")
+        self.nodes[1].loadwallet(ok_path)
+
+        self.log.info("Loading no-reorg wallet exactly at allowed height difference")
+        self.nodes[1].loadwallet(edge_path)
+
+        self.log.info("Loading no-reorg wallet outside allowed height difference")
+        self.nodes[1].loadwallet(not_ok_path)
+
+
+if __name__ == '__main__':
+    WalletCrossChain().main()

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -316,7 +316,7 @@ class MultiWalletTest(BitcoinTestFramework):
             assert_equal(rpc.getaddressinfo(addr)['ismine'], True)
 
         # Test .walletlock file is closed
-        self.start_node(1)
+        self.start_node(1, ["-walletcrosschain=1"])
         wallet = os.path.join(self.options.tmpdir, 'my_wallet')
         self.nodes[0].createwallet(wallet)
         assert_raises_rpc_error(-4, "Error initializing wallet database environment", self.nodes[1].loadwallet, wallet)


### PR DESCRIPTION
This implements a proposal in #12805.

I follow the suggestion by @ryanofsky and compare a genesis block hash, extracted from wallet's best block locator, to an `chainActive`'s genesis block hash. If they don't match, the error is reported.