### PR TITLE
Faster tests with topological mempool rpc sync 🚀

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -123,6 +123,7 @@ def check_estimates(node, fees_seen):
 class EstimateFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
+        self.use_rpc_sync = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -26,6 +26,7 @@ class PSBTTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = False
         self.num_nodes = 3
+        self.use_rpc_sync = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -42,6 +42,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
+        self.use_rpc_sync = True
         self.extra_args = [["-addresstype=legacy", "-txindex"], ["-addresstype=legacy", "-txindex"], ["-addresstype=legacy", "-txindex"]]
 
     def skip_test_if_missing_module(self):

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -95,6 +95,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.nodes = []
         self.network_thread = None
         self.rpc_timeout = 60  # Wait for up to 60 seconds for the RPC server to respond
+        self.use_rpc_sync = False
         self.supports_cli = False
         self.bind_to_localhost_only = True
         self.set_test_params()
@@ -410,7 +411,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         sync_blocks(nodes or self.nodes, **kwargs)
 
     def sync_mempools(self, nodes=None, **kwargs):
-        sync_mempools(nodes or self.nodes, **kwargs)
+        sync_mempools(nodes or self.nodes, use_rpc_sync=self.use_rpc_sync, **kwargs)
 
     def sync_all(self, nodes=None, **kwargs):
         self.sync_blocks(nodes, **kwargs)

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -24,6 +24,7 @@ from test_framework.util import (
 class AbandonConflictTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.use_rpc_sync = True
         self.extra_args = [["-minrelaytxfee=0.00001"], []]
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -69,6 +69,7 @@ from test_framework.util import (
 class AddressTypeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 6
+        self.use_rpc_sync = True
         self.extra_args = [
             ["-addresstype=legacy"],
             ["-addresstype=p2sh-segwit"],

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -47,6 +47,7 @@ class WalletBackupTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
         self.setup_clean_chain = True
+        self.use_rpc_sync = True
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         self.extra_args = [["-keypool=100"], ["-keypool=100"], ["-keypool=100"], []]
 

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -39,6 +39,7 @@ def create_transactions(node, address, amt, fees):
 
 class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
+        self.use_rpc_sync = True
         self.num_nodes = 2
         self.setup_clean_chain = True
 

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -20,6 +20,7 @@ from test_framework.util import (
 class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
+        self.use_rpc_sync = True
         self.setup_clean_chain = True
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -33,6 +33,7 @@ WALLET_PASSPHRASE_TIMEOUT = 3600
 class BumpFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.use_rpc_sync = True
         self.setup_clean_chain = True
         self.extra_args = [[
             "-walletrbf={}".format(i),

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -19,6 +19,7 @@ def assert_approx(v, vexp, vspan=0.00001):
 class WalletGroupTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
+        self.use_rpc_sync = True
         self.num_nodes = 3
         self.extra_args = [[], [], ['-avoidpartialspends']]
         self.rpc_timeout = 120

--- a/test/functional/wallet_listreceivedby.py
+++ b/test/functional/wallet_listreceivedby.py
@@ -16,6 +16,7 @@ from test_framework.util import (
 class ReceivedByTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.use_rpc_sync = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_listtransactions.py
+++ b/test/functional/wallet_listtransactions.py
@@ -23,6 +23,7 @@ def tx_from_hex(hexstring):
 class ListTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
+        self.use_rpc_sync = True
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
Most of the tests spend time waiting for the poisson tx send to timeout. However, tests that don't test p2p behaviour, don't need to.

Speed them up by syncing transactions over rpc.

Overall, the tests run three times as fast for me now:

* Before:

```
ALL                                   | ✓ Passed  | 1395 s (accumulated) 
Runtime: 368 s
```

* After:

```
ALL                                   | ✓ Passed  | 940 s (accumulated) 
Runtime: 120 s
```