### PR TITLE
banman: BanLevel enum

### DIFF
--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -67,13 +67,10 @@ void BanMan::ClearBanned()
     if (m_client_interface) m_client_interface->BannedListChanged();
 }
 
-int BanMan::IsBannedLevel(CNetAddr net_addr)
+BanLevel BanMan::IsBannedLevel(CNetAddr net_addr)
 {
     // Returns the most severe level of banning that applies to this address.
-    // 0 - Not banned
-    // 1 - Automatic misbehavior ban
-    // 2 - Any other ban
-    int level = 0;
+    BanLevel level = BanLevel::NOT_BANNED;
     auto current_time = GetTime();
     LOCK(m_cs_banned);
     for (const auto& it : m_banned) {
@@ -81,8 +78,8 @@ int BanMan::IsBannedLevel(CNetAddr net_addr)
         CBanEntry ban_entry = it.second;
 
         if (current_time < ban_entry.nBanUntil && sub_net.Match(net_addr)) {
-            if (ban_entry.banReason != BanReasonNodeMisbehaving) return 2;
-            level = 1;
+            if (ban_entry.banReason != BanReasonNodeMisbehaving) return BanLevel::ANY_OTHER_BAN;
+            level = BanLevel::AUTOMATIC_MISBEHAVIOUR_BAN;
         }
     }
     return level;

--- a/src/banman.h
+++ b/src/banman.h
@@ -34,6 +34,12 @@ class CSubNet;
 // between nodes running old code and nodes running
 // new code.
 
+enum class BanLevel {
+    NOT_BANNED                  =    0,
+    AUTOMATIC_MISBEHAVIOUR_BAN  =    1,
+    ANY_OTHER_BAN               =    2
+};
+
 class BanMan
 {
 public:
@@ -42,7 +48,7 @@ public:
     void Ban(const CNetAddr& net_addr, const BanReason& ban_reason, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
     void Ban(const CSubNet& sub_net, const BanReason& ban_reason, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
     void ClearBanned();
-    int IsBannedLevel(CNetAddr net_addr);
+    BanLevel IsBannedLevel(CNetAddr net_addr);
     bool IsBanned(CNetAddr net_addr);
     bool IsBanned(CSubNet sub_net);
     bool Unban(const CNetAddr& net_addr);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -933,11 +933,11 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     // on all platforms.  Set it again here just to be sure.
     SetSocketNoDelay(hSocket);
 
-    int bannedlevel = m_banman ? m_banman->IsBannedLevel(addr) : 0;
+    BanLevel bannedlevel = m_banman ? m_banman->IsBannedLevel(addr) : BanLevel::NOT_BANNED;
 
     // Don't accept connections from banned peers, but if our inbound slots aren't almost full, accept
     // if the only banning reason was an automatic misbehavior ban.
-    if (!whitelisted && bannedlevel > ((nInbound + 1 < nMaxInbound) ? 1 : 0))
+    if (!whitelisted && bannedlevel > ((nInbound + 1 < nMaxInbound) ? BanLevel::AUTOMATIC_MISBEHAVIOUR_BAN : BanLevel::NOT_BANNED))
     {
         LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
         CloseSocket(hSocket);
@@ -961,7 +961,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), hSocket, addr, CalculateKeyedNetGroup(addr), nonce, addr_bind, "", true);
     pnode->AddRef();
     pnode->fWhitelisted = whitelisted;
-    pnode->m_prefer_evict = bannedlevel > 0;
+    pnode->m_prefer_evict = bannedlevel != BanLevel::NOT_BANNED;
     m_msgproc->InitializeNode(pnode);
 
     LogPrint(BCLog::NET, "connection from %s accepted\n", addr.ToString());


### PR DESCRIPTION
This pull request modify the banman IsBannedLevel return value from an int to an enum which describes the BanLevel value itself, without using magic numbers to identify different types of ban.

https://github.com/bitcoin/bitcoin/issues/15929