### PR TITLE
rpc: Add missing #include

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -5,7 +5,6 @@
 #include <key_io.h>
 #include <keystore.h>
 #include <policy/fees.h>
-#include <rpc/protocol.h>
 #include <rpc/util.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -7,6 +7,7 @@
 
 #include <node/transaction.h>
 #include <pubkey.h>
+#include <rpc/protocol.h>
 #include <script/standard.h>
 #include <univalue.h>
 


### PR DESCRIPTION
bd0dbe8763fc3029cf96531c9ccaba280b939445 introduced a dependency of `rpc/util.h` on `RPCErrorCode`, defined in `rpc/protocol.h`.  The latter file is only included from `rpc/util.cpp`, though.  This commit fixes the missing include, by moving the `#include` of `rpc/protocol.h` to `rpc/util.h`.