### PR TITLE
CReserveKey should not allow passive key re-use, debug assert in destructor

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -274,6 +274,16 @@ public:
     //! Destructor. If a key has been reserved and not KeepKey'ed, it will be returned to the keypool
     ~CReserveKey()
     {
+        if (nIndex != -1) {
+            LogPrintf("Warning! A CReserveKey was not dealt with until destructor. This is a bug. Please report this if possible, e.g. here: %s%s", PACKAGE_BUGREPORT, "/new\?title=wallet:%20ReserveKey%20was%20not%20dealt%20with%20until%20destructor\n");
+#ifdef DEBUG
+            // To avoid accidental key re-use, we should attempt to have the creator
+            // have it returned or kept before its destructor is called.
+            // TODO: Fix the lifecycle of this object to be less error-prone!
+            assert(false);
+#endif
+
+        }
         ReturnKey();
     }
 


### PR DESCRIPTION
The typical usage pattern of `CReserveKey` is to explicitly `KeepKey`, or `ReturnKey` when it's detected it will not be used.

Implementers such as myself may fail to complete this pattern, and could result in key re-use: https://github.com/bitcoin/bitcoin/pull/15557#discussion_r271956393

Have it assert on debug builds when it's not dealt with, and log an important sounding message otherwise.