### PR TITLE
Drop defunct Windows compat fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
         DPKG_ADD_ARCH="i386"
         PACKAGES="python3 nsis g++-mingw-w64-i686 wine-binfmt wine32"
         GOAL="deploy"
-        BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests"
+        BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests CPPFLAGS=-DFAIL_ON_EXTRANEOUS_COMPAT"
 
     - stage: test
       name: 'Win64  [GOAL: deploy]  [no gui tests]'
@@ -79,7 +79,7 @@ jobs:
         HOST=x86_64-w64-mingw32
         PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
         GOAL="deploy"
-        BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests"
+        BITCOIN_CONFIG="--enable-reduce-exports --disable-gui-tests CPPFLAGS=-DFAIL_ON_EXTRANEOUS_COMPAT"
 
     - stage: test
       name: '32-bit + dash  [GOAL: install]'

--- a/src/compat.h
+++ b/src/compat.h
@@ -48,6 +48,23 @@
 #include <unistd.h>
 #endif
 
+// Fix for ancient MinGW versions, that don't have defined these in ws2tcpip.h.
+// Todo: Can be removed when our pull-tester is upgraded to a modern MinGW version.
+#ifdef WIN32
+#ifndef AI_ADDRCONFIG
+#define AI_ADDRCONFIG 0x00000400
+#elif defined(FAIL_ON_EXTRANEOUS_COMPAT)
+#error Unnecessary fix for AI_ADDRCONFIG
+#endif
+#ifndef PROCESS_DEP_ENABLE
+// We define this here, because GCCs winbase.h limits this to _WIN32_WINNT >= 0x0601 (Windows 7),
+// which is not correct. Can be removed, when GCCs winbase.h is fixed!
+#define PROCESS_DEP_ENABLE 0x00000001
+#elif defined(FAIL_ON_EXTRANEOUS_COMPAT)
+#error Unnecessary fix for PROCESS_DEP_ENABLE
+#endif
+#endif
+
 #ifndef WIN32
 typedef unsigned int SOCKET;
 #include <errno.h>

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -893,11 +893,6 @@ bool AppInitBasicSetup()
     // Enable Data Execution Prevention (DEP)
     // Minimum supported OS versions: WinXP SP3, WinVista >= SP1, Win Server 2008
     // A failure is non-critical and needs no further attention!
-#ifndef PROCESS_DEP_ENABLE
-    // We define this here, because GCCs winbase.h limits this to _WIN32_WINNT >= 0x0601 (Windows 7),
-    // which is not correct. Can be removed, when GCCs winbase.h is fixed!
-#define PROCESS_DEP_ENABLE 0x00000001
-#endif
     typedef BOOL (WINAPI *PSETPROCDEPPOL)(DWORD);
     PSETPROCDEPPOL setProcDEPPol = (PSETPROCDEPPOL)GetProcAddress(GetModuleHandleA("Kernel32.dll"), "SetProcessDEPPolicy");
     if (setProcDEPPol != nullptr) setProcDEPPol(PROCESS_DEP_ENABLE);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -58,17 +58,6 @@ static constexpr int DUMP_PEERS_INTERVAL = 15 * 60;
 #define MSG_DONTWAIT 0
 #endif
 
-// Fix for ancient MinGW versions, that don't have defined these in ws2tcpip.h.
-// Todo: Can be removed when our pull-tester is upgraded to a modern MinGW version.
-#ifdef WIN32
-#ifndef PROTECTION_LEVEL_UNRESTRICTED
-#define PROTECTION_LEVEL_UNRESTRICTED 10
-#endif
-#ifndef IPV6_PROTECTION_LEVEL
-#define IPV6_PROTECTION_LEVEL 23
-#endif
-#endif
-
 /** Used to pass flags to the Bind() function */
 enum BindFlags {
     BF_NONE         = 0,

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -80,11 +80,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
     aiHint.ai_socktype = SOCK_STREAM;
     aiHint.ai_protocol = IPPROTO_TCP;
     aiHint.ai_family = AF_UNSPEC;
-#ifdef WIN32
-    aiHint.ai_flags = fAllowLookup ? 0 : AI_NUMERICHOST;
-#else
     aiHint.ai_flags = fAllowLookup ? AI_ADDRCONFIG : AI_NUMERICHOST;
-#endif
     struct addrinfo *aiRes = nullptr;
     int nErr = getaddrinfo(pszName, nullptr, &aiHint, &aiRes);
     if (nErr)


### PR DESCRIPTION
"The AI_ADDRCONFIG flag is defined on the Windows SDK for Windows Vista and later.
The AI_ADDRCONFIG flag is supported on Windows Vista and later."
https://docs.microsoft.com/en-us/windows/desktop/api/ws2tcpip/nf-ws2tcpip-getaddrinfo

However, the version of MinGW we use on Travis is not current and does
not carry the relevant definition, as such I defined it in compat.
https://github.com/wine-mirror/wine/blob/master/include/ws2tcpip.h

Testing confirms that the PROTECTION_LEVEL_UNRESTRICTED and
IPV6_PROTECTION_LEVEL are now supported by the version of windows that
we test against, so can be removed.
https://travis-ci.org/bitcoin/bitcoin/jobs/483255439