### PR TITLE
Remove unreferenced boost headers

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -12,7 +12,6 @@
 #endif
 
 #include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 /** Filesystem operations and types */
 namespace fs = boost::filesystem;

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -35,7 +35,6 @@
 #endif
 
 #include <atomic>
-#include <boost/thread/thread.hpp>
 #include <univalue.h>
 
 class CWallet;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -38,7 +38,6 @@
 
 #include <univalue.h>
 
-#include <boost/algorithm/string.hpp>
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
 
 #include <memory>

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -9,8 +9,6 @@
 #include <script/standard.h>
 #include <univalue.h>
 
-#include <boost/variant/static_visitor.hpp>
-
 #include <string>
 #include <vector>
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -73,7 +73,6 @@
 #include <malloc.h>
 #endif
 
-#include <boost/thread.hpp>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 #include <openssl/conf.h>


### PR DESCRIPTION
Building with clang (e.g. on FreeBSD) is very noisy due to `-Wthread-safety-analysis` warnings regarding boost. This change removes a number of unnecessary boost includes, and silences the rest of the warnings when building with clang. This allows more potentially interesting warnings to surface from the noise.

Tested on FreeBSD 11.2
