### PR TITLE
policy: Add experimental -mempoolreplacement=full (off by default)

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -273,6 +273,8 @@ enum ServiceFlags : uint64_t {
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
+
+    NODE_FULL_RBF = (1 << 26),
 };
 
 /**
@@ -299,7 +301,7 @@ enum ServiceFlags : uint64_t {
  * If the NODE_NONE return value is changed, contrib/seeds/makeseeds.py
  * should be updated appropriately to filter for the same nodes.
  */
-ServiceFlags GetDesirableServiceFlags(ServiceFlags services);
+ServiceFlags GetDesirableServiceFlags(ServiceFlags services_them);
 
 /** Set the current IBD status in order to figure out the desirable service flags */
 void SetServiceFlagsIBDCache(bool status);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -114,6 +114,7 @@ bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
+bool g_enable_full_rbf{false};
 
 uint256 hashAssumeValid;
 arith_uint256 nMinimumChainWork;
@@ -478,6 +479,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         if (ptxConflicting) {
             if (!setConflicts.count(ptxConflicting->GetHash()))
             {
+                if (!g_enable_full_rbf) {
                 // Allow opt-out of transaction replacement by setting
                 // nSequence > MAX_BIP125_RBF_SEQUENCE (SEQUENCE_FINAL-2) on all inputs.
                 //
@@ -502,6 +504,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                 if (fReplacementOptOut) {
                     return state.Invalid(ValidationInvalidReason::TX_MEMPOOL_POLICY, false, REJECT_DUPLICATE, "txn-mempool-conflict");
                 }
+                } // g_enable_full_rbf
 
                 setConflicts.insert(ptxConflicting->GetHash());
             }

--- a/src/validation.h
+++ b/src/validation.h
@@ -156,6 +156,8 @@ extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
+/** Experimental support for full rbf (off by default, can be enabled via -mempoolreplacement=full) */
+extern bool g_enable_full_rbf;
 /** If the tip is older than this (in seconds), the node is considered to be in initial block download. */
 extern int64_t nMaxTipAge;
 

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -64,17 +64,16 @@ def make_utxo_util(node, amount, confirmed=True, scriptPubKey=CScript([1])):
 
 class ReplaceByFeeTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.num_nodes = 1
-        self.extra_args = [
-            [
+        self.num_nodes = 2
+        self.extra_args = [[
                 "-acceptnonstdtxn=1",
                 "-maxorphantx=1000",
                 "-limitancestorcount=50",
                 "-limitancestorsize=101",
                 "-limitdescendantcount=200",
                 "-limitdescendantsize=101",
-            ],
-        ]
+                "-mempoolreplacement={}".format(r),
+        ] for r in ['0', 'full']]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -88,6 +87,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
     def run_test(self):
         self.make_utxo(1 * COIN)
+
+        self.RBF_NODES = range(0, 2)
 
         self.log.info("Running test simple doublespend...")
         self.test_simple_doublespend()
@@ -129,7 +130,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         tx1a.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx1a_hex = txToHex(tx1a)
-        tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, 0)
+        for i in self.RBF_NODES:
+            tx1a_txid = self.nodes[i].sendrawtransaction(tx1a_hex, 0)
 
         self.sync_all()
 
@@ -140,7 +142,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # This will raise an exception due to insufficient fee
-        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "insufficient fee", self.nodes[i].sendrawtransaction, tx1b_hex, 0)
 
         # Extra 0.1 BTC fee
         tx1b = CTransaction()
@@ -148,14 +151,15 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b.vout = [CTxOut(int(0.9 * COIN), CScript([b'b' * 35]))]
         tx1b_hex = txToHex(tx1b)
         # Works when enabled
-        tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, 0)
+        for i in self.RBF_NODES:
+            tx1b_txid = self.nodes[i].sendrawtransaction(tx1b_hex, 0)
 
-        mempool = self.nodes[0].getrawmempool()
+            mempool = self.nodes[i].getrawmempool()
 
-        assert tx1a_txid not in mempool
-        assert tx1b_txid in mempool
+            assert tx1a_txid not in mempool
+            assert tx1b_txid in mempool
 
