### PR TITLE
Tests: Add unit testing for the CompressScript function

### DIFF
--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <compressor.h>
-#include <util/system.h>
-#include <test/test_bitcoin.h>
-
-#include <stdint.h>
-
 #include <boost/test/unit_test.hpp>
+#include <compressor.h>
+#include <script/standard.h>
+#include <stdint.h>
+#include <util/system.h>
+
+#include <test/test_bitcoin.h>
 
 // amounts 0.00000001 .. 0.00100000
 #define NUM_MULTIPLES_UNIT 100000
@@ -60,6 +60,87 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
 
     for (uint64_t i = 0; i < 100000; i++)
         BOOST_CHECK(TestDecode(i));
+}
+
+BOOST_AUTO_TEST_CASE(compress_CompressScriptToCKeyID)
+{
+    // case CKeyID
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey pubkey = key.GetPubKey();
+
+    CScript script;
+    script.clear();
+    script << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK_EQUAL(script.size(), 25);
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 21);
+    BOOST_CHECK_EQUAL(out[0], 0x00);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[3], 20), 0); // compare the 20 relevant chars of the CKeyId in the script
+}
+
+BOOST_AUTO_TEST_CASE(compress_CompressScriptToCSriptID)
+{
+    // case CScriptID
+    CScript script, redeemScript;
+
+    script.clear();
+    script << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK_EQUAL(script.size(), 23);
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 21);
+    BOOST_CHECK_EQUAL(out[0], 0x01);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 20), 0); // compare the 20 relevant chars of the CScriptId in the script
+}
+
+BOOST_AUTO_TEST_CASE(compress_CompressScriptToCompressedPubKeyID)
+{
+    CKey key;
+    key.MakeNewKey(true); // case compressed PubKeyID
+
+    CScript script;
+    script.clear();
+    script << ToByteVector(key.GetPubKey()) << OP_CHECKSIG; // COMPRESSED_PUBLIC_KEY_SIZE (33)
+    BOOST_CHECK_EQUAL(script.size(), 35);
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 33);
+    BOOST_CHECK_EQUAL(memcmp(&out[0], &script[1], 1), 0);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 32), 0); // compare the 32 chars of the compressed CPubKey
+}
+
+BOOST_AUTO_TEST_CASE(compress_CompressScriptToUncompressedPubKeyID)
+{
+    CKey key;
+    key.MakeNewKey(false); // case uncompressed PubKeyID
+
+    CScript script;
+    script.clear();
+    script << ToByteVector(key.GetPubKey()) << OP_CHECKSIG; // PUBLIC_KEY_SIZE (65)
+    BOOST_CHECK_EQUAL(script.size(), 67);                   // 1 char code + 65 char pubkey + OP_CHECKSIG
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 33);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 32), 0); // first 32 chars of CPubKey are copied into out[1:]
+    BOOST_CHECK_EQUAL(out[0], 0x04 | (script[65] & 0x01)); // least significant bit (lsb) of last char of pubkey is mapped into out[0]
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Added unit tests for CompressScript function located in: compressor.cpp 

Tested following cases for the CScript:

- CKeyID
- CScriptID
- Uncompressed CPubKey (of size : 65)
- Compressed CPubKey (of size: 32)

