### PR TITLE
doc: correct logging return type and RPC example

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -404,13 +404,13 @@ UniValue logging(const JSONRPCRequest& request)
                 },
                 RPCResult{
             "{                   (json object where keys are the logging categories, and values indicates its status\n"
-            "  \"category\": 0|1,  (numeric) if being debug logged or not. 0:inactive, 1:active\n"
+            "  \"category\": true|false,  (bool) if being debug logged or not. false:inactive, true:active\n"
             "  ...\n"
             "}\n"
                 },
                 RPCExamples{
                     HelpExampleCli("logging", "\"[\\\"all\\\"]\" \"[\\\"http\\\"]\"")
-            + HelpExampleRpc("logging", "[\"all\"], \"[libevent]\"")
+            + HelpExampleRpc("logging", "[\"all\"], [\"libevent\"]")
                 },
             }.ToString());
     }


### PR DESCRIPTION
Logging status is returned as a bool.
```
src/bitcoin-cli logging "[\"all\"]" "[\"http\"]"
{
  "net": true,
  "tor": true,
  "mempool": true,
  "http": false,
  "bench": true,
  "zmq": true,
  "db": true,
  "rpc": true,
  "estimatefee": true,
  "addrman": true,
  "selectcoins": true,
  "reindex": true,
  "cmpctblock": true,
  "rand": true,
  "prune": true,
  "proxy": true,
  "mempoolrej": true,
  "libevent": true,
  "coindb": true,
  "qt": true,
  "leveldb": true
}
```

Also corrects the RPC example so that `libevent` logging will actually be turned off.