### PR TITLE
qt: Use window() instead of obsolete topLevelWidget()

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -339,7 +339,7 @@ bool checkPoint(const QPoint &p, const QWidget *w)
 {
     QWidget *atW = QApplication::widgetAt(w->mapToGlobal(p));
     if (!atW) return false;
-    return atW->topLevelWidget() == w;
+    return atW->window() == w;
 }
 
 bool isObscured(QWidget *w)


### PR DESCRIPTION
`QWidget::topLevelWidget()` is obsolete since at least Qt 4.8.

Refs:
- https://doc-snapshots.qt.io/4.8/qwidget-obsolete.html#topLevelWidget
- https://doc.qt.io/qt-5.9/qwidget-obsolete.html#topLevelWidget