### PR TITLE
zmq: log outbound message high water mark when reusing socket

### DIFF
--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -101,6 +101,7 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
     else
     {
         LogPrint(BCLog::ZMQ, "zmq: Reusing socket for address %s\n", address);
+        LogPrint(BCLog::ZMQ, "zmq: Outbound message high water mark for %s at %s is %d\n", type, address, outbound_message_high_water_mark);
 
         psocket = i->second->psocket;
         mapPublishNotifiers.insert(std::make_pair(address, this));


### PR DESCRIPTION
Running master with `src/bitcoind -zmqpubhashblockhwm=12345 -zmqpubrawtx=tcp://127.0.0.1:28332 -zmqpubhashtxhwm=5000 -zmqpubrawblock=tcp://127.0.0.1:28332 -zmqpubhashtx=tcp://127.0.0.1:28332 -zmqpubhashblock=tcp://127.0.0.1:28332 -debug=zmq`:
```
2019-01-19T14:11:01Z zmq: version 4.3.1
2019-01-19T14:11:01Z zmq: Initialize notification interface
2019-01-19T14:11:01Z zmq: Outbound message high water mark for pubhashblock at tcp://127.0.0.1:28332 is 12345
2019-01-19T14:11:01Z zmq: Notifier pubhashblock ready (address = tcp://127.0.0.1:28332)
2019-01-19T14:11:01Z zmq: Reusing socket for address tcp://127.0.0.1:28332
2019-01-19T14:11:01Z zmq: Notifier pubhashtx ready (address = tcp://127.0.0.1:28332)
2019-01-19T14:11:01Z zmq: Reusing socket for address tcp://127.0.0.1:28332
2019-01-19T14:11:01Z zmq: Notifier pubrawblock ready (address = tcp://127.0.0.1:28332)
2019-01-19T14:11:01Z zmq: Reusing socket for address tcp://127.0.0.1:28332
2019-01-19T14:11:01Z zmq: Notifier pubrawtx ready (address = tcp://127.0.0.1:28332)
```

This PR:
```
2019-01-19T14:06:57Z zmq: version 4.3.1
2019-01-19T14:06:57Z zmq: Initialize notification interface
2019-01-19T14:06:57Z zmq: Outbound message high water mark for pubhashblock at tcp://127.0.0.1:28332 is 12345
2019-01-19T14:06:57Z zmq: Notifier pubhashblock ready (address = tcp://127.0.0.1:28332)
2019-01-19T14:06:57Z zmq: Reusing socket for address tcp://127.0.0.1:28332
2019-01-19T14:06:57Z zmq: Outbound message high water mark for pubhashtx at tcp://127.0.0.1:28332 is 5000
2019-01-19T14:06:57Z zmq: Notifier pubhashtx ready (address = tcp://127.0.0.1:28332)
2019-01-19T14:06:57Z zmq: Reusing socket for address tcp://127.0.0.1:28332
2019-01-19T14:06:57Z zmq: Outbound message high water mark for pubrawblock at tcp://127.0.0.1:28332 is 1000
2019-01-19T14:06:57Z zmq: Notifier pubrawblock ready (address = tcp://127.0.0.1:28332)
2019-01-19T14:06:57Z zmq: Reusing socket for address tcp://127.0.0.1:28332
2019-01-19T14:06:57Z zmq: Outbound message high water mark for pubrawtx at tcp://127.0.0.1:28332 is 1000
2019-01-19T14:06:57Z zmq: Notifier pubrawtx ready (address = tcp://127.0.0.1:28332)
```
