### PR TITLE
build: Remove unused src/obj-test folder

### DIFF
--- a/src/obj-test/.gitignore
+++ b/src/obj-test/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
I believe this is no longer used after we switched from a makefile to autotools