### PR TITLE
qt: Refactoring with QString::toNSString()

### DIFF
--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -24,25 +24,10 @@ void MacNotificationHandler::showNotification(const QString &title, const QStrin
 {
     // check if users OS has support for NSUserNotification
     if(this->hasUserNotificationCenterSupport()) {
-        // okay, seems like 10.8+
-        QByteArray utf8 = title.toUtf8();
-        char* cString = (char *)utf8.constData();
-        NSString *titleMac = [[NSString alloc] initWithUTF8String:cString];
-
-        utf8 = text.toUtf8();
-        cString = (char *)utf8.constData();
-        NSString *textMac = [[NSString alloc] initWithUTF8String:cString];
-
-        // do everything weak linked (because we will keep <10.8 compatibility)
-        id userNotification = [[NSClassFromString(@"NSUserNotification") alloc] init];
-        [userNotification performSelector:@selector(setTitle:) withObject:titleMac];
-        [userNotification performSelector:@selector(setInformativeText:) withObject:textMac];
-
-        id notificationCenterInstance = [NSClassFromString(@"NSUserNotificationCenter") performSelector:@selector(defaultUserNotificationCenter)];
-        [notificationCenterInstance performSelector:@selector(deliverNotification:) withObject:userNotification];
-
-        [titleMac release];
-        [textMac release];
+        NSUserNotification* userNotification = [[NSUserNotification alloc] init];
+        userNotification.title = title.toNSString();
+        userNotification.informativeText = text.toNSString();
+        [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification: userNotification];
         [userNotification release];
     }
 }


### PR DESCRIPTION
This PR makes `MacNotificationHandler::showNotification()` cleaner and more readable.
The used `QString::toNSString()` function was introduced in Qt 5.2 which is minimum version now (#14725).

The behavior of `MacNotificationHandler::showNotification()` has not been changed.

cc: @jonasschnelli 