### PR TITLE
test: Run scripted-diff in subshell

### DIFF
--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -20,23 +20,23 @@ fi
 RET=0
 PREV_BRANCH=`git name-rev --name-only HEAD`
 PREV_HEAD=`git rev-parse HEAD`
-for i in `git rev-list --reverse $1`; do
-    if git rev-list -n 1 --pretty="%s" $i | grep -q "^scripted-diff:"; then
-        git checkout --quiet $i^ || exit
-        SCRIPT="`git rev-list --format=%b -n1 $i | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
+for commit in `git rev-list --reverse $1`; do
+    if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
+        git checkout --quiet $commit^ || exit
+        SCRIPT="`git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
         if test "x$SCRIPT" = "x"; then
-            echo "Error: missing script for: $i"
+            echo "Error: missing script for: $commit"
             echo "Failed"
             RET=1
         else
-            echo "Running script for: $i"
+            echo "Running script for: $commit"
             echo "$SCRIPT"
-            eval "$SCRIPT"
-            git --no-pager diff --exit-code $i && echo "OK" || (echo "Failed"; false) || RET=1
+            (eval "$SCRIPT")
+            git --no-pager diff --exit-code $commit && echo "OK" || (echo "Failed"; false) || RET=1
         fi
         git reset --quiet --hard HEAD
      else
-        if git rev-list "--format=%b" -n1 $i | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
+        if git rev-list "--format=%b" -n1 $commit | grep -q '^-\(BEGIN\|END\)[ a-zA-Z]*-$'; then
             echo "Error: script block marker but no scripted-diff in title"
             echo "Failed"
             RET=1


### PR DESCRIPTION
scripted-diffs should be run in subshells so that their execution does not
affect the shell variables of commit-script-check. Shell variables are not
unset before evaluating the scripted-diff, so that they might be used in
the subshell. To this end, the variable previously named i is now more
descriptively named commit, this also allows scripted-diffs to use the
commonly used variable i without fear of losing a reference to the
commit.