### PR TITLE
refactor: Remove unused includes

### DIFF
--- a/contrib/devtools/circular-dependencies.py
+++ b/contrib/devtools/circular-dependencies.py
@@ -3,11 +3,6 @@
 import sys
 import re
 
-MAPPING = {
-    'core_read.cpp': 'core_io.cpp',
-    'core_write.cpp': 'core_io.cpp',
-}
-
 # Directories with header-based modules, where the assumption that .cpp files
 # define functions and variables declared in corresponding .h files is
 # incorrect.
@@ -16,8 +11,6 @@ HEADER_MODULE_PATHS = [
 ]
 
 def module_name(path):
-    if path in MAPPING:
-        path = MAPPING[path]
     if any(path.startswith(dirpath) for dirpath in HEADER_MODULE_PATHS):
         return path
     if path.endswith(".h"):

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -125,8 +125,9 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   consensus/tx_check.h \
   consensus/tx_verify.h \
-  core_io.h \
   core_memusage.h \
+  core_read.h \
+  core_write.h \
   cuckoocache.h \
   flatfile.h \
   fs.h \

--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -8,8 +8,7 @@
 #include <uint256.h>
 #include <crypto/common.h>
 
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
 
 template <unsigned int BITS>
 base_uint<BITS>::base_uint(const std::string& str)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -12,7 +12,6 @@
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
-#include <vector>
 
 class uint256;
 

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
-#include <assert.h>
 #include <cstring>
 #include <limits>
 #include <stdexcept>

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <vector>
-#include <string>
 
 
 static void Base58Encode(benchmark::State& state)

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -6,7 +6,6 @@
 #define BITCOIN_BENCH_BENCH_H
 
 #include <functional>
-#include <limits>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 
+#include <util/memory.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -10,7 +10,6 @@
 #include <validation.h>
 
 
-#include <list>
 #include <vector>
 
 static void AssembleBlock(benchmark::State& state)

--- a/src/bench/chacha20.cpp
+++ b/src/bench/chacha20.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <crypto/chacha20.h>
 

--- a/src/bench/chacha_poly_aead.cpp
+++ b/src/bench/chacha_poly_aead.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <crypto/chacha_poly_aead.h>
 #include <crypto/poly1305.h> // for the POLY1305_TAGLEN constant

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <hash.h>
 #include <random.h>

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -11,10 +11,6 @@
 #include <txmempool.h>
 #include <validation.h>
 
