### PR TITLE
Fix missing destructor in class

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -28,6 +28,8 @@ public:
     uint32_t nBits;
     uint32_t nNonce;
 
+    virtual ~CBlockHeader() = default;
+
     CBlockHeader()
     {
         SetNull();


### PR DESCRIPTION
Fixes missing destructor in abstract class CBlockHeader. Not an error but introduces annoying warnings if compiling with clang.

Issue reported here:- https://github.com/bitcoin/bitcoin/issues/16685