### PR TITLE
Bugfix: Correctly calculate balances when min_conf is used, and for getbalance("*")

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -48,6 +48,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listreceivedbylabel", 0, "minconf" },
     { "listreceivedbylabel", 1, "include_empty" },
     { "listreceivedbylabel", 2, "include_watchonly" },
+    { "getbalance", 0, "trusted_only" },
     { "getbalance", 1, "minconf" },
     { "getbalance", 2, "include_watchonly" },
     { "getblockhash", 0, "height" },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1874,12 +1874,14 @@ CAmount CWalletTx::GetAvailableCredit(interfaces::Chain::Lock& locked_chain, boo
     CAmount* cache = nullptr;
     bool* cache_used = nullptr;
 
-    if (filter == ISMINE_SPENDABLE) {
-        cache = &nAvailableCreditCached;
-        cache_used = &fAvailableCreditCached;
-    } else if (filter == ISMINE_WATCH_ONLY) {
-        cache = &nAvailableWatchCreditCached;
-        cache_used = &fAvailableWatchCreditCached;
+    if (min_depth == 0) {
+        if (filter == ISMINE_SPENDABLE) {
+            cache = &nAvailableCreditCached;
+            cache_used = &fAvailableCreditCached;
+        } else if (filter == ISMINE_WATCH_ONLY) {
+            cache = &nAvailableWatchCreditCached;
+            cache_used = &fAvailableWatchCreditCached;
+        }
     }
 
     if (fUseCache && cache_used && *cache_used) {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -902,7 +902,7 @@ public:
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(interfaces::Chain::Lock& locked_chain, int64_t nTime, CConnman* connman);
-    CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0) const;
+    CAmount GetBalance(const isminefilter& filter=ISMINE_SPENDABLE, const int min_depth=0, bool trusted_only=true) const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetUnconfirmedWatchOnlyBalance() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -485,7 +485,7 @@ public:
     // annotation "EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwallet->cs_wallet)". The
     // annotation "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid
     // having to resolve the issue of member access into incomplete type CWallet.
-    CAmount GetAvailableCredit(interfaces::Chain::Lock& locked_chain, bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE) const NO_THREAD_SAFETY_ANALYSIS;
+    CAmount GetAvailableCredit(interfaces::Chain::Lock& locked_chain, bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE, int min_depth = 0) const NO_THREAD_SAFETY_ANALYSIS;
     CAmount GetImmatureWatchOnlyCredit(interfaces::Chain::Lock& locked_chain, const bool fUseCache=true) const;
     CAmount GetChange() const;
 
@@ -815,7 +815,7 @@ public:
     bool SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<OutputGroup> groups,
         std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
 
-    bool IsSpent(interfaces::Chain::Lock& locked_chain, const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsSpent(interfaces::Chain::Lock& locked_chain, const uint256& hash, unsigned int n, int min_depth = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, bool single_coin) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -73,8 +73,8 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalance("*", 1, True), 50)
         assert_equal(self.nodes[0].getbalance(minconf=1), 50)
 
-        # first argument of getbalance must be excluded or set to "*"
-        assert_raises_rpc_error(-32, "dummy first argument must be excluded or set to \"*\"", self.nodes[0].getbalance, "")
+        # first argument of getbalance must be trusted_only or set to "*"
+        assert_raises_rpc_error(-32, "accounts no longer supported; set 1st field to trusted_only", self.nodes[0].getbalance, "")
 
         # Check that only first and second nodes have UTXOs
         utxos = self.nodes[0].listunspent()


### PR DESCRIPTION
`getbalance("*")` has always given the final balance ignoring whether the wallet considers coins trusted or not, while `getbalance()` checked the trusted status.

Furthermore, `CWallet::GetBalance` (the trusted-only implementation) did not support setting a `min_conf` parameter. This was added in #13566, but only checked `min_conf` for UTXO creation, not UTXO spending.

This fixes `getbalance` to work correctly in both regards.

It also renames the dummy argument to `trusted_only` and accepts a boolean instead of the fixed string `"*"` to fit more with the no-accounts stuff.

See also: #6276 fixed the first issue in 2015.
