### PR TITLE
[tests] Remove travis_wait from lint script

### DIFF
--- a/.travis/lint_06_script.sh
+++ b/.travis/lint_06_script.sh
@@ -21,5 +21,5 @@ test/lint/lint-all.sh
 if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
     while read -r LINE; do travis_retry gpg --keyserver hkp://subset.pool.sks-keyservers.net --recv-keys $LINE; done < contrib/verify-commits/trusted-keys &&
-    travis_wait 50 contrib/verify-commits/verify-commits.py --clean-merge=2;
+    ./contrib/verify-commits/verify-commits.py --clean-merge=2;
 fi

--- a/contrib/verify-commits/verify-commits.py
+++ b/contrib/verify-commits/verify-commits.py
@@ -5,6 +5,7 @@
 """Verify commits against a trusted keys list."""
 import argparse
 import hashlib
+import logging
 import os
 import subprocess
 import sys
@@ -66,6 +67,11 @@ def tree_sha512sum(commit='HEAD'):
     return overall.hexdigest()
 
 def main():
+
+    # Enable debug logging if running in CI
+    if 'CI' in os.environ and os.environ['CI'].lower() == "true":
+        logging.getLogger().setLevel(logging.DEBUG)
+
     # Parse arguments
     parser = argparse.ArgumentParser(usage='%(prog)s [options] [commit id]')
     parser.add_argument('--disable-tree-check', action='store_false', dest='verify_tree', help='disable SHA-512 tree check')
@@ -95,6 +101,10 @@ def main():
 
     # Iterate through commits
     while True:
+
+        # Log a message to prevent Travis from timing out
+        logging.debug("verify-commits: [in-progress] processing commit {}".format(current_commit[:8]))
+
         if current_commit == verified_root:
             print('There is a valid path from "{}" to {} where all commits are signed!'.format(initial_commit, verified_root))
             sys.exit(0)


### PR DESCRIPTION
Using the `travis_wait` command in conjunction with `set -o errexit` causes problems. The `travis_wait` command will correctly log the command's output if successful, but if the command fails the process exits before the `travis_wait` command can dump the logs. This will hide important debugging information like error messages and stack traces. We ran into this in #15196 and it was very hard to debug because output was being suppressed.

`travis_wait` was being used because the `contrib/verify-commits/verify-commits.py` script can sometimes run for a long time without producing any output. If a script runs for 10 minutes without logging anything, the CI run times out. The `travis_wait` command will extend this timeout by logging a message for you, while sending stderr and stdout to a file.

This PR removes the `travis_wait` command from our CI system and adds additional logging to the `verify-commits.py` script so it doesn't make Travis timeout. 