### PR TITLE
Add test for ArgsManager::GetChainName

### DIFF
--- a/src/test/util.h
+++ b/src/test/util.h
@@ -34,5 +34,37 @@ std::string getnewaddress(CWallet& w);
 /** Returns the generated coin */
 CTxIn generatetoaddress(const std::string& address);
 
+/**
+ * Increment a string. Useful to enumerate all fixed length strings with
+ * characters in [min_char, max_char].
+ */
+template <typename CharType, size_t StringLength>
+bool NextString(CharType (&string)[StringLength], CharType min_char, CharType max_char)
+{
+    for (CharType& elem : string) {
+        bool has_next = elem != max_char;
+        elem = elem < min_char || elem >= max_char ? min_char : CharType(elem + 1);
+        if (has_next) return true;
+    }
+    return false;
+}
+
+/**
+ * Iterate over string values and call function for each string without
+ * successive duplicate characters.
+ */
+template <typename CharType, size_t StringLength, typename Fn>
+void ForEachNoDup(CharType (&string)[StringLength], CharType min_char, CharType max_char, Fn&& fn) {
+    for (bool has_next = true; has_next; has_next = NextString(string, min_char, max_char)) {
+        int prev = -1;
+        bool skip_string = false;
+        for (CharType c : string) {
+            if (c == prev) skip_string = true;
+            if (skip_string || c < min_char || c > max_char) break;
+            prev = c;
+        }
+        if (!skip_string) fn();
+    }
+}
 
 #endif // BITCOIN_TEST_UTIL_H

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -580,7 +580,7 @@ BOOST_AUTO_TEST_CASE(util_GetChainName)
 
 // Test different ways settings can be merged, and verify results. This test can
 // be used to confirm that updates to settings code don't change behavior
-// unintentially.
+// unintentionally.
 //
 // The test covers:
 //
@@ -687,7 +687,7 @@ struct SettingsMergeTestingSetup : public BasicTestingSetup {
 // Regression test covering different ways config settings can be merged. The
 // test parses and merges settings, representing the results as strings that get
 // compared against an expected hash. To debug, the result strings can be dumped
-// to a file (see below).
+// to a file (see comments below).
 BOOST_FIXTURE_TEST_CASE(util_SettingsMerge, SettingsMergeTestingSetup)
 {
     CHash256 out_sha;
@@ -706,7 +706,7 @@ BOOST_FIXTURE_TEST_CASE(util_SettingsMerge, SettingsMergeTestingSetup)
         desc += network;
         parser.m_network = network;
 
-        const std::string& name = net_specific ? "server" : "wallet";
+        const std::string& name = net_specific ? "wallet" : "server";
         const std::string key = "-" + name;
         parser.AddArg(key, name, false, OptionsCategory::OPTIONS);
         if (net_specific) parser.SetNetworkOnlyArg(key);
@@ -801,7 +801,7 @@ BOOST_FIXTURE_TEST_CASE(util_SettingsMerge, SettingsMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <IsArgSet/IsArgNegated/GetArg output> | <GetArgs output> | <GetUnsuitable output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "80964e17fbd3c5569d3c824d032e28e2d319ef57494735b0e76eb7aad9957f2c");
+    BOOST_CHECK_EQUAL(out_sha_hex, "f4281d9bff4c0b398ff118386e3a40caa6bac7645e17b296d6a10b95bff632ae");
 }
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)


### PR DESCRIPTION
There was some test coverage previously, but it was limited and didn't test conflicting and negated arguments.
