### PR TITLE
build: Disallow shadowing variables via -isystem, -Wshadow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,4 +150,4 @@ jobs:
         RUN_UNIT_TESTS=false
         RUN_FUNCTIONAL_TESTS=false
         GOAL="deploy"
-        BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror"
+        BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror --enable-isystem"

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -430,7 +430,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
     QT_LIB_PREFIX=Qt5
     qt5_modules="Qt5Core Qt5Gui Qt5Network Qt5Widgets"
     BITCOIN_QT_CHECK([
-      PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" have_qt=yes],[have_qt=no])
+      PKG_CHECK_MODULES([QT5], [$qt5_modules], [have_qt=yes; BITCOIN_SYSTEM_INCLUDE([QT_INCLUDES], [$QT5_CFLAGS]) QT_MOC_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS"],[have_qt=no])
 
       if test "x$have_qt" != xyes; then
         have_qt=no
@@ -438,9 +438,9 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
       fi
     ])
     BITCOIN_QT_CHECK([
-      PKG_CHECK_MODULES([QT_TEST], [${QT_LIB_PREFIX}Test], [QT_TEST_INCLUDES="$QT_TEST_CFLAGS"; have_qt_test=yes], [have_qt_test=no])
+      PKG_CHECK_MODULES([QT_TEST], [${QT_LIB_PREFIX}Test], [have_qt_test=yes; BITCOIN_SYSTEM_INCLUDE([QT_TEST_INCLUDES], [$QT_TEST_CFLAGS])], [have_qt_test=no])
       if test "x$use_dbus" != xno; then
-        PKG_CHECK_MODULES([QT_DBUS], [${QT_LIB_PREFIX}DBus], [QT_DBUS_INCLUDES="$QT_DBUS_CFLAGS"; have_qt_dbus=yes], [have_qt_dbus=no])
+        PKG_CHECK_MODULES([QT_DBUS], [${QT_LIB_PREFIX}DBus], [have_qt_dbus=yes; BITCOIN_SYSTEM_INCLUDE([QT_DBUS_INCLUDES], [$QT_DBUS_CFLAGS])], [have_qt_dbus=no])
       fi
     ])
   ])
@@ -460,7 +460,8 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   TEMP_LIBS="$LIBS"
   BITCOIN_QT_CHECK([
     if test "x$qt_include_path" != x; then
-      QT_INCLUDES="-I$qt_include_path -I$qt_include_path/QtCore -I$qt_include_path/QtGui -I$qt_include_path/QtWidgets -I$qt_include_path/QtNetwork -I$qt_include_path/QtTest -I$qt_include_path/QtDBus"
+      QT_MOC_INCLUDES="-I$qt_include_path -I$qt_include_path/QtCore -I$qt_include_path/QtGui -I$qt_include_path/QtWidgets -I$qt_include_path/QtNetwork -I$qt_include_path/QtTest -I$qt_include_path/QtDBus"
+      BITCOIN_SYSTEM_INCLUDE([QT_INCLUDES], [$QT_MOC_INCLUDES])
       CPPFLAGS="$QT_INCLUDES $CPPFLAGS"
     fi
   ])
@@ -527,4 +528,3 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   CXXFLAGS="$TEMP_CXXFLAGS"
   LIBS="$TEMP_LIBS"
 ])
-

--- a/build-aux/m4/bitcoin_subdir_to_include.m4
+++ b/build-aux/m4/bitcoin_subdir_to_include.m4
@@ -12,7 +12,8 @@ AC_DEFUN([BITCOIN_SUBDIR_TO_INCLUDE],[
     newinclpath=`${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null | [ tr -d '\\n\\r\\\\' | sed -e 's/^.*[[:space:]:]\(\/[^[:space:]]*\)]$3[\.h[[:space:]].*$/\1/' -e t -e d`]
     AC_MSG_RESULT([${newinclpath}])
     if test "x${newinclpath}" != "x"; then
-      eval "$1=\"\$$1\"' -I${newinclpath}'"
+      BITCOIN_SYSTEM_INCLUDE([newincl], ["-I${newinclpath}"])
+      eval "$1=\"\$$1\"' ${newincl}'"
     fi
   fi
 ])

