### PR TITLE
0.17.2 backport: build with -fstack-reuse=none  and test case

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -693,6 +693,10 @@ if test x$TARGET_OS != xwindows; then
   AX_CHECK_COMPILE_FLAG([-fPIC],[PIC_FLAGS="-fPIC"])
 fi
 
+# All versions of gcc that we commonly use for building are subject to bug
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348. To work around that, set
+# -fstack-reuse=none for all gcc builds. (Only gcc understands this flag)
+AX_CHECK_COMPILE_FLAG([-fstack-reuse=none],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -fstack-reuse=none"])
 if test x$use_hardening != xno; then
   use_hardening=yes
   AX_CHECK_COMPILE_FLAG([-Wstack-protector],[HARDENED_CXXFLAGS="$HARDENED_CXXFLAGS -Wstack-protector"])

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -43,6 +43,7 @@ BITCOIN_TESTS =\
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \
+  test/compilerbug_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \
   test/cuckoocache_tests.cpp \

--- a/src/test/compilerbug_tests.cpp
+++ b/src/test/compilerbug_tests.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/test_bitcoin.h>
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(compilerbug_tests, BasicTestingSetup)
+
+#if defined(__GNUC__)
+// This block will also be built under clang, which is fine (as it supports noinline)
+void __attribute__ ((noinline)) set_one(unsigned char* ptr)
+{
+    *ptr = 1;
+}
+
+int __attribute__ ((noinline)) check_zero(unsigned char const* in, unsigned int len)
+{
+    for (unsigned int i = 0; i < len; ++i) {
+        if (in[i] != 0) return 0;
+    }
+    return 1;
+}
+
+void set_one_on_stack() {
+    unsigned char buf[1];
+    set_one(buf);
+}
+
+BOOST_AUTO_TEST_CASE(gccbug_90348) {
+    // Test for GCC bug 90348. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90348
+    for (int i = 0; i <= 4; ++i) {
+        unsigned char in[4];
+        for (int j = 0; j < i; ++j) {
+            in[j] = 0;
+            set_one_on_stack(); // Apparently modifies in[0]
+        }
+        BOOST_CHECK(check_zero(in, i));
+    }
+}
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Backports:

* [build with -fstack-reuse=none](https://github.com/bitcoin/bitcoin/pull/15983)
* [Add test for GCC bug 90348](https://github.com/bitcoin/bitcoin/pull/15985)

https://github.com/bitcoin/bitcoin/commit/b5a4abeca238a0fa37b34e35ca610dcfe7112c82 has been modified to replace the `setup_common.h` with `test_bitcoin.h` include.