### PR TITLE
Call ProcessNewBlock() asynchronously

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1451,6 +1451,8 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     // ********************************************************* Step 7: load block chain
 
+    threadGroup.create_thread(std::bind(&TraceThread<std::function<void()>>, "blockconn", std::function<void()>(std::bind(&CChainState::ProcessBlockValidationQueue, &ChainstateActive()))));
+
     fReindex = gArgs.GetBoolArg("-reindex", false);
     bool fReindexChainState = gArgs.GetBoolArg("-reindex-chainstate", false);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2803,7 +2803,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 LOCK(cs_main);
                 mapBlockSource.emplace(pblock->GetHash(), std::make_pair(pfrom->GetId(), false));
             }
-            bool fNewBlock = false;
             // Setting fForceProcessing to true means that we bypass some of
             // our anti-DoS protections in AcceptBlock, which filters
             // unrequested blocks that might be trying to waste our resources
@@ -2813,7 +2812,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // we have a chain with at least nMinimumChainWork), and we ignore
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            bool fNewBlock = ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true).get();
             if (fNewBlock) {
                 pfrom->nLastBlockTime = GetTime();
             } else {
@@ -2895,14 +2894,13 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             }
         } // Don't hold cs_main when we call into ProcessNewBlock
         if (fBlockRead) {
-            bool fNewBlock = false;
             // Since we requested this block (it was in mapBlocksInFlight), force it to be processed,
             // even if it would not be a candidate for new tip (missing previous block, chain not long enough, etc)
             // This bypasses some anti-DoS logic in AcceptBlock (eg to prevent
             // disk-space attacks), but this should be safe due to the
             // protections in the compact block handler -- see related comment
             // in compact block optimistic reconstruction handling.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            bool fNewBlock = ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true).get();
             if (fNewBlock) {
                 pfrom->nLastBlockTime = GetTime();
             } else {
@@ -2963,8 +2961,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // so the race between here and cs_main in ProcessNewBlock is fine.
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
-        bool fNewBlock = false;
-        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        bool fNewBlock = ProcessNewBlock(chainparams, pblock, forceProcessing).get();
         if (fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
         } else {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3005,6 +3005,12 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
         vRecv >> *pblock;
 
+        // Call CheckBlock before we hit cs_main so that we can (hopefully) get
+        // the fChecked flag cached in the pblock while the validation thread is
+        // processing some other block.
+        CValidationState statedummy;
+        CheckBlock(*pblock, statedummy, chainparams.GetConsensus(), true, true);
+
         LogPrint(BCLog::NET, "received block %s peer=%d\n", pblock->GetHash().ToString(), pfrom->GetId());
 
         bool forceProcessing = false;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -93,8 +93,10 @@ std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(g_cs_orphans);
 
 void EraseOrphansFor(NodeId peer);
 
+/** Note that this must be locked BEFORE cs_main! */
+CCriticalSection cs_peerstate ACQUIRED_BEFORE(cs_main);
 /** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="") EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="") EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate);
 
 /** Average delay between local address broadcasts in seconds. */
 static constexpr unsigned int AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL = 24 * 60 * 60;
@@ -206,6 +208,20 @@ struct CBlockReject {
  * move most (non-validation-specific) state here.
  */
 struct CPeerState {
+    //! String name of this peer (debugging/logging purposes).
+    const std::string name;
+
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+
+    //! Whether this peer is an inbound connection
+    bool m_is_inbound;
+
+    //! Whether this peer is a manual connection
+    bool m_is_manual_connection;
+
     //! If this peer generated some headers for us to add, we store the resulting
     //! future here and wait for it to complete before we process more data from this
     //! peer.
@@ -213,7 +229,14 @@ struct CPeerState {
     //! The hash of the block which is pending download.
     uint256 pending_block_hash;
 
-    CPeerState() {}
+    CPeerState(std::string addrNameIn, bool is_inbound, bool is_manual) :
+        name(std::move(addrNameIn)),
+        m_is_inbound(is_inbound),
+        m_is_manual_connection (is_manual)
+    {
+        fShouldBan = false;
+        nMisbehavior = 0;
+    }
 };
 
 
@@ -228,12 +251,6 @@ struct CNodeState {
     const CService address;
     //! Whether we have a fully established connection.
     bool fCurrentlyConnected;
-    //! Accumulated misbehaviour score for this peer.
-    int nMisbehavior;
-    //! Whether this peer should be disconnected and banned (unless whitelisted).
-    bool fShouldBan;
-    //! String name of this peer (debugging/logging purposes).
-    const std::string name;
     //! List of asynchronously-determined block rejections to notify this peer about.
     std::vector<CBlockReject> rejects;
     //! The best known block we know this peer has announced.
@@ -378,13 +395,11 @@ struct CNodeState {
     //! Whether this peer is a manual connection
     bool m_is_manual_connection;
 
-    CNodeState(CAddress addrIn, std::string addrNameIn, bool is_inbound, bool is_manual) :
-        address(addrIn), name(std::move(addrNameIn)), m_is_inbound(is_inbound),
+    CNodeState(CAddress addrIn, bool is_inbound, bool is_manual) :
+        address(addrIn), m_is_inbound(is_inbound),
         m_is_manual_connection (is_manual)
     {
         fCurrentlyConnected = false;
-        nMisbehavior = 0;
-        fShouldBan = false;
         pindexBestKnownBlock = nullptr;
         hashLastUnknownBlock.SetNull();
         pindexLastCommonBlock = nullptr;
@@ -411,13 +426,10 @@ struct CNodeState {
 // Keeps track of the time (in microseconds) when transactions were requested last time
 limitedmap<uint256, int64_t> g_already_asked_for GUARDED_BY(cs_main)(MAX_INV_SZ);
 
-/** Note that this must be locked BEFORE cs_main! */
-CCriticalSection cs_peerstate;
-
 /** Map maintaining per-node state. */
 static std::map<NodeId, CPeerState> mapPeerState GUARDED_BY(cs_peerstate);
 
-static CPeerState *PeerState(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) LOCKS_EXCLUDED(cs_main) {
+static CPeerState *PeerState(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) {
     std::map<NodeId, CPeerState>::iterator it = mapPeerState.find(pnode);
     if (it == mapPeerState.end())
         return nullptr;
@@ -800,11 +812,11 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
     NodeId nodeid = pnode->GetId();
     {
         LOCK(cs_main);
-        mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
+        mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, pnode->fInbound, pnode->m_manual_connection));
     }
     {
         LOCK(cs_peerstate);
-        mapPeerState.emplace_hint(mapPeerState.end(), nodeid, CPeerState{});
+        mapPeerState.emplace_hint(mapPeerState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
     }
 
     if(!pnode->fInbound)
@@ -825,7 +837,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     if (state->fSyncStarted)
         nSyncStarted--;
 
-    if (state->nMisbehavior == 0 && state->fCurrentlyConnected) {
+    if (peerstate->nMisbehavior == 0 && state->fCurrentlyConnected) {
         fUpdateConnectionTime = true;
     }
 
@@ -854,11 +866,14 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
 }
 
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
+    LOCK(cs_peerstate);
+    CPeerState* peerstate = PeerState(nodeid);
     LOCK(cs_main);
     CNodeState *state = State(nodeid);
-    if (state == nullptr)
+    if (state == nullptr || peerstate == nullptr)
         return false;
-    stats.nMisbehavior = state->nMisbehavior;
+
+    stats.nMisbehavior = peerstate->nMisbehavior;
     stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
     stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
     for (const QueuedBlock& queue : state->vBlocksInFlight) {
@@ -1001,27 +1016,28 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans)
     return nEvicted;
 }
 
+
 /**
  * Mark a misbehaving peer to be banned depending upon the value of `-banscore`.
  */
-void Misbehaving(NodeId pnode, int howmuch, const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+void Misbehaving(NodeId pnode, int howmuch, const std::string& message) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     if (howmuch == 0)
         return;
 
-    CNodeState *state = State(pnode);
-    if (state == nullptr)
+    CPeerState *peerstate = PeerState(pnode);
+    if (peerstate == nullptr)
         return;
 
-    state->nMisbehavior += howmuch;
+    peerstate->nMisbehavior += howmuch;
     int banscore = gArgs.GetArg("-banscore", DEFAULT_BANSCORE_THRESHOLD);
     std::string message_prefixed = message.empty() ? "" : (": " + message);
-    if (state->nMisbehavior >= banscore && state->nMisbehavior - howmuch < banscore)
+    if (peerstate->nMisbehavior >= banscore && peerstate->nMisbehavior - howmuch < banscore)
     {
-        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED%s\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior, message_prefixed);
-        state->fShouldBan = true;
+        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d) BAN THRESHOLD EXCEEDED%s\n", __func__, peerstate->name, pnode, peerstate->nMisbehavior-howmuch, peerstate->nMisbehavior, message_prefixed);
+        peerstate->fShouldBan = true;
     } else
-        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d)%s\n", __func__, state->name, pnode, state->nMisbehavior-howmuch, state->nMisbehavior, message_prefixed);
+        LogPrint(BCLog::NET, "%s: %s peer=%d (%d -> %d)%s\n", __func__, peerstate->name, pnode, peerstate->nMisbehavior-howmuch, peerstate->nMisbehavior, message_prefixed);
 }
 
 /**
@@ -1047,7 +1063,7 @@ static bool TxRelayMayResultInDisconnect(const CValidationState& state)
  *
  * Changes here may need to be reflected in TxRelayMayResultInDisconnect().
  */
-static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool via_compact_block, const std::string& message = "") {
+static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool via_compact_block, const std::string& message = "") EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) {
     switch (state.GetReason()) {
     case ValidationInvalidReason::NONE:
         break;
@@ -1055,22 +1071,20 @@ static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool v
     case ValidationInvalidReason::CONSENSUS:
     case ValidationInvalidReason::BLOCK_MUTATED:
         if (!via_compact_block) {
-            LOCK(cs_main);
             Misbehaving(nodeid, 100, message);
             return true;
         }
         break;
     case ValidationInvalidReason::CACHED_INVALID:
         {
-            LOCK(cs_main);
-            CNodeState *node_state = State(nodeid);
-            if (node_state == nullptr) {
+            CPeerState *peer_state = PeerState(nodeid);
+            if (peer_state == nullptr) {
                 break;
             }
 
             // Ban outbound (but not inbound) peers if on an invalid chain.
             // Exempt HB compact block peers and manual connections.
-            if (!via_compact_block && !node_state->m_is_inbound && !node_state->m_is_manual_connection) {
+            if (!via_compact_block && !peer_state->m_is_inbound && !peer_state->m_is_manual_connection) {
                 Misbehaving(nodeid, 100, message);
                 return true;
             }
@@ -1080,7 +1094,6 @@ static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool v
     case ValidationInvalidReason::BLOCK_CHECKPOINT:
     case ValidationInvalidReason::BLOCK_INVALID_PREV:
         {
-            LOCK(cs_main);
             Misbehaving(nodeid, 100, message);
         }
         return true;
@@ -1088,7 +1101,6 @@ static bool MaybePunishNode(NodeId nodeid, const CValidationState& state, bool v
     case ValidationInvalidReason::BLOCK_MISSING_PREV:
         {
             // TODO: Handle this much more gracefully (10 DoS points is super arbitrary)
-            LOCK(cs_main);
             Misbehaving(nodeid, 10, message);
         }
         return true;
@@ -1276,6 +1288,7 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
  * peers announce compact blocks.
  */
 void PeerLogicValidation::BlockChecked(const CBlock& block, const CValidationState& state) {
+    LOCK(cs_peerstate);
     LOCK(cs_main);
 
     const uint256 hash(block.GetHash());
@@ -1635,11 +1648,10 @@ static uint32_t GetFetchFlags(CNode* pfrom) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     return nFetchFlags;
 }
 
-inline void static SendBlockTransactions(const CBlock& block, const BlockTransactionsRequest& req, CNode* pfrom, CConnman* connman) {
+inline void static SendBlockTransactions(const CBlock& block, const BlockTransactionsRequest& req, CNode* pfrom, CConnman* connman) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) {
     BlockTransactions resp(req);
     for (size_t i = 0; i < req.indexes.size(); i++) {
         if (req.indexes[i] >= block.vtx.size()) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100, strprintf("Peer %d sent us a getblocktxn with out-of-bounds tx indices", pfrom->GetId()));
             return;
         }
@@ -1651,7 +1663,7 @@ inline void static SendBlockTransactions(const CBlock& block, const BlockTransac
     connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCKTXN, resp));
 }
 
-bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::vector<CBlockHeader>& headers, const CChainParams& chainparams, bool via_compact_block)
+bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::vector<CBlockHeader>& headers, const CChainParams& chainparams, bool via_compact_block) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
     size_t nCount = headers.size();
@@ -1832,9 +1844,10 @@ bool static ProcessHeadersMessage(CNode *pfrom, CConnman *connman, const std::ve
     return true;
 }
 
-void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_set, std::list<CTransactionRef>& removed_txn) EXCLUSIVE_LOCKS_REQUIRED(cs_main, g_cs_orphans)
+void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_set, std::list<CTransactionRef>& removed_txn) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate, cs_main, g_cs_orphans)
 {
     AssertLockHeld(cs_main);
+    AssertLockHeld(cs_peerstate);
     AssertLockHeld(g_cs_orphans);
     std::set<NodeId> setMisbehaving;
     bool done = false;
@@ -1909,7 +1922,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
                strCommand == NetMsgType::FILTERADD))
     {
         if (pfrom->nVersion >= NO_BLOOM_VERSION) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);
             return false;
         } else {
@@ -1950,7 +1962,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
             if (enable_bip61) {
                 connman->PushMessage(pfrom, CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::REJECT, strCommand, REJECT_DUPLICATE, std::string("Duplicate version message")));
             }
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 1);
             return false;
         }
