### PR TITLE
test: Fix descriptor_tests not checking ToString output of public descriptors

### DIFF
--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -62,7 +62,7 @@ void Check(const std::string& prv, const std::string& pub, int flags, const std:
 
     // Check that both versions serialize back to the public version.
     std::string pub1 = parse_priv->ToString();
-    std::string pub2 = parse_priv->ToString();
+    std::string pub2 = parse_pub->ToString();
     BOOST_CHECK_EQUAL(pub, pub1);
     BOOST_CHECK_EQUAL(pub, pub2);
 


### PR DESCRIPTION
This fixes a minor test bug introduced in #13697 that I noticed while reviewing #14646