### PR TITLE
Expire inflight GETDATA requests

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2415,8 +2415,11 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         CValidationState state;
 
         CNodeState* nodestate = State(pfrom->GetId());
-        nodestate->m_tx_download.m_tx_announced.erase(inv.hash);
-        nodestate->m_tx_download.m_tx_in_flight.erase(inv.hash);
+        if (nodestate->m_tx_download.m_tx_in_flight.erase(inv.hash)) {
+            // only erase from m_tx_announced if we've already erased
+            // from m_tx_process_time
+            nodestate->m_tx_download.m_tx_announced.erase(inv.hash);
+        }
         EraseTxRequest(inv.hash);
 
         std::list<CTransactionRef> lRemovedTxn;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -797,6 +797,8 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
     stats.nMisbehavior = state->nMisbehavior;
     stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
     stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
+    stats.nTxInFlight = state->m_tx_download.m_tx_in_flight.size();
+    stats.nTxProcess = state->m_tx_download.m_tx_process_time.size();
     for (const QueuedBlock& queue : state->vBlocksInFlight) {
         if (queue.pindex)
             stats.vHeightInFlight.push_back(queue.pindex->nHeight);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3121,6 +3121,15 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
     if (strCommand == NetMsgType::NOTFOUND) {
         // We do not care about the NOTFOUND message, but logging an Unknown Command
         // message would be undesirable as we transmit it ourselves.
+        std::vector<CInv> vInv;
+        vRecv >> vInv;
+        // note: we don't enforce a limit on number of inv's in a notfound
+
+        LogPrint(BCLog::NET, "received notfound (%u invsz) peer=%d\n", vInv.size(), pfrom->GetId());
+
+        if (vInv.size() > 0) {
+            LogPrint(BCLog::NET, "received notfound for: %s peer=%d\n", vInv[0].ToString(), pfrom->GetId());
+        }
         return true;
     }
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -83,6 +83,8 @@ struct CNodeStateStats {
     int nMisbehavior = 0;
     int nSyncHeight = -1;
     int nCommonHeight = -1;
+    int nTxInFlight = -1;
+    int nTxProcess = -1;
     std::vector<int> vHeightInFlight;
 };
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -106,6 +106,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             "    \"banscore\": n,             (numeric) The ban score\n"
             "    \"synced_headers\": n,       (numeric) The last header we have in common with this peer\n"
             "    \"synced_blocks\": n,        (numeric) The last block we have in common with this peer\n"
+            "    \"tx_inflight\": n,          (numeric) The number of transactions this peer is expected to tell us about\n"
+            "    \"tx_process\": n,           (numeric) The number of transactions we'd like to ask this peer about soon\n"
             "    \"inflight\": [\n"
             "       n,                        (numeric) The heights of blocks we're currently asking from this peer\n"
             "       ...\n"
@@ -178,6 +180,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             obj.pushKV("banscore", statestats.nMisbehavior);
             obj.pushKV("synced_headers", statestats.nSyncHeight);
             obj.pushKV("synced_blocks", statestats.nCommonHeight);
+            obj.pushKV("tx_inflight", statestats.nTxInFlight);
+            obj.pushKV("tx_process", statestats.nTxProcess);
             UniValue heights(UniValue::VARR);
             for (const int height : statestats.vHeightInFlight) {
                 heights.push_back(height);

--- a/test/functional/p2p_getdata_ignore.py
+++ b/test/functional/p2p_getdata_ignore.py
@@ -107,13 +107,12 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         assert_equal(len(node.p2p.getdata_requests), 0)
         assert_equal(node.getpeerinfo()[0]["tx_process"], 60)
 
-        self.log.info("Have 80 unasked-for transactions queued at 32min...")
+        self.log.info("After 30 minutes, have disconnected")
         node.setmocktime(mt+32*60)
-        self.p2p_withheld_tx(20)
+        time.sleep(1)
         assert_equal(len(node.p2p.getdata_requests), 0)
-        assert_equal(node.getpeerinfo()[0]["tx_process"], 80)
         assert_equal(0, node.getmempoolinfo()['size'])  # Mempool should be empty
-        assert_equal(1, len(node.getpeerinfo()))  # still connected
+        assert_equal(0, len(node.getpeerinfo()))  # disconnected
 
 if __name__ == '__main__':
     InvalidTxRequestTest().main()

--- a/test/functional/p2p_getdata_ignore.py
+++ b/test/functional/p2p_getdata_ignore.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test node responses to invalid transactions.
+
+In this test we connect to one node over p2p, and test tx requests."""
+from test_framework.blocktools import create_block, create_coinbase
+from test_framework.messages import (
+    CInv,
+    COIN,
+    COutPoint,
+    CTransaction,
+    CTxIn,
+    CTxOut,
+    msg_inv,
+)
+from test_framework.mininode import P2PDataStore
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+import time
+
+class InvalidTxRequestTest(BitcoinTestFramework):
+    SCRIPT_PUB_KEY_OP_TRUE = b'\x51\x75' * 15 + b'\x51'
+
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.withheld_tx_offset = 0
+
+    def bootstrap_p2p(self, *, num_connections=1):
+        """Add a P2P connection to the node.
+
+        Helper to connect and wait for version handshake."""
+        for _ in range(num_connections):
+            self.nodes[0].add_p2p_connection(P2PDataStore())
+
+    def reconnect_p2p(self, **kwargs):
+        """Tear down and bootstrap the P2P connection to the node.
+
+        The node gets disconnected several times in this test. This helper
+        method reconnects the p2p and restarts the network thread."""
+        self.nodes[0].disconnect_p2ps()
+        self.bootstrap_p2p(**kwargs)
+
+    def p2p_withheld_tx(self, num):
+        node = self.nodes[0]  # convenience reference to the node
+        for i in range(num):
+            tx_withhold = CTransaction()
+            tx_withhold.vin.append(CTxIn(outpoint=COutPoint(self.block1.vtx[0].sha256, 0)))
+            tx_withhold.vout.append(CTxOut(nValue=50 * COIN - 12000 + self.withheld_tx_offset + i, scriptPubKey=self.SCRIPT_PUB_KEY_OP_TRUE))
+            tx_withhold.calc_sha256()
+            self.log.debug("Withheld tx %d %s" % (self.withheld_tx_offset+i+1, tx_withhold.hash))
+            node.p2p.send_message(msg_inv(inv=[CInv(1, tx_withhold.sha256)]))
+        self.withheld_tx_offset += num
+        time.sleep(5) # give it time to actually do some getdata requests
+
+    def run_test(self):
+        node = self.nodes[0]  # convenience reference to the node
+        mt = int(time.time())
+        node.setmocktime(mt)
+
+        self.bootstrap_p2p()  # Add one p2p connection to the node
+
+        best_block = self.nodes[0].getbestblockhash()
+        tip = int(best_block, 16)
+        best_block_time = self.nodes[0].getblock(best_block)['time']
+        block_time = best_block_time + 1
+
+        self.log.info("Create a new block with an anyone-can-spend coinbase.")
+        height = 1
+        block = create_block(tip, create_coinbase(height), block_time)
+        block.solve()
+        # Save the coinbase for later
+        self.block1 = block
+        tip = block.sha256
+        node.p2p.send_blocks_and_test([block], node, success=True)
+
+        self.log.info("Mature the block.")
+        self.nodes[0].generatetoaddress(100, self.nodes[0].get_deterministic_priv_key().address)
+
+        self.log.info('Test withheld transaction handling ... ')
+        # Create a root transaction that we withhold until all dependent transactions
+        # are sent out and in the orphan cache
+
+        time.sleep(1) # catch up
+        node.p2p.getdata_requests = [] # clear this
+        self.p2p_withheld_tx(120)
+
+        assert_equal(0, node.getmempoolinfo()['size'])  # Mempool should be empty
+        assert_equal(1, len(node.getpeerinfo()))  # still connected
+        assert_equal(len(node.p2p.getdata_requests), 100) # stop at >100 getdata requests
+        self.log.info("Correctly asked for 100 transactions out of 120!")
+        node.p2p.getdata_requests = [] # clear again
+
+        self.log.info("Have 40 unasked-for transactions queued at 2min...")
+        node.setmocktime(mt+2*60)
+        self.p2p_withheld_tx(20)
+        assert_equal(len(node.p2p.getdata_requests), 0)
+        assert_equal(node.getpeerinfo()[0]["tx_process"], 40)
+
+        self.log.info("Have 60 unasked-for transactions queued at 28min...")
+        node.setmocktime(mt+28*60)
+        self.p2p_withheld_tx(20)
+        assert_equal(len(node.p2p.getdata_requests), 0)
+        assert_equal(node.getpeerinfo()[0]["tx_process"], 60)
+
+        self.log.info("Have 80 unasked-for transactions queued at 32min...")
+        node.setmocktime(mt+32*60)
+        self.p2p_withheld_tx(20)
+        assert_equal(len(node.p2p.getdata_requests), 0)
+        assert_equal(node.getpeerinfo()[0]["tx_process"], 80)
+        assert_equal(0, node.getmempoolinfo()['size'])  # Mempool should be empty
+        assert_equal(1, len(node.getpeerinfo()))  # still connected
+
+if __name__ == '__main__':
+    InvalidTxRequestTest().main()

--- a/test/functional/p2p_getdata_parent_failure.py
+++ b/test/functional/p2p_getdata_parent_failure.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test node responses to invalid transactions.
+
+In this test we connect to one node over p2p, and test tx requests."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+)
+import time
+
+class GetDataFailureTest(BitcoinTestFramework):
+    NUM_ADDR = 25
+
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def peerinfo_interesting(self, node):
+        pi = node.getpeerinfo()
+        mpi = node.getmempoolinfo()
+        return mpi["size"],pi[0]["tx_inflight"], pi[0]["tx_process"]
+
+    def run_test(self):
+        node_work,node_miss = self.nodes  # convenience reference to the nodes
+
+        mt = int(time.time())
+        node_miss.setmocktime(mt)
+        node_work.setmocktime(mt)
+
+        node_work.generate(2) # 100 BTC mature
+        self.sync_all()
+        node_miss.generate(100)
+
+        self.log.info('Setup %d wallet addresses' % self.NUM_ADDR)
+        addr = [node_work.getnewaddress() for i in range(self.NUM_ADDR)]
+        self.sync_all()
+
+        self.log.info('Setup with %d utxos to spend' % (5*self.NUM_ADDR))
+        assert(5*self.NUM_ADDR*0.351 < 50)
+        node_work.sendmany("", {a: 0.351 for a in addr})
+        node_work.sendmany("", {a: 0.351 for a in addr})
+        node_work.sendmany("", {a: 0.351 for a in addr})
+        node_work.sendmany("", {a: 0.351 for a in addr})
+        node_work.sendmany("", {a: 0.351 for a in addr})
+
+        self.sync_all()
+        node_miss.generate(1)
+        self.sync_all()
+        assert_equal(node_work.getmempoolinfo()["size"], 0)
+        assert_equal(node_miss.getmempoolinfo()["size"], 0)
+
+        self.log.info('Disconnect node_miss, create 100 transactions')
+        disconnect_nodes(self.nodes[0], 1)
+        utxos = []
+        for i in range(100):
+            rawtx = node_work.createrawtransaction( [], [{addr[0]: 0.2}] )
+            rawtxf = node_work.fundrawtransaction(rawtx)
+            vout = 1-rawtxf["changepos"]
+            rawtxs = node_work.signrawtransactionwithwallet(rawtxf["hex"])
+            txid = node_work.sendrawtransaction(rawtxs["hex"])
+            utxos.append( (txid, vout) )
+
+        self.log.info('Bump time by 20 minutes, reconnect nodes')
+        mt += 20*60 # bump time by 20 minutes
+        node_miss.setmocktime(mt)
+        node_work.setmocktime(mt)
+
+        connect_nodes(self.nodes[0], 1)
+
+        self.log.info('Create %d txs with parents in mempool for >15m' % (len(utxos)))
+        for txid,vout in utxos:
+            rawtx = node_work.createrawtransaction( [{"txid":txid, "vout":vout}], [{addr[0]: 0.199}] )
+            rawtxs = node_work.signrawtransactionwithwallet(rawtx)
+            txid = node_work.sendrawtransaction(rawtxs["hex"])
+
+        # time to sync
+        time.sleep(25)
+
+        self.log.info("Check node_miss didn't see any transactions")
+        assert_equal(self.peerinfo_interesting(node_miss), (0, 100, 0))
+        assert_equal(self.peerinfo_interesting(node_work), (200, 0, 0))
+
+        txid = node_miss.sendtoaddress(addr[0], 0.5)
+        self.log.info("Check node_miss transactions still work (%s)" % (txid))
+        time.sleep(25)
+        assert_equal(self.peerinfo_interesting(node_miss), (1, 100, 0))
+        assert_equal(self.peerinfo_interesting(node_work), (201, 0, 0))
+
+        txid = node_work.sendtoaddress(addr[0], 30)
+        self.log.info("Check legit node_work transactions don't work at all (%s)" % (txid))
+        time.sleep(25)
+        assert_equal(self.peerinfo_interesting(node_miss), (1, 100, 1))
+        assert_equal(self.peerinfo_interesting(node_work), (202, 0, 0))
+
+if __name__ == '__main__':
+    GetDataFailureTest().main()

--- a/test/functional/p2p_getdata_parent_failure.py
+++ b/test/functional/p2p_getdata_parent_failure.py
@@ -84,20 +84,20 @@ class GetDataFailureTest(BitcoinTestFramework):
         # time to sync
         time.sleep(25)
 
-        self.log.info("Check node_miss didn't see any transactions")
-        assert_equal(self.peerinfo_interesting(node_miss), (0, 100, 0))
+        self.log.info("Check node_miss didn't see any transactions, but isn't confused either")
+        assert_equal(self.peerinfo_interesting(node_miss), (0, 0, 0))
         assert_equal(self.peerinfo_interesting(node_work), (200, 0, 0))
 
         txid = node_miss.sendtoaddress(addr[0], 0.5)
         self.log.info("Check node_miss transactions still work (%s)" % (txid))
         time.sleep(25)
-        assert_equal(self.peerinfo_interesting(node_miss), (1, 100, 0))
+        assert_equal(self.peerinfo_interesting(node_miss), (1, 0, 0))
         assert_equal(self.peerinfo_interesting(node_work), (201, 0, 0))
 
         txid = node_work.sendtoaddress(addr[0], 30)
-        self.log.info("Check legit node_work transactions don't work at all (%s)" % (txid))
+        self.log.info("Check legit node_work transactions still work too (%s)" % (txid))
         time.sleep(25)
-        assert_equal(self.peerinfo_interesting(node_miss), (1, 100, 1))
+        assert_equal(self.peerinfo_interesting(node_miss), (2, 0, 0))
         assert_equal(self.peerinfo_interesting(node_work), (202, 0, 0))
 
 if __name__ == '__main__':

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -85,6 +85,7 @@ BASE_SCRIPTS = [
     'p2p_segwit.py',
     'p2p_timeouts.py',
     'wallet_dump.py',
+    'p2p_getdata_parent_failure.py',
     'wallet_listtransactions.py',
     # vv Tests less than 60s vv
     'p2p_sendheaders.py',

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -104,6 +104,7 @@ BASE_SCRIPTS = [
     # vv Tests less than 30s vv
     'wallet_keypool_topup.py',
     'interface_zmq.py',
+    'p2p_getdata_ignore.py',
     'interface_bitcoin_cli.py',
     'mempool_resurrect.py',
     'wallet_txn_doublespend.py --mineblock',


### PR DESCRIPTION
I think #14897 introduces a livelock between peers who don't reply to GETDATA requests with TX data. 

Scenario is likely: Alice sends Bob and INV for a new tx, Bob sends GETDATA for the tx, Alice responds with TX, Bob doesn't have the parent so sends GETDATA for the parent, adding it to the tx_in_flight set, Alice replies NOTFOUND due to the parent having expired from the relay set due to being in the mempool for over 15 minutes, so Bob doesn't remove the entry from the tx_in_flight set. Once this happens 100 times (`MAX_PEER_TX_IN_FLIGHT`), Bob will not request any more tx info via GETDATA from Alice. If this happens to all Bob's peers, Bob will not receive tx data except when blocks are found. If Bob is not reachable for inbound nodes, this can plausibly happen for all Bob's outbound nodes.

I think this happened for my node this week (running master-ish), causing my mempool to be empty, despite having 8 good peers who continued sending INV notifications.

Patches are:
 * debugging info for `getpeerinfo` to be able to tell if either of the queues are growing
 * logging of 'notfound' messages
 * test cases for 'notfound' response to getdata, and no response at all to getdata
 * fix to expire inflight tx's that are reported as 'notfound'
 * fix to disconnect nodes that have 100 inflight tx getdata requests as well as additional tx's we'd like to request that have been waiting for 30mins or more