### PR TITLE
[MSVC] allow user level project customization

### DIFF
--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -115,4 +115,5 @@
       <AdditionalDependencies>crypt32.lib;Iphlpapi.lib;ws2_32.lib;Shlwapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <Import Project="common.init.vcxproj.user" Condition="Exists('common.init.vcxproj.user')" />
 </Project>


### PR DESCRIPTION
This PR allow the user to customize the build process.

For example with the following `common.init.vcxproj.user` file
```xml
<?xml version="1.0" encoding="utf-8"?>
<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
  <PropertyGroup>
    <CLToolExe>clcache.exe</CLToolExe>
    <CLToolPath>C:\ProgramData\chocolatey\bin\</CLToolPath>
    <TrackFileAccess>false</TrackFileAccess>
  </PropertyGroup>
</Project>
```
I can use `clcache` while developing in visual studio.