### PR TITLE
Bugfix: GUI: Options: Initialise prune setting range before loading current value, and remove upper bound limit

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -148,6 +148,10 @@ void OptionsDialog::setModel(OptionsModel *_model)
         if (_model->isRestartRequired())
             showRestartWarning(true);
 
+        // Prune values are in GB to be consistent with intro.cpp
+        static constexpr uint64_t nMinDiskSpace = (MIN_DISK_SPACE_FOR_BLOCK_FILES / GB_BYTES) + (MIN_DISK_SPACE_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0;
+        ui->pruneSize->setRange(nMinDiskSpace, _model->node().getAssumedBlockchainSize());
+
         QString strLabel = _model->getOverriddenByCommandLine();
         if (strLabel.isEmpty())
             strLabel = tr("none");
@@ -158,10 +162,6 @@ void OptionsDialog::setModel(OptionsModel *_model)
         mapper->toFirst();
 
         updateDefaultProxyNets();
-
-        // Prune values are in GB to be consistent with intro.cpp
-        static constexpr uint64_t nMinDiskSpace = (MIN_DISK_SPACE_FOR_BLOCK_FILES / GB_BYTES) + (MIN_DISK_SPACE_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0;
-        ui->pruneSize->setRange(nMinDiskSpace, _model->node().getAssumedBlockchainSize());
     }
 
     /* warn when one of the following settings changes by user action (placed here so init via mapper doesn't trigger them) */

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -150,7 +150,7 @@ void OptionsDialog::setModel(OptionsModel *_model)
 
         // Prune values are in GB to be consistent with intro.cpp
         static constexpr uint64_t nMinDiskSpace = (MIN_DISK_SPACE_FOR_BLOCK_FILES / GB_BYTES) + (MIN_DISK_SPACE_FOR_BLOCK_FILES % GB_BYTES) ? 1 : 0;
-        ui->pruneSize->setRange(nMinDiskSpace, _model->node().getAssumedBlockchainSize());
+        ui->pruneSize->setRange(nMinDiskSpace, std::numeric_limits<int>::max());
 
         QString strLabel = _model->getOverriddenByCommandLine();
         if (strLabel.isEmpty())


### PR DESCRIPTION
This fixes two bugs:

1. The prune setting range was set *after* loading the current value. If users had a prune of (eg) 200, it would get limited to 99 before the range was raised. This is fixed by setting the range first.
2. The prune setting was limited to <= the chainparams' "assumed blockchain size". There's no reason for this limit (the UX is the same either way), and there are use cases it breaks (eg, setting a prune size such that it begins pruning at some future point). Therefore, I raised it to the max value.

This is a daggy fix, so should cleanly merge to both master and 0.18 branches.