### PR TITLE
Tests: Contract testing for the procedure AddTimeData and related fixes

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -291,12 +291,12 @@ std::string CNetAddr::ToString() const
 
 bool operator==(const CNetAddr& a, const CNetAddr& b)
 {
-    return (memcmp(a.ip, b.ip, 16) == 0);
+    return (memcmp(a.ip, b.ip, sizeof(a.ip)) == 0);
 }
 
 bool operator<(const CNetAddr& a, const CNetAddr& b)
 {
-    return (memcmp(a.ip, b.ip, 16) < 0);
+    return (memcmp(a.ip, b.ip, sizeof(a.ip)) < 0);
 }
 
 bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <timedata.h>
+#include <netaddress.h>
 #include <test/test_bitcoin.h>
+#include <timedata.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -33,5 +34,212 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
     filter.input(0); // [0 3 7 18 30]
     BOOST_CHECK_EQUAL(filter.median(), 7);
 }
+
+BOOST_AUTO_TEST_CASE(util_MedianFilterShallNotGrowBeyondSize)
+{
+    CMedianFilter<int> filter(2, 15);
+
+    BOOST_CHECK_EQUAL(filter.size(), 1); // 15
+
+    filter.input(100); // 15 100
+    BOOST_CHECK_EQUAL(filter.size(), 2);
+
+    filter.input(10); // 100 10
+    BOOST_CHECK_EQUAL(filter.size(), 2);
+    BOOST_CHECK_EQUAL(filter.sorted()[0], 10);
+    BOOST_CHECK_EQUAL(filter.sorted()[1], 100);
+}
+
+/* Utility function to build a CNetAddr object.
+
+   Using memcpy to build sockaddr_in because compat.h does not support inet_pton with current #define _WIN32_WINNT 0x0501
+*/
+CNetAddr UtilBuildAddress(unsigned char ip1, unsigned char ip2, unsigned char ip3, unsigned char ip4)
+{
+    unsigned char ip[] = {ip1, ip2, ip3, ip4};
+
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sockaddr_in)); // initialize the memory block
+    memcpy(&(sa.sin_addr), &ip, sizeof(ip));
+    CNetAddr addr = CNetAddr(sa.sin_addr);
+    return addr;
+}
+
+BOOST_AUTO_TEST_CASE(util_UtilBuildAddress)
+{
+    CNetAddr cn1 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0D2); // 1.1.1.210
+    CNetAddr cn2 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0D2); // 1.1.1.210
+    bool eq = (cn1 == cn2);
+    BOOST_CHECK(eq);
+
+    CNetAddr cn3 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0D3); // 1.1.1.211
+    bool neq = !(cn1 == cn3);
+    BOOST_CHECK(neq);
+    neq = !(cn2 == cn3);
+    BOOST_CHECK(neq);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmComputeOffsetWhenNewSampleCountIsGreaterEqualFiveAndUneven)
+{
+    unsigned int capacity = 20; //  can store up to 20 samples
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 20 , init sample: 0
+
+    for (unsigned int sample = 1; sample < 10; sample++) { // precondition: at least 4 samples. (including the init sample : 0)
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, (unsigned char)sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset); // 1.1.1.[1,2,3],  offsetSample = [1,2,3]
+    }
+
+    BOOST_CHECK(offset != 0); // offset has changed from the initial value
+    BOOST_CHECK_EQUAL(offsetFilter.size(),10); // next sample will be the 11th (uneven) and will trigger a new computation of the offset
+
+    int samples = offsetFilter.size();
+    int64_t oldOffset = offset;
+    CNetAddr addr2 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0010);
+    AddTimeDataAlgorithm(addr2, 111, knownSet, offsetFilter, offset); // 1.1.1.16 , offsetSample = 111
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1); // sample was added...
+    BOOST_CHECK(oldOffset != offset);                    // ...and new offset was computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmDoNotComputeOffsetWhenNewSampleCountIsGreaterEqualFiveButEven)
+{
+    unsigned int capacity = 20; //  can store up to 20 samples
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 20 , init sample: 0
+
+    for (unsigned int sample = 1; sample < 9; sample++) { // precondition: at least 7 samples. (including the init sample : 0
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, (unsigned char)sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset); // 1.1.1.[1,2,3],  offsetSample = [1,2,3]
+    }
+
+    BOOST_CHECK(offset != 0); // offset has changed from the initial value
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 9); // next sample will be the 10th (even) and will *not* trigger a new computation of the offset
+
+    int samples = offsetFilter.size();
+    int64_t oldOffset = offset;
+    CNetAddr addr2 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0010);
+    AddTimeDataAlgorithm(addr2, 111, knownSet, offsetFilter, offset); // 1.1.1.16 , offsetSample = 111
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1); // sample was added...
+    BOOST_CHECK(oldOffset == offset);                    // ...but new offset was not computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmComputeOffsetWithMedianWithinBounds)
+{
+    unsigned int capacity = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 10 , init sample: 0
+
+    for (unsigned int sample = 1; sample < 4; sample++) { // precondition: 4 samples. (including the init sample : 0)
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, (unsigned char)sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset); // 1.1.1.[1,2,3],  offsetSample = [1,2,3]
+    }
+
+    BOOST_CHECK_EQUAL(offset, 0);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 4);
+
+    int64_t oldOffset = offset;
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 200, knownSet, offsetFilter, offset); // 1.1.1.200 , offsetSample = 200
+    BOOST_CHECK(offset != oldOffset);
+    BOOST_CHECK_EQUAL(offset, offsetFilter.median());
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 5);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmOffsetFlipsToZeroIfMedianIsOutsideBounds)
+{
+    unsigned int capacity = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 10 , init sample: 0
+
+    for (unsigned int sample = 1; sample < 4; sample++) {                                                     // precondition: 4 samples, all outside bounds
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, (unsigned char)sample);                               // 1.1.1.[1,2,3]
+        AddTimeDataAlgorithm(addr, 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // offsetSample  = 2 * DEFAULT_MAX_TIME_ADJUSTMENT (out of bounds)
+    } // sorted filter: 0 x x x  -- x is outside the boundaries
+
+    BOOST_CHECK_EQUAL(offset, 0);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 4);
+
+    // offset is computed only when number of entries is uneven
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x005), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 (x) x x  -- median (x)
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x006), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 x x x
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x007), 1, knownSet, offsetFilter, offset);                               // sorted filter : 0 1 1 (1) x x x x -- median (1)
+    BOOST_CHECK_EQUAL(offset, 1);                                                                                                        // flip to 1
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x008), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 x x x x x
+    BOOST_CHECK_EQUAL(offset, 1);
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x009), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 (x) x x x x x -- median (x)
+    BOOST_CHECK_EQUAL(offset, 0);                                                                                                        // flip back to zero
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 9);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmAtLeastFiveSamplesToComputeOffset)
+{
+    unsigned int capacity = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 10 , init sample: 0
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x001), 1, knownSet, offsetFilter, offset);
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x002), 2, knownSet, offsetFilter, offset);
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x003), 3, knownSet, offsetFilter, offset);
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x004), 4, knownSet, offsetFilter, offset); // this is the fifth entry
+    BOOST_CHECK_EQUAL(offset, 2);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmIgnoreSamplesBeyondInternalCapacity)
+{
+    unsigned int capacity = 10; // internal capacity
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : capacity , initial offset: 0
+
+    for (unsigned int sample = 1; sample < capacity; sample++) { // precondition: fill filter up to the capacity
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, (unsigned char)sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset);
+    }
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), capacity);
+
+    int64_t pre = offset;
+    int size = offsetFilter.size();
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 200, knownSet, offsetFilter, offset); // 1.1.1.200, offsetSample = 200
+
+    BOOST_CHECK_EQUAL(offset, pre);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), size);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmIgnoreSampleWithDuplicateIp)
+{
+    unsigned int capacity = 10; // internal capacity
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : capacity , initial offset: 0
+
+    int samples = offsetFilter.size();
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 200, knownSet, offsetFilter, offset); // 1.1.1.200, offsetSample = 200
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1);                                                     // new sample was accepted
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 201, knownSet, offsetFilter, offset); // 1.1.1.200, offsetSample = 201
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1);                                                     // sample with duplicate ip was ignored
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -50,184 +50,208 @@ BOOST_AUTO_TEST_CASE(util_MedianFilterShallNotGrowBeyondSize)
     BOOST_CHECK_EQUAL(filter.sorted()[1], 100);
 }
 
