### PR TITLE
Avoid UB (member call on nullptr) when failing to read randomness in the startup process

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -132,15 +132,20 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 template <typename... Args>
 static inline void LogPrintf(const char* fmt, const Args&... args)
 {
-    if (g_logger->Enabled()) {
-        std::string log_msg;
-        try {
-            log_msg = tfm::format(fmt, args...);
-        } catch (tinyformat::format_error& fmterr) {
-            /* Original format string will have newline so don't add one here */
-            log_msg = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + fmt;
-        }
+    if (g_logger && !g_logger->Enabled()) {
+        return;
+    }
+    std::string log_msg;
+    try {
+        log_msg = tfm::format(fmt, args...);
+    } catch (tinyformat::format_error& fmterr) {
+        /* Original format string will have newline so don't add one here */
+        log_msg = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + fmt;
+    }
+    if (g_logger) {
         g_logger->LogPrintStr(log_msg);
+    } else {
+        fwrite(log_msg.data(), 1, log_msg.size(), stderr);
     }
 }
 


### PR DESCRIPTION
Avoid UB (member call on `nullptr`) when failing to read randomness in the startup process.

`RandFailure` is called by `GetDevURandom`, `GetOSRand` and `GetRandBytes` when failing to read randomness for some reason.

This is `RandFailure`:

```
[[noreturn]] static void RandFailure()
{
    LogPrintf("Failed to read randomness, aborting\n");
    std::abort();
}
```

This is `LogPrintf`:

```
template <typename... Args>
static inline void LogPrintf(const char* fmt, const Args&... args)
{
    if (g_logger->Enabled()) {
        …
    }
}
```

Compilers are allowed to optimise away calls to `RandFailure` that are guaranteed to take place when `g_logger == nullptr`. Please note that such optimisation would remove the crucial `std::abort` call in `RandFailure`.

Failing to read randomness before this patch (under UBSan):

```
$ src/bitcoind
logging.h:135:19: runtime error: member call on null pointer of type 'BCLog::Logger'
<undefined behaviour>
```

Failing to read randomness after this patch (under UBSan):

```
$ src/bitcoind
Failed to read randomness, aborting
$
```