### PR TITLE
travis: Run all lint scripts even if one fails

### DIFF
--- a/test/lint/lint-all.sh
+++ b/test/lint/lint-all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2017 The Bitcoin Core developers
+# Copyright (c) 2017-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #
@@ -16,11 +16,15 @@ set -u
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 LINTALL=$(basename "${BASH_SOURCE[0]}")
 
+EXIT_CODE=0
+
 for f in "${SCRIPTDIR}"/lint-*.sh; do
   if [ "$(basename "$f")" != "$LINTALL" ]; then
     if ! "$f"; then
       echo "^---- failure generated from $f"
-      exit 1
+      EXIT_CODE=1
     fi
   fi
 done
+
+exit ${EXIT_CODE}


### PR DESCRIPTION
The description reads:

```
# This script runs all contrib/devtools/lint-*.sh files, and fails if any exit
# with a non-zero status code.
```

This runs all scripts and returns with a non-zero exit code if any failed.
