### PR TITLE
validation: avoid potential deadlocks in ValidationInterface

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -827,8 +827,23 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   }
   ])],
   [
-    AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
-    AC_MSG_RESULT(yes)
+   case $host in
+     *mingw*)
+        # mingw32's implementation of thread_local has also been shown to behave
+        # erroneously under concurrent usage; see:
+        # https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
+        AC_MSG_RESULT(no)
+        ;;
+      *darwin*)
+        # TODO enable thread_local on later versions of Darwin where it is
+        # supported (per https://stackoverflow.com/a/29929949)
+        AC_MSG_RESULT(no)
+        ;;
+      *)
+        AC_DEFINE(HAVE_THREAD_LOCAL,1,[Define if thread_local is supported.])
+        AC_MSG_RESULT(yes)
+        ;;
+    esac
   ],
   [
     AC_MSG_RESULT(no)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -95,6 +95,7 @@ BITCOIN_TESTS =\
   test/uint256_tests.cpp \
   test/util_tests.cpp \
   test/validation_block_tests.cpp \
+  test/validationinterface_tests.cpp \
   test/versionbits_tests.cpp
 
 if ENABLE_PROPERTY_TESTS

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -1,0 +1,50 @@
+// Copyright (c) 2012-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <consensus/validation.h>
+#include <scheduler.h>
+#include <validation.h>
+#include <validationinterface.h>
+
+#include <test/test_bitcoin.h>
+
+#include <boost/thread.hpp>
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_FIXTURE_TEST_SUITE(validationinterface_tests, BasicTestingSetup)
+
+/**
+ * Ensure that calls known to pose risk of deadlock cannot be made from within
+ * ValidationInterface threads.
+ */
+BOOST_AUTO_TEST_CASE(no_deadlocks_in_queue)
+{
+    CScheduler scheduler;
+    CMainSignals main_signals;
+    const CChainParams& chainparams = Params();
+
+    boost::thread t = boost::thread(std::bind(&CScheduler::serviceQueue, &scheduler));
+    main_signals.RegisterBackgroundSignalScheduler(scheduler);
+
+    bool callback_executed = false;
+
+    main_signals.AddToProcessQueue([chainparams, &callback_executed]() {
+        CValidationState state;
+#ifdef DEBUG_LOCKORDER
+        BOOST_CHECK_THROW(ActivateBestChain(state, chainparams), std::logic_error);
+#else
+        ActivateBestChain(state, chainparams);
+#endif
+        callback_executed = true;
+    });
+
+    scheduler.stop(true);
+    t.join();
+    assert(callback_executed);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2677,13 +2677,14 @@ bool CChainState::ActivateBestChain(CValidationState &state, const CChainParams&
     do {
         boost::this_thread::interruption_point();
 
+#ifdef DEBUG_LOCKORDER
+        ThrowIfRunningInValidationInterfaceQueue();
+#endif
+
         if (GetMainSignals().CallbacksPending() > 10) {
             // Block until the validation queue drains. This should largely
             // never happen in normal operation, however may happen during
             // reindex, causing memory blowup if we run too far ahead.
-            // Note that if a validationinterface callback ends up calling
-            // ActivateBestChain this may lead to a deadlock! We should
-            // probably have a DEBUG_LOCKORDER test for this in the future.
             SyncWithValidationInterfaceQueue();
         }
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -47,7 +47,9 @@ struct MainSignalsInstance {
     std::unordered_map<CValidationInterface*, ValidationInterfaceConnections> m_connMainSignals;
 
     explicit MainSignalsInstance(CScheduler *pscheduler) : m_schedulerClient(pscheduler) {}
+    ~MainSignalsInstance() {}
 };
+
 
 static CMainSignals g_signals;
 
@@ -81,6 +83,9 @@ static void MarkRunningInQueue() {}
 // because RegisterWithMempoolSignals is currently called before RegisterBackgroundSignalScheduler,
 // so MainSignalsInstance hasn't been created yet.
 static std::unordered_map<CTxMemPool*, boost::signals2::scoped_connection> g_connNotifyEntryRemoved;
+
+CMainSignals::CMainSignals() {}
+CMainSignals::~CMainSignals() {}
 
 void CMainSignals::RegisterBackgroundSignalScheduler(CScheduler& scheduler) {
     assert(!m_internals);

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -184,6 +184,11 @@ private:
     void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
 
 public:
+    // Declare default *structors to avoid compilation issues due to the
+    // forward declaration of MainSignalsInstance.
+    CMainSignals();
+    ~CMainSignals();
+
     /** Register a CScheduler to give callbacks which should run in the background (may only be called once) */
     void RegisterBackgroundSignalScheduler(CScheduler& scheduler);
     /** Unregister a CScheduler to give callbacks which should run in the background - these callbacks will now be dropped! */


### PR DESCRIPTION
Currently, the potential for a deadlock exists if `ActivateBestChain()` is called from within the `ValidationInterface` scheduler thread. This is because ABC itself avoids overrunning the VI queue by waiting for it to drain once it has passed a certain depth.

To avoid this (or at least disallow it during CI runs), this change introduces thread_local state that gets set to indicate execution on ValidationInterface threads. If we've compiled with `DEBUG_LOCKORDER`, calling ABC from within a VI thread throws an exception. A small, ~~necessary~~ refactoring on `CMainSignals` is included.

This changeset also includes a commit from #13168 that limits the platforms where we can rely on the use of thread_local.