### PR TITLE
Require a public key to be retrieved when signing a P2PKH input

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -123,7 +123,7 @@ static bool SignStep(const SigningProvider& provider, const BaseSignatureCreator
     case TX_PUBKEYHASH: {
         CKeyID keyID = CKeyID(uint160(vSolutions[0]));
         CPubKey pubkey;
-        GetPubKey(provider, sigdata, keyID, pubkey);
+        if (!GetPubKey(provider, sigdata, keyID, pubkey)) return false;
         if (!CreateSig(creator, sigdata, provider, sig, pubkey, scriptPubKey, sigversion)) return false;
         ret.push_back(std::move(sig));
         ret.push_back(ToByteVector(pubkey));

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -269,6 +269,10 @@ class PSBTTest(BitcoinTestFramework):
 
         self.test_utxo_conversion()
 
+        # Test that psbts with p2pkh outputs are created properly
+        p2pkh = self.nodes[0].getnewaddress(address_type='legacy')
+        psbt = self.nodes[1].walletcreatefundedpsbt([], [{p2pkh : 1}], 0, {"includeWatching" : True}, True)
+        self.nodes[0].decodepsbt(psbt['psbt'])
 
 if __name__ == '__main__':
     PSBTTest().main()


### PR DESCRIPTION
If we do not have the public key for a P2PKH input, we should not continue to attempt to sign for it.

This fixes a problem where a PSBT with a P2PKH output would include invalid BIP 32 derivation paths that are missing the public key.
