### PR TITLE
Remove mempool expiry, treat txs as replaceable instead

### DIFF
--- a/doc/man/bitcoin-qt.1
+++ b/doc/man/bitcoin-qt.1
@@ -81,11 +81,6 @@ Keep the transaction memory pool below <n> megabytes (default: 300)
 .IP
 Keep at most <n> unconnectable transactions in memory (default: 100)
 .HP
-\fB\-mempoolexpiry=\fR<n>
-.IP
-Do not keep transactions in the mempool longer than <n> hours (default:
-336)
-.HP
 \fB\-par=\fR<n>
 .IP
 Set the number of script verification threads (\fB\-8\fR to 16, 0 = auto, <0 =

--- a/doc/man/bitcoind.1
+++ b/doc/man/bitcoind.1
@@ -81,11 +81,6 @@ Keep the transaction memory pool below <n> megabytes (default: 300)
 .IP
 Keep at most <n> unconnectable transactions in memory (default: 100)
 .HP
-\fB\-mempoolexpiry=\fR<n>
-.IP
-Do not keep transactions in the mempool longer than <n> hours (default:
-336)
-.HP
 \fB\-par=\fR<n>
 .IP
 Set the number of script verification threads (\fB\-8\fR to 16, 0 = auto, <0 =

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -395,6 +395,7 @@ void SetupServerArgs()
     gArgs.AddArg("-includeconf=<file>", "Specify additional configuration file, relative to the -datadir path (only useable from configuration file, not command line)", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-loadblock=<file>", "Imports blocks from external blk000??.dat file on startup", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE), false, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-mempooltxtimeout=<n>", strprintf("Consider transactions in the mempool replacable after <n> hours (default: %u)", DEFAULT_TX_TIMEOUT.count()), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxorphantx=<n>", strprintf("Keep at most <n> unconnectable transactions in memory (default: %u)", DEFAULT_MAX_ORPHAN_TRANSACTIONS), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex()), true, OptionsCategory::OPTIONS);
     gArgs.AddArg("-par=<n>", strprintf("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
@@ -1065,6 +1066,10 @@ bool AppInitParameterInteraction()
     }
 
     // mempool limits
+    const int64_t mempool_timeout{gArgs.GetArg("-mempooltxtimeout", DEFAULT_TX_TIMEOUT.count())};
+    if (mempool_timeout < 0) return InitError(_("-mempooltxtimeout can not be negative"));
+    ::mempool.m_tx_timeout = std::chrono::hours{mempool_timeout};
+
     int64_t nMempoolSizeMax = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     int64_t nMempoolSizeMin = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40;
     if (nMempoolSizeMax < 0 || nMempoolSizeMax < nMempoolSizeMin)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -396,7 +396,6 @@ void SetupServerArgs()
     gArgs.AddArg("-loadblock=<file>", "Imports blocks from external blk000??.dat file on startup", false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxmempool=<n>", strprintf("Keep the transaction memory pool below <n> megabytes (default: %u)", DEFAULT_MAX_MEMPOOL_SIZE), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-maxorphantx=<n>", strprintf("Keep at most <n> unconnectable transactions in memory (default: %u)", DEFAULT_MAX_ORPHAN_TRANSACTIONS), false, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-mempoolexpiry=<n>", strprintf("Do not keep transactions in the mempool longer than <n> hours (default: %u)", DEFAULT_MEMPOOL_EXPIRY), false, OptionsCategory::OPTIONS);
     gArgs.AddArg("-minimumchainwork=<hex>", strprintf("Minimum work assumed to exist on a valid chain in hex (default: %s, testnet: %s)", defaultChainParams->GetConsensus().nMinimumChainWork.GetHex(), testnetChainParams->GetConsensus().nMinimumChainWork.GetHex()), true, OptionsCategory::OPTIONS);
     gArgs.AddArg("-par=<n>", strprintf("Set the number of script verification threads (%u to %d, 0 = auto, <0 = leave that many cores free, default: %d)",
         -GetNumCores(), MAX_SCRIPTCHECK_THREADS, DEFAULT_SCRIPTCHECK_THREADS), false, OptionsCategory::OPTIONS);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -917,22 +917,6 @@ void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPool
     }
 }
 
-int CTxMemPool::Expire(int64_t time) {
-    AssertLockHeld(cs);
-    indexed_transaction_set::index<entry_time>::type::iterator it = mapTx.get<entry_time>().begin();
-    setEntries toremove;
-    while (it != mapTx.get<entry_time>().end() && it->GetTime() < time) {
-        toremove.insert(mapTx.project<0>(it));
-        it++;
-    }
-    setEntries stage;
-    for (txiter removeit : toremove) {
-        CalculateDescendants(removeit, stage);
-    }
-    RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
-    return stage.size();
-}
-
 void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, bool validFeeEstimate)
 {
     setEntries setAncestors;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -346,7 +346,6 @@ struct TxMempoolInfo
  */
 enum class MemPoolRemovalReason {
     UNKNOWN = 0, //!< Manually removed or unknown reason
-    EXPIRY,      //!< Expired from mempool
     SIZELIMIT,   //!< Removed in size limiting
     REORG,       //!< Removed for reorganization
     BLOCK,       //!< Removed for block
@@ -656,9 +655,6 @@ public:
       *  which are not in mempool which no longer have any spends in this mempool.
       */
     void TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining = nullptr) EXCLUSIVE_LOCKS_REQUIRED(cs);
-
-    /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */
-    int Expire(int64_t time) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /**
      * Calculate the ancestor and descendant count for the given transaction.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -7,6 +7,7 @@
 #define BITCOIN_TXMEMPOOL_H
 
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <memory>
 #include <set>
@@ -32,6 +33,8 @@
 class CBlockIndex;
 extern CCriticalSection cs_main;
 
+/** Default for -mempooltxtimeout */
+constexpr std::chrono::hours DEFAULT_TX_TIMEOUT{336};
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
 
@@ -549,9 +552,8 @@ private:
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
     std::map<uint256, CAmount> mapDeltas;
+    std::chrono::hours m_tx_timeout{DEFAULT_TX_TIMEOUT}; //!< After what time txs are considered replaceable
 
-    /** Create a new CTxMemPool.
-     */
     explicit CTxMemPool(CBlockPolicyEstimator* estimator = nullptr);
 
     /**

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -495,6 +495,9 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
                     }
                 }
                 if (fReplacementOptOut) {
+                    fReplacementOptOut = std::chrono::seconds{(*pool.GetIter(ptxConflicting->GetHash()))->GetTime()} + pool.m_tx_timeout > std::chrono::seconds{nAcceptTime};
+                }
+                if (fReplacementOptOut) {
                     return state.Invalid(ValidationInvalidReason::TX_MEMPOOL_POLICY, false, REJECT_DUPLICATE, "txn-mempool-conflict");
                 }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -64,8 +64,6 @@ static const unsigned int DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
 static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 /** Default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
-/** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
-static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 336;
 /** Maximum kilobytes for transactions to store for processing during reorg */
 static const unsigned int MAX_DISCONNECTED_TX_POOL_SIZE = 20000;
 /** The maximum size of a blk?????.dat file (since 0.8) */


### PR DESCRIPTION
There is no reason for tx expiry in the tx pool, as wallets occasionally rebroadcast txs when they are not confirmed. Thus they will only reset the timer and throw away their chance bumping the fee.

Fix that by removing expiry (so that miners don't miss out on long-term fee revenue if the tx stays the same), but treat all txs older than 2 weeks as replaceable in the mempool to give wallets the chance to increase the fee.