### PR TITLE
rpc: Control if rescan updates/notifies existing transactions on importmulti

### DIFF
--- a/doc/release-notes-16050.md
+++ b/doc/release-notes-16050.md
@@ -1,0 +1,5 @@
+RPC changes
+-----------
+The RPC `importmulti` has a new option `update_existing` to control whether
+rescan updates existing transactions. When `false`, only new wallet transactions
+are notified to the `-walletnotify` script.

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -1401,6 +1401,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
                     {"options", RPCArg::Type::OBJ, RPCArg::Optional::OMITTED_NAMED_ARG, "",
                         {
                             {"rescan", RPCArg::Type::BOOL, /* default */ "true", "Stating if should rescan the blockchain after all imports"},
+                            {"update_existing", RPCArg::Type::BOOL, /* default */ "true", "Stating if rescan should update and notify existing transactions"},
                         },
                         "\"options\""},
                 },
@@ -1423,12 +1424,17 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     //Default options
     bool fRescan = true;
+    bool update_existing = true;
 
     if (!mainRequest.params[1].isNull()) {
         const UniValue& options = mainRequest.params[1];
 
         if (options.exists("rescan")) {
             fRescan = options["rescan"].get_bool();
+        }
+
+        if (options.exists("update_existing")) {
+            update_existing = options["update_existing"].get_bool();
         }
     }
 
@@ -1482,7 +1488,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
         }
     }
     if (fRescan && fRunScan && requests.size()) {
-        int64_t scannedTime = pwallet->RescanFromTime(nLowestTimestamp, reserver, true /* update */);
+        int64_t scannedTime = pwallet->RescanFromTime(nLowestTimestamp, reserver, update_existing);
         {
             auto locked_chain = pwallet->chain().lock();
             LOCK(pwallet->cs_wallet);


### PR DESCRIPTION
This PR adds a new option rescanUpdate in importmulti RPC method to optionally do not rescan transactions that already exist in the wallet.

This is very important for large wallets when importing a single address with a old timestamp, which in this moment triggers a rescan to the whole wallet, replaying several already known wallet events (via notify-wallet).

Continues the work done in #11484.

Changed the option from `update` to `update_existing`, added test and release note.