### PR TITLE
scripts and tools: Update ShellCheck linter

### DIFF
--- a/.travis/lint_06_script.sh
+++ b/.travis/lint_06_script.sh
@@ -18,7 +18,7 @@ test/lint/check-doc.py
 test/lint/check-rpc-mappings.py .
 test/lint/lint-all.sh
 
-if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" -a "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" ] && [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
     travis_retry gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $(<contrib/verify-commits/trusted-keys) &&
     ./contrib/verify-commits/verify-commits.py --clean-merge=2;

--- a/.travis/test_05_before_script.sh
+++ b/.travis/test_05_before_script.sh
@@ -10,10 +10,10 @@ DOCKER_EXEC echo \> \$HOME/.bitcoin  # Make sure default datadir does not exist 
 
 mkdir -p depends/SDKs depends/sdk-sources
 
-if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
+if [ -n "$OSX_SDK" ] && [ ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
   curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
 fi
-if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
+if [ -n "$OSX_SDK" ] && [ -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
   tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
 fi
 if [[ $HOST = *-mingw32 ]]; then
@@ -22,4 +22,3 @@ fi
 if [ -z "$NO_DEPENDS" ]; then
   DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
 fi
-

--- a/autogen.sh
+++ b/autogen.sh
@@ -7,10 +7,10 @@ export LC_ALL=C
 set -e
 srcdir="$(dirname $0)"
 cd "$srcdir"
-if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="`which glibtoolize 2>/dev/null`"; then
+if [ -z ${LIBTOOLIZE} ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
   LIBTOOLIZE="${GLIBTOOLIZE}"
   export LIBTOOLIZE
 fi
-which autoreconf >/dev/null || \
+command -v autoreconf >/dev/null || \
   (echo "configuration failed, please install autoconf first" && exit 1)
 autoreconf --install --force --warnings=all

--- a/contrib/devtools/gen-manpages.sh
+++ b/contrib/devtools/gen-manpages.sh
@@ -16,7 +16,7 @@ BITCOINQT=${BITCOINQT:-$BINDIR/qt/bitcoin-qt}
 [ ! -x $BITCOIND ] && echo "$BITCOIND not found or not executable." && exit 1
 
 # The autodetected version git tag can screw up manpage output a little bit
-BTCVER=($($BITCOINCLI --version | head -n1 | awk -F'[ -]' '{ print $6, $7 }'))
+read -r -a BTCVER <<< "$($BITCOINCLI --version | head -n1 | awk -F'[ -]' '{ print $6, $7 }')"
 
 # Create a footer file with copyright content.
 # This gets autodetected fine for bitcoind if --version-string is not set,

--- a/contrib/install_db4.sh
+++ b/contrib/install_db4.sh
@@ -14,7 +14,7 @@ if [ -z "${1}" ]; then
 fi
 
 expand_path() {
-  echo "$(cd "${1}" && pwd -P)"
+  cd "${1}" && pwd -P
 }
 
 BDB_PREFIX="$(expand_path ${1})/db4"; shift;
@@ -23,7 +23,7 @@ BDB_HASH='12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef'
 BDB_URL="https://download.oracle.com/berkeley-db/${BDB_VERSION}.tar.gz"
 
 check_exists() {
-  which "$1" >/dev/null 2>&1
+  command -v "$1" >/dev/null
 }
 
 sha256_check() {
@@ -95,7 +95,9 @@ make install
 echo
 echo "db4 build complete."
 echo
+# shellcheck disable=SC2016
 echo 'When compiling bitcoind, run `./configure` in the following way:'
 echo
 echo "  export BDB_PREFIX='${BDB_PREFIX}'"
+# shellcheck disable=SC2016
 echo '  ./configure BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include" ...'

--- a/contrib/macdeploy/detached-sig-apply.sh
+++ b/contrib/macdeploy/detached-sig-apply.sh
@@ -36,13 +36,13 @@ if [ -z "${CODESIGN_ALLOCATE}" ]; then
 fi
 
 find ${TEMPDIR} -name "*.sign" | while read i; do
-  SIZE=`stat -c %s "${i}"`
-  TARGET_FILE="`echo "${i}" | sed 's/\.sign$//'`"
+  SIZE=$(stat -c %s "${i}")
+  TARGET_FILE="$(echo "${i}" | sed 's/\.sign$//')"
 
   echo "Allocating space for the signature of size ${SIZE} in ${TARGET_FILE}"
   ${CODESIGN_ALLOCATE} -i "${TARGET_FILE}" -a ${ARCH} ${SIZE} -o "${i}.tmp"
 
-  OFFSET=`${PAGESTUFF} "${i}.tmp" -p | tail -2 | grep offset | sed 's/[^0-9]*//g'`
+  OFFSET=$(${PAGESTUFF} "${i}.tmp" -p | tail -2 | grep offset | sed 's/[^0-9]*//g')
   if [ -z ${QUIET} ]; then
     echo "Attaching signature at offset ${OFFSET}"
   fi

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -14,7 +14,7 @@ TEMPLIST=${TEMPDIR}/signatures.txt
 OUT=signature-osx.tar.gz
 OUTROOT=osx
 
-if [ ! -n "$1" ]; then
+if [ -z "$1" ]; then
   echo "usage: $0 <codesign args>"
   echo "example: $0 -s MyIdentity"
   exit 1
@@ -26,20 +26,20 @@ mkdir -p ${TEMPDIR}
 ${CODESIGN} -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
 
 grep -v CodeResources < "${TEMPLIST}" | while read i; do
-  TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"
-  SIZE=`pagestuff "$i" -p | tail -2 | grep size | sed 's/[^0-9]*//g'`
-  OFFSET=`pagestuff "$i" -p | tail -2 | grep offset | sed 's/[^0-9]*//g'`
+  TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"
+  SIZE=$(pagestuff "$i" -p | tail -2 | grep size | sed 's/[^0-9]*//g')
+  OFFSET=$(pagestuff "$i" -p | tail -2 | grep offset | sed 's/[^0-9]*//g')
   SIGNFILE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}.sign"
-  DIRNAME="`dirname "${SIGNFILE}"`"
+  DIRNAME="$(dirname "${SIGNFILE}")"
   mkdir -p "${DIRNAME}"
   echo "Adding detached signature for: ${TARGETFILE}. Size: ${SIZE}. Offset: ${OFFSET}"
   dd if="$i" of="${SIGNFILE}" bs=1 skip=${OFFSET} count=${SIZE} 2>/dev/null
 done
 
 grep CodeResources < "${TEMPLIST}" | while read i; do
-  TARGETFILE="${BUNDLE}/`echo "${i}" | sed "s|.*${BUNDLE}/||"`"
+  TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"
   RESOURCE="${TEMPDIR}/${OUTROOT}/${TARGETFILE}"
-  DIRNAME="`dirname "${RESOURCE}"`"
+  DIRNAME="$(dirname "${RESOURCE}")"
   mkdir -p "${DIRNAME}"
   echo "Adding resource for: \"${TARGETFILE}\""
   cp "${i}" "${RESOURCE}"

--- a/contrib/qos/tc.sh
+++ b/contrib/qos/tc.sh
@@ -33,7 +33,7 @@ tc class add dev ${IF} parent 1:1 classid 1:11 htb rate ${LIMIT} ceil ${LIMIT} p
 tc filter add dev ${IF} parent 1: protocol ip prio 1 handle 1 fw classid 1:10
 tc filter add dev ${IF} parent 1: protocol ip prio 2 handle 2 fw classid 1:11
 
-if [ ! -z "${LOCALNET_V6}" ] ; then
+if [ -n "${LOCALNET_V6}" ] ; then
 	# v6 cannot have the same priority value as v4
 	tc filter add dev ${IF} parent 1: protocol ipv6 prio 3 handle 1 fw classid 1:10
 	tc filter add dev ${IF} parent 1: protocol ipv6 prio 4 handle 2 fw classid 1:11
@@ -56,7 +56,7 @@ fi
 iptables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
 iptables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V4} -j MARK --set-mark 0x2
 
-if [ ! -z "${LOCALNET_V6}" ] ; then
+if [ -n "${LOCALNET_V6}" ] ; then
 	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --dport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
 	ip6tables -t mangle -A OUTPUT -p tcp -m tcp --sport 8333 ! -d ${LOCALNET_V6} -j MARK --set-mark 0x4
 fi

--- a/contrib/verify-commits/gpg.sh
+++ b/contrib/verify-commits/gpg.sh
@@ -21,7 +21,7 @@ else
 	# they've created a collision for. Not the most likely attack, but preventing
 	# it is pretty easy so we do so as a "belt-and-suspenders" measure.
 	GPG_RES=""
-	for LINE in "$(gpg --version)"; do
+	for LINE in $(gpg --version); do
 		case "$LINE" in
 			"gpg (GnuPG) 1.4.1"*|"gpg (GnuPG) 2.0."*)
 				echo "Please upgrade to at least gpg 2.1.10 to check for weak signatures" > /dev/stderr
@@ -35,7 +35,7 @@ else
 	done
 	[ "$GPG_RES" = "" ] && GPG_RES="$(printf '%s\n' "$INPUT" | gpg --trust-model always --weak-digest sha1 "$@" 2>/dev/null)"
 fi
-for LINE in $(echo "$GPG_RES"); do
+for LINE in $GPG_RES; do
 	case "$LINE" in
 	"[GNUPG:] VALIDSIG "*)
 		while read KEY; do

