### PR TITLE
qt: Enable tabbing through labels

### DIFF
--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -24,6 +24,7 @@
     <ClCompile Include="..\..\src\qt\csvmodelwriter.cpp" />
     <ClCompile Include="..\..\src\qt\editaddressdialog.cpp" />
     <ClCompile Include="..\..\src\qt\guiutil.cpp" />
+    <ClCompile Include="..\..\src\qt\highlightlabelwidget.cpp" />
     <ClCompile Include="..\..\src\qt\intro.cpp" />
     <ClCompile Include="..\..\src\qt\modaloverlay.cpp" />
     <ClCompile Include="..\..\src\qt\networkstyle.cpp" />
@@ -76,6 +77,7 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_csvmodelwriter.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_editaddressdialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_guiutil.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_highlightlabelwidget.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_intro.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_modaloverlay.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_networkstyle.cpp" />

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -45,6 +45,7 @@ QT_MOC_CPP = \
   qt/moc_csvmodelwriter.cpp \
   qt/moc_editaddressdialog.cpp \
   qt/moc_guiutil.cpp \
+  qt/moc_highlightlabelwidget.cpp \
   qt/moc_intro.cpp \
   qt/moc_macdockiconhandler.cpp \
   qt/moc_macnotificationhandler.cpp \
@@ -113,6 +114,7 @@ BITCOIN_QT_H = \
   qt/editaddressdialog.h \
   qt/guiconstants.h \
   qt/guiutil.h \
+  qt/highlightlabelwidget.h \
   qt/intro.h \
   qt/macdockiconhandler.h \
   qt/macnotificationhandler.h \
@@ -212,6 +214,7 @@ BITCOIN_QT_BASE_CPP = \
   qt/clientmodel.cpp \
   qt/csvmodelwriter.cpp \
   qt/guiutil.cpp \
+  qt/highlightlabelwidget.cpp \
   qt/intro.cpp \
   qt/modaloverlay.cpp \
   qt/networkstyle.cpp \

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -67,18 +67,9 @@
         </widget>
        </item>
        <item row="1" column="1" colspan="2">
-        <widget class="QLabel" name="clientVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="clientVersion">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -93,18 +84,9 @@
         </widget>
        </item>
        <item row="2" column="1" colspan="2">
-        <widget class="QLabel" name="clientUserAgent">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="clientUserAgent">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -119,18 +101,9 @@
         </widget>
        </item>
        <item row="3" column="1" colspan="2">
-        <widget class="QLabel" name="berkeleyDBVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="berkeleyDBVersion">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -142,24 +115,15 @@
         </widget>
        </item>
        <item row="4" column="1" colspan="2">
-        <widget class="QLabel" name="dataDir">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="dataDir">
          <property name="toolTip">
           <string>To specify a non-default location of the data directory use the '%1' option.</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -171,24 +135,15 @@
         </widget>
        </item>
        <item row="5" column="1" colspan="2">
-        <widget class="QLabel" name="blocksDir">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="blocksDir">
          <property name="toolTip">
           <string>To specify a non-default location of the blocks directory use the '%1' option.</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -200,18 +155,9 @@
         </widget>
        </item>
        <item row="6" column="1" colspan="2">
-        <widget class="QLabel" name="startupTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="startupTime">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -236,18 +182,9 @@
         </widget>
        </item>
        <item row="8" column="1" colspan="2">
-        <widget class="QLabel" name="networkName">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="networkName">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -259,18 +196,9 @@
         </widget>
        </item>
        <item row="9" column="1" colspan="2">
-        <widget class="QLabel" name="numberOfConnections">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="numberOfConnections">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -295,18 +223,9 @@
         </widget>
        </item>
        <item row="11" column="1" colspan="2">
-        <widget class="QLabel" name="numberOfBlocks">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="numberOfBlocks">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -318,18 +237,9 @@
         </widget>
        </item>
        <item row="12" column="1" colspan="2">
-        <widget class="QLabel" name="lastBlockTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="lastBlockTime">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -354,18 +264,9 @@
         </widget>
        </item>
        <item row="14" column="1">
-        <widget class="QLabel" name="mempoolNumberTxs">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="mempoolNumberTxs">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -377,18 +278,9 @@
         </widget>
        </item>
        <item row="15" column="1">
