### PR TITLE
Serve BIP 157 compact filters

### DIFF
--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -144,8 +144,8 @@ public:
 
     template <typename Stream>
     void Serialize(Stream& s) const {
-        s << m_block_hash
-          << static_cast<uint8_t>(m_filter_type)
+        s << static_cast<uint8_t>(m_filter_type)
+          << m_block_hash
           << m_filter.GetEncoded();
     }
 
@@ -154,8 +154,8 @@ public:
         std::vector<unsigned char> encoded_filter;
         uint8_t filter_type;
 
-        s >> m_block_hash
-          >> filter_type
+        s >> filter_type
+          >> m_block_hash
           >> encoded_filter;
 
         m_filter_type = static_cast<BlockFilterType>(filter_type);

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -84,12 +84,12 @@ protected:
 
     virtual DB& GetDB() const = 0;
 
-    /// Get the name of the index for display in logs.
-    virtual const char* GetName() const = 0;
-
 public:
     /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
+
+    /// Get the name of the index for display in logs.
+    virtual const char* GetName() const = 0;
 
     /// Returns whether index has completed the initial sync with the active chain.
     /// After returning true once, this function will return true on all subsequent calls.

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -91,6 +91,10 @@ public:
     /// Destructor interrupts sync thread if running and blocks until it exits.
     virtual ~BaseIndex();
 
+    /// Returns whether index has completed the initial sync with the active chain.
+    /// After returning true once, this function will return true on all subsequent calls.
+    bool IsSynced() const { return m_synced; }
+
     /// Blocks the current thread until the index is caught up to the current
     /// state of the block chain. This only blocks if the index has gotten in
     /// sync once and only needs to process blocks in the ValidationInterface

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -41,12 +41,12 @@ protected:
 
     BaseIndex::DB& GetDB() const override { return *m_db; }
 
-    const char* GetName() const override { return m_name.c_str(); }
-
 public:
     /** Constructs the index, which becomes available to be queried. */
     explicit BlockFilterIndex(BlockFilterType filter_type,
                               size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+
+    const char* GetName() const override { return m_name.c_str(); }
 
     BlockFilterType GetFilterType() const { return m_filter_type; }
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -30,14 +30,14 @@ protected:
 
     BaseIndex::DB& GetDB() const override;
 
-    const char* GetName() const override { return "txindex"; }
-
 public:
     /// Constructs the index, which becomes available to be queried.
     explicit TxIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
     virtual ~TxIndex() override;
+
+    const char* GetName() const override { return "txindex"; }
 
     /// Look up a transaction by hash.
     ///

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1767,6 +1767,13 @@ bool AppInitMain(NodeContext& node)
         GetBlockFilterIndex(filter_type)->Start();
     }
 
