### PR TITLE
rpc: Expose GetUTXOStats for testing

### DIFF
--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -7,6 +7,7 @@
 
 #include <amount.h>
 #include <sync.h>
+#include <uint256.h>
 
 #include <stdint.h>
 #include <vector>
@@ -17,8 +18,22 @@ class CBlock;
 class CBlockIndex;
 class CTxMemPool;
 class UniValue;
+class CCoinsView;
 
 static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
+
+struct CCoinsStats {
+    int nHeight{0};
+    uint256 hashBlock;
+    uint64_t nTransactions{0};
+    uint64_t nTransactionOutputs{0};
+    uint64_t nBogoSize{0};
+    uint256 hashSerialized;
+    uint64_t nDiskSize{0};
+    CAmount nTotalAmount{0};
+};
+
+bool GetUTXOStats(const CCoinsView* const view, CCoinsStats& stats);
 
 /**
  * Get the difficulty of the net wrt to the given block index.


### PR DESCRIPTION
GetUTXOStats is used to report `hash_serialized_2` and `total_amount` (among other things) over the rpc interface. However, none of the logic can be tested by unit tests, as the function is `static` in `rpc/blockchain`.

This pull does two things:
* Remove `static` and expose `GetUTXOStats` via the header file
* Reset all stats to 0 at the beginning of the function. Otherwise the `total_amount` (among others) would accumulate over successive calls, giving obviously incorrect results (seemingly violating BIP 42).