### PR TITLE
Bugfix: QA: Run tests with UPnP disabled

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -91,6 +91,7 @@ class TestNode():
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
             "-uacomment=testnode%d" % i,
+            "-upnp=0",
         ]
 
         self.cli = TestNodeCLI(bitcoin_cli, self.datadir)


### PR DESCRIPTION
Needed for builds configured with --enable-upnp-default
