### PR TITLE
test: Add missing syncwithvalidationinterfacequeue to wallet_balance test

### DIFF
--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -203,6 +203,8 @@ class WalletTest(BitcoinTestFramework):
         self.log.info('Put txs back into mempool of node 1 (not node 0)')
         self.nodes[0].invalidateblock(block_reorg)
         self.nodes[1].invalidateblock(block_reorg)
+        self.sync_blocks()
+        self.nodes[0].syncwithvalidationinterfacequeue()
         assert_equal(self.nodes[0].getbalance(minconf=0), 0)  # wallet txs not in the mempool are untrusted
         self.nodes[0].generatetoaddress(1, ADDRESS_WATCHONLY)
         assert_equal(self.nodes[0].getbalance(minconf=0), 0)  # wallet txs not in the mempool are untrusted


### PR DESCRIPTION
A `syncwithvalidationinterfacequeue` should be sufficient. 

Fixes  #16020