### PR TITLE
interface/wallet: get rid of missing initializer warnings

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -338,6 +338,7 @@ struct WalletTx
     int64_t time;
     std::map<std::string, std::string> value_map;
     bool is_coinbase;
+    WalletTx() {}
 };
 
 //! Updated transaction status.


### PR DESCRIPTION
Debian Jessie (PPC) gives me warnings, which go away with a default empty constructor in `WalletTx`:

```
[...]
  CXX      libbitcoin_server_a-validationinterface.o
  AR       libbitcoin_server.a
  CXX      interfaces/libbitcoin_wallet_a-wallet.o
interfaces/wallet.cpp: In member function ‘virtual interfaces::WalletTx interfaces::{anonymous}::WalletImpl::getWalletTx(const uint256&)’:
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::tx’ [-Wmissing-field-initializers]
         return {};
                 ^
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::txin_is_mine’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::txout_is_mine’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::txout_address’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::txout_address_is_mine’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::credit’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::debit’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::change’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::time’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::value_map’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:306:17: warning: missing initializer for member ‘interfaces::WalletTx::is_coinbase’ [-Wmissing-field-initializers]
interfaces/wallet.cpp: In member function ‘virtual interfaces::WalletTx interfaces::{anonymous}::WalletImpl::getWalletTxDetails(const uint256&, interfaces::WalletTxStatus&, interfaces::WalletOrderForm&, bool&, int&)’:
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::tx’ [-Wmissing-field-initializers]
         return {};
                 ^
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::txin_is_mine’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::txout_is_mine’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::txout_address’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::txout_address_is_mine’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::credit’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::debit’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::change’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::time’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::value_map’ [-Wmissing-field-initializers]
interfaces/wallet.cpp:355:17: warning: missing initializer for member ‘interfaces::WalletTx::is_coinbase’ [-Wmissing-field-initializers]
  CXX      wallet/libbitcoin_wallet_a-coincontrol.o
[...]
```
