### PR TITLE
Get cs_main out of the critical path in ProcessMessages

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1635,6 +1635,8 @@ bool AppInitMain(InitInterfaces& interfaces)
         return false;
     }
 
+    threadGroup.create_thread(std::bind(&TraceThread<std::function<void()>>, "blockconn", std::function<void()>(std::bind(&CChainState::ProcessBlockValidationQueue, &ChainstateActive()))));
+
     fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fsbridge::fopen(est_path, "rb"), SER_DISK, CLIENT_VERSION);
     // Allowed to fail as this file IS missing on first startup.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1324,6 +1324,14 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const CValidationSta
     ::BlockChecked(block, state, connman);
 }
 
+/**
+ * Wake up message handler once a block has been processed to process the
+ * next message from the peer that sent us that block.
+ */
+void PeerLogicValidation::BlockProcessed() {
+    connman->WakeMessageHandler();
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Messages

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2932,12 +2932,7 @@ bool static ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::strin
         }
 
         PartiallyDownloadedBlock& partialBlock = *it->second.second->partialBlock;
-        ReadStatus status;
-        {
-            // FillBlock calls CheckBlock, which requires cs_main
-            LOCK(cs_main);
-            status = partialBlock.FillBlock(*pblock, resp.txn);
-        }
+        ReadStatus status = partialBlock.FillBlock(*pblock, resp.txn);
         if (status == READ_STATUS_INVALID) {
             MarkBlockAsReceived(resp.blockhash); // Reset in-flight state in case of whitelist
             Misbehaving(pfrom->GetId(), 100, strprintf("Peer %d sent us invalid compact block/non-matching block transactions\n", pfrom->GetId()));

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -13,6 +13,9 @@
 
 extern CCriticalSection cs_main;
 
+/** Note that this must be locked BEFORE cs_main! */
+extern CCriticalSection cs_peerstate ACQUIRED_BEFORE(cs_main);
+
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
@@ -26,7 +29,7 @@ private:
     CConnman* const connman;
     BanMan* const m_banman;
 
-    bool SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool SendRejectsAndCheckIfBanned(CNode* pnode, bool enable_bip61) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate);
 public:
     PeerLogicValidation(CConnman* connman, BanMan* banman, CScheduler &scheduler, bool enable_bip61);
 

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -46,6 +46,10 @@ public:
      * Overridden from CValidationInterface.
      */
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
+    /**
+     * Overridden from CValidationInterface.
+     */
+    void BlockProcessed() override;
 
     /** Initialize a peer by adding it to mapNodeState and pushing a message requesting its version */
     void InitializeNode(CNode* pnode) override;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -76,6 +76,7 @@ public:
     std::vector<CTransactionRef> vtx;
 
     // memory only
+    // protected by a lock inside CheckBlock, do not access elsewhere!
     mutable bool fChecked;
 
     CBlock()

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -132,7 +132,8 @@ static UniValue generateBlocks(const CScript& coinbase_script, int nGenerate, ui
             continue;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))
+        CValidationState state;
+        if (!ProcessNewBlock(Params(), shared_pblock, state, true, nullptr) || !state.IsValid())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
         blockHashes.push_back(pblock->GetHash().GetHex());
@@ -733,15 +734,20 @@ static UniValue submitblock(const JSONRPCRequest& request)
     bool new_block;
     submitblock_StateCatcher sc(block.GetHash());
     RegisterValidationInterface(&sc);
-    bool accepted = ProcessNewBlock(Params(), blockptr, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
+    CValidationState dos_state;
+    bool accepted = ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
     UnregisterValidationInterface(&sc);
     if (!new_block && accepted) {
         return "duplicate";
     }
-    if (!sc.found) {
+    if (!sc.found && dos_state.IsValid()) {
         return "inconclusive";
     }
-    return BIP22ValidationResult(sc.state);
+    if (dos_state.IsValid()) {
+        return BIP22ValidationResult(sc.state);
+    } else {
+        return BIP22ValidationResult(dos_state);
+    }
 }
 
 static UniValue submitheader(const JSONRPCRequest& request)

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -736,6 +736,7 @@ static UniValue submitblock(const JSONRPCRequest& request)
     RegisterValidationInterface(&sc);
     CValidationState dos_state;
     bool new_block = ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true).get();
