### PR TITLE
logs: add missing space

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -143,7 +143,7 @@ static bool AppInit(int argc, char* argv[])
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-            tfm::format(std::cout, PACKAGE_NAME "daemon starting\n");
+            tfm::format(std::cout, PACKAGE_NAME " daemon starting\n");
 
             // Daemonize
             if (daemon(1, 0)) { // don't chdir (1), do close FDs (0)


### PR DESCRIPTION
A space was lost when the `PACKAGE_NAME` variable was introduced at https://github.com/bitcoin/bitcoin/pull/16366/files#diff-6e30027c2045842fe842430d98d099fbR143 , e.g. when running `bitcoind -daemon` on Linux before this commit, I see `Bitcoin Coredaemon starting`.  This commit adds back the space. 