### PR TITLE
docs: Remove outdated link in doc/fuzzing.md

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -56,7 +56,6 @@ AFLOUT=$PWD/outputs
 Example inputs are available from:
 
 - https://download.visucore.com/bitcoin/bitcoin_fuzzy_in.tar.xz
-- http://strateman.ninja/fuzzing.tar.xz
 
 Extract these (or other starting inputs) into the `inputs` directory before starting fuzzing.
 


### PR DESCRIPTION
Fixes #15003

The change does not change fundamental bitcoin-core functionality and is limited to documentation.