### PR TITLE
depends: xtrans: Configure flags cleanup.

### DIFF
--- a/depends/packages/xtrans.mk
+++ b/depends/packages/xtrans.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=054d4ee3efd52508c753e9f7bc655ef185a29bd2850dd9e2fc2ccc335
 $(package)_dependencies=
 
 define $(package)_set_vars
-$(package)_config_opts_linux=--with-pic --disable-shared
+  $(package)_config_opts_linux=--disable-docs --without-xmlto --without-fop --without-xsltproc
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
```
xtrans does not understand the --with-pic and --disable-shared flags we
pass it because it is not a library. Instead, we should pass it flags
that disable features/packages we're not using so they don't get a
chance to sneak in.
```

Here's a comparison of stdout and stderr of `make -j(nproc) V=1 xtrans_built` before and after this PR: https://gist.github.com/dongcarl/4ebf6fe9985ebc1508190f75932e4237