### PR TITLE
Native descriptor wallets

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -152,6 +152,10 @@ public:
     {
         return m_wallet->GetKeyFromPool(pub_key, internal);
     }
+    bool getDestinationFromDescriptor(CTxDestination& dest, OutputType type, bool internal) override
+    {
+        return m_wallet->GetDestinationFromDescriptor(dest, type, internal);
+    }
     bool getPubKey(const CKeyID& address, CPubKey& pub_key) override { return m_wallet->GetPubKey(address, pub_key); }
     bool getPrivKey(const CKeyID& address, CKey& key) override { return m_wallet->GetKey(address, key); }
     bool isSpendable(const CTxDestination& dest) override { return IsMine(*m_wallet, dest) & ISMINE_SPENDABLE; }
@@ -469,6 +473,7 @@ public:
     bool IsWalletFlagSet(uint64_t flag) override { return m_wallet->IsWalletFlagSet(flag); }
     OutputType getDefaultAddressType() override { return m_wallet->m_default_address_type; }
     OutputType getDefaultChangeType() override { return m_wallet->m_default_change_type; }
+    bool isDescriptor() override { return m_wallet->IsDescriptor(); }
     CAmount getDefaultMaxTxFee() override { return m_wallet->m_default_max_tx_fee; }
     void remove() override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -79,6 +79,9 @@ public:
     // Get key from pool.
     virtual bool getKeyFromPool(bool internal, CPubKey& pub_key) = 0;
 
+    // Get address from descriptor and type
+    virtual bool getDestinationFromDescriptor(CTxDestination& dest, OutputType type, bool internal) = 0;
+
     //! Get public key.
     virtual bool getPubKey(const CKeyID& address, CPubKey& pub_key) = 0;
 
@@ -252,6 +255,9 @@ public:
 
     // Remove wallet.
     virtual void remove() = 0;
+
+    // Wallet is a descriptor wallet
+    virtual bool isDescriptor() = 0;
 
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -174,6 +174,25 @@ bool CBasicKeyStore::HaveWatchOnly() const
     return (!setWatchOnly.empty());
 }
 
+bool CBasicKeyStore::HaveScriptPubKey(const CScript& script) const
+{
+    LOCK(cs_KeyStore);
+    return m_set_scriptPubKey.count(script) > 0;
+}
+
+bool CBasicKeyStore::HaveScriptPubKeys() const
+{
+    LOCK(cs_KeyStore);
+    return !m_set_scriptPubKey.empty();
+}
+
+bool CBasicKeyStore::AddScriptPubKey(const CScript& script)
+{
+    LOCK(cs_KeyStore);
+    m_set_scriptPubKey.insert(script);
+    return true;
+}
+
 CKeyID GetKeyForDestination(const CKeyStore& store, const CTxDestination& dest)
 {
     // Only supports destinations which map to single public keys, i.e. P2PKH,

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -36,6 +36,9 @@ public:
     virtual bool RemoveWatchOnly(const CScript &dest) =0;
     virtual bool HaveWatchOnly(const CScript &dest) const =0;
     virtual bool HaveWatchOnly() const =0;
+    virtual bool HaveScriptPubKey(const CScript& script) const =0;
+    virtual bool HaveScriptPubKeys() const =0;
+    virtual bool AddScriptPubKey(const CScript& script) =0;
 };
 
 /** Basic key store, that keeps keys in an address->secret map */
@@ -48,11 +51,13 @@ protected:
     using WatchKeyMap = std::map<CKeyID, CPubKey>;
     using ScriptMap = std::map<CScriptID, CScript>;
     using WatchOnlySet = std::set<CScript>;
+    using ScriptPubKeySet = std::set<CScript>;
 
     KeyMap mapKeys GUARDED_BY(cs_KeyStore);
     WatchKeyMap mapWatchKeys GUARDED_BY(cs_KeyStore);
     ScriptMap mapScripts GUARDED_BY(cs_KeyStore);
     WatchOnlySet setWatchOnly GUARDED_BY(cs_KeyStore);
+    ScriptPubKeySet m_set_scriptPubKey GUARDED_BY(cs_KeyStore);
 
     void ImplicitlyLearnRelatedKeyScripts(const CPubKey& pubkey) EXCLUSIVE_LOCKS_REQUIRED(cs_KeyStore);
 
@@ -72,6 +77,10 @@ public:
     bool RemoveWatchOnly(const CScript &dest) override;
     bool HaveWatchOnly(const CScript &dest) const override;
     bool HaveWatchOnly() const override;
