### PR TITLE
Don't warn about activated buried BIP 9 deployments

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -69,8 +69,6 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-        consensus.CSVHeight = 419328; // 000000000000000004a1b34462cb8aeebd5799177f7a29cf28f2d1961716b5b5
-        consensus.SegwitHeight = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -81,6 +79,16 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
+
+        // Add buried depoyments
+        consensus.buried_deployments[Consensus::BURIED_CSV].bit = 0;
+        /** Block height at which CSV (BIP68, BIP112 and BIP113) becomes active */
+        consensus.buried_deployments[Consensus::BURIED_CSV].height = 419328; // 000000000000000004a1b34462cb8aeebd5799177f7a29cf28f2d1961716b5b5
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].bit = 1;
+        /** Block height at which Segwit (BIP141, BIP143 and BIP147) becomes active.
+         * Note that segwit v0 script rules are enforced on all blocks except the
+         * BIP 16 exception blocks. */
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].height = 481824; // 0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x0000000000000000000000000000000000000000051dc8b82f450202ecb3d471");
@@ -175,8 +183,6 @@ public:
         consensus.BIP34Hash = uint256S("0x0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8");
         consensus.BIP65Height = 581885; // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
         consensus.BIP66Height = 330776; // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182
-        consensus.CSVHeight = 770112; // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
-        consensus.SegwitHeight = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -187,6 +193,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 1199145601; // January 1, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
+
+        // Add buried depoyments
+        consensus.buried_deployments[Consensus::BURIED_CSV].bit = 0;
+        consensus.buried_deployments[Consensus::BURIED_CSV].height = 770112; // 00000000025e930139bac5c6c31a403776da130831ab85be56578f3fa75369bb
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].bit = 1;
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].height = 834624; // 00000000002b980fcd729daaa248fd9316a5200e9b367f4ff2c42453e84201ca
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00000000000000000000000000000000000000000000007dbe94253893cbd463");
@@ -259,8 +271,6 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in functional tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in functional tests)
-        consensus.CSVHeight = 432; // CSV activated on regtest (Used in rpc activation tests)
-        consensus.SegwitHeight = 0; // SEGWIT is always activated on regtest unless overridden
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -271,6 +281,12 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
+        // Add buried depoyments
+        consensus.buried_deployments[Consensus::BURIED_CSV].bit = 0;
+        consensus.buried_deployments[Consensus::BURIED_CSV].height = 432; // CSV activated on regtest (Used in rpc activation tests)
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].bit = 1;
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].height = 0; // SEGWIT is always activated on regtest unless overridden
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
@@ -336,14 +352,14 @@ public:
 void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
 {
     if (gArgs.IsArgSet("-segwitheight")) {
-        int64_t height = gArgs.GetArg("-segwitheight", consensus.SegwitHeight);
+        int64_t height = gArgs.GetArg("-segwitheight", consensus.buried_deployments[Consensus::BURIED_SEGWIT].height);
         if (height < -1 || height >= std::numeric_limits<int>::max()) {
             throw std::runtime_error(strprintf("Activation height %ld for segwit is out of valid range. Use -1 to disable segwit.", height));
         } else if (height == -1) {
             LogPrintf("Segwit disabled for testing\n");
             height = std::numeric_limits<int>::max();
         }
-        consensus.SegwitHeight = static_cast<int>(height);
+        consensus.buried_deployments[Consensus::BURIED_SEGWIT].height = static_cast<int>(height);
     }
 
     if (!args.IsArgSet("-vbparams")) return;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -20,6 +20,13 @@ enum DeploymentPos
     MAX_VERSION_BITS_DEPLOYMENTS
 };
 
+enum BuriedDeployments
+{
+    BURIED_CSV,
+    BURIED_SEGWIT,
+    NUM_BURIED_DEPLOYMENTS
+};
+
 /**
  * Struct for each individual consensus rule change using BIP9.
  */
@@ -41,6 +48,11 @@ struct BIP9Deployment {
     static constexpr int64_t ALWAYS_ACTIVE = -1;
 };
 
+struct BuriedBIP9 {
+    int bit;
+    int height;
+};
+
 /**
  * Parameters that influence chain consensus.
  */
@@ -56,12 +68,6 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
-    /** Block height at which CSV (BIP68, BIP112 and BIP113) becomes active */
-    int CSVHeight;
-    /** Block height at which Segwit (BIP141, BIP143 and BIP147) becomes active.
-     * Note that segwit v0 script rules are enforced on all blocks except the
-     * BIP 16 exception blocks. */
-    int SegwitHeight;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.
@@ -70,6 +76,7 @@ struct Params {
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    BuriedBIP9 buried_deployments[NUM_BURIED_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1673,7 +1673,7 @@ bool AppInitMain(InitInterfaces& interfaces)
         }
     }
 
-    if (chainparams.GetConsensus().SegwitHeight != std::numeric_limits<int>::max()) {
+    if (chainparams.GetConsensus().buried_deployments[Consensus::BURIED_SEGWIT].height != std::numeric_limits<int>::max()) {
         // Advertise witness capabilities.
         // The option to not set NODE_WITNESS is only used in the tests and should be removed.
         nLocalServices = ServiceFlags(nLocalServices | NODE_WITNESS);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1344,8 +1344,8 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BuriedForkDescPushBack(softforks, "bip34", consensusParams.BIP34Height);
     BuriedForkDescPushBack(softforks, "bip66", consensusParams.BIP66Height);
     BuriedForkDescPushBack(softforks, "bip65", consensusParams.BIP65Height);
-    BuriedForkDescPushBack(softforks, "csv", consensusParams.CSVHeight);
-    BuriedForkDescPushBack(softforks, "segwit", consensusParams.SegwitHeight);
+    BuriedForkDescPushBack(softforks, "csv", consensusParams.buried_deployments[Consensus::BURIED_CSV].height);
+    BuriedForkDescPushBack(softforks, "segwit", consensusParams.buried_deployments[Consensus::BURIED_SEGWIT].height);
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     obj.pushKV("softforks",             softforks);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -520,7 +520,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     pblock->nNonce = 0;
 
     // NOTE: If at some point we support pre-segwit miners post-segwit-activation, this needs to take segwit support into consideration
-    const bool fPreSegWit = (pindexPrev->nHeight + 1 < consensusParams.SegwitHeight);
+    const bool fPreSegWit = (pindexPrev->nHeight + 1 < consensusParams.buried_deployments[Consensus::BURIED_SEGWIT].height);
 
     UniValue aCaps(UniValue::VARR); aCaps.push_back("proposal");
 


### PR DESCRIPTION
The BIP 9 warning checker finds the blocks to warn on by computing the block version number that it would generate based on current active BIP 9 deployments. For buried deployments, their deployment parameters are removed from the active deployments array, so the warning checker triggers a false positive warning when it comes upon the blocks that activated the buried deployment as their version numbers do not match what it computes.

This PR changes the warning checker to take into account these buried deployments. When it scans through history, it includes the activation bits for buried forks as long as the height of the block it is checking is less than the activation height of the deployment. Thus it will find the blocks that activate buried deployments to have the correct version bits set so it does not trigger a false positive warning.

To facilitate this, the BIP 9 buried deployments (CSV and Segwit) are moved into an array of structs that contain their activation height and bit, in a similar way to active deployments.

Closes #16697