### PR TITLE
init: Fixes for file descriptor accounting

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1001,7 +1001,7 @@ bool AppInitParameterInteraction()
     nUserMaxConnections = gArgs.GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
     int nBind = std::max(nUserBind, size_t(1));
-    int nRpcThreads = std::max(gArgs.GetArg("-rpcthreads", DEFAULT_HTTP_THREADS), 1L);
+    int nRpcThreads = std::max(gArgs.GetArg("-rpcthreads", DEFAULT_HTTP_THREADS), int64_t(1));
     int nFDMin = MIN_CORE_FILEDESCRIPTORS + MAX_ADDNODE_CONNECTIONS + nBind + nRpcThreads;
 
     // Optimistically enforce minimum file descriptors
@@ -1010,12 +1010,12 @@ bool AppInitParameterInteraction()
         return InitError(strprintf(_("Not enough file descriptors available. %d available, %d required."), nFD, nFDMin));
 
     // Calculate new -maxconnection count. Note: std::min<int>(...) to work around FreeBSD compilation issue described in #2695
-    nMaxConnections = std::max(std::min<int>(nMaxConnections, nFD - nFDMin), 0);
+    nMaxConnections = std::min<int>(nMaxConnections, nFD - nFDMin);
     LogPrintf("There are %d file descriptors available, %d required, %d reserved, and %d requested.\n", nFD, nFDMin, nFDMin + nMaxConnections, nFDMin + nUserMaxConnections);
 
     // Display a warning if the number of total maximum connections was lowered
     if (nMaxConnections < nUserMaxConnections)
-        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of file descriptor limitations."), nUserMaxConnections, nMaxConnections));
+        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."), nUserMaxConnections, nMaxConnections));
 
     // ********************************************************* Step 3: parameter-to-internal-flags
     if (gArgs.IsArgSet("-debug")) {
@@ -1777,7 +1777,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     connOptions.nMaxConnections = nMaxConnections;
     connOptions.nMaxOutbound = std::min(MAX_OUTBOUND_CONNECTIONS, connOptions.nMaxConnections);
     connOptions.nMaxAddnode = MAX_ADDNODE_CONNECTIONS;
-    connOptions.nMaxFeeler = NUM_FEELER_CONNECTIONS;
+    connOptions.nMaxFeeler = MAX_FEELER_CONNECTIONS;
     connOptions.nBestHeight = chain_active_height;
     connOptions.uiInterface = &uiInterface;
     connOptions.m_banman = g_banman.get();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1015,7 +1015,7 @@ bool AppInitParameterInteraction()
 
     // Display a warning if the number of total maximum connections was lowered
     if (nMaxConnections < nUserMaxConnections)
-        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."), nUserMaxConnections, nMaxConnections));
+        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of file descriptor limitations."), nUserMaxConnections, nMaxConnections));
 
     // ********************************************************* Step 3: parameter-to-internal-flags
     if (gArgs.IsArgSet("-debug")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1015,7 +1015,7 @@ bool AppInitParameterInteraction()
 
     // Display a warning if the number of total maximum connections was lowered
     if (nMaxConnections < nUserMaxConnections)
-        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of file descriptor limitations."), nUserMaxConnections, nMaxConnections));
+        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."), nUserMaxConnections, nMaxConnections));
 
     // ********************************************************* Step 3: parameter-to-internal-flags
     if (gArgs.IsArgSet("-debug")) {

--- a/src/net.h
+++ b/src/net.h
@@ -60,7 +60,7 @@ static const int MAX_OUTBOUND_CONNECTIONS = 8;
 /** Maximum number of addnode outgoing nodes */
 static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** Number of feeler connections */
-static const int NUM_FEELER_CONNECTIONS = 1;
+static const int MAX_FEELER_CONNECTIONS = 1;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */

--- a/src/net.h
+++ b/src/net.h
@@ -59,6 +59,8 @@ static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 static const int MAX_OUTBOUND_CONNECTIONS = 8;
 /** Maximum number of addnode outgoing nodes */
 static const int MAX_ADDNODE_CONNECTIONS = 8;
+/** Number of feeler connections */
+static const int NUM_FEELER_CONNECTIONS = 1;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */


### PR DESCRIPTION
**Bug 1:** If the daemon does not have enough file descriptors (we'll call them FDs), it is not asserted. 
The daemon only aborts if `FD count < MIN_CORE_FILEDESCRIPTORS(150)`.

**Bug 2:** (Unsure how to reproduce undefined behavior) If the system ulimit setting is a low number, the daemon does not allocate the right amount of FDs during init via `RaiseFileDescriptorLimit`. But it's close.

**Steps to produce Bug 1**: Run `ulimit -n 150`, then start `bitcoind` in the same shell.

**Result:** bitcoind runs normally and displays an erroneous warning:
~~~
Warning: Reducing -maxconnections from 125 to -8, because of system limitations.
...
Using at most -8 automatic connections (150 file descriptors available)
~~~

**Expected:** bitcoind should not start, as it needs roughly 163~172~(?) FDs.

-`MIN_CORE_FILEDESCRIPTORS = 150`
-`MAX_ADDNODE_CONNECTIONS = 8` (new in assertion)
~-`MAX_OUTBOUND_CONNECTIONS = 8`~
~-`CConnman::Options:nMaxFeeler = 1`~(Edit: these exist within the bounds of -maxconnections, if it's high enough)
-Number of `-bind` interfaces, default = 1 (new in allocation)
-Number of `-rpcthreads`, default = 4 (new in allocation and assertion)

150 + 8 + 1 + 4 = 163 minimum
+125 maxconnections = 288 speculative maximum

**Coverage with this patch + `ulimit -n 150`:**
~~~
Bitcoin Core version v0.18.99.0-50ccaa56f -dirty (release build)
Error: Not enough file descriptors available. 150 available, 163 required.
~~~
*daemon closes*

**Coverage with this patch + `ulimit -n 163`:**
~~~
Bitcoin Core version v0.18.99.0-50ccaa56f (release build)
There are 163 file descriptors available, 163 required, 163 reserved, and 288 requested.
Warning: Reducing -maxconnections from 125 to 0, because of file descriptor limitations.
...
Using at most 0 automatic connections (163 file descriptors available)
~~~

**Coverage with this patch + `ulimit -n 203`:**
~~~
Bitcoin Core version v0.18.99.0-50ccaa56f (release build)
There are 203 file descriptors available, 163 required, 203 reserved, and 288 requested.
Warning: Reducing -maxconnections from 125 to 40, because of file descriptor limitations.
...
Using at most 40 automatic connections (203 file descriptors available)
~~~

**Coverage with this patch + 1024 ulimit (matches most Linux systems)**
~~~
Bitcoin Core version v0.18.99.0-50ccaa56f (release build)
There are 1024 file descriptors available, 163 required, 288 reserved, and 288 requested.
...
Using at most 125 automatic connections (1024 file descriptors available)
~~~


The replaced (old) arithmetic smells strange if you consider the subtraction can subtract negative values to increase their value, and any unintended behavior will then be silenced by std::max(x,0). Now there should be less likelyhood of suppressed failure.

Possible fix for #14870

Edit: thanks to IRC chat for the tips!