### PR TITLE
Add log output during initial header sync

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3327,6 +3327,12 @@ bool ProcessNewBlockHeaders(const std::vector<CBlockHeader>& headers, CValidatio
         }
     }
     NotifyHeaderTip();
+    {
+        LOCK(cs_main);
+        if (::ChainstateActive().IsInitialBlockDownload() && ppindex && *ppindex) {
+            LogPrintf("Synchronizing blockheaders, height: %d (~%.2f%%)\n", (*ppindex)->nHeight, 100.0/((*ppindex)->nHeight+(GetAdjustedTime() - (*ppindex)->GetBlockTime()) / Params().GetConsensus().nPowTargetSpacing) * (*ppindex)->nHeight);
+        }
+    }
     return true;
 }
 


### PR DESCRIPTION
The non debug log output is completely quiet during the header sync. I see two main reasons to add infos about the state of the initial header sync...
* users may think the node did fail to start sync
* it's a little complicate to check if your getting throttled during header sync (repeatedly calling `getchaintips` or similar)
