### PR TITLE
Wallet, GUI: Warn when sending to already-used Bitcoin addresses

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -7,6 +7,7 @@
 #include <amount.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
+#include <key_io.h>
 #include <policy/fees.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
@@ -29,6 +30,16 @@
 
 namespace interfaces {
 namespace {
+
+std::set<CScript> AddressesToKeys(std::vector<std::string> addresses)
+{
+    std::set<CScript> keys;
+    for (const auto& address : addresses) {
+        CScript scriptPubKey = GetScriptForDestination(DecodeDestination(address));
+        keys.insert(scriptPubKey);
+    }
+    return keys;
+}
 
 //! Construct wallet tx struct.
 WalletTx MakeWalletTx(interfaces::Chain::Lock& locked_chain, CWallet& wallet, const CWalletTx& wtx)
@@ -174,6 +185,24 @@ public:
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->GetDestValues(prefix);
+    }
+    bool checkAddressForUsage(const std::vector<std::string>& addresses) const override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->FindScriptPubKeyUsed(AddressesToKeys(addresses));
+    }
+    bool findAddressUsage(const std::vector<std::string>& addresses, std::function<void(const std::string&, const WalletTx&, uint32_t)> callback) const override
+    {
+        auto locked_chain = m_wallet->chain().lock();
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->FindScriptPubKeyUsed(AddressesToKeys(addresses), [&callback, &locked_chain, this](const CWalletTx& wtx, uint32_t output_index){
+            CTxDestination dest;
+            bool success = ExtractDestination(wtx.tx->vout[output_index].scriptPubKey, dest);
+            assert(success);  // It shouldn't be possible to end up here with anything unrecognised
+            std::string address = EncodeDestination(dest);
+            WalletTx interface_wtx = MakeWalletTx(*locked_chain, *m_wallet, wtx);
+            callback(address, interface_wtx, output_index);
+        });
     }
     void lockCoin(const COutPoint& output) override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -120,6 +120,9 @@ public:
     //! Get dest values with prefix.
     virtual std::vector<std::string> getDestValues(const std::string& prefix) = 0;
 
+    virtual bool checkAddressForUsage(const std::vector<std::string>& addresses) const = 0;
+    virtual bool findAddressUsage(const std::vector<std::string>& addresses, std::function<void(const std::string&, const WalletTx&, uint32_t)> callback) const = 0;
+
     //! Lock coin.
     virtual void lockCoin(const COutPoint& output) = 0;
 

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -20,6 +20,8 @@ static const bool DEFAULT_SPLASHSCREEN = true;
 
 /* Invalid field background style */
 #define STYLE_INVALID "background:#FF8080"
