### PR TITLE
scripts and tools: Set 'distro' explicitly

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,6 +1,7 @@
 ---
 name: "bitcoin-core-linux-0.19"
 enable_cache: true
+distro: "ubuntu"
 suites:
 - "bionic"
 architectures:

--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -1,5 +1,6 @@
 ---
 name: "bitcoin-dmg-signer"
+distro: "ubuntu"
 suites:
 - "bionic"
 architectures:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,6 +1,7 @@
 ---
 name: "bitcoin-core-osx-0.19"
 enable_cache: true
+distro: "ubuntu"
 suites:
 - "bionic"
 architectures:

--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -1,5 +1,6 @@
 ---
 name: "bitcoin-win-signer"
+distro: "ubuntu"
 suites:
 - "bionic"
 architectures:

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,6 +1,7 @@
 ---
 name: "bitcoin-core-win-0.19"
 enable_cache: true
+distro: "ubuntu"
 suites:
 - "bionic"
 architectures:


### PR DESCRIPTION
The [gitian-builder](https://github.com/devrandom/gitian-builder) implicitly uses `ubuntu` as a default distro.

[bin/gbuild#L237](https://github.com/devrandom/gitian-builder/blob/81edd2fc8e66193bc0e2ca8530a918eb57727139/bin/gbuild#L237):
```ruby
distro = build_desc["distro"] || "ubuntu"
```

This PR sets a gitian building distro explicitly in description files.