### PR TITLE
Add tests for (or remove) untested unused methods

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -108,12 +108,6 @@ void CBloomFilter::clear()
     isEmpty = true;
 }
 
-void CBloomFilter::reset(const unsigned int nNewTweak)
-{
-    clear();
-    nTweak = nNewTweak;
-}
-
 bool CBloomFilter::IsWithinSizeConstraints() const
 {
     return vData.size() <= MAX_BLOOM_FILTER_SIZE && nHashFuncs <= MAX_HASH_FUNCS;

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -85,7 +85,6 @@ public:
     bool contains(const uint256& hash) const;
 
     void clear();
-    void reset(const unsigned int nNewTweak);
 
     //! True if the size is <= MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
     //! (catch a filter which was just deserialized which was too big)

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -389,4 +389,13 @@ BOOST_AUTO_TEST_CASE(TransactionsRequestDeserializationOverflowTest) {
     }
 }
 
+BOOST_AUTO_TEST_CASE(BlockToStringTest) {
+    CBlock block1;
+    CBlock block2;
+    BOOST_CHECK_EQUAL(block1.ToString(), block2.ToString());
+    CBlock block3(BuildBlockTestCase());
+    CBlock block4(BuildBlockTestCase());
+    BOOST_CHECK_NE(block3.ToString(), block4.ToString());
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -180,6 +180,11 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScript
     }
 
 #if defined(HAVE_CONSENSUS_LIB)
+    // Make sure bitcoinconsensus_version() is referenced at least once from
+    // within the project to make sure the removal of bitcoinconsensus_version
+    // wouldn't go unnoticed.
+    BOOST_CHECK(bitcoinconsensus_version() >= 1U);
+
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << tx2;
     int libconsensus_flags = flags & bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL;

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -56,10 +56,28 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     m_wallet.SetHDSeed(master_pub_key);
     m_wallet.NewKeyPool();
 
-    // Call FillPSBT
+    // Call FillPSBT and perform some very basic IsNull sanity checks
     PartiallySignedTransaction psbtx;
+    BOOST_CHECK(psbtx.IsNull());
     CDataStream ssData(ParseHex("70736274ff01009a020000000258e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd750000000000ffffffff838d0427d0ec650a68aa46bb0b098aea4422c071b2ca78352a077959d07cea1d0100000000ffffffff0270aaf00800000000160014d85c2b71d0060b09c9886aeb815e50991dda124d00e1f5050000000016001400aea9a2e5f0f876a588df5546e8742d1d87008f000000000000000000"), SER_NETWORK, PROTOCOL_VERSION);
     ssData >> psbtx;
+    BOOST_CHECK(!psbtx.IsNull());
+    BOOST_CHECK(!psbtx.inputs.empty());
+    for (const PSBTInput& input : psbtx.inputs) {
+        BOOST_CHECK(input.IsNull());
+        PSBTInput modifiedInput = input;
+        BOOST_CHECK(modifiedInput.IsNull());
+        modifiedInput.redeem_script = rs1;
+        BOOST_CHECK(!modifiedInput.IsNull());
+    }
+    BOOST_CHECK(!psbtx.outputs.empty());
+    for (const PSBTOutput& output : psbtx.outputs) {
+        BOOST_CHECK(output.IsNull());
+        PSBTOutput modifiedOutput = output;
+        BOOST_CHECK(modifiedOutput.IsNull());
+        modifiedOutput.redeem_script = rs1;
+        BOOST_CHECK(!modifiedOutput.IsNull());
+    }
 
     // Fill transaction with our data
     bool complete = true;


### PR DESCRIPTION
Changes:
* Add tests for untested unused methods (where YAGNI does not hold).
* Remove untested unused methods (where YAGNI holds).

Rationale:

* Quoting the words of wisdom from Beyoncé's hit song "Unused Method Put a Test on It" from the 2008 album "I Am... A Unit of Test":

> Cause if you liked it, then you should have put a test on it
> If you liked it, then you should have put a test on it
> Don't be mad once you see that they remove it
> If you liked it, then you should have put a test on it
> Oh, oh, oh
> Oh, oh, oh, oh, oh, oh
> Oh, oh, oh
> Oh, oh, oh
> Oh, oh, oh, oh, oh, oh
> Oh, oh, oh
> Cause if you liked it, then you should have put a test on it
> If you liked it, then you should have put a test on it
> Don't be mad once you see that they remove it
> If you liked it, then you should have put a test on it

Notes to reviewers:

* I believe this change to be exhaustive -- no unused methods should be left to discover in the code base (excluding dependencies) after the merge of this PR. Any counter-examples would be very welcome so that I can revisit my methodology!
* Let me know if there are any open PR:s making use of any of these methods, or if there is any compelling evidence that the YAGNI principle does not hold for any of those methods :-)