### PR TITLE
test: Make test cases separate functions

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -60,6 +60,36 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(121)
         self.sync_all()
 
+        self.test_change_position()
+        self.test_simple()
+        self.test_simple_two_coins()
+        self.test_simple_two_outputs()
+        self.test_change()
+        self.test_no_change()
+        self.test_invalid_option()
+        self.test_invalid_change_address()
+        self.test_valid_change_address()
+        self.test_change_type()
+        self.test_coin_selection()
+        self.test_two_vin()
+        self.test_two_vin_two_vout()
+        self.test_invalid_input()
+        self.test_fee_p2pkh()
+        self.test_fee_p2pkh_multi_out()
+        self.test_fee_p2sh()
+        self.test_fee_4of5()
+        self.test_spend_2of2()
+        self.test_locked_wallet()
+        self.test_many_inputs_fee()
+        self.test_many_inputs_send()
+        self.test_op_return()
+        self.test_watchonly()
+        self.test_all_watched_funds()
+        self.test_option_feerate()
+        self.test_address_reuse()
+        self.test_option_subtract_fee_from_outputs()
+
+    def test_change_position(self):
         # ensure that setting changePosition in fundraw with an exact match is handled properly
         rawmatch = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():50})
         rawmatch = self.nodes[2].fundrawtransaction(rawmatch, {"changePosition":1, "subtractFeeFromOutputs":[0]})
@@ -84,6 +114,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
+    def test_simple(self):
         ###############
         # simple test #
         ###############
@@ -92,10 +123,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert len(dec_tx['vin']) > 0  #test that we have enough inputs
 
+    def test_simple_two_coins(self):
         ##############################
         # simple test with two coins #
         ##############################
@@ -105,25 +136,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         assert len(dec_tx['vin']) > 0  #test if we have enough inputs
-
-        ##############################
-        # simple test with two coins #
-        ##############################
-        inputs  = [ ]
-        outputs = { self.nodes[0].getnewaddress() : 2.6 }
-        rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
-
-        rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
-        assert len(dec_tx['vin']) > 0
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
-
+    def test_simple_two_outputs(self):
         ################################
         # simple test with two outputs #
         ################################
@@ -133,7 +150,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         for out in dec_tx['vout']:
@@ -142,7 +158,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert len(dec_tx['vin']) > 0
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
-
+    def test_change(self):
         #########################################################################
         # test a fundrawtransaction with a VIN greater than the required amount #
         #########################################################################
@@ -164,7 +180,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_equal(fee + totalOut, utx['amount']) #compare vin total and totalout+fee
 
-
+    def test_no_change(self):
         #####################################################################
         # test a fundrawtransaction with which will not get a change output #
         #####################################################################
@@ -186,7 +202,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(rawtxfund['changepos'], -1)
         assert_equal(fee + totalOut, utx['amount']) #compare vin total and totalout+fee
 
-
+    def test_invalid_option(self):
         ####################################################
         # test a fundrawtransaction with an invalid option #
         ####################################################
@@ -203,6 +219,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # reserveChangeKey was deprecated and is now removed
         assert_raises_rpc_error(-3, "Unexpected key reserveChangeKey", lambda: self.nodes[2].fundrawtransaction(hexstring=rawtx, options={'reserveChangeKey': True}))
 
+    def test_invalid_change_address(self):
         ############################################################
         # test a fundrawtransaction with an invalid change address #
         ############################################################
@@ -216,6 +233,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_raises_rpc_error(-5, "changeAddress must be a valid bitcoin address", self.nodes[2].fundrawtransaction, rawtx, {'changeAddress':'foobar'})
 
+    def test_valid_change_address(self):
         ############################################################
         # test a fundrawtransaction with a provided change address #
         ############################################################
@@ -234,6 +252,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         out = dec_tx['vout'][0]
         assert_equal(change, out['scriptPubKey']['addresses'][0])
 
+    def test_change_type(self):
         #########################################################
         # test a fundrawtransaction with a provided change type #
         #########################################################
@@ -248,6 +267,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         dec_tx = self.nodes[2].decoderawtransaction(rawtx['hex'])
         assert_equal('witness_v0_keyhash', dec_tx['vout'][rawtx['changepos']]['scriptPubKey']['type'])
 
+    def test_coin_selection(self):
         #########################################################################
         # test a fundrawtransaction with a VIN smaller than the required amount #
         #########################################################################
@@ -265,7 +285,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal("00", dec_tx['vin'][0]['scriptSig']['hex'])
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         matchingOuts = 0
@@ -282,7 +301,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(matchingOuts, 1)
         assert_equal(len(dec_tx['vout']), 2)
 
-
+    def test_two_vin(self):
         ###########################################
         # test a fundrawtransaction with two VINs #
         ###########################################
@@ -296,7 +315,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         matchingOuts = 0
@@ -316,6 +334,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         assert_equal(matchingIns, 2) #we now must see two vins identical to vins given as params
 
+    def test_two_vin_two_vout(self):
         #########################################################
         # test a fundrawtransaction with two VINs and two vOUTs #
         #########################################################
