### PR TITLE
minor: fix extra "non" in source code comment

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3410,7 +3410,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
         }
     }
 
-    // We can't rescan beyond non-pruned blocks, stop and throw an error
+    // We can't rescan beyond pruned blocks, stop and throw an error
     if (fPruneMode) {
         auto locked_chain = pwallet->chain().lock();
         CBlockIndex *block = pindexStop ? pindexStop : pChainTip;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4101,7 +4101,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
 
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)
     {
-        //We can't rescan beyond non-pruned blocks, stop and throw an error
+        //We can't rescan beyond pruned blocks, stop and throw an error
         //this might happen if a user uses an old wallet within a pruned node
         // or if he ran -disablewallet for a longer time, then decided to re-enable
         if (fPruneMode)


### PR DESCRIPTION
in source code comment (one beginning with `// ` and the second with `//`):
`We can't rescan beyond non-pruned blocks`; the `non` looks to be a double negation.
