### PR TITLE
utils and libraries: Replace deprecated Boost Filesystem functions

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -115,7 +115,7 @@ static leveldb::Options GetOptions(size_t nCacheSize)
 }
 
 CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bool fWipe, bool obfuscate)
-    : m_name(fs::basename(path))
+    : m_name{path.stem().string()}
 {
     penv = nullptr;
     readoptions.verify_checksums = true;

--- a/src/fs.h
+++ b/src/fs.h
@@ -11,6 +11,7 @@
 #include <ext/stdio_filebuf.h>
 #endif
 
+#define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -407,13 +407,6 @@ bool BerkeleyBatch::VerifyEnvironment(const fs::path& file_path, std::string& er
     LogPrintf("Using BerkeleyDB version %s\n", DbEnv::version(nullptr, nullptr, nullptr));
     LogPrintf("Using wallet %s\n", file_path.string());
 
-    // Wallet file must be a plain filename without a directory
-    if (walletFile != fs::basename(walletFile) + fs::extension(walletFile))
-    {
-        errorStr = strprintf(_("Wallet %s resides outside wallet directory %s"), walletFile, walletDir.string());
-        return false;
-    }
-
     if (!env->Open(true /* retry */)) {
         errorStr = strprintf(_("Error initializing wallet database environment %s!"), walletDir);
         return false;


### PR DESCRIPTION
Boost Filesystem `basename()` and `extension()` functions are [deprecated since v1.36.0](https://www.boost.org/doc/libs/1_36_0/libs/filesystem/doc/reference.html#Convenience-functions).

See more: https://lists.boost.org/Archives/boost/2010/01/160905.php

Also this PR prevents further use of deprecated Boost Filesystem functions.
Ref: https://www.boost.org/doc/libs/1_64_0/libs/filesystem/doc/index.htm#Coding-guidelines

Note: On my Linux system Boost 1.65.1 header `/usr/include/boost/filesystem/convenience.hpp` contains:
```c++
# ifndef BOOST_FILESYSTEM_NO_DEPRECATED

    inline std::string extension(const path & p)
    {
      return p.extension().string();
    }

    inline std::string basename(const path & p)
    {
      return p.stem().string();
    }

    inline path change_extension( const path & p, const path & new_extension )
    { 
      path new_p( p );
      new_p.replace_extension( new_extension );
      return new_p;
    }

# endif
```

UPDATE:
Also removed unused code as [noted](https://github.com/bitcoin/bitcoin/pull/15880#discussion_r279386614) by **ryanofsky**.