### PR TITLE
build: disable BIP70 support by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_win64.sh"
 
     - stage: test
-      name: '32-bit + dash  [GOAL: install]  [GUI: no BIP70]'
+      name: '32-bit + dash  [GOAL: install]  [GUI: BIP70 enabled]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_i686.sh"
 

--- a/ci/test/00_setup_env_amd64_asan.sh
+++ b/ci/test/00_setup_env_amd64_asan.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export HOST=x86_64-unknown-linux-gnu
-export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-incompatible-bdb --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=address,integer,undefined CC=clang CXX=clang++"

--- a/ci/test/00_setup_env_amd64_qt5.sh
+++ b/ci/test/00_setup_env_amd64_qt5.sh
@@ -7,7 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export HOST=x86_64-unknown-linux-gnu
-export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
 export DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
 export TEST_RUNNER_EXTRA="--coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash
 export GOAL="install"

--- a/ci/test/00_setup_env_amd64_trusty.sh
+++ b/ci/test/00_setup_env_amd64_trusty.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export HOST=x86_64-unknown-linux-gnu
 export DOCKER_NAME_TAG=ubuntu:14.04
-export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libicu-dev libpng-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.1++-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libicu-dev libpng-dev libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.1++-dev libzmq3-dev libqrencode-dev"
 export NO_DEPENDS=1
 export RUN_FUNCTIONAL_TESTS=false
 export GOAL="install"

--- a/ci/test/00_setup_env_amd64_tsan.sh
+++ b/ci/test/00_setup_env_amd64_tsan.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 export HOST=x86_64-unknown-linux-gnu
 export DOCKER_NAME_TAG=ubuntu:16.04
-export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 export NO_DEPENDS=1
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --disable-wallet --with-gui=qt5 CPPFLAGS=-DDEBUG_LOCKORDER --with-sanitizers=thread --disable-hardening --disable-asm CC=clang CXX=clang++"

--- a/ci/test/00_setup_env_i686.sh
+++ b/ci/test/00_setup_env_i686.sh
@@ -9,5 +9,5 @@ export LC_ALL=C.UTF-8
 export HOST=i686-pc-linux-gnu
 export PACKAGES="g++-multilib python3-zmq"
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --disable-bip70 --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
+export BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-bip70 --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
 export CONFIG_SHELL="/bin/dash"

--- a/configure.ac
+++ b/configure.ac
@@ -223,10 +223,10 @@ AC_ARG_ENABLE([zmq],
   [use_zmq=$enableval],
   [use_zmq=yes])
 AC_ARG_ENABLE([bip70],
-  [AS_HELP_STRING([--disable-bip70],
-  [disable BIP70 (payment protocol) support in GUI (enabled by default)])],
+  [AS_HELP_STRING([--enable-bip70],
+  [enable BIP70 (payment protocol) support in the GUI (default is to disable)])],
   [enable_bip70=$enableval],
-  [enable_bip70=auto])
+  [enable_bip70=no])
 
 AC_ARG_WITH([protoc-bindir],[AS_HELP_STRING([--with-protoc-bindir=BIN_DIR],[specify protoc bin path])], [protoc_bin_path=$withval], [])
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -19,7 +19,7 @@ Then install [Homebrew](https://brew.sh).
 
 ## Dependencies
 ```shell
-brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf python qt libevent qrencode
+brew install automake berkeley-db4 libtool boost miniupnpc openssl pkg-config python qt libevent qrencode
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -112,11 +112,15 @@ To build without GUI pass `--without-gui`.
 
 To build with Qt 5 you need the following:
 
-    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools libprotobuf-dev protobuf-compiler
+    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
 
 libqrencode (optional) can be installed with:
 
     sudo apt-get install libqrencode-dev
+
+protobuf (optional) can be installed with:
+
+    sudo apt-get install libprotobuf-dev protobuf-compiler
 
 Once these are installed, they will be found by configure and a bitcoin-qt executable will be
 built by default.
@@ -140,11 +144,15 @@ ZMQ dependencies (provides ZMQ API):
 
 To build with Qt 5 you need the following:
 
-    sudo dnf install qt5-qttools-devel qt5-qtbase-devel protobuf-devel
+    sudo dnf install qt5-qttools-devel qt5-qtbase-devel
 
 libqrencode (optional) can be installed with:
 
     sudo dnf install qrencode-devel
+
+protobuf (optional) can be installed with:
+
+    sudo dnf install protobuf-devel
 
 Notes
 -----

--- a/doc/release-notes-15584.md
+++ b/doc/release-notes-15584.md
@@ -1,0 +1,4 @@
+GUI Changes
+-----------
+- In 0.18.0 a `./configure` flag was introduced to allow disabling BIP70 support in the GUI (support was enabled by default). In 0.19.0 this flag is now __disabled__ by default.
+- If you want compile Bitcoin Core with BIP70 support in the GUI, you can pass `--enable-bip70` to `./configure`.


### PR DESCRIPTION
Disable BIP70 support in the GUI by default for `0.19.0` (for eventual removal in `0.20.0`?). 

Users who want to compile with BIP70 support enabled can pass `--enable-bip70` to `./configure`.

I've inverted the current `--disable-bip70` test to instead pass `--enable-bip70`.

Tested configurations on `macOS` (`protobuf` installed with `brew`).
Protobuf available and `./configure`:
```
Options used to compile and link:
  with wallet   = yes
  with gui / qt = yes
    with bip70  = no
```

Protobuf available and `./configure --enable-bip70`:
```
Options used to compile and link:
  with wallet   = yes
  with gui / qt = yes
    with bip70  = yes
```

Protobuf not available (i.e `brew unlink protobuf`) and `./configure`:
```
Options used to compile and link:
  with wallet   = yes
  with gui / qt = yes
    with bip70  = no
```

Protobuf not available and `./configure --enable-bip70`:
```
checking whether to build test_bitcoin-qt... yes
checking whether to build BIP70 support... configure: error: protobuf missing
```

TODO:
- [x] Remove `protobuf` from other Travis builds
- [ ] Documentation updates (mention that `protobuf` is now optional)?
- [ ] Could split release notes into GUI and build