@@ -2118,7 +2129,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
 
     if (pfrom->nVersion == 0) {
         // Must have a version message before anything else
-        LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 1);
         return false;
     }
@@ -2165,7 +2175,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
 
     if (!pfrom->fSuccessfullyConnected) {
         // Must have a verack message before anything else
-        LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 1);
         return false;
     }
@@ -2179,7 +2188,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
             return true;
         if (vAddr.size() > 1000)
         {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message addr size() = %u", vAddr.size()));
             return false;
         }
@@ -2255,7 +2263,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         vRecv >> vInv;
         if (vInv.size() > MAX_INV_SZ)
         {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message inv size() = %u", vInv.size()));
             return false;
         }
@@ -2313,7 +2320,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         vRecv >> vInv;
         if (vInv.size() > MAX_INV_SZ)
         {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("message getdata size() = %u", vInv.size()));
             return false;
         }
@@ -2974,7 +2980,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
         if (nCount > MAX_HEADERS_RESULTS) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 20, strprintf("headers message size = %u", nCount));
             return false;
         }
@@ -3150,7 +3155,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         if (!filter.IsWithinSizeConstraints())
         {
             // There is no excuse for sending a too-large filter
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);
         }
         else
@@ -3181,7 +3185,6 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
             }
         }
         if (bad) {
-            LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);
         }
         return true;
