### PR TITLE
test: fix script_p2sh_tests OP_PUSHBACK2/4 missing

### DIFF
--- a/src/test/script_p2sh_tests.cpp
+++ b/src/test/script_p2sh_tests.cpp
@@ -237,10 +237,10 @@ BOOST_AUTO_TEST_CASE(is)
     //---------><----- cut here
 
     // orig version loopified, and using both interfaces (string and stream)
-    std::vector<std::vector<unsigned char>>
-     scripts = {{OP_HASH160, OP_PUSHDATA1, 20}, // 8bit
-                {OP_HASH160, OP_PUSHDATA2, 20,0}, // 16bit
-                {OP_HASH160, OP_PUSHDATA4, 20,0,0,0}}; // 32bit
+    std::vector<std::vector<unsigned char>> scripts = {
+        {OP_HASH160, OP_PUSHDATA1, 20},        // 8bit
+        {OP_HASH160, OP_PUSHDATA2, 20,0},      // 16bit
+        {OP_HASH160, OP_PUSHDATA4, 20,0,0,0}}; // 32bit
     std::vector<unsigned char> dum;
     dum.insert(dum.end(), 20, 0); // make an 160bit dummy
     for(auto &script: scripts)


### PR DESCRIPTION
Fixes commit 6b25f29a91 where opcodes where probably lost in translation.

Made two versions, the looped test using the '<<' operator also (stream api).
