### PR TITLE
docs: Use placeholder instead of key expiration date

### DIFF
--- a/contrib/verifybinaries/README.md
+++ b/contrib/verifybinaries/README.md
@@ -6,7 +6,7 @@ Make sure you obtain the proper release signing key and verify the fingerprint w
 
 ```sh
 $ gpg --fingerprint "Bitcoin Core binary release signing key"
-pub   4096R/36C2E964 2015-06-24 [expires: 2017-02-13]
+pub   4096R/36C2E964 2015-06-24 [expires: YYYY-MM-DD]
       Key fingerprint = 01EA 5486 DE18 A882 D4C2  6845 90C8 019E 36C2 E964
 uid                  Wladimir J. van der Laan (Bitcoin Core binary release signing key) <laanwj@gmail.com>
 ```


### PR DESCRIPTION
Use a placeholder instead of the actual expiration date, so that the documentation doesn't require updating every time an expiry date changes.