### PR TITLE
0.18: fix: tor: Call event_base_loopbreak from the event's callback

### DIFF
--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -759,7 +759,9 @@ void InterruptTorControl()
 {
     if (gBase) {
         LogPrintf("tor: Thread interrupt\n");
-        event_base_loopbreak(gBase);
+        event_base_once(gBase, -1, EV_TIMEOUT, [](evutil_socket_t, short, void*) {
+            event_base_loopbreak(gBase);
+        }, nullptr, nullptr);
     }
 }
 


### PR DESCRIPTION
Github-Pull: #16405
Rebased-From: a981e749e6553487cd48eda28e590f769e81c85c