+/* "Warning" field background style */
+#define STYLE_INCORRECT "background:#FFFF80"
 
 /* Transaction list -- unconfirmed transaction */
 #define COLOR_UNCONFIRMED QColor(128, 128, 128)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -65,9 +65,19 @@ void ForceActivation();
 
 namespace GUIUtil {
 
+QString dateStr(const QDate &date)
+{
+    return date.toString(Qt::SystemLocaleShortDate);
+}
+
+QString dateStr(qint64 nTime)
+{
+    return dateStr(QDateTime::fromMSecsSinceEpoch(nTime*1000).date());
+}
+
 QString dateTimeStr(const QDateTime &date)
 {
-    return date.date().toString(Qt::SystemLocaleShortDate) + QString(" ") + date.toString("hh:mm");
+    return dateStr(date.date()) + QString(" ") + date.toString("hh:mm");
 }
 
 QString dateTimeStr(qint64 nTime)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -72,7 +72,7 @@ QString dateTimeStr(const QDateTime &date)
 
 QString dateTimeStr(qint64 nTime)
 {
-    return dateTimeStr(QDateTime::fromTime_t((qint32)nTime));
+    return dateTimeStr(QDateTime::fromMSecsSinceEpoch(nTime*1000));
 }
 
 QFont fixedPitchFont()

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -41,6 +41,8 @@ QT_END_NAMESPACE
 namespace GUIUtil
 {
     // Create human-readable string from date
+    QString dateStr(const QDate &datetime);
+    QString dateStr(qint64 nTime);
     QString dateTimeStr(const QDateTime &datetime);
     QString dateTimeStr(qint64 nTime);
 

--- a/src/qt/qvalidatedlineedit.cpp
+++ b/src/qt/qvalidatedlineedit.cpp
@@ -15,16 +15,28 @@ QValidatedLineEdit::QValidatedLineEdit(QWidget *parent) :
     connect(this, &QValidatedLineEdit::textChanged, this, &QValidatedLineEdit::markValid);
 }
 
-void QValidatedLineEdit::setValid(bool _valid)
+QValidatedLineEdit::~QValidatedLineEdit()
+{
+    delete m_warning_validator;
+}
+
+void QValidatedLineEdit::setValid(bool _valid, bool with_warning)
 {
     if(_valid == this->valid)
     {
-        return;
+        if (with_warning == m_has_warning || !valid) {
+            return;
+        }
     }
 
     if(_valid)
     {
-        setStyleSheet("");
+        m_has_warning = with_warning;
+        if (with_warning) {
+            setStyleSheet(STYLE_INCORRECT);
+        } else {
+            setStyleSheet("");
+        }
     }
     else
     {
@@ -78,13 +90,14 @@ void QValidatedLineEdit::setEnabled(bool enabled)
 
 void QValidatedLineEdit::checkValidity()
 {
+    const bool has_warning = checkWarning();
     if (text().isEmpty())
     {
         setValid(true);
     }
     else if (hasAcceptableInput())
     {
-        setValid(true);
+        setValid(true, has_warning);
 
         // Check contents on focus out
         if (checkValidator)
@@ -92,7 +105,7 @@ void QValidatedLineEdit::checkValidity()
             QString address = text();
             int pos = 0;
             if (checkValidator->validate(address, pos) == QValidator::Acceptable)
-                setValid(true);
+                setValid(true, has_warning);
             else
                 setValid(false);
         }
@@ -120,4 +133,29 @@ bool QValidatedLineEdit::isValid()
     }
 
     return valid;
+}
+
+void QValidatedLineEdit::setWarningValidator(const QValidator *v)
+{
+    delete m_warning_validator;
+    m_warning_validator = v;
+    checkValidity();
+}
+
+bool QValidatedLineEdit::checkWarning() const
+{
+    if (m_warning_validator && !text().isEmpty()) {
+        QString address = text();
+        int pos = 0;
+        if (m_warning_validator->validate(address, pos) != QValidator::Acceptable) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool QValidatedLineEdit::hasWarning() const
+{
+    return m_has_warning;
 }

--- a/src/qt/qvalidatedlineedit.h
+++ b/src/qt/qvalidatedlineedit.h
@@ -16,9 +16,12 @@ class QValidatedLineEdit : public QLineEdit
 
 public:
     explicit QValidatedLineEdit(QWidget *parent);
+    ~QValidatedLineEdit();
     void clear();
     void setCheckValidator(const QValidator *v);
     bool isValid();
+    void setWarningValidator(const QValidator *);
+    bool hasWarning() const;
 
 protected:
     void focusInEvent(QFocusEvent *evt);
@@ -27,9 +30,11 @@ protected:
 private:
     bool valid;
     const QValidator *checkValidator;
+    bool m_has_warning{false};
+    const QValidator *m_warning_validator{nullptr};
 
 public Q_SLOTS:
-    void setValid(bool valid);
+    void setValid(bool valid, bool with_warning=false);
     void setEnabled(bool enabled);
 
 Q_SIGNALS:
@@ -38,6 +43,7 @@ Q_SIGNALS:
 private Q_SLOTS:
     void markValid();
     void checkValidity();
+    bool checkWarning() const;
 };
 
 #endif // BITCOIN_QT_QVALIDATEDLINEEDIT_H

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -305,28 +305,27 @@ void SendCoinsDialog::on_sendButton_clicked()
             });
         }
 
-        QString reuse_question;
+        QString reuse_question, reuse_details;
         if (recipients.size() > 1) {
             reuse_question = tr("You've already paid some of these addresses.");
         } else {
             reuse_question = tr("You've already paid this address.");
         }
