### PR TITLE
BIP-325: Signet support

### DIFF
--- a/contrib/signet/README.md
+++ b/contrib/signet/README.md
@@ -1,0 +1,60 @@
+Contents
+========
+This directory contains tools related to Signet, both for running a Signet yourself and for using one.
+
+The `args.sh` script is a helper script used by the other scripts and should not be invoked directly.
+
+getcoins.sh
+===========
+
+A script to call a faucet to get Signet coins.
+
+Syntax: `getcoins.sh [--help] [--cmd=<bitcoin-cli path>] [--faucet=<faucet URL>] [--addr=<signet bech32 address>] [--password=<faucet password>] [--] [<bitcoin-cli args>]`
+
+* `--cmd` lets you customize the bitcoin-cli path. By default it will look for it in the PATH, then in `../../src/`
+* `--faucet` lets you specify which faucet to use; the faucet is assumed to be compatible with https://github.com/kallewoof/bitcoin-faucet
+* `--addr` lets you specify a Signet address; by default, the address must be a bech32 address. This and `--cmd` above complement each other (i.e. you do not need `bitcoin-cli` if you use `--addr`)
+* `--password` lets you specify a faucet password; this is handy if you are in a classroom and set up your own faucet for your students; (above faucet does not limit by IP when password is enabled)
+
+If using the default network, invoking the script with no arguments should be sufficient under normal
+circumstances, but if multiple people are behind the same IP address, the faucet will by default only
+accept one claim per day. See `--password` above.
+
+issuer.sh
+=========
+
+A script to regularly issue Signet blocks.
+
+Syntax: `issuer.sh <idle time> [--help] [--cmd=<bitcoin-cli path>] [--] [<bitcoin-cli args>]`
+
+* `<idle time>` is a time in seconds to wait between each block generation
+* `--cmd` lets you customize the bitcoin-cli path. By default it will look for it in the PATH, then in `../../src/`
+
+Signet, just like other bitcoin networks, uses proof of work alongside the block signature; this
+includes the difficulty adjustment every 2016 blocks.
+The `<idle time>` exists to allow you to maintain a relatively low difficulty over an extended period
+of time. E.g. an idle time of 540 means your node will end up spending roughly 1 minute grinding
+hashes for each block, and wait 9 minutes after every time.
+
+mkblock.sh
+==========
+
+A script to generate one Signet block.
+
+Syntax: `mkblock.sh <bitcoin-cli path> [<bitcoin-cli args>]`
+
+This script is called by the other block issuing scripts, but can be invoked independently to generate
+1 block immediately.
+
+secondary.sh
+============
+
+A script to act as backup generator in case the primary issuer goes offline.
+
+Syntax: `secondary.sh <trigger time> <idle time> [--cmd=<bitcoin-cli path>] [<bitcoin-cli args>]`
+
+* `<trigger time>` is the time in seconds that must have passed since the last block was seen for the secondary issuer to kick into motion
+* `<idle time>` is the time in seconds to wait after generating a block, and should preferably be the same as the idle time of the main issuer
+
+Running a Signet network, it is recommended to have at least one secondary running in a different
+place, so it doesn't go down together with the main issuer.

--- a/contrib/signet/addtxtoblock.py
+++ b/contrib/signet/addtxtoblock.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import sys
+import os
+import argparse
+
+# dirty hack but makes CBlock etc available
+sys.path.append('/'.join(os.getcwd().split('/')[:-2]) + '/test/functional')
+
+from test_framework.messages import (
+    CBlock,
+    CTransaction,
+    FromHex,
+    ToHex,
+)
+
+from test_framework.blocktools import add_witness_commitment
+
+def main():
+
+    # Parse arguments and pass through unrecognised args
+    parser = argparse.ArgumentParser(add_help=False,
+                                        usage='%(prog)s [addtxtoblock options] [bitcoin block file] [tx file] [fee]',
+                                        description=__doc__,
+                                        epilog='''Help text and arguments:''',
+                                        formatter_class=argparse.RawTextHelpFormatter)
+    _, unknown_args = parser.parse_known_args()
+
+    if len(unknown_args) != 3:
+        print("Need three arguments (block file, tx file, and fee)")
+        sys.exit(1)
+
+    [blockfile, txfile, feestr] = unknown_args
+
+    with open(blockfile, "r", encoding="utf8") as f:
+        blockhex = f.read().strip()
+    with open(txfile,    "r", encoding="utf8") as f:
+        txhex    = f.read().strip()
+
+    fee = int(feestr)
+
+    block = CBlock()
+    FromHex(block, blockhex)
+
+    tx = CTransaction()
+    FromHex(tx, txhex)
+
+    block.vtx[0].vout[0].nValue += fee
+    block.vtx.append(tx)
+    add_witness_commitment(block)
+    print(ToHex(block))
+
+if __name__ == '__main__':
+    main()

