### PR TITLE
rpc: Speedup getrawmempool when verbose=true

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -474,7 +474,10 @@ UniValue MempoolToJSON(const CTxMemPool& pool, bool verbose)
             const uint256& hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);
             entryToJSON(pool, info, e);
-            o.pushKV(hash.ToString(), info);
+            // Mempool has unique entries so there is no advantage in using
+            // UniValue::pushKV, which checks if the key already exists in O(N).
+            // UniValue::__pushKV is used instead which currently is O(1).
+            o.__pushKV(hash.ToString(), info);
         }
         return o;
     } else {


### PR DESCRIPTION
Instead of calling `pushKV(hash, info)`, which incurs in duplicate key checks, call `__pushKV` which (currently) doesn't.

Improves RPC `getrawmempool` and REST `/rest/mempool/contents.json`.

Fixes #14765.