### PR TITLE
refactor/lint: Add ignored shellcheck suggestions to an array

### DIFF
--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -22,27 +22,29 @@ if ! command -v shellcheck > /dev/null; then
 fi
 
 # Disabled warnings:
-# SC1087: Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
-# SC1117: Backslash is literal in "\.". Prefer explicit escaping: "\\.".
-# SC2001: See if you can use ${variable//search/replace} instead.
-# SC2004: $/${} is unnecessary on arithmetic variables.
-# SC2005: Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
-# SC2006: Use $(..) instead of legacy `..`.
-# SC2016: Expressions don't expand in single quotes, use double quotes for that.
-# SC2028: echo won't expand escape sequences. Consider printf.
-# SC2046: Quote this to prevent word splitting.
-# SC2048: Use "$@" (with quotes) to prevent whitespace problems.
-# SC2066: Since you double quoted this, it will not word split, and the loop will only run once.
-# SC2086: Double quote to prevent globbing and word splitting.
-# SC2116: Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
-# SC2148: Tips depend on target shell and yours is unknown. Add a shebang.
-# SC2162: read without -r will mangle backslashes.
-# SC2166: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
-# SC2166: Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
-# SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
-# SC2206: Quote to prevent word splitting, or split robustly with mapfile or read -a.
-# SC2207: Prefer mapfile or read -a to split command output (or quote to avoid splitting).
-# SC2230: which is non-standard. Use builtin 'command -v' instead.
-# SC2236: Don't force -n instead of ! -z.
-shellcheck -e SC1087,SC1117,SC2001,SC2004,SC2005,SC2006,SC2016,SC2028,SC2046,SC2048,SC2066,SC2086,SC2116,SC2148,SC2162,SC2166,SC2181,SC2206,SC2207,SC2230,SC2236 \
+disabled=(
+    SC1087 # Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
+    SC1117 # Backslash is literal in "\.". Prefer explicit escaping: "\\.".
+    SC2001 # See if you can use ${variable//search/replace} instead.
+    SC2004 # $/${} is unnecessary on arithmetic variables.
+    SC2005 # Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
+    SC2006 # Use $(..) instead of legacy `..`.
+    SC2016 # Expressions don't expand in single quotes, use double quotes for that.
+    SC2028 # echo won't expand escape sequences. Consider printf.
+    SC2046 # Quote this to prevent word splitting.
+    SC2048 # Use "$@" (with quotes) to prevent whitespace problems.
+    SC2066 # Since you double quoted this, it will not word split, and the loop will only run once.
+    SC2086 # Double quote to prevent globbing and word splitting.
+    SC2116 # Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
+    SC2148 # Tips depend on target shell and yours is unknown. Add a shebang.
+    SC2162 # read without -r will mangle backslashes.
+    SC2166 # Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
+    SC2166 # Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.
+    SC2181 # Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
+    SC2206 # Quote to prevent word splitting, or split robustly with mapfile or read -a.
+    SC2207 # Prefer mapfile or read -a to split command output (or quote to avoid splitting).
+    SC2230 # which is non-standard. Use builtin 'command -v' instead.
+    SC2236 # Don't force -n instead of ! -z.
+)
+shellcheck -e "$(IFS=","; echo "${disabled[*]}")" \
     $(git ls-files -- "*.sh" | grep -vE 'src/(secp256k1|univalue)/')


### PR DESCRIPTION
By adding excluded shellcheck suggestions to an array, you can avoid the current duplication
between command and comments. This ensures that they never go out of sync, makes it easier to
add new ones, and improves the readability of related diffs.