### PR TITLE
Fixed some times can not remove "$SUFFIX-dirty" on version number cor…

### DIFF
--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -31,6 +31,7 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(
     # if latest commit is tagged and not dirty, then override using the tag name
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)
     if [ "$(git rev-parse HEAD)" = "$(git rev-list -1 $RAWDESC 2>/dev/null)" ]; then
+        git checkout .
         git diff-index --quiet HEAD -- && DESC=$RAWDESC
     fi
 


### PR DESCRIPTION
Fixed some times can not remove "$SUFFIX-dirty" on version number correctly with git tag using Gitian.

Even you use git annotated tag encounter with such problem.