### PR TITLE
docs: Align code example style with clang-format

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -620,8 +620,8 @@ class AddressBookPage
     Mode m_mode;
 }
 
-AddressBookPage::AddressBookPage(Mode _mode) :
-      m_mode(_mode)
+AddressBookPage::AddressBookPage(Mode _mode)
+    : m_mode(_mode)
 ...
 ```
 


### PR DESCRIPTION
With this PR running [clang-format-diff.py](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/clang-format-diff.py) on the code example will not fire a format adjustment.