+    bool HaveScriptPubKey(const CScript& script) const override;
+    bool HaveScriptPubKeys() const override;
+    bool AddScriptPubKey(const CScript& script) override;
+
 };
 
 /** Return the CKeyID of the key involved in a script (if there is a unique one). */

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -667,15 +667,22 @@ void PaymentServer::fetchPaymentACK(WalletModel* walletModel, const SendCoinsRec
 
     // Create a new refund address, or re-use:
     CPubKey newKey;
-    if (walletModel->wallet().getKeyFromPool(false /* internal */, newKey)) {
+    CTxDestination dest;
+    const OutputType change_type = walletModel->wallet().getDefaultChangeType() != OutputType::CHANGE_AUTO ? walletModel->wallet().getDefaultChangeType() : walletModel->wallet().getDefaultAddressType();
+    if (walletModel->wallet().isDescriptor()) {
+        walletModel->wallet().getDestinationFromDescriptor(dest, change_type, true);
+    }
+    else if (walletModel->wallet().getKeyFromPool(false /* internal */, newKey)) {
         // BIP70 requests encode the scriptPubKey directly, so we are not restricted to address
         // types supported by the receiver. As a result, we choose the address format we also
         // use for change. Despite an actual payment and not change, this is a close match:
         // it's the output type we use subject to privacy issues, but not restricted by what
         // other software supports.
-        const OutputType change_type = walletModel->wallet().getDefaultChangeType() != OutputType::CHANGE_AUTO ? walletModel->wallet().getDefaultChangeType() : walletModel->wallet().getDefaultAddressType();
         walletModel->wallet().learnRelatedScripts(newKey, change_type);
-        CTxDestination dest = GetDestinationForKey(newKey, change_type);
+        dest = GetDestinationForKey(newKey, change_type);
+    }
+
+    if (boost::get<CNoDestination>(&dest)) {
         std::string label = tr("Refund from %1").arg(recipient.authenticatedMerchant).toStdString();
         walletModel->wallet().setAddressBook(dest, label, "refund");
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -126,6 +126,8 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importpubkey", 2, "rescan" },
     { "importmulti", 0, "requests" },
     { "importmulti", 1, "options" },
+    { "importdescriptors", 0, "requests" },
+    { "importdescriptors", 1, "options" },
     { "verifychain", 0, "checklevel" },
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -96,6 +96,7 @@ static UniValue createmultisig(const JSONRPCRequest& request)
             "{\n"
             "  \"address\":\"multisigaddress\",  (string) The value of the new multisig address.\n"
             "  \"redeemScript\":\"script\"       (string) The string value of the hex-encoded redemption script.\n"
+            "  \"descriptor\":\"descriptor\"     (string) The descriptor for the P2SH address for this multisig\n"
             "}\n"
                 },
                 RPCExamples{
@@ -134,9 +135,13 @@ static UniValue createmultisig(const JSONRPCRequest& request)
     CBasicKeyStore keystore;
     const CTxDestination dest = AddAndGetDestinationForScript(keystore, inner, output_type);
 
+    // Make the descriptor
+    std::unique_ptr<Descriptor> descriptor = InferDescriptor(GetScriptForDestination(dest), keystore);
+
     UniValue result(UniValue::VOBJ);
     result.pushKV("address", EncodeDestination(dest));
     result.pushKV("redeemScript", HexStr(inner.begin(), inner.end()));
+    result.pushKV("descriptor", descriptor->ToString());
 
     return result;
 }

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -164,6 +164,9 @@ struct PubkeyProvider
 
     /** Get the descriptor string form including private data (if available in arg). */
     virtual bool ToPrivateString(const SigningProvider& arg, std::string& out) const = 0;
+
+    /** Derive a private key, if private data is available in arg. */
+    virtual bool GetPrivKey(int pos, const SigningProvider& arg, CKey& key) const = 0;
 };
 
 class OriginPubkeyProvider final : public PubkeyProvider
@@ -195,6 +198,10 @@ public:
         ret = "[" + OriginString() + "]" + std::move(sub);
         return true;
     }
+    bool GetPrivKey(int pos, const SigningProvider& arg, CKey& key) const override
+    {
+        return m_provider->GetPrivKey(pos, arg, key);
+    }
 };
 
 /** An object representing a parsed constant public key in a descriptor. */
@@ -221,6 +228,10 @@ public:
         if (!arg.GetKey(m_pubkey.GetID(), key)) return false;
         ret = EncodeSecret(key);
         return true;
+    }
+    bool GetPrivKey(int pos, const SigningProvider& arg, CKey& key) const override
+    {
+        return arg.GetKey(m_pubkey.GetID(), key);
     }
 };
 
@@ -310,6 +321,18 @@ public:
             out += "/*";
             if (m_derive == DeriveType::HARDENED) out += '\'';
         }
+        return true;
+    }
+    bool GetPrivKey(int pos, const SigningProvider& arg, CKey& key) const override
+    {
+        CExtKey extkey;
+        if (!GetExtKey(arg, extkey)) return false;
+        for (auto entry : m_path) {
+            extkey.Derive(extkey, entry);
+        }
+        if (m_derive == DeriveType::UNHARDENED) extkey.Derive(extkey, pos);
+        if (m_derive == DeriveType::HARDENED) extkey.Derive(extkey, pos | 0x80000000UL);
+        key = extkey.key;
         return true;
     }
 };
