### PR TITLE
gui: Add Open Wallet menu

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -8,6 +8,10 @@
 
 class CWallet;
 
+namespace interfaces {
+class Chain;
+}
+
 class DummyWalletInit : public WalletInitInterface {
 public:
 
@@ -39,6 +43,11 @@ std::vector<fs::path> ListWalletDir()
 }
 
 std::vector<std::shared_ptr<CWallet>> GetWallets()
+{
+    throw std::logic_error("Wallet function called in non-wallet build.");
+}
+
+std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const std::string& name, std::string& error, std::string& warning)
 {
     throw std::logic_error("Wallet function called in non-wallet build.");
 }

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -42,6 +42,7 @@ class CWallet;
 fs::path GetWalletDir();
 std::vector<fs::path> ListWalletDir();
 std::vector<std::shared_ptr<CWallet>> GetWallets();
+std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const std::string& name, std::string& error, std::string& warning);
 
 namespace interfaces {
 
@@ -251,6 +252,10 @@ public:
             wallets.emplace_back(MakeWallet(wallet));
         }
         return wallets;
+    }
+    std::unique_ptr<Wallet> loadWallet(const std::string& name, std::string& error, std::string& warning) override
+    {
+        return MakeWallet(LoadWallet(*m_interfaces.chain, name, error, warning));
     }
     std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) override
     {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -192,6 +192,11 @@ public:
     //! Return interfaces for accessing wallets (if any).
     virtual std::vector<std::unique_ptr<Wallet>> getWallets() = 0;
 
+    //! Attempts to load a wallet from file or directory.
+    //! The loaded wallet is also notified to handlers previously registered
+    //! with handleLoadWallet.
+    virtual std::unique_ptr<Wallet> loadWallet(const std::string& name, std::string& error, std::string& warning) = 0;
+
     //! Register handler for init messages.
     using InitMessageFn = std::function<void(const std::string& message)>;
     virtual std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) = 0;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -523,7 +523,7 @@ public:
 
 } // namespace
 
-std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet) { return MakeUnique<WalletImpl>(wallet); }
+std::unique_ptr<Wallet> MakeWallet(const std::shared_ptr<CWallet>& wallet) { return wallet ? MakeUnique<WalletImpl>(wallet) : nullptr; }
 
 std::unique_ptr<ChainClient> MakeWalletClient(Chain& chain, std::vector<std::string> wallet_filenames)
 {

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -456,7 +456,7 @@ int GuiMain(int argc, char* argv[])
     //   IMPORTANT if it is no longer a typedef use the normal variant above
     qRegisterMetaType< CAmount >("CAmount");
     qRegisterMetaType< std::function<void()> >("std::function<void()>");
-
+    qRegisterMetaType<QMessageBox::Icon>("QMessageBox::Icon");
     /// 2. Parse command-line options. We do this after qt in order to show an error if there are problems parsing these
     // Command-line options take precedence:
     node->setupServerArgs();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -334,6 +334,10 @@ void BitcoinGUI::createActions()
     openAction = new QAction(platformStyle->TextColorIcon(":/icons/open"), tr("Open &URI..."), this);
     openAction->setStatusTip(tr("Open a bitcoin: URI or payment request"));
 
+    m_open_wallet_action = new QAction(tr("Open Wallet"), this);
+    m_open_wallet_action->setMenu(new QMenu(this));
+    m_open_wallet_action->setStatusTip(tr("Open a wallet"));
+
     showHelpMessageAction = new QAction(platformStyle->TextColorIcon(":/icons/info"), tr("&Command-line options"), this);
     showHelpMessageAction->setMenuRole(QAction::NoRole);
     showHelpMessageAction->setStatusTip(tr("Show the %1 help message to get a list with possible Bitcoin command-line options").arg(tr(PACKAGE_NAME)));
@@ -361,6 +365,16 @@ void BitcoinGUI::createActions()
         connect(usedSendingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedSendingAddresses);
         connect(usedReceivingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedReceivingAddresses);
         connect(openAction, &QAction::triggered, this, &BitcoinGUI::openClicked);
+        connect(m_open_wallet_action->menu(), &QMenu::aboutToShow, [this] {
+            m_open_wallet_action->menu()->clear();
+            for (std::string path : m_wallet_controller->getWalletsAvailableToOpen()) {
+                QString name = path.empty() ? QString("["+tr("default wallet")+"]") : QString::fromStdString(path);
+                QAction* action = m_open_wallet_action->menu()->addAction(name);
+                connect(action, &QAction::triggered, [this, path] {
+                    setCurrentWallet(m_wallet_controller->openWallet(path));
+                });
+            }
+        });
     }
 #endif // ENABLE_WALLET
 
