### PR TITLE
test: .style.yapf: Set column_limit=160

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -55,7 +55,7 @@ blank_line_before_nested_class_or_def=False
 coalesce_brackets=False
 
 # The column limit.
-column_limit=79
+column_limit=160
 
 # The style for continuation alignment. Possible values are:
 #


### PR DESCRIPTION
The current style is pep8, as suggested in https://github.com/bitcoin/bitcoin/blob/master/test/functional/README.md#style-guidelines.

generated with 

```
$ yapf --version 
yapf 0.24.0
$ yapf --style-help --style=pep8 > .style.yapf
```

However, we don't use the column_limit of 79 right now. Practically it is somewhere between 120-240.

Some stats:

```
column_limit=120: 115 files changed, 2423 insertions(+), 1408 deletions(-)
column_limit=160: 108 files changed, 1563 insertions(+), 1247 deletions(-)
column_limit=200: 104 files changed, 1255 insertions(+), 1178 deletions(-)