### PR TITLE
wallet: Added function to remove transactions that are no longer in wallet

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -894,6 +894,7 @@ public:
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx& wtxIn, bool fFlushOnClose=true);
+    bool RemoveFromWallet(const CTransaction& tx);
     void LoadToWallet(const CWalletTx& wtxIn) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void TransactionAddedToMempool(const CTransactionRef& tx) override;
     void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex *pindex, const std::vector<CTransactionRef>& vtxConflicted) override;


### PR DESCRIPTION
When rescanning a wallet for transactions, it will remove transactions that are no longer in the wallet.

Required for #15129