### PR TITLE
GetFee should round up to avoid undershooting feerate

### DIFF
--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -25,7 +25,9 @@ CAmount CFeeRate::GetFee(size_t nBytes_) const
     assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
     int64_t nSize = int64_t(nBytes_);
 
-    CAmount nFee = nSatoshisPerK * nSize / 1000;
+    // Round up to make sure we hit required feerate
+    const int nSatoshisPerK_sign = nSatoshisPerK < 0 ? -1 : 1;
+    CAmount nFee = nSatoshisPerK_sign * (nSatoshisPerK * nSatoshisPerK_sign * nSize + 999) / 1000;
 
     if (nFee == 0 && nSize != 0) {
         if (nSatoshisPerK > 0)

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -50,10 +50,10 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     // Truncates the result, if not integer
     BOOST_CHECK_EQUAL(feeRate.GetFee(0), CAmount(0));
     BOOST_CHECK_EQUAL(feeRate.GetFee(8), CAmount(1)); // Special case: returns 1 instead of 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9), CAmount(1));
-    BOOST_CHECK_EQUAL(feeRate.GetFee(121), CAmount(14));
-    BOOST_CHECK_EQUAL(feeRate.GetFee(122), CAmount(15));
-    BOOST_CHECK_EQUAL(feeRate.GetFee(999), CAmount(122));
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9), CAmount(2));
+    BOOST_CHECK_EQUAL(feeRate.GetFee(121), CAmount(15));
+    BOOST_CHECK_EQUAL(feeRate.GetFee(122), CAmount(16));
+    BOOST_CHECK_EQUAL(feeRate.GetFee(999), CAmount(123));
     BOOST_CHECK_EQUAL(feeRate.GetFee(1e3), CAmount(123));
     BOOST_CHECK_EQUAL(feeRate.GetFee(9e3), CAmount(1107));
 
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     // Truncates the result, if not integer
     BOOST_CHECK_EQUAL(feeRate.GetFee(0), CAmount(0));
     BOOST_CHECK_EQUAL(feeRate.GetFee(8), CAmount(-1)); // Special case: returns -1 instead of 0
-    BOOST_CHECK_EQUAL(feeRate.GetFee(9), CAmount(-1));
+    BOOST_CHECK_EQUAL(feeRate.GetFee(9), CAmount(-2));
 
     // check alternate constructor
     feeRate = CFeeRate(1000);


### PR DESCRIPTION
Currently fee filter and mempool/wallet will disagree on the sufficiency of minrelay fee transactions when the min relay rate is not `% 1000 = 0`. The wallet and mempool will allow a transaction to be created and entered into mempool, but then peers that have the same rate as a fee filter will not receive the transaction because of the undershooting that occurs in `GetFee`.

Fixes https://github.com/bitcoin/bitcoin/issues/16499