### PR TITLE
rpc: Use the return value of GetProxy(...) in GetNetworksInfo(). Mark GetProxy(...) with [[nodiscard]].

### DIFF
--- a/src/netbase.h
+++ b/src/netbase.h
@@ -9,6 +9,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <attributes.h>
 #include <compat.h>
 #include <netaddress.h>
 #include <serialize.h>
@@ -40,7 +41,7 @@ public:
 enum Network ParseNetwork(std::string net);
 std::string GetNetworkName(enum Network net);
 bool SetProxy(enum Network net, const proxyType &addrProxy);
-bool GetProxy(enum Network net, proxyType &proxyInfoOut);
+NODISCARD bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
 bool SetNameProxy(const proxyType &addrProxy);
 bool HaveNameProxy();

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -419,14 +419,17 @@ static UniValue GetNetworksInfo()
         enum Network network = static_cast<enum Network>(n);
         if(network == NET_UNROUTABLE || network == NET_INTERNAL)
             continue;
-        proxyType proxy;
+
         UniValue obj(UniValue::VOBJ);
-        GetProxy(network, proxy);
         obj.pushKV("name", GetNetworkName(network));
         obj.pushKV("limited", !IsReachable(network));
         obj.pushKV("reachable", IsReachable(network));
-        obj.pushKV("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : std::string());
-        obj.pushKV("proxy_randomize_credentials", proxy.randomize_credentials);
+
+        proxyType proxy;
+        bool use_proxy = GetProxy(network, proxy);
+        obj.pushKV("proxy", use_proxy ? proxy.proxy.ToStringIPPort() : std::string());
+        obj.pushKV("proxy_randomize_credentials", use_proxy ? proxy.randomize_credentials : false);
+
         networks.push_back(obj);
     }
     return networks;


### PR DESCRIPTION
* Use the return value of `GetProxy(...)` in `GetNetworksInfo()`.
* Mark `GetProxy(...)` with `[[nodiscard]]`.