### PR TITLE
Always connect NotifyEntryRemoved with MempoolEntryRemoved

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -302,7 +302,6 @@ void Shutdown(InitInterfaces& interfaces)
     interfaces.chain_clients.clear();
     UnregisterAllValidationInterfaces();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
-    GetMainSignals().UnregisterWithMempoolSignals(mempool);
     globalVerifyHandle.reset();
     ECC_Stop();
     LogPrintf("%s: done\n", __func__);
@@ -1285,8 +1284,7 @@ bool AppInitMain(InitInterfaces& interfaces)
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
     threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
-    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
-    GetMainSignals().RegisterWithMempoolSignals(mempool);
+    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler, ::mempool);
 
     // Create client interfaces for wallets that are supposed to be loaded
     // according to -wallet and -disablewallet options. This only constructs

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -78,7 +78,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
     // We have to run a scheduler thread to prevent ActivateBestChain
     // from blocking due to queue overrun.
     threadGroup.create_thread(std::bind(&CScheduler::serviceQueue, &scheduler));
-    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
+    GetMainSignals().RegisterBackgroundSignalScheduler(scheduler, ::mempool);
 
     mempool.setSanityCheck(1.0);
     pblocktree.reset(new CBlockTreeDB(1 << 20, true));

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -158,22 +158,18 @@ private:
     friend void ::UnregisterAllValidationInterfaces();
     friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 
+    /** This gets called from the connected mempool and may set off TransactionRemovedFromMempool callbacks */
     void MempoolEntryRemoved(CTransactionRef tx, MemPoolRemovalReason reason);
 
 public:
     /** Register a CScheduler to give callbacks which should run in the background (may only be called once) */
-    void RegisterBackgroundSignalScheduler(CScheduler& scheduler);
+    void RegisterBackgroundSignalScheduler(CScheduler& scheduler, CTxMemPool& pool);
     /** Unregister a CScheduler to give callbacks which should run in the background - these callbacks will now be dropped! */
     void UnregisterBackgroundSignalScheduler();
     /** Call any remaining callbacks on the calling thread */
     void FlushBackgroundCallbacks();
 
     size_t CallbacksPending();
-
-    /** Register with mempool to call TransactionRemovedFromMempool callbacks */
-    void RegisterWithMempoolSignals(CTxMemPool& pool);
-    /** Unregister with mempool */
-    void UnregisterWithMempoolSignals(CTxMemPool& pool);
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &);


### PR DESCRIPTION
`TransactionRemovedFromMempool` is used to notify of removed tx, excluding txs that were already notified via `BlockConnected`. However, we will miss those notifications, if we forgot to call `RegisterWithMempoolSignals`. This happened in the unit tests (`setup_common`).

Fix it by enforcing that the connection is always established, which simplifies the code. Also, add some docs.