### PR TITLE
Refactor block file logic

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
+  flatfile.h \
   fs.h \
   httprpc.h \
   httpserver.h \
@@ -247,6 +248,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   consensus/tx_verify.cpp \
+  flatfile.cpp \
   httprpc.cpp \
   httpserver.cpp \
   index/base.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -83,6 +83,7 @@ BITCOIN_TESTS =\
   test/cuckoocache_tests.cpp \
   test/denialofservice_tests.cpp \
   test/descriptor_tests.cpp \
+  test/flatfile_tests.cpp \
   test/fs_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \

--- a/src/chain.h
+++ b/src/chain.h
@@ -8,6 +8,7 @@
 
 #include <arith_uint256.h>
 #include <consensus/params.h>
+#include <flatfile.h>
 #include <primitives/block.h>
 #include <tinyformat.h>
 #include <uint256.h>
@@ -88,46 +89,6 @@ public:
          if (nTimeIn > nTimeLast)
              nTimeLast = nTimeIn;
      }
-};
-
-struct CDiskBlockPos
-{
-    int nFile;
-    unsigned int nPos;
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
-        READWRITE(VARINT(nPos));
-    }
-
-    CDiskBlockPos() {
-        SetNull();
-    }
-
-    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
-        nFile = nFileIn;
-        nPos = nPosIn;
-    }
-
-    friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
-        return (a.nFile == b.nFile && a.nPos == b.nPos);
-    }
-
-    friend bool operator!=(const CDiskBlockPos &a, const CDiskBlockPos &b) {
-        return !(a == b);
-    }
-
-    void SetNull() { nFile = -1; nPos = 0; }
-    bool IsNull() const { return (nFile == -1); }
-
-    std::string ToString() const
-    {
-        return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
-    }
-
 };
 
 enum BlockStatus: uint32_t {

--- a/src/chain.h
+++ b/src/chain.h
@@ -227,8 +227,8 @@ public:
         nNonce         = block.nNonce;
     }
 
-    CDiskBlockPos GetBlockPos() const {
-        CDiskBlockPos ret;
+    FlatFilePos GetBlockPos() const {
+        FlatFilePos ret;
         if (nStatus & BLOCK_HAVE_DATA) {
             ret.nFile = nFile;
             ret.nPos  = nDataPos;
@@ -236,8 +236,8 @@ public:
         return ret;
     }
 
-    CDiskBlockPos GetUndoPos() const {
-        CDiskBlockPos ret;
+    FlatFilePos GetUndoPos() const {
+        FlatFilePos ret;
         if (nStatus & BLOCK_HAVE_UNDO) {
             ret.nFile = nFile;
             ret.nPos  = nUndoPos;

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -30,25 +30,24 @@ fs::path FlatFileSeq::FileName(const FlatFilePos& pos) const
     return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
 }
 
-FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool fReadOnly)
+FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool read_only)
 {
-    if (pos.IsNull())
+    if (pos.IsNull()) {
         return nullptr;
+    }
     fs::path path = FileName(pos);
     fs::create_directories(path.parent_path());
-    FILE* file = fsbridge::fopen(path, fReadOnly ? "rb": "rb+");
-    if (!file && !fReadOnly)
+    FILE* file = fsbridge::fopen(path, read_only ? "rb": "rb+");
+    if (!file && !read_only)
         file = fsbridge::fopen(path, "wb+");
     if (!file) {
         LogPrintf("Unable to open file %s\n", path.string());
         return nullptr;
     }
-    if (pos.nPos) {
-        if (fseek(file, pos.nPos, SEEK_SET)) {
-            LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
-            fclose(file);
-            return nullptr;
-        }
+    if (pos.nPos && fseek(file, pos.nPos, SEEK_SET)) {
+        LogPrintf("Unable to seek to position %u of %s\n", pos.nPos, path.string());
+        fclose(file);
+        return nullptr;
     }
     return file;
 }

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -1,4 +1,5 @@
-// Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -17,6 +18,11 @@ FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     if (chunk_size == 0) {
         throw std::invalid_argument("chunk_size must be positive");
     }
+}
+
+std::string CDiskBlockPos::ToString() const
+{
+    return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
 }
 
 fs::path FlatFileSeq::FileName(const CDiskBlockPos& pos) const

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -20,17 +20,17 @@ FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
     }
 }
 
