### PR TITLE
tests: Remove unused includes

### DIFF
--- a/src/qt/test/addressbooktests.cpp
+++ b/src/qt/test/addressbooktests.cpp
@@ -12,7 +12,6 @@
 
 #include <key.h>
 #include <key_io.h>
-#include <pubkey.h>
 #include <wallet/wallet.h>
 
 #include <QApplication>

--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -26,7 +26,6 @@
 #include <QtGlobal>
 #include <QtTest/QtTestWidgets>
 #include <QtTest/QtTestGui>
-#include <new>
 #include <string>
 #include <univalue.h>
 

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -4,7 +4,6 @@
 
 #include <qt/test/rpcnestedtests.h>
 
-#include <fs.h>
 #include <interfaces/node.h>
 #include <rpc/server.h>
 #include <qt/rpcconsole.h>

--- a/src/qt/test/rpcnestedtests.h
+++ b/src/qt/test/rpcnestedtests.h
@@ -8,9 +8,6 @@
 #include <QObject>
 #include <QTest>
 
-#include <txdb.h>
-#include <txmempool.h>
-
 class RPCNestedTests : public QObject
 {
     Q_OBJECT

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -6,7 +6,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <chainparams.h>
 #include <interfaces/node.h>
 #include <qt/bitcoin.h>
 #include <qt/test/apptests.h>

--- a/src/test/allocator_tests.cpp
+++ b/src/test/allocator_tests.cpp
@@ -2,9 +2,9 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/memory.h>
 #include <util/system.h>
 
-#include <support/allocators/secure.h>
 #include <test/setup_common.h>
 
 #include <memory>

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -11,7 +11,6 @@
 #include <uint256.h>
 #include <arith_uint256.h>
 #include <string>
-#include <version.h>
 #include <test/setup_common.h>
 
 BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -4,9 +4,10 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <clientversion.h>
 #include <key.h>
 #include <key_io.h>
-#include <uint256.h>
+#include <streams.h>
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <test/setup_common.h>

--- a/src/test/blockchain_tests.cpp
+++ b/src/test/blockchain_tests.cpp
@@ -2,6 +2,7 @@
 
 #include <stdlib.h>
 
+#include <chain.h>
 #include <rpc/blockchain.h>
 #include <test/setup_common.h>
 

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -6,7 +6,7 @@
 #include <consensus/merkle.h>
 #include <chainparams.h>
 #include <pow.h>
-#include <random.h>
+#include <streams.h>
 
 #include <test/setup_common.h>
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -10,6 +10,7 @@
 #include <pow.h>
 #include <test/setup_common.h>
 #include <script/standard.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <util/memory.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <validation.h>
@@ -17,8 +18,6 @@
 #include <condition_variable>
 
 #include <unordered_set>
-#include <memory>
-#include <random.h>
 
 // BasicTestingSetup not sufficient because nScriptCheckThreads is not set
 // otherwise.

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -3,8 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <attributes.h>
+#include <clientversion.h>
 #include <coins.h>
 #include <script/standard.h>
+#include <streams.h>
 #include <test/setup_common.h>
 #include <uint256.h>
 #include <undo.h>

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -4,8 +4,8 @@
 
 #include <dbwrapper.h>
 #include <uint256.h>
-#include <random.h>
 #include <test/setup_common.h>
+#include <util/memory.h>
 
 #include <memory>
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -11,7 +11,9 @@
 #include <net_processing.h>
 #include <script/sign.h>
 #include <serialize.h>
+#include <util/memory.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <test/setup_common.h>

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -2,8 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <clientversion.h>
 #include <flatfile.h>
+#include <streams.h>
 #include <test/setup_common.h>
+#include <util/system.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -4,6 +4,7 @@
 //
 #include <fs.h>
 #include <test/setup_common.h>
+#include <util/system.h>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <addrdb.h>
 #include <addrman.h>
 #include <blockencodings.h>
 #include <chain.h>
@@ -11,8 +12,6 @@
 #include <net.h>
 #include <primitives/block.h>
 #include <protocol.h>
-#include <pubkey.h>
-#include <script/script.h>
 #include <streams.h>
 #include <undo.h>
 #include <version.h>
@@ -20,8 +19,6 @@
 #include <stdint.h>
 #include <unistd.h>
 
-#include <algorithm>
-#include <memory>
 #include <vector>
 
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_TEST_FUZZ_FUZZ_H
 #define BITCOIN_TEST_FUZZ_FUZZ_H
 
-#include <functional>
 #include <stdint.h>
 #include <vector>
 

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <script/interpreter.h>
-#include <script/script.h>
 #include <streams.h>
 #include <version.h>
 

--- a/src/test/hash_tests.cpp
+++ b/src/test/hash_tests.cpp
@@ -2,12 +2,11 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <clientversion.h>
 #include <crypto/siphash.h>
 #include <hash.h>
 #include <util/strencodings.h>
 #include <test/setup_common.h>
-
-#include <vector>
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -3,13 +3,9 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include <key.h>
 
-#include <base58.h>
-#include <script/script.h>
 #include <uint256.h>
 #include <util/system.h>
-#include <util/strencodings.h>
 #include <test/setup_common.h>
-#include <string>
 #include <vector>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/key_tests.cpp
+++ b/src/test/key_tests.cpp
@@ -5,7 +5,6 @@
 #include <key.h>
 
 #include <key_io.h>
-#include <script/script.h>
 #include <uint256.h>
 #include <util/system.h>
 #include <util/strencodings.h>

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -5,11 +5,11 @@
 #include <policy/policy.h>
 #include <txmempool.h>
 #include <util/system.h>
+#include <util/time.h>
 
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
-#include <list>
 #include <vector>
 
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -9,12 +9,12 @@
 #include <consensus/tx_verify.h>
 #include <miner.h>
 #include <policy/policy.h>
-#include <pubkey.h>
 #include <script/standard.h>
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/time.h>
 #include <validation.h>
 
 #include <test/setup_common.h>

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -9,6 +9,7 @@
 #include <script/script_error.h>
 #include <script/interpreter.h>
 #include <script/sign.h>
+#include <tinyformat.h>
 #include <uint256.h>
 #include <test/setup_common.h>
 

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -1,16 +1,19 @@
 // Copyright (c) 2012-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addrdb.h>
 #include <addrman.h>
+#include <clientversion.h>
 #include <test/setup_common.h>
 #include <string>
 #include <boost/test/unit_test.hpp>
-#include <hash.h>
 #include <serialize.h>
 #include <streams.h>
 #include <net.h>
 #include <netbase.h>
 #include <chainparams.h>
+#include <util/memory.h>
 #include <util/system.h>
 
 #include <memory>

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -7,6 +7,7 @@
 #include <txmempool.h>
 #include <uint256.h>
 #include <util/system.h>
+#include <util/time.h>
 
 #include <test/setup_common.h>
 

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -5,7 +5,6 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <pow.h>
-#include <random.h>
 #include <util/system.h>
 #include <test/setup_common.h>
 

--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -14,8 +14,6 @@
 
 #include <test/setup_common.h>
 
-#include <vector>
-
 #include <boost/test/unit_test.hpp>
 
 static std::map<void*, short> tags;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -9,8 +9,8 @@
 #include <core_io.h>
 #include <init.h>
 #include <interfaces/chain.h>
-
 #include <test/setup_common.h>
+#include <util/time.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -5,7 +5,6 @@
 #include <key.h>
 #include <keystore.h>
 #include <script/script.h>
-#include <script/script_error.h>
 #include <script/standard.h>
 #include <test/setup_common.h>
 

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -14,12 +14,12 @@
 #include <util/strencodings.h>
 #include <test/setup_common.h>
 #include <rpc/util.h>
+#include <streams.h>
 
 #if defined(HAVE_CONSENSUS_LIB)
 #include <script/bitcoinconsensus.h>
 #endif
 
-#include <fstream>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/test/scriptnum10.h
+++ b/src/test/scriptnum10.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_TEST_SCRIPTNUM10_H
 #define BITCOIN_TEST_SCRIPTNUM10_H
 
-#include <algorithm>
 #include <limits>
 #include <stdexcept>
 #include <stdint.h>

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -6,6 +6,7 @@
 #include <streams.h>
 #include <hash.h>
 #include <test/setup_common.h>
+#include <util/strencodings.h>
 
 #include <stdint.h>
 

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -12,15 +12,20 @@
 #include <crypto/sha256.h>
 #include <init.h>
 #include <miner.h>
-#include <net_processing.h>
+#include <net.h>
 #include <noui.h>
 #include <pow.h>
 #include <rpc/register.h>
 #include <rpc/server.h>
 #include <script/sigcache.h>
 #include <streams.h>
+#include <txdb.h>
+#include <util/memory.h>
+#include <util/strencodings.h>
+#include <util/time.h>
 #include <util/validation.h>
 #include <validation.h>
+#include <validationinterface.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 

--- a/src/test/setup_common.h
+++ b/src/test/setup_common.h
@@ -11,10 +11,8 @@
 #include <pubkey.h>
 #include <random.h>
 #include <scheduler.h>
-#include <txdb.h>
 #include <txmempool.h>
 
-#include <memory>
 #include <type_traits>
 
 #include <boost/thread.hpp>

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/consensus.h>
 #include <consensus/tx_verify.h>
-#include <consensus/validation.h>
 #include <pubkey.h>
 #include <key.h>
 #include <script/script.h>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <streams.h>
-#include <support/allocators/zeroafterfree.h>
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -20,6 +20,7 @@
 #include <script/sign.h>
 #include <script/script_error.h>
 #include <script/standard.h>
+#include <streams.h>
 #include <util/strencodings.h>
 
 #include <map>

--- a/src/test/txvalidation_tests.cpp
+++ b/src/test/txvalidation_tests.cpp
@@ -3,8 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <validation.h>
-#include <txmempool.h>
-#include <amount.h>
 #include <consensus/validation.h>
 #include <primitives/transaction.h>
 #include <script/script.h>

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -5,14 +5,10 @@
 #include <consensus/validation.h>
 #include <key.h>
 #include <validation.h>
-#include <miner.h>
-#include <pubkey.h>
 #include <txmempool.h>
-#include <random.h>
 #include <script/standard.h>
 #include <script/sign.h>
 #include <test/setup_common.h>
-#include <util/time.h>
 #include <keystore.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -1,19 +1,17 @@
 // Copyright (c) 2011-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include <arith_uint256.h>
+#include <streams.h>
 #include <uint256.h>
 #include <version.h>
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>
-#include <stdint.h>
 #include <sstream>
 #include <iomanip>
-#include <limits>
-#include <cmath>
 #include <string>
-#include <stdio.h>
 
 BOOST_FIXTURE_TEST_SUITE(uint256_tests, BasicTestingSetup)
 

--- a/src/test/util.cpp
+++ b/src/test/util.cpp
@@ -17,8 +17,6 @@
 #include <wallet/wallet.h>
 #endif
 
-#include <boost/thread.hpp>
-
 const std::string ADDRESS_BCRT1_UNSPENDABLE = "bcrt1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq3xueyj";
 
 #ifdef ENABLE_WALLET

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -5,14 +5,15 @@
 #include <util/system.h>
 
 #include <clientversion.h>
-#include <primitives/transaction.h>
 #include <sync.h>
 #include <test/util.h>
 #include <util/strencodings.h>
 #include <util/moneystr.h>
+#include <util/time.h>
 #include <test/setup_common.h>
 
 #include <stdint.h>
+#include <thread>
 #include <vector>
 #ifndef WIN32
 #include <signal.h>

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -11,8 +11,11 @@
 #include <pow.h>
 #include <random.h>
 #include <test/setup_common.h>
+#include <util/time.h>
 #include <validation.h>
 #include <validationinterface.h>
+
+#include <thread>
 
 struct RegtestingSetup : public TestingSetup {
     RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}

--- a/src/wallet/test/init_test_fixture.cpp
+++ b/src/wallet/test/init_test_fixture.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <fs.h>
+#include <util/system.h>
 
 #include <wallet/test/init_test_fixture.h>
 

--- a/src/wallet/test/init_tests.cpp
+++ b/src/wallet/test/init_tests.cpp
@@ -5,6 +5,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <test/setup_common.h>
+#include <util/system.h>
 #include <wallet/test/init_test_fixture.h>
 
 BOOST_FIXTURE_TEST_SUITE(init_tests, InitWalletDirTestingSetup)

--- a/src/wallet/test/ismine_tests.cpp
+++ b/src/wallet/test/ismine_tests.cpp
@@ -4,7 +4,6 @@
 
 #include <key.h>
 #include <script/script.h>
-#include <script/script_error.h>
 #include <script/standard.h>
 #include <test/setup_common.h>
 #include <wallet/ismine.h>

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -3,12 +3,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <key_io.h>
-#include <script/sign.h>
 #include <util/bip32.h>
 #include <util/strencodings.h>
 #include <wallet/psbtwallet.h>
 #include <wallet/wallet.h>
-#include <univalue.h>
 
 #include <boost/test/unit_test.hpp>
 #include <test/setup_common.h>

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -4,8 +4,6 @@
 
 #include <wallet/test/wallet_test_fixture.h>
 
-#include <wallet/db.h>
-
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     : TestingSetup(chainName),
       m_wallet(m_chain.get(), WalletLocation(), WalletDatabase::CreateMock())

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -5,9 +5,7 @@
 #include <wallet/wallet.h>
 
 #include <memory>
-#include <set>
 #include <stdint.h>
-#include <utility>
 #include <vector>
 
 #include <consensus/validation.h>


### PR DESCRIPTION
Reduce compilation time and unneccessary recompiles by removing unused includes in tests.

A subset of #16273 ("refactor: Reduce total compilation time by 2% and avoid unnecessary recompiles by removing unused includes") as requested by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/16273#issuecomment-505022643.