+    bool cfilters_enabled = std::find(g_enabled_filter_types.begin(),
+                                      g_enabled_filter_types.end(),
+                                      BlockFilterType::BASIC) != g_enabled_filter_types.end();
+    if (cfilters_enabled) {
+        nLocalServices = ServiceFlags(nLocalServices | NODE_COMPACT_FILTERS);
+    }
+
     // ********************************************************* Step 9: load wallet
     for (const auto& client : node.chain_clients) {
         if (!client->load()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1780,6 +1780,19 @@ bool AppInitMain(NodeContext& node)
         GetBlockFilterIndex(filter_type)->Start();
     }
 
+    if (nLocalServices & NODE_COMPACT_FILTERS) {
+        const BlockFilterIndex* const basic_filter_index =
+            GetBlockFilterIndex(BlockFilterType::BASIC);
+        if (!basic_filter_index) {
+            error("NODE_COMPACT_FILTERS is signaled, but filter index is not available");
+            return false;
+        }
+        if (!basic_filter_index->IsSynced()) {
+            InitError(strprintf(_("Cannot enable -peercfilters until basic block filter index is in sync. Please disable and reenable once filters have been indexed.").translated));
+            return false;
+        }
+    }
+
     // ********************************************************* Step 9: load wallet
     for (const auto& client : node.chain_clients) {
         if (!client->load()) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -989,9 +989,9 @@ bool AppInitParameterInteraction()
 
     // Signal NODE_COMPACT_FILTERS if peercfilters and required index are both enabled.
     if (gArgs.GetBoolArg("-peercfilters", DEFAULT_PEERCFILTERS)) {
-        bool index_enabled = std::find(g_enabled_filter_types.begin(),
-                                       g_enabled_filter_types.end(),
-                                       BlockFilterType::BASIC) != g_enabled_filter_types.end();
+        const bool index_enabled = std::find(g_enabled_filter_types.begin(),
+                                             g_enabled_filter_types.end(),
+                                             BlockFilterType::BASIC) != g_enabled_filter_types.end();
         if (!index_enabled) {
             return InitError(_("Cannot set -peercfilters without -blockfilterindex.").translated);
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2675,18 +2675,7 @@ uint64_t CConnman::GetTotalBytesSent()
 
 ServiceFlags CConnman::GetLocalServices() const
 {
-    uint64_t local_services = nLocalServices;
-    if (local_services & NODE_COMPACT_FILTERS) {
-        BlockFilterIndex* basic_filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
-        if (!basic_filter_index) {
-            LogPrintf("WARNING: NODE_COMPACT_FILTERS is signaled, but filter index is not available\n");
-        }
-        if (!basic_filter_index || !basic_filter_index->IsSynced()) {
-            // If block filter index is still syncing, do not advertise the service bit.
-            local_services &= ~NODE_COMPACT_FILTERS;
-        }
-    }
-    return ServiceFlags(local_services);
+    return nLocalServices;
 }
 
 void CConnman::SetBestHeight(int height)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2026,6 +2026,9 @@ static bool PrepareBlockFilterRequest(CNode* pfrom, const CChainParams& chain_pa
     if (!filter_index) {
         return error("Filter index for supported type %s not found", BlockFilterTypeName(filter_type));
     }
+    if (!filter_index->BlockUntilSyncedToCurrentChain()) {
+        return error("%s is not ready yet", filter_index->GetName());
+    }
 
     return true;
 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -131,7 +131,7 @@ static constexpr unsigned int AVG_FEEFILTER_BROADCAST_INTERVAL = 10 * 60;
 /** Maximum feefilter broadcast delay after significant change. */
 static constexpr unsigned int MAX_FEEFILTER_CHANGE_DELAY = 5 * 60;
 /** Maximum number of compact filters that may be requested with one getcfilters. See BIP 157. */
-static constexpr uint32_t MAX_GETCFILTERS_SIZE = 100;
+static constexpr uint32_t MAX_GETCFILTERS_SIZE = 1000;
 /** Maximum number of cf hashes that may be requested with one getcfheaders. See BIP 157. */
 static constexpr uint32_t MAX_GETCFHEADERS_SIZE = 2000;
 /** Interval between compact filter checkpoints. See BIP 157. */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1371,9 +1371,9 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
         connman->WakeMessageHandler();
     }
 
-    ForEachBlockFilterIndex(
-        [](BlockFilterIndex& index) { UpdateCFHeadersCache(index); }
-    );
+    if (connman->GetLocalServices() & NODE_COMPACT_FILTERS) {
+        ForEachBlockFilterIndex([](BlockFilterIndex& index) { UpdateCFHeadersCache(index); });
+    }
 }
 
 /**

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1370,10 +1370,6 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
         });
         connman->WakeMessageHandler();
     }
-
-    if (connman->GetLocalServices() & NODE_COMPACT_FILTERS) {
-        ForEachBlockFilterIndex([](BlockFilterIndex& index) { UpdateCFHeadersCache(index); });
-    }
 }
 
 /**
@@ -2175,6 +2171,8 @@ static bool ProcessGetCFCheckPt(CNode* pfrom, CDataStream& vRecv, const CChainPa
         // Return true because the issue with the invalid request has already been logged.
         return true;
     }
+
+    UpdateCFHeadersCache(*filter_index);
 
     std::vector<uint256> headers(stop_index->nHeight / CFCHECKPT_INTERVAL);
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,6 +30,7 @@
 #include <util/strencodings.h>
 
 #include <memory>
+#include <mutex>
 #include <typeinfo>
 
 #if defined(NDEBUG)
@@ -435,6 +436,10 @@ limitedmap<uint256, std::chrono::microseconds> g_already_asked_for GUARDED_BY(cs
 
 /** Map maintaining per-node state. */
 static std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
+
+/** In-memory cache of all BIP157 compact filter checkpoints for the active chain. */
+static std::vector<std::pair<const CBlockIndex*, uint256>> active_chain_cf_headers;
+static std::mutex active_chain_cf_headers_mtx;
 
 static CNodeState *State(NodeId pnode) EXCLUSIVE_LOCKS_REQUIRED(cs_main) {
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
@@ -1299,6 +1304,40 @@ void PeerLogicValidation::NewPoWValidBlock(const CBlockIndex *pindex, const std:
     });
 }
 
+static bool UpdateCFHeadersCache(const BlockFilterIndex& filter_index)
+{
+    LOCK(cs_main);
+    std::lock_guard<std::mutex> _lock(active_chain_cf_headers_mtx);
+
+    const CChain& active_chain = ::ChainActive();
+
+    // Drop any entries in the checkpoint cache that have been reorganized off the active chain.
+    int new_size = active_chain_cf_headers.size();
+    for (; new_size > 0; new_size--) {
+        if (active_chain.Contains(active_chain_cf_headers[new_size - 1].first)) {
+            break;
+        }
+    }
+    active_chain_cf_headers.resize(new_size);
+
+    // Populate the checkpoint cache with headers for blocks on the active chain.
+    for (uint32_t height = (new_size + 1) * CFCHECKPT_INTERVAL;
+         height <= static_cast<uint32_t>(active_chain.Height());
+         height += CFCHECKPT_INTERVAL) {
+        const CBlockIndex* block_index = active_chain[height];
+        uint256 filter_header;
+
+        if (!filter_index.LookupFilterHeader(block_index, filter_header)) {
+            return error("Failed to find block filter header in index: filter_type=%s, block_hash=%s",
+                         BlockFilterTypeName(filter_index.GetFilterType()),
+                         block_index->GetBlockHash().ToString());
+        }
+        active_chain_cf_headers.emplace_back(block_index, filter_header);
+    }
+
+    return true;
+}
+
 /**
  * Update our best height and announce any block hashes which weren't previously
  * in ::ChainActive() to our peers.
@@ -1331,6 +1370,10 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
         });
         connman->WakeMessageHandler();
     }
+
+    ForEachBlockFilterIndex(
+        [](BlockFilterIndex& index) { UpdateCFHeadersCache(index); }
+    );
 }
 
 /**
@@ -2133,17 +2176,30 @@ static bool ProcessGetCFCheckPt(CNode* pfrom, CDataStream& vRecv, const CChainPa
     }
 
     std::vector<uint256> headers(stop_index->nHeight / CFCHECKPT_INTERVAL);
+    {
+        std::lock_guard<std::mutex> _lock(active_chain_cf_headers_mtx);
 
-    // Populate headers.
-    const CBlockIndex* block_index = stop_index;
-    for (int i = headers.size() - 1; i >= 0; i--) {
-        uint32_t height = (i + 1) * CFCHECKPT_INTERVAL;
-        block_index = block_index->GetAncestor(height);
+        // Populate headers.
+        int i = headers.size() - 1;
+        const CBlockIndex* block_index = stop_index;
+        for (; i >= 0; i--) {
+            uint32_t height = (i + 1) * CFCHECKPT_INTERVAL;
+            block_index = block_index->GetAncestor(height);
 
-        // Filter header requested for stale block.
-        if (!filter_index->LookupFilterHeader(block_index, headers[i])) {
-            return error("Failed to find block filter header in index: filter_type=%s, block_hash=%s",
-                         BlockFilterTypeName(filter_type), block_index->GetBlockHash().ToString());
+            if (static_cast<size_t>(i) < active_chain_cf_headers.size() &&
+                active_chain_cf_headers[i].first == block_index) {
+                break;
+            }
+
+            // Filter header requested for stale block.
+            if (!filter_index->LookupFilterHeader(block_index, headers[i])) {
+                return error("Failed to find block filter header in index: "
+                             "filter_type=%s, block_hash=%s",
+                             BlockFilterTypeName(filter_type), block_index->GetBlockHash().ToString());
+            }
+        }
+        for (; i >= 0; i--) {
+            headers[i] = active_chain_cf_headers[i].second;
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1324,7 +1324,7 @@ static bool UpdateCFHeadersCache(const BlockFilterIndex& filter_index)
     for (uint32_t height = (new_size + 1) * CFCHECKPT_INTERVAL;
          height <= static_cast<uint32_t>(active_chain.Height());
          height += CFCHECKPT_INTERVAL) {
-        const CBlockIndex* block_index = active_chain[height];
+        const CBlockIndex* const block_index = active_chain[height];
         uint256 filter_header;
 
         if (!filter_index.LookupFilterHeader(block_index, filter_header)) {
@@ -2027,7 +2027,7 @@ static bool PrepareBlockFilterRequest(CNode* pfrom, const CChainParams& chain_pa
                                       const CBlockIndex*& stop_index,
                                       BlockFilterIndex*& filter_index)
 {
-    bool supported_filter_type =
+    const bool supported_filter_type =
         (filter_type == BlockFilterType::BASIC &&
          (pfrom->GetLocalServices() & NODE_COMPACT_FILTERS));
     if (!supported_filter_type) {
@@ -2085,7 +2085,7 @@ static bool ProcessGetCFilters(CNode* pfrom, CDataStream& vRecv, const CChainPar
 
     vRecv >> filter_type_ser >> start_height >> stop_hash;
 
-    BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
+    const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
 
     const CBlockIndex* stop_index;
     BlockFilterIndex* filter_index;
@@ -2120,7 +2120,7 @@ static bool ProcessGetCFHeaders(CNode* pfrom, CDataStream& vRecv, const CChainPa
 
     vRecv >> filter_type_ser >> start_height >> stop_hash;
 
-    BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
+    const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
 
     const CBlockIndex* stop_index;
     BlockFilterIndex* filter_index;
@@ -2132,7 +2132,8 @@ static bool ProcessGetCFHeaders(CNode* pfrom, CDataStream& vRecv, const CChainPa
 
     uint256 prev_header;
     if (start_height > 0) {
-        const CBlockIndex* prev_block = stop_index->GetAncestor(start_height - 1);
+        const CBlockIndex* const prev_block =
+            stop_index->GetAncestor(static_cast<int>(start_height - 1));
         if (!filter_index->LookupFilterHeader(prev_block, prev_header)) {
             return error("Failed to find block filter header in index: filter_type=%s, block_hash=%s",
                          BlockFilterTypeName(filter_type), prev_block->GetBlockHash().ToString());
@@ -2164,7 +2165,7 @@ static bool ProcessGetCFCheckPt(CNode* pfrom, CDataStream& vRecv, const CChainPa
 
     vRecv >> filter_type_ser >> stop_hash;
 
-    BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
+    const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
 
     const CBlockIndex* stop_index;
     BlockFilterIndex* filter_index;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -21,6 +21,7 @@ static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
+static const bool DEFAULT_PEERCFILTERS = false;
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -40,6 +40,12 @@ const char *SENDCMPCT="sendcmpct";
 const char *CMPCTBLOCK="cmpctblock";
 const char *GETBLOCKTXN="getblocktxn";
 const char *BLOCKTXN="blocktxn";
+const char *GETCFILTERS="getcfilters";
+const char *CFILTER="cfilter";
+const char *GETCFHEADERS="getcfheaders";
+const char *CFHEADERS="cfheaders";
+const char *GETCFCHECKPT="getcfcheckpt";
+const char *CFCHECKPT="cfcheckpt";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -234,6 +234,43 @@ extern const char *GETBLOCKTXN;
  * @since protocol version 70014 as described by BIP 152
  */
 extern const char *BLOCKTXN;
+
+/**
+ * getcfilters requests compact filters for a range of blocks.
+ * Only available with service bit NODE_COMPACT_FILTERS as described by
+ * BIP 157 & 158.
+ */
+extern const char *GETCFILTERS;
+/**
+ * cfilter is a response to a getcfilters request containing a single compact
+ * filter.
+ */
+extern const char *CFILTER;
+/**
+ * getcfheaders requests compact filter headers for a range of blocks.
+ * Only available with service bit NODE_COMPACT_FILTERS as described by
+ * BIP 157 & 158.
+ */
+extern const char *GETCFHEADERS;
+/**
+ * cfheaders is a response to a getcfheaders request containing a vector of
+ * filter headers for each block in the requested range.
+ */
+extern const char *CFHEADERS;
+/**
+ * getcfcheckpt requests evenly spaced compact filter headers, enabling
+ * parallelized download and validation of the headers between them.
+ * Only available with service bit NODE_COMPACT_FILTERS as described by
+ * BIP 157 & 158.
+ */
+extern const char *GETCFCHECKPT;
+/**
+ * cfcheckpt is a response to a getcfcheckpt request containing a vector of
+ * evenly spaced filter headers for blocks on the requested chain.
+ * Only available with service bit NODE_COMPACT_FILTERS as described by
+ * BIP 157 & 158.
+ */
+extern const char *CFCHECKPT;
 };
 
 /* Get a vector of all valid message types (see above) */

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -258,6 +258,9 @@ enum ServiceFlags : uint64_t {
     // NODE_WITNESS indicates that a node can be asked for blocks and transactions including
     // witness data.
     NODE_WITNESS = (1 << 3),
+    // NODE_COMPACT_FILTERS means the node will service basic block filter requests.
+    // See BIP157 and BIP158 for details on how this is implemented.
+    NODE_COMPACT_FILTERS = (1 << 6),
     // NODE_NETWORK_LIMITED means the same as NODE_NETWORK with the limitation of only
     // serving the last 288 (2 day) blocks
     // See BIP159 for details on how this is implemented.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -745,6 +745,7 @@ QString serviceFlagToStr(const quint64 mask, const int bit)
     case NODE_GETUTXO:         return "GETUTXO";
     case NODE_BLOOM:           return "BLOOM";
     case NODE_WITNESS:         return "WITNESS";
+    case NODE_COMPACT_FILTERS: return "COMPACT_FILTERS";
     case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
     // Not using default, so we get warned when a case is missing
     }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -851,6 +851,8 @@ UniValue GetServicesNames(ServiceFlags services)
         servicesNames.push_back("BLOOM");
     if (services & NODE_WITNESS)
         servicesNames.push_back("WITNESS");
+    if (services & NODE_COMPACT_FILTERS)
+        servicesNames.push_back("COMPACT_FILTERS");
     if (services & NODE_NETWORK_LIMITED)
         servicesNames.push_back("NETWORK_LIMITED");
 

--- a/test/functional/p2p_cfilters.py
+++ b/test/functional/p2p_cfilters.py
@@ -227,7 +227,7 @@ class CompactFiltersTest(BitcoinTestFramework):
             # Requesting too many filters results in disconnection.
             msg_getcfilters(
                 filter_type=FILTER_TYPE_BASIC,
-                start_height=900,
+                start_height=0,
                 stop_hash=int(main_block_hash, 16)
             ),
             # Requesting too many filter headers results in disconnection.

--- a/test/functional/p2p_cfilters.py
+++ b/test/functional/p2p_cfilters.py
@@ -45,7 +45,10 @@ class CompactFiltersTest(BitcoinTestFramework):
         self.setup_clean_chain = True
         self.rpc_timeout = 480
         self.num_nodes = 2
-        self.extra_args = [["-blockfilterindex"], []]
+        self.extra_args = [
+            ["-blockfilterindex", "-peercfilters"],
+            ["-blockfilterindex"],
+        ]
 
     def run_test(self):
         # Node 0 supports COMPACT_FILTERS, node 1 does not.

--- a/test/functional/p2p_cfilters.py
+++ b/test/functional/p2p_cfilters.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests NODE_COMPACT_FILTERS (BIP 157/158).
+
+Tests that a node configured with -blockfilterindex signals NODE_COMPACT_FILTERS and responds
+correctly to GET_CFILTERS, GET_CFHEADERS, GET_CFCHECKPT requests.
+"""
+
+from test_framework.messages import (
+    FILTER_TYPE_BASIC, NODE_COMPACT_FILTERS,
+    msg_getcfilters, msg_getcfheaders, msg_getcfcheckpt,
+    ser_uint256, uint256_from_str, hash256,
+)
+from test_framework.mininode import (
+    P2PInterface,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes, disconnect_nodes, sync_blocks,
+    wait_until,
+)
+
+FILTER_TYPES = ["basic"]
+
+class CFiltersClient(P2PInterface):
+    def __init__(self):
+        super().__init__()
+        # Store the cfilters received.
+        self.cfilters = []
+
+    def pop_cfilters(self):
+        cfilters = self.cfilters
+        self.cfilters = []
+        return cfilters
+
+    def on_cfilter(self, message):
+        """Store cfilters received in a list."""
+        self.cfilters.append(message)
+
+class CompactFiltersTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.rpc_timeout = 480
+        self.num_nodes = 2
+        self.extra_args = [["-blockfilterindex"], []]
+
+    def run_test(self):
+        # Node 0 supports COMPACT_FILTERS, node 1 does not.
+        node0 = self.nodes[0].add_p2p_connection(CFiltersClient())
+        node1 = self.nodes[1].add_p2p_connection(CFiltersClient())
+
+        # Nodes 0 & 1 share the same first 999 blocks in the chain.
+        self.nodes[0].generate(999)
+        sync_blocks(self.nodes)
+
+        # Stale blocks by disconnecting nodes 0 & 1, mining, then reconnecting
+        disconnect_nodes(self.nodes[0], 1)
+
+        self.nodes[0].generate(1)
+        wait_until(lambda: self.nodes[0].getblockcount() == 1000)
+        stale_block_hash = self.nodes[0].getblockhash(1000)
+
+        self.nodes[1].generate(1001)
+        wait_until(lambda: self.nodes[1].getblockcount() == 2000)
+
+        # Reorg node 0 to a new chain
+        connect_nodes(self.nodes[0], 1)
+        sync_blocks(self.nodes)
+
+        main_block_hash = self.nodes[0].getblockhash(1000)
+        assert main_block_hash != stale_block_hash, "node 0 chain did not reorganize"
+
+        # Check that nodes have signalled NODE_COMPACT_FILTERS correctly.
+        assert node0.nServices & NODE_COMPACT_FILTERS != 0
+        assert node1.nServices & NODE_COMPACT_FILTERS == 0
+
+        # Check that the localservices is as expected.
+        assert int(self.nodes[0].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS != 0
+        assert int(self.nodes[1].getnetworkinfo()['localservices'], 16) & NODE_COMPACT_FILTERS == 0
+
+        # Check that peers can fetch cfcheckpt on active chain.
+        tip_hash = self.nodes[0].getbestblockhash()
+        request = msg_getcfcheckpt(
+            filter_type=FILTER_TYPE_BASIC,
+            stop_hash=int(tip_hash, 16)
+        )
+        node0.send_message(request)
+        node0.sync_with_ping()
+        response = node0.last_message['cfcheckpt']
+        assert_equal(response.filter_type, request.filter_type)
+        assert_equal(response.stop_hash, request.stop_hash)
+
+        main_cfcheckpt = self.nodes[0].getblockfilter(main_block_hash, 'basic')['header']
+        tip_cfcheckpt = self.nodes[0].getblockfilter(tip_hash, 'basic')['header']
+        assert_equal(
+            response.headers,
+            [int(header, 16) for header in (main_cfcheckpt, tip_cfcheckpt)]
+        )
+
+        # Check that peers can fetch cfcheckpt on stale chain.
+        request = msg_getcfcheckpt(
+            filter_type=FILTER_TYPE_BASIC,
+            stop_hash=int(stale_block_hash, 16)
+        )
+        node0.send_message(request)
+        node0.sync_with_ping()
+        response = node0.last_message['cfcheckpt']
+
+        stale_cfcheckpt = self.nodes[0].getblockfilter(stale_block_hash, 'basic')['header']
+        assert_equal(
+            response.headers,
+            [int(header, 16) for header in (stale_cfcheckpt,)]
+        )
+
+        # Check that peers can fetch cfheaders on active chain.
+        request = msg_getcfheaders(
+            filter_type=FILTER_TYPE_BASIC,
+            start_height=1,
+            stop_hash=int(main_block_hash, 16)
+        )
+        node0.send_message(request)
+        node0.sync_with_ping()
+        response = node0.last_message['cfheaders']
+        main_cfhashes = response.hashes
+        assert_equal(
+            compute_last_header(response.prev_header, response.hashes),
+            int(main_cfcheckpt, 16)
+        )
+
+        # Check that peers can fetch cfheaders on stale chain.
+        request = msg_getcfheaders(
+            filter_type=FILTER_TYPE_BASIC,
+            start_height=1,
+            stop_hash=int(stale_block_hash, 16)
+        )
+        node0.send_message(request)
+        node0.sync_with_ping()
+        response = node0.last_message['cfheaders']
+        stale_cfhashes = response.hashes
+        assert_equal(
+            compute_last_header(response.prev_header, response.hashes),
+            int(stale_cfcheckpt, 16)
+        )
+
+        # Check that peers can fetch cfilters.
+        stop_hash = self.nodes[0].getblockhash(10)
+        request = msg_getcfilters(
+            filter_type=FILTER_TYPE_BASIC,
+            start_height=1,
+            stop_hash=int(stop_hash, 16)
+        )
+        node0.send_message(request)
+        node0.sync_with_ping()
+        response = node0.pop_cfilters()
+        assert_equal(len(response), 10)
+
+        # Check that cfilter responses are correct.
+        for cfilter, cfhash, height in zip(response, main_cfhashes, range(1, 11)):
+            block_hash = self.nodes[0].getblockhash(height)
+            assert_equal(cfilter.filter_type, FILTER_TYPE_BASIC)
+            assert_equal(cfilter.block_hash, int(block_hash, 16))
+            computed_cfhash = uint256_from_str(hash256(cfilter.filter_data))
+            assert_equal(computed_cfhash, cfhash)
+
+        # Check that peers can fetch cfilters for stale blocks.
+        stop_hash = self.nodes[0].getblockhash(10)
+        request = msg_getcfilters(
+            filter_type=FILTER_TYPE_BASIC,
+            start_height=1000,
+            stop_hash=int(stale_block_hash, 16)
+        )
+        node0.send_message(request)
+        node0.sync_with_ping()
+        response = node0.pop_cfilters()
+        assert_equal(len(response), 1)
+
+        cfilter = response[0]
+        assert_equal(cfilter.filter_type, FILTER_TYPE_BASIC)
+        assert_equal(cfilter.block_hash, int(stale_block_hash, 16))
+        computed_cfhash = uint256_from_str(hash256(cfilter.filter_data))
+        assert_equal(computed_cfhash, stale_cfhashes[999])
+
+        # Requests to node 1 without NODE_COMPACT_FILTERS results in disconnection.
+        requests = [
+            msg_getcfcheckpt(
+                filter_type=FILTER_TYPE_BASIC,
+                stop_hash=int(main_block_hash, 16)
+            ),
+            msg_getcfheaders(
+                filter_type=FILTER_TYPE_BASIC,
+                start_height=1000,
+                stop_hash=int(main_block_hash, 16)
+            ),
+            msg_getcfilters(
+                filter_type=FILTER_TYPE_BASIC,
+                start_height=1000,
+                stop_hash=int(main_block_hash, 16)
+            ),
+        ]
+        for request in requests:
+            node1 = self.nodes[1].add_p2p_connection(CFiltersClient())
+            node1.send_message(request)
+            node1.wait_for_disconnect()
+
+        # Check that invalid requests result in disconnection.
+        requests = [
+            # Requesting too many filters results in disconnection.
+            msg_getcfilters(
+                filter_type=FILTER_TYPE_BASIC,
+                start_height=900,
+                stop_hash=int(main_block_hash, 16)
+            ),
+            # Requesting too many filter headers results in disconnection.
+            msg_getcfheaders(
+                filter_type=FILTER_TYPE_BASIC,
+                start_height=0,
+                stop_hash=int(tip_hash, 16)
+            ),
+            # Requesting unknown filter type results in disconnection.
+            msg_getcfcheckpt(
+                filter_type=255,
+                stop_hash=int(main_block_hash, 16)
+            ),
+            # Requesting unknown hash results in disconnection.
+            msg_getcfcheckpt(
+                filter_type=FILTER_TYPE_BASIC,
+                stop_hash=123456789,
+            ),
+        ]
+        for request in requests:
+            node0 = self.nodes[0].add_p2p_connection(CFiltersClient())
+            node0.send_message(request)
+            node0.wait_for_disconnect()
+
+def compute_last_header(prev_header, hashes):
+    """Compute the last filter header from a starting header and a sequence of filter hashes."""
+    header = ser_uint256(prev_header)
+    for filter_hash in hashes:
+        header = hash256(ser_uint256(filter_hash) + header)
+    return uint256_from_str(header)
+
+if __name__ == '__main__':
+    CompactFiltersTest().main()

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -49,6 +49,7 @@ NODE_NETWORK = (1 << 0)
 NODE_GETUTXO = (1 << 1)
 NODE_BLOOM = (1 << 2)
 NODE_WITNESS = (1 << 3)
+NODE_COMPACT_FILTERS = (1 << 6)
 NODE_NETWORK_LIMITED = (1 << 10)
 
 MSG_TX = 1
@@ -56,6 +57,8 @@ MSG_BLOCK = 2
 MSG_FILTERED_BLOCK = 3
 MSG_WITNESS_FLAG = 1 << 30
 MSG_TYPE_MASK = 0xffffffff >> 2
+
+FILTER_TYPE_BASIC = 0
 
 # Serialization/deserialization tools
 def sha256(s):
@@ -1512,3 +1515,154 @@ class msg_no_witness_blocktxn(msg_blocktxn):
 
     def serialize(self):
         return self.block_transactions.serialize(with_witness=False)
+
+
+class msg_getcfilters:
+    __slots__ = ("filter_type", "start_height", "stop_hash")
+    msgtype =  b"getcfilters"
+
+    def __init__(self, filter_type, start_height, stop_hash):
+        self.filter_type = filter_type
+        self.start_height = start_height
+        self.stop_hash = stop_hash
+
+    def deserialize(self, f):
+        self.filter_type = struct.unpack("<B", f.read(1))[0]
+        self.start_height = struct.unpack("<I", f.read(4))[0]
+        self.stop_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.filter_type)
+        r += struct.pack("<I", self.start_height)
+        r += ser_uint256(self.stop_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_getcfilters(filter_type={:#x}, start_height={}, stop_hash={:x})".format(
+            self.filter_type, self.start_height, self.stop_hash)
+
+class msg_cfilter:
+    __slots__ = ("filter_type", "block_hash", "filter_data")
+    msgtype =  b"cfilter"
+
+    def __init__(self, filter_type=None, block_hash=None, filter_data=None):
+        self.filter_type = filter_type
+        self.block_hash = block_hash
+        self.filter_data = filter_data
+
+    def deserialize(self, f):
+        self.filter_type = struct.unpack("<B", f.read(1))[0]
+        self.block_hash = deser_uint256(f)
+        self.filter_data = deser_string(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.filter_type)
+        r += ser_uint256(self.block_hash)
+        r += ser_string(self.filter_data)
+        return r
+
+    def __repr__(self):
+        return "msg_cfilter(filter_type={:#x}, block_hash={:x})".format(
+            self.filter_type, self.block_hash)
+
+class msg_getcfheaders:
+    __slots__ = ("filter_type", "start_height", "stop_hash")
+    msgtype =  b"getcfheaders"
+
+    def __init__(self, filter_type, start_height, stop_hash):
+        self.filter_type = filter_type
+        self.start_height = start_height
+        self.stop_hash = stop_hash
+
+    def deserialize(self, f):
+        self.filter_type = struct.unpack("<B", f.read(1))[0]
+        self.start_height = struct.unpack("<I", f.read(4))[0]
+        self.stop_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.filter_type)
+        r += struct.pack("<I", self.start_height)
+        r += ser_uint256(self.stop_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_getcfheaders(filter_type={:#x}, start_height={}, stop_hash={:x})".format(
+            self.filter_type, self.start_height, self.stop_hash)
+
+class msg_cfheaders:
+    __slots__ = ("filter_type", "stop_hash", "prev_header", "hashes")
+    msgtype =  b"cfheaders"
+
+    def __init__(self, filter_type=None, stop_hash=None, prev_header=None, hashes=None):
+        self.filter_type = filter_type
+        self.stop_hash = stop_hash
+        self.prev_header = prev_header
+        self.hashes = hashes
+
+    def deserialize(self, f):
+        self.filter_type = struct.unpack("<B", f.read(1))[0]
+        self.stop_hash = deser_uint256(f)
+        self.prev_header = deser_uint256(f)
+        self.hashes = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.filter_type)
+        r += ser_uint256(self.stop_hash)
+        r += ser_uint256(self.prev_header)
+        r += ser_uint256_vector(self.hashes)
+        return r
+
+    def __repr__(self):
+        return "msg_cfheaders(filter_type={:#x}, stop_hash={:x})".format(
+            self.filter_type, self.stop_hash)
+
+class msg_getcfcheckpt:
+    __slots__ = ("filter_type", "stop_hash")
+    msgtype =  b"getcfcheckpt"
+
+    def __init__(self, filter_type, stop_hash):
+        self.filter_type = filter_type
+        self.stop_hash = stop_hash
+
+    def deserialize(self, f):
+        self.filter_type = struct.unpack("<B", f.read(1))[0]
+        self.stop_hash = deser_uint256(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.filter_type)
+        r += ser_uint256(self.stop_hash)
+        return r
+
+    def __repr__(self):
+        return "msg_getcfcheckpt(filter_type={:#x}, stop_hash={:x})".format(
+            self.filter_type, self.stop_hash)
+
+class msg_cfcheckpt:
+    __slots__ = ("filter_type", "stop_hash", "headers")
+    msgtype =  b"cfcheckpt"
+
+    def __init__(self, filter_type=None, stop_hash=None, headers=None):
+        self.filter_type = filter_type
+        self.stop_hash = stop_hash
+        self.headers = headers
+
+    def deserialize(self, f):
+        self.filter_type = struct.unpack("<B", f.read(1))[0]
+        self.stop_hash = deser_uint256(f)
+        self.headers = deser_uint256_vector(f)
+
+    def serialize(self):
+        r = b""
+        r += struct.pack("<B", self.filter_type)
+        r += ser_uint256(self.stop_hash)
+        r += ser_uint256_vector(self.headers)
+        return r
+
+    def __repr__(self):
+        return "msg_cfcheckpt(filter_type={:#x}, stop_hash={:x})".format(
+            self.filter_type, self.stop_hash)

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -31,6 +31,9 @@ from test_framework.messages import (
     msg_block,
     MSG_BLOCK,
     msg_blocktxn,
+    msg_cfilter,
+    msg_cfheaders,
+    msg_cfcheckpt,
     msg_cmpctblock,
     msg_feefilter,
     msg_filteradd,
@@ -67,6 +70,9 @@ MESSAGEMAP = {
     b"addr": msg_addr,
     b"block": msg_block,
     b"blocktxn": msg_blocktxn,
+    b"cfilter": msg_cfilter,
+    b"cfheaders": msg_cfheaders,
+    b"cfcheckpt": msg_cfcheckpt,
     b"cmpctblock": msg_cmpctblock,
     b"feefilter": msg_feefilter,
     b"filteradd": msg_filteradd,
@@ -327,6 +333,9 @@ class P2PInterface(P2PConnection):
     def on_addr(self, message): pass
     def on_block(self, message): pass
     def on_blocktxn(self, message): pass
+    def on_cfilter(self, message): pass
+    def on_cfheaders(self, message): pass
+    def on_cfcheckpt(self, message): pass
     def on_cmpctblock(self, message): pass
     def on_feefilter(self, message): pass
     def on_filteradd(self, message): pass

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -225,6 +225,7 @@ BASE_SCRIPTS = [
     'feature_loadblock.py',
     'p2p_dos_header_tree.py',
     'p2p_unrequested_blocks.py',
+    'p2p_cfilters.py',
     'feature_includeconf.py',
     'feature_asmap.py',
     'mempool_unbroadcast.py',


### PR DESCRIPTION
This enables nodes to serve block filters compliant with [BIP 157](https://github.com/bitcoin/bips/blob/master/bip-0157.mediawiki). This is the last PR required for BIP 157/158 compatibility.

If the node has the block filter index enabled, once the index is in sync, the node will begin signaling the BIP 158 service bit and responding to BIP 157 requests. On invalid requests, the node disconnects the offending peer.

This is tested using functional tests. I have also synced an [lnd](https://github.com/lightningnetwork/lnd) testnet node using the neutrino backend connected to a Core node running this code.

Questions:
- Should there be a separate CLI flag other than `-blockfilterindex` to enable serving of filters from the index?
- Is the mechanism to only signal the service flag once the index is in sync OK?
- Is the use of `boost::shared_lock` around the checkpoint cache acceptable?