### PR TITLE
fix importwallet crash due to out of scope wallet reference

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -718,7 +718,6 @@ UniValue importwallet(const JSONRPCRequest& request)
         pwallet->chain().showProgress("", 100, false); // hide progress dialog in GUI
         pwallet->UpdateTimeFirstKey(nTimeBegin);
     }
-    pwallet->chain().showProgress("", 100, false); // hide progress dialog in GUI
     RescanWallet(*pwallet, reserver, nTimeBegin, false /* update */);
     pwallet->MarkDirty();
 


### PR DESCRIPTION
showProgress hold's a reference that is invalidated because wallet is used outside of the locked scope and inside of RescanWallet it is locked into a new context.. calling showProgress outside of the wallet lock context results in intermittent crashes of core.

