### PR TITLE
lint: Check that all wallet args are hidden

### DIFF
--- a/test/lint/check-doc.py
+++ b/test/lint/check-doc.py
@@ -12,26 +12,23 @@ Author: @MarcoFalke
 
 from subprocess import check_output
 import re
-import sys
 
 FOLDER_GREP = 'src'
 FOLDER_TEST = 'src/test/'
 REGEX_ARG = '(?:ForceSet|SoftSet|Get|Is)(?:Bool)?Args?(?:Set)?\("(-[^"]+)"'
 REGEX_DOC = 'AddArg\("(-[^"=]+?)(?:=|")'
-CMD_ROOT_DIR = '`git rev-parse --show-toplevel`/{}'.format(FOLDER_GREP)
+CMD_ROOT_DIR = '$(git rev-parse --show-toplevel)/{}'.format(FOLDER_GREP)
 CMD_GREP_ARGS = r"git grep --perl-regexp '{}' -- {} ':(exclude){}'".format(REGEX_ARG, CMD_ROOT_DIR, FOLDER_TEST)
+CMD_GREP_WALLET_ARGS = r"git grep --function-context 'void WalletInit::AddWalletOptions' -- {} | grep AddArg".format(CMD_ROOT_DIR)
+CMD_GREP_WALLET_HIDDEN_ARGS = r"git grep --function-context 'void DummyWalletInit::AddWalletOptions' -- {}".format(CMD_ROOT_DIR)
 CMD_GREP_DOCS = r"git grep --perl-regexp '{}' {}".format(REGEX_DOC, CMD_ROOT_DIR)
 # list unsupported, deprecated and duplicate args as they need no documentation
 SET_DOC_OPTIONAL = set(['-h', '-help', '-dbcrashratio', '-forcecompactdb'])
 
 
-def main():
-    if sys.version_info >= (3, 6):
-        used = check_output(CMD_GREP_ARGS, shell=True, universal_newlines=True, encoding='utf8')
-        docd = check_output(CMD_GREP_DOCS, shell=True, universal_newlines=True, encoding='utf8')
-    else:
-        used = check_output(CMD_GREP_ARGS, shell=True).decode('utf8').strip()
-        docd = check_output(CMD_GREP_DOCS, shell=True).decode('utf8').strip()
+def lint_missing_argument_documentation():
+    used = check_output(CMD_GREP_ARGS, shell=True).decode('utf8').strip()
+    docd = check_output(CMD_GREP_DOCS, shell=True).decode('utf8').strip()
 
     args_used = set(re.findall(re.compile(REGEX_ARG), used))
     args_docd = set(re.findall(re.compile(REGEX_DOC), docd)).union(SET_DOC_OPTIONAL)
@@ -45,7 +42,24 @@ def main():
     print("Args unknown     : {}".format(len(args_unknown)))
     print(args_unknown)
 
-    sys.exit(len(args_need_doc))
+    assert 0 == len(args_need_doc), "Please document the following arguments: {}".format(args_need_doc)
+
+
+def lint_missing_hidden_wallet_args():
+    wallet_args = check_output(CMD_GREP_WALLET_ARGS, shell=True).decode('utf8').strip()
+    wallet_hidden_args = check_output(CMD_GREP_WALLET_HIDDEN_ARGS, shell=True).decode('utf8').strip()
+
+    wallet_args = set(re.findall(re.compile(REGEX_DOC), wallet_args))
+    wallet_hidden_args = set(re.findall(re.compile(r'    "([^"=]+)'), wallet_hidden_args))
+
+    hidden_missing = wallet_args.difference(wallet_hidden_args)
+    if hidden_missing:
+        assert 0, "Please add {} to the hidden args in DummyWalletInit::AddWalletOptions".format(hidden_missing)
+
+
+def main():
+    lint_missing_argument_documentation()
+    lint_missing_hidden_wallet_args()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Can be tested by calling `git revert 765d5890be` and then running the script