### PR TITLE
doc: Refer in rpcbind doc to the manpage

### DIFF
--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -70,8 +70,8 @@
 # server=1 tells Bitcoin-Qt and bitcoind to accept JSON-RPC commands
 #server=0
 
-# Bind to given address to listen for JSON-RPC connections. Use [host]:port notation for IPv6.
-# This option can be specified multiple times (default: bind to all interfaces)
+# Bind to given address to listen for JSON-RPC connections.
+# Refer to the manpage or bitcoind -help for further details.
 #rpcbind=<addr>
 
 # If no rpcpassword is set, rpc cookie auth is sought. The default `-rpccookiefile` name


### PR DESCRIPTION
The help was outdated, so refer to the updated manpage instead.


* closes #14740
* closes #9272