### PR TITLE
tests: Add regtest for JSON-RPC batch calls

### DIFF
--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests some generic aspects of the RPC interface."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+class RPCInterfaceTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def test_batch_request(self):
+        self.log.info("Testing basic JSON-RPC batch request...")
+
+        results = self.nodes[0].batch([
+            # A basic request that will work fine.
+            {"method": "getblockcount", "id": 1},
+            # Request that will fail.  The whole batch request should still
+            # work fine.
+            {"method": "invalidmethod", "id": 2},
+            # Another call that should succeed.
+            {"method": "getbestblockhash", "id": 3},
+        ])
+
+        result_by_id = {}
+        for res in results:
+            result_by_id[res["id"]] = res
+
+        assert_equal(result_by_id[1]['error'], None)
+        assert_equal(result_by_id[1]['result'], 0)
+
+        assert_equal(result_by_id[2]['error']['code'], -32601)
+        assert_equal(result_by_id[2]['result'], None)
+
+        assert_equal(result_by_id[3]['error'], None)
+        assert result_by_id[3]['result'] is not None
+
+    def run_test(self):
+        self.test_batch_request()
+
+
+if __name__ == '__main__':
+    RPCInterfaceTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -120,6 +120,7 @@ BASE_SCRIPTS = [
     'wallet_disableprivatekeys.py',
     'wallet_disableprivatekeys.py --usecli',
     'interface_http.py',
+    'interface_rpc.py',
     'rpc_psbt.py',
     'rpc_users.py',
     'feature_proxy.py',


### PR DESCRIPTION
This adds a new regtest file `interface_rpc.py`, containing a test for batch JSON-RPC requests.  Those were previously not tested at all.  Tests for basic requests are not really necessary, as those are used anyway in lots of other regtests.

The existing `interface_http.py` file is more about the underlying HTTP connection, so adding a new interface file for the JSON-RPC specific things makes sense.