### PR TITLE
tests: Use BOOST_CHECK_EQUAL for verbose prints on fail

### DIFF
--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -4,16 +4,16 @@
 
 #include <crypto/aes.h>
 #include <crypto/chacha20.h>
+#include <crypto/hmac_sha256.h>
+#include <crypto/hmac_sha512.h>
 #include <crypto/poly1305.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
 #include <crypto/sha512.h>
-#include <crypto/hmac_sha256.h>
-#include <crypto/hmac_sha512.h>
 #include <random.h>
-#include <util/strencodings.h>
 #include <test/setup_common.h>
+#include <util/strencodings.h>
 
 #include <vector>
 
@@ -552,6 +552,9 @@ BOOST_AUTO_TEST_CASE(sha256d64)
         }
         SHA256D64(out2, in, i);
         BOOST_CHECK(memcmp(out1, out2, 32 * i) == 0);
+        const auto str1 = HexStr(std::vector<unsigned char>{out1, out1 + 32 * i});
+        const auto str2 = HexStr(std::vector<unsigned char>{out2, out2 + 32 * i});
+        BOOST_CHECK_EQUAL(str1, str2);
     }
 }
 


### PR DESCRIPTION
This should print something like:

```
test/crypto_tests.cpp(557): error: in "crypto_tests/sha256d64": check str1 == str2 has failed [b185c0ca629130a6f4fbca4d0ac1164dcebb8e97eff941b1c03cdb406f66d70e != b185c0ca629130a6f4fbca4d0ac1164dcebb8e97eff941b1c03cdb406f66d70a]
