### PR TITLE
GUI: Restore RPC Console to non-wallet tray icon menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -686,9 +686,9 @@ void BitcoinGUI::createTrayIconMenu()
         trayIconMenu->addAction(signMessageAction);
         trayIconMenu->addAction(verifyMessageAction);
         trayIconMenu->addSeparator();
-        trayIconMenu->addAction(openRPCConsoleAction);
     }
     trayIconMenu->addAction(optionsAction);
+    trayIconMenu->addAction(openRPCConsoleAction);
 #ifndef Q_OS_MAC // This is built-in on macOS
     trayIconMenu->addSeparator();
     trayIconMenu->addAction(quitAction);


### PR DESCRIPTION
#14383 moved the debug window's menu position, to make it conditional on wallet mode. The rationale given was to match the behaviour of the 'Help' menu.

#14573 replaced the 'Help' menu's conditional debug window with an unconditional list of items in the new 'Window' menu.

This PR reverts the no-longer-applicable part of #14383, putting the debug window back on the tray menu unconditionally, and in the position it previously had.