### PR TITLE
Standardise deployment handling

### DIFF
--- a/doc/release-notes-16229.md
+++ b/doc/release-notes-16229.md
@@ -1,0 +1,3 @@
+RPC changes
+-----------
+The RPC `getblockchaininfo` response changes the `softforks` key to provide an object whose keys are the softfork ids, rather than a list of softforks. This also now includes any BIP 9 softforks, and associated data. The `bip9_softforks` key is no longer included.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -290,13 +290,13 @@ public:
         consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::Deployment::NO_TIMEOUT;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -133,10 +133,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CLTV] = DeploymentAtFixedHeight<388381>(); // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
 
         // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 1462060800, 1493596800>(); // May 1st, 2016 - May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentAtFixedHeight<419328>(); // 000000000000000004a1b34462cb8aeebd5799177f7a29cf28f2d1961716b5b5
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentByBIP9<1, 1479168000, 1510704000>(); // November 15th, 2016 - November 15th, 2017.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentAtFixedHeight<481824>(); // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000051dc8b82f450202ecb3d471");
@@ -248,10 +248,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CLTV] = DeploymentAtFixedHeight<581885>(); // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
 
         // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 1456790400, 1493596800>(); // March 1st, 2016 - May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentAtFixedHeight<770112>(); // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentByBIP9<1, 1462060800, 1493596800>(); // May 1st 2016 - May 1st 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentAtFixedHeight<834624>(); // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000007dbe94253893cbd463");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,8 +117,6 @@ public:
         consensus.BIP16Exception = uint256S("0x00000000000002dc756eebf4f49723ed8d30cc28a5f108eb94b1ba88ac4f9c22");
         consensus.BIP34Height = 227931;
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
-        consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
-        consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -127,6 +125,12 @@ public:
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY] = DeploymentByBIP9<28, 1199145601, 1230767999>(); // January 1, 2008 - December 31, 2008
+
+        // Deployment of BIP66.
+        consensus.vDeployments[Consensus::DEPLOYMENT_STRICTDER] = DeploymentAtFixedHeight<363725>(); // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+
+        // Deployment of BIP65.
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV] = DeploymentAtFixedHeight<388381>(); // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 1462060800, 1493596800>(); // May 1st, 2016 - May 1st, 2017
@@ -228,8 +232,6 @@ public:
         consensus.BIP16Exception = uint256S("0x00000000dd30457c001f4095d208cc1296b0eed002427aa599874af7a432b105");
         consensus.BIP34Height = 21111;
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
-        consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
-        consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -238,6 +240,12 @@ public:
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY] = DeploymentByBIP9<28, 1199145601, 1230767999>(); // January 1, 2008 - December 31, 2008
+
+        // Deployment of BIP66.
+        consensus.vDeployments[Consensus::DEPLOYMENT_STRICTDER] = DeploymentAtFixedHeight<330776>(); // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
+
+        // Deployment of BIP65.
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV] = DeploymentAtFixedHeight<581885>(); // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 1456790400, 1493596800>(); // March 1st, 2016 - May 1st, 2017
@@ -317,8 +325,6 @@ public:
         consensus.BIP16Exception = uint256();
         consensus.BIP34Height = 500; // BIP34 activated on regtest (Used in functional tests)
         consensus.BIP34Hash = uint256();
-        consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in functional tests)
-        consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in functional tests)
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -327,6 +333,8 @@ public:
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
         consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY] = DeploymentByBIP9<28, 0, Consensus::Deployment::NO_TIMEOUT>();
+        consensus.vDeployments[Consensus::DEPLOYMENT_STRICTDER] = DeploymentAtFixedHeight<1251>(); // BIP66 activated on regtest (Used in functional tests)
+        consensus.vDeployments[Consensus::DEPLOYMENT_CLTV] = DeploymentAtFixedHeight<1351>(); // BIP65 activated on regtest (Used in functional tests)
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 0, Consensus::Deployment::NO_TIMEOUT>();
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentAlwaysActive<1>();
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -56,6 +56,33 @@ static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits
     return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 
