### PR TITLE
tests: Fix value display name in test_runner help text

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -214,7 +214,7 @@ def main():
                                      epilog='''
     Help text and arguments for individual test script:''',
                                      formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('--combinedlogslen', '-c', type=int, default=0, help='print a combined log (of length n lines) from all test nodes and test framework to the console on failure.')
+    parser.add_argument('--combinedlogslen', '-c', type=int, default=0, metavar='n', help='On failure, print a log (of length n lines) to the console, combined from the test framework and all test nodes.')
     parser.add_argument('--coverage', action='store_true', help='generate a basic coverage report for the RPC interface')
     parser.add_argument('--exclude', '-x', help='specify a comma-separated-list of scripts to exclude.')
     parser.add_argument('--extended', action='store_true', help='run the extended test suite in addition to the basic tests')


### PR DESCRIPTION
The help text given by `test/functional/test_runner.py -h` refers to the value `n`, which is defined as `COMBINEDLOGSLEN` in the list of commands. 

To make the help text consistent, this PR changes the display name `COMBINEDLOGSLEN` to `n` by setting the argparse [`metavar`](https://docs.python.org/3/library/argparse.html#metavar) attribute. (`metavar` only changes the _displayed_ name)
 
Alternatively: Do the opposite and change the help text to use `COMBINEDLOGSLEN`.

---

Before PR: 
```
➜  bitcoin > test/functional/test_runner.py -h | grep -A 1 combinedlogslen
  --combinedlogslen COMBINEDLOGSLEN, -c COMBINEDLOGSLEN
                        print a combined log (of length n lines) from all test nodes and test framework to the console on failure.
```

After PR: 
```
➜  bitcoin > test/functional/test_runner.py -h | grep -A 1 combinedlogslen
  --combinedlogslen n, -c n
                        print a combined log (of length n lines) from all test nodes and test frameworks to the console on failure.
```
---
Also, fixed pluralization typo. 

