### PR TITLE
Handle the result of posix_fallocate system call

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1089,11 +1089,12 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
         fcntl(fileno(file), F_PREALLOCATE, &fst);
     }
     ftruncate(fileno(file), fst.fst_length);
-#elif defined(__linux__)
+#else
+    #if defined(__linux__)
     // Version using posix_fallocate
     off_t nEndPos = (off_t)offset + length;
-    posix_fallocate(fileno(file), 0, nEndPos);
-#else
+    if (0 == posix_fallocate(fileno(file), 0, nEndPos)) return;
+    #endif
     // Fallback version
     // TODO: just write one byte per block
     static const char buf[65536] = {};


### PR DESCRIPTION
The system call `posix_fallocate` is not supported on some filesystems.

- catches the result of posix_allocate and fall back to the default behaviour if the return value is different from 0 (success)

Fixes #15624 