### PR TITLE
Relog configuration args on debug.log rotation

### DIFF
--- a/src/init/common.cpp
+++ b/src/init/common.cpp
@@ -124,6 +124,10 @@ void LogPackageVersion()
 #else
     version_string += " (release build)";
 #endif
-    LogPrintf(PACKAGE_NAME " version %s\n", version_string);
+    std::string str{strprintf("%s version %s", PACKAGE_NAME, version_string)};
+    LogPrintf("%s\n", str);
+
+    // Useful to always have in the debug.log file (even after log rotation).
+    LogInstance().AddRelogMessage(str);
 }
 } // namespace init

--- a/src/logging.h
+++ b/src/logging.h
@@ -85,6 +85,13 @@ namespace BCLog {
         bool m_buffering GUARDED_BY(m_cs) = true; //!< Buffer messages before logging can be started.
 
         /**
+         * Some logged messages are important enough that they should be
+         * re-logged to the new debug.log file when it rotates, so that they
+         * are always visible near the start of the current debug.log file.
+         */
+        std::list<std::string> m_msgs_relog;
+
+        /**
          * m_started_new_line is a state variable that will suppress printing of
          * the timestamp when multiple calls are made that don't end in a
          * newline.
@@ -94,7 +101,7 @@ namespace BCLog {
         /** Log categories bitfield. */
         std::atomic<uint32_t> m_categories{0};
 
-        std::string LogTimestampStr(const std::string& str);
+        std::string LogTimestampStr(const std::string& str) const;
 
         /** Slots that connect to the print signal */
         std::list<std::function<void(const std::string&)>> m_print_callbacks GUARDED_BY(m_cs) {};
@@ -160,6 +167,20 @@ namespace BCLog {
         };
 
         bool DefaultShrinkDebugFile() const;
+
+        /** (Re)log important string to debug.log later, each time it rotates */
+        void AddRelogMessage(const std::string& str)
+        {
+            if (m_print_to_file) {
+                m_msgs_relog.push_back(str);
+            }
+        }
+
+        /** Only for testing */
+        void DeleteRelogMessages()
+        {
+            m_msgs_relog.clear();
+        }
     };
 
 } // namespace BCLog

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1115,7 +1115,10 @@ void ArgsManager::logArgsPrefix(
             std::optional<unsigned int> flags = GetArgFlags('-' + arg.first);
             if (flags) {
                 std::string value_str = (*flags & SENSITIVE) ? "****" : value.write();
-                LogPrintf("%s %s%s=%s\n", prefix, section_str, arg.first, value_str);
+                std::string str{strprintf("%s %s%s=%s", prefix, section_str, arg.first, value_str)};
+                LogPrintf("%s\n", str);
+                // Useful to always have in the current debug.log file.
+                LogInstance().AddRelogMessage(str);
             }
         }
     }


### PR DESCRIPTION
This PR was part of #16115 but reviewers requested that this be made into a separate PR. As explained in #16115, it's useful, maybe even crucial, for support, analysis, and debugging purposes for the configuration arguments to be present in the `debug.log` file, as that may be the only artifact provided to the developer or support team. That PR logs the configuration settings (command-line arguments and `bitcoin.conf` contents) when `bitcoind` starts. But sometime later, the debug log file may be "rotated" (a new `debug.log` file started so it doesn't grow unbounded in size) and this information would be lost unless the previous `debug.log` is preserved.

This PR re-logs the configuration information when the log rotates, ensuring that the current `debug.log` file contains this information. Reviewers had reservations about the previous approach (which you can see in #16115's discussion thread), so this PR implements this functionality in a simpler and (I believe) much better way.