### PR TITLE
[0.18] Add missing contributor to 0.18.1 release notes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -126,8 +126,9 @@ Thanks to everyone who directly contributed to this release:
 - Kristaps Kaupe
 - Luke Dashjr
 - MarcoFalke
-- MeshCollider
+- Michele Federici
 - Pieter Wuille
+- Samuel Dobson
 - shannon1916
 - tecnovert
 - Wladimir J. van der Laan


### PR DESCRIPTION
The user contacted me on Twitter and pointed out that he had contributed in both the reporting of the bug #16012 as well as a number of PRs following it

Also changed to use my real name while I'm there