### PR TITLE
p2p: Slightly more private initial tx relay

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -306,10 +306,9 @@ public:
         auto it = ::mempool.GetIter(txid);
         return it && (*it)->GetCountWithDescendants() > 1;
     }
-    void relayTransaction(const uint256& txid) override
+    void relayTransaction(const bool initial, const uint256& txid) override
     {
-        CInv inv(MSG_TX, txid);
-        g_connman->ForEachNode([&inv](CNode* node) { node->PushInventory(inv); });
+        g_connman->RelayTransaction(initial, txid, ::mempool);
     }
     void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) override
     {

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -185,7 +185,7 @@ public:
     virtual bool hasDescendantsInMempool(const uint256& txid) = 0;
 
     //! Relay transaction.
-    virtual void relayTransaction(const uint256& txid) = 0;
+    virtual void relayTransaction(bool initial, const uint256& txid) = 0;
 
     //! Calculate mempool ancestor and descendant counts for the given transaction.
     virtual void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -535,8 +535,8 @@ public:
 
     int64_t GetTxTime() const;
 
-    // RelayWalletTransaction may only be called if fBroadcastTransactions!
-    bool RelayWalletTransaction(interfaces::Chain::Lock& locked_chain);
+    // may only be called if fBroadcastTransactions!
+    bool RelayWalletTransaction(bool initial, interfaces::Chain::Lock& locked_chain);
 
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */
     bool AcceptToMemoryPool(interfaces::Chain::Lock& locked_chain, CValidationState& state);


### PR DESCRIPTION
Transactions from the wallet or RPC are sent to all inbound and outbound peers initially. Outbound connections are chosen by us, whereas inbound connections are cheap to initiate, so inbound peers are more likely to be spy nodes in an adversarial setting.

We can improve the privacy of our initial tx relay by not relaying to inbound peers until some timeout.

My current implementation is an untested draft looking for conceptual review.

The idea is to keep a node-specific relay map that is populated (just like the global mapRelay) via the trickle logic. This is required because there is currently no other way in Bitcoin Core to relay without revealing that we were the source of the transaction. In the future this relay mechanism could be replaced by Dandelion or a mechanism to send the transaction over tor.

The transaction is still added to the mempool, which means an active (tx-creating) attacker could find that we were the source of the transaction in some corner cases. (E.g. They can create descendant txs and trigger a mempool limit). However, it should not be possible to simply request the transaction, since it was only added to a peer specific relay map.

After some timeout the transaction is pushed to all peers as a fallback.