### PR TITLE
rpc: Add rpcallowstop

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -517,6 +517,7 @@ void SetupServerArgs()
 
     gArgs.AddArg("-rest", strprintf("Accept public REST requests (default: %u)", DEFAULT_REST_ENABLE), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcallowip=<ip>", "Allow JSON-RPC connections from specified source. Valid for <ip> are a single IP (e.g. 1.2.3.4), a network/netmask (e.g. 1.2.3.4/255.255.255.0) or a network/CIDR (e.g. 1.2.3.4/24). This option can be specified multiple times", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcallowstop", "Allow stop over a remote RPC client", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcauth=<userpw>", "Username and HMAC-SHA-256 hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcauth. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcbind=<addr>[:port]", "Bind to given address to listen for JSON-RPC connections. Do not expose the RPC server to untrusted networks such as the public internet! This option is ignored unless -rpcallowip is also passed. Port is optional and overrides -rpcport. Use [host]:port notation for IPv6. This option can be specified multiple times (default: 127.0.0.1 and ::1 i.e., localhost)", ArgsManager::ALLOW_ANY | ArgsManager::NETWORK_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-rpccookiefile=<loc>", "Location of the auth cookie. Relative paths will be prefixed by a net-specific datadir location. (default: data dir)", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
@@ -749,7 +750,8 @@ static bool AppInitServers()
     RPCServer::OnStopped(&OnRPCStopped);
     if (!InitHTTPServer())
         return false;
-    StartRPC();
+    if (gArgs.GetBoolArg("-rpcallowstop", true)) StartRPC();
+    else StartRPC(false);
     if (!StartHTTPRPC())
         return false;
     if (gArgs.GetBoolArg("-rest", DEFAULT_REST_ENABLE)) StartREST();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -750,8 +750,7 @@ static bool AppInitServers()
     RPCServer::OnStopped(&OnRPCStopped);
     if (!InitHTTPServer())
         return false;
-    if (gArgs.GetBoolArg("-rpcallowstop", true)) StartRPC();
-    else StartRPC(false);
+    StartRPC(gArgs.GetBoolArg("-rpcallowstop", true));
     if (!StartHTTPRPC())
         return false;
     if (gArgs.GetBoolArg("-rest", DEFAULT_REST_ENABLE)) StartREST();

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -170,7 +170,7 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
             }.ToString());
     // Event loop will exit after current HTTP requests have been handled, so
     // this reply will get back to the client.
-    if(rpcallowstop)
+    if (rpcallowstop)
     {
         StartShutdown();
         if (jsonRequest.params[0].isNum()) {
@@ -182,15 +182,15 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
     {
         // Check if IP is 127.0.0.1
         std::string ip;
-        for(int i = 0; i < jsonRequest.peerAddr.length(); i++)
+        for (int i = 0; i < jsonRequest.peerAddr.length(); i++)
         {
-            if(jsonRequest.peerAddr[i] == ':')
+            if (jsonRequest.peerAddr[i] == ':')
             {
                 break;
             }
             ip += jsonRequest.peerAddr[i];
         }
-        if(ip == "127.0.0.1")
+        if (ip == "127.0.0.1")
         {
             StartShutdown();
             if (jsonRequest.params[0].isNum()) {

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -161,7 +161,7 @@ bool IsDeprecatedRPCEnabled(const std::string& method);
 
 extern CRPCTable tableRPC;
 
-void StartRPC();
+void StartRPC(bool _rpcallowstop=true);
 void InterruptRPC();
 void StopRPC();
 std::string JSONRPCExecBatch(const JSONRPCRequest& jreq, const UniValue& vReq);


### PR DESCRIPTION
This adds a feature to disable to ability to stop Bitcoin Core over the JSON RPC interface except if the sender is localhost.
Based on a suggestion from hebasto in #16543.

All in all it adds a new parameter called `rpcallowstop` which is by default set to 1. If the parameter is set to 0 it will block all RPC requests with stop Bitcoin Core except if the sender is localhost.

I tested it with the following config file:
```
regtest=1

[regtest]
server=1
rpcallowstop=0
rpcport=8332
rpcuser=foo
rpcpassword=bar
rpcallowip=192.168.178.71
rpcallowip=127.0.0.1
rpcbind=192.168.178.71
rpcbind=127.0.0.1
```
A curl request using the internal ip would result in an error. However using 127.0.0.1 would work.