### PR TITLE
[Qt]: fixes m_assumed_blockchain_size variable value

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -107,7 +107,7 @@ public:
         pchMessageStart[3] = 0xd9;
         nDefaultPort = 8333;
         nPruneAfterHeight = 100000;
-        m_assumed_blockchain_size = 200;
+        m_assumed_blockchain_size = 240;
         m_assumed_chain_state_size = 3;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
@@ -219,7 +219,7 @@ public:
         pchMessageStart[3] = 0x07;
         nDefaultPort = 18333;
         nPruneAfterHeight = 1000;
-        m_assumed_blockchain_size = 20;
+        m_assumed_blockchain_size = 30;
         m_assumed_chain_state_size = 2;
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);


### PR DESCRIPTION
This is used by Qt but I'm not sure if this is the right tag here.
Please, edit the title if there's something better.

`m_assumed_blockchain_size` (src/chainparams.cpp:CChainParams) was
`BLOCK_CHAIN_SIZE` (src/qt/intro.cpp) and while the transition was being
made by PR 13216 (merged commit: 9d0e528), 3fc2063 changed its value
from 200 to 220, which 9d0e528 ended up reverting.

So, as per MarcoFalke's suggestion (https://github.com/bitcoin/bitcoin/pull/13216#discussion_r247560123), I'm bumping it to 240 before 0.18 is
branched to avoid any confusion.

Anything else (e.g. constexpr) that should/could be done here? Thanks.