### PR TITLE
Restrict timestamp when mining a diff-adjustment block to prev-600

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -29,6 +29,9 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+    if (pindexPrev->nHeight % consensusParams.DifficultyAdjustmentInterval() == consensusParams.DifficultyAdjustmentInterval() - 1) {
+        nNewTime = std::max(nNewTime, (int64_t)pindexPrev->nTime - 600);
+    }
 
     if (nOldTime < nNewTime)
         pblock->nTime = nNewTime;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -677,7 +677,11 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
     result.pushKV("longpollid", ::ChainActive().Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
-    result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
+    if (pindexPrev->nHeight % consensusParams.DifficultyAdjustmentInterval() == consensusParams.DifficultyAdjustmentInterval() - 1) {
+        result.pushKV("mintime", std::max((int64_t)pindexPrev->GetMedianTimePast()+1, (int64_t)pindexPrev->nTime - 600));
+    } else {
+        result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
+    }
     result.pushKV("mutable", aMutable);
     result.pushKV("noncerange", "00000000ffffffff");
     int64_t nSigOpLimit = MAX_BLOCK_SIGOPS_COST;

--- a/test/functional/mining_timewarp_fork.py
+++ b/test/functional/mining_timewarp_fork.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test getblocktemplate complies with potential future timewarp-fixing
+   softforks (modulo 600 second nTime decrease).
+
+   We first mine a chain up to the difficulty-adjustment block and set
+   the last block's timestamp 2 hours in the future, then check the times
+   returned by getblocktemplate. Note that we cannot check the actual
+   retarget behavior as difficulty adjustments do not occur on regtest
+   (though it still technically has a difficulty adjustment interval)."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+)
+
+
+class TimewarpMiningTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info('Create some old blocks')
+        block_1 = node.generate(2014)[0]
+        last_block_time = node.getblockheader(block_1)["time"] + 7199
+
+        self.log.info('Create a block 7199 seconds in the future')
+        node.setmocktime(last_block_time)
+        block_2015 = node.generate(1)[0]
+        assert_equal(node.getblockheader(block_2015)["time"], last_block_time)
+
+        mining_info = node.getmininginfo()
+        assert_equal(mining_info['blocks'], 2015)
+        assert_equal(mining_info['currentblocktx'], 0)
+        assert_equal(mining_info['currentblockweight'], 4000)
+
+        self.restart_node(0)
+        connect_nodes_bi(self.nodes, 0, 1)
+        node = self.nodes[0]
+
+        self.log.info('Check that mintime and curtime are last-block - 600 seconds')
+        # Now test that mintime and curtime are last_block_time - 600
+        template = node.getblocktemplate({'rules': ['segwit']})
+        assert_equal(template["curtime"], last_block_time - 600)
+        assert_equal(template["mintime"], last_block_time - 600)
+
+        self.log.info('Generate a 2016th block and check that the next block\'s time goes back to now')
+        block_2016 = node.generate(1)[0]
+        assert_equal(node.getblockheader(block_2016)["time"], last_block_time - 600)
+
+        # Assume test doesn't take 2 hours and check that we let time jump backwards
+        # now that we mined the difficulty-adjustment block
+        block_2017 = node.generate(1)[0]
+        assert(node.getblockheader(block_2017)["time"] < last_block_time - 600)
+
+if __name__ == '__main__':
+    TimewarpMiningTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -179,6 +179,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',
     'mining_basic.py',
+    'mining_timewarp_fork.py',
     'wallet_bumpfee.py',
     'wallet_bumpfee_totalfee_deprecation.py',
     'wallet_implicitsegwit.py',


### PR DESCRIPTION
This prepares us for a potential future timewarp-fixing softfork by
ensuring that we always refuse to mine blocks which refuse to
exploit timewarp, no matter the behavior of other miners. Note that
we allow timestamp to go backwards by 600 seconds on the
difficulty-adjustment blocks to avoid bricking any existing
hardware which relies on the ability to roll nTime by up to 600
seconds.

Note that it is possible that the eventual softfork to fix timewarp
has a looser resetriction than the 600 seconds enforced here,
however it seems unlikely we will apply a tighter one, and its fine
if we restrict things further on the mining end than in consensus.