### PR TITLE
gui: Refactor open wallet activity

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -382,31 +382,13 @@ void BitcoinGUI::createActions()
                     continue;
                 }
 
-                connect(action, &QAction::triggered, [this, name, path] {
-                    OpenWalletActivity* activity = m_wallet_controller->openWallet(path);
-
-                    QProgressDialog* dialog = new QProgressDialog(this);
-                    dialog->setLabelText(tr("Opening Wallet <b>%1</b>...").arg(name.toHtmlEscaped()));
-                    dialog->setRange(0, 0);
-                    dialog->setCancelButton(nullptr);
-                    dialog->setWindowModality(Qt::ApplicationModal);
-                    dialog->show();
-
-                    connect(activity, &OpenWalletActivity::message, this, [this] (QMessageBox::Icon icon, QString text) {
-                        QMessageBox box;
-                        box.setIcon(icon);
-                        box.setText(tr("Open Wallet Failed"));
-                        box.setInformativeText(text);
-                        box.setStandardButtons(QMessageBox::Ok);
-                        box.setDefaultButton(QMessageBox::Ok);
-                        connect(this, &QObject::destroyed, &box, &QDialog::accept);
-                        box.exec();
-                    });
+                connect(action, &QAction::triggered, [this, path] {
+                    OpenWalletActivity* activity = new OpenWalletActivity(this);
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet);
                     connect(activity, &OpenWalletActivity::finished, activity, &QObject::deleteLater);
-                    connect(activity, &OpenWalletActivity::finished, dialog, &QObject::deleteLater);
-                    bool invoked = QMetaObject::invokeMethod(activity, "open");
-                    assert(invoked);
+                    activity->setWalletController(m_wallet_controller);
+                    activity->setPath(path);
+                    activity->open();
                 });
             }
             if (wallets.empty()) {


### PR DESCRIPTION
This PR changes the thread of the `OpenWalletActivity`, from the wallet controller thread to the GUI thread. The actual opening is still executed in the wallet controller thread, but in a different way. Considering the current minimum Qt version, the best way to run a function in a different thread is to use `QTimer::singleShot(0, worker, () { ... })` where `worker` is an object in a different thread. With Qt 5.10, the correct way is to use `QMetaObject::invokeMethod`.

This change also removes from `bitcoingui.cpp` the handling of loading messages and progress dialog.