### PR TITLE
[WIP] docs: Improve net comments

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -348,7 +348,12 @@ bool CConnman::CheckIncomingNonce(uint64_t nonce)
     return true;
 }
 
-/** Get the bind address for a socket as CAddress */
+/**
+ * Get the bind address for the specified socket as a CAddress.
+ *
+ * @returns The corresponding CAddress if the specified socket is valid and
+ *          getsockname suceeded. Otherwise, the default CAddress.
+ */
 static CAddress GetBindAddress(SOCKET sock)
 {
     CAddress addr_bind;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -133,8 +133,6 @@ static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn
 {
     // It'll only connect to one or two seed nodes because once it connects,
     // it'll get a pile of addresses with newer timestamps.
-    // Seed nodes are given a random 'last seen time' of between one and two
-    // weeks ago.
     const int64_t nOneWeek = 7*24*60*60;
     std::vector<CAddress> vSeedsOut;
     vSeedsOut.reserve(vSeedsIn.size());
@@ -143,6 +141,8 @@ static std::vector<CAddress> convertSeed6(const std::vector<SeedSpec6> &vSeedsIn
         struct in6_addr ip;
         memcpy(&ip, seed_in.addr, sizeof(ip));
         CAddress addr(CService(ip, seed_in.port), GetDesirableServiceFlags(NODE_NONE));
+        // Seed addresses are given a random 'last seen time' of between one and
+        // two weeks ago.
         addr.nTime = GetTime() - rng.randrange(nOneWeek) - nOneWeek;
         vSeedsOut.push_back(addr);
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -207,7 +207,12 @@ void AdvertiseLocal(CNode *pnode)
     }
 }
 
-// learn a new local address
+/**
+ * Try to learn a new local service and its associated score, incrementing its
+ * score if its address is already known.
+ *
+ * @returns Whether or not the new local service was learned.
+ */
 bool AddLocal(const CService& addr, int nScore)
 {
     if (!addr.IsRoutable())

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -270,7 +270,11 @@ bool IsReachable(const CNetAddr &addr)
     return IsReachable(addr.GetNetwork());
 }
 
-/** vote for a local address */
+/**
+ * Try to vote for a local address by incrementing its score.
+ *
+ * @returns Whether or not the local address is known.
+ */
 bool SeenLocal(const CService& addr)
 {
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -96,7 +96,14 @@ unsigned short GetListenPort()
     return (unsigned short)(gArgs.GetArg("-port", Params().GetDefaultPort()));
 }
 
-// find 'best' local address for a particular peer
+/**
+ * Find the local service with the best reachability from a particular peer,
+ * breaking ties by their scores.
+ *
+ * @param[out]	addr	The local service, if found.
+ *
+ * @returns Whether or not a local service was found.
+ */
 bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
 {
     if (!fListen)


### PR DESCRIPTION
Improves comments for `net`, making them available to Doxygen. These improvements mostly focus on explaining return values, and out parameters.