### PR TITLE
qt: Cleanup MacDockIconHandler class

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -92,12 +92,8 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
         windowTitle += tr("Node");
     }
     windowTitle += " " + networkStyle->getTitleAddText();
-#ifndef Q_OS_MAC
     QApplication::setWindowIcon(networkStyle->getTrayAndWindowIcon());
     setWindowIcon(networkStyle->getTrayAndWindowIcon());
-#else
-    MacDockIconHandler::instance()->setIcon(networkStyle->getAppIcon());
-#endif
     setWindowTitle(windowTitle);
 
     rpcConsole = new RPCConsole(node, _platformStyle, 0);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -595,7 +595,7 @@ void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)
 void BitcoinGUI::createTrayIconMenu()
 {
 #ifndef Q_OS_MAC
-    // return if trayIcon is unset (only on non-Mac OSes)
+    // return if trayIcon is unset (only on non-macOSes)
     if (!trayIcon)
         return;
 
@@ -604,15 +604,15 @@ void BitcoinGUI::createTrayIconMenu()
 
     connect(trayIcon, &QSystemTrayIcon::activated, this, &BitcoinGUI::trayIconActivated);
 #else
-    // Note: On Mac, the dock icon is used to provide the tray's functionality.
+    // Note: On macOS, the Dock icon is used to provide the tray's functionality.
     MacDockIconHandler *dockIconHandler = MacDockIconHandler::instance();
-    dockIconHandler->setMainWindow(static_cast<QMainWindow*>(this));
+    connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, this, &BitcoinGUI::macosDockIconActivated);
     trayIconMenu = dockIconHandler->dockMenu();
 #endif
 
-    // Configuration of the tray icon (or dock icon) icon menu
+    // Configuration of the tray icon (or Dock icon) menu
 #ifndef Q_OS_MAC
-    // Note: On Mac, the dock icon's menu already has show / hide action.
+    // Note: On macOS, the Dock icon's menu already has Show / Hide action.
     trayIconMenu->addAction(toggleHideAction);
     trayIconMenu->addSeparator();
 #endif
@@ -626,7 +626,7 @@ void BitcoinGUI::createTrayIconMenu()
         trayIconMenu->addAction(openRPCConsoleAction);
     }
     trayIconMenu->addAction(optionsAction);
-#ifndef Q_OS_MAC // This is built-in on Mac
+#ifndef Q_OS_MAC // This is built-in on macOS
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);
 #endif
@@ -640,6 +640,12 @@ void BitcoinGUI::trayIconActivated(QSystemTrayIcon::ActivationReason reason)
         // Click on system tray icon triggers show/hide of the main window
         toggleHidden();
     }
+}
+#else
+void BitcoinGUI::macosDockIconActivated()
+{
+    show();
+    activateWindow();
 }
 #endif
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -607,7 +607,9 @@ void BitcoinGUI::createTrayIconMenu()
     // Note: On macOS, the Dock icon is used to provide the tray's functionality.
     MacDockIconHandler *dockIconHandler = MacDockIconHandler::instance();
     connect(dockIconHandler, &MacDockIconHandler::dockIconClicked, this, &BitcoinGUI::macosDockIconActivated);
-    trayIconMenu = dockIconHandler->dockMenu();
+
+    trayIconMenu = new QMenu(this);
+    trayIconMenu->setAsDockMenu();
 #endif
 
     // Configuration of the tray icon (or Dock icon) menu

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -260,6 +260,9 @@ public Q_SLOTS:
 #ifndef Q_OS_MAC
     /** Handle tray icon clicked */
     void trayIconActivated(QSystemTrayIcon::ActivationReason reason);
+#else
+    /** Handle macOS Dock icon clicked */
+    void macosDockIconActivated();
 #endif
 
     /** Show window if hidden, unminimize when minimized, rise when obscured or show if hidden and fToggleHidden is true */

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -1,11 +1,10 @@
-// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Copyright (c) 2011-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_QT_MACDOCKICONHANDLER_H
 #define BITCOIN_QT_MACDOCKICONHANDLER_H
 
-#include <QMainWindow>
 #include <QObject>
 
 QT_BEGIN_NAMESPACE
