### PR TITLE
[net] add dnsseed.emzy.de to DNS seeds

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -125,6 +125,7 @@ public:
         vSeeds.emplace_back("seed.bitcoin.jonasschnelli.ch"); // Jonas Schnelli, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.btc.petertodd.org"); // Peter Todd, only supports x1, x5, x9, and xd
         vSeeds.emplace_back("seed.bitcoin.sprovoost.nl"); // Sjors Provoost
+        vSeeds.emplace_back("dnsseed.emzy.de"); // Stephan Oeste
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);


### PR DESCRIPTION
ACK https://github.com/bitcoin/bitcoin/blob/master/doc/dnsseed-policy.md

I'm willing to keep it up and running, unless something bad happens.
I have 15+ years experience running dns servers.

About my setup:

- the server may change over time, but the service will be up all the time
- running [sipa/bitcoin-seeder](https://github.com/sipa/bitcoin-seeder) with default settings (and the non-root port redirect)


