### PR TITLE
doc: Remove upgrade note in release notes from EOL versions

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -24,14 +24,9 @@ shut down (which might take a few minutes for older versions), then run the
 installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
 or `bitcoind`/`bitcoin-qt` (on Linux).
 
-The first time you run version 0.15.0, your chainstate database will be converted to a
-new format, which will take anywhere from a few minutes to half an hour,
-depending on the speed of your machine.
-
-Note that the block database format also changed in version 0.8.0 and there is no
-automatic upgrade code from before version 0.8 to version 0.15.0. Upgrading
-directly from 0.7.x and earlier without redownloading the blockchain is not supported.
-However, as usual, old wallet versions are still supported.
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but might take some time if the datadir needs to be migrated.  Old
+wallet versions of Bitcoin Core are generally supported.
 
 Downgrading warning
 -------------------


### PR DESCRIPTION
Remove the bloat on how to upgrade from version that are EOL