### PR TITLE
Add locking annotations for RewindBlockIndex and GetNetworkHashPS. Add missing locks.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1590,6 +1590,7 @@ bool AppInitMain(InitInterfaces& interfaces)
                 // It both disconnects blocks based on chainActive, and drops block data in
                 // mapBlockIndex based on lack of available witness data.
                 uiInterface.InitMessage(_("Rewinding blocks..."));
+                LOCK(cs_main);
                 if (!RewindBlockIndex(chainparams)) {
                     strLoadError = _("Unable to rewind the database to a pre-fork state. You will need to redownload the blockchain");
                     break;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -39,7 +39,7 @@
  * or from the last difficulty change if 'lookup' is nonpositive.
  * If 'height' is nonnegative, compute the estimate at the time when a given block was found.
  */
-static UniValue GetNetworkHashPS(int lookup, int height) {
+static UniValue GetNetworkHashPS(int lookup, int height) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     CBlockIndex *pb = chainActive.Tip();
 
     if (height >= 0 && height < chainActive.Height())

--- a/src/validation.h
+++ b/src/validation.h
@@ -393,7 +393,7 @@ bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& pa
 bool IsNullDummyEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
-bool RewindBlockIndex(const CChainParams& params);
+bool RewindBlockIndex(const CChainParams& params) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Update uncommitted block structures (currently: only the witness reserved value). This is safe for submitted blocks. */
 void UpdateUncommittedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -375,7 +375,7 @@ public:
             blocktx = CMutableTransaction(*wallet->mapWallet.at(tx->GetHash()).tx);
         }
         CreateAndProcessBlock({CMutableTransaction(blocktx)}, GetScriptForRawPubKey(coinbaseKey.GetPubKey()));
-        LOCK(wallet->cs_wallet);
+        LOCK2(cs_main, wallet->cs_wallet);
         auto it = wallet->mapWallet.find(tx->GetHash());
         BOOST_CHECK(it != wallet->mapWallet.end());
         it->second.SetMerkleBranch(chainActive.Tip()->GetBlockHash(), 1);


### PR DESCRIPTION
While investigating https://github.com/bitcoin/bitcoin/pull/15948#issuecomment-489648141 I noticed that calling `RewindBlockIndex` and `GetNetworkHashPS` requires holding `cs_main` (due to accessing `chainActive`) without the functions being annotated as such.

This PR simply makes these implicit locking requirements explicit and adds two missing locks.

The only non-test caller not holding the now annotated locks was `AppInitMain`, but that was not a problem in practice since the `RewindBlockIndex` call happens before any background threads are started.