### PR TITLE
validation: Add missing lock in UnloadBlockIndex(). Add missing locking annotation for nBlockSequenceId.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -118,7 +118,7 @@ private:
      */
     CCriticalSection cs_nBlockSequenceId;
     /** Blocks loaded from disk are assigned id 0, so start the counter at 1. */
-    int32_t nBlockSequenceId = 1;
+    int32_t nBlockSequenceId GUARDED_BY(cs_nBlockSequenceId) = 1;
     /** Decreasing counter (used by subsequent preciousblock calls). */
     int32_t nBlockReverseSequenceId = -1;
     /** chainwork for the last block that preciousblock has been applied to. */
@@ -4288,6 +4288,7 @@ bool RewindBlockIndex(const CChainParams& params) {
 }
 
 void CChainState::UnloadBlockIndex() {
+    LOCK(cs_nBlockSequenceId);
     nBlockSequenceId = 1;
     m_failed_blocks.clear();
     setBlockIndexCandidates.clear();


### PR DESCRIPTION
* Add missing locking annotation for `nBlockSequenceId` which is guarded by `cs_nBlockSequenceId`.
* Add missing `cs_nBlockSequenceId` lock in `UnloadBlockIndex()`.
