### PR TITLE
RPC: Do not use cookie auth if -rpcauth set

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -127,8 +127,6 @@ static bool multiUserAuthorized(std::string strUserPass)
 
 static bool RPCAuthorized(const std::string& strAuth, std::string& strAuthUsernameOut)
 {
-    if (strRPCUserColonPass.empty()) // Belt-and-suspenders measure if InitRPCAuthentication was not called
-        return false;
     if (strAuth.substr(0, 6) != "Basic ")
         return false;
     std::string strUserPass64 = strAuth.substr(6);
@@ -138,11 +136,11 @@ static bool RPCAuthorized(const std::string& strAuth, std::string& strAuthUserna
     if (strUserPass.find(':') != std::string::npos)
         strAuthUsernameOut = strUserPass.substr(0, strUserPass.find(':'));
 
-    //Check if authorized under single-user field
-    if (TimingResistantEqual(strUserPass, strRPCUserColonPass)) {
+    if (multiUserAuthorized(strUserPass)) {
         return true;
     }
-    return multiUserAuthorized(strUserPass);
+
+    return !strRPCUserColonPass.empty() && TimingResistantEqual(strUserPass, strRPCUserColonPass);
 }
 
 static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
@@ -214,22 +212,24 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 
 static bool InitRPCAuthentication()
 {
-    if (gArgs.GetArg("-rpcpassword", "") == "")
-    {
-        LogPrintf("No rpcpassword set - using random cookie authentication.\n");
-        if (!GenerateAuthCookie(&strRPCUserColonPass)) {
-            uiInterface.ThreadSafeMessageBox(
-                _("Error: A fatal internal error occurred, see debug.log for details"), // Same message as AbortNode
-                "", CClientUIInterface::MSG_ERROR);
-            return false;
+    if (!gArgs.GetArg("-rpcauth", "").empty()) {
+        LogPrintf("Using -rpcauth authentication.\n");
+        if (gArgs.GetChainName() != CBaseChainParams::REGTEST) {
+            return true;
         }
-    } else {
-        LogPrintf("Config options rpcuser and rpcpassword will soon be deprecated. Locally-run instances may remove rpcuser to use cookie-based auth, or may be replaced with rpcauth. Please see share/rpcauth for rpcauth auth generation.\n");
+    } else if (!gArgs.GetArg("-rpcpassword", "").empty()) {
+        LogPrintf("Config options -rpcuser and -rpcpassword will soon be deprecated. Please see share/rpcauth for -rpcauth auth generation.\n");
         strRPCUserColonPass = gArgs.GetArg("-rpcuser", "") + ":" + gArgs.GetArg("-rpcpassword", "");
+        return true;
+    } else {
+        LogPrintf("Neither -rpcauth nor -rpcpassword set - using random cookie authentication.\n");
     }
-    if (gArgs.GetArg("-rpcauth","") != "")
-    {
-        LogPrintf("Using rpcauth authentication.\n");
+
+    if (!GenerateAuthCookie(&strRPCUserColonPass)) {
+        uiInterface.ThreadSafeMessageBox(
+            _("Error: A fatal internal error occurred, see debug.log for details"), // Same message as AbortNode
+            "", CClientUIInterface::MSG_ERROR);
+        return false;
     }
     return true;
 }


### PR DESCRIPTION
Currently, the client with provided `-rpcauth` option still creates the `.cookie` file.
However, if `-rpcuser` and `-rpcpassword` are provided the `.cookie` file is not generated.

This PR makes client behavior consistent.

Refs:
- #7044
- https://github.com/bitcoin/bitcoin/pull/7044#issuecomment-159030598 by **gmaxwell** 
- #13118

Also this PR ensures that the auth cookie is still generated in regtest mode on test purposes.