### PR TITLE
log: harmonize bitcoind logging

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2019 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -77,7 +77,7 @@ static bool AppInit(int argc, char* argv[])
 
     // Process help and version before taking care about datadir
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
-        std::string strUsage = PACKAGE_NAME " Daemon version " + FormatFullVersion() + "\n";
+        std::string strUsage = PACKAGE_NAME " version " + FormatFullVersion() + "\n";
 
         if (gArgs.IsArgSet("-version"))
         {
@@ -85,7 +85,7 @@ static bool AppInit(int argc, char* argv[])
         }
         else
         {
-            strUsage += "\nUsage:  bitcoind [options]                     Start " PACKAGE_NAME " Daemon\n";
+            strUsage += "\nUsage:  bitcoind [options]                     Start " PACKAGE_NAME "\n";
             strUsage += "\n" + gArgs.GetHelpMessage();
         }
 
@@ -143,7 +143,7 @@ static bool AppInit(int argc, char* argv[])
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-            tfm::format(std::cout, PACKAGE_NAME " daemon starting\n");
+            tfm::format(std::cout, PACKAGE_NAME " starting\n");
 
             // Daemonize
             if (daemon(1, 0)) { // don't chdir (1), do close FDs (0)

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -162,7 +162,7 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
     if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
         throw std::runtime_error(
             RPCHelpMan{"stop",
-                "\nStop Bitcoin server.",
+                "\nRequest a graceful shutdown of " PACKAGE_NAME ".",
                 {},
                 RPCResults{},
                 RPCExamples{""},
@@ -173,7 +173,7 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
     if (jsonRequest.params[0].isNum()) {
         MilliSleep(jsonRequest.params[0].get_int());
     }
-    return "Bitcoin server stopping";
+    return PACKAGE_NAME " stopping";
 }
 
 static UniValue uptime(const JSONRPCRequest& jsonRequest)


### PR DESCRIPTION
Harmonize the user-facing output of the  `bitcoind -daemon`, `bitcoin-cli help stop`, `bitcoin-cli stop`, and `bitcoind -version` commands to be consistent with each other as well as with the "Bitcoin Core is probably already running" messages, e.g. `git grep 'probably already running.")'`.

Before:

```
$ bitcoind -regtest -daemon
Bitcoin Core daemon starting

$ bitcoind -regtest -daemon
Error: Bitcoin Core is probably already running.

$ bitcoind -regtest -version
Bitcoin Core Daemon version v0.18.99.0-e653eeff76-dirty

$ bitcoin-cli -regtest help stop
stop

Stop Bitcoin server.

$ bitcoin-cli -regtest stop
Bitcoin server stopping
```
these five commands output:

"Bitcoin Core daemon"
"Bitcoin Core"
"Bitcoin Core Daemon"
"Bitcoin server"
"Bitcoin server"

After this commit, they are all "Bitcoin Core".

```
$ bitcoind -regtest -daemon
Bitcoin Core starting

$ bitcoind -regtest -daemon
Error: Bitcoin Core is probably already running.

$ bitcoind -regtest -version
Bitcoin Core version v0.18.99.0-e90478f43e-dirty

$ bitcoin-cli -regtest help stop
stop

Request a graceful shutdown of Bitcoin Core.

$ bitcoin-cli -regtest stop
Bitcoin Core stopping
```