### PR TITLE
refactor: remove old bootstrap relevant code

### DIFF
--- a/doc/release-notes-15954.md
+++ b/doc/release-notes-15954.md
@@ -1,0 +1,4 @@
+Configuration option changes
+-----------------------------
+
+Importing blocks upon startup via the `bootstrap.dat` file no longer occurs by default. The file must now be specified with `-loadblock=<file>`.


### PR DESCRIPTION
Just a cleanup PR:

- Remove bootstrap file check from ThreadImport() which is called via the 'loadblk' thread during startup by default.
-  'loadblk' thread will only spawn during AppInitMain() if `-loadblock` is set with arguments, and correctly regards `-noloadblock`.

Additionally:
- `-loadblock` arguments now resolve into absolute paths.

One implication here is that copying something to $datadir/bootstrap.dat and starting with `-loadblock` won't work anymore. You'll have to explicitly specify the file now. Since bootstrapping is gone from all documentation and most of the codebase (this is the last I could find), I think this is a decent change.