### PR TITLE
util: Log early messages

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -855,12 +855,6 @@ void InitLogging()
 {
     LogInstance().m_print_to_file = !gArgs.IsArgNegated("-debuglogfile");
     LogInstance().m_file_path = AbsPathForConfigVal(gArgs.GetArg("-debuglogfile", DEFAULT_DEBUGLOGFILE));
-
-    // Add newlines to the logfile to distinguish this execution from the last
-    // one; called before console logging is set up, so this is only sent to
-    // debug.log.
-    LogPrintf("\n\n\n\n\n");
-
     LogInstance().m_print_to_console = gArgs.GetBoolArg("-printtoconsole", !gArgs.GetBoolArg("-daemon", false));
     LogInstance().m_log_timestamps = gArgs.GetBoolArg("-logtimestamps", DEFAULT_LOGTIMESTAMPS);
     LogInstance().m_log_time_micros = gArgs.GetBoolArg("-logtimemicros", DEFAULT_LOGTIMEMICROS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1249,10 +1249,10 @@ bool AppInitMain(InitInterfaces& interfaces)
             // and because this needs to happen before any other debug.log printing
             LogInstance().ShrinkDebugFile();
         }
-        if (!LogInstance().OpenDebugLog()) {
+    }
+    if (!LogInstance().StartLogging()) {
             return InitError(strprintf("Could not open debug log file %s",
                 LogInstance().m_file_path.string()));
-        }
     }
 
     if (!LogInstance().m_log_timestamps)

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -39,9 +39,10 @@ static int FileWriteStr(const std::string &str, FILE *fp)
     return fwrite(str.data(), 1, str.size(), fp);
 }
 
-bool BCLog::Logger::OpenDebugLog()
+bool BCLog::Logger::StartLogging()
 {
     std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    if (!m_print_to_file) return true;
 
     assert(m_fileout == nullptr);
     assert(!m_file_path.empty());

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -41,7 +41,7 @@ static int FileWriteStr(const std::string &str, FILE *fp)
 
 bool BCLog::Logger::StartLogging()
 {
-    std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    std::lock_guard<std::mutex> scoped_lock(m_cs);
 
     assert(m_buffering);
     assert(m_fileout == nullptr);
@@ -216,9 +216,9 @@ std::string BCLog::Logger::LogTimestampStr(const std::string& str)
     return strStamped;
 }
 
-void BCLog::Logger::LogPrintStr(const std::string &str)
+void BCLog::Logger::LogPrintStr(const std::string& str)
 {
-    std::lock_guard<std::mutex> scoped_lock(m_file_mutex);
+    std::lock_guard<std::mutex> scoped_lock(m_cs);
     std::string str_prefixed = str;
 
     if (m_log_threadnames && m_started_new_line) {

--- a/src/logging.h
+++ b/src/logging.h
@@ -63,6 +63,7 @@ namespace BCLog {
         FILE* m_fileout = nullptr;
         std::mutex m_file_mutex;
         std::list<std::string> m_msgs_before_open;
+        bool m_buffering = true; //!< Buffer messages before logging can be started
 
         /**
          * m_started_new_line is a state variable that will suppress printing of
@@ -91,9 +92,11 @@ namespace BCLog {
         void LogPrintStr(const std::string &str);
 
         /** Returns whether logs will be written to any output */
-        bool Enabled() const { return m_print_to_console || m_print_to_file; }
+        bool Enabled() const { return m_buffering || m_print_to_console || m_print_to_file; }
 
+        /** Start logging (and flush all buffered messages) */
         bool StartLogging();
+
         void ShrinkDebugFile();
 
         uint32_t GetCategoryMask() const { return m_categories.load(); }

--- a/src/logging.h
+++ b/src/logging.h
@@ -60,10 +60,10 @@ namespace BCLog {
     class Logger
     {
     private:
-        FILE* m_fileout = nullptr;
-        std::mutex m_file_mutex;
-        std::list<std::string> m_msgs_before_open;
-        bool m_buffering = true; //!< Buffer messages before logging can be started
+        mutable std::mutex m_cs;                   // Can not use Mutex from sync.h because in debug mode it would cause a deadlock when a potential deadlock was detected
+        FILE* m_fileout = nullptr;                 // GUARDED_BY(m_cs)
+        std::list<std::string> m_msgs_before_open; // GUARDED_BY(m_cs)
+        bool m_buffering{true};                    //!< Buffer messages before logging can be started. GUARDED_BY(m_cs)
 
         /**
          * m_started_new_line is a state variable that will suppress printing of
@@ -89,10 +89,14 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
-        void LogPrintStr(const std::string &str);
+        void LogPrintStr(const std::string& str);
 
         /** Returns whether logs will be written to any output */
-        bool Enabled() const { return m_buffering || m_print_to_console || m_print_to_file; }
+        bool Enabled() const
+        {
+            std::lock_guard<std::mutex> scoped_lock(m_cs);
+            return m_buffering || m_print_to_console || m_print_to_file;
+        }
 
         /** Start logging (and flush all buffered messages) */
         bool StartLogging();

--- a/src/logging.h
+++ b/src/logging.h
@@ -93,7 +93,7 @@ namespace BCLog {
         /** Returns whether logs will be written to any output */
         bool Enabled() const { return m_print_to_console || m_print_to_file; }
 
-        bool OpenDebugLog();
+        bool StartLogging();
         void ShrinkDebugFile();
 
         uint32_t GetCategoryMask() const { return m_categories.load(); }

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -61,8 +61,15 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear
 
+    def test_log_buffer(self):
+        with self.nodes[0].assert_debug_log(expected_msgs=['Warning: parsed potentially confusing double-negative -connect=0']):
+            self.start_node(0, extra_args=['-noconnect=0'])
+        self.stop_node(0)
+
     def run_test(self):
         self.stop_node(0)
+
+        self.test_log_buffer()
 
         self.test_config_file_parser()
 


### PR DESCRIPTION
Early log messages are dropped on the floor and they'd never make it to the console or debug log. This can be tested by running the test included in this pull request without re-compiling the `bitcoind`.

Fix that by buffering early messages and flushing them as soon as all logging options have been initialized and logging has been started.

This pull request is identical to  "Log early messages with -printtoconsole" (#13088)  by **ajtowns**, with the following changes:
* Rebased
* Added docstrings for `m_buffering` and `StartLogging`
* Switch `CCriticalSection` (aka `RecursiveMutex`) to just `Mutex` in the last commit
* Added tests

Fixes #16098
Fixes #13157
Closes #13088