### PR TITLE
Speed up deriveaddresses for large ranges

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -228,8 +228,8 @@ UniValue deriveaddresses(const JSONRPCRequest& request)
         range_end = range.second;
     }
 
-    FlatSigningProvider provider;
-    auto desc = Parse(desc_str, provider, /* require_checksum = */ true);
+    FlatSigningProvider key_provider;
+    auto desc = Parse(desc_str, key_provider, /* require_checksum = */ true);
     if (!desc) {
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Invalid descriptor"));
     }
@@ -245,8 +245,9 @@ UniValue deriveaddresses(const JSONRPCRequest& request)
     UniValue addresses(UniValue::VARR);
 
     for (int i = range_begin; i <= range_end; ++i) {
+        FlatSigningProvider provider;
         std::vector<CScript> scripts;
-        if (!desc->Expand(i, provider, scripts, provider)) {
+        if (!desc->Expand(i, key_provider, scripts, provider)) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Cannot derive script without private keys"));
         }
 


### PR DESCRIPTION
`deriveaddresses` dumps all generated addresses into a single `FlatSigningProvider`, which is also used for looking up information for future derivations. @achow101 points out that the growing data structures may unnecessary increase lookup time for later derivations.

Fix this by separating the provider used for lookups (`key_provider`) and the one we dump things into.

This gives a 10x speedup for a range of 7000 elements, and probably a larger speedup for larger ranges.