### PR TITLE
consensus: Avoid data race in CBlock class

### DIFF
--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -10,9 +10,36 @@
 #include <util/strencodings.h>
 #include <crypto/common.h>
 
+#include <atomic>
+
 uint256 CBlockHeader::GetHash() const
 {
     return SerializeHash(*this);
+}
+
+CBlockHeader::CBlockHeader(const CBlockHeader& header)
+    : nVersion{header.nVersion},
+      hashPrevBlock{header.hashPrevBlock},
+      hashMerkleRoot{header.hashMerkleRoot},
+      nTime{header.nTime},
+      nBits{header.nBits},
+      nNonce{header.nNonce}
+{
+}
+
+CBlock::CBlock(const CBlock& block)
+    : CBlockHeader{static_cast<CBlockHeader>(block)},
+      vtx{block.vtx}
+{
+    std::atomic_store(&m_checked, std::atomic_load(&block.m_checked));
+}
+
+CBlock& CBlock::operator=(const CBlock& block)
+{
+    *(static_cast<CBlockHeader*>(this)) = static_cast<CBlockHeader>(block);
+    vtx = block.vtx;
+    std::atomic_store(&m_checked, std::atomic_load(&block.m_checked));
+    return *this;
 }
 
 std::string CBlock::ToString() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -10,6 +10,8 @@
 #include <serialize.h>
 #include <uint256.h>
 
+#include <atomic>
+
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
  * requirements.  When they solve the proof-of-work, they broadcast the block
@@ -32,6 +34,8 @@ public:
     {
         SetNull();
     }
+
+    CBlockHeader(const CBlockHeader& header);
 
     ADD_SERIALIZE_METHODS;
 
@@ -76,7 +80,7 @@ public:
     std::vector<CTransactionRef> vtx;
 
     // memory only
-    mutable bool fChecked;
+    mutable std::atomic<bool> m_checked;
 
     CBlock()
     {
@@ -88,6 +92,9 @@ public:
         SetNull();
         *(static_cast<CBlockHeader*>(this)) = header;
     }
+
+    CBlock(const CBlock& block);
+    CBlock& operator=(const CBlock& block);
 
     ADD_SERIALIZE_METHODS;
 
@@ -101,7 +108,7 @@ public:
     {
         CBlockHeader::SetNull();
         vtx.clear();
-        fChecked = false;
+        m_checked = false;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -113,14 +113,7 @@ public:
 
     CBlockHeader GetBlockHeader() const
     {
-        CBlockHeader block;
-        block.nVersion       = nVersion;
-        block.hashPrevBlock  = hashPrevBlock;
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
-        return block;
+        return CBlockHeader(static_cast<CBlockHeader>(*this));
     }
 
     std::string ToString() const;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3081,7 +3081,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 {
     // These are checks that are independent of context.
 
-    if (block.fChecked)
+    if (block.m_checked)
         return true;
 
     // Check that the header is valid (particularly PoW).  This is mostly
@@ -3135,7 +3135,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-sigops", false, "out-of-bounds SigOpCount");
 
     if (fCheckPOW && fCheckMerkleRoot)
-        block.fChecked = true;
+        block.m_checked = true;
 
     return true;
 }

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -1,9 +1,6 @@
 # ThreadSanitizer suppressions
 # ============================
 
-# fChecked is theoretically racy, practically only in unit tests
-race:CheckBlock
-
 # WalletBatch (unidentified deadlock)
 deadlock:WalletBatch
 


### PR DESCRIPTION
Ref: #14058, #14072 

CheckBlock can be invoked from multiple threads in parallel. To avoid a data race `std::atomic<bool>` is used.
All comments from #14072 are addressed.

As this PR introduces copy constructors for both `CBlockHeader` and `CBlock` classes, additional refactoring proposed for `CBlock::GetBlockHeader()`.