### PR TITLE
gui: Fix open wallet menu initialization order

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -337,6 +337,7 @@ void BitcoinGUI::createActions()
     m_open_wallet_action = new QAction(tr("Open Wallet"), this);
     m_open_wallet_action->setEnabled(false);
     m_open_wallet_action->setStatusTip(tr("Open a wallet"));
+    m_open_wallet_menu = new QMenu(this);
 
     m_close_wallet_action = new QAction(tr("Close Wallet..."), this);
     m_close_wallet_action->setStatusTip(tr("Close wallet"));
@@ -368,13 +369,13 @@ void BitcoinGUI::createActions()
         connect(usedSendingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedSendingAddresses);
         connect(usedReceivingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedReceivingAddresses);
         connect(openAction, &QAction::triggered, this, &BitcoinGUI::openClicked);
-        connect(m_open_wallet_action->menu(), &QMenu::aboutToShow, [this] {
-            m_open_wallet_action->menu()->clear();
+        connect(m_open_wallet_menu, &QMenu::aboutToShow, [this] {
+            m_open_wallet_menu->clear();
             std::vector<std::string> available_wallets = m_wallet_controller->getWalletsAvailableToOpen();
             std::vector<std::string> wallets = m_node.listWalletDir();
             for (const auto& path : wallets) {
                 QString name = path.empty() ? QString("["+tr("default wallet")+"]") : QString::fromStdString(path);
-                QAction* action = m_open_wallet_action->menu()->addAction(name);
+                QAction* action = m_open_wallet_menu->addAction(name);
 
                 if (std::find(available_wallets.begin(), available_wallets.end(), path) == available_wallets.end()) {
                     // This wallet is already loaded
@@ -410,7 +411,7 @@ void BitcoinGUI::createActions()
                 });
             }
             if (wallets.empty()) {
-                QAction* action = m_open_wallet_action->menu()->addAction(tr("No wallets available"));
+                QAction* action = m_open_wallet_menu->addAction(tr("No wallets available"));
                 action->setEnabled(false);
             }
         });
@@ -634,7 +635,7 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
     m_wallet_controller = wallet_controller;
 
     m_open_wallet_action->setEnabled(true);
-    m_open_wallet_action->setMenu(new QMenu(this));
+    m_open_wallet_action->setMenu(m_open_wallet_menu);
 
     connect(wallet_controller, &WalletController::walletAdded, this, &BitcoinGUI::addWallet);
     connect(wallet_controller, &WalletController::walletRemoved, this, &BitcoinGUI::removeWallet);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -148,6 +148,7 @@ private:
     QAction* openAction = nullptr;
     QAction* showHelpMessageAction = nullptr;
     QAction* m_open_wallet_action{nullptr};
+    QMenu* m_open_wallet_menu{nullptr};
     QAction* m_close_wallet_action{nullptr};
     QAction* m_wallet_selector_label_action = nullptr;
     QAction* m_wallet_selector_action = nullptr;


### PR DESCRIPTION
Fixes #16230, the menu must be created before connecting to aboutToShow signal.