### PR TITLE
validation: assert that pindexPrev is non-null when required

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3267,6 +3267,7 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     // Start enforcing BIP113 (Median Time Past) using versionbits logic.
     int nLockTimeFlags = 0;
     if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV, versionbitscache) == ThresholdState::ACTIVE) {
+        assert(pindexPrev != nullptr);
         nLockTimeFlags |= LOCKTIME_MEDIAN_TIME_PAST;
     }
 


### PR DESCRIPTION
In `ContextualCheckBlock`, we are checking if `pindexPrev == nullptr` conditionally at the start, but then assume it is non-`null` later. This removes the latter assumption.
