### PR TITLE
qt: Add Window menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -325,9 +325,9 @@ void BitcoinGUI::createActions()
     // initially disable the debug window menu item
     openRPCConsoleAction->setEnabled(false);
 
-    usedSendingAddressesAction = new QAction(platformStyle->TextColorIcon(":/icons/address-book"), tr("&Sending addresses..."), this);
+    usedSendingAddressesAction = new QAction(platformStyle->TextColorIcon(":/icons/address-book"), tr("&Sending addresses"), this);
     usedSendingAddressesAction->setStatusTip(tr("Show the list of used sending addresses and labels"));
-    usedReceivingAddressesAction = new QAction(platformStyle->TextColorIcon(":/icons/address-book"), tr("&Receiving addresses..."), this);
+    usedReceivingAddressesAction = new QAction(platformStyle->TextColorIcon(":/icons/address-book"), tr("&Receiving addresses"), this);
     usedReceivingAddressesAction->setStatusTip(tr("Show the list of used receiving addresses and labels"));
 
     openAction = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Open &URI..."), this);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1275,7 +1275,17 @@ void RPCConsole::showOrHideBanTableIfRequired()
     ui->banHeading->setVisible(visible);
 }
 
+RPCConsole::TabTypes RPCConsole::tabFocus() const
+{
+    return (TabTypes) ui->tabWidget->currentIndex();
+}
+
 void RPCConsole::setTabFocus(enum TabTypes tabType)
 {
     ui->tabWidget->setCurrentIndex(tabType);
+}
+
+QString RPCConsole::tabTitle(TabTypes tab_type) const
+{
+    return ui->tabWidget->tabText(tab_type);
 }

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -65,6 +65,11 @@ public:
         TAB_PEERS = 3
     };
 
+    std::vector<TabTypes> tabs() const { return {TAB_INFO, TAB_CONSOLE, TAB_GRAPH, TAB_PEERS}; }
+
+    TabTypes tabFocus() const;
+    QString tabTitle(TabTypes tab_type) const;
+
 protected:
     virtual bool eventFilter(QObject* obj, QEvent *event);
     void keyPressEvent(QKeyEvent *);


### PR DESCRIPTION
Overall this PR does the following:
 - add top level menu Window
 - add Minimize and Zoom actions to Window menu
 - move Sending/Receiving address to Window
 - remove Help->Debug window
 - add one menu entry for each debug window tab

This removes the access to address book from the File menu.

With wallet support:
<img width="522" alt="screenshot 2018-12-11 at 00 33 05" src="https://user-images.githubusercontent.com/3534524/49770451-5bec0800-fcdc-11e8-91d6-f8f850ead92d.png">

Without wallet support:
<img width="593" alt="screenshot 2018-12-11 at 12 55 21" src="https://user-images.githubusercontent.com/3534524/49802183-19f6ac80-fd44-11e8-9973-36fcfb4f129e.png">

