### PR TITLE
Restore warning for individual unknown version bits, as well as unknown version schemas

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2474,12 +2474,38 @@ static void UpdateTip(CTxMemPool& mempool, const CBlockIndex* pindexNew, const C
             }
         }
         // Check the version of the last 100 blocks to see if we need to upgrade:
+        int unexpected_bit_count[VERSIONBITS_NUM_BITS], nonversionbit_count = 0;
+        for (size_t i = 0; i < VERSIONBITS_NUM_BITS; ++i) unexpected_bit_count[i] = 0;
+        static constexpr int WARNING_THRESHOLD = 100/2;
+        bool warning_threshold_hit = false;
         for (int i = 0; i < 100 && pindex != nullptr; i++)
         {
             int32_t nExpectedVersion = ComputeBlockVersion(pindex->pprev, chainParams.GetConsensus());
             if (pindex->nVersion > VERSIONBITS_LAST_OLD_BLOCK_VERSION && (pindex->nVersion & ~nExpectedVersion) != 0)
+            {
                 ++num_unexpected_version;
+                if ((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) {
+                    for (int bit = 0; bit < VERSIONBITS_NUM_BITS; ++bit) {
+                        const int32_t mask = 1 << bit;
+                        if ((nExpectedVersion & mask) != (pindex->nVersion & mask)) {
+                            if (++unexpected_bit_count[bit] > WARNING_THRESHOLD) {
+                                warning_threshold_hit = true;
+                            }
+                        }
+                    }
+                } else {
+                    // Non-versionbits upgrade
+                    if (++nonversionbit_count > WARNING_THRESHOLD) {
+                        warning_threshold_hit = true;
+                    }
+                }
+            }
             pindex = pindex->pprev;
+        }
+        if (warning_threshold_hit) {
+            auto strWarning = _("Warning: Unrecognised block version being mined! Unknown rules may or may not be in effect");
+            // notify GetWarnings(), called by Qt and the JSON-RPC code to warn the user:
+            DoWarning(strWarning);
         }
     }
     LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%f tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -42,6 +42,7 @@ class NotificationsTest(BitcoinTestFramework):
             "-alertnotify=echo > {}".format(os.path.join(self.alertnotify_dir, '%s')),
             "-blocknotify=echo > {}".format(os.path.join(self.blocknotify_dir, '%s')),
         ], [
+            "-blockversion=211",
             "-rescan",
             "-walletnotify=echo > {}".format(os.path.join(self.walletnotify_dir, notify_outputname('%w', '%s'))),
         ]]
@@ -136,6 +137,24 @@ class NotificationsTest(BitcoinTestFramework):
             assert_equal(self.nodes[1].gettransaction(bump2)["confirmations"], 1)
 
         # TODO: add test for `-alertnotify` large fork notifications
+
+        # Mine 51 unknown-version blocks. -alertnotify should trigger on the 51st.
+        self.log.info("test -alertnotify")
+        self.nodes[1].generatetoaddress(51, ADDRESS_BCRT1_UNSPENDABLE)
+        self.sync_all()
+
+        # Give bitcoind 10 seconds to write the alert notification
+        self.wait_until(lambda: len(os.listdir(self.alertnotify_dir)), timeout=10)
+
+        for notify_file in os.listdir(self.alertnotify_dir):
+            os.remove(os.path.join(self.alertnotify_dir, notify_file))
+
+        # Mine more up-version blocks, should not get more alerts:
+        self.nodes[1].generatetoaddress(2, ADDRESS_BCRT1_UNSPENDABLE)
+        self.sync_all()
+
+        self.log.info("-alertnotify should not continue notifying for more unknown version blocks")
+        assert_equal(len(os.listdir(self.alertnotify_dir)), 0)
 
     def expect_wallet_notify(self, tx_ids):
         self.wait_until(lambda: len(os.listdir(self.walletnotify_dir)) >= len(tx_ids), timeout=10)


### PR DESCRIPTION
Prior to #15471, we had a warning for 50% of versions being unexpected as a whole. Overt ASICBoost abuses broke that, so it was removed.

This restores the warning, but only looks for 50% of each version bit independently, or 50% with an unknown version schema. Hopefully this shouldn't get triggered by (or at least can be more practically avoided by) ASICBoost stuff.

Additionally, it changes the phrasing of the warning to reflect the uncertainty of the cause, and avoid searches from turning up "not to worry" responses (that were given to the now-removed warning).