### PR TITLE
travis: Fail the UBSan Travis build in case of newly introduced UBSan errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,7 +107,7 @@ jobs:
     - stage: test
       env: >-
         HOST=x86_64-unknown-linux-gnu
-        PACKAGES="clang python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+        PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
         NO_DEPENDS=1
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --enable-glibc-back-compat --enable-reduce-exports --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=integer,undefined CC=clang CXX=clang++"

--- a/.travis/test_03_before_install.sh
+++ b/.travis/test_03_before_install.sh
@@ -7,6 +7,8 @@
 export LC_ALL=C.UTF-8
 
 PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
+# Add llvm-symbolizer directory to PATH. Needed to get symbolized stack traces from the sanitizers.
+PATH=$PATH:/usr/lib/llvm-6.0/bin/
 export PATH
 
 BEGIN_FOLD () {

--- a/.travis/test_04_install.sh
+++ b/.travis/test_04_install.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 travis_retry docker pull "$DOCKER_NAME_TAG"
-export UBSAN_OPTIONS="suppressions=${TRAVIS_BUILD_DIR}/contrib/sanitizers-ubsan.suppressions"
+export UBSAN_OPTIONS="suppressions=${TRAVIS_BUILD_DIR}/contrib/sanitizers-ubsan.suppressions:print_stacktrace=1:halt_on_error=1"
 env | grep -E '^(CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL|UBSAN_OPTIONS)' | tee /tmp/env
 if [[ $HOST = *-mingw32 ]]; then
   DOCKER_ADMIN="--cap-add SYS_ADMIN"

--- a/contrib/sanitizers-ubsan.suppressions
+++ b/contrib/sanitizers-ubsan.suppressions
@@ -5,10 +5,15 @@ float-divide-by-zero:policy/fees.cpp
 float-divide-by-zero:validation.cpp
 float-divide-by-zero:wallet/wallet.cpp
 nonnull-attribute:support/cleanse.cpp
+unsigned-integer-overflow:arith_uint256.h
 unsigned-integer-overflow:basic_string.h
 unsigned-integer-overflow:bench/bench.h
+unsigned-integer-overflow:bitcoin-tx.cpp
 unsigned-integer-overflow:bloom.cpp
+unsigned-integer-overflow:chain.cpp
 unsigned-integer-overflow:chain.h
+unsigned-integer-overflow:coded_stream.h
+unsigned-integer-overflow:core_write.cpp
 unsigned-integer-overflow:crypto/chacha20.cpp
 unsigned-integer-overflow:crypto/ctaes/ctaes.c
 unsigned-integer-overflow:crypto/ripemd160.cpp
@@ -21,7 +26,11 @@ unsigned-integer-overflow:leveldb/util/bloom.cc
 unsigned-integer-overflow:leveldb/util/crc32c.h
 unsigned-integer-overflow:leveldb/util/hash.cc
 unsigned-integer-overflow:policy/fees.cpp
+unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
+unsigned-integer-overflow:streams.h
 unsigned-integer-overflow:txmempool.cpp
+unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
+vptr:fs.cpp


### PR DESCRIPTION
Fail the UBSan Travis build in case of newly introduced [UBSan (UndefinedBehaviorSanitizer)](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) errors.

Prior to this commit new UBSan errors were printed but didn't fail the UBSan Travis build.

Changes:
* Travis: Add UBSan options: `print_stacktrace` + `halt_on_error`
* Travis: Add UBSan suppressions needed to pass test suite
* Travis: Add `llvm-symbolizer` directory to PATH. Needed to get symbolized stack traces from the sanitizers.

`halt_on_error` should have been part of #14252 really :-)