@@ -3239,10 +3242,12 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
     return true;
 }
 
-bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main, cs_peerstate)
 {
     AssertLockHeld(cs_main);
+    AssertLockHeld(cs_peerstate);
     CNodeState &state = *State(pnode->GetId());
+    CPeerState &peerstate = *PeerState(pnode->GetId());
 
     if (enable_bip61) {
         for (const CBlockReject& reject : state.rejects) {
@@ -3251,8 +3256,8 @@ bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_
     }
     state.rejects.clear();
 
-    if (state.fShouldBan) {
-        state.fShouldBan = false;
+    if (peerstate.fShouldBan) {
+        peerstate.fShouldBan = false;
         if (pnode->fWhitelisted)
             LogPrintf("Warning: not punishing whitelisted peer %s!\n", pnode->addr.ToString());
         else if (pnode->m_manual_connection)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1306,6 +1306,14 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const CValidationSta
         mapBlockSource.erase(it);
 }
 
+/**
+ * Wake up message handler once a block has been processed to process the
+ * next message from the peer that sent us that block.
+ */
+void PeerLogicValidation::BlockProcessed() {
+    connman->WakeMessageHandler();
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Messages

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -200,6 +200,17 @@ struct CBlockReject {
 };
 
 /**
+ * Maintain state about nodes, protected by our own lock. Historically we put all
+ * peer tracking state in CNodeState, however this results in significant cs_main
+ * contention. Thus, new state tracking should go here, and we should eventually
+ * move most (non-validation-specific) state here.
+ */
+struct CPeerState {
+    CPeerState() {}
+};
+
+
+/**
  * Maintain validation-specific state about nodes, protected by cs_main, instead
  * by CNode's own locks. This simplifies asynchronous operation, where
  * processing of incoming data is done after the ProcessMessage call returns,
@@ -393,7 +404,20 @@ struct CNodeState {
 // Keeps track of the time (in microseconds) when transactions were requested last time
 limitedmap<uint256, int64_t> g_already_asked_for GUARDED_BY(cs_main)(MAX_INV_SZ);
 
+/** Note that this must be locked BEFORE cs_main! */
+CCriticalSection cs_peerstate;
+
 /** Map maintaining per-node state. */
+static std::map<NodeId, CPeerState> mapPeerState GUARDED_BY(cs_peerstate);
+
+static CPeerState *PeerState(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate) LOCKS_EXCLUDED(cs_main) {
+    std::map<NodeId, CPeerState>::iterator it = mapPeerState.find(pnode);
+    if (it == mapPeerState.end())
+        return nullptr;
+    return &it->second;
+}
+
+/** Map maintaining new per-node state. */
 static std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
 
 static CNodeState *State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
@@ -771,12 +795,22 @@ void PeerLogicValidation::InitializeNode(CNode *pnode) {
         LOCK(cs_main);
         mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(nodeid), std::forward_as_tuple(addr, std::move(addrName), pnode->fInbound, pnode->m_manual_connection));
     }
+    {
+        LOCK(cs_peerstate);
+        mapPeerState.emplace_hint(mapPeerState.end(), nodeid, CPeerState{});
+    }
+
     if(!pnode->fInbound)
         PushNodeVersion(pnode, connman, GetTime());
 }
 
 void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTime) {
     fUpdateConnectionTime = false;
+
+    LOCK(cs_peerstate);
+    CPeerState* peerstate = PeerState(nodeid);
+    assert(peerstate != nullptr);
+
     LOCK(cs_main);
     CNodeState *state = State(nodeid);
     assert(state != nullptr);
@@ -799,6 +833,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
     assert(g_outbound_peers_with_protect_from_disconnect >= 0);
 
     mapNodeState.erase(nodeid);
+    mapPeerState.erase(nodeid);
 
     if (mapNodeState.empty()) {
         // Do a consistency check after the last peer is removed.
@@ -806,6 +841,7 @@ void PeerLogicValidation::FinalizeNode(NodeId nodeid, bool& fUpdateConnectionTim
         assert(nPreferredDownload == 0);
         assert(nPeersWithValidatedDownloads == 0);
         assert(g_outbound_peers_with_protect_from_disconnect == 0);
+        assert(mapPeerState.empty());
     }
     LogPrint(BCLog::NET, "Cleared nodestate for peer=%d\n", nodeid);
 }
@@ -1843,7 +1879,7 @@ void static ProcessOrphanTx(CConnman* connman, std::set<uint256>& orphan_work_se
     }
 }
 
-bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61)
+bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::string& strCommand, CDataStream& vRecv, int64_t nTimeReceived, const CChainParams& chainparams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     LogPrint(BCLog::NET, "received: %s (%u bytes) peer=%d\n", SanitizeString(strCommand), vRecv.size(), pfrom->GetId());
     if (gArgs.IsArgSet("-dropmessagestest") && GetRand(gArgs.GetArg("-dropmessagestest", 0)) == 0)
