### PR TITLE
Bugfix: dummywallet: Add -ignorepartialspends to list of ignored wallet options

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -23,11 +23,32 @@ public:
 
 void DummyWalletInit::AddWalletOptions() const
 {
-    std::vector<std::string> opts = {"-addresstype", "-changetype", "-disablewallet", "-discardfee=<amt>", "-fallbackfee=<amt>",
-        "-keypool=<n>", "-maxtxfee=<amt>", "-mintxfee=<amt>", "-paytxfee=<amt>", "-rescan", "-salvagewallet", "-spendzeroconfchange",  "-txconfirmtarget=<n>",
-        "-upgradewallet", "-wallet=<path>", "-walletbroadcast", "-walletdir=<dir>", "-walletnotify=<cmd>", "-walletrbf", "-zapwallettxes=<mode>",
-        "-dblogsize=<n>", "-flushwallet", "-privdb", "-walletrejectlongchains"};
-    gArgs.AddHiddenArgs(opts);
+    gArgs.AddHiddenArgs({
+        "-addresstype",
+        "-changetype",
+        "-disablewallet",
+        "-discardfee=<amt>",
+        "-fallbackfee=<amt>",
+        "-keypool=<n>",
+        "-maxtxfee=<amt>",
+        "-mintxfee=<amt>",
+        "-paytxfee=<amt>",
+        "-rescan",
+        "-salvagewallet",
+        "-spendzeroconfchange",
+        "-txconfirmtarget=<n>",
+        "-upgradewallet",
+        "-wallet=<path>",
+        "-walletbroadcast",
+        "-walletdir=<dir>",
+        "-walletnotify=<cmd>",
+        "-walletrbf",
+        "-zapwallettxes=<mode>",
+        "-dblogsize=<n>",
+        "-flushwallet",
+        "-privdb",
+        "-walletrejectlongchains",
+    });
 }
 
 const WalletInitInterface& g_wallet_init_interface = DummyWalletInit();

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -25,6 +25,7 @@ void DummyWalletInit::AddWalletOptions() const
 {
     gArgs.AddHiddenArgs({
         "-addresstype",
+        "-avoidpartialspends",
         "-changetype",
         "-disablewallet",
         "-discardfee=<amt>",


### PR DESCRIPTION
When building w/o wallet support, we add all the wallet options as hidden options to avoid throwing errors/warnings that they're unknown.

`-ignorepartialspends` is missing from this list. This PR adds it.

(This seems like a good candidate for a linter? Or maybe we can autogenerate it?)

Also reformats the dummywallet options list across multiple lines to make conflicts less often.