### PR TITLE
validation: Hold cs_main when reading chainActive in RewindBlockIndex

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4316,6 +4316,7 @@ bool RewindBlockIndex(const CChainParams& params) {
         return false;
     }
 
+    LOCK(cs_main);
     if (::ChainActive().Tip() != nullptr) {
         // FlushStateToDisk can possibly read ::ChainActive(). Be conservative
         // and skip it here, we're about to -reindex-chainstate anyway, so


### PR DESCRIPTION
Fixes #15980.

Hold `cs_main` when reading `chainActive` (via `::ChainActive()`) in `RewindBlockIndex`.