### PR TITLE
 build: Optionally enable -Wthread-safety-attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -163,4 +163,4 @@ jobs:
         RUN_UNIT_TESTS=false
         RUN_FUNCTIONAL_TESTS=false
         GOAL="deploy"
-        BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror"
+        BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror --enable-isystem"

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -410,7 +410,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
     QT_LIB_PREFIX=Qt5
     qt5_modules="Qt5Core Qt5Gui Qt5Network Qt5Widgets"
     BITCOIN_QT_CHECK([
-      PKG_CHECK_MODULES([QT5], [$qt5_modules], [QT_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS" have_qt=yes],[have_qt=no])
+      PKG_CHECK_MODULES([QT5], [$qt5_modules], [have_qt=yes; BITCOIN_SYSTEM_INCLUDE([QT_INCLUDES], [$QT5_CFLAGS]) QT_MOC_INCLUDES="$QT5_CFLAGS"; QT_LIBS="$QT5_LIBS"],[have_qt=no])
 
       if test "x$have_qt" != xyes; then
         have_qt=no
@@ -418,9 +418,9 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
       fi
     ])
     BITCOIN_QT_CHECK([
-      PKG_CHECK_MODULES([QT_TEST], [${QT_LIB_PREFIX}Test], [QT_TEST_INCLUDES="$QT_TEST_CFLAGS"; have_qt_test=yes], [have_qt_test=no])
+      PKG_CHECK_MODULES([QT_TEST], [${QT_LIB_PREFIX}Test], [have_qt_test=yes; BITCOIN_SYSTEM_INCLUDE([QT_TEST_INCLUDES], [$QT_TEST_CFLAGS])], [have_qt_test=no])
       if test "x$use_dbus" != xno; then
-        PKG_CHECK_MODULES([QT_DBUS], [${QT_LIB_PREFIX}DBus], [QT_DBUS_INCLUDES="$QT_DBUS_CFLAGS"; have_qt_dbus=yes], [have_qt_dbus=no])
+        PKG_CHECK_MODULES([QT_DBUS], [${QT_LIB_PREFIX}DBus], [have_qt_dbus=yes; BITCOIN_SYSTEM_INCLUDE([QT_DBUS_INCLUDES], [$QT_DBUS_CFLAGS])], [have_qt_dbus=no])
       fi
     ])
   ])
@@ -440,7 +440,8 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
   TEMP_LIBS="$LIBS"
   BITCOIN_QT_CHECK([
     if test "x$qt_include_path" != x; then
-      QT_INCLUDES="-I$qt_include_path -I$qt_include_path/QtCore -I$qt_include_path/QtGui -I$qt_include_path/QtWidgets -I$qt_include_path/QtNetwork -I$qt_include_path/QtTest -I$qt_include_path/QtDBus"
+      QT_MOC_INCLUDES="-I$qt_include_path -I$qt_include_path/QtCore -I$qt_include_path/QtGui -I$qt_include_path/QtWidgets -I$qt_include_path/QtNetwork -I$qt_include_path/QtTest -I$qt_include_path/QtDBus"
+      BITCOIN_SYSTEM_INCLUDE([QT_INCLUDES], [$QT_MOC_INCLUDES])
       CPPFLAGS="$QT_INCLUDES $CPPFLAGS"
     fi
   ])

--- a/build-aux/m4/bitcoin_subdir_to_include.m4
+++ b/build-aux/m4/bitcoin_subdir_to_include.m4
@@ -12,7 +12,8 @@ AC_DEFUN([BITCOIN_SUBDIR_TO_INCLUDE],[
     newinclpath=`${CXXCPP} ${CPPFLAGS} -M conftest.cpp 2>/dev/null | [ tr -d '\\n\\r\\\\' | sed -e 's/^.*[[:space:]:]\(\/[^[:space:]]*\)]$3[\.h[[:space:]].*$/\1/' -e t -e d`]
     AC_MSG_RESULT([${newinclpath}])
     if test "x${newinclpath}" != "x"; then
-      eval "$1=\"\$$1\"' -I${newinclpath}'"
+      BITCOIN_SYSTEM_INCLUDE([newincl], ["-I${newinclpath}"])
+      eval "$1=\"\$$1\"' ${newincl}'"
     fi
   fi
 ])

