### PR TITLE
test: Compile json to hex separately, at most once

### DIFF
--- a/build_msvc/test_bitcoin/test_bitcoin.vcxproj
+++ b/build_msvc/test_bitcoin/test_bitcoin.vcxproj
@@ -204,7 +204,7 @@
     <ItemGroup>
       <JsonTestFile Include="..\..\src\test\data\*.json" />
     </ItemGroup>
-    <HeaderFromHexdump RawFilePath="%(JsonTestFile.FullPath)" HeaderFilePath="%(JsonTestFile.FullPath).h" SourceHeader="namespace json_tests{ static unsigned const char %(JsonTestFile.Filename)[] = {" SourceFooter="};}" />
+    <HeaderFromHexdump RawFilePath="%(JsonTestFile.FullPath)" HeaderFilePath="%(JsonTestFile.FullPath).h" SourceHeader="#include &lt;string&gt;&#10; namespace json_tests{ static unsigned const char %(JsonTestFile.Filename)[] = {" SourceFooter="}; std::string hex_str_%(JsonTestFile.Filename)() { return std::string{%(JsonTestFile.Filename), %(JsonTestFile.Filename) + sizeof(%(JsonTestFile.Filename))}; }; }" />
   </Target>
   <Import Label="configTarget" Project="..\common.vcxproj" />
   <Import Label="hexdumpTarget" Project="..\msbuild\tasks\hexdump.targets" />

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -36,11 +36,10 @@ TEST_SRCDIR = test
 TEST_BINARY=test/test_bitcoin$(EXEEXT)
 
 JSON_TEST_FILES = \
-  test/data/script_tests.json \
   test/data/base58_encode_decode.json \
   test/data/blockfilters.json \
-  test/data/key_io_valid.json \
   test/data/key_io_invalid.json \
+  test/data/key_io_valid.json \
   test/data/script_tests.json \
   test/data/sighash.json \
   test/data/tx_invalid.json \
@@ -48,7 +47,10 @@ JSON_TEST_FILES = \
 
 RAW_TEST_FILES =
 
-GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
+GENERATED_TEST_FILES = \
+  $(JSON_TEST_FILES:.json=.json_hex.cpp) \
+  $(JSON_TEST_FILES:.json=.json.h) \
+  $(RAW_TEST_FILES:.raw=.raw.h)
 
 BITCOIN_TEST_SUITE = \
   test/main.cpp \
