### PR TITLE
Tests : timedata : unittest : median file filter shall not grow beyond size.

### DIFF
--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <timedata.h>
 #include <test/test_bitcoin.h>
+#include <timedata.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -32,6 +32,21 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
 
     filter.input(0); // [0 3 7 18 30]
     BOOST_CHECK_EQUAL(filter.median(), 7);
+}
+
+BOOST_AUTO_TEST_CASE(util_MedianFilterShallNotGrowBeyondSize)
+{
+    CMedianFilter<int> filter(2, 15);
+
+    BOOST_CHECK_EQUAL(filter.size(), 1); // 15
+
+    filter.input(100); // 15 100
+    BOOST_CHECK_EQUAL(filter.size(), 2);
+
+    filter.input(10); // 100 10
+    BOOST_CHECK_EQUAL(filter.size(), 2);
+    BOOST_CHECK_EQUAL(filter.sorted()[0], 10);
+    BOOST_CHECK_EQUAL(filter.sorted()[1], 100);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION

Added a new test and applied clang-format

- By definition size of filter is fixed during construction
- New entry added at the end and topmost entry is removed when max size is reached.
