### PR TITLE
test: remove redundant setup in addrman_tests

### DIFF
--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -533,9 +533,6 @@ BOOST_AUTO_TEST_CASE(addrman_selecttriedcollision)
 {
     CAddrManTest addrman;
 
-    // Set addrman addr placement to be deterministic.
-    addrman.MakeDeterministic();
-
     BOOST_CHECK(addrman.size() == 0);
 
     // Empty addrman should return blank addrman info.
@@ -567,9 +564,6 @@ BOOST_AUTO_TEST_CASE(addrman_selecttriedcollision)
 BOOST_AUTO_TEST_CASE(addrman_noevict)
 {
     CAddrManTest addrman;
-
-    // Set addrman addr placement to be deterministic.
-    addrman.MakeDeterministic();
 
     // Add twenty two addresses.
     CNetAddr source = ResolveIP("252.2.2.2");
@@ -626,9 +620,6 @@ BOOST_AUTO_TEST_CASE(addrman_noevict)
 BOOST_AUTO_TEST_CASE(addrman_evictionworks)
 {
     CAddrManTest addrman;
-
-    // Set addrman addr placement to be deterministic.
-    addrman.MakeDeterministic();
 
     BOOST_CHECK(addrman.size() == 0);
 


### PR DESCRIPTION
#10765 make this default behavior. No reason to keep these line.