### PR TITLE
0.17: Backport for #15085

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -50,5 +50,6 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_ORG_DOMAIN "bitcoin.org"
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_APP_NAME_REGTEST "Bitcoin-Qt-regtest"
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -17,7 +17,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
-    {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
+    {"regtest", QAPP_APP_NAME_REGTEST, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);
 


### PR DESCRIPTION
Changes the application name to `Bitcoin-Qt-regtest` when instead of `Bitcoin-Qt-testnet`

Fixes #15079