### PR TITLE
Changes to support NAT-PMP 

### DIFF
--- a/build_msvc/common.vcxproj
+++ b/build_msvc/common.vcxproj
@@ -24,7 +24,7 @@
       <DisableSpecificWarnings>4018;4244;4267;4715;4805;</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>_WIN32_WINNT=0x0601;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>..\..\src;..\..\src\univalue\include;..\..\src\secp256k1\include;..\..\src\leveldb\include;..\..\src\leveldb\helpers\memenv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\src;..\..\src\univalue\include;..\..\src\natpmp\include;..\..\src\secp256k1\include;..\..\src\leveldb\include;..\..\src\leveldb\helpers\memenv;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/configure.ac
+++ b/configure.ac
@@ -113,7 +113,7 @@ AC_ARG_WITH([miniupnpc],
   [AS_HELP_STRING([--with-miniupnpc],
   [enable UPNP (default is yes if libminiupnpc is found)])],
   [use_upnp=$withval],
-  [use_upnp=auto])
+  [use_upnp=no])
 
 AC_ARG_ENABLE([upnp-default],
   [AS_HELP_STRING([--enable-upnp-default],

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -156,7 +156,7 @@ Comment:
 License: public-domain
  This work is in the public domain.
 
-Files: src/natpmp/gateway.cpp 
+Files: src/natpmp/gateway.cpp
        src/natpmp/include/gateway.h
        src/natpmp/natpmp.cpp
        src/natpmp/include/natpmp.h

--- a/contrib/debian/copyright
+++ b/contrib/debian/copyright
@@ -155,3 +155,34 @@ Comment:
 
 License: public-domain
  This work is in the public domain.
+
+Files: src/natpmp/gateway.cpp 
+       src/natpmp/include/gateway.h
+       src/natpmp/natpmp.cpp
+       src/natpmp/include/natpmp.h
+Copyright: 2007-2011, Thomas BERNARD
+License:
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+    * The name of the author may not be used to endorse or promote products
+	  derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,6 +22,7 @@ endif
 BITCOIN_INCLUDES=-I$(builddir) $(BDB_CPPFLAGS) $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS)
 
 BITCOIN_INCLUDES += -I$(srcdir)/secp256k1/include
+BITCOIN_INCLUDES += -I$(srcdir)/natpmp/include
 BITCOIN_INCLUDES += $(UNIVALUE_CFLAGS)
 
 LIBBITCOIN_SERVER=libbitcoin_server.a
@@ -149,6 +150,9 @@ BITCOIN_CORE_H = \
   memusage.h \
   merkleblock.h \
   miner.h \
+  natpmp/include/gateway.h \
+  natpmp/include/natpmp.h \
+  natpmp/include/natmap_wrapper.h \
   net.h \
   net_processing.h \
   netaddress.h \
@@ -261,6 +265,9 @@ libbitcoin_server_a_SOURCES = \
   dbwrapper.cpp \
   merkleblock.cpp \
   miner.cpp \
+  natpmp/gateway.cpp \
+  natpmp/natpmp.cpp \
+  natpmp/natmap_wrapper.cpp \
   net.cpp \
   net_processing.cpp \
   node/coin.cpp \
@@ -595,7 +602,7 @@ endif
 
 libbitcoinconsensus_la_LDFLAGS = $(AM_LDFLAGS) -no-undefined $(RELDFLAGS)
 libbitcoinconsensus_la_LIBADD = $(LIBSECP256K1)
-libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -DBUILD_BITCOIN_INTERNAL
+libbitcoinconsensus_la_CPPFLAGS = $(AM_CPPFLAGS) -I$(builddir)/obj -I$(srcdir)/secp256k1/include -I$(srcdir)/natpmp/include -DBUILD_BITCOIN_INTERNAL
 libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -437,16 +437,17 @@ void SetupServerArgs()
     gArgs.AddArg("-torpassword=<pass>", "Tor control port password (default: empty)", false, OptionsCategory::CONNECTION);
 #ifdef USE_UPNP
 #if USE_UPNP
-    gArgs.AddArg("-upnp", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", false, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-portmap", "Use UPnP to map the listening port (default: 1 when listening and no -proxy)", false, OptionsCategory::CONNECTION);
 #else
-    gArgs.AddArg("-upnp", strprintf("Use UPnP to map the listening port (default: %u)", 0), false, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-portmap", strprintf("Use NAT-PMP to map the listening port (default: %u)", 0), false, OptionsCategory::CONNECTION);
 #endif
 #else
-    hidden_args.emplace_back("-upnp");
+    hidden_args.emplace_back("-portmap");
 #endif
     gArgs.AddArg("-whitebind=<addr>", "Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-whitelist=<IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or CIDR notated network (e.g. 1.2.3.0/24). Can be specified multiple times."
-        " Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway", false, OptionsCategory::CONNECTION);
+                                                       " Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway",
+        false, OptionsCategory::CONNECTION);
 
     g_wallet_init_interface.AddWalletOptions();
 
@@ -794,8 +795,8 @@ void InitParameterInteraction()
             LogPrintf("%s: parameter interaction: -proxy set -> setting -listen=0\n", __func__);
         // to protect privacy, do not use UPNP when a proxy is set. The user may still specify -listen=1
         // to listen locally, so don't rely on this happening through -listen below.
-        if (gArgs.SoftSetBoolArg("-upnp", false))
-            LogPrintf("%s: parameter interaction: -proxy set -> setting -upnp=0\n", __func__);
+        if (gArgs.SoftSetBoolArg("-portmap", false))
+            LogPrintf("%s: parameter interaction: -proxy set -> setting -portmap=0\n", __func__);
         // to protect privacy, do not discover addresses by default
         if (gArgs.SoftSetBoolArg("-discover", false))
             LogPrintf("%s: parameter interaction: -proxy set -> setting -discover=0\n", __func__);
@@ -803,8 +804,8 @@ void InitParameterInteraction()
 
     if (!gArgs.GetBoolArg("-listen", DEFAULT_LISTEN)) {
         // do not map ports or try to retrieve public IP when not listening (pointless)
-        if (gArgs.SoftSetBoolArg("-upnp", false))
-            LogPrintf("%s: parameter interaction: -listen=0 -> setting -upnp=0\n", __func__);
+        if (gArgs.SoftSetBoolArg("-portmap", false))
+            LogPrintf("%s: parameter interaction: -listen=0 -> setting -portmap=0\n", __func__);
         if (gArgs.SoftSetBoolArg("-discover", false))
             LogPrintf("%s: parameter interaction: -listen=0 -> setting -discover=0\n", __func__);
         if (gArgs.SoftSetBoolArg("-listenonion", false))
@@ -1737,7 +1738,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     Discover();
 
     // Map ports with UPnP
-    if (gArgs.GetBoolArg("-upnp", DEFAULT_UPNP)) {
+    if (gArgs.GetBoolArg("-portmap", DEFAULT_UPNP)) {
         StartMapPort();
     }
 

--- a/src/natpmp/gateway.cpp
+++ b/src/natpmp/gateway.cpp
@@ -1,0 +1,548 @@
+#include <stdio.h>
+#include <ctype.h>
+#ifndef WIN32
+#include <netinet/in.h>
+#endif
+#if !defined(_MSC_VER)
+#include <sys/param.h>
+#endif
+#ifdef __linux__
+#define USE_PROC_NET_ROUTE
+#undef USE_SOCKET_ROUTE
+#undef USE_SYSCTL_NET_ROUTE
+#endif
+
+#if defined(BSD) || defined(__FreeBSD_kernel__)
+#undef USE_PROC_NET_ROUTE
+#define USE_SOCKET_ROUTE
+#undef USE_SYSCTL_NET_ROUTE
+#endif
+
+#ifdef __APPLE__
+#undef USE_PROC_NET_ROUTE
+#undef USE_SOCKET_ROUTE
+#define USE_SYSCTL_NET_ROUTE
+#endif
+
+#if (defined(sun) && defined(__SVR4))
+#undef USE_PROC_NET_ROUTE
+#define USE_SOCKET_ROUTE
+#undef USE_SYSCTL_NET_ROUTE
+#endif
+
+#ifdef WIN32
+#undef USE_PROC_NET_ROUTE
+#undef USE_SOCKET_ROUTE
+#undef USE_SYSCTL_NET_ROUTE
+//#define USE_WIN32_CODE
+#define USE_WIN32_CODE_2
+#endif
+
+#ifdef __CYGWIN__
+#undef USE_PROC_NET_ROUTE
+#undef USE_SOCKET_ROUTE
+#undef USE_SYSCTL_NET_ROUTE
+#define USE_WIN32_CODE
+#include <stdarg.h>
+#include <w32api/windef.h>
+#include <w32api/winbase.h>
+#include <w32api/winreg.h>
+#endif
+
+#ifdef __HAIKU__
+#include <sys/sockio.h>
+#define USE_HAIKU_CODE
+#endif
+
+#ifdef USE_SYSCTL_NET_ROUTE
+#include <sys/sysctl.h>
+#endif
+
+#ifdef USE_SOCKET_ROUTE
+#include <string.h>
+#endif
+
+#if defined(USE_SOCKET_ROUTE) || defined(__HAIKU__)
+#include <unistd.h>
+#include <net/if.h>
+#endif
+
+#if defined(USE_SYSCTL_NET_ROUTE) || defined(__HAIKU__)
+#include <stdlib.h>
+#endif
+
+#if defined(USE_SOCKET_ROUTE) || defined(USE_SYSCTL_NET_ROUTE)
+#include <sys/socket.h>
+#include <net/route.h>
+#endif
+
+#ifdef USE_WIN32_CODE
+#include <unknwn.h>
+#include <winreg.h>
+#define MAX_KEY_LENGTH 255
+#define MAX_VALUE_LENGTH 16383
+#endif
+
+#ifdef USE_WIN32_CODE_2
+#include <windows.h>
+#include <iphlpapi.h>
+#endif
+#include <gateway.h>
+#ifndef WIN32
+#define SUCCESS (0)
+#define FAILED  (-1)
+#endif
+#ifdef USE_PROC_NET_ROUTE
+#include <sstream>
+#include <list>
+#include <algorithm>
+/*
+ * There is no portable method to get the default route gateway.
+ * So below are four (or five ?) different functions implementing this.
+ * Parsing /proc/net/route is for Linux.
+ * sysctl is the way to access such information on BSD systems.
+ * Many systems should provide route information through raw PF_ROUTE
+ * sockets.
+ * In MS Windows, default gateway is found by looking into the registry
+ * or by using GetBestRoute().
+ *
+ */
+
+/*
+ parse /proc/net/route which is as follow :
+
+Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT
+wlan0   0001A8C0        00000000        0001    0       0       0       00FFFFFF        0       0       0
+eth0    0000FEA9        00000000        0001    0       0       0       0000FFFF        0       0       0
+wlan0   00000000        0101A8C0        0003    0       0       0       00000000        0       0       0
+eth0    00000000        00000000        0001    0       0       1000    00000000        0       0       0
+
+ One header line, and then one line by route by route table entry.
+*/
+
+int TestIfWhiteSpace(char character)
+{
+    std::list<char> whiteSpaces = {'\f', '\n', '\r', '\t', '\v'};
+    return std::count(whiteSpaces.begin(), whiteSpaces.end(), character);
+}
+
+int GetDefaultGateway(in_addr_t * addr)
+{
+        int64_t d = 0;
+        int64_t g = 0;
+        char buf[256] = {0};
+        int line = 0;
+        char * p = nullptr;
+        FILE* f = fopen("/proc/net/route", "r");
+        if(!f)
+                return FAILED;
+        while(fgets(buf, sizeof(buf), f)) {
+                if(line > 0) {  /* skip the first line */
+                        p = buf;
+                        /* skip the interface name */
+                        while(*p && !TestIfWhiteSpace(*p))
+                                p++;
+                        while(*p && TestIfWhiteSpace(*p))
+                                p++;
+            // Want just the gateway column
+                        std::string data(p);
+            data = data.substr(data.find('\t')+1);
+            data = data.substr(0, data.find('\t'));
+
+                        std::stringstream dataParser;
+            dataParser<<std::hex<<data;
+                        dataParser >> g >> d;
+            if(d == 0 && g != 0) {
+                                *addr = (in_addr_t)g;
+                                fclose(f);
+                                return SUCCESS;
+                        }
+                }
+                line++;
+        }
+        /* default route not found ! */
+        if(f)
+                fclose(f);
+        return FAILED;
+}
+#endif /* #ifdef USE_PROC_NET_ROUTE */
+
+
+#ifdef USE_SYSCTL_NET_ROUTE
+
+#define ROUNDUP(a) \
+    ((a) > 0 ? (1 + (((a) - 1) | (sizeof(long) - 1))) : sizeof(long))
+
+int GetDefaultGateway(in_addr_t * addr)
+{
+    /* net.route.0.inet.flags.gateway */
+    int mib[] = {CTL_NET, PF_ROUTE, 0, AF_INET,
+                 NET_RT_FLAGS, RTF_GATEWAY};
+    size_t l = 0;
+    char* buf = nullptr;
+    char* p = nullptr;
+    struct rt_msghdr * rt = {0};
+    struct sockaddr * sa = {0};
+    struct sockaddr * sa_tab[RTAX_MAX];
+    int i = 0;
+    int r = FAILED;
+    if(sysctl(mib, sizeof(mib)/sizeof(int), 0, &l, 0, 0) < 0) {
+        return FAILED;
+    }
+    if(l>0) {
+        buf = (char*)malloc(l);
+        if(sysctl(mib, sizeof(mib)/sizeof(int), buf, &l, 0, 0) < 0) {
+            free(buf);
+            return FAILED;
+        }
+        for(p=buf; p<buf+l; p+=rt->rtm_msglen) {
+            rt = (struct rt_msghdr *)p;
+            sa = (struct sockaddr *)(rt + 1);
+            for(i=0; i<RTAX_MAX; i++) {
+                if(rt->rtm_addrs & (1 << i)) {
+                    sa_tab[i] = sa;
+                    sa = (struct sockaddr *)((char *)sa + ROUNDUP(sa->sa_len));
+                } else {
+                    sa_tab[i] = nullptr;
+                }
+            }
+            if( ((rt->rtm_addrs & (RTA_DST|RTA_GATEWAY)) == (RTA_DST|RTA_GATEWAY))
+              && sa_tab[RTAX_DST]->sa_family == AF_INET
+              && sa_tab[RTAX_GATEWAY]->sa_family == AF_INET) {
+                if(((struct sockaddr_in *)sa_tab[RTAX_DST])->sin_addr.s_addr == 0) {
+                    *addr = ((struct sockaddr_in *)(sa_tab[RTAX_GATEWAY]))->sin_addr.s_addr;
+                    r = SUCCESS;
+                }
+            }
+        }
+        free(buf);
+    }
+    return r;
+}
+#endif
+
+
+#ifdef USE_SOCKET_ROUTE
+/* Thanks to Darren Kenny for this code */
+#define NEXTADDR(w, u) \
+        if (rtm_addrs & (w)) {\
+            l = sizeof(struct sockaddr); memmove(cp, &(u), l); cp += l;\
+        }
+
+#define rtm m_rtmsg.m_rtm
+
+struct {
+  struct rt_msghdr m_rtm;
+  char       m_space[512];
+} m_rtmsg;
+
+int GetDefaultGateway(in_addr_t *addr)
+{
+  int s = 0, seq = 0, l = 0, rtm_addrs = 0, i = 0;
+  pid_t pid = {0};
+  struct sockaddr so_dst = {0}, so_mask = {0};
+  char *cp = m_rtmsg.m_space;
+  struct sockaddr *gate = nullptr, *sa = nullptr;
+  struct rt_msghdr *msg_hdr = nullptr;
+
+  pid = getpid();
+  seq = 0;
+  rtm_addrs = RTA_DST | RTA_NETMASK;
+
+  memset(&so_dst, 0, sizeof(so_dst));
+  memset(&so_mask, 0, sizeof(so_mask));
+  memset(&rtm, 0, sizeof(struct rt_msghdr));
+
+  rtm.rtm_type = RTM_GET;
+  rtm.rtm_flags = RTF_UP | RTF_GATEWAY;
+  rtm.rtm_version = RTM_VERSION;
+  rtm.rtm_seq = ++seq;
+  rtm.rtm_addrs = rtm_addrs;
+
+  so_dst.sa_family = AF_INET;
+  so_mask.sa_family = AF_INET;
+
+  NEXTADDR(RTA_DST, so_dst);
+  NEXTADDR(RTA_NETMASK, so_mask);
+
+  rtm.rtm_msglen = l = cp - (char *)&m_rtmsg;
+
+  s = socket(PF_ROUTE, SOCK_RAW, 0);
+
+  if (write(s, (char *)&m_rtmsg, l) < 0) {
+      close(s);
+      return FAILED;
+  }
+
+  do {
+    l = read(s, (char *)&m_rtmsg, sizeof(m_rtmsg));
+  } while (l > 0 && (rtm.rtm_seq != seq || rtm.rtm_pid != pid));
+
+  close(s);
+
+  msg_hdr = &rtm;
+
+  cp = ((char *)(msg_hdr + 1));
+  if (msg_hdr->rtm_addrs) {
+    for (i = 1; i; i <<= 1)
+      if (i & msg_hdr->rtm_addrs) {
+        sa = (struct sockaddr *)cp;
+        if (i == RTA_GATEWAY )
+          gate = sa;
+
+        cp += sizeof(struct sockaddr);
+      }
+  } else {
+      return FAILED;
+  }
+
+
+  if (gate != nullptr ) {
+      *addr = ((struct sockaddr_in *)gate)->sin_addr.s_addr;
+      return SUCCESS;
+  } else {
+      return FAILED;
+  }
+}
+#endif /* #ifdef USE_SOCKET_ROUTE */
+
+#ifdef USE_WIN32_CODE
+LIBSPEC int GetDefaultGateway(in_addr_t * addr)
+{
+    HKEY networkCardsKey;
+    HKEY networkCardKey;
+    HKEY interfacesKey;
+    HKEY interfaceKey;
+    DWORD i = 0;
+    DWORD numSubKeys = 0;
+    TCHAR keyName[MAX_KEY_LENGTH];
+    DWORD keyNameLength = MAX_KEY_LENGTH;
+    TCHAR keyValue[MAX_VALUE_LENGTH];
+    DWORD keyValueLength = MAX_VALUE_LENGTH;
+    DWORD keyValueType = REG_SZ;
+    TCHAR gatewayValue[MAX_VALUE_LENGTH];
+    DWORD gatewayValueLength = MAX_VALUE_LENGTH;
+    DWORD gatewayValueType = REG_MULTI_SZ;
+    int done = 0;
+
+#ifdef UNICODE
+    LPCTSTR networkCardsPath = L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkCards";
+    LPCTSTR interfacesPath = L"SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces";
+#define STR_SERVICENAME     L"ServiceName"
+#define STR_DHCPDEFAULTGATEWAY L"DhcpDefaultGateway"
+#define STR_DEFAULTGATEWAY    L"DefaultGateway"
+#else
+    LPCTSTR networkCardsPath = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkCards";
+    LPCTSTR interfacesPath = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces";
+#define STR_SERVICENAME     "ServiceName"
+#define STR_DHCPDEFAULTGATEWAY "DhcpDefaultGateway"
+#define STR_DEFAULTGATEWAY    "DefaultGateway"
+#endif
+    // The windows registry lists its primary network devices in the following location:
+    // HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkCards
+    //
+    // Each network device has its own subfolder, named with an index, with various properties:
+    // -NetworkCards
+    //   -5
+    //     -Description = Broadcom 802.11n Network Adapter
+    //     -ServiceName = {E35A72F8-5065-4097-8DFE-C7790774EE4D}
+    //   -8
+    //     -Description = Marvell Yukon 88E8058 PCI-E Gigabit Ethernet Controller
+    //     -ServiceName = {86226414-5545-4335-A9D1-5BD7120119AD}
+    //
+    // The above service name is the name of a subfolder within:
+    // HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces
+    //
+    // There may be more subfolders in this interfaces path than listed in the network cards path above:
+    // -Interfaces
+    //   -{3a539854-6a70-11db-887c-806e6f6e6963}
+    //     -DhcpIPAddress = 0.0.0.0
+    //     -[more]
+    //   -{E35A72F8-5065-4097-8DFE-C7790774EE4D}
+    //     -DhcpIPAddress = 10.0.1.4
+    //     -DhcpDefaultGateway = 10.0.1.1
+    //     -[more]
+    //   -{86226414-5545-4335-A9D1-5BD7120119AD}
+    //     -DhcpIpAddress = 10.0.1.5
+    //     -DhcpDefaultGateay = 10.0.1.1
+    //     -[more]
+    //
+    // In order to extract this information, we enumerate each network card, and extract the ServiceName value.
+    // This is then used to open the interface subfolder, and attempt to extract a DhcpDefaultGateway value.
+    // Once one is found, we're done.
+    //
+    // It may be possible to simply enumerate the interface folders until we find one with a DhcpDefaultGateway value.
+    // However, the technique used is the technique most cited on the web, and we assume it to be more correct.
+
+    if(ERROR_SUCCESS != RegOpenKeyEx(HKEY_LOCAL_MACHINE, // Open registry key or predefined key
+                                     networkCardsPath,   // Name of registry subkey to open
+                                     0,                  // Reserved - must be zero
+                                     KEY_READ,           // Mask - desired access rights
+                                     &networkCardsKey))  // Pointer to output key
+    {
+        // Unable to open network cards keys
+        return -1;
+    }
+
+    if(ERROR_SUCCESS != RegOpenKeyEx(HKEY_LOCAL_MACHINE, // Open registry key or predefined key
+                                     interfacesPath,     // Name of registry subkey to open
+                                     0,                  // Reserved - must be zero
+                                     KEY_READ,           // Mask - desired access rights
+                                     &interfacesKey))    // Pointer to output key
+    {
+        // Unable to open interfaces key
+        RegCloseKey(networkCardsKey);
+        return -1;
+    }
+
+    // Figure out how many subfolders are within the Network Cards folder
+    RegQueryInfoKey(networkCardsKey, nullptr, nullptr, nullptr, &numSubKeys, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+
+    // Enumerate through each subfolder within the Network Cards folder
+    for(i = 0; i < numSubKeys && !done; i++)
+    {
+        keyNameLength = MAX_KEY_LENGTH;
+        if(ERROR_SUCCESS == RegEnumKeyEx(networkCardsKey, // Open registry key
+                                         i,               // Index of sub key to retrieve
+                                         keyName,         // Buffer that receives the name of the sub key
+                                         &keyNameLength,  // Variable that receives the size of the above buffer
+                                         nullptr,            // Reserved - must be nullptr
+                                         nullptr,            // Buffer that receives the class string
+                                         nullptr,            // Variable that receives the size of the above buffer
+                                         nullptr))           // Variable that receives the last write time of sub key
+        {
+            if(RegOpenKeyEx(networkCardsKey,  keyName, 0, KEY_READ, &networkCardKey) == ERROR_SUCCESS)
+            {
+                keyValueLength = MAX_VALUE_LENGTH;
+                if(ERROR_SUCCESS == RegQueryValueEx(networkCardKey,   // Open registry key
+                                                    STR_SERVICENAME,    // Name of key to query
+                                                    nullptr,             // Reserved - must be nullptr
+                                                    &keyValueType,    // Receives value type
+                                                    (LPBYTE)keyValue, // Receives value
+                                                    &keyValueLength)) // Receives value length in bytes
+                {
+                    if(RegOpenKeyEx(interfacesKey, keyValue, 0, KEY_READ, &interfaceKey) == ERROR_SUCCESS)
+                    {
+                        gatewayValueLength = MAX_VALUE_LENGTH;
+                        if(ERROR_SUCCESS == RegQueryValueEx(interfaceKey,         // Open registry key
+                                                            STR_DHCPDEFAULTGATEWAY, // Name of key to query
+                                                            nullptr,                 // Reserved - must be nullptr
+                                                            &gatewayValueType,    // Receives value type
+                                                            (LPBYTE)gatewayValue, // Receives value
+                                                            &gatewayValueLength)) // Receives value length in bytes
+                        {
+                            // Check to make sure it's a string
+                            if((gatewayValueType == REG_MULTI_SZ || gatewayValueType == REG_SZ) && (gatewayValueLength > 1))
+                            {
+                                done = 1;
+                            }
+                        }
+                        else if(ERROR_SUCCESS == RegQueryValueEx(interfaceKey,         // Open registry key
+                                                            STR_DEFAULTGATEWAY, // Name of key to query
+                                                            nullptr,                 // Reserved - must be nullptr
+                                                            &gatewayValueType,    // Receives value type
+                                                            (LPBYTE)gatewayValue,// Receives value
+                                                            &gatewayValueLength)) // Receives value length in bytes
+                        {
+                            // Check to make sure it's a string
+                            if((gatewayValueType == REG_MULTI_SZ || gatewayValueType == REG_SZ) && (gatewayValueLength > 1))
+                            {
+                                done = 1;
+                            }
+                        }
+                        RegCloseKey(interfaceKey);
+                    }
+                }
+                RegCloseKey(networkCardKey);
+            }
+        }
+    }
+
+    RegCloseKey(interfacesKey);
+    RegCloseKey(networkCardsKey);
+
+    if(done)
+    {
+#if UNICODE
+        char tmp[32] = {0};
+        for(i = 0; i < 32; i++) {
+            tmp[i] = (char)gatewayValue[i];
+            if(!tmp[i])
+                break;
+        }
+        tmp[31] = '\0';
+        *addr = inet_addr(tmp);
+#else
+        *addr = inet_addr(gatewayValue);
+#endif
+        return 0;
+    }
+
+    return -1;
+}
+#endif /* #ifdef USE_WIN32_CODE */
+
+#ifdef USE_WIN32_CODE_2
+int GetDefaultGateway(in_addr_t *addr)
+{
+    MIB_IPFORWARDROW ip_forward;
+    memset(&ip_forward, 0, sizeof(ip_forward));
+    if(GetBestRoute(inet_addr("0.0.0.0"), 0, &ip_forward) != NO_ERROR)
+        return -1;
+    *addr = ip_forward.dwForwardNextHop;
+    return 0;
+}
+#endif /* #ifdef USE_WIN32_CODE_2 */
+
+#ifdef USE_HAIKU_CODE
+int GetDefaultGateway(in_addr_t *addr)
+{
+    int fd, ret = -1;
+    struct ifconf config = {0};
+    void *buffer = nullptr;
+    struct ifreq *interface = nullptr;
+
+    if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
+        return -1;
+    }
+    if (ioctl(fd, SIOCGRTSIZE, &config, sizeof(config)) != 0) {
+        goto fail;
+    }
+    if (config.ifc_value < 1) {
+        goto fail; /* No routes */
+    }
+    if ((buffer = malloc(config.ifc_value)) == nullptr) {
+        goto fail;
+    }
+    config.ifc_len = config.ifc_value;
+    config.ifc_buf = buffer;
+    if (ioctl(fd, SIOCGRTTABLE, &config, sizeof(config)) != 0) {
+        goto fail;
+    }
+    for (interface = buffer;
+      (uint8_t *)interface < (uint8_t *)buffer + config.ifc_len; ) {
+        struct route_entry route = interface->ifr_route;
+        int intfSize;
+        if (route.flags & (RTF_GATEWAY | RTF_DEFAULT)) {
+            *addr = ((struct sockaddr_in *)route.gateway)->sin_addr.s_addr;
+            ret = 0;
+            break;
+        }
+        intfSize = sizeof(route) + IF_NAMESIZE;
+        if (route.destination != nullptr) {
+            intfSize += route.destination->sa_len;
+        }
+        if (route.mask != nullptr) {
+            intfSize += route.mask->sa_len;
+        }
+        if (route.gateway != nullptr) {
+            intfSize += route.gateway->sa_len;
+        }
+        interface = (struct ifreq *)((uint8_t *)interface + intfSize);
+    }
+fail:
+    free(buffer);
+    close(fd);
+    return ret;
+}
+#endif /* #ifdef USE_HAIKU_CODE */

--- a/src/natpmp/gateway.cpp
+++ b/src/natpmp/gateway.cpp
@@ -90,7 +90,7 @@
 #include <gateway.h>
 #ifndef WIN32
 #define SUCCESS (0)
-#define FAILED  (-1)
+#define FAILED (-1)
 #endif
 #ifdef USE_PROC_NET_ROUTE
 #include <sstream>
@@ -120,50 +120,49 @@ eth0    00000000        00000000        0001    0       0       1000    00000000
  One header line, and then one line by route by route table entry.
 */
 
-int TestIfWhiteSpace(char character)
+int TestIfWhiteSpace(char c)
 {
-    std::list<char> whiteSpaces = {'\f', '\n', '\r', '\t', '\v'};
-    return std::count(whiteSpaces.begin(), whiteSpaces.end(), character);
+    return c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v';
 }
 
-int GetDefaultGateway(in_addr_t * addr)
+int GetDefaultGateway(in_addr_t* addr)
 {
-        int64_t d = 0;
-        int64_t g = 0;
-        char buf[256] = {0};
-        int line = 0;
-        char * p = nullptr;
-        FILE* f = fopen("/proc/net/route", "r");
-        if(!f)
-                return FAILED;
-        while(fgets(buf, sizeof(buf), f)) {
-                if(line > 0) {  /* skip the first line */
-                        p = buf;
-                        /* skip the interface name */
-                        while(*p && !TestIfWhiteSpace(*p))
-                                p++;
-                        while(*p && TestIfWhiteSpace(*p))
-                                p++;
+    int64_t d = 0;
+    int64_t g = 0;
+    char buf[256] = {0};
+    int line = 0;
+    char* p = nullptr;
+    FILE* f = fopen("/proc/net/route", "r");
+    if (!f)
+        return FAILED;
+    while (fgets(buf, sizeof(buf), f)) {
+        if (line > 0) { /* skip the first line */
+            p = buf;
+            /* skip the interface name */
+            while (*p && !TestIfWhiteSpace(*p))
+                p++;
+            while (*p && TestIfWhiteSpace(*p))
+                p++;
             // Want just the gateway column
-                        std::string data(p);
-            data = data.substr(data.find('\t')+1);
+            std::string data(p);
+            data = data.substr(data.find('\t') + 1);
             data = data.substr(0, data.find('\t'));
 
-                        std::stringstream dataParser;
-            dataParser<<std::hex<<data;
-                        dataParser >> g >> d;
-            if(d == 0 && g != 0) {
-                                *addr = (in_addr_t)g;
-                                fclose(f);
-                                return SUCCESS;
-                        }
-                }
-                line++;
-        }
-        /* default route not found ! */
-        if(f)
+            std::stringstream dataParser;
+            dataParser << std::hex << data;
+            dataParser >> g >> d;
+            if (d == 0 && g != 0) {
+                *addr = (in_addr_t)g;
                 fclose(f);
-        return FAILED;
+                return SUCCESS;
+            }
+        }
+        line++;
+    }
+    /* default route not found ! */
+    if (f)
+        fclose(f);
+    return FAILED;
 }
 #endif /* #ifdef USE_PROC_NET_ROUTE */
 
@@ -171,46 +170,44 @@ int GetDefaultGateway(in_addr_t * addr)
 #ifdef USE_SYSCTL_NET_ROUTE
 
 #define ROUNDUP(a) \
-    ((a) > 0 ? (1 + (((a) - 1) | (sizeof(long) - 1))) : sizeof(long))
+    ((a) > 0 ? (1 + (((a)-1) | (sizeof(long) - 1))) : sizeof(long))
 
-int GetDefaultGateway(in_addr_t * addr)
+int GetDefaultGateway(in_addr_t* addr)
 {
     /* net.route.0.inet.flags.gateway */
     int mib[] = {CTL_NET, PF_ROUTE, 0, AF_INET,
-                 NET_RT_FLAGS, RTF_GATEWAY};
+        NET_RT_FLAGS, RTF_GATEWAY};
     size_t l = 0;
     char* buf = nullptr;
     char* p = nullptr;
-    struct rt_msghdr * rt = {0};
-    struct sockaddr * sa = {0};
-    struct sockaddr * sa_tab[RTAX_MAX];
+    struct rt_msghdr* rt = {0};
+    struct sockaddr* sa = {0};
+    struct sockaddr* sa_tab[RTAX_MAX];
     int i = 0;
     int r = FAILED;
-    if(sysctl(mib, sizeof(mib)/sizeof(int), 0, &l, 0, 0) < 0) {
+    if (sysctl(mib, sizeof(mib) / sizeof(int), 0, &l, 0, 0) < 0) {
         return FAILED;
     }
-    if(l>0) {
+    if (l > 0) {
         buf = (char*)malloc(l);
-        if(sysctl(mib, sizeof(mib)/sizeof(int), buf, &l, 0, 0) < 0) {
+        if (sysctl(mib, sizeof(mib) / sizeof(int), buf, &l, 0, 0) < 0) {
             free(buf);
             return FAILED;
         }
-        for(p=buf; p<buf+l; p+=rt->rtm_msglen) {
-            rt = (struct rt_msghdr *)p;
-            sa = (struct sockaddr *)(rt + 1);
-            for(i=0; i<RTAX_MAX; i++) {
-                if(rt->rtm_addrs & (1 << i)) {
+        for (p = buf; p < buf + l; p += rt->rtm_msglen) {
+            rt = (struct rt_msghdr*)p;
+            sa = (struct sockaddr*)(rt + 1);
+            for (i = 0; i < RTAX_MAX; i++) {
+                if (rt->rtm_addrs & (1 << i)) {
                     sa_tab[i] = sa;
-                    sa = (struct sockaddr *)((char *)sa + ROUNDUP(sa->sa_len));
+                    sa = (struct sockaddr*)((char*)sa + ROUNDUP(sa->sa_len));
                 } else {
                     sa_tab[i] = nullptr;
                 }
             }
-            if( ((rt->rtm_addrs & (RTA_DST|RTA_GATEWAY)) == (RTA_DST|RTA_GATEWAY))
-              && sa_tab[RTAX_DST]->sa_family == AF_INET
-              && sa_tab[RTAX_GATEWAY]->sa_family == AF_INET) {
-                if(((struct sockaddr_in *)sa_tab[RTAX_DST])->sin_addr.s_addr == 0) {
-                    *addr = ((struct sockaddr_in *)(sa_tab[RTAX_GATEWAY]))->sin_addr.s_addr;
+            if (((rt->rtm_addrs & (RTA_DST | RTA_GATEWAY)) == (RTA_DST | RTA_GATEWAY)) && sa_tab[RTAX_DST]->sa_family == AF_INET && sa_tab[RTAX_GATEWAY]->sa_family == AF_INET) {
+                if (((struct sockaddr_in*)sa_tab[RTAX_DST])->sin_addr.s_addr == 0) {
+                    *addr = ((struct sockaddr_in*)(sa_tab[RTAX_GATEWAY]))->sin_addr.s_addr;
                     r = SUCCESS;
                 }
             }
@@ -224,90 +221,92 @@ int GetDefaultGateway(in_addr_t * addr)
 
 #ifdef USE_SOCKET_ROUTE
 /* Thanks to Darren Kenny for this code */
-#define NEXTADDR(w, u) \
-        if (rtm_addrs & (w)) {\
-            l = sizeof(struct sockaddr); memmove(cp, &(u), l); cp += l;\
-        }
+#define NEXTADDR(w, u)               \
+    if (rtm_addrs & (w)) {           \
+        l = sizeof(struct sockaddr); \
+        memmove(cp, &(u), l);        \
+        cp += l;                     \
+    }
 
 #define rtm m_rtmsg.m_rtm
 
 struct {
-  struct rt_msghdr m_rtm;
-  char       m_space[512];
+    struct rt_msghdr m_rtm;
+    char m_space[512];
 } m_rtmsg;
 
-int GetDefaultGateway(in_addr_t *addr)
+int GetDefaultGateway(in_addr_t* addr)
 {
-  int s = 0, seq = 0, l = 0, rtm_addrs = 0, i = 0;
-  pid_t pid = {0};
-  struct sockaddr so_dst = {0}, so_mask = {0};
-  char *cp = m_rtmsg.m_space;
-  struct sockaddr *gate = nullptr, *sa = nullptr;
-  struct rt_msghdr *msg_hdr = nullptr;
+    int s = 0, seq = 0, l = 0, rtm_addrs = 0, i = 0;
+    pid_t pid = {0};
+    struct sockaddr so_dst = {0}, so_mask = {0};
+    char* cp = m_rtmsg.m_space;
+    struct sockaddr *gate = nullptr, *sa = nullptr;
+    struct rt_msghdr* msg_hdr = nullptr;
 
-  pid = getpid();
-  seq = 0;
-  rtm_addrs = RTA_DST | RTA_NETMASK;
+    pid = getpid();
+    seq = 0;
+    rtm_addrs = RTA_DST | RTA_NETMASK;
 
-  memset(&so_dst, 0, sizeof(so_dst));
-  memset(&so_mask, 0, sizeof(so_mask));
-  memset(&rtm, 0, sizeof(struct rt_msghdr));
+    memset(&so_dst, 0, sizeof(so_dst));
+    memset(&so_mask, 0, sizeof(so_mask));
+    memset(&rtm, 0, sizeof(struct rt_msghdr));
 
-  rtm.rtm_type = RTM_GET;
-  rtm.rtm_flags = RTF_UP | RTF_GATEWAY;
-  rtm.rtm_version = RTM_VERSION;
-  rtm.rtm_seq = ++seq;
-  rtm.rtm_addrs = rtm_addrs;
+    rtm.rtm_type = RTM_GET;
+    rtm.rtm_flags = RTF_UP | RTF_GATEWAY;
+    rtm.rtm_version = RTM_VERSION;
+    rtm.rtm_seq = ++seq;
+    rtm.rtm_addrs = rtm_addrs;
 
-  so_dst.sa_family = AF_INET;
-  so_mask.sa_family = AF_INET;
+    so_dst.sa_family = AF_INET;
+    so_mask.sa_family = AF_INET;
 
-  NEXTADDR(RTA_DST, so_dst);
-  NEXTADDR(RTA_NETMASK, so_mask);
+    NEXTADDR(RTA_DST, so_dst);
+    NEXTADDR(RTA_NETMASK, so_mask);
 
-  rtm.rtm_msglen = l = cp - (char *)&m_rtmsg;
+    rtm.rtm_msglen = l = cp - (char*)&m_rtmsg;
 
-  s = socket(PF_ROUTE, SOCK_RAW, 0);
+    s = socket(PF_ROUTE, SOCK_RAW, 0);
 
-  if (write(s, (char *)&m_rtmsg, l) < 0) {
-      close(s);
-      return FAILED;
-  }
+    if (write(s, (char*)&m_rtmsg, l) < 0) {
+        close(s);
+        return FAILED;
+    }
 
-  do {
-    l = read(s, (char *)&m_rtmsg, sizeof(m_rtmsg));
-  } while (l > 0 && (rtm.rtm_seq != seq || rtm.rtm_pid != pid));
+    do {
+        l = read(s, (char*)&m_rtmsg, sizeof(m_rtmsg));
+    } while (l > 0 && (rtm.rtm_seq != seq || rtm.rtm_pid != pid));
 
-  close(s);
+    close(s);
 
-  msg_hdr = &rtm;
+    msg_hdr = &rtm;
 
-  cp = ((char *)(msg_hdr + 1));
-  if (msg_hdr->rtm_addrs) {
-    for (i = 1; i; i <<= 1)
-      if (i & msg_hdr->rtm_addrs) {
-        sa = (struct sockaddr *)cp;
-        if (i == RTA_GATEWAY )
-          gate = sa;
+    cp = ((char*)(msg_hdr + 1));
+    if (msg_hdr->rtm_addrs) {
+        for (i = 1; i; i <<= 1)
+            if (i & msg_hdr->rtm_addrs) {
+                sa = (struct sockaddr*)cp;
+                if (i == RTA_GATEWAY)
+                    gate = sa;
 
-        cp += sizeof(struct sockaddr);
-      }
-  } else {
-      return FAILED;
-  }
+                cp += sizeof(struct sockaddr);
+            }
+    } else {
+        return FAILED;
+    }
 
 
-  if (gate != nullptr ) {
-      *addr = ((struct sockaddr_in *)gate)->sin_addr.s_addr;
-      return SUCCESS;
-  } else {
-      return FAILED;
-  }
+    if (gate != nullptr) {
+        *addr = ((struct sockaddr_in*)gate)->sin_addr.s_addr;
+        return SUCCESS;
+    } else {
+        return FAILED;
+    }
 }
 #endif /* #ifdef USE_SOCKET_ROUTE */
 
 #ifdef USE_WIN32_CODE
-LIBSPEC int GetDefaultGateway(in_addr_t * addr)
+LIBSPEC int GetDefaultGateway(in_addr_t* addr)
 {
     HKEY networkCardsKey;
     HKEY networkCardKey;
@@ -328,15 +327,15 @@ LIBSPEC int GetDefaultGateway(in_addr_t * addr)
 #ifdef UNICODE
     LPCTSTR networkCardsPath = L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkCards";
     LPCTSTR interfacesPath = L"SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces";
-#define STR_SERVICENAME     L"ServiceName"
+#define STR_SERVICENAME L"ServiceName"
 #define STR_DHCPDEFAULTGATEWAY L"DhcpDefaultGateway"
-#define STR_DEFAULTGATEWAY    L"DefaultGateway"
+#define STR_DEFAULTGATEWAY L"DefaultGateway"
 #else
     LPCTSTR networkCardsPath = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\NetworkCards";
     LPCTSTR interfacesPath = "SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters\\Interfaces";
-#define STR_SERVICENAME     "ServiceName"
+#define STR_SERVICENAME "ServiceName"
 #define STR_DHCPDEFAULTGATEWAY "DhcpDefaultGateway"
-#define STR_DEFAULTGATEWAY    "DefaultGateway"
+#define STR_DEFAULTGATEWAY "DefaultGateway"
 #endif
     // The windows registry lists its primary network devices in the following location:
     // HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows NT\CurrentVersion\NetworkCards
@@ -364,7 +363,7 @@ LIBSPEC int GetDefaultGateway(in_addr_t * addr)
     //     -[more]
     //   -{86226414-5545-4335-A9D1-5BD7120119AD}
     //     -DhcpIpAddress = 10.0.1.5
-    //     -DhcpDefaultGateay = 10.0.1.1
+    //     -DhcpDefaultGateway = 10.0.1.1
     //     -[more]
     //
     // In order to extract this information, we enumerate each network card, and extract the ServiceName value.
@@ -374,21 +373,21 @@ LIBSPEC int GetDefaultGateway(in_addr_t * addr)
     // It may be possible to simply enumerate the interface folders until we find one with a DhcpDefaultGateway value.
     // However, the technique used is the technique most cited on the web, and we assume it to be more correct.
 
-    if(ERROR_SUCCESS != RegOpenKeyEx(HKEY_LOCAL_MACHINE, // Open registry key or predefined key
-                                     networkCardsPath,   // Name of registry subkey to open
-                                     0,                  // Reserved - must be zero
-                                     KEY_READ,           // Mask - desired access rights
-                                     &networkCardsKey))  // Pointer to output key
+    if (ERROR_SUCCESS != RegOpenKeyEx(HKEY_LOCAL_MACHINE, // Open registry key or predefined key
+                             networkCardsPath,            // Name of registry subkey to open
+                             0,                           // Reserved - must be zero
+                             KEY_READ,                    // Mask - desired access rights
+                             &networkCardsKey))           // Pointer to output key
     {
         // Unable to open network cards keys
         return -1;
     }
 
-    if(ERROR_SUCCESS != RegOpenKeyEx(HKEY_LOCAL_MACHINE, // Open registry key or predefined key
-                                     interfacesPath,     // Name of registry subkey to open
-                                     0,                  // Reserved - must be zero
-                                     KEY_READ,           // Mask - desired access rights
-                                     &interfacesKey))    // Pointer to output key
+    if (ERROR_SUCCESS != RegOpenKeyEx(HKEY_LOCAL_MACHINE, // Open registry key or predefined key
+                             interfacesPath,              // Name of registry subkey to open
+                             0,                           // Reserved - must be zero
+                             KEY_READ,                    // Mask - desired access rights
+                             &interfacesKey))             // Pointer to output key
     {
         // Unable to open interfaces key
         RegCloseKey(networkCardsKey);
@@ -396,57 +395,53 @@ LIBSPEC int GetDefaultGateway(in_addr_t * addr)
     }
 
     // Figure out how many subfolders are within the Network Cards folder
-    RegQueryInfoKey(networkCardsKey, nullptr, nullptr, nullptr, &numSubKeys, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+    RegQueryInfoKey(networkCardsKey, nullptr, nullptr, nullptr, &numSubKeys,
+        nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
+        nullptr);
 
     // Enumerate through each subfolder within the Network Cards folder
-    for(i = 0; i < numSubKeys && !done; i++)
-    {
+    for (i = 0; i < numSubKeys && !done; i++) {
         keyNameLength = MAX_KEY_LENGTH;
-        if(ERROR_SUCCESS == RegEnumKeyEx(networkCardsKey, // Open registry key
-                                         i,               // Index of sub key to retrieve
-                                         keyName,         // Buffer that receives the name of the sub key
-                                         &keyNameLength,  // Variable that receives the size of the above buffer
-                                         nullptr,            // Reserved - must be nullptr
-                                         nullptr,            // Buffer that receives the class string
-                                         nullptr,            // Variable that receives the size of the above buffer
-                                         nullptr))           // Variable that receives the last write time of sub key
+        if (ERROR_SUCCESS == RegEnumKeyEx(networkCardsKey, // Open registry key
+                                 i,                        // Index of sub key to retrieve
+                                 keyName,                  // Buffer that receives the name of the sub key
+                                 &keyNameLength,           // Variable that receives the size of the above buffer
+                                 nullptr,                  // Reserved - must be nullptr
+                                 nullptr,                  // Buffer that receives the class string
+                                 nullptr,                  // Variable that receives the size of the above buffer
+                                 nullptr))                 // Variable that receives the last write time of sub key
         {
-            if(RegOpenKeyEx(networkCardsKey,  keyName, 0, KEY_READ, &networkCardKey) == ERROR_SUCCESS)
-            {
+            if (RegOpenKeyEx(networkCardsKey, keyName, 0, KEY_READ, &networkCardKey) == ERROR_SUCCESS) {
                 keyValueLength = MAX_VALUE_LENGTH;
-                if(ERROR_SUCCESS == RegQueryValueEx(networkCardKey,   // Open registry key
-                                                    STR_SERVICENAME,    // Name of key to query
-                                                    nullptr,             // Reserved - must be nullptr
-                                                    &keyValueType,    // Receives value type
-                                                    (LPBYTE)keyValue, // Receives value
-                                                    &keyValueLength)) // Receives value length in bytes
+                if (ERROR_SUCCESS == RegQueryValueEx(networkCardKey, // Open registry key
+                                         STR_SERVICENAME,            // Name of key to query
+                                         nullptr,                    // Reserved - must be nullptr
+                                         &keyValueType,              // Receives value type
+                                         (LPBYTE)keyValue,           // Receives value
+                                         &keyValueLength))           // Receives value length in bytes
                 {
-                    if(RegOpenKeyEx(interfacesKey, keyValue, 0, KEY_READ, &interfaceKey) == ERROR_SUCCESS)
-                    {
+                    if (RegOpenKeyEx(interfacesKey, keyValue, 0, KEY_READ, &interfaceKey) == ERROR_SUCCESS) {
                         gatewayValueLength = MAX_VALUE_LENGTH;
-                        if(ERROR_SUCCESS == RegQueryValueEx(interfaceKey,         // Open registry key
-                                                            STR_DHCPDEFAULTGATEWAY, // Name of key to query
-                                                            nullptr,                 // Reserved - must be nullptr
-                                                            &gatewayValueType,    // Receives value type
-                                                            (LPBYTE)gatewayValue, // Receives value
-                                                            &gatewayValueLength)) // Receives value length in bytes
+                        if (ERROR_SUCCESS == RegQueryValueEx(interfaceKey, // Open registry key
+                                                 STR_DHCPDEFAULTGATEWAY,   // Name of key to query
+                                                 nullptr,                  // Reserved - must be nullptr
+                                                 &gatewayValueType,        // Receives value type
+                                                 (LPBYTE)gatewayValue,     // Receives value
+                                                 &gatewayValueLength))     // Receives value length in bytes
                         {
                             // Check to make sure it's a string
-                            if((gatewayValueType == REG_MULTI_SZ || gatewayValueType == REG_SZ) && (gatewayValueLength > 1))
-                            {
+                            if ((gatewayValueType == REG_MULTI_SZ || gatewayValueType == REG_SZ) && (gatewayValueLength > 1)) {
                                 done = 1;
                             }
-                        }
-                        else if(ERROR_SUCCESS == RegQueryValueEx(interfaceKey,         // Open registry key
-                                                            STR_DEFAULTGATEWAY, // Name of key to query
-                                                            nullptr,                 // Reserved - must be nullptr
-                                                            &gatewayValueType,    // Receives value type
-                                                            (LPBYTE)gatewayValue,// Receives value
-                                                            &gatewayValueLength)) // Receives value length in bytes
+                        } else if (ERROR_SUCCESS == RegQueryValueEx(interfaceKey, // Open registry key
+                                                        STR_DEFAULTGATEWAY,       // Name of key to query
+                                                        nullptr,                  // Reserved - must be nullptr
+                                                        &gatewayValueType,        // Receives value type
+                                                        (LPBYTE)gatewayValue,     // Receives value
+                                                        &gatewayValueLength))     // Receives value length in bytes
                         {
                             // Check to make sure it's a string
-                            if((gatewayValueType == REG_MULTI_SZ || gatewayValueType == REG_SZ) && (gatewayValueLength > 1))
-                            {
+                            if ((gatewayValueType == REG_MULTI_SZ || gatewayValueType == REG_SZ) && (gatewayValueLength > 1)) {
                                 done = 1;
                             }
                         }
@@ -461,13 +456,12 @@ LIBSPEC int GetDefaultGateway(in_addr_t * addr)
     RegCloseKey(interfacesKey);
     RegCloseKey(networkCardsKey);
 
-    if(done)
-    {
+    if (done) {
 #if UNICODE
         char tmp[32] = {0};
-        for(i = 0; i < 32; i++) {
+        for (i = 0; i < 32; i++) {
             tmp[i] = (char)gatewayValue[i];
-            if(!tmp[i])
+            if (!tmp[i])
                 break;
         }
         tmp[31] = '\0';
@@ -483,11 +477,11 @@ LIBSPEC int GetDefaultGateway(in_addr_t * addr)
 #endif /* #ifdef USE_WIN32_CODE */
 
 #ifdef USE_WIN32_CODE_2
-int GetDefaultGateway(in_addr_t *addr)
+int GetDefaultGateway(in_addr_t* addr)
 {
     MIB_IPFORWARDROW ip_forward;
     memset(&ip_forward, 0, sizeof(ip_forward));
-    if(GetBestRoute(inet_addr("0.0.0.0"), 0, &ip_forward) != NO_ERROR)
+    if (GetBestRoute(inet_addr("0.0.0.0"), 0, &ip_forward) != NO_ERROR)
         return -1;
     *addr = ip_forward.dwForwardNextHop;
     return 0;
@@ -495,12 +489,12 @@ int GetDefaultGateway(in_addr_t *addr)
 #endif /* #ifdef USE_WIN32_CODE_2 */
 
 #ifdef USE_HAIKU_CODE
-int GetDefaultGateway(in_addr_t *addr)
+int GetDefaultGateway(in_addr_t* addr)
 {
     int fd, ret = -1;
     struct ifconf config = {0};
-    void *buffer = nullptr;
-    struct ifreq *interface = nullptr;
+    void* buffer = nullptr;
+    struct ifreq* interface = nullptr;
 
     if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
         return -1;
@@ -520,11 +514,11 @@ int GetDefaultGateway(in_addr_t *addr)
         goto fail;
     }
     for (interface = buffer;
-      (uint8_t *)interface < (uint8_t *)buffer + config.ifc_len; ) {
+         (uint8_t*)interface < (uint8_t*)buffer + config.ifc_len;) {
         struct route_entry route = interface->ifr_route;
         int intfSize;
         if (route.flags & (RTF_GATEWAY | RTF_DEFAULT)) {
-            *addr = ((struct sockaddr_in *)route.gateway)->sin_addr.s_addr;
+            *addr = ((struct sockaddr_in*)route.gateway)->sin_addr.s_addr;
             ret = 0;
             break;
         }
@@ -538,7 +532,7 @@ int GetDefaultGateway(in_addr_t *addr)
         if (route.gateway != nullptr) {
             intfSize += route.gateway->sa_len;
         }
-        interface = (struct ifreq *)((uint8_t *)interface + intfSize);
+        interface = (struct ifreq*)((uint8_t*)interface + intfSize);
     }
 fail:
     free(buffer);

--- a/src/natpmp/include/gateway.h
+++ b/src/natpmp/include/gateway.h
@@ -1,0 +1,18 @@
+#ifndef BITCOIN_NATPMP_INCLUDE_GATEWAY_H
+#define BITCOIN_NATPMP_INCLUDE_GATEWAY_H
+
+#ifdef WIN32
+#if !defined(_MSC_VER)
+#include <stdint.h>
+#endif
+#endif
+#define in_addr_t uint32_t
+#include <cstdint>
+
+/// @brief Get default gateway
+///
+/// @param addr Address
+///
+/// @return 0 Success, -1 Error
+int GetDefaultGateway(in_addr_t * addr);
+#endif // BITCOIN_NATPMP_INCLUDE_GATEWAY_H

--- a/src/natpmp/include/gateway.h
+++ b/src/natpmp/include/gateway.h
@@ -14,5 +14,5 @@
 /// @param addr Address
 ///
 /// @return 0 Success, -1 Error
-int GetDefaultGateway(in_addr_t * addr);
+int GetDefaultGateway(in_addr_t* addr);
 #endif // BITCOIN_NATPMP_INCLUDE_GATEWAY_H

--- a/src/natpmp/include/natmap_wrapper.h
+++ b/src/natpmp/include/natmap_wrapper.h
@@ -1,0 +1,85 @@
+#ifndef BITCOIN_NATPMP_INCLUDE_NATMAP_WRAPPER_H
+#define BITCOIN_NATPMP_INCLUDE_NATMAP_WRAPPER_H
+
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#endif
+#ifdef WIN32
+#include <winsock2.h>
+#else
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+#include <natpmp.h>
+#include <string>
+#include <iostream>
+#include <logging.h>
+#if defined(_WIN32) || defined(_WIN64)
+#include <ws2ipdef.h>
+#include <ws2tcpip.h>
+#endif
+#include <array>
+
+enum class Protocol {
+    UDP = 1,
+    TCP
+};
+using TimeValType = struct timeval;
+
+/// @brief Wrapper over libnatpmp functions
+class NatMap
+{
+private:
+    natpmp_t m_NatPmpObj;
+    int m_State;
+
+public:
+    /// @brief Constructor
+    ///
+    /// @param alternateGWAddr Pass a known gateway if default not to be used.
+    explicit NatMap(in_addr_t* alternateGWAddr = nullptr);
+    ~NatMap();
+
+    /// @brief Expected to be called immediately after object construction.
+    ///
+    /// @return Zero or error code.
+    int IsGood() const;
+
+    /// @brief Ask gateway his public (internet facing) address. Does about
+    ///        9 re-tries before giving up. So expect it to be a bit time consuming.
+    ///
+    /// @param publicAddressOut You would receive address in this
+    ///
+    /// @return Error code or success
+    int GetPublicAddress(std::string& publicAddressOut);
+
+    /// @brief Ask gateway to map your m/c port on the internet.
+    ///        Pass same data to renew and zero life time to discontinue.
+    ///
+    /// @param protocol TCP/UDP
+    /// @param privatePort your m/c port
+    /// @param publicPortOut port on public IP, IN/Out Param ( Don't
+    ///                      always expect to get what you wish ;))
+    /// @param lifeTimeOut Lifetime of mapping, IN/Out Parameter
+    ///
+    /// @return Error code or success
+    int SendMapReq(Protocol protocol, uint16_t privatePort, uint16_t& publicPortOut, uint32_t& lifeTimeOut);
+    /// @brief Convert your error into meaningful message.
+    ///
+    /// @param err your error code
+    ///
+    /// @return Readable message
+    std::string GetErrMsg(int err);
+
+    /// @brief Get the default gateway
+    ///
+    /// @param addrOut Out parameter
+    ///
+    /// @return yes/no
+    int GetDefaultGateway(std::string& addrOut) const;
+};
+
+#endif // BITCOIN_NATPMP_INCLUDE_NATMAP_WRAPPER_H

--- a/src/natpmp/include/natpmp.h
+++ b/src/natpmp/include/natpmp.h
@@ -20,20 +20,21 @@
 #endif
 #include <cstdint>
 
-typedef struct {
-    int s;    /* socket */
-    in_addr_t gateway;    /* default gateway (IPv4) */
+struct natpmp {
+    int s;             /* socket */
+    in_addr_t gateway; /* default gateway (IPv4) */
     int has_pending_request;
     unsigned char pending_request[12];
     int pending_request_len;
     int try_number;
     struct timeval retry_time;
-} natpmp_t;
+};
+using natpmp_t = struct natpmp;
 
-typedef struct {
-    int16_t type;    /* NATPMP_RESPTYPE_* */
-    int16_t resultcode;    /* NAT-PMP response code */
-    int64_t epoch;    /* Seconds since start of epoch */
+struct natpmpresp {
+    int16_t type;       /* NATPMP_RESPTYPE_* */
+    int16_t resultcode; /* NAT-PMP response code */
+    int64_t epoch;      /* Seconds since start of epoch */
     union {
         struct {
             struct in_addr addr;
@@ -44,7 +45,8 @@ typedef struct {
             int64_t lifetime;
         } newportmapping;
     } pnu;
-} natpmpresp_t;
+};
+using natpmpresp_t = struct natpmpresp;
 
 /* possible values for type field of natpmpresp_t */
 #define NATPMP_RESPTYPE_PUBLICADDRESS (0)
@@ -113,7 +115,7 @@ extern "C" {
  * NATPMP_ERR_CONNECTERR
  *
  */
-int InitNatPmp(natpmp_t * p, int forcegw, in_addr_t forcedgw);
+int InitNatPmp(natpmp_t* p, int forcegw, in_addr_t forcedgw);
 
 /*
  * CloseNatPmp()
@@ -124,7 +126,7 @@ int InitNatPmp(natpmp_t * p, int forcegw, in_addr_t forcedgw);
  * NATPMP_ERR_CLOSEERR
  *
  */
-int CloseNatPmp(natpmp_t * p);
+int CloseNatPmp(natpmp_t* p);
 
 /*
  * SendPublicAddressRequest()
@@ -135,7 +137,7 @@ int CloseNatPmp(natpmp_t * p);
  * NATPMP_ERR_SENDERR
  *
  */
-int SendPublicAddressRequest(natpmp_t * p);
+int SendPublicAddressRequest(natpmp_t* p);
 
 /*
  * SendNewPortMappingRequest()
@@ -152,8 +154,7 @@ int SendPublicAddressRequest(natpmp_t * p);
  * NATPMP_ERR_SENDERR
  *
  */
-int SendNewPortMappingRequest(natpmp_t * p, int protocol, int16_t privateport,
-                              int16_t publicport, int64_t lifetime);
+int SendNewPortMappingRequest(natpmp_t* p, int protocol, int16_t privateport, int16_t publicport, int64_t lifetime);
 
 /*
  * GetNatPmpRequestTimeout()
@@ -166,7 +167,7 @@ int SendNewPortMappingRequest(natpmp_t * p, int protocol, int16_t privateport,
  * NATPMP_ERR_NOPENDINGREQ
  *
  */
-int GetNatPmpRequestTimeout(natpmp_t * p, struct timeval * timeout);
+int GetNatPmpRequestTimeout(natpmp_t* p, struct timeval* timeout);
 
 /*
  * ReadNatPmpResponseOrRetry()
@@ -188,9 +189,9 @@ int GetNatPmpRequestTimeout(natpmp_t * p, struct timeval * timeout);
  * NATPMP_ERR_UNDEFINEDERROR
  *
  */
-int ReadNatPmpResponseOrRetry(natpmp_t * p, natpmpresp_t * response);
+int ReadNatPmpResponseOrRetry(natpmp_t* p, natpmpresp_t* response);
 
-const char * StrNatPmpErr(int t);
+const char* StrNatPmpErr(int err);
 
 #ifdef __cplusplus
 }

--- a/src/natpmp/include/natpmp.h
+++ b/src/natpmp/include/natpmp.h
@@ -1,0 +1,198 @@
+#ifndef BITCOIN_NATPMP_INCLUDE_NATPMP_H
+#define BITCOIN_NATPMP_INCLUDE_NATPMP_H
+
+/* NAT-PMP Port as defined by the NAT-PMP draft */
+#define NATPMP_PORT (5351)
+
+#include <time.h>
+#if !defined(_MSC_VER)
+#include <sys/time.h>
+#endif
+#ifdef WIN32
+#include <winsock2.h>
+#if !defined(_MSC_VER)
+#include <stdint.h>
+#endif
+#define in_addr_t uint32_t
+#else
+#define LIBSPEC
+#include <netinet/in.h>
+#endif
+#include <cstdint>
+
+typedef struct {
+    int s;    /* socket */
+    in_addr_t gateway;    /* default gateway (IPv4) */
+    int has_pending_request;
+    unsigned char pending_request[12];
+    int pending_request_len;
+    int try_number;
+    struct timeval retry_time;
+} natpmp_t;
+
+typedef struct {
+    int16_t type;    /* NATPMP_RESPTYPE_* */
+    int16_t resultcode;    /* NAT-PMP response code */
+    int64_t epoch;    /* Seconds since start of epoch */
+    union {
+        struct {
+            struct in_addr addr;
+        } publicaddress;
+        struct {
+            int16_t privateport;
+            int16_t mappedpublicport;
+            int64_t lifetime;
+        } newportmapping;
+    } pnu;
+} natpmpresp_t;
+
+/* possible values for type field of natpmpresp_t */
+#define NATPMP_RESPTYPE_PUBLICADDRESS (0)
+#define NATPMP_RESPTYPE_UDPPORTMAPPING (1)
+#define NATPMP_RESPTYPE_TCPPORTMAPPING (2)
+
+/* Values to pass to SendNewPortMappingRequest() */
+#define NATPMP_PROTOCOL_UDP (1)
+#define NATPMP_PROTOCOL_TCP (2)
+
+/* return values */
+/* NATPMP_ERR_INVALIDARGS : invalid arguments passed to the function */
+#define NATPMP_ERR_INVALIDARGS (-1)
+/* NATPMP_ERR_SOCKETERROR : socket() failed. Check errno for details */
+#define NATPMP_ERR_SOCKETERROR (-2)
+/* NATPMP_ERR_CANNOTGETGATEWAY : can't get default gateway IP */
+#define NATPMP_ERR_CANNOTGETGATEWAY (-3)
+/* NATPMP_ERR_CLOSEERR : close() failed. Check errno for details */
+#define NATPMP_ERR_CLOSEERR (-4)
+/* NATPMP_ERR_RECVFROM : recvfrom() failed. Check errno for details */
+#define NATPMP_ERR_RECVFROM (-5)
+/* NATPMP_ERR_NOPENDINGREQ : ReadNatPmpResponseOrRetry() called while
+ * no NAT-PMP request was pending */
+#define NATPMP_ERR_NOPENDINGREQ (-6)
+/* NATPMP_ERR_NOGATEWAYSUPPORT : the gateway does not support NAT-PMP */
+#define NATPMP_ERR_NOGATEWAYSUPPORT (-7)
+/* NATPMP_ERR_CONNECTERR : connect() failed. Check errno for details */
+#define NATPMP_ERR_CONNECTERR (-8)
+/* NATPMP_ERR_WRONGPACKETSOURCE : packet not received from the network gateway */
+#define NATPMP_ERR_WRONGPACKETSOURCE (-9)
+/* NATPMP_ERR_SENDERR : send() failed. Check errno for details */
+#define NATPMP_ERR_SENDERR (-10)
+/* NATPMP_ERR_FCNTLERROR : fcntl() failed. Check errno for details */
+#define NATPMP_ERR_FCNTLERROR (-11)
+/* NATPMP_ERR_GETTIMEOFDAYERR : gettimeofday() failed. Check errno for details */
+#define NATPMP_ERR_GETTIMEOFDAYERR (-12)
+
+#define NATPMP_ERR_UNSUPPORTEDVERSION (-14)
+#define NATPMP_ERR_UNSUPPORTEDOPCODE (-15)
+
+/* Errors from the server : */
+#define NATPMP_ERR_UNDEFINEDERROR (-49)
+#define NATPMP_ERR_NOTAUTHORIZED (-51)
+#define NATPMP_ERR_NETWORKFAILURE (-52)
+#define NATPMP_ERR_OUTOFRESOURCES (-53)
+
+/* NATPMP_TRYAGAIN : no data available for the moment. Try again later */
+#define NATPMP_TRYAGAIN (-100)
+/* Failure in select() */
+#define NATMAP_ERR_SELECT (-101)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * InitNatPmp()
+ * Initialize a natpmp_t object
+ * With forcegw=1 the gateway is not detected automatically.
+ * Return values :
+ * 0 = OK
+ * NATPMP_ERR_INVALIDARGS
+ * NATPMP_ERR_SOCKETERROR
+ * NATPMP_ERR_FCNTLERROR
+ * NATPMP_ERR_CANNOTGETGATEWAY
+ * NATPMP_ERR_CONNECTERR
+ *
+ */
+int InitNatPmp(natpmp_t * p, int forcegw, in_addr_t forcedgw);
+
+/*
+ * CloseNatPmp()
+ * Close resources associated with a natpmp_t object
+ * Return values :
+ * 0 = OK
+ * NATPMP_ERR_INVALIDARGS
+ * NATPMP_ERR_CLOSEERR
+ *
+ */
+int CloseNatPmp(natpmp_t * p);
+
+/*
+ * SendPublicAddressRequest()
+ * Send a public address NAT-PMP request to the network gateway
+ * Return values :
+ * 2 = OK (size of the request)
+ * NATPMP_ERR_INVALIDARGS
+ * NATPMP_ERR_SENDERR
+ *
+ */
+int SendPublicAddressRequest(natpmp_t * p);
+
+/*
+ * SendNewPortMappingRequest()
+ * Send a new port mapping NAT-PMP request to the network gateway
+ * Arguments :
+ * protocol is either NATPMP_PROTOCOL_TCP or NATPMP_PROTOCOL_UDP,
+ * lifetime is in seconds.
+ * To remove a port mapping, set lifetime to zero.
+ * To remove all port mappings to the host, set lifetime and both ports
+ * to zero.
+ * Return values :
+ * 12 = OK (size of the request)
+ * NATPMP_ERR_INVALIDARGS
+ * NATPMP_ERR_SENDERR
+ *
+ */
+int SendNewPortMappingRequest(natpmp_t * p, int protocol, int16_t privateport,
+                              int16_t publicport, int64_t lifetime);
+
+/*
+ * GetNatPmpRequestTimeout()
+ * Fills the timeval structure with the timeout duration of the
+ * currently pending NAT-PMP request.
+ * Return values :
+ * 0 = OK
+ * NATPMP_ERR_INVALIDARGS
+ * NATPMP_ERR_GETTIMEOFDAYERR
+ * NATPMP_ERR_NOPENDINGREQ
+ *
+ */
+int GetNatPmpRequestTimeout(natpmp_t * p, struct timeval * timeout);
+
+/*
+ * ReadNatPmpResponseOrRetry()
+ * Fills the natpmpresp_t structure if possible
+ * Return values :
+ * 0 = OK
+ * NATPMP_TRYAGAIN
+ * NATPMP_ERR_INVALIDARGS
+ * NATPMP_ERR_NOPENDINGREQ
+ * NATPMP_ERR_NOGATEWAYSUPPORT
+ * NATPMP_ERR_RECVFROM
+ * NATPMP_ERR_WRONGPACKETSOURCE
+ * NATPMP_ERR_UNSUPPORTEDVERSION
+ * NATPMP_ERR_UNSUPPORTEDOPCODE
+ * NATPMP_ERR_NOTAUTHORIZED
+ * NATPMP_ERR_NETWORKFAILURE
+ * NATPMP_ERR_OUTOFRESOURCES
+ * NATPMP_ERR_UNSUPPORTEDOPCODE
+ * NATPMP_ERR_UNDEFINEDERROR
+ *
+ */
+int ReadNatPmpResponseOrRetry(natpmp_t * p, natpmpresp_t * response);
+
+const char * StrNatPmpErr(int t);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // BITCOIN_NATPMP_INCLUDE_NATPMP_H

--- a/src/natpmp/natmap_wrapper.cpp
+++ b/src/natpmp/natmap_wrapper.cpp
@@ -1,0 +1,106 @@
+#include <natmap_wrapper.h>
+
+NatMap::NatMap(in_addr_t* alternateGWAddr)
+{
+    memset(&m_NatPmpObj, 0, sizeof(m_NatPmpObj));
+    in_addr_t gateway = {0};
+    if (alternateGWAddr) {
+        memcpy(&gateway, alternateGWAddr, sizeof(gateway));
+    }
+    m_State = InitNatPmp(&m_NatPmpObj,
+        alternateGWAddr ? 1 : 0,
+        gateway);
+}
+
+int NatMap::IsGood() const
+{
+    return m_State;
+}
+
+NatMap::~NatMap()
+{
+    int returnCode = CloseNatPmp(&m_NatPmpObj);
+    LogPrint(BCLog::NET, "NAT-PMP: Closed Connection to gateway [%s]\n", GetErrMsg(returnCode));
+}
+
+int NatMap::GetPublicAddress(std::string& publicAddressOut)
+{
+    int returnCode = SendPublicAddressRequest(&m_NatPmpObj);
+    if (returnCode < 0) {
+        return returnCode;
+    }
+    fd_set fds;
+    natpmpresp_t response;
+    TimeValType timeout;
+    memset(&response, 0, sizeof(response));
+    memset(&timeout, 0, sizeof(timeout));
+    do {
+        FD_ZERO(&fds);
+        FD_SET(m_NatPmpObj.s, &fds);
+        GetNatPmpRequestTimeout(&m_NatPmpObj, &timeout);
+        returnCode = select(FD_SETSIZE, &fds, nullptr, nullptr, &timeout);
+        if (returnCode < 0) {
+            return returnCode;
+        }
+        returnCode = ReadNatPmpResponseOrRetry(&m_NatPmpObj, &response);
+    } while (returnCode == NATPMP_TRYAGAIN);
+
+    if (returnCode < 0) {
+        return returnCode;
+    }
+    std::array<char, INET_ADDRSTRLEN> address;
+    address.fill('\0');
+    inet_ntop(AF_INET, &(response.pnu.publicaddress.addr), address.data(), INET_ADDRSTRLEN);
+    publicAddressOut = std::string(address.data());
+    return 0;
+}
+
+int NatMap::SendMapReq(Protocol protocol, uint16_t privatePort, uint16_t& publicPortOut, uint32_t& lifeTimeOut)
+{
+    int baseProtocol = (protocol == Protocol::TCP) ? NATPMP_PROTOCOL_TCP : NATPMP_PROTOCOL_UDP;
+    int returnCode = SendNewPortMappingRequest(&m_NatPmpObj, baseProtocol,
+        privatePort, publicPortOut,
+        lifeTimeOut);
+    if (returnCode < 0) {
+        return returnCode;
+    }
+
+    fd_set fds;
+    TimeValType timeout;
+    natpmpresp_t response;
+    memset(&response, 0, sizeof(response));
+    memset(&timeout, 0, sizeof(timeout));
+    do {
+        FD_ZERO(&fds);
+        FD_SET(m_NatPmpObj.s, &fds);
+        GetNatPmpRequestTimeout(&m_NatPmpObj, &timeout);
+        returnCode = select(FD_SETSIZE, &fds, nullptr, nullptr, &timeout);
+        if (returnCode < 0) {
+            return NATMAP_ERR_SELECT;
+        }
+        returnCode = ReadNatPmpResponseOrRetry(&m_NatPmpObj, &response);
+    } while (returnCode == NATPMP_TRYAGAIN);
+    if (returnCode < 0) {
+        return returnCode;
+    }
+
+    publicPortOut = response.pnu.newportmapping.mappedpublicport;
+    lifeTimeOut = response.pnu.newportmapping.lifetime;
+    return 0;
+}
+
+std::string NatMap::GetErrMsg(int err)
+{
+    return std::string(StrNatPmpErr(err));
+}
+
+int NatMap::GetDefaultGateway(std::string& addrOut) const
+{
+    struct in_addr gateway = {0};
+    gateway.s_addr = m_NatPmpObj.gateway;
+    std::array<char, INET_ADDRSTRLEN> address;
+    address.fill('\0');
+    inet_ntop(AF_INET, &(gateway), address.data(), INET_ADDRSTRLEN);
+    addrOut = std::string(address.data());
+    return 0;
+}

--- a/src/natpmp/natpmp.cpp
+++ b/src/natpmp/natpmp.cpp
@@ -1,0 +1,364 @@
+#ifdef __linux__
+#define _BSD_SOURCE 1
+#endif
+#include <string.h>
+
+#include <errno.h>
+
+#ifdef WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <io.h>
+#ifndef EWOULDBLOCK
+#define EWOULDBLOCK WSAEWOULDBLOCK
+#endif
+#ifndef ECONNREFUSED
+#define ECONNREFUSED WSAECONNREFUSED
+#endif
+#ifdef WIN32
+#if defined(_MSC_VER)
+#include <time.h>
+#else
+#include <sys/time.h>
+#endif
+int gettimeofday(struct timeval* p, void* tz /* IGNORED */);
+#endif
+#else
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#define closesocket close
+#endif
+#include <natpmp.h>
+#include <gateway.h>
+#include <stdio.h>
+
+#ifdef _MSC_VER
+int gettimeofday(struct timeval* p, void* tz)
+{
+    union {
+        long long ns100; /*time since 1 Jan 1601 in 100ns units */
+        FILETIME ft;
+    } _now;
+
+    if(!p)
+        return -1;
+    GetSystemTimeAsFileTime( &(_now.ft) );
+    p->tv_usec =(long)((_now.ns100 / 10LL) % 1000000LL );
+    p->tv_sec = (long)((_now.ns100-(116444736000000000LL))/10000000LL);
+    return 0;
+}
+#endif
+
+int InitNatPmp(natpmp_t * p, int forcegw, in_addr_t forcedgw)
+{
+#ifdef WIN32
+    u_long ioctlArg = 1;
+#else
+    int flags;
+#endif
+    if(!p)
+        return NATPMP_ERR_INVALIDARGS;
+    struct sockaddr_in addr;
+    memset(p, 0, sizeof(natpmp_t));
+    p->s = socket(PF_INET, SOCK_DGRAM, 0);
+    if(p->s < 0)
+        return NATPMP_ERR_SOCKETERROR;
+#ifdef WIN32
+    if(ioctlsocket(p->s, FIONBIO, &ioctlArg) == SOCKET_ERROR)
+        return NATPMP_ERR_FCNTLERROR;
+#else
+    if((flags = fcntl(p->s, F_GETFL, 0)) < 0)
+        return NATPMP_ERR_FCNTLERROR;
+    if(fcntl(p->s, F_SETFL, flags | O_NONBLOCK) < 0)
+        return NATPMP_ERR_FCNTLERROR;
+#endif
+
+    if(forcegw) {
+        p->gateway = forcedgw;
+    } else {
+        if(GetDefaultGateway(&(p->gateway)) < 0)
+            return NATPMP_ERR_CANNOTGETGATEWAY;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(NATPMP_PORT);
+    addr.sin_addr.s_addr = p->gateway;
+    if(connect(p->s, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+        return NATPMP_ERR_CONNECTERR;
+    return 0;
+}
+
+int CloseNatPmp(natpmp_t * p)
+{
+    if(!p)
+        return NATPMP_ERR_INVALIDARGS;
+    if(closesocket(p->s) < 0)
+        return NATPMP_ERR_CLOSEERR;
+    return 0;
+}
+
+int sendpendingrequest(natpmp_t * p)
+{
+    if(!p)
+        return NATPMP_ERR_INVALIDARGS;
+#ifdef __linux__
+    int r = (int)send(p->s, p->pending_request, p->pending_request_len, 0);
+#else
+    int r = (int)send(p->s, (const char*)p->pending_request, p->pending_request_len, 0);
+#endif
+
+    return (r<0) ? NATPMP_ERR_SENDERR : r;
+}
+
+int SendNatPmpRequest(natpmp_t * p)
+{
+    if(!p)
+        return NATPMP_ERR_INVALIDARGS;
+    p->has_pending_request = 1;
+    p->try_number = 1;
+    int n = sendpendingrequest(p);
+    gettimeofday(&p->retry_time, nullptr);
+    p->retry_time.tv_usec += 250000;
+    if(p->retry_time.tv_usec >= 1000000) {
+        p->retry_time.tv_usec -= 1000000;
+        p->retry_time.tv_sec++;
+    }
+    return n;
+}
+
+int GetNatPmpRequestTimeout(natpmp_t * p, struct timeval * timeout)
+{
+    if(!p || !timeout)
+        return NATPMP_ERR_INVALIDARGS;
+    if(!p->has_pending_request)
+        return NATPMP_ERR_NOPENDINGREQ;
+    struct timeval now;
+    memset(&now, 0, sizeof(now));
+    if(gettimeofday(&now, nullptr) < 0)
+        return NATPMP_ERR_GETTIMEOFDAYERR;
+    timeout->tv_sec = p->retry_time.tv_sec - now.tv_sec;
+    timeout->tv_usec = p->retry_time.tv_usec - now.tv_usec;
+    if(timeout->tv_usec < 0) {
+        timeout->tv_usec += 1000000;
+        timeout->tv_sec--;
+    }
+    return 0;
+}
+
+int SendPublicAddressRequest(natpmp_t * p)
+{
+    if(!p)
+        return NATPMP_ERR_INVALIDARGS;
+    p->pending_request[0] = 0;
+    p->pending_request[1] = 0;
+    p->pending_request_len = 2;
+    return SendNatPmpRequest(p);
+}
+
+int SendNewPortMappingRequest(natpmp_t * p, int protocol, int16_t privateport,
+                  int16_t publicport, int64_t lifetime)
+{
+    if(!p || (protocol!=NATPMP_PROTOCOL_TCP && protocol!=NATPMP_PROTOCOL_UDP))
+        return NATPMP_ERR_INVALIDARGS;
+    p->pending_request[0] = 0;
+    p->pending_request[1] = protocol;
+    p->pending_request[2] = 0;
+    p->pending_request[3] = 0;
+    p->pending_request[4] = (privateport >> 8) & 0xff;
+    p->pending_request[5] = privateport & 0xff;
+    p->pending_request[6] = (publicport >> 8) & 0xff;
+    p->pending_request[7] = publicport & 0xff;
+    p->pending_request[8] = (lifetime >> 24) & 0xff;
+    p->pending_request[9] = (lifetime >> 16) & 0xff;
+    p->pending_request[10] = (lifetime >> 8) & 0xff;
+    p->pending_request[11] = lifetime & 0xff;
+    p->pending_request_len = 12;
+    return SendNatPmpRequest(p);
+}
+
+int ReadNatPmpResponse(natpmp_t * p, natpmpresp_t * response)
+{
+    unsigned char buf[16] = {0};
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    socklen_t addrlen = sizeof(addr);
+    int n;
+    if(!p)
+        return NATPMP_ERR_INVALIDARGS;
+#ifdef __linux__
+    n = recvfrom(p->s, buf, sizeof(buf), 0,
+                 (struct sockaddr *)&addr, &addrlen);
+#else
+    n = recvfrom(p->s, (char*)buf, sizeof(buf), 0,
+                 (struct sockaddr *)&addr, &addrlen);
+#endif
+
+    if(n<0) {
+#ifdef WIN32
+        switch(WSAGetLastError()) {
+#else
+        switch(errno) {
+#endif
+            /*case EAGAIN:*/
+            case EWOULDBLOCK:
+                n = NATPMP_TRYAGAIN;
+                break;
+            case ECONNREFUSED:
+                n = NATPMP_ERR_NOGATEWAYSUPPORT;
+                break;
+            default:
+                n = NATPMP_ERR_RECVFROM;
+        }
+    /* check that addr is correct (= gateway) */
+    }else if(addr.sin_addr.s_addr != p->gateway) {
+        n = NATPMP_ERR_WRONGPACKETSOURCE;
+    }else {
+        response->resultcode = ntohs(*((int16_t *)(buf + 2)));
+        response->epoch = ntohl(*((int64_t *)(buf + 4)));
+        if(buf[0] != 0)
+            n = NATPMP_ERR_UNSUPPORTEDVERSION;
+        else if(buf[1] < 128 || buf[1] > 130)
+            n = NATPMP_ERR_UNSUPPORTEDOPCODE;
+        else if(response->resultcode != 0) {
+            switch(response->resultcode) {
+            case 1:
+                n = NATPMP_ERR_UNSUPPORTEDVERSION;
+                break;
+            case 2:
+                n = NATPMP_ERR_NOTAUTHORIZED;
+                break;
+            case 3:
+                n = NATPMP_ERR_NETWORKFAILURE;
+                break;
+            case 4:
+                n = NATPMP_ERR_OUTOFRESOURCES;
+                break;
+            case 5:
+                n = NATPMP_ERR_UNSUPPORTEDOPCODE;
+                break;
+            default:
+                n = NATPMP_ERR_UNDEFINEDERROR;
+            }
+        } else {
+            response->type = buf[1] & 0x7f;
+            if(buf[1] == 128) {
+                response->pnu.publicaddress.addr.s_addr = *((int64_t *)(buf + 8));
+            }else {
+                response->pnu.newportmapping.privateport = ntohs(*((int16_t *)(buf + 8)));
+                response->pnu.newportmapping.mappedpublicport = ntohs(*((int16_t *)(buf + 10)));
+                response->pnu.newportmapping.lifetime = ntohl(*((int64_t *)(buf + 12)));
+            }
+            n = 0;
+        }
+    }
+    return n;
+}
+
+int ReadNatPmpResponseOrRetry(natpmp_t * p, natpmpresp_t * response)
+{
+    if(!p || !response)
+        return NATPMP_ERR_INVALIDARGS;
+    if(!p->has_pending_request)
+        return NATPMP_ERR_NOPENDINGREQ;
+    int n = ReadNatPmpResponse(p, response);
+    if(n<0) {
+        if(n==NATPMP_TRYAGAIN) {
+            struct timeval now;
+            gettimeofday(&now, nullptr);
+            if(timercmp(&now, &p->retry_time, >=)) {
+                int delay, r;
+                if(p->try_number >= 9) {
+                    return NATPMP_ERR_NOGATEWAYSUPPORT;
+                }
+                delay = 250 * (1<<p->try_number);
+                p->retry_time.tv_sec += (delay / 1000);
+                p->retry_time.tv_usec += (delay % 1000) * 1000;
+                if(p->retry_time.tv_usec >= 1000000) {
+                    p->retry_time.tv_usec -= 1000000;
+                    p->retry_time.tv_sec++;
+                }
+                p->try_number++;
+                r = sendpendingrequest(p);
+                if(r<0)
+                    return r;
+            }
+        }
+    } else {
+        p->has_pending_request = 0;
+    }
+    return n;
+}
+
+const char * StrNatPmpErr(int r)
+{
+    const char *s = nullptr;
+    switch(r) {
+    case 0:
+        s = "No Error";
+        break;
+    case NATPMP_ERR_INVALIDARGS:
+        s = "Invalid arguments";
+        break;
+    case NATPMP_ERR_SOCKETERROR:
+        s = "Socket() failed";
+        break;
+    case NATPMP_ERR_CANNOTGETGATEWAY:
+        s = "Cannot get default gateway IP address";
+        break;
+    case NATPMP_ERR_CLOSEERR:
+#ifdef WIN32
+        s = "closesocket() failed";
+#else
+        s = "close() failed";
+#endif
+        break;
+    case NATPMP_ERR_RECVFROM:
+        s = "recvfrom() failed";
+        break;
+    case NATPMP_ERR_NOPENDINGREQ:
+        s = "No pending request";
+        break;
+    case NATPMP_ERR_NOGATEWAYSUPPORT:
+        s = "The gateway does not support NAT-PMP";
+        break;
+    case NATPMP_ERR_CONNECTERR:
+        s = "connect() failed";
+        break;
+    case NATPMP_ERR_WRONGPACKETSOURCE:
+        s = "Packet not received from the default gateway";
+        break;
+    case NATPMP_ERR_SENDERR:
+        s = "send() failed";
+        break;
+    case NATPMP_ERR_FCNTLERROR:
+        s = "fcntl() failed";
+        break;
+    case NATPMP_ERR_GETTIMEOFDAYERR:
+        s = "gettimeofday() failed";
+        break;
+    case NATPMP_ERR_UNSUPPORTEDVERSION:
+        s = "Unsupported NAT-PMP version error from server";
+        break;
+    case NATPMP_ERR_UNSUPPORTEDOPCODE:
+        s = "Unsupported NAT-PMP opcode error from server";
+        break;
+    case NATPMP_ERR_UNDEFINEDERROR:
+        s = "Undefined NAT-PMP server error";
+        break;
+    case NATPMP_ERR_NOTAUTHORIZED:
+        s = "Not authorized";
+        break;
+    case NATPMP_ERR_NETWORKFAILURE:
+        s = "Network failure";
+        break;
+    case NATPMP_ERR_OUTOFRESOURCES:
+        s = "NAT-PMP server out of resources";
+        break;
+    default:
+        s = "Unknown error";
+    }
+    return s;
+}

--- a/src/natpmp/natpmp.cpp
+++ b/src/natpmp/natpmp.cpp
@@ -42,67 +42,66 @@ int gettimeofday(struct timeval* p, void* tz)
         FILETIME ft;
     } _now;
 
-    if(!p)
+    if (!p)
         return -1;
-    GetSystemTimeAsFileTime( &(_now.ft) );
-    p->tv_usec =(long)((_now.ns100 / 10LL) % 1000000LL );
-    p->tv_sec = (long)((_now.ns100-(116444736000000000LL))/10000000LL);
+    GetSystemTimeAsFileTime(&(_now.ft));
+    p->tv_usec = (long)((_now.ns100 / 10LL) % 1000000LL);
+    p->tv_sec = (long)((_now.ns100 - (116444736000000000LL)) / 10000000LL);
     return 0;
 }
 #endif
 
-int InitNatPmp(natpmp_t * p, int forcegw, in_addr_t forcedgw)
+int InitNatPmp(natpmp_t* p, int forcegw, in_addr_t forcedgw)
 {
 #ifdef WIN32
     u_long ioctlArg = 1;
 #else
-    int flags;
+    int flags = 0;
 #endif
-    if(!p)
+    if (!p)
         return NATPMP_ERR_INVALIDARGS;
-    struct sockaddr_in addr;
-    memset(p, 0, sizeof(natpmp_t));
     p->s = socket(PF_INET, SOCK_DGRAM, 0);
-    if(p->s < 0)
+    if (p->s < 0)
         return NATPMP_ERR_SOCKETERROR;
 #ifdef WIN32
-    if(ioctlsocket(p->s, FIONBIO, &ioctlArg) == SOCKET_ERROR)
+    if (ioctlsocket(p->s, FIONBIO, &ioctlArg) == SOCKET_ERROR)
         return NATPMP_ERR_FCNTLERROR;
 #else
-    if((flags = fcntl(p->s, F_GETFL, 0)) < 0)
+    if ((flags = fcntl(p->s, F_GETFL, 0)) < 0)
         return NATPMP_ERR_FCNTLERROR;
-    if(fcntl(p->s, F_SETFL, flags | O_NONBLOCK) < 0)
+    if (fcntl(p->s, F_SETFL, flags | O_NONBLOCK) < 0)
         return NATPMP_ERR_FCNTLERROR;
 #endif
 
-    if(forcegw) {
+    if (forcegw) {
         p->gateway = forcedgw;
     } else {
-        if(GetDefaultGateway(&(p->gateway)) < 0)
+        if (GetDefaultGateway(&(p->gateway)) < 0)
             return NATPMP_ERR_CANNOTGETGATEWAY;
     }
 
+    struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons(NATPMP_PORT);
     addr.sin_addr.s_addr = p->gateway;
-    if(connect(p->s, (struct sockaddr *)&addr, sizeof(addr)) < 0)
+    if (connect(p->s, (struct sockaddr*)&addr, sizeof(addr)) < 0)
         return NATPMP_ERR_CONNECTERR;
     return 0;
 }
 
-int CloseNatPmp(natpmp_t * p)
+int CloseNatPmp(natpmp_t* p)
 {
-    if(!p)
+    if (!p)
         return NATPMP_ERR_INVALIDARGS;
-    if(closesocket(p->s) < 0)
+    if (closesocket(p->s) < 0)
         return NATPMP_ERR_CLOSEERR;
     return 0;
 }
 
-int sendpendingrequest(natpmp_t * p)
+int sendpendingrequest(natpmp_t* p)
 {
-    if(!p)
+    if (!p)
         return NATPMP_ERR_INVALIDARGS;
 #ifdef __linux__
     int r = (int)send(p->s, p->pending_request, p->pending_request_len, 0);
@@ -110,47 +109,49 @@ int sendpendingrequest(natpmp_t * p)
     int r = (int)send(p->s, (const char*)p->pending_request, p->pending_request_len, 0);
 #endif
 
-    return (r<0) ? NATPMP_ERR_SENDERR : r;
+    return (r < 0) ? NATPMP_ERR_SENDERR : r;
 }
 
-int SendNatPmpRequest(natpmp_t * p)
+int SendNatPmpRequest(natpmp_t* p)
 {
-    if(!p)
+    if (!p)
         return NATPMP_ERR_INVALIDARGS;
     p->has_pending_request = 1;
     p->try_number = 1;
     int n = sendpendingrequest(p);
-    gettimeofday(&p->retry_time, nullptr);
+    if (gettimeofday(&p->retry_time, nullptr) < 0) {
+        return NATPMP_ERR_GETTIMEOFDAYERR;
+    }
     p->retry_time.tv_usec += 250000;
-    if(p->retry_time.tv_usec >= 1000000) {
+    if (p->retry_time.tv_usec >= 1000000) {
         p->retry_time.tv_usec -= 1000000;
         p->retry_time.tv_sec++;
     }
     return n;
 }
 
-int GetNatPmpRequestTimeout(natpmp_t * p, struct timeval * timeout)
+int GetNatPmpRequestTimeout(natpmp_t* p, struct timeval* timeout)
 {
-    if(!p || !timeout)
+    if (!p || !timeout)
         return NATPMP_ERR_INVALIDARGS;
-    if(!p->has_pending_request)
+    if (!p->has_pending_request)
         return NATPMP_ERR_NOPENDINGREQ;
     struct timeval now;
     memset(&now, 0, sizeof(now));
-    if(gettimeofday(&now, nullptr) < 0)
+    if (gettimeofday(&now, nullptr) < 0)
         return NATPMP_ERR_GETTIMEOFDAYERR;
     timeout->tv_sec = p->retry_time.tv_sec - now.tv_sec;
     timeout->tv_usec = p->retry_time.tv_usec - now.tv_usec;
-    if(timeout->tv_usec < 0) {
+    if (timeout->tv_usec < 0) {
         timeout->tv_usec += 1000000;
         timeout->tv_sec--;
     }
     return 0;
 }
 
-int SendPublicAddressRequest(natpmp_t * p)
+int SendPublicAddressRequest(natpmp_t* p)
 {
-    if(!p)
+    if (!p)
         return NATPMP_ERR_INVALIDARGS;
     p->pending_request[0] = 0;
     p->pending_request[1] = 0;
@@ -158,10 +159,9 @@ int SendPublicAddressRequest(natpmp_t * p)
     return SendNatPmpRequest(p);
 }
 
-int SendNewPortMappingRequest(natpmp_t * p, int protocol, int16_t privateport,
-                  int16_t publicport, int64_t lifetime)
+int SendNewPortMappingRequest(natpmp_t* p, int protocol, int16_t privateport, int16_t publicport, int64_t lifetime)
 {
-    if(!p || (protocol!=NATPMP_PROTOCOL_TCP && protocol!=NATPMP_PROTOCOL_UDP))
+    if (!p || (protocol != NATPMP_PROTOCOL_TCP && protocol != NATPMP_PROTOCOL_UDP))
         return NATPMP_ERR_INVALIDARGS;
     p->pending_request[0] = 0;
     p->pending_request[1] = protocol;
@@ -179,51 +179,50 @@ int SendNewPortMappingRequest(natpmp_t * p, int protocol, int16_t privateport,
     return SendNatPmpRequest(p);
 }
 
-int ReadNatPmpResponse(natpmp_t * p, natpmpresp_t * response)
+int ReadNatPmpResponse(natpmp_t* p, natpmpresp_t* response)
 {
     unsigned char buf[16] = {0};
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
     socklen_t addrlen = sizeof(addr);
-    int n;
-    if(!p)
+    if (!p)
         return NATPMP_ERR_INVALIDARGS;
 #ifdef __linux__
-    n = recvfrom(p->s, buf, sizeof(buf), 0,
-                 (struct sockaddr *)&addr, &addrlen);
+    int n = recvfrom(p->s, buf, sizeof(buf), 0,
+        (struct sockaddr*)&addr, &addrlen);
 #else
-    n = recvfrom(p->s, (char*)buf, sizeof(buf), 0,
-                 (struct sockaddr *)&addr, &addrlen);
+    int n = recvfrom(p->s, (char*)buf, sizeof(buf), 0,
+        (struct sockaddr*)&addr, &addrlen);
 #endif
 
-    if(n<0) {
+    if (n < 0) {
 #ifdef WIN32
-        switch(WSAGetLastError()) {
+        switch (WSAGetLastError()) {
 #else
-        switch(errno) {
+        switch (errno) {
 #endif
-            /*case EAGAIN:*/
-            case EWOULDBLOCK:
-                n = NATPMP_TRYAGAIN;
-                break;
-            case ECONNREFUSED:
-                n = NATPMP_ERR_NOGATEWAYSUPPORT;
-                break;
-            default:
-                n = NATPMP_ERR_RECVFROM;
+        /*case EAGAIN:*/
+        case EWOULDBLOCK:
+            n = NATPMP_TRYAGAIN;
+            break;
+        case ECONNREFUSED:
+            n = NATPMP_ERR_NOGATEWAYSUPPORT;
+            break;
+        default:
+            n = NATPMP_ERR_RECVFROM;
         }
-    /* check that addr is correct (= gateway) */
-    }else if(addr.sin_addr.s_addr != p->gateway) {
+        /* check that addr is correct (= gateway) */
+    } else if (addr.sin_addr.s_addr != p->gateway) {
         n = NATPMP_ERR_WRONGPACKETSOURCE;
-    }else {
-        response->resultcode = ntohs(*((int16_t *)(buf + 2)));
-        response->epoch = ntohl(*((int64_t *)(buf + 4)));
-        if(buf[0] != 0)
+    } else {
+        response->resultcode = ntohs(*((int16_t*)(buf + 2)));
+        response->epoch = ntohl(*((int64_t*)(buf + 4)));
+        if (buf[0] != 0)
             n = NATPMP_ERR_UNSUPPORTEDVERSION;
-        else if(buf[1] < 128 || buf[1] > 130)
+        else if (buf[1] < 128 || buf[1] > 130)
             n = NATPMP_ERR_UNSUPPORTEDOPCODE;
-        else if(response->resultcode != 0) {
-            switch(response->resultcode) {
+        else if (response->resultcode != 0) {
+            switch (response->resultcode) {
             case 1:
                 n = NATPMP_ERR_UNSUPPORTEDVERSION;
                 break;
@@ -244,12 +243,12 @@ int ReadNatPmpResponse(natpmp_t * p, natpmpresp_t * response)
             }
         } else {
             response->type = buf[1] & 0x7f;
-            if(buf[1] == 128) {
-                response->pnu.publicaddress.addr.s_addr = *((int64_t *)(buf + 8));
-            }else {
-                response->pnu.newportmapping.privateport = ntohs(*((int16_t *)(buf + 8)));
-                response->pnu.newportmapping.mappedpublicport = ntohs(*((int16_t *)(buf + 10)));
-                response->pnu.newportmapping.lifetime = ntohl(*((int64_t *)(buf + 12)));
+            if (buf[1] == 128) {
+                response->pnu.publicaddress.addr.s_addr = *((int64_t*)(buf + 8));
+            } else {
+                response->pnu.newportmapping.privateport = ntohs(*((int16_t*)(buf + 8)));
+                response->pnu.newportmapping.mappedpublicport = ntohs(*((int16_t*)(buf + 10)));
+                response->pnu.newportmapping.lifetime = ntohl(*((int64_t*)(buf + 12)));
             }
             n = 0;
         }
@@ -257,32 +256,35 @@ int ReadNatPmpResponse(natpmp_t * p, natpmpresp_t * response)
     return n;
 }
 
-int ReadNatPmpResponseOrRetry(natpmp_t * p, natpmpresp_t * response)
+int ReadNatPmpResponseOrRetry(natpmp_t* p, natpmpresp_t* response)
 {
-    if(!p || !response)
+    if (!p || !response)
         return NATPMP_ERR_INVALIDARGS;
-    if(!p->has_pending_request)
+    if (!p->has_pending_request)
         return NATPMP_ERR_NOPENDINGREQ;
     int n = ReadNatPmpResponse(p, response);
-    if(n<0) {
-        if(n==NATPMP_TRYAGAIN) {
+    if (n < 0) {
+        if (n == NATPMP_TRYAGAIN) {
             struct timeval now;
-            gettimeofday(&now, nullptr);
-            if(timercmp(&now, &p->retry_time, >=)) {
-                int delay, r;
-                if(p->try_number >= 9) {
+            memset(&now, 0, sizeof(now));
+            if (gettimeofday(&now, nullptr) < 0) {
+                return NATPMP_ERR_GETTIMEOFDAYERR;
+            }
+            if (timercmp(&now, &p->retry_time, >=)) {
+                int delay = 0, r = 0;
+                if (p->try_number >= 9) {
                     return NATPMP_ERR_NOGATEWAYSUPPORT;
                 }
-                delay = 250 * (1<<p->try_number);
+                delay = 250 * (1 << p->try_number);
                 p->retry_time.tv_sec += (delay / 1000);
                 p->retry_time.tv_usec += (delay % 1000) * 1000;
-                if(p->retry_time.tv_usec >= 1000000) {
+                if (p->retry_time.tv_usec >= 1000000) {
                     p->retry_time.tv_usec -= 1000000;
                     p->retry_time.tv_sec++;
                 }
                 p->try_number++;
                 r = sendpendingrequest(p);
-                if(r<0)
+                if (r < 0)
                     return r;
             }
         }
@@ -292,10 +294,10 @@ int ReadNatPmpResponseOrRetry(natpmp_t * p, natpmpresp_t * response)
     return n;
 }
 
-const char * StrNatPmpErr(int r)
+const char* StrNatPmpErr(int err)
 {
-    const char *s = nullptr;
-    switch(r) {
+    const char* s = nullptr;
+    switch (err) {
     case 0:
         s = "No Error";
         break;


### PR DESCRIPTION
Changes to support NAT-PMP port forwarding based on libnatpmp to address #11902.
**Changes include the following:**
* Porting of [libnatpmp](https://github.com/miniupnp/libnatpmp) files (namely gateway.cpp/.h and natpmp.cpp/.h)
* C++ style wrapper for easier integration
* Changes to disable upnp by default and use NAT-PMP as explained in #11902 (Introducing -portmap switch).

**Test**
```bash
$./src/bitcoind -portmap
```

Note to reviewers are [here](https://github.com/bitcoin/bitcoin/pull/15717#issuecomment-483001218), need insights.