@@ -2785,7 +2821,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         } // cs_main
 
         if (fProcessBLOCKTXN)
-            return ProcessMessage(pfrom, NetMsgType::BLOCKTXN, blockTxnMsg, nTimeReceived, chainparams, connman, interruptMsgProc, enable_bip61);
+            return ProcessMessage(pfrom, peerstate, NetMsgType::BLOCKTXN, blockTxnMsg, nTimeReceived, chainparams, connman, interruptMsgProc, enable_bip61);
 
         if (fRevertToHeaderProcessing) {
             // Headers received from HB compact block peers are permitted to be
@@ -3231,6 +3267,8 @@ bool PeerLogicValidation::SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_
 bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
+    LOCK(cs_peerstate);
+    CPeerState* peerstate = PeerState(pfrom->GetId());
     //
     // Message format
     //  (4) message start
@@ -3313,7 +3351,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
     bool fRet = false;
     try
     {
-        fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime, chainparams, connman, interruptMsgProc, m_enable_bip61);
+        fRet = ProcessMessage(pfrom, peerstate, strCommand, vRecv, msg.nTime, chainparams, connman, interruptMsgProc, m_enable_bip61);
         if (interruptMsgProc)
             return false;
         if (!pfrom->vRecvGetData.empty())
@@ -3521,6 +3559,9 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
         // If we get here, the outgoing message serialization version is set and can't change.
         const CNetMsgMaker msgMaker(pto->GetSendVersion());
+
+        LOCK(cs_peerstate);
+        CPeerState* peerstate = PeerState(pto->GetId());
 
         //
         // Message: ping

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -45,6 +45,10 @@ public:
      * Overridden from CValidationInterface.
      */
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
+    /**
+     * Overridden from CValidationInterface.
+     */
+    void BlockProcessed() override;
 
     /** Initialize a peer by adding it to mapNodeState and pushing a message requesting its version */
     void InitializeNode(CNode* pnode) override;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -13,6 +13,9 @@
 
 extern CCriticalSection cs_main;
 
+/** Note that this must be locked BEFORE cs_main! */
+extern CCriticalSection cs_peerstate ACQUIRED_BEFORE(cs_main);
+
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
@@ -25,7 +28,7 @@ private:
     CConnman* const connman;
     BanMan* const m_banman;
 
-    bool SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate);
 public:
     PeerLogicValidation(CConnman* connman, BanMan* banman, CScheduler &scheduler, bool enable_bip61);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -749,6 +749,7 @@ static UniValue submitblock(const JSONRPCRequest& request)
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
     bool new_block = ProcessNewBlock(Params(), blockptr, /* fForceProcessing */ true).get();
