### PR TITLE
contrib: Allow use of github API authentication in github-merge

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -119,7 +119,25 @@ Configuring the github-merge tool for the bitcoin repository is done in the foll
 
     git config githubmerge.repository bitcoin/bitcoin
     git config githubmerge.testcmd "make -j4 check" (adapt to whatever you want to use for testing)
-    git config --global user.signingkey mykeyid (if you want to GPG sign)
+    git config --global user.signingkey mykeyid
+
+Authentication (optional)
+--------------------------
+
+The API request limit for unauthenticated requests is quite low, but the
+limit for authenticated requests is much higher. If you start running
+into rate limiting errors it can be useful to set an authentication token
+so that the script can authenticate requests.
+
+- First, go to [Personal access tokens](https://github.com/settings/tokens).
+- Click 'Generate new token'.
+- Fill in an arbitrary token description. No further privileges are needed.
+- Click the `Generate token` button at the bottom of the form.
+- Copy the generated token (should be a hexadecimal string)
+
+Then do:
+
+    git config --global user.ghtoken "pasted token"
 
 Create and verify timestamps of merge commits
 ---------------------------------------------

--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -168,7 +168,10 @@ def main():
         print("git config --global user.signingkey <key>",file=stderr)
         sys.exit(1)
 
-    host_repo = host+":"+repo # shortcut for push/pull target
+    if host.startswith(('https:','http:')):
+        host_repo = host+"/"+repo+".git"
+    else:
+        host_repo = host+":"+repo
 
     # Extract settings from command line
     args = parse_arguments()

--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -23,6 +23,7 @@ import sys
 import json
 import codecs
 from urllib.request import Request, urlopen
+from urllib.error import HTTPError
 
 # External tools (can be overridden using environment)
 GIT = os.getenv('GIT','git')
@@ -57,6 +58,11 @@ def retrieve_pr_info(repo,pull):
         reader = codecs.getreader('utf-8')
         obj = json.load(reader(result))
         return obj
+    except HTTPError as e:
+        error_message = e.read()
+        print('Warning: unable to retrieve pull information from github: %s' % e)
+        print('Detailed error: %s' % error_message)
+        return None
     except Exception as e:
         print('Warning: unable to retrieve pull information from github: %s' % e)
         return None


### PR DESCRIPTION
Three commits I had locally for `github-merge.py`:

-  *Detailed reporting for http errors in github-merge*: Print detailed error, this makes it easier to diagnose github API issues.
- *Add support for http[s] URLs in github-merge*: Sometimes it can be useful to use github-merge with read-only access (say, for reviewing and testing from untrusted VMs).
- *Allow use of github API authentication in github-merge*: The API request limit for unauthenticated requests is quite low. I started running into rate limiting errors. The limit for authenticated requests is much higher. This patch adds an optional configuration setting `user.ghtoken` that, when set, is used to authenticate requests to the API.