### PR TITLE
travis: Do not specify sudo in .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 os: linux
 language: minimal
@@ -42,7 +41,6 @@ jobs:
 # lint stage
     - stage: lint
       env:
-      sudo: false
       cache: false
       language: python
       python: '3.6'


### PR DESCRIPTION
Travis is deprecating the `sudo` keyword and moves everything to
the same infrastructure (sudo really selects between two infrastructures).

See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration?utm_source=in-app&utm_medium=intercom for more info.
