### PR TITLE
depends: Purge libtool archives

### DIFF
--- a/depends/packages.md
+++ b/depends/packages.md
@@ -151,6 +151,18 @@ Most autotools projects can be properly staged using:
 
     $(MAKE) DESTDIR=$($(package)_staging_dir) install
 
+## Build outputs:
+
+In general, the output of a depends package should not contain any libtool
+archives. Instead, the package should output `.pc` (`pkg-config`) files where
+possible.
+
+From the [Gentoo Wiki entry](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Handling_Libtool_Archives):
+
+>  Libtool pulls in all direct and indirect dependencies into the .la files it
+>  creates. This leads to massive overlinking, which is toxic to the Gentoo
+>  ecosystem, as it leads to a massive number of unnecessary rebuilds.
+
 ## Secondary dependencies:
 
 Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -5,6 +5,10 @@ The package "mylib" will be used here as an example
 
 General tips:
 - mylib_foo is written as $(package)_foo in order to make recipes more similar.
+- Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.
+  those not in `ALLOWED_LIBRARIES` in `contrib/devtools/symbol-check.py`) don't
+  need to be shared and should be built statically whenever possible. See
+  [below](#secondary-dependencies) for more details.
 
 ## Identifiers
 Each package is required to define at least these variables:
@@ -146,3 +150,22 @@ $($(package)_config_opts) will be appended.
 Most autotools projects can be properly staged using:
 
     $(MAKE) DESTDIR=$($(package)_staging_dir) install
+
+## Secondary dependencies:
+
+Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.
+those not in `ALLOWED_LIBRARIES` in `contrib/devtools/symbol-check.py`) don't
+need to be shared and should be built statically whenever possible. This
+improves general build reliability as illustrated by the following example:
+
+When linking an executable against a shared library `libprimary` that has its
+own shared dependency `libsecondary`, we may need to specify the path to
+`libsecondary` on the link command using the `-rpath/-rpath-link` options, it is
+not sufficient to just say `libprimary`.
+
+For us, it's much easier to just link a static `libsecondary` into a shared
+`libprimary`. Especially because in our case, we are linking against a dummy
+`libprimary` anyway that we'll throw away. We don't care if the end-user has a
+static or dynamic `libseconday`, that's not our concern. With a static
+`libseconday`, when we need to link `libprimary` into our executable, there's no
+dependency chain to worry about as `libprimary` has all the symbols.

--- a/depends/packages/dbus.mk
+++ b/depends/packages/dbus.mk
@@ -21,3 +21,7 @@ define $(package)_stage_cmds
   $(MAKE) -C dbus DESTDIR=$($(package)_staging_dir) install-libLTLIBRARIES install-dbusincludeHEADERS install-nodist_dbusarchincludeHEADERS && \
   $(MAKE) DESTDIR=$($(package)_staging_dir) install-pkgconfigDATA
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/dbus.mk
+++ b/depends/packages/dbus.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=6049ddd5f3f3e2618f615f1faeda0a115104423a7996b7aa73e2f36e3
 $(package)_dependencies=expat
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-tests --disable-doxygen-docs --disable-xml-docs --disable-static --without-x
+  $(package)_config_opts=--disable-tests --disable-doxygen-docs --disable-xml-docs --disable-shared --without-x
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -20,3 +20,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -5,7 +5,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --without-docbook
+  $(package)_config_opts=--disable-shared --without-docbook
+  $(package)_config_opts_linux=--with-pic
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -26,3 +26,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -20,3 +20,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/libX11.mk
+++ b/depends/packages/libX11.mk
@@ -25,3 +25,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/libX11.mk
+++ b/depends/packages/libX11.mk
@@ -6,8 +6,9 @@ $(package)_sha256_hash=2aa027e837231d2eeea90f3a4afe19948a6eb4c8b2bec0241eba7dbc8
 $(package)_dependencies=libxcb xtrans xextproto xproto
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-xkb --disable-static
-$(package)_config_opts_linux=--with-pic
+  # See libXext for --disable-malloc0returnsnull rationale.
+  $(package)_config_opts=--disable-xkb --disable-static --disable-malloc0returnsnull
+  $(package)_config_opts_linux=--with-pic
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -25,3 +25,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/libXext.mk
+++ b/depends/packages/libXext.mk
@@ -1,8 +1,8 @@
 package=libXext
-$(package)_version=1.3.2
+$(package)_version=1.3.3
 $(package)_download_path=https://xorg.freedesktop.org/releases/individual/lib/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
