### PR TITLE
refactoring: Remove unused includes

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -8,8 +8,6 @@
 #include <uint256.h>
 #include <crypto/common.h>
 
-#include <stdio.h>
-#include <string.h>
 
 template <unsigned int BITS>
 base_uint<BITS>::base_uint(const std::string& str)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -6,13 +6,11 @@
 #ifndef BITCOIN_ARITH_UINT256_H
 #define BITCOIN_ARITH_UINT256_H
 
-#include <assert.h>
 #include <cstring>
 #include <limits>
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
-#include <vector>
 
 class uint256;
 

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -8,7 +8,6 @@
 
 #include <array>
 #include <vector>
-#include <string>
 
 
 static void Base58Encode(benchmark::State& state)

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -6,7 +6,6 @@
 #define BITCOIN_BENCH_BENCH_H
 
 #include <functional>
-#include <limits>
 #include <map>
 #include <string>
 #include <vector>

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -10,7 +10,6 @@
 #include <validation.h>
 
 
-#include <list>
 #include <vector>
 
 static void AssembleBlock(benchmark::State& state)

--- a/src/bench/chacha20.cpp
+++ b/src/bench/chacha20.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
 
 #include <bench/bench.h>
 #include <crypto/chacha20.h>

--- a/src/bench/chacha_poly_aead.cpp
+++ b/src/bench/chacha_poly_aead.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
 
 #include <bench/bench.h>
 #include <crypto/chacha_poly_aead.h>

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
 
 #include <bench/bench.h>
 #include <hash.h>

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -4,15 +4,12 @@
 
 #include <bench/bench.h>
 #include <chainparams.h>
-#include <coins.h>
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <pow.h>
 #include <txmempool.h>
 #include <validation.h>
 
-#include <list>
-#include <vector>
 
 
 static void DuplicateInputs(benchmark::State& state)

--- a/src/bench/lockedpool.cpp
+++ b/src/bench/lockedpool.cpp
@@ -6,7 +6,6 @@
 
 #include <support/lockedpool.h>
 
-#include <iostream>
 #include <vector>
 
 #define ASIZE 2048

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -6,8 +6,6 @@
 #include <policy/policy.h>
 #include <txmempool.h>
 
