### PR TITLE
Skip redundant OP_CODESEPARATOR scan

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1119,7 +1119,8 @@ public:
                 nCodeSeparators++;
         }
         ::WriteCompactSize(s, scriptCode.size() - nCodeSeparators);
-        it = itBegin;
+        if (nCodeSeparators > 0)
+            it = itBegin;
         while (scriptCode.GetOp(it, opcode)) {
             if (opcode == OP_CODESEPARATOR) {
                 s.write((char*)&itBegin[0], it-itBegin-1);


### PR DESCRIPTION
`CTransactionSignatureSerializer()` scans `OP_CODESEPARATOR` twice. First time to count the number of `OP_CODESEPARATOR`, second time to remove `OP_CODESEPARATOR`. If `OP_CODESEPARATOR` is not found in the first scan, the second scan is redundant.

Since the use of `OP_CODESEPARATOR` is extremely rare, the repeated scan is wasteful is most cases.