### PR TITLE
Add CScriptNum decode python implementation in functional suite

### DIFF
--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -25,7 +25,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     bytes_to_hex_str as b2x,
 )
-
+from test_framework.script import CScriptNum
 
 def assert_template(node, block, expect, rehash=True):
     if rehash:
@@ -65,10 +65,18 @@ class MiningTest(BitcoinTestFramework):
         assert 'proposal' in tmpl['capabilities']
         assert 'coinbasetxn' not in tmpl
 
-        coinbase_tx = create_coinbase(height=int(tmpl["height"]) + 1)
+        next_height = int(tmpl["height"])
+        coinbase_tx = create_coinbase(height=next_height)
         # sequence numbers must not be max for nLockTime to have effect
         coinbase_tx.vin[0].nSequence = 2 ** 32 - 2
         coinbase_tx.rehash()
+
+        # round-trip the encoded bip34 block height commitment
+        assert_equal(CScriptNum.decode(coinbase_tx.vin[0].scriptSig), next_height)
+        # round-trip negative and multi-byte CScriptNums to catch python regression
+        assert_equal(CScriptNum.decode(CScriptNum.encode(CScriptNum(1500))), 1500)
+        assert_equal(CScriptNum.decode(CScriptNum.encode(CScriptNum(-1500))), -1500)
+        assert_equal(CScriptNum.decode(CScriptNum.encode(CScriptNum(-1))), -1)
 
         block = CBlock()
         block.nVersion = tmpl["version"]

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -385,6 +385,22 @@ class CScriptNum:
             r[-1] |= 0x80
         return bytes([len(r)]) + r
 
+    @staticmethod
+    def decode(vch):
+        result = 0
+        # We assume valid push_size and minimal encoding
+        value = vch[1:]
+        if len(value) == 0:
+            return result
+        for i, byte in enumerate(value):
+            result |= int(byte) << 8*i
+        if value[-1] >= 0x80:
+            # Mask for all but the highest result bit
+            num_mask = (2**(len(value)*8) - 1) >> 1
+            result &= num_mask
+            result *= -1
+        return result
+
 
 class CScript(bytes):
     """Serialized script


### PR DESCRIPTION
I needed this for reasons and thought it'd be good to upsteam it.