### PR TITLE
build: add Qt Creator Makefile.am.user to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,9 @@ bitcoin-qt
 Bitcoin-Qt.app
 background.tiff*
 
+# Qt Creator
+Makefile.am.user
+
 # Unit-tests
 Makefile.test
 bitcoin-qt_test


### PR DESCRIPTION
Opening Bitcoin with Qt Creator via the Makefile.am generates a Makefile.am.user. Would be handy to have this file ignored. Looking around I can see this file has snuck into a few downstream projects. I do personally find myself editing commits to remove this file when I've not been paying attention. There's got to have been a few PRs with this file accidentally attached.