### PR TITLE
test: Bump timeout on tests that timeout on windows

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -180,7 +180,7 @@ class AssumeValidTest(BitcoinTestFramework):
         for i in range(2202):
             p2p1.send_message(msg_block(self.blocks[i]))
         # Syncing 2200 blocks can take a while on slow systems. Give it plenty of time to sync.
-        p2p1.sync_with_ping(150)
+        p2p1.sync_with_ping(200)
         assert_equal(self.nodes[1].getblock(self.nodes[1].getbestblockhash())['height'], 2202)
 
         # Send blocks to node2. Block 102 will be rejected.

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -60,6 +60,7 @@ class BIP65Test(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [['-whitelist=127.0.0.1', '-par=1']]  # Use only one script thread to get the exact reject reason for testing
         self.setup_clean_chain = True
+        self.rpc_timeout = 120
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -47,6 +47,7 @@ class BIP66Test(BitcoinTestFramework):
         self.num_nodes = 1
         self.extra_args = [['-whitelist=127.0.0.1', '-par=1', '-enablebip61']]  # Use only one script thread to get the exact reject reason for testing
         self.setup_clean_chain = True
+        self.rpc_timeout = 120
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
Those tests build a ton of blocks and time out for me on Windows with:

```
test_framework.authproxy.JSONRPCException: 'generatetoaddress' RPC took longer than 60.000000 seconds. Consider using larger timeout for calls that take longer to return. (-344)