### PR TITLE
BIP-322: Generic signed message format

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -189,6 +189,7 @@ BITCOIN_CORE_H = \
   scheduler.h \
   script/descriptor.h \
   script/keyorigin.h \
+  script/proof.h \
   script/sigcache.h \
   script/sign.h \
   script/signingprovider.h \
@@ -507,6 +508,7 @@ libbitcoin_util_a_SOURCES = \
   random.cpp \
   randomenv.cpp \
   rpc/request.cpp \
+  script/proof.cpp \
   support/cleanse.cpp \
   sync.cpp \
   threadinterrupt.cpp \

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -10,6 +10,7 @@
 #include <policy/fees.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
+#include <script/proof.h>
 #include <support/allocators/secure.h>
 #include <sync.h>
 #include <ui_interface.h>
@@ -476,6 +477,11 @@ public:
     void remove() override
     {
         RemoveWallet(m_wallet);
+    }
+    void signMessage(const std::string& message, const CTxDestination& destination, std::vector<uint8_t>& signature_out) override
+    {
+        auto provider = m_wallet->GetSigningProvider(GetScriptForDestination(destination));
+        proof::SignMessageWithSigningProvider(std::move(provider), message, destination, signature_out);
     }
     std::unique_ptr<Handler> handleUnload(UnloadFn fn) override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -263,6 +263,11 @@ public:
     // Remove wallet.
     virtual void remove() = 0;
 
+    /**
+     * Attempt to sign a message with the given destination.
+     */
+    virtual void signMessage(const std::string& message, const CTxDestination& destination, std::vector<uint8_t>& signature_out) = 0;
+
     //! Register handler for unload message.
     using UnloadFn = std::function<void()>;
     virtual std::unique_ptr<Handler> handleUnload(UnloadFn fn) = 0;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -134,6 +134,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "importmulti", 1, "options" },
     { "verifychain", 0, "checklevel" },
     { "verifychain", 1, "nblocks" },
