### PR TITLE
Travis: run full test suite on native macOS 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,13 @@ cache:
     - $TRAVIS_BUILD_DIR/depends/built
     - $TRAVIS_BUILD_DIR/depends/sdk-sources
     - $TRAVIS_BUILD_DIR/ci/scratch/.ccache
+    # macOS
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
+before_cache:
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
+  # Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
+  # - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
 stages:
   - lint
   - test
@@ -93,7 +100,7 @@ jobs:
       os: osx
       # Use the earliest macOS that can build our lint dependencies:
       # Xcode 8.3.3, macOS 10.12, JDK 1.8.0_112-b16
-      # https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+      # https://docs.travis-ci.com/user/reference/osx/#macos-version
       osx_image: xcode8.3
       # TODO: if you're updating osx_image, try using "rvm:" to supply the
       # version of ruby required by homebrew. Despite this "rvm:" declaration,
@@ -160,3 +167,13 @@ jobs:
       name: 'macOS 10.10  [GOAL: deploy] [no functional tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_mac.sh"
+
+    - stage: test
+      name: 'macOS 10.14 native [GOAL: install] [GUI: BIP70 enabled] [no depends]'
+      os: osx
+      # Use the most recent version:
+      # Xcode 11, macOS 10.14, JDK 12.0.1
+      # https://docs.travis-ci.com/user/reference/osx/#macos-version
+      osx_image: xcode11
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_mac_functional.sh"

--- a/ci/test/00_setup_env_mac_functional.sh
+++ b/ci/test/00_setup_env_mac_functional.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export HOST=x86_64-apple-darwin14
+export BREW_PACKAGES="automake berkeley-db4 libtool boost miniupnpc pkg-config protobuf qt qrencode python3 ccache zeromq"
+export PIP_PACKAGES="zmq"
+export OSX_SDK=10.11
+export RUN_CI_ON_HOST=true
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=true
+export GOAL="install"
+export BITCOIN_CONFIG="--enable-gui --enable-bip70 --enable-reduce-exports --enable-werror"
+export NO_DEPENDS=1

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -6,6 +6,32 @@
 
 export LC_ALL=C.UTF-8
 
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  set +o errexit
+  pushd /usr/local/Homebrew || exit 1
+  git reset --hard origin/master
+  popd || exit 1
+  set -o errexit
+  ${CI_RETRY_EXE} brew update
+  # brew upgrade returns an error if any of the packages is already up to date
+  # Failure is safe to ignore, unless we really need an update.
+  brew upgrade $BREW_PACKAGES || true
+
+  # install new packages (brew install returns an error if already installed)
+  for i in $BREW_PACKAGES; do
+    if ! brew list | grep -q $i; then
+      ${CI_RETRY_EXE} brew install $i
+    fi
+  done
+
+  export PATH="/usr/local/opt/ccache/libexec:$PATH"
+  OPENSSL_PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+  export PKG_CONFIG_PATH=$OPENSSL_PKG_CONFIG_PATH:$PKG_CONFIG_PATH
+
+  ${CI_RETRY_EXE} pip3 install $PIP_PACKAGES
+
+fi
+
 mkdir -p "${BASE_SCRATCH_DIR}"
 ccache echo "Creating ccache dir if it didn't already exist"
 
@@ -42,11 +68,19 @@ else
   }
 fi
 
-DOCKER_EXEC free -m -h
-DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  top -l 1 -s 0 | awk ' /PhysMem/ {print}'
+  echo "Number of CPUs: $(sysctl -n hw.logicalcpu)"
+else
+  DOCKER_EXEC free -m -h
+  DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+fi
 
-${CI_RETRY_EXE} DOCKER_EXEC apt-get update
-${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
+
+if [ "$TRAVIS_OS_NAME" != "osx" ]; then
+  ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
+  ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
+fi
 
 if [ "$USE_BUSY_BOX" = "true" ]; then
   echo "Setup to use BusyBox utils"

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -6,19 +6,28 @@
 
 export LC_ALL=C.UTF-8
 
-DOCKER_EXEC echo \> \$HOME/.bitcoin  # Make sure default datadir does not exist and is never read by creating a dummy file
+# Make sure default datadir does not exist and is never read by creating a dummy file
+if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  echo > $HOME/Library/Application\ Support/Bitcoin
+else
+  DOCKER_EXEC echo \> \$HOME/.bitcoin
+fi
 
-mkdir -p depends/SDKs depends/sdk-sources
+if [ "$TRAVIS_OS_NAME" != "osx" ]; then
 
-if [ -n "$OSX_SDK" ] && [ ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
-  curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
-fi
-if [ -n "$OSX_SDK" ] && [ -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
-  tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
-fi
-if [[ $HOST = *-mingw32 ]]; then
-  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
-fi
-if [ -z "$NO_DEPENDS" ]; then
-  DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+  mkdir -p depends/SDKs depends/sdk-sources
+
+  if [ -n "$OSX_SDK" ] && [ ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
+    curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
+  fi
+  if [ -n "$OSX_SDK" ] && [ -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
+    tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
+  fi
+  if [[ $HOST = *-mingw32 ]]; then
+    DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
+  fi
+  if [ -z "$NO_DEPENDS" ]; then
+    DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+  fi
+
 fi

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -20,7 +20,11 @@ fi
 END_FOLD
 
 mkdir -p build
+
+# Temporarily disable errexit, because Travis macOS fails without error message
+set +o errexit
 cd build || (echo "could not enter build directory"; exit 1)
+set -o errexit
 
 BEGIN_FOLD configure
 DOCKER_EXEC ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
@@ -30,7 +34,9 @@ BEGIN_FOLD distdir
 DOCKER_EXEC make distdir VERSION=$HOST
 END_FOLD
 
+set +o errexit
 cd "bitcoin-$HOST" || (echo "could not enter distdir bitcoin-$HOST"; exit 1)
+set -o errexit
 
 BEGIN_FOLD configure
 DOCKER_EXEC ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
@@ -43,4 +49,6 @@ BEGIN_FOLD build
 DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
 END_FOLD
 
+set +o errexit
 cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
+set -o errexit

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -6,7 +6,10 @@
 
 export LC_ALL=C.UTF-8
 
+# Temporarily disable errexit, because Travis macOS fails without error message
+set +o errexit
 cd "build/bitcoin-$HOST" || (echo "could not enter distdir build/bitcoin-$HOST"; exit 1)
+set -o errexit
 
 if [ -n "$QEMU_USER_CMD" ]; then
   BEGIN_FOLD wrap-qemu
@@ -46,4 +49,6 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   END_FOLD
 fi
 
+set +o errexit
 cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
+set -o errexit


### PR DESCRIPTION
Adds an additional Travis machine to run the functional test suite on native macOS 

Homebrew is not particularly Travis compatible, but I found some useful hints here: https://discourse.brew.sh/t/best-practice-for-homebrew-on-travis-brew-update-is-5min-to-build-time/5215/11