### PR TITLE
travis: Run once on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,15 @@ jobs:
         DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
         GOAL="install"
         BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug CXXFLAGS=\"-g0 -O2\""
+# x86_64 Linux (trusty, no depends, only system libs)
+    - stage: test
+      env: >-
+        HOST=x86_64-unknown-linux-gnu
+        DOCKER_NAME_TAG=ubuntu:14.04
+        PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libglib2.0-dev libicu-dev libpng-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.1++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+        NO_DEPENDS=1
+        GOAL="install"
+        BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5"
 # x86_64 Linux (xenial, no depends, only system libs, sanitizers: thread (TSan))
     - stage: test
       env: >-


### PR DESCRIPTION
Currently we only build on bionic (since that is the current gitian environment) and once on xenial in travis. However, we usually don't check that `bitcoind` still compiles with old dependencies (e.g. boost).  So use trusty's system libs as a proxy for all old dependencies and compile once in travis.