### PR TITLE
[doc] netaddress: Make IPv4 loopback comment more descriptive

### DIFF
--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -183,15 +183,15 @@ bool CNetAddr::IsTor() const
 bool CNetAddr::IsLocal() const
 {
     // IPv4 loopback
-   if (IsIPv4() && (GetByte(3) == 127 || GetByte(3) == 0))
-       return true;
+    if (IsIPv4() && (GetByte(3) == 127 || GetByte(3) == 0))
+        return true;
 
-   // IPv6 loopback (::1/128)
-   static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
-   if (memcmp(ip, pchLocal, 16) == 0)
-       return true;
+    // IPv6 loopback (::1/128)
+    static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
+    if (memcmp(ip, pchLocal, 16) == 0)
+        return true;
 
-   return false;
+    return false;
 }
 
 bool CNetAddr::IsValid() const

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -182,7 +182,7 @@ bool CNetAddr::IsTor() const
 
 bool CNetAddr::IsLocal() const
 {
-    // IPv4 loopback
+    // IPv4 loopback (127.0.0.0/8 or 0.0.0.0/8)
     if (IsIPv4() && (GetByte(3) == 127 || GetByte(3) == 0))
         return true;
 


### PR DESCRIPTION
This also makes the comment match the IPv6 comment just below this hunk.