### PR TITLE
Add a new peer state tracking class to reduce cs_main contention.

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -198,6 +198,17 @@ struct CBlockReject {
 };
 
 /**
+ * Maintain state about nodes, protected by our own lock. Historically we put all
+ * peer tracking state in CNodeState, however this results in significant cs_main
+ * contention. Thus, new state tracking should go here, and we should eventually
+ * move most (non-validation-specific) state here.
+ */
+struct CPeerState {
+    CPeerState() {}
+};
+
+
+/**
  * Maintain validation-specific state about nodes, protected by cs_main, instead
  * by CNode's own locks. This simplifies asynchronous operation, where
  * processing of incoming data is done after the ProcessMessage call returns,
@@ -388,7 +399,20 @@ struct CNodeState {
 // Keeps track of the time (in microseconds) when transactions were requested last time
 limitedmap<uint256, int64_t> g_already_asked_for GUARDED_BY(cs_main)(MAX_INV_SZ);
 
+/** Note that this must be locked BEFORE cs_main! */
+CCriticalSection cs_peerstate;
+
 /** Map maintaining per-node state. */
+static std::map<NodeId, CPeerState> mapPeerState GUARDED_BY(cs_peerstate);
+
+static CPeerState *PeerState(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) LOCKS_EXCLUDED(cs_main) {
+    std::map<NodeId, CPeerState>::iterator it = mapPeerState.find(pnode);
+    if (it == mapPeerState.end())
+        return nullptr;
+    return &it->second;
+}
+
+/** Map maintaining new per-node state. */
 static std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
 
 static CNodeState *State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
@@ -756,12 +780,22 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
         LOCK(cs_main);
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
     }
+    {
+        LOCK(cs_peerstate);
+        mapPeerState.emplace_hint(mapPeerState.end(), nodeid, CPeerState{});
+    }
+
     if(!pnode->fInbound)
         PushNodeVersion(pnode, connman, GetTime());
 }
 
 void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
     fUpdateConnectionTime = false;
+
+    LOCK(cs_peerstate);
+    CPeerState* peerstate = PeerState(nodeid);
+    assert(peerstate != nullptr);
+
     LOCK(cs_main);
     CNodeState *state = State(nodeid);
     assert(state != nullptr);
@@ -784,6 +818,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
     mapNodeState.erase(nodeid);
+    mapPeerState.erase(nodeid);
 
     if (mapNodeState.empty()) {
         // Do a consistency check after the last peer is removed.
@@ -791,6 +826,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
         assert(nPreferredDownload == 0);
         assert(nPeersWithValidatedDownloads == 0);
         assert(g_outbound_peers_with_protect_from_disconnect == 0);
+        assert(mapPeerState.empty());
     }
     LogPrint(BCLog::NET, "Cleared nodestate for peer=%d\n", nodeid);
 }
@@ -1821,7 +1857,7 @@ void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_se
     }
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
+bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
     if (gArgs.IsArgSet("-dropmessagestest") && GetRand(gArgs.GetArg("-dropmessagestest", 0)) == 0)
@@ -2763,7 +2799,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         } // cs_main
 
         if (fProcessBLOCKTXN)
-            return ProcessMessage(pfrom, NetMsgType::BLOCKTXN, blockTxnMsg, nTimeReceived, chainparams, connman, interruptMsgProc, enable_bip61);
+            return ProcessMessage(pfrom, peerstate, NetMsgType::BLOCKTXN, blockTxnMsg, nTimeReceived, chainparams, connman, interruptMsgProc, enable_bip61);
 
         if (fRevertToHeaderProcessing) {
             // Headers received from HB compact block peers are permitted to be
@@ -3193,6 +3229,8 @@ bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_
 bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
+    LOCK(cs_peerstate);
+    CPeerState* peerstate = PeerState(pfrom->GetId());
     //
     // Message format
     //  (4) message start
@@ -3275,7 +3313,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime, chainparams, connman, interruptMsgProc, m_enable_bip61);
+        fRet = ProcessMessage(pfrom, peerstate, strCommand, vRecv, msg.nTime, chainparams, connman, interruptMsgProc, m_enable_bip61);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())
@@ -3483,6 +3521,9 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
         // If we get here, the outgoing message serialization version is set and can't change.
         const CNetMsgMaker msgMaker(pto->GetSendVersion());
+
+        LOCK(cs_peerstate);
+        CPeerState* peerstate = PeerState(pto->GetId());
 
         //
         // Message: ping

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -91,8 +91,10 @@ std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(g_cs_orphans);
 
 void EraseOrphansFor(NodeId peer);
 
