### PR TITLE
build: Specify AM_CPPFLAGS for ZMQ

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -309,7 +309,7 @@ libbitcoin_server_a_SOURCES += dummywallet.cpp
 endif
 
 if ENABLE_ZMQ
-libbitcoin_zmq_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)
+libbitcoin_zmq_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(ZMQ_CFLAGS)
 libbitcoin_zmq_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_zmq_a_SOURCES = \
   zmq/zmqabstractnotifier.cpp \


### PR DESCRIPTION
When building the ZMQ static library, add `AM_CPPFLAGS` to the library `CPPFLAGS`.  Otherwise, we may miss important flags that are specified elsewhere.  For instance, if `--enable-debug` is passed and
`-DDEBUG_LOCKORDER` set, then that would not apply to the ZMQ library before (causing potential for hard-to-find bugs).