### PR TITLE
[0.18] backport #15754

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -296,8 +296,20 @@ static UniValue getrpcinfo(const JSONRPCRequest& request)
             RPCHelpMan{"getrpcinfo",
                 "\nReturns details of the RPC server.\n",
                 {},
-                RPCResults{},
-                RPCExamples{""},
+                RPCResult{
+            "{\n"
+            " \"active_commands\" (array) All active commands\n"
+            "  [\n"
+            "   {               (object) Information about an active command\n"
+            "    \"method\"       (string)  The name of the RPC command \n"
+            "    \"duration\"     (numeric)  The running time in microseconds\n"
+            "   },...\n"
+            "  ]\n"
+            "}\n"
+                },
+                RPCExamples{
+                    HelpExampleCli("getrpcinfo", "")
+                + HelpExampleRpc("getrpcinfo", "")},
             }.ToString()
         );
     }


### PR DESCRIPTION
Backports #15754 to the 0.18 branch

#15754 added the help message for `getrpcinfo`