### PR TITLE
rpc: Return whether the block was invalidated on invalidateblock

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1597,7 +1597,12 @@ static UniValue invalidateblock(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DATABASE_ERROR, FormatStateMessage(state));
     }
 
-    return NullUniValue;
+    UniValue res(UniValue::VOBJ);
+    {
+        LOCK(cs_main);
+        res.pushKV("invalidated", !chainActive.Contains(pblockindex));
+    }
+    return res;
 }
 
 static UniValue reconsiderblock(const JSONRPCRequest& request)

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -40,7 +40,8 @@ class InvalidateTest(BitcoinTestFramework):
         badhash = self.nodes[1].getblockhash(2)
 
         self.log.info("Invalidate block 2 on node 0 and verify we reorg to node 0's original chain")
-        self.nodes[0].invalidateblock(badhash)
+        res = self.nodes[0].invalidateblock(badhash)
+        assert_equal(res['invalidated'], True)
         assert_equal(self.nodes[0].getblockcount(), 4)
         assert_equal(self.nodes[0].getbestblockhash(), besthash_n0)
 


### PR DESCRIPTION
This PR adds a return value to the RPC `invalidateblock`. For now the the return object has the key `invalidated`.