### PR TITLE
rpc: Add getrpcinfo command

### DIFF
--- a/doc/release-notes-14982.md
+++ b/doc/release-notes-14982.md
@@ -1,0 +1,5 @@
+New RPCs
+--------
+
+- The RPC `getrpcinfo` returns runtime details of the RPC server. At the moment
+  it returns the active commands and the corresponding execution time.

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -36,7 +36,6 @@ static struct CRPCSignals
 {
     boost::signals2::signal<void ()> Started;
     boost::signals2::signal<void ()> Stopped;
-    boost::signals2::signal<void (const CRPCCommand&)> PreCommand;
 } g_rpcSignals;
 
 void RPCServer::OnStarted(std::function<void ()> slot)
@@ -483,8 +482,6 @@ UniValue CRPCTable::execute(const JSONRPCRequest &request) const
     const CRPCCommand *pcmd = tableRPC[request.strMethod];
     if (!pcmd)
         throw JSONRPCError(RPC_METHOD_NOT_FOUND, "Method not found");
-
-    g_rpcSignals.PreCommand(*pcmd);
 
     try
     {

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -5,12 +5,22 @@
 """Tests some generic aspects of the RPC interface."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, assert_greater_than_or_equal
 
 class RPCInterfaceTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
+
+    def test_getrpcinfo(self):
+        self.log.info("Testing getrpcinfo...")
+
+        info = self.nodes[0].getrpcinfo()
+        assert_equal(len(info['active_commands']), 1)
+
+        command = info['active_commands'][0]
+        assert_equal(command['method'], 'getrpcinfo')
+        assert_greater_than_or_equal(command['duration'], 0)
 
     def test_batch_request(self):
         self.log.info("Testing basic JSON-RPC batch request...")
@@ -39,6 +49,7 @@ class RPCInterfaceTest(BitcoinTestFramework):
         assert result_by_id[3]['result'] is not None
 
     def run_test(self):
+        self.test_getrpcinfo()
         self.test_batch_request()
 
 


### PR DESCRIPTION
The new `getrpcinfo` command exposes details of the RPC interface. The details can be configuration properties or runtime values/stats.

This can be particular useful to coordinate concurrent functional tests (see #14958 from where this was extracted).