### PR TITLE
cli: replace testnet with chain and return network name as per BIP70.

### DIFF
--- a/doc/release-notes-15566.md
+++ b/doc/release-notes-15566.md
@@ -1,0 +1,3 @@
+Miscellaneous CLI Changes
+-------------------------
+- The `testnet` field in `bitcoin-cli -getinfo` has been renamed to `chain` and now returns the current network name as defined in BIP70 (main, test, regtest).

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -262,7 +262,7 @@ public:
         result.pushKV("connections", batch[ID_NETWORKINFO]["result"]["connections"]);
         result.pushKV("proxy", batch[ID_NETWORKINFO]["result"]["networks"][0]["proxy"]);
         result.pushKV("difficulty", batch[ID_BLOCKCHAININFO]["result"]["difficulty"]);
-        result.pushKV("testnet", UniValue(batch[ID_BLOCKCHAININFO]["result"]["chain"].get_str() == "test"));
+        result.pushKV("chain", UniValue(batch[ID_BLOCKCHAININFO]["result"]["chain"]));
         if (!batch[ID_WALLETINFO].isNull()) {
             result.pushKV("walletversion", batch[ID_WALLETINFO]["result"]["walletversion"]);
             result.pushKV("balance", batch[ID_WALLETINFO]["result"]["balance"]);

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -65,7 +65,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         assert_equal(cli_get_info['connections'], network_info['connections'])
         assert_equal(cli_get_info['proxy'], network_info['networks'][0]['proxy'])
         assert_equal(cli_get_info['difficulty'], blockchain_info['difficulty'])
-        assert_equal(cli_get_info['testnet'], blockchain_info['chain'] == "test")
+        assert_equal(cli_get_info['chain'], blockchain_info['chain'])
         if self.is_wallet_compiled():
             assert_equal(cli_get_info['balance'], wallet_info['balance'])
             assert_equal(cli_get_info['keypoololdest'], wallet_info['keypoololdest'])


### PR DESCRIPTION
Related IRC discussion [here (line 151)](http://www.erisian.com.au/bitcoin-core-dev/log-2019-03-09.html).