### PR TITLE
ui: Warn the user on file corruption in mempool.dat

### DIFF
--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -59,16 +59,19 @@ void CClientUIInterface::NotifyHeaderTip(bool b, const CBlockIndex* i) { return 
 void CClientUIInterface::BannedListChanged() { return g_ui_signals.BannedListChanged(); }
 
 
-bool InitError(const std::string& str)
+bool UIError(const std::string& str)
 {
     uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_ERROR);
     return false;
 }
 
-void InitWarning(const std::string& str)
+void UIWarning(const std::string& str)
 {
     uiInterface.ThreadSafeMessageBox(str, "", CClientUIInterface::MSG_WARNING);
 }
+
+void InitWarning(const std::string& str) { return UIWarning(str); };
+bool InitError(const std::string& str) { return UIError(str); };
 
 std::string AmountHighWarn(const std::string& optname)
 {

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -121,6 +121,12 @@ public:
 };
 
 /** Show warning message **/
+void UIWarning(const std::string& str);
+
+/** Show error message **/
+bool UIError(const std::string& str);
+
+/** Show warning message **/
 void InitWarning(const std::string& str);
 
 /** Show error message **/

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4749,7 +4749,7 @@ bool LoadMempool()
             mempool.PrioritiseTransaction(i.first, i.second);
         }
     } catch (const std::exception& e) {
-        LogPrintf("Failed to deserialize mempool data on disk: %s. Continuing anyway.\n", e.what());
+        UIWarning(strprintf("Failed to deserialize mempool data on disk: %s. Continuing anyway.\n", e.what()));
         return false;
     }
 

--- a/test/functional/feature_file_corruption.py
+++ b/test/functional/feature_file_corruption.py
@@ -25,6 +25,7 @@ class FileCorruptionTest(BitcoinTestFramework):
             mempool_dat.write(b'ff')
         with self.nodes[0].assert_debug_log(expected_msgs=['Failed to deserialize mempool data on disk']):
             self.start_nodes()
+        self.stop_node(0, expected_stderr='Warning: Failed to deserialize mempool data on disk: CAutoFile::read: end of file: iostream error. Continuing anyway.')
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_file_corruption.py
+++ b/test/functional/feature_file_corruption.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test reported errors on file corruption.
+
+See doc/files.md for a list of files.
+"""
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class FileCorruptionTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.log.info('Test file corruption on mempool.dat')
+        mempool_dat_path = os.path.join(self.nodes[0].datadir, 'regtest', 'mempool.dat')
+        self.stop_nodes()
+        with open(mempool_dat_path, 'rb+') as mempool_dat:
+            mempool_dat.seek(9)
+            mempool_dat.write(b'ff')
+        with self.nodes[0].assert_debug_log(expected_msgs=['Failed to deserialize mempool data on disk']):
+            self.start_nodes()
+
+
+if __name__ == '__main__':
+    FileCorruptionTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -112,6 +112,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
     'interface_rest.py',
+    'feature_file_corruption.py',
     'mempool_spend_coinbase.py',
     'mempool_reorg.py',
     'mempool_persist.py',


### PR DESCRIPTION
File corruption is a common cause of [issue reports](https://github.com/bitcoin/bitcoin/issues?utf8=%E2%9C%93&q=label%3A%22Data+corruption%22+). Often the user is not aware of hardware defects, because corruption error messages are hidden in the debug log file.

Improve this by handing file corruption error messages directly to the user.