### PR TITLE
refactor: Drop redundant wallet reference

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -135,55 +135,55 @@ WalletTxOut MakeWalletTxOut(interfaces::Chain::Lock& locked_chain,
 class WalletImpl : public Wallet
 {
 public:
-    explicit WalletImpl(const std::shared_ptr<CWallet>& wallet) : m_shared_wallet(wallet), m_wallet(*wallet.get()) {}
+    explicit WalletImpl(const std::shared_ptr<CWallet>& wallet) : m_wallet(wallet) {}
 
     bool encryptWallet(const SecureString& wallet_passphrase) override
     {
-        return m_wallet.EncryptWallet(wallet_passphrase);
+        return m_wallet->EncryptWallet(wallet_passphrase);
     }
-    bool isCrypted() override { return m_wallet.IsCrypted(); }
-    bool lock() override { return m_wallet.Lock(); }
-    bool unlock(const SecureString& wallet_passphrase) override { return m_wallet.Unlock(wallet_passphrase); }
-    bool isLocked() override { return m_wallet.IsLocked(); }
+    bool isCrypted() override { return m_wallet->IsCrypted(); }
+    bool lock() override { return m_wallet->Lock(); }
+    bool unlock(const SecureString& wallet_passphrase) override { return m_wallet->Unlock(wallet_passphrase); }
+    bool isLocked() override { return m_wallet->IsLocked(); }
     bool changeWalletPassphrase(const SecureString& old_wallet_passphrase,
         const SecureString& new_wallet_passphrase) override
     {
-        return m_wallet.ChangeWalletPassphrase(old_wallet_passphrase, new_wallet_passphrase);
+        return m_wallet->ChangeWalletPassphrase(old_wallet_passphrase, new_wallet_passphrase);
     }
-    void abortRescan() override { m_wallet.AbortRescan(); }
-    bool backupWallet(const std::string& filename) override { return m_wallet.BackupWallet(filename); }
-    std::string getWalletName() override { return m_wallet.GetName(); }
+    void abortRescan() override { m_wallet->AbortRescan(); }
+    bool backupWallet(const std::string& filename) override { return m_wallet->BackupWallet(filename); }
+    std::string getWalletName() override { return m_wallet->GetName(); }
     bool getKeyFromPool(bool internal, CPubKey& pub_key) override
     {
-        return m_wallet.GetKeyFromPool(pub_key, internal);
+        return m_wallet->GetKeyFromPool(pub_key, internal);
     }
-    bool getPubKey(const CKeyID& address, CPubKey& pub_key) override { return m_wallet.GetPubKey(address, pub_key); }
-    bool getPrivKey(const CKeyID& address, CKey& key) override { return m_wallet.GetKey(address, key); }
-    bool isSpendable(const CTxDestination& dest) override { return IsMine(m_wallet, dest) & ISMINE_SPENDABLE; }
-    bool haveWatchOnly() override { return m_wallet.HaveWatchOnly(); };
+    bool getPubKey(const CKeyID& address, CPubKey& pub_key) override { return m_wallet->GetPubKey(address, pub_key); }
+    bool getPrivKey(const CKeyID& address, CKey& key) override { return m_wallet->GetKey(address, key); }
+    bool isSpendable(const CTxDestination& dest) override { return IsMine(*m_wallet, dest) & ISMINE_SPENDABLE; }
+    bool haveWatchOnly() override { return m_wallet->HaveWatchOnly(); };
     bool setAddressBook(const CTxDestination& dest, const std::string& name, const std::string& purpose) override
     {
-        return m_wallet.SetAddressBook(dest, name, purpose);
+        return m_wallet->SetAddressBook(dest, name, purpose);
     }
     bool delAddressBook(const CTxDestination& dest) override
     {
-        return m_wallet.DelAddressBook(dest);
+        return m_wallet->DelAddressBook(dest);
     }
     bool getAddress(const CTxDestination& dest,
         std::string* name,
         isminetype* is_mine,
         std::string* purpose) override
     {
-        LOCK(m_wallet.cs_wallet);
-        auto it = m_wallet.mapAddressBook.find(dest);
-        if (it == m_wallet.mapAddressBook.end()) {
+        LOCK(m_wallet->cs_wallet);
+        auto it = m_wallet->mapAddressBook.find(dest);
+        if (it == m_wallet->mapAddressBook.end()) {
             return false;
         }
         if (name) {
             *name = it->second.name;
         }
         if (is_mine) {
-            *is_mine = IsMine(m_wallet, dest);
+            *is_mine = IsMine(*m_wallet, dest);
         }
         if (purpose) {
             *purpose = it->second.purpose;
@@ -192,52 +192,52 @@ public:
     }
     std::vector<WalletAddress> getAddresses() override
     {
-        LOCK(m_wallet.cs_wallet);
+        LOCK(m_wallet->cs_wallet);
         std::vector<WalletAddress> result;
-        for (const auto& item : m_wallet.mapAddressBook) {
-            result.emplace_back(item.first, IsMine(m_wallet, item.first), item.second.name, item.second.purpose);
+        for (const auto& item : m_wallet->mapAddressBook) {
+            result.emplace_back(item.first, IsMine(*m_wallet, item.first), item.second.name, item.second.purpose);
         }
         return result;
     }
-    void learnRelatedScripts(const CPubKey& key, OutputType type) override { m_wallet.LearnRelatedScripts(key, type); }
+    void learnRelatedScripts(const CPubKey& key, OutputType type) override { m_wallet->LearnRelatedScripts(key, type); }
     bool addDestData(const CTxDestination& dest, const std::string& key, const std::string& value) override
     {
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.AddDestData(dest, key, value);
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->AddDestData(dest, key, value);
     }
     bool eraseDestData(const CTxDestination& dest, const std::string& key) override
     {
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.EraseDestData(dest, key);
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->EraseDestData(dest, key);
     }
     std::vector<std::string> getDestValues(const std::string& prefix) override
     {
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.GetDestValues(prefix);
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->GetDestValues(prefix);
     }
     void lockCoin(const COutPoint& output) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.LockCoin(output);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->LockCoin(output);
     }
     void unlockCoin(const COutPoint& output) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.UnlockCoin(output);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->UnlockCoin(output);
     }
     bool isLockedCoin(const COutPoint& output) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.IsLockedCoin(output.hash, output.n);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->IsLockedCoin(output.hash, output.n);
     }
     void listLockedCoins(std::vector<COutPoint>& outputs) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.ListLockedCoins(outputs);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->ListLockedCoins(outputs);
     }
     std::unique_ptr<PendingWalletTx> createTransaction(const std::vector<CRecipient>& recipients,
         const CCoinControl& coin_control,
@@ -246,25 +246,25 @@ public:
         CAmount& fee,
         std::string& fail_reason) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        auto pending = MakeUnique<PendingWalletTxImpl>(m_wallet);
-        if (!m_wallet.CreateTransaction(*locked_chain, recipients, pending->m_tx, pending->m_key, fee, change_pos,
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        auto pending = MakeUnique<PendingWalletTxImpl>(*m_wallet);
+        if (!m_wallet->CreateTransaction(*locked_chain, recipients, pending->m_tx, pending->m_key, fee, change_pos,
                 fail_reason, coin_control, sign)) {
             return {};
         }
         return std::move(pending);
     }
-    bool transactionCanBeAbandoned(const uint256& txid) override { return m_wallet.TransactionCanBeAbandoned(txid); }
+    bool transactionCanBeAbandoned(const uint256& txid) override { return m_wallet->TransactionCanBeAbandoned(txid); }
     bool abandonTransaction(const uint256& txid) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.AbandonTransaction(*locked_chain, txid);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->AbandonTransaction(*locked_chain, txid);
     }
     bool transactionCanBeBumped(const uint256& txid) override
     {
-        return feebumper::TransactionCanBeBumped(&m_wallet, txid);
+        return feebumper::TransactionCanBeBumped(m_wallet.get(), txid);
     }
     bool createBumpTransaction(const uint256& txid,
         const CCoinControl& coin_control,
@@ -274,46 +274,46 @@ public:
         CAmount& new_fee,
         CMutableTransaction& mtx) override
     {
-        return feebumper::CreateTransaction(&m_wallet, txid, coin_control, total_fee, errors, old_fee, new_fee, mtx) ==
+        return feebumper::CreateTransaction(m_wallet.get(), txid, coin_control, total_fee, errors, old_fee, new_fee, mtx) ==
                feebumper::Result::OK;
     }
-    bool signBumpTransaction(CMutableTransaction& mtx) override { return feebumper::SignTransaction(&m_wallet, mtx); }
+    bool signBumpTransaction(CMutableTransaction& mtx) override { return feebumper::SignTransaction(m_wallet.get(), mtx); }
     bool commitBumpTransaction(const uint256& txid,
         CMutableTransaction&& mtx,
         std::vector<std::string>& errors,
         uint256& bumped_txid) override
     {
-        return feebumper::CommitTransaction(&m_wallet, txid, std::move(mtx), errors, bumped_txid) ==
+        return feebumper::CommitTransaction(m_wallet.get(), txid, std::move(mtx), errors, bumped_txid) ==
                feebumper::Result::OK;
     }
     CTransactionRef getTx(const uint256& txid) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        auto mi = m_wallet.mapWallet.find(txid);
-        if (mi != m_wallet.mapWallet.end()) {
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        auto mi = m_wallet->mapWallet.find(txid);
+        if (mi != m_wallet->mapWallet.end()) {
             return mi->second.tx;
         }
         return {};
     }
     WalletTx getWalletTx(const uint256& txid) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        auto mi = m_wallet.mapWallet.find(txid);
-        if (mi != m_wallet.mapWallet.end()) {
-            return MakeWalletTx(*locked_chain, m_wallet, mi->second);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        auto mi = m_wallet->mapWallet.find(txid);
+        if (mi != m_wallet->mapWallet.end()) {
+            return MakeWalletTx(*locked_chain, *m_wallet, mi->second);
         }
         return {};
     }
     std::vector<WalletTx> getWalletTxs() override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
         std::vector<WalletTx> result;
-        result.reserve(m_wallet.mapWallet.size());
-        for (const auto& entry : m_wallet.mapWallet) {
-            result.emplace_back(MakeWalletTx(*locked_chain, m_wallet, entry.second));
+        result.reserve(m_wallet->mapWallet.size());
+        for (const auto& entry : m_wallet->mapWallet) {
+            result.emplace_back(MakeWalletTx(*locked_chain, *m_wallet, entry.second));
         }
         return result;
     }
@@ -322,16 +322,16 @@ public:
         int& num_blocks,
         int64_t& block_time) override
     {
-        auto locked_chain = m_wallet.chain().lock(true /* try_lock */);
+        auto locked_chain = m_wallet->chain().lock(true /* try_lock */);
         if (!locked_chain) {
             return false;
         }
-        TRY_LOCK(m_wallet.cs_wallet, locked_wallet);
+        TRY_LOCK(m_wallet->cs_wallet, locked_wallet);
         if (!locked_wallet) {
             return false;
         }
-        auto mi = m_wallet.mapWallet.find(txid);
-        if (mi == m_wallet.mapWallet.end()) {
+        auto mi = m_wallet->mapWallet.find(txid);
+        if (mi == m_wallet->mapWallet.end()) {
             return false;
         }
         if (Optional<int> height = locked_chain->getHeight()) {
@@ -350,37 +350,37 @@ public:
         bool& in_mempool,
         int& num_blocks) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        auto mi = m_wallet.mapWallet.find(txid);
-        if (mi != m_wallet.mapWallet.end()) {
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        auto mi = m_wallet->mapWallet.find(txid);
+        if (mi != m_wallet->mapWallet.end()) {
             num_blocks = locked_chain->getHeight().get_value_or(-1);
             in_mempool = mi->second.InMempool();
             order_form = mi->second.vOrderForm;
             tx_status = MakeWalletTxStatus(*locked_chain, mi->second);
-            return MakeWalletTx(*locked_chain, m_wallet, mi->second);
+            return MakeWalletTx(*locked_chain, *m_wallet, mi->second);
         }
         return {};
     }
     WalletBalances getBalances() override
     {
         WalletBalances result;
-        result.balance = m_wallet.GetBalance();
-        result.unconfirmed_balance = m_wallet.GetUnconfirmedBalance();
-        result.immature_balance = m_wallet.GetImmatureBalance();
-        result.have_watch_only = m_wallet.HaveWatchOnly();
+        result.balance = m_wallet->GetBalance();
+        result.unconfirmed_balance = m_wallet->GetUnconfirmedBalance();
+        result.immature_balance = m_wallet->GetImmatureBalance();
+        result.have_watch_only = m_wallet->HaveWatchOnly();
         if (result.have_watch_only) {
-            result.watch_only_balance = m_wallet.GetBalance(ISMINE_WATCH_ONLY);
-            result.unconfirmed_watch_only_balance = m_wallet.GetUnconfirmedWatchOnlyBalance();
-            result.immature_watch_only_balance = m_wallet.GetImmatureWatchOnlyBalance();
+            result.watch_only_balance = m_wallet->GetBalance(ISMINE_WATCH_ONLY);
+            result.unconfirmed_watch_only_balance = m_wallet->GetUnconfirmedWatchOnlyBalance();
+            result.immature_watch_only_balance = m_wallet->GetImmatureWatchOnlyBalance();
         }
         return result;
     }
     bool tryGetBalances(WalletBalances& balances, int& num_blocks) override
     {
-        auto locked_chain = m_wallet.chain().lock(true /* try_lock */);
+        auto locked_chain = m_wallet->chain().lock(true /* try_lock */);
         if (!locked_chain) return false;
-        TRY_LOCK(m_wallet.cs_wallet, locked_wallet);
+        TRY_LOCK(m_wallet->cs_wallet, locked_wallet);
         if (!locked_wallet) {
             return false;
         }
@@ -388,68 +388,68 @@ public:
         num_blocks = locked_chain->getHeight().get_value_or(-1);
         return true;
     }
-    CAmount getBalance() override { return m_wallet.GetBalance(); }
+    CAmount getBalance() override { return m_wallet->GetBalance(); }
     CAmount getAvailableBalance(const CCoinControl& coin_control) override
     {
-        return m_wallet.GetAvailableBalance(&coin_control);
+        return m_wallet->GetAvailableBalance(&coin_control);
     }
     isminetype txinIsMine(const CTxIn& txin) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.IsMine(txin);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->IsMine(txin);
     }
     isminetype txoutIsMine(const CTxOut& txout) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.IsMine(txout);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->IsMine(txout);
     }
     CAmount getDebit(const CTxIn& txin, isminefilter filter) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.GetDebit(txin, filter);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->GetDebit(txin, filter);
     }
     CAmount getCredit(const CTxOut& txout, isminefilter filter) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
