### PR TITLE
net: Send txs without delay on regtest

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -443,6 +443,7 @@ void SetupServerArgs()
     gArgs.AddArg("-seednode=<ip>", "Connect to a node to retrieve peer addresses, and disconnect. This option can be specified multiple times to connect to multiple nodes.", false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-timeout=<n>", strprintf("Specify connection timeout in milliseconds (minimum: 1, default: %d)", DEFAULT_CONNECT_TIMEOUT), false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-peertimeout=<n>", strprintf("Specify p2p connection timeout in seconds. This option determines the amount of time a peer may be inactive before the connection to it is dropped. (minimum: 1, default: %d)", DEFAULT_PEER_CONNECT_TIMEOUT), true, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-tx_relay_force_flush", strprintf("Force transaction relay without delay. Regtest only. (default: %d)", DEFAULT_TX_RELAY_FORCE_FLUSH), true, OptionsCategory::CONNECTION);
     gArgs.AddArg("-torcontrol=<ip>:<port>", strprintf("Tor control port to use if onion listening enabled (default: %s)", DEFAULT_TOR_CONTROL), false, OptionsCategory::CONNECTION);
     gArgs.AddArg("-torpassword=<pass>", "Tor control port password (default: empty)", false, OptionsCategory::CONNECTION);
 #ifdef USE_UPNP
@@ -1787,7 +1788,11 @@ bool AppInitMain(InitInterfaces& interfaces)
     connOptions.nMaxOutboundTimeframe = nMaxOutboundTimeframe;
     connOptions.nMaxOutboundLimit = nMaxOutboundLimit;
     connOptions.m_peer_connect_timeout = peer_connect_timeout;
-    connOptions.m_tx_relay_force_flush = chainparams.MineBlocksOnDemand(); // Send txs without delay on regtest
+    connOptions.m_tx_relay_force_flush = DEFAULT_TX_RELAY_FORCE_FLUSH;
+    if (chainparams.NetworkIDString() == CBaseChainParams::REGTEST) {
+        // Send txs without delay on regtest
+        connOptions.m_tx_relay_force_flush = gArgs.GetBoolArg("-tx_relay_force_flush", DEFAULT_TX_RELAY_FORCE_FLUSH);
+    }
 
     for (const std::string& strBind : gArgs.GetArgs("-bind")) {
         CService addrBind;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1787,6 +1787,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     connOptions.nMaxOutboundTimeframe = nMaxOutboundTimeframe;
     connOptions.nMaxOutboundLimit = nMaxOutboundLimit;
     connOptions.m_peer_connect_timeout = peer_connect_timeout;
+    connOptions.m_tx_relay_force_flush = chainparams.MineBlocksOnDemand(); // Send txs without delay on regtest
 
     for (const std::string& strBind : gArgs.GetArgs("-bind")) {
         CService addrBind;

--- a/src/net.h
+++ b/src/net.h
@@ -137,6 +137,7 @@ public:
         uint64_t nMaxOutboundTimeframe = 0;
         uint64_t nMaxOutboundLimit = 0;
         int64_t m_peer_connect_timeout = DEFAULT_PEER_CONNECT_TIMEOUT;
+        bool m_tx_relay_force_flush{false};
         std::vector<std::string> vSeedNodes;
         std::vector<CSubNet> vWhitelistedRange;
         std::vector<CService> vBinds, vWhiteBinds;
@@ -159,6 +160,7 @@ public:
         nSendBufferMaxSize = connOptions.nSendBufferMaxSize;
         nReceiveFloodSize = connOptions.nReceiveFloodSize;
         m_peer_connect_timeout = connOptions.m_peer_connect_timeout;
+        m_tx_relay_force_flush = connOptions.m_tx_relay_force_flush;
         {
             LOCK(cs_totalBytesSent);
             nMaxOutboundTimeframe = connOptions.nMaxOutboundTimeframe;
@@ -305,6 +307,9 @@ public:
     unsigned int GetReceiveFloodSize() const;
 
     void WakeMessageHandler();
+
+    /** Send transactions without any delay */
+    std::atomic<bool> m_tx_relay_force_flush;
 
     /** Attempts to obfuscate tx time through exponentially distributed emitting.
         Works assuming that a single interval is used.

--- a/src/net.h
+++ b/src/net.h
@@ -73,6 +73,8 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** The default timeframe for -maxuploadtarget. 1 day. */
 static const uint64_t MAX_UPLOAD_TIMEFRAME = 60 * 60 * 24;
+/** -tx_relay_force_flush default */
+static const bool DEFAULT_TX_RELAY_FORCE_FLUSH{false};
 /** Default for blocks only*/
 static const bool DEFAULT_BLOCKSONLY = false;
 /** -peertimeout default */
@@ -137,7 +139,7 @@ public:
         uint64_t nMaxOutboundTimeframe = 0;
         uint64_t nMaxOutboundLimit = 0;
         int64_t m_peer_connect_timeout = DEFAULT_PEER_CONNECT_TIMEOUT;
-        bool m_tx_relay_force_flush{false};
+        bool m_tx_relay_force_flush{DEFAULT_TX_RELAY_FORCE_FLUSH};
         std::vector<std::string> vSeedNodes;
         std::vector<CSubNet> vWhitelistedRange;
         std::vector<CService> vBinds, vWhiteBinds;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3705,7 +3705,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
             pto->vInventoryBlockToSend.clear();
 
             // Check whether periodic sends should happen
-            bool fSendTrickle = pto->fWhitelisted;
+            bool fSendTrickle = connman->m_tx_relay_force_flush || pto->fWhitelisted;
             if (pto->nNextInvSend < nNow) {
                 fSendTrickle = true;
                 if (pto->fInbound) {

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -123,6 +123,9 @@ def check_estimates(node, fees_seen):
 class EstimateFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 3
+        self.extra_args = [[
+            '-tx_relay_force_flush=1',  # No delay in tx relay to speed up test
+        ]] * self.num_nodes
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -20,6 +20,9 @@ class P2PNode(P2PDataStore):
 class P2PLeakTxTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
+        self.extra_args = [[
+            '-tx_relay_force_flush=0',  # Delay tx relay to avoid test failures on really slow machines
+        ]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
Send txs immediately to all peers, just like blocks are solved immediately on regtest.

Overall, the tests run three times as fast for me now, because they no longer wait for the poisson tx send to timeout.

This is only a regtest change and it is possible to disable it with `-tx_relay_force_flush=0` should specific testing needs require it.

Alternative to:
* Faster tests with topological mempool rpc sync 🚀 #15858
