### PR TITLE
rpc: Added ability to remove watch only addresses

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4137,6 +4137,7 @@ UniValue dumpwallet(const JSONRPCRequest& request);
 UniValue importwallet(const JSONRPCRequest& request);
 UniValue importprunedfunds(const JSONRPCRequest& request);
 UniValue removeprunedfunds(const JSONRPCRequest& request);
+UniValue removeaddress(const JSONRPCRequest& request);
 UniValue importmulti(const JSONRPCRequest& request);
 
 // clang-format off
@@ -4184,6 +4185,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "listwallets",                      &listwallets,                   {} },
     { "wallet",             "loadwallet",                       &loadwallet,                    {"filename"} },
     { "wallet",             "lockunspent",                      &lockunspent,                   {"unlock","transactions"} },
+    { "wallet",             "removeaddress",                    &removeaddress,                 {"address","rescan"} },
     { "wallet",             "removeprunedfunds",                &removeprunedfunds,             {"txid"} },
     { "wallet",             "rescanblockchain",                 &rescanblockchain,              {"start_height", "stop_height"} },
     { "wallet",             "sendmany",                         &sendmany,                      {"dummy","amounts","minconf","comment","subtractfeefrom","replaceable","conf_target","estimate_mode"} },

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -894,6 +894,7 @@ public:
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
+    bool CWallet::RemoveFromWallet(const CTransaction& tx);
     void LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;


### PR DESCRIPTION
I added a new rpc call that allows you to remove a watch only address

Format:
`removeaddress address ( rescan )`
