### PR TITLE
 GUI: Move QRImageWidget to its own file-pair

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -140,6 +140,7 @@ QT_MOC_CPP = \
   qt/moc_overviewpage.cpp \
   qt/moc_peertablemodel.cpp \
   qt/moc_paymentserver.cpp \
+  qt/moc_qrimagewidget.cpp \
   qt/moc_qvalidatedlineedit.cpp \
   qt/moc_qvaluecombobox.cpp \
   qt/moc_receivecoinsdialog.cpp \
@@ -220,6 +221,7 @@ BITCOIN_QT_H = \
   qt/paymentserver.h \
   qt/peertablemodel.h \
   qt/platformstyle.h \
+  qt/qrimagewidget.h \
   qt/qvalidatedlineedit.h \
   qt/qvaluecombobox.h \
   qt/receivecoinsdialog.h \
@@ -340,6 +342,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/openuridialog.cpp \
   qt/overviewpage.cpp \
   qt/paymentserver.cpp \
+  qt/qrimagewidget.cpp \
   qt/receivecoinsdialog.cpp \
   qt/receiverequestdialog.cpp \
   qt/recentrequeststablemodel.cpp \

--- a/src/qt/forms/receiverequestdialog.ui
+++ b/src/qt/forms/receiverequestdialog.ui
@@ -127,7 +127,7 @@
   <customwidget>
    <class>QRImageWidget</class>
    <extends>QLabel</extends>
-   <header>qt/receiverequestdialog.h</header>
+   <header>qt/qrimagewidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -37,12 +37,6 @@ static const bool DEFAULT_SPLASHSCREEN = true;
  */
 static const int TOOLTIP_WRAP_THRESHOLD = 80;
 
-/* Maximum allowed URI length */
-static const int MAX_URI_LENGTH = 255;
-
-/* QRCodeDialog -- size of exported QR Code image */
-#define QR_IMAGE_SIZE 300
-
 /* Number of frames in spinner animation */
 #define SPINNER_FRAMES 36
 

