### PR TITLE
Tools: improve verify-commits.py script

### DIFF
--- a/contrib/verify-commits/README.md
+++ b/contrib/verify-commits/README.md
@@ -3,7 +3,7 @@ Tooling for verification of PGP signed commits
 
 This is an incomplete work in progress, but currently includes a pre-push hook
 script (`pre-push-hook.sh`) for maintainers to ensure that their own commits
-are PGP signed (nearly always merge commits), as well as a script to verify
+are PGP signed (nearly always merge commits), as well as a Python 3 script to verify
 commits against a trusted keys list.
 
 
@@ -17,9 +17,11 @@ be backdoored. Instead, you need to use a trusted version of verify-commits
 prior to checkout to make sure you're checking out only code signed by trusted
 keys:
 
-    git fetch origin && \
-      ./contrib/verify-commits/verify-commits.py origin/master && \
-      git checkout origin/master
+ ```sh
+ git fetch origin && \
+ ./contrib/verify-commits/verify-commits.py origin/master && \
+ git checkout origin/master
+ ```
 
 Note that the above isn't a good UI/UX yet, and needs significant improvements
 to make it more convenient and reduce the chance of errors; pull-reqs
@@ -32,6 +34,13 @@ Configuration files
 * `trusted-sha512-root-commit`: This file should contain a single git commit hash which is the first commit without a SHA512 root commitment.
 * `trusted-keys`: This file should contain a \n-delimited list of all PGP fingerprints of authorized commit signers (primary, not subkeys).
 * `allow-revsig-commits`: This file should contain a \n-delimited list of git commit hashes. See next section for more info.
+
+Import trusted keys
+-------------------
+In order to check the commit signatures you must add the trusted PGP keys to your machine. This can be done in Linux by running
+```sh
+gpg --recv-keys $(<contrib/verify-commits/trusted-keys)
+```
 
 Key expiry/revocation
 ---------------------

--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -139,7 +139,7 @@ def main():
         if len(parents) == 2 and check_merge and not allow_unclean:
             current_tree = subprocess.check_output([GIT, 'show', '--format=%T', current_commit], universal_newlines=True, encoding='utf8').splitlines()[0]
             subprocess.call([GIT, 'checkout', '--force', '--quiet', parents[0]])
-            subprocess.call([GIT, 'merge', '--no-ff', '--quiet', parents[1]], stdout=subprocess.DEVNULL)
+            subprocess.call([GIT, 'merge', '--no-ff', '--quiet', '--no-gpg-sign', parents[1]], stdout=subprocess.DEVNULL)
             recreated_tree = subprocess.check_output([GIT, 'show', '--format=format:%T', 'HEAD'], universal_newlines=True, encoding='utf8').splitlines()[0]
             if current_tree != recreated_tree:
                 print("Merge commit {} is not clean".format(current_commit), file=sys.stderr)


### PR DESCRIPTION
I ran into 3 different issues while trying to run the verify-commits script for the first time and I think documenting them would help save time for future developers.

1. I was trying to just run it with "python" and didn't realize I had multiple python versions installed and this script is only syntactically valid for python 3.x.
2. I needed to import the trusted keys
3. The script was hanging because it was triggering my yubikey for signature verification
