### PR TITLE
Switch all RNG code to the built-in PRNG

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -6,7 +6,6 @@
 
 #include <crypto/sha256.h>
 #include <key.h>
-#include <random.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <validation.h>
@@ -67,7 +66,6 @@ int main(int argc, char** argv)
     const fs::path bench_datadir{SetDataDir()};
 
     SHA256AutoDetect();
-    RandomInit();
     ECC_Start();
     SetupEnvironment();
 

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -17,7 +17,7 @@ private:
     uint64_t bytes;
 
 public:
-    static const size_t OUTPUT_SIZE = 64;
+    static constexpr size_t OUTPUT_SIZE = 64;
 
     CSHA512();
     CSHA512& Write(const unsigned char* data, size_t len);

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -181,12 +181,12 @@ void PaymentServerTests::paymentServerTests()
     QCOMPARE(PaymentServer::verifyExpired(r.paymentRequest.getDetails()), true);
 
     // Test BIP70 DoS protection:
-    unsigned char randData[BIP70_MAX_PAYMENTREQUEST_SIZE + 1];
-    GetRandBytes(randData, sizeof(randData));
+    auto randdata = FastRandomContext().randbytes(BIP70_MAX_PAYMENTREQUEST_SIZE + 1);
+
     // Write data to a temp file:
     QTemporaryFile tempFile;
     tempFile.open();
-    tempFile.write((const char*)randData, sizeof(randData));
+    tempFile.write((const char*)randdata.data(), randdata.size());
     tempFile.close();
     // compares 50001 <= BIP70_MAX_PAYMENTREQUEST_SIZE == false
     QCOMPARE(PaymentServer::verifySize(tempFile.size()), false);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -297,10 +297,11 @@ void GetRandBytes(unsigned char* buf, int num)
 namespace {
 struct RNGState {
     Mutex m_mutex;
-    unsigned char m_state[32] = {0};
-    uint64_t m_counter = 0;
+    unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
+    uint64_t m_counter GUARDED_BY(m_mutex) = 0;
 
-    explicit RNGState() {
+    RNGState()
+    {
         InitHardwareRand();
     }
 };

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -19,6 +19,8 @@
 #include <chrono>
 #include <thread>
 
+#include <support/allocators/secure.h>
+
 #ifndef WIN32
 #include <fcntl.h>
 #include <sys/time.h>
@@ -351,8 +353,8 @@ RNGState& GetRNGState() noexcept
 {
     // This C++11 idiom relies on the guarantee that static variable are initialized
     // on first call, even when multiple parallel calls are permitted.
-    static std::unique_ptr<RNGState> g_rng{new RNGState()};
-    return *g_rng;
+    static std::vector<RNGState, secure_allocator<RNGState>> g_rng(1);
+    return g_rng[0];
 }
 }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -166,13 +166,13 @@ static void RandAddSeedPerfmon()
     if (ret == ERROR_SUCCESS) {
         RAND_add(vData.data(), nSize, nSize / 100.0);
         memory_cleanse(vData.data(), nSize);
-        LogPrint(BCLog::RAND, "%s: %lu bytes\n", __func__, nSize);
     } else {
-        static bool warned = false; // Warn only once
-        if (!warned) {
-            LogPrintf("%s: Warning: RegQueryValueExA(HKEY_PERFORMANCE_DATA) failed with code %i\n", __func__, ret);
-            warned = true;
-        }
+        // Performance data is only a best-effort attempt at improving the
+        // situation when the OS randomness (and other sources) aren't
+        // adequate. As a result, failure to read it is isn't considered critical,
+        // so we don't call RandFailure().
+        // TODO: Add logging when the logger is made functional before global
+        // constructors have been invoked.
     }
 #endif
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -47,6 +47,7 @@
 
 #include <openssl/err.h>
 #include <openssl/rand.h>
+#include <openssl/conf.h>
 
 [[noreturn]] static void RandFailure()
 {
@@ -294,15 +295,46 @@ void GetRandBytes(unsigned char* buf, int num)
     }
 }
 
