### PR TITLE
refactoring: wallet: Fix GCC 7.4.0 warning

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2266,7 +2266,7 @@ void MaybeResendWalletTxs()
 CWallet::Balance CWallet::GetBalance(const int min_depth, bool avoid_reuse) const
 {
     Balance ret;
-    isminefilter reuse_filter = avoid_reuse ? 0 : ISMINE_USED;
+    isminefilter reuse_filter = avoid_reuse ? ISMINE_NO : ISMINE_USED;
     {
         auto locked_chain = chain().lock();
         LOCK(cs_wallet);


### PR DESCRIPTION
Having #13756 and #16239 merged cause GCC warning:
```
$ gcc --version
gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
...
$ make -j 4 > /dev/null 
wallet/wallet.cpp: In member function ‘CWallet::Balance CWallet::GetBalance(int, bool) const’:
wallet/wallet.cpp:2269:45: warning: enumeral and non-enumeral type in conditional expression [-Wextra]
     isminefilter reuse_filter = avoid_reuse ? 0 : ISMINE_USED;
                                 ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```

Fixed with this PR.