### PR TITLE
tests: Mark test coins_tests/updatecoins_simulation_test as non-deterministic

### DIFF
--- a/contrib/devtools/test_deterministic_coverage.sh
+++ b/contrib/devtools/test_deterministic_coverage.sh
@@ -15,6 +15,7 @@ GCOV_EXECUTABLE="gcov"
 # Disable tests known to cause non-deterministic behaviour and document the source or point of non-determinism.
 NON_DETERMINISTIC_TESTS=(
     "blockfilter_index_tests/blockfilter_index_initial_sync"  # src/checkqueue.h: In CCheckQueue::Loop(): while (queue.empty()) { ... }
+    "coins_tests/updatecoins_simulation_test"                 # coinstest_cpp: if (utxoset.count(utxod->first)) {
     "coinselector_tests/knapsack_solver_test"                 # coinselector_tests.cpp: if (equal_sets(setCoinsRet, setCoinsRet2))
     "denialofservice_tests/DoS_mapOrphans"                    # denialofservice_tests.cpp: it = mapOrphanTransactions.lower_bound(InsecureRand256());
     "fs_tests/fsbridge_fstream"                               # deterministic test failure?


### PR DESCRIPTION
Mark test `coins_tests/updatecoins_simulation_test` as non-deterministic:

```
$ contrib/devtools/test_deterministic_coverage.sh 1000
[2019-06-15 05:36:20] Measuring coverage, run #1 of 1000
[2019-06-15 05:38:05] Measuring coverage, run #2 of 1000
[2019-06-15 05:39:49] Measuring coverage, run #3 of 1000
[2019-06-15 05:41:38] Measuring coverage, run #4 of 1000
[2019-06-15 05:43:16] Measuring coverage, run #5 of 1000
...
[2019-06-16 18:25:23] Measuring coverage, run #880 of 1000
[2019-06-16 18:27:12] Measuring coverage, run #881 of 1000
[2019-06-16 18:29:33] Measuring coverage, run #882 of 1000
[2019-06-16 18:33:00] Measuring coverage, run #883 of 1000
[2019-06-16 18:35:32] Measuring coverage, run #884 of 1000

The line coverage is non-deterministic between runs. Exiting.

The test suite must be deterministic in the sense that the set of lines executed at least
once must be identical between runs. This is a necessary condition for meaningful
coverage measuring.

--- gcovr.run-1.txt     2019-06-15 05:38:05.282359029 +0200
+++ gcovr.run-884.txt   2019-06-16 18:37:23.518298374 +0200
@@ -269,7 +269,7 @@
 test/bloom_tests.cpp                         320     320   100%   
 test/bswap_tests.cpp                          13      13   100%   
 test/checkqueue_tests.cpp                    223     222    99%   169
-test/coins_tests.cpp                         478     472    98%   52,68,344-345,511,524
+test/coins_tests.cpp                         478     474    99%   52,68,511,524
 test/compilerbug_tests.cpp                    18      18   100%   
 test/compress_tests.cpp                       27      27   100%   
 test/crypto_tests.cpp                        268     268   100%   
@@ -401,5 +401,5 @@
 zmq/zmqpublishnotifier.h                       5       0     0%   12,31,37,43,49
 zmq/zmqrpc.cpp                                23       3    13%   16,18,20,23,33-35,37,40-47,51,62,64-65
 ------------------------------------------------------------------------------
-TOTAL                                      53323   28305    53%
+TOTAL                                      53323   28307    53%
 ------------------------------------------------------------------------------
```
