### PR TITLE
Allow NODE_BLOOM services for whitelisted peers

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -958,7 +958,12 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     uint64_t nonce = GetDeterministicRandomizer(RANDOMIZER_ID_LOCALHOSTNONCE).Write(id).Finalize();
     CAddress addr_bind = GetBindAddress(hSocket);
 
-    CNode* pnode = new CNode(id, nLocalServices, GetBestHeight(), hSocket, addr, CalculateKeyedNetGroup(addr), nonce, addr_bind, "", true);
+    ServiceFlags nodeLocalServices = nLocalServices;
+    if (whitelisted) 
+    {
+        nodeLocalServices = ServiceFlags(nodeLocalServices | NODE_BLOOM);
+    }
+    CNode* pnode = new CNode(id, nodeLocalServices, GetBestHeight(), hSocket, addr, CalculateKeyedNetGroup(addr), nonce, addr_bind, "", true);
     pnode->AddRef();
     pnode->fWhitelisted = whitelisted;
     pnode->m_prefer_evict = bannedlevel > 0;


### PR DESCRIPTION
As mentioned [here](https://github.com/bitcoin/bitcoin/pull/16152#issuecomment-500205875), I believe that there should be no reason to not support bloom filter for whitelisted peers.

There is no protocol more efficient than this, working as well in pruned mode to sync a light client from your own full node without the need of some middleware like Electrum.

Even BIP157 comes short for this usecase as it needlessly waste bandwidth. (and I think BIP157, as implemented now does not work in pruned mode -might be wrong here-)