+    SyncWithValidationInterfaceQueue();
     UnregisterValidationInterface(&sc);
     if (!new_block && dos_state.IsValid()) {
         return "duplicate";

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -176,7 +176,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+        CValidationState dos_state;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
 
         const CBlockIndex* block_index;
         {
@@ -192,7 +194,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+        CValidationState dos_state;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
 
         const CBlockIndex* block_index;
         {
@@ -219,10 +223,12 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     }
 
     // Reorg back to chain A.
-     for (size_t i = 2; i < 4; i++) {
-         const auto& block = chainA[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
-     }
+    for (size_t i = 2; i < 4; i++) {
+        const auto& block = chainA[i];
+        CValidationState dos_state;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
+    }
 
      // Check that chain A and B blocks can be retrieved.
      chainA_last_header = last_header;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -177,7 +177,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
         CValidationState dos_state;
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        ProcessNewBlock(Params(), block, dos_state, true).wait();
         BOOST_REQUIRE(dos_state.IsValid());
 
         const CBlockIndex* block_index;
@@ -195,7 +195,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
         CValidationState dos_state;
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        ProcessNewBlock(Params(), block, dos_state, true).wait();
         BOOST_REQUIRE(dos_state.IsValid());
 
         const CBlockIndex* block_index;
@@ -226,7 +226,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, TestChain100Setup)
     for (size_t i = 2; i < 4; i++) {
         const auto& block = chainA[i];
         CValidationState dos_state;
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        ProcessNewBlock(Params(), block, dos_state, true).wait();
         BOOST_REQUIRE(dos_state.IsValid());
     }
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -98,11 +98,11 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 
     // Test starts here
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
         dummyNode1.vSendMsg.clear();
     }
@@ -111,17 +111,17 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Wait 21 minutes
     SetMockTime(nStartTime+21*60);
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
     }
     // Wait 3 more minutes
     SetMockTime(nStartTime+24*60);
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in disconnect
     }
     BOOST_CHECK(dummyNode1.fDisconnect == true);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
-        LOCK2(cs_main, dummyNode2.cs_sendProcessing);
+        LOCK(dummyNode2.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(!banman->IsBanned(addr2)); // 2 not banned yet...
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
-        LOCK2(cs_main, dummyNode2.cs_sendProcessing);
+        LOCK(dummyNode2.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(banman->IsBanned(addr2));
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 100);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 10);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 1);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
         Misbehaving(dummyNode.GetId(), 100);
     }
     {
-        LOCK2(cs_main, dummyNode.cs_sendProcessing);
+        LOCK(dummyNode.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
     }
     BOOST_CHECK(banman->IsBanned(addr));

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -45,6 +45,7 @@ extern bool AddOrphanTx(const CTransactionRef& tx, NodeId peer);
 extern void EraseOrphansFor(NodeId peer);
 extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans);
 extern void Misbehaving(NodeId nodeid, int howmuch, const std::string& message="");
