### PR TITLE
qt: Cleanup SplashScreen class

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -217,7 +217,7 @@ Q_SIGNALS:
     void requestedInitialize();
     void requestedShutdown();
     void stopThread();
-    void splashFinished(QWidget *window);
+    void splashFinished();
 
 private:
     QThread *coreThread;
@@ -357,9 +357,9 @@ void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)
 {
     SplashScreen *splash = new SplashScreen(m_node, 0, networkStyle);
     // We don't hold a direct pointer to the splash screen after creation, but the splash
-    // screen will take care of deleting itself when slotFinish happens.
+    // screen will take care of deleting itself when finish() happens.
     splash->show();
-    connect(this, &BitcoinApplication::splashFinished, splash, &SplashScreen::slotFinish);
+    connect(this, &BitcoinApplication::splashFinished, splash, &SplashScreen::finish);
     connect(this, &BitcoinApplication::requestedShutdown, splash, &QWidget::close);
 }
 
@@ -500,7 +500,7 @@ void BitcoinApplication::initializeResult(bool success)
         {
             window->show();
         }
-        Q_EMIT splashFinished(window);
+        Q_EMIT splashFinished();
 
 #ifdef ENABLE_WALLET
         // Now that initialization/startup is done, process any command-line
@@ -514,7 +514,7 @@ void BitcoinApplication::initializeResult(bool success)
 #endif
         pollShutdownTimer->start(200);
     } else {
-        Q_EMIT splashFinished(window); // Make sure splash screen doesn't stick around during shutdown
+        Q_EMIT splashFinished(); // Make sure splash screen doesn't stick around during shutdown
         quit(); // Exit first main loop invocation
     }
 }

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -145,10 +145,8 @@ bool SplashScreen::eventFilter(QObject * obj, QEvent * ev) {
     return QObject::eventFilter(obj, ev);
 }
 
-void SplashScreen::slotFinish(QWidget *mainWin)
+void SplashScreen::finish()
 {
-    Q_UNUSED(mainWin);
-
     /* If the window is minimized, hide() will be ignored. */
     /* Make sure we de-minimize the splashscreen window before hiding */
     if (isMinimized())

--- a/src/qt/splashscreen.h
+++ b/src/qt/splashscreen.h
@@ -5,8 +5,7 @@
 #ifndef BITCOIN_QT_SPLASHSCREEN_H
 #define BITCOIN_QT_SPLASHSCREEN_H
 
-#include <functional>
-#include <QSplashScreen>
+#include <QWidget>
 
 #include <memory>
 
@@ -37,8 +36,8 @@ protected:
     void closeEvent(QCloseEvent *event);
 
 public Q_SLOTS:
-    /** Slot to call finish() method as it's not defined as slot */
-    void slotFinish(QWidget *mainWin);
+    /** Hide the splash screen window and schedule the splash screen object for deletion */
+    void finish();
 
     /** Show message and progress */
     void showMessage(const QString &message, int alignment, const QColor &color);


### PR DESCRIPTION
Cleaning up after replacing the `QSplashScreen` base class with the `QWidget` class (#4941 by @laanwj).

cc @jonasschnelli 