### PR TITLE
[QA] minor p2p_sendheaders fix of height in coinbase

### DIFF
--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -490,7 +490,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Now announce a header that forks the last two blocks
         tip = blocks[0].sha256
-        height -= 1
+        height -= 2
         blocks = []
 
         # Create extra blocks for later


### PR DESCRIPTION
> \# Now announce a header that forks the last two blocks

Doesn't effect any behavior since BIP34 isn't active in regtest for many blocks.