### PR TITLE
depends: add patch to common dependencies

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -43,7 +43,7 @@ No other options are needed, the paths are automatically configured.
 
 Common linux dependencies:
 
-    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3
+    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch
 
 For linux ARM cross compilation:
 


### PR DESCRIPTION
Building on a bare system:
```
/bitcoin/depends/work/download/zeromq-4.3.1/zeromq-4.3.1.tar.gz.temp: OK
Extracting zeromq...
/bitcoin/depends/sources/zeromq-4.3.1.tar.gz: OK
Preprocessing zeromq...
/bin/sh: 1: patch: not found
```