### PR TITLE
depends: cleanup package configure flags

### DIFF
--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f
 $(package)_dependencies=freetype expat
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-docs --disable-static
+  $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -5,8 +5,10 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=fdd477320aeb5cdd67272838722d6b7d544887dfe7de46e1e7cc0c27c2bea4f2
 $(package)_dependencies=xproto
 
+# When updating this package, check the default value of
+# --disable-xthreads. It is currently enabled.
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared
+  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c
 $(package)_dependencies=xcb_proto libXau
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static
+$(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd
 # Because we pass -qt-xcb to Qt, it will compile in a set of xcb helper libraries and extensions,
 # so we skip building all of the extensions here.
 # More info is available from: https://doc.qt.io/qt-5.9/linux-requirements.html

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -5,7 +5,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared -without-tools --disable-sdltest
+$(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest
+$(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
 $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e046514f
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared
+$(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -6,7 +6,9 @@ $(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d83
 $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-docs --disable-shared --without-libsodium --disable-curve --disable-curve-keygen --disable-perf --disable-Werror
+  $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf --disable-Werror --disable-drafts
+  $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
+  $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
 endef


### PR DESCRIPTION
Related to #16354.

This PR adds additional configure flags to packages in depends to explicitly disable features we aren't using; similar to #16183. It also fixes passing `--without-tools` to `qrencode`.

I've added `--disable-drafts` to `zeromq`:
```bash
Build and install draft classes and methods [default=yes]
```

I'm not entirely sure how far we want to take this. i.e in the `zeromq` package we explicitly pass `--without-libsodium`, even though it's disabled by default.

Do we also want to explicitly pass all the other `--without` flags? :
```bash
  --with-libgssapi_krb5   require libzmq build with libgssapi_krb5
                          [default=no]
  --with-libsodium        use libsodium instead of built-in tweetnacl
                          [default=no]
  --with-pgm              build libzmq with PGM extension. Requires pkg-config
                          [default=no]
  --with-norm             build libzmq with NORM protocol extension,
                          optionally specifying norm path [default=no]
  --with-vmci             build libzmq with VMCI transport [default=no]
```