### PR TITLE
[docs] Add doxygen comments for keypool classes

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -181,6 +181,34 @@ public:
     }
 };
 
+/** A key allocated from the key pool. */
+class CReserveKey
+{
+protected:
+    CWallet* pwallet;
+    int64_t nIndex{-1};
+    CPubKey vchPubKey;
+    bool fInternal{false};
+
+public:
+    explicit CReserveKey(CWallet* pwalletIn)
+    {
+        pwallet = pwalletIn;
+    }
+
+    CReserveKey(const CReserveKey&) = delete;
+    CReserveKey& operator=(const CReserveKey&) = delete;
+
+    ~CReserveKey()
+    {
+        ReturnKey();
+    }
+
+    void ReturnKey();
+    bool GetReservedKey(CPubKey &pubkey, bool internal = false);
+    void KeepKey();
+};
+
 /** Address book data */
 class CAddressBookData
 {
@@ -1217,34 +1245,6 @@ public:
  * their transactions. Actual rebroadcast schedule is managed by the wallets themselves.
  */
 void MaybeResendWalletTxs();
-
-/** A key allocated from the key pool. */
-class CReserveKey
-{
-protected:
-    CWallet* pwallet;
-    int64_t nIndex{-1};
-    CPubKey vchPubKey;
-    bool fInternal{false};
-
-public:
-    explicit CReserveKey(CWallet* pwalletIn)
-    {
-        pwallet = pwalletIn;
-    }
-
-    CReserveKey(const CReserveKey&) = delete;
-    CReserveKey& operator=(const CReserveKey&) = delete;
-
-    ~CReserveKey()
-    {
-        ReturnKey();
-    }
-
-    void ReturnKey();
-    bool GetReservedKey(CPubKey &pubkey, bool internal = false);
-    void KeepKey();
-};
 
 /** RAII object to check and reserve a wallet rescan */
 class WalletRescanReserver


### PR DESCRIPTION
Docs/move-only

Adds doxygen comments for the CKeyPool and CReserveKey objects. The way these work is pretty confusing and it's easy to overlook details (eg https://github.com/bitcoin/bitcoin/pull/15557#discussion_r271956393).

These are on the verbose side, but I think too much commenting is better than not enough. Happy to take feedback on what's an appropriate level.