+void LockingCallbackOpenSSL(int mode, int i, const char* file, int line);
+
 namespace {
+
 struct RNGState {
     Mutex m_mutex;
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
+    std::unique_ptr<Mutex[]> m_mutex_openssl;
 
     RNGState()
     {
         InitHardwareRand();
+
+        // Init OpenSSL library multithreading support
+        m_mutex_openssl.reset(new Mutex[CRYPTO_num_locks()]);
+        CRYPTO_set_locking_callback(LockingCallbackOpenSSL);
+
+        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
+        // We don't use them so we don't require the config. However some of our libs may call functions
+        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
+        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
+        // that the config appears to have been loaded and there are no modules/engines available.
+        OPENSSL_no_config();
+
+#ifdef WIN32
+        // Seed OpenSSL PRNG with current contents of the screen
+        RAND_screen();
+#endif
+
+        // Seed OpenSSL PRNG with performance counter
+        RandAddSeed();
+    }
+
+    ~RNGState()
+    {
+        // Securely erase the memory used by the OpenSSL PRNG
+        RAND_cleanup();
+        // Shutdown OpenSSL library multithreading support
+        CRYPTO_set_locking_callback(nullptr);
     }
 
     /** Extract up to 32 bytes of entropy from the RNG state, mixing in new entropy from hasher. */
@@ -341,6 +373,17 @@ RNGState& GetRNGState()
     static std::unique_ptr<RNGState> g_rng{new RNGState()};
     return *g_rng;
 }
+}
+
+void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
+{
+    RNGState& rng = GetRNGState();
+
+    if (mode & CRYPTO_LOCK) {
+        rng.m_mutex_openssl[i].lock();
+    } else {
+        rng.m_mutex_openssl[i].unlock();
+    }
 }
 
 static void AddDataToRng(void* data, size_t len, RNGState& rng);

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -282,6 +282,14 @@ namespace {
 
 class RNGState {
     Mutex m_mutex;
+    /* The RNG state consists of 256 bits of entropy, taken from the output of
+     * one operation's SHA512 output, and fed as input to the next one.
+     * Carrying 256 bits of entropy should be sufficient to guarantee
+     * unpredictability as long as any entropy source was ever unpredictable
+     * to an attacker. To protect against situations where an attacker might
+     * observe the RNG's state, fresh entropy is always mixed when
+     * GetStrongRandBytes is called.
+     */
     unsigned char m_state[32] GUARDED_BY(m_mutex) = {0};
     uint64_t m_counter GUARDED_BY(m_mutex) = 0;
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -503,17 +503,7 @@ void RandAddSeedSleep() { ProcRand(nullptr, 0, RNGLevel::SLEEP); }
 
 uint64_t GetRand(uint64_t nMax) noexcept
 {
-    if (nMax == 0)
-        return 0;
-
-    // The range of the random source must be a multiple of the modulus
-    // to give every possible output value an equal possibility
-    uint64_t nRange = (std::numeric_limits<uint64_t>::max() / nMax) * nMax;
-    uint64_t nRand = 0;
-    do {
-        GetRandBytes((unsigned char*)&nRand, sizeof(nRand));
-    } while (nRand >= nRange);
-    return (nRand % nMax);
+    return FastRandomContext().randrange(nMax);
 }
 
 int GetRandInt(int nMax) noexcept

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -76,7 +76,6 @@ static inline int64_t GetPerformanceCounter()
 }
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
-static std::atomic<bool> hwrand_initialized{false};
 static bool rdrand_supported = false;
 static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
 static void InitHardwareRand()
@@ -85,12 +84,10 @@ static void InitHardwareRand()
     if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
         rdrand_supported = true;
     }