--- a/build-aux/m4/bitcoin_system_include.m4
+++ b/build-aux/m4/bitcoin_system_include.m4
@@ -1,0 +1,19 @@
+dnl Copyright (c) 2018 The Bitcoin Core developers
+dnl Distributed under the MIT software license, see the accompanying
+dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+dnl BITCOIN_SYSTEM_INCLUDE([DESTINATION-VARIABLE-NAME], [INCLUDES-STRING])
+dnl Populates the variable DESTINATION with the value from INCLUDES but
+dnl with -I includes switched to -isystem, with the exception of -I/usr/include,
+dnl which is left unmodified to avoid order issues with /usr/include. See:
+dnl https://stackoverflow.com/questions/37218953/isystem-on-a-system-include-directory-causes-errors
+AC_DEFUN([BITCOIN_SYSTEM_INCLUDE],[
+  if test "x$use_isystem" = "xyes" && test "x$2" != "x"; then
+    dnl Including /usr/include with -isystem is known to cause problems, e.g.
+    dnl breaking include_next due to, the directive changing inclusion order.
+    dnl https://bugreports.qt.io/browse/QTBUG-53367
+    $1=$(echo $2 | sed -e 's| -I| -isystem|g' -e 's|^-I|-isystem|g' -e 's|-isystem/usr/include|-I/usr/include|g')
+  else
+    $1=$2
+  fi
+])

