### PR TITLE
[WIP] GUI: Add Pairing tab with Tor onion address as copyable text and QR code

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -138,6 +138,7 @@ QT_MOC_CPP = \
   qt/moc_optionsdialog.cpp \
   qt/moc_optionsmodel.cpp \
   qt/moc_overviewpage.cpp \
+  qt/moc_pairingpage.cpp \
   qt/moc_peertablemodel.cpp \
   qt/moc_paymentserver.cpp \
   qt/moc_qvalidatedlineedit.cpp \
@@ -216,6 +217,7 @@ BITCOIN_QT_H = \
   qt/optionsdialog.h \
   qt/optionsmodel.h \
   qt/overviewpage.h \
+  qt/pairingpage.h \
   qt/paymentrequestplus.h \
   qt/paymentserver.h \
   qt/peertablemodel.h \
@@ -339,6 +341,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/editaddressdialog.cpp \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
+  qt/pairingpage.cpp \
   qt/paymentserver.cpp \
   qt/receivecoinsdialog.cpp \
   qt/receiverequestdialog.cpp \

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -280,6 +280,10 @@ public:
     {
         return MakeHandler(::uiInterface.NotifyNetworkActiveChanged_connect(fn));
     }
+    std::unique_ptr<Handler> handleNotifyNetworkLocalChanged(NotifyNetworkLocalChangedFn fn) override
+    {
+        return MakeHandler(::uiInterface.NotifyNetworkLocalChanged_connect(fn));
+    }
     std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) override
     {
         return MakeHandler(::uiInterface.NotifyAlertChanged_connect(fn));

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -92,6 +92,15 @@ public:
     }
     void setupServerArgs() override { return SetupServerArgs(); }
     bool getProxy(Network net, proxyType& proxy_info) override { return GetProxy(net, proxy_info); }
+    std::vector<CNetAddr> getNetLocalAddresses() override
+    {
+        std::vector<CNetAddr> ret;
+        LOCK(cs_mapLocalHost);
+        for (const std::pair<const CNetAddr, LocalServiceInfo> &item : mapLocalHost) {
+            ret.emplace_back(item.first);
+        }
+        return ret;
+    }
     size_t getNodeCount(CConnman::NumConnections flags) override
     {
         return g_connman ? g_connman->GetNodeCount(flags) : 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -21,6 +21,7 @@
 class BanMan;
 class CCoinControl;
 class CFeeRate;
+class CNetAddr;
 class CNodeStats;
 class Coin;
 class RPCTimerInterface;
@@ -97,6 +98,9 @@ public:
 
     //! Get proxy.
     virtual bool getProxy(Network net, proxyType& proxy_info) = 0;
+
+    //! Get local network addresses.
+    virtual std::vector<CNetAddr> getNetLocalAddresses() = 0;
 
     //! Get number of connections.
     virtual size_t getNodeCount(CConnman::NumConnections flags) = 0;

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -224,6 +224,10 @@ public:
     using NotifyNetworkActiveChangedFn = std::function<void(bool network_active)>;
     virtual std::unique_ptr<Handler> handleNotifyNetworkActiveChanged(NotifyNetworkActiveChangedFn fn) = 0;
 
+    //! Register handler for network local changed messages.
+    using NotifyNetworkLocalChangedFn = std::function<void()>;
+    virtual std::unique_ptr<Handler> handleNotifyNetworkLocalChanged(NotifyNetworkLocalChangedFn fn) = 0;
+
     //! Register handler for notify alert messages.
     using NotifyAlertChangedFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleNotifyAlertChanged(NotifyAlertChangedFn fn) = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -214,14 +214,19 @@ bool AddLocal(const CService& addr, int nScore)
 
     LogPrintf("AddLocal(%s,%i)\n", addr.ToString(), nScore);
 
+    bool fAlready;
     {
         LOCK(cs_mapLocalHost);
-        bool fAlready = mapLocalHost.count(addr) > 0;
+        fAlready = mapLocalHost.count(addr) > 0;
         LocalServiceInfo &info = mapLocalHost[addr];
         if (!fAlready || nScore >= info.nScore) {
             info.nScore = nScore + (fAlready ? 1 : 0);
             info.nPort = addr.GetPort();
         }
+    }
+
+    if (!fAlready) {
+        uiInterface.NotifyNetworkLocalChanged();
     }
 
     return true;
@@ -234,9 +239,12 @@ bool AddLocal(const CNetAddr &addr, int nScore)
 
 void RemoveLocal(const CService& addr)
 {
-    LOCK(cs_mapLocalHost);
-    LogPrintf("RemoveLocal(%s)\n", addr.ToString());
-    mapLocalHost.erase(addr);
+    {
+        LOCK(cs_mapLocalHost);
+        LogPrintf("RemoveLocal(%s)\n", addr.ToString());
+        mapLocalHost.erase(addr);
+    }
+    uiInterface.NotifyNetworkLocalChanged();
 }
 
 void SetReachable(enum Network net, bool reachable)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -273,6 +273,15 @@ void BitcoinGUI::createActions()
     historyAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_4));
     tabGroup->addAction(historyAction);
 
