### PR TITLE
Optionally return HTTP_OK for RPC errors

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2018 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -77,6 +77,9 @@ static void JSONErrorReply(HTTPRequest* req, const UniValue& objError, const Uni
         nStatus = HTTP_BAD_REQUEST;
     else if (code == RPC_METHOD_NOT_FOUND)
         nStatus = HTTP_NOT_FOUND;
+
+    if (gArgs.GetBoolArg("-rpcerrorhttpok", false))
+        nStatus = HTTP_OK;
 
     std::string strReply = JSONRPCReply(NullUniValue, objError, id);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -515,6 +515,7 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcthreads=<n>", strprintf("Set the number of threads to service RPC calls (default: %d)", DEFAULT_HTTP_THREADS), false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", false, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), true, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcerrorhttpok", "Return HTTP OK (200) for JSON-RPC errors", false, OptionsCategory::RPC);
     gArgs.AddArg("-server", "Accept command line and JSON-RPC commands", false, OptionsCategory::RPC);
 
 #if HAVE_DECL_DAEMON

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -1,11 +1,21 @@
 #!/usr/bin/env python3
-# Copyright (c) 2018 The Bitcoin Core developers
+# Copyright (c) 2018-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Tests some generic aspects of the RPC interface."""
 
+from test_framework.authproxy import JSONRPCException
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_greater_than_or_equal
+
+def expect_http_status(expected_http_status, expected_rpc_code,
+                       fcn, *args):
+    try:
+        fcn(*args)
+        raise AssertionError("Expected RPC error %d, got none" % expected_rpc_code)
+    except JSONRPCException as exc:
+        assert_equal(exc.error["code"], expected_rpc_code)
+        assert_equal(exc.http_status, expected_http_status)
 
 class RPCInterfaceTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -48,9 +58,21 @@ class RPCInterfaceTest(BitcoinTestFramework):
         assert_equal(result_by_id[3]['error'], None)
         assert result_by_id[3]['result'] is not None
 
+    def test_http_status_codes(self):
+        self.log.info("Testing HTTP status codes for JSON-RPC requests...")
+
+        self.restart_node(0, ["-rpcerrorhttpok"])
+        expect_http_status(200, -32601, self.nodes[0].invalidmethod)
+        expect_http_status(200, -8, self.nodes[0].getblockhash, 42)
+
+        self.restart_node(0, ["-norpcerrorhttpok"])
+        expect_http_status(404, -32601, self.nodes[0].invalidmethod)
+        expect_http_status(500, -8, self.nodes[0].getblockhash, 42)
+
     def run_test(self):
         self.test_getrpcinfo()
         self.test_batch_request()
+        self.test_http_status_codes()
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -49,13 +49,14 @@ USER_AGENT = "AuthServiceProxy/0.1"
 log = logging.getLogger("BitcoinRPC")
 
 class JSONRPCException(Exception):
-    def __init__(self, rpc_error):
+    def __init__(self, rpc_error, http_status=None):
         try:
             errmsg = '%(message)s (%(code)i)' % rpc_error
         except (KeyError, TypeError):
             errmsg = ''
         super().__init__(errmsg)
         self.error = rpc_error
+        self.http_status = http_status
 
 
 def EncodeDecimal(o):
@@ -131,19 +132,20 @@ class AuthServiceProxy():
 
     def __call__(self, *args, **argsn):
         postdata = json.dumps(self.get_request(*args, **argsn), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
-        response = self._request('POST', self.__url.path, postdata.encode('utf-8'))
+        response, status = self._request('POST', self.__url.path, postdata.encode('utf-8'))
         if response['error'] is not None:
-            raise JSONRPCException(response['error'])
+            raise JSONRPCException(response['error'], status)
         elif 'result' not in response:
             raise JSONRPCException({
-                'code': -343, 'message': 'missing JSON-RPC result'})
+                'code': -343, 'message': 'missing JSON-RPC result'}, status)
         else:
             return response['result']
 
     def batch(self, rpc_call_list):
         postdata = json.dumps(list(rpc_call_list), default=EncodeDecimal, ensure_ascii=self.ensure_ascii)
         log.debug("--> " + postdata)
-        return self._request('POST', self.__url.path, postdata.encode('utf-8'))
+        response, _ = self._request('POST', self.__url.path, postdata.encode('utf-8'))
+        return response
 
     def _get_response(self):
         req_start_time = time.time()
@@ -162,8 +164,9 @@ class AuthServiceProxy():
 
         content_type = http_response.getheader('Content-Type')
         if content_type != 'application/json':
-            raise JSONRPCException({
-                'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)})
+            raise JSONRPCException(
+                {'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)},
+                http_response.status)
 
         responsedata = http_response.read().decode('utf8')
         response = json.loads(responsedata, parse_float=decimal.Decimal)
@@ -172,7 +175,7 @@ class AuthServiceProxy():
             log.debug("<-%s- [%.6f] %s" % (response["id"], elapsed, json.dumps(response["result"], default=EncodeDecimal, ensure_ascii=self.ensure_ascii)))
         else:
             log.debug("<-- [%.6f] %s" % (elapsed, responsedata))
-        return response
+        return response, http_response.status
 
     def __truediv__(self, relative_uri):
         return AuthServiceProxy("{}/{}".format(self.__service_url, relative_uri), self._service_name, connection=self.__conn)


### PR DESCRIPTION
This adds a new boolean option `-rpcerrorhttpok` (off by default).  If it is turned on, then the HTTP server returns `HTTP_OK` (code 200) also for errors with JSON-RPC calls.

The rationale is this:  Some JSON-RPC libraries (e.g. Python `jsonrpclib`) do not expose the response body at all if HTTP already sets an error code.  In that situation, it is hard to properly handle or debug the actual underlying error.  In such a situation, the new option can be used to bypass this problem.

Also includes general regtests for the returned HTTP status codes (not just in the new situation but also for the existing logic).