### PR TITLE
Use correct RPC port in help curl example

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,10 +1,11 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/server.h>
 
+#include <chainparamsbase.h>
 #include <fs.h>
 #include <key_io.h>
 #include <random.h>
@@ -20,6 +21,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 #include <memory> // for unique_ptr
+#include <sstream>
 #include <unordered_map>
 
 static CCriticalSection cs_rpcWarmup;
@@ -567,8 +569,17 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
-    return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+    const int rpcPort = gArgs.GetArg("-rpcport", BaseParams().RPCPort());
+
+    std::ostringstream helpText;
+    helpText << "> curl --user myusername "
+             << "--data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
+             << "\"method\": \"" << methodname << "\", "
+             << "\"params\": [" << args << "] }' "
+             << "-H 'content-type: text/plain;' "
+             << "http://127.0.0.1:" << rpcPort << "/\n";
+
+    return helpText.str();
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2018-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test RPC help output."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import assert_equal, assert_raises_rpc_error, rpc_port
 
 import os
+import re
 
 
 class HelpRpcTest(BitcoinTestFramework):
@@ -16,6 +17,7 @@ class HelpRpcTest(BitcoinTestFramework):
 
     def run_test(self):
         self.test_categories()
+        self.test_rpc_port()
         self.dump_help()
 
     def test_categories(self):
@@ -42,6 +44,10 @@ class HelpRpcTest(BitcoinTestFramework):
             components.append('Zmq')
 
         assert_equal(titles, components)
+
+    def test_rpc_port(self):
+        help_text = self.nodes[0].help("getblockchaininfo")
+        assert re.search("curl.*http://127.0.0.1:%d" % rpc_port(0), help_text) is not None
 
     def dump_help(self):
         dump_dir = os.path.join(self.options.tmpdir, 'rpc_help_dump')


### PR DESCRIPTION
Put the correct RPC port (default for the selected chain or set explicitly with `-rpcport`) into the RPC help text "curl" example.  Previously, the port there was always reported as 8332 (default mainnet port).  With this change, it will be correct for testnet/regtest or with an explicit `-rpcport`, so that the example can be used as-is in these situations.

This is a simplified version of #15158, following the discussion with @laanwj.