+    SyncWithValidationInterfaceQueue();
     UnregisterValidationInterface(&sc);
     LOCK(cs_main);
     const CBlockIndex* pindex = LookupBlockIndex(blockptr->GetHash());

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -102,7 +102,7 @@ static bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script
         CBlockHeader header = block->GetBlockHeader();
 
         CValidationState state;
-        if (!ProcessNewBlockHeaders({header}, state, Params(), &pindex, nullptr)) {
+        if (!ProcessNewBlockHeaders({header}, state, Params(), &pindex)) {
             return false;
         }
     }
@@ -175,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+        ProcessNewBlock(Params(), block, true).wait();
 
         const CBlockIndex* block_index;
         {
@@ -191,7 +191,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+        ProcessNewBlock(Params(), block, true).wait();
 
         const CBlockIndex* block_index;
         {
@@ -220,7 +220,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     // Reorg back to chain A.
      for (size_t i = 2; i < 4; i++) {
          const auto& block = chainA[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+         ProcessNewBlock(Params(), block, true).wait();
      }
 
      // Check that chain A and B blocks can be retrieved.

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -95,11 +95,11 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 
     // Test starts here
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
         dummyNode1.vSendMsg.clear();
     }
@@ -108,17 +108,17 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Wait 21 minutes
     SetMockTime(nStartTime+21*60);
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
     }
     // Wait 3 more minutes
     SetMockTime(nStartTime+24*60);
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in disconnect
     }
     BOOST_CHECK(dummyNode1.fDisconnect == true);
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
-        LOCK2(cs_main, dummyNode2.cs_sendProcessing);
+        LOCK(dummyNode2.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(!banman->IsBanned(addr2)); // 2 not banned yet...
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
-        LOCK2(cs_main, dummyNode2.cs_sendProcessing);
+        LOCK(dummyNode2.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(banman->IsBanned(addr2));
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 100);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 10);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 1);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
         Misbehaving(dummyNode.GetId(), 100);
     }
     {
-        LOCK2(cs_main, dummyNode.cs_sendProcessing);
+        LOCK(dummyNode.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
     }
     BOOST_CHECK(banman->IsBanned(addr));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        ProcessNewBlock(chainparams, shared_pblock, true).wait();
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -78,6 +78,8 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
     threadGroup.create_thread(std::bind(&CScheduler::serviceQueue, &scheduler));
     GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
 
+    threadGroup.create_thread(std::function<void()>(std::bind(&CChainState::ProcessBlockValidationQueue, &ChainstateActive())));
+
     mempool.setSanityCheck(1.0);
     pblocktree.reset(new CBlockTreeDB(1 << 20, true));
     pcoinsdbview.reset(new CCoinsViewDB(1 << 23, true));

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -156,7 +156,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    ProcessNewBlock(chainparams, shared_pblock, true).wait();
 
     CBlock result = block;
     return result;

--- a/src/test/util.cpp
+++ b/src/test/util.cpp
@@ -68,8 +68,7 @@ CTxIn MineBlock(const CScript& coinbase_scriptPubKey)
         assert(block->nNonce);
     }
 
