### PR TITLE
Drop IsLimited in favor of IsReachable

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1321,7 +1321,7 @@ bool AppInitMain(InitInterfaces& interfaces)
         for (int n = 0; n < NET_MAX; n++) {
             enum Network net = (enum Network)n;
             if (!nets.count(net))
-                SetLimited(net);
+                SetReachable(net, false);
         }
     }
 
@@ -1332,7 +1332,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     // -proxy sets a proxy for all outgoing network traffic
     // -noproxy (or -proxy=0) as well as the empty string can be used to not set a proxy, this is the default
     std::string proxyArg = gArgs.GetArg("-proxy", "");
-    SetLimited(NET_ONION);
+    SetReachable(NET_ONION, false);
     if (proxyArg != "" && proxyArg != "0") {
         CService proxyAddr;
         if (!Lookup(proxyArg.c_str(), proxyAddr, 9050, fNameLookup)) {
@@ -1347,7 +1347,7 @@ bool AppInitMain(InitInterfaces& interfaces)
         SetProxy(NET_IPV6, addrProxy);
         SetProxy(NET_ONION, addrProxy);
         SetNameProxy(addrProxy);
-        SetLimited(NET_ONION, false); // by default, -proxy sets onion as reachable, unless -noonion later
+        SetReachable(NET_ONION, true); // by default, -proxy sets onion as reachable, unless -noonion later
     }
 
     // -onion can be used to set only a proxy for .onion, or override normal proxy for .onion addresses
@@ -1356,7 +1356,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     std::string onionArg = gArgs.GetArg("-onion", "");
     if (onionArg != "") {
         if (onionArg == "0") { // Handle -noonion/-onion=0
-            SetLimited(NET_ONION); // set onions as unreachable
+            SetReachable(NET_ONION, false);
         } else {
             CService onionProxy;
             if (!Lookup(onionArg.c_str(), onionProxy, 9050, fNameLookup)) {
@@ -1366,7 +1366,7 @@ bool AppInitMain(InitInterfaces& interfaces)
             if (!addrOnion.IsValid())
                 return InitError(strprintf(_("Invalid -onion address or hostname: '%s'"), onionArg));
             SetProxy(NET_ONION, addrOnion);
-            SetLimited(NET_ONION, false);
+            SetReachable(NET_ONION, true);
         }
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -520,17 +520,23 @@ enum
 
 bool IsPeerAddrLocalGood(CNode *pnode);
 void AdvertiseLocal(CNode *pnode);
-void SetLimited(enum Network net, bool fLimited = true);
-bool IsLimited(enum Network net);
-bool IsLimited(const CNetAddr& addr);
+
+/**
+ * Mark a network as reachable or unreachable (no automatic connects to it)
+ * @note Networks are reachable by default
+ */
+void SetReachable(enum Network net, bool reachable);
+/** @returns true if the network is reachable, false otherwise */
+bool IsReachable(enum Network net);
+/** @returns true if the address is in a reachable network, false otherwise */
+bool IsReachable(const CNetAddr& addr);
+
 bool AddLocal(const CService& addr, int nScore = LOCAL_NONE);
 bool AddLocal(const CNetAddr& addr, int nScore = LOCAL_NONE);
 void RemoveLocal(const CService& addr);
 bool SeenLocal(const CService& addr);
 bool IsLocal(const CService& addr);
 bool GetLocal(CService &addr, const CNetAddr *paddrPeer = nullptr);
-bool IsReachable(enum Network net);
-bool IsReachable(const CNetAddr &addr);
 CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices);
 
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -423,7 +423,7 @@ static UniValue GetNetworksInfo()
         UniValue obj(UniValue::VOBJ);
         GetProxy(network, proxy);
         obj.pushKV("name", GetNetworkName(network));
-        obj.pushKV("limited", IsLimited(network));
+        obj.pushKV("limited", !IsReachable(network));
         obj.pushKV("reachable", IsReachable(network));
         obj.pushKV("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : std::string());
         obj.pushKV("proxy_randomize_credentials", proxy.randomize_credentials);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -230,26 +230,21 @@ BOOST_AUTO_TEST_CASE(ipv4_peer_with_ipv6_addrMe_test)
 
 BOOST_AUTO_TEST_CASE(LimitedAndReachable_Network)
 {
-    SetLimited(NET_IPV4, true);
-    SetLimited(NET_IPV6, true);
-    SetLimited(NET_ONION, true);
+    BOOST_CHECK_EQUAL(IsReachable(NET_IPV4), true);
+    BOOST_CHECK_EQUAL(IsReachable(NET_IPV6), true);
+    BOOST_CHECK_EQUAL(IsReachable(NET_ONION), true);
 
-    BOOST_CHECK_EQUAL(IsLimited(NET_IPV4), true);
-    BOOST_CHECK_EQUAL(IsLimited(NET_IPV6), true);
-    BOOST_CHECK_EQUAL(IsLimited(NET_ONION), true);
+    SetReachable(NET_IPV4, false);
+    SetReachable(NET_IPV6, false);
+    SetReachable(NET_ONION, false);
 
     BOOST_CHECK_EQUAL(IsReachable(NET_IPV4), false);
     BOOST_CHECK_EQUAL(IsReachable(NET_IPV6), false);
     BOOST_CHECK_EQUAL(IsReachable(NET_ONION), false);
 
-
-    SetLimited(NET_IPV4, false);
-    SetLimited(NET_IPV6, false);
-    SetLimited(NET_ONION, false);
-
-    BOOST_CHECK_EQUAL(IsLimited(NET_IPV4), false);
-    BOOST_CHECK_EQUAL(IsLimited(NET_IPV6), false);
-    BOOST_CHECK_EQUAL(IsLimited(NET_ONION), false);
+    SetReachable(NET_IPV4, true);
+    SetReachable(NET_IPV6, true);
+    SetReachable(NET_ONION, true);
 
     BOOST_CHECK_EQUAL(IsReachable(NET_IPV4), true);
     BOOST_CHECK_EQUAL(IsReachable(NET_IPV6), true);
@@ -258,19 +253,13 @@ BOOST_AUTO_TEST_CASE(LimitedAndReachable_Network)
 
 BOOST_AUTO_TEST_CASE(LimitedAndReachable_NetworkCaseUnroutableAndInternal)
 {
-    BOOST_CHECK_EQUAL(IsLimited(NET_UNROUTABLE), false);
-    BOOST_CHECK_EQUAL(IsLimited(NET_INTERNAL), false);
-
     BOOST_CHECK_EQUAL(IsReachable(NET_UNROUTABLE), true);
     BOOST_CHECK_EQUAL(IsReachable(NET_INTERNAL), true);
 
-    SetLimited(NET_UNROUTABLE, true);
-    SetLimited(NET_INTERNAL, true);
+    SetReachable(NET_UNROUTABLE, false);
+    SetReachable(NET_INTERNAL, false);
 
-    BOOST_CHECK_EQUAL(IsLimited(NET_UNROUTABLE), false); // Ignored for both networks
-    BOOST_CHECK_EQUAL(IsLimited(NET_INTERNAL), false);
-
-    BOOST_CHECK_EQUAL(IsReachable(NET_UNROUTABLE), true);
+    BOOST_CHECK_EQUAL(IsReachable(NET_UNROUTABLE), true); // Ignored for both networks
     BOOST_CHECK_EQUAL(IsReachable(NET_INTERNAL), true);
 }
 
@@ -289,15 +278,13 @@ BOOST_AUTO_TEST_CASE(LimitedAndReachable_CNetAddr)
 {
     CNetAddr addr = UtilBuildAddress(0x001, 0x001, 0x001, 0x001); // 1.1.1.1
 
-    SetLimited(NET_IPV4, false);
-    BOOST_CHECK_EQUAL(IsLimited(addr), false);
+    SetReachable(NET_IPV4, true);
     BOOST_CHECK_EQUAL(IsReachable(addr), true);
 
-    SetLimited(NET_IPV4, true);
-    BOOST_CHECK_EQUAL(IsLimited(addr), true);
+    SetReachable(NET_IPV4, false);
     BOOST_CHECK_EQUAL(IsReachable(addr), false);
 
-    SetLimited(NET_IPV4, false); // have to reset this, because this is stateful.
+    SetReachable(NET_IPV4, true); // have to reset this, because this is stateful.
 }
 
 
@@ -305,7 +292,7 @@ BOOST_AUTO_TEST_CASE(LocalAddress_BasicLifecycle)
 {
     CService addr = CService(UtilBuildAddress(0x002, 0x001, 0x001, 0x001), 1000); // 2.1.1.1:1000
 
-    SetLimited(NET_IPV4, false);
+    SetReachable(NET_IPV4, true);
 
     BOOST_CHECK_EQUAL(IsLocal(addr), false);
     BOOST_CHECK_EQUAL(AddLocal(addr, 1000), true);

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -527,7 +527,7 @@ void TorController::auth_cb(TorControlConnection& _conn, const TorControlReply& 
             CService resolved(LookupNumeric("127.0.0.1", 9050));
             proxyType addrOnion = proxyType(resolved, true);
             SetProxy(NET_ONION, addrOnion);
-            SetLimited(NET_ONION, false);
+            SetReachable(NET_ONION, true);
         }
 
         // Finally - now create the service


### PR DESCRIPTION
These two methods have had the same meaning, but inverted, since
110b62f06992d0fb989153afff2dc3aea62a674f. Having one name for a single
concept simplifies the code.

This is a follow-up to #15051.
/cc #7553 