### PR TITLE
Docs: Add riscv64 to outputs list in release-process.md

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -270,6 +270,7 @@ The list of files should be:
 bitcoin-${VERSION}-aarch64-linux-gnu.tar.gz
 bitcoin-${VERSION}-arm-linux-gnueabihf.tar.gz
 bitcoin-${VERSION}-i686-pc-linux-gnu.tar.gz
+bitcoin-${VERSION}-riscv64-linux-gnu.tar.gz
 bitcoin-${VERSION}-x86_64-linux-gnu.tar.gz
 bitcoin-${VERSION}-osx64.tar.gz
 bitcoin-${VERSION}-osx.dmg


### PR DESCRIPTION
The `riscv64` binary is created by the Gitian scripts and distributed by the Bitcoin Core website, so it should be listed in the release process docs.

I placed it between i686 and x86_64 since it looked like the original list of Linux arches was in alphabetical order; I'm open to including it in a different position if the desire is to keep the two ARM arches together and the two x86 arches together.