### PR TITLE
doc: mention creating application support bitcoin folder on OSX

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -82,6 +82,8 @@ Bitcoin Core is now available at `./src/bitcoind`
 
 Before running, you may create an empty configuration file:
 
+    mkdir -p "/Users/${USER}/Library/Application Support/Bitcoin"
+
     touch "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
 
     chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"


### PR DESCRIPTION
When setting up bitcoin core on my new MacBook via the [`macOS Build Instructions and Notes`](https://github.com/bitcoin/bitcoin/blob/master/doc/build-osx.md), running `touch "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"` resulted in `No such file or directory` because my `/Users/${USER}/Library/Application Support/Bitcoin/` folder had not been created yet. 

This PR adds `mkdir "/Users/${USER}/Library/Application Support/Bitcoin"` to the documentation before creating the configuration file with `touch "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"`