### PR TITLE
doc: analyzepsbt description in doc/psbt.md

### DIFF
--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -82,9 +82,10 @@ hardware implementations will typically implement multiple roles simultaneously.
   transactions.
 - **`decodepsbt`** is a diagnostic utility RPC which will show all information in
   a PSBT in human-readable form, as well as compute its eventual fee if known.
-- **`analyzepsbt`** is a utility RPC that examines an RPC and reports the
-  next steps in the workflow if known, computes the fee of the resulting
-  transaction, and estimates the weight and feerate if possible.
+- **`analyzepsbt`** is a utility RPC that examines a PSBT and reports the
+  current status of its inputs, the next step in the workflow if known, and if
+  possible, computes the fee of the resulting transaction and estimates the
+  final weight and feerate.
 
 
 ### Workflows


### PR DESCRIPTION
- fix: replace "RPC" with "PSBT"

- output includes the current status of the analyzed psbt's inputs

- apply "if possible" to the fee as well as to the estimated weight and feerate, since the fee is only shown if all utxo slots in the psbt have been filled

- add "final" to the estimated weight and feerate
