### PR TITLE
Utils and libraries Revert <<Use getentropy rather than /dev/urandom on macOS>>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -846,14 +846,6 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]],
  [ AC_MSG_RESULT(no)]
 )
 
-AC_MSG_CHECKING(for getentropy via random.h)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
- #include <sys/random.h>]],
- [[ getentropy(nullptr, 32) ]])],
- [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GETENTROPY_RAND, 1,[Define this symbol if the BSD getentropy system call is available with sys/random.h]) ],
- [ AC_MSG_RESULT(no)]
-)
-
 AC_MSG_CHECKING(for sysctl KERN_ARND)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
   #include <sys/sysctl.h>]],

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -28,11 +28,8 @@
 #include <sys/syscall.h>
 #include <linux/random.h>
 #endif
-#if defined(HAVE_GETENTROPY) || (defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX))
+#ifdef HAVE_GETENTROPY
 #include <unistd.h>
-#endif
-#if defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
-#include <sys/random.h>
 #endif
 #ifdef HAVE_SYSCTL_ARND
 #include <util/strencodings.h> // for ARRAYLEN
@@ -241,15 +238,6 @@ void GetOSRand(unsigned char *ent32)
      */
     if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
         RandFailure();
-    }
-#elif defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
-    // We need a fallback for OSX < 10.12
-    if (&getentropy != nullptr) {
-        if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
-            RandFailure();
-        }
-    } else {
-        GetDevURandom(ent32);
     }
 #elif defined(HAVE_SYSCTL_ARND)
     /* FreeBSD and similar. It is possible for the call to return less


### PR DESCRIPTION
This reverts commit ee2d10a (#10301).

I've checked sys/random.h (`/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/sys/random.h`) and it didn't have __attribute__((weak_import)). It was:

```
__attribute__((availability(macosx,introduced=10.12))) __attribute__((availability(ios,introduced=10.0))) __attribute__((availability(tvos,introduced=10.0))) __attribute__((availability(watchos,introduced=3.0)))
int getentropy(void* buffer, size_t size);
```

for Clang. For GCC:

```
int getentropy(void* buffer, size_t size);
```

The unpreprocessed version (so that you can see that it has no intention to `__attribute__((weak_import))`):
```
__BEGIN_DECLS
__OSX_AVAILABLE(10.12) __IOS_AVAILABLE(10.0) __TVOS_AVAILABLE(10.0) __WATCHOS_AVAILABLE(3.0)
int getentropy(void* buffer, size_t size);
__END_DECLS
```

To double-check, I decided to compile this on macOS 10.14 with GCC 8.2:

```
#include <stdio.h>
#include <sys/random.h>

int main(void) {
	unsigned char ent32[10];
	if (getentropy) puts("Have it!");
	else puts("Don't have it!");
	printf("%d\n", getentropy(ent32, 5));
	return 0;
}
```

When I ran it on 10.10, it said:

```
Have it!
dyld: lazy symbol binding failed: Symbol not found: _getentropy
  Referenced from: /Users/me/Downloads/a.out
  Expected in: /usr/lib/libSystem.B.dylib

dyld: Symbol not found: _getentropy
  Referenced from: /Users/me/Downloads/a.out
  Expected in: /usr/lib/libSystem.B.dylib

Trace/BPT trap: 5
```

My suggestion is, if we're supporting 10.11 or lower, we should avoid taking risks and continue with /dev/urandom.