### PR TITLE
developer-notes: allow lowerCamelCase

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -41,12 +41,13 @@ Coding Style (General)
 ----------------------
 
 Various coding styles have been used during the history of the codebase,
-and the result is not very consistent. However, we're now trying to converge to
-a single style, which is specified below. When writing patches, favor the new
-style over attempting to mimic the surrounding style, except for move-only
-commits.
-
-Do not submit patches solely to modify the style of existing code.
+and the result is not very consistent. The style described in this guide is
+generally preferred in new code and when changing existing code, instead of
+mimicking the surrounding style. But developers should use discretion in
+allowing small differences and in not submitting changes that largely (or
+entirely) consist of style changes. We expect style to gradually converge
+in parts of the codebase that are actively developed, but not to the extent
+that this interferes with other priorities.
 
 Coding Style (C++)
 ------------------

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -71,11 +71,15 @@ required when doing so would need changes to significant pieces of existing
 code.
   - Variable (including function arguments) and namespace names are all lowercase, and may use `_` to
     separate words (snake_case).
-    - Class member variables have a `m_` prefix.
-    - Global variables have a `g_` prefix.
+    - Class member variables have a `m_` prefix, so it's obvious when variable
+      references in the code implicitly access the current class instance.
+    - Global variables have a `g_` prefix, so it's obvious when code is
+      accessing global state.
   - Constant names are all uppercase, and use `_` to separate words.
-  - Class names, function names and method names are UpperCamelCase
-    (PascalCase). Do not prefix class names with `C`.
+  - Type names, standalone function names, and static method names are
+    UpperCamelCase. Instance method names are lowerCamelCase, so it's obvious
+    when function calls in the code implicitly access the current class
+    instance. Class names should not be prefixed with `C`.
   - Test suite naming convention: The Boost test suite in file
     `src/test/foo_tests.cpp` should be named `foo_tests`. Test suite names
     must be unique.


### PR DESCRIPTION
This PR changes developer notes to suggest naming instance methods with `lowerCamelCase()`, and other functions with `UpperCamelCase()`.

Lower camel case names were allowed by the developer guide before #10917, and are used in a good amount of [existing code](https://gist.github.com/ryanofsky/8718089b2927912f77db0d7cb1728350).

Using lower camel case to distinguish instance method calls from other types of calls can aid with code readability and review. Seeing a `lowerCase()` call would tell you that an implicit `this` pointer is being passed, and could be a signal during code review that a call has access to more information than needs, or may not be doing exactly what you think it does.

Using a distinct style for instance method names is also analagous with our existing convention for using `m_` prefixes in instance member variable names.