### PR TITLE
tests: Separately check for rapidcheck/boost_test.h in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1366,7 +1366,7 @@ dnl RapidCheck property-based testing
 
 enable_property_tests=no
 if test "x$use_rapidcheck" = xauto; then
-    AC_CHECK_HEADERS([rapidcheck.h], [enable_property_tests=yes])
+    AC_CHECK_HEADER([rapidcheck/boost_test.h], [enable_property_tests=yes])
 elif test "x$use_rapidcheck" != xno; then
     enable_property_tests=yes
 fi


### PR DESCRIPTION
As per https://github.com/emil-e/rapidcheck/blob/master/doc/boost_test.md
Boost Test integration is an "extra" and not guaranteed to be available
alongside rapidcheck itself. Checking for it in configure.ac avoids rapidcheck
being enabled when not fully available.

On my machine, before:
```
  checking rapidcheck.h usability... yes
  checking rapidcheck.h presence... yes
  checking for rapidcheck.h... yes
  [...]
  CXX      wallet/test/test_test_bitcoin-psbt_wallet_tests.o
  test/key_properties.cpp:16:10: fatal error: 'rapidcheck/boost_test.h' file not found
  #include <rapidcheck/boost_test.h>
           ^~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
```

After:
```
  checking rapidcheck.h usability... yes
  checking rapidcheck.h presence... yes
  checking for rapidcheck.h... yes
  checking rapidcheck/boost_test.h usability... no
  checking rapidcheck/boost_test.h presence... no
  checking for rapidcheck/boost_test.h... no
```