### PR TITLE
qt: Fix deselecting peer when switching from peers to console tab

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -992,10 +992,12 @@ void RPCConsole::startExecutor()
 
 void RPCConsole::on_tabWidget_currentChanged(int index)
 {
-    if (ui->tabWidget->widget(index) == ui->tab_console)
+    if (ui->tabWidget->widget(index) == ui->tab_console) {
         ui->lineEdit->setFocus();
-    else if (ui->tabWidget->widget(index) != ui->tab_peers)
+    }
+    if (ui->tabWidget->widget(index) != ui->tab_peers) {
         clearSelectedNode();
+    }
 }
 
 void RPCConsole::on_openDebugLogfileButton_clicked()


### PR DESCRIPTION
The e0597268116cf90d961abeba9d14aaad0ab682d2 commit from #6209 was intended to deselect a peer when switching away from the Peers tab in the RPC console.
But switching away from the Peers tab to the Console tab and back does not deselect a peer.

This PR makes tab switching consistent: a peer is always deselected when switching away from the Peers tab.