### PR TITLE
[0.17] Backport: Update zmq to 4.3.1

### DIFF
--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,8 +1,8 @@
 package=zeromq
-$(package)_version=4.2.3
+$(package)_version=4.3.1
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0
+$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
 $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -26,5 +26,5 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | Qt | [5.9.6](https://download.qt.io/official_releases/qt/) | 5.x | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L87) (Linux only) |
 | xkbcommon |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L86) (Linux only) |
-| ZeroMQ | [4.2.3](https://github.com/zeromq/libzmq/releases) |  | No |  |  |
+| ZeroMQ | [4.3.1](https://github.com/zeromq/libzmq/releases) |  | No |  |  |
 | zlib | [1.2.11](https://zlib.net/) |  |  |  | No |


### PR DESCRIPTION
Backports #15188 to the 0.17 branch.

Addresses https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6250.
