### PR TITLE
[RFC] Switch CTransaction::nVersion to an unsigned integer

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -39,11 +39,7 @@ std::pair<int, int64_t> CalculateSequenceLocks(const CTransaction &tx, int flags
     int nMinHeight = -1;
     int64_t nMinTime = -1;
 
-    // tx.nVersion is signed integer so requires cast to unsigned otherwise
-    // we would be doing a signed comparison and half the range of nVersion
-    // wouldn't support BIP 68.
-    bool fEnforceBIP68 = static_cast<uint32_t>(tx.nVersion) >= 2
-                      && flags & LOCKTIME_VERIFY_SEQUENCE;
+    bool fEnforceBIP68 = tx.nVersion >= 2 && (flags & LOCKTIME_VERIFY_SEQUENCE);
 
     // Do not enforce sequence numbers as a relative lock time
     // unless we have been instructed to

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -179,7 +179,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("hash", tx.GetWitnessHash().GetHex());
-    entry.pushKV("version", tx.nVersion);
+    entry.pushKV("version", (int32_t)tx.nVersion);
     entry.pushKV("size", (int)::GetSerializeSize(tx, PROTOCOL_VERSION));
     entry.pushKV("vsize", (GetTransactionWeight(tx) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR);
     entry.pushKV("weight", GetTransactionWeight(tx));

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -286,7 +286,7 @@ public:
     // structure, including the hash.
     const std::vector<CTxIn> vin;
     const std::vector<CTxOut> vout;
-    const int32_t nVersion;
+    const uint32_t nVersion;
     const uint32_t nLockTime;
 
 private:
@@ -367,7 +367,7 @@ struct CMutableTransaction
 {
     std::vector<CTxIn> vin;
     std::vector<CTxOut> vout;
-    int32_t nVersion;
+    uint32_t nVersion;
     uint32_t nLockTime;
 
     CMutableTransaction();

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1374,7 +1374,7 @@ bool GenericTransactionSignatureChecker<T>::CheckSequence(const CScriptNum& nSeq
 
     // Fail if the transaction's version number is not set high
     // enough to trigger BIP 68 rules.
-    if (static_cast<uint32_t>(txTo->nVersion) < 2)
+    if (txTo->nVersion < 2)
         return false;
 
     // Sequence numbers with their most significant bit set are not


### PR DESCRIPTION
Consensus-wise we already treat it as an unsigned integer (the
only rules around it are in CSV/locktime handling), and it keeps
causing confusion here and there, so might as well just formalize
it.

See-also, https://github.com/rust-bitcoin/rust-bitcoin/pull/299