### PR TITLE
Use real HTTP bind address in curl RPC help

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -239,6 +239,11 @@ bool StartHTTPRPC()
     LogPrint(BCLog::RPC, "Starting HTTP RPC server\n");
     if (!InitRPCAuthentication())
         return false;
+
+    std::string bindAddress;
+    if (GetHTTPBindAddress(bindAddress)) {
+        SetRPCHelpAddress(bindAddress);
+    }
 
     RegisterHTTPHandler("/", true, HTTPReq_JSONRPC);
     if (g_wallet_init_interface.HasWalletSupport()) {

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -135,18 +135,22 @@ struct HTTPPathHandler
 
 /** HTTP module state */
 
+namespace {
+
 //! libevent event loop
-static struct event_base* eventBase = nullptr;
+struct event_base* eventBase = nullptr;
 //! HTTP server
 struct evhttp* eventHTTP = nullptr;
 //! List of subnets to allow RPC connections from
-static std::vector<CSubNet> rpc_allow_subnets;
+std::vector<CSubNet> rpc_allow_subnets;
 //! Work queue for handling longer requests off the event loop thread
-static WorkQueue<HTTPClosure>* workQueue = nullptr;
+WorkQueue<HTTPClosure>* workQueue = nullptr;
 //! Handlers for (sub)paths
 std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets
 std::vector<evhttp_bound_socket *> boundSockets;
+
+} // anonymous namespace
 
 /** Check if a network address is allowed to access the HTTP server */
 static bool ClientAllowed(const CNetAddr& netaddr)

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -31,6 +31,12 @@ void StartHTTPServer();
 void InterruptHTTPServer();
 /** Stop HTTP server */
 void StopHTTPServer();
+
+/**
+ * Tries to get (one) address at which the HTTP server is bound.  Returns
+ * false if the server is not bound anywhere at the moment.
+ */
+bool GetHTTPBindAddress(std::string& address);
 
 /** Change logging level for libevent. Removes BCLog::LIBEVENT from log categories if
  * libevent doesn't support debug logging.*/

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -20,6 +20,7 @@
 #include <boost/algorithm/string/split.hpp>
 
 #include <memory> // for unique_ptr
+#include <sstream>
 #include <unordered_map>
 
 namespace {
@@ -32,6 +33,9 @@ std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";
 RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */
 std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
+
+/** The bind address that is used for the RPC help example.  */
+std::string rpcHelpBindAddress = "http://localhost:8336";
 
 struct RPCCommandExecutionInfo
 {
@@ -405,6 +409,11 @@ bool RPCIsInWarmup(std::string *outStatus)
     return fRPCInWarmup;
 }
 
+void SetRPCHelpAddress(const std::string& address)
+{
+    rpcHelpBindAddress = address;
+}
+
 void JSONRPCRequest::parse(const UniValue& valRequest)
 {
     // Parse request
@@ -571,8 +580,14 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
-    return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+    std::ostringstream helpText;
+    helpText << "> curl --user myusername --data-binary "
+             << "'{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
+             << "\"method\": \"" + methodname + "\", "
+             << "\"params\": [" + args + "] }' "
+             << "-H 'content-type: text/plain;' "
+             << rpcHelpBindAddress << "\n";
+    return helpText.str();
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -22,14 +22,16 @@
 #include <memory> // for unique_ptr
 #include <unordered_map>
 
-static CCriticalSection cs_rpcWarmup;
-static std::atomic<bool> g_rpc_running{false};
-static bool fRPCInWarmup GUARDED_BY(cs_rpcWarmup) = true;
-static std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";
+namespace {
+
+CCriticalSection cs_rpcWarmup;
+std::atomic<bool> g_rpc_running{false};
+bool fRPCInWarmup GUARDED_BY(cs_rpcWarmup) = true;
+std::string rpcWarmupStatus GUARDED_BY(cs_rpcWarmup) = "RPC server started";
 /* Timer-creating functions */
-static RPCTimerInterface* timerInterface = nullptr;
+RPCTimerInterface* timerInterface = nullptr;
 /* Map of name to timer. */
-static std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
+std::map<std::string, std::unique_ptr<RPCTimerBase> > deadlineTimers;
 
 struct RPCCommandExecutionInfo
 {
@@ -43,7 +45,7 @@ struct RPCServerInfo
     std::list<RPCCommandExecutionInfo> active_commands GUARDED_BY(mutex);
 };
 
-static RPCServerInfo g_rpc_server_info;
+RPCServerInfo g_rpc_server_info;
 
 struct RPCCommandExecution
 {
@@ -60,11 +62,13 @@ struct RPCCommandExecution
     }
 };
 
-static struct CRPCSignals
+struct CRPCSignals
 {
     boost::signals2::signal<void ()> Started;
     boost::signals2::signal<void ()> Stopped;
 } g_rpcSignals;
+
+} // anonymous namespace
 
 void RPCServer::OnStarted(std::function<void ()> slot)
 {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -64,6 +64,9 @@ void SetRPCWarmupFinished();
 
 /* returns the current warmup state.  */
 bool RPCIsInWarmup(std::string *outStatus);
+
+/** Sets the bind address to use in the RPC help examples.  */
+void SetRPCHelpAddress(const std::string& address);
 
 /**
  * Type-check arguments; throws JSONRPCError if wrong type given. Does not check that

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2018-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test RPC help output."""
 
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error
+from test_framework.util import assert_equal, assert_raises_rpc_error, rpc_port
 
 import os
+import re
 
 
 class HelpRpcTest(BitcoinTestFramework):
@@ -16,6 +17,7 @@ class HelpRpcTest(BitcoinTestFramework):
 
     def run_test(self):
         self.test_categories()
+        self.test_example_bind_address()
         self.dump_help()
 
     def test_categories(self):
@@ -42,6 +44,10 @@ class HelpRpcTest(BitcoinTestFramework):
             components.append('Zmq')
 
         assert_equal(titles, components)
+
+    def test_example_bind_address(self):
+        help_text = self.nodes[0].help('getblockchaininfo')
+        assert re.search('curl .* http://127.0.0.1:%d' % rpc_port(0), help_text) is not None
 
     def dump_help(self):
         dump_dir = os.path.join(self.options.tmpdir, 'rpc_help_dump')


### PR DESCRIPTION
This change exposes the bind address (one of them if multiple) of the HTTP server.  This allows us to use a real bind address in the `curl` example in RPC help texts.

In particular, this now reports the correct port if it was either explicitly changed through `-rpcport` or is from a different chain than mainnet.

This is a replacement for #15181, based on the feedback from @laanwj there.