### PR TITLE
build: Remove src/obj directory from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ libtool
 src/config/bitcoin-config.h
 src/config/bitcoin-config.h.in
 src/config/stamp-h1
+src/obj
 share/setup.nsi
 share/qt/Info.plist
 

--- a/src/obj/.gitignore
+++ b/src/obj/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
This directory is automatically created by the build process (in the build target directory, see #16588) and doesn't need to be in the repository nor in the tarballs.

Move associated ignore directive to top-level `.gitignore` file.