### PR TITLE
tests: Speedup feature_pruning test and refactor big transaction logic

### DIFF
--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -7,7 +7,7 @@
 from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions, gen_return_txouts
+from test_framework.util import assert_equal, assert_greater_than, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -19,7 +19,6 @@ class MempoolLimitTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        txouts = gen_return_txouts()
         relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
         self.log.info('Check that mempoolminfee is minrelytxfee')
@@ -44,7 +43,7 @@ class MempoolLimitTest(BitcoinTestFramework):
         base_fee = relayfee*100
         for i in range (3):
             txids.append([])
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], txouts, utxos[30*i:30*i+30], 30, (i+1)*base_fee)
+            txids[i] = create_lots_of_big_transactions(self.nodes[0], utxos[30*i:30*i+30], 30, (i+1)*base_fee)
 
         self.log.info('The tx should be evicted by now')
         assert(txid not in self.nodes[0].getrawmempool())

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -8,7 +8,7 @@ import time
 
 from test_framework.messages import COIN, MAX_BLOCK_BASE_SIZE
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions, gen_return_txouts
+from test_framework.util import assert_equal, assert_raises_rpc_error, create_confirmed_utxos, create_lots_of_big_transactions
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -40,7 +40,6 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
         # Test `prioritisetransaction` invalid `fee_delta`
         assert_raises_rpc_error(-1, "JSON value is not an integer as expected", self.nodes[0].prioritisetransaction, txid=txid, fee_delta='foo')
 
-        self.txouts = gen_return_txouts()
         self.relayfee = self.nodes[0].getnetworkinfo()['relayfee']
 
         utxo_count = 90
@@ -54,7 +53,7 @@ class PrioritiseTransactionTest(BitcoinTestFramework):
             txids.append([])
             start_range = i * range_size
             end_range = start_range + range_size
-            txids[i] = create_lots_of_big_transactions(self.nodes[0], self.txouts, utxos[start_range:end_range], end_range - start_range, (i+1)*base_fee)
+            txids[i] = create_lots_of_big_transactions(self.nodes[0], utxos[start_range:end_range], end_range - start_range, (i+1)*base_fee)
 
         # Make sure that the size of each group of transactions exceeds
         # MAX_BLOCK_BASE_SIZE -- otherwise the test needs to be revised to create


### PR DESCRIPTION
### Description 

Extended tests like feature_pruning.py create large blocks by making many large transactions with [a lot of OP_RETURNS](https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/util.py#L511-L527) in a single tx. Under this model roughly [14 of these transactions make a full-ish block](https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/util.py#L549-L560). 

These transactions are already non-standard, so I have just modified the logic to instead just create 1 large output, making a single large transaction, mining a block of roughly the same size (947k). The reduction in tx creation / number of outputs seems to significantly improve performance. 

Another optimization is to splice in the OP_RETURN output _after_ transaction signing, since it reduces the copying of the large OP_RETURN portion during signing. All signatures are `SIGHHASH_NONE`, so splicing after is okay. 

feature_pruning.py has about a 1.5x speedup on my machine (~12 minutes down to ~8 minutes), and `mempool_limit`, and `feature_maxuploadtarget` seem to benefit as well. 

### Refactoring
* The [original](https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/util.py#L511-L527) OP_RETURN generating function is now just a [string](https://github.com/conscott/bitcoin/blob/2018_11_opreturn_splices/test/functional/test_framework/util.py#L176-L192). If there is a better place to put this, I will move it. At the very least I just wanted to document the format because the previous function had little explanation for all the hex values. 
* `create_lots_of_big_transactions` no longer requires providing the OP_RETURN splice, and uses the default from before, with an optional `op_return_txout=` keyword args for using the giant OP_RETURN mentioned above. 