-#include <list>
-#include <vector>
 
 static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {

--- a/src/bench/poly1305.cpp
+++ b/src/bench/poly1305.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
 
 #include <bench/bench.h>
 #include <crypto/poly1305.h>

--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <iostream>
 
 #include <bench/bench.h>
 #include <bloom.h>

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -7,7 +7,6 @@
 
 #include <validation.h>
 #include <streams.h>
-#include <consensus/validation.h>
 #include <rpc/blockchain.h>
 
 #include <univalue.h>

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -8,8 +8,6 @@
 
 #include <univalue.h>
 
-#include <list>
-#include <vector>
 
 static void AddTx(const CTransactionRef& tx, const CAmount& fee, CTxMemPool& pool) EXCLUSIVE_LOCKS_REQUIRED(cs_main, pool.cs)
 {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -9,7 +9,6 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
-#include <fs.h>
 #include <rpc/client.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -11,7 +11,6 @@
 #include <consensus/consensus.h>
 #include <core_io.h>
 #include <key_io.h>
-#include <policy/policy.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
 #include <script/script.h>

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -9,13 +9,11 @@
 #include <chainparams.h>
 #include <chainparamsbase.h>
 #include <logging.h>
-#include <util/strencodings.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallettool.h>
 
 #include <functional>
-#include <stdio.h>
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -10,7 +10,6 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <compat.h>
-#include <fs.h>
 #include <init.h>
 #include <interfaces/chain.h>
 #include <noui.h>

--- a/src/blockencodings.h
+++ b/src/blockencodings.h
@@ -7,7 +7,6 @@
 
 #include <primitives/block.h>
 
-#include <memory>
 
 class CTxMemPool;
 

--- a/src/compressor.cpp
+++ b/src/compressor.cpp
@@ -5,7 +5,6 @@
 
 #include <compressor.h>
 
-#include <hash.h>
 #include <pubkey.h>
 #include <script/standard.h>
 

--- a/src/consensus/merkle.h
+++ b/src/consensus/merkle.h
@@ -5,10 +5,8 @@
 #ifndef BITCOIN_CONSENSUS_MERKLE_H
 #define BITCOIN_CONSENSUS_MERKLE_H
 
-#include <stdint.h>
 #include <vector>
 
-#include <primitives/transaction.h>
 #include <primitives/block.h>
 #include <uint256.h>
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -8,8 +8,6 @@
 
 #include <uint256.h>
 #include <limits>
-#include <map>
-#include <string>
 
 namespace Consensus {
 

--- a/src/crypto/aes.cpp
+++ b/src/crypto/aes.cpp
@@ -4,7 +4,6 @@
 
 #include <crypto/aes.h>
 
-#include <assert.h>
 #include <string.h>
 
 extern "C" {

--- a/src/crypto/chacha_poly_aead.cpp
+++ b/src/crypto/chacha_poly_aead.cpp
@@ -4,7 +4,6 @@
 
 #include <crypto/chacha_poly_aead.h>
 
-#include <crypto/common.h>
 #include <crypto/poly1305.h>
 #include <support/cleanse.h>
 

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -7,7 +7,6 @@
 
 #include <assert.h>
 #include <string.h>
-#include <atomic>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #if defined(USE_ASM)

--- a/src/crypto/sha256_shani.cpp
+++ b/src/crypto/sha256_shani.cpp
@@ -11,7 +11,6 @@
 #include <stdint.h>
 #include <immintrin.h>
 
-#include <crypto/common.h>
 
 
 namespace {

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -11,7 +11,6 @@
 #include <streams.h>
 #include <util/system.h>
 #include <util/strencodings.h>
-#include <version.h>
 
 #include <leveldb/db.h>
 #include <leveldb/write_batch.h>

--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <stdio.h>
 #include <util/system.h>
 #include <walletinitinterface.h>
 #include <support/allocators/secure.h>

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -7,10 +7,8 @@
 #include <chainparams.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
-#include <key_io.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
-#include <sync.h>
 #include <ui_interface.h>
 #include <util/strencodings.h>
 #include <util/system.h>

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -5,8 +5,6 @@
 #ifndef BITCOIN_HTTPRPC_H
 #define BITCOIN_HTTPRPC_H
 
-#include <string>
-#include <map>
 
 /** Start HTTP RPC subsystem.
  * Precondition; HTTP and RPC has been started.

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -22,7 +22,6 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <signal.h>
 
 #include <event2/thread.h>
 #include <event2/buffer.h>

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -6,7 +6,6 @@
 #define BITCOIN_HTTPSERVER_H
 
 #include <string>
-#include <stdint.h>
 #include <functional>
 
 static const int DEFAULT_HTTP_THREADS=4;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -9,7 +9,6 @@
 #include <primitives/block.h>
 #include <primitives/transaction.h>
 #include <threadinterrupt.h>
-#include <uint256.h>
 #include <validationinterface.h>
 
 class CBlockIndex;

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -18,12 +18,10 @@
 #include <policy/settings.h>
 #include <primitives/block.h>
 #include <primitives/transaction.h>
-#include <protocol.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <shutdown.h>
 #include <sync.h>
-#include <threadsafety.h>
 #include <timedata.h>
 #include <txmempool.h>
 #include <ui_interface.h>

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -5,7 +5,6 @@
 #include <interfaces/node.h>
 
 #include <addrdb.h>
-#include <amount.h>
 #include <banman.h>
 #include <chain.h>
 #include <chainparams.h>
@@ -19,7 +18,6 @@
 #include <netbase.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
-#include <policy/policy.h>
 #include <policy/settings.h>
 #include <primitives/block.h>
 #include <rpc/server.h>
@@ -36,7 +34,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <atomic>
 #include <univalue.h>
 
 class CWallet;

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -8,7 +8,6 @@
 #include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
-#include <policy/feerate.h>
 #include <policy/fees.h>
 #include <primitives/transaction.h>
 #include <script/standard.h>
@@ -23,7 +22,6 @@
 #include <wallet/rpcwallet.h>
 #include <wallet/load.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 
 #include <memory>
 #include <string>

--- a/src/key_io.cpp
+++ b/src/key_io.cpp
@@ -6,7 +6,6 @@
 
 #include <base58.h>
 #include <bech32.h>
-#include <script/script.h>
 #include <util/strencodings.h>
 
 #include <boost/variant/apply_visitor.hpp>

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -17,14 +17,12 @@
 #include <policy/policy.h>
 #include <pow.h>
 #include <primitives/transaction.h>
-#include <script/standard.h>
 #include <timedata.h>
 #include <util/moneystr.h>
 #include <util/system.h>
 #include <util/validation.h>
 
 #include <algorithm>
-#include <queue>
 #include <utility>
 
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -13,11 +13,9 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <consensus/consensus.h>
-#include <crypto/common.h>
 #include <crypto/sha256.h>
 #include <netbase.h>
 #include <net_permissions.h>
-#include <primitives/transaction.h>
 #include <scheduler.h>
 #include <ui_interface.h>
 #include <util/strencodings.h>
@@ -35,7 +33,6 @@
 
 #ifdef USE_UPNP
 #include <miniupnpc/miniupnpc.h>
-#include <miniupnpc/miniwget.h>
 #include <miniupnpc/upnpcommands.h>
 #include <miniupnpc/upnperrors.h>
 // The minimum supported miniUPnPc API version is set to 10. This keeps compatibility

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -7,7 +7,6 @@
 
 #include <addrman.h>
 #include <banman.h>
-#include <arith_uint256.h>
 #include <blockencodings.h>
 #include <chainparams.h>
 #include <consensus/validation.h>

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -11,7 +11,6 @@
 
 #include <compat.h>
 #include <serialize.h>
-#include <span.h>
 
 #include <stdint.h>
 #include <string>

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -5,9 +5,7 @@
 
 #include <node/coinstats.h>
 
-#include <amount.h>
 #include <coins.h>
-#include <chain.h>
 #include <hash.h>
 #include <serialize.h>
 #include <validation.h>

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -6,7 +6,6 @@
 #include <consensus/validation.h>
 #include <net.h>
 #include <net_processing.h>
-#include <txmempool.h>
 #include <util/validation.h>
 #include <validation.h>
 #include <validationinterface.h>

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -7,7 +7,6 @@
 
 #include <attributes.h>
 #include <primitives/transaction.h>
-#include <uint256.h>
 #include <util/error.h>
 
 /**

--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -8,8 +8,6 @@
 #include <ui_interface.h>
 #include <util/system.h>
 
-#include <cstdio>
-#include <stdint.h>
 #include <string>
 
 #include <boost/signals2/connection.hpp>

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -6,7 +6,6 @@
 #include <policy/fees.h>
 
 #include <clientversion.h>
-#include <primitives/transaction.h>
 #include <streams.h>
 #include <txmempool.h>
 #include <util/system.h>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -12,7 +12,6 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <iterator>
 #include <type_traits>
 
 #pragma pack(push, 1)

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -7,7 +7,6 @@
 
 #include <hash.h>
 #include <tinyformat.h>
-#include <crypto/common.h>
 
 uint256 CBlockHeader::GetHash() const
 {

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -15,7 +15,6 @@
 #include <uint256.h>
 #include <version.h>
 
-#include <atomic>
 #include <stdint.h>
 #include <string>
 

--- a/src/psbt.cpp
+++ b/src/psbt.cpp
@@ -5,7 +5,6 @@
 #include <psbt.h>
 #include <util/strencodings.h>
 
-#include <numeric>
 
 PartiallySignedTransaction::PartiallySignedTransaction(const CMutableTransaction& tx) : tx(tx)
 {

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -7,8 +7,6 @@
 #include <qt/clientmodel.h>
 
 #include <interfaces/node.h>
-#include <sync.h>
-#include <util/time.h>
 
 #include <algorithm>
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -10,7 +10,6 @@
 #include <qt/bitcoingui.h>
 
 #include <chainparams.h>
-#include <fs.h>
 #include <qt/clientmodel.h>
 #include <qt/guiconstants.h>
 #include <qt/guiutil.h>

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -19,7 +19,6 @@
 #include <wallet/coincontrol.h>
 #include <interfaces/node.h>
 #include <key_io.h>
-#include <policy/fees.h>
 #include <policy/policy.h>
 #include <wallet/wallet.h>
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -9,7 +9,6 @@
 #include <qt/guiutil.h>
 
 #include <interfaces/node.h>
-#include <sync.h>
 
 #include <algorithm>
 

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -14,7 +14,6 @@
 #include <util/validation.h> // For strMessageMagic
 #include <wallet/wallet.h>
 
-#include <string>
 #include <vector>
 
 #include <QClipboard>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -17,7 +17,6 @@
 #include <ui_interface.h>
 #include <util/system.h>
 #include <util/translation.h>
-#include <version.h>
 
 #include <QApplication>
 #include <QCloseEvent>

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -8,7 +8,6 @@
 #include <qt/test/paymentrequestdata.h>
 
 #include <amount.h>
-#include <chainparams.h>
 #include <interfaces/node.h>
 #include <random.h>
 #include <script/script.h>

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -18,7 +18,6 @@
 #include <key_io.h>
 #include <validation.h>
 #include <script/script.h>
-#include <timedata.h>
 #include <util/system.h>
 #include <policy/policy.h>
 #include <wallet/ismine.h>

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -9,7 +9,6 @@
 #include <qt/walletview.h>
 
 #include <cassert>
-#include <cstdio>
 
 #include <QHBoxLayout>
 #include <QLabel>

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -22,7 +22,6 @@
 #include <interfaces/wallet.h>
 #include <support/allocators/secure.h>
 
-#include <map>
 #include <vector>
 
 #include <QObject>

--- a/src/qt/walletmodeltransaction.h
+++ b/src/qt/walletmodeltransaction.h
@@ -7,7 +7,6 @@
 
 #include <qt/walletmodel.h>
 
-#include <memory>
 #include <amount.h>
 
 #include <QObject>

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -16,7 +16,6 @@
 #include <util/time.h> // for GetTime()
 
 #include <stdlib.h>
-#include <chrono>
 #include <thread>
 
 #include <support/allocators/secure.h>
@@ -41,7 +40,6 @@
 #include <sys/sysctl.h>
 #endif
 
-#include <mutex>
 
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #include <cpuid.h>

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -3,7 +3,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <attributes.h>
 #include <chain.h>
 #include <chainparams.h>
 #include <core_io.h>

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -32,7 +32,6 @@
 #include <util/validation.h>
 #include <validation.h>
 #include <validationinterface.h>
-#include <versionbitsinfo.h>
 #include <warnings.h>
 
 #include <assert.h>

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -4,7 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <rpc/client.h>
-#include <rpc/protocol.h>
 #include <util/system.h>
 
 #include <set>

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -3,7 +3,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <crypto/ripemd160.h>
 #include <key_io.h>
 #include <httpserver.h>
 #include <outputtype.h>

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -11,7 +11,6 @@
 #include <net_processing.h>
 #include <net_permissions.h>
 #include <netbase.h>
-#include <policy/policy.h>
 #include <policy/settings.h>
 #include <rpc/protocol.h>
 #include <rpc/util.h>

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -5,7 +5,6 @@
 
 #include <chain.h>
 #include <coins.h>
-#include <compat/byteswap.h>
 #include <consensus/validation.h>
 #include <core_io.h>
 #include <index/txindex.h>
@@ -23,7 +22,6 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/script.h>
-#include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -5,8 +5,6 @@
 
 #include <rpc/server.h>
 
-#include <fs.h>
-#include <key_io.h>
 #include <rpc/util.h>
 #include <shutdown.h>
 #include <sync.h>

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -8,9 +8,7 @@
 
 #include <amount.h>
 #include <rpc/request.h>
-#include <uint256.h>
 
-#include <list>
 #include <map>
 #include <stdint.h>
 #include <string>

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -11,7 +11,6 @@
 
 #include <vector>
 #include <stdint.h>
-#include <string>
 
 class CPubKey;
 class CScript;

--- a/src/script/keyorigin.h
+++ b/src/script/keyorigin.h
@@ -6,7 +6,6 @@
 #define BITCOIN_SCRIPT_KEYORIGIN_H
 
 #include <serialize.h>
-#include <streams.h>
 #include <vector>
 
 struct KeyOriginInfo

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_SCRIPT_SIGN_H
 #define BITCOIN_SCRIPT_SIGN_H
 
-#include <boost/optional.hpp>
 #include <hash.h>
 #include <pubkey.h>
 #include <script/interpreter.h>

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -11,7 +11,6 @@
 
 #include <boost/variant.hpp>
 
-#include <stdint.h>
 
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
 

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -9,7 +9,6 @@
 #include <compat/endian.h>
 
 #include <algorithm>
-#include <assert.h>
 #include <ios>
 #include <limits>
 #include <map>

--- a/src/streams.h
+++ b/src/streams.h
@@ -13,8 +13,6 @@
 #include <assert.h>
 #include <ios>
 #include <limits>
-#include <map>
-#include <set>
 #include <stdint.h>
 #include <stdio.h>
 #include <string>

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -13,10 +13,8 @@
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 
-#include <stdio.h>
 
 #include <map>
-#include <memory>
 #include <set>
 
 #ifdef DEBUG_LOCKCONTENTION

--- a/src/test/bip32_tests.cpp
+++ b/src/test/bip32_tests.cpp
@@ -8,7 +8,6 @@
 #include <key.h>
 #include <key_io.h>
 #include <streams.h>
-#include <util/system.h>
 #include <util/strencodings.h>
 #include <test/setup_common.h>
 

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <compressor.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 
 #include <stdint.h>

--- a/src/test/key_properties.cpp
+++ b/src/test/key_properties.cpp
@@ -4,7 +4,6 @@
 #include <key.h>
 
 #include <uint256.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 #include <vector>
 

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -6,7 +6,6 @@
 #include <policy/fees.h>
 #include <txmempool.h>
 #include <uint256.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <test/setup_common.h>

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -5,7 +5,6 @@
 #include <chain.h>
 #include <chainparams.h>
 #include <pow.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <util/system.h>
 #include <test/setup_common.h>
 
 #include <vector>

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <random.h>
 #include <streams.h>
 #include <test/setup_common.h>
 

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -6,7 +6,6 @@
 #include <index/txindex.h>
 #include <script/standard.h>
 #include <test/setup_common.h>
-#include <util/system.h>
 #include <util/time.h>
 
 #include <boost/test/unit_test.hpp>

--- a/src/threadinterrupt.h
+++ b/src/threadinterrupt.h
@@ -10,7 +10,6 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
-#include <mutex>
 
 /*
     A helper class for interruptible sleeps. Calling operator() will interrupt

--- a/src/torcontrol.h
+++ b/src/torcontrol.h
@@ -8,7 +8,6 @@
 #ifndef BITCOIN_TORCONTROL_H
 #define BITCOIN_TORCONTROL_H
 
-#include <scheduler.h>
 
 extern const std::string DEFAULT_TOR_CONTROL;
 static const bool DEFAULT_LISTEN_ONION = true;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -11,7 +11,6 @@
 #include <chain.h>
 #include <primitives/block.h>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -8,7 +8,6 @@
 
 #include <atomic>
 #include <map>
-#include <memory>
 #include <set>
 #include <string>
 #include <utility>

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -8,7 +8,6 @@
 
 #include <functional>
 #include <memory>
-#include <stdint.h>
 #include <string>
 
 class CBlockIndex;

--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -7,7 +7,6 @@
 
 #include <util/strencodings.h>
 
-#include <stdio.h>
 #include <string.h>
 
 template <unsigned int BITS>

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -8,7 +8,6 @@
 
 #include <assert.h>
 #include <cstring>
-#include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -5,7 +5,6 @@
 
 #include <util/moneystr.h>
 
-#include <primitives/transaction.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 

--- a/src/util/moneystr.h
+++ b/src/util/moneystr.h
@@ -12,7 +12,6 @@
 #include <amount.h>
 #include <attributes.h>
 
-#include <cstdint>
 #include <string>
 
 /* Do not use these functions to represent or parse monetary amounts to or from

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_UTIL_STRING_H
 #define BITCOIN_UTIL_STRING_H
 
-#include <functional>
 #include <string>
 #include <vector>
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -9,7 +9,6 @@
 #include <util/strencodings.h>
 #include <util/translation.h>
 
-#include <stdarg.h>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))
 #include <pthread.h>

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -6,7 +6,6 @@
 #include <config/bitcoin-config.h>
 #endif
 
-#include <atomic>
 #include <thread>
 
 #if (defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__))

--- a/src/util/translation.h
+++ b/src/util/translation.h
@@ -7,7 +7,6 @@
 
 #include <tinyformat.h>
 
-#include <utility>
 
 /**
  * Bilingual messages:

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -28,7 +28,6 @@
 #include <reverse_iterator.h>
 #include <script/script.h>
 #include <script/sigcache.h>
-#include <script/standard.h>
 #include <shutdown.h>
 #include <timedata.h>
 #include <tinyformat.h>
@@ -46,8 +45,6 @@
 #include <validationinterface.h>
 #include <warnings.h>
 
-#include <future>
-#include <sstream>
 #include <string>
 
 #include <boost/algorithm/string/replace.hpp>

--- a/src/validation.h
+++ b/src/validation.h
@@ -24,12 +24,10 @@
 
 #include <algorithm>
 #include <atomic>
-#include <exception>
 #include <map>
 #include <memory>
 #include <set>
 #include <stdint.h>
-#include <string>
 #include <utility>
 #include <vector>
 

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -9,8 +9,6 @@
 #include <scheduler.h>
 #include <txmempool.h>
 
-#include <list>
-#include <atomic>
 #include <future>
 #include <utility>
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -6,11 +6,8 @@
 
 #include <crypto/aes.h>
 #include <crypto/sha512.h>
-#include <script/script.h>
-#include <script/standard.h>
 #include <util/system.h>
 
-#include <string>
 #include <vector>
 
 int CCrypter::BytesToKeySHA512AES(const std::vector<unsigned char>& chSalt, const SecureString& strKeyData, int count, unsigned char *key,unsigned char *iv) const

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -9,7 +9,6 @@
 #include <support/allocators/secure.h>
 #include <script/signingprovider.h>
 
-#include <atomic>
 
 const unsigned int WALLET_CRYPTO_KEY_SIZE = 32;
 const unsigned int WALLET_CRYPTO_SALT_SIZE = 8;

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,9 +10,7 @@
 #include <fs.h>
 #include <serialize.h>
 #include <streams.h>
-#include <sync.h>
 #include <util/system.h>
-#include <version.h>
 
 #include <atomic>
 #include <map>

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -5,7 +5,6 @@
 
 #include <wallet/fees.h>
 
-#include <util/system.h>
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -11,7 +11,6 @@
 #include <util/system.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>
-#include <wallet/walletutil.h>
 #include <walletinitinterface.h>
 
 class WalletInit : public WalletInitInterface {

--- a/src/wallet/ismine.cpp
+++ b/src/wallet/ismine.cpp
@@ -7,7 +7,6 @@
 
 #include <key.h>
 #include <script/script.h>
-#include <script/sign.h>
 #include <script/signingprovider.h>
 #include <wallet/wallet.h>
 

--- a/src/wallet/psbtwallet.h
+++ b/src/wallet/psbtwallet.h
@@ -5,9 +5,7 @@
 #ifndef BITCOIN_WALLET_PSBTWALLET_H
 #define BITCOIN_WALLET_PSBTWALLET_H
 
-#include <node/transaction.h>
 #include <psbt.h>
-#include <primitives/transaction.h>
 #include <wallet/wallet.h>
 
 /**

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -7,7 +7,6 @@
 #include <interfaces/chain.h>
 #include <key_io.h>
 #include <merkleblock.h>
-#include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
 #include <script/script.h>

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -9,7 +9,6 @@
 #include <init.h>
 #include <interfaces/chain.h>
 #include <key_io.h>
-#include <node/transaction.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
 #include <policy/fees.h>
@@ -37,7 +36,6 @@
 
 #include <univalue.h>
 
-#include <functional>
 
 static const std::string WALLET_ENDPOINT_BASE = "/wallet/";
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -32,7 +32,6 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <future>
 
 #include <boost/algorithm/string/replace.hpp>
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -11,7 +11,6 @@
 #include <interfaces/handler.h>
 #include <outputtype.h>
 #include <policy/feerate.h>
-#include <script/sign.h>
 #include <tinyformat.h>
 #include <ui_interface.h>
 #include <util/strencodings.h>

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -7,15 +7,12 @@
 #define BITCOIN_WALLET_WALLETDB_H
 
 #include <amount.h>
-#include <primitives/transaction.h>
 #include <script/sign.h>
 #include <wallet/db.h>
 #include <key.h>
 
-#include <list>
 #include <stdint.h>
 #include <string>
-#include <utility>
 #include <vector>
 
 /**

--- a/src/wallet/wallettool.h
+++ b/src/wallet/wallettool.h
@@ -5,7 +5,6 @@
 #ifndef BITCOIN_WALLET_WALLETTOOL_H
 #define BITCOIN_WALLET_WALLETTOOL_H
 
-#include <wallet/ismine.h>
 #include <wallet/wallet.h>
 
 namespace WalletTool {

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -6,7 +6,6 @@
 #ifndef BITCOIN_WARNINGS_H
 #define BITCOIN_WARNINGS_H
 
-#include <stdlib.h>
 #include <string>
 
 void SetMiscWarning(const std::string& strWarning);

--- a/src/zmq/zmqconfig.h
+++ b/src/zmq/zmqconfig.h
@@ -10,13 +10,11 @@
 #endif
 
 #include <stdarg.h>
-#include <string>
 
 #if ENABLE_ZMQ
 #include <zmq.h>
 #endif
 
-#include <primitives/block.h>
 #include <primitives/transaction.h>
 
 void zmqError(const char *str);

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -5,7 +5,6 @@
 #include <zmq/zmqnotificationinterface.h>
 #include <zmq/zmqpublishnotifier.h>
 
-#include <version.h>
 #include <validation.h>
 #include <util/system.h>
 

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -6,8 +6,6 @@
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
 #include <validationinterface.h>
-#include <string>
-#include <map>
 #include <list>
 
 class CBlockIndex;


### PR DESCRIPTION
As requested by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/16273#issuecomment-521332089:

This PR removes unused includes.

Please note that in contrast to #16273 I'm limiting the scope to the trivial cases of pure removals (i.e. no includes added) to make reviewing easier.

I'm seeking "Concept ACK":s for this obviously non-urgent minor cleanup.

Rationale:
* Avoids unnecessary re-compiles in case of header changes.
* Makes reasoning about code dependencies easier.
* Reduces compile-time memory usage.
* Reduces compilation time.
* Warm fuzzy feeling of being lean :-)