### PR TITLE
qt: Fix wallet selector size adjustment

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -485,6 +485,7 @@ void BitcoinGUI::createToolBars()
         toolbar->addWidget(spacer);
 
         m_wallet_selector = new QComboBox();
+        m_wallet_selector->setSizeAdjustPolicy(QComboBox::AdjustToContents);
         connect(m_wallet_selector, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &BitcoinGUI::setCurrentWalletBySelectorIndex);
 
         m_wallet_selector_label = new QLabel();

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -453,6 +453,9 @@
          </item>
          <item>
           <widget class="QComboBox" name="WalletSelector">
+           <property name="sizeAdjustPolicy">
+            <enum>QComboBox::AdjustToContents</enum>
+           </property>
            <item>
             <property name="text">
              <string>(none)</string>


### PR DESCRIPTION
This PR sets `QComboBox::AdjustToContents` instead of default `QComboBox::AdjustToContentsOnFirstShow` for wallet selectors.

Before (in master):
![screenshot from 2019-01-14 20-47-22](https://user-images.githubusercontent.com/32963518/51133771-83d00d80-183e-11e9-812c-3a1119fa766e.png)

After (with this PR):
![screenshot from 2019-01-14 20-48-43](https://user-images.githubusercontent.com/32963518/51133788-90546600-183e-11e9-8394-eb62a998b90f.png)