### PR TITLE
Docs: correction to test readme compile instructions

### DIFF
--- a/src/test/README.md
+++ b/src/test/README.md
@@ -6,8 +6,8 @@ and tests weren't explicitly disabled.
 After configuring, they can be run with `make check`.
 
 To run the bitcoind tests manually, launch `src/test/test_bitcoin`. To recompile
-after a test file was modified, run `make` and then run the test again. If you
-modify a non-test file, use `make -C src/test` to recompile only what's needed
+after a non-test file was modified, run `make` and then run the test again. If you
+modify a test file, use `make -C src/test` to recompile only what's needed
 to run the bitcoind tests.
 
 To add more bitcoind tests, add `BOOST_AUTO_TEST_CASE` functions to the existing


### PR DESCRIPTION
I'm pretty sure this wording is just switched, but correct me if I'm wrong. If you have only changed a test file, you can just build the files in the test folder, no need to build the entire source.