### PR TITLE
tests: Make coins_tests/updatecoins_simulation_test deterministic

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -278,6 +278,7 @@ UtxoData::iterator FindRandomFrom(const std::set<COutPoint> &utxoSet) {
 BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 {
     SeedInsecureRand(/* deterministic */ true);
+    g_mock_deterministic_tests = true;
 
     bool spent_a_duplicate_coinbase = false;
     // A simple map to track what we expect the cache stack to represent.
@@ -472,6 +473,8 @@ BOOST_AUTO_TEST_CASE(updatecoins_simulation_test)
 
     // Verify coverage.
     BOOST_CHECK(spent_a_duplicate_coinbase);
+
+    g_mock_deterministic_tests = false;
 }
 
 BOOST_AUTO_TEST_CASE(ccoins_serialization)


### PR DESCRIPTION
Make `coins_tests/updatecoins_simulation_test` deterministic.

Before:

```
$ contrib/devtools/test_deterministic_coverage.sh 1000
[2019-06-15 05:36:20] Measuring coverage, run #1 of 1000
[2019-06-15 05:38:05] Measuring coverage, run #2 of 1000
[2019-06-15 05:39:49] Measuring coverage, run #3 of 1000
[2019-06-15 05:41:38] Measuring coverage, run #4 of 1000
[2019-06-15 05:43:16] Measuring coverage, run #5 of 1000
...
[2019-06-16 18:25:23] Measuring coverage, run #880 of 1000
[2019-06-16 18:27:12] Measuring coverage, run #881 of 1000
[2019-06-16 18:29:33] Measuring coverage, run #882 of 1000
[2019-06-16 18:33:00] Measuring coverage, run #883 of 1000
[2019-06-16 18:35:32] Measuring coverage, run #884 of 1000

The line coverage is non-deterministic between runs. Exiting.

The test suite must be deterministic in the sense that the set of lines executed at least
once must be identical between runs. This is a necessary condition for meaningful
coverage measuring.

--- gcovr.run-1.txt     2019-06-15 05:38:05.282359029 +0200
+++ gcovr.run-884.txt   2019-06-16 18:37:23.518298374 +0200
@@ -269,7 +269,7 @@
 test/bloom_tests.cpp                         320     320   100%   
 test/bswap_tests.cpp                          13      13   100%   
 test/checkqueue_tests.cpp                    223     222    99%   169
-test/coins_tests.cpp                         478     472    98%   52,68,344-345,511,524
+test/coins_tests.cpp                         478     474    99%   52,68,511,524
 test/compilerbug_tests.cpp                    18      18   100%   
 test/compress_tests.cpp                       27      27   100%   
 test/crypto_tests.cpp                        268     268   100%   
@@ -401,5 +401,5 @@
 zmq/zmqpublishnotifier.h                       5       0     0%   12,31,37,43,49
 zmq/zmqrpc.cpp                                23       3    13%   16,18,20,23,33-35,37,40-47,51,62,64-65
 ------------------------------------------------------------------------------
-TOTAL                                      53323   28305    53%
+TOTAL                                      53323   28307    53%
 ------------------------------------------------------------------------------
```

After:

```
$ contrib/devtools/test_deterministic_coverage.sh 1000
[2019-06-15 05:36:20] Measuring coverage, run #1 of 1000
[2019-06-15 05:38:05] Measuring coverage, run #2 of 1000
[2019-06-15 05:39:49] Measuring coverage, run #3 of 1000
[2019-06-15 05:41:38] Measuring coverage, run #4 of 1000
[2019-06-15 05:43:16] Measuring coverage, run #5 of 1000
...
$
```
