### PR TITLE
qt: Remove unnecessary columns in Coin Selection window (#11811)

### DIFF
--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -402,7 +402,7 @@
       <bool>false</bool>
      </property>
      <property name="columnCount">
-      <number>10</number>
+      <number>8</number>
      </property>
      <attribute name="headerShowSortIndicator" stdset="0">
       <bool>true</bool>


### PR DESCRIPTION
Fix #11811.

Actually there are 8 columns in the `treeWidget` and 2 of them are hidden.