### PR TITLE
[MSVC]: Create the config.ini as part of bitcoind build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -38,17 +38,6 @@ after_build:
 - ps:  fsutil behavior set disablelastaccess 1 # Disable Access time feature on Windows (better performance)
 - ps:  clcache -z
 before_test:
-- ps:  ${conf_ini} = (Get-Content([IO.Path]::Combine(${env:APPVEYOR_BUILD_FOLDER}, "test", "config.ini.in")))
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@PACKAGE_NAME@", "Bitcoin Core")
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@abs_top_srcdir@", ${env:APPVEYOR_BUILD_FOLDER})
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@abs_top_builddir@", ${env:APPVEYOR_BUILD_FOLDER})
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@EXEEXT@", ".exe")
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@ENABLE_WALLET_TRUE@", "")
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@BUILD_BITCOIN_CLI_TRUE@", "")
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@BUILD_BITCOIND_TRUE@", "")
-- ps:  ${conf_ini} = ${conf_ini}.Replace("@ENABLE_ZMQ_TRUE@", "")
-- ps:  ${utf8} = New-Object System.Text.UTF8Encoding ${false}
-- ps:  '[IO.File]::WriteAllLines([IO.Path]::Combine(${env:APPVEYOR_BUILD_FOLDER}, "test", "config.ini"), ${conf_ini}, ${utf8})'
 - ps:  move "build_msvc\${env:PLATFORM}\${env:CONFIGURATION}\*.exe" src
 test_script:
 - cmd: src\test_bitcoin.exe -k stdout -e stdout 2> NUL

--- a/build_msvc/bitcoind/bitcoind.vcxproj
+++ b/build_msvc/bitcoind/bitcoind.vcxproj
@@ -67,6 +67,8 @@
     <ReplaceInFile FilePath="$(ConfigIniOut)"
                   Replace="@BUILD_BITCOIND_TRUE@" By=""></ReplaceInFile>
     <ReplaceInFile FilePath="$(ConfigIniOut)"
+                  Replace="@ENABLE_FUZZ_TRUE@" By=""></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
                   Replace="@ENABLE_ZMQ_TRUE@" By=""></ReplaceInFile>
   </Target>
 </Project>

--- a/build_msvc/bitcoind/bitcoind.vcxproj
+++ b/build_msvc/bitcoind/bitcoind.vcxproj
@@ -45,4 +45,28 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Label="ReplaceInFile" Project="..\msbuild\tasks\replaceinfile.targets" />
+  <PropertyGroup>
+    <ConfigIniIn>..\..\test\config.ini.in</ConfigIniIn>
+    <ConfigIniOut>..\..\test\config.ini</ConfigIniOut>
+  </PropertyGroup>
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="$(ConfigIniIn)" DestinationFiles="$(ConfigIniOut)" ></Copy>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                   Replace="@PACKAGE_NAME@" By="Bitcoin Core"></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                   Replace="@abs_top_srcdir@" By="..\.." ToFullPath="true"></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                   Replace="@abs_top_builddir@" By="..\.." ToFullPath="true"></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                   Replace="@EXEEXT@" By=".exe"></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                  Replace="@ENABLE_WALLET_TRUE@" By=""></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                  Replace="@BUILD_BITCOIN_CLI_TRUE@" By=""></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                  Replace="@BUILD_BITCOIND_TRUE@" By=""></ReplaceInFile>
+    <ReplaceInFile FilePath="$(ConfigIniOut)"
+                  Replace="@ENABLE_ZMQ_TRUE@" By=""></ReplaceInFile>
+  </Target>
 </Project>

--- a/build_msvc/msbuild/tasks/replaceinfile.targets
+++ b/build_msvc/msbuild/tasks/replaceinfile.targets
@@ -1,0 +1,35 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask
+    TaskName="ReplaceInFile"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+        <FilePath Required="true" />
+        <Replace Required="true" />
+        <By Required="false" />
+        <ToFullPath Required="false" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System"/>
+      <Using Namespace="System.IO"/>
+      <Code Type="Fragment" Language="cs">
+<![CDATA[
+if(File.Exists(FilePath) == false) {
+    Log.LogError("replaceinfile task could not locate " + FilePath + ".");
+}
+else {
+    var data = File.ReadAllText(FilePath);
+    var by = By;
+    if (ToFullPath == "true")
+    {
+       by = Path.GetFullPath(by);
+    }
+    data = data.Replace(Replace, by);
+    Log.LogMessage("Replace '" + Replace + "' by '" + by + "' in " + FilePath);
+    File.WriteAllText(FilePath, data, new System.Text.UTF8Encoding(false));
+}
+]]>
+      </Code>
+    </Task>
+  </UsingTask>
+</Project>


### PR DESCRIPTION
This remove the patchwork of powershell done in AppVeyor to the `AfterBuild` target of `bitcoind` so that windows developers do not have to figure out how to manually edit the config.ini before running the functional tests.

You can easily test with `msbuild /t:AfterBuild` in bitcoind folder.