### PR TITLE
build: Remove unused C++ standard library includes

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -8,8 +8,7 @@
 #include <uint256.h>
 #include <crypto/common.h>
 
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
 
 template <unsigned int BITS>
 base_uint<BITS>::base_uint(const std::string& str)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -12,7 +12,6 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
-#include <vector>
 
 class uint256;
 

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
-#include <assert.h>
 #include <cstring>
 #include <limits>
 #include <stdexcept>

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <vector>
-#include <string>
 
 
 static void Base58Encode(benchmark::State& state)

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -6,7 +6,6 @@
 #define BITCOIN_BENCH_BENCH_H
 
 #include <functional>
-#include <limits>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -10,7 +10,6 @@
 #include <validation.h>
 
 
-#include <list>
 #include <vector>
 
 static void AssembleBlock(benchmark::State& state)

--- a/src/bench/chacha20.cpp
+++ b/src/bench/chacha20.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <crypto/chacha20.h>
 

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <hash.h>
 #include <random.h>

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -11,10 +11,6 @@
 #include <txmempool.h>
 #include <validation.h>
 
-#include <list>
-#include <vector>
-
-
 static void DuplicateInputs(benchmark::State& state)
 {
     const CScript SCRIPT_PUB{CScript(OP_TRUE)};

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -6,7 +6,6 @@
 
 #include <support/lockedpool.h>
 
-#include <iostream>
 #include <vector>
 
 #define ASIZE 2048

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -6,9 +6,6 @@
 #include <policy/policy.h>
 #include <txmempool.h>
 
-#include <list>
-#include <vector>
-
 static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     int64_t nTime = 0;

--- a/src/bench/poly1305.cpp
+++ b/src/bench/poly1305.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <crypto/poly1305.h>
 

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <bloom.h>
 

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -8,9 +8,6 @@
 
 #include <univalue.h>
 
-#include <list>
-#include <vector>
-
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     LockPoints lp;

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -13,8 +13,6 @@
 #include <util/strencodings.h>
 #include <wallet/wallettool.h>
 
-#include <stdio.h>
-
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
 static void SetupWalletToolArgs()

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -19,8 +19,6 @@
 #include <util/threadnames.h>
 #include <util/strencodings.h>
 
-#include <stdio.h>
-
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
 /* Introduction text for doxygen: */

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -7,8 +7,6 @@
 
 #include <primitives/block.h>
 
-#include <memory>
-
 class CTxMemPool;
 
 // Dumb helper to handle CTransaction compression at serialize-time

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -7,7 +7,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 /**
  * CBaseChainParams defines the base parameters (shared between bitcoin-cli and bitcoind)

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_CONSENSUS_MERKLE_H
 #define BITCOIN_CONSENSUS_MERKLE_H
 
-#include <stdint.h>
 #include <vector>
 
 #include <primitives/transaction.h>

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,8 +8,6 @@
 
 #include <uint256.h>
 #include <limits>
-#include <map>
-#include <string>
 
 namespace Consensus {
 

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -4,7 +4,6 @@
 
 #include <crypto/aes.h>
 
-#include <assert.h>
 #include <string.h>
 
 extern "C" {

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -7,7 +7,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <atomic>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #if defined(USE_ASM)

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -4,6 +4,8 @@
 
 #include <crypto/siphash.h>
 
+#include <cassert>
+
 #define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
 
 #define SIPROUND do { \

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <stdio.h>
 #include <util/system.h>
 #include <walletinitinterface.h>
 

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -5,9 +5,6 @@
 #ifndef BITCOIN_HTTPRPC_H
 #define BITCOIN_HTTPRPC_H
 
-#include <string>
-#include <map>
-
 /** Start HTTP RPC subsystem.
  * Precondition; HTTP and RPC has been started.
  */

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -23,7 +23,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <signal.h>
 
 #include <event2/thread.h>
 #include <event2/buffer.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <thread>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -6,7 +6,6 @@
 #define BITCOIN_HTTPSERVER_H
 
 #include <string>
-#include <stdint.h>
 #include <functional>
 
 static const int DEFAULT_HTTP_THREADS=4;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -12,6 +12,8 @@
 #include <uint256.h>
 #include <validationinterface.h>
 
+#include <thread>
+
 class CBlockIndex;
 
 /**

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -35,7 +35,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <atomic>
 #include <univalue.h>
 
 class CWallet;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -24,7 +24,6 @@
 #include <util/validation.h>
 
 #include <algorithm>
-#include <queue>
 #include <utility>
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -8,8 +8,6 @@
 #include <ui_interface.h>
 #include <util/system.h>
 
-#include <cstdio>
-#include <stdint.h>
 #include <string>
 
 #include <boost/signals2/connection.hpp>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iterator>
 #include <type_traits>
 
 #pragma pack(push, 1)

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,7 +15,6 @@
 #include <uint256.h>
 #include <version.h>
 
-#include <atomic>
 #include <stdint.h>
 #include <string>
 

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -5,8 +5,6 @@
 #include <psbt.h>
 #include <util/strencodings.h>
 
-#include <numeric>
-
 PartiallySignedTransaction::PartiallySignedTransaction(const CMutableTransaction& tx) : tx(tx)
 {
     inputs.resize(tx.vin.size());

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -36,7 +36,6 @@
 #include <util/system.h>
 
 #include <memory>
-#include <stdint.h>
 
 #include <boost/thread.hpp>
 

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -11,7 +11,6 @@
 
 #include <QApplication>
 #include <memory>
-#include <vector>
 
 class BitcoinGUI;
 class ClientModel;

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -36,9 +36,6 @@
 #include <ui_interface.h>
 #include <util/system.h>
 
-#include <iostream>
-#include <memory>
-
 #include <QAction>
 #include <QApplication>
 #include <QComboBox>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -14,7 +14,6 @@
 #include <util/validation.h> // For strMessageMagic
 #include <wallet/wallet.h>
 
-#include <string>
 #include <vector>
 
 #include <QClipboard>

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -25,7 +25,6 @@
 #include <QtGlobal>
 #include <QtTest/QtTestWidgets>
 #include <QtTest/QtTestGui>
-#include <new>
 #include <string>
 #include <univalue.h>
 

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -8,7 +8,6 @@
 #include <qt/walletmodel.h>
 #include <sync.h>
 
-#include <list>
 #include <memory>
 #include <vector>
 

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -9,7 +9,6 @@
 #include <qt/walletview.h>
 
 #include <cassert>
-#include <cstdio>
 
 #include <QHBoxLayout>
 #include <QLabel>

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -22,7 +22,6 @@
 #include <interfaces/wallet.h>
 #include <support/allocators/secure.h>
 
-#include <map>
 #include <vector>
 
 #include <QObject>

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -16,7 +16,6 @@
 #include <util/time.h> // for GetTime()
 
 #include <stdlib.h>
-#include <chrono>
 #include <thread>
 
 #include <support/allocators/secure.h>
@@ -40,8 +39,6 @@
 #include <util/strencodings.h> // for ARRAYLEN
 #include <sys/sysctl.h>
 #endif
-
-#include <mutex>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #include <cpuid.h>

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -8,8 +8,6 @@
 
 #include <fs.h>
 
-#include <list>
-#include <map>
 #include <stdint.h>
 #include <string>
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -32,7 +32,6 @@
 #include <validationinterface.h>
 
 
-#include <numeric>
 #include <stdint.h>
 
 #include <univalue.h>

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -10,7 +10,6 @@
 #include <rpc/protocol.h>
 #include <uint256.h>
 
-#include <list>
 #include <map>
 #include <stdint.h>
 #include <string>

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -11,7 +11,6 @@
 
 #include <vector>
 #include <stdint.h>
-#include <string>
 
 class CPubKey;
 class CScript;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -11,8 +11,6 @@
 
 #include <boost/variant.hpp>
 
-#include <stdint.h>
-
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 
 class CKeyID;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -9,7 +9,6 @@
 #include <compat/endian.h>
 
 #include <algorithm>
-#include <assert.h>
 #include <ios>
 #include <limits>
 #include <map>

--- a/src/streams.h
+++ b/src/streams.h
@@ -13,8 +13,6 @@
 #include <assert.h>
 #include <ios>
 #include <limits>
-#include <map>
-#include <set>
 #include <stdint.h>
 #include <stdio.h>
 #include <string>

--- a/src/support/events.h
+++ b/src/support/events.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_SUPPORT_EVENTS_H
 #define BITCOIN_SUPPORT_EVENTS_H
 
-#include <ios>
 #include <memory>
+#include <string>
 
 #include <event2/event.h>
 #include <event2/http.h>

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -13,8 +13,6 @@
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 
-#include <stdio.h>
-
 #include <map>
 #include <set>
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -16,7 +16,6 @@
 #include <stdio.h>
 
 #include <map>
-#include <memory>
 #include <set>
 
 #ifdef DEBUG_LOCKCONTENTION

--- a/src/sync.h
+++ b/src/sync.h
@@ -9,7 +9,6 @@
 #include <threadsafety.h>
 
 #include <condition_variable>
-#include <thread>
 #include <mutex>
 
 

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -17,7 +17,6 @@
 #include <condition_variable>
 
 #include <unordered_set>
-#include <memory>
 #include <random.h>
 
 // BasicTestingSetup not sufficient because nScriptCheckThreads is not set

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -20,8 +20,6 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include <algorithm>
-#include <memory>
 #include <vector>
 
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_TEST_FUZZ_FUZZ_H
 #define BITCOIN_TEST_FUZZ_FUZZ_H
 
-#include <functional>
 #include <stdint.h>
 #include <vector>
 

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -7,8 +7,6 @@
 #include <util/strencodings.h>
 #include <test/setup_common.h>
 
-#include <vector>
-
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(hash_tests, BasicTestingSetup)

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -9,7 +9,6 @@
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <test/setup_common.h>
-#include <string>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -9,7 +9,6 @@
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
-#include <list>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -14,8 +14,6 @@
 
 #include <test/setup_common.h>
 
-#include <vector>
-
 #include <boost/test/unit_test.hpp>
 
 static std::map<void*, short> tags;

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -19,7 +19,6 @@
 #include <script/bitcoinconsensus.h>
 #endif
 
-#include <fstream>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_TEST_SCRIPTNUM10_H
 #define BITCOIN_TEST_SCRIPTNUM10_H
 
-#include <algorithm>
 #include <limits>
 #include <stdexcept>
 #include <stdint.h>

--- a/src/test/setup_common.h
+++ b/src/test/setup_common.h
@@ -14,7 +14,6 @@
 #include <txdb.h>
 #include <txmempool.h>
 
-#include <memory>
 #include <type_traits>
 
 #include <boost/thread.hpp>

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -7,12 +7,9 @@
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
-#include <stdint.h>
 #include <sstream>
 #include <iomanip>
-#include <cmath>
 #include <string>
-#include <stdio.h>
 
 BOOST_FIXTURE_TEST_SUITE(uint256_tests, BasicTestingSetup)
 

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include <sstream>
 #include <iomanip>
-#include <limits>
 #include <cmath>
 #include <string>
 #include <stdio.h>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -13,6 +13,7 @@
 #include <test/setup_common.h>
 
 #include <stdint.h>
+#include <thread>
 #include <vector>
 #ifndef WIN32
 #include <signal.h>

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -14,6 +14,8 @@
 #include <validation.h>
 #include <validationinterface.h>
 
+#include <thread>
+
 struct RegtestingSetup : public TestingSetup {
     RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
 };

--- a/src/threadinterrupt.h
+++ b/src/threadinterrupt.h
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <mutex>
 
 /*
     A helper class for interruptible sleeps. Calling operator() will interrupt

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,7 +11,6 @@
 #include <chain.h>
 #include <primitives/block.h>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_TXMEMPOOL_H
 #define BITCOIN_TXMEMPOOL_H
 
-#include <memory>
 #include <set>
 #include <map>
 #include <vector>

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -8,7 +8,6 @@
 
 #include <functional>
 #include <memory>
-#include <stdint.h>
 #include <string>
 
 class CBlockIndex;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -7,7 +7,7 @@
 
 #include <util/strencodings.h>
 
-#include <stdio.h>
+#include <cassert>
 #include <string.h>
 
 template <unsigned int BITS>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -8,7 +8,6 @@
 
 #include <assert.h>
 #include <cstring>
-#include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_UINT256_H
 #define BITCOIN_UINT256_H
 
-#include <assert.h>
 #include <cstring>
 #include <stdint.h>
 #include <string>

--- a/src/util/moneystr.h
+++ b/src/util/moneystr.h
@@ -12,7 +12,6 @@
 #include <amount.h>
 #include <attributes.h>
 
-#include <cstdint>
 #include <string>
 
 /* Do not use these functions to represent or parse monetary amounts to or from

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -8,8 +8,6 @@
 #include <chainparamsbase.h>
 #include <util/strencodings.h>
 
-#include <stdarg.h>
-
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>
 #include <pthread_np.h>

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -25,13 +25,11 @@
 #include <util/memory.h>
 #include <util/time.h>
 
-#include <atomic>
 #include <exception>
 #include <map>
 #include <set>
 #include <stdint.h>
 #include <string>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -6,12 +6,11 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <atomic>
-#include <thread>
-
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>
 #include <pthread_np.h>
+#elif defined(MAC_OSX)
+#include <thread>
 #endif
 
 #include <util/threadnames.h>

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
+#include <chrono>
 #include <ctime>
 #include <tinyformat.h>
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -8,7 +8,6 @@
 
 #include <stdint.h>
 #include <string>
-#include <chrono>
 
 /**
  * DEPRECATED

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -45,8 +45,6 @@
 #include <validationinterface.h>
 #include <warnings.h>
 
-#include <future>
-#include <sstream>
 #include <string>
 
 #include <boost/algorithm/string/replace.hpp>

--- a/src/validation.h
+++ b/src/validation.h
@@ -22,12 +22,10 @@
 
 #include <algorithm>
 #include <atomic>
-#include <exception>
 #include <map>
 #include <memory>
 #include <set>
 #include <stdint.h>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -9,8 +9,6 @@
 #include <scheduler.h>
 #include <txmempool.h>
 
-#include <list>
-#include <atomic>
 #include <future>
 #include <utility>
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -10,7 +10,6 @@
 #include <script/standard.h>
 #include <util/system.h>
 
-#include <string>
 #include <vector>
 
 int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -37,8 +37,6 @@
 
 #include <univalue.h>
 
-#include <functional>
-
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 
 bool GetWalletNameFromJSONRPCRequest(const JSONRPCRequest& request, std::string& wallet_name)

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -5,9 +5,7 @@
 #include <wallet/wallet.h>
 
 #include <memory>
-#include <set>
 #include <stdint.h>
-#include <utility>
 #include <vector>
 
 #include <consensus/validation.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -32,7 +32,7 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <future>
+#include <thread>
 
 #include <boost/algorithm/string/replace.hpp>
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -12,10 +12,8 @@
 #include <wallet/db.h>
 #include <key.h>
 
-#include <list>
 #include <stdint.h>
 #include <string>
-#include <utility>
 #include <vector>
 
 /**

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_WALLETINITINTERFACE_H
 #define BITCOIN_WALLETINITINTERFACE_H
 
-#include <string>
-
 class CScheduler;
 class CRPCTable;
 struct InitInterfaces;

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_WARNINGS_H
 #define BITCOIN_WARNINGS_H
 
-#include <stdlib.h>
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -9,8 +9,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <stdarg.h>
-
 #if ENABLE_ZMQ
 #include <zmq.h>
 #endif

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -10,7 +10,6 @@
 #endif
 
 #include <stdarg.h>
-#include <string>
 
 #if ENABLE_ZMQ
 #include <zmq.h>

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,8 +6,6 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
-#include <string>
-#include <map>
 #include <list>
 
 class CBlockIndex;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -10,6 +10,8 @@
 #include <util/system.h>
 #include <rpc/server.h>
 
+#include <cstdarg>
+
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
 static const char *MSG_HASHBLOCK = "hashblock";


### PR DESCRIPTION
Reduce accumulated max memory usage (RSS) during build by ~1% (-838 MB) by not including unused C++ standard library headers.

This is a follow-up to now merged #16129 which [reduced the memory usage by ~2% (-2632 MB)](https://github.com/bitcoin/bitcoin/pull/16129#issuecomment-502875291).

Comparing max memory usage (RSS) between old revision 44d81723236114f9370f386f3b3310477a6dde43 (branch `master`) and new revision 50f005631f053f2531738f574d4363378b69a5fc (branch `c++-standard-library-headers`):

| File                                                         | Old       | New       | Diff      | Percent   |
| :----------------------------------------------------------- | --------: | --------: | --------: | --------: |
| `bench/bench_bench_bitcoin-bench_bitcoin.o`                  |    236 MB |    218 MB |    -18 MB |      -8 % |
| `libbitcoin_common_a-netbase.o`                              |    281 MB |    263 MB |    -18 MB |      -6 % |
| `libbitcoin_common_a-protocol.o`                             |    236 MB |    218 MB |    -18 MB |      -7 % |
| `libbitcoin_common_a-warnings.o`                             |    212 MB |    195 MB |    -17 MB |      -8 % |
| `libbitcoin_server_a-addrman.o`                              |    286 MB |    270 MB |    -17 MB |      -6 % |
| `libbitcoin_server_a-banman.o`                               |    253 MB |    235 MB |    -18 MB |      -7 % |
| `libbitcoin_server_a-dbwrapper.o`                            |    287 MB |    269 MB |    -18 MB |      -6 % |
| `libbitcoin_server_a-flatfile.o`                             |    239 MB |    221 MB |    -18 MB |      -8 % |
| `libbitcoin_server_a-timedata.o`                             |    256 MB |    239 MB |    -17 MB |      -7 % |
| `libbitcoin_util_a-chainparamsbase.o`                        |    225 MB |    208 MB |    -17 MB |      -8 % |
| `rpc/libbitcoin_cli_a-client.o`                              |    263 MB |    246 MB |    -17 MB |      -6 % |
| `rpc/libbitcoin_util_a-protocol.o`                           |    258 MB |    240 MB |    -18 MB |      -7 % |
| `util/libbitcoin_util_a-error.o`                             |    220 MB |    202 MB |    -17 MB |      -8 % |
| `util/libbitcoin_util_a-threadnames.o`                       |     69 MB |     48 MB |    -21 MB |     -31 % |
| `wallet/libbitcoin_wallet_a-walletutil.o`                    |    249 MB |    232 MB |    -17 MB |      -7 % |
| ... suppressing 438 unchanged measurements ...               | ...       | ...       | ...       | ...       |
| Average (N=453)                                              |    319 MB |    317 MB |     -2 MB |      -1 % |
| Sum (N=453)                                                  | 144380 MB | 143542 MB |   -838 MB |      -1 % |

Measured using:

```
$ g++ --version
g++ (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
```

Please note that the removed headers are not removable by being "transitively included" by other still included headers. Thus the removals are real. (In other words: the naïve and totally pointless "remove as long as it compiles" method to include "reduction" has **not** be used.)