### PR TITLE
tests: util.h: explicitly include required QString header

### DIFF
--- a/src/qt/test/util.h
+++ b/src/qt/test/util.h
@@ -1,6 +1,8 @@
 #ifndef BITCOIN_QT_TEST_UTIL_H
 #define BITCOIN_QT_TEST_UTIL_H
 
+#include <QString>
+
 /**
  * Press "Ok" button in message box dialog.
  *


### PR DESCRIPTION
Alternative to #14713.

Instead of depending on clang formatter to not reorder includes, another fix is to explicitly include the missing header file.