### PR TITLE
consensus: skip genesis block POW check

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -274,7 +274,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams))
+                if (pindexNew->GetBlockHash() != consensusParams.hashGenesisBlock && !CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams))
                     return error("%s: CheckProofOfWork failed: %s", __func__, pindexNew->ToString());
 
                 pcursor->Next();


### PR DESCRIPTION
It's been on the agenda for some time to disable POW check for genesis block. As signet blocks will not have valid proof of work for the genesis block, it makes sense to do this change unconditionally.

This is a part of #16411 but as it is a minor consensus tweak, it probably deserves its own PR.