### PR TITLE
Exclude depends/Makefile in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ src/qt/bitcoin-qt.includes
 # Compilation and Qt preprocessor part
 *.qm
 Makefile
+!depends/Makefile
 bitcoin-qt
 Bitcoin-Qt.app
 background.tiff*


### PR DESCRIPTION
At least atom editor does't show the file - it doesn't check the file is committed.