### PR TITLE
qt: Remove redundant WalletController::addWallet slot

### DIFF
--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -99,6 +99,9 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
 
     // Instantiate model and register it.
     WalletModel* wallet_model = new WalletModel(std::move(wallet), m_node, m_platform_style, m_options_model, nullptr);
+    // Handler callback runs in a different thread so fix wallet model thread affinity.
+    wallet_model->moveToThread(thread());
+    wallet_model->setParent(this);
     m_wallets.push_back(wallet_model);
 
     connect(wallet_model, &WalletModel::unload, [this, wallet_model] {
@@ -119,23 +122,9 @@ WalletModel* WalletController::getOrCreateWallet(std::unique_ptr<interfaces::Wal
     connect(wallet_model, &WalletModel::coinsSent, this, &WalletController::coinsSent);
 
     // Notify walletAdded signal on the GUI thread.
-    if (QThread::currentThread() == thread()) {
-        addWallet(wallet_model);
-    } else {
-        // Handler callback runs in a different thread so fix wallet model thread affinity.
-        wallet_model->moveToThread(thread());
-        bool invoked = QMetaObject::invokeMethod(this, "addWallet", Qt::QueuedConnection, Q_ARG(WalletModel*, wallet_model));
-        assert(invoked);
-    }
+    Q_EMIT walletAdded(wallet_model);
 
     return wallet_model;
-}
-
-void WalletController::addWallet(WalletModel* wallet_model)
-{
-    // Take ownership of the wallet model and register it.
-    wallet_model->setParent(this);
-    Q_EMIT walletAdded(wallet_model);
 }
 
 void WalletController::removeAndDeleteWallet(WalletModel* wallet_model)

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -50,9 +50,6 @@ public:
     OpenWalletActivity* openWallet(const std::string& name, QWidget* parent = nullptr);
     void closeWallet(WalletModel* wallet_model, QWidget* parent = nullptr);
 
-private Q_SLOTS:
-    void addWallet(WalletModel* wallet_model);
-
 Q_SIGNALS:
     void walletAdded(WalletModel* wallet_model);
     void walletRemoved(WalletModel* wallet_model);


### PR DESCRIPTION
~~Fix #15453.~~ It is fixed by https://github.com/bitcoin/bitcoin/pull/16348#issuecomment-509308347

The _only_ reason of these lines on master (8c69fae94410f54bad13be0f34d54370fddbf4b3)
https://github.com/bitcoin/bitcoin/blob/2679bb8919b5089f8067ccfd94f766747b8df671/src/qt/walletcontroller.cpp#L121-L128
is to `Q_EMIT walletAdded(wallet_model);` in a thread-safe manner;

This PR makes this in a line of code:
https://github.com/bitcoin/bitcoin/blob/1b83875006749d79916af0197bed65aecdc7ff17/src/qt/walletcontroller.cpp#L121


EDITED:
To establish the ownership of a new `WalletModel` object is not necessary on the master (https://github.com/bitcoin/bitcoin/pull/16349#discussion_r301679192 by **promag**).
But:
> it's good habit to set ownership

And I agree. It is a safe practice.