### PR TITLE
[rebase] threads: fix unitialized members in sched_param

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1293,7 +1293,7 @@ fs::path AbsPathForConfigVal(const fs::path& path, bool net_specific)
 int ScheduleBatchPriority()
 {
 #ifdef SCHED_BATCH
-    const static sched_param param{0};
+    const static sched_param param{};
     if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param)) {
         LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;


### PR DESCRIPTION
Rebased theuni's #14342.

Building with gcc 8.2 against musl libc, which apparently has more attributes available in its sched_param. The following warnings were produced:

    warning: missing initializer for member 'sched_param::sched_ss_low_priority' [-Wmissing-field-initializers]
    warning: missing initializer for member 'sched_param::sched_ss_repl_period' [-Wmissing-field-initializers]
    warning: missing initializer for member 'sched_param::sched_ss_init_budget' [-Wmissing-field-initializers]
    warning: missing initializer for member 'sched_param::sched_ss_max_repl' [-Wmissing-field-initializers]

Since the current thread may have interesting non-zero values for these fields, we want to be sure to only change the intended one. Query and modify the current sched_param rather than starting from a zeroed one.