### PR TITLE
Remove unnecessary call to CTransaction::IsCoinBase()

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1979,7 +1979,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
         nInputs += tx.vin.size();
 
-        if (!tx.IsCoinBase())
+        if (i > 0) // !tx.IsCoinBase()
         {
             CAmount txfee = 0;
             if (!Consensus::CheckTxInputs(tx, state, view, pindex->nHeight, txfee)) {
@@ -2023,7 +2023,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
                              REJECT_INVALID, "bad-blk-sigops");
 
         txdata.emplace_back(tx);
-        if (!tx.IsCoinBase())
+        if (i > 0) // !tx.IsCoinBase()
         {
             std::vector<CScriptCheck> vChecks;
             bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */


### PR DESCRIPTION
Replaces `CTransaction::IsCoinbase()` with the same cheap check as: https://github.com/bitcoin/bitcoin/blob/76e2cded477bc483ec610212bdadf21fe35292d4/src/validation.cpp#L2048