### PR TITLE
Use real bind address in RPC help curl example

### DIFF
--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -31,6 +31,11 @@ void StartHTTPServer();
 void InterruptHTTPServer();
 /** Stop HTTP server */
 void StopHTTPServer();
+
+/** Returns one of the addresses the server is binding to.
+ * If the server has not been initialised yet, returns false.
+ */
+bool GetHTTPServerBindAddress(std::string& addr);
 
 /** Change logging level for libevent. Removes BCLog::LIBEVENT from log categories if
  * libevent doesn't support debug logging.*/

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,11 +1,12 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/server.h>
 
 #include <fs.h>
+#include <httpserver.h>
 #include <key_io.h>
 #include <random.h>
 #include <rpc/util.h>
@@ -514,8 +515,13 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
+    std::string bindAddr;
+    if (!GetHTTPServerBindAddress(bindAddr)) {
+        bindAddr = "http://127.0.0.1:8332/";
+    }
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' "
+        "-H 'content-type: text/plain;' " + bindAddr + "\n";
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2018-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test RPC help output."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import assert_equal, assert_raises_rpc_error, rpc_port
 
 import os
+import re
 
 
 class HelpRpcTest(BitcoinTestFramework):
@@ -16,6 +17,7 @@ class HelpRpcTest(BitcoinTestFramework):
 
     def run_test(self):
         self.test_categories()
+        self.test_example_url()
         self.dump_help()
 
     def test_categories(self):
@@ -42,6 +44,10 @@ class HelpRpcTest(BitcoinTestFramework):
             components.append('Zmq')
 
         assert_equal(titles, components)
+
+    def test_example_url(self):
+        text = self.nodes[0].help("getblockchaininfo")
+        assert re.search("curl .* http:\\/\\/.*:%d\\/" % rpc_port(0), text) is not None
 
     def dump_help(self):
         dump_dir = os.path.join(self.options.tmpdir, 'rpc_help_dump')


### PR DESCRIPTION
Expose (one of) the real bind addresses for the HTTP server and use that in the RPC help text's `curl` example.  This makes sure that e.g. a differently configured RPC port (or just the RPC port for regtest/testnet) is reported there, so that the example can be used directly as is even if a non-standard configuration is applied or the daemon is not running on mainnet.