### PR TITLE
gitignore: plist and dat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ contrib/devtools/split-debug.sh
 
 # Output from running db4 installation
 db4/
+
+# clang-check
+*.plist

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ src/qt/bitcoin-qt.includes
 *.a
 *.pb.cc
 *.pb.h
+*.dat
 
 *.log
 *.trs


### PR DESCRIPTION
Ignore anything ending in `.dat` and files generated by clang-check. 