-$(package)_sha256_hash=f829075bc646cdc085fa25d98d5885d83b1759ceb355933127c257e8e50432e0
+$(package)_sha256_hash=b518d4d332231f313371fdefac59e3776f4f0823bcb23cf7c7305bfb57b16e35
 $(package)_dependencies=xproto xextproto libX11 libXau
 
 define $(package)_set_vars

--- a/depends/packages/libXext.mk
+++ b/depends/packages/libXext.mk
@@ -6,7 +6,30 @@ $(package)_sha256_hash=b518d4d332231f313371fdefac59e3776f4f0823bcb23cf7c7305bfb5
 $(package)_dependencies=xproto xextproto libX11 libXau
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared
+  # A number of steps in the autoconfig process implicitly assume that the build
+  # system and the host system are the same. For example, library components
+  # want to build and run test programs to determine the behavior of certain
+  # host system elements. This is clearly impossible when crosscompiling. To
+  # work around these issues, the --enable-malloc0returnsnull (or
+  # --disable-malloc0returnsnull, depending on the host system) must be passed
+  # to configure.
+  #                                -- https://www.x.org/wiki/CrossCompilingXorg/
+  #
+  # Concretely, between the releases of libXext 1.3.2 and 1.3.3,
+  # XORG_CHECK_MALLOC_ZERO from xorg-macros was changed to use the autoconf
+  # cache, expecting cross-compilation environments to seed this cache as there
+  # is no single correct value when cross compiling (think uclibc, musl, etc.).
+  # You can see the actual change in commit 72fdc868b56fe2b7bdc9a69872651baeca72
+  # in the freedesktop/xorg-macros repo.
+  #
+  # As a result of this change, if we don't seed the cache and we don't use
+  # either --{en,dis}able-malloc0returnsnull, the AC_RUN_IFELSE block has no
+  # optional action-if-cross-compiling argument and configure prints an error
+  # message and exits as documented in the autoconf manual. Prior to this
+  # commit, the AC_RUN_IFELSE block had an action-if-cross-compiling argument
+  # which set the more pessimistic default value MALLOC_ZERO_RETURNS_NULL=yes.
+  # This is why the flag was not required prior to libXext 1.3.3.
+  $(package)_config_opts=--disable-static --disable-malloc0returnsnull
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libXext.mk
+++ b/depends/packages/libXext.mk
@@ -24,3 +24,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/libXext.mk
+++ b/depends/packages/libXext.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=f829075bc646cdc085fa25d98d5885d83b1759ceb355933127c257e8e
 $(package)_dependencies=xproto xextproto libX11 libXau
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static
+  $(package)_config_opts=--disable-shared
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -27,4 +27,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
+  rm lib/*.la
 endef

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -32,5 +32,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm -rf share/man share/doc
+  rm -rf share/man share/doc lib/*.la
 endef

--- a/depends/packages/protobuf.mk
+++ b/depends/packages/protobuf.mk
@@ -30,5 +30,5 @@ define $(package)_stage_cmds
 endef
 
 define $(package)_postprocess_cmds
-  rm lib/libprotoc.a
+  rm lib/libprotoc.a lib/*.la
 endef

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -24,3 +24,7 @@ endef
 define $(package)_stage_cmds
   $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
+
+define $(package)_postprocess_cmds
+  rm lib/*.la
+endef

--- a/depends/packages/xtrans.mk
+++ b/depends/packages/xtrans.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=054d4ee3efd52508c753e9f7bc655ef185a29bd2850dd9e2fc2ccc335
 $(package)_dependencies=
 
 define $(package)_set_vars
-$(package)_config_opts_linux=--with-pic --disable-static
+$(package)_config_opts_linux=--with-pic --disable-shared
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -31,5 +31,5 @@ endef
 
 define $(package)_postprocess_cmds
   sed -i.old "s/ -lstdc++//" lib/pkgconfig/libzmq.pc && \
-  rm -rf bin share
+  rm -rf bin share lib/*.la
 endef


### PR DESCRIPTION
```
We use pkg-config where we can, which generally replaces libtool at a
higher level and does not have the same downsides as libtool. These
archives sit in our depends tree with no purpose and pollute the final
bitcoin build with massive overlinking.
```

See [here](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Handling_Libtool_Archives) for an explanation of the various problems libtool archives can cause.

Unrelated in every way except in spirit: `-D__LIBTOOL_IS_A_FOOL__`!!

-----

This PR is based on #16041, and therefore should be merged after #16041.