### PR TITLE
util: Add Join helper to join a list of strings

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -211,6 +211,7 @@ BITCOIN_CORE_H = \
   util/memory.h \
   util/moneystr.h \
   util/rbf.h \
+  util/string.h \
   util/threadnames.h \
   util/time.h \
   util/translation.h \
@@ -501,6 +502,7 @@ libbitcoin_util_a_SOURCES = \
   util/rbf.cpp \
   util/threadnames.cpp \
   util/strencodings.cpp \
+  util/string.cpp \
   util/time.cpp \
   util/url.cpp \
   util/validation.cpp \

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -4,11 +4,12 @@
 
 #include <key_io.h>
 #include <outputtype.h>
-#include <script/signingprovider.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
+#include <script/signingprovider.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 
 #include <tuple>
 
@@ -645,11 +646,7 @@ std::string RPCArg::ToString(const bool oneline) const
     }
     case Type::OBJ:
     case Type::OBJ_USER_KEYS: {
-        std::string res;
-        for (size_t i = 0; i < m_inner.size();) {
-            res += m_inner[i].ToStringObj(oneline);
-            if (++i < m_inner.size()) res += ",";
-        }
+        const std::string res = Join(m_inner, ",", [&](const RPCArg& i) { return i.ToStringObj(oneline); });
         if (m_type == Type::OBJ) {
             return "{" + res + "}";
         } else {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -6,11 +6,12 @@
 
 #include <clientversion.h>
 #include <sync.h>
-#include <test/util.h>
-#include <util/strencodings.h>
-#include <util/moneystr.h>
-#include <util/time.h>
 #include <test/setup_common.h>
+#include <test/util.h>
+#include <util/moneystr.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/time.h>
 
 #include <stdint.h>
 #include <thread>
@@ -123,6 +124,19 @@ BOOST_AUTO_TEST_CASE(util_HexStr)
     );
 }
 
+BOOST_AUTO_TEST_CASE(util_Join)
+{
+    // Normal version
+    BOOST_CHECK_EQUAL(Join({}, ", "), "");
+    BOOST_CHECK_EQUAL(Join({"foo"}, ", "), "foo");
+    BOOST_CHECK_EQUAL(Join({"foo", "bar"}, ", "), "foo, bar");
+
+    // Version with unary operator
+    const auto op_upper = [](const std::string& s) { return ToUpper(s); };
+    BOOST_CHECK_EQUAL(Join<std::string>({}, ", ", op_upper), "");
+    BOOST_CHECK_EQUAL(Join<std::string>({"foo"}, ", ", op_upper), "FOO");
+    BOOST_CHECK_EQUAL(Join<std::string>({"foo", "bar"}, ", ", op_upper), "FOO, BAR");
+}
 
 BOOST_AUTO_TEST_CASE(util_FormatISO8601DateTime)
 {

--- a/src/util/string.cpp
+++ b/src/util/string.cpp
@@ -1,0 +1,5 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/string.h>

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_STRING_H
+#define BITCOIN_UTIL_STRING_H
+
+#include <functional>
+#include <string>
+#include <vector>
+
+/**
+ * Join a list of items
+ *
+ * @param list       The list to join
+ * @param separator  The separator
+ * @param unary_op   Apply this operator to each item in the list
+ */
+template <typename T, typename UnaryOp>
+std::string Join(const std::vector<T>& list, const std::string& separator, UnaryOp unary_op)
+{
+    std::string ret;
+    for (size_t i = 0; i < list.size(); ++i) {
+        if (i > 0) ret += separator;
+        ret += unary_op(list.at(i));
+    }
+    return ret;
+}
+
+inline std::string Join(const std::vector<std::string>& list, const std::string& separator)
+{
+    return Join(list, separator, [](const std::string& i) { return i; });
+}
+
+#endif // BITCOIN_UTIL_STRENCODINGS_H


### PR DESCRIPTION
We have a lot of enumerations in the code and sometimes those enumerations need to be mentioned in the RPC or command line documentation. Previously, each caller would have a couple of lines inline to join the strings or the joined string is hardcoded in the documentation. A helper to join strings would make code such as https://github.com/bitcoin/bitcoin/pull/16629#discussion_r315852446 less verbose and easier to read.

Also, warnings commonly accumulate in complex RPCs, since a warning doesn't lead to an early return. A helper to join those warnings would make code such as https://github.com/bitcoin/bitcoin/pull/16394/files#r309324997 less verbose and easier to read.