@@ -461,6 +484,20 @@ public:
     {
         Span<const unsigned char> span = MakeSpan(cache);
         return ExpandHelper(pos, DUMMY_SIGNING_PROVIDER, &span, output_scripts, out, nullptr) && span.size() == 0;
+    }
+
+    void ExpandPrivate(int pos, const SigningProvider& provider, FlatSigningProvider& out) const final
+    {
+        for (const auto& p : m_pubkey_args) {
+            CKey key;
+            if (!p->GetPrivKey(pos, provider, key)) continue;
+            out.keys.emplace(key.GetPubKey().GetID(), key);
+        }
+        if (m_script_arg) {
+            FlatSigningProvider subprovider;
+            m_script_arg->ExpandPrivate(pos, provider, subprovider);
+            out = Merge(out, subprovider);
+        }
     }
 };
 

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -878,6 +878,12 @@ std::unique_ptr<DescriptorImpl> InferScript(const CScript& script, ParseScriptCo
 
 } // namespace
 
+DescriptorID::DescriptorID(const Descriptor& desc)
+{
+    std::string desc_str = desc.ToString();
+    CSHA256().Write((unsigned char*)desc_str.data(), desc_str.size()).Finalize(begin());
+}
+
 std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProvider& out, bool require_checksum)
 {
     Span<const char> sp(descriptor.data(), descriptor.size());

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -61,6 +61,14 @@ struct Descriptor {
      * out: scripts and public keys necessary for solving the expanded scriptPubKeys will be put here (may be equal to provider).
      */
     virtual bool ExpandFromCache(int pos, const std::vector<unsigned char>& cache, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const = 0;
+
+    /** Expand the private key for a descriptor at a specified position, if possible.
+     *
+     * pos: the position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * provider: the provider to query for the private keys.
+     * out: any private keys available for the specified pos will be placed here.
+     */
+    virtual void ExpandPrivate(int pos, const SigningProvider& provider, FlatSigningProvider& out) const = 0;
 };
 
 struct DescriptorID : public uint256

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -7,6 +7,7 @@
 
 #include <script/script.h>
 #include <script/sign.h>
+#include <uint256.h>
 
 #include <vector>
 
@@ -60,6 +61,14 @@ struct Descriptor {
      * out: scripts and public keys necessary for solving the expanded scriptPubKeys will be put here (may be equal to provider).
      */
     virtual bool ExpandFromCache(int pos, const std::vector<unsigned char>& cache, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const = 0;
+};
+
+struct DescriptorID : public uint256
+{
+    DescriptorID() : uint256() {}
+    explicit DescriptorID(const uint256& hash) : uint256(hash) {}
+    explicit DescriptorID(const Descriptor& desc);
+    using uint256::uint256;
 };
 
 /** Parse a descriptor string. Included private keys are put in out.

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -174,17 +174,22 @@ IsMineResult IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey,
 
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey)
 {
-    if (keystore.HaveScriptPubKey(scriptPubKey)) {
-        return ISMINE_SPENDABLE;
-    }
-    switch (IsMineInner(keystore, scriptPubKey, IsMineSigVersion::TOP)) {
-    case IsMineResult::INVALID:
-    case IsMineResult::NO:
-        return ISMINE_NO;
-    case IsMineResult::WATCH_ONLY:
-        return ISMINE_WATCH_ONLY;
-    case IsMineResult::SPENDABLE:
-        return ISMINE_SPENDABLE;
+    if (keystore.HaveScriptPubKeys()) {
+        if (keystore.HaveScriptPubKey(scriptPubKey)) {
+            return ISMINE_SPENDABLE;
+        } else {
+            return ISMINE_NO;
+        }
+    } else {
+        switch (IsMineInner(keystore, scriptPubKey, IsMineSigVersion::TOP)) {
+        case IsMineResult::INVALID:
+        case IsMineResult::NO:
+            return ISMINE_NO;
+        case IsMineResult::WATCH_ONLY:
+            return ISMINE_WATCH_ONLY;
+        case IsMineResult::SPENDABLE:
+            return ISMINE_SPENDABLE;
+        }
     }
     assert(false);
 }

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -174,6 +174,9 @@ IsMineResult IsMineInner(const CKeyStore& keystore, const CScript& scriptPubKey,
 
 isminetype IsMine(const CKeyStore& keystore, const CScript& scriptPubKey)
 {
+    if (keystore.HaveScriptPubKey(scriptPubKey)) {
+        return ISMINE_SPENDABLE;
+    }
     switch (IsMineInner(keystore, scriptPubKey, IsMineSigVersion::TOP)) {
     case IsMineResult::INVALID:
     case IsMineResult::NO:

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -138,6 +138,10 @@ UniValue importprivkey(const JSONRPCRequest& request)
                 },
             }.ToString());
 
+    if (pwallet->IsDescriptor()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "importprivkey is not available for descriptor wallets");
+    }
+
     if (pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
         throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import private keys to a wallet with private keys disabled");
     }
@@ -312,6 +316,9 @@ UniValue importaddress(const JSONRPCRequest& request)
                 },
             }.ToString());
 
+    if (pwallet->IsDescriptor()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "importaddress is not available for descriptor wallets");
+    }
 
     std::string strLabel;
     if (!request.params[1].isNull())
@@ -510,6 +517,9 @@ UniValue importpubkey(const JSONRPCRequest& request)
                 },
             }.ToString());
 
+    if (pwallet->IsDescriptor()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "importpubkey is not available for descriptor wallets");
+    }
 
     std::string strLabel;
     if (!request.params[1].isNull())
@@ -798,6 +808,10 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
             + HelpExampleRpc("dumpprivkey", "\"myaddress\"")
                 },
             }.ToString());
+
+    if (pwallet->IsDescriptor()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "dumpprivkey is not available for descriptor wallets");
+    }
 
     auto locked_chain = pwallet->chain().lock();
     LOCK(pwallet->cs_wallet);
@@ -1436,6 +1450,9 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
             }.ToString()
         );
 
+    if (pwallet->IsDescriptor()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "importmulti is not available for descriptor wallets");
+    }
 
     RPCTypeCheck(mainRequest.params, {UniValue::VARR, UniValue::VOBJ});
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2669,6 +2669,7 @@ static UniValue createwallet(const JSONRPCRequest& request)
             {"disable_private_keys", RPCArg::Type::BOOL, /* default */ "false", "Disable the possibility of private keys (only watchonlys are possible in this mode)."},
             {"blank", RPCArg::Type::BOOL, /* default */ "false", "Create a blank wallet. A blank wallet has no keys or HD seed. One can be set using sethdseed."},
             {"passphrase", RPCArg::Type::STR, RPCArg::Optional::OMITTED, "Encrypt the wallet with this passphrase."},
+            {"descriptor", RPCArg::Type::BOOL, /* default */ "false", "Create a native descriptor wallet. The wallet will use descriptors internally to handle address creation"},
         },
         RPCResult{
             "{\n"
@@ -2708,6 +2709,9 @@ static UniValue createwallet(const JSONRPCRequest& request)
         }
         // Born encrypted wallets need to be blank first so that wallet creation doesn't make any unencrypted keys
         flags |= WALLET_FLAG_BLANK_WALLET;
+    }
+    if (!request.params[4].isNull() && request.params[3].get_bool()) {
+        flags |= WALLET_FLAG_DESCRIPTORS;
     }
 
     WalletLocation location(request.params[0].get_str());

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2488,6 +2488,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
             "      \"duration\" : xxxx              (numeric) elapsed seconds since scan start\n"
             "      \"progress\" : x.xxxx,           (numeric) scanning progress percentage [0.0, 1.0]\n"
             "    }\n"
