### PR TITLE
tests: Switch one of the Travis jobs to an unsigned char environment (-funsigned-char)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,14 +116,14 @@ jobs:
         CONFIG_SHELL="/bin/dash"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout]'
+      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout] [unsigned char]'
       env: >-
         HOST=x86_64-unknown-linux-gnu
         PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
         DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
         TEST_RUNNER_EXTRA="--coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
         GOAL="install"
-        BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug CXXFLAGS=\"-g0 -O2\""
+        BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug CFLAGS=\"-g0 -O2 -funsigned-char\" CXXFLAGS=\"-g0 -O2 -funsigned-char\""
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [trusty]  [no functional tests, no depends, only system libs]'


### PR DESCRIPTION
Switch one of the Travis jobs to an unsigned char environment (`-funsigned-char`).

This will help us catch errors due to code written under the assumption that `char` has the same value range as `signed char`.

The signedness of `char` is implementation-defined.

Example:

```
$ uname -a
Linux […] x86_64 x86_64 x86_64 GNU/Linux
$ cat foo.cpp
#include <iostream>

int main() {
    char c;
    std::cin >> c;
    int i = (unsigned char)c;
    std::cout << i << "\n";
}
$ clang++ -o foo foo.cpp
$ echo -e "\xff" | ./foo
255
$ clang++ -fsigned-char -o foo foo.cpp
$ echo -e "\xff" | ./foo
255
$ clang++ -funsigned-char -o foo foo.cpp
$ echo -e "\xff" | ./foo
255
$ cat bar.cpp
#include <iostream>

int main() {
    char c;
    std::cin >> c;
    int i = c;
    std::cout << i << "\n";
}
$ clang++ -o bar bar.cpp
$ echo -e "\xff" | ./bar
-1
$ clang++ -fsigned-char -o bar bar.cpp
$ echo -e "\xff" | ./bar
-1
$ clang++ -funsigned-char -o bar bar.cpp
$ echo -e "\xff" | ./bar
255
```

`gcc` chars:
* signed: alpha, hppa, ia64, m68k, mips, sh, sparc, x86
* unsigned: arm, powerpc, s390

About `-funsigned-char`:

> Let the type "char" be unsigned, like "unsigned char".
> 
> Each kind of machine has a default for what "char" should be.  It is either like "unsigned char" by default or like "signed char" by default.
> 
> Ideally, a portable program should always use "signed char" or "unsigned char" when it depends on the signedness of an object.  But many programs have been written to use plain "char" and expect it to be signed, or expect it to be unsigned, depending on the machines they were written for.
> 
> This option, and its inverse, let you make such a program work with the opposite default. The type "char" is always a distinct type from each of "signed char" or "unsigned char", even though its behavior is always just like one of those two.