+    m_action_pairing = new QAction(platformStyle->SingleColorIcon(":/icons/connect_1"), tr("&Pairing"), this);
+    m_action_pairing->setStatusTip(tr("Pair other software or devices with your node"));
+    m_action_pairing->setToolTip(m_action_pairing->statusTip());
+    m_action_pairing->setCheckable(true);
+    m_action_pairing->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
+    connect(m_action_pairing, &QAction::triggered, [this]{ showNormalIfMinimized(); });
+    connect(m_action_pairing, &QAction::triggered, this, &BitcoinGUI::gotoPairingPage);
+    tabGroup->addAction(m_action_pairing);
+
 #ifdef ENABLE_WALLET
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
     // can be triggered from the tray menu, and need to show the GUI to be useful.
@@ -476,6 +485,7 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
+        toolbar->addAction(m_action_pairing);
         overviewAction->setChecked(true);
 
 #ifdef ENABLE_WALLET
@@ -642,7 +652,6 @@ void BitcoinGUI::removeAllWallets()
 
 void BitcoinGUI::setWalletActionsEnabled(bool enabled)
 {
-    overviewAction->setEnabled(enabled);
     sendCoinsAction->setEnabled(enabled);
     sendCoinsMenuAction->setEnabled(enabled);
     receiveCoinsAction->setEnabled(enabled);
@@ -766,6 +775,7 @@ void BitcoinGUI::openClicked()
         Q_EMIT receivedURI(dlg.getURI());
     }
 }
+#endif
 
 void BitcoinGUI::gotoOverviewPage()
 {
@@ -773,6 +783,13 @@ void BitcoinGUI::gotoOverviewPage()
     if (walletFrame) walletFrame->gotoOverviewPage();
 }
 
+void BitcoinGUI::gotoPairingPage()
+{
+    m_action_pairing->setChecked(true);
+    if (walletFrame) walletFrame->gotoPairingPage();
+}
+
+#ifdef ENABLE_WALLET
 void BitcoinGUI::gotoHistoryPage()
 {
     historyAction->setChecked(true);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -127,6 +127,7 @@ private:
     QMenuBar* appMenuBar = nullptr;
     QToolBar* appToolBar = nullptr;
     QAction* overviewAction = nullptr;
+    QAction* m_action_pairing = nullptr;
     QAction* historyAction = nullptr;
     QAction* quitAction = nullptr;
     QAction* sendCoinsAction = nullptr;
@@ -252,9 +253,11 @@ private:
     void updateWindowTitle();
 
 public Q_SLOTS:
-#ifdef ENABLE_WALLET
     /** Switch to overview (home) page */
     void gotoOverviewPage();
+    /** Switch to pairing page */
+    void gotoPairingPage();
+#ifdef ENABLE_WALLET
     /** Switch to history (transactions) page */
     void gotoHistoryPage();
     /** Switch to receive coins page */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -115,6 +115,11 @@ void ClientModel::updateNetworkActive(bool networkActive)
     Q_EMIT networkActiveChanged(networkActive);
 }
 
