### PR TITLE
Default -whitelistforcerelay to off

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -111,6 +111,14 @@ Configuration option changes
   ambiguous whether the hash character is meant for the password or as a
   comment.
 
+- The `whitelistforcerelay` option is used to relay transactions from
+  whitelisted peers even when not accepted to the mempool. This option now
+  defaults to being off, so that changes in policy and disconnect/ban behavior
+  will not cause a node that is whitelisting another to be dropped by peers.
+  Users can still explicitly enable this behavior with the command line option
+  (and may want to consider letting the Bitcoin Core project know about their
+  use-case, as this feature could be deprecated in the future).
+
 Documentation
 -------------
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -50,7 +50,7 @@ struct LockPoints;
 /** Default for -whitelistrelay. */
 static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for -whitelistforcerelay. */
-static const bool DEFAULT_WHITELISTFORCERELAY = true;
+static const bool DEFAULT_WHITELISTFORCERELAY = false;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 //! -maxtxfee default

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -755,7 +755,7 @@ class SegWitTest(BitcoinTestFramework):
         spend_tx.vin[0].scriptSig = CScript([p2wsh_pubkey, b'a'])
         spend_tx.rehash()
         with self.nodes[0].assert_debug_log(
-                expected_msgs=('Not relaying invalid transaction {}'.format(spend_tx.hash), 'was not accepted: mandatory-script-verify-flag-failed (Script evaluated without error but finished with a false/empty top stack element)')):
+                expected_msgs=(spend_tx.hash, 'was not accepted: mandatory-script-verify-flag-failed (Script evaluated without error but finished with a false/empty top stack element)')):
             test_transaction_acceptance(self.nodes[0], self.test_node, spend_tx, with_witness=False, accepted=False)
 
         # Now put the witness script in the witness, should succeed after


### PR DESCRIPTION
No one seems to use this "feature", and at any rate the behavior of relaying transactions when they violate local policy is error-prone, if we ever consider changing the ban behavior of our software from one version to the next.

Defaulting this to off means that users who use -whitelist won't be unexpectedly surprised by this interaction.  If anyone is still relying on this feature, it can still be explicitly turned on.