### PR TITLE
qt: Use bilinear filtering for icon

### DIFF
--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -71,8 +71,8 @@ NetworkStyle::NetworkStyle(const QString &_appName, const int iconColorHueShift,
         pixmap.convertFromImage(img);
     }
 
-    appIcon             = QIcon(pixmap);
-    trayAndWindowIcon   = QIcon(pixmap.scaled(QSize(256,256)));
+    appIcon = QIcon(pixmap);
+    trayAndWindowIcon = QIcon(pixmap.scaled(QSize(64, 64), Qt::KeepAspectRatio, Qt::SmoothTransformation));
 }
 
 const NetworkStyle *NetworkStyle::instantiate(const QString &networkId)


### PR DESCRIPTION
This PR makes app icon edge smoother in Ubuntu Bionic Dock and GNOME Activities Favorites (e.g., Fedora 29).

Ubuntu Bionic - BEFORE:
![screenshot from 2018-12-18 07-17-31](https://user-images.githubusercontent.com/32963518/50134661-c7fcdc00-0299-11e9-87fe-94e936b72a7c.png)

Ubuntu Bionic - AFTER:
![screenshot from 2018-12-18 07-15-43](https://user-images.githubusercontent.com/32963518/50134689-e95dc800-0299-11e9-8409-ea2955532d6e.png)

Fedora 29 - BEFORE:
![screenshot from 2018-12-18 07-31-02](https://user-images.githubusercontent.com/32963518/50134725-0db9a480-029a-11e9-94c6-2626bf6c80ba.png)

Fedora 29 - AFTER:
![screenshot from 2018-12-18 07-34-02](https://user-images.githubusercontent.com/32963518/50134743-232ece80-029a-11e9-8de3-79a999115feb.png)
