### PR TITLE
build: Check QT library version

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -81,8 +81,6 @@ AC_DEFUN([BITCOIN_QT_INIT],[
 
 dnl Find the appropriate version of Qt libraries and includes.
 dnl Inputs: $1: Whether or not pkg-config should be used. yes|no. Default: yes.
-dnl Inputs: $2: If $1 is "yes" and --with-gui=auto, which qt version should be
-dnl         tried first.
 dnl Outputs: See _BITCOIN_QT_FIND_LIBS_*
 dnl Outputs: Sets variables for all qt-related tools.
 dnl Outputs: bitcoin_enable_qt, bitcoin_enable_qt_dbus, bitcoin_enable_qt_test
@@ -98,6 +96,12 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   else
     BITCOIN_QT_CHECK([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG])
   fi
+
+  BITCOIN_QT_CHECK([
+    if test "x$bitcoin_cv_qt_minimumrequired" != xyes; then
+      BITCOIN_QT_FAIL([Qt version not supported])
+    fi
+  ])
 
   dnl This is ugly and complicated. Yuck. Works as follows:
   dnl For Qt5, we can check a header to find out whether Qt is build
@@ -211,7 +215,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
        ])
   esac
 
-
   dnl enable qt support
   AC_MSG_CHECKING(whether to build ]AC_PACKAGE_NAME[ GUI)
   BITCOIN_QT_CHECK([
@@ -257,9 +260,9 @@ dnl ----
 
 dnl Internal. Check included version of Qt against minimum specified in doc/dependencies.md
 dnl Requires: INCLUDES must be populated as necessary.
-dnl Output: bitcoin_cv_qt5=yes|no
-AC_DEFUN([_BITCOIN_QT_CHECK_QT5],[
-  AC_CACHE_CHECK(for Qt 5, bitcoin_cv_qt5,[
+dnl Output: bitcoin_cv_qt_minimumrequired=yes|no
+AC_DEFUN([_BITCOIN_QT_CHECK_MINIMUM_REQUIRED],[
+  AC_CACHE_CHECK(for Qt >= 5.5.1, bitcoin_cv_qt_minimumrequired,[
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
       #include <QtCore/qconfig.h>
       #ifndef QT_VERSION
@@ -271,15 +274,15 @@ AC_DEFUN([_BITCOIN_QT_CHECK_QT5],[
       choke
       #endif
     ]])],
-    [bitcoin_cv_qt5=yes],
-    [bitcoin_cv_qt5=no])
+    [bitcoin_cv_qt_minimumrequired=yes],
+    [bitcoin_cv_qt_minimumrequired=no])
 ])])
 
-dnl Internal. Check if the included version of Qt is greater than Qt58.
+dnl Internal. Check if the included version of Qt is >= 5.8.
 dnl Requires: INCLUDES must be populated as necessary.
 dnl Output: bitcoin_cv_qt58=yes|no
 AC_DEFUN([_BITCOIN_QT_CHECK_QT58],[
-  AC_CACHE_CHECK(for > Qt 5.7, bitcoin_cv_qt58,[
+  AC_CACHE_CHECK(for >= Qt 5.8, bitcoin_cv_qt58,[
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
       #include <QtCore/qconfig.h>
       #ifndef QT_VERSION
@@ -410,10 +413,6 @@ AC_DEFUN([_BITCOIN_QT_FIND_STATIC_PLUGINS],[
 ])
 
 dnl Internal. Find Qt libraries using pkg-config.
-dnl Inputs: bitcoin_qt_want_version (from --with-gui=). The version to check
-dnl         first.
-dnl Inputs: $1: If bitcoin_qt_want_version is "auto", check for this version
-dnl         first.
 dnl Outputs: All necessary QT_* variables are set.
 dnl Outputs: have_qt_test and have_qt_dbus are set (if applicable) to yes|no.
 AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
@@ -434,6 +433,16 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
         PKG_CHECK_MODULES([QT_DBUS], [${QT_LIB_PREFIX}DBus], [QT_DBUS_INCLUDES="$QT_DBUS_CFLAGS"; have_qt_dbus=yes], [have_qt_dbus=no])
       fi
     ])
+    BITCOIN_QT_CHECK([
+      AC_CACHE_CHECK(for Qt >= 5.5.1,bitcoin_cv_qt_minimumrequired,
+        PKG_CHECK_EXISTS(Qt5Core < 5.5.1,[bitcoin_cv_qt_minimumrequired=no],[bitcoin_cv_qt_minimumrequired=yes])
+      )
+    ])
+    BITCOIN_QT_CHECK([
+      AC_CACHE_CHECK(for Qt >= 5.8.0,bitcoin_cv_qt58,
+        PKG_CHECK_EXISTS(Qt5Core < 5.8.0,[bitcoin_cv_qt58=no],[bitcoin_cv_qt58=yes])
+      )
+    ])
   ])
   true; dnl
 ])
@@ -441,7 +450,8 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITH_PKGCONFIG],[
 dnl Internal. Find Qt libraries without using pkg-config. Version is deduced
 dnl from the discovered headers.
 dnl Inputs: bitcoin_qt_want_version (from --with-gui=). The version to use.
-dnl         If "auto", the version will be discovered by _BITCOIN_QT_CHECK_QT5.
+dnl         If "auto", the version will be discovered by _BITCOIN_QT_CHECK_MINIMUM_REQUIRED
+dnl         and _BITCOIN_QT_CHECK_QT58.
 dnl Outputs: All necessary QT_* variables are set.
 dnl Outputs: have_qt_test and have_qt_dbus are set (if applicable) to yes|no.
 AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
@@ -462,7 +472,7 @@ AC_DEFUN([_BITCOIN_QT_FIND_LIBS_WITHOUT_PKGCONFIG],[
 
   BITCOIN_QT_CHECK([
     if test "x$bitcoin_qt_want_version" = xauto; then
-      _BITCOIN_QT_CHECK_QT5
+      _BITCOIN_QT_CHECK_MINIMUM_REQUIRED
       _BITCOIN_QT_CHECK_QT58
     fi
     QT_LIB_PREFIX=Qt5


### PR DESCRIPTION
Fixes #15688 

Due to a bug, the version of the QT library was not checked at configure time for systems using pkg-config. Without any check at configure time, the build process stopped with unexplicative errors on systems with QT versions not supported.

This PR introduces the control of the version of the QT library, with a warning, or an error, at configure time, if the installed version is not supported.

Tested in all the following cases (all combinations):
* on Debian Jessie (QT 5.3.2) and on Debian Stretch (QT 5.7.1)
* with depends system (QT 5.9.7) enabled and disabled
* with `--with-gui` and `--without-gui` on configure command line

Since the current 0.18 branch is affected, with compilation errors on some systems, like Debian Jessie ([EOL on June 30, 2020](https://wiki.debian.org/LTS/)), I suggest to include this low impact PR in 0.18.