### PR TITLE
Avoid redefine warning

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -3,7 +3,9 @@
 #ifndef WIN32
 #include <fcntl.h>
 #else
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <codecvt>
 #include <windows.h>
 #endif


### PR DESCRIPTION
Wrap preprocessor definition of NOMINMAX in ifndef conditional to suppress warning when cross compiling Windows.

`fs.cpp:6:0: warning: "NOMINMAX" redefined`
`/usr/lib/gcc/x86_64-w64-mingw32/7.3-posix/include/c++/x86_64-w64-mingw32/bits/os_defines.h:45:0: note: this is the location of the previous definition
 #define NOMINMAX 1`

#define NOMINMAX was introduced in the following merge.

https://github.com/bitcoin/bitcoin/pull/14426