### PR TITLE
Add missing cs_main locks in ThreadImport(...)/Shutdown(...)/gettxoutsetinfo(...)/InitScriptExecutionCache(). Add missing locking annotations.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -688,7 +688,10 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
             LoadExternalBlockFile(chainparams, file, &pos);
             nFile++;
         }
-        pblocktree->WriteReindexing(false);
+        {
+            LOCK(cs_main);
+            pblocktree->WriteReindexing(false);
+        }
         fReindex = false;
         LogPrintf("Reindexing finished\n");
         // To avoid ending up in a situation without genesis block, re-try initializing (no-op if reindexing worked):

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -256,8 +256,11 @@ void Shutdown(InitInterfaces& interfaces)
     }
 
     // FlushStateToDisk generates a ChainStateFlushed callback, which we should avoid missing
-    if (pcoinsTip != nullptr) {
-        ::ChainstateActive().ForceFlushStateToDisk();
+    {
+        LOCK(cs_main);
+        if (pcoinsTip != nullptr) {
+            ::ChainstateActive().ForceFlushStateToDisk();
+        }
     }
 
     // After there are no more peers/RPC left to give us new data which may generate

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1099,7 +1099,12 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
 
     CCoinsStats stats;
     ::ChainstateActive().ForceFlushStateToDisk();
-    if (GetUTXOStats(pcoinsdbview.get(), stats)) {
+    CCoinsView *currentView;
+    {
+        LOCK(cs_main);
+        currentView = pcoinsdbview.get();
+    }
+    if (GetUTXOStats(currentView, stats)) {
         ret.pushKV("height", (int64_t)stats.nHeight);
         ret.pushKV("bestblock", stats.hashBlock.GetHex());
         ret.pushKV("transactions", (int64_t)stats.nTransactions);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1200,13 +1200,14 @@ int GetSpendHeight(const CCoinsViewCache& inputs)
 }
 
 
-static CuckooCache::cache<uint256, SignatureCacheHasher> scriptExecutionCache;
+static CuckooCache::cache<uint256, SignatureCacheHasher> scriptExecutionCache GUARDED_BY(cs_main);
 static uint256 scriptExecutionCacheNonce(GetRandHash());
 
 void InitScriptExecutionCache() {
     // nMaxCacheSize is unsigned. If -maxsigcachesize is set to zero,
     // setup_bytes creates the minimum possible cache (2 elements).
     size_t nMaxCacheSize = std::min(std::max((int64_t)0, gArgs.GetArg("-maxsigcachesize", DEFAULT_MAX_SIG_CACHE_SIZE) / 2), MAX_MAX_SIG_CACHE_SIZE) * ((size_t) 1 << 20);
+    LOCK(cs_main);
     size_t nElems = scriptExecutionCache.setup_bytes(nMaxCacheSize);
     LogPrintf("Using %zu MiB out of %zu/2 requested for script execution cache, able to store %zu elements\n",
             (nElems*sizeof(uint256)) >>20, (nMaxCacheSize*2)>>20, nElems);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -304,7 +304,7 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
 // Returns the script flags which should be checked for a given block
 static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consensus::Params& chainparams);
 
-static void LimitMempoolSize(CTxMemPool& pool, size_t limit, unsigned long age) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+static void LimitMempoolSize(CTxMemPool& pool, size_t limit, unsigned long age) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     int expired = pool.Expire(GetTime() - age);
     if (expired != 0) {
@@ -2092,7 +2092,7 @@ static void AppendWarning(std::string& res, const std::string& warn)
 }
 
 /** Check warning conditions and do some notifications on new chain tip set. */
-void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainParams) {
+void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainParams) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     // New best block
     mempool.AddTransactionsUpdated(1);
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -619,7 +619,7 @@ CChain& ChainActive();
 extern std::unique_ptr<CCoinsViewDB> pcoinsdbview GUARDED_BY(cs_main);
 
 /** Global variable that points to the active CCoinsView (protected by cs_main) */
-extern std::unique_ptr<CCoinsViewCache> pcoinsTip;
+extern std::unique_ptr<CCoinsViewCache> pcoinsTip GUARDED_BY(cs_main);
 
 /** Global variable that points to the active block tree (protected by cs_main) */
 extern std::unique_ptr<CBlockTreeDB> pblocktree;

--- a/src/validation.h
+++ b/src/validation.h
@@ -616,7 +616,7 @@ CChainState& ChainstateActive();
 CChain& ChainActive();
 
 /** Global variable that points to the coins database (protected by cs_main) */
-extern std::unique_ptr<CCoinsViewDB> pcoinsdbview;
+extern std::unique_ptr<CCoinsViewDB> pcoinsdbview GUARDED_BY(cs_main);
 
 /** Global variable that points to the active CCoinsView (protected by cs_main) */
 extern std::unique_ptr<CCoinsViewCache> pcoinsTip;

--- a/src/validation.h
+++ b/src/validation.h
@@ -622,7 +622,7 @@ extern std::unique_ptr<CCoinsViewDB> pcoinsdbview GUARDED_BY(cs_main);
 extern std::unique_ptr<CCoinsViewCache> pcoinsTip GUARDED_BY(cs_main);
 
 /** Global variable that points to the active block tree (protected by cs_main) */
-extern std::unique_ptr<CBlockTreeDB> pblocktree;
+extern std::unique_ptr<CBlockTreeDB> pblocktree GUARDED_BY(cs_main);
 
 /**
  * Return the spend height, which is one more than the inputs.GetBestBlock().


### PR DESCRIPTION
* Add missing `cs_main` lock required when accessing `pblocktree`. Add annotation.
* Add missing `cs_main` lock required when accessing `pcoinsTip`. Add annotation.
* Add missing `cs_main` lock required when accessing `pcoinsdbview`. Add annotation.
* Add missing `cs_main` lock required when accessing `scriptExecutionCache`. Add annotation.