### PR TITLE
addrdb: Avoid eating inodes - remove temporary files created by SerializeFileDB in case of errors

### DIFF
--- a/src/addrdb.cpp
+++ b/src/addrdb.cpp
@@ -44,18 +44,30 @@ bool SerializeFileDB(const std::string& prefix, const fs::path& path, const Data
     fs::path pathTmp = GetDataDir() / tmpfn;
     FILE *file = fsbridge::fopen(pathTmp, "wb");
     CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
+    if (fileout.IsNull()) {
+        fileout.fclose();
+        remove(pathTmp);
         return error("%s: Failed to open file %s", __func__, pathTmp.string());
+    }
 
     // Serialize
-    if (!SerializeDB(fileout, data)) return false;
-    if (!FileCommit(fileout.Get()))
+    if (!SerializeDB(fileout, data)) {
+        fileout.fclose();
+        remove(pathTmp);
+        return false;
+    }
+    if (!FileCommit(fileout.Get())) {
+        fileout.fclose();
+        remove(pathTmp);
         return error("%s: Failed to flush file %s", __func__, pathTmp.string());
+    }
     fileout.fclose();
 
     // replace existing file, if any, with new file
-    if (!RenameOver(pathTmp, path))
+    if (!RenameOver(pathTmp, path)) {
+        remove(pathTmp);
         return error("%s: Rename-into-place failed", __func__);
+    }
 
     return true;
 }


### PR DESCRIPTION
Remove temporary files created in `SerializeFileDB` in case of errors.

_Edit: Previously this was hit non-deterministically from the tests: that is no longer the case but the cleanup issue remains :-)_