### PR TITLE
init: systemd directory fix

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -13,7 +13,7 @@ Description=Bitcoin daemon
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/bitcoind -daemon \
+ExecStart=/usr/local/bin/bitcoind -daemon \
                             -pid=/run/bitcoind/bitcoind.pid \
                             -conf=/etc/bitcoin/bitcoin.conf \
                             -datadir=/var/lib/bitcoind


### PR DESCRIPTION
When you install Bitcoin Core over the makefile it is being installed to `/usr/local/bin/` and not `/usr/bin/`.
When you use the systemd file out of the box it will causes an error because `/usr/bin/bitcoind` was not found. This patch fixes it.