### PR TITLE
refactor: Improve CRollingBloomFilter::reset by using std::fill

### DIFF
--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -28,4 +28,13 @@ static void RollingBloom(benchmark::State& state)
     }
 }
 
+static void RollingBloomReset(benchmark::State& state)
+{
+    CRollingBloomFilter filter(120000, 0.000001);
+    while (state.KeepRunning()) {
+        filter.reset();
+    }
+}
+
 BENCHMARK(RollingBloom, 1500 * 1000);
+BENCHMARK(RollingBloomReset, 20000);

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -14,6 +14,7 @@
 #include <math.h>
 #include <stdlib.h>
 
+#include <algorithm>
 
 #define LN2SQUARED 0.4804530139182014246671025263266649717305529515945455
 #define LN2 0.6931471805599453094172321214581765680755001343602552
@@ -304,7 +305,5 @@ void CRollingBloomFilter::reset()
     nTweak = GetRand(std::numeric_limits<unsigned int>::max());
     nEntriesThisGeneration = 0;
     nGeneration = 1;
-    for (std::vector<uint64_t>::iterator it = data.begin(); it != data.end(); it++) {
-        *it = 0;
-    }
+    std::fill(data.begin(), data.end(), 0);
 }


### PR DESCRIPTION
Cleaner code. Also improves performance with `--enable-debug` (which is meaningless to non-developers).

Before:
```
# Benchmark, evals, iterations, total, min, max, median
RollingBloomReset, 5, 150, 19.3008, 0.0254917, 0.0259195, 0.0257395
```
After:
```
# Benchmark, evals, iterations, total, min, max, median
RollingBloomReset, 5, 150, 5.43269, 0.00720651, 0.00729697, 0.00724854
```