--- a/build-aux/m4/bitcoin_system_include.m4
+++ b/build-aux/m4/bitcoin_system_include.m4
@@ -1,0 +1,19 @@
+dnl Copyright (c) 2018 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+dnl BITCOIN_SYSTEM_INCLUDE([DESTINATION-VARIABLE-NAME], [INCLUDES-STRING])
+dnl Populates the variable DESTINATION with the value from INCLUDES but
+dnl with -I includes switched to -isystem, with the exception of -I/usr/include,
+dnl which is left unmodified to avoid order issues with /usr/include. See:
+dnl https://stackoverflow.com/questions/37218953/isystem-on-a-system-include-directory-causes-errors
+AC_DEFUN([BITCOIN_SYSTEM_INCLUDE],[
+  if test "x$use_isystem" = "xyes" && test "x$2" != "x"; then
+    dnl Including /usr/include with -isystem is known to cause problems, e.g.
+    dnl breaking include_next due to, the directive changing inclusion order.
+    dnl https://bugreports.qt.io/browse/QTBUG-53367
+    $1=$(echo $2 | sed -e 's| -I| -isystem|g' -e 's|^-I|-isystem|g' -e 's|-isystem/usr/include|-I/usr/include|g')
+  else
+    $1=$2
+  fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -330,6 +330,7 @@ if test "x$enable_werror" = "xyes"; then
   ## isystem. See below for their non-werror equivalents.
   if test "x$use_isystem" = "xyes"; then
     AX_CHECK_COMPILE_FLAG([-Werror=documentation],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=documentation"],,[[$CXXFLAG_WERROR]])
+    AX_CHECK_COMPILE_FLAG([-Werror=shadow],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=shadow"],,[[$CXXFLAG_WERROR]])
   fi
 fi
 
@@ -358,6 +359,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   ## of isystem. See above for their werror equivalents.
   if test "x$use_isystem" = "xyes" && test "x$enable_werror" == "x"; then
     AX_CHECK_COMPILE_FLAG([-Wdocumentation],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"],,[[$CXXFLAG_WERROR]])
+    AX_CHECK_COMPILE_FLAG([-Wshadow],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wshadow"],,[[$CXXFLAG_WERROR]])
   fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,14 @@ if test "x$enable_werror" = "xyes"; then
   fi
   AX_CHECK_COMPILE_FLAG([-Werror=vla],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=vla"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=thread-safety-analysis],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=thread-safety-analysis"],,[[$CXXFLAG_WERROR]])
+
+  ## Some warnings alert on violations in our dependencies. Only enable them when
+  ## isystem is in use to keep the build clean
+  ## These represent the werror versions of warnings enabled given the use of
+  ## isystem. See below for their non-werror equivalents.
+  if test "x$use_isystem" = "xyes"; then
+    AX_CHECK_COMPILE_FLAG([-Werror=documentation],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=documentation"],,[[$CXXFLAG_WERROR]])
+  fi
 fi
 
 if test "x$CXXFLAGS_overridden" = "xno"; then
@@ -343,6 +351,14 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
+
+  ## Some warnings alert on violations in our dependencies. Only enable them when
+  ## isystem is in use to keep the build clean
+  ## These represent the non-werror versions of warnings enabled given the use
+  ## of isystem. See above for their werror equivalents.
+  if test "x$use_isystem" = "xyes" && test "x$enable_werror" == "x"; then
+    AX_CHECK_COMPILE_FLAG([-Wdocumentation],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"],,[[$CXXFLAG_WERROR]])
+  fi
 fi
 
 # Check for optional instruction set support. Enabling these does _not_ imply that all code will

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,12 @@ AC_ARG_ENABLE([ccache],
   [use_ccache=$enableval],
   [use_ccache=auto])
 
+AC_ARG_ENABLE([isystem],
+  [AS_HELP_STRING([--enable-isystem],
+  [enable isystem includes for dependencies and stricter warning checks (default is no)])],
+  [use_isystem=$enableval],
+  [use_isystem=no])
+
 AC_ARG_ENABLE([lcov],
   [AS_HELP_STRING([--enable-lcov],
   [enable lcov testing (default is no)])],
@@ -539,7 +545,8 @@ case $host in
            export PKG_CONFIG_PATH
          fi
          if test x$bdb_prefix != x; then
-           CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
+           BITCOIN_SYSTEM_INCLUDE([bdb_cppflags], ["-I$bdb_prefix/include"])
+           CPPFLAGS="$CPPFLAGS $bdb_cppflags"
            LIBS="$LIBS -L$bdb_prefix/lib"
          fi
          if test x$qt5_prefix != x; then
@@ -1081,6 +1088,8 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 LIBS="$TEMP_LIBS"
 CPPFLAGS="$TEMP_CPPFLAGS"
 fi
+dnl Treat boost includes with isystem if applicable
+BITCOIN_SYSTEM_INCLUDE([BOOST_CPPFLAGS], [$BOOST_CPPFLAGS])
 
 if test x$boost_sleep != xyes; then
   AC_MSG_ERROR(No working boost sleep implementation found.)
@@ -1093,18 +1102,18 @@ if test x$use_pkgconfig = xyes; then
   m4_ifdef(
     [PKG_CHECK_MODULES],
     [
-      PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl not found.)])
-      PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
+      PKG_CHECK_MODULES([SSL], [libssl], [BITCOIN_SYSTEM_INCLUDE([SSL_CFLAGS], [$SSL_CFLAGS])], [AC_MSG_ERROR(openssl not found.)])
+      PKG_CHECK_MODULES([CRYPTO], [libcrypto], [BITCOIN_SYSTEM_INCLUDE([CRYPTO_CFLAGS], [$CRYPTO_CFLAGS])],[AC_MSG_ERROR(libcrypto not found.)])
       if test x$enable_bip70 != xno; then
-        BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [have_protobuf=no])])
+        BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes; BITCOIN_SYSTEM_INCLUDE([PROTOBUF_CFLAGS], [$PROTOBUF_CFLAGS])], [have_protobuf=no])])
       fi
       if test x$use_qr != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
       fi
       if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests != xnononono; then