@@ -329,7 +348,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(utx['txid'], dec_tx['vin'][0]['txid'])
 
         rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
-        fee = rawtxfund['fee']
         dec_tx  = self.nodes[2].decoderawtransaction(rawtxfund['hex'])
         totalOut = 0
         matchingOuts = 0
@@ -341,16 +359,16 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(matchingOuts, 2)
         assert_equal(len(dec_tx['vout']), 3)
 
+    def test_invalid_input(self):
         ##############################################
         # test a fundrawtransaction with invalid vin #
         ##############################################
         inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
         outputs = { self.nodes[0].getnewaddress() : 1.0}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
-        dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
-
         assert_raises_rpc_error(-4, "Insufficient funds", self.nodes[2].fundrawtransaction, rawtx)
 
+    def test_fee_p2pkh(self):
         ############################################################
         #compare fee of a standard pubkeyhash transaction
         inputs = []
@@ -367,6 +385,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
         ############################################################
 
+    def test_fee_p2pkh_multi_out(self):
         ############################################################
         #compare fee of a standard pubkeyhash transaction with multiple outputs
         inputs = []
@@ -382,7 +401,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
         ############################################################
 
-
+    def test_fee_p2sh(self):
         ############################################################
         #compare fee of a 2of2 multisig p2sh transaction
 
@@ -409,7 +428,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
         ############################################################
 
-
+    def test_fee_4of5(self):
         ############################################################
         #compare fee of a standard pubkeyhash transaction
 
@@ -442,7 +461,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
         ############################################################
 
-
+    def test_spend_2of2(self):
         ############################################################
         # spend a 2of2 multisig transaction over fundraw
 
@@ -457,7 +476,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
 
         # send 1.2 BTC to msig addr
-        txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
+        self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -469,7 +488,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[2].fundrawtransaction(rawtx)
 
         signedTx = self.nodes[2].signrawtransactionwithwallet(fundedTx['hex'])
-        txId = self.nodes[2].sendrawtransaction(signedTx['hex'])
+        self.nodes[2].sendrawtransaction(signedTx['hex'])
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -477,6 +496,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # make sure funds are received at node1
         assert_equal(oldBalance+Decimal('1.10000000'), self.nodes[1].getbalance())
 
+    def test_locked_wallet(self):
         ############################################################
         # locked wallet test
         self.nodes[1].encryptwallet("test")
@@ -524,14 +544,14 @@ class RawTransactionsTest(BitcoinTestFramework):
         #now we need to unlock
         self.nodes[1].walletpassphrase("test", 600)
         signedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
-        txId = self.nodes[1].sendrawtransaction(signedTx['hex'])
+        self.nodes[1].sendrawtransaction(signedTx['hex'])
         self.nodes[1].generate(1)
         self.sync_all()
 
         # make sure funds are received at node1
         assert_equal(oldBalance+Decimal('51.10000000'), self.nodes[0].getbalance())
 
-
+    def test_many_inputs_fee(self):
         ###############################################
         # multiple (~19) inputs tx test | Compare fee #
         ###############################################
@@ -561,7 +581,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance * 19  #~19 inputs
 
-
+    def test_many_inputs_send(self):
         #############################################
         # multiple (~19) inputs tx test | sign/send #
         #############################################
@@ -585,12 +605,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
         fundedAndSignedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
-        txId = self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
+        self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
         assert_equal(oldBalance+Decimal('50.19000000'), self.nodes[0].getbalance()) #0.19+block reward
 
+    def test_op_return(self):
         #####################################################
         # test fundrawtransaction with OP_RETURN and no vin #
         #####################################################
@@ -607,7 +628,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_greater_than(len(dec_tx['vin']), 0) # at least one vin
         assert_equal(len(dec_tx['vout']), 2) # one change output added
 
-
+    def test_watchonly(self):
         ##################################################
         # test a fundrawtransaction using only watchonly #
         ##################################################
@@ -624,6 +645,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert "fee" in result.keys()
         assert_greater_than(result["changepos"], -1)
 
+    def test_all_watched_funds(self):
         ###############################################################
         # test fundrawtransaction using the entirety of watched funds #
         ###############################################################
@@ -650,6 +672,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
+    def test_option_feerate(self):
         #######################
         # Test feeRate option #
         #######################
@@ -668,6 +691,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_fee_amount(result2['fee'], count_bytes(result2['hex']), 2 * result_fee_rate)
         assert_fee_amount(result3['fee'], count_bytes(result3['hex']), 10 * result_fee_rate)
 
+    def test_address_reuse(self):
         ################################
         # Test no address reuse occurs #
         ################################
@@ -684,6 +708,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # Now the change address key should be removed from the keypool
         assert changeaddress != nextaddr
 
+    def test_option_subtract_fee_from_outputs(self):
         ######################################
         # Test subtractFeeFromOutputs option #
         ######################################


### PR DESCRIPTION
This prevents scope-leak of symbols that are supposed to be local to one test case.