### PR TITLE
rpc: fix showing wrong amount when not all inputs are from me in gettransaction

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1739,7 +1739,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
     CAmount nCredit = wtx.GetCredit(*locked_chain, filter);
     CAmount nDebit = wtx.GetDebit(filter);
     CAmount nNet = nCredit - nDebit;
-    CAmount nFee = (wtx.IsFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
+    CAmount nFee = (wtx.IsAllFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
 
     entry.pushKV("amount", ValueFromAmount(nNet - nFee));
     if (wtx.IsFromMe(filter))

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -577,6 +577,7 @@ public:
     {
         return (GetDebit(filter) > 0);
     }
+    bool IsAllFromMe(const isminefilter& filter) const;
 
     // True if only scriptSigs are different
     bool IsEquivalentTo(const CWalletTx& tx) const;


### PR DESCRIPTION
Fix #14136.

In the rpc `gettransaction`, there is an error in calculating `nFee`.
```
CAmount nFee = (wtx.IsFromMe(filter) ? wtx.tx->GetValueOut() - nDebit : 0);
```

If not all the inputs are from me (like the case of CoinJoin), `wtx.IsFromMe(filter)` returns `true`, and `nFee` would get a wrong value from `wtx.tx->GetValueOut() - nDebit`. Here `nDebit` only stands for sum of my inputs rather than all inputs, so in this case, `nFee` would equal to all outputs minus my inputs.

A feasible solution is to use `IsAllFromMe` instead of `IsFromMe`. By this method, `nFee` is set as `0` and `amount` can be correctly calculated from `nCredit - nDebit`, aka, all my outputs minus all my inputs.

The right `amount` and `fee` in the case of #14136 is successfully got through this way, as illustrated below. Here we use `importaddress`, aka the watch-only mode, to simulate the case.

![image](https://user-images.githubusercontent.com/3756217/59401540-9f2f4c80-8dcd-11e9-8f95-3f8150bb6ff5.png)
