### PR TITLE
Tests: IsReachable is the inverse of IsLimited (DRY)

### DIFF
--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -296,6 +296,8 @@ BOOST_AUTO_TEST_CASE(LimitedAndReachable_CNetAddr)
     SetLimited(NET_IPV4, true);
     BOOST_CHECK_EQUAL(IsLimited(addr), true);
     BOOST_CHECK_EQUAL(IsReachable(addr), false);
+
+    SetLimited(NET_IPV4, false); // have to reset this, because this is stateful.
 }
 
 


### PR DESCRIPTION
IsReachable is the inverse of IsLimited, but the implementation is duplicated (DRY)

- Changed the implementation accordingly.
- Added unittests to document behavior and relationship
- Unittests have to reset values because of internal statefull variables. 
- My modification in net.cpp  applies only to IsReachable.
- Applied clang -> (unfortunately) lots of changes on formatting
