### PR TITLE
Remove global symbols: Avoid using the global namespace if possible

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -139,15 +139,15 @@ struct HTTPPathHandler
 //! libevent event loop
 static struct event_base* eventBase = nullptr;
 //! HTTP server
-struct evhttp* eventHTTP = nullptr;
+static struct evhttp* eventHTTP = nullptr;
 //! List of subnets to allow RPC connections from
 static std::vector<CSubNet> rpc_allow_subnets;
 //! Work queue for handling longer requests off the event loop thread
 static WorkQueue<HTTPClosure>* workQueue = nullptr;
 //! Handlers for (sub)paths
-std::vector<HTTPPathHandler> pathHandlers;
+static std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets
-std::vector<evhttp_bound_socket *> boundSockets;
+static std::vector<evhttp_bound_socket *> boundSockets;
 
 /** Check if a network address is allowed to access the HTTP server */
 static bool ClientAllowed(const CNetAddr& netaddr)
@@ -420,7 +420,7 @@ bool UpdateHTTPServerLogging(bool enable) {
 #endif
 }
 
-std::thread threadHTTP;
+static std::thread threadHTTP;
 static std::vector<std::thread> g_thread_http_workers;
 
 void StartHTTPServer()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -74,7 +74,7 @@
 #include <zmq/zmqrpc.h>
 #endif
 
-bool fFeeEstimatesInitialized = false;
+static bool fFeeEstimatesInitialized = false;
 static const bool DEFAULT_PROXYRANDOMIZE = true;
 static const bool DEFAULT_REST_ENABLE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -8,10 +8,10 @@
 #include <util/system.h>
 #include <warnings.h>
 
-CCriticalSection cs_warnings;
-std::string strMiscWarning GUARDED_BY(cs_warnings);
-bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
-bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
+static RecursiveMutex cs_warnings;
+static std::string strMiscWarning GUARDED_BY(cs_warnings);
+static bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
+static bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
 
 void SetMiscWarning(const std::string& strWarning)
 {


### PR DESCRIPTION
Remove global symbols: Avoid using the global namespace if possible.

Partially resolves #15612 ("Reduce the number of global symbols used").

Change in global symbols as reported by `nm bitcoind` before vs after:

```
$ diff -u <(nm src/bitcoind-before | c++filt | grep -E '^[0-9a-f]+ [A-Z] ' | cut -f3- -d' ' | sort -u) \
          <(nm src/bitcoind-after  | c++filt | grep -E '^[0-9a-f]+ [A-Z] ' | cut -f3- -d' ' | sort -u) \
          | grep -E '^[+-][^+-]'
-boundSockets
-cs_warnings
-eventHTTP
-fFeeEstimatesInitialized
-fLargeWorkForkFound
-fLargeWorkInvalidChainFound
-pathHandlers
-strMiscWarning[abi:cxx11]
-threadHTTP
```