### PR TITLE
util: optimize for diagnosis of deadlock

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -28,6 +28,12 @@ void PrintLockContention(const char* pszName, const char* pszFile, int nLine)
     LogPrintf("LOCKCONTENTION: %s\n", pszName);
     LogPrintf("Locker: %s:%d\n", pszFile, nLine);
 }
+
+void PrintLockContentionOwned(const char* pszName, const char* pszFile, int nLine)
+{
+    LogPrintf("LOCKOWNED after lock contention: %s\n", pszName);
+    LogPrintf("Locker: %s:%d\n", pszFile, nLine);
+}
 #endif /* DEBUG_LOCKCONTENTION */
 
 #ifdef DEBUG_LOCKORDER

--- a/src/sync.h
+++ b/src/sync.h
@@ -112,6 +112,7 @@ typedef AnnotatedMixin<std::mutex> Mutex;
 
 #ifdef DEBUG_LOCKCONTENTION
 void PrintLockContention(const char* pszName, const char* pszFile, int nLine);
+void PrintLockContentionOwned(const char* pszName, const char* pszFile, int nLine);
 #endif
 
 /** Wrapper around std::unique_lock style lock for Mutex. */
@@ -128,6 +129,7 @@ private:
 #endif
             Base::lock();
 #ifdef DEBUG_LOCKCONTENTION
+            PrintLockContentionOwned(pszName, pszFile, nLine);
         }
 #endif
     }


### PR DESCRIPTION
optimize for diagnosis of deadlock
it is not intuitive we use pstack/thread backtrace all to get lock information, or the original debug information.