### PR TITLE
systemd service script: set usable permissions on /etc/bitcoin config dir

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -38,7 +38,7 @@ RuntimeDirectoryMode=0710
 
 # /etc/bitcoin
 ConfigurationDirectory=bitcoin
-ConfigurationDirectoryMode=0710
+ConfigurationDirectoryMode=0755
 
 # /var/lib/bitcoind
 StateDirectory=bitcoind
@@ -63,6 +63,9 @@ PrivateDevices=true
 
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true
+
+# Deny access to /home
+ProtectHome=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The current sample systemd script sets 0710 permissions on `/etc/bitcoin` which means it can only be read by the owner. If `/etc/bitcoin` does not exist when the systemd script is run for the first time then the directory gets created with `root` as the owner. The 0710 permissions will/may prevent a non-root user from being able to list the directory (on Ubuntu 18.04 the file can be listed but the permissions are inaccessible).

Even after copying `bitcoin.conf` to `/etc/bitcoin` it will remain unusable until either the directory permissions are changed or the service user is made the owner.

This PR adjusts the permissions that the service script will set on `/etc/bitcoin` so that all users can read and list the default config directory. A user will still have to copy the bitcoin.conf file to it but the adjustment will avoid them having to manually set permissions or change ownership of `/etc/bitcoin`.

In addition the `ProtectHome` option has been added. The rationale being if using a service to run bitcoind it's more likely to be a headless daemon that should not need access to user home directories.

Best link I found for systemd [options].(https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ConfigurationDirectory=)