### PR TITLE
add rpc_misc.py, mv test getmemoryinfo, add test mallocinfo

### DIFF
--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test RPC misc output."""
+import xml.etree.ElementTree as ET
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_raises_rpc_error,
+    assert_equal,
+    assert_greater_than,
+)
+
+from test_framework.authproxy import JSONRPCException
+
+
+class RpcMiscTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("test getmemoryinfo")
+        memory = node.getmemoryinfo()['locked']
+        assert_greater_than(memory['used'], 0)
+        assert_greater_than(memory['free'], 0)
+        assert_greater_than(memory['total'], 0)
+        assert_greater_than(memory['locked'], 0)
+        assert_greater_than(memory['chunks_used'], 0)
+        assert_greater_than(memory['chunks_free'], 0)
+        assert_equal(memory['used'] + memory['free'], memory['total'])
+
+        self.log.info("test mallocinfo")
+        try:
+            mallocinfo = node.getmemoryinfo(mode="mallocinfo")
+            self.log.info('getmemoryinfo(mode="mallocinfo") call succeeded')
+            tree = ET.fromstring(mallocinfo)
+            assert_equal(tree.tag, 'malloc')
+        except JSONRPCException:
+            self.log.info('getmemoryinfo(mode="mallocinfo") not available')
+            assert_raises_rpc_error(-8, 'mallocinfo is only available when compiled with glibc 2.10+', node.getmemoryinfo, mode="mallocinfo")
+
+        assert_raises_rpc_error(-8, "unknown mode foobar", node.getmemoryinfo, mode="foobar")
+
+if __name__ == '__main__':
+    RpcMiscTest().main()

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -10,6 +10,7 @@ from test_framework.util import (
     assert_raises_rpc_error,
     assert_equal,
     assert_greater_than,
+    assert_greater_than_or_equal,
 )
 
 from test_framework.authproxy import JSONRPCException
@@ -27,7 +28,8 @@ class RpcMiscTest(BitcoinTestFramework):
         assert_greater_than(memory['used'], 0)
         assert_greater_than(memory['free'], 0)
         assert_greater_than(memory['total'], 0)
-        assert_greater_than(memory['locked'], 0)
+        # assert_greater_than_or_equal() for locked in case locking pages failed at some point
+        assert_greater_than_or_equal(memory['locked'], 0)
         assert_greater_than(memory['chunks_used'], 0)
         assert_greater_than(memory['chunks_free'], 0)
         assert_equal(memory['used'] + memory['free'], memory['total'])

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -112,6 +112,7 @@ BASE_SCRIPTS = [
     'wallet_txn_clone.py',
     'wallet_txn_clone.py --segwit',
     'rpc_getchaintips.py',
+    'rpc_misc.py',
     'interface_rest.py',
     'mempool_spend_coinbase.py',
     'mempool_reorg.py',

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -11,7 +11,6 @@ from test_framework.util import (
     assert_array_result,
     assert_equal,
     assert_fee_amount,
-    assert_greater_than,
     assert_raises_rpc_error,
     connect_nodes_bi,
     sync_blocks,
@@ -85,13 +84,8 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(txout['value'], 50)
 
         # Send 21 BTC from 0 to 2 using sendtoaddress call.
-        # Locked memory should increase to sign transactions
-        self.log.info("test getmemoryinfo")
-        memory_before = self.nodes[0].getmemoryinfo()
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 11)
         mempool_txid = self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), 10)
-        memory_after = self.nodes[0].getmemoryinfo()
-        assert_greater_than(memory_after['locked']['used'], memory_before['locked']['used'])
 
         self.log.info("test gettxout (second part)")
         # utxo spent in mempool should be visible if you exclude mempool


### PR DESCRIPTION
Creating the `rpc_misc.py` functional test file to add space for adding tests to a file that doesn't have a lot of coverage.
  - Removing the `getmemoryinfo()` smoke test from wallet basic rather than moving it to keep the wallet decoupled. Feel like testing for reasonable memory allocation values should suffice.
  - Adding coverage for `mallocinfo()`. Introduced standard lib XML parser since the function exports an XML string that describes the current state of the memory-allocation implementation in the caller.