### PR TITLE
[doc] conf: Remove deprecated options from docs, Other cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The `master` branch is regularly built and tested, but is not guaranteed to be
 completely stable. [Tags](https://github.com/bitcoin/bitcoin/tags) are created
 regularly to indicate new official, stable release versions of Bitcoin Core.
 
-The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md).
+The contribution workflow is described in [CONTRIBUTING.md](CONTRIBUTING.md)
+and useful hints for developers can be found in [doc/developer-notes.md](doc/developer-notes.md).
 
 Testing
 -------

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -80,9 +80,9 @@ Running
 
 Bitcoin Core is now available at `./src/bitcoind`
 
-Before running, it's recommended that you create an RPC configuration file:
+Before running, you may create an empty configuration file:
 
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+    touch "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 
     chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -71,12 +71,9 @@
 # is .cookie and found in the `-datadir` being used for bitcoind. This option is typically used
 # when the server and client are run as the same user.
 #
-# If not, you must set rpcuser and rpcpassword to secure the JSON-RPC api. The first
-# method(DEPRECATED) is to set this pair for the server and client:
-#rpcuser=Ulysseys
-#rpcpassword=YourSuperGreatPasswordNumber_DO_NOT_USE_THIS_OR_YOU_WILL_GET_ROBBED_385593
+# If not, you must set rpcuser and rpcpassword to secure the JSON-RPC API.
 #
-# The second method `rpcauth` can be added to server startup argument. It is set at initialization time
+# The config option `rpcauth` can be added to server startup argument. It is set at initialization time
 # using the output from the script in share/rpcauth/rpcauth.py after providing a username:
 #
 # ./share/rpcauth/rpcauth.py alice
@@ -116,20 +113,20 @@
 # running on another host using this option:
 #rpcconnect=127.0.0.1
 
+# Wallet options
+
 # Create transactions that have enough fees so they are likely to begin confirmation within n blocks (default: 6).
 # This setting is over-ridden by the -paytxfee option.
 #txconfirmtarget=n
+
+# Pay a transaction fee every time you send bitcoins.
+#paytxfee=0.000x
 
 # Miscellaneous options
 
 # Pre-generate this many public/private key pairs, so wallet backups will be valid for
 # both prior transactions and several dozen future transactions.
 #keypool=100
-
-# Pay an optional transaction fee every time you send bitcoins.  Transactions with fees
-# are more likely than free transactions to be included in generated blocks, so may
-# be validated sooner.
-#paytxfee=0.00
 
 # Enable pruning to reduce storage requirements by deleting old blocks. 
 # This mode is incompatible with -txindex and -rescan.

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2018 The Bitcoin Core developers
-// Distributed under the MIT/X11 software license, see the accompanying
+// Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>


### PR DESCRIPTION
Some dumb fixes, like removing the mention that free transactions are still a thing or that rpcuser/pass should be used (as opposed to rpcauth or rpc cookie).

Combined with other fixes because I don't want to create 3 pull requests:
* conf: Remove deprecated options from docs
* Remove only mention of MIT/X11
* Link to developer notes in README.md