@@ -382,6 +396,8 @@ void BitcoinGUI::createMenuBar()
     QMenu *file = appMenuBar->addMenu(tr("&File"));
     if(walletFrame)
     {
+        file->addAction(m_open_wallet_action);
+        file->addSeparator();
         file->addAction(openAction);
         file->addAction(backupWalletAction);
         file->addAction(signMessageAction);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -371,7 +371,9 @@ void BitcoinGUI::createActions()
                 QString name = path.empty() ? QString("["+tr("default wallet")+"]") : QString::fromStdString(path);
                 QAction* action = m_open_wallet_action->menu()->addAction(name);
                 connect(action, &QAction::triggered, [this, path] {
-                    setCurrentWallet(m_wallet_controller->openWallet(path));
+                    OpenWalletActivity* activity = m_wallet_controller->openWallet(path);
+                    connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet);
+                    connect(activity, &OpenWalletActivity::finished, activity, &QObject::deleteLater);
                 });
             }
         });

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -147,6 +147,7 @@ private:
     QAction* openRPCConsoleAction = nullptr;
     QAction* openAction = nullptr;
     QAction* showHelpMessageAction = nullptr;
+    QAction* m_open_wallet_action{nullptr};
     QAction* m_wallet_selector_label_action = nullptr;
     QAction* m_wallet_selector_action = nullptr;
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -55,17 +55,12 @@ std::vector<std::string> WalletController::getWalletsAvailableToOpen() const
     return wallets;
 }
 
-WalletModel* WalletController::openWallet(const std::string& name, QWidget* parent)
+OpenWalletActivity* WalletController::openWallet(const std::string& name, QWidget* parent)
 {
-    std::string error, warning;
-    WalletModel* wallet_model = getOrCreateWallet(m_node.loadWallet(name, error, warning));
-    if (!wallet_model) {
-        QMessageBox::warning(parent, tr("Open Wallet"), QString::fromStdString(error));
-    }
-    if (!warning.empty()) {
-        QMessageBox::information(parent, tr("Open Wallet"), QString::fromStdString(warning));
-    }
-    return wallet_model;
+    OpenWalletActivity* activity = new OpenWalletActivity(this, name);
+    activity->moveToThread(&m_activity_thread);
+    QMetaObject::invokeMethod(activity, "open", Qt::QueuedConnection);
+    return activity;
 }
 
 WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wallet> wallet)
@@ -123,4 +118,25 @@ void WalletController::removeAndDeleteWallet(WalletModel* wallet_model)
     // Currently this can trigger the unload since the model can hold the last
     // CWallet shared pointer.
     delete wallet_model;
+}
+
+
+OpenWalletActivity::OpenWalletActivity(WalletController* wallet_controller, const std::string& name)
+    : m_wallet_controller(wallet_controller)
+    , m_name(name)
+{}
+
+void OpenWalletActivity::open()
+{
+    std::string error, warning;
+    std::unique_ptr<interfaces::Wallet> wallet = m_wallet_controller->m_node.loadWallet(m_name, error, warning);
+    if (!warning.empty()) {
+        Q_EMIT message(QMessageBox::Warning, QString::fromStdString(warning));
+    }
+    if (wallet) {
+        Q_EMIT opened(m_wallet_controller->getOrCreateWallet(std::move(wallet)));
+    } else {
+        Q_EMIT message(QMessageBox::Critical, QString::fromStdString(error));
+    }
+    Q_EMIT finished();
 }

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -26,11 +26,17 @@ WalletController::WalletController(interfaces::Node& node, const PlatformStyle* 
     for (std::unique_ptr<interfaces::Wallet>& wallet : m_node.getWallets()) {
         getOrCreateWallet(std::move(wallet));
     }
+
+    m_activity_thread.start();
 }
 
 // Not using the default destructor because not all member types definitions are
 // available in the header, just forward declared.
