### PR TITLE
Allow proper linearize-data execution on pruned node

### DIFF
--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -103,6 +103,8 @@ class BlockDataCopier:
         self.blkmap = blkmap
 
         self.inFn = 0
+        # Setting self.inFn to the number of first available 'blkNNNNN.dat' file.
+        # On pruned node this file may be different than 'blk00000.dat'.
         fnPattern = os.path.join(self.settings['input'], "blk[0-9][0-9][0-9][0-9][0-9].dat")
         fnList = glob.glob(fnPattern)
         fnList.sort()

--- a/contrib/linearize/linearize-data.py
+++ b/contrib/linearize/linearize-data.py
@@ -17,6 +17,7 @@ import datetime
 import time
 from collections import namedtuple
 from binascii import unhexlify
+import glob
 
 settings = {}
 
@@ -102,6 +103,13 @@ class BlockDataCopier:
         self.blkmap = blkmap
 
         self.inFn = 0
+        fnPattern = os.path.join(self.settings['input'], "blk[0-9][0-9][0-9][0-9][0-9].dat")
+        fnList = glob.glob(fnPattern)
+        fnList.sort()
+        if len(fnList) > 0:
+          firstFn = os.path.basename(fnList[0])
+          self.inFn = int(firstFn[3:8])
+
         self.inF = None
         self.outFn = 0
         self.outsz = 0


### PR DESCRIPTION
linearize-hashes.py properly creates hashlist within given min_height and max_height on a pruned node.

linearize-data.py expects to find blk00000.dat (which may be missing on pruned node along with additional subsequent blk files) and throws error:
```
   $ ./linearize-data.py linearize.cfg 
   Read 15000 hashes
   Input file <some-dir>/blocks/blk00000.dat
   Premature end of block data
```
even though blocks in the range min_height-max_height are not pruned.

To avoid this error and allow for proper linearize-data run on pruned node it is enough to start with first non-pruned blk file. Attached code does exactly this.
