### PR TITLE
QA: Fix race condition in wallet_encryption test

### DIFF
--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -49,7 +49,7 @@ class WalletEncryptionTest(BitcoinTestFramework):
         assert_equal(privkey, self.nodes[0].dumpprivkey(address))
 
         # Check that the timeout is right
-        time.sleep(2)
+        time.sleep(3)
         assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)
 
         # Test wrong passphrase


### PR DESCRIPTION
There is some imprecision probably in the internal HTTPRPCTimer class (haven't exactly figured out where).
But we can't expect that waiting excatly 2 seconds right after calling `walletpassphrase(2)` will result in a locked wallet due to the nature how we internally handle threads/timers.

The wallet_encryption test fails regularely in CIs.

Here is a logged session:
```shell
[0;34m node0 2019-07-18T18:51:22.569739Z [] ThreadRPCServer method=walletpassphrase user=__cookie__ [0m
[0;34m node0 2019-07-18T18:51:22.628656Z [] queue run of timer lockwallet() in 2 seconds (using HTTP) [0m
[0;34m node0 2019-07-18T18:51:22.629002Z [] Received a POST request for / from 127.0.0.1:46898 [0m
[0;34m node0 2019-07-18T18:51:22.629081Z [] ThreadRPCServer method=dumpprivkey user=__cookie__ [0m
[0;34m node0 2019-07-18T18:51:24.445620Z [] Flushing wallet.dat [0m
[0;34m node0 2019-07-18T18:51:24.451421Z [] Flushed wallet.dat 6ms [0m
[0;34m node0 2019-07-18T18:51:24.631703Z [] Received a POST request for / from 127.0.0.1:46898 [0m
[0;34m node0 2019-07-18T18:51:24.631737Z [] ThreadRPCServer method=dumpprivkey user=__cookie__ [0m
[0;36m test  2019-07-18T18:51:24.632000Z TestFramework (ERROR): Assertion failed [0m
[0;36m                                   Traceback (most recent call last):[0m
[0;36m                                     File "/home/ubuntu/src/test/functional/test_framework/test_framework.py", line 193, in main[0m
[0;36m                                       self.run_test()[0m
[0;36m                                     File "/home/ubuntu/src/test/functional/wallet_encryption.py", line 53, in run_test[0m
[0;36m                                       assert_raises_rpc_error(-13, "Please enter the wallet passphrase with walletpassphrase first", self.nodes[0].dumpprivkey, address)[0m
```