### PR TITLE
Replace incorrectly named comment with func

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1655,7 +1655,7 @@ static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, CValidationState&
     if (pindex->GetUndoPos().IsNull()) {
         FlatFilePos _pos;
         if (!FindUndoPos(state, pindex->nFile, _pos, ::GetSerializeSize(blockundo, CLIENT_VERSION) + 40))
-            return error("ConnectBlock(): FindUndoPos failed");
+            return error("%s: FindUndoPos failed", __func__);
         if (!UndoWriteToDisk(blockundo, _pos, pindex->pprev->GetBlockHash(), chainparams.MessageStart()))
             return AbortNode(state, "Failed to write undo data");
 


### PR DESCRIPTION
This code was previously part of ConnectBlock() hence the log string, at some point it was moved to WriteUndoDataForBlock(). It seems sensible to me to use the magic constant __func__.

I'd also like to update several other places where __func__ has been used intermittently. It's helpful to make logging code more dynamic, but also remove logging code from grep results when searching on function name. I was actually grepping ConnectBlock() and saw this misplaced result, ConnectBlock() itself has several logging lines that both use and do not use __func__, it's somewhat piecemeal.

I'm not entirely sure whether use of __func__ falls under the category of style but the change in this pull request changes a incorrectly labelled log entry.