### PR TITLE
rpc: Compile on GCC4.8

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -51,7 +51,7 @@ struct RPCCommandExecution
     explicit RPCCommandExecution(const std::string& method)
     {
         LOCK(g_rpc_server_info.mutex);
-        it = g_rpc_server_info.active_commands.insert(g_rpc_server_info.active_commands.cend(), {method, GetTimeMicros()});
+        it = g_rpc_server_info.active_commands.insert(g_rpc_server_info.active_commands.end(), {method, GetTimeMicros()});
     }
     ~RPCCommandExecution()
     {


### PR DESCRIPTION
GCC 4.8 is lacking some C++11 signatures (see "Adjust C++11 signatures to take a const_iterator." in GCC 4.9: https://github.com/gcc-mirror/gcc/commit/3d2b2f494d78e0f4168d2c7ba5a76c05b4f4af71)

Fix that by changing the code to use the pre-GCC 4.9 signature.

Can be reverted after #13356.

Fixes #15172 (reports on `Linux Mint 17.3 Rosa` and `CentOS Linux release 7.5.1804 (Core)`)