### PR TITLE
Add Qt programs to msvc build (updated, no code changes)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,12 +7,16 @@ clone_depth: 5
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   CLCACHE_SERVER: 1
-  PACKAGES: berkeleydb boost-filesystem boost-signals2 boost-test libevent openssl rapidcheck zeromq
+  PACKAGES: berkeleydb boost-filesystem boost-signals2 boost-test libevent openssl rapidcheck zeromq double-conversion
   PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
   PYTHONUTF8: 1
+  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.0/Qt5.9.7_ssl_x64_static_vs2017.zip'
+  QT_DOWNLOAD_HASH: 'D4D35B8112302B67E5610A03421BB3E43FE13F14D9A5F637C22AE60DCEC0E0F5'
+  QT_LOCAL_PATH: 'C:\Qt5.9.7_ssl_x64_static_vs2017'
 cache:
-- C:\tools\vcpkg\installed -> .appveyor.yml
+- C:\tools\vcpkg\installed
 - C:\Users\appveyor\clcache -> .appveyor.yml, build_msvc\**, **\Makefile.am, **\*.vcxproj.in
+- C:\Qt5.9.7_ssl_x64_static_vs2017
 install:
 - cmd: pip install --quiet git+https://github.com/frerich/clcache.git@v4.2.0
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.
@@ -22,6 +26,23 @@ install:
 - cmd: vcpkg install --triplet %PLATFORM%-windows-static %PACKAGES% > NUL
 before_build:
 - ps:  clcache -M 536870912
