### PR TITLE
Trivial: Add explicit [[fallthrough]] to switch statement

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -46,8 +46,10 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
     switch (vDataToHash.size() & 3) {
         case 3:
             k1 ^= tail[2] << 16;
+            [[fallthrough]];
         case 2:
             k1 ^= tail[1] << 8;
+            [[fallthrough]];
         case 1:
             k1 ^= tail[0];
             k1 *= c1;


### PR DESCRIPTION
This avoids compiler warning "this statement may fall through" which would be generated if -Wimplicit-fallthrough were enabled.