### PR TITLE
docs: fix testmempoolaccept CLI syntax

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1135,7 +1135,7 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
             "Sign the transaction, and get back the hex\n"
             + HelpExampleCli("signrawtransactionwithwallet", "\"myhex\"") +
             "\nTest acceptance of the transaction (signed hex)\n"
-            + HelpExampleCli("testmempoolaccept", "\"signedhex\"") +
+            + HelpExampleCli("testmempoolaccept", "[\"signedhex\"]") +
             "\nAs a JSON-RPC call\n"
             + HelpExampleRpc("testmempoolaccept", "[\"signedhex\"]")
             );


### PR DESCRIPTION
`testmempoolaccept "hexstring"` will give a "JSON parse error". The correct syntax is `testmempoolaccept \[\"hexstring\"\]` (but seems escaping is not displayed in other areas so leaving backspaces out).
