### PR TITLE
RPC : More user-friendly services field in getnetworkinfo and getpeerinfo

### DIFF
--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -88,6 +88,10 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             "    \"addrbind\":\"ip:port\",    (string) Bind address of the connection to the peer\n"
             "    \"addrlocal\":\"ip:port\",   (string) Local address as reported by the peer\n"
             "    \"services\":\"xxxxxxxxxxxxxxxx\",   (string) The services offered\n"
+            "    \"servicesnames\": [              (array) the services offered\n"
+            "       \"SERVICE NAME\",         (string) the service name\n"
+            "        ...\n"
+            "     ],\n"
             "    \"relaytxes\":true|false,    (boolean) Whether peer has asked us to relay transactions to it\n"
             "    \"lastsend\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last send\n"
             "    \"lastrecv\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last receive\n"
@@ -153,6 +157,20 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         if (stats.addrBind.IsValid())
             obj.pushKV("addrbind", stats.addrBind.ToString());
         obj.pushKV("services", strprintf("%016x", stats.nServices));
+        UniValue servicesnames(UniValue::VARR);
+        if (stats.nServices & NODE_NETWORK)
+            servicesnames.push_back("NODE_NETWORK");
+        if (stats.nServices & NODE_GETUTXO)
+            servicesnames.push_back("NODE_GETUTXO");
+        if (stats.nServices & NODE_BLOOM)
+            servicesnames.push_back("NODE_BLOOM");
+        if (stats.nServices & NODE_WITNESS)
+            servicesnames.push_back("NODE_WITNESS");
+        if (stats.nServices & NODE_XTHIN)
+            servicesnames.push_back("NODE_XTHIN");
+        if (stats.nServices & NODE_NETWORK_LIMITED)
+            servicesnames.push_back("NODE_NETWORK_LIMITED");
+        obj.pushKV("servicesnames", servicesnames);
         obj.pushKV("relaytxes", stats.fRelayTxes);
         obj.pushKV("lastsend", stats.nLastSend);
         obj.pushKV("lastrecv", stats.nLastRecv);
@@ -455,6 +473,10 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
             "  \"subversion\": \"/Satoshi:x.x.x/\",     (string) the server subversion string\n"
             "  \"protocolversion\": xxxxx,              (numeric) the protocol version\n"
             "  \"localservices\": \"xxxxxxxxxxxxxxxx\", (string) the services we offer to the network\n"
+            "  \"localservicesnames\": [                     (array) the services we offer to the network\n"
+            "  \"SERVICE NAME\",                        (string) the service name\n"
+            "  ...\n"
+            "  ],\n"
             "  \"localrelay\": true|false,              (bool) true if transaction relay is requested from peers\n"
             "  \"timeoffset\": xxxxx,                   (numeric) the time offset\n"
             "  \"connections\": xxxxx,                  (numeric) the number of connections\n"
@@ -493,8 +515,24 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
     obj.pushKV("version",       CLIENT_VERSION);
     obj.pushKV("subversion",    strSubVersion);
     obj.pushKV("protocolversion",PROTOCOL_VERSION);
-    if(g_connman)
-        obj.pushKV("localservices", strprintf("%016x", g_connman->GetLocalServices()));
+    if(g_connman) {
+        ServiceFlags services = g_connman->GetLocalServices();
+        obj.pushKV("localservices", strprintf("%016x", services));
+        UniValue servicesnames(UniValue::VARR);
+        if (services & NODE_NETWORK)
+            servicesnames.push_back("NODE_NETWORK");
+        if (services & NODE_GETUTXO)
+            servicesnames.push_back("NODE_GETUTXO");
+        if (services & NODE_BLOOM)
+            servicesnames.push_back("NODE_BLOOM");
+        if (services & NODE_WITNESS)
+            servicesnames.push_back("NODE_WITNESS");
+        if (services & NODE_XTHIN)
+            servicesnames.push_back("NODE_XTHIN");
+        if (services & NODE_NETWORK_LIMITED)
+            servicesnames.push_back("NODE_NETWORK_LIMITED");
+        obj.pushKV("localservicesnames", servicesnames);
+    }
     obj.pushKV("localrelay",     fRelayTxes);
     obj.pushKV("timeoffset",    GetTimeOffset());
     if (g_connman) {


### PR DESCRIPTION
~~The commands `getpeerinfo` and `getnetworkinfo` returns the services a node provides in the form of a flag (in the field `services`). This PR adds a field `servicesnames` (resp. `localservicesnames`) which contains the names of these services so that a user does not have to parse the flag to know which services his node provides.~~
EDIT: see https://github.com/bitcoin/bitcoin/pull/15511#issuecomment-527087370