### PR TITLE
Do not pass in command line arguments to QApplication

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -169,8 +169,11 @@ void BitcoinCore::shutdown()
     }
 }
 
-BitcoinApplication::BitcoinApplication(interfaces::Node& node, int &argc, char **argv):
-    QApplication(argc, argv),
+static int qt_argc = 1;
+static const char* qt_argv = "bitcoin-qt";
+
+BitcoinApplication::BitcoinApplication(interfaces::Node& node):
+    QApplication(qt_argc, const_cast<char **>(&qt_argv)),
     coreThread(nullptr),
     m_node(node),
     optionsModel(nullptr),
@@ -433,7 +436,7 @@ int GuiMain(int argc, char* argv[])
     QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
 #endif
 
-    BitcoinApplication app(*node, argc, argv);
+    BitcoinApplication app(*node);
 
     // Register meta types used for QMetaObject::invokeMethod
     qRegisterMetaType< bool* >();

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -56,7 +56,7 @@ class BitcoinApplication: public QApplication
 {
     Q_OBJECT
 public:
-    explicit BitcoinApplication(interfaces::Node& node, int &argc, char **argv);
+    explicit BitcoinApplication(interfaces::Node& node);
     ~BitcoinApplication();
 
 #ifdef ENABLE_WALLET

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -68,7 +68,7 @@ int main(int argc, char *argv[])
 
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests
-    BitcoinApplication app(*node, argc, argv);
+    BitcoinApplication app(*node);
     app.setApplicationName("Bitcoin-Qt-test");
 
     AppTests app_tests(app);


### PR DESCRIPTION
QApplication takes the command line arguments and parses them itself for some [built in command line arguments](https://doc.qt.io/qt-5/qapplication.html#QApplication) that it has. We don't want any of those built in arguments, so instead give it dummy arguments.

To test, you can use the `-reverse` option. Without this patch, everything will appear right-to-left; things that were on the left side will be on the right and everything is right aligned.

After this patch, `-reverse` will now give a startup error since we do not support this argument.