### PR TITLE
check bad-prevblk is right error for invalid descendants

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3437,7 +3437,7 @@ bool CChainState::AcceptBlockHeader(const CBlockHeader& block, CValidationState&
                         setDirtyBlockIndex.insert(invalid_walk);
                         invalid_walk = invalid_walk->pprev;
                     }
-                    return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_PREV, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk");
+                    return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_PREV, error("%s: prev block invalid", __func__), REJECT_INVALID, "bad-prevblk-desc");
                 }
             }
         }

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -301,6 +301,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         block_293.solve()
         headers_message = msg_headers()
         headers_message.headers.append(CBlockHeader(block_293))
+        assert_raises_rpc_error(-25, 'bad-prevblk-desc', lambda: self.nodes[0].submitheader(CBlockHeader(block_293).serialize().hex()))
         test_node.send_message(headers_message)
         test_node.wait_for_disconnect()
 


### PR DESCRIPTION
I am confused reading this code block `if (!pindexPrev->IsValid(BLOCK_VALID_SCRIPTS)) {`...
Then I find bad-prevblk is returned twice. One here and one above `if (pindexPrev->nStatus & BLOCK_FAILED_MASK)`...

To disambiguate, I change bad-prevblk to bad-prevblk-desc and verify that this is the right error being tested in p2p_unrequested_blocks.  This the only place this behavior is tested I think.