### PR TITLE
net: Remove -whitelistforcerelay

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -528,7 +528,6 @@ void SetupServerArgs()
     gArgs.AddArg("-mempoolreplacement", strprintf("Enable transaction replacement in the memory pool (default: %u)", DEFAULT_ENABLE_REPLACEMENT), false, OptionsCategory::NODE_RELAY);
     gArgs.AddArg("-minrelaytxfee=<amt>", strprintf("Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and transaction creation (default: %s)",
         CURRENCY_UNIT, FormatMoney(DEFAULT_MIN_RELAY_TX_FEE)), false, OptionsCategory::NODE_RELAY);
-    gArgs.AddArg("-whitelistforcerelay", strprintf("Force relay of transactions from whitelisted peers even if the transactions were already in the mempool or violate local relay policy (default: %d)", DEFAULT_WHITELISTFORCERELAY), false, OptionsCategory::NODE_RELAY);
     gArgs.AddArg("-whitelistrelay", strprintf("Accept relayed transactions received from whitelisted peers even when not relaying transactions (default: %d)", DEFAULT_WHITELISTRELAY), false, OptionsCategory::NODE_RELAY);
 
 
@@ -831,12 +830,6 @@ void InitParameterInteraction()
     if (gArgs.GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY)) {
         if (gArgs.SoftSetBoolArg("-whitelistrelay", false))
             LogPrintf("%s: parameter interaction: -blocksonly=1 -> setting -whitelistrelay=0\n", __func__);
-    }
-
-    // Forcing relay from whitelisted hosts implies we will accept relays from them in the first place.
-    if (gArgs.GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY)) {
-        if (gArgs.SoftSetBoolArg("-whitelistrelay", true))
-            LogPrintf("%s: parameter interaction: -whitelistforcerelay=1 -> setting -whitelistrelay=1\n", __func__);
     }
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -49,8 +49,6 @@ struct LockPoints;
 
 /** Default for -whitelistrelay. */
 static const bool DEFAULT_WHITELISTRELAY = true;
-/** Default for -whitelistforcerelay. */
-static const bool DEFAULT_WHITELISTFORCERELAY = false;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
 static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */


### PR DESCRIPTION
This flag has been added in 86755bc to allow "(re-)broadcast" of transactions through a "gateway" node.

However, if our gateway node does not accept the transaction, the peers connected to the gateway are likely to not accept it as well.
For illustrative purposes, a list of example tx reject reasons that would result in tx (re-)broadcast:
* Tx is already in the mempool
* Tx has too low fee to get into the mempool
* Tx violates standardness policy

So a smaller than default mempool (or higher than default minrelaytxfee) is probably the only reason a tx could be rejected by our gateway and be accepted by other peers.

Instead of using `whitelistforcerelay` for that use case, I suggest to run a recent version of Bitcoin Core with a default (or higher than default) maxmempool setting and default (or lower than default) minrelaytxfee settings.

Note that the setting has then been turned off by default in 72bd4ab.
