### PR TITLE
travis: Fix caching issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ language: minimal
 cache:
   ccache: true
   directories:
-    - depends/built
-    - depends/sdk-sources
+    - $TRAVIS_BUILD_DIR/depends/built
+    - $TRAVIS_BUILD_DIR/depends/sdk-sources
     - $HOME/.ccache
 stages:
   - lint

--- a/.travis/test_06_script_b.sh
+++ b/.travis/test_06_script_b.sh
@@ -25,3 +25,5 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   DOCKER_EXEC test/fuzz/test_runner.py -l DEBUG ${DIR_FUZZ_IN}
   END_FOLD
 fi
+
+cd ${TRAVIS_BUILD_DIR} || (echo "could not enter travis build dir $TRAVIS_BUILD_DIR"; exit 1)


### PR DESCRIPTION
It appears that the travis caching infrastructure changed under us without any notice. I believe we can no longer use relative paths as cache paths, unless:
* we go back to the root travis build dir before the caching step, or
* we specify absolute paths for caching

Apply both fixes here.

Thanks to **promag** for helping me debug this: https://github.com/bitcoin/bitcoin/issues/16148#issuecomment-502078938