-CNetAddr UtilBuildAddress(const std::string& address)
+/* Utility function to build a CNetAddr object.
+
+   Using memcpy to build sockaddr_in because compat.h does not support inet_pton with current #define _WIN32_WINNT 0x0501
+*/
+CNetAddr UtilBuildAddress(unsigned char ip1, unsigned char ip2, unsigned char ip3, unsigned char ip4)
 {
+    unsigned char ip[] = {ip1, ip2, ip3, ip4};
+
     struct sockaddr_in sa;
-    memset(&sa, 0, sizeof(sockaddr_in));
-    inet_pton(AF_INET, address.c_str(), &(sa.sin_addr));
+    memset(&sa, 0, sizeof(sockaddr_in)); // initialize the memory block
+    memcpy(&(sa.sin_addr), &ip, sizeof(ip));
     CNetAddr addr = CNetAddr(sa.sin_addr);
     return addr;
 }
 
-void UtilPreconditionIsAtLeastFiveEntriesRequired(const std::string& baseip, int basevalue)
+BOOST_AUTO_TEST_CASE(util_UtilBuildAddress)
 {
-    for (int i = CountOffsetSamples(); i < 5; i++) { // precondition 1: at least 5 entries required to compute any offset
-        int val = basevalue + i;
-        std::stringstream stream;
-        stream << baseip << val;
-        std::string ip = stream.str();
-        AddTimeData(UtilBuildAddress(ip), val);
-    }
+    CNetAddr cn1 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0D2); // 1.1.1.210
+
+    CNetAddr cn2 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0D2); // 1.1.1.210
+
+    bool eq = (cn1 == cn2);
+
+    BOOST_CHECK(eq);
+
+    CNetAddr cn3 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0D3); // 1.1.1.211
+
+    bool neq = !(cn1 == cn3);
+
+    BOOST_CHECK(neq);
+
+    neq = !(cn2 == cn3);
+
+    BOOST_CHECK(neq);
 }
 
