### PR TITLE
tests: Reduce noise level in test_bitcoin output

### DIFF
--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -386,6 +386,7 @@ BOOST_AUTO_TEST_CASE(TransactionsRequestDeserializationOverflowTest) {
         BOOST_CHECK(0);
     } catch(std::ios_base::failure &) {
         // deserialize should fail
+        BOOST_CHECK(true); // Needed to suppress "Test case [...] did not check any assertions"
     }
 }
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -167,7 +167,6 @@ static void Correct_Queue_range(std::vector<size_t> range)
         BOOST_REQUIRE(control.Wait());
         if (FakeCheckCheckCompletion::n_calls != i) {
             BOOST_REQUIRE_EQUAL(FakeCheckCheckCompletion::n_calls, i);
-            BOOST_TEST_MESSAGE("Failure on trial " << i << " expected, got " << FakeCheckCheckCompletion::n_calls);
         }
     }
     tg.interrupt_all();

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -45,7 +45,11 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     // TODO: fix the code to support SegWit blocks.
     gArgs.ForceSetArg("-vbparams", strprintf("segwit:0:%d", (int64_t)Consensus::BIP9Deployment::NO_TIMEOUT));
     SelectParams(chainName);
-    noui_connect();
+    static bool noui_connected = false;
+    if (!noui_connected) {
+        noui_connect();
+        noui_connected = true;
+    }
 }
 
 BasicTestingSetup::~BasicTestingSetup()

--- a/src/test/torcontrol_tests.cpp
+++ b/src/test/torcontrol_tests.cpp
@@ -20,7 +20,6 @@ BOOST_FIXTURE_TEST_SUITE(torcontrol_tests, BasicTestingSetup)
 
 static void CheckSplitTorReplyLine(std::string input, std::string command, std::string args)
 {
-    BOOST_TEST_MESSAGE(std::string("CheckSplitTorReplyLine(") + input + ")");
     auto ret = SplitTorReplyLine(input);
     BOOST_CHECK_EQUAL(ret.first, command);
     BOOST_CHECK_EQUAL(ret.second, args);
@@ -61,7 +60,6 @@ BOOST_AUTO_TEST_CASE(util_SplitTorReplyLine)
 
 static void CheckParseTorReplyMapping(std::string input, std::map<std::string,std::string> expected)
 {
-    BOOST_TEST_MESSAGE(std::string("CheckParseTorReplyMapping(") + input + ")");
     auto ret = ParseTorReplyMapping(input);
     BOOST_CHECK_EQUAL(ret.size(), expected.size());
     auto r_it = ret.begin();
@@ -173,7 +171,6 @@ BOOST_AUTO_TEST_CASE(util_ParseTorReplyMapping)
 
     // Special handling for null case
     // (needed because string comparison reads the null as end-of-string)
-    BOOST_TEST_MESSAGE(std::string("CheckParseTorReplyMapping(Null=\"\\0\")"));
     auto ret = ParseTorReplyMapping("Null=\"\\0\"");
     BOOST_CHECK_EQUAL(ret.size(), 1U);
     auto r_it = ret.begin();

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -36,8 +36,10 @@ BOOST_AUTO_TEST_CASE(util_criticalsection)
 
     do {
         TRY_LOCK(cs, lockTest);
-        if (lockTest)
+        if (lockTest) {
+            BOOST_CHECK(true); // Needed to suppress "Test case [...] did not check any assertions"
             break;
+        }
 
         BOOST_ERROR("break was swallowed!");
     } while(0);

--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -135,7 +135,6 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     /////////////////////////
     // Known Outcome tests //
     /////////////////////////
-    BOOST_TEST_MESSAGE("Testing known outcomes");
 
     // Empty utxo pool
     BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 1 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));


### PR DESCRIPTION
Reduce noise level in `test_bitcoin` output.