-        assert_equal(tx1b_hex, self.nodes[0].getrawtransaction(tx1b_txid))
+            assert_equal(tx1b_hex, self.nodes[i].getrawtransaction(tx1b_txid))
 
     def test_doublespend_chain(self):
         """Doublespend of a long chain"""
@@ -172,7 +176,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             tx.vin = [CTxIn(prevout, nSequence=0)]
             tx.vout = [CTxOut(remaining_value, CScript([1, OP_DROP] * 15 + [1]))]
             tx_hex = txToHex(tx)
-            txid = self.nodes[0].sendrawtransaction(tx_hex, 0)
+            for i in self.RBF_NODES:
+                txid = self.nodes[i].sendrawtransaction(tx_hex, 0)
             chain_txids.append(txid)
             prevout = COutPoint(int(txid, 16), 0)
 
@@ -184,18 +189,20 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         dbl_tx_hex = txToHex(dbl_tx)
 
         # This will raise an exception due to insufficient fee
-        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "insufficient fee", self.nodes[i].sendrawtransaction, dbl_tx_hex, 0)
 
         # Accepted with sufficient fee
         dbl_tx = CTransaction()
         dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         dbl_tx.vout = [CTxOut(1 * COIN, CScript([1] * 35))]
         dbl_tx_hex = txToHex(dbl_tx)
-        self.nodes[0].sendrawtransaction(dbl_tx_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(dbl_tx_hex, 0)
 
-        mempool = self.nodes[0].getrawmempool()
-        for doublespent_txid in chain_txids:
-            assert doublespent_txid not in mempool
+            mempool = self.nodes[i].getrawmempool()
+            for doublespent_txid in chain_txids:
+                assert doublespent_txid not in mempool
 
     def test_doublespend_tree(self):
         """Doublespend of a big tree of transactions"""
@@ -221,7 +228,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             tx_hex = txToHex(tx)
 
             assert len(tx.serialize()) < 100000
-            txid = self.nodes[0].sendrawtransaction(tx_hex, 0)
+            for i in self.RBF_NODES:
+                txid = self.nodes[i].sendrawtransaction(tx_hex, 0)
             yield tx
             _total_txs[0] += 1
 
@@ -245,20 +253,22 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         dbl_tx.vout = [CTxOut(initial_nValue - fee * n, CScript([1] * 35))]
         dbl_tx_hex = txToHex(dbl_tx)
         # This will raise an exception due to insufficient fee
-        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "insufficient fee", self.nodes[i].sendrawtransaction, dbl_tx_hex, 0)
 
         # 1 BTC fee is enough
         dbl_tx = CTransaction()
         dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         dbl_tx.vout = [CTxOut(initial_nValue - fee * n - 1 * COIN, CScript([1] * 35))]
         dbl_tx_hex = txToHex(dbl_tx)
-        self.nodes[0].sendrawtransaction(dbl_tx_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(dbl_tx_hex, 0)
 
-        mempool = self.nodes[0].getrawmempool()
+            mempool = self.nodes[i].getrawmempool()
 
-        for tx in tree_txs:
-            tx.rehash()
-            assert tx.hash not in mempool
+            for tx in tree_txs:
+                tx.rehash()
+                assert tx.hash not in mempool
 
         # Try again, but with more total transactions than the "max txs
         # double-spent at once" anti-DoS limit.
@@ -273,11 +283,13 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             dbl_tx.vout = [CTxOut(initial_nValue - 2 * fee * n, CScript([1] * 35))]
             dbl_tx_hex = txToHex(dbl_tx)
             # This will raise an exception
-            assert_raises_rpc_error(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, dbl_tx_hex, 0)
+            for i in self.RBF_NODES:
+                assert_raises_rpc_error(-26, "too many potential replacements", self.nodes[i].sendrawtransaction,
+                                        dbl_tx_hex, 0)
 
-            for tx in tree_txs:
-                tx.rehash()
-                self.nodes[0].getrawtransaction(tx.hash)
+                for tx in tree_txs:
+                    tx.rehash()
+                    self.nodes[i].getrawtransaction(tx.hash)
 
     def test_replacement_feeperkb(self):
         """Replacement requires fee-per-KB to be higher"""
@@ -287,7 +299,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         tx1a.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx1a_hex = txToHex(tx1a)
-        self.nodes[0].sendrawtransaction(tx1a_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(tx1a_hex, 0)
 
         # Higher fee, but the fee per KB is much lower, so the replacement is
         # rejected.
@@ -297,7 +310,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # This will raise an exception due to insufficient fee
-        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "insufficient fee", self.nodes[i].sendrawtransaction, tx1b_hex, 0)
 
     def test_spends_of_conflicting_outputs(self):
         """Replacements that spend conflicting tx outputs are rejected"""
@@ -308,7 +322,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vin = [CTxIn(utxo1, nSequence=0)]
         tx1a.vout = [CTxOut(int(1.1 * COIN), CScript([b'a' * 35]))]
         tx1a_hex = txToHex(tx1a)
-        tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, 0)
+        for i in self.RBF_NODES:
+            tx1a_txid = self.nodes[i].sendrawtransaction(tx1a_hex, 0)
 
         tx1a_txid = int(tx1a_txid, 16)
 
