### PR TITLE
Use __func__ for log messages

### DIFF
--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -86,7 +86,7 @@ bool CBasicKeyStore::GetKey(const CKeyID &address, CKey &keyOut) const
 bool CBasicKeyStore::AddCScript(const CScript& redeemScript)
 {
     if (redeemScript.size() > MAX_SCRIPT_ELEMENT_SIZE)
-        return error("CBasicKeyStore::AddCScript(): redeemScripts > %i bytes are invalid", MAX_SCRIPT_ELEMENT_SIZE);
+        return error("CBasicKeyStore::%s: redeemScripts > %i bytes are invalid", __func__, MAX_SCRIPT_ELEMENT_SIZE);
 
     LOCK(cs_KeyStore);
     mapScripts[CScriptID(redeemScript)] = redeemScript;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -474,7 +474,7 @@ SOCKET CreateSocket(const CService &addrConnect)
     // Set to non-blocking
     if (!SetSocketNonBlocking(hSocket, true)) {
         CloseSocket(hSocket);
-        LogPrintf("ConnectSocketDirectly: Setting socket to non-blocking failed, error %s\n", NetworkErrorString(WSAGetLastError()));
+        LogPrintf("%s: Setting socket to non-blocking failed, error %s\n", __func__, NetworkErrorString(WSAGetLastError()));
     }
     return hSocket;
 }

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -895,7 +895,7 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
         int nVersionRequired, nVersionThatWrote;
         filein >> nVersionRequired >> nVersionThatWrote;
         if (nVersionRequired > CLIENT_VERSION)
-            return error("CBlockPolicyEstimator::Read(): up-version (%d) fee estimate file", nVersionRequired);
+            return error("CBlockPolicyEstimator::%s: up-version (%d) fee estimate file", __func__, nVersionRequired);
 
         // Read fee estimates file into temporary variables so existing data
         // structures aren't corrupted if there is an exception.
@@ -942,7 +942,7 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
         }
     }
     catch (const std::exception& e) {
-        LogPrintf("CBlockPolicyEstimator::Read(): unable to read policy estimator data (non-fatal): %s\n",e.what());
+        LogPrintf("CBlockPolicyEstimator::%s: unable to read policy estimator data (non-fatal): %s\n", __func__, e.what());
         return false;
     }
     return true;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -841,7 +841,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             ++nTransactionsUpdated;
         }
     }
-    LogPrintf("PrioritiseTransaction: %s feerate += %s\n", hash.ToString(), FormatMoney(nFeeDelta));
+    LogPrintf("CTxMemPool::%s: %s feerate += %s\n", __func__, hash.ToString(), FormatMoney(nFeeDelta));
 }
 
 void CTxMemPool::ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1682,8 +1682,8 @@ void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
 
         if (!ExtractDestination(txout.scriptPubKey, address) && !txout.scriptPubKey.IsUnspendable())
         {
-            pwallet->WalletLogPrintf("CWalletTx::GetAmounts: Unknown transaction type found, txid %s\n",
-                                    this->GetHash().ToString());
+            pwallet->WalletLogPrintf("CWalletTx::%s: Unknown transaction type found, txid %s\n",
+                                    __func__, this->GetHash().ToString());
             address = CNoDestination();
         }
 


### PR DESCRIPTION
Remove literal function names and print them using __func__. There are a few updated log messages in this commit that have been moved to a new function but still refer to their previous function, printing the function name with __func__ will resolve this in future. Using __func__ also removes logging code from grep results when searching on function name.

A previous PR to change a single mislabelled log entry was added here.

https://github.com/bitcoin/bitcoin/pull/15979

This PR includes the change from the previous one and adds every additional entry found by myself and practicalswift.