-BOOST_AUTO_TEST_CASE(util_AddTimeDataComputeOffsetWhenSampleCountIsUneven)
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmComputeOffsetWhenNewSampleCountIsGreaterEqualFiveAndUneven)
 {
-    UtilPreconditionIsAtLeastFiveEntriesRequired("1.1.1.", 200); // precondition 1: at least 5 entries required to compute any offset
-    BOOST_CHECK(CountOffsetSamples() >= 5);
-
-
-    if ((CountOffsetSamples() % 2) == 1) { // precondition 2: start with an even number of samples
-        AddTimeData(UtilBuildAddress("1.1.1.210"), 210);
-    }
-
-    BOOST_CHECK(CountOffsetSamples() % 2 == 0);
-
-
-    int64_t offset = GetTimeOffset();
-    int samples = CountOffsetSamples();
-    AddTimeData(UtilBuildAddress("1.1.1.211"), 211);
-
-    BOOST_CHECK_EQUAL(CountOffsetSamples(), samples + 1); // sample was added
-    BOOST_CHECK(GetTimeOffset() != offset);               // and new offset was computed
-}
-
-BOOST_AUTO_TEST_CASE(util_AddTimeDataDoNotComputeOffsetWhenSampleCountIsEven)
-{
-    UtilPreconditionIsAtLeastFiveEntriesRequired("1.1.1.", 100); // precondition 1: at least 5 entries required to compute any offset
-
-    BOOST_CHECK(CountOffsetSamples() >= 5);
-
-    if (CountOffsetSamples() % 2 == 0) { // precondition 2: start with an uneven number of samples
-        AddTimeData(UtilBuildAddress("1.1.1.110"), 110);
-    }
-
-    BOOST_CHECK(CountOffsetSamples() % 2 == 1);
-
-
-    int64_t offset = GetTimeOffset();
-    int samples = CountOffsetSamples();
-    AddTimeData(UtilBuildAddress("1.1.1.111"), 111);
-
-    BOOST_CHECK_EQUAL(CountOffsetSamples(), samples + 1); // sample was added
-    BOOST_CHECK_EQUAL(GetTimeOffset(), offset);           //new offset was not computed
-}
-
-BOOST_AUTO_TEST_CASE(util_AddTimeDataIgnoreSampleWithDuplicateIP)
-{
-    UtilPreconditionIsAtLeastFiveEntriesRequired("1.1.3.", 50); // precondition 1: at least 5 entries required to compute any offset
-    BOOST_CHECK(CountOffsetSamples() >= 5);
-
-
-    AddTimeData(UtilBuildAddress("1.1.3.60"), 60);
-
-    int64_t offset = GetTimeOffset();
-    int samples = CountOffsetSamples();
-    AddTimeData(UtilBuildAddress("1.1.3.60"), 61);
-
-    BOOST_CHECK_EQUAL(CountOffsetSamples(), samples); // sample was ignored
-    BOOST_CHECK_EQUAL(GetTimeOffset(), offset);       //new offset was not computed
-}
-
-BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmMedianIsWithinBounds)
-{
-    int limit = 10;
+    int capacity = 20; //  can store up to 20 samples
     int64_t offset = 0;
     std::set<CNetAddr> knownSet;
-    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : 10 , init value: 0
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 20 , init sample: 0
 
 
-    for (int sample = 1; sample < 4; sample++) { // precondition: 4 samples, all within bounds
-        std::stringstream stream;
-        stream << "1.1.1." << sample;
-        std::string ip = stream.str();
-        AddTimeDataAlgorithm(UtilBuildAddress(ip), sample, knownSet, offsetFilter, offset);
+    for (unsigned int sample = 1; sample < 10; sample++) { // precondition: at least 4 samples. (including the init sample : 0)
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset); // 1.1.1.[1,2,3],  offsetSample = [1,2,3]
+    }
+
+    BOOST_CHECK(offset != 0); // offset has changed from the initial value
+
+    assert(offsetFilter.size() == 10); // next sample will be the 11th (uneven) and will trigger a new computation of the offset
+
+
+    int samples = offsetFilter.size();
+    int64_t oldOffset = offset;
+    CNetAddr addr2 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0010);
+    AddTimeDataAlgorithm(addr2, 111, knownSet, offsetFilter, offset); // 1.1.1.16 , offsetSample = 111
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1); // sample was added...
+    BOOST_CHECK(oldOffset != offset);                    // ...and new offset was computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmDoNotComputeOffsetWhenNewSampleCountIsGreaterEqualFiveButEven)
+{
+    int capacity = 20; //  can store up to 20 samples
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 20 , init sample: 0
+
+
+    for (unsigned int sample = 1; sample < 9; sample++) { // precondition: at least 7 samples. (including the init sample : 0
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset); // 1.1.1.[1,2,3],  offsetSample = [1,2,3]
+    }
+
+    BOOST_CHECK(offset != 0); // offset has changed from the initial value
+
+    assert(offsetFilter.size() == 9); // next sample will be the 10th (even) and will *not* trigger a new computation of the offset
+
+
+    int samples = offsetFilter.size();
+    int64_t oldOffset = offset;
+    CNetAddr addr2 = UtilBuildAddress(0x001, 0x001, 0x001, 0x0010);
+    AddTimeDataAlgorithm(addr2, 111, knownSet, offsetFilter, offset); // 1.1.1.16 , offsetSample = 111
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1); // sample was added...
+    BOOST_CHECK(oldOffset == offset);                    // ...but new offset was not computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmComputeOffsetWithMedianWithinBounds)
+{
+    int capacity = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 10 , init samplee: 0
+
+
+    for (unsigned int sample = 1; sample < 4; sample++) { // precondition: 4 samples. (including the init sample : 0)
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset); // 1.1.1.[1,2,3],  offsetSample = [1,2,3]
     }
 
     BOOST_CHECK_EQUAL(offset, 0);
     BOOST_CHECK_EQUAL(offsetFilter.size(), 4);
 
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.200"), 200, knownSet, offsetFilter, offset);
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 200, knownSet, offsetFilter, offset); // 1.1.1.200 , offsetSample = 200
 
     BOOST_CHECK_EQUAL(offset, offsetFilter.median());
     BOOST_CHECK_EQUAL(offsetFilter.size(), 5);
 }
 
-BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmMedianIsOutsideBounds)
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmOffsetFlipsToZeroIfMedianIsOutsideBounds)
 {
-    int limit = 10;
+    int capacity = 10;
     int64_t offset = 0;
     std::set<CNetAddr> knownSet;
-    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : limit , init value: 0
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 10 , init sample: 0
 
-    for (int sample = 1; sample < 4; sample++) { // precondition: 4 samples, all outside bounds
-        std::stringstream stream;
-        stream << "1.1.1." << 1 + sample;
-        std::string ip = stream.str();
-        AddTimeDataAlgorithm(UtilBuildAddress(ip), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset);
+    for (int sample = 1; sample < 4; sample++) {                                                     // precondition: 4 samples, all outside bounds
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, sample);                               // 1.1.1.[1,2,3]
+        AddTimeDataAlgorithm(addr, 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // offsetSample  = 2 * DEFAULT_MAX_TIME_ADJUSTMENT (out of bounds)
+
     } // sorted filter: 0 x x x  -- x is outside the boundaries
 
     BOOST_CHECK_EQUAL(offset, 0);
     BOOST_CHECK_EQUAL(offsetFilter.size(), 4);
 
     // offset is computed only when number of entries is uneven
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.5"), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 (x) x x  -- median (x)
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x005), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 (x) x x  -- median (x)
     BOOST_CHECK_EQUAL(offset, 0);
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.6"), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 x x x
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x006), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 x x x
     BOOST_CHECK_EQUAL(offset, 0);
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.7"), 1, knownSet, offsetFilter, offset);                               // sorted filter : 0 1 1 (1) x x x x -- median (1)
-    BOOST_CHECK_EQUAL(offset, 1);                                                                                       // flip to 1
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.8"), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 x x x x x
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x007), 1, knownSet, offsetFilter, offset);                               // sorted filter : 0 1 1 (1) x x x x -- median (1)
+    BOOST_CHECK_EQUAL(offset, 1);                                                                                                        // flip to 1
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x008), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 x x x x x
     BOOST_CHECK_EQUAL(offset, 1);
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.9"), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 (x) x x x x x -- median (x)
-    BOOST_CHECK_EQUAL(offset, 0);                                                                                       // flip back to zero
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x009), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 (x) x x x x x -- median (x)
+    BOOST_CHECK_EQUAL(offset, 0);                                                                                                        // flip back to zero
 
     BOOST_CHECK_EQUAL(offsetFilter.size(), 9);
 }
 
 BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmAtLeastFiveSamplesToComputeOffset)
 {
-    int limit = 10;
+    int capacity = 10;
     int64_t offset = 0;
     std::set<CNetAddr> knownSet;
-    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : limit , init value: 0
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : 10 , init sample: 0
 
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.1"), 1, knownSet, offsetFilter, offset);
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x001), 1, knownSet, offsetFilter, offset);
     BOOST_CHECK_EQUAL(offset, 0);
 
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.2"), 2, knownSet, offsetFilter, offset);
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x002), 2, knownSet, offsetFilter, offset);
     BOOST_CHECK_EQUAL(offset, 0);
 
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.3"), 3, knownSet, offsetFilter, offset);
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x003), 3, knownSet, offsetFilter, offset);
     BOOST_CHECK_EQUAL(offset, 0);
 
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.4"), 4, knownSet, offsetFilter, offset); // this is the fifth entry
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x004), 4, knownSet, offsetFilter, offset); // this is the fifth entry
     BOOST_CHECK_EQUAL(offset, 2);
 }
 
-BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmIgnoresSamplesBeyondInternalLimit)
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmIgnoreSamplesBeyondInternalCapacity)
 {
-    int limit = 10;
+    int capacity = 10; // internal capacity
     int64_t offset = 0;
     std::set<CNetAddr> knownSet;
-    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : limit , init value: 0
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : capacity , initial offset: 0
 
 
-    for (int sample = 1; sample < limit; sample++) { // precondition: limit samples
-        std::stringstream stream;
-        stream << "1.1.1." << sample;
-        std::string ip = stream.str();
-        AddTimeDataAlgorithm(UtilBuildAddress(ip), sample, knownSet, offsetFilter, offset);
+    for (int sample = 1; sample < capacity; sample++) { // precondition: fill filter up to the capacity
+        CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, sample);
+        AddTimeDataAlgorithm(addr, sample, knownSet, offsetFilter, offset);
     }
 
-    BOOST_CHECK_EQUAL(offsetFilter.size(), limit);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), capacity);
 
     int64_t pre = offset;
     int size = offsetFilter.size();
 
-    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.200"), 200, knownSet, offsetFilter, offset);
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 200, knownSet, offsetFilter, offset); // 1.1.1.200, offsetSample = 200
 
     BOOST_CHECK_EQUAL(offset, pre);
     BOOST_CHECK_EQUAL(offsetFilter.size(), size);
 }
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmIgnoreSampleWithDuplicateIp)
+{
+    int capacity = 10; // internal capacity
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(capacity, 0); // max size : capacity , initial offset: 0
+
+    int samples = offsetFilter.size();
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 200, knownSet, offsetFilter, offset); // 1.1.1.200, offsetSample = 200
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1);                                                     // new sample was accepted
+
+    AddTimeDataAlgorithm(UtilBuildAddress(0x001, 0x001, 0x001, 0x0C8), 201, knownSet, offsetFilter, offset); // 1.1.1.200, offsetSample = 201
+    BOOST_CHECK_EQUAL(offsetFilter.size(), samples + 1);                                                     // sample with duplicate ip was ignored
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -2,8 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 //
-#include <timedata.h>
+#include <netaddress.h>
 #include <test/test_bitcoin.h>
+#include <timedata.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -32,6 +33,201 @@ BOOST_AUTO_TEST_CASE(util_MedianFilter)
 
     filter.input(0); // [0 3 7 18 30]
     BOOST_CHECK_EQUAL(filter.median(), 7);
