### PR TITLE
doc/lint: Fix spelling errors identified by codespell 1.15.0

### DIFF
--- a/.travis/lint_04_install.sh
+++ b/.travis/lint_04_install.sh
@@ -6,7 +6,7 @@
 
 export LC_ALL=C
 
-travis_retry pip install codespell==1.13.0
+travis_retry pip install codespell==1.15.0
 travis_retry pip install flake8==3.5.0
 travis_retry pip install vulture==0.29
 

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -144,7 +144,7 @@ Then do:
 Create and verify timestamps of merge commits
 ---------------------------------------------
 To create or verify timestamps on the merge commits, install the OpenTimestamps
-client via `pip3 install opentimestamps-client`. Then, dowload the gpg wrapper
+client via `pip3 install opentimestamps-client`. Then, download the gpg wrapper
 `ots-git-gpg-wrapper.sh` and set it as git's `gpg.program`. See
 [the ots git integration documentation](https://github.com/opentimestamps/opentimestamps-client/blob/master/doc/git-integration.md#usage)
 for further details.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -280,7 +280,7 @@ thread](https://askubuntu.com/questions/50145/how-to-install-perf-monitoring-too
 for specific instructions.
 
 Certain kernel parameters may need to be set for perf to be able to inspect the
-running process' stack.
+running process's stack.
 
 ```sh
 $ sudo sysctl -w kernel.perf_event_paranoid=-1

--- a/doc/release-notes/release-notes-0.12.0.md
+++ b/doc/release-notes/release-notes-0.12.0.md
@@ -127,7 +127,7 @@ minimum relay feerate. The initial minimum relay feerate is set to
 Bitcoin Core 0.12 also introduces new default policy limits on the length and
 size of unconfirmed transaction chains that are allowed in the mempool
 (generally limiting the length of unconfirmed chains to 25 transactions, with a
-total size of 101 KB).  These limits can be overriden using command line
+total size of 101 KB).  These limits can be overridden using command line
 arguments; see the extended help (`--help -help-debug`) for more information.
 
 Opt-in Replace-by-fee transactions

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -239,7 +239,7 @@ bool CNetAddr::IsLocal() const
  *          be used to refer to an actual host.
  *
  * @note A valid address may or may not be publicly routable on the global
- *       internet. As in, the set of valid addreses is a superset of the set of
+ *       internet. As in, the set of valid addresses is a superset of the set of
  *       publicly routable addresses.
  *
  * @see CNetAddr::IsRoutable()
@@ -287,7 +287,7 @@ bool CNetAddr::IsValid() const
  * @returns Whether or not this network address is publicly routable on the
  *          global internet.
  *
- * @note A routable address is always valid. As in, the set of routable addreses
+ * @note A routable address is always valid. As in, the set of routable addresses
  *       is a subset of the set of valid addresses.
  *
  * @see CNetAddr::IsValid()

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -47,7 +47,7 @@ private:
     std::vector<double> txCtAvg;
 
     // Count the total # of txs confirmed within Y blocks in each bucket
-    // Track the historical moving average of theses totals over blocks
+    // Track the historical moving average of these totals over blocks
     std::vector<std::vector<double>> confAvg; // confAvg[Y][X]
 
     // Track moving avg of txs which have been evicted from the mempool

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -39,7 +39,7 @@
 
 /** High fee for sendrawtransaction and testmempoolaccept.
  * By default, transaction with a fee higher than this will be rejected by the
- * RPCs. This can be overriden with the maxfeerate argument.
+ * RPCs. This can be overridden with the maxfeerate argument.
  */
 constexpr static CAmount DEFAULT_MAX_RAW_TX_FEE{COIN / 10};
 

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE(poly1305_testvector)
 
 BOOST_AUTO_TEST_CASE(hkdf_hmac_sha256_l32_tests)
 {
-    // Use rfc5869 test vectors but trucated to 32 bytes (our implementation only support length 32)
+    // Use rfc5869 test vectors but truncated to 32 bytes (our implementation only support length 32)
     TestHKDF_SHA256_32(
                 /* IKM */ "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b",
                 /* salt */ "000102030405060708090a0b0c",

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -412,7 +412,7 @@ public:
     TorController(struct event_base* base, const std::string& target);
     ~TorController();
 
-    /** Get name fo file to store private key in */
+    /** Get name of file to store private key in */
     fs::path GetPrivateKeyFile();
 
     /** Reconnect, after getting disconnected */

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -5,3 +5,10 @@ mut
 objext
 unselect
 useable
+wit
+unparseable
+copyable
+cachable
+errorstring
+keyserver
+homogenous


### PR DESCRIPTION
Note all changes are to comments / documentation.

After this commit, the only remaining output is:

```
  $ test/lint/lint-spelling.sh
  src/test/base32_tests.cpp:14: fo  ==> of, for
  src/test/base64_tests.cpp:14: fo  ==> of, for
  ^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/lint-spelling.ignore-words.txt
```

Note:
* I ignore several valid alternative spellings ~, but changed homogenous
to homogeneous as the latter is a more specific term according to the
Google dictionary definitions I found~
* homogenous is present in tinyformat, hence should be addressed upstream
* process' is correct only if there are plural processes