### PR TITLE
build: disable libxcb extensions

### DIFF
--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -7,6 +7,18 @@ $(package)_dependencies=xcb_proto libXau
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-static
+# Because we pass -qt-xcb to Qt, it will compile in a set of xcb helper libraries and extensions,
+# so we skip building all of the extensions here.
+# More info is available from: https://doc.qt.io/qt-5.9/linux-requirements.html
+$(package)_config_opts += --disable-composite --disable-damage --disable-dpms
+$(package)_config_opts += --disable-dri2 --disable-dri3 --disable-glx
+$(package)_config_opts += --disable-present --disable-randr --disable-record
+$(package)_config_opts += --disable-render --disable-resource --disable-screensaver
+$(package)_config_opts += --disable-shape --disable-shm --disable-sync
+$(package)_config_opts += --disable-xevie --disable-xfixes --disable-xfree86-dri
+$(package)_config_opts += --disable-xinerama --disable-xinput --disable-xkb
+$(package)_config_opts += --disable-xprint --disable-selinux --disable-xtest
+$(package)_config_opts += --disable-xv --disable-xvmc
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
Closes #16447.
Keeping this separate from #16370. So far I've tested the resulting `bitcoin-qt` on Debian Buster.

I've done a [binary comparison](https://github.com/bitcoin-core/bitcoin-maintainer-tools/blob/master/build-for-compare.py) of `bitcoin-qt` between master (e653eeff7651d823407e2e31a89176cc0b240c62) and this PR (fdd48a88e84bec6b728b7b308f1d4b9a234e126d) and could not see any differences:
```bash
root@1417805b82d9:/tmp# shasum compare/*.stripped no_xcb/*.stripped
2cba7e9985cfe79f0f6ecde39db107b4a998de71  compare/bitcoin-qt.e653eeff7651d823407e2e31a89176cc0b240c62.stripped
6b0960fcf3e348568c954812ccc5375275500208  compare/bitcoind.e653eeff7651d823407e2e31a89176cc0b240c62.stripped
2cba7e9985cfe79f0f6ecde39db107b4a998de71  no_xcb/bitcoin-qt.fdd48a88e84bec6b728b7b308f1d4b9a234e126d.stripped
6b0960fcf3e348568c954812ccc5375275500208  no_xcb/bitcoind.fdd48a88e84bec6b728b7b308f1d4b9a234e126d.stripped
```

