### PR TITLE
Pin flake8 version to earlier version to avoid pyflakes update

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -7,4 +7,4 @@
 export LC_ALL=C
 
 travis_retry pip install codespell==1.13.0
-travis_retry pip install flake8
+travis_retry pip install flake8==3.5.0


### PR DESCRIPTION
pyflakes dep was ratcheted to 2.0 which seems to have broken a lot of the lint checking: https://gitlab.com/pycqa/flake8/commit/527af5c214ef0eccfde3dd58d7ea15e09c483bd3

Also could use a backport to 0.17.