@@ -320,14 +335,16 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2_hex = txToHex(tx2)
 
         # This will raise an exception
-        assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[i].sendrawtransaction, tx2_hex, 0)
 
         # Spend tx1a's output to test the indirect case.
         tx1b = CTransaction()
         tx1b.vin = [CTxIn(COutPoint(tx1a_txid, 0), nSequence=0)]
         tx1b.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx1b_hex = txToHex(tx1b)
-        tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, 0)
+        for i in self.RBF_NODES:
+            tx1b_txid = self.nodes[i].sendrawtransaction(tx1b_hex, 0)
         tx1b_txid = int(tx1b_txid, 16)
 
         tx2 = CTransaction()
@@ -337,7 +354,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2_hex = txToHex(tx2)
 
         # This will raise an exception
-        assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[0].sendrawtransaction, tx2_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "bad-txns-spends-conflicting-tx", self.nodes[i].sendrawtransaction, tx2_hex, 0)
 
     def test_new_unconfirmed_inputs(self):
         """Replacements that add new unconfirmed inputs are rejected"""
@@ -348,7 +366,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1.vin = [CTxIn(confirmed_utxo)]
         tx1.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx1_hex = txToHex(tx1)
-        self.nodes[0].sendrawtransaction(tx1_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(tx1_hex, 0)
 
         tx2 = CTransaction()
         tx2.vin = [CTxIn(confirmed_utxo), CTxIn(unconfirmed_utxo)]
@@ -356,7 +375,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2_hex = txToHex(tx2)
 
         # This will raise an exception
-        assert_raises_rpc_error(-26, "replacement-adds-unconfirmed", self.nodes[0].sendrawtransaction, tx2_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "replacement-adds-unconfirmed", self.nodes[i].sendrawtransaction, tx2_hex, 0)
 
     def test_too_many_replacements(self):
         """Replacements that evict too many transactions are rejected"""
@@ -378,7 +398,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         splitting_tx.vout = outputs
         splitting_tx_hex = txToHex(splitting_tx)
 
-        txid = self.nodes[0].sendrawtransaction(splitting_tx_hex, 0)
+        for i in self.RBF_NODES:
+            txid = self.nodes[i].sendrawtransaction(splitting_tx_hex, 0)
         txid = int(txid, 16)
 
         # Now spend each of those outputs individually
@@ -387,7 +408,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
             tx_i.vin = [CTxIn(COutPoint(txid, i), nSequence=0)]
             tx_i.vout = [CTxOut(split_value - fee, CScript([b'a' * 35]))]
             tx_i_hex = txToHex(tx_i)
-            self.nodes[0].sendrawtransaction(tx_i_hex, 0)
+            for i in self.RBF_NODES:
+                self.nodes[i].sendrawtransaction(tx_i_hex, 0)
 
         # Now create doublespend of the whole lot; should fail.
         # Need a big enough fee to cover all spending transactions and have
@@ -402,14 +424,17 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         double_tx_hex = txToHex(double_tx)
 
         # This will raise an exception
-        assert_raises_rpc_error(-26, "too many potential replacements", self.nodes[0].sendrawtransaction, double_tx_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "too many potential replacements", self.nodes[i].sendrawtransaction,
+                                    double_tx_hex, 0)
 
         # If we remove an input, it should pass
         double_tx = CTransaction()
         double_tx.vin = inputs[0:-1]
         double_tx.vout = [CTxOut(double_spend_value, CScript([b'a']))]
         double_tx_hex = txToHex(double_tx)
-        self.nodes[0].sendrawtransaction(double_tx_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(double_tx_hex, 0)
 
     def test_opt_in(self):
         """Replacing should only work if orig tx opted in"""
@@ -420,10 +445,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0xffffffff)]
         tx1a.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx1a_hex = txToHex(tx1a)