-    bool processed{ProcessNewBlock(Params(), block, true, nullptr)};
-    assert(processed);
+    ProcessNewBlock(Params(), block, true).wait();
 
     return CTxIn{block->vtx[0]->GetHash(), 0};
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2293,7 +2293,7 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
     {
         CCoinsViewCache view(pcoinsTip.get());
         bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, chainparams);
-        GetMainSignals().BlockChecked(blockConnecting, state);
+        GetMainSignals().BlockChecked(pthisBlock, state);
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);
@@ -3475,7 +3475,7 @@ void CChainState::ProcessBlockValidationQueue()
                 ret = ::ChainstateActive().AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, &fNewBlock);
             }
             if (!ret) {
-                GetMainSignals().BlockChecked(*pblock, state);
+                GetMainSignals().BlockChecked(pblock, state);
                 error("%s: AcceptBlock FAILED (%s)", __func__, FormatStateMessage(state));
                 result_promise.set_value(fNewBlock);
                 continue;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3489,6 +3489,7 @@ void CChainState::ProcessBlockValidationQueue()
             error("%s: ActivateBestChain failed (%s)", __func__, FormatStateMessage(state));
 
         result_promise.set_value(fNewBlock);
+        GetMainSignals().BlockProcessed();
     }
 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <atomic>
 #include <exception>
