### PR TITLE
[wallet] wallet-tool: command to remove key metadata

### DIFF
--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -30,6 +30,7 @@ static void SetupWalletToolArgs()
 
     gArgs.AddArg("info", "Get wallet info", false, OptionsCategory::COMMANDS);
     gArgs.AddArg("create", "Create new wallet file", false, OptionsCategory::COMMANDS);
+    gArgs.AddArg("keymetadata", "Manipulate key metadata: (delete: deletes all key metadata)", false, OptionsCategory::COMMANDS);
 }
 
 static bool WalletAppInit(int argc, char* argv[])
@@ -103,7 +104,8 @@ int main(int argc, char* argv[])
 
     const std::set<std::string> methods = {
         "create",
-        "info"};
+        "info",
+        "keymetadata"};
 
     if (methods.find(method) == methods.end()) { // Use contains() as of c++20
         fprintf(stderr, "Invalid method: %s\n", method.c_str());
@@ -131,6 +133,19 @@ int main(int argc, char* argv[])
             return EXIT_FAILURE;
         }
         if (!WalletTool::ExecuteWalletInfo(name)) return EXIT_FAILURE;
+    } else if (method == "keymetadata") {
+        if (arguments.size() > 1) {
+            fprintf(stderr, "Error: unexpected argument(s)\n");
+            return EXIT_FAILURE;
+        }
+        const std::set<std::string> operations = {
+            "delete"
+        };
+        if (arguments.empty() || operations.find(arguments[0]) == operations.end()) {
+            fprintf(stderr, "Specify operation: delete\n");
+            return EXIT_FAILURE;
+        }
+        if (!WalletTool::ExecuteKeyMetadata(name, arguments[0])) return EXIT_FAILURE;
     } else {
         assert(false);
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -872,6 +872,7 @@ public:
     //! Load metadata (used by LoadWallet)
     void LoadKeyMetadata(const CKeyID& keyID, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void EraseScriptMetadata(const CScriptID& script_id) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
     void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Delete stored CKeyMetadata objects
@@ -900,6 +901,7 @@ public:
 
     //! Adds a watch-only address to the store, and saves it to disk.
     bool AddWatchOnly(const CScript& dest, int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool EraseWatchOnlyMeta(const CScript& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     bool RemoveWatchOnly(const CScript &dest) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -779,6 +779,7 @@ public:
     // Map from Script ID to key metadata (for watch-only keys).
     std::map<CScriptID, CKeyMetadata> m_script_metadata GUARDED_BY(cs_wallet);
 
+    bool EraseKeyMetadata(const CPubKey& pubkey);
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, bool overwrite);
 
     typedef std::map<unsigned int, CMasterKey> MasterKeyMap;
@@ -873,6 +874,8 @@ public:
     void LoadScriptMetadata(const CScriptID& script_id, const CKeyMetadata &metadata) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
     void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Delete stored CKeyMetadata objects
+    void DeleteKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     bool LoadMinVersion(int nVersion) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet) { AssertLockHeld(cs_wallet); nWalletVersion = nVersion; nWalletMaxVersion = std::max(nWalletMaxVersion, nVersion); return true; }
     void UpdateTimeFirstKey(int64_t nCreateTime) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -57,6 +57,11 @@ bool WalletBatch::EraseTx(uint256 hash)
     return EraseIC(std::make_pair(std::string("tx"), hash));
 }
 
+bool WalletBatch::EraseKeyMetadata(const CPubKey& pubkey)
+{
+    return EraseIC(std::make_pair(std::string("keymeta"), pubkey));
+}
+
 bool WalletBatch::WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, const bool overwrite)
 {
     return WriteIC(std::make_pair(std::string("keymeta"), pubkey), meta, overwrite);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -116,9 +116,14 @@ bool WalletBatch::WriteWatchOnly(const CScript &dest, const CKeyMetadata& keyMet
     return WriteIC(std::make_pair(std::string("watchs"), dest), '1');
 }
 
+bool WalletBatch::EraseWatchOnlyMeta(const CScript& dest)
+{
+    return EraseIC(std::make_pair(std::string("watchmeta"), dest));
+}
+
 bool WalletBatch::EraseWatchOnly(const CScript &dest)
 {
-    if (!EraseIC(std::make_pair(std::string("watchmeta"), dest))) {
+    if (!EraseWatchOnlyMeta(dest)) {
         return false;
     }
     return EraseIC(std::make_pair(std::string("watchs"), dest));

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -197,6 +197,7 @@ public:
     bool WriteCScript(const uint160& hash, const CScript& redeemScript);
 
     bool WriteWatchOnly(const CScript &script, const CKeyMetadata &keymeta);
+    bool EraseWatchOnlyMeta(const CScript& script);
     bool EraseWatchOnly(const CScript &script);
 
     bool WriteBestBlock(const CBlockLocator& locator);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -188,6 +188,7 @@ public:
     bool WriteTx(const CWalletTx& wtx);
     bool EraseTx(uint256 hash);
 
+    bool EraseKeyMetadata(const CPubKey& pubkey);
     bool WriteKeyMetadata(const CKeyMetadata& meta, const CPubKey& pubkey, const bool overwrite);
     bool WriteKey(const CPubKey& vchPubKey, const CPrivKey& vchPrivKey, const CKeyMetadata &keyMeta);
     bool WriteCryptedKey(const CPubKey& vchPubKey, const std::vector<unsigned char>& vchCryptedSecret, const CKeyMetadata &keyMeta);

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -127,4 +127,17 @@ bool ExecuteWalletInfo(const std::string& name)
     wallet_instance->Flush(true);
     return true;
 }
+
+bool ExecuteKeyMetadata(const std::string& name, std::string& operation) {
+    fs::path path = fs::absolute(name, GetWalletDir());
+    std::shared_ptr<CWallet> wallet_instance = LoadWallet(name, path);
+    if (wallet_instance == nullptr) return false;
+    LOCK(wallet_instance->cs_wallet);
+    fprintf(stdout, "Modifying key metadata...\n=========================\n");
+    fprintf(stdout, "Operation: %s\n", operation.c_str());
+    fprintf(stdout, "Key: all\n");
+    // wallet_instance->DeleteKeyMetadata();
+    wallet_instance->Flush(true);
+    return true;
+}
 } // namespace WalletTool

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -136,7 +136,7 @@ bool ExecuteKeyMetadata(const std::string& name, std::string& operation) {
     fprintf(stdout, "Modifying key metadata...\n=========================\n");
     fprintf(stdout, "Operation: %s\n", operation.c_str());
     fprintf(stdout, "Key: all\n");
-    // wallet_instance->DeleteKeyMetadata();
+    wallet_instance->DeleteKeyMetadata();
     wallet_instance->Flush(true);
     return true;
 }

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -68,23 +68,26 @@ static std::shared_ptr<CWallet> LoadWallet(const std::string& name, const fs::pa
     }
 
     if (load_wallet_ret != DBErrors::LOAD_OK) {
-        wallet_instance = nullptr;
         if (load_wallet_ret == DBErrors::CORRUPT) {
-            fprintf(stderr, "Error loading %s: Wallet corrupted", name.c_str());
+            fprintf(stderr, "Error loading %s: Wallet corrupted\n", name.c_str());
+            wallet_instance = nullptr;
             return nullptr;
         } else if (load_wallet_ret == DBErrors::NONCRITICAL_ERROR) {
             fprintf(stderr, "Error reading %s! All keys read correctly, but transaction data"
-                            " or address book entries might be missing or incorrect.",
+                            " or address book entries might be missing or incorrect.\n",
                 name.c_str());
         } else if (load_wallet_ret == DBErrors::TOO_NEW) {
-            fprintf(stderr, "Error loading %s: Wallet requires newer version of %s",
+            fprintf(stderr, "Error loading %s: Wallet requires newer version of %s\n",
                 name.c_str(), PACKAGE_NAME);
+            wallet_instance = nullptr;
             return nullptr;
         } else if (load_wallet_ret == DBErrors::NEED_REWRITE) {
-            fprintf(stderr, "Wallet needed to be rewritten: restart %s to complete", PACKAGE_NAME);
+            fprintf(stderr, "Wallet needed to be rewritten: restart %s to complete\n", PACKAGE_NAME);
+            wallet_instance = nullptr;
             return nullptr;
         } else {
-            fprintf(stderr, "Error loading %s", name.c_str());
+            fprintf(stderr, "Error loading %s\n", name.c_str());
+            wallet_instance = nullptr;
             return nullptr;
         }
     }

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -15,6 +15,7 @@ std::shared_ptr<CWallet> LoadWallet(const std::string& name, const fs::path& pat
 void WalletShowInfo(CWallet* wallet_instance);
 bool ExecuteCreateWallet(const std::string& name);
 bool ExecuteWalletInfo(const std::string& name);
+bool ExecuteKeyMetadata(const std::string& name, std::string& operation);
 } // namespace WalletTool
 
 #endif // BITCOIN_WALLET_WALLETTOOL_H

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -13,8 +13,8 @@ namespace WalletTool {
 std::shared_ptr<CWallet> CreateWallet(const std::string& name, const fs::path& path);
 std::shared_ptr<CWallet> LoadWallet(const std::string& name, const fs::path& path);
 void WalletShowInfo(CWallet* wallet_instance);
-bool ExecuteWalletToolFunc(const std::string& command, const std::string& file);
-
+bool ExecuteCreateWallet(const std::string& name);
+bool ExecuteWalletInfo(const std::string& name);
 } // namespace WalletTool
 
 #endif // BITCOIN_WALLET_WALLETTOOL_H

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -101,5 +101,30 @@ class ToolWalletTest(BitcoinTestFramework):
         assert_equal(1000, out['keypoolsize_hd_internal'])
         assert_equal(True, 'hdseedid' in out)
 
+        self.log.info("Test method: keymetadata")
+        self.start_node(0, ['-wallet=foo'])
+        address = self.nodes[0].getnewaddress()
+        address_info_before = self.nodes[0].getaddressinfo(address)
+        assert ("hdmasterfingerprint" in address_info_before)
+        self.nodes[0].importmulti([{
+            "desc":
+            "wpkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+            "timestamp": "now",
+            "watchonly": True
+        }])
+        self.stop_node(0)
+        out = textwrap.dedent('''\
+            Modifying key metadata...
+            =========================
+            Operation: delete
+            Key: all
+        ''')
+        self.assert_tool_output(out, '-wallet=foo', 'keymetadata', 'delete')
+        self.start_node(0, ['-wallet=foo'])
+        address_info_after = self.nodes[0].getaddressinfo(address)
+        assert ("hdmasterfingerprint" not in address_info_after)
+        self.stop_node(0)
+
+
 if __name__ == '__main__':
     ToolWalletTest().main()

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -106,12 +106,16 @@ class ToolWalletTest(BitcoinTestFramework):
         address = self.nodes[0].getnewaddress()
         address_info_before = self.nodes[0].getaddressinfo(address)
         assert ("hdmasterfingerprint" in address_info_before)
-        self.nodes[0].importmulti([{
+        result = self.nodes[0].importmulti([{
             "desc":
-            "wpkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+            "wpkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)#yk54u40t",
             "timestamp": "now",
             "watchonly": True
         }])
+        assert (result[0]["success"])
+        address_watch_only = "bcrt1qngw83fg8dz0k749cg7k3emc7v98wy0c7azaa6h"
+        address_watch_only_info_before = self.nodes[0].getaddressinfo(address_watch_only)
+        assert_equal(address_watch_only_info_before["hdmasterfingerprint"], "deadbeef")
         self.stop_node(0)
         out = textwrap.dedent('''\
             Modifying key metadata...
@@ -123,6 +127,8 @@ class ToolWalletTest(BitcoinTestFramework):
         self.start_node(0, ['-wallet=foo'])
         address_info_after = self.nodes[0].getaddressinfo(address)
         assert ("hdmasterfingerprint" not in address_info_after)
+        address_watch_only_info_after = self.nodes[0].getaddressinfo(address)
+        assert ("hdmasterfingerprint" not in address_watch_only_info_after)
         self.stop_node(0)
 
 

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -38,16 +38,18 @@ class ToolWalletTest(BitcoinTestFramework):
 
     def run_test(self):
 
-        self.assert_raises_tool_error('Invalid command: foo', 'foo')
+        self.assert_raises_tool_error('Invalid method: foo', 'foo')
         # `bitcoin-wallet help` is an error. Use `bitcoin-wallet -help`
-        self.assert_raises_tool_error('Invalid command: help', 'help')
-        self.assert_raises_tool_error('Error: two methods provided (info and create). Only one method should be provided.', 'info', 'create')
+        self.assert_raises_tool_error('Invalid method: help', 'help')
+        self.assert_raises_tool_error('Error: unexpected argument(s)', 'info', 'create')
         self.assert_raises_tool_error('Error parsing command line arguments: Invalid parameter -foo', '-foo')
-        self.assert_raises_tool_error('Error loading wallet.dat. Is wallet being used by other process?', '-wallet=wallet.dat', 'info')
+        self.assert_raises_tool_error('Error loading wallet.dat. Is wallet being used by another process?', '-wallet=wallet.dat', 'info')
         self.assert_raises_tool_error('Error: no wallet file at nonexistent.dat', '-wallet=nonexistent.dat', 'info')
 
         # stop the node to close the wallet to call info command
         self.stop_node(0)
+
+        self.log.info("Test method: info")
 
         out = textwrap.dedent('''\
             Wallet info
@@ -75,6 +77,8 @@ class ToolWalletTest(BitcoinTestFramework):
             Address Book: 3
         ''')
         self.assert_tool_output(out, '-wallet=wallet.dat', 'info')
+
+        self.log.info("Test method: create")
 
         out = textwrap.dedent('''\
             Topping up keypool...


### PR DESCRIPTION
Adds a `keymetadata` method to `wallet-tool` with currently only a `delete` operation.