### PR TITLE
Implement BIPXXX's new softfork rules (The Great Consensus Cleanup)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -90,6 +90,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1479168000; // November 15th, 2016.
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
 
+        // Deployment of BIPXXX
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].nStartTime = 1564617600; // August 1st, 2019
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].nTimeout = 1596240000; // August 1st, 2020
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000051dc8b82f450202ecb3d471");
 
@@ -207,6 +212,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
 
+        // Deployment of BIPXXX
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].nStartTime = 1559347200; // June 1st, 2019
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].nTimeout = 1590969600; // June 1st, 2020
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000007dbe94253893cbd463");
 
@@ -297,6 +307,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].bit = 3;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLEANUPS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -18,6 +18,7 @@ enum DeploymentPos
     DEPLOYMENT_TESTDUMMY,
     DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
     DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
+    DEPLOYMENT_CLEANUPS, // Deployment of BIPXXX.
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
     MAX_VERSION_BITS_DEPLOYMENTS
 };

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -33,6 +33,9 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime = std::max(pindexPrev->GetMedianTimePast()+1, GetAdjustedTime());
+    if (pindexPrev->nHeight % consensusParams.DifficultyAdjustmentInterval() == consensusParams.DifficultyAdjustmentInterval() - 1) {
+        nNewTime = std::max(nNewTime, (int64_t)pindexPrev->nTime - 600);
+    }
 
     if (nOldTime < nNewTime)
         pblock->nTime = nNewTime;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -66,7 +66,9 @@ static constexpr unsigned int STANDARD_SCRIPT_VERIFY_FLAGS = MANDATORY_SCRIPT_VE
                                                              SCRIPT_VERIFY_WITNESS |
                                                              SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM |
                                                              SCRIPT_VERIFY_WITNESS_PUBKEYTYPE |
-                                                             SCRIPT_VERIFY_CONST_SCRIPTCODE;
+                                                             SCRIPT_VERIFY_CONST_SCRIPTCODE |
+                                                             SCRIPT_VERIFY_DEFINED_SIGHASH |
+                                                             SCRIPT_VERIFY_SIGPUSHONLY;
 
 /** For convenience, standard but not mandatory verify flags. */
 static constexpr unsigned int STANDARD_NOT_MANDATORY_VERIFY_FLAGS = STANDARD_SCRIPT_VERIFY_FLAGS & ~MANDATORY_SCRIPT_VERIFY_FLAGS;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -652,7 +652,11 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
     result.pushKV("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
-    result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
+    if (pindexPrev->nHeight % consensusParams.DifficultyAdjustmentInterval() == consensusParams.DifficultyAdjustmentInterval() - 1) {
+        result.pushKV("mintime", std::max((int64_t)pindexPrev->GetMedianTimePast()+1, (int64_t)pindexPrev->nTime - 600));
+    } else {
+        result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
+    }
     result.pushKV("mutable", aMutable);
     result.pushKV("noncerange", "00000000ffffffff");
     int64_t nSigOpLimit = MAX_BLOCK_SIGOPS_COST;

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -52,12 +52,17 @@ enum
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH                = (1U << 0), // evaluate P2SH (BIP16) subscripts
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG              = (1U << 2), // enforce strict DER (BIP66) compliance
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NULLDUMMY           = (1U << 4), // enforce NULLDUMMY (BIP147)
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_SIGPUSHONLY         = (1U << 5), // enforce scriptSig IsPushOnly (BIPXXX)
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY = (1U << 9), // enable CHECKLOCKTIMEVERIFY (BIP65)
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY = (1U << 10), // enable CHECKSEQUENCEVERIFY (BIP112)
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS             = (1U << 11), // enable WITNESS (BIP141)
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CONST_SCRIPTCODE    = (1U << 16), // enforce const scriptCode (BIPXXX)
+    bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DEFINED_SIGHASH     = (1U << 17), // enforce defined sighashes (BIPXXX)
     bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL                 = bitcoinconsensus_SCRIPT_FLAGS_VERIFY_P2SH | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DERSIG |
                                                                bitcoinconsensus_SCRIPT_FLAGS_VERIFY_NULLDUMMY | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKLOCKTIMEVERIFY |
-                                                               bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS
+                                                               bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CHECKSEQUENCEVERIFY | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_WITNESS |
+                                                               bitcoinconsensus_SCRIPT_FLAGS_VERIFY_SIGPUSHONLY | bitcoinconsensus_SCRIPT_FLAGS_VERIFY_CONST_SCRIPTCODE |
+                                                               bitcoinconsensus_SCRIPT_FLAGS_VERIFY_DEFINED_SIGHASH
 };
 
 /// Returns 1 if the input nIn of the serialized transaction pointed to by

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -208,7 +208,7 @@ bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned i
     } else if ((flags & SCRIPT_VERIFY_LOW_S) != 0 && !IsLowDERSignature(vchSig, serror)) {
         // serror is set
         return false;
-    } else if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 && !IsDefinedHashtypeSignature(vchSig)) {
+    } else if ((flags & (SCRIPT_VERIFY_STRICTENC | SCRIPT_VERIFY_DEFINED_SIGHASH)) != 0 && !IsDefinedHashtypeSignature(vchSig)) {
         return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
     }
     return true;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -115,6 +115,10 @@ enum
     // Making OP_CODESEPARATOR and FindAndDelete fail any non-segwit scripts
     //
     SCRIPT_VERIFY_CONST_SCRIPTCODE = (1U << 16),
