### PR TITLE
gui: move coin control "OK" to the right hand side of the dialog

### DIFF
--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -467,12 +467,6 @@
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>


### PR DESCRIPTION
Fixes #16101

The simplest fix seems to be to just drop the `sizePolicy` property, as we don't use that on any other instances of `QDialogButtonBox`.

master (76e2cded477bc483ec610212bdadf21fe35292d4):
![master](https://user-images.githubusercontent.com/863730/58490351-fc26d380-813a-11e9-9906-043ff4f4959f.png)

This PR:
![right-side](https://user-images.githubusercontent.com/863730/58490360-00eb8780-813b-11e9-80fb-2dab04a5ba54.png)
