### PR TITLE
appveyor: ignore functional test failure

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -54,5 +54,5 @@ test_script:
 - cmd: src\bench_bitcoin.exe -evals=1 -scaling=0 > NUL
 - ps:  python test\util\bitcoin-util-test.py
 - cmd: python test\util\rpcauth-test.py
-- cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast
+- cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast || echo "ignore test failure" && cmd /c exit
 deploy: off


### PR DESCRIPTION
suggested by MarcoFalke in https://github.com/bitcoin/bitcoin/issues/14446#issuecomment-460729962
Unfortunately that `echo` doesn't change `errorlevel` on Windows. So I add a dummy command to set the return code to be 0 at the end.

Tested in here: https://ci.appveyor.com/project/ken2812221/bitcoin/builds/22245530