### PR TITLE
refactor: small optimization for IsHex method

### DIFF
--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -59,12 +59,13 @@ signed char HexDigit(char c)
 
 bool IsHex(const std::string& str)
 {
+    if (str.size() == 0 || str.size()%2 != 0) return false;
     for(std::string::const_iterator it(str.begin()); it != str.end(); ++it)
     {
         if (HexDigit(*it) < 0)
             return false;
     }
-    return (str.size() > 0) && (str.size()%2 == 0);
+    return true;
 }
 
 bool IsHexNumber(const std::string& str)


### PR DESCRIPTION
In case the condition is `false`, every character is checked first. This operation is not necessary.

If you call the method with a truncated hex string, you will loose performance. The last check will be done, so is better to do it the first one