### PR TITLE
build: disable building libsecp256k1 benchmarks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1625,7 +1625,7 @@ if test x$need_bundled_univalue = xyes; then
   AC_CONFIG_SUBDIRS([src/univalue])
 fi
 
-ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
+ac_configure_args="${ac_configure_args} --disable-shared --with-pic --enable-benchmark=no --with-bignum=no --enable-module-recovery --disable-jni"
 AC_CONFIG_SUBDIRS([src/secp256k1])
 
 AC_OUTPUT


### PR DESCRIPTION
These were previously disabled, but upstream changed to having benchmarks enabled by default
in https://github.com/bitcoin-core/secp256k1/pull/480 and we pulled that change in as part of #15703.
