### PR TITLE
rpc: use walletrbf as default setting in walletcreatefundedpsbt

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4059,7 +4059,7 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
                                     {"vout_index", RPCArg::Type::NUM, RPCArg::Optional::OMITTED, "The zero-based output index, before a change output is added."},
                                 },
                             },
-                            {"replaceable", RPCArg::Type::BOOL, /* default */ "false", "Marks this transaction as BIP125 replaceable.\n"
+                            {"replaceable", RPCArg::Type::BOOL, /* default */ "fallback to wallet's default", "Marks this transaction as BIP125 replaceable.\n"
                             "                              Allows this transaction to be replaced by a transaction with higher fees"},
                             {"conf_target", RPCArg::Type::NUM, /* default */ "Fallback to wallet's confirmation target", "Confirmation target (in blocks)"},
                             {"estimate_mode", RPCArg::Type::STR, /* default */ "UNSET", "The fee estimate mode, must be one of:\n"
@@ -4094,7 +4094,8 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
 
     CAmount fee;
     int change_position;
-    CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], request.params[3]["replaceable"]);
+    UniValue replaceable = request.params[3]["replaceable"].isNull() ? pwallet->m_signal_rbf : request.params[3]["replaceable"];
+    CMutableTransaction rawTx = ConstructTransaction(request.params[0], request.params[1], request.params[2], replaceable);
     FundTransaction(pwallet, rawTx, fee, change_position, request.params[3]);
 
     // Make a blank psbt

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -193,7 +193,7 @@ class PSBTTest(BitcoinTestFramework):
         self.nodes[0].generate(6)
         self.sync_all()
 
-        # Test additional args in walletcreatepsbt
+        # Test additional args in walletcreatefundedpsbt
         # Make sure both pre-included and funded inputs
         # have the correct sequence numbers based on
         # replaceable arg


### PR DESCRIPTION
Fixes #15878.
I've also fixed a trivial comment typo in the test file `rpc_psbt` in this PR.