### PR TITLE
gui: Set progressDialog to nullptr

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1341,6 +1341,7 @@ void BitcoinGUI::showProgress(const QString &title, int nProgress)
         if (progressDialog) {
             progressDialog->close();
             progressDialog->deleteLater();
+            progressDialog = nullptr;
         }
     } else if (progressDialog) {
         progressDialog->setValue(nProgress);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -316,6 +316,7 @@ void WalletView::showProgress(const QString &title, int nProgress)
         if (progressDialog) {
             progressDialog->close();
             progressDialog->deleteLater();
+            progressDialog = nullptr;
         }
     } else if (progressDialog) {
         if (progressDialog->wasCanceled()) {


### PR DESCRIPTION
If a progress notification `> 0` arrives immediately after notification `= 100` then `progressDialog` is a dangling pointer.

Potential fix for #16134.