### PR TITLE
Don't use global (external) symbols for symbols that are used in only one translation unit

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2287,8 +2287,8 @@ public:
         WSACleanup();
 #endif
     }
-}
-instance_of_cnetcleanup;
+};
+static CNetCleanup instance_of_cnetcleanup;
 
 void CConnman::Interrupt()
 {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4023,4 +4023,5 @@ public:
         mapOrphanTransactions.clear();
         mapOrphanTransactionsByPrev.clear();
     }
-} instance_of_cnetprocessingcleanup;
+};
+static CNetProcessingCleanup instance_of_cnetprocessingcleanup;

--- a/src/ui_interface.cpp
+++ b/src/ui_interface.cpp
@@ -22,7 +22,8 @@ struct UISignals {
     boost::signals2::signal<CClientUIInterface::NotifyBlockTipSig> NotifyBlockTip;
     boost::signals2::signal<CClientUIInterface::NotifyHeaderTipSig> NotifyHeaderTip;
     boost::signals2::signal<CClientUIInterface::BannedListChangedSig> BannedListChanged;
-} g_ui_signals;
+};
+static UISignals g_ui_signals;
 
 #define ADD_SIGNALS_IMPL_WRAPPER(signal_name)                                                                 \
     boost::signals2::connection CClientUIInterface::signal_name##_connect(std::function<signal_name##Sig> fn) \

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -78,7 +78,7 @@ bool CBlockIndexWorkComparator::operator()(const CBlockIndex *pa, const CBlockIn
     return false;
 }
 
-CChainState g_chainstate;
+static CChainState g_chainstate;
 
 CChainState& ChainstateActive() { return g_chainstate; }
 
@@ -1049,7 +1049,7 @@ bool CChainState::IsInitialBlockDownload() const
     return false;
 }
 
-CBlockIndex *pindexBestForkTip = nullptr, *pindexBestForkBase = nullptr;
+static CBlockIndex *pindexBestForkTip = nullptr, *pindexBestForkBase = nullptr;
 
 static void AlertNotify(const std::string& strMessage)
 {
@@ -4762,4 +4762,5 @@ public:
             delete (*it1).second;
         mapBlockIndex.clear();
     }
-} instance_of_cmaincleanup;
+};
+static CMainCleanup instance_of_cmaincleanup;


### PR DESCRIPTION
Don't use global (external) symbols for symbols that are used in only one translation unit.

Before:

```
$ for SYMBOL in $(nm src/bitcoind | grep -E ' [BD] ' | c++filt | cut -f3- -d' ' | grep -v @ | grep -v : | sort | grep '[a-z]' | sort -u | grep -vE '(^_|typeinfo|vtable)'); do
      REFERENCES=$(git grep -lE "([^a-zA-Z]|^)${SYMBOL}([^a-zA-Z]|\$)" -- "*.cpp" "*.h")
      N_REFERENCES=$(wc -l <<< "${REFERENCES}")
      if [[ ${N_REFERENCES} > 1 ]]; then
          continue
      fi
      echo "Global symbol ${SYMBOL} is used in only one translation unit: ${REFERENCES}"
  done
Global symbol g_chainstate is used in only one translation unit: src/validation.cpp
Global symbol g_ui_signals is used in only one translation unit: src/ui_interface.cpp
Global symbol instance_of_cmaincleanup is used in only one translation unit: src/validation.cpp
Global symbol instance_of_cnetcleanup is used in only one translation unit: src/net.cpp
Global symbol instance_of_cnetprocessingcleanup is used in only one translation unit: src/net_processing.cpp
Global symbol pindexBestForkBase is used in only one translation unit: src/validation.cpp
Global symbol pindexBestForkTip is used in only one translation unit: src/validation.cpp
$ 
```

After:

```
$ for SYMBOL in $(nm src/bitcoind | grep -E ' [BD] ' | c++filt | cut -f3- -d' ' | grep -v @ | grep -v : | sort | grep '[a-z]' | sort -u | grep -vE '(^_|typeinfo|vtable)'); do
      REFERENCES=$(git grep -lE "([^a-zA-Z]|^)${SYMBOL}([^a-zA-Z]|\$)" -- "*.cpp" "*.h")
      N_REFERENCES=$(wc -l <<< "${REFERENCES}")
      if [[ ${N_REFERENCES} > 1 ]]; then
          continue
      fi
      echo "Global symbol ${SYMBOL} is used in only one translation unit: ${REFERENCES}"
  done
$ 
```

♻️ Think about future generations: save the global namespace from unnecessary pollution!  ♻️