### PR TITLE
clang-format: do not sort include calls

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -52,3 +52,4 @@ SpacesInParentheses: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
+SortIncludes:    false


### PR DESCRIPTION
The `SortIncludes` flag in clang-format will not correctly identify main header file includes in sources (probably due to usage of brackets and full paths).

This results in broken code, if clang-format is applied to e.g.

https://github.com/bitcoin/bitcoin/blob/47ed24cf8aa7be3b778731b1f140ad9941157933/src/qt/test/wallettests.cpp#L1-L2

which will reorder the two includes alphabetically (`u < w`), and the `util.h` include will then fail to compile due to missing `QString` definition.
