### PR TITLE
gettransaction: add an argument to decode the transaction

### DIFF
--- a/doc/release-notes-16185.md
+++ b/doc/release-notes-16185.md
@@ -1,0 +1,3 @@
+RPC changes
+-----------
+The `gettransaction` RPC now accepts a third (boolean) argument `decode`. If set to `true`, a new `decoded` field will be added to the response containing the decoded transaction.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -85,6 +85,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockheader", 1, "verbose" },
     { "getchaintxstats", 0, "nblocks" },
     { "gettransaction", 1, "include_watchonly" },
+    { "gettransaction", 2, "decode" },
     { "getrawtransaction", 1, "verbose" },
     { "createrawtransaction", 0, "inputs" },
     { "createrawtransaction", 1, "outputs" },

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -499,6 +499,11 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[0].setlabel(change, 'foobar')
         assert_equal(self.nodes[0].getaddressinfo(change)['ischange'], False)
 
+        # Test "decoded" field value in gettransaction response
+        self.log.info("Testing gettransaction decoding...")
+        tx = self.nodes[0].gettransaction(txid=txid, decode=True)
+        assert_equal(tx["decoded"], self.nodes[0].decoderawtransaction(tx["hex"]))
+
 
 if __name__ == '__main__':
     WalletTest().main()


### PR DESCRIPTION
This PR adds a new parameter to the `gettransaction` call : `decode`. If set to `true`, it will add a new `decoded` field to the response. This mimics the behavior of `getrawtransaction`'s `verbose` argument to avoid using 2 calls if we want to decode a wallet transaction (`gettransaction` then `decoderawtransaction`).

Fix #16181 .