### PR TITLE
add `--retry 5` to curl opts in install_db4.sh

### DIFF
--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -51,7 +51,7 @@ http_get() {
   if [ -f "${2}" ]; then
     echo "File ${2} already exists; not downloading again"
   elif check_exists curl; then
-    curl --insecure "${1}" -o "${2}"
+    curl --insecure --retry 5 "${1}" -o "${2}"
   else
     wget --no-check-certificate "${1}" -O "${2}"
   fi


### PR DESCRIPTION
I ran into some network issue that caused the clang patch to not download and the script exited. A retry would have solved it. The fallback choice, `wget`, has a default 20 retries.

I chose 5 retries because `curl` backs of after each try, starting at one second and doubling each time. 5 retries means that worst case scenario would be a total of 31 seconds waiting between attempts. IMO that should be enough tries if internet is working, but not too much if internet is not working.