### PR TITLE
Add option to create an encrypted wallet

### DIFF
--- a/doc/release-notes-15006.md
+++ b/doc/release-notes-15006.md
@@ -1,0 +1,4 @@
+Miscellaneous RPC changes
+------------
+
+- `createwallet` can now create encrypted wallets if a non-empty passphrase is specified.


### PR DESCRIPTION
This PR adds a new `passphrase` argument to `createwallet` which will create a wallet that is encrypted with that passphrase.

This is built on #15226 because it needs to first create an empty wallet, then encrypt the empty wallet and generate new keys that have only been stored in an encrypted state.