### PR TITLE
[consensus] skip bip30 checks when assumevalid is set for the block

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1819,6 +1819,8 @@ bool CChainState::ConnectBlock(const CBlock& block, CValidationState& state, CBl
     CBlockIndex *pindexBIP34height = pindex->pprev->GetAncestor(chainparams.GetConsensus().BIP34Height);
     //Only continue to enforce if we're below BIP34 activation height or the block hash at that height doesn't correspond.
     fEnforceBIP30 = fEnforceBIP30 && (!pindexBIP34height || !(pindexBIP34height->GetBlockHash() == chainparams.GetConsensus().BIP34Hash));
+    // And we're not assuming the block is valid.
+    fEnforceBIP30 = fEnforceBIP30 && !fAssumeValid;
 
     // TODO: Remove BIP30 checking from block height 1,983,702 on, once we have a
     // consensus change that ensures coinbases at those heights can not


### PR DESCRIPTION
This eliminates the BIP30 checks for blocks before the BIP34 activation.

Those checks consist of one LevelDB Get call for each transaction in the block (34,846,734 in total).