### PR TITLE
doc: Add ZMQ dependencies to the Fedora build instructions

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -96,7 +96,7 @@ Otherwise, you can build from self-compiled `depends` (see above).
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](/doc/build-unix.md#disable-wallet-mode)
 
 
-Optional (see --with-miniupnpc and --enable-upnp-default):
+Optional (see `--with-miniupnpc` and `--enable-upnp-default`):
 
     sudo apt-get install libminiupnpc-dev
 
@@ -130,9 +130,13 @@ Build requirements:
 
     sudo dnf install gcc-c++ libtool make autoconf automake openssl-devel libevent-devel boost-devel libdb4-devel libdb4-cxx-devel python3
 
-Optional:
+Optional (see `--with-miniupnpc` and `--enable-upnp-default`):
 
     sudo dnf install miniupnpc-devel
+
+ZMQ dependencies (provides ZMQ API):
+
+    sudo dnf install zeromq-devel
 
 To build with Qt 5 you need the following:
 


### PR DESCRIPTION
Without `zeromq-devel` package on Fedora 30:
```
$ ./configure | grep zmq
configure: WARNING: libzmq version 4.x or greater not found, disabling
  with zmq      = no
```

With installed `zeromq-devel`:
```
$ ./configure | grep zmq
  with zmq      = yes
```

Also this PR improves style in the `miniupnpc` related paragraphs.