### PR TITLE
Avoid reading uninitialized variables in serialization code (triggered when running "make check")

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -311,7 +311,7 @@ public:
     void Unserialize(Stream &s) {
         unsigned int nCode = 0;
         // version
-        unsigned int nVersionDummy;
+        unsigned int nVersionDummy = 0;
         ::Unserialize(s, VARINT(nVersionDummy));
         // header code
         ::Unserialize(s, VARINT(nCode));

--- a/src/undo.h
+++ b/src/undo.h
@@ -53,7 +53,7 @@ public:
             // Old versions stored the version number for the last spend of
             // a transaction's outputs. Non-final spends were indicated with
             // height = 0.
-            unsigned int nVersionDummy;
+            unsigned int nVersionDummy = 0;
             ::Unserialize(s, VARINT(nVersionDummy));
         }
         ::Unserialize(s, CTxOutCompressor(REF(txout->out)));


### PR DESCRIPTION
Avoid reading uninitialized variables in serialization code (triggered when running `make check`).

Note that the variable `nVersionDummy` is **read** in the call to the `CVarInt` constructor:

```
template<VarIntMode Mode, typename I>
class CVarInt
{
protected:
    I &n;
public:
    explicit CVarInt(I& nIn) : n(nIn) { }
…
}

template<typename T>
inline T& REF(const T& val)
{
    return const_cast<T&>(val);
}

CVarInt<Mode, I> WrapVarInt(I& n) { return CVarInt<Mode, I>{n}; }

#define VARINT(obj, ...) WrapVarInt<__VA_ARGS__>(REF(obj))

unsigned int nVersionDummy;
::Unserialize(s, VARINT(nVersionDummy));
```