### PR TITLE
[0.18] Doc: remove old release notes about systemd and riscv changes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -2,7 +2,7 @@ Bitcoin Core version 0.18.1 is now available from:
 
   <https://bitcoincore.org/bin/bitcoin-core-0.18.1/>
 
-This is a new major version release, including new features, various bug
+This is a new minor version release, including new features, various bug
 fixes and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:
@@ -46,19 +46,6 @@ From 0.17.0 onwards, macOS <10.10 is no longer supported. 0.17.0 is
 built using Qt 5.9.x, which doesn't support versions of macOS older than
 10.10. Additionally, Bitcoin Core does not yet change appearance when
 macOS "dark mode" is activated.
-
-In addition to previously-supported CPU platforms, this release's
-pre-compiled distribution also provides binaries for the RISC-V
-platform.
-
-If you are using the `systemd` unit configuration file located at
-`contrib/init/bitcoind.service`, it has been changed to use
-`/var/lib/bitcoind` as the data directory instead of
-`~bitcoin/.bitcoin`. When switching over to the new configuration file,
-please make sure that the filesystem on which `/var/lib/bitcoind` will
-exist has enough space (check using `df -h /var/lib/bitcoind`), and
-optionally copy over your existing data directory. See the [systemd init
-file section](#systemd-init-file) for more details.
 
 Known issues
 ============


### PR DESCRIPTION
Removes these two paragraphs that were part of the 0.18.0 release notes but which I don't think need to be repeated for the 0.18.1 release notes.  The systemd release note in particular links to a section that isn't part of the document.