### PR TITLE
build: echo property tests status during build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -133,7 +133,7 @@ AC_ARG_ENABLE(gui-tests,
 
 AC_ARG_WITH([rapidcheck],
   [AS_HELP_STRING([--with-rapidcheck],
-  [enable RapidCheck property based tests (default is yes if librapidcheck is found)])],
+  [enable RapidCheck property-based tests (default is yes if librapidcheck is found)])],
   [use_rapidcheck=$withval],
   [use_rapidcheck=auto])
 
@@ -1275,7 +1275,7 @@ AC_CHECK_DECLS([EVP_MD_CTX_new],,,[AC_INCLUDES_DEFAULT
 ])
 CXXFLAGS="${save_CXXFLAGS}"
 
-dnl RapidCheck Property Based Testing
+dnl RapidCheck property-based testing
 
 enable_property_tests=no
 if test "x$use_rapidcheck" = xauto; then
@@ -1657,6 +1657,7 @@ fi
 echo "  with zmq      = $use_zmq"
 echo "  with test     = $use_tests"
 if test x$use_tests != xno; then
+    echo "    with prop   = $enable_property_tests"
     echo "    with fuzz   = $enable_fuzz"
 fi
 echo "  with bench    = $use_bench"


### PR DESCRIPTION
Enable users to see if the prop tests are enabled during the build. This can be particularly helpful as property-based tests are silently auto-enabled by default if librapidcheck is found.

Sample build output:

```
Options used to compile and link:
  with wallet   = yes
  with gui / qt = yes
    with bip70  = yes
    with qr     = yes
  with zmq      = yes
  with test     = yes
    with prop   = yes                  <--- new
    with fuzz   = no
  with bench    = no
```