-        return m_wallet.GetCredit(txout, filter);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->GetCredit(txout, filter);
     }
     CoinsList listCoins() override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
         CoinsList result;
-        for (const auto& entry : m_wallet.ListCoins(*locked_chain)) {
+        for (const auto& entry : m_wallet->ListCoins(*locked_chain)) {
             auto& group = result[entry.first];
             for (const auto& coin : entry.second) {
                 group.emplace_back(COutPoint(coin.tx->GetHash(), coin.i),
-                    MakeWalletTxOut(*locked_chain, m_wallet, *coin.tx, coin.i, coin.nDepth));
+                    MakeWalletTxOut(*locked_chain, *m_wallet, *coin.tx, coin.i, coin.nDepth));
             }
         }
         return result;
     }
     std::vector<WalletTxOut> getCoins(const std::vector<COutPoint>& outputs) override
     {
-        auto locked_chain = m_wallet.chain().lock();
-        LOCK(m_wallet.cs_wallet);
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
         std::vector<WalletTxOut> result;
         result.reserve(outputs.size());
         for (const auto& output : outputs) {
             result.emplace_back();
-            auto it = m_wallet.mapWallet.find(output.hash);
-            if (it != m_wallet.mapWallet.end()) {
+            auto it = m_wallet->mapWallet.find(output.hash);
+            if (it != m_wallet->mapWallet.end()) {
                 int depth = it->second.GetDepthInMainChain(*locked_chain);
                 if (depth >= 0) {
-                    result.back() = MakeWalletTxOut(*locked_chain, m_wallet, it->second, output.n, depth);
+                    result.back() = MakeWalletTxOut(*locked_chain, *m_wallet, it->second, output.n, depth);
                 }
             }
         }
         return result;
     }
-    CAmount getRequiredFee(unsigned int tx_bytes) override { return GetRequiredFee(m_wallet, tx_bytes); }
+    CAmount getRequiredFee(unsigned int tx_bytes) override { return GetRequiredFee(*m_wallet, tx_bytes); }
     CAmount getMinimumFee(unsigned int tx_bytes,
         const CCoinControl& coin_control,
         int* returned_target,
@@ -457,55 +457,54 @@ public:
     {
         FeeCalculation fee_calc;
         CAmount result;
-        result = GetMinimumFee(m_wallet, tx_bytes, coin_control, ::mempool, ::feeEstimator, &fee_calc);
+        result = GetMinimumFee(*m_wallet, tx_bytes, coin_control, ::mempool, ::feeEstimator, &fee_calc);
         if (returned_target) *returned_target = fee_calc.returnedTarget;
         if (reason) *reason = fee_calc.reason;
         return result;
     }
-    unsigned int getConfirmTarget() override { return m_wallet.m_confirm_target; }
-    bool hdEnabled() override { return m_wallet.IsHDEnabled(); }
-    bool canGetAddresses() override { return m_wallet.CanGetAddresses(); }
-    bool IsWalletFlagSet(uint64_t flag) override { return m_wallet.IsWalletFlagSet(flag); }
-    OutputType getDefaultAddressType() override { return m_wallet.m_default_address_type; }
-    OutputType getDefaultChangeType() override { return m_wallet.m_default_change_type; }
+    unsigned int getConfirmTarget() override { return m_wallet->m_confirm_target; }
+    bool hdEnabled() override { return m_wallet->IsHDEnabled(); }
+    bool canGetAddresses() override { return m_wallet->CanGetAddresses(); }
+    bool IsWalletFlagSet(uint64_t flag) override { return m_wallet->IsWalletFlagSet(flag); }
+    OutputType getDefaultAddressType() override { return m_wallet->m_default_address_type; }
+    OutputType getDefaultChangeType() override { return m_wallet->m_default_change_type; }
     void remove() override
     {
-        RemoveWallet(m_shared_wallet);
+        RemoveWallet(m_wallet);
     }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {
-        return MakeHandler(m_wallet.NotifyUnload.connect(fn));
+        return MakeHandler(m_wallet->NotifyUnload.connect(fn));
     }
     std::unique_ptr<Handler> handleShowProgress(ShowProgressFn fn) override
     {
-        return MakeHandler(m_wallet.ShowProgress.connect(fn));
+        return MakeHandler(m_wallet->ShowProgress.connect(fn));
     }
     std::unique_ptr<Handler> handleStatusChanged(StatusChangedFn fn) override
     {
-        return MakeHandler(m_wallet.NotifyStatusChanged.connect([fn](CCryptoKeyStore*) { fn(); }));
+        return MakeHandler(m_wallet->NotifyStatusChanged.connect([fn](CCryptoKeyStore*) { fn(); }));
     }
     std::unique_ptr<Handler> handleAddressBookChanged(AddressBookChangedFn fn) override
     {
-        return MakeHandler(m_wallet.NotifyAddressBookChanged.connect(
+        return MakeHandler(m_wallet->NotifyAddressBookChanged.connect(
             [fn](CWallet*, const CTxDestination& address, const std::string& label, bool is_mine,
                 const std::string& purpose, ChangeType status) { fn(address, label, is_mine, purpose, status); }));
     }
     std::unique_ptr<Handler> handleTransactionChanged(TransactionChangedFn fn) override
     {
-        return MakeHandler(m_wallet.NotifyTransactionChanged.connect(
+        return MakeHandler(m_wallet->NotifyTransactionChanged.connect(
             [fn](CWallet*, const uint256& txid, ChangeType status) { fn(txid, status); }));
     }
     std::unique_ptr<Handler> handleWatchOnlyChanged(WatchOnlyChangedFn fn) override
     {
-        return MakeHandler(m_wallet.NotifyWatchonlyChanged.connect(fn));
+        return MakeHandler(m_wallet->NotifyWatchonlyChanged.connect(fn));
     }
     std::unique_ptr<Handler> handleCanGetAddressesChanged(CanGetAddressesChangedFn fn) override
     {
-        return MakeHandler(m_wallet.NotifyCanGetAddressesChanged.connect(fn));
+        return MakeHandler(m_wallet->NotifyCanGetAddressesChanged.connect(fn));
     }
 
-    std::shared_ptr<CWallet> m_shared_wallet;
-    CWallet& m_wallet;
+    std::shared_ptr<CWallet> m_wallet;
 };
 
 class WalletClientImpl : public ChainClient


### PR DESCRIPTION
Removes the redudant wallet reference from `WalletImpl`.

```cpp
// before:
std::shared_ptr<CWallet> m_shared_wallet;
CWallet& m_wallet;

// after
std::shared_ptr<CWallet> m_wallet;
```