+}
+
+BOOST_AUTO_TEST_CASE(util_MedianFilterShallNotGrowBeyondSize)
+{
+    CMedianFilter<int> filter(2, 15);
+
+    BOOST_CHECK_EQUAL(filter.size(), 1); // 15
+
+    filter.input(100); // 15 100
+    BOOST_CHECK_EQUAL(filter.size(), 2);
+
+    filter.input(10); // 100 10
+    BOOST_CHECK_EQUAL(filter.size(), 2);
+    BOOST_CHECK_EQUAL(filter.sorted()[0], 10);
+    BOOST_CHECK_EQUAL(filter.sorted()[1], 100);
+}
+
+CNetAddr UtilBuildAddress(const std::string& address)
+{
+    struct sockaddr_in sa;
+    memset(&sa, 0, sizeof(sockaddr_in));
+    inet_pton(AF_INET, address.c_str(), &(sa.sin_addr));
+    CNetAddr addr = CNetAddr(sa.sin_addr);
+    return addr;
+}
+
+void UtilPreconditionIsAtLeastFiveEntriesRequired(const std::string& baseip, int basevalue)
+{
+    for (int i = CountOffsetSamples(); i < 5; i++) { // precondition 1: at least 5 entries required to compute any offset
+        int val = basevalue + i;
+        std::stringstream stream;
+        stream << baseip << val;
+        std::string ip = stream.str();
+        AddTimeData(UtilBuildAddress(ip), val);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataComputeOffsetWhenSampleCountIsUneven)
+{
+    UtilPreconditionIsAtLeastFiveEntriesRequired("1.1.1.", 200); // precondition 1: at least 5 entries required to compute any offset
+    BOOST_CHECK(CountOffsetSamples() >= 5);
+
+
+    if ((CountOffsetSamples() % 2) == 1) { // precondition 2: start with an even number of samples
+        AddTimeData(UtilBuildAddress("1.1.1.210"), 210);
+    }
+
+    BOOST_CHECK(CountOffsetSamples() % 2 == 0);
+
+
+    int64_t offset = GetTimeOffset();
+    int samples = CountOffsetSamples();
+    AddTimeData(UtilBuildAddress("1.1.1.211"), 211);
+
+    BOOST_CHECK_EQUAL(CountOffsetSamples(), samples + 1); // sample was added
+    BOOST_CHECK(GetTimeOffset() != offset);               // and new offset was computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataDoNotComputeOffsetWhenSampleCountIsEven)
+{
+    UtilPreconditionIsAtLeastFiveEntriesRequired("1.1.1.", 100); // precondition 1: at least 5 entries required to compute any offset
+
+    BOOST_CHECK(CountOffsetSamples() >= 5);
+
+    if (CountOffsetSamples() % 2 == 0) { // precondition 2: start with an uneven number of samples
+        AddTimeData(UtilBuildAddress("1.1.1.110"), 110);
+    }
+
+    BOOST_CHECK(CountOffsetSamples() % 2 == 1);
+
+
+    int64_t offset = GetTimeOffset();
+    int samples = CountOffsetSamples();
+    AddTimeData(UtilBuildAddress("1.1.1.111"), 111);
+
+    BOOST_CHECK_EQUAL(CountOffsetSamples(), samples + 1); // sample was added
+    BOOST_CHECK_EQUAL(GetTimeOffset(), offset);           //new offset was not computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataIgnoreSampleWithDuplicateIP)
+{
+    UtilPreconditionIsAtLeastFiveEntriesRequired("1.1.3.", 50); // precondition 1: at least 5 entries required to compute any offset
+    BOOST_CHECK(CountOffsetSamples() >= 5);
+
+
+    AddTimeData(UtilBuildAddress("1.1.3.60"), 60);
+
+    int64_t offset = GetTimeOffset();
+    int samples = CountOffsetSamples();
+    AddTimeData(UtilBuildAddress("1.1.3.60"), 61);
+
+    BOOST_CHECK_EQUAL(CountOffsetSamples(), samples); // sample was ignored
+    BOOST_CHECK_EQUAL(GetTimeOffset(), offset);       //new offset was not computed
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmMedianIsWithinBounds)
+{
+    int limit = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : 10 , init value: 0
+
+
+    for (int sample = 1; sample < 4; sample++) { // precondition: 4 samples, all within bounds
+        std::stringstream stream;
+        stream << "1.1.1." << sample;
+        std::string ip = stream.str();
+        AddTimeDataAlgorithm(UtilBuildAddress(ip), sample, knownSet, offsetFilter, offset);
+    }
+
+    BOOST_CHECK_EQUAL(offset, 0);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 4);
+
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.200"), 200, knownSet, offsetFilter, offset);
+
+    BOOST_CHECK_EQUAL(offset, offsetFilter.median());
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 5);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmMedianIsOutsideBounds)
+{
+    int limit = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : limit , init value: 0
+
+    for (int sample = 1; sample < 4; sample++) { // precondition: 4 samples, all outside bounds
+        std::stringstream stream;
+        stream << "1.1.1." << 1 + sample;
+        std::string ip = stream.str();
+        AddTimeDataAlgorithm(UtilBuildAddress(ip), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset);
+    } // sorted filter: 0 x x x  -- x is outside the boundaries
+
+    BOOST_CHECK_EQUAL(offset, 0);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 4);
+
+    // offset is computed only when number of entries is uneven
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.5"), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 (x) x x  -- median (x)
+    BOOST_CHECK_EQUAL(offset, 0);
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.6"), 1, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 x x x
+    BOOST_CHECK_EQUAL(offset, 0);
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.7"), 1, knownSet, offsetFilter, offset);                               // sorted filter : 0 1 1 (1) x x x x -- median (1)
+    BOOST_CHECK_EQUAL(offset, 1);                                                                                       // flip to 1
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.8"), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 x x x x x
+    BOOST_CHECK_EQUAL(offset, 1);
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.9"), 2 * DEFAULT_MAX_TIME_ADJUSTMENT, knownSet, offsetFilter, offset); // sorted filter : 0 1 1 1 (x) x x x x x -- median (x)
+    BOOST_CHECK_EQUAL(offset, 0);                                                                                       // flip back to zero
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), 9);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmAtLeastFiveSamplesToComputeOffset)
+{
+    int limit = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : limit , init value: 0
+
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.1"), 1, knownSet, offsetFilter, offset);
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.2"), 2, knownSet, offsetFilter, offset);
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.3"), 3, knownSet, offsetFilter, offset);
+    BOOST_CHECK_EQUAL(offset, 0);
+
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.4"), 4, knownSet, offsetFilter, offset); // this is the fifth entry
+    BOOST_CHECK_EQUAL(offset, 2);
+}
+
+BOOST_AUTO_TEST_CASE(util_AddTimeDataAlgorithmIgnoresSamplesBeyondInternalLimit)
+{
+    int limit = 10;
+    int64_t offset = 0;
+    std::set<CNetAddr> knownSet;
+    CMedianFilter<int64_t> offsetFilter(limit, 0); // max size : limit , init value: 0
+
+
+    for (int sample = 1; sample < limit; sample++) { // precondition: limit samples
+        std::stringstream stream;
+        stream << "1.1.1." << sample;
+        std::string ip = stream.str();
+        AddTimeDataAlgorithm(UtilBuildAddress(ip), sample, knownSet, offsetFilter, offset);
+    }
+
+    BOOST_CHECK_EQUAL(offsetFilter.size(), limit);
+
+    int64_t pre = offset;
+    int size = offsetFilter.size();
+
+    AddTimeDataAlgorithm(UtilBuildAddress("1.1.1.200"), 200, knownSet, offsetFilter, offset);
+
+    BOOST_CHECK_EQUAL(offset, pre);
+    BOOST_CHECK_EQUAL(offsetFilter.size(), size);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -44,20 +44,36 @@ static int64_t abs64(int64_t n)
 
 #define BITCOIN_TIMEDATA_MAX_SAMPLES 200
 
+
+static std::set<CNetAddr> setKnown;
+
+static CMedianFilter<int64_t> vTimeOffsets(BITCOIN_TIMEDATA_MAX_SAMPLES, 0);
+
+int CountOffsetSamples()
+{
+    LOCK(cs_nTimeOffset);
+    return vTimeOffsets.size();
+}
+
 void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
 {
     LOCK(cs_nTimeOffset);
+
+    AddTimeDataAlgorithm(ip, nOffsetSample, setKnown, vTimeOffsets, nTimeOffset);
+}
+
+void AddTimeDataAlgorithm(const CNetAddr& ip, const int64_t nOffsetSample, std::set<CNetAddr>& knownSet, CMedianFilter<int64_t>& offsetFilter, int64_t& offset)
+{
     // Ignore duplicates
-    static std::set<CNetAddr> setKnown;
-    if (setKnown.size() == BITCOIN_TIMEDATA_MAX_SAMPLES)
+
+    if (knownSet.size() == BITCOIN_TIMEDATA_MAX_SAMPLES)
         return;
-    if (!setKnown.insert(ip).second)
+    if (!knownSet.insert(ip).second)
         return;
 
     // Add data
-    static CMedianFilter<int64_t> vTimeOffsets(BITCOIN_TIMEDATA_MAX_SAMPLES, 0);
-    vTimeOffsets.input(nOffsetSample);
-    LogPrint(BCLog::NET,"added time data, samples %d, offset %+d (%+d minutes)\n", vTimeOffsets.size(), nOffsetSample, nOffsetSample/60);
+    offsetFilter.input(nOffsetSample);
+    LogPrint(BCLog::NET, "added time data, samples %d, offset %+d (%+d minutes)\n", offsetFilter.size(), nOffsetSample, nOffsetSample / 60);
 
     // There is a known issue here (see issue #4521):
     //
@@ -76,31 +92,25 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
     // So we should hold off on fixing this and clean it up as part of
     // a timing cleanup that strengthens it in a number of other ways.
     //
-    if (vTimeOffsets.size() >= 5 && vTimeOffsets.size() % 2 == 1)
-    {
-        int64_t nMedian = vTimeOffsets.median();
-        std::vector<int64_t> vSorted = vTimeOffsets.sorted();
+    if (offsetFilter.size() >= 5 && offsetFilter.size() % 2 == 1) {
+        int64_t nMedian = offsetFilter.median();
+        std::vector<int64_t> vSorted = offsetFilter.sorted();
         // Only let other nodes change our time by so much
-        if (abs64(nMedian) <= std::max<int64_t>(0, gArgs.GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT)))
-        {
-            nTimeOffset = nMedian;
-        }
-        else
-        {
-            nTimeOffset = 0;
+        if (abs64(nMedian) <= std::max<int64_t>(0, gArgs.GetArg("-maxtimeadjustment", DEFAULT_MAX_TIME_ADJUSTMENT))) {
+            offset = nMedian;
+        } else {
+            offset = 0;
 
-            static bool fDone;
-            if (!fDone)
-            {
+            static bool gDone;
+            if (!gDone) {
                 // If nobody has a time different than ours but within 5 minutes of ours, give a warning
                 bool fMatch = false;
                 for (const int64_t nOffset : vSorted)
                     if (nOffset != 0 && abs64(nOffset) < 5 * 60)
                         fMatch = true;
 
-                if (!fMatch)
-                {
-                    fDone = true;
+                if (!fMatch) {
+                    gDone = true;
                     std::string strMessage = strprintf(_("Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly."), _(PACKAGE_NAME));
                     SetMiscWarning(strMessage);
                     uiInterface.ThreadSafeMessageBox(strMessage, "", CClientUIInterface::MSG_WARNING);
@@ -114,7 +124,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
             }
             LogPrint(BCLog::NET, "|  "); /* Continued */
 
-            LogPrint(BCLog::NET, "nTimeOffset = %+d  (%+d minutes)\n", nTimeOffset, nTimeOffset/60);
+            LogPrint(BCLog::NET, "nTimeOffset = %+d  (%+d minutes)\n", offset, offset / 60);
         }
     }
 }

--- a/src/timedata.h
+++ b/src/timedata.h
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <set>
 #include <stdint.h>
 #include <vector>
 
@@ -74,5 +75,9 @@ public:
 int64_t GetTimeOffset();
 int64_t GetAdjustedTime();
 void AddTimeData(const CNetAddr& ip, int64_t nTime);
+
+/** Functions to isolate the contract in AddTimeData */
+int CountOffsetSamples();
+void AddTimeDataAlgorithm(const CNetAddr& ip, const int64_t nOffsetSample, std::set<CNetAddr>& knownSet, CMedianFilter<int64_t>& offsetFilter, int64_t& offset);
 
 #endif // BITCOIN_TIMEDATA_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -12,12 +12,13 @@
 
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
+#include <policy/policy.h>
 #include <rpc/server.h>
 #include <test/test_bitcoin.h>
+#include <timedata.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/test/wallet_test_fixture.h>
-#include <policy/policy.h>
 
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
@@ -258,11 +259,10 @@ BOOST_FIXTURE_TEST_CASE(coin_mark_dirty_immature_credit, TestChain100Setup)
     BOOST_CHECK_EQUAL(wtx.GetImmatureCredit(*locked_chain), 50*COIN);
 }
 
-static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64_t blockTime)
+static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t blockTime)
 {
     CMutableTransaction tx;
     tx.nLockTime = lockTime;
-    SetMockTime(mockTime);
     CBlockIndex* block = nullptr;
     if (blockTime > 0) {
         auto locked_chain = wallet.chain().lock();
@@ -290,25 +290,52 @@ static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64
 // expanded to cover more corner cases of smart time logic.
 BOOST_AUTO_TEST_CASE(ComputeTimeSmart)
 {
+    // The ComputeTimeSmart function within the wallet reads the current time using the GetAdjustedTime function in timedata.
+    //
+    // This function computes the time based on the system time (which suports mocking)
+    // and the time offset, which is not necessarily zero (and does not support mocking)
+    //
+    // Tests have to be executed in order, because the individual cases are stateful
+
+
     // New transaction should use clock time if lower than block time.
-    BOOST_CHECK_EQUAL(AddTx(m_wallet, 1, 100, 120), 100);
+    SetMockTime(10);
+    int64_t clockTime = GetAdjustedTime(); // time + time offset (unfortunately, from a statefull data structure)
+    int64_t blockTime = clockTime + 5;
+
+    BOOST_CHECK_EQUAL(AddTx(m_wallet, 1, blockTime), clockTime); // clocktime shall be used
 
     // Test that updating existing transaction does not change smart time.
-    BOOST_CHECK_EQUAL(AddTx(m_wallet, 1, 200, 220), 100);
+    SetMockTime(20);
+    int64_t newBlockTime = GetAdjustedTime() + 10;
+    BOOST_CHECK_EQUAL(AddTx(m_wallet, 1, newBlockTime), clockTime); // time has not changed from the preceeding transaction
+
 
     // New transaction should use clock time if there's no block time.
-    BOOST_CHECK_EQUAL(AddTx(m_wallet, 2, 300, 0), 300);
+    SetMockTime(30);
+    clockTime = GetAdjustedTime();
+    blockTime = 0;                                               // block time is not set
+    BOOST_CHECK_EQUAL(AddTx(m_wallet, 2, blockTime), clockTime); // clocktime used, because blocktime was not set (zero)
 
     // New transaction should use block time if lower than clock time.
-    BOOST_CHECK_EQUAL(AddTx(m_wallet, 3, 420, 400), 400);
+    SetMockTime(40);
+    clockTime = GetAdjustedTime();
+    blockTime = clockTime - 2;
+    BOOST_CHECK_EQUAL(AddTx(m_wallet, 3, blockTime), blockTime); // blocktime shall be used
 
     // New transaction should use latest entry time if higher than
     // min(block time, clock time).
-    BOOST_CHECK_EQUAL(AddTx(m_wallet, 4, 500, 390), 400);
+    SetMockTime(5);
+    newBlockTime = blockTime - 5;
+    BOOST_CHECK_EQUAL(AddTx(m_wallet, 4, newBlockTime), blockTime); // using the blocktime of the preceeding transaction
+
 
     // If there are future entries, new transaction should use time of the
     // newest entry that is no more than 300 seconds ahead of the clock time.
-    BOOST_CHECK_EQUAL(AddTx(m_wallet, 5, 50, 600), 300);
+    SetMockTime(1);
+    clockTime = GetAdjustedTime();
+    newBlockTime = clockTime + 1000;                                // this is way too far in the future
+    BOOST_CHECK_EQUAL(AddTx(m_wallet, 5, newBlockTime), blockTime); // the newest entry was the last one
 
     // Reset mock time for other tests.
     SetMockTime(0);


### PR DESCRIPTION
Objective: Make the contract for AddTimeData testable.

The procedure AddTimeData is stateful, so any testing beyond trivialities requires some modification in the code:

- Separation between orchestration (lock/unlock) and algorithm
- Pushing static (stateful) variables out of the procedure body
- Applied clang-format-diff.py

Additionally:
wallet_tests.cpp contains errors -> Tests for ComputeTimeSmart falsely assumed that time offset is zero

