### PR TITLE
Scripts and tools: Use #!/usr/bin/env bash instead of #!/bin/bash.

### DIFF
--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Copyright (c) 2017 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -28,6 +28,8 @@ Developer Notes
     - [Strings and formatting](#strings-and-formatting)
     - [Variable names](#variable-names)
     - [Threads and synchronization](#threads-and-synchronization)
+    - [Scripts](#scripts)
+        - [Shebang](#shebang)
     - [Source code organization](#source-code-organization)
     - [GUI](#gui)
     - [Subtrees](#subtrees)
@@ -600,6 +602,31 @@ TRY_LOCK(cs_vNodes, lockNodes);
 {
     ...
 }
+```
+
+Scripts
+--------------------------
+
+### Shebang
+
+- Use `#!/usr/bin/env bash` instead of obsolete `#!/bin/bash`.
+
+  - [*Rationale*](https://github.com/dylanaraps/pure-bash-bible#shebang):
+
+    `#!/bin/bash` assumes it is always installed to /bin/ which can cause issues;
+
+    `#!/usr/bin/env bash` searches the user's PATH to find the bash binary.
+
+  OK:
+
+```bash
+#!/usr/bin/env bash
+```
+
+  Wrong:
+
+```bash
+#!/bin/bash
 ```
 
 Source code organization

--- a/src/qt/res/movies/makespinner.sh
+++ b/src/qt/res/movies/makespinner.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Copyright (c) 2014-2015 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.

--- a/test/lint/lint-python-dead-code.sh
+++ b/test/lint/lint-python-dead-code.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2018 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying

--- a/test/lint/lint-shebang.sh
+++ b/test/lint/lint-shebang.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Shebang must use python3 (not python or python2)
+# Assert expected shebang lines
 
 export LC_ALL=C
 EXIT_CODE=0
@@ -7,6 +7,13 @@ for PYTHON_FILE in $(git ls-files -- "*.py"); do
     if [[ $(head -c 2 "${PYTHON_FILE}") == "#!" &&
           $(head -n 1 "${PYTHON_FILE}") != "#!/usr/bin/env python3" ]]; then
         echo "Missing shebang \"#!/usr/bin/env python3\" in ${PYTHON_FILE} (do not use python or python2)"
+        EXIT_CODE=1
+    fi
+done
+for SHELL_FILE in $(git ls-files -- "*.sh"); do
+    if [[ $(head -n 1 "${SHELL_FILE}") != "#!/usr/bin/env bash" &&
+          $(head -n 1 "${SHELL_FILE}") != "#!/bin/sh" ]]; then
+        echo "Missing expected shebang \"#!/usr/bin/env bash\" or \"#!/bin/sh\" in ${SHELL_FILE}"
         EXIT_CODE=1
     fi
 done


### PR DESCRIPTION
As it was discussed in [#13510](https://github.com/bitcoin/bitcoin/pull/13510), it is better to use `#!/usr/bin/env bash` instead of `#!/bin/bash`.