### PR TITLE
rpcwallet: default include_watchonly to true for watchonly wallets

### DIFF
--- a/doc/release-notes-16383.md
+++ b/doc/release-notes-16383.md
@@ -1,0 +1,8 @@
+RPC changes
+-----------
+
+RPCs which have an `include_watchonly` argument or `includeWatching`
+option now default to `true` for watch-only wallets. Affected RPCs
+are: `getbalance`, `listreceivedbyaddress`, `listreceivedbylabel`,
+`listtransactions`, `listsinceblock`, `gettransaction`,
+`walletcreatefundedpsbt`, and `fundrawtransaction`.

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -732,7 +732,7 @@ static UniValue getbalance(const JSONRPCRequest& request)
                 {
                     {"dummy", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "Remains for backward compatibility. Must be excluded or set to \"*\"."},
                     {"minconf", RPCArg::Type::NUM, /* default */ "0", "Only include transactions confirmed at least this many times."},
-                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "false", "Also include balance in watch-only addresses (see 'importaddress')"},
+                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Also include balance in watch-only addresses (see 'importaddress')"},
                     {"avoid_reuse", RPCArg::Type::BOOL, /* default */ "true", "(only available if avoid_reuse wallet flag is set) Do not include balance in dirty outputs; addresses are considered dirty if they have previously been used in a transaction."},
                 },
                 RPCResult{
@@ -1194,7 +1194,7 @@ static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
                 {
                     {"minconf", RPCArg::Type::NUM, /* default */ "1", "The minimum number of confirmations before payments are included."},
                     {"include_empty", RPCArg::Type::BOOL, /* default */ "false", "Whether to include addresses that haven't received any payments."},
-                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "false", "Whether to include watch-only addresses (see 'importaddress')."},
+                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Whether to include watch-only addresses (see 'importaddress')"},
                     {"address_filter", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "If present, only return information on this address."},
                 },
                 RPCResult{
@@ -1245,7 +1245,7 @@ static UniValue listreceivedbylabel(const JSONRPCRequest& request)
                 {
                     {"minconf", RPCArg::Type::NUM, /* default */ "1", "The minimum number of confirmations before payments are included."},
                     {"include_empty", RPCArg::Type::BOOL, /* default */ "false", "Whether to include labels that haven't received any payments."},
-                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "false", "Whether to include watch-only addresses (see 'importaddress')."},
+                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Whether to include watch-only addresses (see 'importaddress')"},
                 },
                 RPCResult{
             "[\n"
@@ -1386,7 +1386,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
             "              with the specified label, or \"*\" to disable filtering and return all transactions."},
                     {"count", RPCArg::Type::NUM, /* default */ "10", "The number of transactions to return"},
                     {"skip", RPCArg::Type::NUM, /* default */ "0", "The number of transactions to skip"},
-                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "false", "Include transactions to watch-only addresses (see 'importaddress')"},
+                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Include transactions to watch-only addresses (see 'importaddress')"},
                 },
                 RPCResult{
             "[\n"
@@ -1518,7 +1518,7 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
                 {
                     {"blockhash", RPCArg::Type::STR, RPCArg::Optional::OMITTED_NAMED_ARG, "If set, the block hash to list transactions since, otherwise list all transactions."},
                     {"target_confirmations", RPCArg::Type::NUM, /* default */ "1", "Return the nth block hash from the main chain. e.g. 1 would mean the best block hash. Note: this is not used as a filter, but only affects [lastblock] in the return value"},
-                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "false", "Include transactions to watch-only addresses (see 'importaddress')"},
+                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Include transactions to watch-only addresses (see 'importaddress')"},
                     {"include_removed", RPCArg::Type::BOOL, /* default */ "true", "Show transactions that were removed due to a reorg in the \"removed\" array\n"
             "                                                           (not guaranteed to work on pruned nodes)"},
                 },