+/** Note that this must be locked BEFORE cs_main! */
+CCriticalSection cs_peerstate ACQUIRED_BEFORE(cs_main);
 /** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="") EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="") EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate);
 
 /** Average delay between local address broadcasts in seconds. */
 static constexpr unsigned int AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL = 24 * 60 * 60;
@@ -204,7 +206,28 @@ struct CBlockReject {
  * move most (non-validation-specific) state here.
  */
 struct CPeerState {
-    CPeerState() {}
+    //! String name of this peer (debugging/logging purposes).
+    const std::string name;
+
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+
+    //! Whether this peer is an inbound connection
+    bool m_is_inbound;
+
+    //! Whether this peer is a manual connection
+    bool m_is_manual_connection;
+
+    CPeerState(std::string addrNameIn, bool is_inbound, bool is_manual) :
+        name(std::move(addrNameIn)),
+        m_is_inbound(is_inbound),
+        m_is_manual_connection (is_manual)
+    {
+        fShouldBan = false;
+        nMisbehavior = 0;
+    }
 };
 
 
@@ -219,12 +242,6 @@ struct CNodeState {
     const CService address;
     //! Whether we have a fully established connection.
     bool fCurrentlyConnected;
-    //! Accumulated misbehaviour score for this peer.
-    int nMisbehavior;
-    //! Whether this peer should be disconnected and banned (unless whitelisted).
-    bool fShouldBan;
-    //! String name of this peer (debugging/logging purposes).
-    const std::string name;
     //! List of asynchronously-determined block rejections to notify this peer about.
     std::vector<CBlockReject> rejects;
     //! The best known block we know this peer has announced.
@@ -366,13 +383,11 @@ struct CNodeState {
     //! Whether this peer is a manual connection
     bool m_is_manual_connection;
 
-    CNodeState(CAddress addrIn, std::string addrNameIn, bool is_inbound, bool is_manual) :
-        address(addrIn), name(std::move(addrNameIn)), m_is_inbound(is_inbound),
+    CNodeState(CAddress addrIn, bool is_inbound, bool is_manual) :
+        address(addrIn), m_is_inbound(is_inbound),
         m_is_manual_connection (is_manual)
     {
         fCurrentlyConnected = false;
-        nMisbehavior = 0;
-        fShouldBan = false;
         pindexBestKnownBlock = nullptr;
         hashLastUnknownBlock.SetNull();
         pindexLastCommonBlock = nullptr;
@@ -399,13 +414,10 @@ struct CNodeState {
 // Keeps track of the time (in microseconds) when transactions were requested last time
 limitedmap<uint256, int64_t> g_already_asked_for GUARDED_BY(cs_main)(MAX_INV_SZ);
 
-/** Note that this must be locked BEFORE cs_main! */
-CCriticalSection cs_peerstate;
-
 /** Map maintaining per-node state. */
 static std::map<NodeId, CPeerState> mapPeerState GUARDED_BY(cs_peerstate);
 
-static CPeerState *PeerState(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) LOCKS_EXCLUDED(cs_main) {
+static CPeerState *PeerState(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) {
     std::map<NodeId, CPeerState>::iterator it = mapPeerState.find(pnode);
     if (it == mapPeerState.end())
         return nullptr;
@@ -778,11 +790,11 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
     NodeId nodeid = pnode->GetId();
     {
         LOCK(cs_main);
-        mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
+        mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, pnode->fInbound, pnode->m_manual_connection));
     }
     {
         LOCK(cs_peerstate);
-        mapPeerState.emplace_hint(mapPeerState.end(), nodeid, CPeerState{});
+        mapPeerState.emplace_hint(mapPeerState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
     }
 
     if(!pnode->fInbound)
@@ -803,7 +815,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     if (state->fSyncStarted)
         nSyncStarted--;
 
-    if (state->nMisbehavior == 0 && state->fCurrentlyConnected) {
+    if (peerstate->nMisbehavior == 0 && state->fCurrentlyConnected) {
         fUpdateConnectionTime = true;
     }
 
@@ -832,11 +844,14 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
 }
 
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
+    LOCK(cs_peerstate);
+    CPeerState* peerstate = PeerState(nodeid);
     LOCK(cs_main);
     CNodeState *state = State(nodeid);
-    if (state == nullptr)
+    if (state == nullptr || peerstate == nullptr)
         return false;
-    stats.nMisbehavior = state->nMisbehavior;
+
+    stats.nMisbehavior = peerstate->nMisbehavior;
     stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
     stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
     for (const QueuedBlock& queue : state->vBlocksInFlight) {
@@ -979,27 +994,28 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
     return nEvicted;
 }
 
+
 /**
  * Mark a misbehaving peer to be banned depending upon the value of `-banscore`.
  */
-void Misbehaving(NodeId pnode, int howmuch, const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+void Misbehaving(NodeId pnode, int howmuch, const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     if (howmuch == 0)
         return;
 
-    CNodeState *state = State(pnode);
-    if (state == nullptr)
+    CPeerState *peerstate = PeerState(pnode);
+    if (peerstate == nullptr)
         return;
 
-    state->nMisbehavior += howmuch;
+    peerstate->nMisbehavior += howmuch;
     int banscore = gArgs.GetArg("-banscore", DEFAULT_BANSCORE_THRESHOLD);
     std::string message_prefixed = message.empty() ? "" : (": " + message);
-    if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore)
+    if (peerstate->nMisbehavior >= banscore && peerstate->nMisbehavior - howmuch < banscore)
     {
-        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED%s\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior, message_prefixed);
-        state->fShouldBan = true;
+        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED%s\n", __func__, peerstate->name, pnode, peerstate->nMisbehavior-howmuch, peerstate->nMisbehavior, message_prefixed);
+        peerstate->fShouldBan = true;
     } else
-        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d)%s\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior, message_prefixed);
+        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d)%s\n", __func__, peerstate->name, pnode, peerstate->nMisbehavior-howmuch, peerstate->nMisbehavior, message_prefixed);
 }
 
 /**
@@ -1025,7 +1041,7 @@ static bool TxRelayMayResultInDisconnect(const CValidationState& state)
  *
  * Changes here may need to be reflected in TxRelayMayResultInDisconnect().
  */
-static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool via_compact_block, const std::string& message = "") {
+static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool via_compact_block, const std::string& message = "") EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) {
     switch (state.GetReason()) {
     case ValidationInvalidReason::NONE:
         break;
@@ -1033,22 +1049,20 @@ static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool v
     case ValidationInvalidReason::CONSENSUS:
     case ValidationInvalidReason::BLOCK_MUTATED:
         if (!via_compact_block) {
-            LOCK(cs_main);
             Misbehaving(nodeid, 100, message);
             return true;
         }
         break;
     case ValidationInvalidReason::CACHED_INVALID:
         {
-            LOCK(cs_main);
-            CNodeState *node_state = State(nodeid);
-            if (node_state == nullptr) {
+            CPeerState *peer_state = PeerState(nodeid);
+            if (peer_state == nullptr) {
                 break;
             }
 
             // Ban outbound (but not inbound) peers if on an invalid chain.
             // Exempt HB compact block peers and manual connections.
-            if (!via_compact_block && !node_state->m_is_inbound && !node_state->m_is_manual_connection) {
+            if (!via_compact_block && !peer_state->m_is_inbound && !peer_state->m_is_manual_connection) {
                 Misbehaving(nodeid, 100, message);
                 return true;
             }
@@ -1058,7 +1072,6 @@ static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool v
     case ValidationInvalidReason::BLOCK_CHECKPOINT:
     case ValidationInvalidReason::BLOCK_INVALID_PREV:
         {
-            LOCK(cs_main);
             Misbehaving(nodeid, 100, message);
         }
         return true;
@@ -1066,7 +1079,6 @@ static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool v
     case ValidationInvalidReason::BLOCK_MISSING_PREV:
         {
             // TODO: Handle this much more gracefully (10 DoS points is super arbitrary)
-            LOCK(cs_main);
             Misbehaving(nodeid, 10, message);
         }
         return true;
@@ -1254,6 +1266,7 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
  * peers announce compact blocks.
  */
 void PeerLogicValidation::BlockChecked(const CBlock& block, const CValidationState& state) {
+    LOCK(cs_peerstate);
     LOCK(cs_main);
 
     const uint256 hash(block.GetHash());
@@ -1598,11 +1611,10 @@ static uint32_t GetFetchFlags(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     return nFetchFlags;
 }
 
-inline void static SendBlockTransactions(const CBlock& block, const BlockTransactionsRequest& req, CNode* pfrom, CConnman* connman) {
+inline void static SendBlockTransactions(const CBlock& block, const BlockTransactionsRequest& req, CNode* pfrom, CConnman* connman) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) {
     BlockTransactions resp(req);
     for (size_t i = 0; i < req.indexes.size(); i++) {
         if (req.indexes[i] >= block.vtx.size()) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100, strprintf("Peer %d sent us a getblocktxn with out-of-bounds tx indices", pfrom->GetId()));
             return;
         }
@@ -1614,7 +1626,7 @@ inline void static SendBlockTransactions(const CBlock& block, const BlockTransac
     connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCKTXN, resp));
 }
 
-bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::vector<CBlockHeader>& headers, const CChainParams& chainparams, bool via_compact_block)
+bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::vector<CBlockHeader>& headers, const CChainParams& chainparams, bool via_compact_block) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
     size_t nCount = headers.size();
@@ -1795,9 +1807,10 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     return true;
 }
 
-void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_set, std::list<CTransactionRef>& removed_txn) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans)
+void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_set, std::list<CTransactionRef>& removed_txn) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate, cs_main, g_cs_orphans)
 {
     AssertLockHeld(cs_main);
+    AssertLockHeld(cs_peerstate);
     AssertLockHeld(g_cs_orphans);
     std::set<NodeId> setMisbehaving;
     bool done = false;
@@ -1872,7 +1885,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
                strCommand == NetMsgType::FILTERADD))
     {
         if (pfrom->nVersion >= NO_BLOOM_VERSION) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);
             return false;
         } else {
@@ -1913,7 +1925,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
             if (enable_bip61) {
                 connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_DUPLICATE, std::string("Duplicate version message")));
             }
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 1);
             return false;
         }
