### PR TITLE
QA: Avoid re-reading config.ini unnecessarily

### DIFF
--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -553,21 +553,12 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     def is_cli_compiled(self):
         """Checks whether bitcoin-cli was compiled."""
-        config = configparser.ConfigParser()
-        config.read_file(open(self.options.configfile))
-
-        return config["components"].getboolean("ENABLE_CLI")
+        return self.config["components"].getboolean("ENABLE_CLI")
 
     def is_wallet_compiled(self):
         """Checks whether the wallet module was compiled."""
-        config = configparser.ConfigParser()
-        config.read_file(open(self.options.configfile))
-
-        return config["components"].getboolean("ENABLE_WALLET")
+        return self.config["components"].getboolean("ENABLE_WALLET")
 
     def is_zmq_compiled(self):
         """Checks whether the zmq module was compiled."""
-        config = configparser.ConfigParser()
-        config.read_file(open(self.options.configfile))
-
-        return config["components"].getboolean("ENABLE_ZMQ")
+        return self.config["components"].getboolean("ENABLE_ZMQ")


### PR DESCRIPTION
BitcoinTestFramework.main already loads and stores config.ini on the object itself; just access that instead of re-reading the file to check for features
