### PR TITLE
gui: Enable console line edit on setClientModel

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -636,6 +636,9 @@
            <property name="placeholderText">
             <string/>
            </property>
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
           </widget>
          </item>
         </layout>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -677,6 +677,9 @@ void RPCConsole::setClientModel(ClientModel *model)
         wordList.sort();
         autoCompleter = new QCompleter(wordList, this);
         autoCompleter->setModelSorting(QCompleter::CaseSensitivelySortedModel);
+        // ui->lineEdit is initially disabled because running commands is only
+        // possible from now on.
+        ui->lineEdit->setEnabled(true);
         ui->lineEdit->setCompleter(autoCompleter);
         autoCompleter->popup()->installEventFilter(this);
         // Start thread to execute RPC commands.


### PR DESCRIPTION
Make console line edit disable by default, and only enable once `RPCConsole::setClientModel` is called.

Fixes #16119.