-        PKG_CHECK_MODULES([EVENT], [libevent],, [AC_MSG_ERROR(libevent not found.)])
+        PKG_CHECK_MODULES([EVENT], [libevent], [BITCOIN_SYSTEM_INCLUDE([EVENT_CFLAGS], [$EVENT_CFLAGS])], [AC_MSG_ERROR(libevent not found.)])
         if test x$TARGET_OS != xwindows; then
-          PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads],, [AC_MSG_ERROR(libevent_pthreads not found.)])
+          PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads], [BITCOIN_SYSTEM_INCLUDE([EVENT_PTHREADS_CFLAGS], [$EVENT_PTHREADS_CFLAGS])], [AC_MSG_ERROR(libevent_pthreads not found.)])
         fi
       fi
 
@@ -1228,6 +1237,7 @@ fi
 
 if test x$need_bundled_univalue = xyes ; then
   UNIVALUE_CFLAGS='-I$(srcdir)/univalue/include'
+  BITCOIN_SYSTEM_INCLUDE([UNIVALUE_CFLAGS], [$UNIVALUE_CFLAGS])
   UNIVALUE_LIBS='univalue/libunivalue.la'
 fi
 
@@ -1559,6 +1569,7 @@ fi
 echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  use asm       = $use_asm"
+echo "  use isystem   = $use_isystem"
 echo "  sanitizers    = $use_sanitizers"
 echo "  debug enabled = $enable_debug"
 echo "  gprof enabled = $enable_gprof"

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -477,11 +477,11 @@ ui_%.h: %.ui
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(UIC) -o $@ $< || (echo "Error creating $@"; false)
 
 %.moc: %.cpp
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES) $(MOC_DEFS) $< | \
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_MOC_INCLUDES) $(MOC_DEFS) $< | \
 	  $(SED) -e '/^\*\*.*Created:/d' -e '/^\*\*.*by:/d' > $@
 
 moc_%.cpp: %.h
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES) $(MOC_DEFS) $< | \
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_MOC_INCLUDES) $(MOC_DEFS) $< | \
 	  $(SED) -e '/^\*\*.*Created:/d' -e '/^\*\*.*by:/d' > $@
 
 %.qm: %.ts

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -81,8 +81,8 @@ static void AssembleBlock(benchmark::State& state)
         thread_group.create_thread(std::bind(&CScheduler::serviceQueue, &scheduler));
         GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
         LoadGenesisBlock(chainparams);
-        CValidationState state;
-        ActivateBestChain(state, chainparams);
+        CValidationState validation_state;
+        ActivateBestChain(validation_state, chainparams);
         assert(::chainActive.Tip() != nullptr);
         const bool witness_enabled{IsWitnessEnabled(::chainActive.Tip(), chainparams.GetConsensus())};
         assert(witness_enabled);