--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <qt/qrimagewidget.h>
+
+#include <qt/guiutil.h>
+
+#include <QApplication>
+#include <QClipboard>
+#include <QDrag>
+#include <QMenu>
+#include <QMimeData>
+#include <QMouseEvent>
+#include <QPainter>
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h> /* for USE_QRCODE */
+#endif
+
+#ifdef USE_QRCODE
+#include <qrencode.h>
+#endif
+
+QRImageWidget::QRImageWidget(QWidget *parent):
+    QLabel(parent), contextMenu(nullptr)
+{
+    contextMenu = new QMenu(this);
+    QAction *saveImageAction = new QAction(tr("&Save Image..."), this);
+    connect(saveImageAction, &QAction::triggered, this, &QRImageWidget::saveImage);
+    contextMenu->addAction(saveImageAction);
+    QAction *copyImageAction = new QAction(tr("&Copy Image"), this);
+    connect(copyImageAction, &QAction::triggered, this, &QRImageWidget::copyImage);
+    contextMenu->addAction(copyImageAction);
+}
+
+bool QRImageWidget::setQR(const QString& data, const QString& text)
+{
+#ifdef USE_QRCODE
+    setText("");
+    if (data.isEmpty()) return false;
+
+    // limit length
+    if (data.length() > MAX_URI_LENGTH) {
+        setText(tr("Resulting URI too long, try to reduce the text for label / message."));
+        return false;
+    }
+
+    QRcode *code = QRcode_encodeString(data.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
+
+    if (!code) {
+        setText(tr("Error encoding URI into QR Code."));
+        return false;
+    }
+
+    QImage qrImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
+    qrImage.fill(0xffffff);
+    unsigned char *p = code->data;
+    for (int y = 0; y < code->width; ++y) {
+        for (int x = 0; x < code->width; ++x) {
+            qrImage.setPixel(x + 4, y + 4, ((*p & 1) ? 0x0 : 0xffffff));
+            ++p;
+        }
+    }
+    QRcode_free(code);
+
+    QImage qrAddrImage = QImage(QR_IMAGE_SIZE, QR_IMAGE_SIZE + (text.isEmpty() ? 0 : 20), QImage::Format_RGB32);
+    qrAddrImage.fill(0xffffff);
+    QPainter painter(&qrAddrImage);
+    painter.drawImage(0, 0, qrImage.scaled(QR_IMAGE_SIZE, QR_IMAGE_SIZE));
+
+    if (!text.isEmpty()) {
+        QFont font = GUIUtil::fixedPitchFont();
+        QRect paddedRect = qrAddrImage.rect();
+
+        // calculate ideal font size
+        qreal font_size = GUIUtil::calculateIdealFontSize(paddedRect.width() - 20, text, font);
+        font.setPointSizeF(font_size);
+
+        painter.setFont(font);
+        paddedRect.setHeight(QR_IMAGE_SIZE+12);
+        painter.drawText(paddedRect, Qt::AlignBottom|Qt::AlignCenter, text);
+    }
+
+    painter.end();
+    setPixmap(QPixmap::fromImage(qrAddrImage));
+
+    return true;
+#else
+    setText(tr("QR code support not available."));
+    return false;
+#endif
+}
+
+QImage QRImageWidget::exportImage()
+{
+    if(!pixmap())
+        return QImage();
+    return pixmap()->toImage();
+}
+
+void QRImageWidget::mousePressEvent(QMouseEvent *event)
+{
+    if(event->button() == Qt::LeftButton && pixmap())
+    {
+        event->accept();
+        QMimeData *mimeData = new QMimeData;
+        mimeData->setImageData(exportImage());
+
+        QDrag *drag = new QDrag(this);
+        drag->setMimeData(mimeData);
+        drag->exec();
+    } else {
+        QLabel::mousePressEvent(event);
+    }
+}
+
+void QRImageWidget::saveImage()
+{
+    if(!pixmap())
+        return;
+    QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Image (*.png)"), nullptr);
+    if (!fn.isEmpty())
+    {
+        exportImage().save(fn);
+    }
+}
+
+void QRImageWidget::copyImage()
+{
+    if(!pixmap())
+        return;
+    QApplication::clipboard()->setImage(exportImage());
+}
+
+void QRImageWidget::contextMenuEvent(QContextMenuEvent *event)
+{
+    if(!pixmap())
+        return;
+    contextMenu->exec(event->globalPos());
+}

--- a/src/qt/qrimagewidget.h
+++ b/src/qt/qrimagewidget.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2011-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_QRIMAGEWIDGET_H
+#define BITCOIN_QT_QRIMAGEWIDGET_H
+
+#include <QImage>
+#include <QLabel>
+
+/* Maximum allowed URI length */
+static const int MAX_URI_LENGTH = 255;
+
+/* Size of exported QR Code image */
+static const int QR_IMAGE_SIZE = 300;
+
+QT_BEGIN_NAMESPACE
+class QMenu;
+QT_END_NAMESPACE
+
+/* Label widget for QR code. This image can be dragged, dropped, copied and saved
+ * to disk.
+ */
+class QRImageWidget : public QLabel
+{
+    Q_OBJECT
+
+public:
+    explicit QRImageWidget(QWidget *parent = nullptr);
+    bool setQR(const QString& data, const QString& text = "");
+    QImage exportImage();
+
+public Q_SLOTS:
+    void saveImage();
+    void copyImage();
+
+protected:
+    virtual void mousePressEvent(QMouseEvent *event);
+    virtual void contextMenuEvent(QContextMenuEvent *event);
+
+private:
+    QMenu *contextMenu;
+};
+
+#endif // BITCOIN_QT_QRIMAGEWIDGET_H

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -6,142 +6,16 @@
 #include <qt/forms/ui_receiverequestdialog.h>
 
 #include <qt/bitcoinunits.h>
-#include <qt/guiconstants.h>
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
+#include <qt/qrimagewidget.h>
 
 #include <QClipboard>
-#include <QDrag>
-#include <QMenu>
-#include <QMimeData>
-#include <QMouseEvent>
 #include <QPixmap>
 
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h> /* for USE_QRCODE */
 #endif
-
-#ifdef USE_QRCODE
-#include <qrencode.h>
-#endif
-
-QRImageWidget::QRImageWidget(QWidget *parent):
-    QLabel(parent), contextMenu(nullptr)
-{
-    contextMenu = new QMenu(this);
-    QAction *saveImageAction = new QAction(tr("&Save Image..."), this);
-    connect(saveImageAction, &QAction::triggered, this, &QRImageWidget::saveImage);
-    contextMenu->addAction(saveImageAction);
-    QAction *copyImageAction = new QAction(tr("&Copy Image"), this);
-    connect(copyImageAction, &QAction::triggered, this, &QRImageWidget::copyImage);
-    contextMenu->addAction(copyImageAction);
-}
-
-bool QRImageWidget::setQR(const QString& data, const QString& text)
-{
-#ifdef USE_QRCODE
-    setText("");
-    if (data.isEmpty()) return false;
-
-    // limit length
-    if (data.length() > MAX_URI_LENGTH) {
-        setText(tr("Resulting URI too long, try to reduce the text for label / message."));
-        return false;
-    }
-
-    QRcode *code = QRcode_encodeString(data.toUtf8().constData(), 0, QR_ECLEVEL_L, QR_MODE_8, 1);
-
-    if (!code) {
-        setText(tr("Error encoding URI into QR Code."));
-        return false;
-    }
-
-    QImage qrImage = QImage(code->width + 8, code->width + 8, QImage::Format_RGB32);
-    qrImage.fill(0xffffff);
-    unsigned char *p = code->data;
-    for (int y = 0; y < code->width; ++y) {
-        for (int x = 0; x < code->width; ++x) {
-            qrImage.setPixel(x + 4, y + 4, ((*p & 1) ? 0x0 : 0xffffff));
-            ++p;
-        }
-    }
-    QRcode_free(code);
-
-    QImage qrAddrImage = QImage(QR_IMAGE_SIZE, QR_IMAGE_SIZE + (text.isEmpty() ? 0 : 20), QImage::Format_RGB32);
-    qrAddrImage.fill(0xffffff);
-    QPainter painter(&qrAddrImage);
-    painter.drawImage(0, 0, qrImage.scaled(QR_IMAGE_SIZE, QR_IMAGE_SIZE));
-
-    if (!text.isEmpty()) {
-        QFont font = GUIUtil::fixedPitchFont();
-        QRect paddedRect = qrAddrImage.rect();
-
-        // calculate ideal font size
-        qreal font_size = GUIUtil::calculateIdealFontSize(paddedRect.width() - 20, text, font);
-        font.setPointSizeF(font_size);
-
-        painter.setFont(font);
-        paddedRect.setHeight(QR_IMAGE_SIZE+12);
-        painter.drawText(paddedRect, Qt::AlignBottom|Qt::AlignCenter, text);
-    }
-
-    painter.end();
-    setPixmap(QPixmap::fromImage(qrAddrImage));
-
-    return true;
-#else
-    setText(tr("QR code support not available."));
-    return false;
-#endif
-}
-
-QImage QRImageWidget::exportImage()
-{
-    if(!pixmap())
-        return QImage();
-    return pixmap()->toImage();
-}
-
-void QRImageWidget::mousePressEvent(QMouseEvent *event)
-{
-    if(event->button() == Qt::LeftButton && pixmap())
-    {
-        event->accept();
-        QMimeData *mimeData = new QMimeData;
-        mimeData->setImageData(exportImage());
-
-        QDrag *drag = new QDrag(this);
-        drag->setMimeData(mimeData);
-        drag->exec();
-    } else {
-        QLabel::mousePressEvent(event);
-    }
-}
-
-void QRImageWidget::saveImage()
-{
-    if(!pixmap())
-        return;
-    QString fn = GUIUtil::getSaveFileName(this, tr("Save QR Code"), QString(), tr("PNG Image (*.png)"), nullptr);
-    if (!fn.isEmpty())
-    {
-        exportImage().save(fn);
-    }
-}
-
-void QRImageWidget::copyImage()
-{
-    if(!pixmap())
-        return;
-    QApplication::clipboard()->setImage(exportImage());
-}
-
-void QRImageWidget::contextMenuEvent(QContextMenuEvent *event)
-{
-    if(!pixmap())
-        return;
-    contextMenu->exec(event->globalPos());
-}
 
 ReceiveRequestDialog::ReceiveRequestDialog(QWidget *parent) :
     QDialog(parent),

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -29,6 +29,7 @@ class QRImageWidget : public QLabel
 
 public:
     explicit QRImageWidget(QWidget *parent = nullptr);
+    bool setQR(const QString& data, const QString& text = "");
     QImage exportImage();
 
 public Q_SLOTS:

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -8,41 +8,10 @@
 #include <qt/walletmodel.h>
 
 #include <QDialog>
-#include <QImage>
-#include <QLabel>
-#include <QPainter>
 
 namespace Ui {
     class ReceiveRequestDialog;
 }
-
-QT_BEGIN_NAMESPACE
-class QMenu;
-QT_END_NAMESPACE
-
-/* Label widget for QR code. This image can be dragged, dropped, copied and saved
- * to disk.
- */
-class QRImageWidget : public QLabel
-{
-    Q_OBJECT
-
-public:
-    explicit QRImageWidget(QWidget *parent = nullptr);
-    bool setQR(const QString& data, const QString& text = "");
-    QImage exportImage();
-
-public Q_SLOTS:
-    void saveImage();
-    void copyImage();
-
-protected:
-    virtual void mousePressEvent(QMouseEvent *event);
-    virtual void contextMenuEvent(QContextMenuEvent *event);
-
-private:
-    QMenu *contextMenu;
-};
 
 class ReceiveRequestDialog : public QDialog
 {


### PR DESCRIPTION
For at least QR-code based pairing of mobile wallets with nodes, it will be desirable to render QR codes even without wallet support.

Therefore, this prepares by moving the QRImageWidget out of a wallet-specific file into its own `qrencoder` file-pair.