### PR TITLE
scripts: Remove Python 2 import workarounds

### DIFF
--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -14,7 +14,6 @@
 
 # In case of a clean merge that is accepted by the user, the local branch with
 # name $BRANCH is overwritten with the merged result, and optionally pushed.
-from __future__ import division,print_function,unicode_literals
 import os
 from sys import stdin,stdout,stderr
 import argparse
@@ -23,10 +22,7 @@ import subprocess
 import sys
 import json
 import codecs
-try:
-    from urllib.request import Request,urlopen
-except ImportError:
-    from urllib2 import Request,urlopen
+from urllib.request import Request, urlopen
 
 # External tools (can be overridden using environment)
 GIT = os.getenv('GIT','git')

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -7,7 +7,6 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from __future__ import print_function, division
 import struct
 import re
 import os

--- a/contrib/linearize/linearize-hashes.py
+++ b/contrib/linearize/linearize-hashes.py
@@ -7,11 +7,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
 
-from __future__ import print_function
-try: # Python 3
-    import http.client as httplib
-except ImportError: # Python 2
-    import httplib
+from http.client import HttpConnection
 import json
 import re
 import base64
@@ -31,7 +27,7 @@ class BitcoinRPC:
         authpair = "%s:%s" % (username, password)
         authpair = authpair.encode('utf-8')
         self.authhdr = b"Basic " + base64.b64encode(authpair)
-        self.conn = httplib.HTTPConnection(host, port=port, timeout=30)
+        self.conn = HttpConnection(host, port=port, timeout=30)
 
     def execute(self, obj):
         try:

--- a/test/util/bitcoin-util-test.py
+++ b/test/util/bitcoin-util-test.py
@@ -9,14 +9,9 @@ Runs automatically during `make check`.
 
 Can also be run manually."""
 
-from __future__ import division,print_function,unicode_literals
-
 import argparse
 import binascii
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
+import configparser
 import difflib
 import json
 import logging


### PR DESCRIPTION
Remove Python 2 import workarounds.

As noted by @jnewbery in https://github.com/bitcoin/bitcoin/pull/14903#discussion_r241396925:

> This exception handling is a vestige from when github-merge.py supported Python 2 and Python 3. We only support Python 3 now so we should be able to remove it entirely and just import from urllib.request.