### PR TITLE
doc: update labels in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,21 +80,15 @@ The title of the pull request should be prefixed by the component or area that
 the pull request affects. Valid areas as:
 
   - *Consensus* for changes to consensus critical code
-  - *Docs* for changes to the documentation
+  - *Doc* for changes to the documentation
   - *Qt* for changes to bitcoin-qt
+  - *Log* Changes to log messages
   - *Mining* for changes to the mining code
   - *Net* or *P2P* for changes to the peer-to-peer network code
+  - *Refactor* for structural changes that do not change behavior
   - *RPC/REST/ZMQ* for changes to the RPC, REST or ZMQ APIs
   - *Scripts and tools* for changes to the scripts and tools
-  - *Tests* for changes to the bitcoin unit tests or QA tests
-  - *Trivial* should **only** be used for PRs that do not change generated
-    executable code. Notably, refactors (change of function arguments and code
-    reorganization) and changes in behavior should **not** be marked as trivial.
-    Examples of trivial PRs are changes to:
-    - comments
-    - whitespace
-    - variable names
-    - logging and messages
+  - *Test* for changes to the bitcoin unit tests or QA tests
   - *Utils and libraries* for changes to the utils and libraries
   - *Wallet* for changes to the wallet code
 
@@ -103,10 +97,10 @@ Examples:
     Consensus: Add new opcode for BIP-XXXX OP_CHECKAWESOMESIG
     Net: Automatically create hidden service, listen on Tor
     Qt: Add feed bump button
-    Trivial: Fix typo in init.cpp
+    Log: Fix typo in log message
 
 Note that translations should not be submitted as pull requests, please see
-[Translation Process](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md) 
+[Translation Process](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md)
 for more information on helping with translations.
 
 If a pull request is not to be considered for merging (yet), please
@@ -322,7 +316,7 @@ The project leader is the release manager for each Bitcoin Core release.
 Copyright
 ---------
 
-By contributing to this repository, you agree to license your work under the 
-MIT license unless specified otherwise in `contrib/debian/copyright` or at 
-the top of the file itself. Any work contributed where you are not the original 
+By contributing to this repository, you agree to license your work under the
+MIT license unless specified otherwise in `contrib/debian/copyright` or at
+the top of the file itself. Any work contributed where you are not the original
 author must contain its license header with the original author(s) and source.


### PR DESCRIPTION
None of the examples in the "trivial" area are acceptable pull requests, unless they are acceptable in a different area (like "doc" or "log").

Fix that by removing the "trivial" area.