### PR TITLE
doc: Fix broken link in doc/build-osx.md

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -112,7 +112,7 @@ tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
 ## Notes
 * Tested on OS X 10.10 Yosemite through macOS 10.14 Mojave on 64-bit Intel
 processors only.
-* Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/issues/7714)
+* Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714).
 
 ## Deterministic macOS DMG Notes
 Working macOS DMGs are created in Linux by combining a recent `clang`, the Apple


### PR DESCRIPTION
This fixes the regression in PR #15964 as noted here:

https://github.com/bitcoin/bitcoin/pull/15964/files#r298798933
