### PR TITLE
rpc: Actually use sendmany::minconf

### DIFF
--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -18,6 +18,7 @@ void CCoinControl::SetNull()
     fOverrideFeeRate = false;
     m_confirm_target.reset();
     m_signal_bip125_rbf.reset();
+    m_min_conf_depth.reset();
     m_fee_mode = FeeEstimateMode::UNSET;
 }
 

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -32,6 +32,8 @@ public:
     boost::optional<unsigned int> m_confirm_target;
     //! Override the wallet's m_signal_rbf if set
     boost::optional<bool> m_signal_bip125_rbf;
+    //! Only use coins confirmed at least this often
+    boost::optional<int> m_min_conf_depth;
     //! Avoid partial use of funds sent to a given address
     bool m_avoid_partial_spends;
     //! Fee estimation mode to control arguments to estimateSmartFee

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -155,6 +155,7 @@ BASE_SCRIPTS = [
     'rpc_signmessage.py',
     'wallet_balance.py',
     'feature_nulldummy.py',
+    'wallet_send.py',
     'mempool_accept.py',
     'wallet_import_rescan.py',
     'wallet_import_with_label.py',

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -24,7 +24,8 @@ class WalletRBFTest(BitcoinTestFramework):
         self.restart_node(0, extra_args=["-fallbackfee=0"])
         assert_raises_rpc_error(-4, "Fee estimation failed", lambda: self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1))
         assert_raises_rpc_error(-4, "Fee estimation failed", lambda: self.nodes[0].fundrawtransaction(self.nodes[0].createrawtransaction([], {self.nodes[0].getnewaddress(): 1})))
-        assert_raises_rpc_error(-6, "Fee estimation failed", lambda: self.nodes[0].sendmany("", {self.nodes[0].getnewaddress(): 1}))
+        assert_raises_rpc_error(-6, "Fee estimation failed", lambda: self.nodes[0].sendmany(minconf=0, amounts={self.nodes[0].getnewaddress(): 1}))
+
 
 if __name__ == '__main__':
     WalletRBFTest().main()

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the wallet send RPC methods."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error,
+)
+
+
+class WalletTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        # Check that nodes don't own any UTXOs
+        assert_equal(len(self.nodes[0].listunspent()), 0)
+        assert_equal(len(self.nodes[1].listunspent()), 0)
+
+        self.log.info("Mine blocks on node 1 and give two coins to wallet 0")
+
+        self.nodes[1].generate(101)
+        self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        self.nodes[1].generate(1)
+        self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        self.log.info("Check that we have two coins at different confirmation levels")
+        assert_equal(self.nodes[0].getbalance(), 2)
+        assert_equal({u['confirmations'] for u in self.nodes[0].listunspent()}, {1, 2})
+
+        self.log.info("Check that we only spend the older coin")
+        self.nodes[0].sendmany(amounts={self.nodes[1].getnewaddress(): 0.1}, minconf=2)
+        assert_equal({u['confirmations'] for u in self.nodes[0].listunspent()}, {1})
+
+        self.log.info("Check that sending more than we have fails")
+        assert_raises_rpc_error(-6, 'Insufficient funds', lambda: self.nodes[0].sendmany(minconf=0, amounts={self.nodes[1].getnewaddress(): 3}))
+
+
+if __name__ == '__main__':
+    WalletTest().main()


### PR DESCRIPTION
For the entirety of its history `sendmany::minconf` has always been ignored for the purpose of creating the transaction. It has only been used to exit early if "the balance confirmed at least this many times" is less than the total amount to send.

Fix that by actually passing it down via coincontrol.

This is a bugfix, but not a regression, so can go into 0.19.0.