### PR TITLE
contrib: add curl as a required program in gitian-build.py

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -7,7 +7,7 @@ import sys
 
 def setup():
     global args, workdir
-    programs = ['ruby', 'git', 'make', 'wget']
+    programs = ['ruby', 'git', 'make', 'wget', 'curl']
     if args.kvm:
         programs += ['apt-cacher-ng', 'python-vm-builder', 'qemu-kvm', 'qemu-utils']
     elif args.docker and not os.path.isfile('/lib/systemd/system/docker.service'):


### PR DESCRIPTION
Fixes: #16109

Adds `curl` to the list of base programs required by the `gitian-build.py` script.