### PR TITLE
contrib: Adding -daemon default option to bitcoind.init

### DIFF
--- a/contrib/init/bitcoind.init
+++ b/contrib/init/bitcoind.init
@@ -26,7 +26,7 @@ lockfile=${BITCOIND_LOCKFILE-/var/lock/subsys/bitcoind}
 bitcoind=${BITCOIND_BIN-/usr/bin/bitcoind}
 
 # bitcoind opts default to -disablewallet, override with BITCOIND_OPTS
-bitcoind_opts=${BITCOIND_OPTS--disablewallet}
+bitcoind_opts=${BITCOIND_OPTS--conf=/.bitcoin/bitcoin.conf -datadir=/.bitcoin -daemon -disablewallet}
 
 start() {
     echo -n $"Starting $prog: "


### PR DESCRIPTION
Adding -daemon default option otherwise it won't `sudo service bitcoind start` hangs. Also specifying explicitly the -conf and -datadir options, for clarity, and to let users know how to override.