### PR TITLE
gui: remove unused PlatformStyle::TextColorIcon

### DIFF
--- a/src/qt/platformstyle.cpp
+++ b/src/qt/platformstyle.cpp
@@ -114,11 +114,6 @@ QIcon PlatformStyle::SingleColorIcon(const QIcon& icon) const
     return ColorizeIcon(icon, SingleColor());
 }
 
-QIcon PlatformStyle::TextColorIcon(const QString& filename) const
-{
-    return ColorizeIcon(filename, TextColor());
-}
-
 QIcon PlatformStyle::TextColorIcon(const QIcon& icon) const
 {
     return ColorizeIcon(icon, TextColor());

--- a/src/qt/platformstyle.h
+++ b/src/qt/platformstyle.h
@@ -33,9 +33,6 @@ public:
     /** Colorize an icon (given object) with the icon color */
     QIcon SingleColorIcon(const QIcon& icon) const;
 
-    /** Colorize an icon (given filename) with the text color */
-    QIcon TextColorIcon(const QString& filename) const;
-
     /** Colorize an icon (given object) with the text color */
     QIcon TextColorIcon(const QIcon& icon) const;
 


### PR DESCRIPTION
This is unused after #16612.