### PR TITLE
tests: Test for expected return values when calling functions returning a success code

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -154,11 +154,11 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
     CService addr1 = ResolveService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
     CService addr1_port = ResolveService("250.1.1.1", 8334);
-    addrman.Add(CAddress(addr1_port, NODE_NONE), source);
+    BOOST_CHECK(!addrman.Add(CAddress(addr1_port, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
     CAddrInfo addr_ret2 = addrman.Select();
     BOOST_CHECK_EQUAL(addr_ret2.ToString(), "250.1.1.1:8333");
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
 
     // Test: Select from new with 1 addr in new.
     CService addr1 = ResolveService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 1U);
 
     bool newOnly = true;
@@ -205,20 +205,20 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CService addr3 = ResolveService("250.3.2.2", 9999);
     CService addr4 = ResolveService("250.3.3.3", 9999);
 
-    addrman.Add(CAddress(addr2, NODE_NONE), ResolveService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr3, NODE_NONE), ResolveService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr4, NODE_NONE), ResolveService("250.4.1.1", 8333));
+    BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE), ResolveService("250.3.1.1", 8333)));
+    BOOST_CHECK(addrman.Add(CAddress(addr3, NODE_NONE), ResolveService("250.3.1.1", 8333)));
+    BOOST_CHECK(addrman.Add(CAddress(addr4, NODE_NONE), ResolveService("250.4.1.1", 8333)));
 
     // Add three addresses to tried table.
     CService addr5 = ResolveService("250.4.4.4", 8333);
     CService addr6 = ResolveService("250.4.5.5", 7777);
     CService addr7 = ResolveService("250.4.6.6", 8333);
 
