### PR TITLE
gui: Refactor OpenWalletActivity

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -379,31 +379,11 @@ void BitcoinGUI::createActions()
                     continue;
                 }
 
-                connect(action, &QAction::triggered, [this, name, path] {
-                    OpenWalletActivity* activity = m_wallet_controller->openWallet(path);
-
-                    QProgressDialog* dialog = new QProgressDialog(this);
-                    dialog->setLabelText(tr("Opening Wallet <b>%1</b>...").arg(name.toHtmlEscaped()));
-                    dialog->setRange(0, 0);
-                    dialog->setCancelButton(nullptr);
-                    dialog->setWindowModality(Qt::ApplicationModal);
-                    dialog->show();
-
-                    connect(activity, &OpenWalletActivity::message, this, [this] (QMessageBox::Icon icon, QString text) {
-                        QMessageBox box;
-                        box.setIcon(icon);
-                        box.setText(tr("Open Wallet Failed"));
-                        box.setInformativeText(text);
-                        box.setStandardButtons(QMessageBox::Ok);
-                        box.setDefaultButton(QMessageBox::Ok);
-                        connect(this, &QObject::destroyed, &box, &QDialog::accept);
-                        box.exec();
-                    });
+                connect(action, &QAction::triggered, [this, path] {
+                    auto activity = new OpenWalletActivity(m_wallet_controller, this);
                     connect(activity, &OpenWalletActivity::opened, this, &BitcoinGUI::setCurrentWallet);
                     connect(activity, &OpenWalletActivity::finished, activity, &QObject::deleteLater);
-                    connect(activity, &OpenWalletActivity::finished, dialog, &QObject::deleteLater);
-                    bool invoked = QMetaObject::invokeMethod(activity, "open");
-                    assert(invoked);
+                    activity->open(path);
                 });
             }
             if (m_open_wallet_menu->isEmpty()) {

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <qt/guiutil.h>
 #include <qt/walletcontroller.h>
 
 #include <interfaces/handler.h>
@@ -13,10 +14,13 @@
 #include <QMessageBox>
 #include <QMutexLocker>
 #include <QThread>
+#include <QTimer>
 #include <QWindow>
 
 WalletController::WalletController(interfaces::Node& node, const PlatformStyle* platform_style, OptionsModel* options_model, QObject* parent)
     : QObject(parent)
+    , m_activity_thread(new QThread(this))
+    , m_activity_worker(new QObject)
     , m_node(node)
     , m_platform_style(platform_style)
     , m_options_model(options_model)
@@ -29,15 +33,17 @@ WalletController::WalletController(interfaces::Node& node, const PlatformStyle* 
         getOrCreateWallet(std::move(wallet));
     }
 
-    m_activity_thread.start();
+    m_activity_worker->moveToThread(m_activity_thread);
+    m_activity_thread->start();
 }
 
 // Not using the default destructor because not all member types definitions are
 // available in the header, just forward declared.
 WalletController::~WalletController()
 {
-    m_activity_thread.quit();
-    m_activity_thread.wait();
+    m_activity_thread->quit();
+    m_activity_thread->wait();
+    delete m_activity_worker;
 }
 
 std::vector<WalletModel*> WalletController::getOpenWallets() const
@@ -58,13 +64,6 @@ std::map<std::string, bool> WalletController::listWalletDir() const
         if (it != wallets.end()) it->second = true;
     }
     return wallets;
-}
-
-OpenWalletActivity* WalletController::openWallet(const std::string& name, QWidget* parent)
-{
-    OpenWalletActivity* activity = new OpenWalletActivity(this, name);
-    activity->moveToThread(&m_activity_thread);
-    return activity;
 }
 
 void WalletController::closeWallet(WalletModel* wallet_model, QWidget* parent)
@@ -140,23 +139,60 @@ void WalletController::removeAndDeleteWallet(WalletModel* wallet_model)
     delete wallet_model;
 }
 
