### PR TITLE
validation: static_assert to ensure width in unit class

### DIFF
--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -48,6 +48,8 @@ public:
 
     base_uint& operator=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] = b.pn[i];
         return *this;
@@ -86,6 +88,8 @@ public:
 
     base_uint& operator=(uint64_t b)
     {
+        static_assert(BITS/32 > 0 && BITS%32 == 0, "Template parameter BITS must be a positive multiple of 32.");
+
         pn[0] = (unsigned int)b;
         pn[1] = (unsigned int)(b >> 32);
         for (int i = 2; i < WIDTH; i++)

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -126,6 +126,8 @@ public:
 
     base_uint& operator^=(uint64_t b)
     {
+        static_assert(WIDTH >= 2, "Assertion WIDTH >= 2 failed (WIDTH = BITS / 32). BITS is a template parameter.");
+
         pn[0] ^= (unsigned int)b;
         pn[1] ^= (unsigned int)(b >> 32);
         return *this;
@@ -133,6 +135,8 @@ public:
 
     base_uint& operator|=(uint64_t b)
     {
+        static_assert(WIDTH >= 2, "Assertion WIDTH >= 2 failed (WIDTH = BITS / 32). BITS is a template parameter.");
+
         pn[0] |= (unsigned int)b;
         pn[1] |= (unsigned int)(b >> 32);
         return *this;

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -95,6 +95,8 @@ public:
 
     base_uint& operator^=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] ^= b.pn[i];
         return *this;
@@ -102,6 +104,8 @@ public:
 
     base_uint& operator&=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] &= b.pn[i];
         return *this;
@@ -109,6 +113,8 @@ public:
 
     base_uint& operator|=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] |= b.pn[i];
         return *this;

--- a/src/arith_uint256.h
+++ b/src/arith_uint256.h
@@ -95,6 +95,8 @@ public:
 
     base_uint& operator^=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] ^= b.pn[i];
         return *this;
@@ -102,6 +104,8 @@ public:
 
     base_uint& operator&=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] &= b.pn[i];
         return *this;
@@ -109,6 +113,8 @@ public:
 
     base_uint& operator|=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         for (int i = 0; i < WIDTH; i++)
             pn[i] |= b.pn[i];
         return *this;
@@ -133,6 +139,8 @@ public:
 
     base_uint& operator+=(const base_uint& b)
     {
+        static_assert(WIDTH == b.WIDTH, "Template parameter WIDTH must be equal.");
+
         uint64_t carry = 0;
         for (int i = 0; i < WIDTH; i++)
         {


### PR DESCRIPTION
Because operators are implemented in the base class, and being inherited by uint256 and unit512, if a copy or read is made between these types, random memory would be being accessed.