### PR TITLE
[docs] release note for disabling reject messages by default

### DIFF
--- a/doc/release-notes-14054.md
+++ b/doc/release-notes-14054.md
@@ -1,0 +1,7 @@
+P2P changes
+-----------
+
+BIP 61 reject messages were deprecated in v0.18. They are now disabled by
+default, but can be enabled by setting the `-enablebip61` command line option.
+BIP 61 reject messages will be removed entirely in a future version of
+Bitcoin Core.


### PR DESCRIPTION
v0.18 deprecated BIP 61 REJECT messages.

v0.19 disables them by default (#14054). This adds a release note to document that.

BIP 61 REJECT messages will be removed entirely in a future version.