### PR TITLE
mempool: remove unused magic number from consistency check

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -601,7 +601,7 @@ static void CheckInputsAndUpdateCoins(const CTransaction& tx, CCoinsViewCache& m
     CAmount txfee = 0;
     bool fCheckResult = tx.IsCoinBase() || Consensus::CheckTxInputs(tx, state, mempoolDuplicate, spendheight, txfee);
     assert(fCheckResult);
-    UpdateCoins(tx, mempoolDuplicate, 1000000);
+    UpdateCoins(tx, mempoolDuplicate, std::numeric_limits<int>::max());
 }
 
 void CTxMemPool::check(const CCoinsViewCache *pcoins) const


### PR DESCRIPTION
Unexplained magic numbers are no good. Since the exact number does not matter, opt for a constant that is less peculiar.

Note that this could only possibly affect mempool consistency checks which is not active by default except on regtest.

see discussion: https://github.com/bitcoin/bitcoin/issues/15080