### PR TITLE
Remove sharp edge (uninit member) when using the compiler-generated ctor for BlockFilter

### DIFF
--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -251,6 +251,8 @@ bool BlockFilter::BuildParams(GCSFilter::Params& params) const
         params.m_P = BASIC_FILTER_P;
         params.m_M = BASIC_FILTER_M;
         return true;
+    case BlockFilterType::INVALID:
+        return false;
     }
 
     return false;

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -83,9 +83,10 @@ public:
 constexpr uint8_t BASIC_FILTER_P = 19;
 constexpr uint32_t BASIC_FILTER_M = 784931;
 
-enum BlockFilterType : uint8_t
+enum class BlockFilterType : uint8_t
 {
     BASIC = 0,
+    INVALID = 255,
 };
 
 /**
@@ -95,7 +96,7 @@ enum BlockFilterType : uint8_t
 class BlockFilter
 {
 private:
-    BlockFilterType m_filter_type;
+    BlockFilterType m_filter_type = BlockFilterType::INVALID;
     uint256 m_block_hash;
     GCSFilter m_filter;
 

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -112,6 +112,12 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
     BOOST_CHECK_EQUAL(block_filter.GetFilterType(), block_filter2.GetFilterType());
     BOOST_CHECK_EQUAL(block_filter.GetBlockHash(), block_filter2.GetBlockHash());
     BOOST_CHECK(block_filter.GetEncodedFilter() == block_filter2.GetEncodedFilter());
+
+    BlockFilter default_ctor_block_filter_1;
+    BlockFilter default_ctor_block_filter_2;
+    BOOST_CHECK_EQUAL(default_ctor_block_filter_1.GetFilterType(), default_ctor_block_filter_2.GetFilterType());
+    BOOST_CHECK_EQUAL(default_ctor_block_filter_1.GetBlockHash(), default_ctor_block_filter_2.GetBlockHash());
+    BOOST_CHECK(default_ctor_block_filter_1.GetEncodedFilter() == default_ctor_block_filter_2.GetEncodedFilter());
 }
 
 BOOST_AUTO_TEST_CASE(blockfilters_json_test)


### PR DESCRIPTION
Remove sharp edge (uninitialised member `m_filter_type`) when using the compiler-generated constructor for `BlockFilter`.

Before (but after added test):

```
$ src/test/test_bitcoin -t blockfilter_tests/blockfilter_basic_test
Running 1 test case...
test/blockfilter_tests.cpp(118): error: in "blockfilter_tests/blockfilter_basic_test": check default_ctor_block_filter_1.GetFilterType() == default_ctor_block_filter_2.GetFilterType() has failed [ != ]

*** 1 failure is detected in the test module "Bitcoin Test Suite"
``` 

After:

```
$ src/test/test_bitcoin -t blockfilter_tests/blockfilter_basic_test
Running 1 test case...

*** No errors detected
```