### PR TITLE
doc: update Python command in msvc readme

### DIFF
--- a/build_msvc/README.md
+++ b/build_msvc/README.md
@@ -44,7 +44,7 @@ The instructions below use `vcpkg` to install the dependencies.
 - Use Python to generate *.vcxproj from Makefile
 
 ```
-    PS >python msvc-autogen.py
+    PS >py -3 msvc-autogen.py
 ```
 
 - Build in Visual Studio.


### PR DESCRIPTION
Trivial doc update to the msvc build readme. It updates the python command to use the `py` python launcher so that it will work where Python2 & 3 are installed and 2 is the default (the msvc generator script is incompatible with Python 2).

