### PR TITLE
net: Correct comparison of addr count

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -174,8 +174,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer, ServiceFlags nLocalServices)
 static int GetnScore(const CService& addr)
 {
     LOCK(cs_mapLocalHost);
-    if (mapLocalHost.count(addr) == LOCAL_NONE)
-        return 0;
+    if (mapLocalHost.count(addr) == 0) return 0;
     return mapLocalHost[addr].nScore;
 }
 


### PR DESCRIPTION
`LOCAL_NONE` is supposed to be an enum indicating the `nScore` of a
`LocalServiceInfo` rather than the count of an addr in `mapLocalHost`.