-std::string CDiskBlockPos::ToString() const
+std::string FlatFilePos::ToString() const
 {
-    return strprintf("CDiskBlockPos(nFile=%i, nPos=%i)", nFile, nPos);
+    return strprintf("FlatFilePos(nFile=%i, nPos=%i)", nFile, nPos);
 }
 
-fs::path FlatFileSeq::FileName(const CDiskBlockPos& pos) const
+fs::path FlatFileSeq::FileName(const FlatFilePos& pos) const
 {
     return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
 }
 
-FILE* FlatFileSeq::Open(const CDiskBlockPos& pos, bool fReadOnly)
+FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool fReadOnly)
 {
     if (pos.IsNull())
         return nullptr;
@@ -53,7 +53,7 @@ FILE* FlatFileSeq::Open(const CDiskBlockPos& pos, bool fReadOnly)
     return file;
 }
 
-size_t FlatFileSeq::Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space)
+size_t FlatFileSeq::Allocate(const FlatFilePos& pos, size_t add_size, bool& out_of_space)
 {
     out_of_space = false;
 
@@ -79,7 +79,7 @@ size_t FlatFileSeq::Allocate(const CDiskBlockPos& pos, size_t add_size, bool& ou
     return 0;
 }
 
-bool FlatFileSeq::Flush(const CDiskBlockPos& pos, bool finalize)
+bool FlatFileSeq::Flush(const FlatFilePos& pos, bool finalize)
 {
     FILE* file = Open(FlatFilePos(pos.nFile, 0)); // Avoid fseek to nPos
     if (!file) {

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <stdexcept>
+
+#include <flatfile.h>
+#include <tinyformat.h>
+
+FlatFileSeq::FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size) :
+    m_dir(std::move(dir)),
+    m_prefix(prefix),
+    m_chunk_size(chunk_size)
+{
+    if (chunk_size == 0) {
+        throw std::invalid_argument("chunk_size must be positive");
+    }
+}
+
+fs::path FlatFileSeq::FileName(const CDiskBlockPos& pos) const
+{
+    return m_dir / strprintf("%s%05u.dat", m_prefix, pos.nFile);
+}

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -31,6 +31,9 @@ public:
 
     /** Get the name of the file at the given position. */
     fs::path FileName(const CDiskBlockPos& pos) const;
+
+    /** Open a handle to the file at the given position. */
+    FILE* Open(const CDiskBlockPos& pos, bool fReadOnly = false);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_FLATFILE_H
+#define BITCOIN_FLATFILE_H
+
+#include <chain.h>
+#include <fs.h>
+
+/**
+ * FlatFileSeq represents a sequence of numbered files storing raw data. This class facilitates
+ * access to and efficient management of these files.
+ */
+class FlatFileSeq
+{
+private:
+    const fs::path m_dir;
+    const char* const m_prefix;
+    const size_t m_chunk_size;
+
+public:
+    /**
+     * Constructor
+     *
+     * @param dir The base directory that all files live in.
+     * @param prefix A short prefix given to all file names.
+     * @param chunk_size Disk space is pre-allocated in multiples of this amount.
+     */
+    FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size);
+
+    /** Get the name of the file at the given position. */
+    fs::path FileName(const CDiskBlockPos& pos) const;
+};
+
+#endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -45,6 +45,15 @@ public:
      * @return The number of bytes successfully allocated.
      */
     size_t Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space);
+
+    /**
+     * Commit a file to disk, and optionally truncate off extra pre-allocated bytes if final.
+     *
+     * @param[in] pos The first unwritten position in the file to be flushed.
+     * @param[in] finalize True if no more data will be written to this file.
+     * @return true on success, false on failure.
+     */
+    bool Flush(const CDiskBlockPos& pos, bool finalize = false);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -24,14 +24,12 @@ struct FlatFilePos
         READWRITE(VARINT(nPos));
     }
 
-    FlatFilePos() {
-        SetNull();
-    }
+    FlatFilePos() : nFile(-1), nPos(0) {}
 