--- a/configure.ac
+++ b/configure.ac
@@ -328,6 +328,7 @@ if test "x$enable_werror" = "xyes"; then
   ## isystem is in use to keep the build clean
   if test "x$use_isystem" = "xyes"; then
     AX_CHECK_COMPILE_FLAG([-Werror=documentation],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=documentation"],,[[$CXXFLAG_WERROR]])
+    AX_CHECK_COMPILE_FLAG([-Werror=thread-safety-attributes],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=thread-safety-attributes"],,[[$CXXFLAG_WERROR]])
   fi
   werror_enabled = yes
 fi
@@ -355,6 +356,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   ## isystem is in use to keep the build clean
   if test "x$use_isystem" = "xyes" && test "x$werror_enabled" == "x"; then
     AX_CHECK_COMPILE_FLAG([-Wdocumentation],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"],,[[$CXXFLAG_WERROR]])
+    AX_CHECK_COMPILE_FLAG([-Wthread-safety-attributes],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wthread-safety-attributes"],,[[$CXXFLAG_WERROR]])
   fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -176,6 +176,12 @@ AC_ARG_ENABLE([ccache],
   [use_ccache=$enableval],
   [use_ccache=auto])
 
+AC_ARG_ENABLE([isystem],
+  [AS_HELP_STRING([--enable-isystem],
+  [enable isystem includes for dependencies and stricter warning checks (default is no)])],
+  [use_isystem=$enableval],
+  [use_isystem=no])
+
 AC_ARG_ENABLE([lcov],
   [AS_HELP_STRING([--enable-lcov],
   [enable lcov testing (default is no)])],
@@ -539,7 +545,8 @@ case $host in
            export PKG_CONFIG_PATH
          fi
          if test x$bdb_prefix != x; then
-           CPPFLAGS="$CPPFLAGS -I$bdb_prefix/include"
+           BITCOIN_SYSTEM_INCLUDE([bdb_cppflags], ["-I$bdb_prefix/include"])
+           CPPFLAGS="$CPPFLAGS $bdb_cppflags"
            LIBS="$LIBS -L$bdb_prefix/lib"
          fi
          if test x$qt5_prefix != x; then
@@ -1081,6 +1088,8 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 LIBS="$TEMP_LIBS"
 CPPFLAGS="$TEMP_CPPFLAGS"
 fi
+dnl Treat boost includes with isystem if applicable
+BITCOIN_SYSTEM_INCLUDE([BOOST_CPPFLAGS], [$BOOST_CPPFLAGS])
 
 if test x$boost_sleep != xyes; then
   AC_MSG_ERROR(No working boost sleep implementation found.)
@@ -1093,18 +1102,18 @@ if test x$use_pkgconfig = xyes; then
   m4_ifdef(
     [PKG_CHECK_MODULES],
     [
-      PKG_CHECK_MODULES([SSL], [libssl],, [AC_MSG_ERROR(openssl not found.)])
-      PKG_CHECK_MODULES([CRYPTO], [libcrypto],,[AC_MSG_ERROR(libcrypto not found.)])
+      PKG_CHECK_MODULES([SSL], [libssl], [BITCOIN_SYSTEM_INCLUDE([SSL_CFLAGS], [$SSL_CFLAGS])], [AC_MSG_ERROR(openssl not found.)])
+      PKG_CHECK_MODULES([CRYPTO], [libcrypto], [BITCOIN_SYSTEM_INCLUDE([CRYPTO_CFLAGS], [$CRYPTO_CFLAGS])],[AC_MSG_ERROR(libcrypto not found.)])
       if test x$enable_bip70 != xno; then
-        BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes], [have_protobuf=no])])
+        BITCOIN_QT_CHECK([PKG_CHECK_MODULES([PROTOBUF], [protobuf], [have_protobuf=yes; BITCOIN_SYSTEM_INCLUDE([PROTOBUF_CFLAGS], [$PROTOBUF_CFLAGS])], [have_protobuf=no])])
       fi
       if test x$use_qr != xno; then
         BITCOIN_QT_CHECK([PKG_CHECK_MODULES([QR], [libqrencode], [have_qrencode=yes], [have_qrencode=no])])
       fi
       if test x$build_bitcoin_cli$build_bitcoind$bitcoin_enable_qt$use_tests != xnononono; then
-        PKG_CHECK_MODULES([EVENT], [libevent],, [AC_MSG_ERROR(libevent not found.)])
+        PKG_CHECK_MODULES([EVENT], [libevent], [BITCOIN_SYSTEM_INCLUDE([EVENT_CFLAGS], [$EVENT_CFLAGS])], [AC_MSG_ERROR(libevent not found.)])
         if test x$TARGET_OS != xwindows; then
-          PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads],, [AC_MSG_ERROR(libevent_pthreads not found.)])
+          PKG_CHECK_MODULES([EVENT_PTHREADS], [libevent_pthreads], [BITCOIN_SYSTEM_INCLUDE([EVENT_PTHREADS_CFLAGS], [$EVENT_PTHREADS_CFLAGS])], [AC_MSG_ERROR(libevent_pthreads not found.)])
         fi
       fi
 
@@ -1228,6 +1237,7 @@ fi
 
 if test x$need_bundled_univalue = xyes ; then
   UNIVALUE_CFLAGS='-I$(srcdir)/univalue/include'
+  BITCOIN_SYSTEM_INCLUDE([UNIVALUE_CFLAGS], [$UNIVALUE_CFLAGS])
   UNIVALUE_LIBS='univalue/libunivalue.la'
 fi
 
@@ -1559,6 +1569,7 @@ fi
 echo "  with bench    = $use_bench"
 echo "  with upnp     = $use_upnp"
 echo "  use asm       = $use_asm"
+echo "  use isystem   = $use_isystem"
 echo "  sanitizers    = $use_sanitizers"
 echo "  debug enabled = $enable_debug"
 echo "  gprof enabled = $enable_gprof"

--- a/configure.ac
+++ b/configure.ac
@@ -323,6 +323,13 @@ if test "x$enable_werror" = "xyes"; then
   fi
   AX_CHECK_COMPILE_FLAG([-Werror=vla],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=vla"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=thread-safety-analysis],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=thread-safety-analysis"],,[[$CXXFLAG_WERROR]])
+
+  ## Some warnings alert on violations in our dependencies. Only enable them when
+  ## isystem is in use to keep the build clean
+  if test "x$use_isystem" = "xyes"; then
+    AX_CHECK_COMPILE_FLAG([-Werror=documentation],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=documentation"],,[[$CXXFLAG_WERROR]])
+  fi
+  werror_enabled = yes
 fi
 
 if test "x$CXXFLAGS_overridden" = "xno"; then
@@ -343,6 +350,12 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
+
+  ## Some warnings alert on violations in our dependencies. Only enable them when
+  ## isystem is in use to keep the build clean
+  if test "x$use_isystem" = "xyes" && test "x$werror_enabled" == "x"; then
+    AX_CHECK_COMPILE_FLAG([-Wdocumentation],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdocumentation"],,[[$CXXFLAG_WERROR]])
+  fi
 fi
 
 # Check for optional instruction set support. Enabling these does _not_ imply that all code will

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -477,11 +477,11 @@ ui_%.h: %.ui
 	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(UIC) -o $@ $< || (echo "Error creating $@"; false)
 
 %.moc: %.cpp
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES) $(MOC_DEFS) $< | \
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_MOC_INCLUDES) $(MOC_DEFS) $< | \
 	  $(SED) -e '/^\*\*.*Created:/d' -e '/^\*\*.*by:/d' > $@
 
 moc_%.cpp: %.h