-        tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, 0)
+        for i in self.RBF_NODES:
+            tx1a_txid = self.nodes[i].sendrawtransaction(tx1a_hex, 0)
 
-        # This transaction isn't shown as replaceable
-        assert_equal(self.nodes[0].getmempoolentry(tx1a_txid)['bip125-replaceable'], False)
+            # This transaction isn't shown as replaceable
+            assert_equal(self.nodes[i].getmempoolentry(tx1a_txid)['bip125-replaceable'], False)
 
         # Shouldn't be able to double-spend
         tx1b = CTransaction()
@@ -433,6 +459,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[0].sendrawtransaction, tx1b_hex, 0)
+        # Other node will accept it
+        self.nodes[1].sendrawtransaction(tx1b_hex, 0)
 
         tx1_outpoint = self.make_utxo(int(1.1 * COIN))
 
@@ -441,7 +469,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2a.vin = [CTxIn(tx1_outpoint, nSequence=0xfffffffe)]
         tx2a.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx2a_hex = txToHex(tx2a)
-        tx2a_txid = self.nodes[0].sendrawtransaction(tx2a_hex, 0)
+        for i in self.RBF_NODES:
+            tx2a_txid = self.nodes[i].sendrawtransaction(tx2a_hex, 0)
 
         # Still shouldn't be able to double-spend
         tx2b = CTransaction()
@@ -451,6 +480,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # This will raise an exception
         assert_raises_rpc_error(-26, "txn-mempool-conflict", self.nodes[0].sendrawtransaction, tx2b_hex, 0)
+        # Other node will accept it
+        self.nodes[1].sendrawtransaction(tx2b_hex, 0)
+        # Sync both mempools to the same state
+        self.nodes[1].prioritisetransaction(txid=tx2a_txid, fee_delta=int(0.2 * COIN))
+        self.nodes[1].sendrawtransaction(tx2a_hex, 0)
 
         # Now create a new transaction that spends from tx1a and tx2a
         # opt-in on one of the inputs
@@ -465,10 +499,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx3a.vout = [CTxOut(int(0.9 * COIN), CScript([b'c'])), CTxOut(int(0.9 * COIN), CScript([b'd']))]
         tx3a_hex = txToHex(tx3a)
 
-        tx3a_txid = self.nodes[0].sendrawtransaction(tx3a_hex, 0)
+        for i in self.RBF_NODES:
+            tx3a_txid = self.nodes[i].sendrawtransaction(tx3a_hex, 0)
 
-        # This transaction is shown as replaceable
-        assert_equal(self.nodes[0].getmempoolentry(tx3a_txid)['bip125-replaceable'], True)
+            # This transaction is shown as replaceable
+            assert_equal(self.nodes[i].getmempoolentry(tx3a_txid)['bip125-replaceable'], True)
 
         tx3b = CTransaction()
         tx3b.vin = [CTxIn(COutPoint(tx1a_txid, 0), nSequence=0)]
@@ -480,10 +515,11 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx3c.vout = [CTxOut(int(0.5 * COIN), CScript([b'f' * 35]))]
         tx3c_hex = txToHex(tx3c)
 
