### PR TITLE
depends: Build secondary deps statically.

### DIFF
--- a/depends/packages.md
+++ b/depends/packages.md
@@ -5,6 +5,10 @@ The package "mylib" will be used here as an example
 
 General tips:
 - mylib_foo is written as $(package)_foo in order to make recipes more similar.
+- Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.
+  those not in `ALLOWED_LIBRARIES` in `contrib/devtools/symbol-check.py`) don't
+  need to be shared and should be built statically whenever possible. See
+  [below](#secondary-dependencies) for more details.
 
 ## Identifiers
 Each package is required to define at least these variables:
@@ -146,3 +150,22 @@ $($(package)_config_opts) will be appended.
 Most autotools projects can be properly staged using:
 
     $(MAKE) DESTDIR=$($(package)_staging_dir) install
+
+## Secondary dependencies:
+
+Secondary dependency packages relative to the bitcoin binaries/libraries (i.e.
+those not in `ALLOWED_LIBRARIES` in `contrib/devtools/symbol-check.py`) don't
+need to be shared and should be built statically whenever possible. This
+improves general build reliability as illustrated by the following example:
+
+When linking an executable against a shared library `libprimary` that has its
+own shared dependency `libsecondary`, we may need to specify the path to
+`libsecondary` on the link command using the `-rpath/-rpath-link` options, it is
+not sufficient to just say `libprimary`.
+
+For us, it's much easier to just link a static `libsecondary` into a shared
+`libprimary`. Especially because in our case, we are linking against a dummy
+`libprimary` anyway that we'll throw away. We don't care if the end-user has a
+static or dynamic `libsecondary`, that's not our concern. With a static
+`libsecondary`, when we need to link `libprimary` into our executable, there's
+no dependency chain to worry about as `libprimary` has all the symbols.

--- a/depends/packages/dbus.mk
+++ b/depends/packages/dbus.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=6049ddd5f3f3e2618f615f1faeda0a115104423a7996b7aa73e2f36e3
 $(package)_dependencies=expat
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-tests --disable-doxygen-docs --disable-xml-docs --disable-static --without-x
+  $(package)_config_opts=--disable-tests --disable-doxygen-docs --disable-xml-docs --disable-shared --without-x
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -5,7 +5,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=17b43c2716d521369f82fc2dc70f359860e90fa440bea65b3b85f0b246ea81f2
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --without-docbook
+  $(package)_config_opts=--disable-shared --without-docbook
+  $(package)_config_opts_linux=--with-pic
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libXext.mk
+++ b/depends/packages/libXext.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=f829075bc646cdc085fa25d98d5885d83b1759ceb355933127c257e8e
 $(package)_dependencies=xproto xextproto libX11 libXau
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-static
+  $(package)_config_opts=--disable-shared
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/xtrans.mk
+++ b/depends/packages/xtrans.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=054d4ee3efd52508c753e9f7bc655ef185a29bd2850dd9e2fc2ccc335
 $(package)_dependencies=
 
 define $(package)_set_vars
-$(package)_config_opts_linux=--with-pic --disable-static
+$(package)_config_opts_linux=--with-pic --disable-shared
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
Secondary dependencies don't need to be shared. Comes at theuni's request.

~~To do: add documentation so future secondary dependencies aren't shared.~~ DONE

-----

Let's merge this first as https://github.com/bitcoin/bitcoin/pull/15844 is based on this PR.