### PR TITLE
test: Prevent "Duplicate-wallet filename specified"

### DIFF
--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -15,7 +15,9 @@ from test_framework.test_node import ErrorMatch
 from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
+    wait_until,
 )
+from test_framework.authproxy import JSONRPCException
 
 
 class MultiWalletTest(BitcoinTestFramework):
@@ -308,11 +310,11 @@ class MultiWalletTest(BitcoinTestFramework):
             rpc.backupwallet(backup)
             self.nodes[0].unloadwallet(wallet_name)
             shutil.copyfile(empty_wallet, wallet_file(wallet_name))
-            self.nodes[0].loadwallet(wallet_name)
+            wait_until(lambda: self.nodes[0].loadwallet(wallet_name), ignore_exceptions=(JSONRPCException,))
             assert_equal(rpc.getaddressinfo(addr)['ismine'], False)
             self.nodes[0].unloadwallet(wallet_name)
             shutil.copyfile(backup, wallet_file(wallet_name))
-            self.nodes[0].loadwallet(wallet_name)
+            wait_until(lambda: self.nodes[0].loadwallet(wallet_name), ignore_exceptions=(JSONRPCException,))
             assert_equal(rpc.getaddressinfo(addr)['ismine'], True)
 
 


### PR DESCRIPTION
```wallet_multiwallet.py --usecli``` may sometimes fails with
"Duplicate -wallet filename specified"
```unloadwallet()``` RPC command just notify the unload intention
and it may delay a little bit until actual unloading.

This patch check the completion of unloading by using ```listwallets()```.

This fixes #14917