### PR TITLE
doc: Declare BLOCK_VALID_HEADER reserved

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -95,8 +95,8 @@ enum BlockStatus: uint32_t {
     //! Unused.
     BLOCK_VALID_UNKNOWN      =    0,
 
-    //! Parsed, version ok, hash satisfies claimed PoW, 1 <= vtx count <= max, timestamp not in future
-    BLOCK_VALID_HEADER       =    1,
+    //! Reserved (was BLOCK_VALID_HEADER).
+    BLOCK_VALID_RESERVED     =    1,
 
     //! All parent headers found, difficulty matches, timestamp >= median previous, checkpoint. Implies all parents
     //! are also at least TREE.
@@ -117,7 +117,7 @@ enum BlockStatus: uint32_t {
     BLOCK_VALID_SCRIPTS      =    5,
 
     //! All validity bits.
-    BLOCK_VALID_MASK         =   BLOCK_VALID_HEADER | BLOCK_VALID_TREE | BLOCK_VALID_TRANSACTIONS |
+    BLOCK_VALID_MASK         =   BLOCK_VALID_RESERVED | BLOCK_VALID_TREE | BLOCK_VALID_TRANSACTIONS |
                                  BLOCK_VALID_CHAIN | BLOCK_VALID_SCRIPTS,
 
     BLOCK_HAVE_DATA          =    8, //!< full block available in blk*.dat


### PR DESCRIPTION
`BLOCK_VALID_HEADER` was never used and the comment is confusing to me in several ways:

* It claims "version ok". However, without the previous header, it is not possible to check the validity of the version since the height needs to be known (c.f. BIP 90)
* It claims "hash satisfies claimed PoW". While it is possible to check against the claimed PoW, it is not possible without the previous header to check that the claimed PoW is itself valid.
* It claims "1 <= vtx count <= max". However, with the header alone and current consensus rules, the number of transactions is unknown.