### PR TITLE
tinyformat: Add format_no_throw

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -135,14 +135,7 @@ template <typename... Args>
 static inline void LogPrintf(const char* fmt, const Args&... args)
 {
     if (LogInstance().Enabled()) {
-        std::string log_msg;
-        try {
-            log_msg = tfm::format(fmt, args...);
-        } catch (tinyformat::format_error& fmterr) {
-            /* Original format string will have newline so don't add one here */
-            log_msg = "Error \"" + std::string(fmterr.what()) + "\" while formatting log message: " + fmt;
-        }
-        LogInstance().LogPrintStr(log_msg);
+        LogInstance().LogPrintStr(tfm::format_no_throw(fmt, args...));
     }
 }
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -7,10 +7,10 @@
 #include <clientversion.h>
 #include <primitives/transaction.h>
 #include <sync.h>
-#include <test/util.h>
-#include <util/strencodings.h>
-#include <util/moneystr.h>
 #include <test/setup_common.h>
+#include <test/util.h>
+#include <util/moneystr.h>
+#include <util/strencodings.h>
 
 #include <stdint.h>
 #include <vector>
@@ -121,6 +121,27 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
     );
 }
 
+BOOST_AUTO_TEST_CASE(tinyformat_throw)
+{
+    const std::string fmt{"%s"};
+    for (const bool use_c_str : {true, false}) {
+        // format_no_throw does not throw
+        BOOST_CHECK_EQUAL(use_c_str ?
+                              tfm::format_no_throw(fmt.c_str(), 1, 2) :
+                              tfm::format_no_throw(fmt, 1, 2),
+            "Error \"tinyformat: Not enough conversion specifiers in format string\" while formatting message: %s");
+
+        // format might throw
+        try {
+            use_c_str ?
+                tfm::format(fmt.c_str(), 1, 2) :
+                tfm::format(fmt, 1, 2);
+            BOOST_REQUIRE(false);
+        } catch (const tfm::format_error& e) {
+            BOOST_CHECK_EQUAL(std::string(e.what()), "tinyformat: Not enough conversion specifiers in format string");
+        }
+    }
+}
 
 BOOST_AUTO_TEST_CASE(util_FormatISO8601DateTime)
 {

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -155,7 +155,7 @@ namespace tfm = tinyformat;
 #endif
 
 #ifdef __APPLE__
-// Workaround OSX linker warning: Xcode uses different default symbol
+// Workaround OSX linker warning: xcode uses different default symbol
 // visibilities for static libs vs executables (see issue #25)
 #   define TINYFORMAT_HIDDEN __attribute__((visibility("hidden")))
 #else
@@ -496,13 +496,13 @@ class FormatArg
 {
     public:
         FormatArg()
-             : m_value(nullptr),
-             m_formatImpl(nullptr),
-             m_toIntImpl(nullptr)
-         { }
+            : m_value(NULL),
+            m_formatImpl(NULL),
+            m_toIntImpl(NULL)
+        { }
 
         template<typename T>
-        explicit FormatArg(const T& value)
+        FormatArg(const T& value)
             : m_value(static_cast<const void*>(&value)),
             m_formatImpl(&formatImpl<T>),
             m_toIntImpl(&toIntImpl<T>)
@@ -592,7 +592,7 @@ inline const char* printFormatStringLiteral(std::ostream& out, const char* fmt)
 // Formatting options which can't be natively represented using the ostream
 // state are returned in spacePadPositive (for space padded positive numbers)
 // and ntrunc (for truncating conversions).  argIndex is incremented if
-// necessary to pull out variable width and precision.  The function returns a
+// necessary to pull out variable width and precision .  The function returns a
 // pointer to the character after the end of the current format spec.
 inline const char* streamStateFromFormat(std::ostream& out, bool& spacePadPositive,
                                          int& ntrunc, const char* fmtStart,
@@ -879,7 +879,7 @@ class FormatListN : public FormatList
     public:
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
         template<typename... Args>
-        explicit FormatListN(const Args&... args)
+        FormatListN(const Args&... args)
             : FormatList(&m_formatterStore[0], N),
             m_formatterStore { FormatArg(args)... }
         { static_assert(sizeof...(args) == N, "Number of args must be N"); }
@@ -888,7 +888,7 @@ class FormatListN : public FormatList
 #       define TINYFORMAT_MAKE_FORMATLIST_CONSTRUCTOR(n)       \
                                                                \
         template<TINYFORMAT_ARGTYPES(n)>                       \
-        explicit FormatListN(TINYFORMAT_VARARGS(n))            \
+        FormatListN(TINYFORMAT_VARARGS(n))                     \
             : FormatList(&m_formatterStore[0], n)              \
         { assert(n == N); init(0, TINYFORMAT_PASSARGS(n)); }   \
                                                                \
@@ -993,6 +993,7 @@ void printfln(const char* fmt, const Args&... args)
     std::cout << '\n';
 }
 
+
 #else // C++98 version
 
 inline void format(std::ostream& out, const char* fmt)
@@ -1052,7 +1053,9 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 
 #endif
 
-// Added for Bitcoin Core
+// Bitcoin Core specific patches
+// Underlying tinyformat is up to date as of upstream commit
+// https://raw.githubusercontent.com/c42f/tinyformat/689695cf58700e6defe3741829564cd682d5ae57/tinyformat.h
 template<typename... Args>
 std::string format(const std::string &fmt, const Args&... args)
 {

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1056,12 +1056,25 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 // Bitcoin Core specific patches
 // Underlying tinyformat is up to date as of upstream commit
 // https://raw.githubusercontent.com/c42f/tinyformat/689695cf58700e6defe3741829564cd682d5ae57/tinyformat.h
-template<typename... Args>
-std::string format(const std::string &fmt, const Args&... args)
+template <typename... Args>
+std::string format(const std::string& fmt, const Args&... args)
 {
-    std::ostringstream oss;
-    format(oss, fmt.c_str(), args...);
-    return oss.str();
+    return format(fmt.c_str(), args...);
+}
+
+/**
+ * Bitcoin Core specific
+ * Wraps format() to return an error string instead of throwing tinyformat::format_error.
+ */
+template <typename... Args>
+std::string format_no_throw(const std::string& fmt, const Args&... args)
+{
+    try {
+        return format(fmt, args...);
+    } catch (const format_error& fmterr) {
+        /* Original format string will have newline so don't add one here */
+        return "Error \"" + std::string(fmterr.what()) + "\" while formatting message: " + fmt;
+    }
 }
 
 } // namespace tinyformat


### PR DESCRIPTION
This adds a `tinyformat::format_no_throw` that (on error) returns the format string with the error message. `format_no_throw` is currently only used in logging, but can be used by other modules after this patch.

The fist commit reverts some style-changes that have been made to tinyformat, which is to be treated like a "subtree", so style-fixes should go upstream and are not acceptable in Bitcoin Core. 