### PR TITLE
[wip] util: Improve evaluation of includeconf lines in network sections of the config file

### DIFF
--- a/doc/release-notes-14866.md
+++ b/doc/release-notes-14866.md
@@ -1,0 +1,7 @@
+Updated settings
+----------------
+
+- Included configurations from includeconf lines in [main] [test] and [regtest]
+  sections of the config file are now evaluated in context of that section and
+  not treated like top-level includes. Config files included within a section
+  are also now disallowed from changing settings in other sections. (#14866)

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -188,7 +188,7 @@ protected:
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
     std::list<SectionInfo> m_config_sections GUARDED_BY(cs_args);
 
-    NODISCARD bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
+    NODISCARD bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false, bool includeconf_enabled = true);
 
     /**
      * Returns true if settings values from the default section should be used,

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -52,7 +52,7 @@ class IncludeConfTest(BitcoinTestFramework):
 
         subversion = self.nodes[0].getnetworkinfo()["subversion"]
         assert subversion.endswith("main; relative)/")
-        self.stop_node(0, expected_stderr="warning: -includeconf cannot be used from included files; ignoring -includeconf=relative2.conf")
+        self.stop_node(0, expected_stderr="Warning: relative.conf:2: -includeconf cannot be used from included files; ignoring -includeconf=relative2.conf")
 
         self.log.info("-includeconf cannot contain invalid arg")
 


### PR DESCRIPTION
This PR intends to make it easy to understand how the configuration files are interpreted.

1. Evaluate "includeconf" at the position described in the config file (like #include directive in C/C++), rather than at the end.

2. If once a section is specified with square brackets like [main], the only way to configure another network is to use square brackets again, e.g. [test].

3. In the "included" config file, the section is taken over from the "including" file. If no sections are specified yet, using square brackets or section prefix is still possible in the "included" file.

4. Changing the section in the "included" config file does not affects the including file. The section of the including file is kept.

5. If the "included" config file is included after the section has been specified by using square brackets or if they are included by using section prefix, any square brackets can not be used in that file.

ex) With Following 3 files, the properties are read as: 
```
    port=8444, main.port=8445, test.port=8442, regtest.port: undefined
```

 bitcoin.conf
 ---
 ```
test.includeconf=inc1.conf
includeconf=inc2.conf
port=8441   # ignored (2nd appearance of w/o section)
```

 inc1.conf
 ---
```
 port=8442   # test
 [regtest]
 port=8443   # ignored
```

 inc2.conf
 ---
```
 port=8444   # w/o section
 [main]
 port=8445   # main
 [regtest]
```