-        <widget class="QLabel" name="mempoolSize">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+        <widget class="HighlightLabelWidget" name="mempoolSize">
          <property name="text">
           <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -1564,6 +1456,11 @@
    <slots>
     <slot>clear()</slot>
    </slots>
+  </customwidget>
+  <customwidget>
+   <class>HighlightLabelWidget</class>
+   <extends>QLabel</extends>
+   <header>qt/highlightlabelwidget.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -72,6 +72,9 @@
                 <height>16777215</height>
                </size>
               </property>
+              <property name="focusPolicy">
+               <enum>Qt::ClickFocus</enum>
+              </property>
               <property name="toolTip">
                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</string>
               </property>
@@ -115,15 +118,12 @@
              <number>12</number>
             </property>
             <item row="2" column="2">
-             <widget class="QLabel" name="labelWatchPending">
+             <widget class="HighlightLabelWidget" name="labelWatchPending">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Unconfirmed transactions to watch-only addresses</string>
@@ -134,21 +134,15 @@
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
              </widget>
             </item>
             <item row="2" column="1">
-             <widget class="QLabel" name="labelUnconfirmed">
+             <widget class="HighlightLabelWidget" name="labelUnconfirmed">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
@@ -159,21 +153,15 @@
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
              </widget>
             </item>
             <item row="3" column="2">
-             <widget class="QLabel" name="labelWatchImmature">
+             <widget class="HighlightLabelWidget" name="labelWatchImmature">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Mined balance in watch-only addresses that has not yet matured</string>
@@ -183,9 +171,6 @@
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -223,15 +208,12 @@
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QLabel" name="labelImmature">
+             <widget class="HighlightLabelWidget" name="labelImmature">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Mined balance that has not yet matured</string>
@@ -241,9 +223,6 @@
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -268,15 +247,12 @@
              </widget>
             </item>
             <item row="5" column="1">
-             <widget class="QLabel" name="labelTotal">
+             <widget class="HighlightLabelWidget" name="labelTotal">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Your current total balance</string>
@@ -287,21 +263,15 @@
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
              </widget>
             </item>
             <item row="5" column="2">
-             <widget class="QLabel" name="labelWatchTotal">
+             <widget class="HighlightLabelWidget" name="labelWatchTotal">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Current total balance in watch-only addresses</string>
@@ -311,9 +281,6 @@
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -335,15 +302,12 @@
              </widget>
             </item>
             <item row="1" column="1">
-             <widget class="QLabel" name="labelBalance">
+             <widget class="HighlightLabelWidget" name="labelBalance">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Your current spendable balance</string>
@@ -354,21 +318,15 @@
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-              </property>
              </widget>
             </item>
             <item row="1" column="2">
-             <widget class="QLabel" name="labelWatchAvailable">
+             <widget class="HighlightLabelWidget" name="labelWatchAvailable">
               <property name="font">
                <font>
                 <weight>75</weight>
                 <bold>true</bold>
                </font>
-              </property>
-              <property name="cursor">
-               <cursorShape>IBeamCursor</cursorShape>
               </property>
               <property name="toolTip">
                <string>Your current balance in watch-only addresses</string>
@@ -378,9 +336,6 @@
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
               </property>
              </widget>
             </item>
@@ -458,6 +413,9 @@
                 <height>16777215</height>
                </size>
               </property>
+              <property name="focusPolicy">
+               <enum>Qt::ClickFocus</enum>
+              </property>
               <property name="toolTip">
                <string>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</string>
               </property>
@@ -497,6 +455,9 @@
           </item>
           <item>
            <widget class="QListView" name="listTransactions">
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
             <property name="styleSheet">
              <string notr="true">QListView { background: transparent; }</string>
             </property>
