### PR TITLE
test: Always define the raii_event_tests test suite

### DIFF
--- a/src/test/raii_event_tests.cpp
+++ b/src/test/raii_event_tests.cpp
@@ -4,9 +4,6 @@
 
 #include <event2/event.h>
 
-#ifdef EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED
-// It would probably be ideal to define dummy test(s) that report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
-
 #include <map>
 #include <stdlib.h>
 
@@ -17,6 +14,10 @@
 #include <vector>
 
 #include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(raii_event_tests, BasicTestingSetup)
+
+#ifdef EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED
 
 static std::map<void*, short> tags;
 static std::map<void*, uint16_t> orders;
@@ -35,8 +36,6 @@ static void tag_free(void* mem) {
     orders[mem] = tagSequence++;
     free(mem);
 }
-
-BOOST_FIXTURE_TEST_SUITE(raii_event_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(raii_event_creation)
 {
@@ -89,6 +88,14 @@ BOOST_AUTO_TEST_CASE(raii_event_order)
     event_set_mem_functions(malloc, realloc, free);
 }
 
-BOOST_AUTO_TEST_SUITE_END()
+#else
+
+BOOST_AUTO_TEST_CASE(raii_event_tests_SKIPPED)
+{
+    // It would probably be ideal to report skipped, but boost::test doesn't seem to make that practical (at least not in versions available with common distros)
+    BOOST_TEST_MESSAGE("Skipping raii_event_tess: libevent doesn't support event_set_mem_functions");
+}
 
 #endif  // EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The test suite must always be defined (even when EVENT_SET_MEM_FUNCTIONS_IMPLEMENTED is not defined) so that the test harness doesn't fail due to not being able to find the raii_event_tests test.

This improves upon 95f97f4 actually fixing https://github.com/bitcoin/bitcoin/issues/9493