### PR TITLE
qt: Replace obsolete functions of QSslSocket

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -41,8 +41,8 @@
 #include <QNetworkReply>
 #include <QNetworkRequest>
 #include <QSslCertificate>
+#include <QSslConfiguration>
 #include <QSslError>
-#include <QSslSocket>
 #include <QStringList>
 #include <QTextDocument>
 #include <QUrlQuery>
@@ -448,9 +448,9 @@ void PaymentServer::LoadRootCAs(X509_STORE* _store)
 
         certList = QSslCertificate::fromPath(certFile);
         // Use those certificates when fetching payment requests, too:
-        QSslSocket::setDefaultCaCertificates(certList);
+        QSslConfiguration::defaultConfiguration().setCaCertificates(certList);
     } else
-        certList = QSslSocket::systemCaCertificates();
+        certList = QSslConfiguration::systemCaCertificates();
 
     int nRootCerts = 0;
     const QDateTime currentTime = QDateTime::currentDateTime();


### PR DESCRIPTION
The [`QSslSocket::setDefaultCaCertificates()`](https://doc.qt.io/qt-5/qsslsocket-obsolete.html#setDefaultCaCertificates) and [`QSslSocket::systemCaCertificates()`](https://doc.qt.io/qt-5/qsslsocket-obsolete.html#systemCaCertificates) member functions are [obsolete](https://doc.qt.io/qt-5.12/qsslsocket-obsolete.html) since Qt 5.12.

This PR replaces them, does not change behavior and keeps compatibility with [Qt 5.5.1](https://github.com/bitcoin/bitcoin/pull/15393).