+
+    // Using an undefined hashtype in a checksig operation causes script failure.
+    // This is implied by SCRIPT_VERIFY_STRICTENC
+    SCRIPT_VERIFY_DEFINED_SIGHASH = (1U << 17),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1425,8 +1425,11 @@ bool CheckInputs(const CTransaction& tx, CValidationState &state, const CCoinsVi
                         // non-upgraded nodes.
                         CScriptCheck check2(coin.out, tx, i,
                                 flags & ~STANDARD_NOT_MANDATORY_VERIFY_FLAGS, cacheSigStore, &txdata);
-                        if (check2())
+                        if (check2()) {
                             return state.Invalid(false, REJECT_NONSTANDARD, strprintf("non-mandatory-script-verify-flag (%s)", ScriptErrorString(check.GetScriptError())));
+                        } else {
+                            return state.DoS(100, false, REJECT_INVALID, strprintf("mandatory-script-verify-flag-failed (%s)", ScriptErrorString(check2.GetScriptError())));
+                        }
                     }
                     // Failures of other flags indicate a transaction that is
                     // invalid in new blocks, e.g. an invalid P2SH. We DoS ban

--- a/src/versionbitsinfo.cpp
+++ b/src/versionbitsinfo.cpp
@@ -18,5 +18,9 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
     {
         /*.name =*/ "segwit",
         /*.gbt_force =*/ true,
+    },
+    {
+        /*.name =*/ "cleanups",
+        /*.gbt_force =*/ true,
     }
 };

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -180,7 +180,7 @@ class AssumeValidTest(BitcoinTestFramework):
         for i in range(2202):
             p2p1.send_message(msg_block(self.blocks[i]))
         # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
-        p2p1.sync_with_ping(150)
+        p2p1.sync_with_ping(200)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2202)
 
         # Send blocks to node2. Block 102 will be rejected.

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -43,7 +43,7 @@ from test_framework.messages import (
     msg_headers
 )
 from test_framework.mininode import P2PInterface
