### PR TITLE
rpc: Allow testmempoolaccept to test unsigned transactions

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -97,6 +97,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendrawtransaction", 1, "allowhighfees" },
     { "testmempoolaccept", 0, "rawtxs" },
     { "testmempoolaccept", 1, "allowhighfees" },
+    { "testmempoolaccept", 2, "allowunsignedtxs" },
     { "combinerawtransaction", 0, "txs" },
     { "fundrawtransaction", 1, "options" },
     { "fundrawtransaction", 2, "iswitness" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1163,9 +1163,9 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
     UniValue result_0(UniValue::VOBJ);
     result_0.pushKV("txid", tx_hash.GetHex());
 
-    bool test_accept_unsigned = false;
+    MemPoolValidationScope validation_scope = MemPoolValidationScope::TEST_ACCEPT;
     if (!request.params[2].isNull() && request.params[2].get_bool()) {
-        test_accept_unsigned = true;
+        validation_scope = MemPoolValidationScope::TEST_ACCEPT_UNSIGNED;
     }
 
     CValidationState state;
@@ -1174,7 +1174,7 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
     {
         LOCK(cs_main);
         test_accept_res = AcceptToMemoryPool(mempool, state, std::move(tx), &missing_inputs,
-            nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, /* test_accept */ true, test_accept_unsigned);
+            nullptr /* plTxnReplaced */, false /* bypass_limits */, max_raw_tx_fee, validation_scope);
     }
     result_0.pushKV("allowed", test_accept_res);
     if (!test_accept_res) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -559,7 +559,7 @@ static bool CheckInputsFromMempoolAndCache(const CTransaction& tx, CValidationSt
 
 static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool& pool, CValidationState& state, const CTransactionRef& ptx,
                               bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                              bool bypass_limits, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache, bool test_accept, bool test_accept_unsigned) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+                              bool bypass_limits, const CAmount& nAbsurdFee, std::vector<COutPoint>& coins_to_uncache, MemPoolValidationScope validation_scope) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     const CTransaction& tx = *ptx;
     const uint256 hash = tx.GetHash();
@@ -885,7 +885,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
             }
         }
 
-        if (test_accept_unsigned) {
+        if (validation_scope == MemPoolValidationScope::TEST_ACCEPT_UNSIGNED) {
             // Unsigned Tx could be accepted. It is not added
             return true;
         }
@@ -929,7 +929,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                     __func__, hash.ToString(), FormatStateMessage(state));
         }
 
-        if (test_accept) {
+        if (validation_scope == MemPoolValidationScope::TEST_ACCEPT) {
             // Tx was accepted, but not added
             return true;
         }
@@ -973,10 +973,10 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 /** (try to) add transaction to memory pool with a specified acceptance time **/
 static bool AcceptToMemoryPoolWithTime(const CChainParams& chainparams, CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
                         bool* pfMissingInputs, int64_t nAcceptTime, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept, bool test_accept_unsigned) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+                        bool bypass_limits, const CAmount nAbsurdFee, MemPoolValidationScope validation_scope) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     std::vector<COutPoint> coins_to_uncache;
-    bool res = AcceptToMemoryPoolWorker(chainparams, pool, state, tx, pfMissingInputs, nAcceptTime, plTxnReplaced, bypass_limits, nAbsurdFee, coins_to_uncache, test_accept, test_accept_unsigned);
+    bool res = AcceptToMemoryPoolWorker(chainparams, pool, state, tx, pfMissingInputs, nAcceptTime, plTxnReplaced, bypass_limits, nAbsurdFee, coins_to_uncache, validation_scope);
     if (!res) {
         for (const COutPoint& hashTx : coins_to_uncache)
             pcoinsTip->Uncache(hashTx);
@@ -989,10 +989,10 @@ static bool AcceptToMemoryPoolWithTime(const CChainParams& chainparams, CTxMemPo
 
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept, bool test_accept_unsigned)
+                        bool bypass_limits, const CAmount nAbsurdFee, MemPoolValidationScope validation_scope)
 {
     const CChainParams& chainparams = Params();
-    return AcceptToMemoryPoolWithTime(chainparams, pool, state, tx, pfMissingInputs, GetTime(), plTxnReplaced, bypass_limits, nAbsurdFee, test_accept, test_accept_unsigned);
+    return AcceptToMemoryPoolWithTime(chainparams, pool, state, tx, pfMissingInputs, GetTime(), plTxnReplaced, bypass_limits, nAbsurdFee, validation_scope);
 }
 
 /**
@@ -4728,7 +4728,7 @@ bool LoadMempool()
                 LOCK(cs_main);
                 AcceptToMemoryPoolWithTime(chainparams, mempool, state, tx, nullptr /* pfMissingInputs */, nTime,
                                            nullptr /* plTxnReplaced */, false /* bypass_limits */, 0 /* nAbsurdFee */,
-                                           false /* test_accept */, false /* test_accept_unsigned */);
+                                           MemPoolValidationScope::ACCEPT);
                 if (state.IsValid()) {
                     ++count;
                 } else {

--- a/src/validation.h
+++ b/src/validation.h
@@ -302,11 +302,20 @@ void PruneAndFlush();
 /** Prune block files up to a given height */
 void PruneBlockFilesManual(int nManualPruneHeight);
 
+/** To what extend a transaction has to be validated
+ * by AcceptToMemoryPool.
+ */
+enum class MemPoolValidationScope {
+    ACCEPT,                 //!< Validate signed transaction and add to the pool
+    TEST_ACCEPT,            //!< Validate signed transaction but DO NOT add to the pool
+    TEST_ACCEPT_UNSIGNED    //!< Validate unsigned transaction (except scripts)
+};
+
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false, bool test_accept_unsigned=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                        bool bypass_limits, const CAmount nAbsurdFee, MemPoolValidationScope validation_scope=MemPoolValidationScope::ACCEPT) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);

--- a/src/validation.h
+++ b/src/validation.h
@@ -306,7 +306,7 @@ void PruneBlockFilesManual(int nManualPruneHeight);
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
 bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
-                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+                        bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false, bool test_accept_unsigned=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);


### PR DESCRIPTION
`testmempoolaccept` RPC is useful for checking if signed raw transaction can be accepted into the current transaction pool, however there is no available mechanism from checking whether an still unsigned transaction could be accepted or not, except for the fact that is not signed yet. 

This PR adds an optional parameter that provides a way for the caller to specify the script evaluation should is skipped. Services that build transactions collectively require to perform several rpc calls in order to verify that built transaction could be accepted before requesting the parts to sign it. This flag could simplify that process.  

Fixes #14859