### PR TITLE
cli/gui: support "@height" in place of blockhash for getblock on client side

### DIFF
--- a/doc/release-notes-16439.md
+++ b/doc/release-notes-16439.md
@@ -1,0 +1,9 @@
+Specify block by height in CLI or Debug Console
+-----------------------------------------------
+
+The ability to specify a block by a height instead of its hash
+has been added to bitcoin-cli and the GUI debug console. This is a
+client-side shortcut for first querying the hash via `getblockhash` or
+`getbestblockhash`. The syntax is `getblockheader @123456` to refer to
+the block at height 123456 or `getblockheader @best` to refer to the tip.
+(#16439)

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -206,6 +206,8 @@ static const CRPCConvertParam rpc_params_convert_blockhash[] =
     { "getblockfilter", 0, "blockhash" },
     { "getrawtransaction", 2, "blockhash" },
     { "gettxoutproof", 1, "blockhash" },
+    { "getdeploymentinfo", 0, "blockhash" },
+    { "listsinceblock", 0, "blockhash" },
 };
 // clang-format on
 

--- a/src/rpc/client.h
+++ b/src/rpc/client.h
@@ -14,6 +14,12 @@ UniValue RPCConvertValues(const std::string& strMethod, const std::vector<std::s
 /** Convert named arguments to command-specific RPC representation */
 UniValue RPCConvertNamedValues(const std::string& strMethod, const std::vector<std::string>& strParams);
 
+/** Whether this is a positional blockhash parameter */
+bool RPCConvertBlockhash(const std::string& method, int pos);
+
+/** Whether this is a named blockhash parameter */
+bool RPCConvertNamedBlockhash(const std::string& method, const std::string& param);
+
 /** Non-RFC4627 JSON parser, accepts internal values (such as numbers, true, false, null)
  * as well as objects and arrays.
  */

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -42,6 +42,19 @@ class TestBitcoinCli(BitcoinTestFramework):
         rpc_response = self.nodes[0].getblockchaininfo()
         assert_equal(cli_response, rpc_response)
 
+        header_tests = [ ("@50", self.nodes[0].getblockhash(50)),
+                         ("@best", self.nodes[0].getbestblockhash()),
+                       ]
+        for at,hash in header_tests:
+            self.log.info("Compare response from getblockheader RPC %s/%s" % (at,hash))
+            rpc_response = self.nodes[0].getblockheader(hash)
+            cli_response = self.nodes[0].cli.getblockheader(hash)
+            cli_response_at = self.nodes[0].cli.getblockheader(at)
+            cli_response_at_named = self.nodes[0].cli.getblockheader(blockhash=at)
+            assert_equal(cli_response, rpc_response)
+            assert_equal(cli_response_at, rpc_response)
+            assert_equal(cli_response_at_named, rpc_response)
+
         user, password = get_auth_cookie(self.nodes[0].datadir, self.chain)
 
         self.log.info("Test -stdinrpcpass option")


### PR DESCRIPTION
Update bitcoin-cli and gui debug console so that RPC calls that accept a block hash to reference a block will also accept a block by height prefixed by `@`, or `@best` to reference the tip. The clients will just make an RPC call to `getblockhash` or `getbestblockhash` to replace the argument with the hash before making the requested RPC call.

Affected RPCs:

 * getblockheader
 * getblock
 * preciousblock
 * invalidateblock
 * getchaintxstats
 * getblockfilter
 * getrawtransaction
 * gettxoutproof

The RPC calls waitforblock, and reconsiderblock are unaffected because specifying a blockhash already in the main chain for those calls is not useful, and getblockstats is unaffected because it already accepts a height.