### PR TITLE
qt: Improve "help-console" message

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -396,13 +396,12 @@ void RPCExecutor::request(const QString &command, const WalletModel* wallet_mode
         std::string executableCommand = command.toStdString() + "\n";
 
         // Catch the console-only-help command before RPC call is executed and reply with help text as-if a RPC reply.
-        if(executableCommand == "help-console\n")
-        {
+        if(executableCommand == "help-console\n") {
             Q_EMIT reply(RPCConsole::CMD_REPLY, QString(("\n"
                 "This console accepts RPC commands using the standard syntax.\n"
                 "   example:    getblockhash 0\n\n"
 
-                "This console can also accept RPC commands using parenthesized syntax.\n"
+                "This console can also accept RPC commands using the parenthesized syntax.\n"
                 "   example:    getblockhash(0)\n\n"
 
                 "Commands may be nested when specified with the parenthesized syntax.\n"
@@ -412,11 +411,11 @@ void RPCExecutor::request(const QString &command, const WalletModel* wallet_mode
                 "   example:    getblockhash 0\n"
                 "               getblockhash,0\n\n"
 
-                "Named results can be queried with a non-quoted key string in brackets.\n"
-                "   example:    getblock(getblockhash(0) true)[tx]\n\n"
+                "Named results can be queried with a non-quoted key string in brackets using the parenthesized syntax.\n"
+                "   example:    getblock(getblockhash(0) 1)[tx]\n\n"
 
-                "Results without keys can be queried using an integer in brackets.\n"
-                "   example:    getblock(getblockhash(0),true)[tx][0]\n\n")));
+                "Results without keys can be queried with an integer in brackets using the parenthesized syntax.\n"
+                "   example:    getblock(getblockhash(0),1)[tx][0]\n\n")));
             return;
         }
         if (!RPCConsole::RPCExecuteCommandLine(m_node, result, executableCommand, nullptr, wallet_model)) {


### PR DESCRIPTION
Added a note that results can be queried in the parenthesized syntax as it does not work in the standard syntax.

Deprecated (since #8704) boolean `verbose` replaced with numerical `verbosity` in `getblock` examples.

Current master (acec9e45c6fb6d5e72908c1a87b2b14f1ca5e3a0):
![screenshot from 2019-01-16 13-40-10](https://user-images.githubusercontent.com/32963518/51248127-d96bfd80-1997-11e9-83d3-47cf157e2f8d.png)

Master + this PR:
![screenshot from 2019-01-16 14-00-39](https://user-images.githubusercontent.com/32963518/51248137-e852b000-1997-11e9-94dc-e9c949690beb.png)