-
-OpenWalletActivity::OpenWalletActivity(WalletController* wallet_controller, const std::string& name)
-    : m_wallet_controller(wallet_controller)
-    , m_name(name)
-{}
-
-void OpenWalletActivity::open()
+WalletControllerActivity::WalletControllerActivity(WalletController* wallet_controller, QWidget* parent_widget)
+    : QObject(wallet_controller)
+    , m_wallet_controller(wallet_controller)
+    , m_parent_widget(parent_widget)
 {
-    std::string error, warning;
-    std::unique_ptr<interfaces::Wallet> wallet = m_wallet_controller->m_node.loadWallet(m_name, error, warning);
-    if (!warning.empty()) {
-        Q_EMIT message(QMessageBox::Warning, QString::fromStdString(warning));
+}
+
+WalletControllerActivity::~WalletControllerActivity()
+{
+    delete m_progress_dialog;
+}
+
+void WalletControllerActivity::showProgressDialog(const QString& label_text)
+{
+    m_progress_dialog = new QProgressDialog(m_parent_widget);
+
+    m_progress_dialog->setLabelText(label_text);
+    m_progress_dialog->setRange(0, 0);
+    m_progress_dialog->setCancelButton(nullptr);
+    m_progress_dialog->setWindowModality(Qt::ApplicationModal);
+    GUIUtil::PolishProgressDialog(m_progress_dialog);
+}
+
+OpenWalletActivity::OpenWalletActivity(WalletController* wallet_controller, QWidget* parent_widget)
+    : WalletControllerActivity(wallet_controller, parent_widget)
+{
+}
+
+void OpenWalletActivity::finish()
+{
+    m_progress_dialog->hide();
+
+    if (!m_error_message.empty()) {
+        QMessageBox::critical(m_parent_widget, tr("Open wallet failed"), QString::fromStdString(m_error_message));
+    } else if (!m_warning_message.empty()) {
+        QMessageBox::warning(m_parent_widget, tr("Open wallet warning"), QString::fromStdString(m_warning_message));
     }
-    if (wallet) {
-        Q_EMIT opened(m_wallet_controller->getOrCreateWallet(std::move(wallet)));
-    } else {
-        Q_EMIT message(QMessageBox::Critical, QString::fromStdString(error));
-    }
+
+    if (m_wallet_model) Q_EMIT opened(m_wallet_model);
+
     Q_EMIT finished();
+}
+
+void OpenWalletActivity::open(const std::string& path)
+{
+    QString name = path.empty() ? QString("["+tr("default wallet")+"]") : QString::fromStdString(path);
+
+    showProgressDialog(tr("Opening Wallet <b>%1</b>...").arg(name.toHtmlEscaped()));
+
+    QTimer::singleShot(0, worker(), [this, path] {
+        std::unique_ptr<interfaces::Wallet> wallet = node().loadWallet(path, m_error_message, m_warning_message);
+
+        if (wallet) m_wallet_model = m_wallet_controller->getOrCreateWallet(std::move(wallet));
+
+        QTimer::singleShot(0, this, &OpenWalletActivity::finish);
+    });
 }

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -10,10 +10,13 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <QMessageBox>
 #include <QMutex>
+#include <QProgressDialog>
+#include <QString>
 #include <QThread>
 
 class OptionsModel;
@@ -25,6 +28,7 @@ class Node;
 } // namespace interfaces
 
 class OpenWalletActivity;
+class WalletControllerActivity;
 
 /**
  * Controller between interfaces::Node, WalletModel instances and the GUI.
@@ -33,7 +37,6 @@ class WalletController : public QObject
 {
     Q_OBJECT
 
-    WalletModel* getOrCreateWallet(std::unique_ptr<interfaces::Wallet> wallet);
     void removeAndDeleteWallet(WalletModel* wallet_model);
 
 public:
@@ -43,11 +46,12 @@ public:
     //! Returns wallet models currently open.
     std::vector<WalletModel*> getOpenWallets() const;
 
+    WalletModel* getOrCreateWallet(std::unique_ptr<interfaces::Wallet> wallet);
+
     //! Returns all wallet names in the wallet dir mapped to whether the wallet
     //! is loaded.
     std::map<std::string, bool> listWalletDir() const;
 
-    OpenWalletActivity* openWallet(const std::string& name, QWidget* parent = nullptr);
     void closeWallet(WalletModel* wallet_model, QWidget* parent = nullptr);
 
 Q_SIGNALS:
@@ -57,7 +61,8 @@ Q_SIGNALS:
     void coinsSent(WalletModel* wallet_model, SendCoinsRecipient recipient, QByteArray transaction);
 
 private:
-    QThread m_activity_thread;
+    QThread* const m_activity_thread;
+    QObject* const m_activity_worker;
     interfaces::Node& m_node;
     const PlatformStyle* const m_platform_style;
     OptionsModel* const m_options_model;
@@ -65,27 +70,48 @@ private:
     std::vector<WalletModel*> m_wallets;
     std::unique_ptr<interfaces::Handler> m_handler_load_wallet;
 
-    friend class OpenWalletActivity;
+    friend class WalletControllerActivity;
 };
 
-class OpenWalletActivity : public QObject
+class WalletControllerActivity : public QObject
 {
     Q_OBJECT
 
 public:
-    OpenWalletActivity(WalletController* wallet_controller, const std::string& name);
-
-public Q_SLOTS:
-    void open();
+    WalletControllerActivity(WalletController* wallet_controller, QWidget* parent_widget);
+    virtual ~WalletControllerActivity();
 
 Q_SIGNALS:
-    void message(QMessageBox::Icon icon, const QString text);
     void finished();
+
+protected:
+    interfaces::Node& node() const { return m_wallet_controller->m_node; }
+    QObject* worker() const { return m_wallet_controller->m_activity_worker; }
+
+    void showProgressDialog(const QString& label_text);
+
+    WalletController* const m_wallet_controller;
+    QWidget* const m_parent_widget;
+    QProgressDialog* m_progress_dialog{nullptr};
+    WalletModel* m_wallet_model{nullptr};
+    std::string m_error_message;
+    std::string m_warning_message;
+};
+
+class OpenWalletActivity : public WalletControllerActivity
+{
+    Q_OBJECT
+
+public:
+    OpenWalletActivity(WalletController* wallet_controller, QWidget* parent_widget);
+
+    void open(const std::string& path);
+
+Q_SIGNALS:
     void opened(WalletModel* wallet_model);
 
 private:
-    WalletController* const m_wallet_controller;
-    std::string const m_name;
+    void finish();
 };
 
 #endif // BITCOIN_QT_WALLETCONTROLLER_H


### PR DESCRIPTION
This PR consists in 3 refactors:

 1. Split from `OpenWalletActivity` a base class `WalletControllerActivity` to simplify new activities, like the upcoming `CreateWalletActivity`;
 2. Move from `BitcoinGUI` the details of the wallet opening;
 3. Change threading model - `WalletControllerActivity` instances belong to the GUI thread and some code (the blocking code) is now executed in the worker thread asynchronously, which allows for a responsive GUI.
