### PR TITLE
test: Support -cli tests using external bitcoin-cli

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -532,12 +532,15 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             raise SkipTest("wallet has not been compiled.")
 
     def skip_if_no_cli(self):
-        """Skip the running test if bitcoin-cli has not been compiled."""
-        if not self.is_cli_compiled():
+        """Skip the running test if bitcoin-cli is not available."""
+        if not self.is_cli_available():
             raise SkipTest("bitcoin-cli has not been compiled.")
 
-    def is_cli_compiled(self):
-        """Checks whether bitcoin-cli was compiled."""
+    def is_cli_available(self):
+        """Checks whether bitcoin-cli is available."""
+        if os.getenv("BITCOINCLI", "__NOT_SET__") != "__NOT_SET__":
+            return True
+
         config = configparser.ConfigParser()
         config.read_file(open(self.options.configfile))
 


### PR DESCRIPTION
It can be useful to build only bitcoind and still run the full test suite using an external bitcoin-cli instance.

Use case: Automated package testing can have a build-time dependency on the bitcoin-cli package and use it to run tests on a bitcoind-only build.