### PR TITLE
[wallet-tool] Close bdb when flushing wallet

### DIFF
--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -17,7 +17,7 @@ namespace WalletTool {
 static void WalletToolReleaseWallet(CWallet* wallet)
 {
     wallet->WalletLogPrintf("Releasing wallet\n");
-    wallet->Flush();
+    wallet->Flush(true);
     delete wallet;
 }
 
@@ -112,7 +112,7 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
         std::shared_ptr<CWallet> wallet_instance = CreateWallet(name, path);
         if (wallet_instance) {
             WalletShowInfo(wallet_instance.get());
-            wallet_instance->Flush();
+            wallet_instance->Flush(true);
         }
     } else if (command == "info") {
         if (!fs::exists(path)) {
@@ -127,7 +127,7 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
         std::shared_ptr<CWallet> wallet_instance = LoadWallet(name, path);
         if (!wallet_instance) return false;
         WalletShowInfo(wallet_instance.get());
-        wallet_instance->Flush();
+        wallet_instance->Flush(true);
     } else {
         fprintf(stderr, "Invalid command: %s\n", command.c_str());
         return false;


### PR DESCRIPTION
bdb would not be closed when closing the wallet in wallet-tool. Fix this by calling wallet->flush with true.