### PR TITLE
docs: add rapidcheck to vcpkg install list

### DIFF
--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -17,16 +17,17 @@ Options for installing the dependencies in a Visual Studio compatible manner are
 - Download the source code, build each dependency, add the required include paths, link libraries and binary tools to the Visual Studio project files.
 - Use [nuget](https://www.nuget.org/) packages with the understanding that any binary files have been compiled by an untrusted third party.
 
-The external dependencies required for the Visual Studio build are (see the [dependencies doc](https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md) for versions):
+The external dependencies required for the Visual Studio build are (see [dependencies.md](https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md) for more info):
 
-- Berkeley DB,
-- OpenSSL,
-- Boost,
-- libevent,
+- Berkeley DB
+- OpenSSL
+- Boost
+- libevent
 - ZeroMQ
+- RapidCheck
 
-Additional dependencies required from the [bitcoin-core](https://github.com/bitcoin-core) github repository are:
-- SECP256K1,
+Additional dependencies required from the [bitcoin-core](https://github.com/bitcoin-core) GitHub repository are:
+- libsecp256k1
 - LevelDB
 
 Building
@@ -37,7 +38,7 @@ The instructions below use `vcpkg` to install the dependencies.
 - Install the required packages (replace x64 with x86 as required):
 
 ```
-    PS >.\vcpkg install --triplet x64-windows-static boost-filesystem boost-signals2 boost-test libevent openssl zeromq berkeleydb secp256k1 leveldb
+    PS >.\vcpkg install --triplet x64-windows-static boost-filesystem boost-signals2 boost-test libevent openssl zeromq berkeleydb secp256k1 leveldb rapidcheck
 ```
 
 - Use Python to generate *.vcxproj from Makefile


### PR DESCRIPTION
Setting up a fresh Windows 10 VM using [this guide](https://github.com/fanquake/core-review/blob/master/windows.md), installing `rapidcheck` and building using the changes in #16235 resulted in a working `bitcoind` and all tests passing.