### PR TITLE
gui: Add Close Wallet action

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -468,6 +468,10 @@ public:
     bool IsWalletFlagSet(uint64_t flag) override { return m_wallet.IsWalletFlagSet(flag); }
     OutputType getDefaultAddressType() override { return m_wallet.m_default_address_type; }
     OutputType getDefaultChangeType() override { return m_wallet.m_default_change_type; }
+    void remove() override
+    {
+        RemoveWallet(m_shared_wallet);
+    }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {
         return MakeHandler(m_wallet.NotifyUnload.connect(fn));

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -247,6 +247,9 @@ public:
     // Get default change type.
     virtual OutputType getDefaultChangeType() = 0;
 
+    // Remove wallet.
+    virtual void remove() = 0;
+
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleUnload(UnloadFn fn) = 0;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -338,6 +338,9 @@ void BitcoinGUI::createActions()
     m_open_wallet_action->setMenu(new QMenu(this));
     m_open_wallet_action->setStatusTip(tr("Open a wallet"));
 
+    m_close_wallet_action = new QAction(tr("Close Wallet..."), this);
+    m_close_wallet_action->setStatusTip(tr("Close wallet"));
+
     showHelpMessageAction = new QAction(platformStyle->TextColorIcon(":/icons/info"), tr("&Command-line options"), this);
     showHelpMessageAction->setMenuRole(QAction::NoRole);
     showHelpMessageAction->setStatusTip(tr("Show the %1 help message to get a list with possible Bitcoin command-line options").arg(tr(PACKAGE_NAME)));
@@ -396,6 +399,9 @@ void BitcoinGUI::createActions()
                 });
             }
         });
+        connect(m_close_wallet_action, &QAction::triggered, [this] {
+            m_wallet_controller->closeWallet(walletFrame->currentWalletModel(), this);
+        });
     }
 #endif // ENABLE_WALLET
 
@@ -418,6 +424,7 @@ void BitcoinGUI::createMenuBar()
     if(walletFrame)
     {
         file->addAction(m_open_wallet_action);
+        file->addAction(m_close_wallet_action);
         file->addSeparator();
         file->addAction(openAction);
         file->addAction(backupWalletAction);
@@ -693,6 +700,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     usedSendingAddressesAction->setEnabled(enabled);
     usedReceivingAddressesAction->setEnabled(enabled);
     openAction->setEnabled(enabled);
+    m_close_wallet_action->setEnabled(enabled);
 }
 
 void BitcoinGUI::createTrayIcon()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -148,6 +148,7 @@ private:
     QAction* openAction = nullptr;
     QAction* showHelpMessageAction = nullptr;
     QAction* m_open_wallet_action{nullptr};
+    QAction* m_close_wallet_action{nullptr};
     QAction* m_wallet_selector_label_action = nullptr;
     QAction* m_wallet_selector_action = nullptr;
 

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -63,6 +63,22 @@ OpenWalletActivity* WalletController::openWallet(const std::string& name, QWidge
     return activity;
 }
 
+void WalletController::closeWallet(WalletModel* wallet_model, QWidget* parent)
+{
+    QMessageBox box(parent);
+    box.setWindowTitle(tr("Close wallet"));
+    box.setText(tr("Are you sure you wish to close wallet <i>%1</i>?").arg(wallet_model->getDisplayName()));
+    box.setInformativeText(tr("Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled."));
+    box.setStandardButtons(QMessageBox::Yes|QMessageBox::Cancel);
+    box.setDefaultButton(QMessageBox::Yes);
+    if (box.exec() != QMessageBox::Yes) return;
+
+    // First remove wallet from node.
+    wallet_model->wallet().remove();
+    // Now release the model.
+    removeAndDeleteWallet(wallet_model);
+}
+
 WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wallet> wallet)
 {
     QMutexLocker locker(&m_mutex);

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -44,6 +44,7 @@ public:
     std::vector<std::string> getWalletsAvailableToOpen() const;
 
     OpenWalletActivity* openWallet(const std::string& name, QWidget* parent = nullptr);
+    void closeWallet(WalletModel* wallet_model, QWidget* parent = nullptr);
 
 private Q_SLOTS:
     void addWallet(WalletModel* wallet_model);


### PR DESCRIPTION
This PR adds support to close the current wallet in the GUI.

<img width="543" alt="screenshot 2019-01-18 at 00 44 26" src="https://user-images.githubusercontent.com/3534524/51358241-424b9680-1aba-11e9-88f2-b85869507737.png">
<img width="532" alt="screenshot 2019-01-18 at 00 44 38" src="https://user-images.githubusercontent.com/3534524/51358242-424b9680-1aba-11e9-83e2-fa275a9017b3.png">
