### PR TITLE
wallet: Clarify rescanblockchain doc

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3408,12 +3408,12 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
                 "\nRescan the local blockchain for wallet related transactions.\n",
                 {
                     {"start_height", RPCArg::Type::NUM, /* opt */ true, /* default_val */ "0", "block height where the rescan should start"},
-                    {"stop_height", RPCArg::Type::NUM, /* opt */ true, /* default_val */ "tip height", "the last block height that should be scanned"},
+                    {"stop_height", RPCArg::Type::NUM, /* opt */ true, /* default_val */ "", "the last block height that should be scanned. If none is provided it will rescan up to the tip at return time of this call."},
                 },
                 RPCResult{
             "{\n"
-            "  \"start_height\"     (numeric) The block height where the rescan has started. If omitted, rescan started from the genesis block.\n"
-            "  \"stop_height\"      (numeric) The height of the last rescanned block. If omitted, rescan stopped at the chain tip.\n"
+            "  \"start_height\"     (numeric) The block height where the rescan has started.\n"
+            "  \"stop_height\"      (numeric) The height of the last rescanned block.\n"
             "}\n"
                 },
                 RPCExamples{


### PR DESCRIPTION
This was probably accidentally added to the wrong line when addressing the feedback here: https://github.com/bitcoin/bitcoin/pull/7061#discussion_r142199778

I already added the default values in #14877, but it could be clarified more that this really has no specific block height as default value, since the tip can change during a rescan.