### PR TITLE
doc: Mention other ways to conserve memory on compilation

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -61,6 +61,14 @@ tuned to conserve memory with additional CXXFLAGS:
 
     ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
 
+Alternatively, or in addition, debugging information can be skipped for compilation. The default compile flags are
+`-g -O2`, and can be changed with:
+
+    ./configure CXXFLAGS="-O2"
+
+Finally, clang (often less resource hungry) can be used instead of gcc, which is used by default:
+
+    ./configure CXX=clang++ CC=clang
 
 ## Linux Distribution Specific Instructions
 


### PR DESCRIPTION
Related to:

*  Building requires >1GB memory #6658 