### PR TITLE
docs: Minor textual improvements in translation_strings_policy.md

### DIFF
--- a/doc/translation_strings_policy.md
+++ b/doc/translation_strings_policy.md
@@ -33,25 +33,25 @@ General recommendations
 
 Try not to burden translators with translating messages that are e.g. slight variations of other messages.
 In the GUI, avoid the use of text where an icon or symbol will do.
-Make sure that placeholder texts in forms don't end up in the list of strings to be translated (use `<string notr="true">`).
+Make sure that placeholder texts in forms do not end up in the list of strings to be translated (use `<string notr="true">`).
 
 ### Make translated strings understandable
 
-Try to write translation strings in an understandable way, for both the user and the translator. Avoid overly technical or detailed messages
+Try to write translation strings in an understandable way, for both the user and the translator. Avoid overly technical or detailed messages.
 
 ### Do not translate internal errors
 
-Do not translate internal errors, or log messages, or messages that appear on the RPC interface. If an error is to be shown to the user,
-use a translatable generic message, then log the detailed message to the log. E.g. "A fatal internal error occurred, see debug.log for details".
+Do not translate internal errors, log messages, or messages that appear on the RPC interface. If an error is to be shown to the user,
+use a translatable generic message, then log the detailed message to the log. E.g., "A fatal internal error occurred, see debug.log for details".
 This helps troubleshooting; if the error is the same for everyone, the likelihood is increased that it can be found using a search engine.
 
 ### Avoid fragments
 
-Avoid dividing up a message into fragments. Translators see every string separately, so may misunderstand the context if the messages are not self-contained.
+Avoid dividing up a message into fragments. Translators see every string separately, so they may misunderstand the context if the messages are not self-contained.
 
 ### Avoid HTML in translation strings
 
-There have been difficulties with use of HTML in translation strings; translators should not be able to accidentally affect the formatting of messages.
+There have been difficulties with the use of HTML in translation strings; translators should not be able to accidentally affect the formatting of messages.
 This may sometimes be at conflict with the recommendation in the previous section.
 
 ### Plurals
@@ -66,7 +66,7 @@ Plurals can be complex in some languages. A quote from the gettext documentation
     25-31 pliko'w
     and so on
 
-In Qt code use tr's third argument for optional plurality. For example:
+In Qt code, use tr's third argument for optional plurality. For example:
 
     tr("%n hour(s)","",secs/HOUR_IN_SECONDS);
     tr("%n day(s)","",secs/DAY_IN_SECONDS);
@@ -82,7 +82,7 @@ This adds `<numerusform>`s to the respective `.ts` file, which can be translated
         </translation>
     </message>
 
-Where it is possible try to avoid embedding numbers into the flow of the string at all. e.g.
+Where possible, try to avoid embedding numbers into the flow of the string at all. E.g.,
 
     WARNING: check your network connection, %d blocks received in the last %d hours (%d expected)
 


### PR DESCRIPTION
Found a few places where the reading flow was interrupted by minor grammar and punctuation issues.  