@@ -2081,7 +2092,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
 
     if (pfrom->nVersion == 0) {
         // Must have a version message before anything else
-        LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 1);
         return false;
     }
@@ -2128,7 +2138,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
 
     if (!pfrom->fSuccessfullyConnected) {
         // Must have a verack message before anything else
-        LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 1);
         return false;
     }
@@ -2142,7 +2151,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
             return true;
         if (vAddr.size() > 1000)
         {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message addr size() = %u", vAddr.size()));
             return false;
         }
@@ -2218,7 +2226,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         vRecv >> vInv;
         if (vInv.size() > MAX_INV_SZ)
         {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message inv size() = %u", vInv.size()));
             return false;
         }
@@ -2276,7 +2283,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         vRecv >> vInv;
         if (vInv.size() > MAX_INV_SZ)
         {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message getdata size() = %u", vInv.size()));
             return false;
         }
@@ -2940,7 +2946,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
         if (nCount > MAX_HEADERS_RESULTS) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("headers message size = %u", nCount));
             return false;
         }
@@ -3122,7 +3127,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         if (!filter.IsWithinSizeConstraints())
         {
             // There is no excuse for sending a too-large filter
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);
         }
         else
@@ -3153,7 +3157,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
             }
         }
         if (bad) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);
         }
         return true;