@@ -371,9 +373,22 @@ endif
 %.json.h: %.json
 	@$(MKDIR_P) $(@D)
 	@{ \
+	 echo "#include <string>" && \
+	 echo "namespace json_tests{" && \
+	 echo "std::string hex_str_$(*F)();" && \
+	 echo "};"; \
+	} > "$@.new" && mv -f "$@.new" "$@"
+	@echo "Generated $@"
+
+%.json_hex.cpp: %.json
+	@$(MKDIR_P) $(@D)
+	@{ \
+	 echo "#include <string>" && \
 	 echo "namespace json_tests{" && \
 	 echo "static unsigned const char $(*F)[] = {" && \
 	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
-	 echo "};};"; \
+	 echo "};" && \
+	 echo "std::string hex_str_$(*F)() { return std::string{$(*F), $(*F) + sizeof($(*F))}; }" && \
+	 echo "};"; \
 	} > "$@.new" && mv -f "$@.new" "$@"
 	@echo "Generated $@"

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -20,7 +20,7 @@ BOOST_FIXTURE_TEST_SUITE(base58_tests, BasicTestingSetup)
 // Goal: test low-level base58 encoding functionality
 BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 {
-    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
+    UniValue tests = read_json(json_tests::hex_str_base58_encode_decode());
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
         std::string strTest = test.write();
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
 // Goal: test low-level base58 decoding functionality
 BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
 {
-    UniValue tests = read_json(std::string(json_tests::base58_encode_decode, json_tests::base58_encode_decode + sizeof(json_tests::base58_encode_decode)));
+    UniValue tests = read_json(json_tests::hex_str_base58_encode_decode());
     std::vector<unsigned char> result;
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -128,9 +128,7 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
 BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 {
     UniValue json;
-    std::string json_data(json_tests::blockfilters,
-                          json_tests::blockfilters + sizeof(json_tests::blockfilters));
-    if (!json.read(json_data) || !json.isArray()) {
+    if (!json.read(json_tests::hex_str_blockfilters()) || !json.isArray()) {
         BOOST_ERROR("Parse error.");
         return;
     }

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -22,7 +22,7 @@ BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    UniValue tests = read_json(json_tests::hex_str_key_io_valid());
     CKey privkey;
     CTxDestination destination;
     SelectParams(CBaseChainParams::MAIN);
@@ -83,7 +83,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 // Goal: check that generated keys match test vectors
 BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    UniValue tests = read_json(json_tests::hex_str_key_io_valid());
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE(key_io_valid_gen)
 // Goal: check that base58 parsing code is robust against a variety of corrupted data
 BOOST_AUTO_TEST_CASE(key_io_invalid)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_invalid, json_tests::key_io_invalid + sizeof(json_tests::key_io_invalid))); // Negative testcases
+    UniValue tests = read_json(json_tests::hex_str_key_io_invalid()); // Negative testcases
     CKey privkey;
     CTxDestination destination;
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -930,7 +930,7 @@ BOOST_AUTO_TEST_CASE(script_build)
     std::set<std::string> tests_set;
 
     {
-        UniValue json_tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
+        UniValue json_tests = read_json(json_tests::hex_str_script_tests());
 
         for (unsigned int idx = 0; idx < json_tests.size(); idx++) {
             const UniValue& tv = json_tests[idx];
@@ -969,7 +969,7 @@ BOOST_AUTO_TEST_CASE(script_json_test)
     // scripts.
     // If a witness is given, then the last value in the array should be the
     // amount (nValue) to use in the crediting tx
-    UniValue tests = read_json(std::string(json_tests::script_tests, json_tests::script_tests + sizeof(json_tests::script_tests)));
+    UniValue tests = read_json(json_tests::hex_str_script_tests());
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(sighash_test)
 // Goal: check that SignatureHash generates correct hash
 BOOST_AUTO_TEST_CASE(sighash_from_data)
 {
-    UniValue tests = read_json(std::string(json_tests::sighash, json_tests::sighash + sizeof(json_tests::sighash)));
+    UniValue tests = read_json(json_tests::hex_str_sighash());
 
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
         UniValue test = tests[idx];

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(tx_valid)
     // ... where all scripts are stringified scripts.
     //
     // verifyFlags is a comma separated list of script verification flags to apply, or "NONE"
-    UniValue tests = read_json(std::string(json_tests::tx_valid, json_tests::tx_valid + sizeof(json_tests::tx_valid)));
+    UniValue tests = read_json(json_tests::hex_str_tx_valid());
 
     ScriptError err;
     for (unsigned int idx = 0; idx < tests.size(); idx++) {
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
     // ... where all scripts are stringified scripts.
     //
     // verifyFlags is a comma separated list of script verification flags to apply, or "NONE"
-    UniValue tests = read_json(std::string(json_tests::tx_invalid, json_tests::tx_invalid + sizeof(json_tests::tx_invalid)));
+    UniValue tests = read_json(json_tests::hex_str_tx_invalid());
 
     // Initialize to SCRIPT_ERR_OK. The tests expect err to be changed to a
     // value other than SCRIPT_ERR_OK.


### PR DESCRIPTION
The json test data serialized in hex can be quite large and would be parsed by the compiler each time the header file is included, causing OOM even with `make -j 1`.

Slightly decrease the memory usage by compiling the json to hex separately from the tests and do it at most once (regardless of how often the header is included).