### PR TITLE
Wallet: Remove "-Wunused-variable" warning while build with "--disable-wallet" option

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -904,12 +904,9 @@ void RPCConsole::on_lineEdit_returnPressed()
 
         cmdBeforeBrowsing = QString();
 
-        WalletModel* wallet_model{nullptr};
 #ifdef ENABLE_WALLET
         const int wallet_index = ui->WalletSelector->currentIndex();
-        if (wallet_index > 0) {
-            wallet_model = ui->WalletSelector->itemData(wallet_index).value<WalletModel*>();
-        }
+        WalletModel* const wallet_model{wallet_index > 0 ? ui->WalletSelector->itemData(wallet_index).value<WalletModel*>() : nullptr};
 
         if (m_last_wallet_model != wallet_model) {
             if (wallet_model) {


### PR DESCRIPTION
Currently in master:
```
$ make distclean
$ ./configure --disable-wallet
$ make >> /dev/null
...
qt/rpcconsole.cpp: In member function ‘void RPCConsole::on_lineEdit_returnPressed()’:
qt/rpcconsole.cpp:907:22: warning: unused variable ‘wallet_model’ [-Wunused-variable]
         WalletModel* wallet_model{nullptr};
                      ^~~~~~~~~~~~
```

This refactoring PR does not change the behavior of code.

cc @promag 