### PR TITLE
Install bitcoin-wallet manpage

### DIFF
--- a/doc/man/Makefile.am
+++ b/doc/man/Makefile.am
@@ -15,3 +15,9 @@ endif
 if BUILD_BITCOIN_TX
   dist_man1_MANS+=bitcoin-tx.1
 endif
+
+if ENABLE_WALLET
+if BUILD_BITCOIN_WALLET
+  dist_man1_MANS+=bitcoin-wallet.1
+endif
+endif


### PR DESCRIPTION
This change marks the already-existing `bitcoin-wallet.1` manpage file for installation together with the others.  Previously, only `bitcoind.1`, `bitcoin-cli.1`, `bitcoin-tx.1` and `bitcoin-qt.1` would be installed.