### PR TITLE
Disallow double negation syntax (-nofoo=0) for options

### DIFF
--- a/doc/release-notes-16508.md
+++ b/doc/release-notes-16508.md
@@ -1,0 +1,4 @@
+Configuration options
+---------------------
+
+The double negation syntax (`-nofoo=0`) is not allowed for boolean type options which are marked with the `ArgsManager::ALLOW_BOOL` flag.

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -80,10 +80,6 @@ BOOST_AUTO_TEST_CASE(boolarg)
     BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
     BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
 
-    ResetArgs("-foo=0 -nofoo=0");  // -nofoo=0 should win
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
-
     // New 0.6 feature: treat -- same as -:
     ResetArgs("--foo=1");
     BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
@@ -169,10 +165,6 @@ BOOST_AUTO_TEST_CASE(boolargno)
     ResetArgs("-nofoo=1");
     BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
     BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-
-    ResetArgs("-nofoo=0");
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
 
     ResetArgs("-foo --nofoo"); // --nofoo should win
     BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -27,6 +27,7 @@ class ConfArgsTest(BitcoinTestFramework):
         )
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('dash_conf=1\n')
+        # This also tests log buffering.
         with self.nodes[0].assert_debug_log(expected_msgs=['Ignoring unknown configuration value dash_conf']):
             self.start_node(0)
         self.stop_node(0)
@@ -77,15 +78,8 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear
 
-    def test_log_buffer(self):
-        with self.nodes[0].assert_debug_log(expected_msgs=['Warning: parsed potentially confusing double-negative -connect=0']):
-            self.start_node(0, extra_args=['-noconnect=0'])
-        self.stop_node(0)
-
     def run_test(self):
         self.stop_node(0)
-
-        self.test_log_buffer()
 
         self.test_config_file_parser()
 

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -78,8 +78,17 @@ class ConfArgsTest(BitcoinTestFramework):
         with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear
 
+    def test_option_negating_policy(self):
+        self.nodes[0].assert_start_raises_init_error(
+            expected_msg='Error: Error parsing command line arguments: Double-negative -nolisten=0 is not allowed',
+            extra_args=['-nolisten=0'],
+        )
+        self.stop_node(0)
+
     def run_test(self):
         self.stop_node(0)
+
+        self.test_option_negating_policy()
 
         self.test_config_file_parser()
 


### PR DESCRIPTION
The double negation syntax for options (`-nofoo=0`) is confusing and doesn't have any uses that make sense.

This PR disallows the double negation syntax for boolean type options which are marked with the `ArgsManager::ALLOW_BOOL` flag. Please note, that non-boolean options (without the `ArgsManager::ALLOW_BOOL` flag) cannot be negated at all after #16097.

With this PR:
```
$ src/bitcoind -nolisten=0
Error: Error parsing command line arguments: Double-negative -nolisten=0 is not allowed
```

NOTES for reviewers:
- this PR is based on top of #16097, so only the last three commits are to be reviewed here
- ref: 4d34fcc7138f0ffc831f0f8601c50cc7f494c197
- [release notes for 0.6.0](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.6.0.md):
> The `-nolisten`, `-noupnp` and `-nodnsseed` command-line options were renamed to `-listen`, `-upnp` and `-dnsseed`, with a default value of `1`. The old names are still supported for compatibility (so specifying `-nolisten` is automatically interpreted as `-listen=0`; every boolean argument can now be specified as either `-foo` or `-nofoo`).