+void ClientModel::updateNetworkLocal()
+{
+    Q_EMIT networkLocalChanged();
+}
+
 void ClientModel::updateAlert()
 {
     Q_EMIT alertsChanged(getStatusBarWarnings());
@@ -209,6 +214,11 @@ static void NotifyNetworkActiveChanged(ClientModel *clientmodel, bool networkAct
                               Q_ARG(bool, networkActive));
 }
 
+static void NotifyNetworkLocalChanged(ClientModel *clientmodel)
+{
+    QMetaObject::invokeMethod(clientmodel, "updateNetworkLocal", Qt::QueuedConnection);
+}
+
 static void NotifyAlertChanged(ClientModel *clientmodel)
 {
     qDebug() << "NotifyAlertChanged";
@@ -255,6 +265,7 @@ void ClientModel::subscribeToCoreSignals()
     m_handler_show_progress = m_node.handleShowProgress(std::bind(ShowProgress, this, std::placeholders::_1, std::placeholders::_2));
     m_handler_notify_num_connections_changed = m_node.handleNotifyNumConnectionsChanged(std::bind(NotifyNumConnectionsChanged, this, std::placeholders::_1));
     m_handler_notify_network_active_changed = m_node.handleNotifyNetworkActiveChanged(std::bind(NotifyNetworkActiveChanged, this, std::placeholders::_1));
+    m_handler_notify_network_local_changed = m_node.handleNotifyNetworkLocalChanged(std::bind(NotifyNetworkLocalChanged, this));
     m_handler_notify_alert_changed = m_node.handleNotifyAlertChanged(std::bind(NotifyAlertChanged, this));
     m_handler_banned_list_changed = m_node.handleBannedListChanged(std::bind(BannedListChanged, this));
     m_handler_notify_block_tip = m_node.handleNotifyBlockTip(std::bind(BlockTipChanged, this, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4, false));
@@ -267,6 +278,7 @@ void ClientModel::unsubscribeFromCoreSignals()
     m_handler_show_progress->disconnect();
     m_handler_notify_num_connections_changed->disconnect();
     m_handler_notify_network_active_changed->disconnect();
+    m_handler_notify_network_local_changed->disconnect();
     m_handler_notify_alert_changed->disconnect();
     m_handler_banned_list_changed->disconnect();
     m_handler_notify_block_tip->disconnect();

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -294,3 +294,14 @@ bool ClientModel::getProxyInfo(std::string& ip_port) const
     }
     return false;
 }
