### PR TITLE
Avoid expanding descriptor scriptPubKeys

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2252,7 +2252,7 @@ UniValue scantxoutset(const JSONRPCRequest& request)
             if (!desc->IsRange()) range = 0;
             for (int i = 0; i <= range; ++i) {
                 std::vector<CScript> scripts;
-                if (!desc->Expand(i, provider, scripts, provider)) {
+                if (!desc->Expand(i, provider, &scripts, provider)) {
                     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Cannot derive script without private keys: '%s'", desc_str));
                 }
                 for (const auto& script : scripts) {

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -46,10 +46,10 @@ struct Descriptor {
      *
      * pos: the position at which to expand the descriptor. If IsRange() is false, this is ignored.
      * provider: the provider to query for private keys in case of hardened derivation.
-     * output_script: the expanded scriptPubKeys will be put here.
+     * output_script: optionally the expanded scriptPubKeys will be put here.
      * out: scripts and public keys necessary for solving the expanded scriptPubKeys will be put here (may be equal to provider).
      */
-    virtual bool Expand(int pos, const SigningProvider& provider, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const = 0;
+    virtual bool Expand(int pos, const SigningProvider& provider, std::vector<CScript>* output_scripts, FlatSigningProvider& out) const = 0;
 };
 
 /** Parse a descriptor string. Included private keys are put in out. Returns nullptr if parsing fails. */

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -90,7 +90,7 @@ void Check(const std::string& prv, const std::string& pub, int flags, const std:
             const FlatSigningProvider& key_provider = (flags & HARDENED) ? keys_priv : keys_pub;
             FlatSigningProvider script_provider;
             std::vector<CScript> spks;
-            BOOST_CHECK((t ? parse_priv : parse_pub)->Expand(i, key_provider, spks, script_provider));
+            BOOST_CHECK((t ? parse_priv : parse_pub)->Expand(i, key_provider, &spks, script_provider));
             BOOST_CHECK_EQUAL(spks.size(), ref.size());
             for (size_t n = 0; n < spks.size(); ++n) {
                 BOOST_CHECK_EQUAL(ref[n], HexStr(spks[n].begin(), spks[n].end()));
@@ -108,7 +108,7 @@ void Check(const std::string& prv, const std::string& pub, int flags, const std:
                 BOOST_CHECK_EQUAL(inferred->IsSolvable(), !(flags & UNSOLVABLE));
                 std::vector<CScript> spks_inferred;
                 FlatSigningProvider provider_inferred;
-                BOOST_CHECK(inferred->Expand(0, provider_inferred, spks_inferred, provider_inferred));
+                BOOST_CHECK(inferred->Expand(0, provider_inferred, &spks_inferred, provider_inferred));
                 BOOST_CHECK_EQUAL(spks_inferred.size(), 1);
                 BOOST_CHECK(spks_inferred[0] == spks[n]);
                 BOOST_CHECK_EQUAL(IsSolvable(provider_inferred, spks_inferred[0]), !(flags & UNSOLVABLE));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -107,9 +107,8 @@ std::string COutput::ToString() const
 
 std::vector<CKeyID> GetAffectedKeys(const CScript& spk, const SigningProvider& provider)
 {
-    std::vector<CScript> dummy;
     FlatSigningProvider out;
-    InferDescriptor(spk, provider)->Expand(0, DUMMY_SIGNING_PROVIDER, dummy, out);
+    InferDescriptor(spk, provider)->Expand(0, DUMMY_SIGNING_PROVIDER, nullptr, out);
     std::vector<CKeyID> ret;
     for (const auto& entry : out.pubkeys) {
         ret.push_back(entry.first);


### PR DESCRIPTION
Output scripts aren't needed in `GetAffectedKeys`, this change avoids computing them.

Based on #14821.