### PR TITLE
test: Add BOOST_REQUIRE to getters returning optional

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -2,17 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <attributes.h>
 #include <coins.h>
+#include <consensus/validation.h>
 #include <script/standard.h>
+#include <test/test_bitcoin.h>
 #include <uint256.h>
 #include <undo.h>
 #include <util/strencodings.h>
-#include <test/test_bitcoin.h>
 #include <validation.h>
-#include <consensus/validation.h>
 
-#include <vector>
 #include <map>
+#include <vector>
 
 #include <boost/test/unit_test.hpp>
 
@@ -36,7 +37,7 @@ class CCoinsViewTest : public CCoinsView
     std::map<COutPoint, Coin> map_;
 
 public:
-    bool GetCoin(const COutPoint& outpoint, Coin& coin) const override
+    NODISCARD bool GetCoin(const COutPoint& outpoint, Coin& coin) const override
     {
         std::map<COutPoint, Coin>::const_iterator it = map_.find(outpoint);
         if (it == map_.end()) {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -102,15 +102,15 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
         char key_res;
         uint256 val_res;
 
-        it->GetKey(key_res);
-        it->GetValue(val_res);
+        BOOST_REQUIRE(it->GetKey(key_res));
+        BOOST_REQUIRE(it->GetValue(val_res));
         BOOST_CHECK_EQUAL(key_res, key);
         BOOST_CHECK_EQUAL(val_res.ToString(), in.ToString());
 
         it->Next();
 
-        it->GetKey(key_res);
-        it->GetValue(val_res);
+        BOOST_REQUIRE(it->GetKey(key_res));
+        BOOST_REQUIRE(it->GetValue(val_res));
         BOOST_CHECK_EQUAL(key_res, key2);
         BOOST_CHECK_EQUAL(val_res.ToString(), in2.ToString());
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -187,7 +187,7 @@ struct TestArgsManager : public ArgsManager
             m_config_args.clear();
         }
         std::string error;
-        ReadConfigStream(streamConfig, error);
+        BOOST_REQUIRE(ReadConfigStream(streamConfig, error));
     }
     void SetNetworkOnlyArg(const std::string arg)
     {

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -150,7 +150,7 @@ protected:
     std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
 
-    bool ReadConfigStream(std::istream& stream, std::string& error, bool ignore_invalid_keys = false);
+    NODISCARD bool ReadConfigStream(std::istream& stream, std::string& error, bool ignore_invalid_keys = false);
 
 public:
     ArgsManager();
@@ -161,7 +161,7 @@ public:
     void SelectConfigNetwork(const std::string& network);
 
     NODISCARD bool ParseParameters(int argc, const char* const argv[], std::string& error);
-    bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);
+    NODISCARD bool ReadConfigFiles(std::string& error, bool ignore_invalid_keys = false);
 
     /**
      * Log warnings for options in m_section_only_args when


### PR DESCRIPTION
Usually the returned value is already checked for equality, but for sanity we might as well require that the getter successfully returned.