+            "  \"descriptors\": true|false          (boolean) true if the wallet supports descriptors\n"
             "}\n"
                 },
                 RPCExamples{
@@ -2539,6 +2540,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     } else {
         obj.pushKV("scanning", false);
     }
+    obj.pushKV("descriptors", pwallet->IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS));
     return obj;
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -995,6 +995,10 @@ static UniValue addmultisigaddress(const JSONRPCRequest& request)
         throw std::runtime_error(msg);
     }
 
+    if (pwallet->IsDescriptor()) {
+        throw JSONRPCError(RPC_WALLET_ERROR, "addmultisigaddress is not available for descriptor wallets");
+    }
+
     auto locked_chain = pwallet->chain().lock();
     LOCK(pwallet->cs_wallet);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4169,6 +4169,7 @@ UniValue importwallet(const JSONRPCRequest& request);
 UniValue importprunedfunds(const JSONRPCRequest& request);
 UniValue removeprunedfunds(const JSONRPCRequest& request);
 UniValue importmulti(const JSONRPCRequest& request);
+UniValue importdescriptors(const JSONRPCRequest& request);
 
 // clang-format off
 static const CRPCCommand commands[] =
@@ -4201,6 +4202,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "importprunedfunds",                &importprunedfunds,             {"rawtransaction","txoutproof"} },
     { "wallet",             "importpubkey",                     &importpubkey,                  {"pubkey","label","rescan"} },
     { "wallet",             "importwallet",                     &importwallet,                  {"filename"} },
+    { "wallet",             "importdescriptors",                &importdescriptors,             {"requests","options"} },
     { "wallet",             "keypoolrefill",                    &keypoolrefill,                 {"newsize"} },
     { "wallet",             "listaddressgroupings",             &listaddressgroupings,          {} },
     { "wallet",             "listlabels",                       &listlabels,                    {"purpose"} },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1726,7 +1726,7 @@ bool CWallet::CanGetAddresses(bool internal)
     // Check if the keypool has keys
     bool keypool_has_keys;
     if (internal && CanSupportFeature(FEATURE_HD_SPLIT)) {
-        keypool_has_keys = setInternalKeyPool.size() > 0;
+        keypool_has_keys = GetKeyPoolSize() - KeypoolCountExternalKeys() > 0;
     } else {
         keypool_has_keys = KeypoolCountExternalKeys() > 0;
     }