-        reuse_question.append("<br />");
 
         for (const auto& rcp : recipients) {
 #ifdef ENABLE_BIP70
             if (rcp.paymentRequest.IsInitialized()) continue;
 #endif
             if (!prior_usage_info.contains(rcp.address)) continue;
+            if (!reuse_details.isEmpty()) reuse_details.append("\n\n");
             const auto& rcp_prior_usage_info = prior_usage_info.value(rcp.address);
             const QString label_and_address = rcp.label.isEmpty() ? rcp.address : (QString("'") + rcp.label + "' (" + rcp.address + ")");
-            reuse_question.append("<br />");
             if (rcp_prior_usage_info.num_txs == 1) {
                 //: %1 is an amount (eg, "1 BTC"); %2 is a Bitcoin address and its label; %3 is a date (eg, "2019-05-08")
-                reuse_question.append(tr("Sent %1 to %2 on %3").arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp_prior_usage_info.total_amount), label_and_address, GUIUtil::dateStr(rcp_prior_usage_info.tx_time_newest)));
+                reuse_details.append(tr("Sent %1 to %2 on %3").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp_prior_usage_info.total_amount), label_and_address, GUIUtil::dateStr(rcp_prior_usage_info.tx_time_newest)));
             } else {
                 //: %1 is an amount (eg, "1 BTC"); %2 is a Bitcoin address and its label; %3 is the number of transactions; %4 and %5 are dates (eg, "2019-05-08"), earlier first
-                reuse_question.append(tr("Sent %1 to %2 across %3 transactions from %4 through %5").arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp_prior_usage_info.total_amount), label_and_address, QString::number(rcp_prior_usage_info.num_txs), GUIUtil::dateStr(rcp_prior_usage_info.tx_time_oldest), GUIUtil::dateStr(rcp_prior_usage_info.tx_time_newest)));
+                reuse_details.append(tr("Sent %1 to %2 across %3 transactions from %4 through %5").arg(BitcoinUnits::formatWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp_prior_usage_info.total_amount), label_and_address, QString::number(rcp_prior_usage_info.num_txs), GUIUtil::dateStr(rcp_prior_usage_info.tx_time_oldest), GUIUtil::dateStr(rcp_prior_usage_info.tx_time_newest)));
             }
         }
 
@@ -334,7 +333,7 @@ void SendCoinsDialog::on_sendButton_clicked()
         reuse_question.append(tr("Bitcoin addresses are intended to only be used once, for a single payment. Sending to the same address again will harm the recipient's security, as well as the privacy of all Bitcoin users!"));
         reuse_question.append("</span>");
 
