### PR TITLE
gui: Fix window title update

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1225,16 +1225,18 @@ void BitcoinGUI::updateProxyIcon()
 
 void BitcoinGUI::updateWindowTitle()
 {
-    QString window_title = tr(PACKAGE_NAME) + " - ";
+    QString window_title = tr(PACKAGE_NAME);
 #ifdef ENABLE_WALLET
     if (walletFrame) {
         WalletModel* const wallet_model = walletFrame->currentWalletModel();
         if (wallet_model && !wallet_model->getWalletName().isEmpty()) {
-            window_title += wallet_model->getDisplayName() + " - ";
+            window_title += " - " + wallet_model->getDisplayName();
         }
     }
 #endif
-    window_title += m_network_style->getTitleAddText();
+    if (!m_network_style->getTitleAddText().isEmpty()) {
+        window_title += " - " + m_network_style->getTitleAddText();
+    }
     setWindowTitle(window_title);
 }
 


### PR DESCRIPTION
Removes trailing `-` from window title when running on mainnet.

Reported by @Sjors in https://github.com/bitcoin/bitcoin/pull/15149#issuecomment-455787938.