-	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES) $(MOC_DEFS) $< | \
+	$(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_MOC_INCLUDES) $(MOC_DEFS) $< | \
 	  $(SED) -e '/^\*\*.*Created:/d' -e '/^\*\*.*by:/d' > $@
 
 %.qm: %.ts

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -27,8 +27,8 @@ std::string TransactionErrorString(const TransactionError error);
  * Broadcast a transaction
  *
  * @param[in]  tx the transaction to broadcast
- * @param[out] &txid the txid of the transaction, if successfully broadcast
- * @param[out] &err_string reference to std::string to fill with error string if available
+ * @param[out] txid the txid of the transaction, if successfully broadcast
+ * @param[out] err_string std::string to fill with error string if available
  * @param[in]  highfee Reject txs with fees higher than this (if 0, accept any fee)
  * return error
  */

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -557,7 +557,7 @@ bool SignPSBTInput(const SigningProvider& provider, PartiallySignedTransaction& 
 /**
  * Finalizes a PSBT if possible, combining partial signatures.
  *
- * @param[in,out] &psbtx reference to PartiallySignedTransaction to finalize
+ * @param[in,out] psbtx PartiallySignedTransaction to finalize
  * return True if the PSBT is now complete, false otherwise
  */
 bool FinalizePSBT(PartiallySignedTransaction& psbtx);
@@ -565,7 +565,7 @@ bool FinalizePSBT(PartiallySignedTransaction& psbtx);
 /**
  * Finalizes a PSBT if possible, and extracts it to a CMutableTransaction if it could be finalized.
  *
- * @param[in]  &psbtx reference to PartiallySignedTransaction
+ * @param[in]  psbtx PartiallySignedTransaction
  * @param[out] result CMutableTransaction representing the complete transaction, if successful
  * @return True if we successfully extracted the transaction, false otherwise
  */
@@ -574,7 +574,7 @@ bool FinalizeAndExtractPSBT(PartiallySignedTransaction& psbtx, CMutableTransacti
 /**
  * Combines PSBTs with the same underlying transaction, resulting in a single PSBT with all partial signatures from each input.
  *
- * @param[out] &out   the combined PSBT, if successful
+ * @param[out] out   the combined PSBT, if successful
  * @param[in]  psbtxs the PSBTs to combine
  * @return error (OK if we successfully combined the transactions, other error if they were not compatible)
  */

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -157,7 +157,7 @@ std::string LocksHeld()
     return result;
 }
 
-void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, void* cs)
+void AssertLockHeldInternal(const char* pszName, const char* pszFile, int nLine, Lock* cs)
 {
     for (const std::pair<void*, CLockLocation>& i : g_lockstack)
         if (i.first == cs)

--- a/src/wallet/psbtwallet.h
+++ b/src/wallet/psbtwallet.h
@@ -17,8 +17,8 @@
  * finalize.) Sets `error` and returns false if something goes wrong.
  *
  * @param[in]  pwallet pointer to a wallet
- * @param[in]  &psbtx reference to PartiallySignedTransaction to fill in
- * @param[out] &complete indicates whether the PSBT is now complete
+ * @param[in]  psbtx PartiallySignedTransaction to fill in
+ * @param[out] complete indicates whether the PSBT is now complete
  * @param[in]  sighash_type the sighash type to use when signing (if PSBT does not specify)
  * @param[in]  sign whether to sign or not
  * @param[in]  bip32derivs whether to fill in bip32 derivation information if available

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -101,7 +101,7 @@ public:
     std::string hdKeypath; //optional HD/bip32 keypath. Still used to determine whether a key is a seed. Also kept for backwards compatibility
     CKeyID hd_seed_id; //id of the HD seed used to derive this key
     KeyOriginInfo key_origin; // Key origin info with path and fingerprint
-    bool has_key_origin = false; //< Whether the key_origin is useful
+    bool has_key_origin = false; //!< Whether the key_origin is useful
 
     CKeyMetadata()
     {


### PR DESCRIPTION
And solve `error: 'assert_exclusive_lock' attribute requires arguments whose type is annotated with 'capability' attribute; type here is 'void *'` by introducing an abstract base `Lock` class.

Builds on #14920.