### PR TITLE
test: Avoid race in p2p_timeouts

### DIFF
--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -72,7 +72,11 @@ class TimeoutsTest(BitcoinTestFramework):
         ]
 
         with self.nodes[0].assert_debug_log(expected_msgs=expected_timeout_logs):
-            sleep(2)
+            sleep(3)
+            # By now, we waited a total of 5 seconds. Off-by-two for two
+            # reasons:
+            #  * The internal precision is one second
+            #  * Account for network delay
             assert not no_verack_node.is_connected
             assert not no_version_node.is_connected
             assert not no_send_node.is_connected


### PR DESCRIPTION
Avoid filesystem/network racyness by sleeping another second. The alternative would be to poll the `debug.log`, but that seems overkill to avoid a sleep in a test that already requires them.