### PR TITLE
Net: Consistently log outgoing INV messages

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -283,8 +283,7 @@ public:
     }
     void relayTransaction(const uint256& txid) override
     {
-        CInv inv(MSG_TX, txid);
-        g_connman->ForEachNode([&inv](CNode* node) { node->PushInventory(inv); });
+        g_connman->RelayTransaction(txid);
     }
     void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) override
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2610,6 +2610,12 @@ int CConnman::GetBestHeight() const
     return nBestHeight.load(std::memory_order_acquire);
 }
 
+void CConnman::RelayTransaction(const uint256& txid) const
+{
+    CInv inv(MSG_TX, txid);
+    ForEachNode([&inv](CNode* node) { node->PushInventory(inv); });
+}
+
 unsigned int CConnman::GetReceiveFloodSize() const { return nReceiveFloodSize; }
 
 CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn, SOCKET hSocketIn, const CAddress& addrIn, uint64_t nKeyedNetGroupIn, uint64_t nLocalHostNonceIn, const CAddress& addrBindIn, const std::string& addrNameIn, bool fInboundIn)

--- a/src/net.h
+++ b/src/net.h
@@ -299,6 +299,9 @@ public:
     void SetBestHeight(int height);
     int GetBestHeight() const;
 
+    /** Announce transaction to all peers */
+    void RelayTransaction(const uint256& txid) const;
+
     /** Get a unique deterministic randomizer. */
     CSipHasher GetDeterministicRandomizer(uint64_t id) const;
 

--- a/src/net.h
+++ b/src/net.h
@@ -842,17 +842,12 @@ public:
         }
     }
 
-    void PushInventory(const CInv& inv)
-    {
-        LOCK(cs_inventory);
-        if (inv.type == MSG_TX) {
-            if (!filterInventoryKnown.contains(inv.hash)) {
-                setInventoryTxToSend.insert(inv.hash);
-            }
-        } else if (inv.type == MSG_BLOCK) {
-            vInventoryBlockToSend.push_back(inv.hash);
-        }
-    }
+    //! Pushes a tx inv to this peer, unless already known
+    //! @returns true if the inv will be sent, false if not
+    bool PushTransactionInventory(const uint256& txid);
+
+    //! Pushes a block inv to this peer
+    void PushBlockInventory(const uint256& blockhash);
 
     void PushBlockHash(const uint256 &hash)
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1292,15 +1292,6 @@ bool static AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     return true;
 }
 
