### PR TITLE
gui: Sort wallets in open wallet menu

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -371,13 +371,12 @@ void BitcoinGUI::createActions()
         connect(openAction, &QAction::triggered, this, &BitcoinGUI::openClicked);
         connect(m_open_wallet_menu, &QMenu::aboutToShow, [this] {
             m_open_wallet_menu->clear();
-            std::vector<std::string> available_wallets = m_wallet_controller->getWalletsAvailableToOpen();
-            std::vector<std::string> wallets = m_node.listWalletDir();
-            for (const auto& path : wallets) {
+            for (const std::pair<const std::string, bool>& i : m_wallet_controller->listWalletDir()) {
+                const std::string& path = i.first;
                 QString name = path.empty() ? QString("["+tr("default wallet")+"]") : QString::fromStdString(path);
                 QAction* action = m_open_wallet_menu->addAction(name);
 
-                if (std::find(available_wallets.begin(), available_wallets.end(), path) == available_wallets.end()) {
+                if (i.second) {
                     // This wallet is already loaded
                     action->setEnabled(false);
                     continue;
@@ -410,7 +409,7 @@ void BitcoinGUI::createActions()
                     assert(invoked);
                 });
             }
-            if (wallets.empty()) {
+            if (m_open_wallet_menu->isEmpty()) {
                 QAction* action = m_open_wallet_menu->addAction(tr("No wallets available"));
                 action->setEnabled(false);
             }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -639,7 +639,7 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
     connect(wallet_controller, &WalletController::walletAdded, this, &BitcoinGUI::addWallet);
     connect(wallet_controller, &WalletController::walletRemoved, this, &BitcoinGUI::removeWallet);
 
-    for (WalletModel* wallet_model : m_wallet_controller->getWallets()) {
+    for (WalletModel* wallet_model : m_wallet_controller->getOpenWallets()) {
         addWallet(wallet_model);
     }
 }

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -40,7 +40,7 @@ WalletController::~WalletController()
     m_activity_thread.wait();
 }
 
-std::vector<WalletModel*> WalletController::getWallets() const
+std::vector<WalletModel*> WalletController::getOpenWallets() const
 {
     QMutexLocker locker(&m_mutex);
     return m_wallets;

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -46,13 +46,16 @@ std::vector<WalletModel*> WalletController::getWallets() const
     return m_wallets;
 }
 
-std::vector<std::string> WalletController::getWalletsAvailableToOpen() const
+std::map<std::string, bool> WalletController::listWalletDir() const
 {
     QMutexLocker locker(&m_mutex);
-    std::vector<std::string> wallets = m_node.listWalletDir();
+    std::map<std::string, bool> wallets;
+    for (const std::string& name : m_node.listWalletDir()) {
+        wallets[name] = false;
+    }
     for (WalletModel* wallet_model : m_wallets) {
-        auto it = std::remove(wallets.begin(), wallets.end(), wallet_model->wallet().getWalletName());
-        if (it != wallets.end()) wallets.erase(it);
+        auto it = wallets.find(wallet_model->wallet().getWalletName());
+        if (it != wallets.end()) it->second = true;
     }
     return wallets;
 }

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -40,7 +40,8 @@ public:
     WalletController(interfaces::Node& node, const PlatformStyle* platform_style, OptionsModel* options_model, QObject* parent);
     ~WalletController();
 
-    std::vector<WalletModel*> getWallets() const;
+    //! Returns wallet models currently open.
+    std::vector<WalletModel*> getOpenWallets() const;
 
     //! Returns all wallet names in the wallet dir mapped to whether the wallet
     //! is loaded.

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -8,7 +8,7 @@
 #include <qt/walletmodel.h>
 #include <sync.h>
 
-#include <list>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -41,7 +41,10 @@ public:
     ~WalletController();
 
     std::vector<WalletModel*> getWallets() const;
-    std::vector<std::string> getWalletsAvailableToOpen() const;
+
+    //! Returns all wallet names in the wallet dir mapped to whether the wallet
+    //! is loaded.
+    std::map<std::string, bool> listWalletDir() const;
 
     OpenWalletActivity* openWallet(const std::string& name, QWidget* parent = nullptr);
     void closeWallet(WalletModel* wallet_model, QWidget* parent = nullptr);


### PR DESCRIPTION
Ensure wallets are sorted by name in the open wallet menu. This also improves the change done in #15957, since it avoids a second call to `listWalletDir`.