### PR TITLE
[qa] Create cached blocks with current timestamps

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -477,10 +477,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             for node in self.nodes:
                 node.wait_for_rpc_connection()
 
-            # For backward compatibility of the python scripts with previous
-            # versions of the cache, set mocktime to Jan 1,
-            # 2014 + (201 * 10 * 60)"""
-            self.mocktime = 1388534400 + (201 * 10 * 60)
+            # Create the blocks, spaced 10 minutes apart, starting now
+            self.mocktime = int(time.time())
 
             # Create a 200-block-long chain; each of the 4 first nodes
             # gets 25 mature blocks and 25 immature.

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -7,17 +7,23 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
 )
+import time
 
 
 class CreateTxWalletTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
+        self.setup_clean_chain = True
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
 
     def run_test(self):
+        # Create 200 old blocks (1 year old)
+        self.nodes[0].setmocktime(int(time.time()) - 3600*24*365)
+        self.nodes[0].generate(200)
+        self.nodes[0].setmocktime(0)
+
         self.log.info('Check that we have some (old) blocks and that anti-fee-sniping is disabled')
         assert_equal(self.nodes[0].getblockchaininfo()['blocks'], 200)
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -34,6 +34,14 @@ class TxnMallTest(BitcoinTestFramework):
     def run_test(self):
         # All nodes should start with 1,250 BTC:
         starting_balance = 1250
+
+        # All nodes should be out of IBD.
+        # If the nodes are not all out of IBD, that can interfere with
+        # blockchain sync later in the test when nodes are connected, due to
+        # timing issues.
+        for n in self.nodes:
+            assert n.getblockchaininfo()["initialblockdownload"] == False
+
         for i in range(4):
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!


### PR DESCRIPTION
There doesn't seem to be any benefit to creating the cached data directories with old timestamps, but it does seem to interfere with tests because nodes using the cached chain were starting off in IBD, which interferes with chain sync.

This PR changes the cache to use current timestamps.  One test seemed to be relying on the blocks in the cache being old, so I modified it to explicitly create old blocks.

Changing the cache to use recent timestamps -- and thus have nodes be out of IBD on startup -- fixes a bug in the wallet_txn_doublespend.py test, noted in #14446.  Block sync to a node in IBD might fail because we are willing to wait a long time for our headers-sync peer to respond before we send getheaders messages to other peers.  In wallet_txn_doublespend.py, the test tries to workaround this issue by mining a block after connection, which happens to trigger the IBD-node to send a getheaders after receiving the block INV.  However, there is a race, where node connection and initial handshake could take longer than the call to generate the block, resulting in no block announcement going to the IBD peer, causing test failure.