### PR TITLE
revert removal of fstream.hpp header in fs.h

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -12,6 +12,7 @@
 #endif
 
 #include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
 
 /** Filesystem operations and types */
 namespace fs = boost::filesystem;


### PR DESCRIPTION
We cannot (yet) remove the EXPECTED_BOOST_INCLUDES entry as this header is still needed in `fs.h` (see #14763).

Partially reverts #14718.