### PR TITLE
rpc: Make HTTP RPC debug logging more informative

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -241,7 +241,7 @@ static void http_request_cb(struct evhttp_request* req, void* arg)
     }
 
     LogPrint(BCLog::HTTP, "Received a %s request for %s from %s\n",
-             RequestMethodString(hreq->GetRequestMethod()), SanitizeString(hreq->GetURI()).substr(0, 100), hreq->GetPeer().ToString());
+             RequestMethodString(hreq->GetRequestMethod()), SanitizeString(hreq->GetURI(), SAFE_CHARS_URI).substr(0, 100), hreq->GetPeer().ToString());
 
     // Find registered handler for prefix
     std::string strURI = hreq->GetURI();

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -20,6 +20,7 @@ static const std::string SAFE_CHARS[] =
     CHARS_ALPHA_NUM + " .,;-_/:?@()", // SAFE_CHARS_DEFAULT
     CHARS_ALPHA_NUM + " .,;-_?@", // SAFE_CHARS_UA_COMMENT
     CHARS_ALPHA_NUM + ".-_", // SAFE_CHARS_FILENAME
+    CHARS_ALPHA_NUM + "!*'();:@&=+$,/?#[]-_.~%", // SAFE_CHARS_URI
 };
 
 std::string SanitizeString(const std::string& str, int rule)

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -25,6 +25,7 @@ enum SafeChars
     SAFE_CHARS_DEFAULT, //!< The full set of allowed chars
     SAFE_CHARS_UA_COMMENT, //!< BIP-0014 subset
     SAFE_CHARS_FILENAME, //!< Chars allowed in filenames
+    SAFE_CHARS_URI, //!< Chars allowed in URIs (RFC 3986)
 };
 
 /**


### PR DESCRIPTION
* Make HTTP RPC debug logging more informative
* Avoid excessively large log messages (which could theoretically fill up the disk) when running with debug option `-debug=http`