### PR TITLE
http: Release server before waiting for event base loop exit

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -465,13 +465,15 @@ void StopHTTPServer()
         evhttp_del_accept_socket(eventHTTP, socket);
     }
     boundSockets.clear();
+    if (eventHTTP) {
+        event_base_once(eventBase, -1, EV_TIMEOUT, [](evutil_socket_t, short, void*) {
+            evhttp_free(eventHTTP);
+            eventHTTP = nullptr;
+        }, nullptr, nullptr);
+    }
     if (eventBase) {
         LogPrint(BCLog::HTTP, "Waiting for HTTP event thread to exit\n");
         if (g_thread_http.joinable()) g_thread_http.join();
-    }
-    if (eventHTTP) {
-        evhttp_free(eventHTTP);
-        eventHTTP = nullptr;
     }
     if (eventBase) {
         event_base_free(eventBase);


### PR DESCRIPTION
Call `evhttp_free` in the event loop to trigger server shutdown, in particular to close connections.