### PR TITLE
cli: remove duplicate wallet fields from -getinfo

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -253,10 +253,6 @@ public:
         }
         result.pushKV("version", batch[ID_NETWORKINFO]["result"]["version"]);
         result.pushKV("protocolversion", batch[ID_NETWORKINFO]["result"]["protocolversion"]);
-        if (!batch[ID_WALLETINFO].isNull()) {
-            result.pushKV("walletversion", batch[ID_WALLETINFO]["result"]["walletversion"]);
-            result.pushKV("balance", batch[ID_WALLETINFO]["result"]["balance"]);
-        }
         result.pushKV("blocks", batch[ID_BLOCKCHAININFO]["result"]["blocks"]);
         result.pushKV("timeoffset", batch[ID_NETWORKINFO]["result"]["timeoffset"]);
         result.pushKV("connections", batch[ID_NETWORKINFO]["result"]["connections"]);

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -57,9 +57,6 @@ class TestBitcoinCli(BitcoinTestFramework):
 
         assert_equal(cli_get_info['version'], network_info['version'])
         assert_equal(cli_get_info['protocolversion'], network_info['protocolversion'])
-        if self.is_wallet_compiled():
-            assert_equal(cli_get_info['walletversion'], wallet_info['walletversion'])
-            assert_equal(cli_get_info['balance'], wallet_info['balance'])
         assert_equal(cli_get_info['blocks'], blockchain_info['blocks'])
         assert_equal(cli_get_info['timeoffset'], network_info['timeoffset'])
         assert_equal(cli_get_info['connections'], network_info['connections'])
@@ -67,6 +64,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(cli_get_info['difficulty'], blockchain_info['difficulty'])
         assert_equal(cli_get_info['testnet'], blockchain_info['chain'] == "test")
         if self.is_wallet_compiled():
+            assert_equal(cli_get_info['walletversion'], wallet_info['walletversion'])
             assert_equal(cli_get_info['balance'], wallet_info['balance'])
             assert_equal(cli_get_info['keypoololdest'], wallet_info['keypoololdest'])
             assert_equal(cli_get_info['keypoolsize'], wallet_info['keypoolsize'])


### PR DESCRIPTION
`walletversion` and `balance` are both included below.