### PR TITLE
Add package acceptance logic to mempool

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -41,7 +41,8 @@ enum class TxValidationResult {
      * Currently this is only used if the transaction already exists in the mempool or on chain.
      */
     TX_CONFLICT,
-    TX_MEMPOOL_POLICY,        //!< violated mempool's fee/size/descendant/RBF/etc limits
+    TX_MEMPOOL_POLICY,        //!< violated mempool's size/descendant/RBF/etc limits
+    TX_MEMPOOL_INSUFFICIENT_FEE, //!< violated mempool's feerate requirements
 };
 
 /** A "reason" why a block was invalid, suitable for determining whether the

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -899,6 +899,12 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
     // conflict with the underlying cache, and it cannot have pruned entries (as it contains full)
     // transactions. First checking the underlying cache risks returning a pruned entry instead.
     CTransactionRef ptx = mempool.get(outpoint.hash);
+    if (!ptx) {
+        // If a coin is missing from the mempool, check to see if it's part of
+        // a candidate package
+        auto it = package_tx.find(outpoint.hash);
+        if (it != package_tx.end()) ptx = it->second;
+    }
     if (ptx) {
         if (outpoint.n < ptx->vout.size()) {
             coin = Coin(ptx->vout[outpoint.n], MEMPOOL_HEIGHT, false);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -752,8 +752,12 @@ private:
  */
 class CCoinsViewMemPool : public CCoinsViewBacked
 {
+public:
+    void AddPotentialTransaction(const CTransactionRef& ptx) { package_tx.emplace(ptx->GetHash(), ptx); }
+
 protected:
     const CTxMemPool& mempool;
+    std::map<uint256, const CTransactionRef> package_tx;
 
 public:
     CCoinsViewMemPool(CCoinsView* baseIn, const CTxMemPool& mempoolIn);

--- a/src/validation.h
+++ b/src/validation.h
@@ -278,6 +278,10 @@ bool AcceptToMemoryPool(CTxMemPool& pool, TxValidationState &state, const CTrans
                         std::list<CTransactionRef>* plTxnReplaced,
                         bool bypass_limits, const CAmount nAbsurdFee, bool test_accept=false) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
+bool AcceptPackageToMemoryPool(CTxMemPool& pool, TxValidationState &state, std::list<CTransactionRef>& tx_list,
+                               std::list<CTransactionRef>* replaced_transactions,
+                               const CAmount nAbsurdFee, bool test_accept) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 /** Get the BIP9 state for a given deployment at the current tip. */
 ThresholdState VersionBitsTipState(const Consensus::Params& params, Consensus::DeploymentPos pos);
 


### PR DESCRIPTION
Accepting a single transaction to the mempool only succeeds if (among other things) the feerate of the transaction is greater than both the min relay fee and the mempool min fee. Consequently, a transaction below the minimum fee may not be accepted to the mempool, even if we later learn of a transaction with a high fee that depends on it.

This PR adds code to validation that will accept a package of transactions to the mempool under the following conditions:

- All package transactions must be direct parents of the final transaction.
  This is a simple heuristic for ensuring that a candidate list of transactions
  is in fact a package (we wouldn't want arbitrary transactions to be paying
  for random low feerate transactions)

- The feerate of the package, as a whole, exceeds the mempool min fee and the
  min relay fee.

- No transactions in the mempool conflict with any transactions in the package.
  This is a simplification that makes the logic easier to write. Without this
  requirement, we would need to do additional checks to ensure that no parent
  transaction would evict a transaction from the mempool that some other child
  depends on.

- The ancestor/descendant size limits are calculated assuming that any mempool
  ancestor of any candidate transaction is an ancestor of all the candidate
  transactions.
  This allows for doing simpler calculations to ensure that we're staying
  within the mempool's package limits. If we eliminated this, we would need to
  do much more careful package calculations for each candidate transaction and each
  in-mempool ancestor.

This PR also adds code to net_processing that will attempt to process transaction packages in one narrow case: if a transaction fails to get into the mempool due to insufficient fee, but has an orphan in the orphan pool, then we will try to process the pair together to see if they can be accepted as a package.

This PR is definitely WIP, but I'm opening it as a proof-of-concept motivation for refactoring ATMP (#16400).