### PR TITLE
build with -fstack-reuse=none

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -734,6 +734,10 @@ if test x$TARGET_OS != xwindows; then
   AX_CHECK_COMPILE_FLAG([-fPIC],[PIC_FLAGS="-fPIC"])
 fi
 
+# All versions of gcc that we commonly use for building are subject to bug
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348. To work around that, set
+# -fstack-reuse=none for all gcc builds. (Only gcc understands this flag)
+AX_CHECK_COMPILE_FLAG([-fstack-reuse=none],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-reuse=none"])
 if test x$use_hardening != xno; then
   use_hardening=yes
   AX_CHECK_COMPILE_FLAG([-Wstack-protector],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"])


### PR DESCRIPTION
All versions of gcc that we commonly use for building are subject to bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348. To work around that, set `-fstack-reuse=none` for all builds. See https://github.com/bitcoin/bitcoin/pull/15959#issuecomment-490423900

This option does not exist for clang https://clang.llvm.org/docs/ClangCommandLineReference.html#target-independent-compilation-options, but it does for gcc https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html