### PR TITLE
init: Throw error when network specific config is ignored

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -73,8 +73,13 @@ Example item
 Low-level changes
 =================
 
-Example item
+Configuration
 ------------
+
+* An error is issued where previously a warning was issued when a setting in
+  the config file was specified in the default section, but not overriden for
+  the selected network. This change takes only effect if the selected network
+  is not mainnet.
 
 Credits
 =======

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -77,7 +77,7 @@ Configuration
 ------------
 
 * An error is issued where previously a warning was issued when a setting in
-  the config file was specified in the default section, but not overriden for
+  the config file was specified in the default section, but not overridden for
   the selected network. This change takes only effect if the selected network
   is not mainnet.
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -828,19 +828,6 @@ void InitParameterInteraction()
         if (gArgs.SoftSetBoolArg("-whitelistrelay", true))
             LogPrintf("%s: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1\n", __func__);
     }
-
-    // Warn if network-specific options (-addnode, -connect, etc) are
-    // specified in default section of config file, but not overridden
-    // on the command line or in this network's section of the config file.
-    std::string network = gArgs.GetChainName();
-    for (const auto& arg : gArgs.GetUnsuitableSectionOnlyArgs()) {
-        InitWarning(strprintf(_("Config setting for %s only applied on %s network when in [%s] section."), arg, network, network));
-    }
-
-    // Warn if unrecognized section name are present in the config file.
-    for (const auto& section : gArgs.GetUnrecognizedSections()) {
-        InitWarning(strprintf("%s:%i " + _("Section [%s] is not recognized."), section.m_file, section.m_line, section.m_name));
-    }
 }
 
 static std::string ResolveErrMsg(const char * const optname, const std::string& strBind)
@@ -949,6 +936,19 @@ bool AppInitParameterInteraction()
     // ********************************************************* Step 2: parameter interactions
 
     // also see: InitParameterInteraction()
+
+    // Warn if network-specific options (-addnode, -connect, etc) are
+    // specified in default section of config file, but not overridden
+    // on the command line or in this network's section of the config file.
+    std::string network = gArgs.GetChainName();
+    for (const auto& arg : gArgs.GetUnsuitableSectionOnlyArgs()) {
+        return InitError(strprintf(_("Config setting for %s only applied on %s network when in [%s] section."), arg, network, network));
+    }
+
+    // Warn if unrecognized section name are present in the config file.
+    for (const auto& section : gArgs.GetUnrecognizedSections()) {
+        InitWarning(strprintf("%s:%i " + _("Section [%s] is not recognized."), section.m_file, section.m_line, section.m_name));
+    }
 
     if (!fs::is_directory(GetBlocksDir())) {
         return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist."), gArgs.GetArg("-blocksdir", "").c_str()));

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2803,7 +2803,7 @@ bool CChainState::InvalidateBlock(CValidationState& state, const CChainParams& c
         bool ret = DisconnectTip(state, chainparams, &disconnectpool);
         // DisconnectTip will add transactions to disconnectpool.
         // Adjust the mempool to be consistent with the new tip, adding
-        // transactions back to the mempool if disconnecting was succesful,
+        // transactions back to the mempool if disconnecting was successful,
         // and we're not doing a very deep invalidation (in which case
         // keeping the mempool up to date is probably futile anyway).
         UpdateMempoolForReorg(disconnectpool, /* fAddToMempool = */ (++disconnected <= 10) && ret);

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -25,6 +25,10 @@ class ConfArgsTest(BitcoinTestFramework):
             conf.write('-dash=1\n')
         self.nodes[0].assert_start_raises_init_error(expected_msg='Error reading configuration file: parse error on line 1: -dash=1, options in configuration file must be specified without leading -')
 
+        with open(inc_conf_file_path, 'w', encoding='utf8') as conf:
+            conf.write("wallet=foo\n")
+        self.nodes[0].assert_start_raises_init_error(expected_msg='Error: Config setting for -wallet only applied on regtest network when in [regtest] section.')
+
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('nono\n')
         self.nodes[0].assert_start_raises_init_error(expected_msg='Error reading configuration file: parse error on line 1: nono, if you intended to specify a negated option, use nono=1 instead')

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -369,7 +369,7 @@ class TestNode():
                 stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL) == 0
 
         if not sys.platform.startswith('linux'):
-            self.log.warning("Can't profile with perf; only availabe on Linux platforms")
+            self.log.warning("Can't profile with perf; only available on Linux platforms")
             return None
 
         if not test_success('which perf'):

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -759,7 +759,7 @@ class ImportMultiTest(BitcoinTestFramework):
         assert_equal(addr2, newaddr2)
 
         # Import a multisig and make sure the keys don't go into the keypool
-        self.log.info('Imported scripts with pubkeys shoud not have their pubkeys go into the keypool')
+        self.log.info('Imported scripts with pubkeys should not have their pubkeys go into the keypool')
         addr1 = self.nodes[0].getnewaddress()
         addr2 = self.nodes[0].getnewaddress()
         pub1 = self.nodes[0].getaddressinfo(addr1)['pubkey']


### PR DESCRIPTION
This should have no effect on mainnet users, but simplifies testing, where config settings are currently ignored with only a warning. Fix this by making it an error.

Issues:
*  bitcoin client 0.17.0 ignores wallet's name (file) #14523 
*  Can't set custom rpcport on testnet #13777 
* ...