### PR TITLE
rpc/gui: Remove 'Unknown block versions being mined' warning

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2259,12 +2259,6 @@ void static UpdateTip(const CBlockIndex *pindexNew, const CChainParams& chainPar
         }
         if (nUpgraded > 0)
             AppendWarning(warningMessages, strprintf(_("%d of last 100 blocks have unexpected version"), nUpgraded));
-        if (nUpgraded > 100/2)
-        {
-            std::string strWarning = _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect");
-            // notify GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
-            DoWarning(strWarning);
-        }
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -66,23 +66,7 @@ class NotificationsTest(BitcoinTestFramework):
             txids_rpc = list(map(lambda t: t['txid'], self.nodes[1].listtransactions("*", block_count)))
             assert_equal(sorted(txids_rpc), sorted(os.listdir(self.walletnotify_dir)))
 
-        # Mine another 41 up-version blocks. -alertnotify should trigger on the 51st.
-        self.log.info("test -alertnotify")
-        self.nodes[1].generatetoaddress(41, ADDRESS_BCRT1_UNSPENDABLE)
-        self.sync_all()
-
-        # Give bitcoind 10 seconds to write the alert notification
-        wait_until(lambda: len(os.listdir(self.alertnotify_dir)), timeout=10)
-
-        for notify_file in os.listdir(self.alertnotify_dir):
-            os.remove(os.path.join(self.alertnotify_dir, notify_file))
-
-        # Mine more up-version blocks, should not get more alerts:
-        self.nodes[1].generatetoaddress(2, ADDRESS_BCRT1_UNSPENDABLE)
-        self.sync_all()
-
-        self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
-        assert_equal(len(os.listdir(self.alertnotify_dir)), 0)
+        # TODO: add test for `-alertnotify` large fork notifications
 
 if __name__ == '__main__':
     NotificationsTest().main()

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -22,7 +22,6 @@ VB_TOP_BITS = 0x20000000
 VB_UNKNOWN_BIT = 27       # Choose a bit unassigned to any deployment
 VB_UNKNOWN_VERSION = VB_TOP_BITS | (1 << VB_UNKNOWN_BIT)
 
-WARN_UNKNOWN_RULES_MINED = "Unknown block versions being mined! It's possible unknown rules are in effect"
 WARN_UNKNOWN_RULES_ACTIVE = "unknown new rules activated (versionbit {})".format(VB_UNKNOWN_BIT)
 VB_PATTERN = re.compile("Warning: unknown new rules activated.*versionbit")
 
@@ -78,14 +77,9 @@ class VersionBitsWarningTest(BitcoinTestFramework):
         assert(not VB_PATTERN.match(node.getmininginfo()["warnings"]))
         assert(not VB_PATTERN.match(node.getnetworkinfo()["warnings"]))
 
-        self.log.info("Check that there is a warning if >50 blocks in the last 100 were an unknown version")
         # Build one period of blocks with VB_THRESHOLD blocks signaling some unknown bit
         self.send_blocks_with_version(node.p2p, VB_THRESHOLD, VB_UNKNOWN_VERSION)
         node.generatetoaddress(VB_PERIOD - VB_THRESHOLD, node_deterministic_address)
-
-        # Check that get*info() shows the 51/100 unknown block version error.
-        assert(WARN_UNKNOWN_RULES_MINED in node.getmininginfo()["warnings"])
-        assert(WARN_UNKNOWN_RULES_MINED in node.getnetworkinfo()["warnings"])
 
         self.log.info("Check that there is a warning if previous VB_BLOCKS have >=VB_THRESHOLD blocks with unknown versionbits version.")
         # Mine a period worth of expected blocks so the generic block-version warning


### PR DESCRIPTION
Due to miners inserting garbage into the version numbers causing false positives, the current version signalling has become completely useless. This removes the "unknown block versions" warning which has the tendency to scare users unnecessarily (and might get them to "update" to something bad).

It preserves the warning in the logs. Whether this is desirable can be a point of discussion.
