### PR TITLE
Remove filesystem/fstream from EXPECTED_BOOST_INCLUDES

### DIFF
--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -54,7 +54,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/chrono/chrono.hpp
     boost/date_time/posix_time/posix_time.hpp
     boost/filesystem.hpp
-    boost/filesystem/fstream.hpp
     boost/multi_index/hashed_index.hpp
     boost/multi_index/ordered_index.hpp
     boost/multi_index/sequenced_index.hpp


### PR DESCRIPTION
#14718 caused the Travis linter machine to fail due to:

```
test/lint/lint-includes.sh
Good job! The Boost dependency "boost/filesystem/fstream.hpp" is no longer used.
Please remove it from EXPECTED_BOOST_INCLUDES in test/lint/lint-includes.sh
to make sure this dependency is not accidentally reintroduced.
```