### PR TITLE
wallet: Log and ignore errors in ListWalletDir and IsBerkeleyBtree

### DIFF
--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/walletutil.h>
 
+#include <logging.h>
 #include <util/system.h>
 
 fs::path GetWalletDir()
@@ -33,7 +34,9 @@ static bool IsBerkeleyBtree(const fs::path& path)
     // A Berkeley DB Btree file has at least 4K.
     // This check also prevents opening lock files.
     boost::system::error_code ec;
-    if (fs::file_size(path, ec) < 4096) return false;
+    auto size = fs::file_size(path, ec);
+    if (ec) LogPrintf("%s: %s %s\n", __func__, ec.message(), path.string());
+    if (size < 4096) return false;
 
     fsbridge::ifstream file(path, std::ios::binary);
     if (!file.is_open()) return false;
@@ -54,8 +57,14 @@ std::vector<fs::path> ListWalletDir()
     const fs::path wallet_dir = GetWalletDir();
     const size_t offset = wallet_dir.string().size() + 1;
     std::vector<fs::path> paths;
+    boost::system::error_code ec;
 
-    for (auto it = fs::recursive_directory_iterator(wallet_dir); it != fs::recursive_directory_iterator(); ++it) {
+    for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
+        if (ec) {
+            LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
+            continue;
+        }
+
         // Get wallet path relative to walletdir by removing walletdir from the wallet path.
         // This can be replaced by boost::filesystem::lexically_relative once boost is bumped to 1.60.
         const fs::path path = it->path().string().substr(offset);


### PR DESCRIPTION
Use the `noexcept` members of `boost::filesystem::recursive_directory_iterator` in order to ignore `boost::filesystem::directory_iterator::construct: Permission denied` errors. The errors are logged though.

Steps to reproduce the issue:

```sh
# 1. create directory for -walletdir without read access:
mkdir /tmp/foo && chmod a-r /tmp/foo

# 2. run bitcoin-qt and should print an error, but continues running:
/Volumes/Bitcoin-Core/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt -regtest -walletdir=/tmp/foo
/private/tmp/foo: Permission denied

# 4. go to File -> Open Wallet and should segfault:
EXCEPTION: N5boost10filesystem16filesystem_errorE
boost::filesystem::directory_iterator::construct: Permission denied: "/private/tmp/foo"
bitcoin in Runaway exception
```