### PR TITLE
p2p: Request NOTFOUND transactions immediately from other outbound peers, when possible

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1944,8 +1944,10 @@ void CConnman::OpenNetworkConnection(const CAddress& addrConnect, bool fCountFai
 
 void CConnman::ThreadMessageHandler()
 {
+    uint64_t sequence_number = 0;
     while (!flagInterruptMsgProc)
     {
+        ++sequence_number;
         std::vector<CNode*> vNodesCopy;
         {
             LOCK(cs_vNodes);
@@ -1970,7 +1972,7 @@ void CConnman::ThreadMessageHandler()
             // Send messages
             {
                 LOCK(pnode->cs_sendProcessing);
-                m_msgproc->SendMessages(pnode);
+                m_msgproc->SendMessages(pnode, sequence_number);
             }
 
             if (flagInterruptMsgProc)

--- a/src/net.h
+++ b/src/net.h
@@ -472,7 +472,7 @@ class NetEventsInterface
 {
 public:
     virtual bool ProcessMessages(CNode* pnode, std::atomic<bool>& interrupt) = 0;
-    virtual bool SendMessages(CNode* pnode) = 0;
+    virtual bool SendMessages(CNode* pnode, uint64_t sequence_number) = 0;
     virtual void InitializeNode(CNode* pnode) = 0;
     virtual void FinalizeNode(NodeId id, bool& update_connection_time) = 0;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3514,7 +3514,7 @@ public:
 };
 }
 
-bool PeerLogicValidation::SendMessages(CNode* pto)
+bool PeerLogicValidation::SendMessages(CNode* pto, uint64_t sequence_number)
 {
     const Consensus::Params& consensusParams = Params().GetConsensus();
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -79,7 +79,8 @@ static_assert(INBOUND_PEER_TX_DELAY >= MAX_GETDATA_RANDOM_DELAY,
 "To preserve security, MAX_GETDATA_RANDOM_DELAY should not exceed INBOUND_PEER_DELAY");
 /** Limit to avoid sending big packets. Not used in processing incoming GETDATA for compatibility */
 static const unsigned int MAX_GETDATA_SZ = 1000;
-
+/** Maximum number of NOTFOUND notifications we'll push to other peers */
+static constexpr int32_t MAX_PEER_NOTFOUND = 100;
 
 struct COrphanTx {
     // When modifying, adapt the copy of this definition in tests/DoS_tests.
@@ -312,6 +313,15 @@ struct CNodeState {
      *   an adversary from using inbound connections to blind us to a
      *   transaction (InvBlock).
      *
+     *   When we call SendMessages() for a given peer, we'll first check to see
+     *   if any NOTFOUND transactions have been added to m_tx_not_found -- we may
+     *   have a txid queued up for download sometime in the future, but as soon
+     *   as we've gotten a NOTFOUND from the peer we requested it from, we want
+     *   to try downloading from a backup peer that has announced it. So we
+     *   loop over the contents of m_tx_not_found, and request any transactions
+     *   that have not yet been requested by others (within the
+     *   MAX_GETDATA_TX_DELAY window).
+     *
      *   When we call SendMessages() for a given peer,
      *   we will loop over the transactions in m_tx_process_time, looking
      *   at the transactions whose process_time <= nNow. We'll request each
@@ -341,6 +351,11 @@ struct CNodeState {
      *   peers.
      */
     struct TxDownloadState {
+        /* Notifications of NOTFOUND transactions (from other peers) which
+         * this peer has recently announced.
+         */
+        std::list<uint256> m_tx_not_found;
+
         /* Track when to attempt download of announced transactions (process
          * time in micros -> txid)
          */
@@ -843,7 +858,9 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     g_outbound_peers_with_protect_from_disconnect -= state->m_chain_sync.m_protect;
     assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
+    // Remove entry from g_outbound_peers, if present.
     g_outbound_peers.erase(nodeid);
+
     mapNodeState.erase(nodeid);
 
     if (mapNodeState.empty()) {
@@ -3233,6 +3250,23 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                     }
                     state->m_tx_download.m_tx_in_flight.erase(in_flight_it);
                     state->m_tx_download.m_tx_announced.erase(inv.hash);
+                    EraseTxRequest(inv.hash);
+                    // If we don't already have this transaction, check to see
+                    // if any of our outbound peers have offered it to us, and
+                    // if so signal them to try to request immediately. This avoids
+                    // waiting for the download timeout to expire before
+                    // re-requesting a transaction.
+                    if (!AlreadyHave(inv)) {
+                        for (const NodeId& outbound_id : g_outbound_peers) {
+                            if (outbound_id == pfrom->GetId()) continue;
+                            CNodeState *node_state = State(outbound_id);
+                            if (!node_state->m_tx_download.m_tx_announced.count(inv.hash)) continue;
+                            while (node_state->m_tx_download.m_tx_not_found.size() >= MAX_PEER_NOTFOUND) {
+                                node_state->m_tx_download.m_tx_not_found.erase(state->m_tx_download.m_tx_not_found.begin());
+                            }
+                            node_state->m_tx_download.m_tx_not_found.push_back(inv.hash);
+                        }
+                    }
                 }
             }
         }
@@ -4052,6 +4086,27 @@ bool PeerLogicValidation::SendMessages(CNode* pto, uint64_t sequence_number)
             // On average, we do this check every TX_EXPIRY_INTERVAL. Randomize
             // so that we're not doing this for all peers at the same time.
             state.m_tx_download.m_check_expiry_timer = nNow + TX_EXPIRY_INTERVAL/2 + GetRand(TX_EXPIRY_INTERVAL);
+        }
+
+        // First check to see if there's anything in our notfound queue to request.
+        if (!state.m_tx_download.m_tx_not_found.empty()) {
+            // Check to see if it's our turn to drain the NOTFOUND queue.
+            // The idea is that we would like to randomly assign NOTFOUND
+            // transactions' next download request uniformly at random to our
+            // outbound peers, even though we don't necessarily know which ones
+            // will have the transaction available to download and not be up
+            // against their in-flight limit (or any other future restrictions
+            // we might impose).
+            // Our algorithm is to use the SendMessages sequence number to rotate
+            // through our outbound peers in turn.
+            auto outbound_it = g_outbound_peers.begin();
+            std::advance(outbound_it, sequence_number % g_outbound_peers.size());
+            if (*outbound_it == pto->GetId()) {
+                while (!state.m_tx_download.m_tx_not_found.empty() && state.m_tx_download.m_tx_in_flight.size() < MAX_PEER_TX_IN_FLIGHT) {
+                    TryRequestTx(state, pto, state.m_tx_download.m_tx_not_found.front(), vGetData, nNow, connman, msgMaker);
+                    state.m_tx_download.m_tx_not_found.pop_front();
+                }
+            }
         }
 
         auto& tx_process_time = state.m_tx_download.m_tx_process_time;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -395,6 +395,7 @@ limitedmap<uint256, int64_t> g_already_asked_for GUARDED_BY(cs_main)(MAX_INV_SZ)
 
 /** Map maintaining per-node state. */
 static std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
+static std::set<NodeId> g_outbound_peers GUARDED_BY(cs_main);
 
 static CNodeState *State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
@@ -770,9 +771,13 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
     {
         LOCK(cs_main);
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
+        if (!pnode->fInbound) {
+            g_outbound_peers.insert(nodeid);
+        }
     }
-    if(!pnode->fInbound)
+    if(!pnode->fInbound) {
         PushNodeVersion(pnode, connman, GetTime());
+    }
 }
 
 void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
@@ -798,6 +803,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     g_outbound_peers_with_protect_from_disconnect -= state->m_chain_sync.m_protect;
     assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
+    g_outbound_peers.erase(nodeid);
     mapNodeState.erase(nodeid);
 
     if (mapNodeState.empty()) {
@@ -806,6 +812,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
         assert(nPreferredDownload == 0);
         assert(nPeersWithValidatedDownloads == 0);
         assert(g_outbound_peers_with_protect_from_disconnect == 0);
+        assert(g_outbound_peers.empty());
     }
     LogPrint(BCLog::NET, "Cleared nodestate for peer=%d\n", nodeid);
 }

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -61,9 +61,11 @@ public:
     * Send queued protocol messages to be sent to a give node.
     *
     * @param[in]   pto             The node which we are sending messages to.
+    * @param[in]   sequence_number A counter that increments after SendMessages
+    *                              has been called on all peers
     * @return                      True if there is more work to be done
     */
-    bool SendMessages(CNode* pto) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
+    bool SendMessages(CNode* pto, uint64_t sequence_number) override EXCLUSIVE_LOCKS_REQUIRED(pto->cs_sendProcessing);
 
     /** Consider evicting an outbound peer based on the amount of time they've been behind our tip */
     void ConsiderEviction(CNode *pto, int64_t time_in_seconds) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Test starts here
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0)); // should result in getheaders
     }
     {
         LOCK2(cs_main, dummyNode1.cs_vSend);
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     SetMockTime(nStartTime+21*60);
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0)); // should result in getheaders
     }
     {
         LOCK2(cs_main, dummyNode1.cs_vSend);
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     SetMockTime(nStartTime+24*60);
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in disconnect
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0)); // should result in disconnect
     }
     BOOST_CHECK(dummyNode1.fDisconnect == true);
     SetMockTime(0);
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
     BOOST_CHECK(!banman->IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     {
         LOCK2(cs_main, dummyNode2.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2, 0));
     }
     BOOST_CHECK(!banman->IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(banman->IsBanned(addr1));  // ... but 1 still should be
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     }
     {
         LOCK2(cs_main, dummyNode2.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode2, 0));
     }
     BOOST_CHECK(banman->IsBanned(addr2));
 
@@ -289,7 +289,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
     {
@@ -298,7 +298,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
     {
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     {
         LOCK2(cs_main, dummyNode1.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode1, 0));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
     gArgs.ForceSetArg("-banscore", std::to_string(DEFAULT_BANSCORE_THRESHOLD));
@@ -339,7 +339,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     }
     {
         LOCK2(cs_main, dummyNode.cs_sendProcessing);
-        BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
+        BOOST_CHECK(peerLogic->SendMessages(&dummyNode, 0));
     }
     BOOST_CHECK(banman->IsBanned(addr));
 


### PR DESCRIPTION
Currently when a peer asks for a transaction that we cannot (or will not) deliver, we send a NOTFOUND message for the given txid.  However, our software currently ignores the NOTFOUND messages we receive from others -- if other peers have announced a transaction, we wait until the transaction request times out before requesting from our next peer.

Improve this by immediately requesting the transaction from one of the outbound peers who have recently announced it (if any).