### PR TITLE
build: remove -Wall from rapidcheck build flags

### DIFF
--- a/depends/packages/rapidcheck.mk
+++ b/depends/packages/rapidcheck.mk
@@ -8,6 +8,10 @@ define $(package)_config_cmds
   cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true -DRC_INSTALL_ALL_EXTRAS=ON
 endef
 
+define $(package)_preprocess_cmds
+  sed -i.old 's/ -Wall//' CMakeLists.txt
+endef
+
 define $(package)_build_cmds
   $(MAKE) rapidcheck
 endef


### PR DESCRIPTION
Fixes #16062.

Remove `-Wall` from the rapidcheck build flags pre compilation.

Discussed briefly with theuni.