### PR TITLE
.gitignore: Don't ignore depends patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ src/qt/bitcoin-qt.includes
 *.pyc
 *.o
 *.o-*
-*.patch
 *.a
 *.pb.cc
 *.pb.h
@@ -74,6 +73,10 @@ src/qt/bitcoin-qt.includes
 
 *.json.h
 *.raw.h
+
+# Only ignore unexpected patches
+*.patch
+!depends/patches/*.patch
 
 #libtool object files
 *.lo


### PR DESCRIPTION
Ignoring patches might be useful for those who use `git format-patch` often, but in our depends folder we **_want_** to keep track of our patches.