### PR TITLE
test: only include and use OpenSSL where it's actually needed (BIP70)

### DIFF
--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -16,6 +16,7 @@
 #include <test/setup_common.h>
 #include <util/strencodings.h>
 
+#include <openssl/ssl.h>
 #include <openssl/x509.h>
 #include <openssl/x509_vfy.h>
 
@@ -66,6 +67,7 @@ static SendCoinsRecipient handleRequest(PaymentServer* server, std::vector<unsig
 
 void PaymentServerTests::paymentServerTests()
 {
+    SSL_library_init();
     BasicTestingSetup testing_setup(CBaseChainParams::MAIN);
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -26,8 +26,6 @@
 #include <QObject>
 #include <QTest>
 
-#include <openssl/ssl.h>
-
 #if defined(QT_STATICPLUGIN)
 #include <QtPlugin>
 #if defined(QT_QPA_PLATFORM_MINIMAL)
@@ -72,8 +70,6 @@ int main(int argc, char *argv[])
     // QApplication:: and QCoreApplication:: in the tests
     BitcoinApplication app(*node, argc, argv);
     app.setApplicationName("Bitcoin-Qt-test");
-
-    SSL_library_init();
 
     AppTests app_tests(app);
     if (QTest::qExec(&app_tests) != 0) {


### PR DESCRIPTION
This should save initializing OpenSSL during tests if compiled with `--disable-bip70`.