### PR TITLE
qt: Notificator class refactoring

### DIFF
--- a/src/qt/notificator.cpp
+++ b/src/qt/notificator.cpp
@@ -39,7 +39,7 @@ Notificator::Notificator(const QString &_programName, QSystemTrayIcon *_trayIcon
     mode(None),
     trayIcon(_trayIcon)
 #ifdef USE_DBUS
-    ,interface(0)
+    ,interface(nullptr)
 #endif
 {
     if(_trayIcon && _trayIcon->supportsMessages())
@@ -154,14 +154,14 @@ QVariant FreedesktopImage::toVariant(const QImage &img)
 
 void Notificator::notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
 {
-    Q_UNUSED(cls);
-    // Arguments for DBus call:
+    // https://developer.gnome.org/notification-spec/
+    // Arguments for DBus "Notify" call:
     QList<QVariant> args;
 
     // Program Name:
     args.append(programName);
 
-    // Unique ID of this notification type:
+    // Replaces ID; A value of 0 means that this notification won't replace any existing notifications:
     args.append(0U);
 
     // Application Icon, empty string
@@ -209,9 +209,8 @@ void Notificator::notifyDBus(Class cls, const QString &title, const QString &tex
 }
 #endif
 
-void Notificator::notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
+void Notificator::notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout)
 {
-    Q_UNUSED(icon);
     QSystemTrayIcon::MessageIcon sicon = QSystemTrayIcon::NoIcon;
     switch(cls) // Set icon based on class
     {
@@ -222,13 +221,12 @@ void Notificator::notifySystray(Class cls, const QString &title, const QString &
     trayIcon->showMessage(title, text, sicon, millisTimeout);
 }
 
-// Based on Qt's tray icon implementation
 #ifdef Q_OS_MAC
-void Notificator::notifyMacUserNotificationCenter(Class cls, const QString &title, const QString &text, const QIcon &icon) {
+void Notificator::notifyMacUserNotificationCenter(const QString &title, const QString &text)
+{
     // icon is not supported by the user notification center yet. OSX will use the app icon.
     MacNotificationHandler::instance()->showNotification(title, text);
 }
-
 #endif
 
 void Notificator::notify(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout)
@@ -241,11 +239,11 @@ void Notificator::notify(Class cls, const QString &title, const QString &text, c
         break;
 #endif
     case QSystemTray:
-        notifySystray(cls, title, text, icon, millisTimeout);
+        notifySystray(cls, title, text, millisTimeout);
         break;
 #ifdef Q_OS_MAC
     case UserNotificationCenter:
-        notifyMacUserNotificationCenter(cls, title, text, icon);
+        notifyMacUserNotificationCenter(title, text);
         break;
 #endif
     default:

--- a/src/qt/notificator.h
+++ b/src/qt/notificator.h
@@ -57,7 +57,7 @@ private:
     enum Mode {
         None,                       /**< Ignore informational notifications, and show a modal pop-up dialog for Critical notifications. */
         Freedesktop,                /**< Use DBus org.freedesktop.Notifications */
-        QSystemTray,                /**< Use QSystemTray::showMessage */
+        QSystemTray,                /**< Use QSystemTrayIcon::showMessage() */
         UserNotificationCenter      /**< Use the 10.8+ User Notification Center (Mac only) */
     };
     QString programName;
@@ -68,9 +68,9 @@ private:
 
     void notifyDBus(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
 #endif
-    void notifySystray(Class cls, const QString &title, const QString &text, const QIcon &icon, int millisTimeout);
+    void notifySystray(Class cls, const QString &title, const QString &text, int millisTimeout);
 #ifdef Q_OS_MAC
-    void notifyMacUserNotificationCenter(Class cls, const QString &title, const QString &text, const QIcon &icon);
+    void notifyMacUserNotificationCenter(const QString &title, const QString &text);
 #endif
 };
 


### PR DESCRIPTION
This PR:
- removes misplaced `Q_UNUSED(cls)`; `cls` is actually used:
https://github.com/bitcoin/bitcoin/blob/eb7daf4d600eeb631427c018a984a77a34aca66e/src/qt/notificator.cpp#L188

- removes unused parameters in functions `notifySystray()` and `notifyMacUserNotificationCenter()`

- improves comments