+extern CCriticalSection cs_peerstate ACQUIRED_BEFORE(cs_main);
 
 struct COrphanTx {
     CTransactionRef tx;
@@ -231,7 +232,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     dummyNode1.nVersion = 1;
     dummyNode1.fSuccessfullyConnected = true;
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     }
     {
@@ -248,7 +249,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     dummyNode2.nVersion = 1;
     dummyNode2.fSuccessfullyConnected = true;
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
@@ -258,7 +259,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(!banman->IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(banman->IsBanned(addr1));  // ... but 1 still should be
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
@@ -287,7 +288,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     dummyNode1.nVersion = 1;
     dummyNode1.fSuccessfullyConnected = true;
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode1.GetId(), 100);
     }
     {
@@ -296,7 +297,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode1.GetId(), 10);
     }
     {
@@ -305,7 +306,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode1.GetId(), 1);
     }
     {
@@ -337,7 +338,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     dummyNode.fSuccessfullyConnected = true;
 
     {
-        LOCK(cs_main);
+        LOCK(cs_peerstate);
         Misbehaving(dummyNode.GetId(), 100);
     }
     {
@@ -359,7 +360,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 static CTransactionRef RandomOrphan()
 {
     std::map<uint256, COrphanTx>::iterator it;
-    LOCK2(cs_main, g_cs_orphans);
+    LOCK(g_cs_orphans);
     it = mapOrphanTransactions.lower_bound(InsecureRand256());
     if (it == mapOrphanTransactions.end())
         it = mapOrphanTransactions.begin();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
+#include <consensus/validation.h>
 #include <miner.h>
 #include <policy/policy.h>
 #include <script/standard.h>
@@ -247,7 +248,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        CValidationState dos_state;
+        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
+        BOOST_CHECK(dos_state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         CValidationState dos_state;
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
+        ProcessNewBlock(chainparams, shared_pblock, dos_state, true).wait();
         BOOST_CHECK(dos_state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -165,7 +165,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     CValidationState dos_state;
-    ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr);
+    ProcessNewBlock(chainparams, shared_pblock, dos_state, true).wait();
 
     CBlock result = block;
     return result;

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -164,7 +164,8 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    CValidationState dos_state;
+    ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr);
 
     CBlock result = block;
     return result;

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -71,9 +71,6 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     // shutdown sequence (c.f. Shutdown() in init.cpp)
     txindex.Stop();
 
-    threadGroup.interrupt_all();
-    threadGroup.join_all();
-
     // Rest of shutdown sequence and destructors happen in ~TestingSetup()
 }
 

--- a/src/test/util.cpp
+++ b/src/test/util.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <consensus/validation.h>
 #include <key_io.h>
 #include <miner.h>
 #include <outputtype.h>
@@ -61,8 +62,10 @@ CTxIn MineBlock(const CScript& coinbase_scriptPubKey)
         assert(block->nNonce);
     }
 
-    bool processed{ProcessNewBlock(Params(), block, true, nullptr)};
+    CValidationState dos_state;
+    bool processed{ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
     assert(processed);
+    assert(dos_state.IsValid());
 
     return CTxIn{block->vtx[0]->GetHash(), 0};
 }

--- a/src/test/util.cpp
+++ b/src/test/util.cpp
@@ -63,8 +63,7 @@ CTxIn MineBlock(const CScript& coinbase_scriptPubKey)
     }
 
     CValidationState dos_state;
-    bool processed{ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
-    assert(processed);
+    ProcessNewBlock(Params(), block, dos_state, true).wait();
     assert(dos_state.IsValid());
 
     return CTxIn{block->vtx[0]->GetHash(), 0};

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -159,7 +159,8 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     BOOST_CHECK(ProcessNewBlockHeaders(headers, state, Params()));
 
     // Connect the genesis block and drain any outstanding events
-    BOOST_CHECK(ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), true, &ignored));
+    CValidationState dos_state;
+    BOOST_CHECK(ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), dos_state, true, &ignored));
     SyncWithValidationInterfaceQueue();
 
     // subscribe to events (this subscriber will validate event ordering)
@@ -181,14 +182,17 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
             FastRandomContext insecure;
             for (int i = 0; i < 1000; i++) {
                 auto block = blocks[insecure.randrange(blocks.size() - 1)];
-                ProcessNewBlock(Params(), block, true, &ignored);
+                CValidationState dos_state;
+                ProcessNewBlock(Params(), block, dos_state, true, &ignored);
             }
 
             // to make sure that eventually we process the full chain - do it here
             for (auto block : blocks) {
                 if (block->vtx.size() == 1) {
-                    bool processed = ProcessNewBlock(Params(), block, true, &ignored);
+                    CValidationState dos_state;
+                    bool processed = ProcessNewBlock(Params(), block, dos_state, true, &ignored);
                     assert(processed);
+                    assert(dos_state.IsValid());
                 }
             }
         });
