### PR TITLE
correct -onion default to -proxy behavior

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -522,9 +522,9 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
     if (reply.code == 250) {
         LogPrint(BCLog::TOR, "tor: Authentication successful\n");
 
-        // Now that we know Tor is running setup the proxy for onion addresses
-        // if -onion isn't set to something else.
-        if (gArgs.GetArg("-onion", "") == "") {
+        // Now that we know Tor is running, setup the proxy for onion addresses
+        // if -onion and -proxy isn't set to something else.
+        if (gArgs.GetArg("-onion", "") == "" && gArgs.GetArg("-proxy", "") == "") {
             CService resolved(LookupNumeric("127.0.0.1", 9050));
             proxyType addrOnion = proxyType(resolved, true);
             SetProxy(NET_ONION, addrOnion);


### PR DESCRIPTION
- fixes #14722
- only use default tor ip:port (127.0.0.1:9050) if -onion and -proxy not set

I'm not sure if this is done correctly, but it does fix the behavior in my tests. I will not be offended if this gets rejected for a more appropriate method.