### PR TITLE
test: Add test for unknown args

### DIFF
--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -21,6 +21,16 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(os.path.join(self.nodes[0].datadir, 'bitcoin.conf'), 'a', encoding='utf-8') as conf:
             conf.write('includeconf={}\n'.format(inc_conf_file_path))
 
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error parsing command line arguments: Invalid parameter -dash_cli',
+            extra_args=['-dash_cli=1'],
+        )
+        with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
+            conf.write('dash_conf=1\n')
+        with self.nodes[0].assert_debug_log(expected_msgs=['Ignoring unknown configuration value dash_conf']):
+            self.start_node(0)
+        self.stop_node(0)
+
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('-dash=1\n')
         self.nodes[0].assert_start_raises_init_error(expected_msg='Error reading configuration file: parse error on line 1: -dash=1, options in configuration file must be specified without leading -')


### PR DESCRIPTION
Currently uncovered.


Further reading:

* https://marcofalke.github.io/btc_cov/total.coverage/src/util/system.cpp.gcov.html
*  Fail on unknown config file options #15021 