### PR TITLE
tests: RPC bumpfee totalFee deprecation

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -19,6 +19,7 @@
 #include <protocol.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
+#include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>
 #include <threadsafety.h>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -364,13 +364,6 @@ void JSONRPCRequest::parse(const UniValue& valRequest)
         throw JSONRPCError(RPC_INVALID_REQUEST, "Params must be an array or object");
 }
 
-bool IsDeprecatedRPCEnabled(const std::string& method)
-{
-    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
-
-    return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
-}
-
 static UniValue JSONRPCExecOne(JSONRPCRequest jreq, const UniValue& req)
 {
     UniValue rpc_result(UniValue::VOBJ);

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -171,8 +171,6 @@ public:
     bool removeCommand(const std::string& name, const CRPCCommand* pcmd);
 };
 
-bool IsDeprecatedRPCEnabled(const std::string& method);
-
 extern CRPCTable tableRPC;
 
 void StartRPC();

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -7,6 +7,7 @@
 #include <rpc/util.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 
 #include <tuple>
 
@@ -684,4 +685,11 @@ std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value)
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Range is too large");
     }
     return {low, high};
+}
+
+bool IsDeprecatedRPCEnabled(const std::string& method)
+{
+    const std::vector<std::string> enabled_methods = gArgs.GetArgs("-deprecatedrpc");
+
+    return find(enabled_methods.begin(), enabled_methods.end(), method) != enabled_methods.end();
 }

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -245,4 +245,6 @@ private:
     const RPCExamples m_examples;
 };
 
+bool IsDeprecatedRPCEnabled(const std::string& method);
+
 #endif // BITCOIN_RPC_UTIL_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3253,12 +3253,12 @@ static UniValue bumpfee(const JSONRPCRequest& request)
                 "\nBumps the fee of an opt-in-RBF transaction T, replacing it with a new transaction B.\n"
                 "An opt-in RBF transaction with the given txid must be in the wallet.\n"
                 "The command will pay the additional fee by reducing change outputs or adding inputs when necessary. It may add a new change output if one does not already exist.\n"
-                "If `totalFee` is given, adding inputs is not supported, so there must be a single change output that is big enough or it will fail.\n"
+                "If `totalFee`(DEPRECATED) is given, adding inputs is not supported, so there must be a single change output that is big enough or it will fail.\n"
                 "All inputs in the original transaction will be included in the replacement transaction.\n"
                 "The command will fail if the wallet or mempool contains a transaction that spends one of T's outputs.\n"
                 "By default, the new fee will be calculated automatically using estimatesmartfee.\n"
                 "The user can specify a confirmation target for estimatesmartfee.\n"
