### PR TITLE
[qt] Ensure tx send error highlight is visible

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -230,7 +230,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             {
                 recipients.append(entry->getValue());
             }
-            else if(valid)
+            else if (valid)
             {
                 ui->scrollArea->ensureWidgetVisible(entry);
                 valid = false;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -230,8 +230,9 @@ void SendCoinsDialog::on_sendButton_clicked()
             {
                 recipients.append(entry->getValue());
             }
-            else
+            else if(valid)
             {
+                ui->scrollArea->ensureWidgetVisible(entry);
                 valid = false;
             }
         }


### PR DESCRIPTION
If sending to multiple recipients and one of the recipient fields is malformed, the highlighted field may have been scrolled out of view leading to a confusing lack of error feedback when clicking Send.  To avoid this problem ensure the first field containing an error is scrolled into view when Send is clicked.