### PR TITLE
wallet: Avoid logging no_such_file_or_directory error

### DIFF
--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -31,6 +31,8 @@ fs::path GetWalletDir()
 
 static bool IsBerkeleyBtree(const fs::path& path)
 {
+    if (!fs::exists(path)) return false;
+
     // A Berkeley DB Btree file has at least 4K.
     // This check also prevents opening lock files.
     boost::system::error_code ec;


### PR DESCRIPTION
Avoid logging `IsBerkeleyBtree: No such file or directory ...`. The result of `IsBerkeleyBtree` is the same since `fs::file_size()` returns 0 for non existent files.

Fix #15912.