### PR TITLE
test: Correct ineffectual WithOrVersion from transactions_tests

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -64,12 +64,6 @@ public:
     size_t size() const { return stream->size(); }
 };
 
-template<typename S>
-OverrideStream<S> WithOrVersion(S* s, int nVersionFlag)
-{
-    return OverrideStream<S>(s, s->GetType(), s->GetVersion() | nVersionFlag);
-}
-
 /* Minimal stream for overwriting and/or appending to an existing byte vector
  *
  * The referenced vector will grow as necessary

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -414,7 +414,8 @@ static void ReplaceRedeemScript(CScript& script, const CScript& redeemScript)
     script = PushAll(stack);
 }
 
-BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
+BOOST_AUTO_TEST_CASE(test_big_witness_transaction)
+{
     CMutableTransaction mtx;
     mtx.nVersion = 1;
 
@@ -456,9 +457,8 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     }
 
     CDataStream ssout(SER_NETWORK, PROTOCOL_VERSION);
-    auto vstream = WithOrVersion(&ssout, 0);
-    vstream << mtx;
-    CTransaction tx(deserialize, vstream);
+    ssout << mtx;
+    CTransaction tx(deserialize, ssout);
 
     // check all inputs concurrently, with the cache
     PrecomputedTransactionData txdata(tx);


### PR DESCRIPTION
`WithOrVersion` uses `|` to combine the versions, and `|` with 0 is a no-op.

NicolasDorier / sipa do you recall why the version is being overridden here?

Introduced in ab48c5e72156b34300db4a6521cb3c9969be3937
Last updated 81e3228fcb33e8ed32d8b9fbe917444ba080073a