### PR TITLE
Refactor and slightly stricter p2p message processing

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -649,8 +649,9 @@ int V1TransportDeserializer::readHeader(const char *pch, unsigned int nBytes)
         return -1;
     }
 
-    // reject messages larger than MAX_SIZE or MAX_PROTOCOL_MESSAGE_LENGTH
-    if (hdr.nMessageSize > MAX_SIZE || hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
+    // reject if message has an invalid header
+    if (!hdr.IsValid(Params().MessageStart())) {
+        LogPrint(BCLog::NET, "INVALID HEADER DETECTED\n");
         return -1;
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -51,8 +51,6 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const int FEELER_INTERVAL = 120;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
 /** Maximum length of the user agent string in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** Maximum number of automatic outgoing nodes over which we'll relay everything (blocks, tx, addrs, etc) */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3378,12 +3378,6 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     CNetMessage& msg(msgs.front());
 
     msg.SetVersion(pfrom->GetRecvVersion());
-    // Check network magic
-    if (!msg.m_valid_netmagic) {
-        LogPrint(BCLog::NET, "PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%d\n", SanitizeString(msg.m_command), pfrom->GetId());
-        pfrom->fDisconnect = true;
-        return false;
-    }
 
     // Check header
     if (!msg.m_valid_header)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3379,12 +3379,6 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
 
     msg.SetVersion(pfrom->GetRecvVersion());
 
-    // Check header
-    if (!msg.m_valid_header)
-    {
-        LogPrint(BCLog::NET, "PROCESSMESSAGE: ERRORS IN HEADER %s peer=%d\n", SanitizeString(msg.m_command), pfrom->GetId());
-        return fMoreWork;
-    }
     const std::string& msg_type = msg.m_command;
 
     // Message size

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -104,8 +104,10 @@ std::string CMessageHeader::GetCommand() const
 bool CMessageHeader::IsValid(const MessageStartChars& pchMessageStartIn) const
 {
     // Check start string
-    if (memcmp(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE) != 0)
+    if (memcmp(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE) != 0) {
+        LogPrint(BCLog::NET, "INVALID MESSAGESTART %s\n", SanitizeString(GetCommand()));
         return false;
+    }
 
     // Check the command string for errors
     for (const char* p1 = pchCommand; p1 < pchCommand + COMMAND_SIZE; p1++)

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -123,8 +123,8 @@ bool CMessageHeader::IsValid(const MessageStartChars& pchMessageStartIn) const
             return false;
     }
 
-    // Message size
-    if (nMessageSize > MAX_SIZE)
+    // reject messages larger than MAX_SIZE or MAX_PROTOCOL_MESSAGE_LENGTH
+    if (nMessageSize > MAX_SIZE || nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH)
     {
         LogPrintf("CMessageHeader::IsValid(): (%s, %u bytes) nMessageSize > MAX_SIZE\n", GetCommand(), nMessageSize);
         return false;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -18,6 +18,9 @@
 #include <stdint.h>
 #include <string>
 
+/** Maximum length of incoming protocol messages (no message over 4 MB is currently acceptable). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 4 * 1000 * 1000;
+
 /** Message header.
  * (4) message start.
  * (12) command.

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -157,7 +157,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
         # we might run into races later on
         asyncio.run_coroutine_threadsafe(swap_magic_bytes(), NetworkThread.network_event_loop).result()
 
-        with self.nodes[0].assert_debug_log(['PROCESSMESSAGE: INVALID MESSAGESTART ping']):
+        with self.nodes[0].assert_debug_log(['INVALID MESSAGESTART ping']):
             conn.send_message(messages.msg_ping(nonce=0xff))
             conn.wait_for_disconnect(timeout=1)
             self.nodes[0].disconnect_p2ps()

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -193,14 +193,14 @@ class InvalidMessagesTest(BitcoinTestFramework):
 
     def test_msgtype(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
-        with self.nodes[0].assert_debug_log(['PROCESSMESSAGE: ERRORS IN HEADER']):
+        with self.nodes[0].assert_debug_log(['INVALID HEADER DETECTED']):
             msg = msg_unrecognized(str_data="d")
             msg.msgtype = b'\xff' * 12
             msg = conn.build_message(msg)
             # Modify msgtype
             msg = msg[:7] + b'\x00' + msg[7 + 1:]
             self.nodes[0].p2p.send_raw_message(msg)
-            conn.sync_with_ping(timeout=1)
+            conn.wait_for_disconnect(timeout=1)
             self.nodes[0].disconnect_p2ps()
 
     def test_large_inv(self):


### PR DESCRIPTION
There are currently redundant checks of the network magic and the `MAX_SIZE` which makes the code more difficult to read.

This moves and refactors network magic and message header verification from `ProcessMessages()` to the deserialisation of a network message.

**Slightly stricter because...**
... directly disconnect when network magic is invalid even before reading the rest of the message
... disconnect directly rather then skipping a message when a command string in invalid (not all zeros after the first zero, invalid chars)

Simplifies possible p2p protocol upgrades like BIP151