### PR TITLE
doc: update NetBSD build instructions for 8.0

### DIFF
--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -1,6 +1,6 @@
 NetBSD build guide
 ======================
-(updated for NetBSD 7.0)
+(updated for NetBSD 8.0)
 
 This guide describes how to build bitcoind and command-line utilities on NetBSD.
 
@@ -15,20 +15,37 @@ You will need the following modules, which can be installed via pkgsrc or pkgin:
 autoconf
 automake
 boost
-db4
 git
 gmake
 libevent
 libtool
-python27
-```
+pkg-config
+python37
 
-Download the source code:
-```
-git clone https://github.com/bitcoin/bitcoin
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
+
+### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
+`--disable-wallet` to `./configure` and skip to the next section.
+
+It is recommended to use Berkeley DB 4.8. You cannot use the BerkeleyDB library
+from ports, for the same reason as boost above (g++/libstd++ incompatibility).
+If you have to build it yourself, you can use [the installation script included
+in contrib/](/contrib/install_db4.sh) like so:
+
+```shell
+./contrib/install_db4.sh `pwd`
+```
+
+from the root of the repository. Then set `BDB_PREFIX` for the next section:
+
+```shell
+export BDB_PREFIX="$PWD/db4"
+```
 
 ### Building Bitcoin Core
 
@@ -37,13 +54,26 @@ See [dependencies.md](dependencies.md) for a complete overview.
 With wallet:
 ```
 ./autogen.sh
-./configure CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
-gmake
+./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
+    LDFLAGS="-L/usr/pkg/lib" \
+    BOOST_CPPFLAGS="-I/usr/pkg/include" \
+    BOOST_LDFLAGS="-L/usr/pkg/lib" \
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
 Without wallet:
 ```
 ./autogen.sh
-./configure --disable-wallet CPPFLAGS="-I/usr/pkg/include" LDFLAGS="-L/usr/pkg/lib" BOOST_CPPFLAGS="-I/usr/pkg/include" BOOST_LDFLAGS="-L/usr/pkg/lib"
-gmake
+./configure --with-gui=no --disable-wallet \
+    CPPFLAGS="-I/usr/pkg/include" \
+    LDFLAGS="-L/usr/pkg/lib" \
+    BOOST_CPPFLAGS="-I/usr/pkg/include" \
+    BOOST_LDFLAGS="-L/usr/pkg/lib"
+```
+
+Build and run the tests:
+```bash
+gmake # use -jX here for parallelism
+gmake check
 ```


### PR DESCRIPTION
Updates the NetBSD build documentation for 8.0.
Use Python37 and add pkg-config.
Switches to using our `contrib/install_db4.sh` script for installing bdb.