### PR TITLE
Fix icc (Intel C++ compiler) warnings

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -80,7 +80,7 @@ CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
     memset(pchCommand, 0, sizeof(pchCommand));
-    nMessageSize = -1;
+    nMessageSize = std::numeric_limits<decltype(nMessageSize)>::max();
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }
 

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(varints)
     }
 
     for (uint64_t i = 0;  i < 100000000000ULL; i += 999999937) {
-        uint64_t j = -1;
+        uint64_t j = std::numeric_limits<uint64_t>::max();
         ss >> VARINT(j);
         BOOST_CHECK_MESSAGE(i == j, "decoded:" << j << " expected:" << i);
     }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -147,9 +147,9 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
-    friend void ::RegisterValidationInterface(CValidationInterface*);
-    friend void ::UnregisterValidationInterface(CValidationInterface*);
-    friend void ::UnregisterAllValidationInterfaces();
+    friend void RegisterValidationInterface(CValidationInterface*);
+    friend void UnregisterValidationInterface(CValidationInterface*);
+    friend void UnregisterAllValidationInterfaces();
 };
 
 struct MainSignalsInstance;
@@ -157,10 +157,10 @@ class CMainSignals {
 private:
     std::unique_ptr<MainSignalsInstance> m_internals;
 
-    friend void ::RegisterValidationInterface(CValidationInterface*);
-    friend void ::UnregisterValidationInterface(CValidationInterface*);
-    friend void ::UnregisterAllValidationInterfaces();
-    friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
+    friend void RegisterValidationInterface(CValidationInterface*);
+    friend void UnregisterValidationInterface(CValidationInterface*);
+    friend void UnregisterAllValidationInterfaces();
+    friend void CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 
     void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
 


### PR DESCRIPTION
Rationale:
* By silencing these warnings real issues become easier to spot when building with `icc`.

Fix `icc` (Intel C++ compiler) warnings:

```
protocol.cpp(83): warning #68: integer conversion resulted in a change of sign
      nMessageSize = -1;
                     ^
test/serialize_tests.cpp(203): warning #68: integer conversion resulted in a change of sign
          uint64_t j = -1;
                       ^
./validationinterface.h(150): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::RegisterValidationInterface(CValidationInterface*);
                  ^
./validationinterface.h(151): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::UnregisterValidationInterface(CValidationInterface*);
                  ^
./validationinterface.h(152): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::UnregisterAllValidationInterfaces();
                  ^
./validationinterface.h(160): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::RegisterValidationInterface(CValidationInterface*);
                  ^
./validationinterface.h(161): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::UnregisterValidationInterface(CValidationInterface*);
                  ^
./validationinterface.h(162): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::UnregisterAllValidationInterfaces();
                  ^
./validationinterface.h(163): warning #1098: the qualifier on this friend declaration is ignored
      friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
                  ^
```