-        SendConfirmationDialog confirmation_dialog(QMessageBox::Warning, tr("Already paid"), reuse_question, QMessageBox::Ignore, tr("Override"), QMessageBox::Ok, "", "", ADDRESS_REUSE_OVERRIDE_DELAY, this);
+        SendConfirmationDialog confirmation_dialog(QMessageBox::Warning, tr("Already paid"), reuse_question, QMessageBox::Ignore, tr("Override"), QMessageBox::Ok, "", reuse_details, ADDRESS_REUSE_OVERRIDE_DELAY, this);
         if (!confirmation_dialog.exec()) {
             fNewRecipientAllowed = true;
             return;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -220,6 +220,7 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     QList<SendCoinsRecipient> recipients;
     bool valid = true;
+    bool have_warning = false;
 
     for(int i = 0; i < ui->entries->count(); ++i)
     {
@@ -229,6 +230,7 @@ void SendCoinsDialog::on_sendButton_clicked()
             if(entry->validate(model->node()))
             {
                 recipients.append(entry->getValue());
+                have_warning |= entry->hasPaytoWarning();
             }
             else if (valid)
             {
@@ -272,6 +274,71 @@ void SendCoinsDialog::on_sendButton_clicked()
     if(prepareStatus.status != WalletModel::OK) {
         fNewRecipientAllowed = true;
         return;
+    }
+
+    if (have_warning) {
+        struct prior_usage_info_t {
+            CAmount total_amount{0};
+            int num_txs{0};
+            qint64 tx_time_oldest;
+            qint64 tx_time_newest;
+        };
+        QMap<QString, prior_usage_info_t> prior_usage_info;
+        {
+            QStringList addresses;
+            for (const auto& recipient : recipients) {
+#ifdef ENABLE_BIP70
+                if (recipient.paymentRequest.IsInitialized()) continue;
+#endif
+                addresses.append(recipient.address);
+            }
+            model->findAddressUsage(addresses, [&prior_usage_info](const QString& address, const interfaces::WalletTx& wtx, uint32_t output_index){
+                auto& info = prior_usage_info[address];
+                info.total_amount += wtx.tx->vout[output_index].nValue;
+                ++info.num_txs;
+                if (info.num_txs == 1 || wtx.time < info.tx_time_oldest) {
+                    info.tx_time_oldest = wtx.time;
+                }
+                if (info.num_txs == 1 || wtx.time > info.tx_time_newest) {
+                    info.tx_time_newest = wtx.time;
+                }
+            });
+        }
+
+        QString reuse_question;
+        if (recipients.size() > 1) {
+            reuse_question = tr("You've already paid some of these addresses.");
+        } else {
+            reuse_question = tr("You've already paid this address.");
+        }
+        reuse_question.append("<br />");
+
+        for (const auto& rcp : recipients) {
+#ifdef ENABLE_BIP70
+            if (rcp.paymentRequest.IsInitialized()) continue;
+#endif
+            if (!prior_usage_info.contains(rcp.address)) continue;
+            const auto& rcp_prior_usage_info = prior_usage_info.value(rcp.address);
+            const QString label_and_address = rcp.label.isEmpty() ? rcp.address : (QString("'") + rcp.label + "' (" + rcp.address + ")");
+            reuse_question.append("<br />");
+            if (rcp_prior_usage_info.num_txs == 1) {
+                //: %1 is an amount (eg, "1 BTC"); %2 is a Bitcoin address and its label; %3 is a date (eg, "2019-05-08")
+                reuse_question.append(tr("Sent %1 to %2 on %3").arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp_prior_usage_info.total_amount), label_and_address, GUIUtil::dateStr(rcp_prior_usage_info.tx_time_newest)));
+            } else {
+                //: %1 is an amount (eg, "1 BTC"); %2 is a Bitcoin address and its label; %3 is the number of transactions; %4 and %5 are dates (eg, "2019-05-08"), earlier first
+                reuse_question.append(tr("Sent %1 to %2 across %3 transactions from %4 through %5").arg(BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp_prior_usage_info.total_amount), label_and_address, QString::number(rcp_prior_usage_info.num_txs), GUIUtil::dateStr(rcp_prior_usage_info.tx_time_oldest), GUIUtil::dateStr(rcp_prior_usage_info.tx_time_newest)));
+            }
+        }
+
+        reuse_question.append("<br /><br /><span style='font-size:10pt;'>");
+        reuse_question.append(tr("Bitcoin addresses are intended to only be used once, for a single payment. Sending to the same address again will harm the recipient's security, as well as the privacy of all Bitcoin users!"));
+        reuse_question.append("</span>");
+
+        SendConfirmationDialog confirmation_dialog(QMessageBox::Warning, tr("Already paid"), reuse_question, QMessageBox::Ignore, tr("Override"), QMessageBox::Ok, "", "", ADDRESS_REUSE_OVERRIDE_DELAY, this);
+        if (!confirmation_dialog.exec()) {
+            fNewRecipientAllowed = true;
+            return;
+        }
     }
 
     CAmount txFee = currentTransaction.getTransactionFee();

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -102,6 +102,7 @@ Q_SIGNALS:
 
 
 #define SEND_CONFIRM_DELAY   3
+#define ADDRESS_REUSE_OVERRIDE_DELAY   10
 
 class SendConfirmationDialog : public QMessageBox
 {

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -108,7 +108,7 @@ class SendConfirmationDialog : public QMessageBox
     Q_OBJECT
 
 public:
-    SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, QWidget* parent = nullptr);
+    SendConfirmationDialog(QMessageBox::Icon, const QString& title, const QString& text, QMessageBox::StandardButton yes_button = QMessageBox::Yes, const QString &yes_button_text = "", QMessageBox::StandardButton cancel_button = QMessageBox::Cancel, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, QWidget* parent = nullptr);
     int exec();
 
 private Q_SLOTS:
@@ -117,6 +117,7 @@ private Q_SLOTS:
 
 private:
     QAbstractButton *yesButton;
+    QString m_yes_button_text;
     QTimer countDownTimer;
     int secDelay;
 };

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -85,6 +85,12 @@ void SendCoinsEntry::setModel(WalletModel *_model)
 {
     this->model = _model;
 
+    if (_model) {
+        ui->payTo->setWarningValidator(new BitcoinAddressUnusedInWalletValidator(*_model));
+    } else {
+        ui->payTo->setWarningValidator(nullptr);
+    }
+
     if (_model && _model->getOptionsModel())
         connect(_model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &SendCoinsEntry::updateDisplayUnit);
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -176,6 +176,11 @@ bool SendCoinsEntry::validate(interfaces::Node& node)
     return retval;
 }
 