@@ -3543,7 +3543,33 @@ bool CWallet::NewKeyPool()
 size_t CWallet::KeypoolCountExternalKeys()
 {
     AssertLockHeld(cs_wallet);
+    if (IsDescriptor()) {
+        size_t count = 0;
+        for (const auto& desc_id : m_primary_descriptors) {
+            WalletDescriptor& desc = m_map_descriptors[desc_id.second];
+            count += desc.range_end - desc.next_index;
+        }
+        return count;
+    }
     return setExternalKeyPool.size() + set_pre_split_keypool.size();
+}
+
+unsigned int CWallet::GetKeyPoolSize()
+{
+    AssertLockHeld(cs_wallet);
+    if (IsDescriptor()) {
+        size_t count = 0;
+        for (const auto& desc_id : m_primary_descriptors) {
+            WalletDescriptor& desc = m_map_descriptors[desc_id.second];
+            count += desc.range_end - desc.next_index;
+        }
+        for (const auto& desc_id : m_change_descriptors) {
+            WalletDescriptor& desc = m_map_descriptors[desc_id.second];
+            count += desc.range_end - desc.next_index;
+        }
+        return count;
+    }
+    return setInternalKeyPool.size() + setExternalKeyPool.size() + set_pre_split_keypool.size();;
 }
 
 void CWallet::LoadKeyPool(int64_t nIndex, const CKeyPool &keypool)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -512,7 +512,7 @@ bool CWallet::LoadDescriptor(const WalletDescriptor& desc)
         desc.descriptor->ExpandFromCache(i, desc.cache[i - desc.range_start], scripts_temp, out_keys);
         // Add all of the scriptPubKeys to the scriptPubKey set
         for (const auto& script : scripts_temp) {
-            AddScriptPubKey(script);
+            AddScriptPubKey(script, id, i);
         }
         // Add the scripts to in memory
         for (const auto& script : out_keys.scripts) {
@@ -1578,6 +1578,17 @@ bool CWallet::AddWalletDescriptor(const WalletDescriptor& wallet_desc)
     // Add the descriptor to wallet in memory
     LoadDescriptor(wallet_desc);
     return true;
+}
+
+bool CWallet::AddScriptPubKey(const CScript& script)
+{
+    return CBasicKeyStore::AddScriptPubKey(script);
+}
+
+bool CWallet::AddScriptPubKey(const CScript& script, const DescriptorID& id, int pos)
+{
+    m_map_scriptPubKeys[CScriptID(script)] = std::make_pair(id, pos);
+    return AddScriptPubKey(script);
 }
 
 bool CWallet::IsHDEnabled() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1575,6 +1575,11 @@ bool CWallet::IsHDEnabled() const
     return !hdChain.seed_id.IsNull();
 }
 
+bool CWallet::IsDescriptor() const
+{
+    return IsWalletFlagSet(WALLET_FLAG_DESCRIPTORS);
+}
+
 bool CWallet::CanGenerateKeys()
 {
     // A wallet can generate keys if it has an HD seed (IsHDEnabled) or it is a non-HD wallet (pre FEATURE_HD)
@@ -1621,7 +1626,7 @@ void CWallet::UnsetWalletFlagWithDB(WalletBatch& batch, uint64_t flag)
         throw std::runtime_error(std::string(__func__) + ": writing wallet flags failed");
 }
 
-bool CWallet::IsWalletFlagSet(uint64_t flag)
+bool CWallet::IsWalletFlagSet(uint64_t flag) const
 {
     return (m_wallet_flags & flag);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -526,6 +526,16 @@ bool CWallet::LoadDescriptor(const WalletDescriptor& desc)
     return true;
 }
 
+std::set<std::tuple<std::shared_ptr<Descriptor>, int32_t, int32_t, uint64_t>> CWallet::GetDescriptors() const
+{
+    AssertLockHeld(cs_wallet);
+    std::set<std::tuple<std::shared_ptr<Descriptor>, int32_t, int32_t, uint64_t>> descriptors;
+    for (const auto& desc : m_map_descriptors) {
+        descriptors.emplace(desc.second.descriptor, desc.second.range_start, desc.second.range_end, desc.second.creation_time);
+    }
+    return descriptors;
+}
+
 bool CWallet::Unlock(const SecureString& strWalletPassphrase, bool accept_no_keys)
 {
     CCrypter crypter;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -805,6 +805,7 @@ private:
     std::map<CKeyID, int64_t> m_pool_key_to_index;
     std::atomic<uint64_t> m_wallet_flags{0};
     std::map<DescriptorID, WalletDescriptor> m_map_descriptors GUARDED_BY(cs_wallet);
+    std::map<CScriptID, std::pair<DescriptorID, int>> m_map_scriptPubKeys GUARDED_BY(cs_wallet);
 
     int64_t nTimeFirstKey GUARDED_BY(cs_wallet) = 0;
 
@@ -838,6 +839,8 @@ private:
 
     //! Unsets a wallet flag and saves it to disk
     void UnsetWalletFlagWithDB(WalletBatch& batch, uint64_t flag);
+
+    bool AddScriptPubKey(const CScript& script) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Interface for accessing chain state. */
     interfaces::Chain* m_chain;
@@ -1031,6 +1034,9 @@ public:
 
     //! Get all of the descriptors from the set
     std::set<std::tuple<std::shared_ptr<Descriptor>, int32_t, int32_t, uint64_t>> GetDescriptors() const;
+
+    //! Add a script pubkey to the wallet and the descriptor and position it came from
+    bool AddScriptPubKey(const CScript& script, const DescriptorID& id, int pos) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime = 0;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1029,6 +1029,9 @@ public:
     //! Load a descriptor
     bool LoadDescriptor(const WalletDescriptor& desc);
 
+    //! Get all of the descriptors from the set
+    std::set<std::tuple<std::shared_ptr<Descriptor>, int32_t, int32_t, uint64_t>> GetDescriptors() const;
+
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime = 0;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1167,6 +1167,10 @@ public:
     void ReturnKey(int64_t nIndex, bool fInternal, const CPubKey& pubkey);
     bool GetKeyFromPool(CPubKey &key, bool internal = false);
     int64_t GetOldestKeyPoolTime();
+
+    /** Fetch an address from the specified descriptor and address type */
+    bool GetDestinationFromDescriptor(CTxDestination& dest, OutputType type, bool internal);
+
     /**
      * Marks all keys in the keypool up to and including reserve_key as used.
      */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1213,11 +1213,7 @@ public:
 
     const std::string& GetLabelName(const CScript& scriptPubKey) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
-    unsigned int GetKeyPoolSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet)
-    {
-        AssertLockHeld(cs_wallet);
-        return setInternalKeyPool.size() + setExternalKeyPool.size();
-    }
+    unsigned int GetKeyPoolSize() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! signify that a particular wallet feature is now used. this may change nWalletVersion and nWalletMaxVersion if those are lower
     void SetMinVersion(enum WalletFeature, WalletBatch* batch_in = nullptr, bool fExplicit = false);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -788,6 +788,10 @@ private:
     /* the HD chain data model (external chain counters) */
     CHDChain hdChain;
 