@@ -228,7 +232,8 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
 {
     bool ignored;
     auto ProcessBlock = [&ignored](std::shared_ptr<const CBlock> block) -> bool {
-        return ProcessNewBlock(Params(), block, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
+        CValidationState dos_state;
+        return ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
     };
 
     // Process all mined blocks

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3507,7 +3507,54 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     return true;
 }
 
-std::future<bool> ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing)
+void CChainState::AwaitBlockValidationParked()
+{
+    std::unique_lock<CCriticalSection> lock(m_cs_block_validation_queue);
+    m_cv_block_validation_parked.wait(lock, [this] { return m_block_validation_parked; });
+}
+
+void CChainState::ProcessBlockValidationQueue()
+{
+    while (true) {
+        std::shared_ptr<const CBlock> pblock;
+        bool fForceProcessing;
+        std::promise<bool> result_promise;
+        {
+            std::unique_lock<CCriticalSection> lock(m_cs_block_validation_queue);
+            if (m_block_validation_queue.empty()) {
+                m_block_validation_parked = true;
+                m_cv_block_validation_parked.notify_all();
+                m_cv_block_validation_queue.wait_for(lock, std::chrono::milliseconds(100));
+                m_block_validation_parked = false;
+            }
+            if (ShutdownRequested())
+                break;
+            boost::this_thread::interruption_point();
+            if (m_block_validation_queue.empty()) {
+                continue;
+            }
+
+            std::tuple<std::shared_ptr<const CBlock>, bool, std::promise<bool>>& tuple = m_block_validation_queue.front();
+            pblock = std::move(std::get<0>(tuple));
+            fForceProcessing = std::get<1>(tuple);
+            result_promise = std::move(std::get<2>(tuple));
+            m_block_validation_queue.pop_front();
+        }
+
+        CChainParams chainparams = Params();
+
+        NotifyHeaderTip();
+
+        CValidationState state; // Only used to report errors, not invalidity - ignore it
+        if (!::ChainstateActive().ActivateBestChain(state, chainparams, pblock))
+            error("%s: ActivateBestChain failed (%s)", __func__, FormatStateMessage(state));
+
+        result_promise.set_value(true);
+        LimitValidationInterfaceQueue();
+    }
+}
+
+std::future<bool> CChainState::ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing)
 {
     AssertLockNotHeld(cs_main);
 
@@ -3529,22 +3576,26 @@ std::future<bool> ProcessNewBlock(const CChainParams& chainparams, const std::sh
             // Store to disk
             ret = ::ChainstateActive().AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, &fNewBlock);
         }
-        if (!ret) {
-            error("%s: AcceptBlock FAILED (%s)", __func__, FormatStateMessage(state));
+        if (!ret || !fNewBlock) {
+            if (!ret) {
+                error("%s: AcceptBlock FAILED (%s)", __func__, FormatStateMessage(state));
+            }
             result_promise.set_value(fNewBlock);
             return result;
         }
     }
 
-    result_promise.set_value(fNewBlock);
-
-    NotifyHeaderTip();
-
-    CValidationState dummy_state; // Only used to report errors, not invalidity - ignore it
-    if (!::ChainstateActive().ActivateBestChain(dummy_state, chainparams, pblock))
-        error("%s: ActivateBestChain failed (%s)", __func__, FormatStateMessage(state));
-
+    {
+        LOCK(m_cs_block_validation_queue);
+        m_block_validation_queue.emplace_back(std::move(pblock), fForceProcessing, std::move(result_promise));
+    }
+    m_cv_block_validation_queue.notify_one();
     return result;
