### PR TITLE
Utils and libraries: fix static_assert for macro HAVE_THREAD_LOCAL

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -2,6 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <sync.h>
 #include <tinyformat.h>
 


### PR DESCRIPTION
Utils and libraries: fix static_assert for macro HAVE_THREAD_LOCAL if define DEBUG_LOCKCONTENTION