### PR TITLE
build: Drop AC_CHECK_DECLS for unused __builtin_clz

### DIFF
--- a/build_msvc/bitcoin_config.h
+++ b/build_msvc/bitcoin_config.h
@@ -146,10 +146,6 @@
    don't. */
 #define HAVE_DECL_STRNLEN 1
 
-/* Define to 1 if you have the declaration of `__builtin_clz', and to 0 if you
-   don't. */
-//#define HAVE_DECL___BUILTIN_CLZ 1
-
 /* Define to 1 if you have the declaration of `__builtin_clzl', and to 0 if
    you don't. */
 //#define HAVE_DECL___BUILTIN_CLZL 1

--- a/configure.ac
+++ b/configure.ac
@@ -771,7 +771,7 @@ AC_CHECK_DECLS([bswap_16, bswap_32, bswap_64],,,
                  #include <byteswap.h>
                  #endif])
 
-AC_CHECK_DECLS([__builtin_clz, __builtin_clzl, __builtin_clzll])
+AC_CHECK_DECLS([__builtin_clzl, __builtin_clzll])
 
 dnl Check for malloc_info (for memory statistics information in getmemoryinfo)
 AC_MSG_CHECKING(for getmemoryinfo)


### PR DESCRIPTION
__builtin_clz has never been used, decl check introduced in 4fd2d2fc97e21efceab849576e544160fd5e3e3d