### PR TITLE
rpc: List all message types in getpeerinfo recv/send stats

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -778,7 +778,6 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
         nBytes -= handled;
 
         if (msg.complete()) {
-
             //store received bytes per message command
             //to prevent a memory DOS, only allow valid commands
             mapMsgCmdSize::iterator i = mapRecvBytesPerMsgCmd.find(msg.hdr.pchCommand);
@@ -2709,8 +2708,8 @@ int CConnman::GetBestHeight() const
 
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 
-CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress &addrBindIn, const std::string& addrNameIn, bool fInboundIn) :
-    nTimeConnected(GetSystemTimeInSeconds()),
+CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress& addrBindIn, const std::string& addrNameIn, bool fInboundIn)
+    : nTimeConnected(GetSystemTimeInSeconds()),
     addr(addrIn),
     addrBind(addrBindIn),
     fInbound(fInboundIn),
@@ -2771,8 +2770,10 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fPauseSend = false;
     nProcessQueueSize = 0;
 
-    for (const std::string &msg : getAllNetMessageTypes())
+    for (const std::string& msg : getAllNetMessageTypes()) {
         mapRecvBytesPerMsgCmd[msg] = 0;
+        mapSendBytesPerMsgCmd[msg] = 0;
+    }
     mapRecvBytesPerMsgCmd[NET_MESSAGE_COMMAND_OTHER] = 0;
 
     if (fLogIPs) {
@@ -2846,7 +2847,7 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         bool optimisticSend(pnode->vSendMsg.empty());
 
         //log total amount of bytes per command
-        pnode->mapSendBytesPerMsgCmd[msg.command] += nTotalSize;
+        pnode->mapSendBytesPerMsgCmd.at(msg.command) += nTotalSize;
         pnode->nSendSize += nTotalSize;
 
         if (pnode->nSendSize > nSendBufferMaxSize)

--- a/src/net.h
+++ b/src/net.h
@@ -694,8 +694,8 @@ public:
     const uint64_t nKeyedNetGroup;
     std::atomic_bool fPauseRecv;
     std::atomic_bool fPauseSend;
-protected:
 
+protected:
     mapMsgCmdSize mapSendBytesPerMsgCmd;
     mapMsgCmdSize mapRecvBytesPerMsgCmd GUARDED_BY(cs_vRecv);
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -178,16 +178,14 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("minfeefilter", ValueFromAmount(stats.minFeeFilter));
 
         UniValue sendPerMsgCmd(UniValue::VOBJ);
-        for (const mapMsgCmdSize::value_type &i : stats.mapSendBytesPerMsgCmd) {
-            if (i.second > 0)
-                sendPerMsgCmd.pushKV(i.first, i.second);
+        for (const auto& i : stats.mapSendBytesPerMsgCmd) {
+            sendPerMsgCmd.pushKV(i.first, i.second);
         }
         obj.pushKV("bytessent_per_msg", sendPerMsgCmd);
 
         UniValue recvPerMsgCmd(UniValue::VOBJ);
-        for (const mapMsgCmdSize::value_type &i : stats.mapRecvBytesPerMsgCmd) {
-            if (i.second > 0)
-                recvPerMsgCmd.pushKV(i.first, i.second);
+        for (const auto& i : stats.mapRecvBytesPerMsgCmd) {
+            recvPerMsgCmd.pushKV(i.first, i.second);
         }
         obj.pushKV("bytesrecv_per_msg", recvPerMsgCmd);
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -48,6 +48,12 @@ class NetTest(BitcoinTestFramework):
         # from getpeerinfo are bounded by those values.
         net_totals_before = self.nodes[0].getnettotals()
         peer_info = self.nodes[0].getpeerinfo()
+
+        assert '*other*' not in peer_info[0]['bytessent_per_msg']
+        assert_equal(peer_info[0]['bytessent_per_msg']['addr'], 0)
+        assert_equal(peer_info[0]['bytesrecv_per_msg']['*other*'], 0)
+        assert_equal(peer_info[0]['bytesrecv_per_msg']['addr'], 0)
+
         net_totals_after = self.nodes[0].getnettotals()
         assert_equal(len(peer_info), 2)
         peers_recv = sum([peer['bytesrecv'] for peer in peer_info])


### PR DESCRIPTION
Makes it easier to parse the json, since integers of `0` are no longer special cased. See for example #15069 where the special case was forgotten and lead to issues.