+    { "verifymessage", 3, "verbosity" },
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
     { "pruneblockchain", 0, "height" },

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1414,6 +1414,20 @@ bool GenericTransactionSignatureChecker<T>::CheckSequence(const CScriptNum& nSeq
 template class GenericTransactionSignatureChecker<CTransaction>;
 template class GenericTransactionSignatureChecker<CMutableTransaction>;
 
+bool SimpleSignatureChecker::CheckSig(const std::vector<unsigned char>& vchSigIn, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+{
+    CPubKey pubkey(vchPubKey);
+    if (!pubkey.IsValid()) return false;
+
+    // Hash type is one byte tacked on to the end of the signature
+    std::vector<unsigned char> vchSig(vchSigIn);
+    if (vchSig.empty()) return false;
+    // int nHashType = vchSig.back();
+    vchSig.pop_back();
+
+    return pubkey.Verify(hash, vchSig);
+}
+
 static bool VerifyWitnessProgram(const CScriptWitness& witness, int witversion, const std::vector<unsigned char>& program, unsigned int flags, const BaseSignatureChecker& checker, ScriptError* serror)
 {
     std::vector<std::vector<unsigned char> > stack;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -161,6 +161,18 @@ public:
     virtual ~BaseSignatureChecker() {}
 };
 
+/** A general purpose signature checker. */
+class SimpleSignatureChecker : public BaseSignatureChecker
+{
+private:
+    uint256 hash;
+
+public:
+    const uint256& GetHash() const { return hash; }
+    explicit SimpleSignatureChecker(const uint256& hash_in) : hash(hash_in) {}
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const override;
+};
+
 template <class T>
 class GenericTransactionSignatureChecker : public BaseSignatureChecker
 {

--- a/src/script/proof.cpp
+++ b/src/script/proof.cpp
@@ -54,7 +54,7 @@ void SignMessageWithSigningProvider(std::unique_ptr<SigningProvider> sp, const s
     }
 }
 
-void SignMessageWithPrivateKey(CKey& key, OutputType address_type, const std::string& message, std::vector<uint8_t>& signature_out)
+void SignMessageWithPrivateKey(const CKey& key, OutputType address_type, const std::string& message, std::vector<uint8_t>& signature_out)
 {
     if (address_type == OutputType::LEGACY) {
         CHashWriter ss(SER_GETHASH, 0);

--- a/src/script/proof.cpp
+++ b/src/script/proof.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2019-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/proof.h>
+
+/**
+ * Text used to signify that a signed message follows and to prevent
+ * inadvertently signing a transaction.
+ */
+const std::string MESSAGE_MAGIC = "Bitcoin Signed Message:\n";
+
+namespace proof
+{
+
+Result SignMessage::Prepare(const std::string& message, std::set<CScript>& inputs_out, uint256& sighash_out, CScript& spk_out) const {
+    Result rv = Purpose::Prepare(m_scriptpubkey, inputs_out);
+    if (rv != Result::Valid) return rv;
+    CHashWriter hw(SER_DISK, 0);
+    std::string s = MESSAGE_MAGIC + message;
+    hw << m_scriptpubkey << s;
+    sighash_out = hw.GetHash();
+    spk_out = m_scriptpubkey;
+    return Result::Valid;
+}
+
+void SignMessageWithSigningProvider(std::unique_ptr<SigningProvider> sp, const std::string& message, const CTxDestination& destination, std::vector<uint8_t>& signature_out)
+{
+    signature_out.clear();
+
+    // if this is a P2PKH, use the legacy approach
+    const PKHash *pkhash = boost::get<PKHash>(&destination);
+    if (pkhash) {
+        CKey key;
+        if (!sp->GetKey(CKeyID(*pkhash), key)) {
+            throw privkey_unavailable_error();
+        }
+
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << MESSAGE_MAGIC << message;
+
+        if (!key.SignCompact(ss.GetHash(), signature_out)) {
+            throw signing_error();
+        }
+    } else {
+        SignMessageWorkspace p;
+
+        p.AppendDestinationChallenge(destination);
+
+        p.Prove(message, std::move(sp));
+
+        CVectorWriter w(SER_DISK, PROTOCOL_VERSION, signature_out, 0);
+        w << p.m_proof;
+    }
+}
+
+void SignMessageWithPrivateKey(CKey& key, OutputType address_type, const std::string& message, std::vector<uint8_t>& signature_out)
+{
+    if (address_type == OutputType::LEGACY) {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << MESSAGE_MAGIC << message;
+
+        if (!key.SignCompact(ss.GetHash(), signature_out)) {
+            throw signing_error();
+        }
+    } else {
+        SignMessageWorkspace p;
+
+        p.AppendPrivKeyChallenge(key, address_type);
+
+        p.Prove(message);
+
+        CVectorWriter w(SER_DISK, PROTOCOL_VERSION, signature_out, 0);
+        w << p.m_proof;
+    }
+}
+
+Result VerifySignature(const std::string& message, const CTxDestination& destination, const std::vector<uint8_t>& signature)
+{
+    // if this is a P2PKH, use the legacy approach
+    const PKHash* pkhash = boost::get<PKHash>(&destination);
+    if (pkhash) {
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << MESSAGE_MAGIC << message;
+        CPubKey pubkey;
+        return ResultFromBool(pubkey.RecoverCompact(ss.GetHash(), signature) && pubkey.GetID() == *pkhash);
+    }
+
+    SignMessageWorkspace p;
+
+    p.AppendDestinationChallenge(destination);
+
+    CDataStream stream(signature, SER_DISK, PROTOCOL_VERSION);
+    try {
+        stream >> p.m_proof;
+        return p.Verify(message);
+    } catch (const std::runtime_error&) {
+        return Result::Error;
+    }
+}
+
+} // namespace proof

--- a/src/script/proof.h
+++ b/src/script/proof.h
@@ -1,0 +1,270 @@
+// Copyright (c) 2019-2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SCRIPT_PROOF_H
+#define BITCOIN_SCRIPT_PROOF_H
+
+#include <script/bitcoinconsensus.h> // Block script flags
+#include <script/interpreter.h>      // SimpleSignatureChecker
+#include <script/standard.h>         // CTxDestination
+#include <script/sign.h>             // ProduceSignature, SimpleSignatureCreator
+#include <serialize.h>
+#include <outputtype.h>              // GetDestinationForKey
+#include <policy/policy.h>           // for STANDARD_SCRIPT_VERIFY_FLAGS
+#include <hash.h>                    // CHashWriter
+#include <util/memory.h>             // MakeUnique
+
+extern const std::string MESSAGE_MAGIC;
+
+namespace proof {
+
+class dest_unavailable_error : public std::runtime_error { public: explicit dest_unavailable_error(const std::string& str = "Destination is not available") : std::runtime_error(str) {} };
+class privkey_unavailable_error : public std::runtime_error { public: explicit privkey_unavailable_error(const std::string& str = "Private key is not available") : std::runtime_error(str) {} };
+class signing_error : public std::runtime_error { public: explicit signing_error(const std::string& str = "Sign failed") : std::runtime_error(str) {} };
+class serialization_error : public std::runtime_error { public: explicit serialization_error(const std::string& str = "Serialization error") : std::runtime_error(str) {} };
+
+/**
+ * Result codes ordered numerically by severity, so that A is reported, if A <= B and A and B are
+ * two results for a verification attempt.
+ */
+enum class Result : int8_t {
+    Valid = 0,           //!< All proofs were deemed valid.
+    Inconclusive = -1,   //!< One or several of the given proofs used unknown opcodes or the scriptPubKey had an unknown witness version, perhaps due to the verifying node being outdated.
+    Incomplete = -2,     //!< One or several of the given challenges had an empty proof. The prover may need some other entity to complete the proof.
+    Invalid = -3,        //!< One or more of the given proofs were invalid
+    Error = -4,          //!< An error was encountered
+};
+
+inline std::string ResultString(const Result r) {
+    static const char *strings[] = {"ERROR", "INVALID", "INCOMPLETE", "INCONCLUSIVE", "VALID"};
+    return r < Result::Error || r > Result::Valid ? "???" : strings[(int)r + 4];
+}
+
+inline Result ResultFromBool(bool success) {
+    return success ? Result::Valid : Result::Invalid;
+}
+
+static constexpr uint32_t BIP322_FORMAT_VERSION = 1;
+
+struct Header {
+    uint32_t m_version;     //!< Format version
+    uint8_t m_entries;      //!< Number of proof entries
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        m_version = BIP322_FORMAT_VERSION;
+        READWRITE(m_version);
+        if (m_version > BIP322_FORMAT_VERSION) throw serialization_error("Unknown BIP322 proof format; you may need to update your node");
+        if (m_version < BIP322_FORMAT_VERSION) throw serialization_error("Outdated BIP322 proof format; ask prover to re-sign using newer software");
+        READWRITE(m_entries);
+    }
+};
+
+struct SignatureProof {
+    CScript m_scriptsig; //!< ScriptSig data
+    CScriptWitness m_witness;   //!< Witness
+
+    explicit SignatureProof(const SignatureData& sigdata = SignatureData()) {
+        m_scriptsig = sigdata.scriptSig;
+        m_witness = sigdata.scriptWitness;
+    }
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(m_scriptsig);
+        READWRITE(m_witness.stack);
+    }
+};
+
+struct Purpose {
+    template<typename T>
+    Result Prepare(const T& input, std::set<T>& inputs_out) const {
+        if (inputs_out.count(input)) return Result::Error;
+        inputs_out.insert(input);
+        return Result::Valid;
+    }
+};
+
+/**
+ * Purpose: SignMessage
+ *
+ * Generate a sighash based on a scriptPubKey and a message. Emits VALID on success.
+ */
+struct SignMessage: Purpose {
+    CScript m_scriptpubkey;
+
+    explicit SignMessage(const CScript& scriptpubkey = CScript()) : m_scriptpubkey(scriptpubkey) {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(m_scriptpubkey);
+    }
+
+    Result Prepare(const std::string& message, std::set<CScript>& inputs_out, uint256& sighash_out, CScript& spk_out) const;
+
+    inline std::set<CScript> InputsSet() { return std::set<CScript>(); }
+};
+
+struct Proof: public Header {
+    std::vector<SignatureProof> m_items;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        Header::SerializationOp(s, ser_action);
+        m_items.resize(m_entries);
+        for (auto& e : m_items) {
+            READWRITE(e);
+        }
+    }
+};
+
+template<typename T>
+struct BaseWorkSpace {
+    std::map<CTxDestination, CKey> privkeys;
+    std::vector<T> m_challenge;
+    Proof m_proof;
+
+    virtual void GenerateSingleProof(std::unique_ptr<SigningProvider> sp, const uint256& sighash, const CScript& scriptPubKey) = 0;
+    virtual Result VerifySingleProof(unsigned int flags, const SignatureProof& proof, const uint256& sighash, const CScript& scriptPubKey) = 0;
+
+    void Prove(const std::string& message, std::unique_ptr<SigningProvider> signingProvider = nullptr) {
+        assert(m_challenge.size() <= 255);
+        m_proof.m_items.clear();
+        m_proof.m_version = BIP322_FORMAT_VERSION;
+        m_proof.m_entries = m_challenge.size();
+        if (m_challenge.size() == 0) return;
+        auto inputs = m_challenge.back().InputsSet();
+        uint256 sighash;
+        CScript scriptPubKey;
+        for (auto& c : m_challenge) {
+            auto r = c.Prepare(message, inputs, sighash, scriptPubKey);
+            if (r != Result::Valid) {
+                throw std::runtime_error("Prepare call failed (error: " + ResultString(r) + ")");
+            }
+            CTxDestination destination;
+            if (!ExtractDestination(scriptPubKey, destination)) {
+                throw dest_unavailable_error();
+            }
+            CKey secret;
+            if (privkeys.count(destination)) {
+                secret = privkeys.at(destination);
+            } else if (signingProvider) {
+                auto keyid = GetKeyForDestination(*signingProvider, destination);
+                if (keyid.IsNull()) {
+                    throw privkey_unavailable_error("ScriptPubKey does not refer to a key (note: multisig is not yet supported)");
+                }
+                if (!signingProvider->GetKey(keyid, secret)) {
+                    throw privkey_unavailable_error("Private key for scriptPubKey is not known");
+                }
+            } else {
+                throw privkey_unavailable_error("Failed to obtain private key for destination");
+            }
+            std::unique_ptr<FillableSigningProvider> sp = MakeUnique<FillableSigningProvider>();
+            sp->AddKey(secret);
+            GenerateSingleProof(std::move(sp), sighash, scriptPubKey);
+        }
+    }
+
+    Result Verify(const std::string& message) {
+        size_t proofs = m_proof.m_items.size();
+        size_t challenges = m_challenge.size();
+        if (challenges == 0) {
+            throw std::runtime_error("Nothing to verify");
+        }
+        if (proofs != challenges) {
+            // TODO: fill out vector with empty proofs if too few and get incomplete result? What to do about too many?
+            throw std::runtime_error(proofs < challenges ? "Proofs missing" : "Too many proofs");
+        }
+
+        auto inputs = m_challenge.back().InputsSet();
+        Result aggres = Result::Valid;
+        for (size_t i = 0; i < proofs; ++i) {
+            auto& proof = m_proof.m_items.at(i);
+            if (proof.m_scriptsig.size() == 0 && proof.m_witness.stack.size() == 0) {
+                if (aggres == Result::Valid) aggres = Result::Incomplete;
+                continue;
+            }
+            auto& challenge = m_challenge.at(i);
+            uint256 sighash;
+            CScript scriptPubKey;
+            Result res = challenge.Prepare(message, inputs, sighash, scriptPubKey);
+            if (res != Result::Valid) return res;
+            // verify using consensus rules first
+            res = VerifySingleProof(bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL, proof, sighash, scriptPubKey);
+            if (res == Result::Error || res == Result::Invalid) return res;
+            if (res == Result::Valid) {
+                res = VerifySingleProof(STANDARD_SCRIPT_VERIFY_FLAGS, proof, sighash, scriptPubKey);
+                if (res == Result::Invalid) res = Result::Inconclusive;
+            }
+            if (res < aggres) {
+                aggres = res;
+            }
+        }
+        return aggres;
+    }
+};
+
+template<typename T> struct Workspace: public BaseWorkSpace<T> {};
+
+template<>
+struct Workspace<SignMessage>: public BaseWorkSpace<SignMessage> {
+    void AppendDestinationChallenge(const CTxDestination& destination) {
+        auto a = GetScriptForDestination(destination);
+        m_challenge.emplace_back(a);
+    }
+    void AppendPrivKeyChallenge(const CKey& key, OutputType address_type = OutputType::BECH32) {
+        auto d = GetDestinationForKey(key.GetPubKey(), address_type);
+        auto a = GetScriptForDestination(d);
+        privkeys[d] = key;
+        m_challenge.emplace_back(a);
+    }
+    void GenerateSingleProof(std::unique_ptr<SigningProvider> sp, const uint256& sighash, const CScript& scriptPubKey) override {
+        SimpleSignatureCreator sc(sighash);
+        SignatureData sigdata;
+        if (!ProduceSignature(*sp, sc, scriptPubKey, sigdata)) {
+            throw signing_error("Failed to produce a signature");
+        }
+        m_proof.m_items.emplace_back(sigdata);
+    }
+    Result VerifySingleProof(unsigned int flags, const SignatureProof& proof, const uint256& sighash, const CScript& scriptPubKey) override {
+        auto& scriptSig = proof.m_scriptsig;
+        auto& witness = proof.m_witness;
+        SimpleSignatureChecker sc(sighash);
+        ScriptError serror;
+        if (!VerifyScript(scriptSig, scriptPubKey, witness.stack.size() ? &witness : nullptr, flags, sc, &serror)) {
+            // TODO: inconclusive check
+            return Result::Invalid;
+        }
+        return Result::Valid;
+    }
+};
+
+typedef Workspace<SignMessage> SignMessageWorkspace;
+
+/**
+ * Attempt to sign a message with the given destination.
+ */
+void SignMessageWithSigningProvider(std::unique_ptr<SigningProvider> sp, const std::string& message, const CTxDestination& destination, std::vector<uint8_t>& signature_out);
+
+/**
+ * Attempt to sign a message with the given private key and address format.
+ */
+void SignMessageWithPrivateKey(CKey& key, OutputType address_type, const std::string& message, std::vector<uint8_t>& signature_out);
+
+/**
+ * Determine if a signature is valid for the given message.
+ */
+Result VerifySignature(const std::string& message, const CTxDestination& destination, const std::vector<uint8_t>& signature);
+
+} // namespace proof
+
+#endif // BITCOIN_SCRIPT_PROOF_H

--- a/src/script/proof.h
+++ b/src/script/proof.h
@@ -258,7 +258,7 @@ void SignMessageWithSigningProvider(std::unique_ptr<SigningProvider> sp, const s
 /**
  * Attempt to sign a message with the given private key and address format.
  */
-void SignMessageWithPrivateKey(CKey& key, OutputType address_type, const std::string& message, std::vector<uint8_t>& signature_out);
+void SignMessageWithPrivateKey(const CKey& key, OutputType address_type, const std::string& message, std::vector<uint8_t>& signature_out);
 
 /**
  * Determine if a signature is valid for the given message.

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -33,6 +33,15 @@ bool MutableTransactionSignatureCreator::CreateSig(const SigningProvider& provid
     return true;
 }
 
+bool SimpleSignatureCreator::CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const
+{
+    CKey key;
+    if (!provider.GetKey(keyid, key)) return false;
+    if (!key.Sign(checker.GetHash(), vchSig)) return false;
+    vchSig.push_back((unsigned char)SIGHASH_ALL);
+    return true;
+}
+
 static bool GetCScript(const SigningProvider& provider, const SignatureData& sigdata, const CScriptID& scriptid, CScript& script)
 {
     if (provider.GetCScript(scriptid, script)) {

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -31,6 +31,17 @@ public:
     virtual bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const =0;
 };
 
+/** A general purpose signature creator. */
+class SimpleSignatureCreator : public BaseSignatureCreator
+{
+    SimpleSignatureChecker checker;
+
+public:
+    explicit SimpleSignatureCreator(const uint256& hashIn) : BaseSignatureCreator(), checker(hashIn) {};
+    const BaseSignatureChecker& Checker() const override { return checker; }
+    bool CreateSig(const SigningProvider& provider, std::vector<unsigned char>& vchSig, const CKeyID& keyid, const CScript& scriptCode, SigVersion sigversion) const override;
+};
+
 /** A signature creator for transactions. */
 class MutableTransactionSignatureCreator : public BaseSignatureCreator {
     const CMutableTransaction* txTo;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -19,6 +19,7 @@
 #include <util/time.h>
 #include <util/spanparsing.h>
 #include <util/vector.h>
+#include <outputtype.h>
 
 #include <array>
 #include <stdint.h>
@@ -2058,7 +2059,7 @@ BOOST_AUTO_TEST_CASE(message_sign)
     BOOST_REQUIRE_MESSAGE(!privkey.IsValid(),
         "Confirm the private key is invalid");
 
-    BOOST_CHECK_MESSAGE(!MessageSign(privkey, message, generated_signature),
+    BOOST_CHECK_MESSAGE(!MessageSign(privkey, message, OutputType::LEGACY, generated_signature),
         "Sign with an invalid private key");
 
     privkey.Set(privkey_bytes.begin(), privkey_bytes.end(), true);
@@ -2066,7 +2067,7 @@ BOOST_AUTO_TEST_CASE(message_sign)
     BOOST_REQUIRE_MESSAGE(privkey.IsValid(),
         "Confirm the private key is valid");
 
-    BOOST_CHECK_MESSAGE(MessageSign(privkey, message, generated_signature),
+    BOOST_CHECK_MESSAGE(MessageSign(privkey, message, OutputType::LEGACY, generated_signature),
         "Sign with a valid private key");
 
     BOOST_CHECK_EQUAL(expected_signature, generated_signature);

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -12,7 +12,8 @@
 #include <test/util/setup_common.h>
 #include <test/util/str.h>
 #include <uint256.h>
-#include <util/message.h> // For MessageSign(), MessageVerify(), MESSAGE_MAGIC
+#include <util/message.h> // For MessageSign(), MessageVerify()
+#include <script/proof.h> // For MESSAGE_MAGIC
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>
@@ -2084,13 +2085,6 @@ BOOST_AUTO_TEST_CASE(message_verify)
 
     BOOST_CHECK_EQUAL(
         MessageVerify(
-            "3B5fQsEXEaV8v6U3ejYc8XaKXAkyQj2MjV",
-            "signature should be irrelevant",
-            "message too"),
-        MessageVerificationResult::ERR_ADDRESS_NO_KEY);
-
-    BOOST_CHECK_EQUAL(
-        MessageVerify(
             "1KqbBpLy5FARmTPD4VZnDDpYjkUvkr82Pm",
             "invalid signature, not in base64 encoding",
             "message should be irrelevant"),
@@ -2101,14 +2095,7 @@ BOOST_AUTO_TEST_CASE(message_verify)
             "1KqbBpLy5FARmTPD4VZnDDpYjkUvkr82Pm",
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
             "message should be irrelevant"),
-        MessageVerificationResult::ERR_PUBKEY_NOT_RECOVERED);
-
-    BOOST_CHECK_EQUAL(
-        MessageVerify(
-            "15CRxFdyRpGZLW9w8HnHvVduizdL5jKNbs",
-            "IPojfrX2dfPnH26UegfbGQQLrdK844DlHq5157/P6h57WyuS/Qsl+h/WSVGDF4MUi4rWSswW38oimDYfNNUBUOk=",
-            "I never signed this"),
-        MessageVerificationResult::ERR_NOT_SIGNED);
+        MessageVerificationResult::ERR_MALFORMED_SIGNATURE);
 
     BOOST_CHECK_EQUAL(
         MessageVerify(

--- a/src/util/message.cpp
+++ b/src/util/message.cpp
@@ -15,12 +15,6 @@
 #include <string>
 #include <vector>
 
-/**
- * Text used to signify that a signed message follows and to prevent
- * inadvertently signing a transaction.
- */
-const std::string MESSAGE_MAGIC = "Bitcoin Signed Message:\n";
-
 MessageVerificationResult MessageVerify(
     const std::string& address,
     const std::string& signature,

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -11,7 +11,7 @@
 
 #include <string>
 
-extern const std::string MESSAGE_MAGIC;
+enum class OutputType;
 
 /** The result of a signed message verification.
  * Message verification takes as an input:

--- a/src/util/message.h
+++ b/src/util/message.h
@@ -13,6 +13,8 @@
 
 enum class OutputType;
 
+enum class OutputType;
+
 /** The result of a signed message verification.
  * Message verification takes as an input:
  * - address (with whose private key the message is supposed to have been signed)
@@ -39,6 +41,11 @@ enum class MessageVerificationResult {
     OK
 };
 
+inline std::string MessageVerificationResultString(const MessageVerificationResult r) {
+    static const char *strings[] = {"ERR_INVALID_ADDRESS", "ERR_ADDRESS_NO_KEY", "ERR_MALFORMED_SIGNATURE", "ERR_PUBKEY_NOT_RECOVERED", "ERR_NOT_SIGNED", "OK"};
+    return strings[(int)r];
+}
+
 /** Verify a signed message.
  * @param[in] address Signer's bitcoin address, it must refer to a public key.
  * @param[in] signature The signature in base64 format.
@@ -50,13 +57,15 @@ MessageVerificationResult MessageVerify(
     const std::string& message);
 
 /** Sign a message.
- * @param[in] privkey Private key to sign with.
- * @param[in] message The message to sign.
+ * @param[in] privkey      Private key to sign with.
+ * @param[in] message      The message to sign.
+ * @param[in] address_type The address type to use for signing
  * @param[out] signature Signature, base64 encoded, only set if true is returned.
  * @return true if signing was successful. */
 bool MessageSign(
     const CKey& privkey,
     const std::string& message,
+    const OutputType& address_type,
     std::string& signature);
 
 /**

--- a/test/functional/rpc_signmessage.py
+++ b/test/functional/rpc_signmessage.py
@@ -11,7 +11,7 @@ class SignMessagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 1
-        self.extra_args = [["-addresstype=legacy"]]
+        self.extra_args = [["-addresstype=bech32"]]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -20,23 +20,65 @@ class SignMessagesTest(BitcoinTestFramework):
         message = 'This is just a test message'
 
         self.log.info('test signing with priv_key')
+        self.log.info('test signing with priv_key with bech32')
+        priv_key = 'cVbpmtsSXkBJhSZakwBSUY7jxhUgXZeT4hCAGyKixccRZwMG4jrf'
+        address = 'bcrt1qf2yvxk355rc6pqgprrn7q4d3lctr22ta3ne08w'
+        signature = self.nodes[0].signmessagewithprivkey(priv_key, message, 'bech32')
+        assert self.nodes[0].verifymessage(address, signature, message)
+        assert_equal("OK", self.nodes[0].verifymessage(address, signature, message, 1))
+
+        self.log.info('test legacy key signing')
         priv_key = 'cUeKHd5orzT3mz8P9pxyREHfsWtVfgsfDjiZZBcjUBAaGk1BTj7N'
         address = 'mpLQjfK79b7CCV4VMJWEWAj5Mpx8Up5zxB'
         expected_signature = 'INbVnW4e6PeRmsv2Qgu8NuopvrVjkcxob+sX8OcZG0SALhWybUjzMLPdAsXI46YZGb0KQTRii+wWIQzRpG/U+S0='
         signature = self.nodes[0].signmessagewithprivkey(priv_key, message)
         assert_equal(expected_signature, signature)
         assert self.nodes[0].verifymessage(address, signature, message)
+        assert_equal("OK", self.nodes[0].verifymessage(address, signature, message, 1))
 
         self.log.info('test signing with an address with wallet')
         address = self.nodes[0].getnewaddress()
         signature = self.nodes[0].signmessage(address, message)
         assert self.nodes[0].verifymessage(address, signature, message)
+        assert_equal("OK", self.nodes[0].verifymessage(address, signature, message, 1))
 
         self.log.info('test verifying with another address should not work')
         other_address = self.nodes[0].getnewaddress()
+        legacy_address = self.nodes[0].getnewaddress(address_type='legacy')
         other_signature = self.nodes[0].signmessage(other_address, message)
+        legacy_signature = self.nodes[0].signmessage(legacy_address, message)
         assert not self.nodes[0].verifymessage(other_address, signature, message)
         assert not self.nodes[0].verifymessage(address, other_signature, message)
+        assert not self.nodes[0].verifymessage(legacy_address, signature, message)
+        assert not self.nodes[0].verifymessage(address, legacy_signature, message)
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(other_address, signature, message, 1))
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(address, other_signature, message, 1))
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(legacy_address, signature, message, 1))
+        # We get an error here, because the verifier believes the proof should be a BIP-322 proof, due to
+        # the address not being P2PKH, but the proof is a legacy proof
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(address, legacy_signature, message, 1))
+
+        self.log.info('test signing with a legacy address with wallet')
+        address = self.nodes[0].getnewaddress(address_type='legacy')
+        signature = self.nodes[0].signmessage(address, message)
+        assert self.nodes[0].verifymessage(address, signature, message)
+        assert_equal("OK", self.nodes[0].verifymessage(address, signature, message, 1))
+
+        self.log.info('test verifying legacy proof with another address should not work')
+        other_address = self.nodes[0].getnewaddress()
+        legacy_address = self.nodes[0].getnewaddress(address_type='legacy')
+        other_signature = self.nodes[0].signmessage(other_address, message)
+        legacy_signature = self.nodes[0].signmessage(legacy_address, message)
+        assert not self.nodes[0].verifymessage(other_address, signature, message)
+        assert not self.nodes[0].verifymessage(address, other_signature, message)
+        assert not self.nodes[0].verifymessage(legacy_address, signature, message)
+        assert not self.nodes[0].verifymessage(address, legacy_signature, message)
+        # We get an error here, because the verifier believes the proof should be a BIP-322 proof, due to
+        # the address not being P2PKH, but the proof is a legacy proof
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(other_address, signature, message, 1))
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(address, other_signature, message, 1))
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(legacy_address, signature, message, 1))
+        assert_equal("ERR_MALFORMED_SIGNATURE", self.nodes[0].verifymessage(address, legacy_signature, message, 1))
 
 if __name__ == '__main__':
     SignMessagesTest().main()


### PR DESCRIPTION
This PR implements [BIP-322](https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki), for the single proof (no multiple addresses simultaneously) single signer (no multisig addresses) case.

UI (CLI/QT) are restricted to the single proof case, but the underlying code (`script/proof.h`) supports multiple proofs.

Recommend `?w=1` / `-w` to avoid whitespace spam.

There is a related PR #16653 that includes the sign/verify components of this and the signet PR (#16411).