### PR TITLE
[wallet] Fix getbalance with minconf

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -488,7 +488,7 @@ public:
     // annotation "EXCLUSIVE_LOCKS_REQUIRED(cs_main, pwallet->cs_wallet)". The
     // annotation "NO_THREAD_SAFETY_ANALYSIS" was temporarily added to avoid
     // having to resolve the issue of member access into incomplete type CWallet.
-    CAmount GetAvailableCredit(interfaces::Chain::Lock& locked_chain, bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE) const NO_THREAD_SAFETY_ANALYSIS;
+    CAmount GetAvailableCredit(interfaces::Chain::Lock& locked_chain, bool fUseCache=true, const isminefilter& filter=ISMINE_SPENDABLE, int min_depth = 0) const NO_THREAD_SAFETY_ANALYSIS;
     CAmount GetImmatureWatchOnlyCredit(interfaces::Chain::Lock& locked_chain, const bool fUseCache=true) const;
     CAmount GetChange() const;
 
@@ -818,7 +818,7 @@ public:
     bool SelectCoinsMinConf(const CAmount& nTargetValue, const CoinEligibilityFilter& eligibility_filter, std::vector<OutputGroup> groups,
         std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet, const CoinSelectionParams& coin_selection_params, bool& bnb_used) const;
 
-    bool IsSpent(interfaces::Chain::Lock& locked_chain, const uint256& hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsSpent(interfaces::Chain::Lock& locked_chain, const uint256& hash, unsigned int n, int min_depth = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, bool single_coin) const;
 
     bool IsLockedCoin(uint256 hash, unsigned int n) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -89,10 +89,9 @@ class WalletTest(BitcoinTestFramework):
         # Same with minconf=0
         assert_equal(self.nodes[0].getbalance(minconf=0), Decimal('9.99'))
         assert_equal(self.nodes[1].getbalance(minconf=0), Decimal('29.99'))
-        # getbalance with a minconf incorrectly excludes coins that have been spent more recently than the minconf blocks ago
-        # TODO: fix getbalance tracking of coin spentness depth
-        assert_equal(self.nodes[0].getbalance(minconf=1), Decimal('0'))
-        assert_equal(self.nodes[1].getbalance(minconf=1), Decimal('0'))
+        # getbalance with a minconf includes coins that have been spent more recently than the minconf blocks ago
+        assert_equal(self.nodes[0].getbalance(minconf=1), Decimal('50'))
+        assert_equal(self.nodes[1].getbalance(minconf=1), Decimal('50'))
         # getunconfirmedbalance
         assert_equal(self.nodes[0].getunconfirmedbalance(), Decimal('60'))  # output of node 1's spend
         assert_equal(self.nodes[1].getunconfirmedbalance(), Decimal('0'))  # Doesn't include output of node 0's send since it was spent
@@ -121,10 +120,9 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[1].generatetoaddress(2, RANDOM_COINBASE_ADDRESS)
         self.sync_all()
 
-        # getbalance with a minconf incorrectly excludes coins that have been spent more recently than the minconf blocks ago
-        # TODO: fix getbalance tracking of coin spentness depth
+        # getbalance with a minconf includes coins that have been spent more recently than the minconf blocks ago
         # getbalance with minconf=3 should still show the old balance
-        assert_equal(self.nodes[1].getbalance(minconf=3), Decimal('0'))
+        assert_equal(self.nodes[1].getbalance(minconf=3), Decimal('29.98'))
 
         # getbalance with minconf=2 will show the new balance.
         assert_equal(self.nodes[1].getbalance(minconf=2), Decimal('0'))


### PR DESCRIPTION
When getting balance w/ min_conf, include UTXOs that were spent more
recently.