-from test_framework.script import (CScript, OP_TRUE)
+from test_framework.script import (CScript, OP_TRUE, OP_DROP)
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
@@ -131,7 +131,7 @@ class AssumeValidTest(BitcoinTestFramework):
         # Create a transaction spending the coinbase output with an invalid (null) signature
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.block1.vtx[0].sha256, 0), scriptSig=b""))
-        tx.vout.append(CTxOut(49 * 100000000, CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(49 * 100000000, CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])))
         tx.calc_sha256()
 
         block102 = create_block(self.tip, create_coinbase(height), self.block_time)

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -78,7 +78,7 @@ class FullBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [[]]
+        self.extra_args = [['-vbparams=cleanups:0:0']] # Don't enforce new cleanup softfork rules
 
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -143,7 +143,8 @@ class BIP68_112_113Test(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=4', '-addresstype=legacy']]
+        # We run some non-push opcodes in scriptSigs so disable the cleanups rules
+        self.extra_args = [['-whitelist=127.0.0.1', '-blockversion=4', '-addresstype=legacy', '-vbparams=cleanups:0:0']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/mining_timewarp_fork.py
+++ b/test/functional/mining_timewarp_fork.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test getblocktemplate complies with potential future timewarp-fixing
+   softforks (modulo 600 second nTime decrease).
+
+   We first mine a chain up to the difficulty-adjustment block and set
+   the last block's timestamp 2 hours in the future, then check the times
+   returned by getblocktemplate. Note that we cannot check the actual
+   retarget behavior as difficulty adjustments do not occur on regtest
+   (though it still technically has a difficulty adjustment interval)."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes_bi,
+)
+
+
+class TimewarpMiningTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        self.log.info('Create some old blocks')
+        block_1 = self.nodes[0].generate(1)[0]
+        for i in range(2013):
+            self.nodes[0].generate(1)
+        last_block_time = self.nodes[0].getblockheader(block_1)["time"] + 7199
+
+        self.log.info('Create a block 7199 seconds in the future')
+        self.nodes[0].setmocktime(last_block_time)
+        block_2015 = self.nodes[0].generate(1)[0]
+        assert_equal(self.nodes[0].getblockheader(block_2015)["time"], last_block_time)
+
+        mining_info = self.nodes[0].getmininginfo()
+        assert_equal(mining_info['blocks'], 2015)
+        assert_equal(mining_info['currentblocktx'], 0)
+        assert_equal(mining_info['currentblockweight'], 4000)
+
+        self.restart_node(0)
+        connect_nodes_bi(self.nodes, 0, 1)
+
+        self.log.info('Check that mintime and curtime are last-block - 600 seconds')
+        # Now test that mintime and curtime are last_block_time - 600
+        template = self.nodes[0].getblocktemplate({'rules': ['segwit']})
+        assert_equal(template["curtime"], last_block_time - 600)
+        assert_equal(template["mintime"], last_block_time - 600)
+
+        self.log.info('Generate a 2016th block and check that the next block\'s time goes back to now')
+        block_2016 = self.nodes[0].generate(1)[0]
+        assert_equal(self.nodes[0].getblockheader(block_2016)["time"], last_block_time - 600)
+
+        # Assume test doesn't take 2 hours and check that we let time jump backwards
+        # now that we mined the difficulty-adjustment block
+        block_2017 = self.nodes[0].generate(1)[0]
+        assert(self.nodes[0].getblockheader(block_2017)["time"] < last_block_time - 600)
+
+if __name__ == '__main__':
+    TimewarpMiningTest().main()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -328,7 +328,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx = CTransaction()
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
-        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE])))
+        tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])))
         tx.wit.vtxinwit.append(CTxInWitness())
         tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([CScriptNum(1)])]
 
@@ -496,7 +496,7 @@ class SegWitTest(BitcoinTestFramework):
         # Now try to spend the outputs. This should fail since SCRIPT_VERIFY_WITNESS is always enabled.
         p2wsh_tx = CTransaction()
         p2wsh_tx.vin = [CTxIn(COutPoint(txid, 0), b'')]
-        p2wsh_tx.vout = [CTxOut(value, CScript([OP_TRUE]))]
+        p2wsh_tx.vout = [CTxOut(value, CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP]))]
         p2wsh_tx.wit.vtxinwit.append(CTxInWitness())
         p2wsh_tx.wit.vtxinwit[0].scriptWitness.stack = [CScript([OP_TRUE])]
         p2wsh_tx.rehash()
@@ -813,7 +813,7 @@ class SegWitTest(BitcoinTestFramework):
         tx.vin.append(CTxIn(COutPoint(self.utxo[0].sha256, self.utxo[0].n), b""))
 
         # Let's construct a witness program
