### PR TITLE
docs: add "sections" info to example bitcoin.conf

### DIFF
--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -4,6 +4,10 @@
  
 # Network-related settings:
 
+# Note that if you use testnet or regtest, particularly with the options
+# addnode, connect, port, bind, rpcport, rpcbind or wallet, you will also
+# want to read "[Sections]" further down.
+
 # Run on the test network instead of the real bitcoin network.
 #testnet=0
 
@@ -52,6 +56,9 @@
 
 # Listening mode, enabled by default except when 'connect' is being used
 #listen=1
+
+# Port on which to listen for connections (default: 8333, testnet: 18333, regtest: 18444)
+#port=
 
 # Maximum number of inbound+outbound connections.
 #maxconnections=
@@ -115,6 +122,10 @@
 
 # Wallet options
 
+# Specify where to find wallet, lockfile and logs. If not present, those files will be
+# created as new.
+#wallet=</path/to/dir>
+
 # Create transactions that have enough fees so they are likely to begin confirmation within n blocks (default: 6).
 # This setting is over-ridden by the -paytxfee option.
 #txconfirmtarget=n
@@ -142,3 +153,19 @@
 
 # Minimize to the system tray
 #minimizetotray=1
+
+# [Sections]
+# Most options apply to mainnet, testnet and regtest.
+# If you want to confine an option to just one network, you should add it in the
+# relevant section below.
+# EXCEPTIONS: The options addnode, connect, port, bind, rpcport, rpcbind and wallet
+# only apply to mainnet unless they appear in the appropriate section below.
+
+# Options only for mainnet
+[main]
+
+# Options only for testnet
+[test]
+
+# Options only for regtest
+[regtest]


### PR DESCRIPTION
Rebased / commit message fixed version of #15387. 
This had ACKs, but just needed the commit message fixed up.

> Most bitcoin.conf options apply to all three networks,
however some apply only to mainnet unless specified in a section.
As stands, conf file has no indication that sections are now in use
or are in some circumstances mandatory (eg, changing rpcport for testnet.)

> Proposed change notifies the reader early which options are affected,
specifically adds those options affected but not already in the example,
adds brief explanation as to what's going on and provides a skeleton template for the sections themselves.