+    /* Descriptors to use for address generation */
+    std::map<OutputType, DescriptorID> m_primary_descriptors;
+    std::map<OutputType, DescriptorID> m_change_descriptors;
+
     /* HD derive new child key (on internal or external chain) */
     void DeriveNewChildKey(WalletBatch& batch, CKeyMetadata& metadata, CKey& secret, bool internal = false) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
@@ -797,6 +801,7 @@ private:
     int64_t m_max_keypool_index GUARDED_BY(cs_wallet) = 0;
     std::map<CKeyID, int64_t> m_pool_key_to_index;
     std::atomic<uint64_t> m_wallet_flags{0};
+    std::map<DescriptorID, WalletDescriptor> m_map_descriptors GUARDED_BY(cs_wallet);
 
     int64_t nTimeFirstKey GUARDED_BY(cs_wallet) = 0;
 
@@ -1017,6 +1022,9 @@ public:
     bool RemoveWatchOnly(const CScript &dest) override EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a watch-only address to the store, without saving it to disk (used by LoadWallet)
     bool LoadWatchOnly(const CScript &dest);
+
+    //! Load a descriptor
+    bool LoadDescriptor(const WalletDescriptor& desc);
 
     //! Holds a timestamp at which point the wallet is scheduled (externally) to be relocked. Caller must arrange for actual relocking to occur via Lock().
     int64_t nRelockTime = 0;
@@ -1272,6 +1280,16 @@ public:
     /* Set the HD chain model (chain child index counters) */
     void SetHDChain(const CHDChain& chain, bool memonly);
     const CHDChain& GetHDChain() const { return hdChain; }
+
+    /* Set the descriptors being used */
+    void SetPrimaryDescriptor(const DescriptorID& id, bool memonly, OutputType type);
+    void SetChangeDescriptor(const DescriptorID& id, bool memonly, OutputType type);
+
+    /* Add a descriptor to the wallet */
+    bool AddWalletDescriptor(const WalletDescriptor& wallet_desc);
+
+    /* Whether the descriptor is part of the wallet */
+    bool HaveWalletDescriptor(const DescriptorID& id) const;
 
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1315,6 +1315,9 @@ public:
     /* Returns true if the wallet can give out new addresses. This means it has keys in the keypool or can generate new keys */
     bool CanGetAddresses(bool internal = false);
 
+    /* Generate a new HD seed and a corresponding descriptor of the specified output type */
+    void GenerateNewDescriptor(CKeyID seed, OutputType type) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     /* Generates a new HD seed (will not be activated) */
     CPubKey GenerateNewSeed();
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -138,6 +138,9 @@ enum WalletFlags : uint64_t {
     //! bitcoin from opening the wallet, thinking it was newly created, and
     //! then improperly reinitializing it.
     WALLET_FLAG_BLANK_WALLET = (1ULL << 33),
+
+    //! Flag set when the wallet uses descriptors natively
+    WALLET_FLAG_DESCRIPTORS = (1ULL << 34),
 };
 
 static constexpr uint64_t g_known_wallet_flags = WALLET_FLAG_DISABLE_PRIVATE_KEYS | WALLET_FLAG_BLANK_WALLET | WALLET_FLAG_KEY_ORIGIN_METADATA;
@@ -1294,6 +1297,9 @@ public:
     /* Returns true if HD is enabled */
     bool IsHDEnabled() const;
 
+    /* Returns true if this is a descriptor wallet */
+    bool IsDescriptor() const;
+
     /* Returns true if the wallet can generate new keys */
     bool CanGenerateKeys();
 
