### PR TITLE
Switch wallet default to reject too-long transaction chains for mempool

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -83,7 +83,7 @@ static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -walletrejectlongchains
-static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = false;
+static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = true;
 //! Default for -avoidpartialspends
 static const bool DEFAULT_AVOIDPARTIALSPENDS = false;
 //! -txconfirmtarget default


### PR DESCRIPTION
The benefits seem to outweigh the drawbacks: I still semi-regularly see chain limits being hit and users getting scared that they have lost their funds.