### PR TITLE
[doc] developer-notes.md: point out that UniValue deviates from upstream

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -714,7 +714,7 @@ Current subtrees include:
   - Upstream at https://github.com/bitcoin-core/ctaes ; actively maintained by Core contributors.
 
 - src/univalue
-  - Upstream at https://github.com/jgarzik/univalue ; report important PRs to Core to avoid delay.
+  - Upstream at https://github.com/bitcoin-core/univalue ; actively maintained by Core contributors, deviates from upstream https://github.com/jgarzik/univalue
 
 Upgrading LevelDB
 ---------------------


### PR DESCRIPTION
While debugging an issue I was somewhat surprised to [learn](https://github.com/bitcoin/bitcoin/pull/14164#issuecomment-419752678) that we've moved `src/univalue` from https://github.com/jgarzik/univalue to https://github.com/bitcoin-core/univalue, that these repos are both maintained and they're different.

The first mention of using the bitcoin-core repo is from late 2015 in #7157. I didn't check when the last common ancestor commit is.

I couldn't find documentation as to why (these things just happen in open source of course), but at minimum we should make this more clear.

There's also the following line in `config.ac` that I'm not sure what to do with:
```
AC_INIT([univalue], [1.0.3],
        [http://github.com/jgarzik/univalue/])
```