### PR TITLE
Removing unnecessary comparison of size_t maxConfirms 

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -408,7 +408,7 @@ void TxConfirmStats::Read(CAutoFile& filein, int nFileVersion, size_t numBuckets
     // Read data file and do some very basic sanity checking
     // buckets and bucketMap are not updated yet, so don't access them
     // If there is a read failure, we'll just discard this entire object anyway
-    size_t maxConfirms, maxPeriods;
+    ssize_t maxConfirms, maxPeriods;
 
     // The current version will store the decay with each individual TxConfirmStats and also keep a scale factor
     filein >> decay;


### PR DESCRIPTION
`maxConfirms` here has type `size_t` and therefore `maxConfirms < 0` will never be true even in case of a corruption. That scenario is correctly accounted for and handled by the `maxConfirms > 6 * 24 * 7` condition anyway.
