### PR TITLE
bench: Replace <wallet/crypter.h> with <keystore.h> in src/bench/ccoins_caching.cpp

### DIFF
--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -4,8 +4,8 @@
 
 #include <bench/bench.h>
 #include <coins.h>
+#include <keystore.h>
 #include <policy/policy.h>
-#include <wallet/crypter.h>
 
 #include <vector>
 


### PR DESCRIPTION
This pull request replaces the included `<wallet/crypter.h>` header  in `src/bench/ccoins_caching.cpp` with `<keystore.h>` because only the latter is required.

For context see: 
- [Bitcoin developer notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#source-code-organization):
> Every .cpp and .h file should #include every header file it directly uses classes, functions or other definitions from, even if those headers are already included indirectly through other headers.
- [SF.10 Avoid dependencies on implicitly included names](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf10-avoid-dependencies-on-implicitly-included-names)
> Avoid surprises. Avoid having to change #includes if an #included header changes. Avoid accidentally becoming dependent on implementation details and logically separate entities included in a header.
