### PR TITLE
doc: update FreeBSD build guide for 12.0

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,6 +1,6 @@
 FreeBSD build guide
 ======================
-(updated for FreeBSD 11.1)
+(updated for FreeBSD 12.0)
 
 This guide describes how to build bitcoind and command-line utilities on FreeBSD.
 
@@ -10,55 +10,51 @@ This guide does not contain instructions for building the GUI.
 
 You will need the following dependencies, which can be installed as root via pkg:
 
-```
+```shell
 pkg install autoconf automake boost-libs git gmake libevent libtool openssl pkgconf
+
+git clone https://github.com/bitcoin/bitcoin.git
 ```
 
 In order to run the test suite (recommended), you will need to have Python 3 installed:
 
-```
+```shell
 pkg install python3
-```
-
-For the wallet (optional):
-```
-./contrib/install_db4.sh `pwd`
-export BDB_PREFIX="$PWD/db4"
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-Download the source code:
-```
-git clone https://github.com/bitcoin/bitcoin
+### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
+`--disable-wallet` to `./configure` and skip to the next section.
+
+```shell
+./contrib/install_db4.sh `pwd`
+export BDB_PREFIX="$PWD/db4"
 ```
 
 ## Building Bitcoin Core
 
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error):
 
-```
+With wallet:
+```shell
 ./autogen.sh
-
-./configure                  # to build with wallet OR
-./configure --disable-wallet # to build without wallet
+./configure --with-gui=no \
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include"
 ```
 
-followed by either:
-
-```
-gmake
-```
-
-to build without testing, or
-
-```
-gmake check
+Without wallet:
+```shell
+./autogen.sh
+./configure --with-gui=no --disable-wallet
 ```
 
-to also run the test suite (recommended, if Python 3 is installed).
+followed by:
 
-*Note on debugging*: The version of `gdb` installed by default is [ancient and considered harmful](https://wiki.freebsd.org/GdbRetirement).
-It is not suitable for debugging a multi-threaded C++ program, not even for getting backtraces. Please install the package `gdb` and
-use the versioned gdb command (e.g. `gdb7111`).
-
+```shell
+gmake # use -jX here for parallelism
+gmake check # Run tests if Python 3 is available
+```


### PR DESCRIPTION
Updated the build guide for FreeBSD 12.0 (also bought more inline with the other `BSD` guides.

As of FreeBSD 12.0, an ancient GDB is [no longer installed by default](https://www.freebsd.org/releases/12.0R/relnotes.html). Instead, a modern version is available from [`devel/gdb`](https://www.freshports.org/devel/gdb), which is currently version 8.2.x. A recent `LLDB` is also available.