### PR TITLE
fix an undefined behavior in uint::SetHex

### DIFF
--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -37,16 +37,15 @@ void base_blob<BITS>::SetHex(const char* psz)
         psz += 2;
 
     // hex string to uint
-    const char* pbegin = psz;
-    while (::HexDigit(*psz) != -1)
-        psz++;
-    psz--;
+    size_t digits = 0;
+    while (::HexDigit(psz[digits]) != -1)
+        digits++;
     unsigned char* p1 = (unsigned char*)data;
     unsigned char* pend = p1 + WIDTH;
-    while (psz >= pbegin && p1 < pend) {
-        *p1 = ::HexDigit(*psz--);
-        if (psz >= pbegin) {
-            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+    while (digits > 0 && p1 < pend) {
+        *p1 = ::HexDigit(psz[--digits]);
+        if (digits > 0) {
+            *p1 |= ((unsigned char)::HexDigit(psz[--digits]) << 4);
             p1++;
         }
     }


### PR DESCRIPTION
Decrementing psz beyond the beginning of the string is UB, even though
the out-of-bounds pointer is never dereferenced.

I don't think any clang sanitizer covers this, so I don't see any way a test could catch the original behavior.