### PR TITLE
consensus: Move CheckBlock() call to critical section

### DIFF
--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -1,9 +1,6 @@
 # ThreadSanitizer suppressions
 # ============================
 
-# fChecked is theoretically racy, practically only in unit tests
-race:CheckBlock
-
 # WalletBatch (unidentified deadlock)
 deadlock:WalletBatch
 


### PR DESCRIPTION
This is an alternative to #14803.

Refs:
- #14058
- #14072
- https://github.com/bitcoin/bitcoin/pull/14803#issuecomment-442233211 by @gmaxwell
> It doesn't support multithreaded validation and there are lot of things that prevent that, which is why I was concerned. Why doesn't the lock on the block index or even cs main prevent concurrency here?

- https://github.com/bitcoin/bitcoin/pull/14803#issuecomment-442237566 by @MarcoFalke