### PR TITLE
List new RPCs in psbt.md and descriptors.md

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -1,11 +1,18 @@
 # Support for Output Descriptors in Bitcoin Core
 
-Since Bitcoin Core v0.17, there is support for Output Descriptors in the
-`scantxoutset` RPC call. This is a simple language which can be used to
-describe collections of output scripts.
+Since Bitcoin Core v0.17, there is support for Output Descriptors. This is a
+simple language which can be used to describe collections of output scripts.
+Supporting RPCs are:
+- `scantxoutset` takes as input descriptors to scan for, and also reports
+  specialized descriptors for the matching UTXOs.
+- `getdescriptorinfo` analyzes a descriptor, and reports a canonicalized version
+  with checksum added.
+- `deriveaddresses` takes as input a descriptor and computes the corresponding
+  addresses.
+- `listunspent` outputs a specialized descriptor for the reported unspent outputs.
 
-This document describes the language. For the specifics on usage for scanning
-the UTXO set, see the `scantxoutset` RPC help.
+This document describes the language. For the specifics on usage, see the RPC
+documentation for the functions mentioned above.
 
 ## Features
 

--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -67,6 +67,9 @@ hardware implementations will typically implement multiple roles simultaneously.
   input a PSBT, adds UTXO, key, and script data to inputs and outputs that miss
   it, and optionally signs inputs. Where possible it also finalizes the partial
   signatures.
+- **`utxoupdatepsbt` (Updater)** is a node RPC that takes a PSBT and updates it
+  to include information available from the UTXO set (works only for SegWit
+  inputs).
 - **`finalizepsbt` (Finalizer, Extractor)** is a utility RPC that finalizes any
   partial signatures, and if all inputs are finalized, converts the result to a
   fully signed transaction which can be broadcast with `sendrawtransaction`.
@@ -74,8 +77,15 @@ hardware implementations will typically implement multiple roles simultaneously.
   can be used at any point in the workflow to merge information added to
   different versions of the same PSBT. In particular it is useful to combine the
   output of multiple Updaters or Signers.
+- **`joinpsbts`** (Creator) is a utility RPC that joins multiple PSBTs together,
+  concatenating the inputs and outputs. This can be used to construct CoinJoin
+  transactions.
 - **`decodepsbt`** is a diagnostic utility RPC which will show all information in
   a PSBT in human-readable form, as well as compute its eventual fee if known.
+- **`analyzepsbt`** is a utility RPC that examines an RPC and reports the
+  next steps in the workflow if known, computes the fee of the resulting
+  transaction, and estimates the weight and feerate if possible.
+
 
 ### Workflows
 


### PR DESCRIPTION
The documentation in `psbt.md` and `descriptors.md` does not list new and updated RPCs (`analyzepsbt`, `utxoupdatepsbt`, `joinpsbts`, `deriveaddresses`, `getdescriptorinfo`, `listunspent`). Fix this.

It'd be good to have this in 0.18 (only documentation).