### PR TITLE
test: stop generating lcov coverage when functional tests fail

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -198,7 +198,7 @@ test_bitcoin_filtered.info: test_bitcoin.info
 	$(LCOV) -a $@ $(LCOV_OPTS) -o $@
 
 functional_test.info: test_bitcoin_filtered.info
-	-@TIMEOUT=15 test/functional/test_runner.py $(EXTENDED_FUNCTIONAL_TESTS)
+	@TIMEOUT=15 test/functional/test_runner.py $(EXTENDED_FUNCTIONAL_TESTS)
 	$(LCOV) -c $(LCOV_OPTS) -d $(abs_builddir)/src --t functional-tests -o $@
 	$(LCOV) -z $(LCOV_OPTS) -d $(abs_builddir)/src
 


### PR DESCRIPTION
Fixes #15648

Functional tests can fail and lcov still generates a coverage file, which is inaccurate. This change stops `make` from proceeding if functional tests fail.

before:

![image](https://user-images.githubusercontent.com/6106941/59449220-a9a11480-8dd4-11e9-9eff-81c42513aafa.png)

after:
![image](https://user-images.githubusercontent.com/6106941/59449234-b160b900-8dd4-11e9-9d80-6e9c7f41c241.png)
