### PR TITLE
Comment for seemingly duplicate LIBBITCOIN_SERVER

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -497,6 +497,8 @@ if TARGET_WINDOWS
 bitcoind_SOURCES += bitcoind-res.rc
 endif
 
+# Libraries below may be listed more than once to resolve circular dependencies (see
+# https://eli.thegreenplace.net/2013/07/09/library-order-in-static-linking#circular-dependency)
 bitcoind_LDADD = \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_WALLET) \


### PR DESCRIPTION
Added a comment to explain the addition of LIBBITCOIN_SERVER twice in bitcoind_LDADD which seems incorrect at a glance until the behaviour of Linux linkers is understood.