+bool SendCoinsEntry::hasPaytoWarning() const
+{
+    return ui->payTo->hasWarning();
+}
+
 SendCoinsRecipient SendCoinsEntry::getValue()
 {
 #ifdef ENABLE_BIP70

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -31,6 +31,7 @@ public:
 
     void setModel(WalletModel *model);
     bool validate(interfaces::Node& node);
+    bool hasPaytoWarning() const;
     SendCoinsRecipient getValue();
 
     /** Return whether the entry is still empty and unedited */

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -44,7 +44,14 @@ void ConfirmSend(QString* text = nullptr, bool cancel = false)
             if (widget->inherits("SendConfirmationDialog")) {
                 SendConfirmationDialog* dialog = qobject_cast<SendConfirmationDialog*>(widget);
                 if (text) *text = dialog->text();
-                QAbstractButton* button = dialog->button(cancel ? QMessageBox::Cancel : QMessageBox::Yes);
+                QAbstractButton* button = nullptr;
+                auto desired_button_role = cancel ? QMessageBox::NoRole : QMessageBox::YesRole;
+                for (QAbstractButton* maybe_button : dialog->buttons()) {
+                    if (dialog->buttonRole(maybe_button) == desired_button_role) {
+                        button = maybe_button;
+                        break;
+                    }
+                }
                 button->setEnabled(true);
                 button->click();
             }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -123,6 +123,22 @@ bool WalletModel::validateAddress(const QString &address)
     return IsValidDestinationString(address.toStdString());
 }
 
+bool WalletModel::checkAddressForUsage(const std::vector<std::string>& addresses) const
+{
+    return m_wallet->checkAddressForUsage(addresses);
+}
+
+bool WalletModel::findAddressUsage(const QStringList& addresses, std::function<void(const QString&, const interfaces::WalletTx&, uint32_t)> callback) const
+{
+    std::vector<std::string> std_addresses;
+    for (const auto& address : addresses) {
+        std_addresses.push_back(address.toStdString());
+    }
+    return m_wallet->findAddressUsage(std_addresses, [&callback](const std::string& address, const interfaces::WalletTx& wtx, uint32_t output_index){
+        callback(QString::fromStdString(address), wtx, output_index);
+    });
+}
+
 WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl)
 {
     CAmount total = 0;

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -620,3 +620,18 @@ bool WalletModel::isMultiwallet()
 {
     return m_node.getWallets().size() > 1;
 }
+
+BitcoinAddressUnusedInWalletValidator::BitcoinAddressUnusedInWalletValidator(const WalletModel& wallet_model, QObject *parent) :
+    QValidator(parent),
+    m_wallet_model(wallet_model)
+{
+}
+
+QValidator::State BitcoinAddressUnusedInWalletValidator::validate(QString &input, int &pos) const
+{
+    Q_UNUSED(pos);
+    if (m_wallet_model.checkAddressForUsage(std::vector<std::string>{input.toStdString()})) {
+        return QValidator::Invalid;
+    }
+    return QValidator::Acceptable;
+}

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -561,12 +561,10 @@ bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
     questionString.append("</td><td>");
     questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee));
     questionString.append("</td></tr></table>");
-    SendConfirmationDialog confirmationDialog(tr("Confirm fee bump"), questionString);
-    confirmationDialog.exec();
-    QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
 
+    SendConfirmationDialog confirmationDialog(QMessageBox::Question, tr("Confirm fee bump"), questionString);
     // cancel sign&broadcast if user doesn't want to bump the fee
