### PR TITLE
Replace boost::mutex/condition_variable with std equivalents

### DIFF
--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -67,7 +67,6 @@ EXPECTED_BOOST_INCLUDES=(
     boost/test/unit_test.hpp
     boost/thread.hpp
     boost/thread/condition_variable.hpp
-    boost/thread/mutex.hpp
     boost/thread/thread.hpp
     boost/variant.hpp
     boost/variant/apply_visitor.hpp


### PR DESCRIPTION
Not sure why boost::condition_variable and boost::mutex have not already been replaced by newer the stand library equivalents. From what I can tell the behaviour should be the same but perhaps I'm missing something subtle or not.