### PR TITLE
[Tests] Suppress output in test_bitcoin for expected errors

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -13,6 +13,12 @@
 #include <string>
 
 #include <boost/signals2/connection.hpp>
+#include <boost/signals2/signal.hpp>
+
+/** Store connections so we can disconnect them when suppressing output */
+boost::signals2::connection noui_ThreadSafeMessageBoxConn;
+boost::signals2::connection noui_ThreadSafeQuestionConn;
+boost::signals2::connection noui_InitMessageConn;
 
 bool noui_ThreadSafeMessageBox(const std::string& message, const std::string& caption, unsigned int style)
 {
@@ -53,7 +59,39 @@ void noui_InitMessage(const std::string& message)
 
 void noui_connect()
 {
-    uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
-    uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
-    uiInterface.InitMessage_connect(noui_InitMessage);
+    noui_ThreadSafeMessageBoxConn = uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBox);
+    noui_ThreadSafeQuestionConn = uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestion);
+    noui_InitMessageConn = uiInterface.InitMessage_connect(noui_InitMessage);
+}
+
+bool noui_ThreadSafeMessageBoxSuppressed(const std::string& message, const std::string& caption, unsigned int style)
+{
+    return false;
+}
+
+bool noui_ThreadSafeQuestionSuppressed(const std::string& /* ignored interactive message */, const std::string& message, const std::string& caption, unsigned int style)
+{
+    return false;
+}
+
+void noui_InitMessageSuppressed(const std::string& message)
+{
+}
+
+void noui_suppress()
+{
+    noui_ThreadSafeMessageBoxConn.disconnect();
+    noui_ThreadSafeQuestionConn.disconnect();
+    noui_InitMessageConn.disconnect();
+    noui_ThreadSafeMessageBoxConn = uiInterface.ThreadSafeMessageBox_connect(noui_ThreadSafeMessageBoxSuppressed);
+    noui_ThreadSafeQuestionConn = uiInterface.ThreadSafeQuestion_connect(noui_ThreadSafeQuestionSuppressed);
+    noui_InitMessageConn = uiInterface.InitMessage_connect(noui_InitMessageSuppressed);
+}
+
+void noui_reconnect()
+{
+    noui_ThreadSafeMessageBoxConn.disconnect();
+    noui_ThreadSafeQuestionConn.disconnect();
+    noui_InitMessageConn.disconnect();
+    noui_connect();
 }

--- a/src/noui.h
+++ b/src/noui.h
@@ -17,4 +17,10 @@ void noui_InitMessage(const std::string& message);
 /** Connect all bitcoind signal handlers */
 void noui_connect();
 
+/** Suppress all bitcoind signal handlers. Used to suppress output during test runs that produce expected errors */
+void noui_suppress();
+
+/** Reconnects the regular Non-GUI handlers after having used noui_suppress */
+void noui_reconnect();
+
 #endif // BITCOIN_NOUI_H

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <noui.h>
 #include <test/setup_common.h>
 #include <wallet/test/init_test_fixture.h>
 
@@ -32,21 +33,27 @@ BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_custom)
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_does_not_exist)
 {
     SetWalletDir(m_walletdir_path_cases["nonexistent"]);
+    noui_suppress();
     bool result = m_chain_client->verify();
+    noui_reconnect();
     BOOST_CHECK(result == false);
 }
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_directory)
 {
     SetWalletDir(m_walletdir_path_cases["file"]);
+    noui_suppress();
     bool result = m_chain_client->verify();
+    noui_reconnect();
     BOOST_CHECK(result == false);
 }
 
 BOOST_AUTO_TEST_CASE(walletinit_verify_walletdir_is_not_relative)
 {
     SetWalletDir(m_walletdir_path_cases["relative"]);
+    noui_suppress();
     bool result = m_chain_client->verify();
+    noui_reconnect();
     BOOST_CHECK(result == false);
 }
 


### PR DESCRIPTION
Closes #15944 

This adds two methods to noui, that allows temporarily suppressing (and then resuming) the output from `noui`. For situations where errors are expected, it's confusing for the test binary to output an error and then conclude with `No errors detected`.

It also uses this supress/reconnect in the tests that currently produce verbose errors when running `test_bitcoin`.

Output of `test_bitcoin` on current master:
```
gertjaap@gjdesktop:~/src/bitcoin$ src/test/test_bitcoin
Running 351 test cases...
Error: Specified -walletdir "/tmp/test_common_Bitcoin Core/1561389554_943311758/tempdir/path_does_not_exist" does not exist
Error: Specified -walletdir "/tmp/test_common_Bitcoin Core/1561389554_643733972/tempdir/not_a_directory.dat" is not a directory
Error: Specified -walletdir "wallets" is a relative path

*** No errors detected
```

Output after this code is merged:

```
gertjaap@gjdesktop:~/src/bitcoin$ src/test/test_bitcoin
Running 351 test cases...

*** No errors detected
```