### PR TITLE
build_msvc: Fix the build problem in libbitcoin_server

### DIFF
--- a/build_msvc/libbitcoin_server/libbitcoin_server.vcxproj.in
+++ b/build_msvc/libbitcoin_server/libbitcoin_server.vcxproj.in
@@ -154,12 +154,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\rpc\net.cpp">
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\netrpc.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\netrpc.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)\netrpc.obj</ObjectFileName>
-      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)\netrpc.obj</ObjectFileName>
-    </ClCompile>
 @SOURCE_FILES@
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes https://github.com/bitcoin/bitcoin/issues/15049

The reason of this problem is existance two similar lines in the libbitcoin_server.vcxproj file that appears after the executing the msvc-autogen.py script .

line 157
>   <ItemGroup>
    <ClCompile Include="..\..\src\rpc\net.cpp">
      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\netrpc.obj</ObjectFileName>
      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(IntDir)\netrpc.obj</ObjectFileName>
      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)\netrpc.obj</ObjectFileName>
      <ObjectFileName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(IntDir)\netrpc.obj</ObjectFileName>
    </ClCompile>

line 256

>   <ItemGroup>
    <ClCompile Include="..\..\src\rpc\net.cpp"> 
      <ObjectFileName>$(IntDir)rpc_net.obj</ObjectFileName>
    </ClCompile>




