### PR TITLE
[wallet] allow adding pubkeys from imported private keys to keypool

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1630,7 +1630,7 @@ bool CWallet::ImportScripts(const std::set<CScript> scripts)
     return true;
 }
 
-bool CWallet::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp)
+bool CWallet::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const bool add_keypool, const bool internal, const int64_t timestamp)
 {
     WalletBatch batch(*database);
     for (const auto& entry : privkey_map) {
@@ -1642,6 +1642,9 @@ bool CWallet::ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const in
         // If the private key is not present in the wallet, insert it.
         if (!HaveKey(id) && !AddKeyPubKeyWithDB(batch, key, pubkey)) {
             return false;
+        }
+        if (add_keypool) {
+             AddKeypoolPubkeyWithDB(pubkey, internal, batch);
         }
         UpdateTimeFirstKey(timestamp);
     }
@@ -1666,7 +1669,7 @@ bool CWallet::ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const st
         }
         mapKeyMetadata[id].nCreateTime = timestamp;
 
-        // Add to keypool only works with pubkeys
+        // Add pubkey to keypool
         if (add_keypool) {
             AddKeypoolPubkeyWithDB(pubkey, internal, batch);
             NotifyCanGetAddressesChanged();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1067,7 +1067,7 @@ public:
     bool DummySignInput(CTxIn &tx_in, const CTxOut &txout, bool use_max_sig = false) const;
 
     bool ImportScripts(const std::set<CScript> scripts) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool ImportPrivKeys(const std::map<CKeyID, CKey>& privkey_map, const bool add_keypool, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportPubKeys(const std::vector<CKeyID>& ordered_pubkeys, const std::map<CKeyID, CPubKey>& pubkey_map, const std::map<CKeyID, std::pair<CPubKey, KeyOriginInfo>>& key_origins, const bool add_keypool, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool ImportScriptPubKeys(const std::string& label, const std::set<CScript>& script_pub_keys, const bool have_solving_data, const bool internal, const int64_t timestamp) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 


### PR DESCRIPTION
#14075 added a `keypool` param to `importmulti` which imports public keys into the keypool, but this was restricted to watch-only wallets (wallets created with `disable_private_keys`).

This PR relaxes that constraint to also allow private keys.

This is a step towards #14449, being able to import any BIP44/49/84 compatible external wallet. Once imported it's not safe to go back though, because the `getnewaddress` command is unaware of the intended address type. For that to really work we either need descriptor based wallets, or import could descriptors as metadata to individual keys in the wallet and make the wallet enforce those when generating a new (change) address.

This also enables me to write a test in #14912 which creates an unsigned PSBT in a wallet without private keys and then signs it in a wallet with those private keys (which simulates an external hardware wallet). There are probably other ways I can build that test though. 