Context: When working on the non-determinism issues in the unit tests (see #15296) I got a bit tired of the amount of noise in the `test_bitcoin` output :-)

Before:

```
$ src/test/test_bitcoin --log_level=test_suite 2>&1 | grep -vE '(Entering|Leaving)' | uniq -c
      1 Running 341 test cases...
      1 Test case blockencodings_tests/TransactionsRequestDeserializationOverflowTest did not check any assertions
      1 CheckSplitTorReplyLine(PROTOCOLINFO PIVERSION)
      1 CheckSplitTorReplyLine(AUTH METHODS=COOKIE,SAFECOOKIE COOKIEFILE="/home/x/.tor/control_auth_cookie")
      1 CheckSplitTorReplyLine(AUTH METHODS=NULL)
      1 CheckSplitTorReplyLine(AUTH METHODS=HASHEDPASSWORD)
      1 CheckSplitTorReplyLine(VERSION Tor="0.2.9.8 (git-a0df013ea241b026)")
      1 CheckSplitTorReplyLine(AUTHCHALLENGE SERVERHASH=aaaa SERVERNONCE=bbbb)
      1 CheckSplitTorReplyLine(COMMAND)
      1 CheckSplitTorReplyLine(COMMAND SOME  ARGS)
      1 CheckSplitTorReplyLine(COMMAND  ARGS)
      1 CheckSplitTorReplyLine(COMMAND   EVEN+more  ARGS)
      1 CheckParseTorReplyMapping(METHODS=COOKIE,SAFECOOKIE COOKIEFILE="/home/x/.tor/control_auth_cookie")
      1 CheckParseTorReplyMapping(METHODS=NULL)
      1 CheckParseTorReplyMapping(METHODS=HASHEDPASSWORD)
      1 CheckParseTorReplyMapping(Tor="0.2.9.8 (git-a0df013ea241b026)")
      1 CheckParseTorReplyMapping(SERVERHASH=aaaa SERVERNONCE=bbbb)
      1 CheckParseTorReplyMapping(ServiceID=exampleonion1234)
      1 CheckParseTorReplyMapping(PrivateKey=RSA1024:BLOB)
      1 CheckParseTorReplyMapping(ClientAuth=bob:BLOB)
      1 CheckParseTorReplyMapping(Foo=Bar=Baz Spam=Eggs)
      1 CheckParseTorReplyMapping(Foo="Bar=Baz")
      1 CheckParseTorReplyMapping(Foo="Bar Baz")
      1 CheckParseTorReplyMapping(Foo="Bar\ Baz")
      1 CheckParseTorReplyMapping(Foo="Bar\Baz")
      1 CheckParseTorReplyMapping(Foo="Bar\@Baz")
      1 CheckParseTorReplyMapping(Foo="Bar\"Baz" Spam="\"Eggs\"")
      1 CheckParseTorReplyMapping(Foo="Bar\\Baz")
      1 CheckParseTorReplyMapping(Foo="Bar\nBaz\t" Spam="\rEggs" Octals="\1a\11\17\18\81\377\378\400\2222" Final=Check)
      1 CheckParseTorReplyMapping(Valid=Mapping Escaped="Escape\\")
      1 CheckParseTorReplyMapping(Valid=Mapping Bare="Escape\")
      1 CheckParseTorReplyMapping(OneOctal="OneEnd\1" TwoOctal="TwoEnd\11")
      1 CheckParseTorReplyMapping(Null="\0")
      1 CheckParseTorReplyMapping(SOME=args,here MORE optional=arguments  here)
      1 CheckParseTorReplyMapping(ARGS)
      1 CheckParseTorReplyMapping(MORE ARGS)
      1 CheckParseTorReplyMapping(MORE  ARGS)
      1 CheckParseTorReplyMapping(EVEN more=ARGS)
      1 CheckParseTorReplyMapping(EVEN+more ARGS)
      1 Test case util_tests/util_criticalsection did not check any assertions
      1 Testing known outcomes
    326 Error: Specified -walletdir "/tmp/test_bitcoin/1553850209_943311758/tempdir/path_does_not_exist" does not exist
    327 Error: Specified -walletdir "/tmp/test_bitcoin/1553850209_643733972/tempdir/not_a_directory.dat" is not a directory
    328 Error: Specified -walletdir "wallets" is a relative path
      1
      1 *** No errors detected

```

After:

```
$ src/test/test_bitcoin --log_level=test_suite 2>&1 | grep -vE '(Entering|Leaving)' | uniq -c
      1 Running 341 test cases...
      1 Error: Specified -walletdir "/tmp/test_bitcoin/1553850026_943311758/tempdir/path_does_not_exist" does not exist
      1 Error: Specified -walletdir "/tmp/test_bitcoin/1553850026_643733972/tempdir/not_a_directory.dat" is not a directory
      1 Error: Specified -walletdir "wallets" is a relative path
      1
      1 *** No errors detected

```

