### PR TITLE
docs: Fix download link in doc/README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -5,7 +5,7 @@ Setup
 ---------------------
 Bitcoin Core is the original Bitcoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of Bitcoin transactions, which requires a few hundred gigabytes of disk space. Depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
-To download Bitcoin Core, visit [bitcoincore.org](https://bitcoincore.org/en/releases/).
+To download Bitcoin Core, visit [bitcoincore.org](https://bitcoincore.org/en/download/).
 
 Running
 ---------------------


### PR DESCRIPTION
The document currently refers readers to bitcoincore.org at **/en/releases/** for downloads. It makes more sense to point them to  **/en/download/**, which is the main page for downloads. 
That page also includes a link to **/en/releases/** for those interested in the release history.

This commit is also included in #14787, which has not been getting much attention. (Maybe it was trying to do too much...) 