-    FlatFilePos(int nFileIn, unsigned int nPosIn) {
-        nFile = nFileIn;
-        nPos = nPosIn;
-    }
+    FlatFilePos(int nFileIn, unsigned int nPosIn) :
+        nFile(nFileIn),
+        nPos(nPosIn)
+    {}
 
     friend bool operator==(const FlatFilePos &a, const FlatFilePos &b) {
         return (a.nFile == b.nFile && a.nPos == b.nPos);
@@ -72,7 +70,7 @@ public:
     fs::path FileName(const FlatFilePos& pos) const;
 
     /** Open a handle to the file at the given position. */
-    FILE* Open(const FlatFilePos& pos, bool fReadOnly = false);
+    FILE* Open(const FlatFilePos& pos, bool read_only = false);
 
     /**
      * Allocate additional space in a file after the given starting position. The amount allocated

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -1,12 +1,51 @@
-// Copyright (c) 2019 The Bitcoin Core developers
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_FLATFILE_H
 #define BITCOIN_FLATFILE_H
 
-#include <chain.h>
+#include <string>
+
 #include <fs.h>
+#include <serialize.h>
+
+struct CDiskBlockPos
+{
+    int nFile;
+    unsigned int nPos;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
+        READWRITE(VARINT(nPos));
+    }
+
+    CDiskBlockPos() {
+        SetNull();
+    }
+
+    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
+        nFile = nFileIn;
+        nPos = nPosIn;
+    }
+
+    friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+        return (a.nFile == b.nFile && a.nPos == b.nPos);
+    }
+
+    friend bool operator!=(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+        return !(a == b);
+    }
+
+    void SetNull() { nFile = -1; nPos = 0; }
+    bool IsNull() const { return (nFile == -1); }
+
+    std::string ToString() const;
+};
 
 /**
  * FlatFileSeq represents a sequence of numbered files storing raw data. This class facilitates

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -34,6 +34,17 @@ public:
 
     /** Open a handle to the file at the given position. */
     FILE* Open(const CDiskBlockPos& pos, bool fReadOnly = false);
+
+    /**
+     * Allocate additional space in a file after the given starting position. The amount allocated
+     * will be the minimum multiple of the sequence chunk size greater than add_size.
+     *
+     * @param[in] pos The starting position that bytes will be allocated after.
+     * @param[in] add_size The minimum number of bytes to be allocated.
+     * @param[out] out_of_space Whether the allocation failed due to insufficient disk space.
+     * @return The number of bytes successfully allocated.
+     */
+    size_t Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/flatfile.h
+++ b/src/flatfile.h
@@ -11,7 +11,7 @@
 #include <fs.h>
 #include <serialize.h>
 
-struct CDiskBlockPos
+struct FlatFilePos
 {
     int nFile;
     unsigned int nPos;
@@ -24,20 +24,20 @@ struct CDiskBlockPos
         READWRITE(VARINT(nPos));
     }
 
-    CDiskBlockPos() {
+    FlatFilePos() {
         SetNull();
     }
 
-    CDiskBlockPos(int nFileIn, unsigned int nPosIn) {
+    FlatFilePos(int nFileIn, unsigned int nPosIn) {
         nFile = nFileIn;
         nPos = nPosIn;
     }
 
-    friend bool operator==(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+    friend bool operator==(const FlatFilePos &a, const FlatFilePos &b) {
         return (a.nFile == b.nFile && a.nPos == b.nPos);
     }
 
-    friend bool operator!=(const CDiskBlockPos &a, const CDiskBlockPos &b) {
+    friend bool operator!=(const FlatFilePos &a, const FlatFilePos &b) {
         return !(a == b);
     }
 
@@ -69,10 +69,10 @@ public:
     FlatFileSeq(fs::path dir, const char* prefix, size_t chunk_size);
 
     /** Get the name of the file at the given position. */
-    fs::path FileName(const CDiskBlockPos& pos) const;
+    fs::path FileName(const FlatFilePos& pos) const;
 
     /** Open a handle to the file at the given position. */
-    FILE* Open(const CDiskBlockPos& pos, bool fReadOnly = false);
+    FILE* Open(const FlatFilePos& pos, bool fReadOnly = false);
 
     /**
      * Allocate additional space in a file after the given starting position. The amount allocated
@@ -83,7 +83,7 @@ public:
      * @param[out] out_of_space Whether the allocation failed due to insufficient disk space.
      * @return The number of bytes successfully allocated.
      */
-    size_t Allocate(const CDiskBlockPos& pos, size_t add_size, bool& out_of_space);
+    size_t Allocate(const FlatFilePos& pos, size_t add_size, bool& out_of_space);
 
     /**
      * Commit a file to disk, and optionally truncate off extra pre-allocated bytes if final.
@@ -92,7 +92,7 @@ public:
      * @param[in] finalize True if no more data will be written to this file.
      * @return true on success, false on failure.
      */
-    bool Flush(const CDiskBlockPos& pos, bool finalize = false);
+    bool Flush(const FlatFilePos& pos, bool finalize = false);
 };
 
 #endif // BITCOIN_FLATFILE_H

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -16,7 +16,7 @@ constexpr char DB_TXINDEX_BLOCK = 'T';
 
 std::unique_ptr<TxIndex> g_txindex;
 
-struct CDiskTxPos : public CDiskBlockPos
+struct CDiskTxPos : public FlatFilePos
 {
     unsigned int nTxOffset; // after header
 
@@ -24,11 +24,11 @@ struct CDiskTxPos : public CDiskBlockPos
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action) {
-        READWRITEAS(CDiskBlockPos, *this);
+        READWRITEAS(FlatFilePos, *this);
         READWRITE(VARINT(nTxOffset));
     }
 
-    CDiskTxPos(const CDiskBlockPos &blockIn, unsigned int nTxOffsetIn) : CDiskBlockPos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
+    CDiskTxPos(const FlatFilePos &blockIn, unsigned int nTxOffsetIn) : FlatFilePos(blockIn.nFile, blockIn.nPos), nTxOffset(nTxOffsetIn) {
     }
 
     CDiskTxPos() {
@@ -36,7 +36,7 @@ struct CDiskTxPos : public CDiskBlockPos
     }
 
     void SetNull() {
-        CDiskBlockPos::SetNull();
+        FlatFilePos::SetNull();
         nTxOffset = 0;
     }
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -672,7 +672,7 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
     if (fReindex) {
         int nFile = 0;
         while (true) {
-            CDiskBlockPos pos(nFile, 0);
+            FlatFilePos pos(nFile, 0);
             if (!fs::exists(GetBlockPosFilename(pos)))
                 break; // No block files left to reindex
             FILE *file = OpenBlockFile(pos, true);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1675,11 +1675,11 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     // ********************************************************* Step 11: import blocks
 
-    if (!CheckDiskSpace(/* additional_bytes */ 0, /* blocks_dir */ false)) {
+    if (!CheckDiskSpace(GetDataDir())) {
         InitError(strprintf(_("Error: Disk space is low for %s"), GetDataDir()));
         return false;
     }
-    if (!CheckDiskSpace(/* additional_bytes */ 0, /* blocks_dir */ true)) {
+    if (!CheckDiskSpace(GetBlocksDir())) {
         InitError(strprintf(_("Error: Disk space is low for %s"), GetBlocksDir()));
         return false;
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -673,7 +673,7 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
         int nFile = 0;
         while (true) {
             CDiskBlockPos pos(nFile, 0);
-            if (!fs::exists(GetBlockPosFilename(pos, "blk")))
+            if (!fs::exists(GetBlockPosFilename(pos)))
                 break; // No block files left to reindex
             FILE *file = OpenBlockFile(pos, true);
             if (!file)

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <flatfile.h>
+#include <test/test_bitcoin.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(flatfile_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(flatfile_filename)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+
+    FlatFilePos pos(456, 789);
+
+    FlatFileSeq seq1(data_dir, "a", 16 * 1024);
+    BOOST_CHECK_EQUAL(seq1.FileName(pos), data_dir / "a00456.dat");
+
+    FlatFileSeq seq2(data_dir / "a", "b", 16 * 1024);
+    BOOST_CHECK_EQUAL(seq2.FileName(pos), data_dir / "a" / "b00456.dat");
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_open)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 16 * 1024);
+
+    std::string line1("A purely peer-to-peer version of electronic cash would allow online "
+                      "payments to be sent directly from one party to another without going "
+                      "through a financial institution.");
+    std::string line2("Digital signatures provide part of the solution, but the main benefits are "
+                      "lost if a trusted third party is still required to prevent double-spending.");
+
+    size_t pos1 = 0;
+    size_t pos2 = pos1 + GetSerializeSize(line1, CLIENT_VERSION);
+
+    // Write first line to file.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos1)), SER_DISK, CLIENT_VERSION);
+        file << LIMITED_STRING(line1, 256);
+    }
+
+    // Attempt to append to file opened in read-only mode.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2), true), SER_DISK, CLIENT_VERSION);
+        BOOST_CHECK_THROW(file << LIMITED_STRING(line2, 256), std::ios_base::failure);
+    }
+
+    // Append second line to file.
+    {
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2)), SER_DISK, CLIENT_VERSION);
+        file << LIMITED_STRING(line2, 256);
+    }
+
+    // Read text from file in read-only mode.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(0, pos1), true), SER_DISK, CLIENT_VERSION);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line1);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line2);
+    }
+
+    // Read text from file with position offset.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(0, pos2)), SER_DISK, CLIENT_VERSION);
+
+        file >> LIMITED_STRING(text, 256);
+        BOOST_CHECK_EQUAL(text, line2);
+    }
+
+    // Ensure another file in the sequence has no data.
+    {
+        std::string text;
+        CAutoFile file(seq.Open(FlatFilePos(1, pos2)), SER_DISK, CLIENT_VERSION);
+        BOOST_CHECK_THROW(file >> LIMITED_STRING(text, 256), std::ios_base::failure);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_allocate)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 100);
+
+    bool out_of_space;
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), 100);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 0))), 100);
+    BOOST_CHECK(!out_of_space);
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 1, out_of_space), 0);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 100);
+    BOOST_CHECK(!out_of_space);
+
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 2, out_of_space), 101);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 200);
+    BOOST_CHECK(!out_of_space);
+}
+
+BOOST_AUTO_TEST_CASE(flatfile_flush)
+{
+    auto data_dir = SetDataDir("flatfile_test");
+    FlatFileSeq seq(data_dir, "a", 100);
+
+    bool out_of_space;
+    seq.Allocate(FlatFilePos(0, 0), 1, out_of_space);
+
+    // Flush without finalize should not truncate file.
+    seq.Flush(FlatFilePos(0, 1));
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 100);
+
+    // Flush with finalize should truncate file.
+    seq.Flush(FlatFilePos(0, 1), true);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -135,12 +135,12 @@ bool DirIsWritable(const fs::path& directory)
     return true;
 }
 
-bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes)
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
 {
-    constexpr uint64_t nMinDiskSpace = 52428800; // 50 MiB
+    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
 
-    uint64_t nFreeBytesAvailable = fs::space(dir).available;
-    return nFreeBytesAvailable >= nMinDiskSpace + nAdditionalBytes;
+    uint64_t free_bytes_available = fs::space(dir).available;
+    return free_bytes_available >= min_disk_space + additional_bytes;
 }
 
 /**

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -135,6 +135,14 @@ bool DirIsWritable(const fs::path& directory)
     return true;
 }
 
+bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes)
+{
+    constexpr uint64_t nMinDiskSpace = 52428800; // 50 MiB
+
+    uint64_t nFreeBytesAvailable = fs::space(dir).available;
+    return nFreeBytesAvailable >= nMinDiskSpace + nAdditionalBytes;
+}
+
 /**
  * Interpret a string argument as a boolean.
  *

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -72,7 +72,7 @@ bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name);
 bool DirIsWritable(const fs::path& directory);
-bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes = 0);
+bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -72,6 +72,7 @@ bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name);
 bool DirIsWritable(const fs::path& directory);
+bool CheckDiskSpace(const fs::path& dir, uint64_t nAdditionalBytes = 0);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3014,21 +3014,13 @@ static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int
         vinfoBlockFile[nFile].nSize += nAddSize;
 
     if (!fKnown) {
-        unsigned int nOldChunks = (pos.nPos + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
-        unsigned int nNewChunks = (vinfoBlockFile[nFile].nSize + BLOCKFILE_CHUNK_SIZE - 1) / BLOCKFILE_CHUNK_SIZE;
-        if (nNewChunks > nOldChunks) {
-            if (fPruneMode)
-                fCheckForPruning = true;
-            if (CheckDiskSpace(GetBlocksDir(), nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos)) {
-                FILE *file = OpenBlockFile(pos);
-                if (file) {
-                    LogPrintf("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE, pos.nFile);
-                    AllocateFileRange(file, pos.nPos, nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos);
-                    fclose(file);
-                }
-            }
-            else
-                return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
+        bool out_of_space;
+        size_t bytes_allocated = BlockFileSeq().Allocate(pos, nAddSize, out_of_space);
+        if (out_of_space) {
+            return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
+        }
+        if (bytes_allocated != 0 && fPruneMode) {
+            fCheckForPruning = true;
         }
     }
 
@@ -3042,27 +3034,17 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
 
     LOCK(cs_LastBlockFile);
 
-    unsigned int nNewSize;
     pos.nPos = vinfoBlockFile[nFile].nUndoSize;
-    nNewSize = vinfoBlockFile[nFile].nUndoSize += nAddSize;
+    vinfoBlockFile[nFile].nUndoSize += nAddSize;
     setDirtyFileInfo.insert(nFile);
 
-    unsigned int nOldChunks = (pos.nPos + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
-    unsigned int nNewChunks = (nNewSize + UNDOFILE_CHUNK_SIZE - 1) / UNDOFILE_CHUNK_SIZE;
-    if (nNewChunks > nOldChunks) {
-        if (fPruneMode)
-            fCheckForPruning = true;
-        if (CheckDiskSpace(GetBlocksDir(), nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos)) {
-            FILE *file = OpenUndoFile(pos);
-            if (file) {
-                LogPrintf("Pre-allocating up to position 0x%x in rev%05u.dat\n", nNewChunks * UNDOFILE_CHUNK_SIZE, pos.nFile);
-                AllocateFileRange(file, pos.nPos, nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos);
-                fclose(file);
-            }
-        }
-        else {
-            return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
-        }
+    bool out_of_space;
+    size_t bytes_allocated = UndoFileSeq().Allocate(pos, nAddSize, out_of_space);
+    if (out_of_space) {
+        return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+    }
+    if (bytes_allocated != 0 && fPruneMode) {
+        fCheckForPruning = true;
     }
 
     return true;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2134,8 +2134,9 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
         // Write blocks and block index to disk.
         if (fDoFullFlush || fPeriodicWrite) {
             // Depend on nMinDiskSpace to ensure we can write block index
-            if (!CheckDiskSpace(0, true))
-                return state.Error("out of disk space");
+            if (!CheckDiskSpace(GetBlocksDir())) {
+                return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+            }
             // First make sure all block and undo data is flushed to disk.
             FlushBlockFile();
             // Then update all block file information (which may refer to block and undo files).
@@ -2168,8 +2169,9 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
             // twice (once in the log, and once in the tables). This is already
             // an overestimation, as most will delete an existing entry or
             // overwrite one. Still, use a conservative safety factor of 2.
-            if (!CheckDiskSpace(48 * 2 * 2 * pcoinsTip->GetCacheSize()))
-                return state.Error("out of disk space");
+            if (!CheckDiskSpace(GetDataDir(), 48 * 2 * 2 * pcoinsTip->GetCacheSize())) {
+                return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+            }
             // Flush the chainstate (which may refer to block index entries).
             if (!pcoinsTip->Flush())
                 return AbortNode(state, "Failed to write to coin database");
@@ -3014,7 +3016,7 @@ static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int
         if (nNewChunks > nOldChunks) {
             if (fPruneMode)
                 fCheckForPruning = true;
-            if (CheckDiskSpace(nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos, true)) {
+            if (CheckDiskSpace(GetBlocksDir(), nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos)) {
                 FILE *file = OpenBlockFile(pos);
                 if (file) {
                     LogPrintf("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE, pos.nFile);
@@ -3023,7 +3025,7 @@ static bool FindBlockPos(CDiskBlockPos &pos, unsigned int nAddSize, unsigned int
                 }
             }
             else
-                return error("out of disk space");
+                return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
         }
     }
 
@@ -3047,7 +3049,7 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
     if (nNewChunks > nOldChunks) {
         if (fPruneMode)
             fCheckForPruning = true;
-        if (CheckDiskSpace(nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos, true)) {
+        if (CheckDiskSpace(GetBlocksDir(), nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos)) {
             FILE *file = OpenUndoFile(pos);
             if (file) {
                 LogPrintf("Pre-allocating up to position 0x%x in rev%05u.dat\n", nNewChunks * UNDOFILE_CHUNK_SIZE, pos.nFile);
@@ -3055,8 +3057,9 @@ static bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, 
                 fclose(file);
             }
         }
-        else
-            return state.Error("out of disk space");
+        else {
+            return AbortNode(state, "Disk space is low!", _("Error: Disk space is low!"));
+        }
     }
 
     return true;
@@ -3761,17 +3764,6 @@ static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfte
            nPruneTarget/1024/1024, nCurrentUsage/1024/1024,
            ((int64_t)nPruneTarget - (int64_t)nCurrentUsage)/1024/1024,
            nLastBlockWeCanPrune, count);
-}
-
-bool CheckDiskSpace(uint64_t nAdditionalBytes, bool blocks_dir)
-{
-    uint64_t nFreeBytesAvailable = fs::space(blocks_dir ? GetBlocksDir() : GetDataDir()).available;
-
-    // Check for nMinDiskSpace bytes (currently 50MB)
-    if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
-        return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
-
-    return true;
 }
 
 static FILE* OpenDiskFile(const CDiskBlockPos &pos, const char *prefix, bool fReadOnly)

--- a/src/validation.h
+++ b/src/validation.h
@@ -243,11 +243,11 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex = nullptr, CBlockHeader* first_invalid = nullptr) LOCKS_EXCLUDED(cs_main);
 
 /** Open a block file (blk?????.dat) */
-FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
+FILE* OpenBlockFile(const FlatFilePos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos);
+fs::path GetBlockPosFilename(const FlatFilePos &pos);
 /** Import blocks from an external file */
-bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp = nullptr);
+bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, FlatFilePos *dbp = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */
 bool LoadGenesisBlock(const CChainParams& chainparams);
 /** Load the block tree and coins database from disk,
@@ -386,9 +386,9 @@ void InitScriptExecutionCache();
 
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus::Params& consensusParams);
+bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
-bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CDiskBlockPos& pos, const CMessageHeader::MessageStartChars& message_start);
+bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const CBlockIndex* pindex, const CMessageHeader::MessageStartChars& message_start);
 
 /** Functions for validating blocks and updating the block tree */

--- a/src/validation.h
+++ b/src/validation.h
@@ -181,9 +181,6 @@ extern arith_uint256 nMinimumChainWork;
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;
 
-/** Minimum disk space required - used in CheckDiskSpace() */
-static const uint64_t nMinDiskSpace = 52428800;
-
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */
 extern bool fHavePruned;
@@ -245,8 +242,6 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
  */
 bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, CValidationState& state, const CChainParams& chainparams, const CBlockIndex** ppindex = nullptr, CBlockHeader* first_invalid = nullptr) LOCKS_EXCLUDED(cs_main);
 
-/** Check whether enough disk space is available for an incoming block */
-bool CheckDiskSpace(uint64_t nAdditionalBytes = 0, bool blocks_dir = false);
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */

--- a/src/validation.h
+++ b/src/validation.h
@@ -245,7 +245,7 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& block, CValidationS
 /** Open a block file (blk?????.dat) */
 FILE* OpenBlockFile(const CDiskBlockPos &pos, bool fReadOnly = false);
 /** Translation to a filesystem path */
-fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
+fs::path GetBlockPosFilename(const CDiskBlockPos &pos);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskBlockPos *dbp = nullptr);
 /** Ensures we have a genesis block in the block tree, possibly writing one to disk. */


### PR DESCRIPTION
This cleans up and refactors block file helpers so that they may be used by the block filter indexer. Per [design discussion](https://github.com/bitcoin/bitcoin/pull/14121#issuecomment-451252591) about storing BIP 157 block filters, it has been suggested that they are stored in the same way as block and undo data. This refactor is sufficient to simplify file operations for this use case, though in the future perhaps more pruning-related logic ought to be moved into the new classes.

The basic abstraction is a `FlatFileSeq` which manages access to a sequence of numbered files into which raw data is written.
