### PR TITLE
build: Optionally enable -Wzero-as-null-pointer-constant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -457,6 +457,10 @@ if test "$CXXFLAGS_overridden" = "no"; then
 
   if test "$suppress_external_warnings" != "no" ; then
     AX_CHECK_COMPILE_FLAG([-Wdocumentation], [WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"], [], [$CXXFLAG_WERROR])
+    AX_CHECK_COMPILE_FLAG([-Wzero-as-null-pointer-constant], [
+      WARN_CXXFLAGS="$WARN_CXXFLAGS -Wzero-as-null-pointer-constant"
+      AC_DEFINE(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT, 1, [Define this symbol if -Wzero-as-null-pointer-constant is available])
+    ], [], [$CXXFLAG_WERROR])
   fi
 
   dnl Some compilers (gcc) ignore unknown -Wno-* options, but warn about all

--- a/src/Makefile.leveldb.include
+++ b/src/Makefile.leveldb.include
@@ -38,7 +38,7 @@ LEVELDB_CPPFLAGS_INT += -DLEVELDB_PLATFORM_POSIX
 endif
 
 leveldb_libleveldb_a_CPPFLAGS = $(AM_CPPFLAGS) $(LEVELDB_CPPFLAGS_INT) $(LEVELDB_CPPFLAGS)
-leveldb_libleveldb_a_CXXFLAGS = $(filter-out -Wconditional-uninitialized -Werror=conditional-uninitialized -Wsuggest-override -Werror=suggest-override, $(AM_CXXFLAGS)) $(PIE_FLAGS)
+leveldb_libleveldb_a_CXXFLAGS = $(filter-out -Wconditional-uninitialized -Werror=conditional-uninitialized -Wsuggest-override -Werror=suggest-override -Wzero-as-null-pointer-constant -Werror=zero-as-null-pointer-constant, $(AM_CXXFLAGS)) $(PIE_FLAGS)
 
 leveldb_libleveldb_a_SOURCES=
 leveldb_libleveldb_a_SOURCES += leveldb/port/port_stdcxx.h

--- a/src/mapport.cpp
+++ b/src/mapport.cpp
@@ -193,7 +193,7 @@ static bool ProcessUpnp()
         std::string strDesc = PACKAGE_NAME " " + FormatFullVersion();
 
         do {
-            r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", 0, "0");
+            r = UPNP_AddPortMapping(urls.controlURL, data.first.servicetype, port.c_str(), port.c_str(), lanaddr, strDesc.c_str(), "TCP", nullptr, "0");
 
             if (r != UPNPCOMMAND_SUCCESS) {
                 ret = false;
@@ -206,7 +206,7 @@ static bool ProcessUpnp()
         } while (g_mapport_interrupt.sleep_for(PORT_MAPPING_REANNOUNCE_PERIOD));
         g_mapport_interrupt.reset();
 
-        r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", 0);
+        r = UPNP_DeletePortMapping(urls.controlURL, data.first.servicetype, port.c_str(), "TCP", nullptr);
         LogPrintf("UPNP_DeletePortMapping() returned: %d\n", r);
         freeUPNPDevlist(devlist); devlist = nullptr;
         FreeUPNPUrls(&urls);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -675,7 +675,7 @@ bool ConnectThroughProxy(const Proxy& proxy, const std::string& strDest, uint16_
             return false;
         }
     } else {
-        if (!Socks5(strDest, port, 0, sock)) {
+        if (!Socks5(strDest, port, nullptr, sock)) {
             return false;
         }
     }

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -226,7 +226,7 @@ bool Intro::showIfNeeded(bool& did_show_intro, int64_t& prune_MiB)
         }
 
         /* If current default data directory does not exist, let the user choose one */
-        Intro intro(0, Params().AssumedBlockchainSize(), Params().AssumedChainStateSize());
+        Intro intro(nullptr, Params().AssumedBlockchainSize(), Params().AssumedChainStateSize());
         intro.setDataDirectory(dataDir);
         intro.setWindowIcon(QIcon(":icons/bitcoin"));
         did_show_intro = true;

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -363,10 +363,10 @@ void RandAddStaticEnv(CSHA512& hasher)
 
 #if HAVE_DECL_GETIFADDRS && HAVE_DECL_FREEIFADDRS
     // Network interfaces
-    struct ifaddrs *ifad = NULL;
+    struct ifaddrs *ifad = nullptr;
     getifaddrs(&ifad);
     struct ifaddrs *ifit = ifad;
-    while (ifit != NULL) {
+    while (ifit != nullptr) {
         hasher.Write((const unsigned char*)&ifit, sizeof(ifit));
         hasher.Write((const unsigned char*)ifit->ifa_name, strlen(ifit->ifa_name) + 1);
         hasher.Write((const unsigned char*)&ifit->ifa_flags, sizeof(ifit->ifa_flags));

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -37,7 +37,7 @@ struct secure_allocator : public std::allocator<T> {
         typedef secure_allocator<_Other> other;
     };
 
-    T* allocate(std::size_t n, const void* hint = 0)
+    T* allocate(std::size_t n, const void* hint = nullptr)
     {
         T* allocation = static_cast<T*>(LockedPoolManager::Instance().alloc(sizeof(T) * n));
         if (!allocation) {

--- a/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
+++ b/src/test/fuzz/crypto_diff_fuzz_chacha20.cpp
@@ -128,7 +128,7 @@ void ECRYPT_encrypt_bytes(ECRYPT_ctx* x, const u8* m, u8* c, u32 bytes)
 {
     u32 x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15;
     u32 j0, j1, j2, j3, j4, j5, j6, j7, j8, j9, j10, j11, j12, j13, j14, j15;
-    u8* ctarget = NULL;
+    u8* ctarget = nullptr;
     u8 tmp[64];
     uint32_t i;
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2096,6 +2096,7 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
 #if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -2106,8 +2107,8 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
     void (*old_handler)(int) = signal(SIGCHLD, SIG_DFL);
 
 #if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
-#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
     // Fork another process for testing before creating the lock, so that we

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -2092,10 +2092,23 @@ BOOST_AUTO_TEST_CASE(test_LockDirectory)
     fs::path dirname = m_args.GetDataDirBase() / "lock_dir";
     const std::string lockname = ".lock";
 #ifndef WIN32
+// disable Wzero-as-null-pointer-constant for SIG_DFL
+#if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
     // Revert SIGCHLD to default, otherwise boost.test will catch and fail on
     // it: there is BOOST_TEST_IGNORE_SIGCHLD but that only works when defined
     // at build-time of the boost library
     void (*old_handler)(int) = signal(SIGCHLD, SIG_DFL);
+
+#if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
+#endif
 
     // Fork another process for testing before creating the lock, so that we
     // won't fork while holding the lock (which might be undefined, and is not

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -124,6 +124,17 @@
 #ifndef TINYFORMAT_H_INCLUDED
 #define TINYFORMAT_H_INCLUDED
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
 namespace tinyformat {}
 //------------------------------------------------------------------------------
 // Config section.  Customize to your liking!
@@ -1162,5 +1173,10 @@ std::string format(const std::string &fmt, const Args&... args)
 // Added for Bitcoin Core:
 /** Format arguments and return the string or write to given std::ostream (see tinyformat::format doc for details) */
 #define strprintf tfm::format
+
+#if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
+#endif
 
 #endif // TINYFORMAT_H_INCLUDED

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -131,6 +131,7 @@
 #if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -1175,8 +1176,8 @@ std::string format(const std::string &fmt, const Args&... args)
 #define strprintf tfm::format
 
 #if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
-#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 #endif // TINYFORMAT_H_INCLUDED

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -308,7 +308,7 @@ std::map<std::string,std::string> ParseTorReplyMapping(const std::string &s)
 
 TorController::TorController(struct event_base* _base, const std::string& tor_control_center, const CService& target):
     base(_base),
-    m_tor_control_center(tor_control_center), conn(base), reconnect(true), reconnect_ev(0),
+    m_tor_control_center(tor_control_center), conn(base), reconnect(true), reconnect_ev(nullptr),
     reconnect_timeout(RECONNECT_TIMEOUT_START),
     m_target(target)
 {

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -37,6 +37,14 @@ static void ErrorLogCallback(void* arg, int code, const char* msg)
     LogPrintf("SQLite Error. Code: %d. Message: %s\n", code, msg);
 }
 
+// disable -Wzero-as-null-pointer-constant due to SQLITE_STATIC
+#if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+
 static bool BindBlobToStatement(sqlite3_stmt* stmt,
                                 int index,
                                 Span<const std::byte> blob,
@@ -471,6 +479,11 @@ bool SQLiteBatch::HasKey(CDataStream&& key)
     sqlite3_reset(m_read_stmt);
     return res == SQLITE_ROW;
 }
+
+#if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
+#endif
 
 bool SQLiteBatch::StartCursor()
 {

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -41,6 +41,7 @@ static void ErrorLogCallback(void* arg, int code, const char* msg)
 #if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wzero-as-null-pointer-constant"
 #endif
@@ -481,8 +482,8 @@ bool SQLiteBatch::HasKey(CDataStream&& key)
 }
 
 #if defined(HAVE_W_ZERO_AS_NULL_POINTER_CONSTANT)
-#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 
 bool SQLiteBatch::StartCursor()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2768,7 +2768,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     } else if (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) {
         // Make it impossible to disable private keys after creation
         error = strprintf(_("Error loading %s: Private keys can only be disabled during creation"), walletFile);
-        return NULL;
+        return nullptr;
     } else if (walletInstance->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         for (auto spk_man : walletInstance->GetActiveScriptPubKeyMans()) {
             if (spk_man->HavePrivateKeys()) {


### PR DESCRIPTION
~~**Note:** This is based on #14920~~

This enables `-Wzero-as-null-pointer-constant`, while avoiding applying it to dependencies.

~~Used [Qt::NoItemFlags](http://doc.qt.io/qt-5/qt.html#ItemFlag-enum),  [Qt::Widget](http://doc.qt.io/qt-5/qt.html#WindowType-enum) instead where applicable.~~

See #10483, #10645, #13802 for more on `nullptr`.