### PR TITLE
qt: Fix broken notificator on GNOME

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -130,6 +130,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     if (QSystemTrayIcon::isSystemTrayAvailable()) {
         createTrayIcon(networkStyle);
     }
+    notificator = new Notificator(QApplication::applicationName(), trayIcon, this);
 
     // Create status bar
     statusBar();
@@ -537,8 +538,7 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel)
         unitDisplayControl->setOptionsModel(_clientModel->getOptionsModel());
 
         OptionsModel* optionsModel = _clientModel->getOptionsModel();
-        if(optionsModel)
-        {
+        if (optionsModel && trayIcon) {
             // be aware of the tray icon disable state change reported by the OptionsModel object.
             connect(optionsModel, &OptionsModel::hideTrayIconChanged, this, &BitcoinGUI::setTrayIconVisible);
 
@@ -643,14 +643,10 @@ void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)
     assert(QSystemTrayIcon::isSystemTrayAvailable());
 
 #ifndef Q_OS_MAC
-    trayIcon = new QSystemTrayIcon(this);
+    trayIcon = new QSystemTrayIcon(networkStyle->getTrayAndWindowIcon(), this);
     QString toolTip = tr("%1 client").arg(tr(PACKAGE_NAME)) + " " + networkStyle->getTitleAddText();
     trayIcon->setToolTip(toolTip);
-    trayIcon->setIcon(networkStyle->getTrayAndWindowIcon());
-    trayIcon->hide();
 #endif
-
-    notificator = new Notificator(QApplication::applicationName(), trayIcon, this);
 }
 
 void BitcoinGUI::createTrayIconMenu()


### PR DESCRIPTION
Fix #14994; that bug was introduced in #14228 (that was my fault).

~Also this commit explicit separates~ There are two functions of the tray icon:
 - a system tray widget (`QSystemTrayIcon::isSystemTrayAvailable() == true`)
 - a high-level notificator via balloon messages (`QSystemTrayIcon::supportsMessages() == true`)

~These properties are mutually independent,~ e.g., on Fedora 29 + GNOME:
```
QSystemTrayIcon::isSystemTrayAvailable() == false;
QSystemTrayIcon::supportsMessages() == true;
```

UPDATE:

`supportsMessages()` makes no sense without `isSystemTrayAvailable()`: `QSystemTrayIcon::showMessage()` just not working on Fedora 29 + GNOME.