+#include <future>
 #include <map>
 #include <memory>
 #include <set>
@@ -208,15 +209,17 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  * Note that we guarantee that either the proof-of-work is valid on pblock, or
  * (and possibly also) BlockChecked will have been called.
  *
- * May not be called in a
- * validationinterface callback.
+ * May not be called in a validationinterface callback.
+ *
+ * Do NOT block on the returned future waiting for it to resolve as this may
+ * introduce deadlocks (in the case you are holding any mutexes which are
+ * also taken in validationinterface callbacks).
  *
  * @param[in]   pblock  The block we want to process.
  * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
- * @return True if state.IsValid()
+ * @return      A future which complets with a boolean which is set to indicate if the block was first received via this call
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+std::future<bool> ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing) LOCKS_EXCLUDED(cs_main);
 
 /**
  * Process incoming block headers.

--- a/src/validation.h
+++ b/src/validation.h
@@ -512,6 +512,13 @@ private:
      */
     mutable std::atomic<bool> m_cached_finished_ibd{false};
 
+    /** Lock for m_block_validation_queue */
+    CCriticalSection m_cs_block_validation_queue;
+    /** CV for m_block_validation_queue */
+    std::condition_variable_any m_cv_block_validation_queue;
+    /** Queue of blocks to validate */
+    std::list<std::tuple<std::shared_ptr<const CBlock>, bool, std::promise<bool>>> m_block_validation_queue;
+
 public:
     //! The current chain of blockheaders we consult and build on.
     //! @see CChain, CBlockIndex.
