### PR TITLE
gui: Introduce bilingual GUI error messages

### DIFF
--- a/doc/translation_strings_policy.md
+++ b/doc/translation_strings_policy.md
@@ -23,7 +23,8 @@ On a high level, these strings are to be translated:
 
 ### GUI strings
 
-Anything that appears to the user in the GUI is to be translated. This includes labels, menu items, button texts, tooltips and window titles.
+Do not translate extremely rare or technical errors. These cases must be commented in the code explicitly.
+Anything else that appears to the user in the GUI is to be translated. This includes labels, menu items, button texts, tooltips and window titles.
 This includes messages passed to the GUI through the UI interface through `InitMessage`, `ThreadSafeMessageBox` or `ShowProgress`.
 
 General recommendations

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -745,7 +745,8 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
  */
 static bool InitSanityCheck()
 {
-    if(!ECC_InitSanityCheck()) {
+    if (!ECC_InitSanityCheck()) {
+        // This message is intentionally untranslated because the error is extremely rare.
         InitError("Elliptic curve cryptography sanity check failure. Aborting.");
         return false;
     }
@@ -754,6 +755,7 @@ static bool InitSanityCheck()
         return false;
 
     if (!Random_SanityCheck()) {
+        // This message is intentionally untranslated because the error is extremely rare.
         InitError("OS cryptographic RNG sanity check failure. Aborting.");
         return false;
     }
@@ -915,8 +917,10 @@ bool AppInitBasicSetup()
     SetProcessDEPPolicy(PROCESS_DEP_ENABLE);
 #endif
 
-    if (!SetupNetworking())
+    if (!SetupNetworking()) {
+        // This message is intentionally untranslated because the error is extremely rare.
         return InitError("Initializing networking failed");
+    }
 
 #ifndef WIN32
     if (!gArgs.GetBoolArg("-sysperms", false)) {

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -264,6 +264,10 @@ public:
     {
         return MakeHandler(::uiInterface.ThreadSafeMessageBox_connect(fn));
     }
+    std::unique_ptr<Handler> handleBilingualMessageBox(BilingualMessageBoxFn fn) override
+    {
+        return MakeHandler(::uiInterface.ThreadSafeBilingualMessageBox_connect(fn));
+    }
     std::unique_ptr<Handler> handleQuestion(QuestionFn fn) override
     {
         return MakeHandler(::uiInterface.ThreadSafeQuestion_connect(fn));

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -199,9 +199,10 @@ public:
     virtual std::unique_ptr<Handler> handleInitMessage(InitMessageFn fn) = 0;
 
     //! Register handler for message box messages.
-    using MessageBoxFn =
-        std::function<bool(const std::string& message, const std::string& caption, unsigned int style)>;
+    using MessageBoxFn = std::function<bool(const std::string& message, const std::string& caption, unsigned int style)>;
     virtual std::unique_ptr<Handler> handleMessageBox(MessageBoxFn fn) = 0;
+    using BilingualMessageBoxFn = std::function<bool(const std::string& noui_message, const std::string& ui_message, const std::string& caption, unsigned int style)>;
+    virtual std::unique_ptr<Handler> handleBilingualMessageBox(BilingualMessageBoxFn fn) = 0;
 
     //! Register handler for question messages.
     using QuestionFn = std::function<bool(const std::string& message,

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -41,6 +41,11 @@ bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& ca
     return false;
 }
 
+bool noui_ThreadSafeBilingualMessageBox(const std::string& noui_message, const std::string& ui_message, const std::string& caption, unsigned int style)
+{
+    return noui_ThreadSafeMessageBox(noui_message, caption, style);
+}
+
 bool noui_ThreadSafeQuestion(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
 {
     return noui_ThreadSafeMessageBox(message, caption, style);
@@ -54,6 +59,7 @@ void noui_InitMessage(const std::string& message)
 void noui_connect()
 {
     uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
+    uiInterface.ThreadSafeBilingualMessageBox_connect(noui_ThreadSafeBilingualMessageBox);
     uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
     uiInterface.InitMessage_connect(noui_InitMessage);
 }

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -23,13 +23,13 @@ bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& ca
     // Check for usage of predefined caption
     switch (style) {
     case CClientUIInterface::MSG_ERROR:
-        strCaption += _("Error");
+        strCaption += "Error";
         break;
     case CClientUIInterface::MSG_WARNING:
-        strCaption += _("Warning");
+        strCaption += "Warning";
         break;
     case CClientUIInterface::MSG_INFORMATION:
-        strCaption += _("Information");
+        strCaption += "Information";
         break;
     default:
         strCaption += caption; // Use supplied caption (can be empty)

--- a/src/noui.h
+++ b/src/noui.h
@@ -9,6 +9,8 @@
 
 /** Non-GUI handler, which logs and prints messages. */
 bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style);
+/** Non-GUI handler, which logs untranslated messages and prints bilingual ones. */
+bool noui_ThreadSafeBilingualMessageBox(const std::string& noui_message, const std::string& ui_message, const std::string& caption, unsigned int style);
 /** Non-GUI handler, which logs and prints questions. */
 bool noui_ThreadSafeQuestion(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style);
 /** Non-GUI handler, which only logs a message. */

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -427,6 +427,7 @@ int GuiMain(int argc, char* argv[])
 
     // Subscribe to global signals from core
     std::unique_ptr<interfaces::Handler> handler_message_box = node->handleMessageBox(noui_ThreadSafeMessageBox);
+    std::unique_ptr<interfaces::Handler> handler_bilingual_message_box = node->handleBilingualMessageBox(noui_ThreadSafeBilingualMessageBox);
     std::unique_ptr<interfaces::Handler> handler_question = node->handleQuestion(noui_ThreadSafeQuestion);
     std::unique_ptr<interfaces::Handler> handler_init_message = node->handleInitMessage(noui_InitMessage);
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1382,10 +1382,16 @@ static bool ThreadSafeMessageBox(BitcoinGUI* gui, const std::string& message, co
     return ret;
 }
 
+static bool ThreadSafeBilingualMessageBox(BitcoinGUI* gui, const std::string& noui_message, const std::string& ui_message, const std::string& caption, unsigned int style)
+{
+    return ThreadSafeMessageBox(gui, ui_message, caption, style);
+}
+
 void BitcoinGUI::subscribeToCoreSignals()
 {
     // Connect signals to client
     m_handler_message_box = m_node.handleMessageBox(std::bind(ThreadSafeMessageBox, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+    m_handler_bilingual_message_box = m_node.handleBilingualMessageBox(std::bind(ThreadSafeBilingualMessageBox, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4));
     m_handler_question = m_node.handleQuestion(std::bind(ThreadSafeMessageBox, this, std::placeholders::_1, std::placeholders::_3, std::placeholders::_4));
 }
 
@@ -1393,6 +1399,7 @@ void BitcoinGUI::unsubscribeFromCoreSignals()
 {
     // Disconnect signals from client
     m_handler_message_box->disconnect();
+    m_handler_bilingual_message_box->disconnect();
     m_handler_question->disconnect();
 }
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -110,6 +110,7 @@ private:
     interfaces::Node& m_node;
     WalletController* m_wallet_controller{nullptr};
     std::unique_ptr<interfaces::Handler> m_handler_message_box;
+    std::unique_ptr<interfaces::Handler> m_handler_bilingual_message_box;
     std::unique_ptr<interfaces::Handler> m_handler_question;
     ClientModel* clientModel = nullptr;
     WalletFrame* walletFrame = nullptr;

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -11,6 +11,7 @@ CClientUIInterface uiInterface;
 
 struct UISignals {
     boost::signals2::signal<CClientUIInterface::ThreadSafeMessageBoxSig, boost::signals2::last_value<bool>> ThreadSafeMessageBox;
+    boost::signals2::signal<CClientUIInterface::ThreadSafeBilingualMessageBoxSig, boost::signals2::last_value<bool>> ThreadSafeBilingualMessageBox;
     boost::signals2::signal<CClientUIInterface::ThreadSafeQuestionSig, boost::signals2::last_value<bool>> ThreadSafeQuestion;
     boost::signals2::signal<CClientUIInterface::InitMessageSig> InitMessage;
     boost::signals2::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
@@ -30,6 +31,7 @@ struct UISignals {
     }
 
 ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeMessageBox);
+ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeBilingualMessageBox);
 ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeQuestion);
 ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
@@ -42,6 +44,7 @@ ADD_SIGNALS_IMPL_WRAPPER(NotifyHeaderTip);
 ADD_SIGNALS_IMPL_WRAPPER(BannedListChanged);
 
 bool CClientUIInterface::ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeMessageBox(message, caption, style); }
+bool CClientUIInterface::ThreadSafeBilingualMessageBox(const std::string& noui_message, const std::string& ui_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeBilingualMessageBox(noui_message, ui_message, caption, style); }
 bool CClientUIInterface::ThreadSafeQuestion(const std::string& message, const std::string& non_interactive_message, const std::string& caption, unsigned int style) { return g_ui_signals.ThreadSafeQuestion(message, non_interactive_message, caption, style); }
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -6,6 +6,9 @@
 #ifndef BITCOIN_UI_INTERFACE_H
 #define BITCOIN_UI_INTERFACE_H
 
+#include <tinyformat.h>
+#include <util/system.h>
+
 #include <functional>
 #include <memory>
 #include <stdint.h>
@@ -130,5 +133,21 @@ void InitWarning(const std::string& str);
 bool InitError(const std::string& str);
 
 extern CClientUIInterface uiInterface;
+
+/** Show bilingual error message **/
+template <typename... Args>
+bool InitError(const bilingual_str& fmt, const Args&... args)
+{
+    const std::string noui_message = tfm::format(fmt.original_str, args...);
+    const std::string translated_message = tfm::format(fmt.translated_str, args...);
+    std::string ui_message;
+    if (noui_message == translated_message) {
+        ui_message = noui_message;
+    } else {
+        ui_message = translated_message + "\n\n" + _("Original message:") + "\n" + noui_message;
+    }
+    uiInterface.ThreadSafeBilingualMessageBox(noui_message, ui_message, "", CClientUIInterface::MSG_ERROR);
+    return false;
+}
 
 #endif // BITCOIN_UI_INTERFACE_H

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -85,6 +85,7 @@ public:
 
     /** Show message box. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeMessageBox, bool, const std::string& message, const std::string& caption, unsigned int style);
+    ADD_SIGNALS_DECL_WRAPPER(ThreadSafeBilingualMessageBox, bool, const std::string& noui_message, const std::string& ui_message, const std::string& caption, unsigned int style);
 
     /** If possible, ask the user a question. If not, falls back to ThreadSafeMessageBox(noninteractive_message, caption, style) and returns false. */
     ADD_SIGNALS_DECL_WRAPPER(ThreadSafeQuestion, bool, const std::string& message, const std::string& noninteractive_message, const std::string& caption, unsigned int style);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -54,6 +54,16 @@ inline std::string _(const char* psz)
     return G_TRANSLATION_FUN ? (G_TRANSLATION_FUN)(psz) : psz;
 }
 
+struct bilingual_str {
+    std::string original_str;
+    std::string translated_str;
+};
+
+inline bilingual_str _(const char* psz, bool translate)
+{
+    return bilingual_str{psz, (translate && G_TRANSLATION_FUN) ? (G_TRANSLATION_FUN)(psz) : psz};
+}
+
 void SetupEnvironment();
 bool SetupNetworking();
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -86,7 +86,7 @@ bool WalletInit::ParameterInteraction() const
 
     if (gArgs.GetBoolArg("-salvagewallet", false)) {
         if (is_multiwallet) {
-            return InitError(strprintf("%s is only allowed with a single wallet file", "-salvagewallet"));
+            return InitError(_("%s is only allowed with a single wallet file", true), "-salvagewallet");
         }
         // Rewrite just private keys: rescan to find transactions
         if (gArgs.SoftSetBoolArg("-rescan", true)) {
@@ -103,7 +103,7 @@ bool WalletInit::ParameterInteraction() const
     // -zapwallettxes implies a rescan
     if (zapwallettxes) {
         if (is_multiwallet) {
-            return InitError(strprintf("%s is only allowed with a single wallet file", "-zapwallettxes"));
+            return InitError(_("%s is only allowed with a single wallet file", true), "-zapwallettxes");
         }
         if (gArgs.SoftSetBoolArg("-rescan", true)) {
             LogPrintf("%s: parameter interaction: -zapwallettxes enabled -> setting -rescan=1\n", __func__);
@@ -112,14 +112,14 @@ bool WalletInit::ParameterInteraction() const
 
     if (is_multiwallet) {
         if (gArgs.GetBoolArg("-upgradewallet", false)) {
-            return InitError(strprintf("%s is only allowed with a single wallet file", "-upgradewallet"));
+            return InitError(_("%s is only allowed with a single wallet file", true), "-upgradewallet");
         }
     }
 
     if (gArgs.GetBoolArg("-sysperms", false))
-        return InitError("-sysperms is not allowed in combination with enabled wallet functionality");
+        return InitError(_("-sysperms is not allowed in combination with enabled wallet functionality", true));
     if (gArgs.GetArg("-prune", 0) && gArgs.GetBoolArg("-rescan", false))
-        return InitError(_("Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again."));
+        return InitError(_("Rescans are not possible in pruned mode. You will need to use -reindex which will download the whole blockchain again.", true));
 
     return true;
 }


### PR DESCRIPTION
Ref: #16218 

This PR:
- makes GUI error messages bilingual: user's native language + untranslated (i.e. English)
- insures that only untranslated messages are written to the debug log file and to `stderr` (that is not the case on master).

![Screenshot from 2019-06-17 01-15-06](https://user-images.githubusercontent.com/32963518/59570219-65946500-909d-11e9-92df-548bd06b1184.png)

Note for reviewers: `InitWarning()` is out of this PR scope.