### PR TITLE
rpc: testmempoolaccept for list of transactions

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -310,8 +310,8 @@ public:
         auto limit_descendant_size = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
         std::string unused_error_string;
         LOCK(::mempool.cs);
-        return ::mempool.CalculateMemPoolAncestors(entry, ancestors, limit_ancestor_count, limit_ancestor_size,
-            limit_descendant_count, limit_descendant_size, unused_error_string);
+        return ::mempool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, ancestors, limit_ancestor_count, limit_ancestor_size,
+            limit_descendant_count, limit_descendant_size, unused_error_string, /* search_parents_for_entry */ &entry);
     }
     CFeeRate estimateSmartFee(int num_blocks, bool conservative, FeeCalculation* calc) override
     {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -391,7 +391,7 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         CTxMemPool::setEntries ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        mempool.CalculateMemPoolAncestors(*iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        mempool.CalculateMemPoolAncestors(iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
 
         onlyUnconfirmed(ancestors);
         ancestors.insert(iter);

--- a/src/node/coin.cpp
+++ b/src/node/coin.cpp
@@ -12,7 +12,7 @@ void FindCoins(std::map<COutPoint, Coin>& coins)
     LOCK2(cs_main, ::mempool.cs);
     assert(pcoinsTip);
     CCoinsViewCache& chain_view = *::pcoinsTip;
-    CCoinsViewMemPool mempool_view(&chain_view, ::mempool);
+    CoinsViewMemPool<CTxMemPool> mempool_view(&chain_view, ::mempool);
     for (auto& coin : coins) {
         if (!mempool_view.GetCoin(coin.first, coin.second)) {
             // Either the coin is not in the CCoinsViewCache or is spent. Clear it.

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -26,8 +26,8 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
     // signaled for RBF if any unconfirmed parents have signaled.
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    CTxMemPoolEntry entry = *pool.mapTx.find(tx.GetHash());
-    pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    auto it_tx = pool.mapTx.find(tx.GetHash());
+    pool.CalculateMemPoolAncestors(it_tx, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy);
 
     for (CTxMemPool::txiter it : setAncestors) {
         if (SignalsOptInRBF(it->GetTx())) {

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -504,7 +504,7 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
             // use db+mempool as cache backend in case user likes to query mempool
             LOCK2(cs_main, mempool.cs);
             CCoinsViewCache& viewChain = *pcoinsTip;
-            CCoinsViewMemPool viewMempool(&viewChain, mempool);
+            CoinsViewMemPool<CTxMemPool> viewMempool(&viewChain, mempool);
             process_utxos(viewMempool, mempool);
         } else {
             LOCK(cs_main);  // no need to lock mempool!

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -566,7 +566,7 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
     CTxMemPool::setEntries setAncestors;
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    mempool.CalculateMemPoolAncestors(*it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    mempool.CalculateMemPoolAncestors(it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy);
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1128,7 +1128,7 @@ UniValue gettxout(const JSONRPCRequest& request)
     Coin coin;
     if (fMempool) {
         LOCK(mempool.cs);
-        CCoinsViewMemPool view(pcoinsTip.get(), mempool);
+        CoinsViewMemPool<CTxMemPool> view(pcoinsTip.get(), mempool);
         if (!view.GetCoin(out, coin) || mempool.isSpent(out)) {
             return NullUniValue;
         }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -825,7 +825,9 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
                 "\nSee sendrawtransaction call.\n",
                 {
                     {"rawtxs", RPCArg::Type::ARR, RPCArg::Optional::NO, "An array of hex strings of raw transactions.\n"
-            "                                        Length must be one for now.",
+                            "The list will be processed in order.\n"
+                            "An accepted transaction may be replaced by later transactions.\n"
+                            "A rejected transaction may be allowed if submitted earlier.",
                         {
                             {"rawtx", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, ""},
                         },
@@ -858,10 +860,6 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
         UniValue::VARR,
         UniValueType(), // NUM or BOOL, checked later
     });
-
-    if (request.params[0].get_array().size() != 1) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "Array must contain exactly one raw transaction for now");
-    }
 
     std::vector<CTransactionRef> txs;
     for (const auto& tx : request.params[0].get_array().getValues()) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -633,7 +633,7 @@ static UniValue combinerawtransaction(const JSONRPCRequest& request)
         LOCK(cs_main);
         LOCK(mempool.cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CoinsViewMemPool<CTxMemPool> viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         for (const CTxIn& txin : mergedTx.vin) {
@@ -1495,7 +1495,7 @@ UniValue utxoupdatepsbt(const JSONRPCRequest& request)
     {
         LOCK2(cs_main, mempool.cs);
         CCoinsViewCache &viewChain = *pcoinsTip;
-        CCoinsViewMemPool viewMempool(&viewChain, mempool);
+        CoinsViewMemPool<CTxMemPool> viewMempool(&viewChain, mempool);
         view.SetBackend(viewMempool); // temporarily switch cache backend to db+mempool view
 
         for (const CTxIn& txin : psbtx.tx->vin) {

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -193,9 +193,10 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx7.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx7.vout[1].nValue = 1 * COIN;
 
+    const CTxMemPoolEntry& search_parents_for_entry_1 = entry.Fee(2000000LL).FromTx(tx7);
     CTxMemPool::setEntries setAncestorsCalculated;
     std::string dummy;
-    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(2000000LL).FromTx(tx7), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy, &search_parents_for_entry_1), true);
     BOOST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(entry.FromTx(tx7), setAncestors);
@@ -252,8 +253,9 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     tx10.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
     tx10.vout[0].nValue = 10 * COIN;
 
+    const CTxMemPoolEntry& search_parents_for_entry_2 = entry.Fee(200000LL).Time(4).FromTx(tx10);
     setAncestorsCalculated.clear();
-    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(entry.Fee(200000LL).Time(4).FromTx(tx10), setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy), true);
+    BOOST_CHECK_EQUAL(pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestorsCalculated, 100, 1000000, 1000, 1000000, dummy, &search_parents_for_entry_2), true);
     BOOST_CHECK(setAncestorsCalculated == setAncestors);
 
     pool.addUnchecked(entry.FromTx(tx10), setAncestors);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -884,13 +884,13 @@ bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
     return true;
 }
 
-CCoinsViewMemPool::CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn) : CCoinsViewBacked(baseIn), mempool(mempoolIn) { }
-
-bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
+template <typename P>
+bool CoinsViewMemPool<P>::GetCoin(const COutPoint& outpoint, Coin& coin) const
+{
     // If an entry in the mempool exists, always return that one, as it's guaranteed to never
     // conflict with the underlying cache, and it cannot have pruned entries (as it contains full)
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
-    CTransactionRef ptx = mempool.get(outpoint.hash);
+    CTransactionRef ptx = m_tx_pool.get(outpoint.hash);
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
             coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);
@@ -901,6 +901,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     }
     return base->GetCoin(outpoint, coin);
 }
+template bool CoinsViewMemPool<CTxMemPool>::GetCoin(const COutPoint& outpoint, Coin& coin) const;
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -219,7 +219,7 @@ bool TxPoolLayer::CalculateMemPoolAncestors(txiter it, setEntries& setAncestors,
 }
 
 template <typename P>
-static void UpdateAncestorsOf(P& pool, bool add, typename P::txiter it, const typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+static void UpdateAncestorsOf(P& pool, bool add, const typename P::txiter& it, typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     auto parentIters = pool.GetMemPoolParents(it);
     // add or remove this tx as a child of each parent
@@ -234,7 +234,7 @@ static void UpdateAncestorsOf(P& pool, bool add, typename P::txiter it, const ty
     }
 }
 
-void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, const setEntries& setAncestors)
+void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries& setAncestors)
 {
     return ::UpdateAncestorsOf(*this, add, it, setAncestors);
 }
@@ -287,7 +287,7 @@ void TxPoolLayer::UpdateChildrenForRemoval(txiter it)
 }
 
 template <typename P>
-static void UpdateForRemoveFromMempool(P& pool, const typename P::setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+static void UpdateForRemoveFromMempool(P& pool, typename P::setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     // For each entry, walk back all ancestors and decrement size associated with this
     // transaction
@@ -343,7 +343,7 @@ static void UpdateForRemoveFromMempool(P& pool, const typename P::setEntries& en
         pool.UpdateChildrenForRemoval(removeIt);
     }
 }
-void CTxMemPool::UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants)
+void CTxMemPool::UpdateForRemoveFromMempool(setEntries& entriesToRemove, bool updateDescendants)
 {
     return ::UpdateForRemoveFromMempool(*this, entriesToRemove, updateDescendants);
 }
@@ -400,7 +400,7 @@ void CTxMemPool::AddTransactionsUpdated(unsigned int n)
 }
 
 template <typename P>
