### PR TITLE
p2p: Disconnect peer that send us tx INVs when we opted out of tx relay

### DIFF
--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test p2p blocksonly"""
 
-from test_framework.messages import msg_inv, CInv, CTransaction, FromHex
+from test_framework.messages import msg_inv, msg_tx, CInv, CTransaction, FromHex
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -17,6 +17,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
 
     def run_test(self):
         self.nodes[0].add_p2p_connection(P2PInterface())  # sends us a tx INV message
+        self.nodes[0].add_p2p_connection(P2PInterface())  # sends us a TX message
         self.nodes[0].add_p2p_connection(P2PInterface())
 
         assert_equal(self.nodes[0].getnetworkinfo()['localrelay'], False)
@@ -48,12 +49,17 @@ class P2PBlocksOnly(BitcoinTestFramework):
             self.nodes[0].p2ps[0].send_message(msg_inv([CInv(1, int(tx.rehash(), 16))]))
             self.nodes[0].p2ps[0].wait_for_disconnect()
 
+        self.log.info('Check that a TX message from a blocks-only peer results in disconnect')
+        with self.nodes[0].assert_debug_log(['in violation of protocol']):
+            self.nodes[0].p2ps[1].send_message(msg_tx(tx))
+            self.nodes[0].p2ps[1].wait_for_disconnect()
+
         self.log.info('Check that txs from rpc are not rejected and relayed to other peers')
         assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], True)
         txid = self.nodes[0].testmempoolaccept([sigtx])[0]['txid']
-        with self.nodes[0].assert_debug_log(['received getdata for: tx {} peer=1'.format(txid)]):
+        with self.nodes[0].assert_debug_log(['received getdata for: tx {} peer=2'.format(txid)]):
             self.nodes[0].sendrawtransaction(sigtx)
-            self.nodes[0].p2ps[1].wait_for_tx(txid)
+            self.nodes[0].p2ps[2].wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
 
 if __name__ == '__main__':

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -4,11 +4,10 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test p2p blocksonly"""
 
-from test_framework.messages import msg_tx, CTransaction, FromHex
+from test_framework.messages import msg_inv, CInv, CTransaction, FromHex
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
-
 
 class P2PBlocksOnly(BitcoinTestFramework):
     def set_test_params(self):
@@ -17,9 +16,12 @@ class P2PBlocksOnly(BitcoinTestFramework):
         self.extra_args = [["-blocksonly"]]
 
     def run_test(self):
+        self.nodes[0].add_p2p_connection(P2PInterface())  # sends us a tx INV message
         self.nodes[0].add_p2p_connection(P2PInterface())
 
-        self.log.info('Check that txs from p2p are rejected and result in disconnect')
+        assert_equal(self.nodes[0].getnetworkinfo()['localrelay'], False)
+
+        self.log.info('Create signed transaction')
         prevtx = self.nodes[0].getblock(self.nodes[0].getblockhash(1), 2)['tx'][0]
         rawtx = self.nodes[0].createrawtransaction(
             inputs=[{
@@ -39,24 +41,20 @@ class P2PBlocksOnly(BitcoinTestFramework):
                 'scriptPubKey': prevtx['vout'][0]['scriptPubKey']['hex'],
             }],
         )['hex']
-        assert_equal(self.nodes[0].getnetworkinfo()['localrelay'], False)
-        with self.nodes[0].assert_debug_log(['transaction sent in violation of protocol peer=0']):
-            self.nodes[0].p2p.send_message(msg_tx(FromHex(CTransaction(), sigtx)))
-            self.nodes[0].p2p.wait_for_disconnect()
-            assert_equal(self.nodes[0].getmempoolinfo()['size'], 0)
+        tx = FromHex(CTransaction(), sigtx)
 
-        # Remove the disconnected peer and add a new one.
-        del self.nodes[0].p2ps[0]
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.log.info('Check that a TX inv from a blocks-only peer results in disconnect')
+        with self.nodes[0].assert_debug_log(['in violation of protocol']):
+            self.nodes[0].p2ps[0].send_message(msg_inv([CInv(1, int(tx.rehash(), 16))]))
+            self.nodes[0].p2ps[0].wait_for_disconnect()
 
         self.log.info('Check that txs from rpc are not rejected and relayed to other peers')
         assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], True)
         txid = self.nodes[0].testmempoolaccept([sigtx])[0]['txid']
         with self.nodes[0].assert_debug_log(['received getdata for: tx {} peer=1'.format(txid)]):
             self.nodes[0].sendrawtransaction(sigtx)
-            self.nodes[0].p2p.wait_for_tx(txid)
+            self.nodes[0].p2ps[1].wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
-
 
 if __name__ == '__main__':
     P2PBlocksOnly().main()

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -4,7 +4,7 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test p2p blocksonly"""
 
-from test_framework.messages import msg_inv, msg_tx, CInv, CTransaction, FromHex
+from test_framework.messages import msg_getdata, msg_inv, msg_tx, CInv, CTransaction, FromHex
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -18,6 +18,7 @@ class P2PBlocksOnly(BitcoinTestFramework):
     def run_test(self):
         self.nodes[0].add_p2p_connection(P2PInterface())  # sends us a tx INV message
         self.nodes[0].add_p2p_connection(P2PInterface())  # sends us a TX message
+        self.nodes[0].add_p2p_connection(P2PInterface())  # sends us a tx GETDATA message for a tx that we didn't INV
         self.nodes[0].add_p2p_connection(P2PInterface())
 
         assert_equal(self.nodes[0].getnetworkinfo()['localrelay'], False)
@@ -54,12 +55,17 @@ class P2PBlocksOnly(BitcoinTestFramework):
             self.nodes[0].p2ps[1].send_message(msg_tx(tx))
             self.nodes[0].p2ps[1].wait_for_disconnect()
 
+        self.log.info('Check that a TX GETDATA from a blocks-only peer results in disconnect')
+        with self.nodes[0].assert_debug_log(['in violation of protocol']):
+            self.nodes[0].p2ps[2].send_message(msg_getdata([CInv(1, int(tx.rehash(), 16))]))
+            self.nodes[0].p2ps[2].wait_for_disconnect()
+
         self.log.info('Check that txs from rpc are not rejected and relayed to other peers')
         assert_equal(self.nodes[0].getpeerinfo()[0]['relaytxes'], True)
         txid = self.nodes[0].testmempoolaccept([sigtx])[0]['txid']
-        with self.nodes[0].assert_debug_log(['received getdata for: tx {} peer=2'.format(txid)]):
+        with self.nodes[0].assert_debug_log(['received getdata for: tx {} peer=3'.format(txid)]):
             self.nodes[0].sendrawtransaction(sigtx)
-            self.nodes[0].p2ps[2].wait_for_tx(txid)
+            self.nodes[0].p2ps[3].wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
 
 if __name__ == '__main__':


### PR DESCRIPTION
`-blocksonly` mode was introduced in
4044f07d1c5eacb0ec732f1232489aa77fb7bb3b and allows nodes to request
that their peers don't relay txs to them. This is done by setting the
'relay' field in the VERSION message (introduced in BIP37) to false.

Tx INVs received from peers when running in blocksonly mode previously
resulted in a log message "transaction inv sent in violation of
protocol". When running in -blocksonly, it has been observed that
several peers advertising as Satoshi:0.18.0 were persistently sending us
tx INVs in violation of the protocol. These are suspected of being spy
nodes.

Change the behaviour to disconnect nodes that send us tx INVs after
we've requested no tx relay.