### PR TITLE
wallet_resendwallettransaction.py: fix coinbase height

### DIFF
--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -57,7 +57,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         # after the last time we tried to broadcast. Use mocktime and give an extra minute to be sure.
         block_time = int(time.time()) + 6 * 60
         node.setmocktime(block_time)
-        block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockchaininfo()['blocks']), block_time)
+        block = create_block(int(node.getbestblockhash(), 16), create_coinbase(node.getblockchaininfo()['blocks']+1), block_time)
         block.nVersion = 3
         block.rehash()
         block.solve()


### PR DESCRIPTION
Coinbase height is yet to be enforced on regtest, which allows these little errors in.