### PR TITLE
rpc: Change Content-Type to plain text for the webroot

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -148,6 +148,7 @@ static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
 {
     // JSONRPC handles only POST
     if (req->GetRequestMethod() != HTTPRequest::POST) {
+        req->WriteHeader("Content-Type", "text/plain");
         req->WriteReply(HTTP_BAD_METHOD, "JSONRPC server handles only POST requests");
         return false;
     }


### PR DESCRIPTION
Hello, I added a header when you call the webserver directly.
Currently it returns invalid html, which could be rendered invalid by a browser.
The PR adds a  `text/plain` header. This is also common for error messages.
Here are some screenshots where the content-type is being showed
(You can see the respone header in the bottom right corner)

[Without my change](https://imgur.com/a/RYXA7Pg)
[With my change](https://imgur.com/a/sv1YrG2)