+- ps: |
+      if(!(Test-Path -Path ($env:QT_LOCAL_PATH))) {
+        Write-Host "Downloading Qt binaries.";
+        Invoke-WebRequest -Uri $env:QT_DOWNLOAD_URL -Out qtdownload.zip;
+        Write-Host "Qt binaries successfully downloaded, checking hash against $env:QT_DOWNLOAD_HASH...";
+        if((Get-FileHash qtdownload.zip).Hash -eq $env:QT_DOWNLOAD_HASH) {
+          Expand-Archive qtdownload.zip -DestinationPath $env:QT_LOCAL_PATH;
+          Write-Host "Qt binary download matched the expected hash.";
+        }
+        else {
+          Write-Host "ERROR: Qt binary download did not match the expected hash.";
+          Exit-AppveyorBuild;
+        }
+      }
+      else {
+         Write-Host "Qt binaries already present.";
+      }
 - cmd: python build_msvc\msvc-autogen.py
 - ps:  $files = (Get-ChildItem -Recurse | where {$_.extension -eq ".vcxproj"}).FullName
 - ps:  for (${i} = 0; ${i} -lt ${files}.length; ${i}++) {
@@ -37,10 +58,13 @@ build_script:
 after_build:
 - ps:  fsutil behavior set disablelastaccess 1 # Disable Access time feature on Windows (better performance)
 - ps:  clcache -z
+#- 7z a bitcoin-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\build_msvc\%platform%\%configuration%\*.exe
 test_script:
 - cmd: src\test_bitcoin.exe -k stdout -e stdout 2> NUL
 - cmd: src\bench_bitcoin.exe -evals=1 -scaling=0 > NUL
 - ps:  python test\util\bitcoin-util-test.py
 - cmd: python test\util\rpcauth-test.py
 - cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast
+artifacts:
+#- path: bitcoin-%APPVEYOR_BUILD_VERSION%.zip
 deploy: off

--- a/build_msvc/.gitignore
+++ b/build_msvc/.gitignore
@@ -10,3 +10,5 @@ packages/*
 *.vcxproj.user
 *.vcxproj
 */Win32
+libbitcoin_qt/QtGeneratedFiles/*
+test_bitcoin-qt/QtGeneratedFiles/*

--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -3,13 +3,23 @@ Building Bitcoin Core with Visual Studio
 
 Introduction
 ---------------------
-Solution and project files to build the Bitcoin Core applications (except Qt dependent ones) with Visual Studio 2017 can be found in the build_msvc directory.
+Solution and project files to build the Bitcoin Core applications `msbuild` or Visual Studio can be found in the build_msvc directory. The build has been tested with Visual Studio 2017 and 2019.
 
 Building with Visual Studio is an alternative to the Linux based [cross-compiler build](https://github.com/bitcoin/bitcoin/blob/master/doc/build-windows.md).
 
+Quick Start
+---------------------
+The minimal steps required to build Bitcoin Core with the msbuild toolchain are below. More detailed instructions are contained in the following sections.
+
+```
+vcpkg install --triplet x64-windows-static boost-filesystem boost-signals2 boost-test libevent openssl zeromq berkeleydb rapidcheck double-conversion
+py -3 build_msvc\msvc-autogen.py
+msbuild /m build_msvc\bitcoin.sln /p:Platform=x64 /p:Configuration=Release /t:build
+```
+
 Dependencies
 ---------------------
-A number of [open source libraries](https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md) are required in order to be able to build Bitcoin.
+A number of [open source libraries](https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md) are required in order to be able to build Bitcoin Core.
 
 Options for installing the dependencies in a Visual Studio compatible manner are:
 
@@ -17,18 +27,30 @@ Options for installing the dependencies in a Visual Studio compatible manner are
 - Download the source code, build each dependency, add the required include paths, link libraries and binary tools to the Visual Studio project files.
 - Use [nuget](https://www.nuget.org/) packages with the understanding that any binary files have been compiled by an untrusted third party.
 
-The external dependencies required for the Visual Studio build are (see [dependencies.md](https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md) for more info):
+The [external dependencies](https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md) required for building are:
 
 - Berkeley DB
-- OpenSSL
 - Boost
+- DoubleConversion
 - libevent
-- ZeroMQ
+- OpenSSL
+- Qt5
 - RapidCheck
+- ZeroMQ
 
-Additional dependencies required from the [bitcoin-core](https://github.com/bitcoin-core) GitHub repository are:
-- libsecp256k1
-- LevelDB
+Qt
+---------------------
+All the Bitcoin Core applications are configured to build with static linking. In order to build the Bitcoin Core Qt applications a static build of Qt is required.
+
+The runtime library version (e.g. v141, v142) and platform type (x86 or x64) must also match. OpenSSL must also be linked into the Qt binaries in order to provide full functionality of the Bitcoin Core Qt programs. An example of the configure command to build Qtv5.9.7 locally to link with Bitcoin Core is shown below (adjust paths accordingly), note it can be expected that the configure and subsequent build will fail numerous times until dependency issues are resolved.
+
+````
+..\Qtv5.9.7_src\configure -developer-build -confirm-license -debug-and-release -opensource -platform win32-msvc -opengl desktop -no-shared -static -no-static-runtime -mp -qt-zlib -qt-pcre -qt-libpng -ltcg -make libs -make tools -no-libjpeg -nomake examples -no-compile-examples -no-dbus -no-libudev -no-qml-debug -no-icu -no-gtk -no-opengles3 -no-angle -no-sql-sqlite -no-sql-odbc -no-sqlite -no-libudev -skip qt3d -skip qtactiveqt -skip qtandroidextras -skip qtcanvas3d -skip qtcharts -skip qtconnectivity -skip qtdatavis3d -skip qtdeclarative -skip qtdoc -skip qtgamepad -skip qtgraphicaleffects -skip qtimageformats -skip qtlocation -skip qtmacextras -skip qtmultimedia -skip qtnetworkauth -skip qtpurchasing -skip qtquickcontrols -skip qtquickcontrols2 -skip qtscript -skip qtscxml -skip qtsensors -skip qtserialbus -skip qtserialport -skip qtspeech -skip qtvirtualkeyboard -skip qtwayland -skip qtwebchannel -skip qtwebengine -skip qtwebsockets -skip qtwebview -skip qtx11extras -skip qtxmlpatterns -nomake tests -openssl-linked -IC:\Dev\github\vcpkg\installed\x64-windows-static\include -LC:\Dev\github\vcpkg\installed\x64-windows-static\lib OPENSSL_LIBS="-llibeay32 -lssleay32 -lgdi32 -luser32 -lwsock32 -ladvapi32" -prefix C:\Qt5.9.7_ssl_x64_static_vs2017
+````
+
+A prebuilt version for x64 and Visual C++ runtime v141 (Visual Studio 2017) can be downloaded from [here](https://github.com/sipsorcery/qt_win_binary/releases). Please be aware this download is NOT an officially sanctioned Bitcoin Core distribution and is provided for developer convenience. It should NOT be used for builds that will be used in a production environment or with real funds.
+
+To build Bitcoin Core without Qt unload or disable the bitcoin-qt, libbitcoin_qt and test_bitcoin-qt projects.
 
 Building
 ---------------------
@@ -38,7 +60,7 @@ The instructions below use `vcpkg` to install the dependencies.
 - Install the required packages (replace x64 with x86 as required):
 
 ```
-    PS >.\vcpkg install --triplet x64-windows-static boost-filesystem boost-signals2 boost-test libevent openssl zeromq berkeleydb secp256k1 leveldb rapidcheck
+    PS >.\vcpkg install --triplet x64-windows-static boost-filesystem boost-signals2 boost-test libevent openssl zeromq berkeleydb rapidcheck double-conversion
 ```
 
 - Use Python to generate *.vcxproj from Makefile
@@ -47,4 +69,27 @@ The instructions below use `vcpkg` to install the dependencies.
     PS >py -3 msvc-autogen.py
 ```
 
-- Build in Visual Studio.
+- An optional step is to adjust the settings in the build_msvc directory and the common.init.vcxproj file. This project file contains settings that are common to all projects such as the runtime library version and target Windows SDK version. The Qt directories can also be set.
+
+- Build with Visual Studio 2017 or msbuild.
+
+```
+msbuild /m bitcoin.sln /p:Platform=x64 /p:Configuration=Release /t:build
+```
+
+- Build with Visual Studio 2019 or msbuild.
+
+```
+msbuild /m bitcoin.sln /p:Platform=x64 /p:Configuration=Release /p:PlatformToolset=v142 /t:build
+```
+
+AppVeyor
+---------------------
+The .appveyor.yml in the root directory is suitable to perform builds on [AppVeyor](https://www.appveyor.com/) Continuous Integration servers. The simplest way to perform an AppVeyor build is to fork Bitcoin Core and then configure a new AppVeyor Project pointing to the forked repository.
+
+For safety reasons the Bitcoin Core .appveyor.yml file has the artifact options disabled. The build will be performed but no executable files will be available. To enable artifacts on a forked repository uncomment the lines shown below:
+
+```
+    #- 7z a bitcoin-%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\build_msvc\%platform%\%configuration%\*.exe
+    #- path: bitcoin-%APPVEYOR_BUILD_VERSION%.zip
+```

--- a/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
+++ b/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\common.init.vcxproj" />
+  <Import Project="..\common.qt.init.vcxproj" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{7E99172D-7FF2-4CB6-B736-AC9B76ED412A}</ProjectGuid>
+    <ConfigurationType>Application</ConfigurationType>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+  </PropertyGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\qt\main.cpp" />
+    <ResourceCompile Include="..\..\src\qt\res\bitcoin-qt-res.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">
+      <Project>{2b384fa8-9ee1-4544-93cb-0d733c25e8ce}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_cli\libbitcoin_cli.vcxproj">
+      <Project>{0667528c-d734-4009-adf9-c0d6c4a5a5a6}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_common\libbitcoin_common.vcxproj">
+      <Project>{7c87e378-df58-482e-aa2f-1bc129bc19ce}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_crypto\libbitcoin_crypto.vcxproj">
+      <Project>{6190199c-6cf4-4dad-bfbd-93fa72a760c1}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_qt\libbitcoin_qt.vcxproj">
+      <Project>{2b4abff8-d1fd-4845-88c9-1f3c0a6512bf}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_server\libbitcoin_server.vcxproj">
+      <Project>{460fee33-1fe1-483f-b3bf-931ff8e969a5}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_util\libbitcoin_util.vcxproj">
+      <Project>{b53a5535-ee9d-4c6f-9a26-f79ee3bc3754}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_wallet\libbitcoin_wallet.vcxproj">
+      <Project>{93b86837-b543-48a5-a89b-7c87abb77df2}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_zmq\libbitcoin_zmq.vcxproj">
+      <Project>{792d487f-f14c-49fc-a9de-3fc150f31c3f}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libleveldb\libleveldb.vcxproj">
+      <Project>{18430fef-6b61-4c53-b396-718e02850f1b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libsecp256k1\libsecp256k1.vcxproj">
+      <Project>{bb493552-3b8c-4a8c-bf69-a6e7a51d2ea6}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libunivalue\libunivalue.vcxproj">
+      <Project>{5724ba7d-a09a-4ba8-800b-c4c1561b3d69}</Project>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QtIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtReleaseLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\..\src;</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(QtIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtDebugLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ResourceCompile>
+      <AdditionalIncludeDirectories>..\..\src;</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>HAVE_CONFIG_H;_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+</Project>

--- a/build_msvc/bitcoin.sln
+++ b/build_msvc/bitcoin.sln
@@ -40,6 +40,10 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libsecp256k1", "libsecp256k
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libleveldb", "libleveldb\libleveldb.vcxproj", "{18430FEF-6B61-4C53-B396-718E02850F1B}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libbitcoin_qt", "libbitcoin_qt\libbitcoin_qt.vcxproj", "{2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bitcoin-qt", "bitcoin-qt\bitcoin-qt.vcxproj", "{7E99172D-7FF2-4CB6-B736-AC9B76ED412A}"
+EndProject
 Global
     GlobalSection(SolutionConfigurationPlatforms) = preSolution
         Debug|x64 = Debug|x64
@@ -200,11 +204,27 @@ Global
         {18430FEF-6B61-4C53-B396-718E02850F1B}.Release|x64.Build.0 = Release|x64
         {18430FEF-6B61-4C53-B396-718E02850F1B}.Release|x86.ActiveCfg = Release|Win32
         {18430FEF-6B61-4C53-B396-718E02850F1B}.Release|x86.Build.0 = Release|Win32
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Debug|x64.ActiveCfg = Debug|x64
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Debug|x64.Build.0 = Debug|x64
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Debug|x86.ActiveCfg = Debug|Win32
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Debug|x86.Build.0 = Debug|Win32
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Release|x64.ActiveCfg = Release|x64
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Release|x64.Build.0 = Release|x64
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Release|x86.ActiveCfg = Release|Win32
+        {2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}.Release|x86.Build.0 = Release|Win32
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Debug|x64.ActiveCfg = Debug|x64
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Debug|x64.Build.0 = Debug|x64
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Debug|x86.ActiveCfg = Debug|Win32
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Debug|x86.Build.0 = Debug|Win32
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Release|x64.ActiveCfg = Release|x64
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Release|x64.Build.0 = Release|x64
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Release|x86.ActiveCfg = Release|Win32
+        {7E99172D-7FF2-4CB6-B736-AC9B76ED412A}.Release|x86.Build.0 = Release|Win32
     EndGlobalSection
     GlobalSection(SolutionProperties) = preSolution
         HideSolutionNode = FALSE
     EndGlobalSection
     GlobalSection(ExtensibilityGlobals) = postSolution
-        SolutionGuid = {DA7D16A6-E5F0-45B3-B194-C3FE64F1BFCD}
+        SolutionGuid = {8AA72EDA-2CD4-4564-B1E4-688B760EEEE9}
     EndGlobalSection
 EndGlobal

--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -6,7 +6,8 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
     <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
-</PropertyGroup>
+   </PropertyGroup>
+
   <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'=='' and !Exists('$(WindowsSdkDir)\DesignTime\CommonConfiguration\Neutral\Windows.props')">
      <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
      <WindowsTargetPlatformVersion_10 Condition="'$(WindowsTargetPlatformVersion_10)' == ''">$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</WindowsTargetPlatformVersion_10>
@@ -20,7 +21,7 @@
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
-        <ProjectConfiguration Include="Debug|x64">
+    <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
@@ -66,6 +67,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -75,6 +77,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <Optimization>MaxSpeed</Optimization>
@@ -88,6 +91,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -103,7 +107,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
-      <DisableSpecificWarnings>4018;4221;4244;4267;4715;4805;</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4018;4221;4244;4267;4334;4715;4805;</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>ZMQ_STATIC;NOMINMAX;WIN32;HAVE_CONFIG_H;_CRT_SECURE_NO_WARNINGS;_SCL_SECURE_NO_WARNINGS;_CONSOLE;_WIN32_WINNT=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>..\..\src;..\..\src\univalue\include;..\..\src\secp256k1\include;..\..\src\leveldb\include;..\..\src\leveldb\helpers\memenv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/build_msvc/common.qt.init.vcxproj
+++ b/build_msvc/common.qt.init.vcxproj
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Label="QtGlobals">
+    <QtBaseDir>C:\Qt5.9.7_ssl_x64_static_vs2017</QtBaseDir>
+    <QtPluginsLibraryDir>$(QtBaseDir)\plugins</QtPluginsLibraryDir>
+    <QtLibraryDir>$(QtBaseDir)\lib</QtLibraryDir>
+    <QtIncludeDir>$(QtBaseDir)\include</QtIncludeDir>
+    <QtIncludes>$(QtIncludeDir);$(QtIncludeDir)\QtNetwork;$(QtIncludeDir)\QtCore;$(QtIncludeDir)\QtWidgets;$(QtIncludeDir)\QtGui;</QtIncludes>
+    <GeneratedFilesOutDir>.\QtGeneratedFiles\qt</GeneratedFilesOutDir>
+    <QtToolsDir>$(QtBaseDir)\bin</QtToolsDir>
+    <QtReleaseLibraries>$(QtPluginsLibraryDir)\platforms\qminimal.lib;$(QtPluginsLibraryDir)\platforms\qwindows.lib;$(QtLibraryDir)\qtfreetype.lib;$(QtLibraryDir)\qtharfbuzz.lib;$(QtLibraryDir)\qtlibpng.lib;$(QtLibraryDir)\qtpcre2.lib;$(QtLibraryDir)\Qt5AccessibilitySupport.lib;$(QtLibraryDir)\Qt5Core.lib;$(QtLibraryDir)\Qt5Concurrent.lib;$(QtLibraryDir)\Qt5EventDispatcherSupport.lib;$(QtLibraryDir)\Qt5FontDatabaseSupport.lib;$(QtLibraryDir)\Qt5Gui.lib;$(QtLibraryDir)\Qt5Network.lib;$(QtLibraryDir)\Qt5PlatformCompositorSupport.lib;$(QtLibraryDir)\Qt5ThemeSupport.lib;$(QtLibraryDir)\Qt5Widgets.lib;$(QtLibraryDir)\Qt5WinExtras.lib;$(QtLibraryDir)\qtmain.lib;userenv.lib;netapi32.lib;imm32.lib;Dwmapi.lib;version.lib;winmm.lib;UxTheme.lib</QtReleaseLibraries>
+    <QtDebugLibraries>$(QtPluginsLibraryDir)\platforms\qwindowsd.lib;$(QtPluginsLibraryDir)\platforms\qminimald.lib;$(QtLibraryDir)\*d.lib;crypt32.lib;userenv.lib;netapi32.lib;imm32.lib;Dwmapi.lib;version.lib;winmm.lib;UxTheme.lib</QtDebugLibraries>
+  </PropertyGroup>
+
+</Project>

--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -1,946 +1,230 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Label="configInitTarget" Project="..\common.init.vcxproj" />
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\common.init.vcxproj" />
+  <Import Project="..\common.qt.init.vcxproj" />
   <PropertyGroup Label="Globals">
-    <VCProjectVersion>15.0</VCProjectVersion>
-    <VcpkgTriplet Condition="'$(Platform)'=='Win32'">x86-windows-static</VcpkgTriplet>
-    <VcpkgTriplet Condition="'$(Platform)'=='x64'">x64-windows-static</VcpkgTriplet>
     <ProjectGuid>{2B4ABFF8-D1FD-4845-88C9-1F3C0A6512BF}</ProjectGuid>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
   <ItemGroup>
-    <CustomBuild Include="..\..\src\qt\bitcoin.qrc">
-      <Command>"$(QTDIR)\bincc.exe" -name bitcoin "%(Fullpath)" -o .\GeneratedFiles\qrc_bitcoin.cpp</Command>
-      <Message>Qt rcc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\qrc_bitcoin.cpp</Outputs>
-      <AdditionalInputs>(QTDIR)\bincc.exe</AdditionalInputs>
-    </CustomBuild>
-    <CustomBuild Include="..\..\src\qt\bitcoin_locale.qrc">
-      <Command>"$(QTDIR)\bincc.exe" -name bitcoin_locale "%(Fullpath)" -o .\GeneratedFiles\qrc_bitcoin_locale.cpp</Command>
-      <Message>Qt rcc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\qrc_bitcoin_locale.cpp</Outputs>
-      <AdditionalInputs>(QTDIR)\bincc.exe</AdditionalInputs>
-    </CustomBuild>
-    <None Include="..\..\src\qt\forms\addressbookpage.ui" />
-    <None Include="..\..\src\qt\forms\askpassphrasedialog.ui" />
-    <None Include="..\..\src\qt\forms\coincontroldialog.ui" />
-    <None Include="..\..\src\qt\forms\debugwindow.ui" />
-    <None Include="..\..\src\qt\forms\editaddressdialog.ui" />
-    <None Include="..\..\src\qt\forms\helpmessagedialog.ui" />
-    <None Include="..\..\src\qt\forms\intro.ui" />
-    <None Include="..\..\src\qt\forms\modaloverlay.ui" />
-    <None Include="..\..\src\qt\forms\openuridialog.ui" />
-    <None Include="..\..\src\qt\forms\optionsdialog.ui" />
-    <None Include="..\..\src\qt\forms\overviewpage.ui" />
-    <None Include="..\..\src\qt\formseceivecoinsdialog.ui" />
-    <None Include="..\..\src\qt\formseceiverequestdialog.ui" />
-    <None Include="..\..\src\qt\forms\sendcoinsdialog.ui" />
-    <None Include="..\..\src\qt\forms\sendcoinsentry.ui" />
-    <None Include="..\..\src\qt\forms\signverifymessagedialog.ui" />
-    <None Include="..\..\src\qt\forms\transactiondescdialog.ui" />
-    <None Include="..\..\src\qt\locale\bitcoin_af.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_af_ZA.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_am.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ar.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_be_BY.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_bg.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_bg_BG.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ca.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ca%40valencia.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ca_ES.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_cs.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_cy.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_da.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_de.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_el.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_el_GR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_en.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_en_GB.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_eo.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_AR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_CL.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_CO.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_DO.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_ES.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_MX.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_UY.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_es_VE.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_et.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_et_EE.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_eu_ES.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_fa.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_fa_IR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_fi.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_fr.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_fr_CA.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_fr_FR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_gl.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_he.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_hi_IN.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_hr.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_hu.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_id.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_id_ID.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_is.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_it.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_it_IT.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ja.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ka.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_kk_KZ.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ko.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ko_KR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ku_IQ.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ky.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_la.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_lt.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_lv_LV.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_mk_MK.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ml.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_mn.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ms_MY.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_nb.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ne.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_nl.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_pam.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_pl.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_pt_BR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_pt_PT.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ro.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ro_RO.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ru.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ru_RU.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sk.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sl_SI.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sn.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sq.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sr.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sr%40latin.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_sv.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_szl.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ta.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_th_TH.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_tr.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_tr_TR.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_uk.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_ur_PK.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_uz%40Cyrl.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_vi.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_vi_VN.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_zh.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_zh_CN.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_zh_HK.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qt\locale\bitcoin_zh_TW.ts">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <CustomBuild Include="..\..\src\qt\paymentrequest.proto">
-      <FileType>Document</FileType>
-      <Command>F:\Dependencies\protobuf-cpp-3.4.1\protobuf-3.4.1\cmake\build\vs\Debug\protoc.exe --proto_path=%(RootDir)%(Directory) %(Fullpath) --cpp_out=.\GeneratedFiles</Command>
-      <Message>ProtoBuf source generation %(RootDir)%(Directory) %(Filename)</Message>
-      <Outputs>.\GeneratedFiles\%(Filename).pb.h;.\GeneratedFiles\(%Filename).pb.cc</Outputs>
-      <AdditionalInputs>F:\Dependencies\protobuf-cpp-3.4.1\protobuf-3.4.1\cmake\build\vs\Debug\protoc.exe</AdditionalInputs>
-      <LinkObjects>false</LinkObjects>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\deps\protobuf\protobuf-3.4.1\cmake\build\vs\Debug\protoc.exe --proto_path=%(RootDir)%(Directory) %(Fullpath) --cpp_out=.\GeneratedFiles</Command>
-      <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">F:\deps\protobuf\protobuf-3.4.1\cmake\build\vs\Debug\protoc.exe</AdditionalInputs>
-    </CustomBuild>
-    <None Include="..\..\src\qt\macdockiconhandler.mm" />
-    <None Include="..\..\src\qt\macnotificationhandler.mm" />
-    <None Include="..\..\src\qtes\icons\bitcoin.icns">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\bitcoin.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\clock_0.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\clock_1.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\clock_2.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\clock_3.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\clock_4.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\connect-0.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\connect-1.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\connect-2.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\connect-3.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\connect-4.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\hd_disabled.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\hd_enabled.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\mine.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\network_disabled.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\qt.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\transaction0.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\tx_in.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="..\..\src\qtes\src\tx_inout.svg">
-      <DeploymentContent>true</DeploymentContent>
-    </None>
-    <None Include="GeneratedFiles\bitcoin.moc" />
-    <None Include="GeneratedFiles\bitcoinamountfield.moc" />
-    <None Include="GeneratedFiles\intro.moc" />
-    <None Include="GeneratedFiles\overviewpage.moc" />
-    <None Include="GeneratedFilespcconsole.moc" />
+    <ClCompile Include="..\..\src\qt\addressbookpage.cpp" />
+    <ClCompile Include="..\..\src\qt\addresstablemodel.cpp" />
+    <ClCompile Include="..\..\src\qt\askpassphrasedialog.cpp" />
+    <ClCompile Include="..\..\src\qt\bantablemodel.cpp" />
+    <ClCompile Include="..\..\src\qt\bitcoin.cpp" />
+    <ClCompile Include="..\..\src\qt\bitcoinaddressvalidator.cpp" />
+    <ClCompile Include="..\..\src\qt\bitcoinamountfield.cpp" />
+    <ClCompile Include="..\..\src\qt\bitcoingui.cpp" />
+    <ClCompile Include="..\..\src\qt\bitcoinstrings.cpp" />
+    <ClCompile Include="..\..\src\qt\bitcoinunits.cpp" />
+    <ClCompile Include="..\..\src\qt\clientmodel.cpp" />
+    <ClCompile Include="..\..\src\qt\coincontroldialog.cpp" />
+    <ClCompile Include="..\..\src\qt\coincontroltreewidget.cpp" />
+    <ClCompile Include="..\..\src\qt\createwalletdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\csvmodelwriter.cpp" />
+    <ClCompile Include="..\..\src\qt\editaddressdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\guiutil.cpp" />
+    <ClCompile Include="..\..\src\qt\intro.cpp" />
+    <ClCompile Include="..\..\src\qt\modaloverlay.cpp" />
+    <ClCompile Include="..\..\src\qt\networkstyle.cpp" />
+    <ClCompile Include="..\..\src\qt\notificator.cpp" />
+    <ClCompile Include="..\..\src\qt\openuridialog.cpp" />
+    <ClCompile Include="..\..\src\qt\optionsdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\optionsmodel.cpp" />
+    <ClCompile Include="..\..\src\qt\overviewpage.cpp" />
+    <ClCompile Include="..\..\src\qt\paymentserver.cpp" />
+    <ClCompile Include="..\..\src\qt\peertablemodel.cpp" />
+    <ClCompile Include="..\..\src\qt\platformstyle.cpp" />
+    <ClCompile Include="..\..\src\qt\qrimagewidget.cpp" />
+    <ClCompile Include="..\..\src\qt\qvalidatedlineedit.cpp" />
+    <ClCompile Include="..\..\src\qt\qvaluecombobox.cpp" />
+    <ClCompile Include="..\..\src\qt\receivecoinsdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\receiverequestdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\recentrequeststablemodel.cpp" />
+    <ClCompile Include="..\..\src\qt\rpcconsole.cpp" />
+    <ClCompile Include="..\..\src\qt\sendcoinsdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\sendcoinsentry.cpp" />
+    <ClCompile Include="..\..\src\qt\signverifymessagedialog.cpp" />
+    <ClCompile Include="..\..\src\qt\splashscreen.cpp" />
+    <ClCompile Include="..\..\src\qt\trafficgraphwidget.cpp" />
+    <ClCompile Include="..\..\src\qt\transactiondesc.cpp" />
+    <ClCompile Include="..\..\src\qt\transactiondescdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\transactionfilterproxy.cpp" />
+    <ClCompile Include="..\..\src\qt\transactionrecord.cpp" />
+    <ClCompile Include="..\..\src\qt\transactiontablemodel.cpp" />
+    <ClCompile Include="..\..\src\qt\transactionview.cpp" />
+    <ClCompile Include="..\..\src\qt\utilitydialog.cpp" />
+    <ClCompile Include="..\..\src\qt\walletcontroller.cpp" />
+    <ClCompile Include="..\..\src\qt\walletframe.cpp" />
+    <ClCompile Include="..\..\src\qt\walletmodel.cpp" />
+    <ClCompile Include="..\..\src\qt\walletmodeltransaction.cpp" />
+    <ClCompile Include="..\..\src\qt\walletview.cpp" />
+    <ClCompile Include="..\..\src\qt\winshutdownmonitor.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbookpage.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addresstablemodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_askpassphrasedialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_bantablemodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_bitcoin.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_bitcoinaddressvalidator.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_bitcoinamountfield.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_bitcoingui.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_bitcoinunits.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_clientmodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_coincontroldialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_coincontroltreewidget.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_createwalletdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_csvmodelwriter.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_editaddressdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_guiutil.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_intro.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_modaloverlay.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_networkstyle.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_notificator.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_openuridialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_optionsdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_optionsmodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_overviewpage.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_paymentserver.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_peertablemodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_platformstyle.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_qrimagewidget.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_qvalidatedlineedit.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_qvaluecombobox.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_receivecoinsdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_receiverequestdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_recentrequeststablemodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcconsole.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcoinsdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcoinsentry.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_signverifymessagedialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_splashscreen.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_trafficgraphwidget.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_transactiondesc.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_transactiondescdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_transactionfilterproxy.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_transactionrecord.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_transactiontablemodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_transactionview.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_utilitydialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_walletcontroller.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_walletframe.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_walletmodel.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_walletmodeltransaction.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_walletview.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_winshutdownmonitor.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\rcc\qrc_bitcoin.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\rcc\qrc_bitcoin_locale.cpp" />
   </ItemGroup>
-  <ItemGroup>
-    <Image Include="..\..\src\qtes\icons\add.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\address-book.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\bitcoin.ico">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\bitcoin.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\bitcoin_testnet.ico">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\chevron.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\clock1.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\clock2.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\clock3.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\clock4.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\clock5.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\connect0.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\connect1.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\connect2.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\connect3.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\connect4.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\edit.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\editcopy.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\editpaste.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\export.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\eye.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\eye_minus.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\eye_plus.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\fontbigger.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\fontsmaller.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\hd_disabled.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\hd_enabled.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\history.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\info.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\lock_closed.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\lock_open.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\network_disabled.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\overview.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\iconseceive.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\iconsemove.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\send.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\synced.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\transaction0.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\transaction2.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\transaction_abandoned.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\transaction_conflicted.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\tx_inout.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\tx_input.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\tx_mined.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\tx_output.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\icons\warning.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-000.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-001.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-002.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-003.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-004.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-005.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-006.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-007.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-008.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-009.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-010.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-011.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-012.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-013.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-014.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-015.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-016.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-017.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-018.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-019.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-020.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-021.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-022.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-023.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-024.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-025.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-026.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-027.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-028.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-029.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-030.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-031.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-032.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-033.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-034.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\movies\spinner-035.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-    <Image Include="..\..\src\qtes\src\spinner.png">
-      <DeploymentContent>true</DeploymentContent>
-    </Image>
-  </ItemGroup>
-  <ItemGroup>
-    <ClCompile Include="GeneratedFiles\qrc_bitcoin.cpp" />
-    <ClCompile Include="GeneratedFiles\qrc_bitcoin_locale.cpp" />
-    <CustomBuild Include="..\..\src\qt\bitcoin.cpp">
-      <Command>"$(QTDIR)\bin\moc.exe" "%(Fullpath)" -o .\GeneratedFiles\%(Filename).moc $(MOC_DEF)</Command>
-      <Message>Qt moc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\%(Filename).moc</Outputs>
-      <AdditionalInputs>(QTDIR)\bin\moc.exe</AdditionalInputs>
-    </CustomBuild>
-    <CustomBuild Include="..\..\src\qt\bitcoinamountfield.cpp">
-      <Command>"$(QTDIR)\bin\moc.exe" "%(Fullpath)" -o .\GeneratedFiles\%(Filename).moc $(MOC_DEF)</Command>
-      <Message>Qt moc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\%(Filename).moc</Outputs>
-      <AdditionalInputs>(QTDIR)\bin\moc.exe</AdditionalInputs>
-    </CustomBuild>
-    <CustomBuild Include="..\..\src\qt\intro.cpp">
-      <Command>"$(QTDIR)\bin\moc.exe" "%(Fullpath)" -o .\GeneratedFiles\%(Filename).moc $(MOC_DEF)</Command>
-      <Message>Qt moc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\%(Filename).moc</Outputs>
-      <AdditionalInputs>(QTDIR)\bin\moc.exe</AdditionalInputs>
-    </CustomBuild>
-    <CustomBuild Include="..\..\src\qt\overviewpage.cpp">
-      <Command>"$(QTDIR)\bin\moc.exe" "%(Fullpath)" -o .\GeneratedFiles\%(Filename).moc $(MOC_DEF)</Command>
-      <Message>Qt moc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\%(Filename).moc</Outputs>
-      <AdditionalInputs>(QTDIR)\bin\moc.exe</AdditionalInputs>
-    </CustomBuild>
-    <CustomBuild Include="..\..\src\qtpcconsole.cpp">
-      <Command>"$(QTDIR)\bin\moc.exe" "%(Fullpath)" -o .\GeneratedFiles\%(Filename).moc $(MOC_DEF)</Command>
-      <Message>Qt moc generation for %(Identity)</Message>
-      <Outputs>.\GeneratedFiles\%(Filename).moc</Outputs>
-      <AdditionalInputs>(QTDIR)\bin\moc.exe</AdditionalInputs>
-    </CustomBuild>
-    <ClCompile Include="GeneratedFiles\moc_addressbookpage.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_addresstablemodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_askpassphrasedialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_bantablemodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_bitcoinaddressvalidator.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_bitcoinamountfield.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_bitcoingui.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_bitcoinunits.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_callback.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_clientmodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_coincontroldialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_coincontroltreewidget.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_csvmodelwriter.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_editaddressdialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_guiconstants.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_guiutil.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_intro.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_macdockiconhandler.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_macnotificationhandler.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_modaloverlay.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_networkstyle.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_notificator.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_openuridialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_optionsdialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_optionsmodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_overviewpage.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_paymentrequestplus.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_paymentserver.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_peertablemodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_platformstyle.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_qvalidatedlineedit.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_qvaluecombobox.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_receivecoinsdialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_receiverequestdialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_recentrequeststablemodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_rpcconsole.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_sendcoinsdialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_sendcoinsentry.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_signverifymessagedialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_splashscreen.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_trafficgraphwidget.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_transactiondesc.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_transactiondescdialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_transactionfilterproxy.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_transactionrecord.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_transactiontablemodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_transactionview.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_utilitydialog.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_walletframe.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_walletmodel.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_walletmodeltransaction.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_walletview.cpp" />
-    <ClCompile Include="GeneratedFiles\moc_winshutdownmonitor.cpp" />
-    <ClCompile Include="GeneratedFiles\paymentrequest.pb.cc" />
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="GeneratedFiles\paymentrequest.pb.h" />
-    <ClInclude Include="GeneratedFiles\ui_addressbookpage.h" />
-    <ClInclude Include="GeneratedFiles\ui_askpassphrasedialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_coincontroldialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_debugwindow.h" />
-    <ClInclude Include="GeneratedFiles\ui_editaddressdialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_helpmessagedialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_intro.h" />
-    <ClInclude Include="GeneratedFiles\ui_modaloverlay.h" />
-    <ClInclude Include="GeneratedFiles\ui_openuridialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_optionsdialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_overviewpage.h" />
-    <ClInclude Include="GeneratedFiles\ui_receivecoinsdialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_receiverequestdialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_sendcoinsdialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_sendcoinsentry.h" />
-    <ClInclude Include="GeneratedFiles\ui_signverifymessagedialog.h" />
-    <ClInclude Include="GeneratedFiles\ui_transactiondescdialog.h" />
-  </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>StaticLibrary</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
+
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-    <Linkage-protobuf>static</Linkage-protobuf>
-    <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-    <Linkage-protobuf>static</Linkage-protobuf>
-    <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-    <Linkage-protobuf>static</Linkage-protobuf>
-    <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <Linkage-protobuf>static</Linkage-protobuf>
-    <CustomBuildBeforeTargets>ClCompile</CustomBuildBeforeTargets>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>false</IntrinsicFunctions>
-      <PreprocessorDefinitions>_X86_;WIN32;HAVE_CONFIG_H;_SCL_SECURE_NO_WARNINGS;WIN32;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>.\GeneratedFiles;..\..\src;..\..\src\univalue\include;.\QtGenerated\mocheaders</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_X86_;WIN32;HAVE_CONFIG_H;_SCL_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>.\GeneratedFiles;..\..\src;..\..\src\univalue\include;.\QtGenerated\mocheaders</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;HAVE_CONFIG_H;_SCL_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>.\GeneratedFiles;..\..\src;..\..\src\univalue\include;.\QtGenerated\mocheaders</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;HAVE_CONFIG_H;_SCL_SECURE_NO_WARNINGS;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>.\GeneratedFiles;..\..\src;..\..\src\univalue\include;.\QtGenerated\mocheaders</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <PreprocessorDefinitions>_AMD64_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(QtIncludes);$(GeneratedFilesOutDir)\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
   </ItemDefinitionGroup>
-  <Import Label="configTarget" Project="..\common.vcxproj" />
-  <Target Name="QtHeadersMocCodeGeneration" BeforeTargets="PrepareForBuild">
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PreprocessorDefinitions>_AMD64_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(QtIncludes);$(GeneratedFilesOutDir)\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_X86_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(QtIncludes);$(GeneratedFilesOutDir)\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PreprocessorDefinitions>_X86_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(QtIncludes);$(GeneratedFilesOutDir)\..;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <QT_MOC Include="..\..\src\qt\bitcoinamountfield.cpp" />
+    <QT_MOC Include="..\..\src\qt\intro.cpp" />
+    <QT_MOC Include="..\..\src\qt\overviewpage.cpp" />
+    <QT_MOC Include="..\..\src\qt\rpcconsole.cpp" />
+    <MocHeaderFiles Include="..\..\src\qt\*.h" />
+    <ResourceTemplates Include="..\..\src\qt\*.qrc" />
+    <UiFormFiles Include="..\..\src\qt\forms\*.ui" />
+    <TranslationFiles Include="..\..\src\qt\locale\*.ts" />
+  </ItemGroup>
+
+  <Target Name="moccode" Inputs="@(QT_MOC)" Outputs="@(QT_MOC->'$(GeneratedFilesOutDir)\%(Filename).moc')">
     <PropertyGroup>
-      <ErrorText>There was an error executing the Qt headers moc code generation tasks.</ErrorText>
+      <ErrorText>There was an error executing the libbitcoin_qt moc code include generation task.</ErrorText>
     </PropertyGroup>
-    <ItemGroup>
-      <QtMocHeaderFiles Include="..\..\src\qt\*.h" />
-    </ItemGroup>
-    <Exec Command="$(QTDIR)\bin\moc.exe &quot;%(QtMocHeaderFiles.Identity)&quot; -o .\GeneratedFiles\moc_%(Filename).cpp $(MOC_DEF)" />
+    <MakeDir Directories="$(GeneratedFilesOutDir)" />
+    <Exec Command="echo Performing libbitcoin_qt moc code include generation task, output path $(GeneratedFilesOutDir)." />
+    <Exec Command="echo $(QtToolsDir)\moc.exe $(MOC_DEFINES) &quot;%(QT_MOC.Identity)&quot; -o $(GeneratedFilesOutDir)\%(Filename).moc." />
+    <Exec Command="$(QtToolsDir)\moc.exe $(MOC_DEFINES) &quot;%(QT_MOC.Identity)&quot; -o $(GeneratedFilesOutDir)\%(Filename).moc" />
   </Target>
-  <Target Name="QtFormsCodeGeneration" BeforeTargets="PrepareForBuild">
+
+  <Target Name="mocheader" Inputs="@(MocHeaderFiles)" Outputs="@(MocHeaderFiles->'$(GeneratedFilesOutDir)\moc\moc_%(Filename).cpp')">
     <PropertyGroup>
-      <ErrorText>There was an error executing the Qt forms code generation tasks.</ErrorText>
+      <ErrorText>There was an error executing the libbitcoin_qt moc header generation task.</ErrorText>
     </PropertyGroup>
-    <ItemGroup>
-      <QtFormFiles Include="..\..\src\qt\forms\*.ui" />
-    </ItemGroup>
-    <Exec Command="$(QTDIR)\bin\uic.exe &quot;%(QtFormFiles.Identity)&quot; -o .\GeneratedFiles\ui_%(Filename).h" />
+    <Exec Command="echo Performing libbitcoin_qt moc header generation task, output path $(GeneratedFilesOutDir)\moc." />
+    <Exec Command="echo $(QtToolsDir)\moc.exe $(MOC_DEFINES) &quot;%(MocHeaderFiles.Identity)&quot; -o $(GeneratedFilesOutDir)\moc\moc_%(Filename).cpp." />
+    <MakeDir Directories="$(GeneratedFilesOutDir)\moc\" />
+    <Exec Command="$(QtToolsDir)\moc.exe $(MOC_DEFINES) &quot;%(MocHeaderFiles.Identity)&quot; -o $(GeneratedFilesOutDir)\moc\moc_%(Filename).cpp" />
   </Target>
-  <Target Name="QtLocaleCodeGeneration" BeforeTargets="PrepareForBuild">
+
+  <Target Name="forms" Inputs="@(UiFormFiles)" Outputs="@(UiFormFiles->'$(GeneratedFilesOutDir)\forms\ui_%(Filename).h')">
     <PropertyGroup>
-      <ErrorText>There was an error executing the Qt local code generation tasks.</ErrorText>
+      <ErrorText>There was an error executing the libbitcoin_qt forms header generation task.</ErrorText>
     </PropertyGroup>
-    <ItemGroup>
-      <QtLocaleFiles Include="..\..\src\qt\locale\*.ts" />
-    </ItemGroup>
-    <Exec Command="$(QTDIR)\bin\lrelease.exe &quot;%(QtLocaleFiles.Identity)&quot; -qm ..\..\src\qt\locale\%(Filename).qm" />
+    <Exec Command="echo Performing libbitcoin_qt forms header generation task, output path $(GeneratedFilesOutDir)\forms." />
+    <MakeDir Directories="$(GeneratedFilesOutDir)\forms\" />
+    <Exec Command="$(QtToolsDir)\uic.exe &quot;%(UiFormFiles.Identity)&quot; -o $(GeneratedFilesOutDir)\forms\ui_%(Filename).h" />
   </Target>
-  <ImportGroup Label="ExtensionTargets">
-    <!--<Import Label="berkleyDbTarget" Project="f:\deps\db-4.8.30\db.targets" />
-    <Import Label="opensslTarget" Project="f:\deps\openssl\1.0.2\openssl.targets" />
-    <Import Label="qtTarget" Project="F:\deps\qt\5.9.2-git-ssl\vc141-x86elease\qt.targets" />
-    <Import Label="protobufTarget" Project="f:\deps\protobuf\protobuf.targets" />-->
-  </ImportGroup>
-  <ProjectExtensions>
-    <VisualStudio>
-      <UserProperties MocDir=".\GeneratedFiles" UicDir=".\GeneratedFiles" RccDir=".\GeneratedFiles" lupdateOptions="" lupdateOnBuild="0" lreleaseOptions="" Qt5Version_x0020_Win32="5.9.1_vs140_x86" Qt5Version_x0020_x64="5.9.1_vs140_x86" MocOptions="DUNICODE -DWIN32 -DQT_DLL -DQT_CORE_LIB -DQT_GUI_LIB -DQT_WIDGETS_LIB &quot;-I.\GeneratedFiles&quot; &quot;-I.&quot; &quot;-I$(QTDIR)\include&quot; &quot;-I$(QTDIR)\include\QtCore&quot; &quot;-I$(QTDIR)\include\QtGui&quot; &quot;-I$(QTDIR)\include\QtWidgets&quot;" />
-    </VisualStudio>
-  </ProjectExtensions>
+
+  <Target Name="translation" Inputs="@(TranslationFiles)" Outputs="@(TranslationFiles->'..\..\src\qt\locale\%(Filename).qm')">
+    <PropertyGroup>
+      <ErrorText>There was an error executing the libbitcoin_qt translation file generation task.</ErrorText>
+    </PropertyGroup>
+    <Exec Command="echo Performing libbitcoin_qt translation file generation task." />
+    <Exec Command="$(QtToolsDir)\lrelease.exe &quot;%(TranslationFiles.Identity)&quot; -qm ..\..\src\qt\locale\%(Filename).qm" />
+  </Target>
+
+  <Target Name="resource" Inputs="@(ResourceTemplates)" Outputs="@(ResourceTemplates->'$(GeneratedFilesOutDir)\rcc\qrc_%(Filename).cpp')" DependsOnTargets="translation">
+    <PropertyGroup>
+      <ErrorText>There was an error executing the libbitcoin_qt resource code generation task.</ErrorText>
+    </PropertyGroup>
+    <Exec Command="echo Performing libbitcoin_qt resource code generation task, output path $(GeneratedFilesOutDir)\rcc." />
+    <MakeDir Directories="$(GeneratedFilesOutDir)\rcc\" />
+    <Exec Command="$(QtToolsDir)\rcc.exe --verbose --name %(Filename) &quot;%(ResourceTemplates.Identity)&quot; -o $(GeneratedFilesOutDir)\rcc\qrc_%(Filename).cpp" />
+  </Target>
+
+  <Target Name="qtclean">
+    <Exec Command="echo Clean libbitcoin_qt generated files from $(GeneratedFilesOutDir)." />
+    <RemoveDir Directories="$(GeneratedFilesOutDir)\forms;$(GeneratedFilesOutDir)\moc;$(GeneratedFilesOutDir)\rcc;" />
+    <RemoveDir Directories="$(GeneratedFilesOutDir)" />
+  </Target>
+
+  <PropertyGroup>
+    <BuildDependsOn>
+        moccode;
+        mocheader;
+        forms;
+        translation;
+        resource;
+        $(BuildDependsOn);
+    </BuildDependsOn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CleanDependsOn>
+        qtclean;
+        $(CleanDependsOn);
+    </CleanDependsOn>
+  </PropertyGroup>
+
 </Project>

--- a/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
+++ b/build_msvc/test_bitcoin-qt/test_bitcoin-qt.vcxproj
@@ -1,146 +1,123 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Label="configInitTarget" Project="..\common.init.vcxproj" />
-  <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Debug|Win32">
-      <Configuration>Debug</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|Win32">
-      <Configuration>Release</Configuration>
-      <Platform>Win32</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-  </ItemGroup>
+  <Import Project="..\common.init.vcxproj" />
+  <Import Project="..\common.qt.init.vcxproj" />
   <PropertyGroup Label="Globals">
-    <VCProjectVersion>15.0</VCProjectVersion>
     <ProjectGuid>{51201D5E-D939-4854-AE9D-008F03FF518E}</ProjectGuid>
-    <Keyword>Win32Proj</Keyword>
-    <RootNamespace>test_bitcoinqt</RootNamespace>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
-  <ImportGroup Label="ExtensionSettings">
-  </ImportGroup>
-  <ImportGroup Label="Shared">
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\src\test\setup_common.cpp" />
+    <ClCompile Include="..\..\src\qt\test\addressbooktests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\apptests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\compattests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\rpcnestedtests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\test_main.cpp" />
+    <ClCompile Include="..\..\src\qt\test\uritests.cpp" />
+    <ClCompile Include="..\..\src\qt\test\util.cpp" />
+    <ClCompile Include="..\..\src\qt\test\wallettests.cpp" />
+    <ClCompile Include="..\..\src\wallet\test\wallet_test_fixture.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_addressbooktests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_apptests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_compattests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcnestedtests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_uritests.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_wallettests.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">
+      <Project>{2b384fa8-9ee1-4544-93cb-0d733c25e8ce}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_cli\libbitcoin_cli.vcxproj">
+      <Project>{0667528c-d734-4009-adf9-c0d6c4a5a5a6}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_common\libbitcoin_common.vcxproj">
+      <Project>{7c87e378-df58-482e-aa2f-1bc129bc19ce}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_crypto\libbitcoin_crypto.vcxproj">
+      <Project>{6190199c-6cf4-4dad-bfbd-93fa72a760c1}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_qt\libbitcoin_qt.vcxproj">
+      <Project>{2b4abff8-d1fd-4845-88c9-1f3c0a6512bf}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_server\libbitcoin_server.vcxproj">
+      <Project>{460fee33-1fe1-483f-b3bf-931ff8e969a5}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_util\libbitcoin_util.vcxproj">
+      <Project>{b53a5535-ee9d-4c6f-9a26-f79ee3bc3754}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_wallet\libbitcoin_wallet.vcxproj">
+      <Project>{93b86837-b543-48a5-a89b-7c87abb77df2}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libbitcoin_zmq\libbitcoin_zmq.vcxproj">
+      <Project>{792d487f-f14c-49fc-a9de-3fc150f31c3f}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libleveldb\libleveldb.vcxproj">
+      <Project>{18430fef-6b61-4c53-b396-718e02850f1b}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libsecp256k1\libsecp256k1.vcxproj">
+      <Project>{bb493552-3b8c-4a8c-bf69-a6e7a51d2ea6}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libunivalue\libunivalue.vcxproj">
+      <Project>{5724ba7d-a09a-4ba8-800b-c4c1561b3d69}</Project>
+    </ProjectReference>
+  </ItemGroup>
+
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <SDLCheck>true</SDLCheck>
+      <AdditionalIncludeDirectories>..\libbitcoin_qt\$(GeneratedFilesOutDir)\..\;$(QtIncludeDir)\QtTest;$(QtIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(QtReleaseLibaries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
-  <Import Label="configTarget" Project="..\common.vcxproj" />
-</Project>
+
+    <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\libbitcoin_qt\$(GeneratedFilesOutDir)\..\;$(QtIncludeDir)\QtTest;$(QtIncludes);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(QtDebugLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <MocTestFiles Include="..\..\src\qt\test\addressbooktests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\apptests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\compattests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\paymentservertests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\rpcnestedtests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\uritests.h" />
+    <MocTestFiles Include="..\..\src\qt\test\wallettests.h" />
+  </ItemGroup>
+  <Target Name="moccode" Inputs="@(MocTestFiles)" Outputs="@(MocTestFiles->'$(GeneratedFilesOutDir)\moc\moc_%(Filename).cpp')">
+    <PropertyGroup>
+      <ErrorText>There was an error executing the test_bitcoin-qt moc code generation task.</ErrorText>
+    </PropertyGroup>
+    <Exec Command="echo Performing test_bitcoin-qt moc generation task, output path $(GeneratedFilesOutDir)\moc." />
+    <MakeDir Directories="$(GeneratedFilesOutDir)\moc\" />
+    <Exec Command="$(QtToolsDir)\moc.exe $(MOC_DEFINES) &quot;%(MocTestFiles.Identity)&quot; -o $(GeneratedFilesOutDir)\moc\moc_%(Filename).cpp" />
+  </Target>
+  <Target Name="QtTestCleanGeneratedFiles">
+    <Exec Command="echo Clean test_bitcoin-qt generated files from $(GeneratedFilesOutDir)." />
+    <RemoveDir Directories="$(GeneratedFilesOutDir)\moc\*" />
+    <RemoveDir Directories="$(GeneratedFilesOutDir)\moc" />
+  </Target>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <PropertyGroup>
+    <BuildDependsOn>
+       moccode;
+       $(BuildDependsOn);
+    </BuildDependsOn>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CleanDependsOn>
+        QtTestCleanGeneratedFiles;
+        $(CleanDependsOn);
+    </CleanDependsOn>
+  </PropertyGroup>
+ </Project>


### PR DESCRIPTION
This PR has ~~90%~~ all of the work done to allow the bitcoin Qt programs to be built with msvc and the appveyor script.

Outstanding issues:

- ~~There are ~~3~~ ~~6~~ 5 code tweaks required for the bitcoin Qt components to be built without warnings with msvc. They seem minor~~,
- Building Qt as a static library for Windows is painful and time consuming. I doubt it will ever be possible to build Qt from source as part of an appveyor job (and it would probably take over an hour even if it was). My tentative solution is to build locally and upload the binaries as a [github release](https://github.com/sipsorcery/qt_win_binary/releases). The msvc build is only for testing and tinkering but even so this doesn't feel like the ideal solution. Open to suggestions?
- ~~There is still an issue to sort out with the payment request URL handling. Building Qt with openssl is an extra headache. I will continue to work on getting this working.~~

The big benefit of this PR is the ability to run bitcoin-qt within a Visual Studio debugging session which could expedite tracking down issues on Windows.

On a side note the test-bitcoin-qt tests fail very early, probably due to *nix specific tests. I haven't dug into them at this point.

**Update 28 Jun 2019**: The ENABLE_BIP70 option is now off (it's flagged for removal as per #15584). With it disabled msbuild does not require any code changes to build the Bitcoin Core Qt applications.