### PR TITLE
Ignore BIP-152 HB requests from non-witness peers.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2058,6 +2058,8 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 State(pfrom->GetId())->fProvidesHeaderAndIDs = true;
                 State(pfrom->GetId())->fWantsCmpctWitness = nCMPCTBLOCKVersion == 2;
             }
+            // ignore HB requests from peers without witness support
+            fAnnounceUsingCMPCTBLOCK = fAnnounceUsingCMPCTBLOCK && (pfrom->GetLocalServices() & NODE_WITNESS);
             if (State(pfrom->GetId())->fWantsCmpctWitness == (nCMPCTBLOCKVersion == 2)) // ignore later version announces
                 State(pfrom->GetId())->fPreferHeaderAndIDs = fAnnounceUsingCMPCTBLOCK;
             if (!State(pfrom->GetId())->fSupportsDesiredCmpctVersion) {


### PR DESCRIPTION
To speed up block propagation  BIP-152 allows peers to signal that
 they would like us to announce new blocks to them by just sending
 a compact block.  But propagation speed through non-witness peers
 is irrelevant, so ignore the request for these and save bandwidth.

Instead we'll just send them a header and they can getdata the
 (compact)block if they actually need it from us.
