### PR TITLE
refactor: remove extra CBlockIndex declaration

### DIFF
--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -16,7 +16,6 @@ extern CCriticalSection cs_main;
 class CBlock;
 class CBlockIndex;
 struct CBlockLocator;
-class CBlockIndex;
 class CConnman;
 class CValidationInterface;
 class CValidationState;


### PR DESCRIPTION
Remove duplicate `class CBlockIndex;` declaration.