### PR TITLE
test: Remove thread_local from test_bitcoin

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -22,6 +22,8 @@
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
+FastRandomContext g_insecure_rand_ctx;
+
 void CConnmanTest::AddNode(CNode& node)
 {
     LOCK(g_connman->cs_vNodes);
@@ -36,8 +38,6 @@ void CConnmanTest::ClearNodes()
     }
     g_connman->vNodes.clear();
 }
-
-thread_local FastRandomContext g_insecure_rand_ctx;
 
 std::ostream& operator<<(std::ostream& os, const uint256& num)
 {

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -26,7 +26,7 @@ std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::os
     return stream << static_cast<typename std::underlying_type<T>::type>(e);
 }
 
-thread_local extern FastRandomContext g_insecure_rand_ctx;
+extern FastRandomContext g_insecure_rand_ctx;
 
 static inline void SeedInsecureRand(bool deterministic = false)
 {

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -26,6 +26,13 @@ std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::os
     return stream << static_cast<typename std::underlying_type<T>::type>(e);
 }
 
+/**
+ * This global and the helpers that use it are not thread-safe.
+ *
+ * If thread-safety is needed, the global could be made thread_local (given
+ * that thread_local is supported on all architectures we support) or a
+ * per-thread instance could be used in the multi-threaded test.
+ */
 extern FastRandomContext g_insecure_rand_ctx;
 
 static inline void SeedInsecureRand(bool deterministic = false)

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -152,12 +152,13 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     // create a bunch of threads that repeatedly process a block generated above at random
     // this will create parallelism and randomness inside validation - the ValidationInterface
     // will subscribe to events generated during block validation and assert on ordering invariance
-    boost::thread_group threads;
+    std::vector<std::thread> threads;
     for (int i = 0; i < 10; i++) {
-        threads.create_thread([&blocks]() {
+        threads.emplace_back([&blocks]() {
             bool ignored;
+            FastRandomContext insecure;
             for (int i = 0; i < 1000; i++) {
-                auto block = blocks[InsecureRandRange(blocks.size() - 1)];
+                auto block = blocks[insecure.randrange(blocks.size() - 1)];
                 ProcessNewBlock(Params(), block, true, &ignored);
             }
 
@@ -171,7 +172,9 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
         });
     }
 
-    threads.join_all();
+    for (auto& t : threads) {
+        t.join();
+    }
     while (GetMainSignals().CallbacksPending() > 0) {
         MilliSleep(100);
     }


### PR DESCRIPTION
`thread_local` seems to be highly controversial according to the discussion in #14953, so remove it again from the tests.

Also remove boost::thread_group in the test that uses it, since I am touching it anyway.