### PR TITLE
tests: Limit Python linting to files in the repo

### DIFF
--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -90,4 +90,10 @@ elif PYTHONWARNINGS="ignore" flake8 --version | grep -q "Python 2"; then
     exit 0
 fi
 
-PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; echo "${enabled[*]}") "${@:-.}"
+PYTHONWARNINGS="ignore" flake8 --ignore=B,C,E,F,I,N,W --select=$(IFS=","; echo "${enabled[*]}") $(
+    if [[ $# == 0 ]]; then
+        git ls-files "*.py"
+    else
+        echo "$@"
+    fi
+)


### PR DESCRIPTION
Limit Python linting to files in the repo.

Before:

```
$ test/lint/lint-python.sh
not_under_version_control.py:195:9: F841 local variable 'e' is assigned to but never used
$
```

After:

```
$ test/lint/lint-python.sh
$
```
