### PR TITLE
bitcoin-cli: Eliminate "Error parsing JSON" errors

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -219,12 +219,13 @@ UniValue RPCConvertValues(const std::string &strMethod, const std::vector<std::s
     for (unsigned int idx = 0; idx < strParams.size(); idx++) {
         const std::string& strVal = strParams[idx];
 
-        if (!rpcCvtTable.convert(strMethod, idx)) {
+        UniValue json_value;
+        if (!rpcCvtTable.convert(strMethod, idx) || !json_value.read(strVal)) {
             // insert string value directly
             params.push_back(strVal);
         } else {
             // parse string as JSON, insert bool/number/object/etc. value
-            params.push_back(ParseNonRFCJSONValue(strVal));
+            params.push_back(json_value);
         }
     }
 
@@ -244,12 +245,13 @@ UniValue RPCConvertNamedValues(const std::string &strMethod, const std::vector<s
         std::string name = s.substr(0, pos);
         std::string value = s.substr(pos+1);
 
-        if (!rpcCvtTable.convert(strMethod, name)) {
+        UniValue json_value;
+        if (!rpcCvtTable.convert(strMethod, name) || !json_value.read(value)) {
             // insert string value directly
             params.pushKV(name, value);
         } else {
             // parse string as JSON, insert bool/number/object/etc. value
-            params.pushKV(name, ParseNonRFCJSONValue(value));
+            params.pushKV(name, json_value);
         }
     }
 


### PR DESCRIPTION
Just pass arguments that can't be parsed as JSON as string arguments. If the
RPC method isn't expecting a string argument, this will result in more specific
errors from the RPC. And if it allows an argument to be a string as one
possible type (for example the `hash_or_height` argument to `getblockstats`),
this avoids the need for bitcoin-cli users to use double JSON quoting+shell
quoting to pass the string.