### PR TITLE
gui: Fix boost::signals2::no_slots_error in early calls to InitWarning

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -561,6 +561,9 @@ int main(int argc, char *argv[])
 #endif
     SetupEnvironment();
 
+    // Connect bitcoind signal handlers
+    noui_connect();
+
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
 
     // Do not refer to data directory yet, this can be overridden by Intro::pickDataDirectory

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -31,7 +31,6 @@
 #include <chainparams.h>
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
-#include <noui.h>
 #include <ui_interface.h>
 #include <util/system.h>
 
@@ -1226,9 +1225,6 @@ void BitcoinGUI::showModalOverlay()
 
 static bool ThreadSafeMessageBox(BitcoinGUI* gui, const std::string& message, const std::string& caption, unsigned int style)
 {
-    // Redundantly log and print message in non-gui fashion
-    noui_ThreadSafeMessageBox(message, caption, style);
-
     bool modal = (style & CClientUIInterface::MODAL);
     // The SECURE flag has no effect in the Qt GUI.
     // bool secure = (style & CClientUIInterface::SECURE);


### PR DESCRIPTION
Adding the following to `bitcoin.conf`
```
[xxx]
disablewallet=1
```
And running `bitcoin-qt` gives:
```
libc++abi.dylib: terminating with uncaught exception of type boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::signals2::no_slots_error> >: boost::signals2::no_slots_error
```

Fixes regression in #14708.