+template <int b>
+inline Consensus::Deployment DeploymentAlwaysActive()
+{
+    // have to specify bit here, so that it AlwaysActive can be overridden usefully by -vbparams
+    static_assert(0 <= b && b <= 28, "Version bit must be between 0 and 28");
+
+    Consensus::Deployment res;
+    res.bit = b;
+    res.nStartTime = Consensus::Deployment::ALWAYS_ACTIVE;
+    res.nTimeout = Consensus::Deployment::NO_TIMEOUT;
+    return res;
+}
+
+template <int b, int64_t start, int64_t end>
+inline Consensus::Deployment DeploymentByBIP9()
+{
+    static_assert(0 <= b && b <= 28, "Version bit must be between 0 and 28");
+    static_assert(start != Consensus::Deployment::ALWAYS_ACTIVE, "Use DeploymentAlwaysActive()");
+    static_assert(end >= start, "End time must be greater than start time");
+
+    Consensus::Deployment res;
+    res.bit = b;
+    res.nStartTime = start;
+    res.nTimeout = end;
+    return res;
+}
+
 /**
  * Main network
  */
@@ -76,19 +103,13 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1916; // 95% of 2016
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY] = DeploymentByBIP9<28, 1199145601, 1230767999>(); // January 1, 2008 - December 31, 2008
 
         // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 1462060800, 1493596800>(); // May 1st, 2016 - May 1st, 2017
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1479168000; // November 15th, 2016.
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1510704000; // November 15th, 2017.
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentByBIP9<1, 1479168000, 1510704000>(); // November 15th, 2016 - November 15th, 2017.
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000051dc8b82f450202ecb3d471");
@@ -193,19 +214,13 @@ public:
         consensus.fPowNoRetargeting = false;
         consensus.nRuleChangeActivationThreshold = 1512; // 75% for testchains
         consensus.nMinerConfirmationWindow = 2016; // nPowTargetTimespan / nPowTargetSpacing
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY] = DeploymentByBIP9<28, 1199145601, 1230767999>(); // January 1, 2008 - December 31, 2008
 
         // Deployment of BIP68, BIP112, and BIP113.
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 1456790400, 1493596800>(); // March 1st, 2016 - May 1st, 2017
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1462060800; // May 1st 2016
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = 1493596800; // May 1st 2017
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentByBIP9<1, 1462060800, 1493596800>(); // May 1st 2016 - May 1st 2017
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000007dbe94253893cbd463");
@@ -288,15 +303,9 @@ public:
         consensus.fPowNoRetargeting = true;
         consensus.nRuleChangeActivationThreshold = 108; // 75% for testchains
         consensus.nMinerConfirmationWindow = 144; // Faster than normal for regtest (144 instead of 2016)
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY] = DeploymentByBIP9<28, 0, Consensus::Deployment::NO_TIMEOUT>();
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV] = DeploymentByBIP9<0, 0, Consensus::Deployment::NO_TIMEOUT>();
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT] = DeploymentAlwaysActive<1>();
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -69,17 +69,40 @@ inline Consensus::Deployment DeploymentAlwaysActive()
     return res;
 }
 
+template <int64_t height>
+inline Consensus::Deployment DeploymentAtFixedHeight()
+{
+    static_assert(0 < height, "Use DeploymentAlwaysActive() or set positive height for fixed activation");
+    static_assert(height < 500000000, "Fixed activation height should not look like a timestamp");
+
+    Consensus::Deployment res;
+    res.bit = 33;
+    res.nStartTime = height;
+    res.nTimeout = Consensus::Deployment::FIXED_ACTIVATION_HEIGHT;
+    return res;
+}
+
 template <int b, int64_t start, int64_t end>
 inline Consensus::Deployment DeploymentByBIP9()
 {
     static_assert(0 <= b && b <= 28, "Version bit must be between 0 and 28");
     static_assert(start != Consensus::Deployment::ALWAYS_ACTIVE, "Use DeploymentAlwaysActive()");
+    static_assert(end != Consensus::Deployment::DISABLED, "Use DeploymentDisabled()");
     static_assert(end >= start, "End time must be greater than start time");
 
     Consensus::Deployment res;
     res.bit = b;
     res.nStartTime = start;
     res.nTimeout = end;
+    return res;
+}
+
+inline Consensus::Deployment DeploymentDisabled()
+{
+    Consensus::Deployment res;
+    res.bit = 33;
+    res.nStartTime = 0;
+    res.nTimeout = Consensus::Deployment::DISABLED;
     return res;
 }
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -25,7 +25,7 @@ enum DeploymentPos
 /**
  * Struct for each individual consensus rule change using BIP9.
  */
