### PR TITLE
travis: Print memory and number of cpus

### DIFF
--- a/.travis/test_04_install.sh
+++ b/.travis/test_04_install.sh
@@ -6,6 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
+free -m -h
+echo "Number of CPUs (nproc): $(nproc)"
+
 travis_retry docker pull "$DOCKER_NAME_TAG"
 
 export DIR_FUZZ_IN=${TRAVIS_BUILD_DIR}/qa-assets


### PR DESCRIPTION
For some reason it shows a different value than the one they advertise. This might be related to the flood of sanitizer warnings we see.


https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system