@@ -13,7 +12,7 @@ class QMenu;
 class QWidget;
 QT_END_NAMESPACE
 
-/** Macintosh-specific dock icon handler.
+/** macOS-specific Dock icon handler.
  */
 class MacDockIconHandler : public QObject
 {
@@ -23,10 +22,8 @@ public:
     ~MacDockIconHandler();
 
     QMenu *dockMenu();
-    void setMainWindow(QMainWindow *window);
     static MacDockIconHandler *instance();
     static void cleanup();
-    void handleDockIconClickEvent();
 
 Q_SIGNALS:
     void dockIconClicked();
@@ -36,7 +33,6 @@ private:
 
     QWidget *m_dummyWidget;
     QMenu *m_dockMenu;
-    QMainWindow *mainWindow;
 };
 
 #endif // BITCOIN_QT_MACDOCKICONHANDLER_H

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -9,7 +9,6 @@
 #include <QObject>
 
 QT_BEGIN_NAMESPACE
-class QIcon;
 class QMenu;
 class QWidget;
 QT_END_NAMESPACE
@@ -24,7 +23,6 @@ public:
     ~MacDockIconHandler();
 
     QMenu *dockMenu();
-    void setIcon(const QIcon &icon);
     void setMainWindow(QMainWindow *window);
     static MacDockIconHandler *instance();
     static void cleanup();

--- a/src/qt/macdockiconhandler.h
+++ b/src/qt/macdockiconhandler.h
@@ -7,11 +7,6 @@
 
 #include <QObject>
 
-QT_BEGIN_NAMESPACE
-class QMenu;
-class QWidget;
-QT_END_NAMESPACE
-
 /** macOS-specific Dock icon handler.
  */
 class MacDockIconHandler : public QObject
@@ -19,9 +14,6 @@ class MacDockIconHandler : public QObject
     Q_OBJECT
 
 public:
-    ~MacDockIconHandler();
-
-    QMenu *dockMenu();
     static MacDockIconHandler *instance();
     static void cleanup();
 
@@ -30,9 +22,6 @@ Q_SIGNALS:
 
 private:
     MacDockIconHandler();
-
-    QWidget *m_dummyWidget;
-    QMenu *m_dockMenu;
 };
 
 #endif // BITCOIN_QT_MACDOCKICONHANDLER_H

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -4,9 +4,7 @@
 
 #include "macdockiconhandler.h"
 
-#include <QImageWriter>
 #include <QMenu>
-#include <QBuffer>
 #include <QWidget>
 
 #undef slots
@@ -69,39 +67,6 @@ MacDockIconHandler::~MacDockIconHandler()
 QMenu *MacDockIconHandler::dockMenu()
 {
     return this->m_dockMenu;
-}
-
-void MacDockIconHandler::setIcon(const QIcon &icon)
-{
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    NSImage *image = nil;
-    if (icon.isNull())
-        image = [[NSImage imageNamed:@"NSApplicationIcon"] retain];
-    else {
-        // generate NSImage from QIcon and use this as dock icon.
-        QSize size = icon.actualSize(QSize(128, 128));
-        QPixmap pixmap = icon.pixmap(size);
-
-        // Write image into a R/W buffer from raw pixmap, then save the image.
-        QBuffer notificationBuffer;
-        if (!pixmap.isNull() && notificationBuffer.open(QIODevice::ReadWrite)) {
-            QImageWriter writer(&notificationBuffer, "PNG");
-            if (writer.write(pixmap.toImage())) {
-                NSData* macImgData = [NSData dataWithBytes:notificationBuffer.buffer().data()
-                                             length:notificationBuffer.buffer().size()];
-                image =  [[NSImage alloc] initWithData:macImgData];
-            }
-        }
-
-        if(!image) {
-            // if testnet image could not be created, load std. app icon
-            image = [[NSImage imageNamed:@"NSApplicationIcon"] retain];
-        }
-    }
-
-    [NSApp setApplicationIconImage:image];
-    [image release];
-    [pool release];
 }
 
 MacDockIconHandler *MacDockIconHandler::instance()

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -4,17 +4,13 @@
 
 #include "macdockiconhandler.h"
 
-#include <QMenu>
-#include <QWidget>
-
 #undef slots
