### PR TITLE
net: Log unknown CInv in PushInventory

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -14,6 +14,7 @@
 #include <crypto/siphash.h>
 #include <hash.h>
 #include <limitedmap.h>
+#include <logging.h>
 #include <netaddress.h>
 #include <policy/feerate.h>
 #include <protocol.h>
@@ -848,6 +849,9 @@ public:
             }
         } else if (inv.type == MSG_BLOCK) {
             vInventoryBlockToSend.push_back(inv.hash);
+        } else {
+            LogPrint(BCLog::NET, "%s: Unknown CInv type:%s\n", __func__, inv.ToString());
+            assert(false); // Should never happen in Bitcoin, only MSG_TX/MSG_BLOCK expected.
         }
     }
 


### PR DESCRIPTION
Message for anyone adding an experimental or malformed CInv and using the PushInventory. Experimental Cinv should probably be added to its own vector for processing elsewhere like setInventoryTxToSend and vInventoryBlockToSend.

Update: Including the five locations below that call PushInventory with a CInv with its member variable 'type' set to either MSG_BLOCK or MSG_TX.

https://github.com/bitcoin/bitcoin/blob/7f0d7e7ed5b2a6a14a3fc9e5bf4d99073017b01e/src/interfaces/chain.cpp#L286-L287
https://github.com/bitcoin/bitcoin/blob/7f0d7e7ed5b2a6a14a3fc9e5bf4d99073017b01e/src/net_processing.cpp#L1206-L1210
https://github.com/bitcoin/bitcoin/blob/7f0d7e7ed5b2a6a14a3fc9e5bf4d99073017b01e/src/net_processing.cpp#L2264
https://github.com/bitcoin/bitcoin/blob/7f0d7e7ed5b2a6a14a3fc9e5bf4d99073017b01e/src/net_processing.cpp#L3680
https://github.com/bitcoin/bitcoin/blob/7f0d7e7ed5b2a6a14a3fc9e5bf4d99073017b01e/src/node/transaction.cpp#L72-L75