### PR TITLE
p2p: Speed up initial connection to p2p network

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1965,6 +1965,8 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     } else if (FindNode(std::string(pszDest)))
         return;
 
+    { LOCK(cs_vNodes); ++conn_attempts; }
+
     CNode* pnode = ConnectNode(addrConnect, pszDest, fCountFailure, manual_connection, block_relay_only);
 
     if (!pnode)
@@ -1981,6 +1983,8 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
     m_msgproc->InitializeNode(pnode);
     {
         LOCK(cs_vNodes);
+        ++conn_success;
+        LogPrintf("Successful connection; %ld of %ld (%.1f%%)\n", conn_success, conn_attempts, conn_success*100.0/conn_attempts);
         vNodes.push_back(pnode);
     }
 }

--- a/src/net.h
+++ b/src/net.h
@@ -414,6 +414,8 @@ private:
     std::vector<std::string> vAddedNodes GUARDED_BY(cs_vAddedNodes);
     CCriticalSection cs_vAddedNodes;
     std::vector<CNode*> vNodes GUARDED_BY(cs_vNodes);
+    uint64_t conn_attempts GUARDED_BY(cs_vNodes) = 0;
+    uint64_t conn_success GUARDED_BY(cs_vNodes) = 0;
     std::list<CNode*> vNodesDisconnected;
     mutable CCriticalSection cs_vNodes;
     std::atomic<NodeId> nLastNodeId{0};

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -360,6 +360,14 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
         throw;
     }
 }
+/**
+ * .. and a wrapper the allows for multiple threads for the same function
+ */
+template <typename Callable> void TraceThreads(const char* name, int index, Callable func)
+{
+    std::string nameidx = strprintf("%s%d", name, index);
+    TraceThread(nameidx.c_str(), func);
+}
 
 std::string CopyrightHolders(const std::string& strPrefix);
 


### PR DESCRIPTION
This patch creates four threads for connecting to the P2P network on startup. This allows more attempts based on peers.dat before the timeout for connecting to two peers hits and the DNS seeds are queried for more peers. Once an initial quorum of outbound peers are connected, these extra threads end, and long term behaviour continues unchanged.

Fixes #15434 

Marked as draft, looking for concept acks. Second patch just dumps some statistics on how successful connections are (successful = connection established, not a VERACK actually received). I get 20%-30% on initial startup; after running a while seems to be down to ~17%.