### PR TITLE
define variables about scriptsig size of coinbase tx

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -18,6 +18,11 @@ static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
+/** The maximum allowed size for scriptSig in vin of coinbase transaction, in bytes */
+static const unsigned int MAX_COINBASE_TX_VIN_SCRIPTSIG_SIZE = 100;
+/** The minimum allowed size for scriptSig in vin of coinbase transaction, in bytes */
+static const unsigned int MIN_COINBASE_TX_VIN_SCRIPTSIG_SIZE = 2;
+
 static const int WITNESS_SCALE_FACTOR = 4;
 
 static const size_t MIN_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR * 60; // 60 is the lower bound for the size of a valid serialized CTransaction

--- a/src/consensus/tx_check.cpp
+++ b/src/consensus/tx_check.cpp
@@ -5,6 +5,7 @@
 #include <consensus/tx_check.h>
 
 #include <primitives/transaction.h>
+#include <consensus/consensus.h>
 #include <consensus/validation.h>
 
 bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fCheckDuplicateInputs)
@@ -43,7 +44,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
 
     if (tx.IsCoinBase())
     {
-        if (tx.vin[0].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
+        if (tx.vin[0].scriptSig.size() < MIN_COINBASE_TX_VIN_SCRIPTSIG_SIZE || tx.vin[0].scriptSig.size() > MAX_COINBASE_TX_VIN_SCRIPTSIG_SIZE)
             return state.Invalid(ValidationInvalidReason::CONSENSUS, false, REJECT_INVALID, "bad-cb-length");
     }
     else

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -438,7 +438,7 @@ void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned
     unsigned int nHeight = pindexPrev->nHeight+1; // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(*pblock->vtx[0]);
     txCoinbase.vin[0].scriptSig = (CScript() << nHeight << CScriptNum(nExtraNonce)) + COINBASE_FLAGS;
-    assert(txCoinbase.vin[0].scriptSig.size() <= 100);
+    assert(txCoinbase.vin[0].scriptSig.size() <= MAX_COINBASE_TX_VIN_SCRIPTSIG_SIZE);
 
     pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);


### PR DESCRIPTION
define variables instead of numbers about scriptsig size of coinbase tx

> /** The maximum allowed size for scriptSig in vin of coinbase transaction, in bytes */
static const unsigned int MAX_COINBASE_TX_VIN_SCRIPTSIG_SIZE = 100;

> /** The minimum allowed size for scriptSig in vin of coinbase transaction, in bytes */
static const unsigned int MIN_COINBASE_TX_VIN_SCRIPTSIG_SIZE = 2;

