### PR TITLE
gui: explicitly disable "Dark Mode" appearance on macOS

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -99,6 +99,9 @@
 
   <key>LSAppNapIsDisabled</key>
     <string>True</string>
+
+  <key>NSRequiresAquaSystemAppearance</key>
+    <string>True</string>
   
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>


### PR DESCRIPTION
Bitcoin Core's gui is pretty broken for a someone using macOS in "Dark Mode"; the biggest issue being lots of white text on a white background, leaving most inputs, the rpc console etc unusable. 

This is likely something we'll have to wait for Qt to fix/support, so it's probably easiest to just disable for now, rather than provide a broken UI; see screenshots below. This issue might not have come up much yet, given the issues with the 0.17.0 dmg.

Apple documentation on "Opting out of Dark Mode" is [here](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_app).
> If you need extra time to work on your app's Dark Mode support, you can temporarily opt out by including the NSRequiresAquaSystemAppearance key (with a value of true) in your app’s Info.plist file. Setting this key to true causes the system to ignore the user's preference and always apply a light appearance to your app.

Related upstream tickets:
* [Qt Applications are not usable under macOS Mojave with dark theme](https://bugreports.qt.io/browse/QTBUG-68850)
* [macOS 10.14 Mojave Support](https://bugreports.qt.io/browse/QTBUG-68891)

Screenshots:
![main](https://user-images.githubusercontent.com/863730/47616668-f8769400-dafa-11e8-9ec5-9f184d8210f8.png)
![pay to](https://user-images.githubusercontent.com/863730/47616670-fad8ee00-dafa-11e8-876f-c656de0e31c4.png)
![qr code - not hilighted](https://user-images.githubusercontent.com/863730/47616671-fdd3de80-dafa-11e8-873f-f7fa3e91c2a0.png)
![qr code](https://user-images.githubusercontent.com/863730/47616672-00363880-dafb-11e8-883c-59a084b18120.png)
