### PR TITLE
tests: When testing with --usecli, unify RPC arg to cli arg conversion and handle dicts and lists

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -402,6 +402,14 @@ class TestNodeCLIAttr:
     def get_request(self, *args, **kwargs):
         return lambda: self(*args, **kwargs)
 
+def arg_to_cli(arg):
+    if isinstance(arg, bool):
+        return str(arg).lower()
+    elif isinstance(arg, dict) or isinstance(arg, list):
+        return json.dumps(arg)
+    else:
+        return str(arg)
+
 class TestNodeCLI():
     """Interface to bitcoin-cli for an individual node"""
 
@@ -433,8 +441,8 @@ class TestNodeCLI():
 
     def send_cli(self, command=None, *args, **kwargs):
         """Run bitcoin-cli command. Deserializes returned string as python object."""
-        pos_args = [str(arg).lower() if type(arg) is bool else str(arg) for arg in args]
-        named_args = [str(key) + "=" + str(value) for (key, value) in kwargs.items()]
+        pos_args = [arg_to_cli(arg) for arg in args]
+        named_args = [str(key) + "=" + arg_to_cli(value) for (key, value) in kwargs.items()]
         assert not (pos_args and named_args), "Cannot use positional arguments and named arguments in the same bitcoin-cli call"
         p_args = [self.binary, "-datadir=" + self.datadir] + self.options
         if named_args:


### PR DESCRIPTION
When running tests with --usecli, unify the conversion from argument objects to strings using a new function arg_to_cli(). This fixes boolean arguments when using named arguments.

Also use json.dumps() to get the string values for arguments that are dicts and lists so that bitcoind's JSON parser does not become confused.