### PR TITLE
Use 'ShellExecute' instead of 'wsystem' in 'runCommand' for Windows.

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1130,11 +1130,22 @@ void runCommand(const std::string& strCommand)
     if (strCommand.empty()) return;
 #ifndef WIN32
     int nErr = ::system(strCommand.c_str());
-#else
-    int nErr = ::_wsystem(std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>,wchar_t>().from_bytes(strCommand).c_str());
-#endif
     if (nErr)
         LogPrintf("runCommand error: system(%s) returned %d\n", strCommand, nErr);
+#else
+    SHELLEXECUTEINFOA ShExecInfo;
+    ShExecInfo.cbSize = sizeof(SHELLEXECUTEINFOA);
+    ShExecInfo.fMask = 0;
+    ShExecInfo.hwnd = NULL;
+    ShExecInfo.lpVerb = NULL; // == action "open"
+    ShExecInfo.lpFile = strCommand.c_str();
+    ShExecInfo.lpParameters = NULL;
+    ShExecInfo.lpDirectory = NULL;
+    ShExecInfo.nShow = SW_HIDE;
+    ShExecInfo.hInstApp = NULL;
+    if (!ShellExecuteExA(&ShExecInfo))
+        LogPrintf("runCommand error: ShellExecute(%s) returned %d\n", strCommand, GetLastError());
+#endif
 }
 
 void RenameThread(const char* name)


### PR DESCRIPTION
As pointed out by #15883, the use of `blocknotify` or `walletnotify` on Windows caused a flickering command window at each call.

This PR substitutes the use of `wsystem` in `runCommand` with [createProcess](https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa), using the [CREATE_NO_WINDOW](https://docs.microsoft.com/en-us/windows/desktop/ProcThread/process-creation-flags) flag to avoid this behavior.