### PR TITLE
doc: describe onlynet option in doc/tor.md

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -43,4 +43,4 @@ Some dependencies are not needed in all configurations. The following are some f
 * ZeroMQ is needed only with the `--with-zmq` option.
 
 #### Other
-* librsvg is only needed if you need to run `make deploy` on (cross-compliation to) macOS.
+* librsvg is only needed if you need to run `make deploy` on (cross-compilation to) macOS.

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -16,7 +16,7 @@ outgoing connections, but more is possible.
 
 	-onion=ip:port  Set the proxy server to use for Tor hidden services. You do not
 	                need to set this if it's the same as -proxy. You can use -noonion
-	                to explicitly disable access to hidden service.
+	                to explicitly disable access to hidden services.
 
 	-listen         When using -proxy, listening is disabled by default. If you want
 	                to run a hidden service (see next section), you'll need to enable
@@ -26,6 +26,11 @@ outgoing connections, but more is possible.
 	-addnode=X      of IP addresses or hostnames in these parameters. It requires
 	-seednode=X     SOCKS5. In Tor mode, such addresses can also be exchanged with
 	                other P2P nodes.
+
+	-onlynet=onion  Make outgoing connections only to .onion addresses. Incoming
+	                connections are not affected by this option. This option can be
+	                specified multiple times to allow multiple network types, e.g.
+	                ipv4, ipv6, or onion.
 
 In a typical situation, this suffices to run behind a Tor proxy:
 


### PR DESCRIPTION
as per http://www.erisian.com.au/bitcoin-core-dev/log-2019-04-11.html#l-102.

Description adapted from [/src/init.cpp#L429](https://github.com/bitcoin/bitcoin/blob/master/src/init.cpp#L429).

Please verify if this is the best place to add it in the documentation.

This commit also fixes a typo in doc/dependencies.md.

[skip ci]
