### PR TITLE
Improve check disk space in bitcoind

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1681,11 +1681,11 @@ bool AppInitMain(InitInterfaces& interfaces)
 
     // ********************************************************* Step 11: import blocks
 
-    if (!CheckDiskSpace(GetDataDir())) {
+    if (!CheckDiskSpace(GetDataDir(), chainparams.AssumedBlockchainSize(), chainparams.AssumedChainStateSize(), nPruneTarget)) {
         InitError(strprintf(_("Error: Disk space is low for %s").translated, GetDataDir()));
         return false;
     }
-    if (!CheckDiskSpace(GetBlocksDir())) {
+    if (!CheckDiskSpace(GetBlocksDir(), chainparams.AssumedBlockchainSize(), chainparams.AssumedChainStateSize(), nPruneTarget)) {
         InitError(strprintf(_("Error: Disk space is low for %s").translated, GetBlocksDir()));
         return false;
     }

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -130,12 +130,21 @@ bool DirIsWritable(const fs::path& directory)
     return true;
 }
 
-bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
+bool CheckDiskSpace(const fs::path& dir, uint64_t blockchain_size, uint64_t chain_state_size, uint64_t prune_target_in_mib)
 {
-    constexpr uint64_t min_disk_space = 52428800; // 50 MiB
-
     uint64_t free_bytes_available = fs::space(dir).available;
-    return free_bytes_available >= min_disk_space + additional_bytes;
+    uint64_t required_space = blockchain_size;
+    constexpr uint64_t GB_BYTES{1000000000};
+
+    if (prune_target_in_mib) {
+        uint64_t pruned_GBs = std::ceil(prune_target_in_mib * 1024 * 1024.0 / GB_BYTES);
+        if (pruned_GBs <= required_space) {
+            required_space = pruned_GBs;
+        }
+    }
+    required_space += chain_state_size;
+
+    return free_bytes_available >= required_space;
 }
 
 /**

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -59,7 +59,7 @@ bool RenameOver(fs::path src, fs::path dest);
 bool LockDirectory(const fs::path& directory, const std::string lockfile_name, bool probe_only=false);
 void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name);
 bool DirIsWritable(const fs::path& directory);
-bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
+bool CheckDiskSpace(const fs::path& dir, uint64_t blockchain_size = 0, uint64_t chain_state_size = 0, uint64_t prune_target = 0);
 
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.


### PR DESCRIPTION
Addressing: https://github.com/bitcoin/bitcoin/issues/15813.

Instead of requiring constant 50MB of space, this checks `chainparams.AssumedBlockchainSize()` and `chainparams.AssumedChainStateSize()` for a more accurate calculation.

This is my first time touching C++ code in Bitcoin, so some questions:
- I adapted this code from the gui: https://github.com/bitcoin/bitcoin/blob/master/src/qt/intro.cpp#L133. From what I can tell, `-prune=1` in `bitcoind` means manual pruning but gui treats that as a valid 1MB pruning limit? Clarification on that would be helpful.
- Do I need to add a test?
- I added the same check for `datadir` and `blocksdir`. Is that right (and necessary)?

Feedback welcome.