-struct BIP9Deployment {
+struct Deployment {
     /** Bit position to select the particular bit in nVersion. */
     int bit;
     /** Start MedianTime for version bits miner confirmation. Can be a date in the past */
@@ -65,7 +65,7 @@ struct Params {
      */
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
-    BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -16,6 +16,8 @@ namespace Consensus {
 enum DeploymentPos
 {
     DEPLOYMENT_TESTDUMMY,
+    DEPLOYMENT_STRICTDER, // Deployment of BIP66
+    DEPLOYMENT_CLTV, // Deployment of BIP65
     DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
     DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp
@@ -62,10 +64,6 @@ struct Params {
     /** Block height and hash at which BIP34 becomes active */
     int BIP34Height;
     uint256 BIP34Hash;
-    /** Block height at which BIP65 becomes active */
-    int BIP65Height;
-    /** Block height at which BIP66 becomes active */
-    int BIP66Height;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -36,11 +36,19 @@ struct Deployment {
     /** Constant for nTimeout very far in the future. */
     static constexpr int64_t NO_TIMEOUT = std::numeric_limits<int64_t>::max();
 
+    /** Constant for nTimeout indicating nStartTime is a fixed block height where activation begins. */
+    static constexpr int64_t FIXED_ACTIVATION_HEIGHT = -1;
+
     /** Special value for nStartTime indicating that the deployment is always active.
      *  This is useful for testing, as it means tests don't need to deal with the activation
      *  process (which takes at least 3 BIP9 intervals). Only tests that specifically test the
      *  behaviour during activation cannot use this. */
     static constexpr int64_t ALWAYS_ACTIVE = -1;
+
+    /** Special value for nTimeout indicating that the deployment is never active.
+     *  This is useful for integrating code changes or activation on regtest/testnet
+     *  before the deployment parameters for mainnet are set. */
+    static constexpr int64_t DISABLED = 0;
 };
 
 /**

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1290,11 +1290,12 @@ static UniValue BIP9SoftForkDesc(const Consensus::Params& consensusParams, Conse
 
 static void BIP9SoftForkDescPushBack(UniValue& bip9_softforks, const Consensus::Params& consensusParams, Consensus::DeploymentPos id)
 {
-    // Deployments with timeout value of 0 are hidden.
+    // Deployments with timeout value of 0 (DISABLED) are hidden.
     // A timeout value of 0 guarantees a softfork will never be activated.
     // This is used when softfork codes are merged without specifying the deployment schedule.
-    if (consensusParams.vDeployments[id].nTimeout > 0)
+    if (consensusParams.vDeployments[id].nTimeout != Consensus::Deployment::DISABLED) {
         bip9_softforks.pushKV(VersionBitsDeploymentInfo[id].name, BIP9SoftForkDesc(consensusParams, id));
+    }
 }
 
 UniValue getblockchaininfo(const JSONRPCRequest& request)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1225,6 +1225,8 @@ static UniValue verifychain(const JSONRPCRequest& request)
 }
 
 /** Implementation of IsSuperMajority with better feedback */
+static VersionBitsCache vbcache GUARDED_BY(cs_main);
+
 static UniValue SoftForkMajorityDesc(int version, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
     UniValue rv(UniValue::VOBJ);
@@ -1235,10 +1237,10 @@ static UniValue SoftForkMajorityDesc(int version, const CBlockIndex* pindex, con
             activated = pindex->nHeight >= consensusParams.BIP34Height;
             break;
         case 3:
-            activated = pindex->nHeight >= consensusParams.BIP66Height;
+            activated = DeploymentActive(pindex->pprev, consensusParams, Consensus::DEPLOYMENT_STRICTDER, vbcache);
             break;
         case 4:
-            activated = pindex->nHeight >= consensusParams.BIP65Height;
+            activated = DeploymentActive(pindex->pprev, consensusParams, Consensus::DEPLOYMENT_CLTV, vbcache);
             break;
     }
     rv.pushKV("status", activated);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -532,7 +532,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     pblock->nNonce = 0;
 
     // NOTE: If at some point we support pre-segwit miners post-segwit-activation, this needs to take segwit support into consideration
-    const bool fPreSegWit = (ThresholdState::ACTIVE != VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache));
+    const bool fPreSegWit = !DeploymentActive(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache);
 
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -117,7 +117,7 @@ TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
 {
     // CreateAndProcessBlock() does not support building SegWit blocks, so don't activate in these tests.
     // TODO: fix the code to support SegWit blocks.
-    gArgs.ForceSetArg("-vbparams", strprintf("segwit:0:%d", (int64_t)Consensus::BIP9Deployment::NO_TIMEOUT));
+    gArgs.ForceSetArg("-vbparams", strprintf("segwit:0:%d", (int64_t)Consensus::Deployment::NO_TIMEOUT));
     SelectParams(CBaseChainParams::REGTEST);
 
     // Generate a 100-block chain:

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -35,7 +35,7 @@ public:
 class TestAlwaysActiveConditionChecker : public TestConditionChecker
 {
 public:
-    int64_t BeginTime(const Consensus::Params& params) const override { return Consensus::BIP9Deployment::ALWAYS_ACTIVE; }
+    int64_t BeginTime(const Consensus::Params& params) const override { return Consensus::Deployment::ALWAYS_ACTIVE; }
 };
 
 #define CHECKERS 6

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1607,12 +1607,12 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
     }
 
     // Start enforcing the DERSIG (BIP66) rule
-    if (pindex->nHeight >= consensusparams.BIP66Height) {
+    if (DeploymentActive(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_STRICTDER, versionbitscache)) {
         flags |= SCRIPT_VERIFY_DERSIG;
     }
 
     // Start enforcing CHECKLOCKTIMEVERIFY (BIP65) rule
-    if (pindex->nHeight >= consensusparams.BIP65Height) {
+    if (DeploymentActive(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_CLTV, versionbitscache)) {
         flags |= SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY;
     }
 
@@ -3132,10 +3132,11 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     // Reject outdated version blocks when 95% (75% on testnet) of the network has upgraded:
     // check for version 2, 3 and 4 upgrades
     if((block.nVersion < 2 && nHeight >= consensusParams.BIP34Height) ||
-       (block.nVersion < 3 && nHeight >= consensusParams.BIP66Height) ||
-       (block.nVersion < 4 && nHeight >= consensusParams.BIP65Height))
+       (block.nVersion < 3 && DeploymentActive(pindexPrev, consensusParams, Consensus::DEPLOYMENT_STRICTDER, versionbitscache)) ||
+       (block.nVersion < 4 && DeploymentActive(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CLTV, versionbitscache))) {
             return state.Invalid(ValidationInvalidReason::BLOCK_INVALID_HEADER, false, REJECT_OBSOLETE, strprintf("bad-version(0x%08x)", block.nVersion),
                                  strprintf("rejected nVersion=0x%08x block", block.nVersion));
+    }
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1617,7 +1617,7 @@ static unsigned int GetBlockScriptFlags(const CBlockIndex* pindex, const Consens
     }
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
-    if (VersionBitsState(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_CSV, versionbitscache) == ThresholdState::ACTIVE) {
+    if (DeploymentActive(pindex->pprev, consensusparams, Consensus::DEPLOYMENT_CSV, versionbitscache)) {
         flags |= SCRIPT_VERIFY_CHECKSEQUENCEVERIFY;
     }
 
@@ -1808,7 +1808,7 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY) using versionbits logic.
     int nLockTimeFlags = 0;
-    if (VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV, versionbitscache) == ThresholdState::ACTIVE) {
+    if (DeploymentActive(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV, versionbitscache)) {
         nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
     }
 
@@ -3011,13 +3011,13 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params)
 {
     LOCK(cs_main);
-    return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == ThresholdState::ACTIVE);
+    return DeploymentActive(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache);
 }
 
 bool IsNullDummyEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params)
 {
     LOCK(cs_main);
-    return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == ThresholdState::ACTIVE);
+    return DeploymentActive(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache);
 }
 
 // Compute at which vout of the block's coinbase transaction the witness
@@ -3152,7 +3152,7 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
 
     // Start enforcing BIP113 (Median Time Past) using versionbits logic.
     int nLockTimeFlags = 0;
-    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV, versionbitscache) == ThresholdState::ACTIVE) {
+    if (DeploymentActive(pindexPrev, consensusParams, Consensus::DEPLOYMENT_CSV, versionbitscache)) {
         assert(pindexPrev != nullptr);
         nLockTimeFlags |= LOCKTIME_MEDIAN_TIME_PAST;
     }
@@ -3187,7 +3187,7 @@ static bool ContextualCheckBlock(const CBlock& block, CValidationState& state, c
     //   {0xaa, 0x21, 0xa9, 0xed}, and the following 32 bytes are SHA256^2(witness root, witness reserved value). In case there are
     //   multiple, the last one is used.
     bool fHaveWitness = false;
-    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == ThresholdState::ACTIVE) {
+    if (DeploymentActive(pindexPrev, consensusParams, Consensus::DEPLOYMENT_SEGWIT, versionbitscache)) {
         int commitpos = GetWitnessCommitmentIndex(block);
         if (commitpos != -1) {
             bool malleated = false;

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -13,7 +13,7 @@ ThresholdState AbstractThresholdConditionChecker::GetStateFor(const CBlockIndex*
     int64_t nTimeTimeout = EndTime(params);
 
     // Check if this deployment is always active.
-    if (nTimeStart == Consensus::BIP9Deployment::ALWAYS_ACTIVE) {
+    if (nTimeStart == Consensus::Deployment::ALWAYS_ACTIVE) {
         return ThresholdState::ACTIVE;
     }
 
@@ -127,7 +127,7 @@ BIP9Stats AbstractThresholdConditionChecker::GetStateStatisticsFor(const CBlockI
 int AbstractThresholdConditionChecker::GetStateSinceHeightFor(const CBlockIndex* pindexPrev, const Consensus::Params& params, ThresholdConditionCache& cache) const
 {
     int64_t start_time = BeginTime(params);
-    if (start_time == Consensus::BIP9Deployment::ALWAYS_ACTIVE) {
+    if (start_time == Consensus::Deployment::ALWAYS_ACTIVE) {
         return 0;
     }
 

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -68,4 +68,9 @@ BIP9Stats VersionBitsStatistics(const CBlockIndex* pindexPrev, const Consensus::
 int VersionBitsStateSinceHeight(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);
 
+inline bool DeploymentActive(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)
+{
+    return VersionBitsState(pindexPrev, params, pos, cache) == ThresholdState::ACTIVE;
+}
+
 #endif // BITCOIN_VERSIONBITS_H

--- a/src/versionbitsinfo.cpp
+++ b/src/versionbitsinfo.cpp
@@ -6,9 +6,17 @@
 
 #include <consensus/params.h>
 
-const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_BITS_DEPLOYMENTS] = {
+const struct VBDeploymentInfo VersionBitsDeploymentInfo[] = {
     {
         /*.name =*/ "testdummy",
+        /*.gbt_force =*/ true,
+    },
+    {
+        /*.name =*/ "strictder",
+        /*.gbt_force =*/ true,
+    },
+    {
+        /*.name =*/ "cltv",
         /*.gbt_force =*/ true,
     },
     {
@@ -20,3 +28,4 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
         /*.gbt_force =*/ true,
     }
 };
+static_assert(sizeof(VersionBitsDeploymentInfo) == Consensus::MAX_VERSION_BITS_DEPLOYMENTS * sizeof(VersionBitsDeploymentInfo[0]), "Must specify names for all deployments");

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -78,7 +78,6 @@ class BlockchainTest(BitcoinTestFramework):
 
         keys = [
             'bestblockhash',
-            'bip9_softforks',
             'blocks',
             'chain',
             'chainwork',

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -123,6 +123,41 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res['prune_target_size'], 576716800)
         assert_greater_than(res['size_on_disk'], 0)
 
+        assert_equal(res['softforks'], {
+            'bip34': {'status': 'defined', 'fixedHeight': 500, 'since': 0},
+            'strictder': {'status': 'defined', 'fixedHeight': 1251, 'since': 0},
+            'cltv': {'status': 'defined', 'fixedHeight': 1351, 'since': 0},
+            'csv': {
+                'status': 'started',
+                'bit': 0,
+                'startTime': 0,
+                'timeout': 9223372036854775807,
+                'since': 144,
+                'statistics': {
+                    'period': 144,
+                    'threshold': 108,
+                    'elapsed': 57,
+                    'count': 57,
+                    'possible': True
+                }
+            },
+            'segwit': {'status': 'active', 'alwaysActive': True, 'since': 0},
+            'testdummy': {
+                'status': 'started',
+                'bit': 28,
+                'startTime': 0,
+                'timeout': 9223372036854775807,
+                'since': 144,
+                'statistics': {
+                    'period': 144,
+                    'threshold': 108,
+                    'elapsed': 57,
+                    'count': 57,
+                    'possible': True
+                }
+            },
+        })
+
     def _test_getchaintxstats(self):
         self.log.info("Test getchaintxstats")
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -343,7 +343,7 @@ def delete_cookie_file(datadir):
 
 def get_bip9_status(node, key):
     info = node.getblockchaininfo()
-    return info['bip9_softforks'][key]
+    return info['softforks'][key]
 
 def set_node_times(nodes, t):
     for node in nodes:


### PR DESCRIPTION
This is a different approach to burying csv/segwit deployments -- rather than converting them from `Consensus::BIP9Deployment` to dedicated members, it uses a generalised `Consensus::Deployment` type to cover both BIP9 activations and fixed height activations.

I think this should make future burials much simpler (it becomes a one-line change), but there's two other benefits: it doesn't change RPC or tests much, and I think it will make it easier to make future changes to activation methods should we wish to do so. The downside is that the activations aren't hardcoded anymore, so there's a function call and a few indirect lookups to determine a fixed-height activation is enabled, rather than just a direct test.

I've added some extra commits to tidy up the `getblockchaininfo` output. It now changes from:
The output of `getblockchaininfo` changes from:

    "softforks": [
      {
        "id": "bip34",
        "version": 2,
        "reject": {
          "status": true
        }
      },
      {
        "id": "bip66",
        "version": 3,
        "reject": {
          "status": true
        }
      },
      {
        "id": "bip65",
        "version": 4,
        "reject": {
          "status": true
        }
      }
    ],
    "bip9_softforks": {
      "csv": {
        "status": "active",
        "startTime": 1462060800,
        "timeout": 1493596800,
        "since": 419328
      },
      "segwit": {
        "status": "active",
        "startTime": 1479168000,
        "timeout": 1510704000,
        "since": 481824
      }
    },

to

    "softforks": {
      "bip34": {
        "status": "active",
        "fixedHeight": 227931,
        "since": 227931
      },
      "strictder": {
        "status": "active",
        "fixedHeight": 363725,
        "since": 363725
      },
      "cltv": {
        "status": "active",
        "fixedHeight": 388381,
        "since": 388381
      },
      "csv": {
        "status": "active",
        "fixedHeight": 419328,
        "since": 419328
      },
      "segwit": {
        "status": "active",
        "fixedHeight": 481824,
        "since": 481824
      }
    },

with this patch set, or, on regtest something like:

    "softforks": {
      "bip34": {
        "status": "active",
        "fixedHeight": 500,
        "since": 500
      },
      "testdummy": {
        "status": "started",
        "bit": 28,
        "startTime": 0,
        "timeout": 9223372036854775807,
        "since": 144,
        "statistics": {
          "period": 144,
          "threshold": 108,
          "elapsed": 141,
          "count": 141,
          "possible": true
        }
      },
      "strictder": {
        "status": "defined",
        "fixedHeight": 1251,
        "since": 0
      },
      "cltv": {
        "status": "defined",
        "fixedHeight": 1351,
        "since": 0
      },
      "csv": {
        "status": "started",
        "bit": 0,
        "startTime": 0,
        "timeout": 9223372036854775807,
        "since": 144,
        "statistics": {
          "period": 144,
          "threshold": 108,
          "elapsed": 141,
          "count": 141,
          "possible": true
        }
      },
      "segwit": {
        "status": "active",
        "alwaysActive": true,
        "since": 0
      }
    },
