### PR TITLE
depends: native_protobuf: avoid system zlib

### DIFF
--- a/depends/packages/native_protobuf.mk
+++ b/depends/packages/native_protobuf.mk
@@ -5,7 +5,7 @@ $(package)_file_name=protobuf-$($(package)_version).tar.bz2
 $(package)_sha256_hash=ee445612d544d885ae240ffbcbf9267faa9f593b7b101f21d58beceb92661910
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared
+$(package)_config_opts=--disable-shared --without-zlib
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
I don't believe we use any zlib features in protobufs