### PR TITLE
qt: remove unused SECURE style

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -16,9 +16,6 @@
 
 bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)
 {
-    bool fSecure = style & CClientUIInterface::SECURE;
-    style &= ~CClientUIInterface::SECURE;
-
     std::string strCaption;
     // Check for usage of predefined caption
     switch (style) {
@@ -35,8 +32,7 @@ bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& ca
         strCaption += caption; // Use supplied caption (can be empty)
     }
 
-    if (!fSecure)
-        LogPrintf("%s: %s\n", strCaption, message);
+    LogPrintf("%s: %s\n", strCaption, message);
     fprintf(stderr, "%s: %s\n", strCaption.c_str(), message.c_str());
     return false;
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1226,9 +1226,6 @@ static bool ThreadSafeMessageBox(BitcoinGUI* gui, const std::string& message, co
     noui_ThreadSafeMessageBox(message, caption, style);
 
     bool modal = (style & CClientUIInterface::MODAL);
-    // The SECURE flag has no effect in the Qt GUI.
-    // bool secure = (style & CClientUIInterface::SECURE);
-    style &= ~CClientUIInterface::SECURE;
     bool ret = false;
     // In case of modal message, use blocking connection to wait for user to click a button
     QMetaObject::invokeMethod(gui, "message",

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -66,9 +66,6 @@ public:
         /** Force blocking, modal message box dialog (not just OS notification) */
         MODAL               = 0x10000000U,
 
-        /** Do not print contents of message to debug log */
-        SECURE              = 0x40000000U,
-
         /** Predefined combinations for certain default usage cases */
         MSG_INFORMATION = ICON_INFORMATION,
         MSG_WARNING = (ICON_WARNING | BTN_OK | MODAL),


### PR DESCRIPTION
SECURE style seem to be unused. According to the comment it do the same thing as `-nodebuglogfile`