### PR TITLE
bench: Move generated data to a dedicated translation unit

### DIFF
--- a/build_msvc/bench_bitcoin/bench_bitcoin.vcxproj
+++ b/build_msvc/bench_bitcoin/bench_bitcoin.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="..\..\src\bench\checkqueue.cpp" />
     <ClCompile Include="..\..\src\bench\coin_selection.cpp" />
     <ClCompile Include="..\..\src\bench\crypto_hash.cpp" />
+    <ClCompile Include="..\..\src\bench\data.cpp" />
     <ClCompile Include="..\..\src\bench\examples.cpp" />
     <ClCompile Include="..\..\src\bench\lockedpool.cpp" />
     <ClCompile Include="..\..\src\bench\mempool_eviction.cpp" />
@@ -68,7 +69,7 @@
     <ItemGroup>
       <RawBenchFile Include="..\..\src\bench\data\*.raw" />
     </ItemGroup>
-    <HeaderFromHexdump RawFilePath="%(RawBenchFile.FullPath)" HeaderFilePath="%(RawBenchFile.FullPath).h" SourceHeader="static unsigned const char %(RawBenchFile.Filename)[] = {" SourceFooter="};" />
+    <HeaderFromHexdump RawFilePath="%(RawBenchFile.FullPath)" HeaderFilePath="%(RawBenchFile.FullPath).h" SourceHeader="static unsigned const char %(RawBenchFile.Filename)_raw[] = {" SourceFooter="};" />
   </Target>
   <Import Label="hexdumpTarget" Project="..\msbuild\tasks\hexdump.targets" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -18,6 +18,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/block_assemble.cpp \
   bench/checkblock.cpp \
   bench/checkqueue.cpp \
+  bench/data.h \
+  bench/data.cpp \
   bench/duplicate_inputs.cpp \
   bench/examples.cpp \
   bench/rollingbloom.cpp \
@@ -76,7 +78,7 @@ CLEAN_BITCOIN_BENCH = bench/*.gcda bench/*.gcno $(GENERATED_BENCH_FILES)
 
 CLEANFILES += $(CLEAN_BITCOIN_BENCH)
 
-bench/checkblock.cpp: bench/data/block413567.raw.h
+bench/data.cpp: bench/data/block413567.raw.h
 
 bitcoin_bench: $(BENCH_BINARY)
 
@@ -89,7 +91,7 @@ bitcoin_bench_clean : FORCE
 %.raw.h: %.raw
 	@$(MKDIR_P) $(@D)
 	@{ \
-	 echo "static unsigned const char $(*F)[] = {" && \
+	 echo "static unsigned const char $(*F)_raw[] = {" && \
 	 $(HEXDUMP) -v -e '8/1 "0x%02x, "' -e '"\n"' $< | $(SED) -e 's/0x  ,//g' && \
 	 echo "};"; \
 	} > "$@.new" && mv -f "$@.new" "$@"

--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -3,15 +3,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bench/bench.h>
+#include <bench/data.h>
 
 #include <chainparams.h>
 #include <validation.h>
 #include <streams.h>
 #include <consensus/validation.h>
-
-namespace block_bench {
-#include <bench/data/block413567.raw.h>
-} // namespace block_bench
 
 // These are the two major time-sinks which happen after we have fully received
 // a block off the wire, but before we can relay the block on to peers using
@@ -19,25 +16,21 @@ namespace block_bench {
 
 static void DeserializeBlockTest(benchmark::State& state)
 {
-    CDataStream stream((const char*)block_bench::block413567,
-            (const char*)block_bench::block413567 + sizeof(block_bench::block413567),
-            SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
     char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
     while (state.KeepRunning()) {
         CBlock block;
         stream >> block;
-        bool rewound = stream.Rewind(sizeof(block_bench::block413567));
+        bool rewound = stream.Rewind(benchmark::data::block413567.size());
         assert(rewound);
     }
 }
 
 static void DeserializeAndCheckBlockTest(benchmark::State& state)
 {
-    CDataStream stream((const char*)block_bench::block413567,
-            (const char*)block_bench::block413567 + sizeof(block_bench::block413567),
-            SER_NETWORK, PROTOCOL_VERSION);
+    CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
     char a = '\0';
     stream.write(&a, 1); // Prevent compaction
 
@@ -46,7 +39,7 @@ static void DeserializeAndCheckBlockTest(benchmark::State& state)
     while (state.KeepRunning()) {
         CBlock block; // Note that CBlock caches its checked state, so we need to recreate it here
         stream >> block;
-        bool rewound = stream.Rewind(sizeof(block_bench::block413567));
+        bool rewound = stream.Rewind(benchmark::data::block413567.size());
         assert(rewound);
 
         CValidationState validationState;

--- a/src/bench/data.cpp
+++ b/src/bench/data.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/data.h>
+
+namespace benchmark {
+namespace data {
+
+#include <bench/data/block413567.raw.h>
+const std::vector<uint8_t> block413567{block413567_raw, block413567_raw + sizeof(block413567_raw) / sizeof(block413567_raw[0])};
+
+} // namespace data
+} // namespace benchmark

--- a/src/bench/data.h
+++ b/src/bench/data.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BENCH_DATA_H
+#define BITCOIN_BENCH_DATA_H
+
+#include <cstdint>
+#include <vector>
+
+namespace benchmark {
+namespace data {
+
+extern const std::vector<uint8_t> block413567;
+
+} // namespace data
+} // namespace benchmark
+
+#endif // BITCOIN_BENCH_DATA_H


### PR DESCRIPTION
With this change multiple benchmarks can use the same data without incurring in a bigger binary.