@@ -3192,10 +3195,12 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
     return true;
 }
 
-bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_peerstate)
 {
     AssertLockHeld(cs_main);
+    AssertLockHeld(cs_peerstate);
     CNodeState &state = *State(pnode->GetId());
+    CPeerState &peerstate = *PeerState(pnode->GetId());
 
     if (enable_bip61) {
         for (const CBlockReject& reject : state.rejects) {
@@ -3204,8 +3209,8 @@ bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_
     }
     state.rejects.clear();
 
-    if (state.fShouldBan) {
-        state.fShouldBan = false;
+    if (peerstate.fShouldBan) {
+        peerstate.fShouldBan = false;
         if (pnode->fWhitelisted)
             LogPrintf("Warning: not punishing whitelisted peer %s!\n", pnode->addr.ToString());
         else if (pnode->m_manual_connection)


### PR DESCRIPTION
CNodeState was added for validation-state-tracking, and thus,
logically, was protected by cs_main. However, as it has grown to
include non-validation state (taking state from CNode), and as
we've reduced cs_main usage for other unrelated things, CNodeState
is left with lots of cs_main locking in net_processing.

This starts the process of moving things out of cs_main (and into a new CPeerState) starting with nDoS and rejects.

This also solves the lowest-hanging fruit by wiping out 10+ (!) cs_main locks that are trivial to remove! It further removes a cs_main lock which is taken on every ProcessMessages iteration, which makes a future rebase of #12934 much more effective by being able to move onto the next peer for processing (at least sometimes) while a block is validating.