### PR TITLE
docs: Update rpcbind doc to match the manpage

### DIFF
--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -63,8 +63,11 @@
 # server=1 tells Bitcoin-Qt and bitcoind to accept JSON-RPC commands
 #server=0
 
-# Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6.
-# This option can be specified multiple times (default: bind to all interfaces)
+# Bind to given address to listen for JSON-RPC connections. This option is ignored
+# unless `-rpcallowip` is also passed. Port is optional and overrides `-rpcport`.
+# Use [host]:port notation for IPv6.  This option can be specified multiple
+# times (default: 127.0.0.1 and ::1 i.e., localhost, or if `-rpcallowip` has
+# been specified, 0.0.0.0 and :: i.e., all addresses)
 #rpcbind=<addr>
 
 # If no rpcpassword is set, rpc cookie auth is sought. The default `-rpccookiefile` name


### PR DESCRIPTION
The `rpcbind` documentation on the example file should match the Manpage. Even more they have opposite meanings. 

This should close #9272