### PR TITLE
0.18: Backport "Add -ignorepartialspends to list of ignored wallet options"

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -25,6 +25,7 @@ void DummyWalletInit::AddWalletOptions() const
 {
     std::vector<std::string> opts = {
         "-addresstype",
+        "-avoidpartialspends",
         "-changetype",
         "-disablewallet",
         "-discardfee=<amt>",

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -23,10 +23,31 @@ public:
 
 void DummyWalletInit::AddWalletOptions() const
 {
-    std::vector<std::string> opts = {"-addresstype", "-changetype", "-disablewallet", "-discardfee=<amt>", "-fallbackfee=<amt>",
-        "-keypool=<n>", "-mintxfee=<amt>", "-paytxfee=<amt>", "-rescan", "-salvagewallet", "-spendzeroconfchange",  "-txconfirmtarget=<n>",
-        "-upgradewallet", "-wallet=<path>", "-walletbroadcast", "-walletdir=<dir>", "-walletnotify=<cmd>", "-walletrbf", "-zapwallettxes=<mode>",
-        "-dblogsize=<n>", "-flushwallet", "-privdb", "-walletrejectlongchains"};
+    std::vector<std::string> opts = {
+        "-addresstype",
+        "-changetype",
+        "-disablewallet",
+        "-discardfee=<amt>",
+        "-fallbackfee=<amt>",
+        "-keypool=<n>",
+        "-mintxfee=<amt>",
+        "-paytxfee=<amt>",
+        "-rescan",
+        "-salvagewallet",
+        "-spendzeroconfchange",
+        "-txconfirmtarget=<n>",
+        "-upgradewallet",
+        "-wallet=<path>",
+        "-walletbroadcast",
+        "-walletdir=<dir>",
+        "-walletnotify=<cmd>",
+        "-walletrbf",
+        "-zapwallettxes=<mode>",
+        "-dblogsize=<n>",
+        "-flushwallet",
+        "-privdb",
+        "-walletrejectlongchains",
+    };
     gArgs.AddHiddenArgs(opts);
 }
 


### PR DESCRIPTION
First run clang-format on the wallet options list (review with `--word-diff-regex=.`). This is not a backport.

Then backport Github-Pull: #15913