-    addrman.Add(CAddress(addr5, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    BOOST_CHECK(addrman.Add(CAddress(addr5, NODE_NONE), ResolveService("250.3.1.1", 8333)));
     addrman.Good(CAddress(addr5, NODE_NONE));
-    addrman.Add(CAddress(addr6, NODE_NONE), ResolveService("250.3.1.1", 8333));
+    BOOST_CHECK(addrman.Add(CAddress(addr6, NODE_NONE), ResolveService("250.3.1.1", 8333)));
     addrman.Good(CAddress(addr6, NODE_NONE));
-    addrman.Add(CAddress(addr7, NODE_NONE), ResolveService("250.1.1.3", 8333));
+    BOOST_CHECK(addrman.Add(CAddress(addr7, NODE_NONE), ResolveService("250.1.1.3", 8333)));
     addrman.Good(CAddress(addr7, NODE_NONE));
 
     // Test: 6 addrs + 1 addr from last test = 7.
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     for (unsigned int i = 1; i < 18; i++) {
         CService addr = ResolveService("250.1.1." + std::to_string(i));
-        addrman.Add(CAddress(addr, NODE_NONE), source);
+        BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
 
         //Test: No collision in new table yet.
         BOOST_CHECK_EQUAL(addrman.size(), i);
@@ -250,11 +250,11 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     //Test: new table collision!
     CService addr1 = ResolveService("250.1.1.18");
-    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 17U);
 
     CService addr2 = ResolveService("250.1.1.19");
-    addrman.Add(CAddress(addr2, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 18U);
 }
 
@@ -268,7 +268,7 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     for (unsigned int i = 1; i < 80; i++) {
         CService addr = ResolveService("250.1.1." + std::to_string(i));
-        addrman.Add(CAddress(addr, NODE_NONE), source);
+        BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
         addrman.Good(CAddress(addr, NODE_NONE));
 
         //Test: No collision in tried table yet.
@@ -277,11 +277,11 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     //Test: tried table collision!
     CService addr1 = ResolveService("250.1.1.80");
-    addrman.Add(CAddress(addr1, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr1, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 79U);
 
     CService addr2 = ResolveService("250.1.1.81");
-    addrman.Add(CAddress(addr2, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr2, NODE_NONE), source));
     BOOST_CHECK_EQUAL(addrman.size(), 80U);
 }
 
@@ -298,9 +298,9 @@ BOOST_AUTO_TEST_CASE(addrman_find)
     CNetAddr source1 = ResolveIP("250.1.2.1");
     CNetAddr source2 = ResolveIP("250.1.2.2");
 
-    addrman.Add(addr1, source1);
-    addrman.Add(addr2, source2);
-    addrman.Add(addr3, source1);
+    BOOST_CHECK(addrman.Add(addr1, source1));
+    BOOST_CHECK(!addrman.Add(addr2, source2));
+    BOOST_CHECK(addrman.Add(addr3, source1));
 
     // Test: ensure Find returns an IP matching what we searched on.
     CAddrInfo* info1 = addrman.Find(addr1);
@@ -382,11 +382,11 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     CNetAddr source2 = ResolveIP("250.2.3.3");
 
     // Test: Ensure GetAddr works with new addresses.
-    addrman.Add(addr1, source1);
-    addrman.Add(addr2, source2);
-    addrman.Add(addr3, source1);
-    addrman.Add(addr4, source2);
-    addrman.Add(addr5, source1);
+    BOOST_CHECK(addrman.Add(addr1, source1));
+    BOOST_CHECK(addrman.Add(addr2, source2));
+    BOOST_CHECK(addrman.Add(addr3, source1));
+    BOOST_CHECK(addrman.Add(addr4, source2));
+    BOOST_CHECK(addrman.Add(addr5, source1));
 
     // GetAddr returns 23% of addresses, 23% of 5 is 1 rounded down.
     BOOST_CHECK_EQUAL(addrman.GetAddr().size(), 1U);
@@ -555,7 +555,7 @@ BOOST_AUTO_TEST_CASE(addrman_selecttriedcollision)
     CNetAddr source = ResolveIP("252.2.2.2");
     for (unsigned int i = 1; i < 23; i++) {
         CService addr = ResolveService("250.1.1."+std::to_string(i));
-        addrman.Add(CAddress(addr, NODE_NONE), source);
+        BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
         addrman.Good(addr);
 
         // No collisions yet.
@@ -585,7 +585,7 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
     CNetAddr source = ResolveIP("252.2.2.2");
     for (unsigned int i = 1; i < 23; i++) {
         CService addr = ResolveService("250.1.1."+std::to_string(i));
-        addrman.Add(CAddress(addr, NODE_NONE), source);
+        BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
         addrman.Good(addr);
 
         // No collision yet.
@@ -595,7 +595,7 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
 
     // Collision between 23 and 19.
     CService addr23 = ResolveService("250.1.1.23");
-    addrman.Add(CAddress(addr23, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr23, NODE_NONE), source));
     addrman.Good(addr23);
 
     BOOST_CHECK(addrman.size() == 23);
@@ -608,7 +608,7 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
     // Lets create two collisions.
     for (unsigned int i = 24; i < 33; i++) {
         CService addr = ResolveService("250.1.1."+std::to_string(i));
-        addrman.Add(CAddress(addr, NODE_NONE), source);
+        BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
         addrman.Good(addr);
 
         BOOST_CHECK(addrman.size() == i);
@@ -617,14 +617,14 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
 
     // Cause a collision.
     CService addr33 = ResolveService("250.1.1.33");
-    addrman.Add(CAddress(addr33, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr33, NODE_NONE), source));
     addrman.Good(addr33);
     BOOST_CHECK(addrman.size() == 33);
 
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "250.1.1.27:0");
 
     // Cause a second collision.
-    addrman.Add(CAddress(addr23, NODE_NONE), source);
+    BOOST_CHECK(!addrman.Add(CAddress(addr23, NODE_NONE), source));
     addrman.Good(addr23);
     BOOST_CHECK(addrman.size() == 33);
 
@@ -649,7 +649,7 @@ BOOST_AUTO_TEST_CASE(addrman_evictionworks)
     CNetAddr source = ResolveIP("252.2.2.2");
     for (unsigned int i = 1; i < 23; i++) {
         CService addr = ResolveService("250.1.1."+std::to_string(i));
-        addrman.Add(CAddress(addr, NODE_NONE), source);
+        BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
         addrman.Good(addr);
 
         // No collision yet.
@@ -659,7 +659,7 @@ BOOST_AUTO_TEST_CASE(addrman_evictionworks)
 
     // Collision between 23 and 19.
     CService addr = ResolveService("250.1.1.23");
-    addrman.Add(CAddress(addr, NODE_NONE), source);
+    BOOST_CHECK(addrman.Add(CAddress(addr, NODE_NONE), source));
     addrman.Good(addr);
 
     BOOST_CHECK(addrman.size() == 23);
@@ -674,14 +674,14 @@ BOOST_AUTO_TEST_CASE(addrman_evictionworks)
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
 
     // If 23 was swapped for 19, then this should cause no collisions.
-    addrman.Add(CAddress(addr, NODE_NONE), source);
+    BOOST_CHECK(!addrman.Add(CAddress(addr, NODE_NONE), source));
     addrman.Good(addr);
 
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "[::]:0");
 
     // If we insert 19 is should collide with 23.
     CService addr19 = ResolveService("250.1.1.19");
-    addrman.Add(CAddress(addr19, NODE_NONE), source);
+    BOOST_CHECK(!addrman.Add(CAddress(addr19, NODE_NONE), source));
     addrman.Good(addr19);
 
     BOOST_CHECK(addrman.SelectTriedCollision().ToString() == "250.1.1.23:0");

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -355,7 +355,7 @@ BOOST_AUTO_TEST_CASE(test_CheckQueue_FrozenCleanup)
         // would get called twice).
         vChecks[0].should_freeze = true;
         control.Add(vChecks);
-        control.Wait(); // Hangs here
+        BOOST_CHECK(control.Wait()); // Hangs here
     });
     {
         std::unique_lock<std::mutex> l(FrozenCleanupCheck::m);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             } else {
                 removed_an_entry = true;
                 coin.Clear();
-                stack.back()->SpendCoin(COutPoint(txid, 0));
+                BOOST_CHECK(stack.back()->SpendCoin(COutPoint(txid, 0)));
             }
         }
 
