### PR TITLE
validation: Check absence of locks at compile-time (LOCKS_EXCLUDED) in addition to the current run-time checking (AssertLockNotHeld)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -159,7 +159,7 @@ public:
 
     bool LoadBlockIndex(const Consensus::Params& consensus_params, CBlockTreeDB& blocktree) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-    bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock);
+    bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams, std::shared_ptr<const CBlock> pblock) LOCKS_EXCLUDED(cs_main);
 
     /**
      * If a block header hasn't already been seen, call CheckBlockHeader on it, ensure
@@ -2624,7 +2624,7 @@ static void NotifyHeaderTip() LOCKS_EXCLUDED(cs_main) {
     }
 }
 
-static void LimitValidationInterfaceQueue() {
+static void LimitValidationInterfaceQueue() LOCKS_EXCLUDED(cs_main) {
     AssertLockNotHeld(cs_main);
 
     if (GetMainSignals().CallbacksPending() > 10) {


### PR DESCRIPTION
Check absence of locks at compile-time (using `LOCKS_EXCLUDED` annotation) in addition to the current run-time checking (using `AssertLockNotHeld(…)`).

In line with the developer notes:

> Generally; compile-time checking is preferred over run-time checking.

For people who are not compiling with `clang -Werror=thread-safety-analysis` -- this is the type of checking these annotations enable:

```
[…]: error: cannot call function 'LimitValidationInterfaceQueue' while mutex 'cs_main' is
     held [-Werror,-Wthread-safety-analysis]
            LimitValidationInterfaceQueue();
            ^
```