### PR TITLE
doc: remove duplicate clone step in build-windows.md

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -71,6 +71,11 @@ If you want to build the windows installer with `make deploy` you need [NSIS](ht
 
     sudo apt install nsis
 
+Acquire the source in the usual way:
+
+    git clone https://github.com/bitcoin/bitcoin.git
+    cd bitcoin
+
 ## Building for 64-bit Windows
 
 The first step is to install the mingw-w64 cross-compilation tool chain:
@@ -87,11 +92,7 @@ Note that for WSL the Bitcoin Core source path MUST be somewhere in the default 
 example /usr/src/bitcoin, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
 This means you cannot use a directory that is located directly on the host Windows file system to perform the build.
 
-Acquire the source in the usual way:
-
-    git clone https://github.com/bitcoin/bitcoin.git
-
-Once the source code is ready the build steps are below:
+Build using:
 
     PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     cd depends
@@ -115,11 +116,7 @@ Note that for WSL the Bitcoin Core source path MUST be somewhere in the default 
 example /usr/src/bitcoin, AND not under /mnt/d/. If this is not the case the dependency autoconf scripts will fail.
 This means you cannot use a directory that located directly on the host Windows file system to perform the build.
 
-Acquire the source in the usual way:
-
-    git clone https://github.com/bitcoin/bitcoin.git
-
-Then build using:
+Build using:
 
     PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') # strip out problematic Windows %PATH% imported var
     cd depends


### PR DESCRIPTION
Replaces #15550, remove duplicate clone and `cd` into `bitcoin/`.