### PR TITLE
doc: update release process for SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,8 @@
 
 ## Supported Versions
 
+Versions of Bitcoin Core that are currently supported with security updates:
+
 | Version | Supported          |
 | ------- | ------------------ |
 | 0.18    | :white_check_mark: |

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -41,10 +41,12 @@ Release Process
 #### After branch-off (on master)
 
 - Update the version of `contrib/gitian-descriptors/*.yml`.
+- Update the versions in `SECURITY.md` as per the software lifecycle [maintenance policy](https://bitcoincore.org/en/lifecycle/#maintenance-period), generally bumping all up one major version.
 
 #### After branch-off (on the major release branch)
 
 - Update the versions and the link to the release notes draft in `doc/release-notes.md`.
+- Delete `SECURITY.md`.
 
 #### Before final release
 


### PR DESCRIPTION
Follow-up to https://github.com/bitcoin/bitcoin/pull/16140:

- Update the release process to maintain SECURITY.md; this looks like the sort of item that can otherwise be easily overlooked during a major release

- Clarify type of support in SECURITY.md

Question: If https://bitcoincore.org/en/lifecycle/#maintenance-period is still current policy, should v0.15 now be unmaintained and v0.16 EOL... seems the schedule on that page could use an update.