### PR TITLE
Refactor: Changes postincrement to preincrement in for loop in src/consensus files

### DIFF
--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -67,7 +67,7 @@ uint256 BlockMerkleRoot(const CBlock& block, bool* mutated)
 {
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
-    for (size_t s = 0; s < block.vtx.size(); s++) {
+    for (size_t s = 0; s < block.vtx.size(); ++s) {
         leaves[s] = block.vtx[s]->GetHash();
     }
     return ComputeMerkleRoot(std::move(leaves), mutated);
@@ -78,7 +78,7 @@ uint256 BlockWitnessMerkleRoot(const CBlock& block, bool* mutated)
     std::vector<uint256> leaves;
     leaves.resize(block.vtx.size());
     leaves[0].SetNull(); // The witness hash of the coinbase is 0.
-    for (size_t s = 1; s < block.vtx.size(); s++) {
+    for (size_t s = 1; s < block.vtx.size(); ++s) {
         leaves[s] = block.vtx[s]->GetWitnessHash();
     }
     return ComputeMerkleRoot(std::move(leaves), mutated);

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -51,7 +51,7 @@ std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, int flags
         return std::make_pair(nMinHeight, nMinTime);
     }
 
-    for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++) {
+    for (size_t txinIndex = 0; txinIndex < tx.vin.size(); ++txinIndex) {
         const CTxIn& txin = tx.vin[txinIndex];
 
         // Sequence numbers with the most significant bit set are not
@@ -124,7 +124,7 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& in
         return 0;
 
     unsigned int nSigOps = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
+    for (unsigned int i = 0; i < tx.vin.size(); ++i)
     {
         const Coin& coin = inputs.AccessCoin(tx.vin[i].prevout);
         assert(!coin.IsSpent());
@@ -146,7 +146,7 @@ int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& i
         nSigOps += GetP2SHSigOpCount(tx, inputs) * WITNESS_SCALE_FACTOR;
     }
 
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
+    for (unsigned int i = 0; i < tx.vin.size(); ++i)
     {
         const Coin& coin = inputs.AccessCoin(tx.vin[i].prevout);
         assert(!coin.IsSpent());


### PR DESCRIPTION
Changed the postincrement operator to a preincrement operator in the for loops in src/consensus/merkle.cpp and src/consensus/tx_verify.cpp.

The compiler might actually optimize the for loop process in either case, but like the Developer Notes say: ++i is preferred over i++.