### PR TITLE
docs: add release note for 14954

### DIFF
--- a/doc/release-notes-14954.md
+++ b/doc/release-notes-14954.md
@@ -1,0 +1,3 @@
+Build system changes
+--------------------
+Python >=3.5 is now required by all aspects of the project. This includes the build systems, test framework and linters. The previously supported minimum (3.4), was EOL in March 2019. See #14954 for more details.


### PR DESCRIPTION
Adds a release note for #14954: build: Require python 3.5.