@@ -103,8 +103,8 @@ static void AssembleBlock(benchmark::State& state)
         LOCK(::cs_main); // Required for ::AcceptToMemoryPool.
 
         for (const auto& txr : txs) {
-            CValidationState state;
-            bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
+            CValidationState validation_state;
+            bool ret{::AcceptToMemoryPool(::mempool, validation_state, txr, nullptr /* pfMissingInputs */, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
             assert(ret);
         }
     }

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -519,9 +519,11 @@ bool SelfTest() {
     }
 
     // Test TransformD64
-    unsigned char out[32];
-    TransformD64(out, data + 1);
-    if (!std::equal(out, out + 32, result_d64)) return false;
+    {
+        unsigned char out[32];
+        TransformD64(out, data + 1);
+        if (!std::equal(out, out + 32, result_d64)) return false;
+    }
 
     // Test TransformD64_2way, if available.
     if (TransformD64_2way) {

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -238,10 +238,10 @@ bool AskPassphraseDialog::event(QEvent *event)
 void AskPassphraseDialog::toggleShowPassword(bool show)
 {
     ui->toggleShowPasswordButton->setDown(show);
-    const auto mode = show ? QLineEdit::Normal : QLineEdit::Password;
-    ui->passEdit1->setEchoMode(mode);
-    ui->passEdit2->setEchoMode(mode);
-    ui->passEdit3->setEchoMode(mode);
+    const auto echo_mode = show ? QLineEdit::Normal : QLineEdit::Password;
+    ui->passEdit1->setEchoMode(echo_mode);
+    ui->passEdit2->setEchoMode(echo_mode);
+    ui->passEdit3->setEchoMode(echo_mode);
 }
 
 bool AskPassphraseDialog::eventFilter(QObject *object, QEvent *event)

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1335,11 +1335,13 @@ UniValue decodepsbt(const JSONRPCRequest& request)
     result.pushKV("tx", tx_univ);
 
     // Unknown data
-    UniValue unknowns(UniValue::VOBJ);
-    for (auto entry : psbtx.unknown) {
-        unknowns.pushKV(HexStr(entry.first), HexStr(entry.second));
+    {
+        UniValue unknowns(UniValue::VOBJ);
+        for (auto entry : psbtx.unknown) {
+            unknowns.pushKV(HexStr(entry.first), HexStr(entry.second));
+        }
+        result.pushKV("unknown", unknowns);
     }
-    result.pushKV("unknown", unknowns);
 
     // inputs
     CAmount total_in = 0;

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -30,6 +30,11 @@ static const std::string strAddressBad = "1HV9Lc3sNHZxwj4Zk6fB38tEmBryq2cBiF";
 
 BOOST_FIXTURE_TEST_SUITE(key_tests, BasicTestingSetup)
 
+static uint256 SignMsg(const std::string& msg)
+{
+    return Hash(msg.begin(), msg.end());
+}
+
 BOOST_AUTO_TEST_CASE(key_test1)
 {
     CKey key1  = DecodeSecret(strSecret1);
@@ -75,8 +80,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
 
     for (int n=0; n<16; n++)
     {
-        std::string strMsg = strprintf("Very secret message %i: 11", n);
-        uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
+        uint256 hashMsg = SignMsg(strprintf("Very secret message %i: 11", n));
 
         // normal signatures
 
@@ -132,8 +136,7 @@ BOOST_AUTO_TEST_CASE(key_test1)
     // test deterministic signing
 
     std::vector<unsigned char> detsig, detsigc;
-    std::string strMsg = "Very deterministic message";
-    uint256 hashMsg = Hash(strMsg.begin(), strMsg.end());
+    uint256 hashMsg = SignMsg("Very deterministic message");
     BOOST_CHECK(key1.Sign(hashMsg, detsig));
     BOOST_CHECK(key1C.Sign(hashMsg, detsigc));
     BOOST_CHECK(detsig == detsigc);
@@ -156,8 +159,7 @@ BOOST_AUTO_TEST_CASE(key_signature_tests)
 {
     // When entropy is specified, we should see at least one high R signature within 20 signatures
     CKey key = DecodeSecret(strSecret1);
-    std::string msg = "A message to be signed";
-    uint256 msg_hash = Hash(msg.begin(), msg.end());
+    uint256 msg_hash = SignMsg("A message to be signed");
     std::vector<unsigned char> sig;
     bool found = false;
 
@@ -177,8 +179,7 @@ BOOST_AUTO_TEST_CASE(key_signature_tests)
     bool found_small = false;
     for (int i = 0; i < 256; ++i) {
         sig.clear();
-        std::string msg = "A message to be signed" + std::to_string(i);
-        msg_hash = Hash(msg.begin(), msg.end());
+        msg_hash = SignMsg("A message to be signed" + std::to_string(i));
         BOOST_CHECK(key.Sign(msg_hash, sig));
         found = sig[3] == 0x20;
         BOOST_CHECK(sig.size() <= 70);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -577,8 +577,8 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
             // be implemented, so no equality checks are needed at all. (Newer
             // versions of BDB have an set_lk_exclusive method for this
             // purpose, but the older version we use does not.)
-            for (const auto& env : g_dbenvs) {
-                CheckUniqueFileid(*env.second.lock().get(), strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
+            for (const auto& check_env : g_dbenvs) {
+                CheckUniqueFileid(*check_env.second.lock().get(), strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
             }
 
             pdb = pdb_temp.release();


### PR DESCRIPTION
Shadowed variables are implicated in logic errors, duplicative code, and
unnecessary operation. Catching them automatically is best.

As with -Wdocumentation, warns when configured with --enable-isystem,
errors if configured with --enable-werror as well.

This is built on / depends on: #14920