### PR TITLE
Drop defunct prevector compat handling

### DIFF
--- a/src/bench/prevector.cpp
+++ b/src/bench/prevector.cpp
@@ -2,12 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <compat.h>
 #include <prevector.h>
 #include <serialize.h>
 #include <streams.h>
+#include <type_traits>
 
 #include <bench/bench.h>
+
+// GCC 4.8 is missing some C++11 type_traits,
+// https://www.gnu.org/software/gcc/gcc-5/changes.html
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
+#define IS_TRIVIALLY_CONSTRUCTIBLE std::has_trivial_default_constructor
+#else
+#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivially_default_constructible
+#endif
 
 struct nontrivial_t {
     int x;

--- a/src/compat.h
+++ b/src/compat.h
@@ -10,16 +10,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <type_traits>
-
-// GCC 4.8 is missing some C++11 type_traits,
-// https://www.gnu.org/software/gcc/gcc-5/changes.html
-#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 5
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::has_trivial_default_constructor
-#else
-#define IS_TRIVIALLY_CONSTRUCTIBLE std::is_trivially_default_constructible
-#endif
-
 #ifdef WIN32
 #ifdef _WIN32_WINNT
 #undef _WIN32_WINNT

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -196,11 +196,7 @@ private:
     T* item_ptr(difference_type pos) { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
     const T* item_ptr(difference_type pos) const { return is_direct() ? direct_ptr(pos) : indirect_ptr(pos); }
 
-    void fill(T* dst, ptrdiff_t count) {
-        std::fill_n(dst, count, T{});
-    }
-
-    void fill(T* dst, ptrdiff_t count, const T& value) {
+    void fill(T* dst, ptrdiff_t count, const T& value = T{}) {
         std::fill_n(dst, count, value);
     }
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -15,8 +15,6 @@
 #include <iterator>
 #include <type_traits>
 
-#include <compat.h>
-
 #pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
  *  elements directly (without heap allocation). The types Size and Diff are


### PR DESCRIPTION
This is clean-up post #14651:
* Use one implementation of `prevector::fill`, as it's possible now that the implementations are identical.
* Only apply the `IS_TRIVIALLY_CONSTRUCTIBLE` handling to the bench file where it is used, and drop the now-unnecessary associated compat includes.