### PR TITLE
-datadir or -datadir="" option implies default datadir

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -741,8 +741,9 @@ const fs::path &GetDataDir(bool fNetSpecific)
     // this function
     if (!path.empty()) return path;
 
-    if (gArgs.IsArgSet("-datadir")) {
-        path = fs::system_complete(gArgs.GetArg("-datadir", ""));
+    std::string datadir = gArgs.GetArg("-datadir", "");
+    if (!datadir.empty()) {
+        path = fs::system_complete(datadir);
         if (!fs::is_directory(path)) {
             path = "";
             return path;


### PR DESCRIPTION
This PR introduces a new behavior for `-datadir` (w/o a value) or `-datadir=""`: it means "use the default one". It allows to unset a `datadir` option specified in the config file by passing `-datadir` or `-datadir=""` as a command line option.

Credits:
This PR is inspired by **ryanofsky**'s [idea](https://github.com/bitcoin/bitcoin/pull/15864#discussion_r281785729):
> If somebody has a `datadir` option specified in the config file, but wants to unset it on the command line by passing `-nodatadir` or `-datadir=""`, it seems like this should be allowed.

The more general approach, however, has been described by **ryanofsky** [here](https://github.com/bitcoin/bitcoin/pull/16097#discussion_r288078111).