### PR TITLE
travis: Avoid timeout on verify-commits check

### DIFF
--- a/.travis/lint_06_script.sh
+++ b/.travis/lint_06_script.sh
@@ -19,6 +19,7 @@ test/lint/check-rpc-mappings.py .
 test/lint/lint-all.sh
 
 if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+    git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
     while read -r LINE; do travis_retry gpg --keyserver hkp://subset.pool.sks-keyservers.net --recv-keys $LINE; done < contrib/verify-commits/trusted-keys &&
-    travis_wait 50 contrib/verify-commits/verify-commits.py;
+    travis_wait 50 contrib/verify-commits/verify-commits.py --clean-merge=2;
 fi

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -365,7 +365,7 @@ def run_tests(*, test_list, src_dir, build_dir, tmpdir, jobs=1, enable_coverage=
         tmpdir=tmpdir,
         test_list=test_list,
         flags=flags,
-        timeout_duration=20 * 60 if runs_ci else float('inf'),  # in seconds
+        timeout_duration=40 * 60 if runs_ci else float('inf'),  # in seconds
     )
     start_time = time.time()
     test_results = []


### PR DESCRIPTION
The verify-commits check is too expensive to run in full (calculate Tree-SHA512 and clean-merge for every single merge commit in history) every day (the cron job runs every ~24h). Since the cron job is running every day, it is also redundant to redo most of the work on the next day.

So, only check two days worth of commits and assume that travis checked the Tree-SHA512 and clean-merge for all other commits already. The script will still check all the signatures, since the check-result for them depends on external inputs such as current time or the public keys we got from the server.

[Note that travis is not meant to do the verification for anyone or is meant to be trusted in any way. This check only serves as a belt-and-suspender to notify maintainers in case of a technical issue or script malfunction. But since the script is timing out for months now, its purpose is diminished right now.]