### PR TITLE
[test]: Update all subprocess.check_output functions to be Python 3.4 compatible

### DIFF
--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -30,8 +30,8 @@ def main():
         used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True, encoding='utf8')
         docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True, encoding='utf8')
     else:
-        used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True) # encoding='utf8'
-        docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True) # encoding='utf8'
+        used = check_output(CMD_GREP_ARGS, shell=True).decode('utf8').strip()
+        docd = check_output(CMD_GREP_DOCS, shell=True).decode('utf8').strip()
 
     args_used = set(re.findall(re.compile(REGEX_ARG), used))
     args_docd = set(re.findall(re.compile(REGEX_DOC), docd)).union(SET_DOC_OPTIONAL)


### PR DESCRIPTION
CI is failing the `lint` stage on every Cron run (regular PR/Push runs still pass). The failure was introduced in 74ce326 and has been broken since. The Python version running in CI was downgraded to 3.4 from 3.6. There were a couple files that were using the `encoding` argument in the `subprocess.check_output` function. This was introduced in Python 3.6 and therefore broke the scripts that were using it. The `universal_newlines` argument was used as well, but in order to use it we must be able to set encoding because of issues on some BSD systems.

To get CI to pass, I removed all `universal_newline` and `encoding` args to the `check_ouput` function. Then I decoded all `check_output` return values. This should keep the same behavior but be Python 3.4 compatible.