-                "Alternatively, the user can specify totalFee, or use RPC settxfee to set a higher fee rate.\n"
+                "Alternatively, the user can specify totalFee(DEPRECATED), or use RPC settxfee to set a higher fee rate.\n"
                 "At a minimum, the new fee rate must be high enough to pay an additional new relay fee (incrementalfee\n"
                 "returned by getnetworkinfo) to enter the node's mempool.\n",
                 {
@@ -3266,7 +3266,7 @@ static UniValue bumpfee(const JSONRPCRequest& request)
                     {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "",
                         {
                             {"confTarget", RPCArg::Type::NUM, /* default */ "fallback to wallet's default", "Confirmation target (in blocks)"},
-                            {"totalFee", RPCArg::Type::NUM, /* default */ "fallback to 'confTarget'", "Total fee (NOT feerate) to pay, in satoshis.\n"
+                            {"totalFee", RPCArg::Type::NUM, /* default */ "(DEPRECATED) fallback to 'confTarget'", "Total fee (NOT feerate) to pay, in satoshis.\n"
             "                         In rare cases, the actual fee paid might be slightly higher than the specified\n"
             "                         totalFee if the tx change output has to be removed because it is too close to\n"
             "                         the dust threshold."},
@@ -3322,6 +3322,9 @@ static UniValue bumpfee(const JSONRPCRequest& request)
         } else if (options.exists("confTarget")) { // TODO: alias this to conf_target
             coin_control.m_confirm_target = ParseConfirmTarget(options["confTarget"], pwallet->chain().estimateMaxBlocks());
         } else if (options.exists("totalFee")) {
+            if (!IsDeprecatedRPCEnabled("totalFee")) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "totalFee argument has been deprecated and will be removed in 0.20. Please use -deprecatedrpc=totalFee to continue using this argument until removal.");
+            }
             totalFee = options["totalFee"].get_int64();
             if (totalFee <= 0) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid totalFee %s (must be greater than 0)", FormatMoney(totalFee)));

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -171,6 +171,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --nonloopback',
     'mining_basic.py',
     'wallet_bumpfee.py',
+    'wallet_bumpfee_totalfee_deprecation.py',
     'rpc_named_arguments.py',
     'wallet_listsinceblock.py',
     'p2p_leak.py',

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -37,6 +37,7 @@ class BumpFeeTest(BitcoinTestFramework):
         self.extra_args = [[
             "-walletrbf={}".format(i),
             "-mintxfee=0.00002",
+            "-deprecatedrpc=totalFee",
         ] for i in range(self.num_nodes)]
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -23,7 +23,6 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
-    connect_nodes_bi,
     hex_str_to_bytes,
 )
 
@@ -44,14 +43,14 @@ class BumpFeeTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        # Encrypt wallet for test_locked_wallet_fails test
-        self.nodes[1].encryptwallet(WALLET_PASSPHRASE)
-        self.nodes[1].walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+        peer_node, rbf_node = self.nodes
 
-        connect_nodes_bi(self.nodes, 0, 1)
+        # Encrypt wallet for test_locked_wallet_fails test
+        rbf_node.encryptwallet(WALLET_PASSPHRASE)
+        rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)
+
         self.sync_all()
 
-        peer_node, rbf_node = self.nodes
         rbf_node_address = rbf_node.getnewaddress()
 
         # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)

--- a/test/functional/wallet_bumpfee_totalfee_deprecation.py
+++ b/test/functional/wallet_bumpfee_totalfee_deprecation.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test deprecation of passing `totalFee` to the bumpfee RPC."""
+from decimal import Decimal
+
+from test_framework.messages import BIP125_SEQUENCE_NUMBER
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+class BumpFeeWithTotalFeeArgumentDeprecationTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.extra_args = [[
+            "-walletrbf={}".format(i),
+            "-mintxfee=0.00002",
+        ] for i in range(self.num_nodes)]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        peer_node, rbf_node = self.nodes
+        peer_node.generate(110)
+        self.sync_all()
+        peer_node.sendtoaddress(rbf_node.getnewaddress(), 0.001)
+        self.sync_all()
+        peer_node.generate(1)
+        self.sync_all()
+        rbfid = spend_one_input(rbf_node, peer_node.getnewaddress())
+
+        self.log.info("Testing bumpfee with totalFee argument raises RPC error with deprecation message")
+        assert_raises_rpc_error(
+            -8,
+            "totalFee argument has been deprecated and will be removed in 0.20. " +
+            "Please use -deprecatedrpc=totalFee to continue using this argument until removal.",
+            rbf_node.bumpfee, rbfid, {"totalFee": 2000})
+
+        self.log.info("Testing bumpfee without totalFee argument does not raise")
+        rbf_node.bumpfee(rbfid)
+
+def spend_one_input(node, dest_address, change_size=Decimal("0.00049000")):
+    tx_input = dict(sequence=BIP125_SEQUENCE_NUMBER,
+                    **next(u for u in node.listunspent() if u["amount"] == Decimal("0.00100000")))
+    destinations = {dest_address: Decimal("0.00050000")}
+    destinations[node.getrawchangeaddress()] = change_size
+    rawtx = node.createrawtransaction([tx_input], destinations)
+    signedtx = node.signrawtransactionwithwallet(rawtx)
+    txid = node.sendrawtransaction(signedtx["hex"])
+    return txid
+
+if __name__ == "__main__":
+    BumpFeeWithTotalFeeArgumentDeprecationTest().main()


### PR DESCRIPTION
This is a follow-up to PR #15996 which deprecates the `totalFee` argument in RPC bumpfee.

If that PR is merged, several of the wallet_bumpfee tests will need to be updated to not use `totalFee`.

But first, we need a test for the deprecation itself. The intent of this PR is to add that coverage.