### PR TITLE
 rpc listtransactions new argument options (paginatebypointer impl) 

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -56,6 +56,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "listtransactions", 1, "count" },
     { "listtransactions", 2, "skip" },
     { "listtransactions", 3, "include_watchonly" },
+    { "listtransactions", 4, "options" },
     { "walletpassphrase", 1, "timeout" },
     { "getblocktemplate", 0, "template_request" },
     { "listsinceblock", 1, "target_confirmations" },

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -102,6 +102,69 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"txid": txid, "label": "watchonly"})
 
         self.run_rbf_opt_in_test()
+        self.run_with_paginatebypointer_test()
+
+    # specific tests with nextpagepointer flag
+    def run_with_paginatebypointer_test(self):
+        def get_with_paginatebypointer(node, count=20, label="*", watchonly=False):
+            i = 1
+            records = []
+            pointer = None
+            while i < count:
+                options = {
+                    "paginatebypointer": True,
+                    "nextpagepointer": pointer,
+                }
+                #if pointer is None:
+                #    del options["nextpagepointer"]
+                result = node.listtransactions(label, i, 0, watchonly, options)
+                pointer = result.get("nextpagepointer", None)
+                records += result["records"]
+                if len(records) >= count or pointer is None:
+                    break
+                i += 1
+            return records
+        # Simple send, 0 to 1:
+        txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
+        self.sync_all()
+        assert_array_result(get_with_paginatebypointer(self.nodes[0]),
+                            {"txid": txid},
+                            {"category": "send", "amount": Decimal("-0.1"), "confirmations": 0})
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"txid": txid},
+                            {"category": "receive", "amount": Decimal("0.1"), "confirmations": 0})
+
+        # sendmany from node1: twice to self, twice to node2:
+        send_to = {self.nodes[0].getnewaddress(): 0.111,
+                   self.nodes[1].getnewaddress(): 0.222,
+                   self.nodes[0].getnewaddress(): 0.333,
+                   self.nodes[1].getnewaddress(): 0.444}
+        txid = self.nodes[1].sendmany("", send_to)
+        self.sync_all()
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"category": "send", "amount": Decimal("-0.111")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[0]),
+                            {"category": "receive", "amount": Decimal("0.111")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"category": "send", "amount": Decimal("-0.222")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"category": "receive", "amount": Decimal("0.222")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"category": "send", "amount": Decimal("-0.333")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[0]),
+                            {"category": "receive", "amount": Decimal("0.333")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"category": "send", "amount": Decimal("-0.444")},
+                            {"txid": txid})
+        assert_array_result(get_with_paginatebypointer(self.nodes[1]),
+                            {"category": "receive", "amount": Decimal("0.444")},
+                            {"txid": txid})
 
     # Check that the opt-in-rbf flag works properly, for sent and received
     # transactions.


### PR DESCRIPTION
Added fifth param to `listtransactions` named `options`, `options` may be an object containing `paginatebypointer` (boolean default: false) and `nextpagepointer` (string default: OMITTED).

With `paginatebypointer` output will have the following changes.

1. Return transactions is ordered by most recent transactions. Though the default does reverse the order after transactions are fetched and clipped.
2. `skip` argument has no effect. Instead `nextpagepointer` will be used for pagination.
3. Return value is an object containing, records (array of txs) and nextpagepointer (string)