### PR TITLE
P2P: Don't fill with zeros twice

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -79,7 +79,7 @@ const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, 
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
-    memset(pchCommand, 0, sizeof(pchCommand));
+    memset(pchCommand, 0, COMMAND_SIZE);
     nMessageSize = -1;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }
@@ -87,7 +87,6 @@ CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
-    memset(pchCommand, 0, sizeof(pchCommand));
     strncpy(pchCommand, pszCommand, COMMAND_SIZE);
     nMessageSize = nMessageSizeIn;
     memset(pchChecksum, 0, CHECKSUM_SIZE);


### PR DESCRIPTION
> destination is padded with zeros until a total of num characters have been written to it.

from http://www.cplusplus.com/reference/cstring/strncpy/

Closes #15151 