### PR TITLE
docs: Improvements to two READMEs in /test

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -66,7 +66,7 @@ By default, up to 4 tests will be run in parallel by test_runner. To specify
 how many jobs to run, append `--jobs=n`
 
 The individual tests and the test_runner harness have many command-line
-options. Run `test_runner.py -h` to see them all.
+options. Run `test/functional/test_runner.py -h` to see them all.
 
 #### Troubleshooting and debugging test failures
 
@@ -79,7 +79,7 @@ killed all its bitcoind nodes), then there may be a port conflict which will
 cause the test to fail. It is recommended that you run the tests on a system
 where no other bitcoind processes are running.
 
-On linux, the test_framework will warn if there is another
+On linux, the test framework will warn if there is another
 bitcoind process running when the tests are started.
 
 If there are zombie bitcoind processes after test failure, you can kill them
@@ -108,11 +108,18 @@ tests will fail. If this happens, remove the cache directory (and make
 sure bitcoind processes are stopped as above):
 
 ```bash
-rm -rf cache
+rm -rf test/cache
 killall bitcoind
 ```
 
 ##### Test logging
+
+The test framework logs to two files:
+ * `<test data directory>/test_framework.log`
+ * `<test data directory>/node<number>/regtest/debug.log`.
+
+The first line of the test output provides the test data directory path. The
+node number is the relevant test node, from node1 to node4.
 
 The tests contain logging at different levels (debug, info, warning, etc). By
 default:
@@ -133,7 +140,7 @@ aggregate log by running the `combine_logs.py` script. The output can be plain
 text, colorized text or html. For example:
 
 ```
-combine_logs.py -c <test data directory> | less -r
+test/functional/combine_logs.py -c <test data directory> | less -r
 ```
 
 will pipe the colorized logs from the test into less.

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -4,13 +4,13 @@
 
 #### Example test
 
-The [example_test.py](example_test.py) is a heavily commented example of a test case that uses both
-the RPC and P2P interfaces. If you are writing your first test, copy that file
-and modify to fit your needs.
+The file [test/functional/example_test.py](example_test.py) is a heavily commented example
+of a test case that uses both the RPC and P2P interfaces. If you are writing your first test, copy
+that file and modify to fit your needs.
 
 #### Coverage
 
-Running `test_runner.py` with the `--coverage` argument tracks which RPCs are
+Running `test/functional/test_runner.py` with the `--coverage` argument tracks which RPCs are
 called by the tests and prints a report of uncovered RPCs in the summary. This
 can be used (along with the `--extended` argument) to find out which RPCs we
 don't have test cases for.
@@ -82,7 +82,7 @@ P2P messages. These can be found in the following source files:
 
 #### Using the P2P interface
 
-- `messages.py` contains all the definitions for objects that pass
+- [messages.py](test_framework/messages.py) contains all the definitions for objects that pass
 over the network (`CBlock`, `CTransaction`, etc, along with the network-level
 wrappers for them, `msg_block`, `msg_tx`, etc).
 
@@ -96,32 +96,35 @@ the Bitcoin Core node application logic. For custom behaviour, subclass the
 P2PInterface object and override the callback methods.
 
 - Can be used to write tests where specific P2P protocol behavior is tested.
-Examples tests are `p2p_unrequested_blocks.py`, `p2p_compactblocks.py`.
+Examples tests are [p2p_unrequested_blocks.py](p2p_unrequested_blocks.py),
+[p2p_compactblocks.py](p2p_compactblocks.py).
 
-### test-framework modules
+### Test framework modules
+The following are useful modules for test developers. They are located in
+[test/functional/test_framework/](test_framework).
 
-#### [test_framework/authproxy.py](test_framework/authproxy.py)
+#### [authproxy.py](test_framework/authproxy.py)
 Taken from the [python-bitcoinrpc repository](https://github.com/jgarzik/python-bitcoinrpc).
 
-#### [test_framework/test_framework.py](test_framework/test_framework.py)
+#### [test_framework.py](test_framework/test_framework.py)
 Base class for functional tests.
 
-#### [test_framework/util.py](test_framework/util.py)
+#### [util.py](test_framework/util.py)
 Generally useful functions.
 
-#### [test_framework/mininode.py](test_framework/mininode.py)
+#### [mininode.py](test_framework/mininode.py)
 Basic code to support P2P connectivity to a bitcoind.
 
-#### [test_framework/script.py](test_framework/script.py)
+#### [script.py](test_framework/script.py)
 Utilities for manipulating transaction scripts (originally from python-bitcoinlib)
 
-#### [test_framework/key.py](test_framework/key.py)
+#### [key.py](test_framework/key.py)
 Wrapper around OpenSSL EC_Key (originally from python-bitcoinlib)
 
-#### [test_framework/bignum.py](test_framework/bignum.py)
+#### [bignum.py](test_framework/bignum.py)
 Helpers for script.py
 
-#### [test_framework/blocktools.py](test_framework/blocktools.py)
+#### [blocktools.py](test_framework/blocktools.py)
 Helper functions for creating blocks and transactions.
 
 ### Benchmarking with perf


### PR DESCRIPTION
**Before** 
- Most commands in test/README.md are relative to the repo root, but not all.
- The locations of the log files are not described. 

**After** 
- All commands are relative to the repo root.
- Info about the location of the test framework log files has been added. 
