### PR TITLE
Increase init file stop timeout

### DIFF
--- a/contrib/init/bitcoind.conf
+++ b/contrib/init/bitcoind.conf
@@ -16,7 +16,7 @@ expect fork
 
 respawn
 respawn limit 5 120
-kill timeout 60
+kill timeout 600
 
 pre-start script
     # this will catch non-existent config files

--- a/contrib/init/bitcoind.init
+++ b/contrib/init/bitcoind.init
@@ -39,7 +39,7 @@ start() {
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc $prog
+    killproc $prog -t600
     RETVAL=$?
     echo
     [ $RETVAL -eq 0 ] && rm -f $lockfile

--- a/contrib/init/bitcoind.openrcconf
+++ b/contrib/init/bitcoind.openrcconf
@@ -30,4 +30,4 @@
 # Note that this will be mapped as argument to start-stop-daemon's
 # '--retry' option, which means you can specify a retry schedule
 # here. For more information see man 8 start-stop-daemon.
-BITCOIND_SIGTERM_TIMEOUT=60
+BITCOIND_SIGTERM_TIMEOUT=600

--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -24,6 +24,7 @@ ExecStart=/usr/bin/bitcoind -daemon \
 Type=forking
 PIDFile=/run/bitcoind/bitcoind.pid
 Restart=on-failure
+TimeoutStopSec=600
 
 # Directory creation and permissions
 ####################################


### PR DESCRIPTION
`bitcoind` can take a long time to flush its db cache to disk upon
shutdown. Systemd sends a `SIGKILL` after a timeout, causing unclean
shutdowns and triggering a long "Rolling forward" at the next startup.
Disabling the timeout should prevent this from happening, and does not
break systemd's `restart` logic.

Addresses #13736.
