### PR TITLE
wallet: Fix a bug where memcmp takes a pointer address as second argument

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -53,7 +53,7 @@ std::map<std::string, BerkeleyEnvironment> g_dbenvs GUARDED_BY(cs_db); //!< Map 
 
 bool WalletDatabaseFileId::operator==(const WalletDatabaseFileId& rhs) const
 {
-    return memcmp(value, &rhs.value, sizeof(value)) == 0;
+    return memcmp(value, rhs.value, sizeof(value)) == 0;
 }
 
 static void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename)


### PR DESCRIPTION

Fix a bug where memcmp takes the address of a pointer as second argument. As far as I can see, the intention with this line of code appears to be comparing two plain arrays.

I have not tested this fix thoroughly.