### PR TITLE
WIP: add basic semaphore2 CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,74 @@
+version: v1.0
+name: Bitcoin Core
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Compile and test Bitcoin-Core
+    task:
+      jobs:
+      - name: x86_64 Linux Ubuntu 18.04 depends tests
+        env_vars:
+        - name: TARGET_HOST
+          value: x86_64-linux-gnu
+        - name: PACKAGES
+          value: ""
+        - name: RUN_UNIT_TESTS
+          value: "true"
+        - name: RUN_FUNCTIONAL_TESTS
+          value: "true"
+        - name: BITCOIN_CONFIG
+          value: "--disable-dependency-tracking --enable-zmq --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports --enable-debug"
+        commands:
+          - checkout
+          - set -o errexit; source .semaphore/update_build_test.sh
+      - name: ARM Linux Ubuntu 18.04 depends tests
+        env_vars:
+        - name: TARGET_HOST
+          value: arm-linux-gnueabihf
+        - name: PACKAGES
+          value: "g++-arm-linux-gnueabihf"
+        - name: RUN_UNIT_TESTS
+          value: "false"
+        - name: RUN_FUNCTIONAL_TESTS
+          value: "false"
+        - name: BITCOIN_CONFIG
+          value: "--disable-dependency-tracking --enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi"
+        commands:
+          - checkout
+          - set -o errexit; source .semaphore/update_build_test.sh
+      - name: Win64 Ubuntu 18.04 depends
+        env_vars:
+        - name: TARGET_HOST
+          value: x86_64-w64-mingw32
+        - name: PACKAGES
+          value: "nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
+        - name: RUN_UNIT_TESTS
+          value: "false"
+        - name: RUN_FUNCTIONAL_TESTS
+          value: "false"
+        - name: BITCOIN_CONFIG
+          value: "--enable-reduce-exports --disable-gui-tests"
+        commands:
+          - checkout
+          - set -o errexit; source .semaphore/update_build_test.sh
+      - name: X86 Ubuntu system libs
+        env_vars:
+        - name: TARGET_HOST
+          value: system
+        - name: PACKAGES
+          value: "python3-zmq libdb-dev libdb++-dev libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        - name: RUN_UNIT_TESTS
+          value: "false"
+        - name: RUN_FUNCTIONAL_TESTS
+          value: "false"
+        - name: BITCOIN_CONFIG
+          value: "--enable-reduce-exports --disable-gui-tests --with-gui=qt5 --with-incompatible-bdb"
+        commands:
+          - g++ --version
+          - sem-version cpp 6
+          - g++ --version
+          - checkout
+          - set -o errexit; source .semaphore/update_build_test.sh

--- a/.semaphore/update_build_test.sh
+++ b/.semaphore/update_build_test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+sudo apt-get update
+sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES
+
+./autogen.sh
+if [ "$TARGET_HOST" != "system" ]; then
+	cd depends
+	ls -la
+	cache list
+	cache restore $TARGET_HOST-built
+	ls -la
+	make HOST=$TARGET_HOST -j4 V=1
+	ls -la
+	cache store $TARGET_HOST-built built/$TARGET_HOST
+	cache list
+	cd ..
+fi
+
+if [[ $TARGET_HOST = *-mingw32 ]]; then
+  sudo update-alternatives --set $TARGET_HOST-g++ $(which $TARGET_HOST-g++-posix)
+fi
+
+if [ "$TARGET_HOST" = "system" ]; then
+	./configure $BITCOIN_CONFIG
+else
+	./configure --prefix=`pwd`/depends/$TARGET_HOST $BITCOIN_CONFIG
+fi
+make -j4
+
+if [ "$RUN_UNIT_TESTS" = "true" ]; then
+	make check VERBOSE=1
+fi
+
+if [ "$RUN_FUNCTIONAL_TESTS" = "true" ]; then
+	./test/functional/test_runner.py --ci --combinedlogslen=4000 --quiet --failfast
+fi


### PR DESCRIPTION
Semaphore2 seems to be quite new though it has some nice features and it is running on fast hardware. It is also possible to ssh-connect to the build-instances for more detailed debugging. The cache tool is also super flexible.

The only missing thing is public view access to the build progress and log. :(
One of the co-founders said that public access is planned for later this year.

Integration with GitHub is possible today and the build state (failed/succeeded) is visible for everyone.

This is WIP PR would add three environments (ARM/X86/W64 depends build with proper caching).