### PR TITLE
Tests: Allow running rpc_bind.py --nonloopback test without IPv6

### DIFF
--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -67,7 +67,7 @@ class RPCBindTest(BitcoinTestFramework):
 
         self.log.info("Check for ipv6")
         have_ipv6 = test_ipv6_local()
-        if not have_ipv6 and not self.options.run_ipv4:
+        if not have_ipv6 and not (self.options.run_ipv4 or self.options.run_nonloopback):
             raise SkipTest("This test requires ipv6 support.")
 
         self.log.info("Check for non-loopback interface")


### PR DESCRIPTION
Don't see a reason why this can't be tested with IPv4 only.