### PR TITLE
travis: Revert "Run extended tests once daily"

### DIFF
--- a/.travis/test_06_script_b.sh
+++ b/.travis/test_06_script_b.sh
@@ -14,12 +14,8 @@ if [ "$RUN_UNIT_TESTS" = "true" ]; then
   END_FOLD
 fi
 
-if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
-  extended="--extended --exclude feature_pruning"
-fi
-
 if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
   BEGIN_FOLD functional-tests
-  DOCKER_EXEC test/functional/test_runner.py --ci --combinedlogslen=4000 --coverage --quiet --failfast ${extended}
+  DOCKER_EXEC test/functional/test_runner.py --ci --combinedlogslen=4000 --coverage --quiet --failfast
   END_FOLD
 fi


### PR DESCRIPTION
Now that the extended tests are only pruning and dbcrash, both which are too long [1] to run on travis, we can revert this commit. All tests other than those two are still run for every travis pull request or cron run.

[1] https://travis-ci.org/bitcoin/bitcoin/jobs/487615211#L2930