### PR TITLE
[build] AppVeyor: clean cache when build configuration changes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,8 +11,8 @@ environment:
   PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
   PYTHONUTF8: 1
 cache:
-- C:\tools\vcpkg\installed
-- C:\Users\appveyor\clcache
+- C:\tools\vcpkg\installed -> appveyor.yml
+- C:\Users\appveyor\clcache -> appveyor.yml, build_msvc\**, **\Makefile.am, **\*.vcxproj.in
 install:
 - cmd: pip install --quiet git+https://github.com/frerich/clcache.git@v4.2.0
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.


### PR DESCRIPTION
AppVeyor builds started starting failing on master after I cleaned the cache in #15382. In addition, it appeared that a new dependency (boost-process) wasn't getting added in that PR without at least cleaning the vcpkg cache.