### PR TITLE
wallet: Drop support to serialize OldKey

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -676,23 +676,6 @@ public:
     }
 };
 
-/** Private key that was serialized by an old wallet (only used for deserialization) */
-struct OldKey {
-    CPrivKey vchPrivKey;
-
-    template <typename Stream>
-    inline void Unserialize(Stream& s) {
-        // no longer used by the wallet, thus dropped after deserialization:
-        int64_t nTimeCreated;
-        int64_t nTimeExpires;
-        std::string strComment;
-
-        int nVersion = s.GetVersion();
-        if (!(s.GetType() & SER_GETHASH)) s >> nVersion;
-        s >> vchPrivKey >> nTimeCreated >> nTimeExpires >> LIMITED_STRING(strComment, 65536);
-    }
-};
-
 struct CoinSelectionParams
 {
     bool use_bnb = true;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -679,22 +679,17 @@ public:
 /** Private key that was serialized by an old wallet (only used for deserialization) */
 struct OldKey {
     CPrivKey vchPrivKey;
-    ADD_SERIALIZE_METHODS;
 
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream& s, Operation ser_action) {
+    template <typename Stream>
+    inline void Unserialize(Stream& s) {
         // no longer used by the wallet, thus dropped after deserialization:
         int64_t nTimeCreated;
         int64_t nTimeExpires;
         std::string strComment;
 
         int nVersion = s.GetVersion();
-        if (!(s.GetType() & SER_GETHASH))
-            READWRITE(nVersion);
-        READWRITE(vchPrivKey);
-        READWRITE(nTimeCreated);
-        READWRITE(nTimeExpires);
-        READWRITE(LIMITED_STRING(strComment, 65536));
+        if (!(s.GetType() & SER_GETHASH)) s >> nVersion;
+        s >> vchPrivKey >> nTimeCreated >> nTimeExpires >> LIMITED_STRING(strComment, 65536);
     }
 };
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -168,6 +168,23 @@ public:
     }
 };
 
+/** Private key that was serialized by an old wallet (only used for deserialization) */
+struct OldKey {
+    CPrivKey vchPrivKey;
+
+    template <typename Stream>
+    inline void Unserialize(Stream& s) {
+        // no longer used by the wallet, thus dropped after deserialization:
+        int64_t nTimeCreated;
+        int64_t nTimeExpires;
+        std::string strComment;
+
+        int nVersion = s.GetVersion();
+        if (!(s.GetType() & SER_GETHASH)) s >> nVersion;
+        s >> vchPrivKey >> nTimeCreated >> nTimeExpires >> LIMITED_STRING(strComment, 65536);
+    }
+};
+
 /** Access to the wallet database.
  * Opens the database and provides read and write access to it. Each read and write is its own transaction.
  * Multiple operation transactions can be started using TxnBegin() and committed using TxnCommit()


### PR DESCRIPTION
Follow up #16475, removes support to serialize `OldKey`. Attempting to serialize `OldKey` results in compilation error.