### PR TITLE
Skip redundant memset(p, 0, 0) calls where p is not valid for writing

### DIFF
--- a/src/crypto/hmac_sha256.cpp
+++ b/src/crypto/hmac_sha256.cpp
@@ -11,7 +11,9 @@ CHMAC_SHA256::CHMAC_SHA256(const unsigned char* key, size_t keylen)
     unsigned char rkey[64];
     if (keylen <= 64) {
         memcpy(rkey, key, keylen);
-        memset(rkey + keylen, 0, 64 - keylen);
+        if (keylen < 64) {
+            memset(rkey + keylen, 0, 64 - keylen);
+        }
     } else {
         CSHA256().Write(key, keylen).Finalize(rkey);
         memset(rkey + 32, 0, 32);

--- a/src/crypto/hmac_sha512.cpp
+++ b/src/crypto/hmac_sha512.cpp
@@ -11,7 +11,9 @@ CHMAC_SHA512::CHMAC_SHA512(const unsigned char* key, size_t keylen)
     unsigned char rkey[128];
     if (keylen <= 128) {
         memcpy(rkey, key, keylen);
-        memset(rkey + keylen, 0, 128 - keylen);
+        if (keylen < 128) {
+            memset(rkey + keylen, 0, 128 - keylen);
+        }
     } else {
         CSHA512().Write(key, keylen).Finalize(rkey);
         memset(rkey + 64, 0, 64);


### PR DESCRIPTION
Skip redundant `memset(p, 0, 0)` calls where `p` is not valid for writing.

Context: See second section of https://github.com/bitcoin/bitcoin/pull/15950#issuecomment-489461791

Nothing urgent obviously and perhaps not even an issue (the spec is a bit unclear) but would be nice to err on the side of caution in unclear cases like this :-)