### PR TITLE
wallet: Do not create unsolicited wallets subdirectory

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -221,8 +221,10 @@ bool Intro::pickDataDirectory(interfaces::Node& node)
             dataDir = intro.getDataDirectory();
             try {
                 if (TryCreateDirectories(GUIUtil::qstringToBoostPath(dataDir))) {
+#ifdef ENABLE_WALLET
                     // If a new data directory has been created, make wallets subdirectory too
                     TryCreateDirectories(GUIUtil::qstringToBoostPath(dataDir) / "wallets");
+#endif
                 }
                 break;
             } catch (const fs::filesystem_error&) {

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -766,8 +766,10 @@ const fs::path &GetDataDir(bool fNetSpecific)
         path /= BaseParams().DataDir();
 
     if (fs::create_directories(path)) {
+#ifdef ENABLE_WALLET
         // This is the first run, create wallets subdirectory too
         fs::create_directories(path / "wallets");
+#endif
     }
 
     return path;


### PR DESCRIPTION
If the client is compiled with the `--disable-wallet` option, the wallets subdirectory is not needed.
