### PR TITLE
test: txindex: interrupt threadGroup before calling destructor

### DIFF
--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -69,7 +69,13 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
         }
     }
 
-    txindex.Stop(); // Stop thread before calling destructor
+    // shutdown sequence (c.f. Shutdown() in init.cpp)
+    txindex.Stop();
+
+    threadGroup.interrupt_all();
+    threadGroup.join_all();
+
+    // Rest of shutdown sequence and destructors happen in ~TestingSetup()
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes the data races with the tread sanitizer such as

* https://travis-ci.org/MarcoFalke/bitcoin-core/jobs/492330554#L3483
* https://github.com/bitcoin/bitcoin/pull/15402#discussion_r256676622
* ...