### PR TITLE
Prevent mutex lock fail even if --enable-debug

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -73,7 +73,11 @@ struct LockData {
     LockOrders lockorders;
     InvLockOrders invlockorders;
     std::mutex dd_mutex;
-} static lockdata;
+};
+LockData& GetLockData() {
+    static LockData lockdata;
+    return lockdata;
+}
 
 static thread_local LockStack g_lockstack;
 
@@ -109,6 +113,7 @@ static void potential_deadlock_detected(const std::pair<void*, void*>& mismatch,
 
 static void push_lock(void* c, const CLockLocation& locklocation)
 {
+    LockData& lockdata = GetLockData();
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
 
     g_lockstack.push_back(std::make_pair(c, locklocation));
@@ -173,6 +178,7 @@ void AssertLockNotHeldInternal(const char* pszName, const char* pszFile, int nLi
 
 void DeleteLock(void* cs)
 {
+    LockData& lockdata = GetLockData();
     if (!lockdata.available) {
         // We're already shutting down.
         return;


### PR DESCRIPTION
This PR intends to resolve #15227.

```configure --enable-debug```  enables ```#ifdef DEBUG_LOCKORDER```.

Then ```lockdata``` (in sync.cpp) will be initialized same as other static objects.

But unfortunately, ```lockdata.push_lock()``` was called before its initialization (via initializing ```signatureCache``` which is declared in ```script/sigcache.cpp```) on macOS.

This PR apply the "Construct On First Use Idiom" to ```lockdata``` to prevent it.

edited --- fix typo.