### PR TITLE
refactoring: Use direct list initialization for Arg struct

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -547,7 +547,7 @@ void ArgsManager::AddArg(const std::string& name, const std::string& help, const
 
     LOCK(cs_args);
     std::map<std::string, Arg>& arg_map = m_available_args[cat];
-    auto ret = arg_map.emplace(name.substr(0, eq_index), Arg(name.substr(eq_index, name.size() - eq_index), help, debug_only));
+    auto ret = arg_map.emplace(name.substr(0, eq_index), Arg{name.substr(eq_index, name.size() - eq_index), help, debug_only});
     assert(ret.second); // Make sure an insertion actually happened
 }
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -147,8 +147,6 @@ protected:
         std::string m_help_param;
         std::string m_help_text;
         bool m_debug_only;
-
-        Arg(const std::string& help_param, const std::string& help_text, bool debug_only) : m_help_param(help_param), m_help_text(help_text), m_debug_only(debug_only) {};
     };
 
     mutable CCriticalSection cs_args;


### PR DESCRIPTION
Using a direct list initialization for `struct Arg` objects makes the constructor needless.

This PR has been split out from #16097 (see: https://github.com/bitcoin/bitcoin/pull/16097#issuecomment-514487370).