### PR TITLE
enable -salvagewallet test in wallet_basic.py

### DIFF
--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -397,8 +397,7 @@ class WalletTest(BitcoinTestFramework):
             '-reindex',
             '-zapwallettxes=1',
             '-zapwallettxes=2',
-            # disabled until issue is fixed: https://github.com/bitcoin/bitcoin/issues/7463
-            # '-salvagewallet',
+            '-salvagewallet',
         ]
         chainlimit = 6
         for m in maintenance:


### PR DESCRIPTION
we should enable '-salvagewallet' test if the problems of salvagewallet are solved.
it depends on issue #7463.
MarcoFalke disabled it at pr #8038