### PR TITLE
Refactor: Changes postincrement to preincrement for iterator in for loops in src/wallet files

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -772,7 +772,7 @@ UniValue dumpwallet(const JSONRPCRequest& request)
             file << "# extended private masterkey: " << EncodeExtKey(masterKey) << "\n\n";
         }
     }
-    for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); it++) {
+    for (std::vector<std::pair<int64_t, CKeyID> >::const_iterator it = vKeyBirth.begin(); it != vKeyBirth.end(); ++it) {
         const CKeyID &keyid = it->second;
         std::string strTime = FormatISO8601DateTime(it->first);
         std::string strAddr;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3661,7 +3661,7 @@ void CWallet::ListLockedCoins(std::vector<COutPoint>& vOutpts) const
 {
     AssertLockHeld(cs_wallet); // setLockedCoins
     for (std::set<COutPoint>::iterator it = setLockedCoins.begin();
-         it != setLockedCoins.end(); it++) {
+         it != setLockedCoins.end(); ++it) {
         COutPoint outpt = (*it);
         vOutpts.push_back(outpt);
     }


### PR DESCRIPTION
Changed the postincrement operator to a preincrement operator for the iterator in the for loops in src/wallet/rpcdump.cpp and src/wallet/wallet.cpp.

For integers the compiler does the optimisation automatically.
In this case an iterator is used, so this changes avoid creating an unnecessary temporary copy of the iterator.

[Comments](https://github.com/bitcoin/bitcoin/pull/7656/files#r56476755) on this PR suggest the use of a preincrement for optimisation.

Targeted only the files in src/wallet to not overcomplicate things and to keep this changes isolated to the scr/wallet files, so it can be easier to review and test.

I look forward to your opinions about this.

Thank you!