### PR TITLE
wallet: Make scan / abort status private to CWallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -216,9 +216,7 @@ UniValue abortrescan(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    if (!pwallet->IsScanning() || pwallet->IsAbortingRescan()) return false;
-    pwallet->AbortRescan();
-    return true;
+    return pwallet->AbortRescan();
 }
 
 UniValue importaddress(const JSONRPCRequest& request)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1586,14 +1586,6 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 
 }
 
-/**
- * Scan active chain for relevant transactions after importing keys. This should
- * be called whenever new keys are added to the wallet, with the oldest key
- * creation time.
- *
- * @return Earliest timestamp that could be successfully scanned from. Timestamp
- * returned will be higher than startTime if relevant blocks could not be read.
- */
 CWallet::ScanResult CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update)
 {
     // Find starting block. May be null if nCreateTime is greater than the
@@ -1615,27 +1607,6 @@ CWallet::ScanResult CWallet::RescanFromTime(int64_t startTime, const WalletResca
     return result;
 }
 
-/**
- * Scan the block chain (starting in start_block) for transactions
- * from or to us. If fUpdate is true, found transactions that already
- * exist in the wallet will be updated.
- *
- * @param[in] start_block Scan starting block. If block is not on the active
- *                        chain, the scan will return SUCCESS immediately.
- * @param[in] stop_block  Scan ending block. If block is not on the active
- *                        chain, the scan will continue until it reaches the
- *                        chain tip.
- *
- * @return ScanResult returning scan information and indicating success or
- *         failure. Return status will be set to SUCCESS if scan was
- *         successful. FAILURE if a complete rescan was not possible (due to
- *         pruning or corruption). USER_ABORT if the rescan was aborted before
- *         it could complete.
- *
- * @pre Caller needs to make sure start_block (and the optional stop_block) are on
- * the main chain after to the addition of any new keys you want to detect
- * transactions for.
- */
 CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_block, const uint256& stop_block, const WalletRescanReserver& reserver, bool fUpdate)
 {
     int64_t nNow = GetTime();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -169,6 +169,13 @@ std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const std::string&
     return LoadWallet(chain, WalletLocation(name), error, warnings);
 }
 
+bool CWallet::AbortRescan()
+{
+    if (!fScanningWallet || fAbortRescan) return false;
+    fAbortRescan = true;
+    return true;
+}
+
 WalletCreationStatus CreateWallet(interfaces::Chain& chain, const SecureString& passphrase, uint64_t wallet_creation_flags, const std::string& name, std::string& error, std::vector<std::string>& warnings, std::shared_ptr<CWallet>& result)
 {
     // Indicate that the wallet is actually supposed to be blank and not just blank to make it encrypted

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1587,7 +1587,7 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
  * @return Earliest timestamp that could be successfully scanned from. Timestamp
  * returned will be higher than startTime if relevant blocks could not be read.
  */
-int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update)
+CWallet::ScanResult CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update)
 {
     // Find starting block. May be null if nCreateTime is greater than the
     // highest blockchain timestamp, in which case there is nothing that needs
@@ -1601,17 +1601,11 @@ int64_t CWallet::RescanFromTime(int64_t startTime, const WalletRescanReserver& r
     }
 
     if (!start_block.IsNull()) {
-        // TODO: this should take into account failure by ScanResult::USER_ABORT
-        ScanResult result = ScanForWalletTransactions(start_block, {} /* stop_block */, reserver, update);
-        if (result.status == ScanResult::FAILURE) {
-            int64_t time_max;
-            if (!chain().findBlock(result.last_failed_block, nullptr /* block */, nullptr /* time */, &time_max)) {
-                throw std::logic_error("ScanForWalletTransactions returned invalid block hash");
-            }
-            return time_max + TIMESTAMP_WINDOW + 1;
-        }
+        return ScanForWalletTransactions(start_block, {} /* stop_block */, reserver, update);
     }
-    return startTime;
+    ScanResult result;
+    result.status = ScanResult::SUCCESS;
+    return result;
 }
 
 /**

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -895,7 +895,41 @@ public:
         //! USER_ABORT.
         uint256 last_failed_block;
     };
+
+    /**
+     * Scan the block chain (starting in start_block) for transactions
+     * from or to us. If fUpdate is true, found transactions that already
+     * exist in the wallet will be updated.
+     *
+     * @param[in] start_block Scan starting block. If block is not on the active
+     *                        chain, the scan will return SUCCESS immediately.
+     * @param[in] stop_block  Scan ending block. If block is not on the active
+     *                        chain, the scan will continue until it reaches the
+     *                        chain tip.
+     *
+     * @return ScanResult returning scan information and indicating success or
+     *         failure. Return status will be set to SUCCESS if scan was
+     *         successful. FAILURE if a complete rescan was not possible (due to
+     *         pruning or corruption). USER_ABORT if the rescan was aborted before
+     *         it could complete.
+     *
+     * @pre Caller needs to make sure start_block (and the optional stop_block) are on
+     * the main chain after to the addition of any new keys you want to detect
+     * transactions for.
+     */
     ScanResult ScanForWalletTransactions(const uint256& first_block, const uint256& last_block, const WalletRescanReserver& reserver, bool fUpdate);
+
+    /**
+     * Scan active chain for relevant transactions after importing keys. This should
+     * be called whenever new keys are added to the wallet, with the oldest key
+     * creation time.
+     *
+     * @return ScanResult returning scan information and indicating success or
+     *         failure. Return status will be set to SUCCESS if scan was
+     *         successful. FAILURE if a complete rescan was not possible (due to
+     *         pruning or corruption). USER_ABORT if the rescan was aborted before
+     *         it could complete.
+     */
     ScanResult RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -828,11 +828,13 @@ public:
     void UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ListLockedCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    /*
-     * Rescan abort properties
+    /**
+     * Abort wallet rescan
+     *
+     * @return true if the abort was effectual, i.e. the wallet was scanning
+     * and was not already aborting
      */
-    void AbortRescan() { fAbortRescan = true; }
-    bool IsAbortingRescan() const { return fAbortRescan; }
+    bool AbortRescan();
     bool IsScanning() const { return fScanningWallet; }
     int64_t ScanningDuration() const { return fScanningWallet ? GetTimeMillis() - m_scanning_start : 0; }
     double ScanningProgress() const { return fScanningWallet ? (double) m_scanning_progress : 0; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -877,7 +877,6 @@ public:
     void BlockConnected(const CBlock& block, const std::vector<CTransactionRef>& vtxConflicted, int height) override;
     void BlockDisconnected(const CBlock& block, int height) override;
     void UpdatedBlockTip() override;
-    int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 
     struct ScanResult {
         enum { SUCCESS, FAILURE, USER_ABORT } status = SUCCESS;
@@ -895,6 +894,7 @@ public:
         uint256 last_failed_block;
     };
     ScanResult ScanForWalletTransactions(const uint256& first_block, const uint256& last_block, const WalletRescanReserver& reserver, bool fUpdate);
+    ScanResult RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
     void TransactionRemovedFromMempool(const CTransactionRef &ptx) override;
     void ReacceptWalletTransactions() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ResendWalletTransactions();


### PR DESCRIPTION
By returning `ScanResult` from `RescanFromTime` and reporting the effectuality of `AbortScan`.

~And consolidate rpc-level error handling across `RescanFromTime` and
`ScanForWalletTransactions`.~

~Note this changes the `rescanblockchain` scan failure error from
`RPC_MISC_ERROR` to `RPC_WALLET_ERROR`, which seems more appropriate and matches the
behavior from the rpcdump methods.~

This follows up on #13076.