### PR TITLE
docs: Less confusing documentation for `torpassword`

### DIFF
--- a/doc/tor.md
+++ b/doc/tor.md
@@ -109,9 +109,13 @@ preconfigured and the creation of a hidden service is automatic. If permission p
 are seen with `-debug=tor` they can be resolved by adding both the user running Tor and
 the user running bitcoind to the same group and setting permissions appropriately. On
 Debian-based systems the user running bitcoind can be added to the debian-tor group,
-which has the appropriate permissions. An alternative authentication method is the use
-of the `-torpassword` flag and a `hash-password` which can be enabled and specified in
-Tor configuration.
+which has the appropriate permissions.
+
+An alternative authentication method is the use
+of the `-torpassword=password` option. The `password` is the clear text form that
+was used when generating the hashed password for the `HashedControlPassword` option
+in the tor configuration file. The hashed password can be obtained with the command
+`tor --hash-password password` (read the tor manual for more details).
 
 ## 4. Privacy recommendations
 


### PR DESCRIPTION
Rebased & squashed #14609.

> The current documentation leads the reader to think hash-password is an other option.
This change is less confusing and make it clear how to use this option.