### PR TITLE
doc: remove orphaned header in developer notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -34,7 +34,6 @@ Developer Notes
     - [Source code organization](#source-code-organization)
     - [GUI](#gui)
     - [Subtrees](#subtrees)
-    - [Git and GitHub tips](#git-and-github-tips)
     - [Scripted diffs](#scripted-diffs)
     - [Release notes](#release-notes)
     - [RPC interface guidelines](#rpc-interface-guidelines)


### PR DESCRIPTION
The "Git and GitHub tips" section was moved from doc/developer-notes.md to doc/productivity.md in 5b76c31, but the header link to that long-gone section in the developer notes remains and needs to go.

So long, Git and GitHub tips, we barely knew ya.