### PR TITLE
qa: Run tests with UPnP disabled

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -293,6 +293,7 @@ def initialize_datadir(dirname, n, chain):
         f.write("discover=0\n")
         f.write("listenonion=0\n")
         f.write("printtoconsole=0\n")
+        f.write("upnp=0\n")
         os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
         os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir


### PR DESCRIPTION
This replaces #16560 by adding `upnp=0` to `bitcoin.conf` rather than passing it to nodes.

> Needed for builds configured with --enable-upnp-default

You can test this change using:
```bash
./configure --enable-upnp-default && make -j6 && test/functional/test_runner.py feature_config_args.py
```

on master the test will fail without this change.