### PR TITLE
qa: fix deprecated log.warn in feature_dbcrash test

### DIFF
--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -267,7 +267,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         # Warn if any of the nodes escaped restart.
         for i in range(3):
             if self.restart_counts[i] == 0:
-                self.log.warn("Node %d never crashed during utxo flush!", i)
+                self.log.warning("Node %d never crashed during utxo flush!", i)
 
 if __name__ == "__main__":
     ChainstateWriteCrashTest().main()


### PR DESCRIPTION
This clears up the following deprecation message when running test/functional/feature_dbcrash.py:
```
test/functional/feature_dbcrash.py:270:
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  self.log.warn("Node %d never crashed during utxo flush!", i)
```

Git grepping indicates that this was the last remaining use of `log.warn` in the functional tests.