--- a/contrib/verifybinaries/verify.sh
+++ b/contrib/verifybinaries/verify.sh
@@ -13,7 +13,7 @@
 
 export LC_ALL=C
 function clean_up {
-   for file in $*
+   for file in "$@"
    do
       rm "$file" 2> /dev/null
    done
@@ -82,22 +82,20 @@ else
    exit 2
 fi
 
-#first we fetch the file containing the signature
-WGETOUT=$(wget -N "$HOST1$BASEDIR$SIGNATUREFILENAME" 2>&1)
-
-#and then see if wget completed successfully
-if [ $? -ne 0 ]; then
+if ! WGETOUT=$(wget -N "$HOST1$BASEDIR$SIGNATUREFILENAME" 2>&1); then
    echo "Error: couldn't fetch signature file. Have you specified the version number in the following format?"
+   # shellcheck disable=SC1087
    echo "[$VERSIONPREFIX]<version>-[$RCVERSIONSTRING[0-9]] (example: ${VERSIONPREFIX}0.10.4-${RCVERSIONSTRING}1)"
    echo "wget output:"
+   # shellcheck disable=SC2001
    echo "$WGETOUT"|sed 's/^/\t/g'
    exit 2
 fi
 
-WGETOUT=$(wget -N -O "$SIGNATUREFILENAME.2" "$HOST2$BASEDIR$SIGNATUREFILENAME" 2>&1)
-if [ $? -ne 0 ]; then
+if ! WGETOUT=$(wget -N -O "$SIGNATUREFILENAME.2" "$HOST2$BASEDIR$SIGNATUREFILENAME" 2>&1); then
    echo "bitcoin.org failed to provide signature file, but bitcoincore.org did?"
    echo "wget output:"
+   # shellcheck disable=SC2001
    echo "$WGETOUT"|sed 's/^/\t/g'
    clean_up $SIGNATUREFILENAME
    exit 3
@@ -128,6 +126,7 @@ if [ $RET -ne 0 ]; then
    fi
 
    echo "gpg output:"
+   # shellcheck disable=SC2001
    echo "$GPGOUT"|sed 's/^/\t/g'
    clean_up $SIGNATUREFILENAME $SIGNATUREFILENAME.2 $TMPFILE
    exit "$RET"

--- a/contrib/windeploy/detached-sig-create.sh
+++ b/contrib/windeploy/detached-sig-create.sh
@@ -8,7 +8,7 @@ if [ -z "$OSSLSIGNCODE" ]; then
   OSSLSIGNCODE=osslsigncode
 fi
 
-if [ ! -n "$1" ]; then
+if [ -z "$1" ]; then
   echo "usage: $0 <osslcodesign args>"
   echo "example: $0 -key codesign.key"
   exit 1
@@ -23,7 +23,7 @@ TIMESERVER=http://timestamp.comodoca.com
 CERTFILE="win-codesign.cert"
 
 mkdir -p "${OUTSUBDIR}"
-basename -a `ls -1 "${SRCDIR}"/*-unsigned.exe` | while read UNSIGNED; do
+basename -a $(ls -1 "${SRCDIR}"/*-unsigned.exe) | while read UNSIGNED; do
   echo Signing "${UNSIGNED}"
   "${OSSLSIGNCODE}" sign -certs "${CERTFILE}" -t "${TIMESERVER}" -in "${SRCDIR}/${UNSIGNED}" -out "${WORKDIR}/${UNSIGNED}" "$@"
   "${OSSLSIGNCODE}" extract-signature -pem -in "${WORKDIR}/${UNSIGNED}" -out "${OUTSUBDIR}/${UNSIGNED}.pem" && rm "${WORKDIR}/${UNSIGNED}"

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -24,9 +24,9 @@ git_check_in_repo() {
 
 DESC=""
 SUFFIX=""
-if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" -a -e "$(which git 2>/dev/null)" -a "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo share/genbuild.sh; then
+if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo share/genbuild.sh; then
     # clean 'dirty' status of touched files that haven't been modified
-    git diff >/dev/null 2>/dev/null 
+    git diff >/dev/null 2>/dev/null
 
     # if latest commit is tagged and not dirty, then override using the tag name
     RAWDESC=$(git describe --abbrev=0 2>/dev/null)

--- a/src/qt/res/movies/makespinner.sh
+++ b/src/qt/res/movies/makespinner.sh
@@ -9,6 +9,6 @@ FRAMEDIR=$(dirname $0)
 for i in {0..35}
 do
     frame=$(printf "%03d" $i)
-    angle=$(($i * 10))
+    angle=$((i * 10))
     convert $FRAMEDIR/../src/spinner.png -background "rgba(0,0,0,0.0)" -distort SRT $angle $FRAMEDIR/spinner-$frame.png
 done

--- a/test/lint/commit-script-check.sh
+++ b/test/lint/commit-script-check.sh
@@ -18,12 +18,12 @@ if test "x$1" = "x"; then
 fi
 
 RET=0
-PREV_BRANCH=`git name-rev --name-only HEAD`
-PREV_HEAD=`git rev-parse HEAD`
-for commit in `git rev-list --reverse $1`; do
+PREV_BRANCH=$(git name-rev --name-only HEAD)
+PREV_HEAD=$(git rev-parse HEAD)
+for commit in $(git rev-list --reverse $1); do
     if git rev-list -n 1 --pretty="%s" $commit | grep -q "^scripted-diff:"; then
         git checkout --quiet $commit^ || exit
-        SCRIPT="`git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d'`"
+        SCRIPT="$(git rev-list --format=%b -n1 $commit | sed '/^-BEGIN VERIFY SCRIPT-$/,/^-END VERIFY SCRIPT-$/{//!b};d')"
         if test "x$SCRIPT" = "x"; then
             echo "Error: missing script for: $commit"
             echo "Failed"

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -39,7 +39,7 @@ CIRCULAR_DEPENDENCIES=()
 
 IFS=$'\n'
 for CIRC in $(cd src && ../contrib/devtools/circular-dependencies.py {*,*/*,*/*/*}.{h,cpp} | sed -e 's/^Circular dependency: //'); do
-    CIRCULAR_DEPENDENCIES+=($CIRC)
+    CIRCULAR_DEPENDENCIES+=( "$CIRC" )
     IS_EXPECTED_CIRC=0
     for EXPECTED_CIRC in "${EXPECTED_CIRCULAR_DEPENDENCIES[@]}"; do
         if [[ "${CIRC}" == "${EXPECTED_CIRC}" ]]; then

--- a/test/lint/lint-logs.sh
+++ b/test/lint/lint-logs.sh
@@ -19,6 +19,7 @@ UNTERMINATED_LOGS=$(git grep --extended-regexp "LogPrintf?\(" -- "*.cpp" | \
     grep -v "LogPrint()" | \
     grep -v "LogPrintf()")
 if [[ ${UNTERMINATED_LOGS} != "" ]]; then
+    # shellcheck disable=SC2028
     echo "All calls to LogPrintf() and LogPrint() should be terminated with \\n"
     echo
     echo "${UNTERMINATED_LOGS}"

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -23,25 +23,9 @@ fi
 
 # Disabled warnings:
 disabled=(
-    SC1087 # Use braces when expanding arrays, e.g. ${array[idx]} (or ${var}[.. to quiet).
-    SC2001 # See if you can use ${variable//search/replace} instead.
-    SC2004 # $/${} is unnecessary on arithmetic variables.
-    SC2005 # Useless echo? Instead of 'echo $(cmd)', just use 'cmd'.
-    SC2006 # Use $(..) instead of legacy `..`.
-    SC2016 # Expressions don't expand in single quotes, use double quotes for that.
-    SC2028 # echo won't expand escape sequences. Consider printf.
     SC2046 # Quote this to prevent word splitting.
-    SC2048 # Use "$@" (with quotes) to prevent whitespace problems.
-    SC2066 # Since you double quoted this, it will not word split, and the loop will only run once.
     SC2086 # Double quote to prevent globbing and word splitting.
-    SC2116 # Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
     SC2162 # read without -r will mangle backslashes.
-    SC2166 # Prefer [ p ] {&&,||} [ q ] as [ p -{a,o} q ] is not well defined.
-    SC2181 # Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.
-    SC2206 # Quote to prevent word splitting, or split robustly with mapfile or read -a.
-    SC2207 # Prefer mapfile or read -a to split command output (or quote to avoid splitting).
-    SC2230 # which is non-standard. Use builtin 'command -v' instead.
-    SC2236 # Don't force -n instead of ! -z.
 )
 shellcheck -e "$(IFS=","; echo "${disabled[*]}")" \
     $(git ls-files -- "*.sh" | grep -vE 'src/(secp256k1|univalue)/')


### PR DESCRIPTION
Enable some simple ShellCheck rules.

Note for reviewers: `bash` and `shellcheck` on macOS are different from ones on Ubuntu.
For local tests the latest `shellcheck` version 0.6.0 should be used (see #15166).