### PR TITLE
remove duplicate boundary check in script.cpp

### DIFF
--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -281,8 +281,6 @@ bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator en
     opcodeRet = OP_INVALIDOPCODE;
     if (pvchRet)
         pvchRet->clear();
-    if (pc >= end)
-        return false;
 
     // Read instruction
     if (end - pc < 1)


### PR DESCRIPTION
If I'm not mistaken, the statement 
```
if (pc >= end) return false;
``` 
is logically equivalent to the next statement
```
if (end - pc < 1) return false;
```
If that's the case, the PR removes the former for better efficiency and code readability. 