### PR TITLE
util: Remove [U](BEGIN|END) macros

### DIFF
--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -53,7 +53,7 @@ uint256 CPartialMerkleTree::CalcHash(int height, unsigned int pos, const std::ve
         else
             right = left;
         // combine subhashes
-        return Hash(BEGIN(left), END(left), BEGIN(right), END(right));
+        return Hash(left.begin(), left.end(), right.begin(), right.end());
     }
 }
 
@@ -109,7 +109,7 @@ uint256 CPartialMerkleTree::TraverseAndExtract(int height, unsigned int pos, uns
             right = left;
         }
         // and combine them before returning
-        return Hash(BEGIN(left), END(left), BEGIN(right), END(right));
+        return Hash(left.begin(), left.end(), right.begin(), right.end());
     }
 }
 

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -13,9 +13,9 @@ static uint256 ComputeMerkleRootFromBranch(const uint256& leaf, const std::vecto
     uint256 hash = leaf;
     for (std::vector<uint256>::const_iterator it = vMerkleBranch.begin(); it != vMerkleBranch.end(); ++it) {
         if (nIndex & 1) {
-            hash = Hash(BEGIN(*it), END(*it), BEGIN(hash), END(hash));
+            hash = Hash(it->begin(), it->end(), hash.begin(), hash.end());
         } else {
-            hash = Hash(BEGIN(hash), END(hash), BEGIN(*it), END(*it));
+            hash = Hash(hash.begin(), hash.end(), it->begin(), it->end());
         }
         nIndex >>= 1;
     }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1224,7 +1224,7 @@ BOOST_AUTO_TEST_CASE(test_ToLower)
     BOOST_CHECK_EQUAL(ToLower('Z'), 'z');
     BOOST_CHECK_EQUAL(ToLower('['), '[');
     BOOST_CHECK_EQUAL(ToLower(0), 0);
-    BOOST_CHECK_EQUAL(ToLower(255), 255);
+    BOOST_CHECK_EQUAL(ToLower('\xff'), '\xff');
 
     std::string testVector;
     Downcase(testVector);
@@ -1246,7 +1246,7 @@ BOOST_AUTO_TEST_CASE(test_ToUpper)
     BOOST_CHECK_EQUAL(ToUpper('z'), 'Z');
     BOOST_CHECK_EQUAL(ToUpper('{'), '{');
     BOOST_CHECK_EQUAL(ToUpper(0), 0);
-    BOOST_CHECK_EQUAL(ToUpper(255), 255);
+    BOOST_CHECK_EQUAL(ToUpper('\xff'), '\xff');
 }
 
 BOOST_AUTO_TEST_CASE(test_Capitalize)

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -33,7 +33,7 @@ void base_blob<BITS>::SetHex(const char* psz)
         psz++;
 
     // skip 0x
-    if (psz[0] == '0' && ToLower((unsigned char)psz[1]) == 'x')
+    if (psz[0] == '0' && ToLower(psz[1]) == 'x')
         psz += 2;
 
     // hex string to uint

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -589,7 +589,7 @@ bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypa
 
 void Downcase(std::string& str)
 {
-    std::transform(str.begin(), str.end(), str.begin(), [](unsigned char c){return ToLower(c);});
+    std::transform(str.begin(), str.end(), str.begin(), [](char c){return ToLower(c);});
 }
 
 std::string Capitalize(std::string str)

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -208,7 +208,7 @@ NODISCARD bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32
  * @return          the lowercase equivalent of c; or the argument
  *                  if no conversion is possible.
  */
-constexpr unsigned char ToLower(unsigned char c)
+constexpr char ToLower(char c)
 {
     return (c >= 'A' && c <= 'Z' ? (c - 'A') + 'a' : c);
 }
@@ -229,7 +229,7 @@ void Downcase(std::string& str);
  * @return          the uppercase equivalent of c; or the argument
  *                  if no conversion is possible.
  */
-constexpr unsigned char ToUpper(unsigned char c)
+constexpr char ToUpper(char c)
 {
     return (c >= 'a' && c <= 'z' ? (c - 'a') + 'A' : c);
 }

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -15,10 +15,6 @@
 #include <string>
 #include <vector>
 
-#define BEGIN(a)            ((char*)&(a))
-#define END(a)              ((char*)&((&(a))[1]))
-#define UBEGIN(a)           ((unsigned char*)&(a))
-#define UEND(a)             ((unsigned char*)&((&(a))[1]))
 #define ARRAYLEN(array)     (sizeof(array)/sizeof((array)[0]))
 
 /** Used by SanitizeString() */


### PR DESCRIPTION
Two cleanups in `util/strencodings.h`:

- Remove `[U](BEGIN|END)` macros — The only use of these was in the Merkle tree code with `uint256` which has its own `begin` and `end` methods which are better.
- Make ToLower and ToUpper take a char — Unfortunately, `std::string` elements are (bare) chars. As these are the most likely type to be passed to these functions, make them use char instead of unsigned char. This avoids some casts.