### PR TITLE
travis: use extended 90 minute timeout when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,8 +64,10 @@ before_script:
 script:
   - export CONTINUE=1
   - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
+  - if [ $TRAVIS_REPO_SLUG = "bitcoin/bitcoin" ]; then export CONTINUE=1; fi  # Whitelisted repo (90 minutes build time)
   - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/test_06_script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
   - if [ $SECONDS -gt 2000 ]; then export CONTINUE=0; fi  # Likely the build took very long; The tests take about 1000s, so we should abort if we have less than 50*60-1000=2000s left
+  - if [ $TRAVIS_REPO_SLUG = "bitcoin/bitcoin" ]; then export CONTINUE=1; fi  # Whitelisted repo (90 minutes build time)
   - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/test_06_script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 after_script:
   - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
The default is 50 minutes, see https://docs.travis-ci.com/user/customizing-the-build#build-timeouts

Travis is willing to raise the default for the `bitcoin/bitcoin` repo slug to 90 minutes, see https://github.com/bitcoin/bitcoin/pull/16595#issuecomment-520917665

This allows us to bypass the "exit early to save the depends or compiler cache" for `bitcoin/bitcoin`, but not for forks of this repo.

Fixes #16148