--- a/contrib/signet/args.sh
+++ b/contrib/signet/args.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+args="-signet"
+eoc=
+
+command -v bitcoin-cli > /dev/null \
+&& bcli="bitcoin-cli" \
+|| bcli="$(dirname $0)/../../src/bitcoin-cli"
+
+if [ "$VARCHECKS" = "" ]; then
+    VARCHECKS='if [ "$varname" = "cmd" ]; then bcli=$value;'
+fi
+
+# compatibility; previously the bitcoin-cli path was given as first argument
+if [[ "$1" != "" && "${1:$((${#1}-11))}" = "bitcoin-cli" ]]; then
+    echo "using $1 as bcli"
+    bcli=$1
+    shift
+fi
+
+for i in "$@"; do
+    if [ $eoc ]; then
+        args="$args $i"
+    elif [ "$i" = "--" ]; then
+        # end of commands; rest into args for bitcoin-cli
+        eoc=1
+        continue
+    elif [ "${i:0:2}" = "--" ]; then
+        # command
+        j=${i:2}
+        if [ "$j" = "help" ]; then
+            >&2 echo -e $HELPSTRING
+            exit 1
+        fi
+        export varname=${j%=*}
+        export value=${j#*=}
+        eval $VARCHECKS '
+        else
+            >&2 echo "unknown parameter $varname (from \"$i\"); for help, type: $0 --help"
+            exit 1
+        fi'
+    else
+        # arg
+        args="$args $i"
+    fi
+done
+
+if ! [ -e "$bcli" ]; then
+    command -v "$bcli" >/dev/null 2>&1 || { echo >&2 "error: unable to find bitcoin-cli binary: $bcli"; exit 1; }
+fi

--- a/contrib/signet/forker.sh
+++ b/contrib/signet/forker.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+#
+# Take the hex formatted line separated transactions in reorg-list.txt where every even transaction is put into the even set, and every odd transaction is put into the odd set.
+# That is, transactions on line 1, 3, 5, 7, ... go into the odd set, and transactions on line 2, 4, 6, 8, ... go into the even set.
+#
+# - Generate two blocks A and B, where A contains all or some of the odd set, and B contains the corresponding even set.
+# - Sign, grind, and broadcast block A
+# - Wait a random amount of time (1-10 mins)
+# - Invalidate block A
+# - Sign, grind, and broadcast block B
+#
+
+bcli=$1
+shift
+
+function log()
+{
+    echo "- $(date +%H:%M:%S): $*"
+}
+
+if [ ! -e "reorg-list.txt" ]; then
+    echo "reorg-list.txt not found"
+    exit 1
+fi
+
+# get address for coinbase output
+addr=$($bcli "$@" getnewaddress)
+
+# create blocks A and B
+$bcli "$@" getnewblockhex $addr > $PWD/block-a
+cp block-a block-b
+
+odd=1
+while read -r line; do
+    if [ "$line" = "" ]; then continue; fi
+    echo $line > tx
+    if [ $odd -eq 1 ]; then blk="block-a"; else blk="block-b"; fi
+    ./addtxtoblock.py $blk tx 100 > t # note: we are throwing away all fees above 100 satoshis for now; should figure out a way to determine fees
+    mv t $blk
+    (( odd=1-odd ))
+done < reorg-list.txt
+
+rm reorg-list.txt
+
+log "mining block A (to-orphan block)"
+while true; do
+    $bcli "$@" signblock $PWD/block-a > signed-a
+    blockhash_a=$($bcli "$@" grindblock $PWD/signed-a 1000000000)
+    if [ "$blockhash_a" != "false" ]; then break; fi
+done
+log "mined block with hash $blockhash_a"
+(( waittime=RANDOM%570 ))
+(( waittime=30+waittime ))
+log "waiting for $waittime s"
+sleep $waittime
+log "invalidating $blockhash_a"
+$bcli "$@" invalidateblock $blockhash_a
+
+log "mining block B (replace block)"
+while true; do
+    $bcli "$@" signblock $PWD/block-b > signed-b
+    blockhash_b=$($bcli "$@" grindblock $PWD/signed-b 1000000000)
+    if [ "$blockhash_b" != "false" ]; then break; fi
+done
+
+echo "mined $blockhash_b"
+echo "cleaning up"
+rm block-b signed-b block-a signed-a

--- a/contrib/signet/getcoins.sh
+++ b/contrib/signet/getcoins.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+#
+# Get coins from Signet Faucet
+#
+
+export VARCHECKS='
+        if [ "$varname" = "cmd" ]; then
+            bcli=$value;
+        elif [ "$varname" = "faucet" ]; then
+            faucet=$value;
+        elif [ "$varname" = "addr" ]; then
+            addr=$value;
+        elif [ "$varname" = "password" ]; then
+            password=$value;
+    '
+export HELPSTRING="syntax: $0 [--help] [--cmd=<bitcoin-cli path>] [--faucet=<faucet URL>] [--addr=<signet bech32 address>] [--password=<faucet password>] [--] [<bitcoin-cli args>]"
+
+bcli=
+args=
+password=
+addr=
+faucet="https://signet.bc-2.jp/claim"
+
+# shellcheck source=contrib/signet/args.sh
+source $(dirname $0)/args.sh "$@"
+
+if [ "$addr" = "" ]; then
+    # get address for receiving coins
+    addr=$($bcli $args getnewaddress faucet bech32) || { echo >&2 "for help, type: $0 --help"; exit 1; }
+fi
+
+# shellcheck disable=SC2015
+command -v "curl" > /dev/null \
+&& curl -X POST -d "address=$addr&password=$password" $faucet \
+|| wget -qO - --post-data "address=$addr&password=$password" $faucet
+
+echo

--- a/contrib/signet/issuer.sh
+++ b/contrib/signet/issuer.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+#
+# Issue blocks using a local node at a given interval.
+#
+
+export HELPSTRING="syntax: $0 <idle time> [--help] [--cmd=<bitcoin-cli path>] [--] [<bitcoin-cli args>]"
+
+if [ $# -lt 1 ]; then
+    echo $HELPSTRING
+    exit 1
+fi
+
+function log()
+{
+    echo "- $(date +%H:%M:%S): $*"
+}
+
+idletime=$1
+shift
+
+bcli=
+args=
+
+# shellcheck source=contrib/signet/args.sh
+source $(dirname $0)/args.sh "$@"
+
+MKBLOCK=$(dirname $0)/mkblock.sh
+
+if [ ! -e "$MKBLOCK" ]; then
+    >&2 echo "error: cannot locate mkblock.sh (expected to find in $MKBLOCK"
+    exit 1
+fi
+
+echo "- checking node status"
+conns=$($bcli $args getconnectioncount) || { echo >&2 "node error"; exit 1; }
+
+if [ $conns -lt 1 ]; then
+    echo "warning: node is not connected to any other node"
+fi
+
+log "node OK with $conns connection(s)"
+log "mining at maximum capacity with $idletime second delay between each block"
+log "hit ^C to stop"
+
+while true; do
+    if [ -e "reorg-list.txt" ]; then
+        ./forker.sh $bcli $args
+    else
+        log "generating next block"
+        blockhash=$("$MKBLOCK" "$bcli" $args) || { echo "node error; aborting" ; exit 1; }
+        log "mined block $($bcli $args getblockcount) $blockhash to $($bcli $args getconnectioncount) peer(s); idling for $idletime seconds"
+    fi
+    sleep $idletime
+done

--- a/contrib/signet/mkblock.sh
+++ b/contrib/signet/mkblock.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+#
+# Generate a block
+#
+
+if [ $# -lt 1 ]; then
+    >&2 echo "syntax: $0 <bitcoin-cli path> [<bitcoin-cli args>]" ; exit 1
+fi
+
+bcli=$1
+shift
+
+if ! [ -e "$bcli" ]; then
+    command -v "$bcli" >/dev/null 2>&1 || { echo >&2 "error: unable to find bitcoin binary: $bcli"; exit 1; }
+fi
+
+# get address for coinbase output
+addr=$($bcli "$@" getnewaddress)
+# start looping; we re-create the block every time we fail to grind as that resets the nonce and gives us an updated
+# version of the block
+while true; do
+    # create an unsigned, un-PoW'd block
+    $bcli "$@" getnewblockhex $addr > $PWD/unsigned
+    # sign it
+    $bcli "$@" signblock $PWD/unsigned > $PWD/signed
+    # grind proof of work; this ends up broadcasting the block, if successful (akin to "generatetoaddress")
+    blockhash=$($bcli "$@" grindblock $PWD/signed 10000000)
+    if [ "$blockhash" != "false" ]; then break; fi
+done
+
+echo $blockhash

--- a/contrib/signet/secondary.sh
+++ b/contrib/signet/secondary.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C
+
+#
+# Backup Issuer which will begin to issue blocks if it sees no blocks within
+# a specified period of time. It will continue to make blocks until a block
+# is generated from an external source (i.e. the primary issuer is back online)
+#
+
+export HELPSTRING="syntax: $0 <trigger time> <idle time> [--cmd=<bitcoin-cli path>] [<bitcoin-cli args>]"
+
+if [ $# -lt 3 ]; then
+    echo $HELPSTRING
+    exit 1
+fi
+
+function log()
+{
+    echo "- $(date +%H:%M:%S): $*"
+}
+
+triggertime=$1
+shift
+
+idletime=$1
+shift
+
+bcli=
+args=
+
+# shellcheck source=contrib/signet/args.sh
+source $(dirname $0)/args.sh "$@"
+
+echo "- checking node status"
+conns=$($bcli $args getconnectioncount) || { echo >&2 "node error"; exit 1; }
+
+if [ $conns -lt 1 ]; then
+    echo "warning: node is not connected to any other node"
+fi
+
+MKBLOCK=$(dirname $0)/mkblock.sh
+
+if [ ! -e "$MKBLOCK" ]; then
+    >&2 echo "error: cannot locate mkblock.sh (expected to find in $MKBLOCK"
+    exit 1
+fi
+
+log "node OK with $conns connection(s)"
+log "hit ^C to stop"
+
+# outer loop alternates between watching and mining
+while true; do
+    # inner watchdog loop
+    blocks=$($bcli $args getblockcount)
+    log "last block #$blocks; waiting up to $triggertime seconds for a new block"
+    remtime=$triggertime
+    while true; do
+        waittime=1800
+        if [ $waittime -gt $remtime ]; then waittime=$remtime; fi
+        conns=$($bcli $args getconnectioncount)
+        if [ $conns -eq 1 ]; then s=""; else s="s"; fi
+        log "waiting $waittime/$remtime seconds with $conns peer$s"
+        sleep $waittime
+        new_blocks=$($bcli $args getblockcount)
+        if [ $new_blocks -gt $blocks ]; then
+            log "detected block count increase $blocks -> $new_blocks; resetting timer"
+            remtime=$triggertime
+            blocks=$new_blocks
+        else
+            (( remtime=remtime-waittime ))
+            if [ $remtime -lt 1 ]; then break; fi
+        fi
+    done
+    log "*** no blocks in $triggertime seconds; initiating issuance ***"
+    # inner issuer loop
+    while true; do
+        log "generating next block"
+        blockhash=$("$MKBLOCK" "$bcli" "$2") || { echo "node error; aborting" ; exit 1; }
+        blocks=$($bcli $args getblockcount)
+        log "mined block $new_blocks $blockhash to $($bcli $args getconnectioncount) peer(s); idling for $idletime seconds"
+        sleep $idletime
+        new_blocks=$($bcli $args getblockcount)
+        if [ $blocks -lt $new_blocks ]; then
+            log "primary issuer appears to be back online ($blocks -> $new_blocks blocks during downtime); going back to watching"
+            break
+        fi
+    done
+done

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -195,6 +195,7 @@ BITCOIN_CORE_H = \
   script/signingprovider.h \
   script/standard.h \
   shutdown.h \
+  signet.h \
   streams.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
@@ -485,6 +486,7 @@ libbitcoin_common_a_SOURCES = \
   script/sign.cpp \
   script/signingprovider.cpp \
   script/standard.cpp \
+  signet.cpp \
   versionbitsinfo.cpp \
   warnings.cpp \
   $(BITCOIN_CORE_H)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -264,17 +264,22 @@ public:
         vSeeds.clear();
 
         if (!args.IsArgSet("-signet_blockscript")) {
-            throw std::runtime_error(strprintf("%s: -signet_blockscript is mandatory for signet networks", __func__));
-        }
-        if (args.GetArgs("-signet_blockscript").size() != 1) {
-            throw std::runtime_error(strprintf("%s: -signet_blockscript cannot be multiple values.", __func__));
-        }
-        bin = ParseHex(args.GetArgs("-signet_blockscript")[0]);
-        if (args.IsArgSet("-signet_seednode")) {
-            vSeeds = gArgs.GetArgs("-signet_seednode");
-        }
+            LogPrintf("Using default signet network\n");
+            bin = ParseHex("512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be43051ae");
+            vSeeds.push_back("178.128.221.177");
+            vSeeds.push_back("2a01:7c8:d005:390::5");
+            vSeeds.push_back("ntv3mtqw5wt63red.onion:38333");
+        } else {
+            if (args.GetArgs("-signet_blockscript").size() != 1) {
+                throw std::runtime_error(strprintf("%s: -signet_blockscript cannot be multiple values.", __func__));
+            }
+            bin = ParseHex(args.GetArgs("-signet_blockscript")[0]);
+            if (args.IsArgSet("-signet_seednode")) {
+                vSeeds = gArgs.GetArgs("-signet_seednode");
+            }
 
-        LogPrintf("SigNet with block script %s\n", gArgs.GetArgs("-signet_blockscript")[0]);
+            LogPrintf("SigNet with block script %s\n", gArgs.GetArgs("-signet_blockscript")[0]);
+        }
 
         strNetworkID = CBaseChainParams::SIGNET;
         g_signet_blockscript = CScript(bin.begin(), bin.end());

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -13,6 +13,7 @@
 
 const std::string CBaseChainParams::MAIN = "main";
 const std::string CBaseChainParams::TESTNET = "test";
+const std::string CBaseChainParams::SIGNET = "signet";
 const std::string CBaseChainParams::REGTEST = "regtest";
 
 void SetupChainParamsBaseOptions()
@@ -23,6 +24,10 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-segwitheight=<n>", "Set the activation height of segwit. -1 to disable. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-signet", "Use the signet chain. Note that the network is defined by the signet_blockscript parameter", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-signet_blockscript", "Blocks must satisfy the given script to be considered valid (only for signet networks)", ArgsManager::ALLOW_STRING, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-signet_hrp", "Human readable part of bech32 address (suffixed by \"sb\"; default = \"\")", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-signet_seednode", "Specify a seed node for the signet network (may be used multiple times to specify multiple seed nodes)", ArgsManager::ALLOW_STRING, OptionsCategory::CHAINPARAMS);
 }
 
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
@@ -41,8 +46,9 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         return MakeUnique<CBaseChainParams>("testnet3", 18332);
     else if (chain == CBaseChainParams::REGTEST)
         return MakeUnique<CBaseChainParams>("regtest", 18443);
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+    else if (chain == CBaseChainParams::SIGNET)
+        return MakeUnique<CBaseChainParams>("signet", 38332);
+    throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 
 void SelectBaseParams(const std::string& chain)

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -19,6 +19,7 @@ public:
     /** Chain name strings */
     static const std::string MAIN;
     static const std::string TESTNET;
+    static const std::string SIGNET;
     static const std::string REGTEST;
     ///@}
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -80,6 +80,12 @@ struct Params {
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
+
+    /**
+     * If true, witness commitments contain a payload equal to a Bitcoin Script solution
+     * to a signet challenge as defined in the chain params.
+     */
+    bool signet_blocks{false};
 };
 } // namespace Consensus
 

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -158,10 +158,27 @@ bool DecodeHexBlockHeader(CBlockHeader& header, const std::string& hex_header)
     return true;
 }
 
+inline bool ReadFromDisk(const std::string& path, std::string& output)
+{
+    FILE* fp = fopen(path.c_str(), "rb");
+    if (!fp) return false;
+    char buf[1025];
+    size_t r;
+    buf[1024] = 0;
+    output = "";
+    while (0 < (r = fread(buf, 1, 1024, fp))) { buf[r] = 0; output += buf; }
+    while (output.size() > 0 && output[output.size() - 1] == '\n') output = output.substr(0, output.size() - 1);
+    fclose(fp);
+    return true;
+}
+
 bool DecodeHexBlk(CBlock& block, const std::string& strHexBlk)
 {
-    if (!IsHex(strHexBlk))
+    if (!IsHex(strHexBlk)) {
+        std::string actual;
+        if (ReadFromDisk(strHexBlk, actual)) return DecodeHexBlk(block, actual);
         return false;
+    }
 
     std::vector<unsigned char> blockData(ParseHex(strHexBlk));
     CDataStream ssBlock(blockData, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -28,3 +28,65 @@ std::string CBlock::ToString() const
     }
     return s.str();
 }
+
+bool CBlock::GetWitnessCommitmentSection(const uint8_t header[4], std::vector<uint8_t>& result) const
+{
+    int cidx = GetWitnessCommitmentIndex();
+    if (cidx == -1) return false;
+    auto script = vtx.at(0)->vout.at(cidx).scriptPubKey;
+    opcodetype opcode;
+    CScript::const_iterator pc = script.begin();
+    ++pc; // move beyond initial OP_RETURN
+    while (script.GetOp(pc, opcode, result)) {
+        if (result.size() > 3 && !memcmp(result.data(), header, 4)) {
+            result.erase(result.begin(), result.begin() + 4);
+            return true;
+        }
+    }
+    result.clear();
+    return false;
+}
+
+bool CBlock::SetWitnessCommitmentSection(CMutableTransaction& mtx, const uint8_t header[4], const std::vector<uint8_t>& data)
+{
+    int cidx = GetWitnessCommitmentIndex(mtx);
+    if (cidx == -1) return false;
+
+    CScript result;
+    std::vector<uint8_t> pushdata;
+    auto script = mtx.vout[cidx].scriptPubKey;
+    opcodetype opcode;
+    CScript::const_iterator pc = script.begin();
+    result.push_back(*pc++);
+    bool found = false;
+    while (script.GetOp(pc, opcode, pushdata)) {
+        if (pushdata.size() > 0) {
+            if (pushdata.size() > 3 && !memcmp(pushdata.data(), header, 4)) {
+                // replace pushdata
+                found = true;
+                pushdata.erase(pushdata.begin() + 4, pushdata.end());
+                pushdata.insert(pushdata.end(), data.begin(), data.end());
+            }
+            result << pushdata;
+        } else {
+            result << opcode;
+        }
+    }
+    if (!found) {
+        // append section as it did not exist
+        pushdata.clear();
+        pushdata.insert(pushdata.end(), header, header + 4);
+        pushdata.insert(pushdata.end(), data.begin(), data.end());
+        result << pushdata;
+    }
+    mtx.vout[cidx].scriptPubKey = result;
+    return true;
+}
+
+bool CBlock::SetWitnessCommitmentSection(const uint8_t header[4], const std::vector<uint8_t>& data)
+{
+    auto mtx = CMutableTransaction(*vtx[0]);
+    if (!SetWitnessCommitmentSection(mtx, header, data)) return false;
+    vtx[0] = std::make_shared<CTransaction>(mtx);
+    return true;
+}

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -47,6 +47,7 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
 #define QAPP_APP_NAME_REGTEST "Bitcoin-Qt-regtest"
+#define QAPP_APP_NAME_SIGNET "Bitcoin-Qt-signet"
 
 /* One gigabyte (GB) in bytes */
 static constexpr uint64_t GB_BYTES{1000000000};

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -19,7 +19,8 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30},
-    {"regtest", QAPP_APP_NAME_REGTEST, 160, 30}
+    {"regtest", QAPP_APP_NAME_REGTEST, 160, 30},
+    {"signet", QAPP_APP_NAME_SIGNET, 35, 15},
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1266,6 +1266,9 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     }
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
+    if (consensusParams.signet_blocks) {
+        obj.pushKV("signet-blockscript", HexStr(g_signet_blockscript));
+    }
     UniValue softforks(UniValue::VOBJ);
     BuriedForkDescPushBack(softforks, "bip34", consensusParams.BIP34Height);
     BuriedForkDescPushBack(softforks, "bip66", consensusParams.BIP66Height);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -24,6 +24,7 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