-static void RelayTransaction(const CTransaction& tx, CConnman* connman)
-{
-    CInv inv(MSG_TX, tx.GetHash());
-    connman->ForEachNode([&inv](CNode* pnode)
-    {
-        pnode->PushInventory(inv);
-    });
-}
-
 static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connman)
 {
     unsigned int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
@@ -1786,7 +1777,7 @@ void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_se
         if (setMisbehaving.count(fromPeer)) continue;
         if (AcceptToMemoryPool(mempool, orphan_state, porphanTx, &fMissingInputs2, &removed_txn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
             LogPrint(BCLog::MEMPOOL, "   accepted orphan tx %s\n", orphanHash.ToString());
-            RelayTransaction(orphanTx, connman);
+            connman->RelayTransaction(orphanHash);
             for (unsigned int i = 0; i < orphanTx.vout.size(); i++) {
                 auto it_by_prev = mapOrphanTransactionsByPrev.find(COutPoint(orphanHash, i));
                 if (it_by_prev != mapOrphanTransactionsByPrev.end()) {
@@ -2473,7 +2464,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         if (!AlreadyHave(inv) &&
             AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */)) {
             mempool.check(pcoinsTip.get());
-            RelayTransaction(tx, connman);
+            connman->RelayTransaction(inv.hash);
             for (unsigned int i = 0; i < tx.vout.size(); i++) {
                 auto it_by_prev = mapOrphanTransactionsByPrev.find(COutPoint(inv.hash, i));
                 if (it_by_prev != mapOrphanTransactionsByPrev.end()) {
@@ -2552,7 +2543,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     LogPrintf("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n", tx.GetHash().ToString(), pfrom->GetId(), FormatStateMessage(state));
                 } else {
                     LogPrintf("Force relaying tx %s from whitelisted peer=%d\n", tx.GetHash().ToString(), pfrom->GetId());
-                    RelayTransaction(tx, connman);
+                    connman->RelayTransaction(tx.GetHash());
                 }
             }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1472,7 +1472,7 @@ void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, c
         // Trigger the peer node to send a getblocks request for the next batch of inventory
         if (inv.hash == pfrom->hashContinue)
         {
-            // Bypass PushInventory, this must send even if redundant,
+            // Bypass PushBlockInventory, this must send even if redundant,
             // and we want it right after the last block so they don't
             // wait for other stuff first.
             std::vector<CInv> vInv;
@@ -2304,7 +2304,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 LogPrint(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }
-            pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
+            pfrom->PushBlockInventory(pindex->GetBlockHash());
             if (--nLimit <= 0)
             {
                 // When this block is requested, we'll send an inv that'll
@@ -3705,9 +3705,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
                     // If the peer's chain has this block, don't inv it back.
                     if (!PeerHasHeader(&state, pindex)) {
-                        pto->PushInventory(CInv(MSG_BLOCK, hashToAnnounce));
-                        LogPrint(BCLog::NET, "%s: sending inv peer=%d hash=%s\n", __func__,
-                            pto->GetId(), hashToAnnounce.ToString());
+                        pto->PushBlockInventory(hashToAnnounce);
                     }
                 }
             }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -69,10 +69,7 @@ TransactionError BroadcastTransaction(const CTransactionRef tx, uint256& hashTx,
         return TransactionError::P2P_DISABLED;
     }
 
-    CInv inv(MSG_TX, hashTx);
-    g_connman->ForEachNode([&inv](CNode* pnode) {
-        pnode->PushInventory(inv);
-    });
+    g_connman->RelayTransaction(hashTx);
 
     return TransactionError::OK;
 }


### PR DESCRIPTION
These are logged in some cases, but not in others, which can make debugging test failures impractical in cases where the TX INVs are important.

Also fix  the `sending inv peer=%d hash=%s` to explicitly note that a block inv was being sent.

Here's an example of where this might come in useful.
```
2019-01-25T01:39:16.043000Z TestFramework (INFO): Initializing test directory /tmp/test_runner_₿_🏃_20190125_013849/p2p_sendheaders_98
2019-01-25T01:39:17.467000Z TestFramework (INFO): Verify getheaders with null locator and valid hashstop returns headers.
2019-01-25T01:39:17.518000Z TestFramework (INFO): Verify getheaders with null locator and invalid hashstop does not return headers.
2019-01-25T01:39:17.622000Z TestFramework (INFO): Part 1: headers don't start before sendheaders message...
2019-01-25T01:39:18.061000Z TestFramework (INFO): Part 1: success!
2019-01-25T01:39:18.061000Z TestFramework (INFO): Part 2: announce blocks with headers after sendheaders message...
2019-01-25T01:39:25.881000Z TestFramework (INFO): Part 2: success!
2019-01-25T01:39:25.882000Z TestFramework (INFO): Part 3: headers announcements can stop after large reorg, and resume after headers/inv from peer...
2019-01-25T01:39:28.607000Z TestFramework (ERROR): Assertion failed
Traceback (most recent call last):
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/test_framework/test_framework.py", line 173, in main
    self.run_test()
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/p2p_sendheaders.py", line 252, in run_test
    self.test_nonnull_locators(test_node, inv_node)
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/p2p_sendheaders.py", line 392, in test_nonnull_locators
    inv_node.check_last_inv_announcement(inv=[tip])
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/p2p_sendheaders.py", line 202, in check_last_inv_announcement
    assert_equal(compare_inv, inv)
  File "/home/travis/build/bitcoin/bitcoin/build/bitcoin-x86_64-unknown-linux-gnu/test/functional/test_framework/util.py", line 39, in assert_equal
    raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
AssertionError: not([40204527931277807332276281381170204987709290312442988532095433649182475622986] == [30543910617856476296290423477244797212992354123001017184131728944424831123554])
```
From log previously held here: https://travis-ci.org/bitcoin/bitcoin/jobs/484159397 but since overwritten. I have the full log available locally if anyone is curious to see it.