@@ -1341,7 +1347,7 @@ public:
     void UnsetWalletFlag(uint64_t flag);
 
     /** check if a certain wallet flag is set */
-    bool IsWalletFlagSet(uint64_t flag);
+    bool IsWalletFlagSet(uint64_t flag) const;
 
     /** overwrite all flags by the given uint64_t
        returns false if unknown, non-tolerable flags are present */

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -423,6 +423,28 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
                 strErr = "Error reading wallet database: Unknown non-tolerable wallet flags found";
                 return false;
             }
+        } else if (strType == "descriptor") {
+            WalletDescriptor desc;
+            ssValue >> desc;
+            pwallet->LoadDescriptor(desc);
+        } else if (strType == "primarydescriptor") {
+            std::string type_str;
+            ssKey >> type_str;
+            OutputType type;
+            assert(ParseOutputType(type_str, type));
+
+            DescriptorID id;
+            ssValue >> id;
+            pwallet->SetPrimaryDescriptor(id, true, type);
+        } else if (strType == "changedescriptor") {
+            std::string type_str;
+            ssKey >> type_str;
+            OutputType type;
+            assert(ParseOutputType(type_str, type));
+
+            DescriptorID id;
+            ssValue >> id;
+            pwallet->SetChangeDescriptor(id, true, type);
         } else if (strType != "bestblock" && strType != "bestblock_nomerkle" &&
                 strType != "minversion" && strType != "acentry") {
             wss.m_unknown_records++;
@@ -763,6 +785,16 @@ bool WalletBatch::EraseDestData(const std::string &address, const std::string &k
 bool WalletBatch::WriteHDChain(const CHDChain& chain)
 {
     return WriteIC(std::string("hdchain"), chain);
+}
+
+bool WalletBatch::WritePrimaryDescriptor(const uint256& id, OutputType type)
+{
+    return WriteIC(std::make_pair(std::string("primarydescriptor"), FormatOutputType(type)), id);
+}
+
+bool WalletBatch::WriteChangeDescriptor(const uint256& id, OutputType type)
+{
+    return WriteIC(std::make_pair(std::string("changedescriptor"), FormatOutputType(type)), id);
 }
 
 bool WalletBatch::WriteWalletFlags(const uint64_t flags)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -156,6 +156,11 @@ bool WalletBatch::WriteMinVersion(int nVersion)
     return WriteIC(std::string("minversion"), nVersion);
 }
 
+bool WalletBatch::WriteDescriptor(const WalletDescriptor& descriptor)
+{
+    return WriteIC(std::make_pair(std::string("descriptor"), DescriptorID(*descriptor.descriptor)), descriptor);
+}
+
 class CWalletScanState {
 public:
     unsigned int nKeys{0};

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLETDB_H
 
 #include <amount.h>
+#include <outputtype.h>
 #include <primitives/transaction.h>
 #include <script/sign.h>
 #include <wallet/db.h>
@@ -244,6 +245,10 @@ public:
 
     //! write the hdchain model (external chain child index counter)
     bool WriteHDChain(const CHDChain& chain);
+
+    //! Write the descriptors in use
+    bool WritePrimaryDescriptor(const uint256& id, OutputType type);
+    bool WriteChangeDescriptor(const uint256& id, OutputType type);
 
     bool WriteWalletFlags(const uint64_t flags);
     //! Begin a new transaction

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -40,6 +40,7 @@ class CWallet;
 class CWalletTx;
 class uint160;
 class uint256;
+class WalletDescriptor;
 
 /** Backend-agnostic database type. */
 using WalletDatabase = BerkeleyDatabase;
@@ -214,6 +215,8 @@ public:
     bool ReadPool(int64_t nPool, CKeyPool& keypool);
     bool WritePool(int64_t nPool, const CKeyPool& keypool);
     bool ErasePool(int64_t nPool);
+
+    bool WriteDescriptor(const WalletDescriptor& descriptor);
 
     bool WriteMinVersion(int nVersion);
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -140,6 +140,7 @@ BASE_SCRIPTS = [
     'wallet_disable.py',
     'rpc_net.py',
     'wallet_keypool.py',
+    'wallet_descriptor.py',
     'p2p_mempool.py',
     'p2p_blocksonly.py',
     'mining_prioritisetransaction.py',

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test descriptor wallet function."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error
+)
+
+
+class WalletDescriptorTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [['-keypool=100']]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        # Make a descriptor wallet
+        self.log.info("Making a descriptor wallet")
+        self.nodes[0].createwallet("desc1", False, False, True)
+        self.nodes[0].unloadwallet("")
+
+        # A descriptor wallet should have 100 addresses * 3 types = 300 keys
+        self.log.info("Checking wallet info")
+        wallet_info = self.nodes[0].getwalletinfo()
+        assert_equal(wallet_info['keypoolsize'], 300)
+        assert_equal(wallet_info['keypoolsize_hd_internal'], 300)
+        assert wallet_info['descriptors']
+
+        # Check that getnewaddress works
+        self.log.info("Test that getnewaddress and getrawchangeaddress work")
+        addr = self.nodes[0].getnewaddress("", "legacy")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert_equal(addr_info['hdkeypath'], 'm/44\'/0\'/0\'')
+
+        addr = self.nodes[0].getnewaddress("", "p2sh-segwit")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert_equal(addr_info['hdkeypath'], 'm/49\'/0\'/0\'')
+
+        addr = self.nodes[0].getnewaddress("", "bech32")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert_equal(addr_info['hdkeypath'], 'm/84\'/0\'/0\'')
+
+        # Check that getrawchangeaddress works
+        addr = self.nodes[0].getrawchangeaddress("legacy")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert_equal(addr_info['hdkeypath'], 'm/44\'/1\'/0\'')
+
+        addr = self.nodes[0].getrawchangeaddress("p2sh-segwit")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert_equal(addr_info['hdkeypath'], 'm/49\'/1\'/0\'')
+
+        addr = self.nodes[0].getrawchangeaddress("bech32")
+        addr_info = self.nodes[0].getaddressinfo(addr)
+        assert_equal(addr_info['hdkeypath'], 'm/84\'/1\'/0\'')
+
+        # Make a wallet to receive coins at
+        self.nodes[0].createwallet("desc2", False, False, True)
+        recv_wrpc = self.nodes[0].get_wallet_rpc("desc2")
+        assert recv_wrpc.getwalletinfo()['descriptors']
+        send_wrpc = self.nodes[0].get_wallet_rpc("desc1")
+
+        # Generate some coins
+        send_wrpc.generatetoaddress(101, send_wrpc.getnewaddress())
+
+        # Make transactions
+        self.log.info("Test sending and receiving")
+        addr = recv_wrpc.getnewaddress()
+        send_wrpc.sendtoaddress(addr, 10)
+
+        # Make sure things are disabled
+        self.log.info("Test disabled RPCs")
+        assert_raises_rpc_error(-4, "importprivkey is not available for descriptor wallets", recv_wrpc.importprivkey, "cVpF924EspNh8KjYsfhgY96mmxvT6DgdWiTYMtMjuM74hJaU5psW")
+        assert_raises_rpc_error(-4, "addmultisigaddress is not available for descriptor wallets", recv_wrpc.addmultisigaddress, 1, [recv_wrpc.getnewaddress()])
+        assert_raises_rpc_error(-4, "importaddress is not available for descriptor wallets", recv_wrpc.importaddress, recv_wrpc.getnewaddress())
+        assert_raises_rpc_error(-4, "dumpprivkey is not available for descriptor wallets", recv_wrpc.dumpprivkey, recv_wrpc.getnewaddress())
+        assert_raises_rpc_error(-4, "importpubkey is not available for descriptor wallets", recv_wrpc.importpubkey, send_wrpc.getaddressinfo(send_wrpc.getnewaddress()))
+        assert_raises_rpc_error(-4, "importmulti is not available for descriptor wallets", recv_wrpc.importmulti, [])
+
+if __name__ == '__main__':
+    WalletDescriptorTest().main ()

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -19,6 +19,7 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
     "src/util/system.cpp:.*atoi"
+    "src/wallet/rpcdump.cpp:.*stoi"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"


### PR DESCRIPTION
Introducing the wallet of the glorious future: native descriptor wallets. With native descriptor wallet, addresses are generated from descriptors. Instead of generating keys and deriving addresses from keys, addresses come from the scriptPubKeys produced by a descriptor.

Descriptor wallets will now store only keys, keymetadata, and descriptors. Keys are derived from descriptors but those keys are also stored in order to make signing work faster and be less complicated. In order to allow choosing different address types, 6 descriptors are needed for normal use. There is a pair of primary and change descriptors for each of the 3 address types. With the default keypool size of 1000, each descriptor has 1000 keys and scriptPubKeys pregenerated. This has a side effect of making wallets very large since 6000 keys are generated by default, instead of the current 2000. This can probably be improved in the future as we probably don't need so many addresses for each address type.

Descriptors can also be imported with a new `importdescriptor` RPC.

Native descriptor wallets also redefines how ismine and watchonly work. Ismine is changing to the simpler model of "does this scriptPubKey exist in this wallet". To facilitate this, all of the scriptPubKeys for all of the descriptors are computed on wallet loading. A scriptPubKey is considered `ISMINE_SPENDABLE` if it appears in the set of scriptPubKeys for the wallet. Because of this ismine change, watchonly is also redefined. A wallet can no longer contains watchonly things and non-watchonly things. Instead wallets are either watchonly (by having private keys disabled) or not. There is no mixing of watchonly and non-watchonly in a wallet. Some tests that relied on watchonly behavior had to be removed (i.e. part of `feature_segwit.py`)

Additionally several RPCs related to importing and dumping data from a wallet are incompatible with descriptor wallets. These RPCs (`addmultisigaddress`, `importaddress`, `importpubkey`, `importmulti`, `importprivkey`, and `dumpprivkey`) are disabled for normal use.

***

This PR is built on #15741 for batched writing to the wallet so `TopUpKeyPool` works faster, and on #15761 for upgrading wallets with a RPC.