### PR TITLE
mempool: Skip estimator if block is older than X

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -547,7 +547,7 @@ void CTxMemPool::removeConflicts(const CTransaction &tx)
 /**
  * Called when a block is connected. Removes from mempool and updates the miner fee estimator.
  */
-void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight)
+void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight, bool update_estimator)
 {
     LOCK(cs);
     std::vector<const CTxMemPoolEntry*> entries;
@@ -560,7 +560,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
             entries.push_back(&*i);
     }
     // Before the txs in the new block have been removed from the mempool, update policy estimates
-    if (minerPolicyEstimator) {minerPolicyEstimator->processBlock(nBlockHeight, entries);}
+    if (update_estimator && minerPolicyEstimator) {minerPolicyEstimator->processBlock(nBlockHeight, entries);}
     for (const auto& tx : vtx)
     {
         txiter it = mapTx.find(tx->GetHash());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -585,7 +585,7 @@ public:
     void removeRecursive(const CTransaction &tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN);
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
     void removeConflicts(const CTransaction &tx) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
+    void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight, bool update_estimator = true);
 
     void clear();
     void _clear() EXCLUSIVE_LOCKS_REQUIRED(cs); //lock free

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2459,7 +2459,7 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
     int64_t nTime5 = GetTimeMicros(); nTimeChainState += nTime5 - nTime4;
     LogPrint(BCLog::BENCH, "  - Writing chainstate: %.2fms [%.2fs (%.2fms/blk)]\n", (nTime5 - nTime4) * MILLI, nTimeChainState * MICRO, nTimeChainState * MILLI / nBlocksTotal);
     // Remove conflicting transactions from the mempool.;
-    mempool.removeForBlock(blockConnecting.vtx, pindexNew->nHeight);
+    mempool.removeForBlock(blockConnecting.vtx, pindexNew->nHeight, GuessVerificationProgress(chainparams.TxData(), pindexNew) > 0.9);
     disconnectpool.removeForBlock(blockConnecting.vtx);
     // Update m_chain & related variables.
     m_chain.SetTip(pindexNew);

--- a/src/validation.h
+++ b/src/validation.h
@@ -107,6 +107,8 @@ static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 /** Maximum age of our tip in seconds for us to be considered current for fee estimation */
 static const int64_t MAX_FEE_ESTIMATION_TIP_AGE = 3 * 60 * 60;
+/** Maximum block age in seconds for us to be considered suitable for fee estimator */
+static const int64_t MAX_FEE_ESTIMATOR_BLOCK_AGE = 48 * 60 * 60;
 
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;


### PR DESCRIPTION
While profiling IBD it seems to be a waste of resources to keep the estimator updated from the start. Currently, with this change, the estimator is not updated if the block is older than 2 days (`MAX_FEE_ESTIMATOR_BLOCK_AGE`). This is temporary, a proper age should be used so that the estimator result is identical.

Please advice, opening as a draft.

Stack trace before and after:
![Screenshot 2019-05-21 at 16 12 02](https://user-images.githubusercontent.com/3534524/58108325-8fb04f80-7be3-11e9-9363-aac724f3c5a3.png)

![Screenshot 2019-05-21 at 16 13 32](https://user-images.githubusercontent.com/3534524/58108361-9b037b00-7be3-11e9-8d1b-072e7396c871.png)
