### PR TITLE
gui: Enable open wallet menu on setWalletController

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -335,7 +335,7 @@ void BitcoinGUI::createActions()
     openAction->setStatusTip(tr("Open a bitcoin: URI or payment request"));
 
     m_open_wallet_action = new QAction(tr("Open Wallet"), this);
-    m_open_wallet_action->setMenu(new QMenu(this));
+    m_open_wallet_action->setEnabled(false);
     m_open_wallet_action->setStatusTip(tr("Open a wallet"));
 
     m_close_wallet_action = new QAction(tr("Close Wallet..."), this);
@@ -632,6 +632,9 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
     assert(wallet_controller);
 
     m_wallet_controller = wallet_controller;
+
+    m_open_wallet_action->setEnabled(true);
+    m_open_wallet_action->setMenu(new QMenu(this));
 
     connect(wallet_controller, &WalletController::walletAdded, this, &BitcoinGUI::addWallet);
     connect(wallet_controller, &WalletController::walletRemoved, this, &BitcoinGUI::removeWallet);


### PR DESCRIPTION
`BitcoinApplication::initializeResult` and `BitcoinGUI::setWalletController` are only called after the startup rescan is completed. While the rescan is in progress the window menus are already available.

This PR makes the Open Wallet menu disabled until `BitcoinGUI::setWalletController` is called.

![Screenshot 2019-05-29 at 14 17 48](https://user-images.githubusercontent.com/3534524/58560510-35377480-821d-11e9-8f96-d0573c9e47b0.png)

Fixes #16087