### PR TITLE
gui: Add shortcuts for tab tools

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -493,6 +493,7 @@ void BitcoinGUI::createMenuBar()
     window_menu->addSeparator();
     for (RPCConsole::TabTypes tab_type : rpcConsole->tabs()) {
         QAction* tab_action = window_menu->addAction(rpcConsole->tabTitle(tab_type));
+        tab_action->setShortcut(rpcConsole->tabShortcut(tab_type));
         connect(tab_action, &QAction::triggered, [this, tab_type] {
             rpcConsole->setTabFocus(tab_type);
             showDebugWindow();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1276,6 +1276,16 @@ QString RPCConsole::tabTitle(TabTypes tab_type) const
     return ui->tabWidget->tabText(tab_type);
 }
 
+QKeySequence RPCConsole::tabShortcut(TabTypes tab_type) const
+{
+    switch (tab_type) {
+    case TAB_INFO: return QKeySequence(Qt::CTRL + Qt::Key_I);
+    case TAB_CONSOLE: return QKeySequence(Qt::CTRL + Qt::Key_T);
+    case TAB_GRAPH: return QKeySequence(Qt::CTRL + Qt::Key_N);
+    case TAB_PEERS: return QKeySequence(Qt::CTRL + Qt::Key_P);
+    }
+}
+
 void RPCConsole::updateAlerts(const QString& warnings)
 {
     this->ui->label_alerts->setVisible(!warnings.isEmpty());

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -68,6 +68,7 @@ public:
     std::vector<TabTypes> tabs() const { return {TAB_INFO, TAB_CONSOLE, TAB_GRAPH, TAB_PEERS}; }
 
     QString tabTitle(TabTypes tab_type) const;
+    QKeySequence tabShortcut(TabTypes tab_type) const;
 
 protected:
     virtual bool eventFilter(QObject* obj, QEvent *event);


### PR DESCRIPTION
This makes accessing the RPC console very fast/easy. It also improves accessibility. 

<img width="234" alt="Screenshot 2019-10-02 at 01 30 53" src="https://user-images.githubusercontent.com/3534524/66009867-50104300-e4b4-11e9-90b5-6b8dc961a8a1.png">
