### PR TITLE
qa: Make swap_magic_bytes in p2p_invalid_messages atomic

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -3,11 +3,12 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test node responses to invalid network messages."""
+import asyncio
 import os
 import struct
 
 from test_framework import messages
-from test_framework.mininode import P2PDataStore
+from test_framework.mininode import P2PDataStore, NetworkThread
 from test_framework.test_framework import BitcoinTestFramework
 
 
@@ -143,8 +144,15 @@ class InvalidMessagesTest(BitcoinTestFramework):
 
     def test_magic_bytes(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
-        conn._on_data = lambda: None  # Need to ignore all incoming messages from now, since they come with "invalid" magic bytes
-        conn.magic_bytes = b'\x00\x11\x22\x32'
+
+        def swap_magic_bytes():
+            conn._on_data = lambda: None  # Need to ignore all incoming messages from now, since they come with "invalid" magic bytes
+            conn.magic_bytes = b'\x00\x11\x22\x32'
+
+        # Call .result() to block until the atomic swap is complete, otherwise
+        # we might run into races later on
+        asyncio.run_coroutine_threadsafe(asyncio.coroutine(swap_magic_bytes)(), NetworkThread.network_event_loop).result()
+
         with self.nodes[0].assert_debug_log(['PROCESSMESSAGE: INVALID MESSAGESTART ping']):
             conn.send_message(messages.msg_ping(nonce=0xff))
             conn.wait_for_disconnect(timeout=1)


### PR DESCRIPTION
Otherwise, this will lead to errors logged in the network thread:

https://travis-ci.org/MarcoFalke/bitcoin/jobs/513076282#L2765