### PR TITLE
depends: latest RapidCheck

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -72,7 +72,7 @@ The following can be set when running make: make FOO=bar
     NO_WALLET: Don't download/build/cache libs needed to enable the wallet
     NO_UPNP: Don't download/build/cache packages needed for enabling upnp
     DEBUG: disable some optimizations and enable more runtime checking
-    RAPIDCHECK: build rapidcheck (experimental)
+    RAPIDCHECK: build rapidcheck (experimental, requires cmake)
     HOST_ID_SALT: Optional salt to use when generating host package ids
     BUILD_ID_SALT: Optional salt to use when generating build package ids
 

--- a/depends/packages/rapidcheck.mk
+++ b/depends/packages/rapidcheck.mk
@@ -1,18 +1,17 @@
 package=rapidcheck
-$(package)_version=10fc0cb
-$(package)_download_path=https://github.com/MarcoFalke/rapidcheck/archive
-$(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=9640926223c00af45bce4c7df8b756b5458a89b2ba74cfe3e404467f13ce26df
+$(package)_version=3eb9b4ff69f4ff2d9932e8f852c2b2a61d7c20d3
+$(package)_download_path=https://github.com/emil-e/rapidcheck/archive
+$(package)_file_name=$($(package)_version).tar.gz
+$(package)_sha256_hash=5fbf82755c9a647127e62563be079448ff8b1db9ca80a52a673dd9a88fdb714b
 
 define $(package)_config_cmds
-  cmake -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true .
+  cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true -DRC_INSTALL_ALL_EXTRAS=ON
 endef
 
 define $(package)_build_cmds
-  $(MAKE) && \
-  mkdir -p $($(package)_staging_dir)$(host_prefix)/include && \
-  cp -a include/* $($(package)_staging_dir)$(host_prefix)/include/ && \
-  cp -a extras/boost_test/include/rapidcheck/* $($(package)_staging_dir)$(host_prefix)/include/rapidcheck/ && \
-  mkdir -p $($(package)_staging_dir)$(host_prefix)/lib && \
-  cp -a librapidcheck.a $($(package)_staging_dir)$(host_prefix)/lib/
+  $(MAKE) rapidcheck
+endef
+
+define $(package)_stage_cmds
+  $(MAKE) rapidcheck install
 endef


### PR DESCRIPTION
This updates RapidCheck to the latest version available from https://github.com/emil-e/rapidcheck.

RapidCheck now uses the new `RC_INSTALL_ALL_EXTRAS` option, to install the extra `boost_test` packages, which should unblock progress in #14430.