### PR TITLE
Catch by reference not value in wallettool

### DIFF
--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -59,7 +59,7 @@ static std::shared_ptr<CWallet> LoadWallet(const std::string& name, const fs::pa
     try {
         bool first_run;
         load_wallet_ret = wallet_instance->LoadWallet(first_run);
-    } catch (const std::runtime_error) {
+    } catch (const std::runtime_error&) {
         fprintf(stderr, "Error loading %s. Is wallet being used by another process?\n", name.c_str());
         return nullptr;
     }


### PR DESCRIPTION
Fixes this warning with GCC8/GCC9:
```
wallet/wallettool.cpp: In function ‘std::shared_ptr<CWallet> WalletTool::LoadWallet(const string&, const boost::filesystem::path&)’:
wallet/wallettool.cpp:62:25: warning: catching polymorphic type ‘const class std::runtime_error’ by value [-Wcatch-value=]
     } catch (const std::runtime_error) {
                         ^~~~~~~~~~~~~
```
Related to #15822.