@@ -576,6 +583,12 @@ public:
 
     /** Check whether we are doing an initial block download (synchronizing from disk or network) */
     bool IsInitialBlockDownload() const;
+
+    /** Drain the block validation queue in a loop */
+    void ProcessBlockValidationQueue();
+
+    /** Push a new block to the block validation queue */
+    std::future<bool> ProcessNewBlock(const std::shared_ptr<const CBlock> pblock, bool fForceProcessing);
 
 private:
     bool ActivateBestChainStep(CValidationState& state, const CChainParams& chainparams, CBlockIndex* pindexMostWork, const std::shared_ptr<const CBlock>& pblock, bool& fInvalidFound, ConnectTrace& connectTrace) EXCLUSIVE_LOCKS_REQUIRED(cs_main);

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -5,6 +5,7 @@
 
 #include <validationinterface.h>
 
+#include <consensus/validation.h>
 #include <primitives/block.h>
 #include <scheduler.h>
 #include <txmempool.h>
@@ -173,8 +174,10 @@ void CMainSignals::ChainStateFlushed(const CBlockLocator &locator) {
     });
 }
 
-void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& state) {
-    m_internals->BlockChecked(block, state);
+void CMainSignals::BlockChecked(const std::shared_ptr<const CBlock> &pblock, const CValidationState& state) {
+    m_internals->m_schedulerClient.AddToProcessQueue([pblock, state, this] {
+        m_internals->BlockChecked(*pblock, state);
+    });
 }
 
 void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -138,6 +138,8 @@ protected:
      * If the provided CValidationState IsValid, the provided block
      * is guaranteed to be the current best block at the time the
      * callback was generated (not necessarily now)
+     *
+     * Called on a background thread.
      */
     virtual void BlockChecked(const CBlock&, const CValidationState&) {}
     /**
@@ -187,7 +189,7 @@ public:
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::shared_ptr<const std::vector<CTransactionRef>> &);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &);
     void ChainStateFlushed(const CBlockLocator &);
-    void BlockChecked(const CBlock&, const CValidationState&);
+    void BlockChecked(const std::shared_ptr<const CBlock> &block, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
     void BlockProcessed();
 };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -144,6 +144,12 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    /**
+     * Notifies listeners that a block which was submitted has been fully processed.
+     *
+     * Called on a background thread.
+     */
+    virtual void BlockProcessed() {}
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -183,6 +189,7 @@ public:
     void ChainStateFlushed(const CBlockLocator &);
     void BlockChecked(const CBlock&, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void BlockProcessed();
 };
 
 CMainSignals& GetMainSignals();


### PR DESCRIPTION
This is essentially a rebase of #12934, though its actually greenfield to reduce diff a bit. Based on #16174 as without it the parallelism would be almost entirely useless. Note that this is draft as I haven't (yet) bothered doing the backgrounding of the block validation, its currently just a return value change and the net_processing changes to handle it.