### PR TITLE
Extract CConnman::RelayTransaction

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -170,6 +170,7 @@ BITCOIN_CORE_H = \
   protocol.h \
   psbt.h \
   random.h \
+  relay.h \
   reverse_iterator.h \
   reverselock.h \
   rpc/blockchain.h \
@@ -280,6 +281,7 @@ libbitcoin_server_a_SOURCES = \
   policy/rbf.cpp \
   policy/settings.cpp \
   pow.cpp \
+  relay.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
   rpc/mining.cpp \

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -17,6 +17,7 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <protocol.h>
+#include <relay.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <shutdown.h>
@@ -296,8 +297,7 @@ public:
     }
     void relayTransaction(const uint256& txid) override
     {
-        CInv inv(MSG_TX, txid);
-        g_connman->ForEachNode([&inv](CNode* node) { node->PushInventory(inv); });
+        RelayTransaction(txid, g_connman);
     }
     void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) override
     {

--- a/src/net.h
+++ b/src/net.h
@@ -839,16 +839,20 @@ public:
         }
     }
 
-    void PushInventory(const CInv& inv)
+    //! Pushes a tx inv to this peer, unless already known
+    void PushTransactionInventory(const uint256& txid)
     {
         LOCK(cs_inventory);
-        if (inv.type == MSG_TX) {
-            if (!filterInventoryKnown.contains(inv.hash)) {
-                setInventoryTxToSend.insert(inv.hash);
-            }
-        } else if (inv.type == MSG_BLOCK) {
-            vInventoryBlockToSend.push_back(inv.hash);
+        if (!filterInventoryKnown.contains(txid)) {
+            setInventoryTxToSend.insert(txid);
         }
+    }
+
+    //! Pushes a block inv to this peer
+    void PushBlockInventory(const uint256& blockhash)
+    {
+        LOCK(cs_inventory);
+        vInventoryBlockToSend.push_back(blockhash);
     }
 
     void PushBlockHash(const uint256 &hash)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1473,7 +1473,7 @@ void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, c
         // Trigger the peer node to send a getblocks request for the next batch of inventory
         if (inv.hash == pfrom->hashContinue)
         {
-            // Bypass PushInventory, this must send even if redundant,
+            // Bypass PushBlockInventory, this must send even if redundant,
             // and we want it right after the last block so they don't
             // wait for other stuff first.
             std::vector<CInv> vInv;
@@ -2305,7 +2305,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 LogPrint(BCLog::NET, " getblocks stopping, pruned or too old block at %d %s\n", pindex->nHeight, pindex->GetBlockHash().ToString());
                 break;
             }
-            pfrom->PushInventory(CInv(MSG_BLOCK, pindex->GetBlockHash()));
+            pfrom->PushBlockInventory(pindex->GetBlockHash());
             if (--nLimit <= 0)
             {
                 // When this block is requested, we'll send an inv that'll
@@ -3706,7 +3706,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
                     // If the peer's chain has this block, don't inv it back.
                     if (!PeerHasHeader(&state, pindex)) {
-                        pto->PushInventory(CInv(MSG_BLOCK, hashToAnnounce));
+                        pto->PushBlockInventory(hashToAnnounce);
                         LogPrint(BCLog::NET, "%s: sending inv peer=%d hash=%s\n", __func__,
                             pto->GetId(), hashToAnnounce.ToString());
                     }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -5,6 +5,7 @@
 
 #include <consensus/validation.h>
 #include <net.h>
+#include <relay.h>
 #include <txmempool.h>
 #include <util/validation.h>
 #include <validation.h>
@@ -69,10 +70,7 @@ TransactionError BroadcastTransaction(const CTransactionRef tx, uint256& hashTx,
         return TransactionError::P2P_DISABLED;
     }
 
-    CInv inv(MSG_TX, hashTx);
-    g_connman->ForEachNode([&inv](CNode* pnode) {
-        pnode->PushInventory(inv);
-    });
+    RelayTransaction(hashTx, g_connman);
 
     return TransactionError::OK;
 }

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <relay.h>
+
+void RelayTransaction(const uint256& txid, CConnman* connman)
+{
+    CInv inv(MSG_TX, txid);
+    connman.ForEachNode([&inv](CNode* node) {
+        node->PushInventory(inv);
+    });
+}

--- a/src/relay.cpp
+++ b/src/relay.cpp
@@ -7,8 +7,7 @@
 
 void RelayTransaction(const uint256& txid, CConnman* connman)
 {
-    CInv inv(MSG_TX, txid);
-    connman.ForEachNode([&inv](CNode* node) {
-        node->PushInventory(inv);
+    connman.ForEachNode([&txid](CNode* node) {
+        node->PushTransactionInventory(txid);
     });
 }

--- a/src/relay.h
+++ b/src/relay.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RELAY_H
+#define BITCOIN_RELAY_H
+
+#include <net.h>
+#include <uint256.h>
+
+/** Announce transaction to all peers */
+void RelayTransaction(const uint256& txid, CConnman* connman);
+
+#endif // BITCOIN_RELAY_H


### PR DESCRIPTION
* Implement `RelayTransaction` on `CConnman` only, rather than chain interface, `BroadcastTransaction`, and locally in net processing.
* Split node `PushInventory` into `PushBlockInventory` and `PushTransactionInventory`, as at every call-site the block/tx distinction is already made.

Extracted from #15253