@@ -536,6 +497,23 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>HighlightLabelWidget</class>
+   <extends>QLabel</extends>
+   <header>qt/highlightlabelwidget.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>labelBalance</tabstop>
+  <tabstop>labelUnconfirmed</tabstop>
+  <tabstop>labelImmature</tabstop>
+  <tabstop>labelTotal</tabstop>
+  <tabstop>labelWatchAvailable</tabstop>
+  <tabstop>labelWatchPending</tabstop>
+  <tabstop>labelWatchImmature</tabstop>
+  <tabstop>labelWatchTotal</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/qt/highlightlabelwidget.cpp
+++ b/src/qt/highlightlabelwidget.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/highlightlabelwidget.h>
+
+#include <QFocusEvent>
+#include <QLabel>
+#include <QString>
+#include <QWidget>
+
+HighlightLabelWidget::HighlightLabelWidget(QWidget* parent)
+    : QLabel(parent)
+{
+    setCursor(Qt::IBeamCursor);
+    setFocusPolicy(Qt::StrongFocus);
+    setTextFormat(Qt::PlainText);
+    setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard | Qt::LinksAccessibleByKeyboard);
+}
+
+void HighlightLabelWidget::setText(const QString& text)
+{
+    const bool selected = hasSelectedText();
+    QLabel::setText(text);
+    if (selected) {
+        SelectAll();
+    }
+}
+
+void HighlightLabelWidget::focusInEvent(QFocusEvent* ev)
+{
+    if (ev->reason() == Qt::TabFocusReason || ev->reason() == Qt::BacktabFocusReason) {
+        // Highligt label when focused via keyboard.
+        SelectAll();
+    }
+}
+
+void HighlightLabelWidget::focusOutEvent(QFocusEvent* ev)
+{
+    if (ev->reason() != Qt::PopupFocusReason) {
+        Reset();
+    }
+}
+
+void HighlightLabelWidget::Reset()
+{
+    const QString content = text();
+    clear();
+    QLabel::setText(content);
+}
+
+void HighlightLabelWidget::SelectAll()
+{
+    setSelection(0, text().size());
+}

--- a/src/qt/highlightlabelwidget.h
+++ b/src/qt/highlightlabelwidget.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_HIGHLIGHTLABELWIDGET_H
+#define BITCOIN_QT_HIGHLIGHTLABELWIDGET_H
+
+#include <amount.h>
+
+#include <QLabel>
+#include <QObject>
+
+QT_BEGIN_NAMESPACE
+class QFocusEvent;
+class QString;
+class QWidget;
+QT_END_NAMESPACE
+
+/**
+ * Widget for displaying bitcoin amounts with privacy facilities
+ */
+class HighlightLabelWidget : public QLabel
+{
+    Q_OBJECT
+
+public:
+    explicit HighlightLabelWidget(QWidget* parent = nullptr);
+
+public Q_SLOTS:
+    // Hide QLabel::setText(const QString&)
+    void setText(const QString& text);
+
+protected:
+    void focusInEvent(QFocusEvent* ev) override;
+    void focusOutEvent(QFocusEvent* ev) override;
+
+private:
+    // Prevent zombie cursor (|).
+    void Reset();
+    // Select all the text (i.e., highlight it).
+    void SelectAll();
+};
+
+#endif // BITCOIN_QT_HIGHLIGHTLABELWIDGET_H

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -9,6 +9,7 @@
 #include <qt/clientmodel.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>
+#include <qt/highlightlabelwidget.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/transactionfilterproxy.h>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -9,15 +9,16 @@
 #include <qt/rpcconsole.h>
 #include <qt/forms/ui_debugwindow.h>
 
-#include <qt/bantablemodel.h>
-#include <qt/clientmodel.h>
-#include <qt/platformstyle.h>
-#include <qt/walletmodel.h>
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <netbase.h>
-#include <rpc/server.h>
+#include <qt/bantablemodel.h>
+#include <qt/clientmodel.h>
+#include <qt/highlightlabelwidget.h>
+#include <qt/platformstyle.h>
+#include <qt/walletmodel.h>
 #include <rpc/client.h>
+#include <rpc/server.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 


### PR DESCRIPTION
This PR:
- fixes a visual bug described in #14577
- improves UX by enabling moving focus through fields using keyboard (**Tab** and **Shift+Tab** as usual) on Overview tab of the main window and on Info tab of the Debug window (other tabs leaved untouched as tab order for them seems a bit entangled). Inspired by **laanwj**'s https://github.com/bitcoin/bitcoin/pull/14577#issuecomment-438652059

Also applied a style-fix from [#15220](https://github.com/bitcoin/bitcoin/pull/15220#issuecomment-456377390):
> please just do this the next time you're editing these files.