### PR TITLE
refactor: Work around gcc compiler bug 90348

### DIFF
--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -541,9 +541,9 @@ BOOST_AUTO_TEST_CASE(countbits_tests)
 
 BOOST_AUTO_TEST_CASE(sha256d64)
 {
+    unsigned char in[64 * 32];
+    unsigned char out1[32 * 32], out2[32 * 32];
     for (int i = 0; i <= 32; ++i) {
-        unsigned char in[64 * 32];
-        unsigned char out1[32 * 32], out2[32 * 32];
         for (int j = 0; j < 64 * i; ++j) {
             in[j] = InsecureRandBits(8);
         }


### PR DESCRIPTION
The gcc compiler creates "optimized" code (`-finline-small-functions`) that modifies `in` a second time after it has been initialized with random bits.

Working around the bug can be achieved in different ways: Moving `in` into a new `const` array, rearranging the loop to break the optimization, or moving the array into the outer scope, ...

This fix is needed to release 0.18.1 on 32 bit platforms, thus needs backport.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348
Fixes #14580