-#include <list>
-#include <vector>
-
-
 static void DuplicateInputs(benchmark::State& state)
 {
     const CScript SCRIPT_PUB{CScript(OP_TRUE)};

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -4,10 +4,10 @@
 
 #include <bench/bench.h>
 #include <chainparams.h>
-#include <coins.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <pow.h>
+#include <random.h>
 #include <txmempool.h>
 #include <validation.h>
 

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -6,7 +6,6 @@
 
 #include <support/lockedpool.h>
 
-#include <iostream>
 #include <vector>
 
 #define ASIZE 2048

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -6,9 +6,6 @@
 #include <policy/policy.h>
 #include <txmempool.h>
 
-#include <list>
-#include <vector>
-
 static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     int64_t nTime = 0;

--- a/src/bench/poly1305.cpp
+++ b/src/bench/poly1305.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <crypto/poly1305.h>
 

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
-
 #include <bench/bench.h>
 #include <bloom.h>
 

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -5,12 +5,12 @@
 #include <bench/bench.h>
 #include <bench/data.h>
 
-#include <validation.h>
+#include <chain.h>
+#include <primitives/block.h>
 #include <streams.h>
-#include <consensus/validation.h>
 #include <rpc/blockchain.h>
-
 #include <univalue.h>
+#include <version.h>
 
 static void BlockToJsonVerbose(benchmark::State& state) {
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -8,9 +8,6 @@
 
 #include <univalue.h>
 
-#include <list>
-#include <vector>
-
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {
     LockPoints lp;

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -7,8 +7,9 @@
 #if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>
 #endif
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
 #include <script/script.h>
-#include <script/standard.h>
 #include <streams.h>
 
 #include <array>

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -14,8 +14,10 @@
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <util/strencodings.h>
+
 #include <util/system.h>
 #include <util/translation.h>
+#include <util/time.h>
 
 #include <functional>
 #include <memory>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -11,6 +11,7 @@
 #include <consensus/consensus.h>
 #include <core_io.h>
 #include <key_io.h>
+#include <keystore.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -9,10 +9,9 @@
 #include <clientversion.h>
 #include <coins.h>
 #include <consensus/consensus.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key_io.h>
-#include <keystore.h>
-#include <policy/policy.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
 #include <script/script.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -15,7 +15,6 @@
 #include <wallet/wallettool.h>
 
 #include <functional>
-#include <stdio.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -9,9 +9,9 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <logging.h>
-#include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
+#include <random.h>
 #include <wallet/wallettool.h>
 
 #include <functional>

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -16,12 +16,14 @@
 #include <noui.h>
 #include <shutdown.h>
 #include <ui_interface.h>
-#include <util/strencodings.h>
 #include <util/system.h>
 #include <util/threadnames.h>
+
 #include <util/translation.h>
 
 #include <functional>
+#include <util/strencodings.h>
+#include <util/time.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -7,8 +7,6 @@
 
 #include <primitives/block.h>
 
-#include <memory>
-
 class CTxMemPool;
 
 // Dumb helper to handle CTransaction compression at serialize-time

--- a/src/coins.h
+++ b/src/coins.h
@@ -8,7 +8,6 @@
 
 #include <primitives/transaction.h>
 #include <compressor.h>
-#include <core_memusage.h>
 #include <crypto/siphash.h>
 #include <memusage.h>
 #include <serialize.h>

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -5,7 +5,6 @@
 
 #include <compressor.h>
 
-#include <hash.h>
 #include <pubkey.h>
 #include <script/standard.h>
 

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 
-#include <primitives/transaction.h>
 #include <primitives/block.h>
 #include <uint256.h>
 

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_CONSENSUS_MERKLE_H
 #define BITCOIN_CONSENSUS_MERKLE_H
 
-#include <stdint.h>
 #include <vector>
 
 #include <primitives/transaction.h>

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,8 +8,6 @@
 
 #include <uint256.h>
 #include <limits>
-#include <map>
-#include <string>
 
 namespace Consensus {
 

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -6,8 +6,8 @@
 
 #include <primitives/block.h>
 #include <primitives/transaction.h>
+#include <script/interpreter.h>
 #include <script/script.h>
-#include <script/sign.h>
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <core_io.h>
+#include <core_read.h>
 
 #include <primitives/block.h>
 #include <primitives/transaction.h>

--- a/src/core_read.h
+++ b/src/core_read.h
@@ -2,10 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_CORE_IO_H
-#define BITCOIN_CORE_IO_H
+#ifndef BITCOIN_CORE_READ_H
+#define BITCOIN_CORE_READ_H
 
-#include <amount.h>
 #include <attributes.h>
 
 #include <string>
@@ -14,14 +13,11 @@
 class CBlock;
 class CBlockHeader;
 class CScript;
-class CTransaction;
 struct CMutableTransaction;
 class uint256;
 class UniValue;
 
-// core_read.cpp
 CScript ParseScript(const std::string& s);
-std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
 NODISCARD bool DecodeHexTx(CMutableTransaction& tx, const std::string& hex_tx, bool try_no_witness = false, bool try_witness = true);
 NODISCARD bool DecodeHexBlk(CBlock&, const std::string& strHexBlk);
 bool DecodeHexBlockHeader(CBlockHeader&, const std::string& hex_header);
@@ -38,13 +34,4 @@ bool ParseHashStr(const std::string& strHex, uint256& result);
 std::vector<unsigned char> ParseHexUV(const UniValue& v, const std::string& strName);
 int ParseSighashString(const UniValue& sighash);
 
-// core_write.cpp
-UniValue ValueFromAmount(const CAmount& amount);
-std::string FormatScript(const CScript& script);
-std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
-std::string SighashToStr(unsigned char sighash_type);
-void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
-void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
-void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
-
-#endif // BITCOIN_CORE_IO_H
+#endif // BITCOIN_CORE_READ_H

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <core_io.h>
+#include <core_write.h>
 
 #include <consensus/consensus.h>
 #include <consensus/validation.h>

--- a/src/core_write.h
+++ b/src/core_write.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CORE_WRITE_H
+#define BITCOIN_CORE_WRITE_H
+
+#include <amount.h>
+
+#include <string>
+
+class CScript;
+class CTransaction;
+class uint256;
+class UniValue;
+
+UniValue ValueFromAmount(const CAmount& amount);
+std::string FormatScript(const CScript& script);
+std::string EncodeHexTx(const CTransaction& tx, const int serializeFlags = 0);
+std::string SighashToStr(unsigned char sighash_type);
+void ScriptPubKeyToUniv(const CScript& scriptPubKey, UniValue& out, bool fIncludeHex);
+std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDecode = false);
+void ScriptToUniv(const CScript& script, UniValue& out, bool include_address);
+void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry, bool include_hex = true, int serialize_flags = 0);
+
+#endif // BITCOIN_CORE_WRITE_H

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -4,7 +4,6 @@
 
 #include <crypto/aes.h>
 
-#include <assert.h>
 #include <string.h>
 
 extern "C" {

--- a/src/crypto/chacha_poly_aead.cpp
+++ b/src/crypto/chacha_poly_aead.cpp
@@ -4,7 +4,6 @@
 
 #include <crypto/chacha_poly_aead.h>
 
-#include <crypto/common.h>
 #include <crypto/poly1305.h>
 #include <support/cleanse.h>
 

--- a/src/crypto/hkdf_sha256_32.cpp
+++ b/src/crypto/hkdf_sha256_32.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <crypto/hkdf_sha256_32.h>
+#include <crypto/hmac_sha256.h>
 
 #include <assert.h>
 #include <string.h>

--- a/src/crypto/hkdf_sha256_32.h
+++ b/src/crypto/hkdf_sha256_32.h
@@ -5,10 +5,9 @@
 #ifndef BITCOIN_CRYPTO_HKDF_SHA256_32_H
 #define BITCOIN_CRYPTO_HKDF_SHA256_32_H
 
-#include <crypto/hmac_sha256.h>
-
 #include <stdint.h>
 #include <stdlib.h>
+#include <string>
 
 /** A rfc5869 HKDF implementation with HMAC_SHA256 and fixed key output length of 32 bytes (L=32) */
 class CHKDF_HMAC_SHA256_L32

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -7,7 +7,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <atomic>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #if defined(USE_ASM)

--- a/src/crypto/sha256_shani.cpp
+++ b/src/crypto/sha256_shani.cpp
@@ -11,9 +11,6 @@
 #include <stdint.h>
 #include <immintrin.h>
 
-#include <crypto/common.h>
-
-
 namespace {
 
 const __m128i MASK = _mm_set_epi64x(0x0c0d0e0f08090a0bULL, 0x0405060700010203ULL);

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -4,6 +4,8 @@
 
 #include <crypto/siphash.h>
 
+#include <cassert>
+
 #define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
 
 #define SIPROUND do { \

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -11,7 +11,6 @@
 #include <streams.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#include <version.h>
 
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <stdio.h>
 #include <util/system.h>
 #include <walletinitinterface.h>
 

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -7,13 +7,14 @@
 #include <chainparams.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
-#include <key_io.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
-#include <sync.h>
-#include <ui_interface.h>
-#include <util/strencodings.h>
+
+#include <util/memory.h>
 #include <util/system.h>
+#include <util/strencodings.h>
+#include <util/time.h>
+#include <ui_interface.h>
 #include <util/translation.h>
 #include <walletinitinterface.h>
 

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -5,9 +5,6 @@
 #ifndef BITCOIN_HTTPRPC_H
 #define BITCOIN_HTTPRPC_H
 
-#include <string>
-#include <map>
-
 /** Start HTTP RPC subsystem.
  * Precondition; HTTP and RPC has been started.
  */

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -23,7 +23,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <signal.h>
 
 #include <event2/thread.h>
 #include <event2/buffer.h>

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string>
+#include <thread>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -6,7 +6,6 @@
 #define BITCOIN_HTTPSERVER_H
 
 #include <string>
-#include <stdint.h>
 #include <functional>
 
 static const int DEFAULT_HTTP_THREADS=4;

--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -8,6 +8,7 @@
 #include <tinyformat.h>
 #include <ui_interface.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <validation.h>
 #include <warnings.h>
 

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -9,7 +9,6 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <threadinterrupt.h>
-#include <uint256.h>
 #include <validationinterface.h>
 
 #include <thread>

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -12,6 +12,8 @@
 #include <uint256.h>
 #include <validationinterface.h>
 
+#include <thread>
+
 class CBlockIndex;
 
 /**

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -6,6 +6,7 @@
 
 #include <dbwrapper.h>
 #include <index/blockfilterindex.h>
+#include <util/memory.h>
 #include <util/system.h>
 #include <validation.h>
 

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -4,7 +4,9 @@
 
 #include <index/txindex.h>
 #include <shutdown.h>
+#include <txdb.h>
 #include <ui_interface.h>
+#include <util/memory.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <validation.h>

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -7,7 +7,6 @@
 
 #include <chain.h>
 #include <index/base.h>
-#include <txdb.h>
 
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -46,10 +46,13 @@
 #include <txdb.h>
 #include <txmempool.h>
 #include <ui_interface.h>
+
 #include <util/moneystr.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
+#include <util/memory.h>
+#include <util/time.h>
 #include <util/validation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -21,12 +21,12 @@
 #include <rpc/server.h>
 #include <shutdown.h>
 #include <sync.h>
-#include <threadsafety.h>
 #include <timedata.h>
 #include <txmempool.h>
 #include <ui_interface.h>
 #include <uint256.h>
 #include <univalue.h>
+#include <util/memory.h>
 #include <util/system.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -35,7 +35,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <atomic>
 #include <univalue.h>
 
 class CWallet;

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -5,7 +5,6 @@
 #include <interfaces/node.h>
 
 #include <addrdb.h>
-#include <amount.h>
 #include <banman.h>
 #include <chain.h>
 #include <chainparams.h>
@@ -19,7 +18,6 @@
 #include <netbase.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
-#include <policy/policy.h>
 #include <policy/settings.h>
 #include <primitives/block.h>
 #include <rpc/server.h>
@@ -27,6 +25,7 @@
 #include <sync.h>
 #include <txmempool.h>
 #include <ui_interface.h>
+#include <util/memory.h>
 #include <util/system.h>
 #include <validation.h>
 #include <warnings.h>

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -8,7 +8,6 @@
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
-#include <policy/feerate.h>
 #include <policy/fees.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
@@ -23,7 +22,6 @@
 #include <wallet/rpcwallet.h>
 #include <wallet/load.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 
 #include <memory>
 #include <string>

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -6,7 +6,6 @@
 
 #include <base58.h>
 #include <bech32.h>
-#include <script/script.h>
 #include <util/strencodings.h>
 
 #include <boost/variant/apply_visitor.hpp>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -24,7 +24,6 @@
 #include <util/validation.h>
 
 #include <algorithm>
-#include <queue>
 #include <utility>
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -17,10 +17,10 @@
 #include <policy/policy.h>
 #include <pow.h>
 #include <primitives/transaction.h>
-#include <script/standard.h>
 #include <timedata.h>
 #include <util/moneystr.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <util/validation.h>
 
 #include <algorithm>

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -13,14 +13,15 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <consensus/consensus.h>
-#include <crypto/common.h>
 #include <crypto/sha256.h>
 #include <netbase.h>
-#include <primitives/transaction.h>
 #include <scheduler.h>
 #include <ui_interface.h>
+#include <util/memory.h>
 #include <util/strencodings.h>
+
 #include <util/translation.h>
+#include <util/time.h>
 
 #ifdef WIN32
 #include <string.h>
@@ -34,7 +35,6 @@
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniupnpc.h>
-#include <miniupnpc/miniwget.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
 // The minimum supported miniUPnPc API version is set to 10. This keeps compatibility

--- a/src/net.h
+++ b/src/net.h
@@ -6,16 +6,13 @@
 #ifndef BITCOIN_NET_H
 #define BITCOIN_NET_H
 
-#include <addrdb.h>
 #include <addrman.h>
 #include <amount.h>
 #include <bloom.h>
 #include <compat.h>
 #include <crypto/siphash.h>
 #include <hash.h>
-#include <limitedmap.h>
 #include <netaddress.h>
-#include <policy/feerate.h>
 #include <protocol.h>
 #include <random.h>
 #include <streams.h>

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -7,15 +7,16 @@
 
 #include <addrman.h>
 #include <banman.h>
-#include <arith_uint256.h>
 #include <blockencodings.h>
 #include <chainparams.h>
 #include <consensus/validation.h>
 #include <hash.h>
 #include <validation.h>
+#include <limitedmap.h>
 #include <merkleblock.h>
 #include <netmessagemaker.h>
 #include <netbase.h>
+#include <util/time.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
 #include <primitives/block.h>

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -11,7 +11,6 @@
 
 #include <compat.h>
 #include <serialize.h>
-#include <span.h>
 
 #include <stdint.h>
 #include <string>

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -9,6 +9,7 @@
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/strencodings.h>
+#include <util/time.h>
 
 #include <atomic>
 

--- a/src/node/psbt.h
+++ b/src/node/psbt.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_NODE_PSBT_H
 #define BITCOIN_NODE_PSBT_H
 
+#include <optional.h>
+#include <policy/feerate.h>
 #include <psbt.h>
 
 /**

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -8,8 +8,6 @@
 #include <ui_interface.h>
 #include <util/system.h>
 
-#include <cstdio>
-#include <stdint.h>
 #include <string>
 
 #include <boost/signals2/connection.hpp>

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -3,10 +3,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <logging.h>
 #include <noui.h>
 
 #include <ui_interface.h>
-#include <util/system.h>
 
 #include <string>
 

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -6,10 +6,10 @@
 #include <policy/fees.h>
 
 #include <clientversion.h>
-#include <primitives/transaction.h>
 #include <streams.h>
 #include <txmempool.h>
 #include <util/system.h>
+#include <util/time.h>
 
 static constexpr double INF_FEERATE = 1e99;
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iterator>
 #include <type_traits>
 
 #pragma pack(push, 1)

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -7,7 +7,6 @@
 
 #include <hash.h>
 #include <tinyformat.h>
-#include <crypto/common.h>
 
 uint256 CBlockHeader::GetHash() const
 {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -7,6 +7,7 @@
 #define BITCOIN_PRIMITIVES_TRANSACTION_H
 
 #include <stdint.h>
+
 #include <amount.h>
 #include <script/script.h>
 #include <serialize.h>

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,7 +15,6 @@
 #include <uint256.h>
 #include <version.h>
 
-#include <atomic>
 #include <stdint.h>
 #include <string>
 

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -5,8 +5,6 @@
 #include <psbt.h>
 #include <util/strencodings.h>
 
-#include <numeric>
-
 PartiallySignedTransaction::PartiallySignedTransaction(const CMutableTransaction& tx) : tx(tx)
 {
     inputs.resize(tx.vin.size());

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -6,13 +6,13 @@
 #define BITCOIN_PSBT_H
 
 #include <attributes.h>
-#include <node/transaction.h>
-#include <optional.h>
-#include <policy/feerate.h>
+#include <boost/optional.hpp>
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
+#include <streams.h>
+#include <util/error.h>
 
 // Magic bytes
 static constexpr uint8_t PSBT_MAGIC_BYTES[5] = {'p', 's', 'b', 't', 0xff};

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -7,8 +7,6 @@
 #include <qt/clientmodel.h>
 
 #include <interfaces/node.h>
-#include <sync.h>
-#include <util/time.h>
 
 #include <QDebug>
 #include <QList>

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -5,7 +5,8 @@
 #ifndef BITCOIN_QT_BANTABLEMODEL_H
 #define BITCOIN_QT_BANTABLEMODEL_H
 
-#include <net.h>
+#include <addrdb.h>
+#include <netaddress.h>
 
 #include <memory>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -38,8 +38,6 @@
 
 #include <memory>
 
-#include <boost/thread.hpp>
-
 #include <QApplication>
 #include <QDebug>
 #include <QLibraryInfo>

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -38,6 +38,8 @@
 
 #include <memory>
 
+#include <boost/thread.hpp>
+
 #include <QApplication>
 #include <QDebug>
 #include <QLibraryInfo>

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -35,6 +35,7 @@
 #include <interfaces/node.h>
 #include <ui_interface.h>
 #include <util/system.h>
+#include <util/time.h>
 
 #include <QAction>
 #include <QApplication>

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -15,6 +15,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <util/system.h>
+#include <util/time.h>
 
 #include <stdint.h>
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -19,7 +19,6 @@
 #include <wallet/coincontrol.h>
 #include <interfaces/node.h>
 #include <key_io.h>
-#include <policy/fees.h>
 #include <policy/policy.h>
 #include <wallet/wallet.h>
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -9,7 +9,6 @@
 #include <qt/guiutil.h>
 
 #include <interfaces/node.h>
-#include <sync.h>
 
 #include <QDebug>
 #include <QList>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <wallet/wallet.h>
+#include <outputtype.h>
 
 #include <qt/receivecoinsdialog.h>
 #include <qt/forms/ui_receivecoinsdialog.h>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -20,6 +20,7 @@
 #include <rpc/client.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 
 #include <univalue.h>
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -23,9 +23,8 @@
 #include <key_io.h>
 #include <wallet/coincontrol.h>
 #include <ui_interface.h>
-#include <txmempool.h>
 #include <policy/fees.h>
-#include <wallet/fees.h>
+#include <wallet/wallet.h>
 
 #include <QFontMetrics>
 #include <QScrollBar>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -14,7 +14,6 @@
 #include <util/validation.h> // For strMessageMagic
 #include <wallet/wallet.h>
 
-#include <string>
 #include <vector>
 
 #include <QClipboard>

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -11,8 +11,8 @@
 #include <qt/walletmodel.h>
 
 #include <key_io.h>
+#include <util/strencodings.h>
 #include <util/validation.h> // For strMessageMagic
-#include <wallet/wallet.h>
 
 #include <vector>
 

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -17,7 +17,6 @@
 #include <ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <version.h>
 
 #include <QApplication>
 #include <QCloseEvent>

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -8,7 +8,6 @@
 #include <qt/test/paymentrequestdata.h>
 
 #include <amount.h>
-#include <chainparams.h>
 #include <interfaces/node.h>
 #include <random.h>
 #include <script/script.h>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -18,7 +18,6 @@
 #include <key_io.h>
 #include <validation.h>
 #include <script/script.h>
-#include <timedata.h>
 #include <util/system.h>
 #include <policy/policy.h>
 #include <wallet/ismine.h>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -13,7 +13,7 @@
 #include <qt/transactionrecord.h>
 #include <qt/walletmodel.h>
 
-#include <core_io.h>
+#include <core_write.h>
 #include <interfaces/handler.h>
 #include <uint256.h>
 

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -9,7 +9,6 @@
 #include <qt/walletview.h>
 
 #include <cassert>
-#include <cstdio>
 
 #include <QHBoxLayout>
 #include <QLabel>

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -22,7 +22,6 @@
 #include <interfaces/wallet.h>
 #include <support/allocators/secure.h>
 
-#include <map>
 #include <vector>
 
 #include <QObject>

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -7,8 +7,8 @@
 
 #include <amount.h>
 #include <key.h>
+#include <primitives/transaction.h>
 #include <serialize.h>
-#include <script/standard.h>
 
 #if defined(HAVE_CONFIG_H)
 #include <config/bitcoin-config.h>

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -7,7 +7,6 @@
 
 #include <qt/walletmodel.h>
 
-#include <memory>
 #include <amount.h>
 
 #include <QObject>

--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -6,7 +6,6 @@
 
 #if defined(Q_OS_WIN)
 #include <shutdown.h>
-#include <util/system.h>
 
 #include <windows.h>
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -16,7 +16,6 @@
 #include <util/time.h> // for GetTime()
 
 #include <stdlib.h>
-#include <chrono>
 #include <thread>
 
 #include <support/allocators/secure.h>
@@ -40,8 +39,6 @@
 #include <util/strencodings.h> // for ARRAYLEN
 #include <sys/sysctl.h>
 #endif
-
-#include <mutex>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #include <cpuid.h>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -3,7 +3,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <attributes.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <core_io.h>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -5,7 +5,8 @@
 
 #include <chain.h>
 #include <chainparams.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <httpserver.h>
 #include <index/txindex.h>
 #include <primitives/block.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -11,7 +11,7 @@
 #include <chainparams.h>
 #include <coins.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_write.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
 #include <key.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -14,6 +14,7 @@
 #include <core_io.h>
 #include <hash.h>
 #include <index/blockfilterindex.h>
+#include <key.h>
 #include <policy/feerate.h>
 #include <policy/policy.h>
 #include <policy/rbf.h>

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/client.h>
-#include <rpc/protocol.h>
 #include <util/system.h>
 
 #include <set>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -25,6 +25,7 @@
 #include <util/fees.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <util/validation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -9,7 +9,8 @@
 #include <consensus/consensus.h>
 #include <consensus/params.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key_io.h>
 #include <miner.h>
 #include <net.h>

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -3,16 +3,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/ripemd160.h>
 #include <key_io.h>
 #include <httpserver.h>
 #include <outputtype.h>
-#include <rpc/blockchain.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
 #include <util/system.h>
 #include <util/strencodings.h>
+#include <util/time.h>
 #include <util/validation.h>
 
 #include <stdint.h>
@@ -22,6 +21,8 @@
 #endif
 
 #include <univalue.h>
+
+extern CCriticalSection cs_main;
 
 static UniValue validateaddress(const JSONRPCRequest& request)
 {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -6,7 +6,7 @@
 
 #include <banman.h>
 #include <clientversion.h>
-#include <core_io.h>
+#include <core_write.h>
 #include <net.h>
 #include <net_processing.h>
 #include <netbase.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -10,7 +10,6 @@
 #include <net.h>
 #include <net_processing.h>
 #include <netbase.h>
-#include <policy/policy.h>
 #include <policy/settings.h>
 #include <rpc/protocol.h>
 #include <rpc/util.h>
@@ -18,6 +17,7 @@
 #include <timedata.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <validation.h>
 #include <version.h>
 #include <warnings.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -5,7 +5,6 @@
 
 #include <chain.h>
 #include <coins.h>
-#include <compat/byteswap.h>
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <index/txindex.h>
@@ -21,7 +20,6 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/script.h>
-#include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -6,7 +6,8 @@
 #include <chain.h>
 #include <coins.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <index/txindex.h>
 #include <key_io.h>
 #include <merkleblock.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -32,7 +32,6 @@
 #include <validationinterface.h>
 
 
-#include <numeric>
 #include <stdint.h>
 
 #include <univalue.h>

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -6,7 +6,8 @@
 #include <rpc/rawtransaction_util.h>
 
 #include <coins.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key_io.h>
 #include <policy/policy.h>
 #include <primitives/transaction.h>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -5,13 +5,12 @@
 
 #include <rpc/server.h>
 
-#include <fs.h>
-#include <key_io.h>
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 
 #include <boost/signals2/signal.hpp>
 #include <boost/algorithm/string/classification.hpp>

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -10,7 +10,6 @@
 #include <rpc/request.h>
 #include <uint256.h>
 
-#include <list>
 #include <map>
 #include <stdint.h>
 #include <string>

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -8,7 +8,6 @@
 
 #include <amount.h>
 #include <rpc/request.h>
-#include <uint256.h>
 
 #include <map>
 #include <stdint.h>

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -10,7 +10,6 @@
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <script/script.h>
-#include <script/sign.h>
 #include <script/standard.h>
 #include <univalue.h>
 #include <util/error.h>

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_RPC_UTIL_H
 #define BITCOIN_RPC_UTIL_H
 
-#include <node/transaction.h>
 #include <outputtype.h>
 #include <pubkey.h>
 #include <rpc/protocol.h>
@@ -14,7 +13,9 @@
 #include <script/sign.h>
 #include <script/standard.h>
 #include <univalue.h>
+#include <util/error.h>
 
+#include <list>
 #include <string>
 #include <vector>
 

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -11,6 +11,7 @@
 
 #include <span.h>
 #include <util/bip32.h>
+#include <util/memory.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -11,7 +11,6 @@
 
 #include <vector>
 #include <stdint.h>
-#include <string>
 
 class CPubKey;
 class CScript;

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -6,7 +6,6 @@
 #define BITCOIN_SCRIPT_KEYORIGIN_H
 
 #include <serialize.h>
-#include <streams.h>
 #include <vector>
 
 struct KeyOriginInfo

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_SCRIPT_SIGN_H
 #define BITCOIN_SCRIPT_SIGN_H
 
-#include <boost/optional.hpp>
 #include <hash.h>
 #include <pubkey.h>
 #include <script/interpreter.h>

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -10,7 +10,6 @@
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/keyorigin.h>
-#include <streams.h>
 
 class CKey;
 class CKeyID;

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -11,8 +11,6 @@
 
 #include <boost/variant.hpp>
 
-#include <stdint.h>
-
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 
 class CKeyID;

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -9,7 +9,6 @@
 #include <compat/endian.h>
 
 #include <algorithm>
-#include <assert.h>
 #include <ios>
 #include <limits>
 #include <map>

--- a/src/streams.h
+++ b/src/streams.h
@@ -13,8 +13,6 @@
 #include <assert.h>
 #include <ios>
 #include <limits>
-#include <map>
-#include <set>
 #include <stdint.h>
 #include <stdio.h>
 #include <string>

--- a/src/support/events.h
+++ b/src/support/events.h
@@ -5,8 +5,8 @@
 #ifndef BITCOIN_SUPPORT_EVENTS_H
 #define BITCOIN_SUPPORT_EVENTS_H
 
-#include <ios>
 #include <memory>
+#include <string>
 
 #include <event2/event.h>
 #include <event2/http.h>

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -13,8 +13,6 @@
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 
-#include <stdio.h>
-
 #include <map>
 #include <set>
 

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -16,7 +16,6 @@
 #include <stdio.h>
 
 #include <map>
-#include <memory>
 #include <set>
 
 #ifdef DEBUG_LOCKCONTENTION

--- a/src/sync.h
+++ b/src/sync.h
@@ -9,7 +9,6 @@
 #include <threadsafety.h>
 
 #include <condition_variable>
-#include <thread>
 #include <mutex>
 
 

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -8,7 +8,6 @@
 #include <key.h>
 #include <key_io.h>
 #include <streams.h>
-#include <util/system.h>
 #include <util/strencodings.h>
 #include <test/setup_common.h>
 

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -6,7 +6,7 @@
 #include <test/setup_common.h>
 
 #include <blockfilter.h>
-#include <core_io.h>
+#include <core_read.h>
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compressor.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 
 #include <stdint.h>

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -4,7 +4,6 @@
 #include <key.h>
 
 #include <uint256.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 #include <vector>
 

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -6,9 +6,9 @@
 
 #include <key_io.h>
 #include <uint256.h>
-#include <util/system.h>
 #include <util/strencodings.h>
 #include <test/setup_common.h>
+#include <tinyformat.h>
 
 #include <string>
 #include <vector>

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -6,7 +6,6 @@
 #include <policy/fees.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/setup_common.h>

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -5,7 +5,6 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <pow.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -6,7 +6,7 @@
 #include <rpc/client.h>
 #include <rpc/util.h>
 
-#include <core_io.h>
+#include <core_write.h>
 #include <init.h>
 #include <interfaces/chain.h>
 #include <test/setup_common.h>

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -4,7 +4,8 @@
 
 #include <test/data/script_tests.json.h>
 
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <key.h>
 #include <script/script.h>
 #include <script/script_error.h>

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 
 #include <vector>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -10,7 +10,7 @@
 #include <checkqueue.h>
 #include <consensus/tx_check.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
 #include <key.h>
 #include <validation.h>
 #include <policy/policy.h>

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,7 +6,6 @@
 #include <index/txindex.h>
 #include <script/standard.h>
 #include <test/setup_common.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/threadinterrupt.h
+++ b/src/threadinterrupt.h
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <mutex>
 
 /*
     A helper class for interruptible sleeps. Calling operator() will interrupt

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -12,7 +12,9 @@
 #include <sync.h>
 #include <ui_interface.h>
 #include <util/system.h>
+
 #include <util/translation.h>
+#include <util/time.h>
 #include <warnings.h>
 
 

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -8,8 +8,6 @@
 #ifndef BITCOIN_TORCONTROL_H
 #define BITCOIN_TORCONTROL_H
 
-#include <scheduler.h>
-
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,7 +11,6 @@
 #include <chain.h>
 #include <primitives/block.h>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -8,7 +8,6 @@
 
 #include <atomic>
 #include <map>
-#include <memory>
 #include <set>
 #include <string>
 #include <utility>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -15,12 +15,12 @@
 
 #include <amount.h>
 #include <coins.h>
+#include <core_memusage.h>
 #include <crypto/siphash.h>
 #include <indirectmap.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <sync.h>
-#include <random.h>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -8,7 +8,6 @@
 
 #include <functional>
 #include <memory>
-#include <stdint.h>
 #include <string>
 
 class CBlockIndex;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -7,7 +7,7 @@
 
 #include <util/strencodings.h>
 
-#include <stdio.h>
+#include <cassert>
 #include <string.h>
 
 template <unsigned int BITS>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -8,7 +8,6 @@
 
 #include <assert.h>
 #include <cstring>
-#include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_UINT256_H
 #define BITCOIN_UINT256_H
 
-#include <assert.h>
 #include <cstring>
 #include <stdint.h>
 #include <string>

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -5,7 +5,6 @@
 
 #include <util/moneystr.h>
 
-#include <primitives/transaction.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 

--- a/src/util/moneystr.h
+++ b/src/util/moneystr.h
@@ -12,7 +12,6 @@
 #include <amount.h>
 #include <attributes.h>
 
-#include <cstdint>
 #include <string>
 
 /* Do not use these functions to represent or parse monetary amounts to or from

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -9,8 +9,6 @@
 #include <util/strencodings.h>
 #include <util/translation.h>
 
-#include <stdarg.h>
-
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>
 #include <pthread_np.h>

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -6,8 +6,11 @@
 #include <util/system.h>
 
 #include <chainparamsbase.h>
+#include <util/memory.h>
 #include <util/strencodings.h>
+
 #include <util/translation.h>
+#include <util/time.h>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -21,9 +21,7 @@
 #include <logging.h>
 #include <sync.h>
 #include <tinyformat.h>
-#include <util/memory.h>
 #include <util/threadnames.h>
-#include <util/time.h>
 
 #include <exception>
 #include <map>

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -6,12 +6,11 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <atomic>
-#include <thread>
-
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>
 #include <pthread_np.h>
+#elif defined(MAC_OSX)
+#include <thread>
 #endif
 
 #include <util/threadnames.h>

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/thread.hpp>
+#include <chrono>
 #include <ctime>
 #include <tinyformat.h>
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -8,7 +8,6 @@
 
 #include <stdint.h>
 #include <string>
-#include <chrono>
 
 /**
  * DEPRECATED

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -7,8 +7,6 @@
 
 #include <tinyformat.h>
 
-#include <utility>
-
 /**
  * Bilingual messages:
  *   - in GUI: user's native language + untranslated (i.e. English)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,8 +46,6 @@
 #include <validationinterface.h>
 #include <warnings.h>
 
-#include <future>
-#include <sstream>
 #include <string>
 
 #include <boost/algorithm/string/replace.hpp>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -28,7 +28,6 @@
 #include <reverse_iterator.h>
 #include <script/script.h>
 #include <script/sigcache.h>
-#include <script/standard.h>
 #include <shutdown.h>
 #include <timedata.h>
 #include <tinyformat.h>
@@ -42,6 +41,7 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
+#include <util/time.h>
 #include <util/validation.h>
 #include <validationinterface.h>
 #include <warnings.h>

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,12 +23,10 @@
 
 #include <algorithm>
 #include <atomic>
-#include <exception>
 #include <map>
 #include <memory>
 #include <set>
 #include <stdint.h>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -9,8 +9,6 @@
 #include <scheduler.h>
 #include <txmempool.h>
 
-#include <list>
-#include <atomic>
 #include <future>
 #include <utility>
 

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -5,6 +5,7 @@
 #include <wallet/coincontrol.h>
 
 #include <util/system.h>
+#include <wallet/wallet.h>
 
 void CCoinControl::SetNull()
 {

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -5,10 +5,11 @@
 #ifndef BITCOIN_WALLET_COINCONTROL_H
 #define BITCOIN_WALLET_COINCONTROL_H
 
+#include <outputtype.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
 #include <primitives/transaction.h>
-#include <wallet/wallet.h>
+#include <script/standard.h>
 
 #include <boost/optional.hpp>
 

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -4,6 +4,7 @@
 
 #include <wallet/coinselection.h>
 
+#include <random.h>
 #include <util/system.h>
 #include <util/moneystr.h>
 

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -7,7 +7,6 @@
 
 #include <amount.h>
 #include <primitives/transaction.h>
-#include <random.h>
 
 //! target minimum change amount
 static constexpr CAmount MIN_CHANGE{COIN / 100};

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -6,8 +6,6 @@
 
 #include <crypto/aes.h>
 #include <crypto/sha512.h>
-#include <script/script.h>
-#include <script/standard.h>
 #include <util/system.h>
 
 #include <vector>

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -10,7 +10,6 @@
 #include <script/standard.h>
 #include <util/system.h>
 
-#include <string>
 #include <vector>
 
 int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -9,8 +9,6 @@
 #include <support/allocators/secure.h>
 #include <script/signingprovider.h>
 
-#include <atomic>
-
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;
 const unsigned int WALLET_CRYPTO_IV_SIZE = 16;

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -5,9 +5,10 @@
 #ifndef BITCOIN_WALLET_CRYPTER_H
 #define BITCOIN_WALLET_CRYPTER_H
 
+#include <key.h>
+#include <pubkey.h>
 #include <serialize.h>
 #include <support/allocators/secure.h>
-#include <script/signingprovider.h>
 
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -6,7 +6,9 @@
 #include <wallet/db.h>
 
 #include <util/strencodings.h>
+
 #include <util/translation.h>
+#include <util/time.h>
 
 #include <stdint.h>
 

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,9 +10,8 @@
 #include <fs.h>
 #include <serialize.h>
 #include <streams.h>
-#include <sync.h>
+#include <util/memory.h>
 #include <util/system.h>
-#include <version.h>
 
 #include <atomic>
 #include <map>

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -5,7 +5,6 @@
 
 #include <wallet/fees.h>
 
-#include <util/system.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -11,7 +11,6 @@
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 #include <walletinitinterface.h>
 
 class WalletInit : public WalletInitInterface {

--- a/src/wallet/ismine.cpp
+++ b/src/wallet/ismine.cpp
@@ -7,7 +7,6 @@
 
 #include <key.h>
 #include <script/script.h>
-#include <script/sign.h>
 #include <script/signingprovider.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/psbtwallet.h
+++ b/src/wallet/psbtwallet.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_WALLET_PSBTWALLET_H
 #define BITCOIN_WALLET_PSBTWALLET_H
 
-#include <node/transaction.h>
 #include <psbt.h>
-#include <primitives/transaction.h>
 #include <wallet/wallet.h>
 
 /**

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -7,7 +7,6 @@
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <merkleblock.h>
-#include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
 #include <script/script.h>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <core_io.h>
+#include <core_read.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <merkleblock.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -9,7 +9,6 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
-#include <node/transaction.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -37,8 +37,6 @@
 
 #include <univalue.h>
 
-#include <functional>
-
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 
 static inline bool GetAvoidReuseFlag(CWallet * const pwallet, const UniValue& param) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5,7 +5,8 @@
 
 #include <amount.h>
 #include <consensus/validation.h>
-#include <core_io.h>
+#include <core_read.h>
+#include <core_write.h>
 #include <init.h>
 #include <interfaces/chain.h>
 #include <key_io.h>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -12,6 +12,7 @@
 #include <interfaces/chain.h>
 #include <policy/policy.h>
 #include <rpc/request.h>
+#include <script/sign.h>
 #include <test/setup_common.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -11,7 +11,7 @@
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <policy/policy.h>
-#include <rpc/server.h>
+#include <rpc/request.h>
 #include <test/setup_common.h>
 #include <validation.h>
 #include <wallet/coincontrol.h>

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -33,7 +33,7 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <future>
+#include <thread>
 
 #include <boost/algorithm/string/replace.hpp>
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -11,7 +11,7 @@
 #include <interfaces/handler.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
-#include <script/sign.h>
+#include <script/keyorigin.h>
 #include <tinyformat.h>
 #include <ui_interface.h>
 #include <util/strencodings.h>

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -16,6 +16,7 @@
 #include <ui_interface.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <validationinterface.h>
 #include <wallet/coinselection.h>
 #include <wallet/crypter.h>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -12,10 +12,8 @@
 #include <wallet/db.h>
 #include <key.h>
 
-#include <list>
 #include <stdint.h>
 #include <string>
-#include <utility>
 #include <vector>
 
 /**

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -7,8 +7,7 @@
 #define BITCOIN_WALLET_WALLETDB_H
 
 #include <amount.h>
-#include <primitives/transaction.h>
-#include <script/sign.h>
+#include <script/keyorigin.h>
 #include <wallet/db.h>
 #include <key.h>
 

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_WALLET_WALLETTOOL_H
 #define BITCOIN_WALLET_WALLETTOOL_H
 
-#include <wallet/ismine.h>
 #include <wallet/wallet.h>
 
 namespace WalletTool {

--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_WALLETINITINTERFACE_H
 #define BITCOIN_WALLETINITINTERFACE_H
 
-#include <string>
-
 class CScheduler;
 class CRPCTable;
 struct InitInterfaces;

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_WARNINGS_H
 #define BITCOIN_WARNINGS_H
 
-#include <stdlib.h>
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -2,7 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <primitives/transaction.h>
 #include <zmq/zmqabstractnotifier.h>
+
+#include <cassert>
 
 const int CZMQAbstractNotifier::DEFAULT_ZMQ_SNDHWM;
 

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -5,7 +5,9 @@
 #ifndef BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 #define BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 
-#include <zmq/zmqconfig.h>
+#include <primitives/transaction.h>
+
+#include <string>
 
 class CBlockIndex;
 class CZMQAbstractNotifier;

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -9,8 +9,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <stdarg.h>
-
 #if ENABLE_ZMQ
 #include <zmq.h>
 #endif

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -13,9 +13,6 @@
 #include <zmq.h>
 #endif
 
-#include <primitives/block.h>
-#include <primitives/transaction.h>
-
 void zmqError(const char *str);
 
 #endif // BITCOIN_ZMQ_ZMQCONFIG_H

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -10,7 +10,6 @@
 #endif
 
 #include <stdarg.h>
-#include <string>
 
 #if ENABLE_ZMQ
 #include <zmq.h>

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <zmq/zmqconfig.h>
 #include <zmq/zmqnotificationinterface.h>
 #include <zmq/zmqpublishnotifier.h>
 
-#include <version.h>
 #include <validation.h>
 #include <util/system.h>
 

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,8 +6,6 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
-#include <string>
-#include <map>
 #include <list>
 
 class CBlockIndex;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -10,6 +10,8 @@
 #include <util/system.h>
 #include <rpc/server.h>
 
+#include <cstdarg>
+
 static std::multimap<std::string, CZMQAbstractPublishNotifier*> mapPublishNotifiers;
 
 static const char *MSG_HASHBLOCK = "hashblock";

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -5,6 +5,8 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <streams.h>
+#include <zmq/zmqabstractnotifier.h>
+#include <zmq/zmqconfig.h>
 #include <zmq/zmqpublishnotifier.h>
 #include <validation.h>
 #include <util/system.h>


### PR DESCRIPTION
Reduce compile-time memory usage by 2%, compilation time by 2% and avoid unnecessary recompiles by removing unused includes.

---

The total accumulated max RSS usage is reduced by 2% (roughly -3564 MB, low variance measurement).

The total compilation time is reduced by 2% (roughly -73 seconds in user CPU time, slightly higher variance measurement).

Commits:
* Reduce memory usage during build by not including unused C++ standard library headers
* Reduce memory usage during build by not including unused C compatibility headers
* Reduce memory usage during build by not including unused headers (project local headers and headers for external dependencies)
* Minimise includes and simplify header analysis/reasoning by splitting the `core_io.h` into the expected `core_read.h`/`core_write.h` (matching `core_read.cpp`/`core_write.cpp`)

The two first commits account for half of the speedup and the third commit account for the other half.

This PR is a follow-up to the merged PR #16129 which reduced max RSS and compilation time by 2%.

---

Comparing max memory usage (RSS) between old revision 2cbcc55ba6aea26d64eae3981b83dac04f70240f (branch `master`) and new revision fd2f3033591a370438cf2c15f26f28a6608238b5 (branch `cut-compilation-bloat`):

| File                                                         | Old       | New       | Diff      | Percent   |
| :----------------------------------------------------------- | --------: | --------: | --------: | --------: |
| `bench/bench_bench_bitcoin-bench_bitcoin.o`                  |    235 MB |    218 MB |    -18 MB |      -7 % |
| `bench/bench_bench_bitcoin-verify_script.o`                  |    218 MB |    178 MB |    -39 MB |     -18 % |
| `libbitcoin_common_a-netbase.o`                              |    281 MB |    263 MB |    -17 MB |      -6 % |
| `libbitcoin_common_a-protocol.o`                             |    236 MB |    218 MB |    -18 MB |      -8 % |
| `libbitcoin_common_a-warnings.o`                             |    212 MB |    194 MB |    -17 MB |      -8 % |
| `libbitcoin_server_a-addrman.o`                              |    286 MB |    269 MB |    -17 MB |      -6 % |
| `libbitcoin_server_a-banman.o`                               |    253 MB |    235 MB |    -17 MB |      -7 % |
| `libbitcoin_server_a-dbwrapper.o`                            |    287 MB |    270 MB |    -17 MB |      -6 % |
| `libbitcoin_server_a-flatfile.o`                             |    239 MB |    221 MB |    -18 MB |      -7 % |
| `libbitcoin_server_a-httprpc.o`                              |    398 MB |    363 MB |    -35 MB |      -9 % |
| `libbitcoin_server_a-timedata.o`                             |    257 MB |    239 MB |    -18 MB |      -7 % |
| `libbitcoin_server_a-torcontrol.o`                           |    604 MB |    504 MB |    -99 MB |     -16 % |
| `libbitcoin_util_a-chainparamsbase.o`                        |    225 MB |    208 MB |    -17 MB |      -8 % |
| `qt/qt_libbitcoinqt_a-bitcoin.o`                             |    595 MB |    498 MB |    -97 MB |     -16 % |
| `qt/qt_libbitcoinqt_a-moc_bantablemodel.o`                   |    304 MB |    199 MB |   -105 MB |     -35 % |
| `qt/qt_libbitcoinqt_a-receivecoinsdialog.o`                  |    585 MB |    471 MB |   -114 MB |     -19 % |
| `qt/qt_libbitcoinqt_a-sendcoinsdialog.o`                     |    809 MB |    706 MB |   -103 MB |     -13 % |
| `qt/qt_libbitcoinqt_a-signverifymessagedialog.o`             |    620 MB |    400 MB |   -220 MB |     -36 % |
| `qt/test/qt_test_test_bitcoin_qt-moc_rpcnestedtests.o`       |    438 MB |    145 MB |   -293 MB |     -67 % |
| `qt/test/qt_test_test_bitcoin_qt-test_main.o`                |    539 MB |    438 MB |   -102 MB |     -19 % |
| `rpc/libbitcoin_cli_a-client.o`                              |    263 MB |    246 MB |    -17 MB |      -6 % |
| `rpc/libbitcoin_common_a-rawtransaction_util.o`              |    423 MB |    395 MB |    -28 MB |      -7 % |
| `rpc/libbitcoin_common_a-util.o`                             |    408 MB |    384 MB |    -23 MB |      -6 % |
| `rpc/libbitcoin_util_a-protocol.o`                           |    258 MB |    241 MB |    -17 MB |      -7 % |
| `test/bench_bench_bitcoin-util.o`                            |    613 MB |    518 MB |    -95 MB |     -15 % |
| `test/test_test_bitcoin-bech32_tests.o`                      |    541 MB |    513 MB |    -28 MB |      -5 % |
| `test/test_test_bitcoin-fs_tests.o`                          |    540 MB |    513 MB |    -27 MB |      -5 % |
| `test/test_test_bitcoin-reverselock_tests.o`                 |    549 MB |    520 MB |    -29 MB |      -5 % |
| `util/libbitcoin_util_a-error.o`                             |    220 MB |    202 MB |    -18 MB |      -8 % |
| `util/libbitcoin_util_a-moneystr.o`                          |    108 MB |     81 MB |    -27 MB |     -25 % |
| `util/libbitcoin_util_a-threadnames.o`                       |     69 MB |     48 MB |    -21 MB |     -31 % |
| `wallet/libbitcoin_wallet_a-walletutil.o`                    |    249 MB |    232 MB |    -17 MB |      -7 % |
| `zmq/libbitcoin_zmq_a-zmqrpc.o`                              |    347 MB |    326 MB |    -21 MB |      -6 % |
| ... suppressing 421 unchanged measurements ...               | ...       | ...       | ...       | ...       |
| Average (N=454)                                              |    321 MB |    313 MB |     -8 MB |      -2 % |
| Sum (N=454)                                                  | 145549 MB | 141986 MB |  -3564 MB |      -2 % |

Comparing build time (user CPU time) between old revision 2cbcc55ba6aea26d64eae3981b83dac04f70240f (branch `master`) and new revision fd2f3033591a370438cf2c15f26f28a6608238b5 (branch `cut-compilation-bloat`), listing filenames and individual results only for files with a measured change in max memory usage (RSS) to reduce noise:

| File                                                         | Old       | New       | Diff      | Percent   |
| :----------------------------------------------------------- | --------: | --------: | --------: | --------: |
| `bench/bench_bench_bitcoin-bench_bitcoin.o`                  |      3 s. |      3 s. |     -0 s. |      -5 % |
| `bench/bench_bench_bitcoin-verify_script.o`                  |      4 s. |      3 s. |     -1 s. |     -15 % |
| `libbitcoin_common_a-netbase.o`                              |      6 s. |      6 s. |     -0 s. |      -1 % |
| `libbitcoin_common_a-protocol.o`                             |      4 s. |      4 s. |     -0 s. |      -7 % |
| `libbitcoin_common_a-warnings.o`                             |      3 s. |      3 s. |     -0 s. |      -9 % |
| `libbitcoin_server_a-addrman.o`                              |      5 s. |      5 s. |     -0 s. |      -3 % |
| `libbitcoin_server_a-banman.o`                               |      4 s. |      4 s. |     -0 s. |      -0 % |
| `libbitcoin_server_a-dbwrapper.o`                            |      6 s. |      6 s. |     -0 s. |      -1 % |
| `libbitcoin_server_a-flatfile.o`                             |      4 s. |      4 s. |     -0 s. |      -1 % |
| `libbitcoin_server_a-httprpc.o`                              |      9 s. |      8 s. |     -1 s. |      -8 % |
| `libbitcoin_server_a-timedata.o`                             |      4 s. |      4 s. |     -0 s. |      -2 % |
| `libbitcoin_server_a-torcontrol.o`                           |     15 s. |     12 s. |     -2 s. |     -17 % |
| `libbitcoin_util_a-chainparamsbase.o`                        |      3 s. |      3 s. |     -0 s. |      -6 % |
| `qt/qt_libbitcoinqt_a-bitcoin.o`                             |     13 s. |     10 s. |     -3 s. |     -25 % |
| `qt/qt_libbitcoinqt_a-moc_bantablemodel.o`                   |      4 s. |      2 s. |     -1 s. |     -36 % |
| `qt/qt_libbitcoinqt_a-receivecoinsdialog.o`                  |     11 s. |      8 s. |     -3 s. |     -31 % |
| `qt/qt_libbitcoinqt_a-sendcoinsdialog.o`                     |     16 s. |     14 s. |     -1 s. |      -7 % |
| `qt/qt_libbitcoinqt_a-signverifymessagedialog.o`             |     12 s. |      8 s. |     -4 s. |     -36 % |
| `qt/test/qt_test_test_bitcoin_qt-moc_rpcnestedtests.o`       |      6 s. |      2 s. |     -5 s. |     -72 % |
| `qt/test/qt_test_test_bitcoin_qt-test_main.o`                |     10 s. |      7 s. |     -3 s. |     -28 % |
| `rpc/libbitcoin_cli_a-client.o`                              |      4 s. |      4 s. |     -0 s. |      -3 % |
| `rpc/libbitcoin_common_a-rawtransaction_util.o`              |      9 s. |      9 s. |     -0 s. |      -3 % |
| `rpc/libbitcoin_common_a-util.o`                             |      9 s. |      8 s. |     -0 s. |      -2 % |
| `rpc/libbitcoin_util_a-protocol.o`                           |      5 s. |      5 s. |     -0 s. |      -1 % |
| `test/bench_bench_bitcoin-util.o`                            |     13 s. |      9 s. |     -4 s. |     -31 % |
| `test/test_test_bitcoin-bech32_tests.o`                      |     11 s. |     11 s. |     -1 s. |      -5 % |
| `test/test_test_bitcoin-fs_tests.o`                          |     11 s. |     11 s. |     -1 s. |      -5 % |
| `test/test_test_bitcoin-reverselock_tests.o`                 |     12 s. |     11 s. |     -1 s. |      -6 % |
| `util/libbitcoin_util_a-error.o`                             |      3 s. |      3 s. |     -0 s. |      -4 % |
| `util/libbitcoin_util_a-moneystr.o`                          |      2 s. |      1 s. |     -0 s. |     -24 % |
| `util/libbitcoin_util_a-threadnames.o`                       |      1 s. |      0 s. |     -0 s. |     -35 % |
| `wallet/libbitcoin_wallet_a-walletutil.o`                    |      4 s. |      4 s. |     -0 s. |      -4 % |
| `zmq/libbitcoin_zmq_a-zmqrpc.o`                              |      6 s. |      5 s. |     -1 s. |      -9 % |
| ... suppressing 421 measurements ...                         | ...       | ...       | ...       | ...       |
| Average (N=454)                                              |      7 s. |      6 s. |     -0 s. |      -2 % |
| Sum (N=454)                                                  |   2994 s. |   2921 s. |    -73 s. |      -2 % |