### PR TITLE
assumeutxo

### DIFF
--- a/contrib/devtools/test_utxo_snapshots.sh
+++ b/contrib/devtools/test_utxo_snapshots.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# Demonstrate the creation and usage of UTXO snapshots.
+#
+# A server node starts up, IBDs up to a certain height, then generates a UTXO
+# snapshot at that point.
+#
+# The server then downloads more blocks (to create a diff from the snapshot).
+#
+# We bring a client up, load the UTXO snapshot, and we show the client sync to
+# the "network tip" and then start a background validation of the snapshot it
+# loaded. We see the background validation chainstate removed after validation
+# completes.
+#
+
+export LC_ALL=C
+set -e
+
+BASE_HEIGHT=${1:-30000}
+INCREMENTAL_HEIGHT=20000
+FINAL_HEIGHT=$(("$BASE_HEIGHT" + "$INCREMENTAL_HEIGHT"))
+
+SERVER_DATADIR="$(pwd)/utxodemo-data-server-$BASE_HEIGHT"
+CLIENT_DATADIR="$(pwd)/utxodemo-data-client-$BASE_HEIGHT"
+UTXO_DAT_FILE="$(pwd)/utxo.$BASE_HEIGHT.dat"
+
+# Chosen to try to not interfere with any running bitcoind processes.
+SERVER_PORT=8633
+SERVER_RPC_PORT=8632
+
+CLIENT_PORT=8733
+CLIENT_RPC_PORT=8732
+
+SERVER_PORTS="-port=${SERVER_PORT} -rpcport=${SERVER_RPC_PORT}"
+CLIENT_PORTS="-port=${CLIENT_PORT} -rpcport=${CLIENT_RPC_PORT}"
+
+# Ensure the client exercises all indexes.
+ALL_INDEXES="-txindex -coinstatsindex -blockfilterindex=1"
+
+if ! command -v jq >/dev/null ; then
+  echo "This script requires jq to parse JSON RPC output. Please install it."
+  echo "(e.g. sudo apt install jq)"
+  exit 1
+fi
+
+finish() {
+  echo
+  echo "Killing server and client PIDs ($SERVER_PID, $CLIENT_PID) and cleaning up datadirs"
+  echo
+  rm -f "$UTXO_DAT_FILE" "$DUMP_OUTPUT"
+  rm -rf "$SERVER_DATADIR" "$CLIENT_DATADIR"
+  kill -9 "$SERVER_PID" "$CLIENT_PID"
+}
+
+trap finish EXIT
+
+# Need to specify these to trick client into accepting server as a peer
+# it can IBD from.
+CHAIN_HACK_FLAGS="-maxtipage=9223372036854775207 -minimumchainwork=0x00"
+
+server_rpc() {
+  ./src/bitcoin-cli -rpcport=$SERVER_RPC_PORT -datadir="$SERVER_DATADIR" "$@"
+}
+client_rpc() {
+  ./src/bitcoin-cli -rpcport=$CLIENT_RPC_PORT -datadir="$CLIENT_DATADIR" "$@"
+}
+server_sleep_til_boot() {
+  while ! server_rpc ping >/dev/null 2>&1; do sleep 0.1; done
+}
+client_sleep_til_boot() {
+  while ! client_rpc ping >/dev/null 2>&1; do sleep 0.1; done
+}
+
+mkdir -p "$SERVER_DATADIR" "$CLIENT_DATADIR"
+
+echo "Hi, welcome to the assumeutxo demo/test"
+echo
+echo "We're going to"
+echo
+echo "  - start up a 'server' node, sync it via mainnet IBD to height ${BASE_HEIGHT}"
+echo "  - create a UTXO snapshot at that height"
+echo "  - IBD ${INCREMENTAL_HEIGHT} more blocks on top of that"
+echo
+echo "then we'll demonstrate assumeutxo by "
+echo
+echo "  - starting another node (the 'client') and loading the snapshot in"
+echo "    * first you'll have to modify the code slightly (chainparams) and recompile"
+echo "    * don't worry, we'll make it easy"
+echo "  - observing the client sync ${INCREMENTAL_HEIGHT} blocks on top of the snapshot from the server"
+echo "  - observing the client validate the snapshot chain via background IBD"
+echo
+read -p "Press [enter] to continue" _
+
+echo
+echo "-- Starting the demo. You might want to run the two following commands in"
+echo "   separate terminal windows:"
+echo
+echo "   watch -n0.1 tail -n 30 $SERVER_DATADIR/debug.log"
+echo "   watch -n0.1 tail -n 30 $CLIENT_DATADIR/debug.log"
+echo
+read -p "Press [enter] to continue" _
+
+echo
+echo "-- IBDing the blocks (height=$BASE_HEIGHT) required to the server node..."
+./src/bitcoind -logthreadnames=1 $SERVER_PORTS \
+    -datadir="$SERVER_DATADIR" $CHAIN_HACK_FLAGS -stopatheight="$BASE_HEIGHT" >/dev/null
+
+echo
+echo "-- Creating snapshot at ~ height $BASE_HEIGHT ($UTXO_DAT_FILE)..."
+sleep 2
+./src/bitcoind -logthreadnames=1 $SERVER_PORTS \
+    -datadir="$SERVER_DATADIR" $CHAIN_HACK_FLAGS -connect=0 -listen=0 >/dev/null &
+SERVER_PID="$!"
+
+DUMP_OUTPUT="dumptxoutset-output-$BASE_HEIGHT.json"
+
+server_sleep_til_boot
+server_rpc dumptxoutset "$UTXO_DAT_FILE" > "$DUMP_OUTPUT"
+cat "$DUMP_OUTPUT"
+kill -9 "$SERVER_PID"
+
+RPC_BASE_HEIGHT=$(jq -r .base_height < "$DUMP_OUTPUT")
+RPC_AU=$(jq -r .txoutset_hash < "$DUMP_OUTPUT")
+RPC_NCHAINTX=$(jq -r .nchaintx < "$DUMP_OUTPUT")
+
+# Wait for server to shutdown...
+while server_rpc ping >/dev/null 2>&1; do sleep 0.1; done
+
+echo
+echo "-- Now: add the following to CMainParams::m_assumeutxo_data"
+echo "   in src/kernel/chainparams.cpp, and recompile:"
+echo
+echo "     {"
+echo "         ${RPC_BASE_HEIGHT},"
+echo "         {AssumeutxoHash{uint256S(\"0x${RPC_AU}\")}, ${RPC_NCHAINTX}},"
+echo "     },"
+echo
+echo
+echo "-- IBDing more blocks to the server node (height=$FINAL_HEIGHT) so there is a diff between snapshot and tip..."
+./src/bitcoind $SERVER_PORTS -logthreadnames=1 -datadir="$SERVER_DATADIR" \
+    $CHAIN_HACK_FLAGS -stopatheight="$FINAL_HEIGHT" >/dev/null
+
+echo
+echo "-- Staring the server node to provide blocks to the client node..."
+./src/bitcoind $SERVER_PORTS -logthreadnames=1 -debug=net -datadir="$SERVER_DATADIR" \
+    $CHAIN_HACK_FLAGS -connect=0 -listen=1 >/dev/null &
+SERVER_PID="$!"
+server_sleep_til_boot
+
+echo
+echo "-- Okay, what you're about to see is the client starting up and activating the snapshot."
+echo "   I'm going to display the top 14 log lines from the client on top of an RPC called"
+echo "   getchainstates, which is like getblockchaininfo but for both the snapshot and "
+echo "   background validation chainstates."
+echo
+echo "   You're going to first see the snapshot chainstate sync to the server's tip, then"
+echo "   the background IBD chain kicks in to validate up to the base of the snapshot."
+echo
+echo "   Once validation of the snapshot is done, you should see log lines indicating"
+echo "   that we've deleted the background validation chainstate."
+echo
+echo "   Once everything completes, exit the watch command with CTRL+C."
+echo
+read -p "When you're ready for all this, hit [enter]" _
+
+echo
+echo "-- Starting the client node to get headers from the server, then load the snapshot..."
+./src/bitcoind $CLIENT_PORTS $ALL_INDEXES -logthreadnames=1 -datadir="$CLIENT_DATADIR" \
+    -connect=0 -addnode=127.0.0.1:$SERVER_PORT -debug=net $CHAIN_HACK_FLAGS >/dev/null &
+CLIENT_PID="$!"
+client_sleep_til_boot
+
+echo
+echo "-- Initial state of the client:"
+client_rpc getchainstates
+
+echo
+echo "-- Loading UTXO snapshot into client..."
+client_rpc loadtxoutset "$UTXO_DAT_FILE"
+
+watch -n 0.3 "( tail -n 14 $CLIENT_DATADIR/debug.log ; echo ; ./src/bitcoin-cli -rpcport=$CLIENT_RPC_PORT -datadir=$CLIENT_DATADIR getchainstates) | cat"
+
+echo
+echo "-- Okay, now I'm going to restart the client to make sure that the snapshot chain reloads "
+echo "   as the main chain properly..."
+echo
+echo "   Press CTRL+C after you're satisfied to exit the demo"
+echo
+read -p "Press [enter] to continue"
+
+while kill -0 "$CLIENT_PID"; do
+    sleep 1
+done
+./src/bitcoind $CLIENT_PORTS $ALL_INDEXES -logthreadnames=1 -datadir="$CLIENT_DATADIR" -connect=0 \
+    -addnode=127.0.0.1:$SERVER_PORT "$CHAIN_HACK_FLAGS" >/dev/null &
+CLIENT_PID="$!"
+client_sleep_til_boot
+
+watch -n 0.3 "( tail -n 14 $CLIENT_DATADIR/debug.log ; echo ; ./src/bitcoin-cli -rpcport=$CLIENT_RPC_PORT -datadir=$CLIENT_DATADIR getchainstates) | cat"
+
+echo
+echo "-- Done!"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -43,6 +43,11 @@ Release Process
     - On mainnet, the selected value must not be orphaned, so it may be useful to set the height two blocks back from the tip.
     - Testnet should be set with a height some tens of thousands back from the tip, due to reorgs there.
   - `nMinimumChainWork` with the "chainwork" value of RPC `getblockheader` using the same height as that selected for the previous step.
+  - `m_assumeutxo_data` with the updated assumeutxo hash and nChainTx count.
+    - You can obtain this information, and the corresponding snapshot, by running
+      `./contrib/devtools/utxo_snapshot.sh <blockheight> <snapshot-out-path>`.
+    - The height used should probably the be same as the assumevalid height chosen.
+    - Ensure the resulting snapshot is uploaded somewhere publicly accessible (torrent, HTTP server, etc.).
 - Clear the release notes and move them to the wiki (see "Write the release notes" below).
 - Translations on Transifex:
     - Pull translations from Transifex into the master branch.

