### PR TITLE
Handle exception when creating default -datadir

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -765,9 +765,12 @@ const fs::path &GetDataDir(bool fNetSpecific)
     if (fNetSpecific)
         path /= BaseParams().DataDir();
 
-    if (fs::create_directories(path)) {
+    // Try to create data dir and wallets subdirectory. Errors are ignored here
+    // since there are further checks.
+    boost::system::error_code ec;
+    if (fs::create_directories(path, ec)) {
         // This is the first run, create wallets subdirectory too
-        fs::create_directories(path / "wallets");
+        fs::create_directories(path / "wallets", ec);
     }
 
     return path;


### PR DESCRIPTION
To test determine the default `-datadir` by following:
https://github.com/bitcoin/bitcoin/blob/08bd21a3bda9f621948c535e951880d7e318caa5/src/util/system.cpp#L687-L690
Then, for instance, on linux:
```sh
# create a file with that path:
touch ~/.bitcoin
# launch daemon:
src/bitcoind
```
Without this PR:
```
EXCEPTION: N5boost10filesystem16filesystem_errorE
boost::filesystem::create_directory: File exists: "..."
bitcoin in AppInit()

Assertion failed: (globalChainBaseParams), function BaseParams, file chainparamsbase.cpp, line 30.
```