### PR TITLE
test_runner: Move pruning back to extended

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -66,10 +66,16 @@ if os.name != 'nt' or sys.getwindowsversion() >= (10, 0, 14393):
 TEST_EXIT_PASSED = 0
 TEST_EXIT_SKIPPED = 77
 
+EXTENDED_SCRIPTS = [
+    # These tests are not run by the travis build process.
+    # Longest test should go first, to favor running tests in parallel
+    'feature_pruning.py',
+    'feature_dbcrash.py',
+]
+
 BASE_SCRIPTS = [
     # Scripts that are run by the travis build process.
     # Longest test should go first, to favor running tests in parallel
-    'feature_pruning.py',
     'feature_fee_estimation.py',
     'wallet_hd.py',
     'wallet_backup.py',
@@ -195,12 +201,6 @@ BASE_SCRIPTS = [
     'feature_shutdown.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
-]
-
-EXTENDED_SCRIPTS = [
-    # These tests are not run by the travis build process.
-    # Longest test should go first, to favor running tests in parallel
-    'feature_dbcrash.py',
 ]
 
 # Place EXTENDED_SCRIPTS first since it has the 3 longest running tests


### PR DESCRIPTION
This reverts fafb55e2c2b257efd4e584f72adf62401c01d573, since the test is still too slow to run with asan enabled on a network hdd