### PR TITLE
doc: Removing redundant line: "Windows XP not supported"

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -47,8 +47,9 @@ processing the entire blockchain.
 Compatibility
 ==============
 
-Bitcoin Core is extensively tested on multiple operating systems using
-the Linux kernel, macOS 10.10+, and Windows 7 and newer (Windows XP is not supported).
+Bitcoin Core is supported and extensively tested on operating systems using
+the Linux kernel, macOS 10.10+, and Windows 7 and newer.  It is not recommended
+to use Bitcoin Core on unsupported systems.
 
 Bitcoin Core should also work on most other Unix-like systems but is not
 frequently tested on them.


### PR DESCRIPTION
With the doc saying that we only support Windows 7+ stating that XP isn't supported is redundant and can be removed. Bitcoin stop supporting Windows XP in 0.13 so users should have had plenty of time to learn that XP is no longer supported.