-    if (retval != QMessageBox::Yes) {
+    if (!confirmationDialog.exec()) {
         return false;
     }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -7,6 +7,7 @@
 
 #include <amount.h>
 #include <key.h>
+#include <primitives/transaction.h>
 #include <serialize.h>
 #include <script/standard.h>
 
@@ -22,6 +23,7 @@
 #include <interfaces/wallet.h>
 #include <support/allocators/secure.h>
 
+#include <string>
 #include <vector>
 
 #include <QObject>
@@ -158,6 +160,8 @@ public:
 
     // Check address for validity
     bool validateAddress(const QString &address);
+    bool checkAddressForUsage(const std::vector<std::string>& addresses) const;
+    bool findAddressUsage(const QStringList& addresses, std::function<void(const QString&, const interfaces::WalletTx&, uint32_t)> callback) const;
 
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include <QObject>
+#include <QValidator>
 
 enum class OutputType;
 
@@ -304,6 +305,18 @@ public Q_SLOTS:
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */
     void pollBalanceChanged();
+};
+
+class BitcoinAddressUnusedInWalletValidator : public QValidator
+{
+    Q_OBJECT
+
+    const WalletModel& m_wallet_model;
+
+public:
+    explicit BitcoinAddressUnusedInWalletValidator(const WalletModel&, QObject *parent=nullptr);
+
+    State validate(QString &input, int &pos) const;
 };
 
 #endif // BITCOIN_QT_WALLETMODEL_H

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -45,6 +45,9 @@ const std::map<uint64_t,std::string> WALLET_FLAG_CAVEATS{
 
 static const size_t OUTPUT_GROUP_MAX_ENTRIES = 10;
 
+static const unsigned int ADDR_BLOOM_FILTER_TX_TO_ELEMENTS_FACTOR = 3 /* outputs */ * 2 /* room to grow */;
+static const double ADDR_BLOOM_FILTER_FP_RATE = 0.000001;
+
 static CCriticalSection cs_wallets;
 static std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
 
@@ -850,12 +853,47 @@ void CWallet::AddToAddressBloomFilter(const CWalletTx& wtx)
 
 void CWallet::BuildAddressBloomFilter()
 {
-    m_address_bloom_filter_elems = std::max<size_t>(100, mapWallet.size() * 2);
-    m_address_bloom_filter = CBloomFilter(m_address_bloom_filter_elems, 0.000001, 0, BLOOM_UPDATE_ALL);
+    if (m_address_bloom_filter_elems < 100) m_address_bloom_filter_elems = 100;
+    m_address_bloom_filter_elems = std::max<size_t>(m_address_bloom_filter_elems, mapWallet.size() * ADDR_BLOOM_FILTER_TX_TO_ELEMENTS_FACTOR);
+    m_address_bloom_filter = CBloomFilter(m_address_bloom_filter_elems, ADDR_BLOOM_FILTER_FP_RATE, 0, BLOOM_UPDATE_ALL);
     for (const auto& entry : mapWallet) {
         const CWalletTx& wtx = entry.second;
         AddToAddressBloomFilter(wtx);
     }
+}
+
+bool CWallet::FindScriptPubKeyUsed(const std::set<CScript>& keys, const boost::variant<boost::blank, std::function<void(const CWalletTx&)>, std::function<void(const CWalletTx&, uint32_t)>>& callback) const
+{
+    bool found_any = false;
+    for (const auto& key : keys) {
+        if (m_address_bloom_filter.contains(ToByteVector(key))) {
+            found_any = true;
+            break;
+        }
+    }
+    if (!found_any) {
+        return false;
+    }
+
+    found_any = false;
+    for (const auto& entry : mapWallet) {
+        const CWalletTx& wtx = entry.second;
+        for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
+            const auto& output = wtx.tx->vout[i];
+            if (keys.count(output.scriptPubKey)) {
+                const auto callback_type = callback.which();
+                if (callback_type == 0) return true;
+                found_any = true;
+                if (callback_type == 1) {
+                    boost::get<std::function<void(const CWalletTx&)>>(callback)(wtx);
+                    break;
+                }
+                boost::get<std::function<void(const CWalletTx&, uint32_t)>>(callback)(wtx, i);
+            }
+        }
+    }
+
+    return found_any;
 }
 
 bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1019,6 +1019,8 @@ public:
     void UnlockAllCoins() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ListLockedCoins(std::vector<COutPoint>& vOutpts) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
+    bool FindScriptPubKeyUsed(const std::set<CScript>& keys, const boost::variant<boost::blank, std::function<void(const CWalletTx&)>, std::function<void(const CWalletTx&, uint32_t)>>& callback = boost::blank()) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
     /*
      * Rescan abort properties
      */

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <amount.h>
+#include <bloom.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <outputtype.h>
@@ -784,6 +785,11 @@ private:
     TxSpends mapTxSpends GUARDED_BY(cs_wallet);
     void AddToSpends(const COutPoint& outpoint, const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void AddToSpends(const uint256& wtxid) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+
+    size_t m_address_bloom_filter_elems GUARDED_BY(cs_wallet) {0};
+    CBloomFilter m_address_bloom_filter GUARDED_BY(cs_wallet);
+    void AddToAddressBloomFilter(const CWalletTx&) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void BuildAddressBloomFilter() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Add a transaction to the wallet, or update it.  pIndex and posInBlock should


### PR DESCRIPTION
- An in-memory bloom filter is used to detect potential address reuse, avoiding wasting unnecessary memory with large wallets.
- Entering a used address in the GUI Send tab makes the field turn yellow.
- Sending to a used address from the GUI prompts with detailed information about prior usage, as well as a note about best practices to avoid address reuse.
- (I also fixed `GUIUtil::dateTimeStr` to not overflow with 64-bit timestamps.)