### PR TITLE
Drop BanLevel in favor of Optional<BanReason>

### DIFF
--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -16,12 +16,12 @@ class CSubNet;
 class CAddrMan;
 class CDataStream;
 
-typedef enum BanReason
+enum class BanReason
 {
-    BanReasonUnknown          = 0,
-    BanReasonNodeMisbehaving  = 1,
-    BanReasonManuallyAdded    = 2
-} BanReason;
+    Unknown          = 0,
+    NodeMisbehaving  = 1,
+    ManuallyAdded    = 2
+};
 
 class CBanEntry
 {
@@ -30,7 +30,7 @@ public:
     int nVersion;
     int64_t nCreateTime;
     int64_t nBanUntil;
-    uint8_t banReason;
+    BanReason banReason;
 
     CBanEntry()
     {
@@ -55,7 +55,7 @@ public:
         READWRITE(this->nVersion);
         READWRITE(nCreateTime);
         READWRITE(nBanUntil);
-        READWRITE(banReason);
+        READWRITE((uint8_t) banReason);
     }
 
     void SetNull()
@@ -63,17 +63,17 @@ public:
         nVersion = CBanEntry::CURRENT_VERSION;
         nCreateTime = 0;
         nBanUntil = 0;
-        banReason = BanReasonUnknown;
+        banReason = BanReason::Unknown;
     }
 
     std::string banReasonToString() const
     {
         switch (banReason) {
-        case BanReasonNodeMisbehaving:
+        case BanReason::NodeMisbehaving:
             return "node misbehaving";
-        case BanReasonManuallyAdded:
+        case BanReason::ManuallyAdded:
             return "manually added";
-        default:
+        case BanReason::Unknown:
             return "unknown";
         }
     }

--- a/src/banman.cpp
+++ b/src/banman.cpp
@@ -78,8 +78,8 @@ Optional<BanReason> BanMan::IsBannedReason(CNetAddr net_addr)
         CBanEntry ban_entry = it.second;
 
         if (current_time < ban_entry.nBanUntil && sub_net.Match(net_addr)) {
-            if (ban_entry.banReason != BanReasonNodeMisbehaving) return BanReason(ban_entry.banReason);
-            reason = BanReason(ban_entry.banReason);
+            if (ban_entry.banReason != BanReason::NodeMisbehaving) return ban_entry.banReason;
+            reason = ban_entry.banReason;
         }
     }
     return reason;
@@ -133,7 +133,7 @@ void BanMan::Ban(const CSubNet& sub_net, const BanReason& ban_reason, int64_t ba
     if (m_client_interface) m_client_interface->BannedListChanged();
 
     //store banlist to disk immediately if user requested ban
-    if (ban_reason == BanReasonManuallyAdded) DumpBanlist();
+    if (ban_reason == BanReason::ManuallyAdded) DumpBanlist();
 }
 
 bool BanMan::Unban(const CNetAddr& net_addr)

--- a/src/banman.h
+++ b/src/banman.h
@@ -10,6 +10,7 @@
 
 #include <addrdb.h>
 #include <fs.h>
+#include <optional.h>
 #include <sync.h>
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
@@ -42,7 +43,7 @@ public:
     void Ban(const CNetAddr& net_addr, const BanReason& ban_reason, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
     void Ban(const CSubNet& sub_net, const BanReason& ban_reason, int64_t ban_time_offset = 0, bool since_unix_epoch = false);
     void ClearBanned();
-    int IsBannedLevel(CNetAddr net_addr);
+    Optional<BanReason> IsBannedReason(CNetAddr net_addr);
     bool IsBanned(CNetAddr net_addr);
     bool IsBanned(CSubNet sub_net);
     bool Unban(const CNetAddr& net_addr);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -938,7 +938,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
 
     // Don't accept connections from banned peers, but if our inbound slots aren't almost full, accept
     // if the only banning reason was an automatic misbehavior ban.
-    if (!whitelisted && bannedreason != nullopt && ((nInbound + 1 >= nMaxInbound) || bannedreason != BanReasonNodeMisbehaving)) {
+    if (!whitelisted && bannedreason != nullopt && ((nInbound + 1 >= nMaxInbound) || bannedreason != BanReason::NodeMisbehaving)) {
         LogPrint(BCLog::NET, "connection from %s dropped (banned)\n", addr.ToString());
         CloseSocket(hSocket);
         return;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3183,7 +3183,7 @@ bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_
         } else {
             // Disconnect and ban all nodes sharing the address
             if (m_banman) {
-                m_banman->Ban(pnode->addr, BanReasonNodeMisbehaving);
+                m_banman->Ban(pnode->addr, BanReason::NodeMisbehaving);
             }
             connman->DisconnectNode(pnode->addr);
         }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1215,7 +1215,7 @@ void RPCConsole::banSelectedNode(int bantime)
         // Find possible nodes, ban it and clear the selected node
         const CNodeCombinedStats *stats = clientModel->getPeerTableModel()->getNodeStats(detailNodeRow);
         if (stats) {
-            m_node.ban(stats->nodeStats.addr, BanReasonManuallyAdded, bantime);
+            m_node.ban(stats->nodeStats.addr, BanReason::ManuallyAdded, bantime);
             m_node.disconnect(stats->nodeStats.addr);
         }
     }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -582,12 +582,12 @@ static UniValue setban(const JSONRPCRequest& request)
             absolute = true;
 
         if (isSubnet) {
-            g_banman->Ban(subNet, BanReasonManuallyAdded, banTime, absolute);
+            g_banman->Ban(subNet, BanReason::ManuallyAdded, banTime, absolute);
             if (g_connman) {
                 g_connman->DisconnectNode(subNet);
             }
         } else {
-            g_banman->Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
+            g_banman->Ban(netAddr, BanReason::ManuallyAdded, banTime, absolute);
             if (g_connman) {
                 g_connman->DisconnectNode(netAddr);
             }


### PR DESCRIPTION
BanLevel was a very narrow concept which served a limited purpose. Removing
it removes a layer of indirection.

Alternative to #16018
Fixes #15929