-    hwrand_initialized.store(true);
 }
 
 static void ReportHardwareRand()
 {
-    assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
         // This must be done in a separate function, as HWRandInit() may be indirectly called
         // from global constructors, before logging is initialized.
@@ -110,7 +107,6 @@ static void ReportHardwareRand() {}
 
 static bool GetHardwareRand(unsigned char* ent32) {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
-    assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
         uint8_t ok;
         // Not all assemblers support the rdrand instruction, write it in hex.

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -55,7 +55,7 @@
     std::abort();
 }
 
-static inline int64_t GetPerformanceCounter()
+static inline int64_t GetPerformanceCounter() noexcept
 {
     // Read the hardware time stamp counter when available.
     // See https://en.wikipedia.org/wiki/Time_Stamp_Counter for more information.
@@ -105,7 +105,7 @@ static void InitHardwareRand() {}
 static void ReportHardwareRand() {}
 #endif
 
-static bool GetHardwareRand(unsigned char* ent32) {
+static bool GetHardwareRand(unsigned char* ent32) noexcept {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
     if (rdrand_supported) {
         uint8_t ok;
@@ -285,7 +285,7 @@ struct RNGState {
     bool m_strongly_seeded GUARDED_BY(m_mutex) = false;
     std::unique_ptr<Mutex[]> m_mutex_openssl;
 
-    RNGState()
+    RNGState() noexcept
     {
         InitHardwareRand();
 
@@ -313,7 +313,7 @@ struct RNGState {
      *
      * If this function has never been called with strong_seed = true, false is returned.
      */
-    bool MixExtract(unsigned char* out, size_t num, CSHA512&& hasher, bool strong_seed)
+    bool MixExtract(unsigned char* out, size_t num, CSHA512&& hasher, bool strong_seed) noexcept
     {
         assert(num <= 32);
         unsigned char buf[64];
@@ -344,7 +344,7 @@ struct RNGState {
     }
 };
 
-RNGState& GetRNGState()
+RNGState& GetRNGState() noexcept
 {
     // This C++11 idiom relies on the guarantee that static variable are initialized
     // on first call, even when multiple parallel calls are permitted.
@@ -364,13 +364,28 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THRE
     }
 }
 
-static void SeedTimestamp(CSHA512& hasher)
+/* A note on the use of noexcept in the seeding functions below:
+ *
+ * None of the RNG code should ever throw any exception, with the sole exception
+ * of MilliSleep in SeedSleep, which can (and does) support interruptions which
+ * cause a boost::thread_interrupted to be thrown.
+ *
+ * This means that SeedSleep, and all functions that invoke it are throwing.
+ * However, we know that GetRandBytes() and GetStrongRandBytes() never trigger
+ * this sleeping logic, so they are noexcept. The same is true for all the
+ * GetRand*() functions that use GetRandBytes() indirectly.
+ *
+ * TODO: After moving away from interruptible boost-based thread management,
+ * everything can become noexcept here.
+ */
+
+static void SeedTimestamp(CSHA512& hasher) noexcept
 {
     int64_t perfcounter = GetPerformanceCounter();
     hasher.Write((const unsigned char*)&perfcounter, sizeof(perfcounter));
 }
 
-static void SeedFast(CSHA512& hasher)
+static void SeedFast(CSHA512& hasher) noexcept
 {
     unsigned char buffer[32];
 
@@ -386,7 +401,7 @@ static void SeedFast(CSHA512& hasher)
     SeedTimestamp(hasher);
 }
 
-static void SeedSlow(CSHA512& hasher)
+static void SeedSlow(CSHA512& hasher) noexcept
 {
     unsigned char buffer[32];
 
@@ -426,7 +441,7 @@ static void SeedSleep(CSHA512& hasher)
     RandAddSeedPerfmon(hasher);
 }
 
-static void SeedStartup(CSHA512& hasher)
+static void SeedStartup(CSHA512& hasher) noexcept
 {
 #ifdef WIN32
     RAND_screen();
@@ -482,11 +497,11 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
     }
 }
 
-void GetRandBytes(unsigned char* buf, int num) { ProcRand(buf, num, RNGLevel::FAST); }
-void GetStrongRandBytes(unsigned char* buf, int num) { ProcRand(buf, num, RNGLevel::SLOW); }
+void GetRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::FAST); }
+void GetStrongRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::SLOW); }
 void RandAddSeedSleep() { ProcRand(nullptr, 0, RNGLevel::SLEEP); }
 
-uint64_t GetRand(uint64_t nMax)
+uint64_t GetRand(uint64_t nMax) noexcept
 {
     if (nMax == 0)
         return 0;
@@ -501,12 +516,12 @@ uint64_t GetRand(uint64_t nMax)
     return (nRand % nMax);
 }
 
-int GetRandInt(int nMax)
+int GetRandInt(int nMax) noexcept
 {
     return GetRand(nMax);
 }
 
-uint256 GetRandHash()
+uint256 GetRandHash() noexcept
 {
     uint256 hash;
     GetRandBytes((unsigned char*)&hash, sizeof(hash));
@@ -520,7 +535,7 @@ void FastRandomContext::RandomSeed()
     requires_seed = false;
 }
 
-uint256 FastRandomContext::rand256()
+uint256 FastRandomContext::rand256() noexcept
 {
     if (bytebuf_size < 32) {
         FillByteBuffer();
@@ -541,7 +556,7 @@ std::vector<unsigned char> FastRandomContext::randbytes(size_t len)
     return ret;
 }
 
-FastRandomContext::FastRandomContext(const uint256& seed) : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
+FastRandomContext::FastRandomContext(const uint256& seed) noexcept : requires_seed(false), bytebuf_size(0), bitbuf_size(0)
 {
     rng.SetKey(seed.begin(), 32);
 }
@@ -592,7 +607,7 @@ bool Random_SanityCheck()
     return true;
 }
 
-FastRandomContext::FastRandomContext(bool fDeterministic) : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)
+FastRandomContext::FastRandomContext(bool fDeterministic) noexcept : requires_seed(!fDeterministic), bytebuf_size(0), bitbuf_size(0)
 {
     if (!fDeterministic) {
         return;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -78,7 +78,7 @@ static inline int64_t GetPerformanceCounter()
 static std::atomic<bool> hwrand_initialized{false};
 static bool rdrand_supported = false;
 static constexpr uint32_t CPUID_F1_ECX_RDRAND = 0x40000000;
-static void RDRandInit()
+static void InitHardwareRand()
 {
     uint32_t eax, ebx, ecx, edx;
     if (__get_cpuid(1, &eax, &ebx, &ecx, &edx) && (ecx & CPUID_F1_ECX_RDRAND)) {
@@ -87,7 +87,7 @@ static void RDRandInit()
     hwrand_initialized.store(true);
 }
 
-static void RDRandReport()
+static void ReportHardwareRand()
 {
     assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
@@ -98,11 +98,16 @@ static void RDRandReport()
 }
 
 #else
-static void RDRandInit() {}
-static void RDRandReport() {}
+/* Access to other hardware random number generators could be added here later,
+ * assuming it is sufficiently fast (in the order of a few hundred CPU cycles).
+ * Slower sources should probably be invoked separately, and/or only from
+ * RandAddSeedSleep (which is called during idle background operation).
+ */
+static void InitHardwareRand() {}
+static void ReportHardwareRand() {}
 #endif
 
-static bool GetHWRand(unsigned char* ent32) {
+static bool GetHardwareRand(unsigned char* ent32) {
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
     assert(hwrand_initialized.load(std::memory_order_relaxed));
     if (rdrand_supported) {
@@ -296,7 +301,7 @@ struct RNGState {
     uint64_t m_counter = 0;
 
     explicit RNGState() {
-        RDRandInit();
+        InitHardwareRand();
     }
 };
 
@@ -361,7 +366,7 @@ void GetStrongRandBytes(unsigned char* out, int num)
     hasher.Write(buf, 32);
 
     // Third source: HW RNG, if available.
-    if (GetHWRand(buf)) {
+    if (GetHardwareRand(buf)) {
         hasher.Write(buf, 32);
     }
 
@@ -512,5 +517,5 @@ void RandomInit()
     // Invoke RNG code to trigger initialization (if not already performed)
     GetRNGState();
 
-    RDRandReport();
+    ReportHardwareRand();
 }

--- a/src/random.h
+++ b/src/random.h
@@ -21,10 +21,10 @@
  *
  * Thread-safe.
  */
-void GetRandBytes(unsigned char* buf, int num);
-uint64_t GetRand(uint64_t nMax);
-int GetRandInt(int nMax);
-uint256 GetRandHash();
+void GetRandBytes(unsigned char* buf, int num) noexcept;
+uint64_t GetRand(uint64_t nMax) noexcept;
+int GetRandInt(int nMax) noexcept;
+uint256 GetRandHash() noexcept;
 
 /**
  * Gather entropy from various sources, feed it into the internal PRNG, and
@@ -34,7 +34,7 @@ uint256 GetRandHash();
  *
  * Thread-safe.
  */
-void GetStrongRandBytes(unsigned char* buf, int num);
+void GetStrongRandBytes(unsigned char* buf, int num) noexcept;
 
 /**
  * Sleep for 1ms, gather entropy from various sources, and feed them to the PRNG state.
@@ -78,10 +78,10 @@ private:
     }
 
 public:
-    explicit FastRandomContext(bool fDeterministic = false);
+    explicit FastRandomContext(bool fDeterministic = false) noexcept;
 
     /** Initialize with explicit seed (only for testing) */
-    explicit FastRandomContext(const uint256& seed);
+    explicit FastRandomContext(const uint256& seed) noexcept;
 
     // Do not permit copying a FastRandomContext (move it, or create a new one to get reseeded).
     FastRandomContext(const FastRandomContext&) = delete;
@@ -92,7 +92,7 @@ public:
     FastRandomContext& operator=(FastRandomContext&& from) noexcept;
 
     /** Generate a random 64-bit integer. */
-    uint64_t rand64()
+    uint64_t rand64() noexcept
     {
         if (bytebuf_size < 8) FillByteBuffer();
         uint64_t ret = ReadLE64(bytebuf + 64 - bytebuf_size);
@@ -101,7 +101,7 @@ public:
     }
 
     /** Generate a random (bits)-bit integer. */
-    uint64_t randbits(int bits) {
+    uint64_t randbits(int bits) noexcept {
         if (bits == 0) {
             return 0;
         } else if (bits > 32) {
@@ -116,7 +116,7 @@ public:
     }
 
     /** Generate a random integer in the range [0..range). */
-    uint64_t randrange(uint64_t range)
+    uint64_t randrange(uint64_t range) noexcept
     {
         --range;
         int bits = CountBits(range);
@@ -130,19 +130,19 @@ public:
     std::vector<unsigned char> randbytes(size_t len);
 
     /** Generate a random 32-bit integer. */
-    uint32_t rand32() { return randbits(32); }
+    uint32_t rand32() noexcept { return randbits(32); }
 
     /** generate a random uint256. */
-    uint256 rand256();
+    uint256 rand256() noexcept;
 
     /** Generate a random boolean. */
-    bool randbool() { return randbits(1); }
+    bool randbool() noexcept { return randbits(1); }
 
     // Compatibility with the C++11 UniformRandomBitGenerator concept
     typedef uint64_t result_type;
     static constexpr uint64_t min() { return 0; }
     static constexpr uint64_t max() { return std::numeric_limits<uint64_t>::max(); }
-    inline uint64_t operator()() { return rand64(); }
+    inline uint64_t operator()() noexcept { return rand64(); }
 };
 
 /** More efficient than using std::shuffle on a FastRandomContext.

--- a/src/random.h
+++ b/src/random.h
@@ -178,7 +178,12 @@ void GetOSRand(unsigned char *ent32);
  */
 bool Random_SanityCheck();
 
-/** Initialize the RNG. */
+/**
+ * Initialize global RNG state and log any CPU features that are used.
+ *
+ * Calling this function is optional. RNG state will be initialized when first
+ * needed if it is not called.
+ */
 void RandomInit();
 
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -13,11 +13,13 @@
 #include <stdint.h>
 #include <limits>
 
-/* Seed OpenSSL PRNG with additional entropy data */
-void RandAddSeed();
-
 /**
- * Functions to gather random data via the OpenSSL PRNG
+ * Generate random data via the internal PRNG.
+ *
+ * These functions are designed to be fast (sub microsecond), but do not necessarily
+ * meaningfully add entropy to the PRNG state.
+ *
+ * Thread-safe.
  */
 void GetRandBytes(unsigned char* buf, int num);
 uint64_t GetRand(uint64_t nMax);
@@ -25,21 +27,26 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
- * Add a little bit of randomness to the output of GetStrongRangBytes.
- * This sleeps for a millisecond, so should only be called when there is
- * no other work to be done.
- */
-void RandAddSeedSleep();
-
-/**
- * Function to gather random data from multiple sources, failing whenever any
- * of those sources fail to provide a result.
+ * Gather entropy from various sources, feed it into the internal PRNG, and
+ * generate random data using it.
+ *
+ * This function will cause failure whenever the OS RNG fails.
+ *
+ * Thread-safe.
  */
 void GetStrongRandBytes(unsigned char* buf, int num);
 
 /**
+ * Sleep for 1ms, gather entropy from various sources, and feed them to the PRNG state.
+ *
+ * Thread-safe.
+ */
+void RandAddSeedSleep();
+
+/**
  * Fast randomness source. This is seeded once with secure random data, but
- * is completely deterministic and insecure after that.
+ * is completely deterministic and does not gather more entropy after that.
+ *
  * This class is not thread-safe.
  */
 class FastRandomContext {

--- a/src/random.h
+++ b/src/random.h
@@ -14,6 +14,49 @@
 #include <limits>
 
 /**
+ * Overall design of the RNG and entropy sources.
+ *
+ * We maintain a single global 256-bit RNG state for all high-quality randomness.
+ * The following (classes of) functions interact with that state by mixing in new
+ * entropy, and optionally extracting random output from it:
+ *
+ * - The GetRand*() class of functions, as well as construction of FastRandomContext objects,
+ *   perform 'fast' seeding, consisting of mixing in:
+ *   - A stack pointer (indirectly committing to calling thread and call stack)
+ *   - A high-precision timestamp (rdtsc when available, c++ high_resolution_clock otherwise)
+ *   - Hardware RNG (rdrand) when available.
+ *   These entropy sources are very fast, and only designed to protect against situations
+ *   where a VM state restore/copy results in multiple systems with the same randomness.
+ *   FastRandomContext on the other hand does not protect against this once created, but
+ *   is even faster (and acceptable to use inside tight loops).
+ *
+ * - The GetStrongRand*() class of function perform 'slow' seeding, including everything
+ *   that fast seeding includes, but additionally:
+ *   - OS entropy (/dev/urandom, getrandom(), ...). The application will terminate if
+ *     this entropy source fails.
+ *   - Bytes from OpenSSL's RNG (which itself may be seeded from various sources)
+ *   - Another high-precision timestamp (indirectly committing to a benchmark of all the
+ *     previous sources).
+ *   These entropy sources are slower, but designed to make sure the RNG state contains
+ *   fresh data that is unpredictable to attackers.
+ *
+ * - RandAddSeedSleep() seeds everything that fast seeding includes, but additionally:
+ *   - A high-precision timestamp before and after sleeping 1ms.
+ *   - (On Windows) Once every 10 minutes, performance monitoring data from the OS.
+ *   These just exploit the fact the system is idle to improve the quality of the RNG
+ *   slightly.
+ *
+ * On first use of the RNG (regardless of what function is called first), all entropy
+ * sources used in the 'slow' seeder are included, but also:
+ * - (On Windows) Performance monitoring data from the OS.
+ * - (On Windows) Through OpenSSL, the screen contents.
+ *
+ * When mixing in new entropy, H = SHA512(entropy || old_rng_state) is computed, and
+ * (up to) the first 32 bytes of H are produced as output, while the last 32 bytes
+ * become the new RNG state.
+*/
+
+/**
  * Generate random data via the internal PRNG.
  *
  * These functions are designed to be fast (sub microsecond), but do not necessarily

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -41,7 +41,7 @@ void CScheduler::serviceQueue()
         try {
             if (!shouldStop() && taskQueue.empty()) {
                 reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
-                // Use this chance to get a tiny bit more entropy
+                // Use this chance to get more entropy
                 RandAddSeedSleep();
             }
             while (!shouldStop() && taskQueue.empty()) {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -49,7 +49,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     : m_path_root(fs::temp_directory_path() / "test_bitcoin" / strprintf("%lu_%i", (unsigned long)GetTime(), (int)(InsecureRandRange(1 << 30))))
 {
     SHA256AutoDetect();
-    RandomInit();
     ECC_Start();
     SetupEnvironment();
     SetupNetworking();

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -73,9 +73,6 @@
 #include <malloc.h>
 #endif
 
-#include <openssl/crypto.h>
-#include <openssl/rand.h>
-#include <openssl/conf.h>
 #include <thread>
 
 // Application startup time (used for uptime calculation)
@@ -85,54 +82,6 @@ const char * const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char * const BITCOIN_PID_FILENAME = "bitcoind.pid";
 
 ArgsManager gArgs;
-
-/** Init OpenSSL library multithreading support */
-static std::unique_ptr<CCriticalSection[]> ppmutexOpenSSL;
-void locking_callback(int mode, int i, const char* file, int line) NO_THREAD_SAFETY_ANALYSIS
-{
-    if (mode & CRYPTO_LOCK) {
-        ENTER_CRITICAL_SECTION(ppmutexOpenSSL[i]);
-    } else {
-        LEAVE_CRITICAL_SECTION(ppmutexOpenSSL[i]);
-    }
-}
-
-// Singleton for wrapping OpenSSL setup/teardown.
-class CInit
-{
-public:
-    CInit()
-    {
-        // Init OpenSSL library multithreading support
-        ppmutexOpenSSL.reset(new CCriticalSection[CRYPTO_num_locks()]);
-        CRYPTO_set_locking_callback(locking_callback);
-
-        // OpenSSL can optionally load a config file which lists optional loadable modules and engines.
-        // We don't use them so we don't require the config. However some of our libs may call functions
-        // which attempt to load the config file, possibly resulting in an exit() or crash if it is missing
-        // or corrupt. Explicitly tell OpenSSL not to try to load the file. The result for our libs will be
-        // that the config appears to have been loaded and there are no modules/engines available.
-        OPENSSL_no_config();
-
-#ifdef WIN32
-        // Seed OpenSSL PRNG with current contents of the screen
-        RAND_screen();
-#endif
-
-        // Seed OpenSSL PRNG with performance counter
-        RandAddSeed();
-    }
-    ~CInit()
-    {
-        // Securely erase the memory used by the PRNG
-        RAND_cleanup();
-        // Shutdown OpenSSL library multithreading support
-        CRYPTO_set_locking_callback(nullptr);
-        // Clear the set of locks now to maintain symmetry with the constructor.
-        ppmutexOpenSSL.reset();
-    }
-}
-instance_of_cinit;
 
 /** A map that contains all the currently held directory locks. After
  * successful locking, these will be held here until the global destructor


### PR DESCRIPTION
This does not remove OpenSSL, but makes our own PRNG the 'main' one; for GetStrongRandBytes, the OpenSSL RNG is still used (indirectly, by feeding its output into our PRNG state).

It includes a few policy changes (regarding what entropy is seeded when).

Before this PR:
* GetRand*:
  * OpenSSL
* GetStrongRand*:
  * CPU cycle counter
  * Perfmon data (on Windows, once 10 min)
  * /dev/urandom (or equivalent)
  * rdrand (if available)
* From scheduler when idle:
  * CPU cycle counter before and after 1ms sleep
* At startup:
  * CPU cycle counter before and after 1ms sleep

After this PR:
* GetRand*:
  * Stack pointer (which indirectly identifies thread and some call stack information)
  * rdrand (if available)
  * CPU cycle counter
* GetStrongRand*:
  * Stack pointer (which indirectly identifies thread and some call stack information)
  * rdrand (if available)
  * CPU cycle counter
  * /dev/urandom (or equivalent)
  * OpenSSL
  * CPU cycle counter again
* From scheduler when idle:
  * Stack pointer (which indirectly identifies thread and some call stack information)
  * rdrand (if available)
  * CPU cycle counter before and after 1ms sleep
  * Perfmon data (on Windows, once every 10 min)
* At startup:
  * Stack pointer (which indirectly identifies thread and some call stack information)
  * rdrand (if available)
  * CPU cycle counter
  * /dev/urandom (or equivalent)
  * OpenSSL
  * CPU cycle counter again
  * Perfmon data (on Windows, once every 10 min)

The interface of random.h is also simplified, and documentation is added.

This implements most of #14623.