### PR TITLE
build: Check usages of #if defined(...)

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -4,7 +4,7 @@
 
 #include <bench/bench.h>
 #include <key.h>
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
 #include <script/bitcoinconsensus.h>
 #endif
 #include <script/script.h>
@@ -92,7 +92,7 @@ static void VerifyScriptBench(benchmark::State& state)
         assert(err == SCRIPT_ERR_OK);
         assert(success);
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
         CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
         stream << txSpend;
         int csuccess = bitcoinconsensus_verify_script_with_amount(

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -620,13 +620,13 @@ std::string SHA256AutoDetect()
         TransformD64 = TransformD64Wrapper<sha256_sse4::Transform>;
         ret = "sse4(1way)";
 #endif
-#if defined(ENABLE_SSE41) && !defined(BUILD_BITCOIN_INTERNAL)
+#if ENABLE_SSE41 && !defined(BUILD_BITCOIN_INTERNAL)
         TransformD64_4way = sha256d64_sse41::Transform_4way;
         ret += ",sse41(4way)";
 #endif
     }
 
-#if defined(ENABLE_AVX2) && !defined(BUILD_BITCOIN_INTERNAL)
+#if ENABLE_AVX2 && !defined(BUILD_BITCOIN_INTERNAL)
     if (have_avx2 && have_avx && enabled_avx) {
         TransformD64_8way = sha256d64_avx2::Transform_8way;
         ret += ",avx2(8way)";

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -83,7 +83,7 @@ int main(int argc, char *argv[])
     if (QTest::qExec(&test1) != 0) {
         fInvalid = true;
     }
-#if defined(ENABLE_WALLET) && defined(ENABLE_BIP70)
+#if ENABLE_WALLET && ENABLE_BIP70
     PaymentServerTests test2;
     if (QTest::qExec(&test2) != 0) {
         fInvalid = true;

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -18,7 +18,7 @@
         #define EXPORT_SYMBOL
       #endif
     #endif
-  #elif defined(HAVE_FUNC_ATTRIBUTE_VISIBILITY)
+  #elif HAVE_FUNC_ATTRIBUTE_VISIBILITY
     #define EXPORT_SYMBOL __attribute__ ((visibility ("default")))
   #endif
 #elif defined(MSC_VER) && !defined(STATIC_LIBBITCOINCONSENSUS)

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -16,7 +16,7 @@
 #include <rpc/util.h>
 #include <streams.h>
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
 #include <script/bitcoinconsensus.h>
 #endif
 
@@ -179,7 +179,7 @@ void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScript
         BOOST_CHECK_MESSAGE(VerifyScript(scriptSig, scriptPubKey, &scriptWitness, combined_flags, MutableTransactionSignatureChecker(&tx, 0, txCredit.vout[0].nValue), &err) == expect, message + strprintf(" (with flags %x)", combined_flags));
     }
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << tx2;
     int libconsensus_flags = flags & bitcoinconsensus_SCRIPT_FLAGS_VERIFY_ALL;
@@ -1521,7 +1521,7 @@ BOOST_AUTO_TEST_CASE(script_can_append_self)
 }
 
 
-#if defined(HAVE_CONSENSUS_LIB)
+#if HAVE_CONSENSUS_LIB
 
 /* Test simple (successful) usage of bitcoinconsensus_verify_script */
 BOOST_AUTO_TEST_CASE(bitcoinconsensus_verify_script_returns_true)


### PR DESCRIPTION
PR for #16419. 

I have gone through `bitcoin_config.h` constants and removed defined where not needed.

The rationale was to remove the ones where the constant is defined in both `config/bitcoin_config.h` and `build_msvc/bitcoin_conf.h` and is declared as 1 or 0. If the constant is commented out or not declared at all in any of those config files, I left the check as `#if defined(...)`, otherwise I changed the definition to `#if ...`

If there are any other cases where `#if defined` is not needed, let me know and I'll update the PR.