### PR TITLE
Drop unnecessary merkle mutation checks

### DIFF
--- a/src/bench/merkle_root.cpp
+++ b/src/bench/merkle_root.cpp
@@ -6,7 +6,8 @@
 
 #include <uint256.h>
 #include <random.h>
-#include <consensus/merkle.h>
+
+uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated);
 
 static void MerkleRoot(benchmark::State& state)
 {

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -46,7 +46,7 @@
 uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated) {
     bool mutation = false;
     while (hashes.size() > 1) {
-        if (mutated) {
+        if (mutated != nullptr && !mutation) {
             for (size_t pos = 0; pos + 1 < hashes.size(); pos += 2) {
                 if (hashes[pos] == hashes[pos + 1]) mutation = true;
             }
@@ -57,7 +57,7 @@ uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated) {
         SHA256D64(hashes[0].begin(), hashes[0].begin(), hashes.size() / 2);
         hashes.resize(hashes.size() / 2);
     }
-    if (mutated) *mutated = mutation;
+    if (mutated != nullptr) *mutated = mutation;
     if (hashes.size() == 0) return uint256();
     return hashes[0];
 }
@@ -83,4 +83,3 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated)
     }
     return ComputeMerkleRoot(std::move(leaves), mutated);
 }
-

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -12,8 +12,6 @@
 #include <primitives/block.h>
 #include <uint256.h>
 
-uint256 ComputeMerkleRoot(std::vector<uint256> hashes, bool* mutated = nullptr);
-
 /*
  * Compute the Merkle root of the transactions in a block.
  * *mutated is set to true if a duplicated subtree was found.


### PR DESCRIPTION
Ok this is consensus code so I'm prepared to see this rejected, but I figure I'd bring it up just in case:
* Don't publish `ComputeMerkleRoot` declaration in consensus/merkle.h, it's only used in the bench.
* Don't continue checking for mutations in `ComputeMerkleRoot` if one has already been found.
* Compare `mutated` to `nullptr` to clarify that it's a pointer rather than a bool.

I saw a ~3% MerkleRoot bench improvement due either to random chance or the dropped mutation checks.