### PR TITLE
wallet: lower -txmaxfee default from 0.1 to 0.01 BTC

### DIFF
--- a/doc/release-notes-16539.md
+++ b/doc/release-notes-16539.md
@@ -1,0 +1,3 @@
+Wallet changes
+--------------
+Lower wallet fee cap from 0.1 BTC to 0.01 BTC. This can be configured with `-txmaxfee`.

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -83,11 +83,11 @@ static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 //! -maxtxfee default
-constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{COIN / 10};
+constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{COIN / 100};
 //! Discourage users to set fees higher than this amount (in satoshis) per kB
 constexpr CAmount HIGH_TX_FEE_PER_KB{COIN / 100};
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
-constexpr CAmount HIGH_MAX_TX_FEE{100 * HIGH_TX_FEE_PER_KB};
+constexpr CAmount HIGH_MAX_TX_FEE{10 * HIGH_TX_FEE_PER_KB};
 
 //! Pre-calculated constants for input size estimation in *virtual size*
 static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -135,14 +135,14 @@ class PSBTTest(BitcoinTestFramework):
         assert_equal(walletprocesspsbt_out['complete'], True)
         self.nodes[1].sendrawtransaction(self.nodes[1].finalizepsbt(walletprocesspsbt_out['psbt'])['hex'])
 
-        # feeRate of 0.1 BTC / KB produces a total fee slightly below -maxtxfee (~0.05280000):
-        res = self.nodes[1].walletcreatefundedpsbt([{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99}, 0, {"feeRate": 0.1})
-        assert_greater_than(res["fee"], 0.05)
-        assert_greater_than(0.06, res["fee"])
+        # feeRate of 0.01 BTC / KB produces a total fee slightly below -maxtxfee (~0.005280000):
+        res = self.nodes[1].walletcreatefundedpsbt([{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99}, 0, {"feeRate": 0.01})
+        assert_greater_than(res["fee"], 0.003)
+        assert_greater_than(0.006, res["fee"])
 
-        # feeRate of 10 BTC / KB produces a total fee well above -maxtxfee
+        # feeRate of 1 BTC / KB produces a total fee well above -maxtxfee
         # previously this was silently capped at -maxtxfee
-        assert_raises_rpc_error(-4, "Fee exceeds maximum configured by -maxtxfee", self.nodes[1].walletcreatefundedpsbt, [{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99}, 0, {"feeRate": 10})
+        assert_raises_rpc_error(-4, "Fee exceeds maximum configured by -maxtxfee", self.nodes[1].walletcreatefundedpsbt, [{"txid":txid,"vout":p2wpkh_pos},{"txid":txid,"vout":p2sh_p2wpkh_pos},{"txid":txid,"vout":p2pkh_pos}], {self.nodes[1].getnewaddress():29.99}, 0, {"feeRate": 1})
 
         # partially sign multisig things with node 1
         psbtx = self.nodes[1].walletcreatefundedpsbt([{"txid":txid,"vout":p2wsh_pos},{"txid":txid,"vout":p2sh_pos},{"txid":txid,"vout":p2sh_p2wsh_pos}], {self.nodes[1].getnewaddress():29.99})['psbt']

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -15,7 +15,7 @@ class WalletGroupTest(BitcoinTestFramework):
     def set_test_params(self):
         self.setup_clean_chain = True
         self.num_nodes = 3
-        self.extra_args = [[], [], ['-avoidpartialspends']]
+        self.extra_args = [['-maxtxfee=0.1'], [], ['-avoidpartialspends']]
         self.rpc_timeout = 120
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
There's a wallet safety feature, configurable via `-txmaxfee`, that refuses to create transactions with a fee above 0.1 BTC. This PR lowers that to 0.01 BTC.

The highest priority fee in 2017 was about 1000 satoshi per vbyte. A transaction with 6 legacy inputs and 3 outputs is about 1000 vbyte. Such a transaction is still possible with the lower `-txmaxfee` default.

The current value was decided in late 2014. In terms of several popular fiat currencies the highest seen price has increased by over a factor 10. Similarly the lowest seen price in two years is ~10x higher than the lowest price in 2014.

Of course we can't predict the future and shouldn't be changing this number too often.

The worst case scenario I can think of would be a high fee low price scenario where GUI users are suddenly forced to edit the config file. This could be mitigated by making settings easier to edit (#12833).

Another factor to consider is the potential for very large coin joins, which are becoming more feasible recently. In that case we could just consider fees from our own inputs rather than the full transaction. 

See also #16257 which reduced the likeness of accidental `-maxtxfee` spends, which [do happen](https://blockchair.com/bitcoin/transactions?q=fee(10000000)#). This PR reduces the damage is if it happens in some other way.

<img width="1185" alt="feees" src="https://user-images.githubusercontent.com/10217/62396197-cd7e0c80-b572-11e9-9ef5-aa8745d8bfd7.png">