### PR TITLE
net: 'break' should be 'continue' here?

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1867,7 +1867,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
 
             // if we selected an invalid address, restart
             if (!addr.IsValid() || setConnected.count(addr.GetGroup()) || IsLocal(addr))
-                break;
+                continue;
 
             // If we didn't find an appropriate destination after trying 100 addresses fetched from addrman,
             // stop this loop, and let the outer loop run again (which sleeps, adds seed nodes, recalculates


### PR DESCRIPTION
If we 'break' rather than 'continue' here, we very rarely get to the 30 failed attempts needed to consider very recently tried nodes, since the break resets the nTries to zero.