### PR TITLE
Let systemd bitcoind write to /etc/bitcoin

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -26,8 +26,9 @@ Restart=on-failure
 # Provide a private /tmp and /var/tmp.
 PrivateTmp=true
 
-# Mount /usr, /boot/ and /etc read-only for the process.
+# Mount /usr, /boot/ and /etc read-only for the process, but allow writes to /etc/bitcoin.
 ProtectSystem=full
+ReadwritePaths=/etc/bitcoin
 
 # Disallow the process and all of its children to gain
 # new privileges through execve().


### PR DESCRIPTION
The hardening measure `ProtectSystem=full` makes /etc read-only along with its subdirectories, including /etc/bitcoin. That prevents bitcoind from launching successfully when it finds it cannot write to /etc/bitcoin/debug.log and such.

Exempt /etc/bitcoin with the directive `ReadWritePaths=/etc/bitcoin`

To verify this change:
1. Log in as root.
2. Copy `bitcoind.service` to the relevant directory for your OS, e.g.:
```
$ cp bitcoind.service /lib/systemd/system/bitcoind.service
```
3. Reload systemd's daemon configs, enable, and start bitcoind through systemd:
```
$ sudo systemctl daemon-reload
$ sudo systemctl enable bitcoind
$ sudo systemctl start bitcoind
```
4. Verify that bitcoind launched successfully:
```
$ sudo systemctl status bitcoind.service
* bitcoind.service - Bitcoin daemon
   Loaded: loaded (/lib/systemd/system/bitcoind.service; enabled; vendor preset:
   Active: active (running) since 
```