### PR TITLE
Docs: add gmake syntax to autoconf script

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -40,8 +40,8 @@ git clone https://github.com/bitcoin/bitcoin
 ```
 ./autogen.sh
 
-./configure                  # to build with wallet OR
-./configure --disable-wallet # to build without wallet
+./configure MAKE=gmake                   # to build with wallet OR
+./configure MAKE=gmake  --disable-wallet # to build without wallet
 ```
 
 followed by either:


### PR DESCRIPTION
Environment: FreeBSD 11.2

Running the autoconf script ./configure without MAKE=gmake results in the following error:

"config.status: error: Something went wrong bootstrapping makefile fragments
    for automatic dependency tracking.  Try re-running configure with the
    '--disable-dependency-tracking' option to at least be able to build
    the package (albeit without support for automatic dependency tracking).
See `config.log' for more details"

Defining MAKE as gmake resolves the error.