-        witness_program = CScript([OP_TRUE])
+        witness_program = CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])
         witness_hash = sha256(witness_program)
         script_pubkey = CScript([OP_0, witness_hash])
         tx.vout.append(CTxOut(self.utxo[0].nValue - 1000, script_pubkey))
@@ -1114,7 +1114,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])))
         tx2.wit.vtxinwit.append(CTxInWitness())
         # First try a 521-byte stack element
         tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a' * (MAX_SCRIPT_ELEMENT_SIZE + 1), witness_program]
@@ -1155,7 +1155,7 @@ class SegWitTest(BitcoinTestFramework):
 
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue - 1000, CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])))
         tx2.wit.vtxinwit.append(CTxInWitness())
         tx2.wit.vtxinwit[0].scriptWitness.stack = [b'a'] * 44 + [long_witness_program]
         tx2.rehash()
@@ -1444,7 +1444,7 @@ class SegWitTest(BitcoinTestFramework):
 
         block = self.build_next_block()
         # Change the output of the block to be a witness output.
-        witness_program = CScript([OP_TRUE])
+        witness_program = CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])
         witness_hash = sha256(witness_program)
         script_pubkey = CScript([OP_0, witness_hash])
         block.vtx[0].vout[0].scriptPubKey = script_pubkey
@@ -1716,7 +1716,7 @@ class SegWitTest(BitcoinTestFramework):
         sign_p2pk_witness_input(witness_program, tx, 0, SIGHASH_ALL, temp_utxos[0].nValue, key)
         tx2 = CTransaction()
         tx2.vin.append(CTxIn(COutPoint(tx.sha256, 0), b""))
-        tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE])))
+        tx2.vout.append(CTxOut(tx.vout[0].nValue, CScript([OP_TRUE, OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])))
 
         script = get_p2pkh_script(pubkeyhash)
         sig_hash = SegwitVersion1SignatureHash(script, tx2, 0, SIGHASH_ALL, tx.vout[0].nValue)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -36,6 +36,7 @@ from .script import (
     OP_CHECKSIG,
     OP_RETURN,
     OP_TRUE,
+    OP_DROP,
     hash160,
 )
 from .util import assert_equal
@@ -120,12 +121,13 @@ def create_coinbase(height, pubkey=None):
     if (pubkey is not None):
         coinbaseoutput.scriptPubKey = CScript([pubkey, OP_CHECKSIG])
     else:
-        coinbaseoutput.scriptPubKey = CScript([OP_TRUE])
+        # Use three OP_TRUEs to ensure we're always > 64 bytes in non-witness size
+        coinbaseoutput.scriptPubKey = CScript([OP_TRUE, OP_TRUE, OP_DROP])
     coinbase.vout = [coinbaseoutput]
     coinbase.calc_sha256()
     return coinbase
 
-def create_tx_with_script(prevtx, n, script_sig=b"", *, amount, script_pub_key=CScript()):
+def create_tx_with_script(prevtx, n, script_sig=b"", *, amount, script_pub_key=CScript([OP_TRUE, OP_DROP, OP_TRUE, OP_DROP])):
     """Return one-input, one-output transaction object
        spending the prevtx's n-th output with the given amount.
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -161,6 +161,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',
     'mining_basic.py',
+    'mining_timewarp_fork.py',
     'wallet_bumpfee.py',
     'rpc_named_arguments.py',
     'wallet_listsinceblock.py',


### PR DESCRIPTION
Some notes:
 * Three tests use non-push opcodes in scriptSigs, so those have
   the fork explicitly disabled.
 * The 64-byte transaction check is executed in a new
   ContextualBlockPreCheck which must be run before CheckBlock (at
   least in the final checking before writing the block to disk).
   This function is a bit awkward but is seemingly the simplest way
   to implement the new check, with the caveat that, because the
   new function is called before CheckBlock, it can never return a
   non-CorruptionPossible error state.

Based on #15481. BIP available at https://github.com/TheBlueMatt/bips/blob/cleanup-softfork/bip-XXXX.mediawiki (I'll post it on the mailing list later tonight, hopefully).