-WalletController::~WalletController() {}
+WalletController::~WalletController()
+{
+    m_activity_thread.quit();
+    m_activity_thread.wait();
+}
 
 std::vector<WalletModel*> WalletController::getWallets() const
 {

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <QMutex>
+#include <QThread>
 
 class OptionsModel;
 class PlatformStyle;
@@ -51,6 +52,7 @@ Q_SIGNALS:
     void coinsSent(WalletModel* wallet_model, SendCoinsRecipient recipient, QByteArray transaction);
 
 private:
+    QThread m_activity_thread;
     interfaces::Node& m_node;
     const PlatformStyle* const m_platform_style;
     OptionsModel* const m_options_model;

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -12,6 +12,7 @@
 #include <memory>
 #include <vector>
 
+#include <QMessageBox>
 #include <QMutex>
 #include <QThread>
 
@@ -22,6 +23,8 @@ namespace interfaces {
 class Handler;
 class Node;
 } // namespace interfaces
+
+class OpenWalletActivity;
 
 /**
  * Controller between interfaces::Node, WalletModel instances and the GUI.
@@ -40,7 +43,7 @@ public:
     std::vector<WalletModel*> getWallets() const;
     std::vector<std::string> getWalletsAvailableToOpen() const;
 
-    WalletModel* openWallet(const std::string& name, QWidget* parent = nullptr);
+    OpenWalletActivity* openWallet(const std::string& name, QWidget* parent = nullptr);
 
 private Q_SLOTS:
     void addWallet(WalletModel* wallet_model);
@@ -59,6 +62,28 @@ private:
     mutable QMutex m_mutex;
     std::vector<WalletModel*> m_wallets;
     std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
+
+    friend class OpenWalletActivity;
+};
+
+class OpenWalletActivity : public QObject
+{
+    Q_OBJECT
+
+public:
+    OpenWalletActivity(WalletController* wallet_controller, const std::string& name);
+
+public Q_SLOTS:
+    void open();
+
+Q_SIGNALS:
+    void message(QMessageBox::Icon icon, const QString text);
+    void finished();
+    void opened(WalletModel* wallet_model);
+
+private:
+    WalletController* const m_wallet_controller;
+    std::string const m_name;
 };
 
 #endif // BITCOIN_QT_WALLETCONTROLLER_H

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -37,6 +37,9 @@ public:
     ~WalletController();
 
     std::vector<WalletModel*> getWallets() const;
+    std::vector<std::string> getWalletsAvailableToOpen() const;
+
+    WalletModel* openWallet(const std::string& name, QWidget* parent = nullptr);
 
 private Q_SLOTS:
     void addWallet(WalletModel* wallet_model);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2544,7 +2544,6 @@ static UniValue loadwallet(const JSONRPCRequest& request)
             }.ToString());
 
     WalletLocation location(request.params[0].get_str());
-    std::string error;
 
     if (!location.Exists()) {
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Wallet " + location.GetName() + " not found.");
@@ -2556,18 +2555,9 @@ static UniValue loadwallet(const JSONRPCRequest& request)
         }
     }
 
-    std::string warning;
-    if (!CWallet::Verify(*g_rpc_interfaces->chain, location, false, error, warning)) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet file verification failed: " + error);
-    }
-
-    std::shared_ptr<CWallet> const wallet = CWallet::CreateWalletFromFile(*g_rpc_interfaces->chain, location);
-    if (!wallet) {
-        throw JSONRPCError(RPC_WALLET_ERROR, "Wallet loading failed.");
-    }
-    AddWallet(wallet);
-
-    wallet->postInitProcess();
+    std::string error, warning;
+    std::shared_ptr<CWallet> const wallet = LoadWallet(*g_rpc_interfaces->chain, location, error, warning);
+    if (!wallet) throw JSONRPCError(RPC_WALLET_ERROR, error);
 
     UniValue obj(UniValue::VOBJ);
     obj.pushKV("name", wallet->GetName());

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -130,6 +130,28 @@ void UnloadWallet(std::shared_ptr<CWallet>&& wallet)
     }
 }
 
+std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const WalletLocation& location, std::string& error, std::string& warning)
+{
+    if (!CWallet::Verify(chain, location, false, error, warning)) {
+        error = "Wallet file verification failed: " + error;
+        return nullptr;
+    }
+
+    std::shared_ptr<CWallet> wallet = CWallet::CreateWalletFromFile(chain, location);
+    if (!wallet) {
+        error = "Wallet loading failed.";
+        return nullptr;
+    }
+    AddWallet(wallet);
+    wallet->postInitProcess();
+    return wallet;
+}
+
+std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const std::string& name, std::string& error, std::string& warning)
+{
+    return LoadWallet(chain, WalletLocation(name), error, warning);
+}
+
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 
 const uint256 CMerkleTx::ABANDON_HASH(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -66,6 +66,7 @@ bool RemoveWallet(const std::shared_ptr<CWallet>& wallet);
 bool HasWallets();
 std::vector<std::shared_ptr<CWallet>> GetWallets();
 std::shared_ptr<CWallet> GetWallet(const std::string& name);
+std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const WalletLocation& location, std::string& error, std::string& warning);
 
 //! Default for -keypool
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;


### PR DESCRIPTION
The *Open Wallet* menu has all the available wallets currently not loaded. The list of the available wallets comes from `listWalletDir`.

In the future the menu can be replaced by a custom dialog.

<img width="674" alt="screenshot 2019-01-12 at 12 17 02" src="https://user-images.githubusercontent.com/3534524/51073166-ac041480-1664-11e9-8302-be81702bc146.png">