+}
+
+std::future<bool> ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing)
+{
+    return ::ChainstateActive().ProcessNewBlock(chainparams, pblock, state, fForceProcessing);
 }
 
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2365,7 +2365,7 @@ bool CChainState::ConnectTip(CValidationState& state, const CChainParams& chainp
     {
         CCoinsViewCache view(&CoinsTip());
         bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, chainparams);
-        GetMainSignals().BlockChecked(blockConnecting, state);
+        GetMainSignals().BlockChecked(pthisBlock, state);
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3507,13 +3507,16 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CVali
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing, bool *fNewBlock)
+std::future<bool> ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing)
 {
     AssertLockNotHeld(cs_main);
 
+    std::promise<bool> result_promise;
+    std::future<bool> result = result_promise.get_future();
+    bool fNewBlock = false;
+
     {
         CBlockIndex *pindex = nullptr;
-        if (fNewBlock) *fNewBlock = false;
 
         // CheckBlock() does not support multi-threaded block validation because CBlock::fChecked can cause data race.
         // Therefore, the following critical section must include the CheckBlock() call as well.
@@ -3524,20 +3527,24 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
         bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus());
         if (ret) {
             // Store to disk
-            ret = ::ChainstateActive().AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
+            ret = ::ChainstateActive().AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, &fNewBlock);
         }
         if (!ret) {
-            return error("%s: AcceptBlock FAILED (%s)", __func__, FormatStateMessage(state));
+            error("%s: AcceptBlock FAILED (%s)", __func__, FormatStateMessage(state));
+            result_promise.set_value(fNewBlock);
+            return result;
         }
     }
+
+    result_promise.set_value(fNewBlock);
 
     NotifyHeaderTip();
 
     CValidationState dummy_state; // Only used to report errors, not invalidity - ignore it
     if (!::ChainstateActive().ActivateBestChain(dummy_state, chainparams, pblock))
-        return error("%s: ActivateBestChain failed (%s)", __func__, FormatStateMessage(state));
+        error("%s: ActivateBestChain failed (%s)", __func__, FormatStateMessage(state));
 
-    return true;
+    return result;
 }
 
 bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3550,6 +3550,7 @@ void CChainState::ProcessBlockValidationQueue()
             error("%s: ActivateBestChain failed (%s)", __func__, FormatStateMessage(state));
 
         result_promise.set_value(true);
+        GetMainSignals().BlockProcessed();
         LimitValidationInterfaceQueue();
     }
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -613,6 +613,22 @@ private:
     /** Indicates the block validation thread is parked */
     bool m_block_validation_parked;
 
+    /**
+     * Utility function to check if it makes sense to write the given block to
+     * disk right now.
+     * Checks whether we already had/have the block and whether it meets DoS
+     * criteria.
+     */
+    bool ShouldMaybeWrite(CBlockIndex* pindex, bool fRequested) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Performs initial DoS checks for the given block (assuming ShouldMaybeWrite
+     * passes).
+     * Will detect any cases of malleability, ie if this passes, pblock is a
+     * "good" copy of the block.
+     */
+    bool PreWriteCheckBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, bool* fShouldWrite) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 public:
     CChainState(BlockManager& blockman) : m_blockman(blockman) {}
     CChainState();

--- a/src/validation.h
+++ b/src/validation.h
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include <atomic>
 #include <exception>
+#include <future>
 #include <map>
 #include <memory>
 #include <set>
@@ -210,19 +211,22 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  * If pblock connects, and has been mutation, state is guaranteed to be some
  * non-IsValid() state.
  *
- * If fForceProcessing is set (or fNewBlock returns true), barring pruning and
+ * If fForceProcessing is set (or the future returns true), barring pruning and
  * a desire to re-download a pruned block, if state.IsValid(), there should
  * never be any reason to re-ProcessNewBlock any block with the same hash.
  *
  * May not be called in a validationinterface callback.
  *
+ * Do NOT block on the returned future waiting for it to resolve as this may
+ * introduce deadlocks (in the case you are holding any mutexes which are
+ * also taken in validationinterface callbacks).
+ *
  * @param[in]   pblock  The block we want to process.
  * @param[out] state This may be set to an Error state if any error occurred processing them
  * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
