### PR TITLE
tests: Make test updatecoins_simulation_test deterministic

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -279,6 +279,8 @@ UtxoData::iterator FindRandomFrom(const std::set<COutPoint> &utxoSet) {
 // has the expected effect (the other duplicate is overwritten at all cache levels)
 BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 {
+    SeedInsecureRand(/* deterministic */ true);
+
     bool spent_a_duplicate_coinbase = false;
     // A simple map to track what we expect the cache stack to represent.
     std::map<COutPoint, Coin> result;


### PR DESCRIPTION
Make test `updatecoins_simulation_test` deterministic.

Can be verified using `contrib/test_deterministic_coverage.sh` introduced in #15296.

Related:
* #15296: "tests: Add script checking for deterministic line coverage in unit tests"
* #15324: "test: Make bloom tests deterministic"
* #14343: "coverage reports non-deterministic"
