### PR TITLE
rest: Return 404 in /rest/headers if block hash does not exists

### DIFF
--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -143,6 +143,7 @@ static bool rest_headers(HTTPRequest* req,
         LOCK(cs_main);
         tip = chainActive.Tip();
         const CBlockIndex* pindex = LookupBlockIndex(hash);
+        if (!pindex) return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
         while (pindex != nullptr && chainActive.Contains(pindex)) {
             headers.push_back(pindex);
             if (headers.size() == (unsigned long)count)

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -201,6 +201,10 @@ class RESTTest (BitcoinTestFramework):
         self.log.info("Test the /block and /headers URIs")
         bb_hash = self.nodes[0].getbestblockhash()
 
+        # Should give 404 if block hash does not exists
+        self.test_rest_request('/block/0000000000000000000000000000000000000000000000000000000000000000', status=404, ret_type=RetType.OBJ)
+        self.test_rest_request('/headers/1/0000000000000000000000000000000000000000000000000000000000000000', status=404, ret_type=RetType.OBJ)
+
         # Check binary format
         response = self.test_rest_request("/block/{}".format(bb_hash), req_type=ReqType.BIN, ret_type=RetType.OBJ)
         assert_greater_than(int(response.getheader('content-length')), 80)


### PR DESCRIPTION
This PR changes `/rest/headers` response to 404 when the given block hash does not exists. Before the response would be an empty array of headers.

Also add a test for `/rest/block/` which already returns the 404 error.

Note, will add release note if accepted.