+
+bool ClientModel::getTorInfo(QString& out_onion) const
+{
+    for (const auto& addr : m_node.getNetLocalAddresses()) {
+        if (addr.IsTor()) {
+            out_onion = QString::fromStdString(addr.ToStringIP());
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -82,6 +82,7 @@ private:
     std::unique_ptr<interfaces::Handler> m_handler_show_progress;
     std::unique_ptr<interfaces::Handler> m_handler_notify_num_connections_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_network_active_changed;
+    std::unique_ptr<interfaces::Handler> m_handler_notify_network_local_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_alert_changed;
     std::unique_ptr<interfaces::Handler> m_handler_banned_list_changed;
     std::unique_ptr<interfaces::Handler> m_handler_notify_block_tip;
@@ -100,6 +101,7 @@ Q_SIGNALS:
     void numBlocksChanged(int count, const QDateTime& blockDate, double nVerificationProgress, bool header);
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void networkActiveChanged(bool networkActive);
+    void networkLocalChanged();
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
 
@@ -113,6 +115,7 @@ public Q_SLOTS:
     void updateTimer();
     void updateNumConnections(int numConnections);
     void updateNetworkActive(bool networkActive);
+    void updateNetworkLocal();
     void updateAlert();
     void updateBanlist();
 };

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -72,6 +72,7 @@ public:
     QString blocksDir() const;
 
     bool getProxyInfo(std::string& ip_port) const;
+    bool getTorInfo(QString& out_onion) const;
 
     // caches for the best header
     mutable std::atomic<int> cachedBestHeaderHeight;

--- a/src/qt/pairingpage.cpp
+++ b/src/qt/pairingpage.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/pairingpage.h>
+
+PairingPage::PairingPage(QWidget *parent) :
+    QWidget(parent)
+{
+}

--- a/src/qt/pairingpage.cpp
+++ b/src/qt/pairingpage.cpp
@@ -2,9 +2,60 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <qt/clientmodel.h>
 #include <qt/pairingpage.h>
+#include <qt/receiverequestdialog.h>
+
+#include <QFormLayout>
+#include <QLabel>
+#include <QLayout>
+#include <QLineEdit>
 
 PairingPage::PairingPage(QWidget *parent) :
     QWidget(parent)
 {
+    QVBoxLayout *layout = new QVBoxLayout(this);
+
+    QLabel *label_summary = new QLabel(this);
+    label_summary->setText(tr("Below you will find information to pair other software or devices with this node:"));
+    layout->addWidget(label_summary);
+
+    QFormLayout *form_layout = new QFormLayout(this);
+    m_onion_address = new QLineEdit(this);
+    m_onion_address->setReadOnly(true);
+    form_layout->addRow(tr("Onion address: "), m_onion_address);
+
+    layout->addLayout(form_layout);
+
+    m_qrcode = new QRImageWidget(this);
+#ifdef USE_QRCODE
+    layout->addWidget(m_qrcode);
+#endif
+
+    layout->addStretch();
+
+    refresh();
+}
+
+void PairingPage::setClientModel(ClientModel *client_model)
+{
+    m_client_model = client_model;
+    connect(client_model, &ClientModel::networkLocalChanged, this, &PairingPage::refresh);
+    refresh();
+}
+
+void PairingPage::refresh()
+{
+    QString onion;
+    if (m_client_model && m_client_model->getTorInfo(onion)) {
+        m_onion_address->setText(onion);
+        m_onion_address->setEnabled(true);
+        QString uri = QString("bitcoin-p2p://") + onion;
+        m_qrcode->setQR(uri);
+        m_qrcode->setVisible(true);
+    } else {
+        m_onion_address->setText(tr("(not connected)"));
+        m_onion_address->setEnabled(false);
+        m_qrcode->setVisible(false);
+    }
 }

--- a/src/qt/pairingpage.h
+++ b/src/qt/pairingpage.h
@@ -7,6 +7,13 @@
 
 #include <QWidget>
 
+class ClientModel;
+class QRImageWidget;
+
+QT_BEGIN_NAMESPACE
+class QLineEdit;
+QT_END_NAMESPACE
+
 class PairingPage : public QWidget
 {
     Q_OBJECT
@@ -14,6 +21,16 @@ class PairingPage : public QWidget
 public:
     explicit PairingPage(QWidget *parent = nullptr);
     ~PairingPage() {};
+
+    void setClientModel(ClientModel *);
+
+public Q_SLOTS:
+    void refresh();
+
+private:
+    ClientModel *m_client_model{nullptr};
+    QLineEdit *m_onion_address{nullptr};
+    QRImageWidget *m_qrcode{nullptr};
 };
 
 #endif // BITCOIN_QT_PAIRINGPAGE_H

--- a/src/qt/pairingpage.h
+++ b/src/qt/pairingpage.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_PAIRINGPAGE_H
+#define BITCOIN_QT_PAIRINGPAGE_H
+
+#include <QWidget>
+
+class PairingPage : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PairingPage(QWidget *parent = nullptr);
+    ~PairingPage() {};
+};
+
+#endif // BITCOIN_QT_PAIRINGPAGE_H

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -28,6 +28,8 @@
 QRImageWidget::QRImageWidget(QWidget *parent):
     QLabel(parent), contextMenu(nullptr)
 {
+    setAlignment(Qt::AlignCenter);
+
     contextMenu = new QMenu(this);
     QAction *saveImageAction = new QAction(tr("&Save Image..."), this);
     connect(saveImageAction, &QAction::triggered, this, &QRImageWidget::saveImage);

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -29,6 +29,7 @@ class QRImageWidget : public QLabel
 
 public:
     explicit QRImageWidget(QWidget *parent = nullptr);
+    bool setQR(const QString& data, const QString& text = "");
     QImage exportImage();
 
 public Q_SLOTS:

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <qt/pairingpage.h>
 #include <qt/walletframe.h>
 #include <qt/walletmodel.h>
 
@@ -31,6 +32,9 @@ WalletFrame::WalletFrame(const PlatformStyle *_platformStyle, BitcoinGUI *_gui) 
     QLabel *noWallet = new QLabel(tr("No wallet has been loaded."));
     noWallet->setAlignment(Qt::AlignCenter);
     walletStack->addWidget(noWallet);
+
+    m_page_pairing = new PairingPage(this);
+    m_global_stack->addWidget(m_page_pairing);
 }
 
 WalletFrame::~WalletFrame()
@@ -132,6 +136,11 @@ void WalletFrame::gotoOverviewPage()
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoOverviewPage();
     m_global_stack->setCurrentWidget(walletStack);
+}
+
+void WalletFrame::gotoPairingPage()
+{
+    m_global_stack->setCurrentWidget(m_page_pairing);
 }
 
 void WalletFrame::gotoHistoryPage()

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -44,6 +44,7 @@ WalletFrame::~WalletFrame()
 void WalletFrame::setClientModel(ClientModel *_clientModel)
 {
     this->clientModel = _clientModel;
+    m_page_pairing->setClientModel(_clientModel);
 }
 
 bool WalletFrame::addWallet(WalletModel *walletModel)

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -23,8 +23,10 @@ WalletFrame::WalletFrame(const PlatformStyle *_platformStyle, BitcoinGUI *_gui) 
     QHBoxLayout *walletFrameLayout = new QHBoxLayout(this);
     setContentsMargins(0,0,0,0);
     walletStack = new QStackedWidget(this);
