### PR TITLE
scripts and tools: Update copyright_header.py script

### DIFF
--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -97,7 +97,6 @@ EXPECTED_HOLDER_NAMES = [
     "Wladimir J. van der Laan\n",
     "Jeff Garzik\n",
     "Jan-Klaas Kollhof\n",
-    "Sam Rushing\n",
     "ArtForz -- public domain half-a-node\n",
     "Intel Corporation",
     "The Zcash developers",

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -34,7 +34,7 @@ EXCLUDE_DIRS = [
     "src/univalue/",
 ]
 
-INCLUDE = ['*.h', '*.cpp', '*.cc', '*.c', '*.py']
+INCLUDE = ['*.h', '*.cpp', '*.cc', '*.c', '*.mm', '*.py']
 INCLUDE_COMPILED = re.compile('|'.join([fnmatch.translate(m) for m in INCLUDE]))
 
 def applies_to_file(filename):

--- a/contrib/devtools/copyright_header.py
+++ b/contrib/devtools/copyright_header.py
@@ -90,7 +90,6 @@ def compile_copyright_regex(copyright_style, year_style, name):
 EXPECTED_HOLDER_NAMES = [
     "Satoshi Nakamoto\n",
     "The Bitcoin Core developers\n",
-    "Bitcoin Core Developers\n",
     "BitPay Inc\.\n",
     "University of Illinois at Urbana-Champaign\.\n",
     "Pieter Wuille\n",

--- a/contrib/devtools/github-merge.py
+++ b/contrib/devtools/github-merge.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2016-2017 Bitcoin Core Developers
+# Copyright (c) 2016-2017 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -411,4 +411,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
Now the `copyright_header.py` script handles Objective-C source files `*.mm`:
```
src/qt/macdockiconhandler.mm
src/qt/macnotificationhandler.mm
src/qt/macos_appnap.mm
```

Also the only occurrence of `Bitcoin Core Developers` replaced with ubiquitous `The Bitcoin Core developers`.

EDITED:
The reason to remove "Sam Rushing" is (on master):
```
$ git grep "Sam Rushing"
contrib/devtools/copyright_header.py:    "Sam Rushing\n",
```