### PR TITLE
refactor: use RelayTransaction in BroadcastTransaction utility

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -9,6 +9,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/wallet.h>
 #include <net.h>
+#include <net_processing.h>
 #include <node/coin.h>
 #include <policy/fees.h>
 #include <policy/policy.h>
@@ -292,8 +293,7 @@ public:
     }
     void relayTransaction(const uint256& txid) override
     {
-        CInv inv(MSG_TX, txid);
-        g_connman->ForEachNode([&inv](CNode* node) { node->PushInventory(inv); });
+        RelayTransaction(txid, *g_connman);
     }
     void getTransactionAncestry(const uint256& txid, size_t& ancestors, size_t& descendants) override
     {

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -90,4 +90,7 @@ struct CNodeStateStats {
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 
+/** Relay transaction to every node */
+void RelayTransaction(const uint256&, const CConnman& connman);
+
 #endif // BITCOIN_NET_PROCESSING_H

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -5,6 +5,7 @@
 
 #include <consensus/validation.h>
 #include <net.h>
+#include <net_processing.h>
 #include <txmempool.h>
 #include <util/validation.h>
 #include <validation.h>
@@ -69,10 +70,7 @@ TransactionError BroadcastTransaction(const CTransactionRef tx, uint256& hashTx,
         return TransactionError::P2P_DISABLED;
     }
 
-    CInv inv(MSG_TX, hashTx);
-    g_connman->ForEachNode([&inv](CNode* pnode) {
-        pnode->PushInventory(inv);
-    });
+    RelayTransaction(hashTx, *g_connman);
 
     return TransactionError::OK;
 }


### PR DESCRIPTION
Implementing suggestion in https://github.com/bitcoin/bitcoin/pull/15713#discussion_r306571420.

Seems a reason of these node utilities is to glue with already there functions, so we should reuse them.
