### PR TITLE
rpc: Report reason for replaceable txpool transactions

### DIFF
--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -8,6 +8,7 @@
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <pow.h>
+#include <random.h>
 #include <txmempool.h>
 #include <validation.h>
 

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -18,7 +18,8 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 
     // If this transaction is not in our mempool, then we can't be sure
     // we will know about all its inputs.
-    if (!pool.exists(tx.GetHash())) {
+    const Optional<CTxMemPool::txiter> it = pool.GetIter(tx.GetHash());
+    if (!it) {
         return RBFTransactionState::UNKNOWN;
     }
 
@@ -26,7 +27,7 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
     // signaled for RBF if any unconfirmed parents have signaled.
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    CTxMemPoolEntry entry = *pool.mapTx.find(tx.GetHash());
+    const CTxMemPoolEntry& entry = **it;
     pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
 
     for (CTxMemPool::txiter it : setAncestors) {

--- a/src/policy/rbf.h
+++ b/src/policy/rbf.h
@@ -10,7 +10,7 @@
 enum class RBFTransactionState {
     UNKNOWN,
     REPLACEABLE_BIP125,
-    FINAL
+    FINAL,
 };
 
 // Determine whether an in-mempool transaction is signaling opt-in to RBF

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -155,7 +155,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
         // GetMemPoolParents() is only valid for entries in the mempool, so we
         // iterate mapTx to find parents.
         for (unsigned int i = 0; i < tx.vin.size(); i++) {
-            boost::optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
+            Optional<txiter> piter = GetIter(tx.vin[i].prevout.hash);
             if (piter) {
                 parentHashes.insert(*piter);
                 if (parentHashes.size() + 1 > limitAncestorCount) {
@@ -860,7 +860,7 @@ const CTransaction* CTxMemPool::GetConflictTx(const COutPoint& prevout) const
     return it == mapNextTx.end() ? nullptr : it->second;
 }
 
-boost::optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) const
+Optional<CTxMemPool::txiter> CTxMemPool::GetIter(const uint256& txid) const
 {
     auto it = mapTx.find(txid);
     if (it != mapTx.end()) return it;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,10 +18,10 @@
 #include <coins.h>
 #include <crypto/siphash.h>
 #include <indirectmap.h>
+#include <optional.h>
 #include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <sync.h>
-#include <random.h>
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/hashed_index.hpp>
@@ -600,7 +600,7 @@ public:
     const CTransaction* GetConflictTx(const COutPoint& prevout) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Returns an iterator to the given hash, if found */
-    boost::optional<txiter> GetIter(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    Optional<txiter> GetIter(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Translate a set of hashes into a set of pool iterators to avoid repeated lookups */
     setEntries GetIterSet(const std::set<uint256>& hashes) const EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -428,6 +428,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # This transaction isn't shown as replaceable
         assert_equal(self.nodes[0].getmempoolentry(tx1a_txid)['bip125-replaceable'], False)
+        assert_equal(self.nodes[0].getmempoolentry(tx1a_txid)['replaceable'], False)
+        assert_equal(self.nodes[0].getmempoolentry(tx1a_txid)['replaceable-reason'], None)
 
         # Shouldn't be able to double-spend
         tx1b = CTransaction()
@@ -473,6 +475,8 @@ class ReplaceByFeeTest(BitcoinTestFramework):
 
         # This transaction is shown as replaceable
         assert_equal(self.nodes[0].getmempoolentry(tx3a_txid)['bip125-replaceable'], True)
+        assert_equal(self.nodes[0].getmempoolentry(tx3a_txid)['replaceable'], True)
+        assert_equal(self.nodes[0].getmempoolentry(tx3a_txid)['replaceable-reason'], 'bip125')
 
         tx3b = CTransaction()
         tx3b.vin = [CTxIn(COutPoint(tx1a_txid, 0), nSequence=0)]


### PR DESCRIPTION
Currently, the reason for the boolean `bip125-replaceable` is not given. However, future versions of Bitcoin Core (or software forks of Bitcoin Core) might offer different mempool (replacement) policies to their users. So instead of a flat boolean, it would be nice to return the reason why `bip125-replaceable` is true or false. This pull does that among a refactoring commit.