### PR TITLE
validation: Add missing cs_{LastBlockFile,nBlockSequenceId} locks in PruneAndFlush() and UnloadBlockIndex(). Add missing locking annotations.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -134,12 +134,12 @@ namespace {
 
     CCriticalSection cs_LastBlockFile;
     std::vector<CBlockFileInfo> vinfoBlockFile;
-    int nLastBlockFile = 0;
+    int nLastBlockFile GUARDED_BY(cs_LastBlockFile) = 0;
     /** Global flag to indicate we should check to see if there are
      *  block/undo files that should be deleted.  Set on startup
      *  or if we allocate more file space when we're in prune mode
      */
-    bool fCheckForPruning = false;
+    bool fCheckForPruning GUARDED_BY(cs_LastBlockFile) = false;
 
     /** Dirty block index entries. */
     std::set<CBlockIndex*> setDirtyBlockIndex;
@@ -2064,7 +2064,10 @@ void CChainState::ForceFlushStateToDisk() {
 
 void CChainState::PruneAndFlush() {
     CValidationState state;
-    fCheckForPruning = true;
+    {
+        LOCK(cs_LastBlockFile);
+        fCheckForPruning = true;
+    }
     const CChainParams& chainparams = Params();
 
     if (!this->FlushStateToDisk(chainparams, state, FlushStateMode::NONE)) {
@@ -3753,6 +3756,7 @@ bool static LoadBlockIndexDB(const CChainParams& chainparams) EXCLUSIVE_LOCKS_RE
     if (!::ChainstateActive().LoadBlockIndex(chainparams.GetConsensus(), *pblocktree))
         return false;
 
+    LOCK(cs_LastBlockFile);
     // Load block file info
     pblocktree->ReadLastBlockFile(nLastBlockFile);
     vinfoBlockFile.resize(nLastBlockFile + 1);
@@ -4192,7 +4196,10 @@ void UnloadBlockIndex()
     mempool.clear();
     mapBlocksUnlinked.clear();
     vinfoBlockFile.clear();
-    nLastBlockFile = 0;
+    {
+        LOCK(cs_LastBlockFile);
+        nLastBlockFile = 0;
+    }
     setDirtyBlockIndex.clear();
     setDirtyFileInfo.clear();
     versionbitscache.Clear();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4179,7 +4179,10 @@ bool RewindBlockIndex(const CChainParams& params) {
 }
 
 void CChainState::UnloadBlockIndex() {
-    nBlockSequenceId = 1;
+    {
+        LOCK(cs_nBlockSequenceId);
+        nBlockSequenceId = 1;
+    }
     m_failed_blocks.clear();
     setBlockIndexCandidates.clear();
 }


### PR DESCRIPTION
* Add missing `cs_LastBlockFile` locks in `PruneAndFlush()` and `UnloadBlockIndex()`.
* Add missing locking annotation for `nLastBlockFile` and `fCheckForPruning`.
* Add missing locking annotation for `nBlockSequenceId` which is guarded by `cs_nBlockSequenceId`.
* Add missing `cs_nBlockSequenceId` lock in `UnloadBlockIndex()`.
