### PR TITLE
refactor: Avoid UniValue copy constructor

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -443,7 +443,7 @@ static int CommandLineRPC(int argc, char *argv[])
 
                 // Parse reply
                 const UniValue& result = find_value(reply, "result");
-                const UniValue& error  = find_value(reply, "error");
+                const UniValue& error = find_value(reply, "error");
 
                 if (!error.isNull()) {
                     // Error
@@ -454,8 +454,8 @@ static int CommandLineRPC(int argc, char *argv[])
                     nRet = abs(code);
                     if (error.isObject())
                     {
-                        UniValue errCode = find_value(error, "code");
-                        UniValue errMsg  = find_value(error, "message");
+                        const UniValue& errCode = find_value(error, "code");
+                        const UniValue& errMsg  = find_value(error, "message");
                         strPrint = errCode.isNull() ? "" : "error code: "+errCode.getValStr()+"\n";
 
                         if (errMsg.isStr())

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -487,8 +487,8 @@ static UniValue getmemoryinfo(const JSONRPCRequest& request)
     }
 }
 
-static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
-    cats = cats.get_array();
+static void EnableOrDisableLogCategories(const UniValue& categories, bool enable) {
+    const UniValue& cats = categories.get_array();
     for (unsigned int i = 0; i < cats.size(); ++i) {
         std::string cat = cats[i].get_str();
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -248,7 +248,7 @@ static UniValue gettxoutproof(const JSONRPCRequest& request)
 
     std::set<uint256> setTxids;
     uint256 oneTxid;
-    UniValue txids = request.params[0].get_array();
+    const UniValue& txids = request.params[0].get_array();
     for (unsigned int idx = 0; idx < txids.size(); idx++) {
         const UniValue& txid = txids[idx];
         uint256 hash(ParseHashV(txid, "txid"));
@@ -566,8 +566,7 @@ static UniValue decodescript(const JSONRPCRequest& request)
     }
     ScriptPubKeyToUniv(script, r, /* fIncludeHex */ false);
 
-    UniValue type;
-    type = find_value(r, "type");
+    const UniValue& type = find_value(r, "type");
 
     if (type.isStr() && type.get_str() != "scripthash") {
         // P2SH cannot be wrapped in a P2SH. If this script is already a P2SH,
@@ -631,7 +630,7 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
             }.ToString());
 
 
-    UniValue txs = request.params[0].get_array();
+    const UniValue& txs = request.params[0].get_array();
     std::vector<CMutableTransaction> txVariants(txs.size());
 
     for (unsigned int idx = 0; idx < txs.size(); idx++) {
@@ -763,7 +762,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
     CBasicKeyStore keystore;
     const UniValue& keys = request.params[1].get_array();
     for (unsigned int idx = 0; idx < keys.size(); ++idx) {
-        UniValue k = keys[idx];
+        const UniValue& k = keys[idx];
         CKey key = DecodeSecret(k.get_str());
         if (!key.IsValid()) {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid private key");
@@ -1262,7 +1261,7 @@ UniValue combinepsbt(const JSONRPCRequest& request)
 
     // Unserialize the transactions
     std::vector<PartiallySignedTransaction> psbtxs;
-    UniValue txs = request.params[0].get_array();
+    const UniValue& txs = request.params[0].get_array();
     if (txs.empty()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Parameter 'txs' cannot be empty");
     }
@@ -1577,7 +1576,7 @@ UniValue joinpsbts(const JSONRPCRequest& request)
 
     // Unserialize the transactions
     std::vector<PartiallySignedTransaction> psbtxs;
-    UniValue txs = request.params[0].get_array();
+    const UniValue& txs = request.params[0].get_array();
 
     if (txs.size() <= 1) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "At least two PSBTs are required to join PSBTs.");

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -205,7 +205,7 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
                         {"redeemScript", UniValueType(UniValue::VSTR)},
                         {"witnessScript", UniValueType(UniValue::VSTR)},
                     }, true);
-                UniValue rs = find_value(prevOut, "redeemScript");
+                const UniValue& rs = find_value(prevOut, "redeemScript");
                 if (!rs.isNull()) {
                     std::vector<unsigned char> rsData(ParseHexV(rs, "redeemScript"));
                     CScript redeemScript(rsData.begin(), rsData.end());
@@ -214,7 +214,7 @@ UniValue SignTransaction(CMutableTransaction& mtx, const UniValue& prevTxsUnival
                     // This is only for compatibility, it is encouraged to use the explicit witnessScript field instead.
                     keystore->AddCScript(GetScriptForWitness(redeemScript));
                 }
-                UniValue ws = find_value(prevOut, "witnessScript");
+                const UniValue& ws = find_value(prevOut, "witnessScript");
                 if (!ws.isNull()) {
                     std::vector<unsigned char> wsData(ParseHexV(ws, "witnessScript"));
                     CScript witnessScript(wsData.begin(), wsData.end());

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -90,7 +90,7 @@ std::string CRPCTable::help(const std::string& strCommand, const JSONRPCRequest&
 
     JSONRPCRequest jreq(helpreq);
     jreq.fHelp = true;
-    jreq.params = UniValue();
+    jreq.params = NullUniValue;
 
     for (const std::pair<std::string, const CRPCCommand*>& command : vCommands)
     {
@@ -342,7 +342,7 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
     id = find_value(request, "id");
 
     // Parse method
-    UniValue valMethod = find_value(request, "method");
+    const UniValue& valMethod = find_value(request, "method");
     if (valMethod.isNull())
         throw JSONRPCError(RPC_INVALID_REQUEST, "Missing method");
     if (!valMethod.isStr())
@@ -355,7 +355,7 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
         LogPrint(BCLog::RPC, "ThreadRPCServer method=%s user=%s\n", SanitizeString(strMethod), this->authUser);
 
     // Parse params
-    UniValue valParams = find_value(request, "params");
+    const UniValue& valParams = find_value(request, "params");
     if (valParams.isArray() || valParams.isObject())
         params = valParams;
     else if (valParams.isNull())
@@ -436,7 +436,7 @@ static inline JSONRPCRequest transformNamedArguments(const JSONRPCRequest& in, c
                 // Fill hole between specified parameters with JSON nulls,
                 // but not at the end (for backwards compatibility with calls
                 // that act based on number of specified parameters).
-                out.params.push_back(UniValue());
+                out.params.push_back(NullUniValue);
             }
             hole = 0;
             out.params.push_back(*fr->second);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -33,12 +33,11 @@ public:
     UniValue id;
     std::string strMethod;
     UniValue params;
-    bool fHelp;
+    bool fHelp{false};
     std::string URI;
     std::string authUser;
     std::string peerAddr;
 
-    JSONRPCRequest() : id(NullUniValue), params(NullUniValue), fHelp(false) {}
     void parse(const UniValue& valRequest);
 };
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -994,8 +994,8 @@ static UniValue ProcessImportLegacy(ImportData& import_data, std::map<CKeyID, CP
     // Optional fields.
     const std::string& strRedeemScript = data.exists("redeemscript") ? data["redeemscript"].get_str() : "";
     const std::string& witness_script_hex = data.exists("witnessscript") ? data["witnessscript"].get_str() : "";
-    const UniValue& pubKeys = data.exists("pubkeys") ? data["pubkeys"].get_array() : UniValue();
-    const UniValue& keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
+    const UniValue& pubKeys = data.exists("pubkeys") ? data["pubkeys"].get_array() : NullUniValue;
+    const UniValue& keys = data.exists("keys") ? data["keys"].get_array() : NullUniValue;
     const bool internal = data.exists("internal") ? data["internal"].get_bool() : false;
     const bool watchOnly = data.exists("watchonly") ? data["watchonly"].get_bool() : false;
 
@@ -1152,7 +1152,7 @@ static UniValue ProcessImportDescriptor(ImportData& import_data, std::map<CKeyID
         }
     }
 
-    const UniValue& priv_keys = data.exists("keys") ? data["keys"].get_array() : UniValue();
+    const UniValue& priv_keys = data.exists("keys") ? data["keys"].get_array() : NullUniValue;
 
     // Expand all descriptors to get public keys and scripts.
     // TODO: get private keys from descriptors too

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3490,7 +3490,7 @@ UniValue rescanblockchain(const JSONRPCRequest& request)
     }
     UniValue response(UniValue::VOBJ);
     response.pushKV("start_height", start_height);
-    response.pushKV("stop_height", result.last_scanned_height ? *result.last_scanned_height : UniValue());
+    response.pushKV("stop_height", result.last_scanned_height ? *result.last_scanned_height : NullUniValue);
     return response;
 }
 


### PR DESCRIPTION
Remove unnecessary `UniValue` copies. Not sure if this change is exhaustive without changing `UniValue` or if there is a way to detect that.

A followup is to add move semantics to `UniValue` and remove some unnecessary members of `UniValue`.

This work is related to #15925.