### PR TITLE
doc: Change block chain to blockchain in doc

### DIFF
--- a/doc/JSON-RPC-interface.md
+++ b/doc/JSON-RPC-interface.md
@@ -20,7 +20,7 @@ RPC interface will be abused.
   includes being able to record any passphrases you enter for unlocking
   your encrypted wallets or changing settings so that your Bitcoin Core
   program tells you that certain transactions have multiple
-  confirmations even when they aren't part of the best block chain.  For
+  confirmations even when they aren't part of the best blockchain.  For
   this reason, you should not use Bitcoin Core for security sensitive
   operations on systems you do not exclusively control, such as shared
   computers or virtual private servers.

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -48,7 +48,7 @@ Given a height: returns hash of block in best-block-chain at height provided.
 #### Chaininfos
 `GET /rest/chaininfo.json`
 
-Returns various state info regarding block chain processing.
+Returns various state info regarding blockchain processing.
 Only supports JSON as output format.
 * chain : (string) current network name as defined in BIP70 (main, test, regtest)
 * blocks : (numeric) the current number of blocks processed in the server

--- a/doc/files.md
+++ b/doc/files.md
@@ -24,12 +24,12 @@ guisettings.ini.bak | backup of former GUI settings after `-resetguisettings` is
 
 Only used in pre-0.8.0
 ---------------------
-* blktree/*; block chain index (LevelDB); since pre-0.8, replaced by blocks/index/* in 0.8.0
+* blktree/*; blockchain index (LevelDB); since pre-0.8, replaced by blocks/index/* in 0.8.0
 * coins/*; unspent transaction output database (LevelDB); since pre-0.8, replaced by chainstate/* in 0.8.0
 
 Only used before 0.8.0
 ---------------------
-* blkindex.dat: block chain index database (BDB); replaced by {chainstate/*,blocks/index/*,blocks/rev000??.dat} in 0.8.0
+* blkindex.dat: blockchain index database (BDB); replaced by {chainstate/*,blocks/index/*,blocks/rev000??.dat} in 0.8.0
 * blk000?.dat: block data (custom, 2 GiB per file); replaced by blocks/blk000??.dat in 0.8.0
 
 Only used before 0.7.0

--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -348,7 +348,7 @@ Fee (in BTC/kB) to add to transactions you send (default: 0.00)
 .HP
 \fB\-rescan\fR
 .IP
-Rescan the block chain for missing wallet transactions on startup
+Rescan the blockchain for missing wallet transactions on startup
 .HP
 \fB\-salvagewallet\fR
 .IP

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -348,7 +348,7 @@ Fee (in BTC/kB) to add to transactions you send (default: 0.00)
 .HP
 \fB\-rescan\fR
 .IP
-Rescan the block chain for missing wallet transactions on startup
+Rescan the blockchain for missing wallet transactions on startup
 .HP
 \fB\-salvagewallet\fR
 .IP

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -109,7 +109,7 @@ No authentication or authorization is done on connecting clients; it
 is assumed that the ZeroMQ port is exposed only to trusted entities,
 using other means such as firewalling.
 
-Note that when the block chain tip changes, a reorganisation may occur
+Note that when the blockchain tip changes, a reorganisation may occur
 and just the tip will be notified. It is up to the subscriber to
 retrieve the chain from the last known block to the new tip.
 


### PR DESCRIPTION
The term blockchain is more common than the old block chain, so I replaced all matches for "block chain" with "blockchain" in the doc/ folder, except the matches in doc/release-notes for historical reasons.