### PR TITLE
doc: clarify RPC rawtransaction documentation

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -939,7 +939,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
                 "this transaction depends on but may not yet be in the block chain.\n",
                 {
                     {"hexstring", RPCArg::Type::STR, false},
-                    {"privkyes", RPCArg::Type::ARR,
+                    {"privkeys", RPCArg::Type::ARR,
                         {
                             {"privatekey", RPCArg::Type::STR_HEX, false},
                         },
@@ -1142,7 +1142,7 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
         throw std::runtime_error(
             // clang-format off
             "testmempoolaccept [\"rawtxs\"] ( allowhighfees )\n"
-            "\nReturns if raw transaction (serialized, hex-encoded) would be accepted by mempool.\n"
+            "\nReturns result of mempool acceptance tests indicating if raw transaction (serialized, hex-encoded) would be accepted by mempool.\n"
             "\nThis checks if the transaction violates the consensus or policy rules.\n"
             "\nSee sendrawtransaction call.\n"
             "\nArguments:\n"


### PR DESCRIPTION
Fixing an RPC documentation typo and clarifying the wording of the testmempoolaccept function.