### PR TITLE
test: Remove confusing hash256 function in util

### DIFF
--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -7,14 +7,14 @@ import struct
 
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.messages import CTransaction
-from test_framework.util import (
-    assert_equal,
-    hash256,
-)
+from test_framework.messages import CTransaction, hash256
+from test_framework.util import assert_equal
 from io import BytesIO
 
 ADDRESS = "tcp://127.0.0.1:28332"
+
+def hash256_reversed(byte_str):
+    return hash256(byte_str)[::-1]
 
 class ZMQSubscriber:
     def __init__(self, socket, topic):
@@ -103,7 +103,7 @@ class ZMQTest (BitcoinTestFramework):
 
             # Should receive the generated raw block.
             block = self.rawblock.receive()
-            assert_equal(genhashes[x], hash256(block[:80]).hex())
+            assert_equal(genhashes[x], hash256_reversed(block[:80]).hex())
 
         if self.is_wallet_compiled():
             self.log.info("Wait for tx from second node")
@@ -116,7 +116,7 @@ class ZMQTest (BitcoinTestFramework):
 
             # Should receive the broadcasted raw transaction.
             hex = self.rawtx.receive()
-            assert_equal(payment_txid, hash256(hex).hex())
+            assert_equal(payment_txid, hash256_reversed(hex).hex())
 
 
         self.log.info("Test the getzmqnotifications RPC")

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -7,7 +7,6 @@
 from base64 import b64encode
 from binascii import unhexlify
 from decimal import Decimal, ROUND_DOWN
-import hashlib
 import inspect
 import json
 import logging
@@ -183,12 +182,6 @@ def check_json_precision():
 def count_bytes(hex_string):
     return len(bytearray.fromhex(hex_string))
 
-def hash256(byte_str):
-    sha256 = hashlib.sha256()
-    sha256.update(byte_str)
-    sha256d = hashlib.sha256()
-    sha256d.update(sha256.digest())
-    return sha256d.digest()[::-1]
 
 def hex_str_to_bytes(hex_str):
     return unhexlify(hex_str.encode('ascii'))


### PR DESCRIPTION
Right now there are two `hash256(bytes)` in the test framework:
first: https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/util.py#L186
second: https://github.com/bitcoin/bitcoin/blob/master/test/functional/test_framework/messages.py#L60

While they have the same name they're actually doing different things, one just does a sha256d and the other sha256d and reverses the bytes.
so I renamed the second one to be `hash256_reversed` to signify that it's hash256 reversed.