### PR TITLE
fix: GuessVerificationProgress requires cs_main lock

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -262,7 +262,7 @@ bool ActivateBestChain(CValidationState& state, const CChainParams& chainparams,
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
 /** Guess verification progress (as a fraction between 0.0=genesis and 1.0=current tip). */
-double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pindex);
+double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
 /** Calculate the amount of disk space the block & undo files currently use */
 uint64_t CalculateCurrentUsage();


### PR DESCRIPTION
All calls to `GuessVerificationProgress`, except the ones touched in this change, already have `cs_main` locked. Make it consistent by adding the remaining locks and the TSAN annotation.

Despite not being always necessary, because if the block is in the active chain then `nChainTx` is already updated, this is a safe change.

Closes #15994.