### PR TITLE
travis: Bump second timeout to 33 minutes, Add rationale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ script:
   - export CONTINUE=1
   - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
   - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/test_06_script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-  - if [ $SECONDS -gt 1800 ]; then export CONTINUE=0; fi  # Likely the build took very long
+  - if [ $SECONDS -gt 2000 ]; then export CONTINUE=0; fi  # Likely the build took very long; The tests take about 1000s, so we should abort if we have less than 50*60-1000=2000s left
   - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/test_06_script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 after_script:
   - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
People have been complaining on IRC about timeouts, but I don't think we can bump it much further. The tests take more than 15 minutes in some cases [1], so if there is less than 1000 seconds left to finish them we need to abort and save the cache. :man_shrugging:.

[1] https://travis-ci.org/bitcoin/bitcoin/jobs/518788414#L3568