### PR TITLE
Wallet: Catches situations where capping on maxtxfee drops the fee too low

### DIFF
--- a/doc/release-notes-16192.md
+++ b/doc/release-notes-16192.md
@@ -1,0 +1,12 @@
+Wallet: Transaction fees
+------------------------
+
+Currently the wallet caps fees at `-maxtxfee=<x>` (default: 
+0.10) BTC. A user can set the minimum fee rate for all 
+transactions with `-mintxfee=<i>`, which defaults to 
+1000 satoshis per kB. Users can also decide to pay a 
+predefined fee rate by setting `-paytxfee=<n>` (or 
+`settxfee <n>` rpc during runtime). These settings could 
+conflict with one another. If capping at `-maxtxfee` would 
+render the fee lower than `-mintxfee` per kB or `-paytxfee`
+per kB, the wallet will now return an error.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2959,6 +2959,19 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     return false;
                 }
 
+                // If the fee was capped to MAXTXFEE and this results in a too low fee rate given our current
+                // configuration, abort.
+                if (feeCalc.reason == FeeReason::MAXTXFEE) {
+                    if (nFeeNeeded < m_pay_tx_fee.GetFee(nBytes)) {
+                        strFailReason = _("Fee rate too low after limiting to -maxtxfee");
+                        return false;
+                    }
+                    if (nFeeNeeded < m_min_fee.GetFee(nBytes)) {
+                        strFailReason = _("Fee rate too low after limiting to -maxtxfee");
+                        return false;
+                    }
+                }
+
                 if (nFeeRet >= nFeeNeeded) {
                     // Reduce fee to only the needed amount if possible. This
                     // prevents potential overpayment in fees if the coins

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -139,6 +139,7 @@ BASE_SCRIPTS = [
     'rpc_deprecated.py',
     'wallet_disable.py',
     'rpc_net.py',
+    'wallet_maxtxfee.py',
     'wallet_keypool.py',
     'p2p_mempool.py',
     'p2p_blocksonly.py',

--- a/test/functional/wallet_maxtxfee.py
+++ b/test/functional/wallet_maxtxfee.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test wallet maxtxfee limiting in conjunction with settxfee or mintxfee."""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+class WalletMaxFeeTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.nodes[0].generate(105)
+
+        outputs = {}
+
+        for i in range(10):
+            outputs[self.nodes[0].getnewaddress()] = 0.001
+
+        # test sending a tx with normal fee parameters (must work)
+        self.nodes[0].sendmany("",outputs)
+
+        # test sending a tx with very low max fee (must still work)
+        self.restart_node(0, extra_args=["-maxtxfee=0.0001"])
+        self.nodes[0].sendmany("",outputs)
+
+        # test sending a tx with very low max fee and a high paytxfee (must fail)
+        self.restart_node(0, extra_args=["-maxtxfee=0.0001","-paytxfee=0.0005"])
+        assert_raises_rpc_error(-6, "Fee rate too low after limiting to -maxtxfee", lambda: self.nodes[0].sendmany("",outputs))
+
+        # test sending a tx with very low max fee and a high mintxfee (must fail)
+        self.restart_node(0, extra_args=["-maxtxfee=0.0001","-mintxfee=0.0005"])
+        assert_raises_rpc_error(-6, "Fee rate too low after limiting to -maxtxfee", lambda: self.nodes[0].sendmany("",outputs))
+
+if __name__ == '__main__':
+    WalletMaxFeeTest().main()


### PR DESCRIPTION
This is a possible fix for #10122

If the fee is capped on `-maxtxfee`, it will check if the fee is still above `-mintxfee` and `-paytxfee` for the given transaction. However, it seems this is a very edge case. In order to run into this, I had to pass `-maxtxfee=0.01 -mintxfee=0.005` and then send a transaction that was about 89kB.

It seems that under the defaults no one would run into this; but maybe there's more scenario's under which this would be a problem.
