### PR TITLE
rpc: Tidy up reporting of buried and ongoing softforks

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -106,6 +106,8 @@ Low-level changes
 RPC
 ---
 
+- The array `softforks` and object `bip9_softforks` in the `getblockchaininfo` RPC are combined and moved into a new
+  `getforkinfo` RPC. Refer to the RPC help for further details.
 
 Tests
 -----

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1225,8 +1225,8 @@ static UniValue BIP9SoftForkDesc(const CBlockIndex* pindex, const Consensus::Par
     }
 
     UniValue rv(UniValue::VOBJ);
-    rv.pushKV("type", "bip9");
-    rv.pushKV("bip9", bip9);
+    rv.pushKV("type", "vb");
+    rv.pushKV("vb", bip9);
     if (ThresholdState::LOCKED_IN == thresholdState) {
         rv.pushKV("height", since_height + consensusParams.nMinerConfirmationWindow);
     } else if (ThresholdState::ACTIVE == thresholdState) {
@@ -1322,8 +1322,8 @@ UniValue getforkinfo(const JSONRPCRequest& request)
                 RPCResult{
             "{\n"
             "     \"xxxx\" : {                 (string) name of the softfork\n"
-            "      \"type\": \"xxxx\",           (string) one of \"buried\", \"bip9\"\n"
-            "      \"bip9\": {                 (object) status of bip9 softforks (only for \"bip9\" type)\n"
+            "      \"type\": \"xxxx\",           (string) one of \"buried\", \"vb\"\n"
+            "      \"vb\": {                 (object) status of versionbits softforks (only for \"vb\" type)\n"
             "        \"status\": \"xxxx\",       (string) one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\"\n"
             "        \"bit\": xx,              (numeric) the bit (0-28) in the block version field used to signal this softfork (only for \"started\" status)\n"
             "        \"startTime\": xx,        (numeric) the minimum median time past of a block at which the bit gains its meaning\n"
@@ -1337,7 +1337,7 @@ UniValue getforkinfo(const JSONRPCRequest& request)
             "           \"possible\": xx       (boolean) returns false if there are not enough blocks left in this period to pass activation threshold \n"
             "        }\n"
             "      },\n"
-            "      \"height\": \"xxxxxx\",       (numeric) height of the first block which the rules are enforced (only for \"buried\" type, or \"bip9\" type with \"locked_in\" or \"active\" status)\n"
+            "      \"height\": \"xxxxxx\",       (numeric) height of the first block which the rules are enforced (only for \"buried\" type, or \"vb\" type with \"locked_in\" or \"active\" status)\n"
             "      \"active\": xx,             (boolean) true if the rules are enforced after this block\n"
             "     }\n"
             "}\n"

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4608,24 +4608,6 @@ CBlockFileInfo* GetBlockFileInfo(size_t n)
     return &vinfoBlockFile.at(n);
 }
 
-ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos)
-{
-    LOCK(cs_main);
-    return VersionBitsState(::ChainActive().Tip(), params, pos, versionbitscache);
-}
-
-BIP9Stats VersionBitsTipStatistics(const Consensus::Params& params, Consensus::DeploymentPos pos)
-{
-    LOCK(cs_main);
-    return VersionBitsStatistics(::ChainActive().Tip(), params, pos);
-}
-
-int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::DeploymentPos pos)
-{
-    LOCK(cs_main);
-    return VersionBitsStateSinceHeight(::ChainActive().Tip(), params, pos, versionbitscache);
-}
-
 static const uint64_t MEMPOOL_DUMP_VERSION = 1;
 
 bool LoadMempool(CTxMemPool& pool)

--- a/src/validation.h
+++ b/src/validation.h
@@ -280,16 +280,6 @@ bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransa
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
                         bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
-/** Get the BIP9 state for a given deployment at the current tip. */
-ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
-
-/** Get the numerical statistics for the BIP9 state for a given deployment at the current tip. */
-BIP9Stats VersionBitsTipStatistics(const Consensus::Params& params, Consensus::DeploymentPos pos);
-
-/** Get the block height at which the BIP9 deployment switched into the state for the block building on the current tip. */
-int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::DeploymentPos pos);
-
-
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
 
@@ -669,7 +659,7 @@ extern std::unique_ptr<CBlockTreeDB> pblocktree;
  */
 int GetSpendHeight(const CCoinsViewCache& inputs);
 
