### PR TITLE
Add process based prctl spectre mitigation controls.

### DIFF
--- a/src/util/system.h
+++ b/src/util/system.h
@@ -40,6 +40,11 @@ int64_t GetStartupTime();
 
 extern const char * const BITCOIN_CONF_FILENAME;
 extern const char * const BITCOIN_PID_FILENAME;
+#ifdef ENABLE_WALLET
+static const bool DEFAULT_MITIGATE_SPECTRE = true;
+#else
+static const bool DEFAULT_MITIGATE_SPECTRE = false;
+#endif
 
 /** Translate a message to the native language of the user. */
 const extern std::function<std::string(const char*)> G_TRANSLATION_FUN;
@@ -53,6 +58,7 @@ inline std::string _(const char* psz)
     return G_TRANSLATION_FUN ? (G_TRANSLATION_FUN)(psz) : psz;
 }
 
+void SpectreMitigation(bool enable);
 void SetupEnvironment();
 bool SetupNetworking();
 


### PR DESCRIPTION
This should ensure that kernel spectre mitigations are enabled if available when the wallet is enabled and disabled if possible when there is no wallet for improved performance.

I also added a `-mitigatespectre` config switch to override the default behavior.

I'm not entirely sure if this specific spectre mitigation should be automatically enabled but it appears the prctl interface will be used for newer more important process level spectre mitigations as well.