### PR TITLE
Wallet passive startup

### DIFF
--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -27,7 +27,7 @@ static void WalletBalance(benchmark::Bench& bench, const bool set_dirty, const b
         wallet.SetupDescriptorScriptPubKeyMans();
         if (wallet.LoadWallet() != DBErrors::LOAD_OK) assert(false);
     }
-    auto handler = test_setup->m_node.chain->handleNotifications({&wallet, [](CWallet*) {}});
+    CWallet::AttachChain({&wallet, [](CWallet*) {}});
 
     const std::optional<std::string> address_mine{add_mine ? std::optional<std::string>{getnewaddress(wallet)} : std::nullopt};
 

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -46,6 +46,7 @@ public:
     FoundBlock& time(int64_t& time) { m_time = &time; return *this; }
     FoundBlock& maxTime(int64_t& max_time) { m_max_time = &max_time; return *this; }
     FoundBlock& mtpTime(int64_t& mtp_time) { m_mtp_time = &mtp_time; return *this; }
+    FoundBlock& locator(CBlockLocator& locator) { m_locator = &locator; return *this; }
     //! Return whether block is in the active (most-work) chain.
     FoundBlock& inActiveChain(bool& in_active_chain) { m_in_active_chain = &in_active_chain; return *this; }
     //! Return next block in the active chain if current block is in the active chain.
@@ -59,6 +60,7 @@ public:
     int64_t* m_time = nullptr;
     int64_t* m_max_time = nullptr;
     int64_t* m_mtp_time = nullptr;
+    CBlockLocator* m_locator = nullptr;
     bool* m_in_active_chain = nullptr;
     const FoundBlock* m_next_block = nullptr;
     CBlock* m_data = nullptr;