+    m_global_stack = new QStackedWidget(this);
+    m_global_stack->addWidget(walletStack);
     walletFrameLayout->setContentsMargins(0,0,0,0);
-    walletFrameLayout->addWidget(walletStack);
+    walletFrameLayout->addWidget(m_global_stack);
 
     QLabel *noWallet = new QLabel(tr("No wallet has been loaded."));
     noWallet->setAlignment(Qt::AlignCenter);
@@ -129,6 +131,7 @@ void WalletFrame::gotoOverviewPage()
     QMap<WalletModel*, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoOverviewPage();
+    m_global_stack->setCurrentWidget(walletStack);
 }
 
 void WalletFrame::gotoHistoryPage()
@@ -136,6 +139,7 @@ void WalletFrame::gotoHistoryPage()
     QMap<WalletModel*, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoHistoryPage();
+    m_global_stack->setCurrentWidget(walletStack);
 }
 
 void WalletFrame::gotoReceiveCoinsPage()
@@ -143,6 +147,7 @@ void WalletFrame::gotoReceiveCoinsPage()
     QMap<WalletModel*, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoReceiveCoinsPage();
+    m_global_stack->setCurrentWidget(walletStack);
 }
 
 void WalletFrame::gotoSendCoinsPage(QString addr)
@@ -150,6 +155,7 @@ void WalletFrame::gotoSendCoinsPage(QString addr)
     QMap<WalletModel*, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoSendCoinsPage(addr);
+    m_global_stack->setCurrentWidget(walletStack);
 }
 
 void WalletFrame::gotoSignMessageTab(QString addr)

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -50,6 +50,7 @@ Q_SIGNALS:
     void requestedSyncWarningInfo();
 
 private:
+    QStackedWidget *m_global_stack;
     QStackedWidget *walletStack;
     BitcoinGUI *gui;
     ClientModel *clientModel;

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -10,6 +10,7 @@
 
 class BitcoinGUI;
 class ClientModel;
+class PairingPage;
 class PlatformStyle;
 class SendCoinsRecipient;
 class WalletModel;
