### PR TITLE
doc: Remove ppa from linux build instructions

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -78,18 +78,12 @@ Now, you can either build from self-compiled [depends](/depends/README.md) or in
 
 BerkeleyDB is required for the wallet.
 
-**For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
-You can add the repository and install using the following commands:
-
-    sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:bitcoin/bitcoin
-    sudo apt-get update
-    sudo apt-get install libdb4.8-dev libdb4.8++-dev
-
 Ubuntu and Debian have their own libdb-dev and libdb++-dev packages, but these will install
 BerkeleyDB 5.1 or later. This will break binary wallet compatibility with the distributed executables, which
 are based on BerkeleyDB 4.8. If you do not care about wallet compatibility,
 pass `--with-incompatible-bdb` to configure.
+
+Otherwise, you can build from self-compiled `depends` (see above).
 
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](/doc/build-unix.md#disable-wallet-mode)
 


### PR DESCRIPTION
bdb (5.x) is provided by the vanilla Debian/Ubuntu package manager.

If someone needs bdb4.8, they can use `./depends` or `./contrib/install_db4.sh`.

I don't think we need a forth way to install bdb. Those ppa instructions only leads to confusion for debian users: Closes #3757