### PR TITLE
Adjust configure so that only bip70 is disabled when protobuf is missing instead of the GUI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -213,7 +213,7 @@ AC_ARG_ENABLE([bip70],
   [AS_HELP_STRING([--disable-bip70],
   [disable BIP70 (payment protocol) support in GUI (enabled by default)])],
   [enable_bip70=$enableval],
-  [enable_bip70=yes])
+  [enable_bip70=auto])
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 
@@ -1088,7 +1088,7 @@ if test x$use_pkgconfig = xyes; then
       PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl not found.)])
       PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
       if test x$enable_bip70 != xno; then
-        BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [BITCOIN_QT_FAIL(libprotobuf not found)])])
+        BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [have_protobuf=no])])
       fi
       if test x$use_qr != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
@@ -1150,7 +1150,7 @@ else
   fi
 
   if test x$enable_bip70 != xno; then
-    BITCOIN_QT_CHECK(AC_CHECK_LIB([protobuf] ,[main],[PROTOBUF_LIBS=-lprotobuf], BITCOIN_QT_FAIL(libprotobuf not found)))
+    BITCOIN_QT_CHECK(AC_CHECK_LIB([protobuf] ,[main],[PROTOBUF_LIBS=-lprotobuf], [have_protobuf=no]))
   fi
   if test x$use_qr != xno; then
     BITCOIN_QT_CHECK([AC_CHECK_LIB([qrencode], [main],[QR_LIBS=-lqrencode], [have_qrencode=no])])
@@ -1229,8 +1229,10 @@ AM_CONDITIONAL([EMBEDDED_UNIVALUE],[test x$need_bundled_univalue = xyes])
 AC_SUBST(UNIVALUE_CFLAGS)
 AC_SUBST(UNIVALUE_LIBS)
 
-if test x$enable_bip70 != xno; then
-BITCOIN_QT_PATH_PROGS([PROTOC], [protoc],$protoc_bin_path)
+
+if test x$have_protobuf != xno &&
+   test x$enable_bip70 != xno; then
+  BITCOIN_QT_PATH_PROGS([PROTOC], [protoc],$protoc_bin_path)
 fi
 
 AC_MSG_CHECKING([whether to build bitcoind])
@@ -1351,12 +1353,20 @@ if test x$bitcoin_enable_qt != xno; then
   fi
 
   AC_MSG_CHECKING([whether to build BIP70 support])
-  if test x$enable_bip70 != xno; then
-    AC_DEFINE([ENABLE_BIP70],[1],[Define if BIP70 support should be compiled in])
-    enable_bip70=yes
-    AC_MSG_RESULT([yes])
+  if test x$have_protobuf = xno; then
+    if test x$enable_bip70 = xyes; then
+      AC_MSG_ERROR(protobuf missing)
+    fi
+    enable_bip70=no
+    AC_MSG_RESULT(no)
   else
-    AC_MSG_RESULT([no])
+    if test x$enable_bip70 != xno; then
+      AC_DEFINE([ENABLE_BIP70],[1],[Define if BIP70 support should be compiled in])
+      enable_bip70=yes
+      AC_MSG_RESULT([yes])
+    else
+      AC_MSG_RESULT([no])
+    fi
   fi
 fi
 


### PR DESCRIPTION
This change ensures that the GUI is still built even if protobuf is missing unless --enable-bip70 is passed to configure. If protobuf is present bip70 support will be compiled in unless --disable-bip70 is passed.