### PR TITLE
refactor: remove usage of locale dependent std::isspace

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -6,6 +6,7 @@
 
 #include <hash.h>
 #include <uint256.h>
+#include <utilstrencodings.h>
 
 #include <assert.h>
 #include <string.h>
@@ -34,7 +35,7 @@ static const int8_t mapBase58[256] = {
 bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
 {
     // Skip leading spaces.
-    while (*psz && isspace(*psz))
+    while (*psz && IsSpace(*psz))
         psz++;
     // Skip and count leading '1's.
     int zeroes = 0;
@@ -48,7 +49,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
     std::vector<unsigned char> b256(size);
     // Process the characters.
     static_assert(sizeof(mapBase58)/sizeof(mapBase58[0]) == 256, "mapBase58.size() should be 256"); // guarantee not out of range
-    while (*psz && !isspace(*psz)) {
+    while (*psz && !IsSpace(*psz)) {
         // Decode base58 character
         int carry = mapBase58[(uint8_t)*psz];
         if (carry == -1)  // Invalid b58 character
@@ -64,7 +65,7 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch)
         psz++;
     }
     // Skip trailing spaces.
-    while (isspace(*psz))
+    while (IsSpace(*psz))
         psz++;
     if (*psz != 0)
         return false;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -29,7 +29,7 @@ void base_blob<BITS>::SetHex(const char* psz)
     memset(data, 0, sizeof(data));
 
     // skip leading spaces
-    while (isspace(*psz))
+    while (IsSpace(*psz))
         psz++;
 
     // skip 0x

--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -41,7 +41,7 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
     std::string strWhole;
     int64_t nUnits = 0;
     const char* p = pszIn;
-    while (isspace(*p))
+    while (IsSpace(*p))
         p++;
     for (; *p; p++)
     {
@@ -56,14 +56,14 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
             }
             break;
         }
-        if (isspace(*p))
+        if (IsSpace(*p))
             break;
         if (!isdigit(*p))
             return false;
         strWhole.insert(strWhole.end(), *p);
     }
     for (; *p; p++)
-        if (!isspace(*p))
+        if (!IsSpace(*p))
             return false;
     if (strWhole.size() > 10) // guard against 63 bit overflow
         return false;

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -85,7 +85,7 @@ std::vector<unsigned char> ParseHex(const char* psz)
     std::vector<unsigned char> vch;
     while (true)
     {
-        while (isspace(*psz))
+        while (IsSpace(*psz))
             psz++;
         signed char c = HexDigit(*psz++);
         if (c == (signed char)-1)
@@ -266,7 +266,7 @@ static bool ParsePrechecks(const std::string& str)
 {
     if (str.empty()) // No empty string allowed
         return false;
-    if (str.size() >= 1 && (isspace(str[0]) || isspace(str[str.size()-1]))) // No padding allowed
+    if (str.size() >= 1 && (IsSpace(str[0]) || IsSpace(str[str.size()-1]))) // No padding allowed
         return false;
     if (str.size() != strlen(str.c_str())) // No embedded NUL characters allowed
         return false;

--- a/src/utilstrencodings.h
+++ b/src/utilstrencodings.h
@@ -72,6 +72,21 @@ constexpr bool IsDigit(char c)
 }
 
 /**
+ * Tests if the given character is a whitespace character. The whitespace characters
+ * are: space, form-feed ('\f'), newline ('\n'), carriage return ('\r'), horizontal
+ * tab ('\t'), and vertical tab ('\v').
+ *
+ * This function is locale independent. Under the C locale this function gives the
+ * same result as std::isspace.
+ *
+ * @param[in] c     character to test
+ * @return          true if the argument is a whitespace character; otherwise false
+ */
+constexpr inline bool IsSpace(char c) noexcept {
+    return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
+}
+
+/**
  * Convert string to signed 32-bit integer with strict parse error feedback.
  * @returns true if the entire string could be parsed as valid integer,
  *   false if not the entire string could be parsed or when overflow or underflow occurred.

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -2,7 +2,6 @@
 
 export LC_ALL=C
 KNOWN_VIOLATIONS=(
-    "src/base58.cpp:.*isspace"
     "src/bitcoin-tx.cpp.*stoul"
     "src/bitcoin-tx.cpp.*trim_right"
     "src/bitcoin-tx.cpp:.*atoi"
@@ -18,15 +17,12 @@ KNOWN_VIOLATIONS=(
     "src/test/getarg_tests.cpp.*split"
     "src/torcontrol.cpp:.*atoi"
     "src/torcontrol.cpp:.*strtol"
-    "src/uint256.cpp:.*isspace"
     "src/uint256.cpp:.*tolower"
     "src/util.cpp:.*atoi"
     "src/util.cpp:.*fprintf"
     "src/util.cpp:.*tolower"
     "src/utilmoneystr.cpp:.*isdigit"
-    "src/utilmoneystr.cpp:.*isspace"
     "src/utilstrencodings.cpp:.*atoi"
-    "src/utilstrencodings.cpp:.*isspace"
     "src/utilstrencodings.cpp:.*strtol"
     "src/utilstrencodings.cpp:.*strtoll"
     "src/utilstrencodings.cpp:.*strtoul"


### PR DESCRIPTION
Don't rely on locale dependent function `std::isspace` in `base_blob<BITS>::SetHex(...)` (uint256), `DecodeBase58(...)`, `ParseMoney(...)` and `ParseHex(...)`.

Rationale:

```
$ uname -s
Darwin
$ cat poc.cpp
#include <iostream>
#include <locale>

int main(void) {
    setlocale(LC_ALL, "");
    std::cout << std::isspace(133) << ' ' << std::isspace(154) << ' ' << std::isspace(160);
    std::cout << '\n';
}
$ clang++ -o poc poc.cpp
$ ./poc
1 0 1
$ LC_ALL=en_US ./poc
1 0 1
$ LC_ALL=C ./poc
0 0 0
$ LC_ALL=ru_RU.KOI8-R ./poc # an "interesting" locale
0 1 0
```
