### PR TITLE
wallet: Log absolute paths for the wallets

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -389,7 +389,7 @@ bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, std::string& er
     fs::path walletDir = env->Directory();
 
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(nullptr, nullptr, nullptr));
-    LogPrintf("Using wallet %s\n", walletFile);
+    LogPrintf("Using wallet %s\n", file_path.string());
 
     // Wallet file must be a plain filename without a directory
     if (walletFile != fs::basename(walletFile) + fs::extension(walletFile))


### PR DESCRIPTION
Fix #15333 

`debug.log` with this PR:
```
...
2019-02-03T19:02:35Z Using wallet directory /home/hebasto/.bitcoin/testnet3/wallets
2019-02-03T19:02:35Z init message: Verifying wallet(s)...
2019-02-03T19:02:35Z Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2019-02-03T19:02:35Z Using wallet test_alpha/wallet.dat
2019-02-03T19:02:35Z BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/test_alpha/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/test_alpha/db.log
2019-02-03T19:02:35Z Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2019-02-03T19:02:35Z Using wallet alpha_wallet/wallet.dat
2019-02-03T19:02:35Z BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/alpha_wallet/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/alpha_wallet/db.log
2019-02-03T19:02:35Z Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2019-02-03T19:02:35Z Using wallet wallet.dat
2019-02-03T19:02:35Z BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/db.log
2019-02-03T19:02:35Z Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2019-02-03T19:02:35Z Using wallet none/wallet.dat
2019-02-03T19:02:35Z BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/none/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/none/db.log
2019-02-03T19:02:35Z init message: Loading banlist...
...
```