@@ -1658,7 +1658,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
                 "\nGet detailed information about in-wallet transaction <txid>\n",
                 {
                     {"txid", RPCArg::Type::STR, RPCArg::Optional::NO, "The transaction id"},
-                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "false", "Whether to include watch-only addresses in balance calculation and details[]"},
+                    {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Whether to include watch-only addresses in balance calculation and details[]"},
                 },
                 RPCResult{
             "{\n"
@@ -3120,7 +3120,7 @@ static UniValue fundrawtransaction(const JSONRPCRequest& request)
                             {"changeAddress", RPCArg::Type::STR, /* default */ "pool address", "The bitcoin address to receive the change"},
                             {"changePosition", RPCArg::Type::NUM, /* default */ "random", "The index of the change output"},
                             {"change_type", RPCArg::Type::STR, /* default */ "set by -changetype", "The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
-                            {"includeWatching", RPCArg::Type::BOOL, /* default */ "false", "Also select inputs which are watch only"},
+                            {"includeWatching", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Also select inputs which are watch only"},
                             {"lockUnspents", RPCArg::Type::BOOL, /* default */ "false", "Lock selected unspent outputs"},
                             {"feeRate", RPCArg::Type::AMOUNT, /* default */ "not set: makes wallet determine the fee", "Set a specific fee rate in " + CURRENCY_UNIT + "/kB"},
                             {"subtractFeeFromOutputs", RPCArg::Type::ARR, /* default */ "empty array", "A json array of integers.\n"
@@ -4062,7 +4062,7 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
                             {"changeAddress", RPCArg::Type::STR_HEX, /* default */ "pool address", "The bitcoin address to receive the change"},
                             {"changePosition", RPCArg::Type::NUM, /* default */ "random", "The index of the change output"},
                             {"change_type", RPCArg::Type::STR, /* default */ "set by -changetype", "The output type to use. Only valid if changeAddress is not specified. Options are \"legacy\", \"p2sh-segwit\", and \"bech32\"."},
-                            {"includeWatching", RPCArg::Type::BOOL, /* default */ "false", "Also select inputs which are watch only"},
+                            {"includeWatching", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Also select inputs which are watch only"},
                             {"lockUnspents", RPCArg::Type::BOOL, /* default */ "false", "Lock selected unspent outputs"},
                             {"feeRate", RPCArg::Type::AMOUNT, /* default */ "not set: makes wallet determine the fee", "Set a specific fee rate in " + CURRENCY_UNIT + "/kB"},
                             {"subtractFeeFromOutputs", RPCArg::Type::ARR, /* default */ "empty array", "A json array of integers.\n"

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -127,6 +127,8 @@ BASE_SCRIPTS = [
     'wallet_multiwallet.py --usecli',
     'wallet_createwallet.py',
     'wallet_createwallet.py --usecli',
+    'wallet_watchonly.py',
+    'wallet_watchonly.py --usecli',
     'interface_http.py',
     'interface_rpc.py',
     'rpc_psbt.py',

--- a/test/functional/wallet_watchonly.py
+++ b/test/functional/wallet_watchonly.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test createwallet arguments.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_rpc_error
+)
+
+
+class CreateWalletWatchonlyTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+        self.supports_cli = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.nodes[0].createwallet(wallet_name='default')
+        def_wallet = node.get_wallet_rpc('default')
+
+        a1 = def_wallet.getnewaddress()
+        wo_change = def_wallet.getnewaddress()
+        wo_addr = def_wallet.getnewaddress()
+
+        self.nodes[0].createwallet(wallet_name='wo', disable_private_keys=True)
+        wo_wallet = node.get_wallet_rpc('wo')
+
+        wo_wallet.importpubkey(pubkey=def_wallet.getaddressinfo(wo_addr)['pubkey'])
+        wo_wallet.importpubkey(pubkey=def_wallet.getaddressinfo(wo_change)['pubkey'])
+
+        # generate some btc for testing
+        node.generatetoaddress(101, a1)
+
+        # send 1 btc to our watch-only address
+        txid = def_wallet.sendtoaddress(wo_addr, 1)
+        self.nodes[0].generate(1)
+
+        # getbalance
+        self.log.info('include_watchonly should default to true for watch-only wallets')
+        self.log.info('Testing getbalance watch-only defaults')
+        assert_equal(wo_wallet.getbalance(), 1)
+        assert_equal(len(wo_wallet.listtransactions()), 1)
+        assert_equal(wo_wallet.getbalance(include_watchonly=False), 0)
+
+        self.log.info('Testing listreceivedbyaddress watch-only defaults')
+        result = wo_wallet.listreceivedbyaddress()
+        assert_equal(len(result), 1)
+        assert_equal(result[0]["involvesWatchonly"], True)
+        result = wo_wallet.listreceivedbyaddress(include_watchonly=False)
+        assert_equal(len(result), 0)
+
+        self.log.info('Testing listreceivedbylabel watch-only defaults')
+        result = wo_wallet.listreceivedbylabel()
+        assert_equal(len(result), 1)
+        assert_equal(result[0]["involvesWatchonly"], True)
+        result = wo_wallet.listreceivedbylabel(include_watchonly=False)
+        assert_equal(len(result), 0)
+
+        self.log.info('Testing listtransactions watch-only defaults')
+        result = wo_wallet.listtransactions()
+        assert_equal(len(result), 1)
+        assert_equal(result[0]["involvesWatchonly"], True)
+        result = wo_wallet.listtransactions(include_watchonly=False)
+        assert_equal(len(result), 0)
+
+        self.log.info('Testing listsinceblock watch-only defaults')
+        result = wo_wallet.listsinceblock()
+        assert_equal(len(result["transactions"]), 1)
+        assert_equal(result["transactions"][0]["involvesWatchonly"], True)
+        result = wo_wallet.listsinceblock(include_watchonly=False)
+        assert_equal(len(result["transactions"]), 0)
+
+        self.log.info('Testing gettransaction watch-only defaults')
+        result = wo_wallet.gettransaction(txid)
+        assert_equal(result["details"][0]["involvesWatchonly"], True)
+        result = wo_wallet.gettransaction(txid=txid, include_watchonly=False)
+        assert_equal(len(result["details"]), 0)
+
+        self.log.info('Testing walletcreatefundedpsbt watch-only defaults')
+        inputs = []
+        outputs = [{a1: 0.5}]
+        options = {'changeAddress': wo_change}
+        no_wo_options = {'changeAddress': wo_change, 'includeWatching': False}
+
+        result = wo_wallet.walletcreatefundedpsbt(inputs=inputs, outputs=outputs, options=options)
+        assert_equal("psbt" in result, True)
+        assert_raises_rpc_error(-4, "Insufficient funds", wo_wallet.walletcreatefundedpsbt, inputs, outputs, 0, no_wo_options)
+
+        self.log.info('Testing fundrawtransaction watch-only defaults')
+        rawtx = wo_wallet.createrawtransaction(inputs=inputs, outputs=outputs)
+        result = wo_wallet.fundrawtransaction(hexstring=rawtx, options=options)
+        assert_equal("hex" in result, True)
+        assert_raises_rpc_error(-4, "Insufficient funds", wo_wallet.fundrawtransaction, rawtx, no_wo_options)
+
+
+
+if __name__ == '__main__':
+    CreateWalletWatchonlyTest().main()


### PR DESCRIPTION
Right now it's a bit annoying to deal with watchonly wallets, many rpc commands have an `include_watchonly` argument that needs to be explicitly set. 

Wallets created with `createwallet` can have a `disable_private_keys` parameter, for those wallets we already know that they are watchonly, so there's no reason to have to explicitly ask for it for every command. Instead we check this wallet flag when the `include_watchonly` parameter isn't set.