### PR TITLE
build: Drop macports support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -511,17 +511,6 @@ case $host in
      LEVELDB_TARGET_FLAGS="-DOS_MACOSX"
      if  test x$cross_compiling != xyes; then
        BUILD_OS=darwin
-       AC_CHECK_PROG([PORT],port, port)
-       if test x$PORT = xport; then
-         dnl add default macports paths
-         CPPFLAGS="$CPPFLAGS -isystem /opt/local/include"
-         LIBS="$LIBS -L/opt/local/lib"
-         if test -d /opt/local/include/db48; then
-           CPPFLAGS="$CPPFLAGS -I/opt/local/include/db48"
-           LIBS="$LIBS -L/opt/local/lib/db48"
-         fi
-       fi
-
        AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
        AC_CHECK_PROG([BREW],brew, brew)
        if test x$BREW = xbrew; then

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -172,12 +172,6 @@ class DeploymentInfo(object):
         if os.path.exists(os.path.join(parentDir, "translations")):
             # Classic layout, e.g. "/usr/local/Trolltech/Qt-4.x.x"
             self.qtPath = parentDir
-        elif os.path.exists(os.path.join(parentDir, "share", "qt4", "translations")):
-            # MacPorts layout, e.g. "/opt/local/share/qt4"
-            self.qtPath = os.path.join(parentDir, "share", "qt4")
-        elif os.path.exists(os.path.join(os.path.dirname(parentDir), "share", "qt4", "translations")):
-            # Newer Macports layout
-            self.qtPath = os.path.join(os.path.dirname(parentDir), "share", "qt4")
         else:
             self.qtPath = os.getenv("QTDIR", None)
 


### PR DESCRIPTION
It's unmaintained, according to @theuni.
https://github.com/bitcoin/bitcoin/pull/14920/files#r246964938

Alternative is to put it under CI. I don't have a strong opinion on this, opened for separate consideration.