### PR TITLE
wallet: Require a start block in ScanForWalletTransactions

### DIFF
--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -146,7 +146,7 @@ void TestGUI()
         auto locked_chain = wallet->chain().lock();
         WalletRescanReserver reserver(wallet.get());
         reserver.reserve();
-        wallet->ScanForWalletTransactions(chainActive.Genesis(), nullptr, reserver, true);
+        wallet->ScanForWalletTransactions(*::chainActive.Genesis(), nullptr, reserver, true);
     }
     wallet->SetBroadcastTransactions(true);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3294,7 +3294,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Wallet is currently rescanning. Abort existing rescan or wait.");
     }
 
-    CBlockIndex *pindexStart = nullptr;
+    CBlockIndex* pindexStart;
     CBlockIndex *pindexStop = nullptr;
     CBlockIndex *pChainTip = nullptr;
     {
@@ -3304,9 +3304,9 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
 
         if (!request.params[0].isNull()) {
             pindexStart = chainActive[request.params[0].get_int()];
-            if (!pindexStart) {
+        }
+        if (!pindexStart) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid start_height");
-            }
         }
 
         if (!request.params[1].isNull()) {
@@ -3314,7 +3314,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
             if (!pindexStop) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid stop_height");
             }
-            else if (pindexStop->nHeight < pindexStart->nHeight) {
+            if (pindexStop->nHeight < pindexStart->nHeight) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, "stop_height must be greater than start_height");
             }
         }
@@ -3332,7 +3332,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
         }
     }
 
-    CBlockIndex *stopBlock = pwallet->ScanForWalletTransactions(pindexStart, pindexStop, reserver, true);
+    const CBlockIndex* stopBlock = pwallet->ScanForWalletTransactions(*pindexStart, pindexStop, reserver, true);
     if (!stopBlock) {
         if (pwallet->IsAbortingRescan()) {
             throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted.");

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -53,7 +53,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
-        BOOST_CHECK_EQUAL(nullBlock, wallet.ScanForWalletTransactions(oldTip, nullptr, reserver));
+        BOOST_CHECK_EQUAL(nullBlock, wallet.ScanForWalletTransactions(*oldTip, nullptr, reserver));
         BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 100 * COIN);
     }
 
@@ -68,7 +68,7 @@ BOOST_FIXTURE_TEST_CASE(rescan, TestChain100Setup)
         AddKey(wallet, coinbaseKey);
         WalletRescanReserver reserver(&wallet);
         reserver.reserve();
-        BOOST_CHECK_EQUAL(oldTip, wallet.ScanForWalletTransactions(oldTip, nullptr, reserver));
+        BOOST_CHECK_EQUAL(oldTip, wallet.ScanForWalletTransactions(*oldTip, nullptr, reserver));
         BOOST_CHECK_EQUAL(wallet.GetImmatureBalance(), 50 * COIN);
     }
 
@@ -286,7 +286,7 @@ public:
         AddKey(*wallet, coinbaseKey);
         WalletRescanReserver reserver(wallet.get());
         reserver.reserve();
-        wallet->ScanForWalletTransactions(chainActive.Genesis(), nullptr, reserver);
+        wallet->ScanForWalletTransactions(*chainActive.Genesis(), nullptr, reserver);
     }
 
     ~ListCoinsTestingSetup()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1613,7 +1613,7 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     }
 
     if (startBlock) {
-        const CBlockIndex* const failedBlock = ScanForWalletTransactions(startBlock, nullptr, reserver, update);
+        const CBlockIndex* const failedBlock = ScanForWalletTransactions(*startBlock, nullptr, reserver, update);
         if (failedBlock) {
             return failedBlock->GetBlockTimeMax() + TIMESTAMP_WINDOW + 1;
         }
@@ -1622,7 +1622,7 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
 }
 
 /**
- * Scan the block chain (starting in pindexStart) for transactions
+ * Scan the block chain (starting in index_start) for transactions
  * from or to us. If fUpdate is true, found transactions that already
  * exist in the wallet will be updated.
  *
@@ -1633,24 +1633,23 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
  * If pindexStop is not a nullptr, the scan will stop at the block-index
  * defined by pindexStop
  *
- * Caller needs to make sure pindexStop (and the optional pindexStart) are on
+ * Caller needs to make sure pindexStop (and the index_start) are on
  * the main chain after to the addition of any new keys you want to detect
  * transactions for.
  */
-CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop, const WalletRescanReserver &reserver, bool fUpdate)
+const CBlockIndex* CWallet::ScanForWalletTransactions(const CBlockIndex& index_start, const CBlockIndex* const pindexStop, const WalletRescanReserver& reserver, bool fUpdate)
 {
     int64_t nNow = GetTime();
     const CChainParams& chainParams = Params();
 
     assert(reserver.isReserved());
     if (pindexStop) {
-        assert(pindexStop->nHeight >= pindexStart->nHeight);
+        assert(pindexStop->nHeight >= index_start.nHeight);
     }
 
-    CBlockIndex* pindex = pindexStart;
-    CBlockIndex* ret = nullptr;
+    const CBlockIndex* ret = nullptr;
 
-    if (pindex) WalletLogPrintf("Rescan started from block %d...\n", pindex->nHeight);
+    WalletLogPrintf("Rescan started from block %d...\n", index_start.nHeight);
 
     {
         fAbortRescan = false;
@@ -1660,7 +1659,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
         double progress_end;
         {
             auto locked_chain = chain().lock();
-            progress_begin = GuessVerificationProgress(chainParams.TxData(), pindex);
+            progress_begin = GuessVerificationProgress(chainParams.TxData(), &index_start);
             if (pindexStop == nullptr) {
                 tip = chainActive.Tip();
                 progress_end = GuessVerificationProgress(chainParams.TxData(), tip);
@@ -1669,6 +1668,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
             }
         }
         double progress_current = progress_begin;
+        const CBlockIndex* pindex = &index_start;
         while (pindex && !fAbortRescan && !ShutdownRequested())
         {
             if (pindex->nHeight % 100 == 0 && progress_end - progress_begin > 0.0) {
@@ -1683,7 +1683,7 @@ CBlockIndex* CWallet::ScanForWalletTransactions(CBlockIndex* pindexStart, CBlock
             if (ReadBlockFromDisk(block, pindex, Params().GetConsensus())) {
                 auto locked_chain = chain().lock();
                 LOCK(cs_wallet);
-                if (pindex && !chainActive.Contains(pindex)) {
+                if (!chainActive.Contains(pindex)) {
                     // Abort scan if current block is no longer active, to prevent
                     // marking transactions as coming from the wrong block.
                     ret = pindex;
@@ -4164,13 +4164,15 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         }
 
         nStart = GetTimeMillis();
-        {
+        if (pindexRescan) {
             WalletRescanReserver reserver(walletInstance.get());
             if (!reserver.reserve()) {
                 InitError(_("Failed to rescan the wallet during initialization"));
                 return nullptr;
             }
-            walletInstance->ScanForWalletTransactions(pindexRescan, nullptr, reserver, true);
+            walletInstance->ScanForWalletTransactions(*pindexRescan, nullptr, reserver, true);
+        } else {
+            walletInstance->WalletLogPrintf("No blocks to rescan for wallet (nTimeFirstKey=%d)\n", walletInstance->nTimeFirstKey);
         }
         walletInstance->WalletLogPrintf("Rescan completed in %15dms\n", GetTimeMillis() - nStart);
         walletInstance->ChainStateFlushed(chainActive.GetLocator());

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -896,7 +896,7 @@ public:
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock) override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
-    CBlockIndex* ScanForWalletTransactions(CBlockIndex* pindexStart, CBlockIndex* pindexStop, const WalletRescanReserver& reserver, bool fUpdate = false);
+    const CBlockIndex* ScanForWalletTransactions(const CBlockIndex& index_start, const CBlockIndex* const pindexStop, const WalletRescanReserver& reserver, bool fUpdate = false);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime, CConnman* connman) override EXCLUSIVE_LOCKS_REQUIRED(cs_main);


### PR DESCRIPTION
`ScanForWalletTransactions` incorrectly documents that `pindexStart` is optional. Fix that by making that parameter a const reference.

To the best of my knowledge it is impossible to hit those code paths from functional tests and I think it is not worth to write a unit test for this edge case:

```cpp
pindexStart == nullptr /* i.e. "optional" */ && pindexStop != nullptr