### PR TITLE
docs: Add more Doxygen information to Developer Notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -7,8 +7,8 @@ Developer Notes
 - [Developer Notes](#developer-notes)
     - [Coding Style (General)](#coding-style-general)
     - [Coding Style (C++)](#coding-style-c)
-    - [Doxygen comments](#doxygen-comments)
     - [Coding Style (Python)](#coding-style-python)
+    - [Coding Style (Doxygen-compatible comments)](#coding-style-doxygen-compatible-comments)
     - [Development tips and tricks](#development-tips-and-tricks)
         - [Compiling for debugging](#compiling-for-debugging)
         - [Compiling for gprof profiling](#compiling-for-gprof-profiling)
@@ -118,10 +118,17 @@ public:
 } // namespace foo
 ```
 
-Doxygen comments
------------------
+Coding Style (Python)
+---------------------
 
-To facilitate the generation of documentation, use doxygen-compatible comment blocks for functions, methods and fields.
+Refer to [/test/functional/README.md#style-guidelines](/test/functional/README.md#style-guidelines).
+
+Coding Style (Doxygen-compatible comments)
+------------------------------------------
+
+Bitcoin Core uses [Doxygen](http://www.doxygen.nl/) to generate its official documentation.
+
+Use Doxygen-compatible comment blocks for functions, methods, and fields.
 
 For example, to describe a function use:
 ```c++
@@ -154,7 +161,7 @@ int var; //!< Detailed description after the member
 ```
 
 or
-```cpp
+```c++
 //! Description before the member
 int var;
 ```
@@ -174,15 +181,15 @@ Not OK (used plenty in the current source, but not picked up):
 //
 ```
 
-A full list of comment syntaxes picked up by doxygen can be found at http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html,
-but if possible use one of the above styles.
+A full list of comment syntaxes picked up by Doxygen can be found at https://www.stack.nl/~dimitri/doxygen/manual/docblocks.html,
+but the above styles are favored.
 
-Documentation can be generated with `make docs` and cleaned up with `make clean-docs`.
+Documentation can be generated with `make docs` and cleaned up with `make clean-docs`. The resulting files are located in `doc/doxygen/html`; open `index.html` to view the homepage.
 
-Coding Style (Python)
----------------------
-
-Refer to [/test/functional/README.md#style-guidelines](/test/functional/README.md#style-guidelines).
+Before running `make docs`, you will need to install dependencies `doxygen` and `dot`. For example, on MacOS via Homebrew:
+```
+brew install doxygen --with-graphviz
+```
 
 Development tips and tricks
 ---------------------------


### PR DESCRIPTION
Update information about Doxygen in `doc/developer-notes.md`.

Alternatively, this could have its own file (like `doc/web-documentation.md`), since there are installation steps included.

For example, I had to run:
```
brew install doxygen graphviz
```
on MacOS, otherwise failures occurred.

This information could also be linked to the `doc/release-process.md`.