### PR TITLE
tests: Use std::vector API for construction of test data

### DIFF
--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -213,14 +213,22 @@ BOOST_AUTO_TEST_CASE(is)
     BOOST_CHECK(p2sh.IsPayToScriptHash());
 
     // Not considered pay-to-script-hash if using one of the OP_PUSHDATA opcodes:
-    static const unsigned char direct[] =    { OP_HASH160, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(CScript(direct, direct+sizeof(direct)).IsPayToScriptHash());
-    static const unsigned char pushdata1[] = { OP_HASH160, OP_PUSHDATA1, 20, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(!CScript(pushdata1, pushdata1+sizeof(pushdata1)).IsPayToScriptHash());
-    static const unsigned char pushdata2[] = { OP_HASH160, OP_PUSHDATA2, 20,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(!CScript(pushdata2, pushdata2+sizeof(pushdata2)).IsPayToScriptHash());
-    static const unsigned char pushdata4[] = { OP_HASH160, OP_PUSHDATA4, 20,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, OP_EQUAL };
-    BOOST_CHECK(!CScript(pushdata4, pushdata4+sizeof(pushdata4)).IsPayToScriptHash());
+    std::vector<unsigned char> direct = {OP_HASH160, 20};
+    direct.insert(direct.end(), 20, 0);
+    direct.push_back(OP_EQUAL);
+    BOOST_CHECK(CScript(direct.begin(), direct.end()).IsPayToScriptHash());
+    std::vector<unsigned char> pushdata1 = {OP_HASH160, OP_PUSHDATA1, 20};
+    pushdata1.insert(pushdata1.end(), 20, 0);
+    pushdata1.push_back(OP_EQUAL);
+    BOOST_CHECK(!CScript(pushdata1.begin(), pushdata1.end()).IsPayToScriptHash());
+    std::vector<unsigned char> pushdata2 = {OP_HASH160, 20, 0};
+    pushdata2.insert(pushdata2.end(), 20, 0);
+    pushdata2.push_back(OP_EQUAL);
+    BOOST_CHECK(!CScript(pushdata2.begin(), pushdata2.end()).IsPayToScriptHash());
+    std::vector<unsigned char> pushdata4 = {OP_HASH160, 20, 0, 0, 0};
+    pushdata4.insert(pushdata4.end(), 20, 0);
+    pushdata4.push_back(OP_EQUAL);
+    BOOST_CHECK(!CScript(pushdata4.begin(), pushdata4.end()).IsPayToScriptHash());
 
     CScript not_p2sh;
     BOOST_CHECK(!not_p2sh.IsPayToScriptHash());


### PR DESCRIPTION
For constructing test scripts, use `std::vector` and, in particular, `std::vector::insert` to insert 20 zero bytes rather than listing the full array of bytes explicitly.  This makes the code easier to read and makes it immediately obvious what the structure of the data is, without having to count the zeros to understand it.

Of course, that is a matter of taste - so if you disagree that the change makes the code easier to read, let me know.

This has been split out of #14752.