### PR TITLE
test: Fix rpc_net.py "pong" race condition

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -67,8 +67,8 @@ class NetTest(BitcoinTestFramework):
 
         peer_info_after_ping = self.nodes[0].getpeerinfo()
         for before, after in zip(peer_info, peer_info_after_ping):
-            assert_greater_than_or_equal(after['bytesrecv_per_msg']['pong'], before['bytesrecv_per_msg']['pong'] + 32)
-            assert_greater_than_or_equal(after['bytessent_per_msg']['ping'], before['bytessent_per_msg']['ping'] + 32)
+            assert_greater_than_or_equal(after['bytesrecv_per_msg'].get('pong', 0), before['bytesrecv_per_msg'].get('pong', 0) + 32)
+            assert_greater_than_or_equal(after['bytessent_per_msg'].get('ping', 0), before['bytessent_per_msg'].get('ping', 0) + 32)
 
     def _test_getnetworkinginfo(self):
         assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)


### PR DESCRIPTION
Prior to this change, the test fails with KeyError if pong has
a zero value at the time this is called, as getpeerinfo's
bytesrecv_per_msg result excludes zero-values.

Combined these to a single wait_until as well, which will be a bit more
forgiving re the timeout while still enforcing the same 2 seconds
overall.

https://ci.appveyor.com/project/DrahtBot/bitcoin/builds/21310881#L62