### PR TITLE
[test] Remove -txindex to start nodes

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -20,7 +20,8 @@ Supported API
 
 Given a transaction hash: returns a transaction in binary, hex-encoded binary, or JSON formats.
 
-For full TX query capability, one must enable the transaction index via "txindex=1" command line / configuration option.
+By default, this endpoint will only search the mempool.
+To query for a confirmed transaction, enable the transaction index via "txindex=1" command line / configuration option.
 
 #### Blocks
 `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -43,8 +43,7 @@ class RESTTest (BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 2
-        # TODO: remove -txindex. Currently required for getrawtransaction call.
-        self.extra_args = [["-rest", "-txindex"], []]
+        self.extra_args = [["-rest"], []]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -91,15 +90,17 @@ class RESTTest (BitcoinTestFramework):
 
         txid = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.sync_all()
-        self.nodes[1].generatetoaddress(1, not_related_address)
-        self.sync_all()
-        bb_hash = self.nodes[0].getbestblockhash()
 
-        assert_equal(self.nodes[1].getbalance(), Decimal("0.1"))
-
-        self.log.info("Load the transaction using the /tx URI")
+        self.log.info("Test the /tx URI")
 
         json_obj = self.test_rest_request("/tx/{}".format(txid))
+        assert_equal(json_obj['txid'], txid)
+
+        # Check hex format response
+        hex_response = self.test_rest_request("/tx/{}".format(txid), req_type=ReqType.HEX, ret_type=RetType.OBJ)
+        assert_greater_than_or_equal(int(hex_response.getheader('content-length')),
+                                     json_obj['size']*2)
+
         spent = (json_obj['vin'][0]['txid'], json_obj['vin'][0]['vout'])  # get the vin to later check for utxo (should be spent by then)
         # get n of 0.1 outpoint
         n, = filter_output_indices_by_value(json_obj['vout'], Decimal('0.1'))
@@ -107,9 +108,14 @@ class RESTTest (BitcoinTestFramework):
 
         self.log.info("Query an unspent TXO using the /getutxos URI")
 
-        json_obj = self.test_rest_request("/getutxos/{}-{}".format(*spending))
+        self.nodes[1].generatetoaddress(1, not_related_address)
+        self.sync_all()
+        bb_hash = self.nodes[0].getbestblockhash()
+
+        assert_equal(self.nodes[1].getbalance(), Decimal("0.1"))
 
         # Check chainTip response
+        json_obj = self.test_rest_request("/getutxos/{}-{}".format(*spending))
         assert_equal(json_obj['chaintipHash'], bb_hash)
 
         # Make sure there is one utxo
@@ -273,17 +279,6 @@ class RESTTest (BitcoinTestFramework):
         self.sync_all()
         json_obj = self.test_rest_request("/headers/5/{}".format(bb_hash))
         assert_equal(len(json_obj), 5)  # now we should have 5 header objects
-
-        self.log.info("Test the /tx URI")
-
-        tx_hash = block_json_obj['tx'][0]['txid']
-        json_obj = self.test_rest_request("/tx/{}".format(tx_hash))
-        assert_equal(json_obj['txid'], tx_hash)
-
-        # Check hex format response
-        hex_response = self.test_rest_request("/tx/{}".format(tx_hash), req_type=ReqType.HEX, ret_type=RetType.OBJ)
-        assert_greater_than_or_equal(int(hex_response.getheader('content-length')),
-                                     json_obj['size']*2)
 
         self.log.info("Test tx inclusion in the /mempool and /block URIs")
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -20,8 +20,6 @@ class PSBTTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = False
         self.num_nodes = 3
-       # TODO: remove -txindex. Currently required for getrawtransaction call.
-        self.extra_args = [["-txindex"], ["-txindex"], ["-txindex"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -161,11 +159,11 @@ class PSBTTest(BitcoinTestFramework):
         node1_addr = self.nodes[1].getnewaddress()
         node2_addr = self.nodes[2].getnewaddress()
         txid1 = self.nodes[0].sendtoaddress(node1_addr, 13)
-        txid2 =self.nodes[0].sendtoaddress(node2_addr, 13)
-        self.nodes[0].generate(6)
+        txid2 = self.nodes[0].sendtoaddress(node2_addr, 13)
+        blockhash = self.nodes[0].generate(6)[0]
         self.sync_all()
-        vout1 = find_output(self.nodes[1], txid1, 13)
-        vout2 = find_output(self.nodes[2], txid2, 13)
+        vout1 = find_output(self.nodes[1], txid1, 13, blockhash=blockhash)
+        vout2 = find_output(self.nodes[2], txid2, 13, blockhash=blockhash)
 
         # Create a psbt spending outputs from nodes 1 and 2
         psbt_orig = self.nodes[0].createpsbt([{"txid":txid1,  "vout":vout1}, {"txid":txid2, "vout":vout2}], {self.nodes[0].getnewaddress():25.999})
@@ -344,9 +342,9 @@ class PSBTTest(BitcoinTestFramework):
         addr = self.nodes[1].getnewaddress("", "p2sh-segwit")
         txid = self.nodes[0].sendtoaddress(addr, 7)
         addrinfo = self.nodes[1].getaddressinfo(addr)
-        self.nodes[0].generate(6)
+        blockhash = self.nodes[0].generate(6)[0]
         self.sync_all()
-        vout = find_output(self.nodes[0], txid, 7)
+        vout = find_output(self.nodes[0], txid, 7, blockhash=blockhash)
         psbt = self.nodes[1].createpsbt([{"txid":txid, "vout":vout}], {self.nodes[0].getnewaddress("", "p2sh-segwit"):Decimal('6.999')})
         analyzed = self.nodes[0].analyzepsbt(psbt)
         assert not analyzed['inputs'][0]['has_utxo'] and not analyzed['inputs'][0]['is_final'] and analyzed['inputs'][0]['next'] == 'updater' and analyzed['next'] == 'updater'

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -42,7 +42,6 @@ class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
-        # TODO: remove -txindex. Currently required for getrawtransaction call.
         self.extra_args = [["-addresstype=legacy", "-txindex"], ["-addresstype=legacy", "-txindex"], ["-addresstype=legacy", "-txindex"]]
 
     def skip_test_if_missing_module(self):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -410,12 +410,12 @@ def sync_mempools(rpc_connections, *, wait=1, timeout=60, flush_scheduler=True):
 # Transaction/Block functions
 #############################
 
-def find_output(node, txid, amount):
+def find_output(node, txid, amount, *, blockhash=None):
     """
     Return index to output of txid with value amount
     Raises exception if there is none.
     """
-    txdata = node.getrawtransaction(txid, 1)
+    txdata = node.getrawtransaction(txid, 1, blockhash)
     for i in range(len(txdata["vout"])):
         if txdata["vout"][i]["value"] == amount:
             return i

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -26,8 +26,7 @@ from test_framework.util import (
 class AbandonConflictTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        # TODO: remove -txindex. Currently required for getrawtransaction call.
-        self.extra_args = [["-minrelaytxfee=0.00001", "-txindex"], []]
+        self.extra_args = [["-minrelaytxfee=0.00001"], []]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -24,8 +24,6 @@ class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.setup_clean_chain = True
-        # TODO: remove -txindex. Currently required for getrawtransaction call.
-        self.extra_args = [[], [], ["-txindex"], []]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
Original todos added when removing getrawtransaction default behavior of searching unspent utxos.