### PR TITLE
Remove 'boost::optional'-related false positive -Wmaybe-uninitialized warnings on GCC compiler

### DIFF
--- a/src/optional.h
+++ b/src/optional.h
@@ -5,11 +5,20 @@
 #ifndef BITCOIN_OPTIONAL_H
 #define BITCOIN_OPTIONAL_H
 
+#include <utility>
+
 #include <boost/optional.hpp>
 
 //! Substitute for C++17 std::optional
 template <typename T>
 using Optional = boost::optional<T>;
+
+//! Substitute for C++17 std::make_optional
+template <typename T>
+Optional<T> MakeOptional(bool condition, T&& value)
+{
+    return boost::make_optional(condition, std::forward<T>(value));
+}
 
 //! Substitute for C++17 std::nullopt
 static auto& nullopt = boost::none;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1591,7 +1591,8 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     auto locked_chain = pwallet->chain().lock();
     LOCK(pwallet->cs_wallet);
 
-    Optional<int> height;    // Height of the specified block or the common ancestor, if the block provided was in a deactivated chain.
+    // The way the 'height' is initialized is just a workaround for the gcc bug #47679 since version 4.6.0.
+    Optional<int> height = MakeOptional(false, int()); // Height of the specified block or the common ancestor, if the block provided was in a deactivated chain.
     Optional<int> altheight; // Height of the specified block, even if it's in a deactivated chain.
     int target_confirms = 1;
     isminefilter filter = ISMINE_SPENDABLE;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1642,7 +1642,8 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
         fAbortRescan = false;
         ShowProgress(strprintf("%s " + _("Rescanning..."), GetDisplayName()), 0); // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup
         uint256 tip_hash;
-        Optional<int> block_height;
+        // The way the 'block_height' is initialized is just a workaround for the gcc bug #47679 since version 4.6.0.
+        Optional<int> block_height = MakeOptional(false, int());
         double progress_begin;
         double progress_end;
         {


### PR DESCRIPTION
#14711 introduced some warnings when building with gcc compiler.

See:
- https://github.com/bitcoin/bitcoin/pull/14711#issuecomment-454760017 by @laanwj 
- https://github.com/bitcoin/bitcoin/pull/14711#pullrequestreview-193702611 by @ryanofsky 

This gcc [issue](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=47679) has been known since version 4.6.0 and last updated in 2017.
From the boost [docs](https://www.boost.org/doc/libs/1_69_0/libs/optional/doc/html/boost_optional/quick_start/optional_automatic_variables.html):
> The default constructor of `optional` creates an _uninitialized_ `optional` object.

Also: [False positive with -Wmaybe-uninitialized](https://www.boost.org/doc/libs/1_69_0/libs/optional/doc/html/boost_optional/tutorial/gotchas/false_positive_with__wmaybe_uninitialized.html) ([pointed out](https://github.com/bitcoin/bitcoin/pull/15292#issuecomment-459063170) by @Empact)

This PR removes these warnings.

cc: @Empact @practicalswift 