### PR TITLE
tests: Reduce memory usage by 0.5 GB when compiling script_tests.cpp

### DIFF
--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -483,6 +483,12 @@ std::string JSONPrettyPrint(const UniValue& univalue)
 }
 } // namespace
 
+// The gcc optimizer (as of g++ (Ubuntu 7.4.0-1ubuntu1~18.04.1)) doesn't handle script_build
+// very well: by disabling optimisations we reduce compile-time memory use by 0.5 GB (!).
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC push_options
+#pragma GCC optimize ("O0")
+#endif
 BOOST_AUTO_TEST_CASE(script_build)
 {
     const KeyData keys;
@@ -959,6 +965,9 @@ BOOST_AUTO_TEST_CASE(script_build)
     fclose(file);
 #endif
 }
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC pop_options
+#endif
 
 BOOST_AUTO_TEST_CASE(script_json_test)
 {


### PR DESCRIPTION
Reduce compile-time memory usage (max RSS) by 0.5 GB when compiling script_tests.cpp (from 1.4 GB to 0.9 GB).

Context:
* See compile-time memory consumption [wall of shame in this month's State of the Repo Report](https://github.com/bitcoin/bitcoin/issues/16298).
* TheBlueMatt's issue #6658: "Building requires >1GB memory"

Compile-time memory consumption wall of shame before this PR:

| #  | File | Max memory usage (RSS) |
| -: | :--- | ---------------------: |
| 1 | `test/test_test_bitcoin-script_tests.o` | 1416 MB |
| 2 | `wallet/libbitcoin_wallet_a-wallet.o` | 1102 MB |
| 3 | `wallet/libbitcoin_wallet_a-rpcwallet.o` | 1059 MB |
| 4 | `libbitcoin_server_a-validation.o` | 953 MB |
| 5 | `test/test_test_bitcoin-util_tests.o` | 905 MB |

Compile-time memory consumption wall of shame after this PR:

| #  | File | Max memory usage (RSS) |
| -: | :--- | ---------------------: |
| 1 | `wallet/libbitcoin_wallet_a-wallet.o` | 1102 MB |
| 2 | `wallet/libbitcoin_wallet_a-rpcwallet.o` | 1059 MB |
| 3 | `libbitcoin_server_a-validation.o` | 953 MB |
| 4 | `test/test_test_bitcoin-script_tests.o` | 948 MB |
| 5 | `test/test_test_bitcoin-util_tests.o` | 905 MB |

Before:

```
$ /usr/bin/time g++ -std=c++11 -DHAVE_CONFIG_H -I. -I../src/config -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -I. -DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC -pthread -I/usr/include -I./leveldb/include -I./leveldb/helpers/memenv -I./secp256k1/include -I./univalue/include -DBOOST_TEST_DYN_LINK -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -fstack-reuse=none -Wstack-protector -fstack-protector-all -Wall -Wextra -Wformat -Wvla -Wformat-security -Wredundant-decls -Wno-unused-parameter -Wno-implicit-fallthrough -fPIE -g -O2 -MT test/test_test_bitcoin-script_tests.o -MD -MP -MF test/.deps/test_test_bitcoin-script_tests.Tpo -c -o test/test_test_bitcoin-script_tests.o test/script_tests.cpp
32.63user 0.99system 0:33.63elapsed 99%CPU (0avgtext+0avgdata 1443460maxresident)k
0inputs+114672outputs (0major+439941minor)pagefaults 0swaps
```

After:

```
$ /usr/bin/time g++ -std=c++11 -DHAVE_CONFIG_H -I. -I../src/config -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -I. -DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC -pthread -I/usr/include -I./leveldb/include -I./leveldb/helpers/memenv -I./secp256k1/include -I./univalue/include -DBOOST_TEST_DYN_LINK -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -fstack-reuse=none -Wstack-protector -fstack-protector-all -Wall -Wextra -Wformat -Wvla -Wformat-security -Wredundant-decls -Wno-unused-parameter -Wno-implicit-fallthrough -fPIE -g -O2 -MT test/test_test_bitcoin-script_tests.o -MD -MP -MF test/.deps/test_test_bitcoin-script_tests.Tpo -c -o test/test_test_bitcoin-script_tests.o test/script_tests.cpp
28.86user 0.95system 0:36.14elapsed 82%CPU (0avgtext+0avgdata 947984maxresident)k
0inputs+66112outputs (0major+285149minor)pagefaults 0swaps
```