libxcb depends `./configure` & `make` log diff (trimmed for breverity)
The full logs are [here - with extensions](https://gist.github.com/fanquake/f2689a360ea8baafd44c92dd396f66ff) and [here - without extensions](https://gist.github.com/fanquake/9720a195c5031b5c3ca299a72384787c):
```diff
@@ -183,31 +183,31 @@ config.status: executing libtool commands
     XCB buffer size.....: 16384
 
   X11 extensions
-    Composite...........: yes
-    Damage..............: yes
-    Dpms................: yes
-    Dri2................: yes
-    Dri3................: yes
-    Glx.................: yes
-    Randr...............: yes
-    Record..............: yes
-    Render..............: yes
-    Resource............: yes
-    Screensaver.........: yes
+    Composite...........: no
+    Damage..............: no
+    Dpms................: no
+    Dri2................: no
+    Dri3................: no
+    Glx.................: no
+    Randr...............: no
+    Record..............: no
+    Render..............: no
+    Resource............: no
+    Screensaver.........: no
     selinux.............: no
-    Shape...............: yes
-    Shm.................: yes
-    Sync................: yes
-    Xevie...............: yes
-    Xfixes..............: yes
-    Xfree86-dri.........: yes
-    xinerama............: yes
+    Shape...............: no
+    Shm.................: no
+    Sync................: no
+    Xevie...............: no
+    Xfixes..............: no
+    Xfree86-dri.........: no
+    xinerama............: no
     xinput..............: no
-    xkb.................: yes
-    xprint..............: yes
-    xtest...............: yes
-    xv..................: yes
-    xvmc................: yes
+    xkb.................: no
+    xprint..............: no
+    xtest...............: no
+    xv..................: no
+    xvmc................: no
 
   Used CFLAGS:
     CPPFLAGS............: -I/bitcoin/depends/x86_64-pc-linux-gnu/include    
@@ -218,9 +218,9 @@ config.status: executing libtool commands
     Prefix..............: /bitcoin/depends/x86_64-pc-linux-gnu
 
 Building libxcb...
-make[1]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f'
+make[1]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe'
 Making all in src
-make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
+make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
 /usr/bin/python3 ./c_client.py -p /bitcoin/depends/x86_64-pc-linux-gnu/lib/python3.7/site-packages /bitcoin/depends/x86_64-pc-linux-gnu/share/xcb/xproto.xml
 /usr/bin/python3 ./c_client.py -p /bitcoin/depends/x86_64-pc-linux-gnu/lib/python3.7/site-packages /bitcoin/depends/x86_64-pc-linux-gnu/share/xcb/bigreq.xml
 /usr/bin/python3 ./c_client.py -p /bitcoin/depends/x86_64-pc-linux-gnu/lib/python3.7/site-packages /bitcoin/depends/x86_64-pc-linux-gnu/share/xcb/xc_misc.xml
@@ -251,332 +251,140 @@ make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/lib
 /usr/bin/python3 ./c_client.py -p /bitcoin/depends/x86_64-pc-linux-gnu/lib/python3.7/site-packages /bitcoin/depends/x86_64-pc-linux-gnu/share/xcb/xv.xml
 /usr/bin/python3 ./c_client.py -p /bitcoin/depends/x86_64-pc-linux-gnu/lib/python3.7/site-packages /bitcoin/depends/x86_64-pc-linux-gnu/share/xcb/xvmc.xml
 make  all-am
-make[3]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
+make[3]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
   CC       xcb_conn.lo
   CC       xcb_out.lo
   CC       xcb_in.lo
-  CC       xcb_ext.lo
   CC       xcb_xid.lo
+  CC       xcb_ext.lo
   CC       xcb_list.lo
   CC       xcb_util.lo
   CC       xcb_auth.lo
   CC       xproto.lo
   CC       bigreq.lo
-  CC       composite.lo
   CC       xc_misc.lo
-  CC       damage.lo
-  CC       dpms.lo
-  CC       dri2.lo
-  CC       dri3.lo
-  CC       present.lo
-  CC       glx.lo
-  CC       randr.lo
-  CC       record.lo
-  CC       render.lo
-  CC       res.lo
-  CC       screensaver.lo
-  CC       shape.lo
-  CC       shm.lo
-  CC       sync.lo
-  CC       xevie.lo
-  CC       xf86dri.lo
-  CC       xfixes.lo
-  CC       xinerama.lo
-  CC       xkb.lo
-  CC       xprint.lo
-  CC       xtest.lo
-  CC       xv.lo
-  CC       xvmc.lo
   CCLD     libxcb.la
-  CCLD     libxcb-composite.la
-  CCLD     libxcb-dpms.la
-  CCLD     libxcb-damage.la
-  CCLD     libxcb-dri2.la
-  CCLD     libxcb-dri3.la
-  CCLD     libxcb-present.la
-  CCLD     libxcb-glx.la
-  CCLD     libxcb-randr.la
-  CCLD     libxcb-record.la
-  CCLD     libxcb-render.la
-  CCLD     libxcb-res.la
-  CCLD     libxcb-screensaver.la
-  CCLD     libxcb-shape.la
-  CCLD     libxcb-shm.la
-  CCLD     libxcb-sync.la
-  CCLD     libxcb-xevie.la
-  CCLD     libxcb-xf86dri.la
-  CCLD     libxcb-xfixes.la
-  CCLD     libxcb-xinerama.la
-  CCLD     libxcb-xprint.la
-  CCLD     libxcb-xtest.la
-  CCLD     libxcb-xv.la
-  CCLD     libxcb-xvmc.la
-  CCLD     libxcb-xkb.la
-make[3]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
-make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
+make[3]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
+make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
 Making all in tests
-make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/tests'
-make[3]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/tests'
+make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/tests'
+make[3]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/tests'
 make[3]: Nothing to be done for 'all-am'.
-make[3]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/tests'
-make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/tests'
+make[3]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/tests'
+make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/tests'
 Making all in doc
-make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/doc'
+make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/doc'
 make[2]: Nothing to be done for 'all'.
-make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/doc'
-make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f'
+make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/doc'
+make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe'
 make[2]: Nothing to be done for 'all-am'.
-make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f'
-make[1]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f'
+make[2]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe'
+make[1]: Leaving directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe'
 Staging libxcb...
 make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule.
-make[1]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f'
+make[1]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe'
 Making install in src
-make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
+make[2]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
 make  install-am
-make[3]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
-make[4]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src'
- /bin/mkdir -p '/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib'
- /bin/bash ../libtool   --mode=install /usr/bin/install -c   libxcb.la libxcb-composite.la libxcb-damage.la libxcb-dpms.la libxcb-dri2.la libxcb-dri3.la libxcb-present.la libxcb-glx.la libxcb-randr.la libxcb-record.la libxcb-render.la libxcb-res.la libxcb-screensaver.la libxcb-shape.la libxcb-shm.la libxcb-sync.la libxcb-xevie.la libxcb-xf86dri.la libxcb-xfixes.la libxcb-xinerama.la libxcb-xkb.la libxcb-xprint.la libxcb-xtest.la libxcb-xv.la libxcb-xvmc.la '/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib'
-libtool: install: /usr/bin/install -c .libs/libxcb.so.1.1.0 /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb.so.1.1.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb.so.1.1.0 libxcb.so.1 || { rm -f libxcb.so.1 && ln -s libxcb.so.1.1.0 libxcb.so.1; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb.so.1.1.0 libxcb.so || { rm -f libxcb.so && ln -s libxcb.so.1.1.0 libxcb.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb.la
-libtool: install: warning: relinking `libxcb-composite.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-composite.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib composite.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-composite.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-composite.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-composite.so.0.0.0 libxcb-composite.so.0 || { rm -f libxcb-composite.so.0 && ln -s libxcb-composite.so.0.0.0 libxcb-composite.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-composite.so.0.0.0 libxcb-composite.so || { rm -f libxcb-composite.so && ln -s libxcb-composite.so.0.0.0 libxcb-composite.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-composite.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-composite.la
-libtool: install: warning: relinking `libxcb-damage.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-damage.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib damage.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-damage.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-damage.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-damage.so.0.0.0 libxcb-damage.so.0 || { rm -f libxcb-damage.so.0 && ln -s libxcb-damage.so.0.0.0 libxcb-damage.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-damage.so.0.0.0 libxcb-damage.so || { rm -f libxcb-damage.so && ln -s libxcb-damage.so.0.0.0 libxcb-damage.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-damage.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-damage.la
-libtool: install: warning: relinking `libxcb-dpms.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-dpms.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib dpms.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-dpms.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-dpms.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-dpms.so.0.0.0 libxcb-dpms.so.0 || { rm -f libxcb-dpms.so.0 && ln -s libxcb-dpms.so.0.0.0 libxcb-dpms.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-dpms.so.0.0.0 libxcb-dpms.so || { rm -f libxcb-dpms.so && ln -s libxcb-dpms.so.0.0.0 libxcb-dpms.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-dpms.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-dpms.la
-libtool: install: warning: relinking `libxcb-dri2.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-dri2.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib dri2.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-dri2.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-dri2.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-dri2.so.0.0.0 libxcb-dri2.so.0 || { rm -f libxcb-dri2.so.0 && ln -s libxcb-dri2.so.0.0.0 libxcb-dri2.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-dri2.so.0.0.0 libxcb-dri2.so || { rm -f libxcb-dri2.so && ln -s libxcb-dri2.so.0.0.0 libxcb-dri2.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-dri2.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-dri2.la
-libtool: install: warning: relinking `libxcb-dri3.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-dri3.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib dri3.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-dri3.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-dri3.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-dri3.so.0.0.0 libxcb-dri3.so.0 || { rm -f libxcb-dri3.so.0 && ln -s libxcb-dri3.so.0.0.0 libxcb-dri3.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-dri3.so.0.0.0 libxcb-dri3.so || { rm -f libxcb-dri3.so && ln -s libxcb-dri3.so.0.0.0 libxcb-dri3.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-dri3.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-dri3.la
-libtool: install: warning: relinking `libxcb-present.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-present.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib present.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-present.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-present.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-present.so.0.0.0 libxcb-present.so.0 || { rm -f libxcb-present.so.0 && ln -s libxcb-present.so.0.0.0 libxcb-present.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-present.so.0.0.0 libxcb-present.so || { rm -f libxcb-present.so && ln -s libxcb-present.so.0.0.0 libxcb-present.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-present.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-present.la
-libtool: install: warning: relinking `libxcb-glx.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-glx.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib glx.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-glx.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-glx.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-glx.so.0.0.0 libxcb-glx.so.0 || { rm -f libxcb-glx.so.0 && ln -s libxcb-glx.so.0.0.0 libxcb-glx.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-glx.so.0.0.0 libxcb-glx.so || { rm -f libxcb-glx.so && ln -s libxcb-glx.so.0.0.0 libxcb-glx.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-glx.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-glx.la
-libtool: install: warning: relinking `libxcb-randr.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 1:0:1 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-randr.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib randr.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-randr.so.0.1.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-randr.so.0.1.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-randr.so.0.1.0 libxcb-randr.so.0 || { rm -f libxcb-randr.so.0 && ln -s libxcb-randr.so.0.1.0 libxcb-randr.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-randr.so.0.1.0 libxcb-randr.so || { rm -f libxcb-randr.so && ln -s libxcb-randr.so.0.1.0 libxcb-randr.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-randr.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-randr.la
-libtool: install: warning: relinking `libxcb-record.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-record.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib record.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-record.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-record.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-record.so.0.0.0 libxcb-record.so.0 || { rm -f libxcb-record.so.0 && ln -s libxcb-record.so.0.0.0 libxcb-record.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-record.so.0.0.0 libxcb-record.so || { rm -f libxcb-record.so && ln -s libxcb-record.so.0.0.0 libxcb-record.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-record.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-record.la
-libtool: install: warning: relinking `libxcb-render.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-render.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib render.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-render.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-render.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-render.so.0.0.0 libxcb-render.so.0 || { rm -f libxcb-render.so.0 && ln -s libxcb-render.so.0.0.0 libxcb-render.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-render.so.0.0.0 libxcb-render.so || { rm -f libxcb-render.so && ln -s libxcb-render.so.0.0.0 libxcb-render.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-render.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-render.la
-libtool: install: warning: relinking `libxcb-res.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-res.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib res.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-res.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-res.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-res.so.0.0.0 libxcb-res.so.0 || { rm -f libxcb-res.so.0 && ln -s libxcb-res.so.0.0.0 libxcb-res.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-res.so.0.0.0 libxcb-res.so || { rm -f libxcb-res.so && ln -s libxcb-res.so.0.0.0 libxcb-res.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-res.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-res.la
-libtool: install: warning: relinking `libxcb-screensaver.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-screensaver.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib screensaver.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-screensaver.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-screensaver.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-screensaver.so.0.0.0 libxcb-screensaver.so.0 || { rm -f libxcb-screensaver.so.0 && ln -s libxcb-screensaver.so.0.0.0 libxcb-screensaver.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-screensaver.so.0.0.0 libxcb-screensaver.so || { rm -f libxcb-screensaver.so && ln -s libxcb-screensaver.so.0.0.0 libxcb-screensaver.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-screensaver.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-screensaver.la
-libtool: install: warning: relinking `libxcb-shape.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-shape.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib shape.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-shape.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-shape.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-shape.so.0.0.0 libxcb-shape.so.0 || { rm -f libxcb-shape.so.0 && ln -s libxcb-shape.so.0.0.0 libxcb-shape.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-shape.so.0.0.0 libxcb-shape.so || { rm -f libxcb-shape.so && ln -s libxcb-shape.so.0.0.0 libxcb-shape.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-shape.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-shape.la
-libtool: install: warning: relinking `libxcb-shm.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-shm.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib shm.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-shm.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-shm.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-shm.so.0.0.0 libxcb-shm.so.0 || { rm -f libxcb-shm.so.0 && ln -s libxcb-shm.so.0.0.0 libxcb-shm.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-shm.so.0.0.0 libxcb-shm.so || { rm -f libxcb-shm.so && ln -s libxcb-shm.so.0.0.0 libxcb-shm.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-shm.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-shm.la
-libtool: install: warning: relinking `libxcb-sync.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 1:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-sync.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib sync.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-sync.so.1.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-sync.so.1.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-sync.so.1.0.0 libxcb-sync.so.1 || { rm -f libxcb-sync.so.1 && ln -s libxcb-sync.so.1.0.0 libxcb-sync.so.1; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-sync.so.1.0.0 libxcb-sync.so || { rm -f libxcb-sync.so && ln -s libxcb-sync.so.1.0.0 libxcb-sync.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-sync.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-sync.la
-libtool: install: warning: relinking `libxcb-xevie.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xevie.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xevie.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xevie.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xevie.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xevie.so.0.0.0 libxcb-xevie.so.0 || { rm -f libxcb-xevie.so.0 && ln -s libxcb-xevie.so.0.0.0 libxcb-xevie.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xevie.so.0.0.0 libxcb-xevie.so || { rm -f libxcb-xevie.so && ln -s libxcb-xevie.so.0.0.0 libxcb-xevie.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xevie.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xevie.la
-libtool: install: warning: relinking `libxcb-xf86dri.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xf86dri.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xf86dri.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xf86dri.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xf86dri.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xf86dri.so.0.0.0 libxcb-xf86dri.so.0 || { rm -f libxcb-xf86dri.so.0 && ln -s libxcb-xf86dri.so.0.0.0 libxcb-xf86dri.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xf86dri.so.0.0.0 libxcb-xf86dri.so || { rm -f libxcb-xf86dri.so && ln -s libxcb-xf86dri.so.0.0.0 libxcb-xf86dri.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xf86dri.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xf86dri.la
-libtool: install: warning: relinking `libxcb-xfixes.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xfixes.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xfixes.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xfixes.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xfixes.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xfixes.so.0.0.0 libxcb-xfixes.so.0 || { rm -f libxcb-xfixes.so.0 && ln -s libxcb-xfixes.so.0.0.0 libxcb-xfixes.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xfixes.so.0.0.0 libxcb-xfixes.so || { rm -f libxcb-xfixes.so && ln -s libxcb-xfixes.so.0.0.0 libxcb-xfixes.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xfixes.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xfixes.la
-libtool: install: warning: relinking `libxcb-xinerama.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xinerama.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xinerama.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xinerama.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xinerama.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xinerama.so.0.0.0 libxcb-xinerama.so.0 || { rm -f libxcb-xinerama.so.0 && ln -s libxcb-xinerama.so.0.0.0 libxcb-xinerama.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xinerama.so.0.0.0 libxcb-xinerama.so || { rm -f libxcb-xinerama.so && ln -s libxcb-xinerama.so.0.0.0 libxcb-xinerama.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xinerama.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xinerama.la
-libtool: install: warning: relinking `libxcb-xkb.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 1:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xkb.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xkb.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xkb.so.1.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xkb.so.1.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xkb.so.1.0.0 libxcb-xkb.so.1 || { rm -f libxcb-xkb.so.1 && ln -s libxcb-xkb.so.1.0.0 libxcb-xkb.so.1; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xkb.so.1.0.0 libxcb-xkb.so || { rm -f libxcb-xkb.so && ln -s libxcb-xkb.so.1.0.0 libxcb-xkb.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xkb.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xkb.la
-libtool: install: warning: relinking `libxcb-xprint.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xprint.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xprint.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xprint.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xprint.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xprint.so.0.0.0 libxcb-xprint.so.0 || { rm -f libxcb-xprint.so.0 && ln -s libxcb-xprint.so.0.0.0 libxcb-xprint.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xprint.so.0.0.0 libxcb-xprint.so || { rm -f libxcb-xprint.so && ln -s libxcb-xprint.so.0.0.0 libxcb-xprint.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xprint.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xprint.la
-libtool: install: warning: relinking `libxcb-xtest.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xtest.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xtest.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xtest.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xtest.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xtest.so.0.0.0 libxcb-xtest.so.0 || { rm -f libxcb-xtest.so.0 && ln -s libxcb-xtest.so.0.0.0 libxcb-xtest.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xtest.so.0.0.0 libxcb-xtest.so || { rm -f libxcb-xtest.so && ln -s libxcb-xtest.so.0.0.0 libxcb-xtest.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xtest.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xtest.la
-libtool: install: warning: relinking `libxcb-xv.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xv.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xv.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xv.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xv.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xv.so.0.0.0 libxcb-xv.so.0 || { rm -f libxcb-xv.so.0 && ln -s libxcb-xv.so.0.0.0 libxcb-xv.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xv.so.0.0.0 libxcb-xv.so || { rm -f libxcb-xv.so && ln -s libxcb-xv.so.0.0.0 libxcb-xv.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xv.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xv.la
-libtool: install: warning: relinking `libxcb-xvmc.la'
-libtool: install: (cd /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/src; /bin/bash /bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/libtool  --silent --tag CC --mode=relink gcc -m64 -Wall -Wpointer-arith -Wold-style-definition -Wstrict-prototypes -Wmissing-declarations -Wnested-externs -I/bitcoin/depends/x86_64-pc-linux-gnu/include -pipe -O2 -version-info 0:0:0 -no-undefined -L/bitcoin/depends/x86_64-pc-linux-gnu/lib -o libxcb-xvmc.la -rpath /bitcoin/depends/x86_64-pc-linux-gnu/lib xvmc.lo libxcb.la -inst-prefix-dir /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f)
-libtool: install: /usr/bin/install -c .libs/libxcb-xvmc.so.0.0.0T /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xvmc.so.0.0.0
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xvmc.so.0.0.0 libxcb-xvmc.so.0 || { rm -f libxcb-xvmc.so.0 && ln -s libxcb-xvmc.so.0.0.0 libxcb-xvmc.so.0; }; })
-libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb-xvmc.so.0.0.0 libxcb-xvmc.so || { rm -f libxcb-xvmc.so && ln -s libxcb-xvmc.so.0.0.0 libxcb-xvmc.so; }; })
-libtool: install: /usr/bin/install -c .libs/libxcb-xvmc.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-69eae692c4f/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb-xvmc.la
+make[3]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
+make[4]: Entering directory '/bitcoin/depends/work/build/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/src'
+ /bin/mkdir -p '/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/bitcoin/depends/x86_64-pc-linux-gnu/lib'
+ /bin/bash ../libtool   --mode=install /usr/bin/install -c   libxcb.la '/bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/bitcoin/depends/x86_64-pc-linux-gnu/lib'
+libtool: install: /usr/bin/install -c .libs/libxcb.so.1.1.0 /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb.so.1.1.0
+libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb.so.1.1.0 libxcb.so.1 || { rm -f libxcb.so.1 && ln -s libxcb.so.1.1.0 libxcb.so.1; }; })
+libtool: install: (cd /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/bitcoin/depends/x86_64-pc-linux-gnu/lib && { ln -s -f libxcb.so.1.1.0 libxcb.so || { rm -f libxcb.so && ln -s libxcb.so.1.1.0 libxcb.so; }; })
+libtool: install: /usr/bin/install -c .libs/libxcb.lai /bitcoin/depends/work/staging/x86_64-pc-linux-gnu/libxcb/1.10-6757b70fafe/bitcoin/depends/x86_64-pc-linux-gnu/lib/libxcb.la
 libtool: install: warning: remember to run `libtool --finish /bitcoin/depends/x86_64-pc-linux-gnu/lib'
< snip man and other stuff... >
 Postprocessing libxcb...
 Caching libxcb...
```