### PR TITLE
Fix portability issue with pthreads

### DIFF
--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -9,6 +9,11 @@
 #include <atomic>
 #include <thread>
 
+#if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
+#include <pthread.h>
+#include <pthread_np.h>
+#endif
+
 #include <util/threadnames.h>
 
 #ifdef HAVE_SYS_PRCTL_H


### PR DESCRIPTION
This change resolves the following issue:
https://github.com/bitcoin/bitcoin/issues/15951

Only tested on OpenBSD 6.5/amd64