@@ -56,6 +57,8 @@ private:
     ClientModel *clientModel;
     QMap<WalletModel*, WalletView*> mapWalletViews;
 
+    PairingPage *m_page_pairing;
+
     bool bOutOfSync;
 
     const PlatformStyle *platformStyle;
@@ -67,6 +70,8 @@ public:
 public Q_SLOTS:
     /** Switch to overview (home) page */
     void gotoOverviewPage();
+    /** Switch to pairing page */
+    void gotoPairingPage();
     /** Switch to history (transactions) page */
     void gotoHistoryPage();
     /** Switch to receive coins page */

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -16,6 +16,7 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::InitMessageSig> InitMessage;
     boost::signals2::signal<CClientUIInterface::NotifyNumConnectionsChangedSig> NotifyNumConnectionsChanged;
     boost::signals2::signal<CClientUIInterface::NotifyNetworkActiveChangedSig> NotifyNetworkActiveChanged;
+    boost::signals2::signal<CClientUIInterface::NotifyNetworkLocalChangedSig> NotifyNetworkLocalChanged;
     boost::signals2::signal<CClientUIInterface::NotifyAlertChangedSig> NotifyAlertChanged;
     boost::signals2::signal<CClientUIInterface::LoadWalletSig> LoadWallet;
     boost::signals2::signal<CClientUIInterface::ShowProgressSig> ShowProgress;
@@ -39,6 +40,7 @@ ADD_SIGNALS_IMPL_WRAPPER(ThreadSafeQuestion);
 ADD_SIGNALS_IMPL_WRAPPER(InitMessage);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNumConnectionsChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyNetworkActiveChanged);
+ADD_SIGNALS_IMPL_WRAPPER(NotifyNetworkLocalChanged);
 ADD_SIGNALS_IMPL_WRAPPER(NotifyAlertChanged);
 ADD_SIGNALS_IMPL_WRAPPER(LoadWallet);
 ADD_SIGNALS_IMPL_WRAPPER(ShowProgress);
@@ -51,6 +53,7 @@ bool CClientUIInterface::ThreadSafeQuestion(const std::string& message, const st
 void CClientUIInterface::InitMessage(const std::string& message) { return g_ui_signals.InitMessage(message); }
 void CClientUIInterface::NotifyNumConnectionsChanged(int newNumConnections) { return g_ui_signals.NotifyNumConnectionsChanged(newNumConnections); }
 void CClientUIInterface::NotifyNetworkActiveChanged(bool networkActive) { return g_ui_signals.NotifyNetworkActiveChanged(networkActive); }
+void CClientUIInterface::NotifyNetworkLocalChanged() { return g_ui_signals.NotifyNetworkLocalChanged(); }
 void CClientUIInterface::NotifyAlertChanged() { return g_ui_signals.NotifyAlertChanged(); }
 void CClientUIInterface::LoadWallet(std::shared_ptr<CWallet> wallet) { return g_ui_signals.LoadWallet(wallet); }
 void CClientUIInterface::ShowProgress(const std::string& title, int nProgress, bool resume_possible) { return g_ui_signals.ShowProgress(title, nProgress, resume_possible); }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -96,6 +96,9 @@ public:
     /** Network activity state changed. */
     ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkActiveChanged, void, bool networkActive);
 
+    /** Network local addresses changed. */
+    ADD_SIGNALS_DECL_WRAPPER(NotifyNetworkLocalChanged, void, );
+
     /**
      * Status bar alerts changed.
      */


### PR DESCRIPTION
This is intended to be merged only once the node can reliably provide a Tor hidden service for inbound connections.

It adds a "Pairing" tab to the GUI, which displays the onion address as copyable text, and a QR code (for scanning by mobile wallets).

TODO: Probably a BIP should be written for the `bitcoin-p2p:` URI scheme added here, and pairing behaviours.
![20190502-Knots-Pairing](https://user-images.githubusercontent.com/1095675/57066218-265faf80-6cbb-11e9-8c7e-347117b25a2d.png)
