### PR TITLE
qa: mininode: Clearer error message on invalid magic bytes

### DIFF
--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -171,7 +171,7 @@ class P2PConnection(asyncio.Protocol):
                 if len(self.recvbuf) < 4:
                     return
                 if self.recvbuf[:4] != self.magic_bytes:
-                    raise ValueError("got garbage %s" % repr(self.recvbuf))
+                    raise ValueError("magic bytes mismatch: {} != {}".format(repr(self.magic_bytes), repr(self.recvbuf)))
                 if len(self.recvbuf) < 4 + 12 + 4 + 4:
                     return
                 command = self.recvbuf[4:4+12].split(b"\x00", 1)[0]


### PR DESCRIPTION
Old message:
```
ValueError: got garbage b'\xfa\xbf\xb5\xdafeefilter\x00\x00\x00\x08\x00\x00\x00\xe8\x0f\xd1\x9f\xe8\x03\x00\x00\x00\x00\x00\x00'
```

New message:
```
ValueError: magic bytes mismatch: b'\x00\x11"2' != b'\xfa\xbf\xb5\xdapong\x00\x00\x00\x00\x00\x00\x00\x00\x08\x00\x00\x00\x97\xe6\x04\xd2\xff\x00\x00\x00\x00\x00\x00\x00'
```