### PR TITLE
Early "-" check for bitcoin-tx using stdin in ParseParameters()

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -383,6 +383,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
 
     for (int i = 1; i < argc; i++) {
         std::string key(argv[i]);
+        if (key == "-") continue; //bitcoin-tx using stdin
         std::string val;
         size_t is_index = key.find('=');
         if (is_index != std::string::npos) {


### PR DESCRIPTION
The `bitcoin-tx` utility uses common `stdin` convention `-`.
https://github.com/bitcoin/bitcoin/blob/536590f358dc3d3e5821eba7f1009452ea93b205/src/bitcoin-tx.cpp#L793-L796

This PR makes it explicit in the `ArgsManager::ParseParameters()` function.