### PR TITLE
Update configure.ac to remove extra no in $use_tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1506,7 +1506,7 @@ else
   AC_MSG_RESULT([no])
 fi
 
-if test x$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests = xnononononononono; then
+if test x$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests = xnonononononono; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 


### PR DESCRIPTION
There was an additional 'no' included on line 1509 for the $use_tests variable. This has been removed to reflect 'xnonononononono' used in the rest of the code.