### PR TITLE
rpc: Fix data race (UB) in InterruptRPC()

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -24,7 +24,7 @@
 #include <unordered_map>
 
 static CCriticalSection cs_rpcWarmup;
-static bool fRPCRunning = false;
+static std::atomic<bool> g_rpc_running{false};
 static bool fRPCInWarmup GUARDED_BY(cs_rpcWarmup) = true;
 static std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";
 /* Timer-creating functions */
@@ -303,7 +303,7 @@ bool CRPCTable::appendCommand(const std::string& name, const CRPCCommand* pcmd)
 void StartRPC()
 {
     LogPrint(BCLog::RPC, "Starting RPC\n");
-    fRPCRunning = true;
+    g_rpc_running = true;
     g_rpcSignals.Started();
 }
 
@@ -311,7 +311,7 @@ void InterruptRPC()
 {
     LogPrint(BCLog::RPC, "Interrupting RPC\n");
     // Interrupt e.g. running longpolls
-    fRPCRunning = false;
+    g_rpc_running = false;
 }
 
 void StopRPC()
@@ -324,7 +324,7 @@ void StopRPC()
 
 bool IsRPCRunning()
 {
-    return fRPCRunning;
+    return g_rpc_running;
 }
 
 void SetRPCWarmupStatus(const std::string& newStatus)

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -7,9 +7,6 @@ deadlock:WalletBatch
 # Intentional deadlock in tests
 deadlock:TestPotentialDeadLockDetected
 
-# fRPCRunning race
-race:InterruptRPC
-
 # Wildcard for all gui tests, should be replaced with non-wildcard suppressions
 race:src/qt/test/*
 deadlock:src/qt/test/*


### PR DESCRIPTION
Fix data race (UB) in `InterruptRPC()`.

Before:

```
$ ./configure --with-sanitizers=thread
$ make
$ test/functional/test_runner.py feature_shutdown.py
…
SUMMARY: ThreadSanitizer: data race rpc/server.cpp:314 in InterruptRPC()
…
ALL                 | ✖ Failed  | 2 s (accumulated)
```

After:

```
$ ./configure --with-sanitizers=thread
$ make
$ test/functional/test_runner.py feature_shutdown.py
…
ALL                 | ✓ Passed  | 3 s (accumulated)
```