### PR TITLE
[Qt] Restore < Qt5.6 compatibility for addAction

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -400,16 +400,18 @@ void BitcoinGUI::createMenuBar()
 
     QMenu* window_menu = appMenuBar->addMenu(tr("&Window"));
 
-    QAction* minimize_action = window_menu->addAction(tr("Minimize"), [] {
+    QAction* minimize_action = window_menu->addAction(tr("Minimize"));
+    minimize_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_M));
+    connect(minimize_action, &QAction::triggered, [] {
         qApp->focusWindow()->showMinimized();
-    }, QKeySequence(Qt::CTRL + Qt::Key_M));
-
+    });
     connect(qApp, &QApplication::focusWindowChanged, [minimize_action] (QWindow* window) {
         minimize_action->setEnabled(window != nullptr && (window->flags() & Qt::Dialog) != Qt::Dialog && window->windowState() != Qt::WindowMinimized);
     });
 
 #ifdef Q_OS_MAC
-    QAction* zoom_action = window_menu->addAction(tr("Zoom"), [] {
+    QAction* zoom_action = window_menu->addAction(tr("Zoom"));
+    connect(zoom_action, &QAction::triggered, [] {
         QWindow* window = qApp->focusWindow();
         if (window->windowState() != Qt::WindowMaximized) {
             window->showMaximized();
@@ -422,7 +424,8 @@ void BitcoinGUI::createMenuBar()
         zoom_action->setEnabled(window != nullptr);
     });
 #else
-    QAction* restore_action = window_menu->addAction(tr("Restore"), [] {
+    QAction* restore_action = window_menu->addAction(tr("Restore"));
+    connect(restore_action, &QAction::triggered, [] {
         qApp->focusWindow()->showNormal();
     });
 
@@ -433,7 +436,8 @@ void BitcoinGUI::createMenuBar()
 
     if (walletFrame) {
         window_menu->addSeparator();
-        window_menu->addAction(tr("Main Window"), [this] {
+        QAction* main_window_action = window_menu->addAction(tr("Main Window"));
+        connect(main_window_action, &QAction::triggered, [this] {
             GUIUtil::bringToFront(this);
         });
 
@@ -444,7 +448,8 @@ void BitcoinGUI::createMenuBar()
 
     window_menu->addSeparator();
     for (RPCConsole::TabTypes tab_type : rpcConsole->tabs()) {
-        window_menu->addAction(rpcConsole->tabTitle(tab_type), [this, tab_type] {
+        QAction* tab_action = window_menu->addAction(rpcConsole->tabTitle(tab_type));
+        connect(tab_action, &QAction::triggered, [this, tab_type] {
             rpcConsole->setTabFocus(tab_type);
             showDebugWindow();
         });


### PR DESCRIPTION
#14573 broke < Qt5.6 compatibility due to calling the lambda version of `addAction` that was added in Qt5.6.

This PR re-enables < Qt5.6 compatibility.