--- a/src/node/interfaces.cpp
+++ b/src/node/interfaces.cpp
@@ -351,6 +351,7 @@ bool FillBlock(const CBlockIndex* index, const FoundBlock& block, UniqueLock<Rec
     if (block.m_time) *block.m_time = index->GetBlockTime();
     if (block.m_max_time) *block.m_max_time = index->GetBlockTimeMax();
     if (block.m_mtp_time) *block.m_mtp_time = index->GetMedianTimePast();
+    if (block.m_locator) *block.m_locator = active.GetLocator(index);
     if (block.m_in_active_chain) *block.m_in_active_chain = active[index->nHeight] == index;
     if (block.m_next_block) FillBlock(active[index->nHeight] == index ? active[index->nHeight + 1] : nullptr, *block.m_next_block, lock, active);
     if (block.m_data) {

--- a/src/test/interfaces_tests.cpp
+++ b/src/test/interfaces_tests.cpp
@@ -15,6 +15,16 @@ using interfaces::FoundBlock;
 
 BOOST_FIXTURE_TEST_SUITE(interfaces_tests, TestChain100Setup)
 
+namespace {
+template <typename T>
+inline std::string Ser(const T& value)
+{
+    CDataStream stream(SER_NETWORK, CLIENT_VERSION);
+    stream << value;
+    return stream.str();
+}
+} // namespace
+
 BOOST_AUTO_TEST_CASE(findBlock)
 {
     auto& chain = m_node.chain;
@@ -43,6 +53,10 @@ BOOST_AUTO_TEST_CASE(findBlock)
     int64_t mtp_time = -1;
     BOOST_CHECK(chain->findBlock(active[60]->GetBlockHash(), FoundBlock().mtpTime(mtp_time)));
     BOOST_CHECK_EQUAL(mtp_time, active[60]->GetMedianTimePast());
+
+    CBlockLocator locator;
+    BOOST_CHECK(chain->findBlock(active[70]->GetBlockHash(), FoundBlock().locator(locator)));
+    BOOST_CHECK_EQUAL(Ser(locator), Ser(active.GetLocator(active[70])));
 
     bool cur_active{false}, next_active{false};
     uint256 next_hash;

--- a/src/threadsafety.h
+++ b/src/threadsafety.h
@@ -52,26 +52,31 @@
 #define ASSERT_EXCLUSIVE_LOCK(...)
 #endif // __GNUC__
 
-// StdMutex provides an annotated version of std::mutex for us,
-// and should only be used when sync.h Mutex/LOCK/etc are not usable.
-class LOCKABLE StdMutex : public std::mutex
+template<typename Mutex>
+class LOCKABLE Lockable : public Mutex
 {
 public:
 #ifdef __clang__
     //! For negative capabilities in the Clang Thread Safety Analysis.
     //! A negative requirement uses the EXCLUSIVE_LOCKS_REQUIRED attribute, in conjunction
     //! with the ! operator, to indicate that a mutex should not be held.
-    const StdMutex& operator!() const { return *this; }
+    const Lockable& operator!() const { return *this; }
 #endif // __clang__
 };
 
-// StdLockGuard provides an annotated version of std::lock_guard for us,
-// and should only be used when sync.h Mutex/LOCK/etc are not usable.
-class SCOPED_LOCKABLE StdLockGuard : public std::lock_guard<StdMutex>
+template<typename Mutex, template<typename> class Lock>
+class SCOPED_LOCKABLE ScopedLockable : public Lock<Mutex>
 {
 public:
-    explicit StdLockGuard(StdMutex& cs) EXCLUSIVE_LOCK_FUNCTION(cs) : std::lock_guard<StdMutex>(cs) {}
-    ~StdLockGuard() UNLOCK_FUNCTION() {}
+    explicit ScopedLockable(Mutex& mutex) EXCLUSIVE_LOCK_FUNCTION(mutex) : Lock<Mutex>(mutex) {}
+    ~ScopedLockable() UNLOCK_FUNCTION() {}
 };
+
+// StdMutex, StdLockGuard, and StdUniqueLock provide annotated versions of
+// standard synchronization classes, and should only be used when sync.h
+// Mutex/LOCK/etc are not usable.
+using StdMutex = Lockable<std::mutex>;
+using StdLockGuard = ScopedLockable<std::mutex, std::lock_guard>;
+using StdUniqueLock = ScopedLockable<std::mutex, std::unique_lock>;
 
 #endif // BITCOIN_THREADSAFETY_H

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -310,13 +310,9 @@ RPCHelpMan importaddress()
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
         }
     }
-    if (fRescan)
-    {
+    if (fRescan) {
         RescanWallet(*pwallet, reserver);
-        {
-            LOCK(pwallet->cs_wallet);
-            pwallet->ReacceptWalletTransactions();
-        }
+        pwallet->ReacceptWalletTransactions();
     }
 
     return NullUniValue;
@@ -489,13 +485,9 @@ RPCHelpMan importpubkey()
 
         pwallet->ImportPubKeys({pubKey.GetID()}, {{pubKey.GetID(), pubKey}} , {} /* key_origins */, false /* add_keypool */, false /* internal */, 1 /* timestamp */);
     }
-    if (fRescan)
-    {
+    if (fRescan) {
         RescanWallet(*pwallet, reserver);
-        {
-            LOCK(pwallet->cs_wallet);
-            pwallet->ReacceptWalletTransactions();
-        }
+        pwallet->ReacceptWalletTransactions();
     }
 
     return NullUniValue;
@@ -1407,10 +1399,7 @@ RPCHelpMan importmulti()
     }
     if (fRescan && fRunScan && requests.size()) {
         int64_t scannedTime = pwallet->RescanFromTime(nLowestTimestamp, reserver, true /* update */);
-        {
-            LOCK(pwallet->cs_wallet);
-            pwallet->ReacceptWalletTransactions();
-        }
+        pwallet->ReacceptWalletTransactions();
 
         if (pwallet->IsAbortingRescan()) {
             throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted by user.");
@@ -1696,10 +1685,7 @@ RPCHelpMan importdescriptors()
     // Rescan the blockchain using the lowest timestamp
     if (rescan) {
         int64_t scanned_time = pwallet->RescanFromTime(lowest_timestamp, reserver, true /* update */);
-        {
-            LOCK(pwallet->cs_wallet);
-            pwallet->ReacceptWalletTransactions();
-        }
+        pwallet->ReacceptWalletTransactions();
 
         if (pwallet->IsAbortingRescan()) {
             throw JSONRPCError(RPC_MISC_ERROR, "Rescan aborted by user.");

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -11,7 +11,7 @@ WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
       m_wallet(m_node.chain.get(), "", m_args, CreateMockWalletDatabase())
 {
     m_wallet.LoadWallet();
-    m_chain_notifications_handler = m_node.chain->handleNotifications({ &m_wallet, [](CWallet*) {} });
+    CWallet::AttachChain({ &m_wallet, [](CWallet*) {} });
     m_wallet_client->registerRpcs();
 }
 

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -23,7 +23,6 @@ struct WalletTestingSetup : public TestingSetup {
 
     std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(*m_node.chain, *Assert(m_node.args));
     CWallet m_wallet;
-    std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };
 
 #endif // BITCOIN_WALLET_TEST_WALLET_TEST_FIXTURE_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2778,6 +2778,8 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
         return nullptr;
     }
 
+    LOCK(walletInstance->cs_wallet);
+
     {
         LOCK(context.wallets_mutex);
         for (auto& load_wallet : context.wallet_load_fns) {
@@ -2798,81 +2800,64 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
 
 CWallet::ScanStatus CWallet::AttachChain(std::shared_ptr<CWallet> wallet, bool scan, bool rescan_required)
 {
-    auto& chain = wallet->chain();
-    auto& walletInstance = wallet;
-    LOCK(walletInstance->cs_wallet);
-
-    // Register wallet with validationinterface. It's done before rescan to avoid
-    // missing block connections between end of rescan and validation subscribing.
-    // Because of wallet lock being hold, block connection notifications are going to
-    // be pending on the validation-side until lock release. It's likely to have
-    // block processing duplicata (if rescan block range overlaps with notification one)
-    // but we guarantee at least than wallet state is correct after notifications delivery.
-    // This is temporary until rescan and notifications delivery are unified under same
-    // interface.
-    walletInstance->m_chain_notifications_handler = walletInstance->chain().handleNotifications(walletInstance);
-
-    // If rescan_required = true, rescan_height remains equal to 0
-    int rescan_height = 0;
-    if (!rescan_required)
-    {
-        WalletBatch batch(walletInstance->GetDatabase());
-        CBlockLocator locator;
-        if (batch.ReadBestBlock(locator)) {
-            if (const std::optional<int> fork_height = chain.findLocatorFork(locator)) {
-                rescan_height = *fork_height;
-            }
-        }
-    }
-
-    const std::optional<int> tip_height = chain.getHeight();
-    if (tip_height) {
-        walletInstance->m_last_block_processed = chain.getBlockHash(*tip_height);
-        walletInstance->m_last_block_processed_height = *tip_height;
-    } else {
-        walletInstance->m_last_block_processed.SetNull();
-        walletInstance->m_last_block_processed_height = -1;
-    }
-
+    // Register with the validation interface. Skip requesting mempool transactions if wallet is empty.
+    interfaces::Chain::ScanFn scan_fn;
+    interfaces::Chain::MempoolFn mempool_fn;
+    std::optional<CBlockLocator> best_block_locator;
+    std::optional<int64_t> time_first_key;
     ScanStatus scan_status = ScanStatus::SKIPPED;
-    if (tip_height && *tip_height != rescan_height)
-    {
-        if (chain.havePruned()) {
-            int block_height = *tip_height;
-            while (block_height > 0 && chain.haveBlockOnDisk(block_height - 1) && rescan_height != block_height) {
-                --block_height;
-            }
-
-            if (rescan_height != block_height) {
-                return CWallet::ScanStatus::MISSING_BLOCKS;
-            }
+    if (scan) {
+        // Get best block locator to rescan if not going back and rescanning
+        if (!rescan_required) {
+            best_block_locator.emplace();
+            WalletBatch(wallet->GetDatabase()).ReadBestBlock(*best_block_locator);
         }
-
-        chain.initMessage(_("Rescanning…").translated);
-        walletInstance->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", *tip_height - rescan_height, rescan_height);
 
         // No need to read and scan block if block was created before
         // our wallet birthday (as adjusted for block time variability)
-        std::optional<int64_t> time_first_key;
-        for (auto spk_man : walletInstance->GetAllScriptPubKeyMans()) {
-            int64_t time = spk_man->GetTimeFirstKey();
+        for (auto spk_man : wallet->GetAllScriptPubKeyMans()) {
+            int64_t time = WITH_LOCK(wallet->cs_wallet, return spk_man->GetTimeFirstKey());
             if (!time_first_key || time < *time_first_key) time_first_key = time;
         }
-        if (time_first_key) {
-            chain.findFirstBlockWithTimeAndHeight(*time_first_key - TIMESTAMP_WINDOW, rescan_height, FoundBlock().height(rescan_height));
-        }
-
-        {
-            WalletRescanReserver reserver(*walletInstance);
-            if (!reserver.reserve() || (ScanResult::SUCCESS != walletInstance->ScanForWalletTransactions(chain.getBlockHash(rescan_height), rescan_height, {} /* max height */, reserver, true /* update */).status)) {
-                return CWallet::ScanStatus::FAILED;
+        scan_fn = [&](const uint256& rescan_hash, int rescan_height, const uint256& tip_hash, int tip_height) -> std::optional<uint256> {
+            WITH_LOCK(wallet->cs_wallet, wallet->SetLastBlockProcessed(tip_height, tip_hash));
+            scan_status = ScanStatus::FAILED;
+            wallet->chain().initMessage(_("Rescanning…").translated);
+            wallet->WalletLogPrintf("Rescanning last %i blocks (from block %i)...\n", tip_height - rescan_height, rescan_height);
+            WalletRescanReserver reserver(*wallet);
+            if (reserver.reserve()) {
+                ScanResult result =
+                    wallet->ScanForWalletTransactions(rescan_hash, rescan_height, {} /* max height */, reserver, true /* update */);
+                if (result.status == ScanResult::SUCCESS) {
+                    scan_status = ScanStatus::SUCCESS;
+                    return result.last_scanned_block;
+                }
             }
-            scan_status = ScanStatus::SUCCESS;
-        }
-        walletInstance->chainStateFlushed(chain.getTipLocator());
-        walletInstance->GetDatabase().IncrementUpdateCounter();
+            return std::nullopt;
+        };
+        mempool_fn = [&](const std::vector<CTransactionRef>& mempool_txs) {
+            for (const auto& mempool_tx : mempool_txs) {
+                wallet->transactionAddedToMempool(mempool_tx, 0 /* mempool_sequence */);
+            }
+        };
     }
 
+    uint256 last_block_processed;
+    int last_block_processed_height = -1;
+    CBlockLocator last_block_processed_locator;
+    bool missing_block_data;
+    wallet->m_chain_notifications_handler = wallet->chain().handleNotifications(
+        wallet, scan_fn, mempool_fn, best_block_locator ? &*best_block_locator : nullptr, time_first_key.value_or(0),
+        FoundBlock().hash(last_block_processed).height(last_block_processed_height).locator(last_block_processed_locator),
+        missing_block_data);
+    if (missing_block_data) scan_status = ScanStatus::MISSING_BLOCKS;
+    {
+        LOCK(wallet->cs_wallet);
+        wallet->m_last_block_processed = last_block_processed;
+        wallet->m_last_block_processed_height = last_block_processed_height;
+    }
+    wallet->chainStateFlushed(last_block_processed_locator);
+    wallet->GetDatabase().IncrementUpdateCounter();
     return scan_status;
 }
 
@@ -2926,9 +2911,6 @@ void CWallet::postInitProcess()
     // Add wallet transactions that aren't already in a block to mempool
     // Do this here as mempool requires genesis block to be loaded
     ReacceptWalletTransactions();
-
-    // Update wallet transactions with current mempool transactions.
-    chain().requestMempoolTransactions(*this);
 }
 
 bool CWallet::BackupWallet(const std::string& strDest) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2763,7 +2763,18 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     // Try to top up keypool. No-op if the wallet is locked.
     walletInstance->TopUpKeyPool();
 
-    if (chain && !AttachChain(walletInstance, *chain, rescan_required, error, warnings)) {
+    CWallet::ScanStatus scan_status = chain ? CWallet::AttachChain(walletInstance, !fFirstRun, rescan_required) : CWallet::ScanStatus::SKIPPED;
+    if (scan_status == CWallet::ScanStatus::FAILED) {
+        error = _("Failed to rescan the wallet during initialization");
+        return nullptr;
+    } else if (scan_status == CWallet::ScanStatus::MISSING_BLOCKS) {
+        // We can't rescan beyond non-pruned blocks, stop and throw an error.
+        // This might happen if a user uses an old wallet within a pruned node
+        // or if they ran -disablewallet for a longer time, then decided to re-enable
+        // Exit early and print an error.
+        // If a block is pruned after this check, we will load the wallet,
+        // but fail the rescan with a generic error.
+        error = _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)");
         return nullptr;
     }
 
@@ -2785,12 +2796,11 @@ std::shared_ptr<CWallet> CWallet::Create(WalletContext& context, const std::stri
     return walletInstance;
 }
 
-bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings)
+CWallet::ScanStatus CWallet::AttachChain(std::shared_ptr<CWallet> wallet, bool scan, bool rescan_required)
 {
+    auto& chain = wallet->chain();
+    auto& walletInstance = wallet;
     LOCK(walletInstance->cs_wallet);
-    // allow setting the chain if it hasn't been set already but prevent changing it
-    assert(!walletInstance->m_chain || walletInstance->m_chain == &chain);
-    walletInstance->m_chain = &chain;
 
     // Register wallet with validationinterface. It's done before rescan to avoid
     // missing block connections between end of rescan and validation subscribing.
@@ -2824,6 +2834,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         walletInstance->m_last_block_processed_height = -1;
     }
 
+    ScanStatus scan_status = ScanStatus::SKIPPED;
     if (tip_height && *tip_height != rescan_height)
     {
         if (chain.havePruned()) {
@@ -2833,14 +2844,7 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
             }
 
             if (rescan_height != block_height) {
-                // We can't rescan beyond non-pruned blocks, stop and throw an error.
-                // This might happen if a user uses an old wallet within a pruned node
-                // or if they ran -disablewallet for a longer time, then decided to re-enable
-                // Exit early and print an error.
-                // If a block is pruned after this check, we will load the wallet,
-                // but fail the rescan with a generic error.
-                error = _("Prune: last wallet synchronisation goes beyond pruned data. You need to -reindex (download the whole blockchain again in case of pruned node)");
-                return false;
+                return CWallet::ScanStatus::MISSING_BLOCKS;
             }
         }
 
@@ -2861,15 +2865,15 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
         {
             WalletRescanReserver reserver(*walletInstance);
             if (!reserver.reserve() || (ScanResult::SUCCESS != walletInstance->ScanForWalletTransactions(chain.getBlockHash(rescan_height), rescan_height, {} /* max height */, reserver, true /* update */).status)) {
-                error = _("Failed to rescan the wallet during initialization");
-                return false;
+                return CWallet::ScanStatus::FAILED;
             }
+            scan_status = ScanStatus::SUCCESS;
         }
         walletInstance->chainStateFlushed(chain.getTipLocator());
         walletInstance->GetDatabase().IncrementUpdateCounter();
     }
 
-    return true;
+    return scan_status;
 }
 
 const CAddressBookData* CWallet::FindAddressBookEntry(const CTxDestination& dest, bool allow_change) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1693,6 +1693,7 @@ void CWallet::ReacceptWalletTransactions()
     // If transactions aren't being broadcasted, don't let them into local mempool either
     if (!fBroadcastTransactions)
         return;
+    LOCK(cs_wallet);
     std::map<int64_t, CWalletTx*> mapSorted;
 
     // Sort pending wallet transactions based on their initial wallet insertion order
@@ -2906,8 +2907,6 @@ bool CWallet::UpgradeWallet(int version, bilingual_str& error)
 
 void CWallet::postInitProcess()
 {
-    LOCK(cs_wallet);
-
     // Add wallet transactions that aren't already in a block to mempool
     // Do this here as mempool requires genesis block to be loaded
     ReacceptWalletTransactions();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -536,7 +536,7 @@ public:
     };
     ScanResult ScanForWalletTransactions(const uint256& start_block, int start_height, std::optional<int> max_height, const WalletRescanReserver& reserver, bool fUpdate);
     void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason, uint64_t mempool_sequence) override;
-    void ReacceptWalletTransactions() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void ReacceptWalletTransactions() LOCKS_EXCLUDED(cs_wallet);
     void ResendWalletTransactions();
 
     OutputType TransactionChangeType(const std::optional<OutputType>& change_type, const std::vector<CRecipient>& vecSend) const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -333,13 +333,6 @@ private:
     // ScriptPubKeyMan::GetID. In many cases it will be the hash of an internal structure
     std::map<uint256, std::unique_ptr<ScriptPubKeyMan>> m_spk_managers;
 
-    /**
-     * Catch wallet up to current chain, scanning new blocks, updating the best
-     * block locator and m_last_block_processed, and registering for
-     * notifications about new blocks and transactions.
-     */
-    static bool AttachChain(const std::shared_ptr<CWallet>& wallet, interfaces::Chain& chain, const bool rescan_required, bilingual_str& error, std::vector<bilingual_str>& warnings);
-
 public:
     /**
      * Main wallet lock.
@@ -404,6 +397,16 @@ public:
 
     /** Registered interfaces::Chain::Notifications handler. */
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
+
+    /** Result of scanning a chain for new transactions */
+    enum class ScanStatus { SUCCESS, FAILED, MISSING_BLOCKS, SKIPPED };
+
+    /**
+     * Catch wallet up to current chain, scanning new blocks, updating the best
+     * block locator and m_last_block_processed, and registering for
+     * notifications about new blocks and transactions.
+     */
+    static ScanStatus AttachChain(std::shared_ptr<CWallet> wallet, bool scan = true, bool rescan_required = false);
 
     /** Interface for accessing chain state. */
     interfaces::Chain& chain() const { assert(m_chain); return *m_chain; }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -406,7 +406,7 @@ public:
      * block locator and m_last_block_processed, and registering for
      * notifications about new blocks and transactions.
      */
-    static ScanStatus AttachChain(std::shared_ptr<CWallet> wallet, bool scan = true, bool rescan_required = false);
+    static ScanStatus AttachChain(std::shared_ptr<CWallet> wallet, bool scan = true, bool rescan_required = false) LOCKS_EXCLUDED(wallet->cs_wallet);
 
     /** Interface for accessing chain state. */
     interfaces::Chain& chain() const { assert(m_chain); return *m_chain; }

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -30,6 +30,15 @@ race:validation_chainstatemanager_tests
 deadlock:libdb
 race:libzmq
 
+# Disable spurious error about std::cout.
+# data race /usr/lib/llvm-10/bin/../include/c++/v1/ios:522:12 in std::__1::ios_base::width() const
+# Location is global 'std::__1::cout' of size 160 at 0x7f492785e270 (libc++.so.1+0x0000000c0290)
+# https://travis-ci.org/github/bitcoin/bitcoin/jobs/695004018
+#
+# Uses of std::cout are guaranteed thread safe by the c++ standard
+# https://stackoverflow.com/questions/50322790/thread-safety-and-piping-to-streams
+race:std::__1::ios_base::width
+
 # Intermittent issues
 # -------------------
 #


### PR DESCRIPTION
Move wallet startup code closer to a simple model where the wallet attaches to the chain with a single chain.handleNotifications() call, and just starts passively receiving blocks and mempool notifications from the last update point, instead having to actively rescan blocks and request a mempool snapshot, and deal with the tip changing, and deal with early or stale notifications.

Also, stop locking the cs_wallet mutex and registering for validationinterface notifications before the rescan. This was new behavior since 6a72f26968cf931c985d8d4797b6264274cabd06 https://github.com/bitcoin/bitcoin/pull/16426 and is not ideal because it stops other wallets and rpcs and the gui from receiving new notifications until after the scan completes.

This change is a half-step towards implementing multiwallet scans (https://github.com/bitcoin/bitcoin/issues/11756), since it provides needed locator and birthday timestamp information to the Chain interface, and it rationalizes locking and event ordering in the startup code. The second half of implementing parallel rescans requires moving the ScanForWalletTransactions implementation (which this PR does not touch) from the wallet to the node.