### PR TITLE
travis: fix travis would always be green even if it fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ env:
     - WINEDEBUG=fixme-all
     - DOCKER_PACKAGES="build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache"
 before_install:
-  - set -o errexit; if ! source .travis/test_03_before_install.sh; then set +o errexit; false; fi
+  - set -o errexit; source .travis/test_03_before_install.sh
 install:
-  - set -o errexit; if ! source .travis/test_04_install.sh; then set +o errexit; false; fi
+  - set -o errexit; source .travis/test_04_install.sh
 before_script:
-  - set -o errexit; if ! source .travis/test_05_before_script.sh; then set +o errexit; false; fi
+  - set -o errexit; source .travis/test_05_before_script.sh
 script:
-  - if [ $SECONDS -gt 1200 ]; then set +o errexit; echo "Travis early exit to cache current state"; false; else set -o errexit; if ! source .travis/test_06_script.sh; then set +o errexit; false; fi; fi
+  - if [ $SECONDS -gt 1200 ]; then set +o errexit; echo "Travis early exit to cache current state"; false; else set -o errexit; source .travis/test_06_script.sh; fi
 after_script:
   - echo $TRAVIS_COMMIT_RANGE
   - echo $TRAVIS_COMMIT_LOG


### PR DESCRIPTION
The current travis-ci job would fail only if the last command failed. It would be succeed if other commands than the last one fail.

This PR execute the script in another shell instance, so we should export those variables and bash functions. It would return 1 if the script fail no matter if it's the last command.

Sorry for ruin the travis ci system in #14231

Test: https://travis-ci.org/ken2812221/bitcoin/jobs/467086010