### PR TITLE
Immediately disconnect on invalid net message checksum

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -616,7 +616,6 @@ public:
     int64_t m_time = 0;                  // time (in microseconds) of message receipt.
     bool m_valid_netmagic = false;
     bool m_valid_header = false;
-    bool m_valid_checksum = false;
     uint32_t m_message_size = 0;         // size of the payload
     uint32_t m_raw_message_size = 0;     // used wire size of the message (including header/checksum)
     std::string m_command;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3522,20 +3522,11 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     // Message size
     unsigned int nMessageSize = msg.m_message_size;
 
-    // Checksum
-    CDataStream& vRecv = msg.m_recv;
-    if (!msg.m_valid_checksum)
-    {
-        LogPrint(BCLog::NET, "%s(%s, %u bytes): CHECKSUM ERROR peer=%d\n", __func__,
-           SanitizeString(msg_type), nMessageSize, pfrom->GetId());
-        return fMoreWork;
-    }
-
     // Process message
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, msg_type, vRecv, msg.m_time, chainparams, m_chainman, m_mempool, connman, m_banman, interruptMsgProc);
+        fRet = ProcessMessage(pfrom, msg_type, msg.m_recv, msg.m_time, chainparams, m_chainman, m_mempool, connman, m_banman, interruptMsgProc);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -183,7 +183,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
             # modify checksum
             msg = msg[:cut_len] + b'\xff' * 4 + msg[cut_len + 4:]
             self.nodes[0].p2p.send_raw_message(msg)
-            conn.sync_with_ping(timeout=1)
+            conn.wait_for_disconnect(timeout=1)
             self.nodes[0].disconnect_p2ps()
 
     def test_size(self):


### PR DESCRIPTION
Currently, messages with invalid checksums will be partially tolerated (skipped). The checksum check happens after deserialising all messages in the current read buffer.

This PR moves the checksum check to the network/transport layer (where it probably belongs) and rejects messages with invalid checksums immediately and disconnects the peer.

This PR separates the transport from the processing layer and helps protocol upgrades like BIP151.