### PR TITLE
build: latest rapidcheck, update configuration

### DIFF
--- a/depends/packages/rapidcheck.mk
+++ b/depends/packages/rapidcheck.mk
@@ -1,11 +1,11 @@
 package=rapidcheck
-$(package)_version=3eb9b4ff69f4ff2d9932e8f852c2b2a61d7c20d3
+$(package)_version=d9482c683429fe79122e3dcab14c9655874aeb8e
 $(package)_download_path=https://github.com/emil-e/rapidcheck/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=5fbf82755c9a647127e62563be079448ff8b1db9ca80a52a673dd9a88fdb714b
+$(package)_sha256_hash=b9ee8955b175fd3c0757ebd887bb075541761af08b0c28391b7c6c0685351f6b
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true -DRC_INSTALL_ALL_EXTRAS=ON
+  cmake -DCMAKE_INSTALL_PREFIX=$($(package)_staging_dir)$(host_prefix) -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true -DRC_ENABLE_BOOST_TEST=ON -B .
 endef
 
 define $(package)_preprocess_cmds


### PR DESCRIPTION
- update RapidCheck to the latest commit on master
- install only the extras needed by Bitcoin Core, e.g. ENABLE_BOOST_TEST instead of INSTALL_ALL_EXTRAS
- remove cmake warning by providing `-B` arg:
    ```
    CMake Warning:
  No source or binary directory provided.  Both will be assumed to be the
  same as the current working directory, but note that this warning will
  become a fatal error in future CMake releases.
    ```

Tested with `cd depends && make RAPIDCHECK=1` on Linux Debian.