-static typename P::txiter addUnchecked(P& pool, const CTxMemPoolEntry& entry, const typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
+static typename P::txiter addUnchecked(P& pool, const CTxMemPoolEntry& entry, typename P::setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(pool.cs)
 {
     // Add to memory pool without checking anything.
     // Used by AcceptToMemoryPool(), which DOES do
@@ -442,7 +442,7 @@ static typename P::txiter addUnchecked(P& pool, const CTxMemPoolEntry& entry, co
     return newit;
 }
 
-void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, const setEntries& setAncestors, bool validFeeEstimate)
+void CTxMemPool::addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors, bool validFeeEstimate)
 {
     NotifyEntryAdded(entry.GetSharedTx());
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -751,14 +751,17 @@ private:
  * signrawtransactionwithkey and signrawtransactionwithwallet,
  * as long as the conflicting transaction is not yet confirmed.
  */
-class CCoinsViewMemPool : public CCoinsViewBacked
+template <class P>
+class CoinsViewMemPool : public CCoinsViewBacked
 {
 protected:
-    const CTxMemPool& mempool;
+    const P& m_tx_pool;
 
 public:
-    CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);
-    bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
+    CoinsViewMemPool(CCoinsView* baseIn, const P& mempoolIn)
+        : CCoinsViewBacked(baseIn), m_tx_pool(mempoolIn) {}
+
+    bool GetCoin(const COutPoint& outpoint, Coin& coin) const override EXCLUSIVE_LOCKS_REQUIRED(m_tx_pool.cs);
 };
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -572,7 +572,7 @@ public:
     // and any other callers may break wallet's in-mempool tracking (due to
     // lack of CValidationInterface::TransactionAddedToMempool callbacks).
     void addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void addUnchecked(const CTxMemPoolEntry& entry, const setEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
+    void addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason = MemPoolRemovalReason::UNKNOWN) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
@@ -731,13 +731,13 @@ public:
         cacheMap& cachedDescendants,
         const std::set<uint256>& setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
-    void UpdateAncestorsOf(bool add, txiter hash, const setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateAncestorsOf(bool add, txiter hash, setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
     void UpdateEntryForAncestors(txiter it, const setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
-    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -626,17 +626,18 @@ public:
      */
     void UpdateTransactionsFromBlock(const std::vector<uint256>& vHashesToUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
-    /** Try to calculate all in-mempool ancestors of entry.
+    /** Try to calculate all in-mempool ancestors of the passed iterator.
      *  (these are all calculated including the tx itself)
      *  limitAncestorCount = max number of ancestors
      *  limitAncestorSize = max size of ancestors
      *  limitDescendantCount = max number of descendants any ancestor can have
      *  limitDescendantSize = max size of descendants any ancestor can have
      *  errString = populated with error reason if any limits are hit
-     *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
-     *    look up parents from mapLinks. Must be true for entries not in the mempool
+     *  search_parents_for_entry = Use this entry's tx's vin to search for in-mempool parents.
+     *    Only needed when there is no mapTx iterator to this entry, which could be
+     *    used to look up parents from mapLinks.
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(txiter it, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, const CTxMemPoolEntry* search_parents_for_entry = nullptr) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -764,6 +764,9 @@ public:
     /** An iterator that may be changed from pointing to an entry in m_tx_pool to pointing to an entry in the layer */
     struct txiter {
         boost::variant<txiter_nested, CTxMemPool::txiter> m_variant;
+        explicit txiter(CTxMemPool::txiter val) : m_variant{val} {}
+        explicit txiter(txiter_nested val) : m_variant{val} {}
+        txiter() : m_variant{CTxMemPool::txiter{}} {}
     };
 
     struct CompareIteratorByHash {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -445,7 +445,7 @@ class CTxMemPool
 private:
     uint32_t nCheckFrequency GUARDED_BY(cs); //!< Value n means that n times in 2^32 we check.
     std::atomic<unsigned int> nTransactionsUpdated; //!< Used by getblocktemplate to trigger CreateNewBlock() invocation
-    CBlockPolicyEstimator* minerPolicyEstimator;
+    CBlockPolicyEstimator* const minerPolicyEstimator;
 
     uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
@@ -606,6 +606,9 @@ public:
     /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups */
     setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /** Dereference the txiter */
+    static const CTxMemPoolEntry& GetEntry(txiter it) { return *it; }
+
     /** Remove a set of transactions from the mempool.
      *  If a transaction is in this set, then all in-mempool descendants must
      *  also be in the set, unless this transaction is being removed for being
@@ -725,16 +728,16 @@ public:
      *  same transaction again, if encountered in another transaction chain.
      */
     void UpdateForDescendants(txiter updateIt,
-            cacheMap &cachedDescendants,
-            const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
+        cacheMap& cachedDescendants,
+        const std::set<uint256>& setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, const setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
-    void UpdateEntryForAncestors(txiter it, const setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateEntryForAncestors(txiter it, const setEntries& setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
-    void UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -610,7 +610,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         size_t nLimitDescendants = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
         size_t nLimitDescendantSize = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT)*1000;
         std::string errString;
-        if (!pool.CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString)) {
+        if (!pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString, /* search_parents_for_entry */ &entry)) {
             return state.Invalid(ValidationInvalidReason::TX_MEMPOOL_POLICY, false, REJECT_NONSTANDARD, "too-long-mempool-chain", errString);
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -255,7 +255,7 @@ bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flag
     }
     else {
         // pcoinsTip contains the UTXO set for ::ChainActive().Tip()
-        CCoinsViewMemPool viewMemPool(pcoinsTip.get(), pool);
+        CoinsViewMemPool<CTxMemPool> viewMemPool(pcoinsTip.get(), pool);
         std::vector<int> prevheights;
         prevheights.resize(tx.vin.size());
         for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++) {
@@ -508,7 +508,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
         CCoinsViewCache view(&dummy);
 
         LockPoints lp;
-        CCoinsViewMemPool viewMemPool(pcoinsTip.get(), pool);
+        CoinsViewMemPool<CTxMemPool> viewMemPool(pcoinsTip.get(), pool);
         view.SetBackend(viewMemPool);
 
         // do all inputs exist?

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -614,7 +614,7 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, P& pool, C
         size_t nLimitDescendants = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
         size_t nLimitDescendantSize = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT)*1000;
         std::string errString;
-        if (!pool.CalculateMemPoolAncestors(CTxMemPool::txiter{}, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString, /* search_parents_for_entry */ &entry)) {
+        if (!pool.CalculateMemPoolAncestors(typename P::txiter{}, setAncestors, nLimitAncestors, nLimitAncestorSize, nLimitDescendants, nLimitDescendantSize, errString, /* search_parents_for_entry */ &entry)) {
             return state.Invalid(ValidationInvalidReason::TX_MEMPOOL_POLICY, false, REJECT_NONSTANDARD, "too-long-mempool-chain", errString);
         }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -279,7 +279,8 @@ void PruneBlockFilesManual(int nManualPruneHeight);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
-bool AcceptToMemoryPool(CTxMemPool& pool, CValidationState &state, const CTransactionRef &tx,
+template<typename P>
+bool AcceptToMemoryPool(P& pool, CValidationState& state, const CTransactionRef& tx,
                         bool* pfMissingInputs, std::list<CTransactionRef>* plTxnReplaced,
                         bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
@@ -323,7 +324,8 @@ bool TestLockPointValidity(const LockPoints* lp) EXCLUSIVE_LOCKS_REQUIRED(cs_mai
  *
  * See consensus/consensus.h for flag definitions.
  */
-bool CheckSequenceLocks(const CTxMemPool& pool, const CTransaction& tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+template <typename P>
+bool CheckSequenceLocks(const P& pool, const CTransaction& tx, int flags, LockPoints* lp = nullptr, bool useExistingLockPoints = false) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs);
 
 /**
  * Closure representing one script verification


### PR DESCRIPTION
This extends the testmempoolaccept rpc to run on a vector of transactions. The idea is to keep the current mempool immutable and only keep track of the differences to the underlying mempool.

This is based on the transaction pool layer idea from #13804. Comment from there:

This implements a layer around an immutable tx pool. The layer can be seen as a temporary throw-away shell that provides the same interface as `CTxMemPool`. Its primary purpose right now is to be passed into ATMP while testing acceptance of several (potentially depending) transaction and then to be discarded.

One use case could be to determine if smart contracts that are set up with multiple txs would be accepted by current consensus and policy rules.

In the future it could be extended to support recursive wrapping of layers or a way to commit changes that happened in the layer to the underlying pool or layer. Furthermore, it could be extended to be revivable after changes to the underlying layer happened. (As opposed to be single-use)