-#include <Cocoa/Cocoa.h>
 #include <objc/objc.h>
 #include <objc/message.h>
 
 static MacDockIconHandler *s_instance = nullptr;
 
-bool dockClickHandler(id self,SEL _cmd,...) {
+bool dockClickHandler(id self, SEL _cmd, ...) {
     Q_UNUSED(self)
     Q_UNUSED(_cmd)
 
@@ -32,28 +28,9 @@ void setupDockClickHandler() {
     class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
 
-
 MacDockIconHandler::MacDockIconHandler() : QObject()
 {
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-
     setupDockClickHandler();
-    this->m_dummyWidget = new QWidget();
-    this->m_dockMenu = new QMenu(this->m_dummyWidget);
-#if QT_VERSION >= 0x050200
-    this->m_dockMenu->setAsDockMenu();
-#endif
-    [pool release];
-}
-
-MacDockIconHandler::~MacDockIconHandler()
-{
-    delete this->m_dummyWidget;
-}
-
-QMenu *MacDockIconHandler::dockMenu()
-{
-    return this->m_dockMenu;
 }
 
 MacDockIconHandler *MacDockIconHandler::instance()

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -1,4 +1,4 @@
-// Copyright (c) 2011-2013 The Bitcoin Core developers
+// Copyright (c) 2011-2018 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -18,25 +18,18 @@ bool dockClickHandler(id self,SEL _cmd,...) {
     Q_UNUSED(self)
     Q_UNUSED(_cmd)
 
-    s_instance->handleDockIconClickEvent();
+    Q_EMIT s_instance->dockIconClicked();
 
-    // Return NO (false) to suppress the default OS X actions
+    // Return NO (false) to suppress the default macOS actions
     return false;
 }
 
 void setupDockClickHandler() {
-    Class cls = objc_getClass("NSApplication");
-    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
-
-    if (appInst != nullptr) {
-        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
-        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
-        SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
-        if (class_getInstanceMethod(delClass, shouldHandle))
-            class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
-        else
-            class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
-    }
+    id app = objc_msgSend((id)objc_getClass("NSApplication"), sel_registerName("sharedApplication"));
+    id delegate = objc_msgSend(app, sel_registerName("delegate"));
+    Class delClass = (Class)objc_msgSend(delegate, sel_registerName("class"));
+    SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
+    class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
 }
 
 
@@ -47,21 +40,15 @@ MacDockIconHandler::MacDockIconHandler() : QObject()
     setupDockClickHandler();
     this->m_dummyWidget = new QWidget();
     this->m_dockMenu = new QMenu(this->m_dummyWidget);
-    this->setMainWindow(nullptr);
 #if QT_VERSION >= 0x050200
     this->m_dockMenu->setAsDockMenu();
 #endif
     [pool release];
 }
 
-void MacDockIconHandler::setMainWindow(QMainWindow *window) {
-    this->mainWindow = window;
-}
-
 MacDockIconHandler::~MacDockIconHandler()
 {
     delete this->m_dummyWidget;
-    this->setMainWindow(nullptr);
 }
 
 QMenu *MacDockIconHandler::dockMenu()
@@ -79,15 +66,4 @@ MacDockIconHandler *MacDockIconHandler::instance()
 void MacDockIconHandler::cleanup()
 {
     delete s_instance;
-}
-
-void MacDockIconHandler::handleDockIconClickEvent()
-{
-    if (this->mainWindow)
-    {
-        this->mainWindow->activateWindow();
-        this->mainWindow->show();
-    }
-
-    Q_EMIT this->dockIconClicked();
 }


### PR DESCRIPTION
The Objective-C `MacDockIconHandler` class currently does such jobs on macOS:

1. Set the Dock icon
2. Support the Dock icon menu
3. Handle the Dock icon click event

Qt does the first job natively.
Qt has native support the Dock icon menu only since version 5.2
Qt does not handle `applicationShouldHandleReopen` event. And this brakes all Qt support for the Dock icon click event.

This PR:
- removes Objective-C code for the Dock icon setting. Qt `setWindowIcon()` does this work
- removes Objective-C code for the Dock icon menu. Qt `setAsDockMenu()` does this work
- uses Qt signal for the Dock icon click event
