### PR TITLE
Make clear function argument case in dev notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -69,7 +69,7 @@ tool to clean up patches automatically before submission.
 - **Symbol naming conventions**. These are preferred in new code, but are not
 required when doing so would need changes to significant pieces of existing
 code.
-  - Variable and namespace names are all lowercase, and may use `_` to
+  - Variable (including function arguments) and namespace names are all lowercase, and may use `_` to
     separate words (snake_case).
     - Class member variables have a `m_` prefix.
     - Global variables have a `g_` prefix.


### PR DESCRIPTION
Rationale:

For new developers, they might be confused if they see that function arguments are sometimes `camelCase`'d in the codebase. This makes it clear that they _should_ be `snake_case`'d (maybe because no one's gotten to fixing them yet).