### PR TITLE
Simplify header analysis/reasoning by splitting core_io.h into the expected core_read.h/core_write.h (matching core_read.cpp/core_write.cpp)

### DIFF
--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -3,11 +3,6 @@
 import sys
 import re
 
-MAPPING = {
-    'core_read.cpp': 'core_io.cpp',
-    'core_write.cpp': 'core_io.cpp',
-}
-
 # Directories with header-based modules, where the assumption that .cpp files
 # define functions and variables declared in corresponding .h files is
 # incorrect.
@@ -16,8 +11,6 @@ HEADER_MODULE_PATHS = [
 ]
 
 def module_name(path):
-    if path in MAPPING:
-        path = MAPPING[path]
     if any(path.startswith(dirpath) for dirpath in HEADER_MODULE_PATHS):
         return path
     if path.endswith(".h"):

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,8 +125,9 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   consensus/tx_check.h \
   consensus/tx_verify.h \
-  core_io.h \
   core_memusage.h \
+  core_read.h \
+  core_write.h \
   cuckoocache.h \
   flatfile.h \
   fs.h \

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -9,7 +9,8 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <consensus/consensus.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key_io.h>
 #include <keystore.h>
 #include <policy/policy.h>

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <core_io.h>
+#include <core_read.h>
 
 #include <primitives/block.h>
 #include <primitives/transaction.h>

--- a/src/core_read.h
+++ b/src/core_read.h
@@ -2,10 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CORE_IO_H
-#define BITCOIN_CORE_IO_H
+#ifndef BITCOIN_CORE_READ_H
+#define BITCOIN_CORE_READ_H
 
-#include <amount.h>
 #include <attributes.h>
 
 #include <string>
@@ -14,14 +13,11 @@
 class CBlock;
 class CBlockHeader;
 class CScript;
-class CTransaction;
 struct CMutableTransaction;
 class uint256;
 class UniValue;
 
-// core_read.cpp
 CScript ParseScript(const std::string& s);
-std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
 NODISCARD bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true);
 NODISCARD bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 bool DecodeHexBlockHeader(CBlockHeader&, const std::string& hex_header);
@@ -38,13 +34,4 @@ bool ParseHashStr(const std::string& strHex, uint256& result);
 std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
 int ParseSighashString(const UniValue& sighash);
 
-// core_write.cpp
-UniValue ValueFromAmount(const CAmount& amount);
-std::string FormatScript(const CScript& script);
-std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
-std::string SighashToStr(unsigned char sighash_type);
-void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
-void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
-
-#endif // BITCOIN_CORE_IO_H
+#endif // BITCOIN_CORE_READ_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <core_io.h>
+#include <core_write.h>
 
 #include <consensus/consensus.h>
 #include <consensus/validation.h>

--- a/src/core_write.h
+++ b/src/core_write.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_WRITE_H
+#define BITCOIN_CORE_WRITE_H
+
+#include <amount.h>
+
+#include <string>
+
+class CScript;
+class CTransaction;
+class uint256;
+class UniValue;
+
+UniValue ValueFromAmount(const CAmount& amount);
+std::string FormatScript(const CScript& script);
+std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
+std::string SighashToStr(unsigned char sighash_type);
+void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
+std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
+void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
+
+#endif // BITCOIN_CORE_WRITE_H

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -13,7 +13,7 @@
 #include <qt/transactionrecord.h>
 #include <qt/walletmodel.h>
 
-#include <core_io.h>
+#include <core_write.h>
 #include <interfaces/handler.h>
 #include <uint256.h>
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -6,7 +6,8 @@
 #include <attributes.h>
 #include <chain.h>
 #include <chainparams.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <httpserver.h>
 #include <index/txindex.h>
 #include <primitives/block.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -11,7 +11,7 @@
 #include <chainparams.h>
 #include <coins.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_write.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <key_io.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -9,7 +9,8 @@
 #include <consensus/consensus.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key_io.h>
 #include <miner.h>
 #include <net.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -6,7 +6,7 @@
 
 #include <banman.h>
 #include <clientversion.h>
-#include <core_io.h>
+#include <core_write.h>
 #include <net.h>
 #include <net_processing.h>
 #include <netbase.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -7,7 +7,8 @@
 #include <coins.h>
 #include <compat/byteswap.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <index/txindex.h>
 #include <key_io.h>
 #include <keystore.h>

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -6,7 +6,8 @@
 #include <rpc/rawtransaction_util.h>
 
 #include <coins.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key_io.h>
 #include <keystore.h>
 #include <policy/policy.h>

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -6,7 +6,7 @@
 #include <test/setup_common.h>
 
 #include <blockfilter.h>
-#include <core_io.h>
+#include <core_read.h>
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -6,7 +6,7 @@
 #include <rpc/client.h>
 #include <rpc/util.h>
 
-#include <core_io.h>
+#include <core_write.h>
 #include <init.h>
 #include <interfaces/chain.h>
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -4,7 +4,8 @@
 
 #include <test/data/script_tests.json.h>
 
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key.h>
 #include <keystore.h>
 #include <script/script.h>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -10,7 +10,7 @@
 #include <checkqueue.h>
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
 #include <key.h>
 #include <keystore.h>
 #include <validation.h>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <core_io.h>
+#include <core_read.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <merkleblock.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5,7 +5,8 @@
 
 #include <amount.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <init.h>
 #include <interfaces/chain.h>
 #include <key_io.h>


### PR DESCRIPTION
Simplify header analysis/reasoning by splitting `core_io.h` into the expected `core_read.h`/`core_write.h` (matching `core_read.cpp`/`core_write.cpp`).

As noted by MarcoFalke in the review of #16129:

> For some reason core_io is the header file for both core_read and core_write...

Also noted by sipa when writing extra code to handle this specific case in `contrib/devtools/circular-dependencies.py`:

https://github.com/bitcoin/bitcoin/blob/5d2ccf0ce9ca1571c650a69319fb9c1e0b626ecb/contrib/devtools/circular-dependencies.py#L6-L9

This change makes automated header analysis easier. Also humans will benefit: especially future generations of contributors who joins us with the expectation of normal header naming :-)