### PR TITLE
Add missing contributor to 0.18.1 release notes 

### DIFF
--- a/doc/release-notes/release-notes-0.18.1.md
+++ b/doc/release-notes/release-notes-0.18.1.md
@@ -126,8 +126,9 @@ Thanks to everyone who directly contributed to this release:
 - Kristaps Kaupe
 - Luke Dashjr
 - MarcoFalke
-- MeshCollider
+- Michele Federici
 - Pieter Wuille
+- Samuel Dobson
 - shannon1916
 - tecnovert
 - Wladimir J. van der Laan


### PR DESCRIPTION
The user contacted me on Twitter and pointed out that he had contributed in both the reporting of the bug #16012 as well as a number of PRs following it, so I think he deserves to be credited in the release notes

(also changed to use my real name while I'm there)