### PR TITLE
gui: Fix async open wallet call order

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -396,6 +396,8 @@ void BitcoinGUI::createActions()
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet);
                     connect(activity, &OpenWalletActivity::finished, activity, &QObject::deleteLater);
                     connect(activity, &OpenWalletActivity::finished, dialog, &QObject::deleteLater);
+                    bool invoked = QMetaObject::invokeMethod(activity, "open");
+                    assert(invoked);
                 });
             }
         });

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -59,7 +59,6 @@ OpenWalletActivity* WalletController::openWallet(const std::string& name, QWidge
 {
     OpenWalletActivity* activity = new OpenWalletActivity(this, name);
     activity->moveToThread(&m_activity_thread);
-    QMetaObject::invokeMethod(activity, "open", Qt::QueuedConnection);
     return activity;
 }
 


### PR DESCRIPTION
Fixes #15455. Must call `OpenWalletActivity::open` asynchronously only after all connections are made to the `OpenWalletActivity` instance, otherwise signals can be missed.