### PR TITLE
test: Fix race in mempool_accept

### DIFF
--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -58,6 +58,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         self.mempool_size = 0
         wait_until(lambda: node.getblockcount() == 200)
         assert_equal(node.getmempoolinfo()['size'], self.mempool_size)
+        coins = node.listunspent()
 
         self.log.info('Should not accept garbage to testmempoolaccept')
         assert_raises_rpc_error(-3, 'Expected type array, got string', lambda: node.testmempoolaccept(rawtxs='ff00baar'))
@@ -65,7 +66,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         assert_raises_rpc_error(-22, 'TX decode failed', lambda: node.testmempoolaccept(rawtxs=['ff00baar']))
 
         self.log.info('A transaction already in the blockchain')
-        coin = node.listunspent()[0]  # Pick a random coin(base) to spend
+        coin = coins.pop()  # Pick a random coin(base) to spend
         raw_tx_in_block = node.signrawtransactionwithwallet(node.createrawtransaction(
             inputs=[{'txid': coin['txid'], 'vout': coin['vout']}],
             outputs=[{node.getnewaddress(): 0.3}, {node.getnewaddress(): 49}],
@@ -93,7 +94,7 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         )
 
         self.log.info('A final transaction not in the mempool')
-        coin = node.listunspent()[0]  # Pick a random coin(base) to spend
+        coin = coins.pop()  # Pick a random coin(base) to spend
         raw_tx_final = node.signrawtransactionwithwallet(node.createrawtransaction(
             inputs=[{'txid': coin['txid'], 'vout': coin['vout'], "sequence": 0xffffffff}],  # SEQUENCE_FINAL
             outputs=[{node.getnewaddress(): 0.025}],


### PR DESCRIPTION
If we happen to pick the same random coin to spend, there would be mempool conflicts in some runs of the test. Fix that by popping from a static list of coins to spend from.