### PR TITLE
Upgrade encrypted wallet

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -151,6 +151,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },
+    { "upgradewallet", 0, "wallet_version" },
     // Echo with conversion (For testing only)
     { "echojson", 0, "arg0" },
     { "echojson", 1, "arg1" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4277,6 +4277,54 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
     return result;
 }
 
+static UniValue upgradewallet(const JSONRPCRequest& request)
+{
+    std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
+    CWallet* const pwallet = wallet.get();
+
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp || request.params.size() > 1)
+        throw std::runtime_error(
+            RPCHelpMan{"upgradewallet",
+                "\nUpgrade the wallet to the last version (default) or to a specific version.\n",
+                {
+                    {"version", RPCArg::Type::NUM, RPCArg::Optional::OMITTED_NAMED_ARG, "A specific version to which upgrade the wallet."},
+                },
+                RPCResult{
+            "  \"wallet_version\" : version        (numeric) The new wallet version\n"
+                },
+                RPCExamples{
+                    "Upgrade wallet to the latest version: "
+            + HelpExampleCli("upgradewallet", "")
+                },
+            }.ToString());
+
+    EnsureWalletIsUnlocked(pwallet);
+    LOCK(pwallet->cs_wallet);
+
+    int newVersion;
+    newVersion = request.params[0].isNull() ? FEATURE_LATEST : request.params[0].get_int();
+
+    if (!pwallet->CanSupportFeature(FEATURE_LATEST) && newVersion >= FEATURE_HD_SPLIT && newVersion < FEATURE_PRE_SPLIT_KEYPOOL)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot upgrade a non HD split wallet without upgrading to support pre split keypool.");
+    if (pwallet->GetVersion() > newVersion)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Cannot downgrade the wallet.");
+    if (pwallet->GetVersion() == newVersion)
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Wallet already at latest version.");
+
+    pwallet->SetMaxVersion(newVersion);
+    if (!pwallet->UpgradeWallet())
+        throw JSONRPCError(RPC_INTERNAL_ERROR, strprintf("Cannot upgrade the wallet. Current version: %i.", pwallet->GetVersion()));
+
+    UniValue result(UniValue::VOBJ);
+    result.pushKV("wallet_version", pwallet->GetVersion());
+    return result;
+}
+
+
 UniValue abortrescan(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
 UniValue importprivkey(const JSONRPCRequest& request);
@@ -4343,6 +4391,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "signmessage",                      &signmessage,                   {"address","message"} },
     { "wallet",             "signrawtransactionwithwallet",     &signrawtransactionwithwallet,  {"hexstring","prevtxs","sighashtype"} },
     { "wallet",             "unloadwallet",                     &unloadwallet,                  {"wallet_name"} },
+    { "wallet",             "upgradewallet",                    &upgradewallet,                 {"wallet_version"} },
     { "wallet",             "walletcreatefundedpsbt",           &walletcreatefundedpsbt,        {"inputs","outputs","locktime","options","bip32derivs"} },
     { "wallet",             "walletlock",                       &walletlock,                    {} },
     { "wallet",             "walletpassphrase",                 &walletpassphrase,              {"passphrase","timeout"} },

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1246,6 +1246,9 @@ public:
     /** Mark a transaction as replaced by another transaction (e.g., BIP 125). */
     bool MarkReplaced(const uint256& originalHash, const uint256& newHash);
 
+    /** Upgrade, if supported, the minimum version to HD wallet or HD_SPLIT wallet **/
+    bool UpgradeWallet();
+
     //! Verify wallet naming and perform salvage on the wallet if required
     static bool Verify(interfaces::Chain& chain, const WalletLocation& location, bool salvage_wallet, std::string& error_string, std::string& warning_string);
 


### PR DESCRIPTION
This PR:
- makes the wallet upgrade a method of `CWallet`
- adds a RPC command: `upgradewallet`

Rationale:
User with wallet created with old version of bitcoin-core were not able to use v0.18 because of a keypool error (#16091). If their wallet was encrypted they could not even upgrade the wallet and thus v0.18 became unusable.

Problem:
I don't know how to write a test for this feature (how can I generate an old-version wallet ?) : I could not even find a test for the wallet upgrade functionnality. However I hand-tested and succesfully upgraded with v0.18 a wallet created with 0.11.1.