### PR TITLE
wallet: Add missing cs_db lock

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -147,6 +147,7 @@ BerkeleyEnvironment::BerkeleyEnvironment(const fs::path& dir_path) : strPath(dir
 
 BerkeleyEnvironment::~BerkeleyEnvironment()
 {
+    LOCK(cs_db);
     g_dbenvs.erase(strPath);
     Close();
 }


### PR DESCRIPTION
Without this lock `BerkeleyEnvironment::~BerkeleyEnvironment` and `GetWalletEnv` would race for `g_dbenvs`. This wasn't detected before because thread safety analysis does not check constructors
and destructors.

Reference: http://releases.llvm.org/5.0.2/tools/clang/docs/ThreadSafetyAnalysis.html#no-checking-inside-constructors-and-destructors