@@ -211,14 +211,14 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             // Every 100 iterations, flush an intermediate cache
             if (stack.size() > 1 && InsecureRandBool() == 0) {
                 unsigned int flushIndex = InsecureRandRange(stack.size() - 1);
-                stack[flushIndex]->Flush();
+                BOOST_CHECK(stack[flushIndex]->Flush());
             }
         }
         if (InsecureRandRange(100) == 0) {
             // Every 100 iterations, change the cache stack.
             if (stack.size() > 0 && InsecureRandBool() == 0) {
                 //Remove the top cache
-                stack.back()->Flush();
+                BOOST_CHECK(stack.back()->Flush());
                 delete stack.back();
                 stack.pop_back();
             }
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             // Disconnect the tx from the current UTXO
             // See code in DisconnectBlock
             // remove outputs
-            stack.back()->SpendCoin(utxod->first);
+            BOOST_CHECK(stack.back()->SpendCoin(utxod->first));
             // restore inputs
             if (!tx.IsCoinBase()) {
                 const COutPoint &out = tx.vin[0].prevout;
@@ -444,13 +444,13 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
             // Every 100 iterations, flush an intermediate cache
             if (stack.size() > 1 && InsecureRandBool() == 0) {
                 unsigned int flushIndex = InsecureRandRange(stack.size() - 1);
-                stack[flushIndex]->Flush();
+                BOOST_CHECK(stack[flushIndex]->Flush());
             }
         }
         if (InsecureRandRange(100) == 0) {
             // Every 100 iterations, change the cache stack.
             if (stack.size() > 0 && InsecureRandBool() == 0) {
-                stack.back()->Flush();
+                BOOST_CHECK(stack.back()->Flush());
                 delete stack.back();
                 stack.pop_back();
             }
@@ -589,7 +589,7 @@ void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
     CCoinsMap map;
     InsertCoinsMapEntry(map, value, flags);
-    view.BatchWrite(map, {});
+    BOOST_CHECK(view.BatchWrite(map, {}));
 }
 
 class SingleEntryCacheTest

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -158,7 +158,7 @@ static void test_cache_erase(size_t megabytes)
         set.insert(hashes_insert_copy[i]);
     /** Erase the first quarter */
     for (uint32_t i = 0; i < (n_insert / 4); ++i)
-        set.contains(hashes[i], true);
+        BOOST_CHECK(set.contains(hashes[i], true));
     /** Insert the second half */
     for (uint32_t i = (n_insert / 2); i < n_insert; ++i)
         set.insert(hashes_insert_copy[i]);
@@ -238,7 +238,7 @@ static void test_cache_erase_parallel(size_t megabytes)
             size_t start = ntodo*x;
             size_t end = ntodo*(x+1);
             for (uint32_t i = start; i < end; ++i)
-                set.contains(hashes[i], true);
+                BOOST_CHECK(set.contains(hashes[i], true));
         });
 
     /** Wait for all threads to finish

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_batch)
         // Remove key3 before it's even been written
         batch.Erase(key3);
 
-        dbw.WriteBatch(batch);
+        BOOST_CHECK(dbw.WriteBatch(batch));
 
         BOOST_CHECK(dbw.Read(key, res));
         BOOST_CHECK_EQUAL(res.ToString(), in.ToString());

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Test starts here
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1); // should result in getheaders
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
         LOCK2(cs_main, dummyNode1.cs_vSend);
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     SetMockTime(nStartTime+21*60);
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1); // should result in getheaders
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
         LOCK2(cs_main, dummyNode1.cs_vSend);
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     SetMockTime(nStartTime+24*60);
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1); // should result in disconnect
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in disconnect
     }
     BOOST_CHECK(dummyNode1.fDisconnect == true);
     SetMockTime(0);
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(connman->IsBanned(addr1));
     BOOST_CHECK(!connman->IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     {
         LOCK2(cs_main, dummyNode2.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode2);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(!connman->IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(connman->IsBanned(addr1));  // ... but 1 still should be
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     {
         LOCK2(cs_main, dummyNode2.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode2);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(connman->IsBanned(addr2));
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!connman->IsBanned(addr1));
     {
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!connman->IsBanned(addr1));
     {
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode1);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(connman->IsBanned(addr1));
     gArgs.ForceSetArg("-banscore", std::to_string(DEFAULT_BANSCORE_THRESHOLD));
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     }
     {
         LOCK2(cs_main, dummyNode.cs_sendProcessing);
-        peerLogic->SendMessages(&dummyNode);
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
     }
     BOOST_CHECK(connman->IsBanned(addr));
 
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     CKey key;
     key.MakeNewKey(true);
     CBasicKeyStore keystore;
-    keystore.AddKey(key);
+    BOOST_CHECK(keystore.AddKey(key));
 
     // 50 orphan transactions:
     for (int i = 0; i < 50; i++)
@@ -366,7 +366,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-        SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL);
+        BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL));
 
         AddOrphanTx(MakeTransactionRef(tx), i);
     }
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
             tx.vin[j].prevout.n = j;
             tx.vin[j].prevout.hash = txPrev->GetHash();
         }
-        SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL);
+        BOOST_CHECK(SignSignature(keystore, *txPrev, tx, 0, SIGHASH_ALL));
         // Re-use same signature for other inputs
         // (they don't have to be valid for this test)
         for (unsigned int j = 1; j < tx.vin.size(); j++)

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
         } else {
             CTxDestination dest;
             CScript exp_script(exp_payload.begin(), exp_payload.end());
-            ExtractDestination(exp_script, dest);
+            BOOST_CHECK(ExtractDestination(exp_script, dest));
             std::string address = EncodeDestination(dest);
 
             BOOST_CHECK_EQUAL(address, exp_base58string);

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(key_signature_tests)
 
     for (int i = 1; i <=20; ++i) {
         sig.clear();
-        key.Sign(msg_hash, sig, false, i);
+        BOOST_CHECK(key.Sign(msg_hash, sig, false, i));
         found = sig[3] == 0x21 && sig[4] == 0x00;
         if (found) {
             break;
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(key_signature_tests)
         sig.clear();
         std::string msg = "A message to be signed" + std::to_string(i);
         msg_hash = Hash(msg.begin(), msg.end());
-        key.Sign(msg_hash, sig);
+        BOOST_CHECK(key.Sign(msg_hash, sig));
         found = sig[3] == 0x20;
         BOOST_CHECK(sig.size() <= 70);
         found_small |= sig.size() < 70;

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(multisig_Sign)
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
-        keystore.AddKey(key[i]);
+        BOOST_CHECK(keystore.AddKey(key[i]));
     }
 
     CScript a_and_b;

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -54,10 +54,10 @@ public:
         s << nUBuckets;
 
         CService serv;
-        Lookup("252.1.1.1", serv, 7777, false);
+        BOOST_CHECK(Lookup("252.1.1.1", serv, 7777, false));
         CAddress addr = CAddress(serv, NODE_NONE);
         CNetAddr resolved;
-        LookupHost("252.2.2.2", resolved, false);
+        BOOST_CHECK(LookupHost("252.2.2.2", resolved, false));
         CAddrInfo info = CAddrInfo(addr, resolved);
         s << info;
     }
@@ -82,7 +82,7 @@ BOOST_AUTO_TEST_CASE(cnode_listen_port)
     BOOST_CHECK(port == Params().GetDefaultPort());
     // test set port
     unsigned short altPort = 12345;
-    gArgs.SoftSetArg("-port", std::to_string(altPort));
+    BOOST_CHECK(gArgs.SoftSetArg("-port", std::to_string(altPort)));
     port = GetListenPort();
     BOOST_CHECK(port == altPort);
 }
@@ -94,16 +94,16 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     addrmanUncorrupted.MakeDeterministic();
 
     CService addr1, addr2, addr3;
-    Lookup("250.7.1.1", addr1, 8333, false);
-    Lookup("250.7.2.2", addr2, 9999, false);
-    Lookup("250.7.3.3", addr3, 9999, false);
+    BOOST_CHECK(Lookup("250.7.1.1", addr1, 8333, false));
+    BOOST_CHECK(Lookup("250.7.2.2", addr2, 9999, false));
+    BOOST_CHECK(Lookup("250.7.3.3", addr3, 9999, false));
 
     // Add three addresses to new table.
     CService source;
-    Lookup("252.5.1.1", source, 8333, false);
-    addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), source);
-    addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), source);
-    addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), source);
+    BOOST_CHECK(Lookup("252.5.1.1", source, 8333, false));
+    BOOST_CHECK(addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), source));
+    BOOST_CHECK(addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), source));
+    BOOST_CHECK(addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), source));
 
     // Test that the de-serialization does not throw an exception.
     CDataStream ssPeers1 = AddrmanToStream(addrmanUncorrupted);
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     CAddrMan addrman2;
     CAddrDB adb;
     BOOST_CHECK(addrman2.size() == 0);
-    adb.Read(addrman2, ssPeers2);
+    BOOST_CHECK(adb.Read(addrman2, ssPeers2));
     BOOST_CHECK(addrman2.size() == 3);
 }
 
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(caddrdb_read_corrupted)
     CAddrMan addrman2;
     CAddrDB adb;
     BOOST_CHECK(addrman2.size() == 0);
-    adb.Read(addrman2, ssPeers2);
+    BOOST_CHECK(!adb.Read(addrman2, ssPeers2));
     BOOST_CHECK(addrman2.size() == 0);
 }
 

--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(sign)
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
-        keystore.AddKey(key[i]);
+        BOOST_CHECK(keystore.AddKey(key[i]));
     }
 
     // 8 Scripts: checking all combinations of
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(sign)
     CScript evalScripts[4];
     for (int i = 0; i < 4; i++)
     {
-        keystore.AddCScript(standardScripts[i]);
+        BOOST_CHECK(keystore.AddCScript(standardScripts[i]));
         evalScripts[i] = GetScriptForDestination(CScriptID(standardScripts[i]));
     }
 
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         key[i].MakeNewKey(true);
-        keystore.AddKey(key[i]);
+        BOOST_CHECK(keystore.AddKey(key[i]));
         keys.push_back(key[i].GetPubKey());
     }
 
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(set)
     for (int i = 0; i < 4; i++)
     {
         outer[i] = GetScriptForDestination(CScriptID(inner[i]));
-        keystore.AddCScript(inner[i]);
+        BOOST_CHECK(keystore.AddCScript(inner[i]));
     }
 
     CMutableTransaction txFrom;  // Funding transaction:
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     for (int i = 0; i < 6; i++)
     {
         key[i].MakeNewKey(true);
-        keystore.AddKey(key[i]);
+        BOOST_CHECK(keystore.AddKey(key[i]));
     }
     for (int i = 0; i < 3; i++)
         keys.push_back(key[i].GetPubKey());
@@ -276,7 +276,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
 
     // First three are standard:
     CScript pay1 = GetScriptForDestination(key[0].GetPubKey().GetID());
-    keystore.AddCScript(pay1);
+    BOOST_CHECK(keystore.AddCScript(pay1));
     CScript pay1of3 = GetScriptForMultisig(1, keys);
 
     txFrom.vout[0].scriptPubKey = GetScriptForDestination(CScriptID(pay1)); // P2SH (OP_CHECKSIG)
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     oneAndTwo << OP_3 << OP_CHECKMULTISIGVERIFY;
     oneAndTwo << OP_2 << ToByteVector(key[3].GetPubKey()) << ToByteVector(key[4].GetPubKey()) << ToByteVector(key[5].GetPubKey());
     oneAndTwo << OP_3 << OP_CHECKMULTISIG;
-    keystore.AddCScript(oneAndTwo);
+    BOOST_CHECK(keystore.AddCScript(oneAndTwo));
     txFrom.vout[3].scriptPubKey = GetScriptForDestination(CScriptID(oneAndTwo));
     txFrom.vout[3].nValue = 4000;
 
@@ -302,17 +302,17 @@ BOOST_AUTO_TEST_CASE(AreInputsStandard)
     for (unsigned i = 0; i < MAX_P2SH_SIGOPS; i++)
         fifteenSigops << ToByteVector(key[i%3].GetPubKey());
     fifteenSigops << OP_15 << OP_CHECKMULTISIG;
-    keystore.AddCScript(fifteenSigops);
+    BOOST_CHECK(keystore.AddCScript(fifteenSigops));
     txFrom.vout[4].scriptPubKey = GetScriptForDestination(CScriptID(fifteenSigops));
     txFrom.vout[4].nValue = 5000;
 
     // vout[5/6] are non-standard because they exceed MAX_P2SH_SIGOPS
     CScript sixteenSigops; sixteenSigops << OP_16 << OP_CHECKMULTISIG;
-    keystore.AddCScript(sixteenSigops);
+    BOOST_CHECK(keystore.AddCScript(sixteenSigops));
     txFrom.vout[5].scriptPubKey = GetScriptForDestination(CScriptID(sixteenSigops));
     txFrom.vout[5].nValue = 5000;
     CScript twentySigops; twentySigops << OP_CHECKMULTISIG;
-    keystore.AddCScript(twentySigops);
+    BOOST_CHECK(keystore.AddCScript(twentySigops));
     txFrom.vout[6].scriptPubKey = GetScriptForDestination(CScriptID(twentySigops));
     txFrom.vout[6].nValue = 6000;
 

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -398,7 +398,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has key
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has key
-        keystore.AddKey(uncompressedKey);
+        BOOST_CHECK(keystore.AddKey(uncompressedKey));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -428,7 +428,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has key
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has key
-        keystore.AddKey(uncompressedKey);
+        BOOST_CHECK(keystore.AddKey(uncompressedKey));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -460,12 +460,12 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has redeemScript but no key
-        keystore.AddCScript(redeemScript);
+        BOOST_CHECK(keystore.AddCScript(redeemScript));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has redeemScript and key
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -478,10 +478,10 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         CScript redeemscript = GetScriptForDestination(CScriptID(redeemscript_inner));
         scriptPubKey = GetScriptForDestination(CScriptID(redeemscript));
 
-        keystore.AddCScript(redeemscript);
-        keystore.AddCScript(redeemscript_inner);
-        keystore.AddCScript(scriptPubKey);
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddCScript(redeemscript));
+        BOOST_CHECK(keystore.AddCScript(redeemscript_inner));
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
@@ -494,10 +494,10 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         CScript witnessscript = GetScriptForDestination(CScriptID(redeemscript));
         scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessscript));
 
-        keystore.AddCScript(witnessscript);
-        keystore.AddCScript(redeemscript);
-        keystore.AddCScript(scriptPubKey);
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddCScript(witnessscript));
+        BOOST_CHECK(keystore.AddCScript(redeemscript));
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
@@ -509,9 +509,9 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         CScript witnessscript = GetScriptForDestination(WitnessV0KeyHash(pubkeys[0].GetID()));
         scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessscript));
 
-        keystore.AddCScript(witnessscript);
-        keystore.AddCScript(scriptPubKey);
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddCScript(witnessscript));
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
@@ -524,10 +524,10 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         CScript witnessscript = GetScriptForDestination(WitnessV0ScriptHash(witnessscript_inner));
         scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessscript));
 
-        keystore.AddCScript(witnessscript_inner);
-        keystore.AddCScript(witnessscript);
-        keystore.AddCScript(scriptPubKey);
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddCScript(witnessscript_inner));
+        BOOST_CHECK(keystore.AddCScript(witnessscript));
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
+        BOOST_CHECK(keystore.AddKey(keys[0]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
@@ -535,12 +535,12 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // P2WPKH compressed
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
 
         scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(pubkeys[0].GetID()));
 
         // Keystore implicitly has key and P2SH redeemScript
-        keystore.AddCScript(scriptPubKey);
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // P2WPKH uncompressed
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(uncompressedKey);
+        BOOST_CHECK(keystore.AddKey(uncompressedKey));
 
         scriptPubKey = GetScriptForDestination(WitnessV0KeyHash(uncompressedPubkey.GetID()));
 
@@ -557,7 +557,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has key and P2SH redeemScript
-        keystore.AddCScript(scriptPubKey);
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
@@ -573,19 +573,19 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has 1/2 keys
-        keystore.AddKey(uncompressedKey);
+        BOOST_CHECK(keystore.AddKey(uncompressedKey));
 
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has 2/2 keys
-        keystore.AddKey(keys[1]);
+        BOOST_CHECK(keystore.AddKey(keys[1]));
 
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has 2/2 keys and the script
-        keystore.AddCScript(scriptPubKey);
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
 
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
@@ -594,8 +594,8 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // P2SH multisig
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(uncompressedKey);
-        keystore.AddKey(keys[1]);
+        BOOST_CHECK(keystore.AddKey(uncompressedKey));
+        BOOST_CHECK(keystore.AddKey(keys[1]));
 
         CScript redeemScript = GetScriptForMultisig(2, {uncompressedPubkey, pubkeys[1]});
         scriptPubKey = GetScriptForDestination(CScriptID(redeemScript));
@@ -605,7 +605,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has redeemScript
-        keystore.AddCScript(redeemScript);
+        BOOST_CHECK(keystore.AddCScript(redeemScript));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -613,8 +613,8 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // P2WSH multisig with compressed keys
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(keys[0]);
-        keystore.AddKey(keys[1]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
+        BOOST_CHECK(keystore.AddKey(keys[1]));
 
         CScript witnessScript = GetScriptForMultisig(2, {pubkeys[0], pubkeys[1]});
         scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
@@ -624,12 +624,12 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has keys and witnessScript, but no P2SH redeemScript
-        keystore.AddCScript(witnessScript);
+        BOOST_CHECK(keystore.AddCScript(witnessScript));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has keys, witnessScript, P2SH redeemScript
-        keystore.AddCScript(scriptPubKey);
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -637,8 +637,8 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // P2WSH multisig with uncompressed key
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(uncompressedKey);
-        keystore.AddKey(keys[1]);
+        BOOST_CHECK(keystore.AddKey(uncompressedKey));
+        BOOST_CHECK(keystore.AddKey(keys[1]));
 
         CScript witnessScript = GetScriptForMultisig(2, {uncompressedPubkey, pubkeys[1]});
         scriptPubKey = GetScriptForDestination(WitnessV0ScriptHash(witnessScript));
@@ -648,12 +648,12 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has keys and witnessScript, but no P2SH redeemScript
-        keystore.AddCScript(witnessScript);
+        BOOST_CHECK(keystore.AddCScript(witnessScript));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has keys, witnessScript, P2SH redeemScript
-        keystore.AddCScript(scriptPubKey);
+        BOOST_CHECK(keystore.AddCScript(scriptPubKey));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
     }
@@ -671,14 +671,14 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has witnessScript and P2SH redeemScript, but no keys
-        keystore.AddCScript(redeemScript);
-        keystore.AddCScript(witnessScript);
+        BOOST_CHECK(keystore.AddCScript(redeemScript));
+        BOOST_CHECK(keystore.AddCScript(witnessScript));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_NO);
 
         // Keystore has keys, witnessScript, P2SH redeemScript
-        keystore.AddKey(keys[0]);
-        keystore.AddKey(keys[1]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
+        BOOST_CHECK(keystore.AddKey(keys[1]));
         result = IsMine(keystore, scriptPubKey);
         BOOST_CHECK_EQUAL(result, ISMINE_SPENDABLE);
     }
@@ -686,7 +686,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // OP_RETURN
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
 
         scriptPubKey.clear();
         scriptPubKey << OP_RETURN << ToByteVector(pubkeys[0]);
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // witness unspendable
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
 
         scriptPubKey.clear();
         scriptPubKey << OP_0 << ToByteVector(ParseHex("aabb"));
@@ -710,7 +710,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // witness unknown
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
 
         scriptPubKey.clear();
         scriptPubKey << OP_16 << ToByteVector(ParseHex("aabb"));
@@ -722,7 +722,7 @@ BOOST_AUTO_TEST_CASE(script_standard_IsMine)
     // Nonstandard
     {
         CBasicKeyStore keystore;
-        keystore.AddKey(keys[0]);
+        BOOST_CHECK(keystore.AddKey(keys[0]));
 
         scriptPubKey.clear();
         scriptPubKey << OP_9 << OP_ADD << OP_11 << OP_EQUAL;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1185,7 +1185,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
         key.MakeNewKey(i%2 == 1);
         keys.push_back(key);
         pubkeys.push_back(key.GetPubKey());
-        keystore.AddKey(key);
+        BOOST_CHECK(keystore.AddKey(key));
     }
 
     CMutableTransaction txFrom = BuildCreditingTransaction(GetScriptForDestination(keys[0].GetPubKey().GetID()));
@@ -1198,7 +1198,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     BOOST_CHECK(combined.scriptSig.empty());
 
     // Single signature case:
-    SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL); // changes scriptSig
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL)); // changes scriptSig
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSig, empty);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
@@ -1206,31 +1206,31 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
     SignatureData scriptSigCopy = scriptSig;
     // Signing again will give a different, valid signature:
-    SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL);
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined.scriptSig == scriptSigCopy.scriptSig || combined.scriptSig == scriptSig.scriptSig);
 
     // P2SH, single-signature case:
     CScript pkSingle; pkSingle << ToByteVector(keys[0].GetPubKey()) << OP_CHECKSIG;
-    keystore.AddCScript(pkSingle);
+    BOOST_CHECK(keystore.AddCScript(pkSingle));
     scriptPubKey = GetScriptForDestination(CScriptID(pkSingle));
-    SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL);
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSig, empty);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
     combined = CombineSignatures(txFrom.vout[0], txTo, empty, scriptSig);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);
     scriptSigCopy = scriptSig;
-    SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL);
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSigCopy, scriptSig);
     BOOST_CHECK(combined.scriptSig == scriptSigCopy.scriptSig || combined.scriptSig == scriptSig.scriptSig);
 
     // Hardest case:  Multisig 2-of-3
     scriptPubKey = GetScriptForMultisig(2, pubkeys);
-    keystore.AddCScript(scriptPubKey);
-    SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL);
+    BOOST_CHECK(keystore.AddCScript(scriptPubKey));
+    BOOST_CHECK(SignSignature(keystore, CTransaction(txFrom), txTo, 0, SIGHASH_ALL));
     scriptSig = DataFromTransaction(txTo, 0, txFrom.vout[0]);
     combined = CombineSignatures(txFrom.vout[0], txTo, scriptSig, empty);
     BOOST_CHECK(combined.scriptSig == scriptSig.scriptSig);

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -421,7 +421,7 @@ BOOST_AUTO_TEST_CASE(test_big_witness_transaction) {
     CKey key;
     key.MakeNewKey(true); // Need to use compressed keys in segwit or the signing will fail
     CBasicKeyStore keystore;
-    keystore.AddKeyPubKey(key, key.GetPubKey());
+    BOOST_CHECK(keystore.AddKeyPubKey(key, key.GetPubKey()));
     CKeyID hash = key.GetPubKey().GetID();
     CScript scriptPubKey = CScript() << OP_0 << std::vector<unsigned char>(hash.begin(), hash.end());
 
@@ -518,10 +518,10 @@ BOOST_AUTO_TEST_CASE(test_witness)
     pubkey3 = key3.GetPubKey();
     pubkey1L = key1L.GetPubKey();
     pubkey2L = key2L.GetPubKey();
-    keystore.AddKeyPubKey(key1, pubkey1);
-    keystore.AddKeyPubKey(key2, pubkey2);
-    keystore.AddKeyPubKey(key1L, pubkey1L);
-    keystore.AddKeyPubKey(key2L, pubkey2L);
+    BOOST_CHECK(keystore.AddKeyPubKey(key1, pubkey1));
+    BOOST_CHECK(keystore.AddKeyPubKey(key2, pubkey2));
+    BOOST_CHECK(keystore.AddKeyPubKey(key1L, pubkey1L));
+    BOOST_CHECK(keystore.AddKeyPubKey(key2L, pubkey2L));
     CScript scriptPubkey1, scriptPubkey2, scriptPubkey1L, scriptPubkey2L, scriptMulti;
     scriptPubkey1 << ToByteVector(pubkey1) << OP_CHECKSIG;
     scriptPubkey2 << ToByteVector(pubkey2) << OP_CHECKSIG;
@@ -531,19 +531,19 @@ BOOST_AUTO_TEST_CASE(test_witness)
     oneandthree.push_back(pubkey1);
     oneandthree.push_back(pubkey3);
     scriptMulti = GetScriptForMultisig(2, oneandthree);
-    keystore.AddCScript(scriptPubkey1);
-    keystore.AddCScript(scriptPubkey2);
-    keystore.AddCScript(scriptPubkey1L);
-    keystore.AddCScript(scriptPubkey2L);
-    keystore.AddCScript(scriptMulti);
-    keystore.AddCScript(GetScriptForWitness(scriptPubkey1));
-    keystore.AddCScript(GetScriptForWitness(scriptPubkey2));
-    keystore.AddCScript(GetScriptForWitness(scriptPubkey1L));
-    keystore.AddCScript(GetScriptForWitness(scriptPubkey2L));
-    keystore.AddCScript(GetScriptForWitness(scriptMulti));
-    keystore2.AddCScript(scriptMulti);
-    keystore2.AddCScript(GetScriptForWitness(scriptMulti));
-    keystore2.AddKeyPubKey(key3, pubkey3);
+    BOOST_CHECK(keystore.AddCScript(scriptPubkey1));
+    BOOST_CHECK(keystore.AddCScript(scriptPubkey2));
+    BOOST_CHECK(keystore.AddCScript(scriptPubkey1L));
+    BOOST_CHECK(keystore.AddCScript(scriptPubkey2L));
+    BOOST_CHECK(keystore.AddCScript(scriptMulti));
+    BOOST_CHECK(keystore.AddCScript(GetScriptForWitness(scriptPubkey1)));
+    BOOST_CHECK(keystore.AddCScript(GetScriptForWitness(scriptPubkey2)));
+    BOOST_CHECK(keystore.AddCScript(GetScriptForWitness(scriptPubkey1L)));
+    BOOST_CHECK(keystore.AddCScript(GetScriptForWitness(scriptPubkey2L)));
+    BOOST_CHECK(keystore.AddCScript(GetScriptForWitness(scriptMulti)));
+    BOOST_CHECK(keystore2.AddCScript(scriptMulti));
+    BOOST_CHECK(keystore2.AddCScript(GetScriptForWitness(scriptMulti)));
+    BOOST_CHECK(keystore2.AddKeyPubKey(key3, pubkey3));
 
     CTransactionRef output1, output2;
     CMutableTransaction input1, input2;

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -156,8 +156,8 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
     CScript p2wpkh_scriptPubKey = GetScriptForWitness(p2pkh_scriptPubKey);
 
     CBasicKeyStore keystore;
-    keystore.AddKey(coinbaseKey);
-    keystore.AddCScript(p2pk_scriptPubKey);
+    BOOST_CHECK(keystore.AddKey(coinbaseKey));
+    BOOST_CHECK(keystore.AddCScript(p2pk_scriptPubKey));
 
     // flags to test: SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY, SCRIPT_VERIFY_CHECKSEQUENCE_VERIFY, SCRIPT_VERIFY_NULLDUMMY, uncompressed pubkey thing
 
@@ -314,7 +314,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
 
         // Sign
         SignatureData sigdata;
-        ProduceSignature(keystore, MutableTransactionSignatureCreator(&valid_with_witness_tx, 0, 11*CENT, SIGHASH_ALL), spend_tx.vout[1].scriptPubKey, sigdata);
+        BOOST_CHECK(ProduceSignature(keystore, MutableTransactionSignatureCreator(&valid_with_witness_tx, 0, 11*CENT, SIGHASH_ALL), spend_tx.vout[1].scriptPubKey, sigdata));
         UpdateInput(valid_with_witness_tx.vin[0], sigdata);
 
         // This should be valid under all script flags.
@@ -342,7 +342,7 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
         // Sign
         for (int i=0; i<2; ++i) {
             SignatureData sigdata;
-            ProduceSignature(keystore, MutableTransactionSignatureCreator(&tx, i, 11*CENT, SIGHASH_ALL), spend_tx.vout[i].scriptPubKey, sigdata);
+            BOOST_CHECK(ProduceSignature(keystore, MutableTransactionSignatureCreator(&tx, i, 11*CENT, SIGHASH_ALL), spend_tx.vout[i].scriptPubKey, sigdata));
             UpdateInput(tx.vin[i], sigdata);
         }
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     BOOST_CHECK(ProcessNewBlockHeaders(headers, state, Params()));
 
     // Connect the genesis block and drain any outstanding events
-    ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), true, &ignored);
+    BOOST_CHECK(ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), true, &ignored));
     SyncWithValidationInterfaceQueue();
 
     // subscribe to events (this subscriber will validate event ordering)


### PR DESCRIPTION
Test for expected return values when calling functions returning a success code (instead of discarding the return values).

**Note to reviewers:** The following commands can be used to verify that the only text fragments added in this PR are `BOOST_CHECK(`, `!` and `)` :

```
$ git diff HEAD~1 | grep -E '^[\-][^\-]' | cut -b2- > before.txt
$ git diff HEAD~1 | grep -E '^[\+][^\+]' | cut -b2- > after.txt
$ cat after.txt | sed 's/BOOST_CHECK(//g' | sed 's/));/);/g' | tr -d '!' > after-sed.txt
$ diff -u before.txt after-sed.txt
$ 
```