### PR TITLE
Remove redundant pre-TopUpKeypool check

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3414,8 +3414,7 @@ bool CWallet::TopUpKeyPool(unsigned int kpSize)
     {
         LOCK(cs_wallet);
 
-        if (IsLocked())
-            return false;
+        if (IsLocked()) return false;
 
         // Top up key pool
         unsigned int nTargetSize;
@@ -3476,8 +3475,7 @@ bool CWallet::ReserveKeyFromKeyPool(int64_t& nIndex, CKeyPool& keypool, bool fRe
     {
         LOCK(cs_wallet);
 
-        if (!IsLocked())
-            TopUpKeyPool();
+        TopUpKeyPool();
 
         bool fReturningInternal = fRequestedInternal;
         fReturningInternal &= (IsHDEnabled() && CanSupportFeature(FEATURE_HD_SPLIT)) || IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS);
@@ -3568,9 +3566,8 @@ bool CWallet::GetNewDestination(const OutputType type, const std::string label, 
 {
     LOCK(cs_wallet);
     error.clear();
-    if (!IsLocked()) {
-        TopUpKeyPool();
-    }
+
+    TopUpKeyPool();
 
     // Generate a new key that is added to wallet
     CPubKey new_key;
@@ -3588,9 +3585,8 @@ bool CWallet::GetNewDestination(const OutputType type, const std::string label, 
 bool CWallet::GetNewChangeDestination(const OutputType type, CTxDestination& dest, std::string& error)
 {
     error.clear();
-    if (!IsLocked()) {
-        TopUpKeyPool();
-    }
+
+    TopUpKeyPool();
 
     ReserveDestination reservedest(this);
     if (!reservedest.GetReservedDestination(type, dest, true)) {


### PR DESCRIPTION
TopUpKeypool already has a quick check for `IsLocked()`