### PR TITLE
Improve base_blob<BITS>::IsNull()

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -34,6 +34,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/lockedpool.cpp \
   bench/poly1305.cpp \
   bench/prevector.cpp \
+  bench/uint256.cpp \
   test/setup_common.h \
   test/setup_common.cpp \
   test/util.h \

--- a/src/bench/uint256.cpp
+++ b/src/bench/uint256.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+
+#include <uint256.h>
+
+
+static void UInt256IsNull(benchmark::State& state)
+{
+    uint256 hash;
+    while (state.KeepRunning()) {
+        (void) hash.IsNull();
+    }
+}
+
+BENCHMARK(UInt256IsNull, 600000 * 1000);

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -42,7 +42,7 @@ void base_blob<BITS>::SetHex(const char* psz)
         psz++;
     psz--;
     unsigned char* p1 = (unsigned char*)data;
-    unsigned char* pend = p1 + WIDTH;
+    unsigned char* pend = p1 + WIDTH_8;
     while (psz >= pbegin && p1 < pend) {
         *p1 = ::HexDigit(*psz--);
         if (psz >= pbegin) {

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -18,9 +18,9 @@ template<unsigned int BITS>
 class base_blob
 {
 protected:
-    static constexpr int WIDTH = BITS / 8;
-    static constexpr int WORDS = BITS / 32;
-    uint8_t data[WIDTH];
+    static constexpr int WIDTH_8 = BITS / 8;
+    static constexpr int WIDTH_32 = BITS / 32;
+    uint8_t data[WIDTH_8];
 public:
     base_blob()
     {
@@ -31,7 +31,7 @@ public:
 
     bool IsNull() const
     {
-        for (int i = 0; i < WORDS; ++i)
+        for (int i = 0; i < WIDTH_32; ++i)
             if (((uint32_t*) data)[i] != 0)
                 return false;
         return true;
@@ -60,7 +60,7 @@ public:
 
     unsigned char* end()
     {
-        return &data[WIDTH];
+        return &data[WIDTH_8];
     }
 
     const unsigned char* begin() const
@@ -70,7 +70,7 @@ public:
 
     const unsigned char* end() const
     {
-        return &data[WIDTH];
+        return &data[WIDTH_8];
     }
 
     unsigned int size() const

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -19,6 +19,7 @@ class base_blob
 {
 protected:
     static constexpr int WIDTH = BITS / 8;
+    static constexpr int WORDS = BITS / 32;
     uint8_t data[WIDTH];
 public:
     base_blob()
@@ -30,8 +31,8 @@ public:
 
     bool IsNull() const
     {
-        for (int i = 0; i < WIDTH; i++)
-            if (data[i] != 0)
+        for (int i = 0; i < WORDS; ++i)
+            if (((uint32_t*) data)[i] != 0)
                 return false;
         return true;
     }


### PR DESCRIPTION
This change improves `uint256::IsNull()` and `uint160::IsNull()`, especially for the positive case.

By running the new benchmark `./src/bench/bench_bitcoin -filter=UInt256IsNull`:

Before:
```
# Benchmark, evals, iterations, total, min, max, median
UInt256IsNull, 5, 600000000, 15.3553, 5.0397e-09, 5.35092e-09, 5.05512e-09
```
After:
```
# Benchmark, evals, iterations, total, min, max, median
UInt256IsNull, 5, 600000000, 3.56288, 1.18346e-09, 1.19433e-09, 1.18635e-09
```