### PR TITLE
[doc] remove out-of-date comment on pay-to-witness support

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -153,8 +153,7 @@ bool ExtractDestination(const CScript& scriptPubKey, CTxDestination& addressRet)
  * multisig scripts, this populates the addressRet vector with the pubkey IDs
  * and nRequiredRet with the n required to spend. For other destinations,
  * addressRet is populated with a single value and nRequiredRet is set to 1.
- * Returns true if successful. Currently does not extract address from
- * pay-to-witness scripts.
+ * Returns true if successful.
  *
  * Note: this function confuses destinations (a subset of CScripts that are
  * encodable as an address) with key identifiers (of keys involved in a


### PR DESCRIPTION
The comment below on function 'ExtractDestinations' was added 2017-08-15 while the support was added later on 2017-08-25 through function 'ExtractDestination'.

```
Currently does not extract address from pay-to-witness scripts
```



