### PR TITLE
gui: Ensure transaction send error is always visible

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -230,8 +230,9 @@ void SendCoinsDialog::on_sendButton_clicked()
             {
                 recipients.append(entry->getValue());
             }
-            else
+            else if (valid)
             {
+                ui->scrollArea->ensureWidgetVisible(entry);
                 valid = false;
             }
         }


### PR DESCRIPTION
Rebased and squashed #14956.

> If sending to multiple recipients and one of the recipient fields is malformed, the highlighted field may not be visible due to being scrolled out of view. This results in a confusing lack of error feedback.

> Avoid this problem by ensuring the first field containing an error is scrolled into view when Send is clicked.

You can see the behavior here: https://imgur.com/a/QZG5TQc

How to test:
Add a few recipients and give any of them an invalid address or amount. Scroll the invalid recipient out of view and hit Send. With this change, the GUI will scroll to show the invalid recipient, with master it will not, "hiding" the error.