+#include <signet.h> // for blockToJSON signet_commitment printing
 #include <streams.h>
 #include <sync.h>
 #include <txdb.h>
@@ -167,6 +168,12 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* tip, const CBlockIn
         result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());
     if (pnext)
         result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
+    if (Params().GetConsensus().signet_blocks) {
+        std::vector<uint8_t> signet_commitment;
+        if (block.GetWitnessCommitmentSection(SIGNET_HEADER, signet_commitment)) {
+            result.pushKV("signet-solution", HexStr(signet_commitment));
+        }
+    }
     return result;
 }
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -54,6 +54,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getbalance", 2, "include_watchonly" },
     { "getbalance", 3, "avoid_reuse" },
     { "getblockhash", 0, "height" },
+    { "grindblock", 1, "maxtries" },
     { "waitforblockheight", 0, "height" },
     { "waitforblockheight", 1, "timeout" },
     { "waitforblock", 1, "timeout" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -101,6 +101,24 @@ static UniValue getnetworkhashps(const JSONRPCRequest& request)
     return GetNetworkHashPS(!request.params[0].isNull() ? request.params[0].get_int() : 120, !request.params[1].isNull() ? request.params[1].get_int() : -1);
 }
 
+static bool grindBlock(CBlock* pblock, uint64_t& nMaxTries, uint256& result)
+{
+    while (nMaxTries > 0 && pblock->nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus()) && !ShutdownRequested()) {
+        ++pblock->nNonce;
+        --nMaxTries;
+    }
+    if (ShutdownRequested()) {
+        return false;
+    }
+    if (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) return false;
+    result = pblock->GetHash();
+    std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
+    if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr)) {
+        throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
+    }
+    return true;
+}
+
 static UniValue generateBlocks(const CTxMemPool& mempool, const CScript& coinbase_script, int nGenerate, uint64_t nMaxTries)
 {
     int nHeightEnd = 0;
@@ -112,6 +130,7 @@ static UniValue generateBlocks(const CTxMemPool& mempool, const CScript& coinbas
         nHeightEnd = nHeight+nGenerate;
     }
     unsigned int nExtraNonce = 0;
+    uint256 result;
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd && !ShutdownRequested())
     {
@@ -123,21 +142,12 @@ static UniValue generateBlocks(const CTxMemPool& mempool, const CScript& coinbas
             LOCK(cs_main);
             IncrementExtraNonce(pblock, ::ChainActive().Tip(), nExtraNonce);
         }
-        while (nMaxTries > 0 && pblock->nNonce < std::numeric_limits<uint32_t>::max() && !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus()) && !ShutdownRequested()) {
-            ++pblock->nNonce;
-            --nMaxTries;
-        }
-        if (nMaxTries == 0 || ShutdownRequested()) {
-            break;
-        }
-        if (pblock->nNonce == std::numeric_limits<uint32_t>::max()) {
+        if (!grindBlock(&pblocktemplate->block, nMaxTries, result)) {
+            if (nMaxTries == 0) break;
             continue;
         }
-        std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        if (!ProcessNewBlock(Params(), shared_pblock, true, nullptr))
-            throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
         ++nHeight;
-        blockHashes.push_back(pblock->GetHash().GetHex());
+        blockHashes.push_back(result.GetHex());
     }
     return blockHashes;
 }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1414,6 +1414,18 @@ bool GenericTransactionSignatureChecker<T>::CheckSequence(const CScriptNum& nSeq
 template class GenericTransactionSignatureChecker<CTransaction>;
 template class GenericTransactionSignatureChecker<CMutableTransaction>;
 
+bool SimpleSignatureChecker::CheckSig(const std::vector<unsigned char>& vchSigIn, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+{
+    CPubKey pubkey(vchPubKey);
+    if (!pubkey.IsValid()) return false;
+
+    std::vector<unsigned char> vchSig(vchSigIn);
+    if (vchSig.empty()) return false;
+    vchSig.pop_back();
+
+    return pubkey.Verify(m_hash, vchSig);
+}
+
 static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
 {
     std::vector<std::vector<unsigned char> > stack;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -161,6 +161,17 @@ public:
     virtual ~BaseSignatureChecker() {}
 };
 
+/** A general purpose signature checker. */
+class SimpleSignatureChecker : public BaseSignatureChecker
+{
+private:
+    uint256 m_hash;
+public:
+    const uint256& GetHash() const { return m_hash; }
+    explicit SimpleSignatureChecker(const uint256& hash) : m_hash(hash) {}
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
+};
+
 template <class T>
 class GenericTransactionSignatureChecker : public BaseSignatureChecker
 {

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -33,6 +33,15 @@ bool MutableTransactionSignatureCreator::CreateSig(const SigningProvider& provid
     return true;
 }
 
+bool SimpleSignatureCreator::CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const
+{
+    CKey key;
+    if (!provider.GetKey(keyid, key)) return false;
+    if (!key.Sign(checker.GetHash(), vchSig)) return false;
+    vchSig.push_back((unsigned char)SIGHASH_ALL);
+    return true;
+}
+
 static bool GetCScript(const SigningProvider& provider, const SignatureData& sigdata, const CScriptID& scriptid, CScript& script)
 {
     if (provider.GetCScript(scriptid, script)) {

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -31,6 +31,17 @@ public:
     virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
 };
 
+/** A general purpose signature creator. */
+class SimpleSignatureCreator : public BaseSignatureCreator
+{
+    SimpleSignatureChecker checker;
+
+public:
+    explicit SimpleSignatureCreator(const uint256& hashIn) : BaseSignatureCreator(), checker(hashIn) {};
+    const BaseSignatureChecker& Checker() const override { return checker; }
+    bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
+};
+
 /** A signature creator for transactions. */
 class MutableTransactionSignatureCreator : public BaseSignatureCreator {
     const CMutableTransaction* txTo;

--- a/src/signet.cpp
+++ b/src/signet.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2019-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <signet.h>
+
+#include <consensus/merkle.h>
+#include <consensus/params.h>
+#include <hash.h>
+#include <primitives/block.h>
+#include <script/interpreter.h>
+#include <script/standard.h>        // MANDATORY_SCRIPT_VERIFY_FLAGS
+#include <util/system.h>
+
+CScript g_signet_blockscript;
+
+// Signet block solution checker
+bool CheckBlockSolution(const CBlock& block, const Consensus::Params& consensusParams)
+{
+    std::vector<uint8_t> signet_data;
+    if (!block.GetWitnessCommitmentSection(SIGNET_HEADER, signet_data)) {
+        return error("CheckBlockSolution: Errors in block (block solution missing)");
+    }
+    if (!CheckBlockSolution(GetSignetHash(block), signet_data, consensusParams)) {
+        return error("CheckBlockSolution: Errors in block (block solution invalid)");
+    }
+    return true;
+}
+
+bool CheckBlockSolution(const uint256& signet_hash, const std::vector<uint8_t>& signature, const Consensus::Params& params)
+{
+    SimpleSignatureChecker bsc(signet_hash);
+    CScript solution = CScript(signature.begin(), signature.end());
+    return VerifyScript(solution, g_signet_blockscript, nullptr, MANDATORY_SCRIPT_VERIFY_FLAGS, bsc);
+}
+
+uint256 BlockSignetMerkleRoot(const CBlock& block, bool* mutated = nullptr)
+{
+    std::vector<uint256> leaves;
+    leaves.resize(block.vtx.size());
+    {
+        // find and delete signet signature
+        CMutableTransaction mtx(*block.vtx.at(0));
+        CBlock::SetWitnessCommitmentSection(mtx, SIGNET_HEADER, std::vector<uint8_t>{});
+        leaves[0] = mtx.GetHash();
+    }
+    for (size_t s = 1; s < block.vtx.size(); s++) {
+        leaves[s] = block.vtx[s]->GetHash();
+    }
+    return ComputeMerkleRoot(std::move(leaves), mutated);
+}
+
+uint256 GetSignetHash(const CBlock& block)
+{
+    if (block.vtx.size() == 0) return block.GetHash();
+    return (CHashWriter(SER_DISK, PROTOCOL_VERSION) << block.nVersion << block.hashPrevBlock << BlockSignetMerkleRoot(block) << block.nTime << block.nBits).GetHash();
+}

--- a/src/signet.h
+++ b/src/signet.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SIGNET_H
+#define BITCOIN_SIGNET_H
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <consensus/params.h>
+
+#include <stdint.h>
+
+class CBlock;
+class CScript;
+class uint256;
+
+extern CScript g_signet_blockscript;
+
+constexpr uint8_t SIGNET_HEADER[4] = {0xec, 0xc7, 0xda, 0xa2};
+
+/**
+ * Check whether a block has a valid solution
+ */
+bool CheckBlockSolution(const uint256& signet_hash, const std::vector<uint8_t>& signature, const Consensus::Params&);
+
+/**
+ * Extract signature and check whether a block has a valid solution
+ */
+bool CheckBlockSolution(const CBlock& block, const Consensus::Params& consensusParams);
+
+/**
+ * Generate the signet hash for the given block
+ *
+ * The signet hash differs from the regular block hash in two places:
+ * 1. It hashes a modified merkle root with the signet signature removed.
+ * 2. It skips the nonce.
+ */
+uint256 GetSignetHash(const CBlock& block);
+
+#endif // BITCOIN_SIGNET_H

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -58,6 +58,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         (void)BlockWitnessMerkleRoot(block);
     }
     (void)GetBlockWeight(block);
-    (void)GetWitnessCommitmentIndex(block);
+    (void)block.GetWitnessCommitmentIndex();
     (void)RecursiveDynamicUsage(block);
 }

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1125,7 +1125,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
     // Results file is formatted like:
     //
     //   <input> || <output>
-    BOOST_CHECK_EQUAL(out_sha_hex, "f0b3a3c29869edc765d579c928f7f1690a71fbb673b49ccf39cbc4de18156a0d");
+    BOOST_CHECK_EQUAL(out_sha_hex, "4645298a210e40fd8dfacc2b470be96a186f0ff2ebab328953cfe1ce866e55cf");
 }
 
 BOOST_AUTO_TEST_CASE(util_FormatMoney)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -255,6 +255,7 @@ const std::list<SectionInfo> ArgsManager::GetUnrecognizedSections() const
 {
     // Section names to be recognized in the config file.
     static const std::set<std::string> available_sections{
+        CBaseChainParams::SIGNET,
         CBaseChainParams::REGTEST,
         CBaseChainParams::TESTNET,
         CBaseChainParams::MAIN
@@ -832,15 +833,20 @@ std::string ArgsManager::GetChainName() const
 
     const bool fRegTest = get_net("-regtest");
     const bool fTestNet = get_net("-testnet");
+    const bool fSigNet  = get_net("-signet");
     const bool is_chain_arg_set = IsArgSet("-chain");
 
-    if ((int)is_chain_arg_set + (int)fRegTest + (int)fTestNet > 1) {
-        throw std::runtime_error("Invalid combination of -regtest, -testnet and -chain. Can use at most one.");
+    if ((int)is_chain_arg_set + (int)fRegTest + (int)fTestNet + (int)fSigNet > 1) {
+        throw std::runtime_error("Invalid combination of -regtest, -testnet, -signet and -chain. Can use at most one.");
     }
     if (fRegTest)
         return CBaseChainParams::REGTEST;
     if (fTestNet)
         return CBaseChainParams::TESTNET;
+    if (fSigNet) {
+        return CBaseChainParams::SIGNET;
+    }
+
     return GetArg("-chain", CBaseChainParams::MAIN);
 }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -31,6 +31,7 @@
 #include <script/script.h>
 #include <script/sigcache.h>
 #include <shutdown.h>
+#include <signet.h>
 #include <timedata.h>
 #include <tinyformat.h>
 #include <txdb.h>
@@ -1150,6 +1151,11 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
     // Check the header
     if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
+
+    if (consensusParams.signet_blocks && block.GetHash() != consensusParams.hashGenesisBlock && !CheckBlockSolution(block, consensusParams)) {
+        /* CheckBlockSolution() calls error(..) */
+        return false;
+    }
 
     return true;
 }
@@ -3307,6 +3313,10 @@ bool CheckBlock(const CBlock& block, BlockValidationState& state, const Consensu
     // redundant with the call in AcceptBlockHeader.
     if (!CheckBlockHeader(block, state, consensusParams, fCheckPOW))
         return false;
+
+    if (consensusParams.signet_blocks && fCheckPOW && block.GetHash() != consensusParams.hashGenesisBlock && !CheckBlockSolution(block, consensusParams)) {
+        return false;
+    }
 
     // Check the merkle root.
     if (fCheckMerkleRoot) {

--- a/src/validation.h
+++ b/src/validation.h
@@ -382,9 +382,6 @@ bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& pa
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params) LOCKS_EXCLUDED(cs_main);
 
-/** Compute at which vout of the block's coinbase transaction the witness commitment occurs, or -1 if not found */
-int GetWitnessCommitmentIndex(const CBlock& block);
-
 /** Update uncommitted block structures (currently: only the witness reserved value). This is safe for submitted blocks. */
 void UpdateUncommittedBlockStructures(CBlock& block, const CBlockIndex* pindexPrev, const Consensus::Params& consensusParams);
 

--- a/test/functional/mining_signet.py
+++ b/test/functional/mining_signet.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test signet mining RPCs
+
+- getmininginfo
+- getblocktemplate proposal mode
+- submitblock"""
+
+from decimal import Decimal
+
+from test_framework.blocktools import (
+    create_coinbase,
+)
+from test_framework.messages import (
+    CBlock,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+
+private_key  = "ZFNp4W4HSatHDc4zsheMsDWgUg2uiB5PtnY2Y2hUCNCkQiF81KyV"
+pubkey       = "02c72b24ae2ee333f2da24aea66ce4338c01db8f26d0cc96f586d77edcb5238a4f"
+address      = "sb1qghzjzc0jvkjvvvymxnadmjjpu2tywmvagduwfj"
+blockscript  = "5121" + pubkey + "51ae" # 1-of-1 multisig
+
+def assert_template(node, block, expect, rehash=True):
+    if rehash:
+        block.hashMerkleRoot = block.calc_merkle_root()
+    rsp = node.getblocktemplate(template_request={'data': block.serialize().hex(), 'mode': 'proposal', 'rules': ['segwit']})
+    assert_equal(rsp, expect)
+
+def generate(node, count):
+    for _ in range(count):
+        addr = node.getnewaddress()
+        block = node.getnewblockhex(addr)
+        signed = node.signblock(block)
+        node.grindblock(signed)
+
+
+class SigMiningTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.chain = "signet"
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+        shared_args = ["-signet_blockscript=" + blockscript, "-signet_seednode=localhost:1234"]
+        self.extra_args = [shared_args, shared_args]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # give the privkey to node 1 so it can sign
+        node.importprivkey(private_key)
+        self.log.info('Imported network private key')
+        self.log.info('address: %s, privkey: %s', address, node.dumpprivkey(address))
+
+        self.log.info('getmininginfo')
+        mining_info = node.getmininginfo()
+        assert_equal(mining_info['blocks'], 0)
+        assert_equal(mining_info['chain'], 'signet')
+        assert 'currentblocktx' not in mining_info
+        assert 'currentblockweight' not in mining_info
+        assert_equal(mining_info['networkhashps'], Decimal('0'))
+        assert_equal(mining_info['pooledtx'], 0)
+
+        # Mine a block to leave initial block download
+        # Actually we mine 20 cause there's a bug in the coinbase height serializers
+
+        generate(node, 20)
+        tmpl = node.getblocktemplate({'rules': ['segwit']})
+        self.log.info("getblocktemplate: Test capability advertised")
+        assert 'proposal' in tmpl['capabilities']
+        assert 'coinbasetxn' not in tmpl
+
+        coinbase_tx = create_coinbase(height=int(tmpl["height"]))
+        # sequence numbers must not be max for nLockTime to have effect
+        coinbase_tx.vin[0].nSequence = 2 ** 32 - 2
+        coinbase_tx.rehash()
+
+        block = CBlock()
+        block.nVersion = tmpl["version"]
+        block.hashPrevBlock = int(tmpl["previousblockhash"], 16)
+        block.nTime = tmpl["curtime"]
+        block.nBits = int(tmpl["bits"], 16)
+        block.nNonce = 0
+        block.vtx = [coinbase_tx]
+
+if __name__ == '__main__':
+    SigMiningTest().main()

--- a/test/functional/rpc_help.py
+++ b/test/functional/rpc_help.py
@@ -34,7 +34,7 @@ class HelpRpcTest(BitcoinTestFramework):
         # command titles
         titles = [line[3:-3] for line in node.help().splitlines() if line.startswith('==')]
 
-        components = ['Blockchain', 'Control', 'Generating', 'Mining', 'Network', 'Rawtransactions', 'Util']
+        components = ['Blockchain', 'Control', 'Generating', 'Mining', 'Network', 'Rawtransactions', 'Signet', 'Util']
 
         if self.is_wallet_compiled():
             components.append('Wallet')

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -84,6 +84,7 @@ MAGIC_BYTES = {
     "mainnet": b"\xf9\xbe\xb4\xd9",   # mainnet
     "testnet3": b"\x0b\x11\x09\x07",  # testnet3
     "regtest": b"\xfa\xbf\xb5\xda",   # regtest
+    "signet": b"\xf0\xc7\x70\x6a",    # signet
 }
 
 

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -338,7 +338,8 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             extra_args = self.extra_args
         self.add_nodes(self.num_nodes, extra_args)
         self.start_nodes()
-        self.import_deterministic_coinbase_privkeys()
+        if self.chain != "signet":
+            self.import_deterministic_coinbase_privkeys()
         if not self.setup_clean_chain:
             for n in self.nodes:
                 assert_equal(n.getblockchaininfo()["blocks"], 199)
@@ -553,19 +554,20 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
             # Wait for RPC connections to be ready
             self.nodes[CACHE_NODE_ID].wait_for_rpc_connection()
 
-            # Create a 199-block-long chain; each of the 4 first nodes
-            # gets 25 mature blocks and 25 immature.
-            # The 4th node gets only 24 immature blocks so that the very last
-            # block in the cache does not age too much (have an old tip age).
-            # This is needed so that we are out of IBD when the test starts,
-            # see the tip age check in IsInitialBlockDownload().
-            for i in range(8):
-                self.nodes[CACHE_NODE_ID].generatetoaddress(
-                    nblocks=25 if i != 7 else 24,
-                    address=TestNode.PRIV_KEYS[i % 4].address,
-                )
+            if self.chain != "signet":
+                # Create a 199-block-long chain; each of the 4 first nodes
+                # gets 25 mature blocks and 25 immature.
+                # The 4th node gets only 24 immature blocks so that the very last
+                # block in the cache does not age too much (have an old tip age).
+                # This is needed so that we are out of IBD when the test starts,
+                # see the tip age check in IsInitialBlockDownload().
+                for i in range(8):
+                    self.nodes[CACHE_NODE_ID].generatetoaddress(
+                        nblocks=25 if i != 7 else 24,
+                        address=TestNode.PRIV_KEYS[i % 4].address,
+                    )
 
-            assert_equal(self.nodes[CACHE_NODE_ID].getblockchaininfo()["blocks"], 199)
+                assert_equal(self.nodes[CACHE_NODE_ID].getblockchaininfo()["blocks"], 199)
 
             # Shut it down, and clean up cache directories:
             self.stop_nodes()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -182,6 +182,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',
     'mining_basic.py',
+    'mining_signet.py',
     'wallet_bumpfee.py',
     'wallet_bumpfee_totalfee_deprecation.py',
     'wallet_implicitsegwit.py',

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -30,7 +30,7 @@ enabled=(
     E304 # blank lines found after function decorator
     E306 # expected 1 blank line before a nested definition
     E401 # multiple imports on one line
-    E402 # module level import not at top of file
+    # E402 # module level import not at top of file (interferes with contrib/signet/addtxtoblock.py)
     E502 # the backslash is redundant between brackets
     E701 # multiple statements on one line (colon)
     E702 # multiple statements on one line (semicolon)

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -19,6 +19,7 @@ fi
 # Disabled warnings:
 disabled=(
     SC2046 # Quote this to prevent word splitting.
+    SC2016 # Expressions don't expand in single quotes
     SC2086 # Double quote to prevent globbing and word splitting.
     SC2162 # read without -r will mangle backslashes.
 )


### PR DESCRIPTION
This PR implements BIP 325 (https://github.com/bitcoin/bips/blob/master/bip-0325.mediawiki) -- Signet support.

**Note:** This PR is being split into more bite-sized PR's, the first of which is #18267.

Merged check boxes:
* [ ] Signet consensus: #18267
* [ ] Signet RPC tools: pending consensus merge
* [ ] Signet utility scripts (contrib/signet): pending RPC tool merge

Signet is a proposed new type of test network that requires a signature in the blocks. While this kind of network is centralized, it allows for properties that are desirable in a test network, which testnet alone cannot provide.

Signet has a default global testnet baked in for easy usage, but is built around the concept of there being multiple simultaneous signets. Someone is already working on a signet with bip-taproot etc patched on top of it. When new features are tested globally, starting a temporary signet for that purpose is trivial.

See also: https://en.bitcoin.it/wiki/Signet

Noteworthy:
* ~~proof of work check now skips genesis block for all networks, including mainnet~~
* a new global "is signet" flag is added, which affects consensus: it adds a new enforcement that all blocks must have a valid signature for the "signet block script", a global script
* `DecodeHexBlk` will now attempt to load the block data from a file whose filename is the hex string argument, if it turns out to not be a valid hex string; this has the odd caveat of the relative directory being relative to the execution of `bitcoind`, not `bitcoin-cli` (see `contrib/signet/mkblock.sh`)

Update: proof of work check is back in place; instead, Signet now requires an additional `-signet_genesisnonce` parameter to operate.