### PR TITLE
qt: Remove obsolete QModelIndex::child()

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -261,7 +261,7 @@ void ReceiveCoinsDialog::copyColumnToClipboard(int column)
     if (!firstIndex.isValid()) {
         return;
     }
-    GUIUtil::setClipboard(model->getRecentRequestsTableModel()->data(firstIndex.child(firstIndex.row(), column), Qt::EditRole).toString());
+    GUIUtil::setClipboard(model->getRecentRequestsTableModel()->index(firstIndex.row(), column).data(Qt::EditRole).toString());
 }
 
 // context menu

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -76,7 +76,7 @@ public:
     QVariant data(const QModelIndex &index, int role) const;
     bool setData(const QModelIndex &index, const QVariant &value, int role);
     QVariant headerData(int section, Qt::Orientation orientation, int role) const;
-    QModelIndex index(int row, int column, const QModelIndex &parent) const;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex());
     Qt::ItemFlags flags(const QModelIndex &index) const;
     /*@}*/


### PR DESCRIPTION
The `QModelIndex::child()` member function is [obsolete](https://doc.qt.io/qt-5.12/qmodelindex-obsolete.html) since Qt 5.12.

This PR removes it, does not change behavior and keeps compatibility with [Qt 5.5.1](https://github.com/bitcoin/bitcoin/pull/15393).

Here is an excerpt from the master build log:
```
qt/receivecoinsdialog.cpp: In member function ‘void ReceiveCoinsDialog::copyColumnToClipboard(int)’:
qt/receivecoinsdialog.cpp:264:111: warning: ‘QModelIndex QModelIndex::child(int, int) const’ is deprecated: Use QAbstractItemModel::index [-Wdeprecated-declarations]
     GUIUtil::setClipboard(model->getRecentRequestsTableModel()->data(firstIndex.child(firstIndex.row(), column), Qt::EditRole).toString());
                                                                                                               ^
In file included from /home/hebasto/Qt/5.13.0/gcc_64/include/QtWidgets/qabstractitemview.h:45:0,
                 from /home/hebasto/Qt/5.13.0/gcc_64/include/QtWidgets/qheaderview.h:44,
                 from /home/hebasto/Qt/5.13.0/gcc_64/include/QtWidgets/QHeaderView:1,
                 from ./qt/guiutil.h:12,
                 from ./qt/receivecoinsdialog.h:8,
                 from qt/receivecoinsdialog.cpp:7:
/home/hebasto/Qt/5.13.0/gcc_64/include/QtCore/qabstractitemmodel.h:457:20: note: declared here
 inline QModelIndex QModelIndex::child(int arow, int acolumn) const
                    ^~~~~~~~~~~
```