### PR TITLE
gui: Remove unused RPCConsole::tabFocus

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1265,11 +1265,6 @@ void RPCConsole::showOrHideBanTableIfRequired()
     ui->banHeading->setVisible(visible);
 }
 
-RPCConsole::TabTypes RPCConsole::tabFocus() const
-{
-    return (TabTypes) ui->tabWidget->currentIndex();
-}
-
 void RPCConsole::setTabFocus(enum TabTypes tabType)
 {
     ui->tabWidget->setCurrentIndex(tabType);

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -67,7 +67,6 @@ public:
 
     std::vector<TabTypes> tabs() const { return {TAB_INFO, TAB_CONSOLE, TAB_GRAPH, TAB_PEERS}; }
 
-    TabTypes tabFocus() const;
     QString tabTitle(TabTypes tab_type) const;
 
 protected:


### PR DESCRIPTION
Added in #14573 but not used, so begone.