### PR TITLE
docs: Botbot.me (IRC logs) not available anymore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,8 @@ Most communication about Bitcoin Core development happens on IRC, in the
 #bitcoin-core-dev channel on Freenode. The easiest way to participate on IRC is
 with the web client, [webchat.freenode.net](https://webchat.freenode.net/). Chat
 history logs can be found
-on [botbot.me](https://botbot.me/freenode/bitcoin-core-dev/).
+on [http://www.erisian.com.au/bitcoin-core-dev/](http://www.erisian.com.au/bitcoin-core-dev/)
+and [http://gnusha.org/bitcoin-core-dev/](http://gnusha.org/bitcoin-core-dev/).
 
 Discussion about code base improvements happens in GitHub issues and on pull
 requests.


### PR DESCRIPTION
Remove botbot.me link as it's [not available anymore](https://lincolnloop.com/blog/saying-goodbye-botbotme/) and add two other IRC history log sources for #bitcoin-core-dev, http://www.erisian.com.au/bitcoin-core-dev/ and http://gnusha.org/bitcoin-core-dev/.