-extern VersionBitsCache versionbitscache;
+extern VersionBitsCache versionbitscache GUARDED_BY(cs_main);
 
 /**
  * Determine what nVersion a new block should use.

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -14,7 +14,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_raises_rpc_error,
-    get_bip9_status,
+    get_vb_status,
     satoshi_round,
 )
 
@@ -341,7 +341,7 @@ class BIP68Test(BitcoinTestFramework):
     # being run, then it's possible the test has activated the soft fork, and
     # this test should be moved to run earlier, or deleted.
     def test_bip68_not_consensus(self):
-        assert get_bip9_status(self.nodes[0], 'csv')['status'] != 'active'
+        assert get_vb_status(self.nodes[0], 'csv')['status'] != 'active'
         txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 2)
 
         tx1 = FromHex(CTransaction(), self.nodes[0].getrawtransaction(txid))
@@ -391,9 +391,9 @@ class BIP68Test(BitcoinTestFramework):
         height = self.nodes[0].getblockcount()
         assert_greater_than(min_activation_height - height, 2)
         self.nodes[0].generate(min_activation_height - height - 2)
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], "locked_in")
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], "locked_in")
         self.nodes[0].generate(1)
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], "active")
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], "active")
         self.sync_blocks()
 
     # Use self.nodes[1] to test that version 2 transactions are standard.

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -386,7 +386,7 @@ class BIP68Test(BitcoinTestFramework):
 
     def activateCSV(self):
         # activation should happen at block height 432 (3 periods)
-        # getblockchaininfo will show CSV as active at block 431 (144 * 3 -1) since it's returning whether CSV is active for the next block.
+        # getforkinfo will show CSV as active at block 431 (144 * 3 -1) since it's returning whether CSV is active for the next block.
         min_activation_height = 432
         height = self.nodes[0].getblockcount()
         assert_greater_than(min_activation_height - height, 2)

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -70,13 +70,11 @@ class BIP65Test(BitcoinTestFramework):
 
     def test_cltv_info(self, *, is_active):
         assert_equal(
-            next(s for s in self.nodes[0].getblockchaininfo()['softforks'] if s['id'] == 'bip65'),
+            self.nodes[0].getforkinfo()['bip65'],
             {
-                "id": "bip65",
-                "version": 4,
-                "reject": {
-                    "status": is_active
-                }
+                'type': 'buried',
+                'active': is_active,
+                'height': 1351
             },
         )
 
@@ -106,7 +104,7 @@ class BIP65Test(BitcoinTestFramework):
 
         self.test_cltv_info(is_active=False)
         self.nodes[0].p2p.send_and_ping(msg_block(block))
-        self.test_cltv_info(is_active=False)  # Not active as of current tip, but next block must obey rules
+        self.test_cltv_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         self.log.info("Test that blocks must now be at least version 4")
@@ -155,7 +153,7 @@ class BIP65Test(BitcoinTestFramework):
         block.hashMerkleRoot = block.calc_merkle_root()
         block.solve()
 
-        self.test_cltv_info(is_active=False)  # Not active as of current tip, but next block must obey rules
+        self.test_cltv_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         self.nodes[0].p2p.send_and_ping(msg_block(block))
         self.test_cltv_info(is_active=True)  # Active as of current tip
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -58,7 +58,7 @@ from test_framework.script import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
-    get_bip9_status,
+    get_vb_status,
     hex_str_to_bytes,
 )
 
@@ -188,12 +188,12 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.nodeaddress = self.nodes[0].getnewaddress()
 
         self.log.info("Test that the csv softfork is DEFINED")
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'defined')
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], 'defined')
         test_blocks = self.generate_blocks(61, 4)
         self.send_blocks(test_blocks)
 
         self.log.info("Advance from DEFINED to STARTED, height = 143")
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'started')
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], 'started')
 
         self.log.info("Fail to achieve LOCKED_IN")
         # 100 out of 144 signal bit 0. Use a variety of bits to simulate multiple parallel softforks
@@ -205,7 +205,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.send_blocks(test_blocks)
 
         self.log.info("Failed to advance past STARTED, height = 287")
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'started')
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], 'started')
 
         self.log.info("Generate blocks to achieve LOCK-IN")
         # 108 out of 144 signal bit 0 to achieve lock-in
@@ -217,7 +217,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.send_blocks(test_blocks)
 
         self.log.info("Advanced from STARTED to LOCKED_IN, height = 431")
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'locked_in')
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], 'locked_in')
 
         # Generate 140 more version 4 blocks
         test_blocks = self.generate_blocks(140, 4)
@@ -267,7 +267,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         self.send_blocks(test_blocks)
 
         self.log.info("Not yet advanced to ACTIVE, height = 574 (will activate for block 576, not 575)")
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'locked_in')
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], 'locked_in')
 
         # Test both version 1 and version 2 transactions for all tests
         # BIP113 test transaction will be modified before each use to put in appropriate block time
@@ -343,7 +343,7 @@ class BIP68_112_113Test(BitcoinTestFramework):
         # 1 more version 4 block to get us to height 575 so the fork should now be active for the next block
         test_blocks = self.generate_blocks(1, 4)
         self.send_blocks(test_blocks)
-        assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'active')
+        assert_equal(get_vb_status(self.nodes[0], 'csv')['status'], 'active')
 
         self.log.info("Post-Soft Fork Tests.")
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -53,13 +53,11 @@ class BIP66Test(BitcoinTestFramework):
 
     def test_dersig_info(self, *, is_active):
         assert_equal(
-            next(s for s in self.nodes[0].getblockchaininfo()['softforks'] if s['id'] == 'bip66'),
+            self.nodes[0].getforkinfo()['bip66'],
             {
-                "id": "bip66",
-                "version": 3,
-                "reject": {
-                    "status": is_active
-                }
+                'type': 'buried',
+                'active': is_active,
+                'height': 1251
             },
         )
 
@@ -90,7 +88,7 @@ class BIP66Test(BitcoinTestFramework):
 
         self.test_dersig_info(is_active=False)
         self.nodes[0].p2p.send_and_ping(msg_block(block))
-        self.test_dersig_info(is_active=False)  # Not active as of current tip, but next block must obey rules
+        self.test_dersig_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         assert_equal(self.nodes[0].getbestblockhash(), block.hash)
 
         self.log.info("Test that blocks must now be at least version 3")
@@ -144,7 +142,7 @@ class BIP66Test(BitcoinTestFramework):
         block.rehash()
         block.solve()
 
-        self.test_dersig_info(is_active=False)  # Not active as of current tip, but next block must obey rules
+        self.test_dersig_info(is_active=True)  # Not active as of current tip, but next block must obey rules
         self.nodes[0].p2p.send_and_ping(msg_block(block))
         self.test_dersig_info(is_active=True)  # Active as of current tip
         assert_equal(int(self.nodes[0].getbestblockhash(), 16), block.sha256)

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -14,7 +14,7 @@ from test_framework.messages import BlockTransactions, BlockTransactionsRequest,
 from test_framework.mininode import mininode_lock, P2PInterface
 from test_framework.script import CScript, OP_TRUE, OP_DROP
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, get_bip9_status, wait_until
+from test_framework.util import assert_equal, get_vb_status, wait_until
 
 # TestP2PConn: A peer we use to send messages to bitcoind, and store responses.
 class TestP2PConn(P2PInterface):
@@ -803,7 +803,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         # We will need UTXOs to construct transactions in later tests.
         self.make_utxos()
 
-        assert_equal(get_bip9_status(self.nodes[0], "segwit")["status"], 'active')
+        assert_equal(get_vb_status(self.nodes[0], "segwit")["status"], 'active')
 
         self.log.info("Testing SENDCMPCT p2p message... ")
         self.test_sendcmpct(self.segwit_node, old_node=self.old_node)

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -217,6 +217,9 @@ class SegWitTest(BitcoinTestFramework):
         add_witness_commitment(block, nonce)
         block.solve()
 
+    def get_segwit_info(self, node_id):
+        return self.nodes[node_id].getforkinfo()['segwit']
+
     def run_test(self):
         # Setup the p2p connections
         # self.test_node sets NODE_WITNESS|NODE_NETWORK
@@ -285,12 +288,14 @@ class SegWitTest(BitcoinTestFramework):
             self.log.info("Subtest: {} (Segwit status = {})".format(func.__name__, self.segwit_status))
             # Assert segwit status is as expected
             assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
+            assert_equal(self.get_segwit_info(0)['active'], self.segwit_status == 'active')
             func(self, *args, **kwargs)
             # Each subtest should leave some utxos for the next subtest
             assert self.utxo
             self.sync_blocks()
             # Assert segwit status is as expected at end of subtest
             assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
+            assert_equal(self.get_segwit_info(0)['active'], self.segwit_status == 'active')
 
         return func_wrapper
 
@@ -710,8 +715,10 @@ class SegWitTest(BitcoinTestFramework):
         height = self.nodes[0].getblockcount()
         self.nodes[0].generate(VB_PERIOD - (height % VB_PERIOD) - 2)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
+        assert_equal(self.get_segwit_info(0)['active'], False)
         self.nodes[0].generate(1)
         assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
+        assert_equal(self.get_segwit_info(0)['active'], True)
         self.segwit_status = 'active'
 
     @subtest

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -76,7 +76,7 @@ from test_framework.util import (
     assert_equal,
     connect_nodes,
     disconnect_nodes,
-    get_bip9_status,
+    get_vb_status,
     hex_str_to_bytes,
     assert_raises_rpc_error,
 )
@@ -287,14 +287,14 @@ class SegWitTest(BitcoinTestFramework):
         def func_wrapper(self, *args, **kwargs):
             self.log.info("Subtest: {} (Segwit status = {})".format(func.__name__, self.segwit_status))
             # Assert segwit status is as expected
-            assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
+            assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
             assert_equal(self.get_segwit_info(0)['active'], self.segwit_status == 'active')
             func(self, *args, **kwargs)
             # Each subtest should leave some utxos for the next subtest
             assert self.utxo
             self.sync_blocks()
             # Assert segwit status is as expected at end of subtest
-            assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
+            assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], self.segwit_status)
             assert_equal(self.get_segwit_info(0)['active'], self.segwit_status == 'active')
 
         return func_wrapper
@@ -548,7 +548,7 @@ class SegWitTest(BitcoinTestFramework):
         assert height < VB_PERIOD - 1
         # Advance to end of period, status should now be 'started'
         self.nodes[0].generate(VB_PERIOD - height - 1)
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
+        assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], 'started')
         self.segwit_status = 'started'
 
     @subtest
@@ -584,9 +584,9 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes[0].generate(VB_PERIOD - 1)
         height = self.nodes[0].getblockcount()
         assert (height % VB_PERIOD) == VB_PERIOD - 2
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'started')
+        assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], 'started')
         self.nodes[0].generate(1)
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
+        assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         self.segwit_status = 'locked_in'
 
     @subtest
@@ -714,10 +714,10 @@ class SegWitTest(BitcoinTestFramework):
         """Mine enough blocks to activate segwit."""
         height = self.nodes[0].getblockcount()
         self.nodes[0].generate(VB_PERIOD - (height % VB_PERIOD) - 2)
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'locked_in')
+        assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], 'locked_in')
         assert_equal(self.get_segwit_info(0)['active'], False)
         self.nodes[0].generate(1)
-        assert_equal(get_bip9_status(self.nodes[0], 'segwit')['status'], 'active')
+        assert_equal(get_vb_status(self.nodes[0], 'segwit')['status'], 'active')
         assert_equal(self.get_segwit_info(0)['active'], True)
         self.segwit_status = 'active'
 
@@ -1937,7 +1937,7 @@ class SegWitTest(BitcoinTestFramework):
         self.sync_blocks()
 
         # Make sure that this peer thinks segwit has activated.
-        assert get_bip9_status(self.nodes[2], 'segwit')['status'] == "active"
+        assert get_vb_status(self.nodes[2], 'segwit')['status'] == "active"
 
         # Make sure this peer's blocks match those of node0.
         height = self.nodes[2].getblockcount()

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -78,7 +78,6 @@ class BlockchainTest(BitcoinTestFramework):
 
         keys = [
             'bestblockhash',
-            'bip9_softforks',
             'blocks',
             'chain',
             'chainwork',
@@ -88,7 +87,6 @@ class BlockchainTest(BitcoinTestFramework):
             'mediantime',
             'pruned',
             'size_on_disk',
-            'softforks',
             'verificationprogress',
             'warnings',
         ]

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -343,8 +343,8 @@ def delete_cookie_file(datadir):
         os.remove(os.path.join(datadir, "regtest", ".cookie"))
 
 def get_bip9_status(node, key):
-    info = node.getblockchaininfo()
-    return info['bip9_softforks'][key]
+    info = node.getforkinfo()
+    return info[key]['bip9']
 
 def set_node_times(nodes, t):
     for node in nodes:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -342,9 +342,9 @@ def delete_cookie_file(datadir):
         logger.debug("Deleting leftover cookie file")
         os.remove(os.path.join(datadir, "regtest", ".cookie"))
 
-def get_bip9_status(node, key):
+def get_vb_status(node, key):
     info = node.getforkinfo()
-    return info[key]['bip9']
+    return info[key]['vb']
 
 def set_node_times(nodes, t):
     for node in nodes:


### PR DESCRIPTION
This unifies how softforks (e.g. buried, ISM, BIP9, ...) are reported. The output of `getforkinfo()` is now always a dict, where the key is the name of the softfork and the value is a dict with further details.