### PR TITLE
Comment typo "iff"

### DIFF
--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -57,7 +57,7 @@ CFeeRate GetMinimumFeeRate(const CWallet& wallet, const CCoinControl& coin_contr
     else { // 2. or 4.
         // We will use smart fee estimation
         unsigned int target = coin_control.m_confirm_target ? *coin_control.m_confirm_target : wallet.m_confirm_target;
-        // By default estimates are economical iff we are signaling opt-in-RBF
+        // By default estimates are economical if we are signaling opt-in-RBF
         bool conservative_estimate = !coin_control.m_signal_bip125_rbf.get_value_or(wallet.m_signal_rbf);
         // Allow to override the default fee estimate mode over the CoinControl instance
         if (coin_control.m_fee_mode == FeeEstimateMode::CONSERVATIVE) conservative_estimate = true;


### PR DESCRIPTION
Minor comment typo "iff" instead of "if", spotted while going over the RBF implementation in 0.15, still present in master. Typo introduced in the commit below.

https://github.com/bitcoin/bitcoin/pull/10706/commits/2fffaa97381f741786fff2e6ff25f4b9a74037fe

Please pull or add to list of typos to correct.
