### PR TITLE
refactor: Silence "control reaches end of non-void function" (-Wreturn-type) in psbt.cpp

### DIFF
--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -337,7 +337,9 @@ std::string PSBTRoleName(PSBTRole role) {
     case PSBTRole::SIGNER: return "signer";
     case PSBTRole::FINALIZER: return "finalizer";
     case PSBTRole::EXTRACTOR: return "extractor";
+        // no default case, so the compiler can warn about missing cases
     }
+    assert(false);
 }
 
 bool DecodeBase64PSBT(PartiallySignedTransaction& psbt, const std::string& base64_tx, std::string& error)


### PR DESCRIPTION
Silence GCC 7 warning "control reaches end of non-void function" (`-Wreturn-type`) in `psbt.cpp`.

Context: https://github.com/bitcoin/bitcoin/commit/ef22fe8c1f331b4f13f21a54d12030b92e83fbe7#r33370109

Before this patch:

```
$ ./configure CC=gcc-7 CXX=g++-7
$ make 2>&1 | grep -A2 "warning: "
leveldb/util/logging.cc:58:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
                                  ~~~~~~^~~~~~~~~~~~~~~
--
leveldb/port/port_posix.cc:60:15: warning: ‘ecx’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   return (ecx & (1 << 20)) != 0;
          ~~~~~^~~~~~~~~~~~
--
psbt.cpp:341:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
$
```

After this patch:

```
$ ./configure CC=gcc-7 CXX=g++-7
$ make 2>&1 | grep -A2 "warning: "
leveldb/util/logging.cc:58:40: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
           (v == kMaxUint64/10 && delta > kMaxUint64%10)) {
                                  ~~~~~~^~~~~~~~~~~~~~~
--
leveldb/port/port_posix.cc:60:15: warning: ‘ecx’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   return (ecx & (1 << 20)) != 0;
          ~~~~~^~~~~~~~~~~~
$
```