- * @return True if state.IsValid()
+ * @return      A future which complets with a boolean which is set to indicate if the block was first received via this call
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+std::future<bool> ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing) LOCKS_EXCLUDED(cs_main);
 
 /**
  * Process incoming block headers.

--- a/src/validation.h
+++ b/src/validation.h
@@ -198,22 +198,31 @@ static const uint64_t MIN_DISK_SPACE_FOR_BLOCK_FILES = 550 * 1024 * 1024;
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
  *
- * If you want to *possibly* get feedback on whether pblock is valid, you must
- * install a CValidationInterface (see validationinterface.h) - this will have
- * its BlockChecked method called whenever *any* block completes validation.
+ * Performs initial sanity checks using the provided CValidationState before
+ * connecting any block(s). If you want to *possibly* get feedback on whether
+ * pblock is valid beyond just cursory mutation/DoS checks, you must install
+ * a CValidationInterface (see validationinterface.h) - this will have its
+ * BlockChecked method called whenever *any* block completes validation (note
+ * that any invalidity returned via state will *not* also be provided via
+ * BlockChecked). There is, of course, no guarantee that any given block which
+ * is not a part of the eventual best chain will ever be checked.
  *
- * Note that we guarantee that either the proof-of-work is valid on pblock, or
- * (and possibly also) BlockChecked will have been called.
+ * If pblock connects, and has been mutation, state is guaranteed to be some
+ * non-IsValid() state.
  *
- * May not be called in a
- * validationinterface callback.
+ * If fForceProcessing is set (or fNewBlock returns true), barring pruning and
+ * a desire to re-download a pruned block, if state.IsValid(), there should
+ * never be any reason to re-ProcessNewBlock any block with the same hash.
+ *
+ * May not be called in a validationinterface callback.
  *
  * @param[in]   pblock  The block we want to process.
+ * @param[out] state This may be set to an Error state if any error occurred processing them
  * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
  * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
  * @return True if state.IsValid()
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, CValidationState& state, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
 
 /**
  * Process incoming block headers.

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -5,6 +5,7 @@
 
 #include <validationinterface.h>
 
+#include <consensus/validation.h>
 #include <primitives/block.h>
 #include <scheduler.h>
 #include <txmempool.h>
@@ -173,8 +174,10 @@ void CMainSignals::ChainStateFlushed(const CBlockLocator &locator) {
     });
 }
 
-void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& state) {
-    m_internals->BlockChecked(block, state);
+void CMainSignals::BlockChecked(const std::shared_ptr<const CBlock> &pblock, const CValidationState& state) {
+    m_internals->m_schedulerClient.AddToProcessQueue([pblock, state, this] {
+        m_internals->BlockChecked(*pblock, state);
+    });
 }
 
 void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -137,6 +137,8 @@ protected:
      * If the provided CValidationState IsValid, the provided block
      * is guaranteed to be the current best block at the time the
      * callback was generated (not necessarily now)
+     *
+     * Called on a background thread.
      */
     virtual void BlockChecked(const CBlock&, const CValidationState&) {}
     /**
@@ -186,7 +188,7 @@ public:
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex, const std::shared_ptr<const std::vector<CTransactionRef>> &);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &);
     void ChainStateFlushed(const CBlockLocator &);
-    void BlockChecked(const CBlock&, const CValidationState&);
+    void BlockChecked(const std::shared_ptr<const CBlock> &block, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
     void BlockProcessed();
 };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -143,6 +143,12 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    /**
+     * Notifies listeners that a block which was submitted has been fully processed.
+     *
+     * Called on a background thread.
+     */
+    virtual void BlockProcessed() {}
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -182,6 +188,7 @@ public:
     void ChainStateFlushed(const CBlockLocator &);
     void BlockChecked(const CBlock&, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void BlockProcessed();
 };
 
 CMainSignals& GetMainSignals();


### PR DESCRIPTION
Built on #16323, this takes one next step on the first future-work bullet point listed there - we now do not immediately wait on cs_main after returning from ProcessMessage and can (maybe) get to another peer before blocking ProcessMessage waiting on ActivateBestChain to finish in the background. <strike>Sadly this isn't expected to result in a material performance improvement on IBD until the next ProcessNewBlock calls' CheckBlock can begin running without waiting on cs_main, which is not yet the case.</strike>

Further, this now moves CBlock::fChecked out of cs_main, making CheckBlock parallel.