### PR TITLE
depends: add ability to skip building zeromq

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -7,6 +7,7 @@ SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 RAPIDCHECK ?=
 NO_WALLET ?=
+NO_ZMQ ?=
 NO_UPNP ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
@@ -93,6 +94,7 @@ $(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
 qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
+zmq_packages_$(NO_ZMQ) = $(zmq_packages)
 
 rapidcheck_packages_$(RAPIDCHECK) = $(rapidcheck_packages)
 
@@ -101,6 +103,10 @@ native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_nativ
 
 ifneq ($(qt_packages_),)
 native_packages += $(qt_native_packages)
+endif
+
+ifneq ($(zmq_packages_),)
+packages += $(zmq_packages)
 endif
 
 ifeq ($(rapidcheck_packages_),)
@@ -143,6 +149,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@no_qt@|$(NO_QT)|' \
+            -e 's|@no_zmq@|$(NO_ZMQ)|' \
             -e 's|@no_wallet@|$(NO_WALLET)|' \
             -e 's|@no_upnp@|$(NO_UPNP)|' \
             -e 's|@debug@|$(DEBUG)|' \

--- a/depends/README.md
+++ b/depends/README.md
@@ -68,6 +68,7 @@ The following can be set when running make: make FOO=bar
     SDK_PATH: Path where sdk's can be found (used by macOS)
     FALLBACK_DOWNLOAD_PATH: If a source file can't be fetched, try here before giving up
     NO_QT: Don't download/build/cache qt and its dependencies
+    NO_ZMQ: Don't download/build/cache packages needed for enabling zeromq
     NO_WALLET: Don't download/build/cache libs needed to enable the wallet
     NO_UPNP: Don't download/build/cache packages needed for enabling upnp
     DEBUG: disable some optimizations and enable more runtime checking

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -33,6 +33,10 @@ if test -z $with_gui && test -n "@no_qt@"; then
   with_gui=no
 fi
 
+if test -z $enable_zmq && test -n "@no_zmq@"; then
+  enable_zmq=no
+fi
+
 if test x@host_os@ = xdarwin; then
   BREW=no
   PORT=no

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent zeromq
+packages:=boost openssl libevent
 
 qt_native_packages = native_protobuf
 qt_packages = qrencode protobuf zlib
@@ -11,6 +11,8 @@ qt_darwin_packages=qt
 qt_mingw32_packages=qt
 
 wallet_packages=bdb
+
+zmq_packages=zeromq
 
 upnp_packages=miniupnpc
 


### PR DESCRIPTION
Similar to other depends packages, add the ability to skip building `zeromq` by passing `NO_ZMQ=1`.

Fixes #15918.