### PR TITLE
wallet: Initialize stop_block in CWallet::ScanForWalletTransactions

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1601,6 +1601,7 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const CBlockIndex* const 
 
     const CBlockIndex* pindex = pindexStart;
     failed_block = nullptr;
+    stop_block = nullptr;
 
     if (pindex) WalletLogPrintf("Rescan started from block %d...\n", pindex->nHeight);
 


### PR DESCRIPTION
Previously the argument would be untouched if the first block scan failed. This
makes the behavior predictable, and consistent with the documentation.