### PR TITLE
Add a check for free disk space at first startup.

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -182,7 +182,7 @@ extern CBlockIndex *pindexBestHeader;
 extern bool fHavePruned;
 /** True if we're running in -prune mode. */
 extern bool fPruneMode;
-/** Number of MiB of block files that we're trying to stay below. */
+/** Number of bytes of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;


### PR DESCRIPTION
As mentioned in #15813, there is a check for available disk space at startup in bitcoin-qt. This PR adds it to bitcoind too, at least for the first startup.