### PR TITLE
doc: Remove explicit mention of versions from SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,15 +2,8 @@
 
 ## Supported Versions
 
-Versions of Bitcoin Core that are currently supported with security updates:
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 0.18    | :white_check_mark: |
-| 0.17    | :white_check_mark: |
-| 0.16    | :white_check_mark: |
-| 0.15    | :white_check_mark: |
-| < 0.15  | :x:                |
+See our website for versions of Bitcoin Core that are currently supported with
+security updates: https://bitcoincore.org/en/lifecycle/#schedule
 
 ## Reporting a Vulnerability
 

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -41,12 +41,10 @@ Release Process
 #### After branch-off (on master)
 
 - Update the version of `contrib/gitian-descriptors/*.yml`.
-- Update the versions in `SECURITY.md` as per the software lifecycle [maintenance policy](https://bitcoincore.org/en/lifecycle/#maintenance-period), generally bumping all up one major version.
 
 #### After branch-off (on the major release branch)
 
 - Update the versions and the link to the release notes draft in `doc/release-notes.md`.
-- Delete `SECURITY.md`.
 
 #### Before final release
 
@@ -324,6 +322,9 @@ bitcoin.org (see below for bitcoin.org update instructions).
 - Update other repositories and websites for new version
 
   - bitcoincore.org blog post
+
+  - bitcoincore.org maintained versions update:
+    [table](https://github.com/bitcoin-core/bitcoincore.org/commits/master/_includes/posts/maintenance-table.md)
 
   - bitcoincore.org RPC documentation update
 


### PR DESCRIPTION
The repo should not contain documentation that is not tied to any release. For example meta information like a list of maintained versions of Bitcoin Core falls into this scope.

Replace the list of versions in `./SECURITY.md` with a link to the website.