### PR TITLE
refactor: Improve special member functions definitions

### DIFF
--- a/src/script/signingprovider.h
+++ b/src/script/signingprovider.h
@@ -18,7 +18,15 @@ struct KeyOriginInfo;
 class SigningProvider
 {
 public:
-    virtual ~SigningProvider() {}
+    SigningProvider() = default;
+    virtual ~SigningProvider() = default;
+
+    SigningProvider(const SigningProvider&) = default;
+    SigningProvider& operator=(const SigningProvider&) = default;
+
+    SigningProvider(SigningProvider&&) = default;
+    SigningProvider& operator=(SigningProvider&&) = default;
+
     virtual bool GetCScript(const CScriptID &scriptid, CScript& script) const { return false; }
     virtual bool HaveCScript(const CScriptID &scriptid) const { return false; }
     virtual bool GetPubKey(const CKeyID &address, CPubKey& pubkey) const { return false; }

--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -28,6 +28,7 @@ struct secure_allocator : public std::allocator<T> {
     typedef typename base::value_type value_type;
     secure_allocator() noexcept {}
     secure_allocator(const secure_allocator& a) noexcept : base(a) {}
+    secure_allocator& operator=(const secure_allocator& a) = default;
     template <typename U>
     secure_allocator(const secure_allocator<U>& a) noexcept : base(a)
     {

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -112,6 +112,7 @@ struct FrozenCleanupCheck {
         return true;
     }
     FrozenCleanupCheck() {}
+    FrozenCleanupCheck(const FrozenCleanupCheck&) = default;
     ~FrozenCleanupCheck()
     {
         if (should_freeze) {


### PR DESCRIPTION
This PR fixes special member functions in the following class/struct definitions:
- `struct PartiallySignedTransaction` (done in  #17349)
  The default (i.e., generated by a compiler) copy constructor does the same things. It prevents `-Wdeprecated-copy` warning in GCC 9 (#15822) and `-Wdeprecated` warning in Clang 10 for implicitly declared `operator=`
- `class SigningProvider`
  All special member functions of the SigningProvider class defined `=default` which makes it a well-behaved base class. It prevents `-Wdeprecated` warning in Clang 10
- `struct secure_allocator`
  Define `=default` copy assignment explicitly. It prevents `-Wdeprecated` warning in Clang 10
- `struct FrozenCleanupCheck`
  Define `=default` copy constructor explicitly. It prevents `-Wdeprecated` warning in Clang 10