### PR TITLE
[test] functional: allow custom cwd, use tmpdir as default

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -318,6 +318,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                 bitcoin_cli=self.options.bitcoincli,
                 mocktime=self.mocktime,
                 coverage_dir=self.options.coveragedir,
+                cwd=self.options.tmpdir,
                 extra_conf=extra_confs[i],
                 extra_args=extra_args[i],
                 use_cli=self.options.usecli,
@@ -469,6 +470,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
                     bitcoin_cli=self.options.bitcoincli,
                     mocktime=self.mocktime,
                     coverage_dir=None,
+                    cwd=self.options.tmpdir,
                 ))
                 self.nodes[i].args = args
                 self.start_node(i)


### PR DESCRIPTION
Any process launched by bitcoind will have `self.datadir` as its `cwd`.