### PR TITLE
Fix overflow bug in analyzepsbt fee: CAmount instead of int

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1981,8 +1981,8 @@ UniValue analyzepsbt(const JSONRPCRequest& request)
     }
     if (calc_fee) {
         // Get the output amount
-        CAmount out_amt = std::accumulate(psbtx.tx->vout.begin(), psbtx.tx->vout.end(), 0,
-            [](int a, const CTxOut& b) {
+        CAmount out_amt = std::accumulate(psbtx.tx->vout.begin(), psbtx.tx->vout.end(), CAmount(0),
+            [](CAmount a, const CTxOut& b) {
                 return a += b.nValue;
             }
         );


### PR DESCRIPTION
This causes the `fee` and `estimated_feerate` values in the the analyzepsbt output to be off if the amount being spent exceed 21.47483647 BTC.