### PR TITLE
Make chain state immutable outside of validation

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1528,7 +1528,7 @@ bool AppInitMain(InitInterfaces& interfaces)
 
                 // If the loaded chain has a wrong genesis, bail out immediately
                 // (we're likely using a testnet datadir, or the other way around).
-                if (!mapBlockIndex.empty() && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
+                if (!BlockIndex().empty() && !LookupBlockIndex(chainparams.GetConsensus().hashGenesisBlock)) {
                     return InitError(_("Incorrect or no genesis block found. Wrong datadir for network?"));
                 }
 
@@ -1758,7 +1758,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     //// debug print
     {
         LOCK(cs_main);
-        LogPrintf("mapBlockIndex.size() = %u\n", mapBlockIndex.size());
+        LogPrintf("mapBlockIndex.size() = %u\n", BlockIndex().size());
         chain_active_height = ::ChainActive().Height();
     }
     LogPrintf("nBestHeight = %d\n", chain_active_height);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1443,8 +1443,7 @@ static UniValue getchaintips(const JSONRPCRequest& request)
     std::set<const CBlockIndex*> setOrphans;
     std::set<const CBlockIndex*> setPrevs;
 
-    for (const std::pair<const uint256, CBlockIndex*>& item : mapBlockIndex)
-    {
+    for (const std::pair<const uint256, CBlockIndex*>& item : BlockIndex()) {
         if (!::ChainActive().Contains(item.second)) {
             setOrphans.insert(item.second);
             setPrevs.insert(item.second->pprev);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -8,15 +8,15 @@
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
 #include <consensus/validation.h>
-#include <validation.h>
 #include <miner.h>
 #include <policy/policy.h>
 #include <pubkey.h>
 #include <script/standard.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util/system.h>
 #include <util/strencodings.h>
+#include <util/system.h>
+#include <validation.h>
 
 #include <test/setup_common.h>
 
@@ -377,7 +377,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
-        ::ChainActive().SetTip(next);
+        MutableChainActive().SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
     // Extend to a 210000-long block chain.
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
-        ::ChainActive().SetTip(next);
+        MutableChainActive().SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey));
 
@@ -414,7 +414,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Delete the dummy blocks again.
     while (::ChainActive().Tip()->nHeight > nHeight) {
         CBlockIndex* del = ::ChainActive().Tip();
-        ::ChainActive().SetTip(del->pprev);
+        ::MutableChainActive().SetTip(del->pprev);
         pcoinsTip->SetBestBlock(del->pprev->GetBlockHash());
         delete del->phashBlock;
         delete del;

--- a/src/validation.h
+++ b/src/validation.h
@@ -143,7 +143,6 @@ extern CCriticalSection cs_main;
 extern CBlockPolicyEstimator feeEstimator;
 extern CTxMemPool mempool;
 typedef std::unordered_map<uint256, CBlockIndex*, BlockHasher> BlockMap;
-extern BlockMap& mapBlockIndex GUARDED_BY(cs_main);
 extern Mutex g_best_block_mutex;
 extern std::condition_variable g_best_block_cv;
 extern uint256 g_best_block;
@@ -412,11 +411,17 @@ public:
 /** Replay blocks that aren't fully applied to the database. */
 bool ReplayBlocks(const CChainParams& params, CCoinsView* view);
 
+/** @returns the block index map (a map from hash to block index). */
+const BlockMap& BlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+/** Only used in tests. */
+BlockMap& MutableBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 inline CBlockIndex* LookupBlockIndex(const uint256& hash)
 {
     AssertLockHeld(cs_main);
-    BlockMap::const_iterator it = mapBlockIndex.find(hash);
-    return it == mapBlockIndex.end() ? nullptr : it->second;
+    BlockMap::const_iterator it = BlockIndex().find(hash);
+    return it == BlockIndex().end() ? nullptr : it->second;
 }
 
 /** Find the last common block between the parameter chain and a locator. */
@@ -435,8 +440,11 @@ bool InvalidateBlock(CValidationState& state, const CChainParams& chainparams, C
 /** Remove invalidity status from a block and its descendants. */
 void ResetBlockFailureFlags(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-/** @returns the most-work chain. */
-CChain& ChainActive();
+/** @returns the most-work valid chain (protected by cs_main) */
+const CChain& ChainActive();
+
+/** Only used in tests. */
+CChain& MutableChainActive() EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Global variable that points to the coins database (protected by cs_main) */
 extern std::unique_ptr<CCoinsViewDB> pcoinsdbview;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -12,12 +12,12 @@
 
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
+#include <policy/policy.h>
 #include <rpc/server.h>
 #include <test/setup_common.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/test/wallet_test_fixture.h>
-#include <policy/policy.h>
 
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
@@ -272,7 +272,7 @@ static int64_t AddTx(CWallet& wallet, uint32_t lockTime, int64_t mockTime, int64
     if (blockTime > 0) {
         LockAnnotation lock(::cs_main);
         auto locked_chain = wallet.chain().lock();
-        auto inserted = mapBlockIndex.emplace(GetRandHash(), new CBlockIndex);
+        auto inserted = MutableBlockIndex().emplace(GetRandHash(), new CBlockIndex);
         assert(inserted.second);
         const uint256& hash = inserted.first->first;
         block = inserted.first->second;


### PR DESCRIPTION
This commit makes the chain state (block index map and active chain) `const` outside of validation. The steps are:

* Add helpers to get a `const&` of the chain state
* Add helpers to get a mutable reference of them to be only used in tests
* Remove `mapBlockIndex` from the header and mark `chainActive` "to be removed"