### PR TITLE
net: Don't return unreachable local addresses for peer

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -103,7 +103,8 @@ bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
         return false;
 
     int nBestScore = -1;
-    int nBestReachability = -1;
+    // TODO: Use Reachability enum
+    int nBestReachability = 1;
     {
         LOCK(cs_mapLocalHost);
         for (const auto& entry : mapLocalHost)


### PR DESCRIPTION
It is possible for `GetLocal` to return an unreachable local address if there are no reachable ones. This change makes sure that it doesn't.