### PR TITLE
doc: Update v4.3> zmq.md fix CVE-2019-6250

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -33,8 +33,8 @@ buffering or reassembly.
 
 ## Prerequisites
 
-The ZeroMQ feature in Bitcoin Core requires the ZeroMQ API >= 4.0.0
-[libzmq](https://github.com/zeromq/libzmq/releases).
+The ZeroMQ feature in Bitcoin Core requires the ZeroMQ API >= 4.3.2
+[libzmq](https://github.com/zeromq/libzmq/releases/tag/v4.3.2).
 For version information, see [dependencies.md](dependencies.md).
 Typically, it is packaged by distributions as something like
 *libzmq3-dev*. The C++ wrapper for ZeroMQ is *not* needed.


### PR DESCRIPTION
# the problem: 0MQ v4.0 != 0MQ v4.3 > 

as well as correction.
[Update zmq to 4.3.1](https://github.com/bitcoin/bitcoin/commit/3046e5fc019c7276300c65500fb4701e70f6c9d8#diff-0ffb3fb401bbac1a06c8eefce7584885) by @rex4539 
if library upgrade to version 4.3 or higher required.

## 0MQ [doc](https://github.com/zeromq/libzmq/releases/tag/v4.3.2) explain 
**MQ version 4.3.2 stable, released on 2019/07/08**
    CVE-2019-13132: a remote, unauthenticated client connecting to a
    libzmq application, running with a socket listening with CURVE
    encryption/authentication enabled, may cause a stack overflow and
    overwrite the stack with arbitrary data, due to a buffer overflow in
    the library. Users running public servers with the above configuration
    are highly encouraged to upgrade as soon as possible, as there are no
    known mitigations. **All versions from 4.0.0 and upwards are affected.**
    Thank you Fang-Pen Lin for finding the issue and reporting it!

## Refereces
https://github.com/zeromq/libzmq/releases/tag/v4.3.2 

https://github.com/bitcoin/bitcoin/commit/3046e5fc019c7276300c65500fb4701e70f6c9d8#diff-0ffb3fb401bbac1a06c8eefce7584885 

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6250