### PR TITLE
rpc: Added ability to remove watch only addresses

### DIFF
--- a/doc/release-notes-15129.md
+++ b/doc/release-notes-15129.md
@@ -1,0 +1,4 @@
+New RPCs
+--------
+- A new `removeaddress` RPC will remove a watch only address or script
+  from the current wallet. (#15129)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -138,6 +138,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importprivkey", 2, "rescan" },
     { "importaddress", 2, "rescan" },
     { "importaddress", 3, "p2sh" },
+    { "removeaddress", 1, "p2sh" },
+    { "removeaddress", 2, "purge_transactions" },
     { "importpubkey", 2, "rescan" },
     { "importmulti", 0, "requests" },
     { "importmulti", 1, "options" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4690,6 +4690,7 @@ RPCHelpMan abortrescan();
 RPCHelpMan dumpprivkey();
 RPCHelpMan importprivkey();
 RPCHelpMan importaddress();
+RPCHelpMan removeaddress();
 RPCHelpMan importpubkey();
 RPCHelpMan dumpwallet();
 RPCHelpMan importwallet();
@@ -4749,6 +4750,7 @@ static const CRPCCommand commands[] =
     { "wallet",             &listwallets,                    },
     { "wallet",             &loadwallet,                     },
     { "wallet",             &lockunspent,                    },
+    { "wallet",             &removeaddress,                  },
     { "wallet",             &removeprunedfunds,              },
     { "wallet",             &rescanblockchain,               },
     { "wallet",             &send,                           },

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -882,6 +882,35 @@ bool LegacyScriptPubKeyMan::RemoveWatchOnly(const CScript &dest)
     return true;
 }
 
+bool LegacyScriptPubKeyMan::PurgeWatchOnly(const CScript& dest)
+{
+    {
+        LOCK(cs_KeyStore);
+        setWatchOnly.erase(dest);
+        CPubKey pubKey;
+        if (ExtractPubKey(dest, pubKey)) {
+            CKeyID key_id = pubKey.GetID();
+            mapWatchKeys.erase(key_id);
+            mapKeyMetadata.erase(key_id);
+            if (pubKey.IsCompressed()) {
+                CScript script = GetScriptForDestination(WitnessV0KeyHash(key_id));
+                CScriptID id(script);
+                mapScripts.erase(id);
+                m_script_metadata.erase(id);
+            }
+        }
+    }
+
+    if (!HaveWatchOnly()) {
+        NotifyWatchonlyChanged(false);
+    }
+    if (!WalletBatch(m_storage.GetDatabase()).EraseWatchOnly(dest)) {
+        return false;
+    }
+
+    return true;
+}
+
 bool LegacyScriptPubKeyMan::LoadWatchOnly(const CScript &dest)
 {
     return AddWatchOnlyInMem(dest);

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -440,6 +440,8 @@ public:
     bool HaveWatchOnly() const;
     //! Remove a watch only script from the keystore
     bool RemoveWatchOnly(const CScript &dest);
+    //! Remove a watch only script and superfluous scripts from the keystore
+    bool PurgeWatchOnly(const CScript& dest);
     bool AddWatchOnly(const CScript& dest, int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
     //! Fetches a pubkey from mapWatchKeys if it exists there

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -507,6 +507,8 @@ public:
     int64_t IncOrderPosNext(WalletBatch *batch = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     DBErrors ReorderTransactions();
 
+    void RemoveTransactions(const CScript& script);
+
     void MarkDirty();
 
     //! Callback for updating transaction metadata in mapWallet.


### PR DESCRIPTION
I added a new rpc call that allows you to remove a watch only address

Format:
`removeaddress address/script (p2sh) (purgetransactions)`