--- a/src/bench/wallet_create_tx.cpp
+++ b/src/bench/wallet_create_tx.cpp
@@ -70,7 +70,7 @@ void generateFakeBlock(const CChainParams& params,
 
     // notify wallet
     const auto& pindex = WITH_LOCK(::cs_main, return context.chainman->ActiveChain().Tip());
-    wallet.blockConnected(kernel::MakeBlockInfo(pindex, &block));
+    wallet.blockConnected(ChainstateRole::NORMAL, kernel::MakeBlockInfo(pindex, &block));
 }
 
 struct PreSelectInputs {

--- a/src/bitcoin-chainstate.cpp
+++ b/src/bitcoin-chainstate.cpp
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
             explicit submitblock_StateCatcher(const uint256& hashIn) : hash(hashIn), found(false), state() {}
 
         protected:
-            void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override
+            void BlockChecked(const ChainstateRole role, const CBlock& block, const BlockValidationState& stateIn) override
             {
                 if (block.GetHash() != hash)
                     return;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -90,7 +90,8 @@ bool BaseIndex::Init()
     }
 
     LOCK(cs_main);
-    CChain& active_chain = m_chainstate->m_chain;
+    CChain& index_chain = m_chainstate->m_chain;
+
     if (locator.IsNull()) {
         SetBestBlockIndex(nullptr);
     } else {
@@ -100,24 +101,25 @@ bool BaseIndex::Init()
     // Note: this will latch to true immediately if the user starts up with an empty
     // datadir and an index enabled. If this is the case, indexation will happen solely
     // via `BlockConnected` signals until, possibly, the next restart.
-    m_synced = m_best_block_index.load() == active_chain.Tip();
+    m_synced = m_best_block_index.load() == index_chain.Tip();
     if (!m_synced) {
         bool prune_violation = false;
         if (!m_best_block_index) {
             // index is not built yet
             // make sure we have all block data back to the genesis
-            prune_violation = m_chainstate->m_blockman.GetFirstStoredBlock(*active_chain.Tip()) != active_chain.Genesis();
+            prune_violation = m_chainstate->m_blockman.GetFirstStoredBlock(
+                *index_chain.Tip()) != index_chain.Genesis();
         }
         // in case the index has a best block set and is not fully synced
         // check if we have the required blocks to continue building the index
         else {
             const CBlockIndex* block_to_test = m_best_block_index.load();
-            if (!active_chain.Contains(block_to_test)) {
+            if (!index_chain.Contains(block_to_test)) {
                 // if the bestblock is not part of the mainchain, find the fork
                 // and make sure we have all data down to the fork
-                block_to_test = active_chain.FindFork(block_to_test);
+                block_to_test = index_chain.FindFork(block_to_test);
             }
-            const CBlockIndex* block = active_chain.Tip();
+            const CBlockIndex* block = index_chain.Tip();
             prune_violation = true;
             // check backwards from the tip if we have all block data until we reach the indexes bestblock
             while (block_to_test && block && (block->nStatus & BLOCK_HAVE_DATA)) {
@@ -165,6 +167,8 @@ void BaseIndex::ThreadSync()
         std::chrono::steady_clock::time_point last_locator_write_time{0s};
         while (true) {
             if (m_interrupt) {
+                LogPrintf("%s: m_interrupt set; exiting ThreadSync\n", GetName());
+
                 SetBestBlockIndex(pindex);
                 // No need to handle errors in Commit. If it fails, the error will be already be
                 // logged. The best way to recover is to continue, as index cannot be corrupted by
@@ -274,6 +278,17 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
 
 void BaseIndex::BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
 {
+    // Ignore events from the assumed-valid chain; we will process its blocks
+    // (sequentially) after it is fully verified by the background chainstate. This
+    // is to avoid any out-of-order indexation.
+    //
+    // TODO at some point we could parameterize whether a particular index can be
+    // built out of order, but for now just do the conservative simple thing.
+    if (role == ChainstateRole::ASSUMEDVALID) {
+        return;
+    }
+
+    // Ignore BlockConnected signals until we have fully indexed the chain.
     if (!m_synced) {
         return;
     }
@@ -320,6 +335,12 @@ void BaseIndex::BlockConnected(const ChainstateRole role, const std::shared_ptr<
 
 void BaseIndex::ChainStateFlushed(const ChainstateRole role, const CBlockLocator& locator)
 {
+    // Ignore events from the assumed-valid chain; we will process its blocks
+    // (sequentially) after it is fully verified by the background chainstate.
+    if (role == ChainstateRole::ASSUMEDVALID) {
+        return;
+    }
+
     if (!m_synced) {
         return;
     }
@@ -388,9 +409,15 @@ void BaseIndex::Interrupt()
 
 bool BaseIndex::Start()
 {
+    AssertLockNotHeld(cs_main);
+
+    // May need reset if index is being restarted.
+    m_interrupt.reset();
+
     // m_chainstate member gives indexing code access to node internals. It is
     // removed in followup https://github.com/bitcoin/bitcoin/pull/24230
-    m_chainstate = &m_chain->context()->chainman->ActiveChainstate();
+    m_chainstate = WITH_LOCK(::cs_main,
+        return &m_chain->context()->chainman->GetChainstateForIndexing());
     // Need to register this ValidationInterface before running Init(), so that
     // callbacks are not missed if Init sets m_synced to true.
     RegisterValidationInterface(this);

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -272,7 +272,7 @@ bool BaseIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_ti
     return true;
 }
 
-void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
+void BaseIndex::BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
 {
     if (!m_synced) {
         return;
@@ -318,7 +318,7 @@ void BaseIndex::BlockConnected(const std::shared_ptr<const CBlock>& block, const
     }
 }
 
-void BaseIndex::ChainStateFlushed(const CBlockLocator& locator)
+void BaseIndex::ChainStateFlushed(const ChainstateRole role, const CBlockLocator& locator)
 {
     if (!m_synced) {
         return;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -15,6 +15,7 @@
 class CBlock;
 class CBlockIndex;
 class Chainstate;
+class ChainstateManager;
 namespace interfaces {
 class Chain;
 } // namespace interfaces
@@ -29,6 +30,11 @@ struct IndexSummary {
  * Base class for indices of blockchain data. This implements
  * CValidationInterface and ensures blocks are indexed sequentially according
  * to their position in the active chain.
+ *
+ * In the presence of multiple chainstates (i.e. if a UTXO snapshot is loaded),
+ * only the background "IBD" chainstate will be indexed to avoid building the
+ * index out of order. When the background chainstate completes validation, the
+ * index will be reinitialized and indexation will continue.
  */
 class BaseIndex : public CValidationInterface
 {
@@ -119,9 +125,6 @@ protected:
 
     virtual DB& GetDB() const = 0;
 
-    /// Get the name of the index for display in logs.
-    const std::string& GetName() const LIFETIMEBOUND { return m_name; }
-
     /// Update the internal best block index as well as the prune lock.
     void SetBestBlockIndex(const CBlockIndex* block);
 
@@ -129,6 +132,9 @@ public:
     BaseIndex(std::unique_ptr<interfaces::Chain> chain, std::string name);
     /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
+
+    /// Get the name of the index for display in logs.
+    const std::string& GetName() const LIFETIMEBOUND { return m_name; }
 
     /// Blocks the current thread until the index is caught up to the current
     /// state of the block chain. This only blocks if the index has gotten in

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -99,9 +99,9 @@ protected:
     Chainstate* m_chainstate{nullptr};
     const std::string m_name;
 
-    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
+    void BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override;
 
-    void ChainStateFlushed(const CBlockLocator& locator) override;
+    void ChainStateFlushed(const ChainstateRole role, const CBlockLocator& locator) override;
 
     /// Initialize internal state from the database and block index.
     [[nodiscard]] virtual bool CustomInit(const std::optional<interfaces::BlockKey>& block) { return true; }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1523,7 +1523,9 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
             }
         }
 
-        if (status == node::ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB || status == node::ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE) {
+        if (status == node::ChainstateLoadStatus::FAILURE_INCOMPATIBLE_DB ||
+                status == node::ChainstateLoadStatus::FAILURE_INSUFFICIENT_DBCACHE ||
+                status == node::ChainstateLoadStatus::FAILURE_NO_REINDEX) {
             return InitError(error);
         }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1574,13 +1574,16 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!g_txindex->Start()) {
             return false;
         }
+        chainman.indexers.push_back(g_txindex.get());
     }
 
     for (const auto& filter_type : g_enabled_filter_types) {
         InitBlockFilterIndex([&]{ return interfaces::MakeChain(node); }, filter_type, cache_sizes.filter_index, false, fReindex);
-        if (!GetBlockFilterIndex(filter_type)->Start()) {
+        auto* bfindex = GetBlockFilterIndex(filter_type);
+        if (!bfindex->Start()) {
             return false;
         }
+        chainman.indexers.push_back(bfindex);
     }
 
     if (args.GetBoolArg("-coinstatsindex", DEFAULT_COINSTATSINDEX)) {
@@ -1588,6 +1591,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         if (!g_coin_stats_index->Start()) {
             return false;
         }
+        chainman.indexers.push_back(g_coin_stats_index.get());
     }
 
     // ********************************************************* Step 9: load wallet

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -27,6 +27,7 @@ class Coin;
 class uint256;
 enum class MemPoolRemovalReason;
 enum class RBFTransactionState;
+enum class ChainstateRole;
 struct bilingual_str;
 struct CBlockLocator;
 struct FeeCalculation;
@@ -271,9 +272,10 @@ public:
         virtual void transactionAddedToMempool(const CTransactionRef& tx) {}
         virtual void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {}
         virtual void blockConnected(const BlockInfo& block) {}
+        virtual void blockConnected(const ChainstateRole role, const BlockInfo& block) {}
         virtual void blockDisconnected(const BlockInfo& block) {}
-        virtual void updatedBlockTip() {}
-        virtual void chainStateFlushed(const CBlockLocator& locator) {}
+        virtual void updatedBlockTip(const ChainstateRole role) {}
+        virtual void chainStateFlushed(const ChainstateRole role, const CBlockLocator& locator) {}
     };
 
     //! Register handler for notifications.

--- a/src/kernel/chain.h
+++ b/src/kernel/chain.h
@@ -14,6 +14,22 @@ struct BlockInfo;
 namespace kernel {
 //! Return data from block index.
 interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* block_index, const CBlock* data = nullptr);
+
 } // namespace kernel
+
+//! This enum describes the various roles a specific Chainstate instance can take.
+//! Other parts of the system sometimes need to vary in behavior depending on the
+//! existence of a background validation chainstate, e.g. when building indexes.
+enum class ChainstateRole {
+    // Single chainstate in use, "normal" IBD mode.
+    NORMAL,
+
+    // Doing IBD-style validation in the background. Implies use of an assumed-valid
+    // chainstate.
+    BACKGROUND,
+
+    // Active assumed-valid chainstate. Implies use of a background IBD chainstate.
+    ASSUMEDVALID,
+};
 
 #endif // BITCOIN_KERNEL_CHAIN_H

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -174,7 +174,10 @@ public:
         };
 
         m_assumeutxo_data = MapAssumeutxo{
-         // TODO to be specified in a future patch.
+            {
+                788'000,
+                {AssumeutxoHash{uint256S("0xc5b9112c9260c9978c8df20b6500a074a6d416a1a1ad41ebfb83e4da12c40e49")}, 831210063},
+            },
         };
 
         chainTxData = ChainTxData{

--- a/src/kernel/chainparams.cpp
+++ b/src/kernel/chainparams.cpp
@@ -493,6 +493,11 @@ public:
                 200,
                 {AssumeutxoHash{uint256S("0x51c8d11d8b5c1de51543c579736e786aa2736206d1e11e627568029ce092cf62")}, 200},
             },
+            {
+                // For use by test/functional/feature_assumeutxo.py
+                299,
+                {AssumeutxoHash{uint256S("0xef45ccdca5898b6c2145e4581d2b88c56564dd389e4bd75a1aaf6961d3edd3c0")}, 300},
+            },
         };
 
         chainTxData = ChainTxData{

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -951,6 +951,11 @@ private:
     void ProcessBlockAvailability(NodeId nodeid) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     /** Update tracking information about which blocks a peer is assumed to have. */
     void UpdateBlockAvailability(NodeId nodeid, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Allow the direct fetch of block data if our tip is recent within the past
+     * 200 minutes.
+     */
     bool CanDirectFetch() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -18,6 +18,7 @@
 #include <headerssync.h>
 #include <index/blockfilterindex.h>
 #include <kernel/mempool_entry.h>
+#include <kernel/chain.h>
 #include <merkleblock.h>
 #include <netbase.h>
 #include <netmessagemaker.h>
@@ -506,15 +507,15 @@ public:
                     CTxMemPool& pool, bool ignore_incoming_txs);
 
     /** Overridden from CValidationInterface. */
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override
+    void BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_recent_confirmed_transactions_mutex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex* pindex) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_recent_confirmed_transactions_mutex);
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override
+    void UpdatedBlockTip(const ChainstateRole role, const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    void BlockChecked(const CBlock& block, const BlockValidationState& state) override
+    void BlockChecked(const ChainstateRole role, const CBlock& block, const BlockValidationState& state) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
-    void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override
+    void NewPoWValidBlock(const ChainstateRole role, const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_most_recent_block_mutex);
 
     /** Implement NetEventsInterface */
@@ -1870,7 +1871,10 @@ void PeerManagerImpl::StartScheduledTasks(CScheduler& scheduler)
  * announcements for them. Also save the time of the last tip update and
  * possibly reduce dynamic block stalling timeout.
  */
-void PeerManagerImpl::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindex)
+void PeerManagerImpl::BlockConnected(
+    const ChainstateRole role,
+    const std::shared_ptr<const CBlock>& pblock,
+    const CBlockIndex* pindex)
 {
     m_orphanage.EraseForBlock(*pblock);
     m_last_tip_update = GetTime<std::chrono::seconds>();
@@ -1921,7 +1925,10 @@ void PeerManagerImpl::BlockDisconnected(const std::shared_ptr<const CBlock> &blo
  * Maintain state about the best-seen block and fast-announce a compact block
  * to compatible peers.
  */
-void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock)
+void PeerManagerImpl::NewPoWValidBlock(
+    const ChainstateRole role,
+    const CBlockIndex *pindex,
+    const std::shared_ptr<const CBlock>& pblock)
 {
     auto pcmpctblock = std::make_shared<const CBlockHeaderAndShortTxIDs>(*pblock);
     const CNetMsgMaker msgMaker(PROTOCOL_VERSION);
@@ -1970,7 +1977,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
  * Update our best height and announce any block hashes which weren't previously
  * in the active chain to our peers.
  */
-void PeerManagerImpl::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
+void PeerManagerImpl::UpdatedBlockTip(const ChainstateRole role, const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
     SetBestHeight(pindexNew->nHeight);
     SetServiceFlagsIBDCache(!fInitialDownload);
@@ -2009,7 +2016,7 @@ void PeerManagerImpl::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlock
  * Handle invalid block rejection and consequent peer discouragement, maintain which
  * peers announce compact blocks.
  */
-void PeerManagerImpl::BlockChecked(const CBlock& block, const BlockValidationState& state)
+void PeerManagerImpl::BlockChecked(const ChainstateRole role, const CBlock& block, const BlockValidationState& state)
 {
     LOCK(cs_main);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1876,8 +1876,14 @@ void PeerManagerImpl::BlockConnected(
     const std::shared_ptr<const CBlock>& pblock,
     const CBlockIndex* pindex)
 {
-    m_orphanage.EraseForBlock(*pblock);
+    // Update this for all chainstate roles so that we don't mistakenly see peers
+    // helping us do background IBD as having a stale tip.
     m_last_tip_update = GetTime<std::chrono::seconds>();
+
+    if (role == ChainstateRole::BACKGROUND) {
+        return;
+    }
+    m_orphanage.EraseForBlock(*pblock);
 
     {
         LOCK(m_recent_confirmed_transactions_mutex);
@@ -1979,6 +1985,9 @@ void PeerManagerImpl::NewPoWValidBlock(
  */
 void PeerManagerImpl::UpdatedBlockTip(const ChainstateRole role, const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
+    if (role == ChainstateRole::BACKGROUND) {
+        return;
+    }
     SetBestHeight(pindexNew->nHeight);
     SetServiceFlagsIBDCache(!fInitialDownload);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -5224,9 +5224,10 @@ void PeerManagerImpl::MaybeSendAddr(CNode& node, Peer& peer, std::chrono::micros
     if (!peer.m_addr_relay_enabled) return;
 
     LOCK(peer.m_addr_send_times_mutex);
+    const bool is_ibd{WITH_LOCK(::cs_main, return m_chainman.IsAnyChainInIBD())};
+
     // Periodically advertise our local address to the peer.
-    if (fListen && !m_chainman.ActiveChainstate().IsInitialBlockDownload() &&
-        peer.m_next_local_addr_send < current_time) {
+    if (fListen && !is_ibd && peer.m_next_local_addr_send < current_time) {
         // If we've sent before, clear the bloom filter for the peer, so that our
         // self-announcement will actually go out.
         // This might be unnecessary if the bloom filter has already rolled

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -423,8 +423,18 @@ struct CNodeState {
     const CBlockIndex* pindexBestKnownBlock{nullptr};
     //! The hash of the last unknown block this peer has announced.
     uint256 hashLastUnknownBlock{};
-    //! The last full block we both have.
-    const CBlockIndex* pindexLastCommonBlock{nullptr};
+
+    //! The last full block we both have (per chainstate).
+    //!
+    //! This is namespaced by chainstate to allow syncing two separate chainstates
+    //! simultaneously from a single peer.
+    //!
+    //! Nota bene: this is contingent on the ChainstateManager not destructing
+    //! any Chainstate objects which were in use at any point (e.g. a background
+    //! validation chainstate which has completed) until the end of
+    //! init.cpp:Shutdown(), else we'll have bad pointers here.
+    std::map<const Chainstate*, const CBlockIndex*> m_chainstate_to_last_common_block = {};
+
     //! The best header we have sent our peer.
     const CBlockIndex* pindexBestHeaderSent{nullptr};
     //! Whether we've started headers synchronization with this peer.
@@ -894,10 +904,15 @@ private:
 
     bool TipMayBeStale() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    /** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
-     *  at most count entries.
+    /** Update m_chainstate_to_last_common_block and add not-in-flight missing successors
+     * to vBlocks, until it has at most count entries.
      */
-    void FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    void FindNextBlocksToDownload(
+        const Chainstate& chainstate,
+        const Peer& peer,
+        unsigned int count,
+        std::vector<const CBlockIndex*>& vBlocks,
+        NodeId& nodeStaller) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight GUARDED_BY(cs_main);
 
@@ -1301,7 +1316,12 @@ void PeerManagerImpl::UpdateBlockAvailability(NodeId nodeid, const uint256 &hash
     }
 }
 
-void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int count, std::vector<const CBlockIndex*>& vBlocks, NodeId& nodeStaller)
+void PeerManagerImpl::FindNextBlocksToDownload(
+    const Chainstate& chainstate,
+    const Peer& peer,
+    unsigned int count,
+    std::vector<const CBlockIndex*>& vBlocks,
+    NodeId& nodeStaller)
 {
     if (count == 0)
         return;
@@ -1313,31 +1333,44 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
     ProcessBlockAvailability(peer.m_id);
 
-    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->nChainWork < m_chainman.ActiveChain().Tip()->nChainWork || state->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
+    const CChain& our_chain = chainstate.m_chain;
+    const CBlockIndex* our_tip = our_chain.Tip();
+
+    if (state->pindexBestKnownBlock == nullptr
+            || state->pindexBestKnownBlock->nChainWork < our_tip->nChainWork
+            || state->pindexBestKnownBlock->nChainWork < m_chainman.MinimumChainWork()) {
         // This peer has nothing interesting.
         return;
     }
 
-    if (state->pindexLastCommonBlock == nullptr) {
+    if (!state->m_chainstate_to_last_common_block.count(&chainstate)) {
         // Bootstrap quickly by guessing a parent of our best tip is the forking point.
         // Guessing wrong in either direction is not a problem.
-        state->pindexLastCommonBlock = m_chainman.ActiveChain()[std::min(state->pindexBestKnownBlock->nHeight, m_chainman.ActiveChain().Height())];
+        //
+        // Namespace this by chainstate so that we can simultaneously sync two
+        // separate chainstates at different heights.
+        state->m_chainstate_to_last_common_block[&chainstate] = our_chain[
+            std::min(state->pindexBestKnownBlock->nHeight, our_chain.Height())];
     }
 
-    // If the peer reorganized, our previous pindexLastCommonBlock may not be an ancestor
+    const CBlockIndex*& last_common_block =  state->m_chainstate_to_last_common_block[&chainstate];
+
+    // If the peer reorganized, our previous m_chainstate_to_last_common_block may not be an ancestor
     // of its current tip anymore. Go back enough to fix that.
-    state->pindexLastCommonBlock = LastCommonAncestor(state->pindexLastCommonBlock, state->pindexBestKnownBlock);
-    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
+    last_common_block = LastCommonAncestor(last_common_block, state->pindexBestKnownBlock);
+    if (last_common_block == state->pindexBestKnownBlock) {
         return;
+    }
 
     std::vector<const CBlockIndex*> vToFetch;
-    const CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
+    const CBlockIndex *pindexWalk = last_common_block;
     // Never fetch further than the best block we know the peer has, or more than BLOCK_DOWNLOAD_WINDOW + 1 beyond the last
     // linked block we have in common with this peer. The +1 is so we can detect stalling, namely if we would be able to
     // download that next block if the window were 1 larger.
-    int nWindowEnd = state->pindexLastCommonBlock->nHeight + BLOCK_DOWNLOAD_WINDOW;
+    int nWindowEnd = pindexWalk->nHeight + BLOCK_DOWNLOAD_WINDOW;
     int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
     NodeId waitingfor = -1;
+
     while (pindexWalk->nHeight < nMaxHeight) {
         // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
         // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
@@ -1352,7 +1385,7 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
 
         // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
         // are not yet downloaded and not in flight to vBlocks. In the meantime, update
-        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
+        // m_chainstate_to_last_common_block as long as all ancestors are already downloaded, or if it's
         // already part of our chain (and therefore don't need it even if pruned).
         for (const CBlockIndex* pindex : vToFetch) {
             if (!pindex->IsValid(BLOCK_VALID_TREE)) {
@@ -1363,9 +1396,9 @@ void PeerManagerImpl::FindNextBlocksToDownload(const Peer& peer, unsigned int co
                 // We wouldn't download this block or its descendants from this peer.
                 return;
             }
-            if (pindex->nStatus & BLOCK_HAVE_DATA || m_chainman.ActiveChain().Contains(pindex)) {
+            if (pindex->nStatus & BLOCK_HAVE_DATA || our_chain.Contains(pindex)) {
                 if (pindex->HaveTxsDownloaded())
-                    state->pindexLastCommonBlock = pindex;
+                    last_common_block = pindex;
             } else if (!IsBlockRequested(pindex->GetBlockHash())) {
                 // The block is not already downloaded, and not yet in flight.
                 if (pindex->nHeight > nWindowEnd) {
@@ -1577,7 +1610,15 @@ bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) c
         if (state == nullptr)
             return false;
         stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
-        stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
+        stats.nCommonHeight = -1;
+
+        // Take the max common height with this peer across chainstates.
+        for (const auto& it : state->m_chainstate_to_last_common_block) {
+            const CBlockIndex* block = it.second;
+            if (block && block->nHeight > stats.nCommonHeight) {
+                stats.nCommonHeight = block->nHeight;
+            }
+        }
         for (const QueuedBlock& queue : state->vBlocksInFlight) {
             if (queue.pindex)
                 stats.vHeightInFlight.push_back(queue.pindex->nHeight);
@@ -1927,7 +1968,7 @@ void PeerManagerImpl::NewPoWValidBlock(const CBlockIndex *pindex, const std::sha
 
 /**
  * Update our best height and announce any block hashes which weren't previously
- * in m_chainman.ActiveChain() to our peers.
+ * in the active chain to our peers.
  */
 void PeerManagerImpl::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
@@ -5808,21 +5849,41 @@ bool PeerManagerImpl::SendMessages(CNode* pto)
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (CanServeBlocks(*peer) && ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(*peer)) || !m_chainman.ActiveChainstate().IsInitialBlockDownload()) && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
-            std::vector<const CBlockIndex*> vToDownload;
-            NodeId staller = -1;
-            FindNextBlocksToDownload(*peer, MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller);
-            for (const CBlockIndex *pindex : vToDownload) {
-                uint32_t nFetchFlags = GetFetchFlags(*peer);
-                vGetData.push_back(CInv(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash()));
-                BlockRequested(pto->GetId(), *pindex);
-                LogPrint(BCLog::NET, "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
-                    pindex->nHeight, pto->GetId());
-            }
-            if (state.nBlocksInFlight == 0 && staller != -1) {
-                if (State(staller)->m_stalling_since == 0us) {
-                    State(staller)->m_stalling_since = current_time;
-                    LogPrint(BCLog::NET, "Stall started peer=%d\n", staller);
+
+        // The first chainstate in line for processing will likely exhaust this
+        // during IBD, but once it hits a tip capacity will trickle into subsequent
+        // chainstates.
+        unsigned int requests_available{
+            state.nBlocksInFlight > MAX_BLOCKS_IN_TRANSIT_PER_PEER ?
+                0U :
+                static_cast<unsigned int>(MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight)};
+
+        // GetAllForBlockDownload() ensures we get blocks for the snapshot
+        // chainstate first. It is more important to get to the network's tip
+        // quickly than do the background validation on the snapshot.
+        for (const auto* const chainstate : m_chainman.GetAllForBlockDownload()) {
+            if (CanServeBlocks(*peer) &&
+                    ((sync_blocks_and_headers_from_peer && !IsLimitedPeer(*peer))
+                     || !chainstate->IsInitialBlockDownload())
+                    && state.nBlocksInFlight < MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
+                std::vector<const CBlockIndex*> vToDownload;
+                NodeId staller = -1;
+                FindNextBlocksToDownload(*chainstate, *peer, requests_available, vToDownload, staller);
+
+                for (const CBlockIndex *pindex : vToDownload) {
+                    uint32_t nFetchFlags = GetFetchFlags(*peer);
+                    vGetData.push_back(CInv(MSG_BLOCK | nFetchFlags, pindex->GetBlockHash()));
+                    BlockRequested(pto->GetId(), *pindex);
+                    LogPrint(BCLog::NET, "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
+                        pindex->nHeight, pto->GetId());
+                }
+
+                requests_available -= vToDownload.size();
+                if (state.nBlocksInFlight == 0 && staller != -1) {
+                    if (State(staller)->m_stalling_since == 0us) {
+                        State(staller)->m_stalling_since = current_time;
+                        LogPrint(BCLog::NET, "Stall started peer=%d\n", staller);
+                    }
                 }
             }
         }

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -29,6 +29,7 @@ class CChain;
 class CChainParams;
 class Chainstate;
 class ChainstateManager;
+enum class ChainstateRole;
 struct CCheckpointData;
 struct FlatFilePos;
 namespace Consensus {
@@ -97,7 +98,12 @@ private:
     bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
 
     /* Calculate the block/rev files to delete based on height specified by user with RPC command pruneblockchain */
-    void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight, int chain_tip_height);
+    void FindFilesToPruneManual(
+        std::set<int>& setFilesToPrune,
+        int nManualPruneHeight,
+        int chain_tip_height,
+        const Chainstate& chain,
+        ChainstateManager& chainman);
 
     /**
      * Prune block and undo files (blk???.dat and rev???.dat) so that the disk space used is less than a user-defined target.
@@ -114,7 +120,13 @@ private:
      *
      * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned
      */
-    void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight, int chain_tip_height, int prune_height, bool is_ibd);
+    void FindFilesToPrune(
+        std::set<int>& setFilesToPrune,
+        uint64_t nPruneAfterHeight,
+        int chain_tip_height,
+        int prune_height,
+        const Chainstate& chain,
+        ChainstateManager& chainman);
 
     RecursiveMutex cs_LastBlockFile;
     std::vector<CBlockFileInfo> m_blockfile_info;

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -70,6 +70,13 @@ struct PruneLockInfo {
     int height_first{std::numeric_limits<int>::max()}; //! Height of earliest block that should be kept and not pruned
 };
 
+enum class ChainType {
+    // For the purposes of blockfile fragmentation, treat background IBD chainstates
+    // as normal.
+    NORMAL,
+    ASSUMED,
+};
+
 /**
  * Maintains a tree of blocks (stored in `m_block_index`) which is consulted
  * to determine where the most-work tip is.
@@ -92,9 +99,10 @@ private:
      */
     bool LoadBlockIndex()
         EXCLUSIVE_LOCKS_REQUIRED(cs_main);
-    void FlushBlockFile(bool fFinalize = false, bool finalize_undo = false);
+    void FlushBlockFile(int blockfile_num, bool fFinalize = false, bool finalize_undo = false);
+    void FlushChainstateBlockFile(const Chainstate& chainstate, bool fFinalize = false, bool finalize_undo = false);
     void FlushUndoFile(int block_file, bool finalize = false);
-    bool FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, CChain& active_chain, uint64_t nTime, bool fKnown);
+    bool FindBlockPos(FlatFilePos& pos, unsigned int nAddSize, unsigned int nHeight, const Chainstate& chainstate, uint64_t nTime, bool fKnown) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool FindUndoPos(BlockValidationState& state, int nFile, FlatFilePos& pos, unsigned int nAddSize);
 
     /* Calculate the block/rev files to delete based on height specified by user with RPC command pruneblockchain */
@@ -130,7 +138,26 @@ private:
 
     RecursiveMutex cs_LastBlockFile;
     std::vector<CBlockFileInfo> m_blockfile_info;
-    int m_last_blockfile = 0;
+
+    //! Since assumedvalid chainstates may be syncing a range of the chain that is very
+    //! far away from the normal/background validation process, we should segment blockfiles
+    //! for assumed chainstates. Otherwise, we might have wildly different height ranges
+    //! mixed into the same block files, which would impair our ability to prune
+    //! effectively.
+    //!
+    //! This data structure maintains separate blockfile number cursors for each
+    //! ChainType. The ASSUMED state is initialized, when necessary, in FindBlockPos().
+    std::map<ChainType, std::optional<int>> m_blockfile_cursors GUARDED_BY(cs_LastBlockFile) = {
+        {ChainType::NORMAL, 0},
+        {ChainType::ASSUMED, std::nullopt},
+    };
+    int MaxBlockfileNum() const EXCLUSIVE_LOCKS_REQUIRED(cs_LastBlockFile)
+    {
+        const auto& normal = m_blockfile_cursors.at(ChainType::NORMAL).value_or(0);
+        const auto& assumed = m_blockfile_cursors.at(ChainType::ASSUMED).value_or(0);
+        return std::max(normal, assumed);
+    }
+
     /** Global flag to indicate we should check to see if there are
      *  block/undo files that should be deleted.  Set on startup
      *  or if we allocate more file space when we're in prune mode
@@ -203,7 +230,7 @@ public:
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Store block on disk. If dbp is not nullptr, then it provides the known position of the block within a block file on disk. */
-    FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, CChain& active_chain, const FlatFilePos* dbp);
+    FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, const Chainstate& chainstate, const FlatFilePos* dbp) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /** Whether running in -prune mode. */
     [[nodiscard]] bool IsPruneMode() const { return m_prune_mode; }

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -185,7 +185,14 @@ ChainstateLoadResult LoadChainstate(ChainstateManager& chainman, const CacheSize
     chainman.InitializeChainstate(options.mempool);
 
     // Load a chain created from a UTXO snapshot, if any exist.
-    chainman.DetectSnapshotChainstate(options.mempool);
+    bool has_snapshot = chainman.DetectSnapshotChainstate(options.mempool);
+
+    if (has_snapshot && (options.reindex || options.reindex_chainstate)) {
+        return {ChainstateLoadStatus::FAILURE_NO_REINDEX, _(
+            "Reindex cannot be performed while background validation is in progress. "
+            "Please wait for background sync to complete, or delete data directory "
+            "contents and restart bitcoind.")};
+    }
 
     auto [init_status, init_error] = CompleteChainstateInitialization(chainman, cache_sizes, options);
     if (init_status != ChainstateLoadStatus::SUCCESS) {

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -45,6 +45,7 @@ enum class ChainstateLoadStatus {
     FAILURE,
     FAILURE_INCOMPATIBLE_DB,
     FAILURE_INSUFFICIENT_DBCACHE,
+    FAILURE_NO_REINDEX,
     INTERRUPTED,
 };
 

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -427,19 +427,21 @@ public:
     {
         m_notifications->transactionRemovedFromMempool(tx, reason);
     }
-    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
+    void BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
-        m_notifications->blockConnected(kernel::MakeBlockInfo(index, block.get()));
+        m_notifications->blockConnected(role, kernel::MakeBlockInfo(index, block.get()));
     }
     void BlockDisconnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {
         m_notifications->blockDisconnected(kernel::MakeBlockInfo(index, block.get()));
     }
-    void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
+    void UpdatedBlockTip(const ChainstateRole role, const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {
-        m_notifications->updatedBlockTip();
+        m_notifications->updatedBlockTip(role);
     }
-    void ChainStateFlushed(const CBlockLocator& locator) override { m_notifications->chainStateFlushed(locator); }
+    void ChainStateFlushed(const ChainstateRole role, const CBlockLocator& locator) override {
+        m_notifications->chainStateFlushed(role, locator);
+    }
     std::shared_ptr<Chain::Notifications> m_notifications;
 };
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2782,6 +2782,69 @@ static RPCHelpMan loadtxoutset()
     };
 }
 
+static RPCHelpMan getchainstates()
+{
+return RPCHelpMan{
+        "getchainstates",
+        "\nReturn information about chainstates.\n",
+        {},
+        RPCResult{
+            RPCResult::Type::ELISION, "", "",
+        },
+        RPCExamples{
+            HelpExampleCli("getchainstates", "")
+    + HelpExampleRpc("getchainstates", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    LOCK(cs_main);
+    UniValue obj(UniValue::VOBJ);
+
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    ChainstateManager& chainman = *node.chainman;
+
+    auto make_chain_data = [](Chainstate* cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        AssertLockHeld(::cs_main);
+        UniValue data(UniValue::VOBJ);
+        if (!cs || !cs->m_chain.Tip()) {
+            return data;
+        }
+        const CChain& chain = cs->m_chain;
+        const CBlockIndex* tip = chain.Tip();
+
+        data.pushKV("blocks",                (int)chain.Height());
+        data.pushKV("bestblockhash",         tip->GetBlockHash().GetHex());
+        data.pushKV("difficulty",            (double)GetDifficulty(tip));
+        data.pushKV("verificationprogress",  GuessVerificationProgress(Params().TxData(), tip));
+        data.pushKV("snapshot_blockhash",    cs->m_from_snapshot_blockhash.value_or(uint256{}).ToString());
+        data.pushKV("initialblockdownload",  cs->IsInitialBlockDownload());
+        data.pushKV("coins_db_cache_bytes",  cs->m_coinsdb_cache_size_bytes);
+        data.pushKV("coins_tip_cache_bytes", cs->m_coinstip_cache_size_bytes);
+        data.pushKV("has_mempool",           (bool)cs->GetMempool());
+        return data;
+    };
+
+    auto get_chain_type = [&chainman](Chainstate* cs) EXCLUSIVE_LOCKS_REQUIRED(::cs_main) {
+        AssertLockHeld(::cs_main);
+        if (cs->m_from_snapshot_blockhash) {
+            return (chainman.IsSnapshotValidated() ? "validated_snapshot" : "snapshot");
+        }
+        return "ibd";
+    };
+
+    obj.pushKV("active_chain_type", get_chain_type(&chainman.ActiveChainstate()));
+
+    for (Chainstate* chainstate : chainman.GetAll()) {
+        obj.pushKV(get_chain_type(chainstate), make_chain_data(chainstate));
+    }
+    obj.pushKV("headers", chainman.m_best_header ? chainman.m_best_header->nHeight : -1);
+
+    return obj;
+}
+    };
+}
+
+
 void RegisterBlockchainRPCCommands(CRPCTable& t)
 {
     static const CRPCCommand commands[]{
@@ -2813,6 +2876,7 @@ void RegisterBlockchainRPCCommands(CRPCTable& t)
         {"hidden", &syncwithvalidationinterfacequeue},
         {"hidden", &dumptxoutset},
         {"hidden", &loadtxoutset},
+        {"hidden", &getchainstates},
     };
     for (const auto& c : commands) {
         t.appendCommand(c.name, &c);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -926,7 +926,7 @@ public:
     explicit submitblock_StateCatcher(const uint256 &hashIn) : hash(hashIn), state() {}
 
 protected:
-    void BlockChecked(const CBlock& block, const BlockValidationState& stateIn) override {
+    void BlockChecked(const ChainstateRole role, const CBlock& block, const BlockValidationState& stateIn) override {
         if (block.GetHash() != hash)
             return;
         found = true;

--- a/src/test/blockmanager_tests.cpp
+++ b/src/test/blockmanager_tests.cpp
@@ -10,7 +10,6 @@
 #include <boost/test/unit_test.hpp>
 #include <test/util/setup_common.h>
 
-using node::BlockManager;
 using node::BLOCK_SERIALIZATION_HEADER_SIZE;
 using node::MAX_BLOCKFILE_SIZE;
 using node::OpenBlockFile;
@@ -18,30 +17,27 @@ using node::OpenBlockFile;
 // use BasicTestingSetup here for the data directory configuration, setup, and cleanup
 BOOST_FIXTURE_TEST_SUITE(blockmanager_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(blockmanager_find_block_pos)
+BOOST_FIXTURE_TEST_CASE(blockmanager_find_block_pos, TestingSetup)
 {
-    const auto params {CreateChainParams(ArgsManager{}, CBaseChainParams::MAIN)};
-    node::BlockManager::Options blockman_opts{
-        .chainparams = *params,
-    };
-    BlockManager blockman{blockman_opts};
-    CChain chain {};
-    // simulate adding a genesis block normally
-    BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, chain, nullptr).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
+    auto& blockman = m_node.chainman->m_blockman;
+    const auto& chainstate = m_node.chainman->ActiveChainstate();
+    LOCK(::cs_main);
+    const auto& genesis = ::Params().GenesisBlock();
+
     // simulate what happens during reindex
     // simulate a well-formed genesis block being found at offset 8 in the blk00000.dat file
     // the block is found at offset 8 because there is an 8 byte serialization header
     // consisting of 4 magic bytes + 4 length bytes before each block in a well-formed blk file.
     FlatFilePos pos{0, BLOCK_SERIALIZATION_HEADER_SIZE};
-    BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(params->GenesisBlock(), 0, chain, &pos).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
+    BOOST_CHECK_EQUAL(blockman.SaveBlockToDisk(genesis, 0, chainstate, &pos).nPos, BLOCK_SERIALIZATION_HEADER_SIZE);
     // now simulate what happens after reindex for the first new block processed
     // the actual block contents don't matter, just that it's a block.
     // verify that the write position is at offset 0x12d.
     // this is a check to make sure that https://github.com/bitcoin/bitcoin/issues/21379 does not recur
     // 8 bytes (for serialization header) + 285 (for serialized genesis block) = 293
     // add another 8 bytes for the second block's serialization header and we get 293 + 8 = 301
-    FlatFilePos actual{blockman.SaveBlockToDisk(params->GenesisBlock(), 1, chain, nullptr)};
-    BOOST_CHECK_EQUAL(actual.nPos, BLOCK_SERIALIZATION_HEADER_SIZE + ::GetSerializeSize(params->GenesisBlock(), CLIENT_VERSION) + BLOCK_SERIALIZATION_HEADER_SIZE);
+    FlatFilePos actual{blockman.SaveBlockToDisk(genesis, 1, chainstate, nullptr)};
+    BOOST_CHECK_EQUAL(actual.nPos, BLOCK_SERIALIZATION_HEADER_SIZE + ::GetSerializeSize(genesis, CLIENT_VERSION) + BLOCK_SERIALIZATION_HEADER_SIZE);
 }
 
 BOOST_FIXTURE_TEST_CASE(blockmanager_scan_unlink_already_pruned_files, TestChain100Setup)

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -116,7 +116,7 @@ BOOST_FIXTURE_TEST_CASE(coinstatsindex_unclean_shutdown, TestChain100Setup)
         // Send block connected notification, then stop the index without
         // sending a chainstate flushed notification. Prior to #24138, this
         // would cause the index to be corrupted and fail to reload.
-        ValidationInterfaceTest::BlockConnected(index, new_block, new_block_index);
+        ValidationInterfaceTest::BlockConnected(ChainstateRole::NORMAL, index, new_block, new_block_index);
         index.Stop();
     }
 

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -118,6 +118,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getblockstats",
     "getblocktemplate",
     "getchaintips",
+    "getchainstates",
     "getchaintxstats",
     "getconnectioncount",
     "getdeploymentinfo",

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -77,6 +77,7 @@ const std::vector<std::string> RPC_COMMANDS_NOT_SAFE_FOR_FUZZING{
     "generatetodescriptor", // avoid prohibitively slow execution (when `nblocks` is large)
     "gettxoutproof",        // avoid prohibitively slow execution
     "importwallet", // avoid reading from disk
+    "loadtxoutset",   // avoid reading from disk
     "loadwallet",   // avoid reading from disk
     "savemempool",           // disabled as a precautionary measure: may take a file path argument in the future
     "setban",                // avoid DNS lookups

--- a/src/test/util/validation.cpp
+++ b/src/test/util/validation.cpp
@@ -22,7 +22,11 @@ void TestChainState::JumpOutOfIbd()
     Assert(!IsInitialBlockDownload());
 }
 
-void ValidationInterfaceTest::BlockConnected(CValidationInterface& obj, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex)
+void ValidationInterfaceTest::BlockConnected(
+        const ChainstateRole role,
+        CValidationInterface& obj,
+        const std::shared_ptr<const CBlock>& block,
+        const CBlockIndex* pindex)
 {
-    obj.BlockConnected(block, pindex);
+    obj.BlockConnected(role, block, pindex);
 }

--- a/src/test/util/validation.h
+++ b/src/test/util/validation.h
@@ -19,7 +19,11 @@ struct TestChainState : public Chainstate {
 class ValidationInterfaceTest
 {
 public:
-    static void BlockConnected(CValidationInterface& obj, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex);
+    static void BlockConnected(
+        const ChainstateRole role,
+        CValidationInterface& obj,
+        const std::shared_ptr<const CBlock>& block,
+        const CBlockIndex* pindex);
 };
 
 #endif // BITCOIN_TEST_UTIL_VALIDATION_H

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -39,12 +39,12 @@ struct TestSubscriber final : public CValidationInterface {
 
     explicit TestSubscriber(uint256 tip) : m_expected_tip(tip) {}
 
-    void UpdatedBlockTip(const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
+    void UpdatedBlockTip(const ChainstateRole role, const CBlockIndex* pindexNew, const CBlockIndex* pindexFork, bool fInitialDownload) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, pindexNew->GetBlockHash());
     }
 
-    void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override
+    void BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& block, const CBlockIndex* pindex) override
     {
         BOOST_CHECK_EQUAL(m_expected_tip, block->hashPrevBlock);
         BOOST_CHECK_EQUAL(m_expected_tip, pindex->pprev->GetBlockHash());

--- a/src/test/validation_chainstatemanager_tests.cpp
+++ b/src/test/validation_chainstatemanager_tests.cpp
@@ -24,12 +24,12 @@
 
 using node::SnapshotMetadata;
 
-BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, ChainTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(validation_chainstatemanager_tests, TestingSetup)
 
 //! Basic tests for ChainstateManager.
 //!
 //! First create a legacy (IBD) chainstate, then create a snapshot chainstate.
-BOOST_AUTO_TEST_CASE(chainstatemanager)
+BOOST_FIXTURE_TEST_CASE(chainstatemanager, TestChain100Setup)
 {
     ChainstateManager& manager = *m_node.chainman;
     CTxMemPool& mempool = *m_node.mempool;
@@ -40,11 +40,8 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
 
     // Create a legacy (IBD) chainstate.
     //
-    Chainstate& c1 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(&mempool));
+    Chainstate& c1 = manager.ActiveChainstate();
     chainstates.push_back(&c1);
-    c1.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
-    WITH_LOCK(::cs_main, c1.InitCoinsCache(1 << 23));
 
     BOOST_CHECK(!manager.IsSnapshotActive());
     BOOST_CHECK(WITH_LOCK(::cs_main, return !manager.IsSnapshotValidated()));
@@ -54,8 +51,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     auto& active_chain = WITH_LOCK(manager.GetMutex(), return manager.ActiveChain());
     BOOST_CHECK_EQUAL(&active_chain, &c1.m_chain);
 
-    BOOST_CHECK_EQUAL(WITH_LOCK(manager.GetMutex(), return manager.ActiveHeight()), -1);
-
+    BOOST_CHECK_EQUAL(WITH_LOCK(manager.GetMutex(), return manager.ActiveHeight()), 100);
     auto active_tip = WITH_LOCK(manager.GetMutex(), return manager.ActiveTip());
     auto exp_tip = c1.m_chain.Tip();
     BOOST_CHECK_EQUAL(active_tip, exp_tip);
@@ -64,21 +60,23 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
 
     // Create a snapshot-based chainstate.
     //
-    const uint256 snapshot_blockhash = GetRandHash();
+    const uint256 snapshot_blockhash = WITH_LOCK(::cs_main, return manager.ActiveTip()->GetBlockHash());
     Chainstate& c2 = WITH_LOCK(::cs_main, return manager.ActivateExistingSnapshot(
         &mempool, snapshot_blockhash));
     chainstates.push_back(&c2);
-
-    BOOST_CHECK_EQUAL(manager.SnapshotBlockhash().value(), snapshot_blockhash);
-
     c2.InitCoinsDB(
         /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
-    WITH_LOCK(::cs_main, c2.InitCoinsCache(1 << 23));
-    // Unlike c1, which doesn't have any blocks. Gets us different tip, height.
-    c2.LoadGenesisBlock();
-    BlockValidationState _;
-    BOOST_CHECK(c2.ActivateBestChain(_, nullptr));
+    {
+        LOCK(::cs_main);
+        c2.InitCoinsCache(1 << 23);
+        c2.CoinsTip().SetBestBlock(snapshot_blockhash);
+        c2.setBlockIndexCandidates.insert(manager.m_blockman.LookupBlockIndex(snapshot_blockhash));
+        c2.LoadChainTip();
+    }
 
+    BOOST_CHECK_EQUAL(manager.SnapshotBlockhash().value(), snapshot_blockhash);
+    BlockValidationState _;
+    BOOST_CHECK(c2.ActivateBestChain(_));
     BOOST_CHECK(manager.IsSnapshotActive());
     BOOST_CHECK(WITH_LOCK(::cs_main, return !manager.IsSnapshotValidated()));
     BOOST_CHECK_EQUAL(&c2, &manager.ActiveChainstate());
@@ -89,7 +87,10 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
     auto& active_chain2 = WITH_LOCK(manager.GetMutex(), return manager.ActiveChain());
     BOOST_CHECK_EQUAL(&active_chain2, &c2.m_chain);
 
-    BOOST_CHECK_EQUAL(WITH_LOCK(manager.GetMutex(), return manager.ActiveHeight()), 0);
+    BOOST_CHECK_EQUAL(WITH_LOCK(manager.GetMutex(), return manager.ActiveHeight()), 100);
+    mineBlocks(1);
+    BOOST_CHECK_EQUAL(WITH_LOCK(manager.GetMutex(), return manager.ActiveHeight()), 101);
+    BOOST_CHECK_EQUAL(WITH_LOCK(manager.GetMutex(), return c1.m_chain.Height()), 100);
 
     auto active_tip2 = WITH_LOCK(manager.GetMutex(), return manager.ActiveTip());
     auto exp_tip2 = c2.m_chain.Tip();
@@ -97,7 +98,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager)
 
     // Ensure that these pointers actually correspond to different
     // CCoinsViewCache instances.
-    BOOST_CHECK(exp_tip != exp_tip2);
+    BOOST_CHECK(c1.m_chain.Tip() != c2.m_chain.Tip());
 
     // Let scheduler events finish running to avoid accessing memory that is going to be unloaded
     SyncWithValidationInterfaceQueue();
@@ -117,16 +118,10 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
 
     // Create a legacy (IBD) chainstate.
     //
-    Chainstate& c1 = WITH_LOCK(::cs_main, return manager.InitializeChainstate(&mempool));
+    Chainstate& c1 = WITH_LOCK(::cs_main, return manager.ActiveChainstate());
     chainstates.push_back(&c1);
-    c1.InitCoinsDB(
-        /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
-
     {
         LOCK(::cs_main);
-        c1.InitCoinsCache(1 << 23);
-        BOOST_REQUIRE(c1.LoadGenesisBlock());
-        c1.CoinsTip().SetBestBlock(InsecureRand256());
         manager.MaybeRebalanceCaches();
     }
 
@@ -135,7 +130,7 @@ BOOST_AUTO_TEST_CASE(chainstatemanager_rebalance_caches)
 
     // Create a snapshot-based chainstate.
     //
-    Chainstate& c2 = WITH_LOCK(cs_main, return manager.ActivateExistingSnapshot(&mempool, GetRandHash()));
+    Chainstate& c2 = WITH_LOCK(cs_main, return manager.ActivateExistingSnapshot(&mempool, ::Params().GenesisBlock().GetHash()));
     chainstates.push_back(&c2);
     c2.InitCoinsDB(
         /*cache_size_bytes=*/1 << 23, /*in_memory=*/true, /*should_wipe=*/false);
@@ -461,7 +456,7 @@ BOOST_FIXTURE_TEST_CASE(chainstatemanager_loadblockindex, TestChain100Setup)
     BOOST_CHECK_EQUAL(expected_assumed_valid, num_assumed_valid);
 
     Chainstate& cs2 = WITH_LOCK(::cs_main,
-        return chainman.ActivateExistingSnapshot(&mempool, GetRandHash()));
+        return chainman.ActivateExistingSnapshot(&mempool, ::Params().GenesisBlock().GetHash()));
 
     reload_all_block_indexes();
 

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -8,6 +8,7 @@
 #include <scheduler.h>
 #include <test/util/setup_common.h>
 #include <util/check.h>
+#include <kernel/chain.h>
 #include <validationinterface.h>
 
 #include <atomic>
@@ -15,7 +16,7 @@
 BOOST_FIXTURE_TEST_SUITE(validationinterface_tests, TestingSetup)
 
 struct TestSubscriberNoop final : public CValidationInterface {
-    void BlockChecked(const CBlock&, const BlockValidationState&) override {}
+    void BlockChecked(const ChainstateRole role, const CBlock&, const BlockValidationState&) override {}
 };
 
 BOOST_AUTO_TEST_CASE(unregister_validation_interface_race)
@@ -27,7 +28,7 @@ BOOST_AUTO_TEST_CASE(unregister_validation_interface_race)
         const CBlock block_dummy;
         BlockValidationState state_dummy;
         while (generate) {
-            GetMainSignals().BlockChecked(block_dummy, state_dummy);
+            GetMainSignals().BlockChecked(ChainstateRole::NORMAL, block_dummy, state_dummy);
         }
     }};
 
@@ -59,7 +60,7 @@ public:
     {
         if (m_on_destroy) m_on_destroy();
     }
-    void BlockChecked(const CBlock& block, const BlockValidationState& state) override
+    void BlockChecked(const ChainstateRole role, const CBlock& block, const BlockValidationState& state) override
     {
         if (m_on_call) m_on_call();
     }
@@ -67,7 +68,7 @@ public:
     {
         CBlock block;
         BlockValidationState state;
-        GetMainSignals().BlockChecked(block, state);
+        GetMainSignals().BlockChecked(ChainstateRole::NORMAL, block, state);
     }
     std::function<void()> m_on_call;
     std::function<void()> m_on_destroy;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1639,6 +1639,9 @@ bool Chainstate::IsInitialBlockDownload() const
     }
     LogPrintf("Leaving InitialBlockDownload (latching to false)\n");
     m_cached_finished_ibd.store(true, std::memory_order_relaxed);
+    // Important that this comes *after* the previous line, else we'll wind up in an
+    // infinite recursion.
+    m_chainman.MaybeRebalanceCaches();
     return false;
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3908,8 +3908,10 @@ bool ChainstateManager::ProcessNewBlockHeaders(const std::vector<CBlockHeader>& 
         for (const CBlockHeader& header : headers) {
             CBlockIndex *pindex = nullptr; // Use a temp pindex instead of ppindex to avoid a const_cast
             bool accepted{AcceptBlockHeader(header, state, &pindex, min_pow_checked)};
-            ActiveChainstate().CheckBlockIndex();
 
+            for (Chainstate* chainstate : this->GetAll()) {
+                chainstate->CheckBlockIndex();
+            }
             if (!accepted) {
                 return false;
             }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2543,7 +2543,7 @@ bool Chainstate::FlushStateToDisk(
                 LOG_TIME_MILLIS_WITH_CATEGORY("write block and undo data to disk", BCLog::BENCH);
 
                 // First make sure all block and undo data is flushed to disk.
-                m_blockman.FlushBlockFile();
+                m_blockman.FlushChainstateBlockFile(*this);
             }
 
             // Then update all block file information (which may refer to block and undo files).
@@ -4026,7 +4026,7 @@ bool Chainstate::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockV
     // Write block to history file
     if (fNewBlock) *fNewBlock = true;
     try {
-        FlatFilePos blockPos{m_blockman.SaveBlockToDisk(block, pindex->nHeight, m_chain, dbp)};
+        FlatFilePos blockPos{m_blockman.SaveBlockToDisk(block, pindex->nHeight, *this, dbp)};
         if (blockPos.IsNull()) {
             state.Error(strprintf("%s: Failed to find position to write new block to disk", __func__));
             return false;
@@ -4553,7 +4553,7 @@ bool Chainstate::LoadGenesisBlock()
 
     try {
         const CBlock& block = params.GenesisBlock();
-        FlatFilePos blockPos{m_blockman.SaveBlockToDisk(block, 0, m_chain, nullptr)};
+        FlatFilePos blockPos{m_blockman.SaveBlockToDisk(block, 0, *this, nullptr)};
         if (blockPos.IsNull()) {
             return error("%s: writing genesis block to disk failed", __func__);
         }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5754,6 +5754,16 @@ void Chainstate::InvalidateCoinsDBOnDisk()
     }
 }
 
+ChainstateRole Chainstate::GetRole() const
+{
+    if (!m_chainman.IsSnapshotActive()) {
+        return ChainstateRole::NORMAL;
+    }
+    return (this != &m_chainman.ActiveChainstate()) ?
+               ChainstateRole::BACKGROUND :
+               ChainstateRole::ASSUMEDVALID;
+}
+
 const CBlockIndex* ChainstateManager::GetSnapshotBaseBlock() const
 {
     const auto blockhash_op = this->SnapshotBlockhash();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5229,6 +5229,9 @@ bool ChainstateManager::ActivateSnapshot(
         const bool chaintip_loaded = m_snapshot_chainstate->LoadChainTip();
         assert(chaintip_loaded);
 
+        // Transfer possession of the mempool to the snapshot chianstate.
+        m_snapshot_chainstate->m_mempool = m_active_chainstate->m_mempool;
+        m_active_chainstate->m_mempool = nullptr;
         m_active_chainstate = m_snapshot_chainstate.get();
 
         LogPrintf("[snapshot] successfully activated snapshot %s\n", base_blockhash.ToString());

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3224,6 +3224,14 @@ bool Chainstate::ActivateBestChain(BlockValidationState& state, std::shared_ptr<
 
         if (WITH_LOCK(::cs_main, return m_disabled)) {
             // Background chainstate has reached the snapshot base block, so exit.
+
+            // Restart indexers to resume indexing for all blocks unique to the snapshot
+            // chain. This resumes indexing "in order" from where the indexation on the
+            // background validation chain left off.
+            //
+            // This cannot be done while holding cs_main (within
+            // MaybeCompleteSnapshotValidation) or a cs_main deadlock will occur.
+            m_chainman.restart_indexers(m_chainman);
             break;
         }
 
@@ -5876,4 +5884,10 @@ bool ChainstateManager::IsAnyChainInIBD() const
     return
         (m_snapshot_chainstate && m_snapshot_chainstate->IsInitialBlockDownload()) ||
         (m_ibd_chainstate && m_ibd_chainstate->IsInitialBlockDownload());
+}
+
+Chainstate& ChainstateManager::GetChainstateForIndexing()
+{
+    return (IsSnapshotActive() && !IsSnapshotValidated()) ?
+        *m_ibd_chainstate : *m_active_chainstate;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5010,6 +5010,22 @@ std::vector<Chainstate*> ChainstateManager::GetAll()
     return out;
 }
 
+std::vector<Chainstate*> ChainstateManager::GetAllForBlockDownload() const
+{
+    AssertLockHeld(::cs_main);
+    std::vector<Chainstate*> out;
+
+    if (IsUsable(m_snapshot_chainstate.get())) {
+        out.push_back(m_snapshot_chainstate.get());
+    }
+    if (!IsSnapshotValidated() && m_ibd_chainstate) {
+        out.push_back(m_ibd_chainstate.get());
+    }
+
+    assert(out.size() > 0);
+    return out;
+}
+
 Chainstate& ChainstateManager::InitializeChainstate(CTxMemPool* mempool)
 {
     AssertLockHeld(::cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4021,6 +4021,8 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
 {
     AssertLockNotHeld(cs_main);
 
+    Chainstate* chainstate = WITH_LOCK(::cs_main, return &this->GetChainstateForNewBlock(block->GetHash()));
+
     {
         CBlockIndex *pindex = nullptr;
         if (new_block) *new_block = false;
@@ -4038,7 +4040,8 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         bool ret = CheckBlock(*block, state, GetConsensus());
         if (ret) {
             // Store to disk
-            ret = ActiveChainstate().AcceptBlock(block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
+            ret = chainstate->AcceptBlock(
+                block, state, &pindex, force_processing, nullptr, new_block, min_pow_checked);
         }
         if (!ret) {
             GetMainSignals().BlockChecked(*block, state);
@@ -4046,10 +4049,12 @@ bool ChainstateManager::ProcessNewBlock(const std::shared_ptr<const CBlock>& blo
         }
     }
 
-    NotifyHeaderTip(ActiveChainstate());
+    if (chainstate == &this->ActiveChainstate()) {
+        NotifyHeaderTip(*chainstate);
+    }
 
     BlockValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!ActiveChainstate().ActivateBestChain(state, block)) {
+    if (!chainstate->ActivateBestChain(state, block)) {
         return error("%s: ActivateBestChain failed (%s)", __func__, state.ToString());
     }
 
@@ -5541,6 +5546,29 @@ SnapshotCompletionResult ChainstateManager::MaybeCompleteSnapshotValidation(
     this->MaybeRebalanceCaches();
 
     return SnapshotCompletionResult::SUCCESS;
+}
+
+Chainstate& ChainstateManager::GetChainstateForNewBlock(const uint256& blockhash)
+{
+    AssertLockHeld(::cs_main);
+    // Early return to avoid unnecessary blockindex lookup when assumeutxo is not in use.
+    if (!m_snapshot_chainstate) {
+        return *Assert(m_ibd_chainstate);
+    }
+
+    const auto* pblock{m_blockman.LookupBlockIndex(blockhash)};
+    // If pblock is null, we haven't seen the header for this block.
+    // Because we expect to have received the headers for the IBD chain
+    // contents before receiving blocks, this means that any block for
+    // which we don't have headers should go in the snapshot chain.
+    //
+    // Note that searching the snapshot chain (as below) implicitly searches the ibd
+    // chain, since the former includes the latter.
+    if (m_snapshot_chainstate &&
+            (pblock == nullptr || !m_snapshot_chainstate->m_chain.Contains(pblock))) {
+        return *m_snapshot_chainstate.get();
+    }
+    return *Assert(m_ibd_chainstate);
 }
 
 Chainstate& ChainstateManager::ActiveChainstate() const

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5850,3 +5850,11 @@ bool ChainstateManager::ValidatedSnapshotCleanup()
     }
     return true;
 }
+
+
+bool ChainstateManager::IsAnyChainInIBD() const
+{
+    return
+        (m_snapshot_chainstate && m_snapshot_chainstate->IsInitialBlockDownload()) ||
+        (m_ibd_chainstate && m_ibd_chainstate->IsInitialBlockDownload());
+}

--- a/src/validation.h
+++ b/src/validation.h
@@ -1044,6 +1044,18 @@ public:
             [](bilingual_str msg) { AbortNode(msg.original, msg); })
         EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    //! Return the relevant chainstate for a new block.
+    //!
+    //! Because the use of UTXO snapshots requires the simultaneous maintenance
+    //! of two chainstates, when a new block message arrives we have to decide
+    //! which chain we should attempt to append it to.
+    //!
+    //! If our active chainstate hasn't seen the incoming blockhash, return that.
+    //! Otherwise, return the snapshot chainstate since we're receiving a block that
+    //! has been assumed valid.
+    Chainstate& GetChainstateForNewBlock(
+        const uint256& blockhash) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
     //! The most-work chain.
     Chainstate& ActiveChainstate() const;
     CChain& ActiveChain() const EXCLUSIVE_LOCKS_REQUIRED(GetMutex()) { return ActiveChainstate().m_chain; }

--- a/src/validation.h
+++ b/src/validation.h
@@ -1016,6 +1016,12 @@ public:
     //! Get all chainstates currently being used.
     std::vector<Chainstate*> GetAll();
 
+    //! Return all chainstates to be checked for next blocks to download.
+    //!
+    //! This specifically orders the snapshot chain first (if it exists) to
+    //! expedite syncing to network tip.
+    std::vector<Chainstate*> GetAllForBlockDownload() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     //! Construct and activate a Chainstate on the basis of UTXO snapshot data.
     //!
     //! Steps:

--- a/src/validation.h
+++ b/src/validation.h
@@ -939,10 +939,6 @@ private:
     //! Returns nullptr if no snapshot has been loaded.
     const CBlockIndex* GetSnapshotBaseBlock() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
-    //! Return the height of the base block of the snapshot in use, if one exists, else
-    //! nullopt.
-    std::optional<int> GetSnapshotBaseHeight() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
-
     //! Return true if a chainstate is considered usable.
     //!
     //! This is false when a background validation chainstate has completed its
@@ -1205,6 +1201,17 @@ public:
     //!   when using an assumed-valid chainstate based upon a snapshot, return only the
     //!   fully validated chain.
     Chainstate& GetChainstateForIndexing() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    //! Return the [start, end] (inclusive) of block heights we can prune.
+    //!
+    //! If we're pruning the snapshot chainstate, be sure not to
+    //! prune blocks being used by the background chainstate.
+    std::pair<unsigned int, unsigned int> GetPruneRange(
+        const Chainstate& chainstate, unsigned int prune_height) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
+    //! Return the height of the base block of the snapshot in use, if one exists, else
+    //! nullopt.
+    std::optional<int> GetSnapshotBaseHeight() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     ~ChainstateManager();
 };

--- a/src/validation.h
+++ b/src/validation.h
@@ -13,6 +13,7 @@
 #include <arith_uint256.h>
 #include <attributes.h>
 #include <chain.h>
+#include <kernel/chain.h>
 #include <consensus/amount.h>
 #include <deploymentstatus.h>
 #include <kernel/chainparams.h>
@@ -515,6 +516,11 @@ public:
         node::BlockManager& blockman,
         ChainstateManager& chainman,
         std::optional<uint256> from_snapshot_blockhash = std::nullopt);
+
+    //! Return the current role of the chainstate.
+    //!
+    //! @sa ChainstateRole
+    ChainstateRole GetRole() const;
 
     /**
      * Initialize the CoinsViews UTXO set database management data structures. The in-memory

--- a/src/validation.h
+++ b/src/validation.h
@@ -1180,6 +1180,9 @@ public:
     //! @sa node/chainstate:LoadChainstate()
     bool ValidatedSnapshotCleanup() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
+    //! Returns true if any chainstate in use is in initial block download.
+    bool IsAnyChainInIBD() const EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
+
     ~ChainstateManager();
 };
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -46,6 +46,7 @@
 #include <utility>
 #include <vector>
 
+class BaseIndex;
 class Chainstate;
 class CBlockTreeDB;
 class CTxMemPool;
@@ -955,6 +956,8 @@ public:
     using Options = kernel::ChainstateManagerOpts;
 
     explicit ChainstateManager(Options options, node::BlockManager::Options blockman_options);
+
+    std::vector<BaseIndex*> indexers{};
 
     const CChainParams& GetParams() const { return m_options.chainparams; }
     const Consensus::Params& GetConsensus() const { return m_options.chainparams.GetConsensus(); }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -7,6 +7,7 @@
 #define BITCOIN_VALIDATIONINTERFACE_H
 
 #include <kernel/cs_main.h>
+#include <kernel/chain.h>
 #include <primitives/transaction.h> // CTransaction(Ref)
 #include <sync.h>
 
@@ -87,13 +88,13 @@ protected:
      * but may not be called on every intermediate tip. If the latter behavior is desired,
      * subscribe to BlockConnected() instead.
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
-    virtual void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
+    virtual void UpdatedBlockTip(const ChainstateRole, const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {}
     /**
      * Notifies listeners of a transaction having been added to mempool.
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void TransactionAddedToMempool(const CTransactionRef& tx, uint64_t mempool_sequence) {}
 
@@ -127,7 +128,7 @@ protected:
      * - BlockConnected(A)
      * - BlockConnected(B)
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate.
      */
     virtual void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) {}
     /**
@@ -136,11 +137,12 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void BlockConnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
+    virtual void BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock> &block, const CBlockIndex *pindex) {}
     /**
      * Notifies listeners of a block being disconnected
      *
-     * Called on a background thread.
+     * Called on a background thread. Only called for the active chainstate, since
+     * background chainstates should never disconnect blocks.
      */
     virtual void BlockDisconnected(const std::shared_ptr<const CBlock> &block, const CBlockIndex* pindex) {}
     /**
@@ -159,18 +161,22 @@ protected:
      *
      * Called on a background thread.
      */
-    virtual void ChainStateFlushed(const CBlockLocator &locator) {}
+    virtual void ChainStateFlushed(const ChainstateRole role, const CBlockLocator &locator) {}
     /**
      * Notifies listeners of a block validation result.
      * If the provided BlockValidationState IsValid, the provided block
      * is guaranteed to be the current best block at the time the
-     * callback was generated (not necessarily now)
+     * callback was generated (not necessarily now).
      */
-    virtual void BlockChecked(const CBlock&, const BlockValidationState&) {}
+    virtual void BlockChecked(const ChainstateRole role, const CBlock&, const BlockValidationState&) {}
     /**
      * Notifies listeners that a block which builds directly on our current tip
-     * has been received and connected to the headers tree, though not validated yet */
-    virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+     * has been received and connected to the headers tree, though not validated yet.
+     */
+    virtual void NewPoWValidBlock(
+        const ChainstateRole role,
+        const CBlockIndex *pindex,
+        const std::shared_ptr<const CBlock>& block) {};
     friend class CMainSignals;
     friend class ValidationInterfaceTest;
 };
@@ -196,14 +202,14 @@ public:
     size_t CallbacksPending();
 
 
-    void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
+    void UpdatedBlockTip(const ChainstateRole, const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef&, uint64_t mempool_sequence);
     void TransactionRemovedFromMempool(const CTransactionRef&, MemPoolRemovalReason, uint64_t mempool_sequence);
-    void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
+    void BlockConnected(const ChainstateRole, const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex);
-    void ChainStateFlushed(const CBlockLocator &);
-    void BlockChecked(const CBlock&, const BlockValidationState&);
-    void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void ChainStateFlushed(const ChainstateRole, const CBlockLocator &);
+    void BlockChecked(const ChainstateRole, const CBlock&, const BlockValidationState&);
+    void NewPoWValidBlock(const ChainstateRole, const CBlockIndex *, const std::shared_ptr<const CBlock>&);
 };
 
 CMainSignals& GetMainSignals();

--- a/src/wallet/test/fuzz/notifications.cpp
+++ b/src/wallet/test/fuzz/notifications.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <kernel/chain.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -141,8 +142,8 @@ FUZZ_TARGET_INIT(wallet_notifications, initialize_setup)
                 info.prev_hash = &block.hashPrevBlock;
                 info.height = chain.size();
                 info.data = &block;
-                a.wallet->blockConnected(info);
-                b.wallet->blockConnected(info);
+                a.wallet->blockConnected(ChainstateRole::NORMAL, info);
+                b.wallet->blockConnected(ChainstateRole::NORMAL, info);
                 // Store the coins for the next block
                 Coins coins_new;
                 for (const auto& tx : block.vtx) {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -592,7 +592,7 @@ void CWallet::chainStateFlushed(const ChainstateRole role, const CBlockLocator& 
 {
     // Don't update the best block until the chain is attached so that in case of a shutdown,
     // the rescan will be restarted at next startup.
-    if (m_attaching_chain) {
+    if (m_attaching_chain || role == ChainstateRole::BACKGROUND) {
         return;
     }
     WalletBatch batch(GetDatabase());
@@ -1430,6 +1430,9 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
 
 void CWallet::blockConnected(const ChainstateRole role, const interfaces::BlockInfo& block)
 {
+    if (role == ChainstateRole::BACKGROUND) {
+        return;
+    }
     assert(block.data);
     LOCK(cs_wallet);
 
@@ -1459,7 +1462,9 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
 
 void CWallet::updatedBlockTip(const ChainstateRole role)
 {
-    m_best_block_time = GetTime();
+    if (role != ChainstateRole::BACKGROUND) {
+        m_best_block_time = GetTime();
+    }
 }
 
 void CWallet::BlockUntilSyncedToCurrentChain() const {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -14,6 +14,7 @@
 #include <external_signer.h>
 #include <interfaces/chain.h>
 #include <interfaces/wallet.h>
+#include <kernel/chain.h>
 #include <key.h>
 #include <key_io.h>
 #include <outputtype.h>
@@ -587,7 +588,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString& strOldWalletPassphrase,
     return false;
 }
 
-void CWallet::chainStateFlushed(const CBlockLocator& loc)
+void CWallet::chainStateFlushed(const ChainstateRole role, const CBlockLocator& loc)
 {
     // Don't update the best block until the chain is attached so that in case of a shutdown,
     // the rescan will be restarted at next startup.
@@ -1427,7 +1428,7 @@ void CWallet::transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRe
     }
 }
 
-void CWallet::blockConnected(const interfaces::BlockInfo& block)
+void CWallet::blockConnected(const ChainstateRole role, const interfaces::BlockInfo& block)
 {
     assert(block.data);
     LOCK(cs_wallet);
@@ -1456,7 +1457,7 @@ void CWallet::blockDisconnected(const interfaces::BlockInfo& block)
     }
 }
 
-void CWallet::updatedBlockTip()
+void CWallet::updatedBlockTip(const ChainstateRole role)
 {
     m_best_block_time = GetTime();
 }
@@ -2956,7 +2957,7 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         }
 
         if (chain) {
-            walletInstance->chainStateFlushed(chain->getTipLocator());
+            walletInstance->chainStateFlushed(ChainstateRole::NORMAL, chain->getTipLocator());
         }
     } else if (wallet_creation_flags & WALLET_FLAG_DISABLE_PRIVATE_KEYS) {
         // Make it impossible to disable private keys after creation
@@ -3238,7 +3239,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             }
         }
         walletInstance->m_attaching_chain = false;
-        walletInstance->chainStateFlushed(chain.getTipLocator());
+        walletInstance->chainStateFlushed(ChainstateRole::NORMAL, chain.getTipLocator());
         walletInstance->GetDatabase().IncrementUpdateCounter();
     }
     walletInstance->m_attaching_chain = false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -560,9 +560,9 @@ public:
     CWalletTx* AddToWallet(CTransactionRef tx, const TxState& state, const UpdateWalletTxFn& update_wtx=nullptr, bool fFlushOnClose=true, bool rescanning_old_block = false);
     bool LoadToWallet(const uint256& hash, const UpdateWalletTxFn& fill_wtx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void transactionAddedToMempool(const CTransactionRef& tx) override;
-    void blockConnected(const interfaces::BlockInfo& block) override;
+    void blockConnected(const ChainstateRole role, const interfaces::BlockInfo& block) override;
     void blockDisconnected(const interfaces::BlockInfo& block) override;
-    void updatedBlockTip() override;
+    void updatedBlockTip(const ChainstateRole role) override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 
     struct ScanResult {
@@ -737,7 +737,7 @@ public:
     /** should probably be renamed to IsRelevantToMe */
     bool IsFromMe(const CTransaction& tx) const;
     CAmount GetDebit(const CTransaction& tx, const isminefilter& filter) const;
-    void chainStateFlushed(const CBlockLocator& loc) override;
+    void chainStateFlushed(const ChainstateRole role, const CBlockLocator& loc) override;
 
     DBErrors LoadWallet();
     DBErrors ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256>& vHashOut) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -5,6 +5,7 @@
 #include <zmq/zmqnotificationinterface.h>
 
 #include <common/args.h>
+#include <kernel/chain.h>
 #include <logging.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
@@ -139,7 +140,7 @@ void TryForEachAndRemoveFailed(std::list<std::unique_ptr<CZMQAbstractNotifier>>&
 
 } // anonymous namespace
 
-void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
+void CZMQNotificationInterface::UpdatedBlockTip(const ChainstateRole role, const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload)
 {
     if (fInitialDownload || pindexNew == pindexFork) // In IBD or blocks were disconnected without any new ones
         return;
@@ -168,7 +169,7 @@ void CZMQNotificationInterface::TransactionRemovedFromMempool(const CTransaction
     });
 }
 
-void CZMQNotificationInterface::BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected)
+void CZMQNotificationInterface::BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected)
 {
     for (const CTransactionRef& ptx : pblock->vtx) {
         const CTransaction& tx = *ptx;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -32,9 +32,9 @@ protected:
     // CValidationInterface
     void TransactionAddedToMempool(const CTransactionRef& tx, uint64_t mempool_sequence) override;
     void TransactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) override;
-    void BlockConnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
+    void BlockConnected(const ChainstateRole role, const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexConnected) override;
     void BlockDisconnected(const std::shared_ptr<const CBlock>& pblock, const CBlockIndex* pindexDisconnected) override;
-    void UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
+    void UpdatedBlockTip(const ChainstateRole role, const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) override;
 
 private:
     CZMQNotificationInterface();

--- a/test/functional/feature_assumeutxo.py
+++ b/test/functional/feature_assumeutxo.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test for assumeutxo, a means of quickly bootstrapping a node using
+a serialized version of the UTXO set at a certain height, which corresponds
+to a hash that has been compiled into bitcoind.
+
+The assumeutxo value generated and used here is committed to in
+`CRegTestParams::m_assumeutxo_data` in `src/chainparams.cpp`.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, wait_until_helper
+
+
+class AssumeutxoTest(BitcoinTestFramework):
+    def set_test_params(self):
+        """Use the pregenerated, deterministic chain up to height 199."""
+        self.num_nodes = 2
+        self.rpc_timeout = 120
+
+        self.extra_args = [
+            ["-fastprune", "-prune=1", "-blockfilterindex=1", "-coinstatsindex=1"],
+            ["-fastprune", "-prune=1", "-blockfilterindex=1", "-coinstatsindex=1"],
+        ]
+
+    def setup_network(self):
+        """Start with the nodes disconnected so that one can generate a snapshot
+        including blocks the other hasn't yet seen."""
+        self.add_nodes(2)
+        self.start_nodes(extra_args=self.extra_args)
+
+    def run_test(self):
+        """
+        Bring up two (disconnected) nodes, mine some new blocks on the first,
+        and generate a UTXO snapshot.
+
+        Load the snapshot into the second, ensure it syncs to tip and completes
+        background validation when connected to the first.
+        """
+        n1 = self.nodes[0]
+        n2 = self.nodes[1]
+
+        START_HEIGHT = 199
+        SNAPSHOT_BASE_HEIGHT = 299
+        FINAL_HEIGHT = 399
+
+        # Mock time for a deterministic chain
+        for n in self.nodes:
+            n.setmocktime(n.getblockheader(n.getbestblockhash())['time'])
+
+        self.sync_blocks()
+
+        def no_sync():
+            pass
+
+        # Generate a series of blocks that `n1` will have in the snapshot,
+        # but that n2 doesn't yet see. In order for the snapshot to activate,
+        # though, we have to ferry over the new headers to n2 so that it
+        # isn't waiting forever to see the header of the snapshot's base block
+        # while disconnected from n1.
+        for i in range(100):
+            self.generate(n1, nblocks=1, sync_fun=no_sync)
+            newblock = n1.getblock(n1.getbestblockhash(), 0)
+
+            # make n2 aware of the new header, but don't give it the block.
+            n2.submitheader(newblock)
+
+        # Ensure everyone is seeing the same headers.
+        for n in self.nodes:
+            assert_equal(n.getblockchaininfo()["headers"], SNAPSHOT_BASE_HEIGHT)
+
+        assert_equal(n1.getblockcount(), SNAPSHOT_BASE_HEIGHT)
+        assert_equal(n2.getblockcount(), START_HEIGHT)
+
+        self.log.info(f"Creating a UTXO snapshot at height {SNAPSHOT_BASE_HEIGHT}")
+        dump_output = n1.dumptxoutset('utxos.dat')
+
+        assert_equal(
+            dump_output['txoutset_hash'],
+            'ef45ccdca5898b6c2145e4581d2b88c56564dd389e4bd75a1aaf6961d3edd3c0')
+        assert_equal(dump_output['nchaintx'], 300)
+        assert_equal(n1.getblockchaininfo()["blocks"], SNAPSHOT_BASE_HEIGHT)
+
+        # Mine more blocks on top of the snapshot that n2 hasn't yet seen. This
+        # will allow us to test n2's sync-to-tip on top of a snapshot.
+        self.generate(n1, nblocks=100, sync_fun=no_sync)
+
+        assert_equal(n1.getblockcount(), FINAL_HEIGHT)
+        assert_equal(n2.getblockcount(), START_HEIGHT)
+
+        assert_equal(n1.getblockchaininfo()["blocks"], FINAL_HEIGHT)
+
+        self.log.info(f"Loading snapshot into second node from {dump_output['path']}")
+        loaded = n2.loadtxoutset(dump_output['path'])
+        assert_equal(loaded['coins_loaded'], SNAPSHOT_BASE_HEIGHT)
+        assert_equal(loaded['base_height'], SNAPSHOT_BASE_HEIGHT)
+
+        monitor = n2.getchainstates()
+        assert_equal(monitor['ibd']['blocks'], START_HEIGHT)
+        assert_equal(monitor['snapshot']['blocks'], SNAPSHOT_BASE_HEIGHT)
+        assert_equal(monitor['snapshot']['snapshot_blockhash'], dump_output['base_hash'])
+
+        assert_equal(n2.getblockchaininfo()["blocks"], SNAPSHOT_BASE_HEIGHT)
+
+        # Finally connect the nodes and let them sync.
+        self.connect_nodes(0, 1)
+
+        # TODO: test using stopatheight to interrupt bg sync, then restart.
+
+        self.log.info(f"Ensuring snapshot chain syncs to tip.({FINAL_HEIGHT})")
+        wait_until_helper(lambda: n2.getchainstates()['snapshot']['blocks'] == FINAL_HEIGHT)
+        self.sync_blocks()
+
+        self.log.info("Ensuring background validation completes")
+        # N.B.: the `ibd` key disappears once the background validation is complete.
+        wait_until_helper(lambda: not n2.getchainstates().get('ibd'))
+
+        # Ensure indexes have synced.
+        expected_filter = {
+            'basic block filter index': {'synced': True, 'best_block_height': FINAL_HEIGHT},
+            'coinstatsindex': {'synced': True, 'best_block_height': FINAL_HEIGHT}
+        }
+        self.wait_until(lambda: n2.getindexinfo() == expected_filter)
+
+        # TODO: test submitting a transaction and verifying it appears in mempool
+
+        for i, n in enumerate(self.nodes):
+            self.log.info(f"Restarting node {i} to ensure (Check|Load)BlockIndex passes")
+            self.restart_node(i, extra_args=self.extra_args[i])
+
+            assert_equal(n.getblockchaininfo()["blocks"], FINAL_HEIGHT)
+
+            # Both chains should appear as "ibd"; i.e. fully validated.
+            assert_equal(n.getchainstates()['ibd']['blocks'], FINAL_HEIGHT)
+            assert_equal(n.getchainstates().get('snapshot'), None)
+
+            # Ensure indexes have synced
+            self.wait_until(lambda: n.getindexinfo() == expected_filter)
+        #
+        # TODO: test running a reindex
+
+if __name__ == '__main__':
+    AssumeutxoTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -315,6 +315,7 @@ BASE_SCRIPTS = [
     'wallet_coinbase_category.py --descriptors',
     'feature_filelock.py',
     'feature_loadblock.py',
+    'feature_assumeutxo.py',
     'p2p_dos_header_tree.py',
     'p2p_add_connections.py',
     'feature_bind_port_discover.py',

--- a/test/lint/lint-shell.py
+++ b/test/lint/lint-shell.py
@@ -67,9 +67,13 @@ def main():
         '*.sh',
     ]
     files = get_files(files_cmd)
-    # remove everything that doesn't match this regex
     reg = re.compile(r'src/[leveldb,secp256k1,minisketch]')
-    files[:] = [file for file in files if not reg.match(file)]
+
+    def should_exclude(fname: str) -> bool:
+        return bool(reg.match(fname)) or 'test_utxo_snapshots.sh' in fname
+
+    # remove everything that doesn't match this regex
+    files[:] = [file for file in files if not should_exclude(file)]
 
     # build the `shellcheck` command
     shellcheck_cmd = [


### PR DESCRIPTION
**See the proposal for assumeutxo [here](https://github.com/jamesob/assumeutxo-docs/tree/2019-04-proposal/proposal).**

Testing instructions can be found below the "Progress" section.

---

### Progress

All items here have corresponding commits here, but are unchecked if they haven't been merged yet.

- [x] **Chainstate interface**
  - https://github.com/bitcoin/bitcoin/pull/15976
- [x] **Localize chainstate data**
  - https://github.com/bitcoin/bitcoin/pull/16443
- [x] **Share block data**
  - https://github.com/bitcoin/bitcoin/pull/16194
- [x] **Deglobalize chainstate**
  - https://github.com/bitcoin/bitcoin/pull/15948
- [x] **UpdateTip/CheckBlockIndex** modifications
  - https://github.com/bitcoin/bitcoin/pull/21526
- [x] **ChainstateManager**
  - https://github.com/bitcoin/bitcoin/pull/17737
- [x] **Mempool**
  - https://github.com/bitcoin/bitcoin/pull/22415
- [x] **LoadBlockIndex**
  - https://github.com/bitcoin/bitcoin/pull/23174
- [x] **Init/teardown**
  - https://github.com/bitcoin/bitcoin/pull/24232
  - https://github.com/bitcoin/bitcoin/pull/25667
  - https://github.com/bitcoin/bitcoin/pull/25740
- [x] **Wallet**: includes avoiding rescans when assumed-valid block data is in use
  - https://github.com/bitcoin/bitcoin/pull/23997
  - https://github.com/bitcoin/bitcoin/pull/26282
- [ ] **P2P**: minor changes are made to `init.cpp` and `net_processing.cpp` to make simultaneous IBD across multiple chainstates work.
  - #24008 
- [ ] **Pruning**: implement correct pruning behavior when using a background chainstate
- [ ] **Blockfile separation**: to prevent "fragmentation" in blockfile storage, have background chainstates use separate blockfiles from active snapshot chainstates to avoid interleaving heights and impairing pruning.
- [ ] **Indexing**: all existing `CValidationInterface` events are given with an additional parameter, ChainstateRole, and all indexers ignore events from ChainstateRole::ASSUMEDVALID so that indexation only happens sequentially.
- [ ] Raise error when both `-reindex` and assumeutxo are in use.
- [ ] **RPC**: introduce RPC commands `dumptxoutset`, `loadtxoutset`, and (the probably temporary) `monitorsnapshot`.
  - https://github.com/bitcoin/bitcoin/pull/16899
- [ ] **Release docs & first assumeutxo commitment**: add notes and a particular assumeutxo hash value for first AU-enabled release.
  - This will complete the project and allow use of UTXO snapshots for faster node bootstrap.
- [ ] *(optional)* **Coinscache optimization**: allow flushing chainstate data without emptying the coins cache; results in better performance after UTXO snapshot load.
  - https://github.com/bitcoin/bitcoin/pull/17487
  - https://github.com/bitcoin/bitcoin/pull/27008

---

### Testing

#### For fun (~5min)

If you want to do a quick test, you can run `./contrib/devtools/test_utxo_snapshots.sh` and follow the instructions. This is mostly obviated by the functional tests, though.

#### For real (longer)

If you'd like to experience a real usage of assumeutxo, you can do that too.
I've cut a new snapshot at height 788'000 (http://img.jameso.be/utxo-788000.dat - but you can do it yourself with `./contrib/devtools/utxo_snapshot.sh` if you want). Download that, and then create a datadir for testing:
```sh
$ cd ~/src/bitcoin  # or whatever

# get the snapshot
$ curl http://img.jameso.be/utxo-788000.dat > utxo-788000.dat

# you'll want to do this if you like copy/pasting 
$ export AU_DATADIR=/home/${USER}/au-test # or wherever

$ mkdir ${AU_DATADIR}
$ vim ${AU_DATADIR}/bitcoin.conf

dbcache=8000  # or, you know, something high
blockfilterindex=1
coinstatsindex=1
prune=3000
logthreadnames=1
```
Obtain this branch, build it, and then start bitcoind:
```sh
$ git remote add jamesob https://github.com/jamesob/bitcoin
$ git fetch jamesob utxo-dumpload-compressed
$ git checkout jamesob/utxo-dumpload-compressed

$ ./configure $conf_args && make  # (whatever you like to do here)

# start 'er up and watch the logs
$ ./src/bitcoind -datadir=${AU_DATADIR}
```
Then, in some other window, load the snapshot
```sh
$ ./src/bitcoin-cli -datadir=${AU_DATADIR} loadtxoutset $(pwd)/utxo-788000.dat
```

You'll see some log messages about headers retrieval and waiting to see the snapshot in the headers chain. Once you get the full headers chain, you'll spend a decent amount of time (~10min) loading the snapshot, checking it, and flushing it to disk. After all that happens, you should be syncing to tip in pretty short order, and you'll see the occasional `[background validation]` log message go by.

In yet another window, you can check out chainstate status with
```sh
$ ./src/bitcoin-cli -datadir=${AU_DATADIR} getchainstates
```
as well as usual favorites like `getblockchaininfo`.

---

### Original change description

For those unfamiliar with assumeutxo, here's a brief summary from [the issue](https://github.com/bitcoin/bitcoin/issues/15605) (where any conceptual discussion not specific to this implementation should happen):

> assumeutxo would be a way to initialize a node using a headers chain and a serialized version of the UTXO state which was generated from another node at some block height. A client making use of this UTXO "snapshot" would specify a hash and expect the content of the resulting UTXO set to yield this hash after deserialization. 
> 
> This would allow users to bootstrap a usable pruned node & wallet far more quickly (and with less disk usage) than waiting for a full initial block download to complete, since we only have to sync blocks between the base of the snapshot and the current network tip. Needless to say this is at expense of accepting a different trust model, though how different this really ends up being from `assumevalid` in effect is worth debate.

In short, this is an interesting change because it would allow nodes to get up and running within minutes given a ~3GB file (at time of writing) under an almost identical trust model to assumevalid.

In this implementation, I add a few RPC commands: `dumptxoutset` creates a UTXO snapshot and writes it to disk, and `loadtxoutset` intakes a snapshot from disk, constructs and activates chainstate based on it, and continues a from-scratch initial block download in the background for the sole purpose of validating the snapshot. Once the snapshot is validated, we throw away the chainstate used for background validation.

The assumeutxo procedure as implemented is as follows:

1. A UTXO snapshot is loaded with the `loadtxoutset <path>` RPC command.
1. A new chainstate (`CChainState`) is initialized using `ChainstateManager::ActivateSnapshot()`:
   1. The serialized UTXO data is read in and various sanity checks are performed, e.g. compare expected coin count, recompute the hash and compare it with assumeutxo hash in source code.
   1. We "fast forward" `new_chainstate->m_chain` to have a tip at the base of the snapshot (with or without block data). Lacking block data, we fake the `nTx` counts of the constituent `CBlockIndex` entries.
   1. `LoadChainTip()` is called on the new snapshot and it is installed as our active chainstate.
1. The new assumed-valid chainstate is now our active, and so that enters IBD until it is synced to the network's tip. Presumably the snapshot would be taken relatively close to the current tip but far enough away to avoid meaningful reorgs, say 10,000 blocks deep.
1. Once the active chainstate is out of IBD, our old validation chain continues IBD "in the background" while the active chainstate services requests from most of the system.
1. Once the background validation chainstate reaches a height equal the base of the snapshot, we take the hash of its UTXO set and ensure it equals the expected hash based on the snapshot. If the hashes are equivalent, we delete the validation chainstate and move on without event; if they aren't, we log loudly and fall back to the validation chainstate (we should probably just shut down).

The implicit assumption is that the background validation chain will always be a subset of the assumed-valid snapshot chain while the latter is active. We don't properly handle reorgs that go deeper than the base of the snapshot.

### Changes (already merged/outdated)

![chainstate-beforeafter (1)](https://user-images.githubusercontent.com/73197/54435797-a16b0780-4707-11e9-89c3-c90b5686804d.png)
 
The crux of this change is in removing any assumptions in the codebase that there is a single chainstate, i.e. any references to global variables `chainActive`, `pcoinsTip`, et al. need to be replaced with functions that return the relevant chainstate data at that moment in time. This change also takes `CChainState` to its logical conclusion by making it more self-contained - any references to globals like `chainActive` are removed with class-local references (`m_chain`).

A few minor notes on the implementation:

- When we attempt to load a wallet with a BestBlock locator lower than the base of a snapshot and the snapshot has not yet been validated, we refuse to load the wallet.

- For additional notes, see [the new assumeutxo docs](https://github.com/jamesob/bitcoin/blob/utxo-dumpload-compressed/doc/assumeutxo.md).