### PR TITLE
Docs: Update python docs to reflect that wildcard imports are disallowed

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -26,7 +26,7 @@ don't have test cases for.
   The Travis linter also checks this, but [possibly not in all cases](https://github.com/bitcoin/bitcoin/pull/14884#discussion_r239585126).
 - See [the python lint script](/test/lint/lint-python.sh) that checks for violations that
   could lead to bugs and issues in the test code.
-- Avoid wildcard imports where possible
+- Avoid wildcard imports
 - Use a module-level docstring to describe what the test is testing, and how it
   is testing it.
 - When subclassing the BitcoinTestFramwork, place overrides for the

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -13,7 +13,7 @@ is testing and *how* it's being tested
 # libraries then local imports).
 from collections import defaultdict
 
-# Avoid wildcard * imports if possible
+# Avoid wildcard * imports
 from test_framework.blocktools import (create_block, create_coinbase)
 from test_framework.messages import CInv
 from test_framework.mininode import (


### PR DESCRIPTION
These have been disallowed via flake8 since: #13054