### PR TITLE
docs: create security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.18    | :white_check_mark: |
+| 0.17    | :white_check_mark: |
+| 0.16    | :white_check_mark: |
+| 0.15    | :white_check_mark: |
+| < 0.15  | :x:                |
+
+## Reporting a Vulnerability
+
+To report security issues send an email to security@bitcoincore.org (not for support).
+
+The following keys may be used to communicate sensitive information to developers:
+
+| Name | Fingerprint |
+|------|-------------|
+| Wladimir van der Laan | 71A3 B167 3540 5025 D447  E8F2 7481 0B01 2346 C9A6 |
+| Jonas Schnelli | 32EE 5C4C 3FA1 5CCA DB46  ABE5 29D4 BCB6 416F 53EC |
+| Pieter Wuille | 133E AC17 9436 F14A 5CF1  B794 860F EB80 4E66 9320 |
+
+You can import a key by running the following command with that individual’s fingerprint: `gpg --recv-keys "<fingerprint>"` Ensure that you put quotes around fingerprints containing spaces.


### PR DESCRIPTION
Github has started supporting SECURITY.md to contain a project's
security policy. Right now, the only place to find this project's
security contact is on bitcoincore.org. Adding this information to the
repository makes it easier to find as SECURITY.md becomes a standard.

This is copied almost exactly from https://bitcoincore.org/en/contact/
and based on conversations with EthanHeilman.