-        self.nodes[0].sendrawtransaction(tx3b_hex, 0)
-        # If tx3b was accepted, tx3c won't look like a replacement,
-        # but make sure it is accepted anyway
-        self.nodes[0].sendrawtransaction(tx3c_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(tx3b_hex, 0)
+            # If tx3b was accepted, tx3c won't look like a replacement,
+            # but make sure it is accepted anyway
+            self.nodes[i].sendrawtransaction(tx3c_hex, 0)
 
     def test_prioritised_transactions(self):
         # Ensure that fee deltas used via prioritisetransaction are
@@ -496,7 +532,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1a.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         tx1a.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx1a_hex = txToHex(tx1a)
-        tx1a_txid = self.nodes[0].sendrawtransaction(tx1a_hex, 0)
+        for i in self.RBF_NODES:
+            tx1a_txid = self.nodes[i].sendrawtransaction(tx1a_hex, 0)
 
         # Higher fee, but the actual fee per KB is much lower.
         tx1b = CTransaction()
@@ -505,15 +542,16 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx1b_hex = txToHex(tx1b)
 
         # Verify tx1b cannot replace tx1a.
-        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "insufficient fee", self.nodes[i].sendrawtransaction, tx1b_hex, 0)
 
-        # Use prioritisetransaction to set tx1a's fee to 0.
-        self.nodes[0].prioritisetransaction(txid=tx1a_txid, fee_delta=int(-0.1*COIN))
+            # Use prioritisetransaction to set tx1a's fee to 0.
+            self.nodes[i].prioritisetransaction(txid=tx1a_txid, fee_delta=int(-0.1 * COIN))
 
-        # Now tx1b should be able to replace tx1a
-        tx1b_txid = self.nodes[0].sendrawtransaction(tx1b_hex, 0)
+            # Now tx1b should be able to replace tx1a
+            tx1b_txid = self.nodes[i].sendrawtransaction(tx1b_hex, 0)
 
-        assert tx1b_txid in self.nodes[0].getrawmempool()
+            assert tx1b_txid in self.nodes[i].getrawmempool()
 
         # 2. Check that absolute fee checks use modified fee.
         tx1_outpoint = self.make_utxo(int(1.1 * COIN))
@@ -522,7 +560,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2a.vin = [CTxIn(tx1_outpoint, nSequence=0)]
         tx2a.vout = [CTxOut(1 * COIN, CScript([b'a' * 35]))]
         tx2a_hex = txToHex(tx2a)
-        self.nodes[0].sendrawtransaction(tx2a_hex, 0)
+        for i in self.RBF_NODES:
+            self.nodes[i].sendrawtransaction(tx2a_hex, 0)
 
         # Lower fee, but we'll prioritise it
         tx2b = CTransaction()
@@ -532,15 +571,16 @@ class ReplaceByFeeTest(BitcoinTestFramework):
         tx2b_hex = txToHex(tx2b)
 
         # Verify tx2b cannot replace tx2a.
-        assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx2b_hex, 0)
+        for i in self.RBF_NODES:
+            assert_raises_rpc_error(-26, "insufficient fee", self.nodes[i].sendrawtransaction, tx2b_hex, 0)
 
-        # Now prioritise tx2b to have a higher modified fee
-        self.nodes[0].prioritisetransaction(txid=tx2b.hash, fee_delta=int(0.1*COIN))
+            # Now prioritise tx2b to have a higher modified fee
+            self.nodes[i].prioritisetransaction(txid=tx2b.hash, fee_delta=int(0.1 * COIN))
 
-        # tx2b should now be accepted
-        tx2b_txid = self.nodes[0].sendrawtransaction(tx2b_hex, 0)
+            # tx2b should now be accepted
+            tx2b_txid = self.nodes[i].sendrawtransaction(tx2b_hex, 0)
 
-        assert tx2b_txid in self.nodes[0].getrawmempool()
+            assert tx2b_txid in self.nodes[i].getrawmempool()
 
     def test_rpc(self):
         us0 = self.nodes[0].listunspent()[0]


### PR DESCRIPTION
In experimental settings it could make sense to give users the option to enable full replace by fee. The option is off by default, because it could hurt block or transaction propagation for the node that has it enabled.