### PR TITLE
net: Make poll in InterruptibleRecv only filter for POLLIN events.

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -347,7 +347,7 @@ static IntrRecvError InterruptibleRecv(uint8_t* data, size_t len, int timeout, c
 #ifdef USE_POLL
                 struct pollfd pollfd = {};
                 pollfd.fd = hSocket;
-                pollfd.events = POLLIN | POLLOUT;
+                pollfd.events = POLLIN;
                 int nRet = poll(&pollfd, 1, timeout_ms);
 #else
                 struct timeval tval = MillisToTimeval(timeout_ms);


### PR DESCRIPTION
poll should block until there is data to be read or the timeout expires.

Filtering for the POLLOUT event causes poll to return immediately which leads to high CPU usage when trying to connect to non-responding peers through tor.

When USE_POLL is not defined select is used with the writefds parameter set to nullptr.
Removing POLLOUT causes the behavior of poll to match that of select.

Fixes: #16004.