### PR TITLE
[wallet] Refactor relay transactions

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -535,7 +535,7 @@ public:
 
     int64_t GetTxTime() const;
 
-    // RelayWalletTransaction may only be called if fBroadcastTransactions!
+    // Pass this transaction to the node to relay to its peers
     bool RelayWalletTransaction(interfaces::Chain::Lock& locked_chain);
 
     /** Pass this transaction to the mempool. Fails if absolute fee exceeds absurd fee. */


### PR DESCRIPTION
Refactor `CWalletTx::RelayWalletTransaction()` function.

This was a suggestion from the wallet-node separation PR: https://github.com/bitcoin/bitcoin/pull/15288#discussion_r256036330, which we deferred until after the main PR was merged.

There are also makes two minor behavior changes:

- no longer assert if fBroadcastTransactions is false. Just return false from the function.
- no longer print the relay message if p2pEnabled is set to false (since the transaction is not actually relayed).
