### PR TITLE
qt: Fix wrong unit on hourly progress increase

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -101,7 +101,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
             }
         }
         // show progress increase per hour
-        ui->progressIncreasePerH->setText(QString::number(progressPerHour * 100, 'f', 2)+"%");
+        ui->progressIncreasePerH->setText(QString::number(progressPerHour * 100, 'f', 2)+"%p");
 
         // show expected remaining time
         if(remainingMSecs >= 0) {


### PR DESCRIPTION
The **Progress increase per hour** metric is displayed with the unit **%** (see image). This seems wrong, since a change in percentage should be presented as **percentage points** or **percentage units**. Maybe not a huge problem, but I for one found it confusing when I first saw it. 

I would have preferred to submit a PR changing to **percentage points**, but that would add a translation term. So, In order to keep the change small, I suggest the abbreviation **%p**, which seems to be commonly used ([albeit "non-standard"](https://en.wiktionary.org/wiki/%25p#English)). Everybody knows the **%** symbol, and if they are not familiar with **%p** they can still get the main idea of the metric.

Alternatively,  **pp** can be used. This abbreviation seems to be even more common for English speaking users, but may not be familiar to the rest of the world.

Or should it be added as a new translation term? (Could also be done as the next step)


<img width="956" alt="progress_increase_per_h" src="https://user-images.githubusercontent.com/453092/47361317-e4cdc680-d6d1-11e8-97a4-528d7432322b.png">
