### PR TITLE
gui: add prune to intro screen with smart default

### DIFF
--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -60,6 +60,7 @@ public:
         return gArgs.ParseParameters(argc, argv, error);
     }
     bool readConfigFiles(std::string& error) override { return gArgs.ReadConfigFiles(error, true); }
+    void forceSetArg(const std::string& arg, const std::string& value) override { gArgs.ForceSetArg(arg, value); }
     bool softSetArg(const std::string& arg, const std::string& value) override { return gArgs.SoftSetArg(arg, value); }
     bool softSetBoolArg(const std::string& arg, bool value) override { return gArgs.SoftSetBoolArg(arg, value); }
     void selectParams(const std::string& network) override { SelectParams(network); }

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -44,6 +44,9 @@ public:
     //! Set command line arguments.
     virtual bool parseParameters(int argc, const char* const argv[], std::string& error) = 0;
 
+    //! Set a command line argument
+    virtual void forceSetArg(const std::string& arg, const std::string& value) = 0;
+
     //! Set a command line argument if it doesn't already have a value
     virtual bool softSetArg(const std::string& arg, const std::string& value) = 0;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -282,6 +282,10 @@ void BitcoinApplication::parameterSetup()
     m_node.initParameterInteraction();
 }
 
+void BitcoinApplication::SetPrune(bool prune, bool force) {
+     optionsModel->SetPrune(prune, force);
+}
+
 void BitcoinApplication::requestInitialize()
 {
     qDebug() << __func__ << ": Requesting initialize";

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -492,8 +492,9 @@ int GuiMain(int argc, char* argv[])
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory
     bool did_show_intro = false;
+    bool prune = false; // Intro dialog prune check box
     // Gracefully exit if the user cancels
-    if (!Intro::showIfNeeded(*node, did_show_intro)) return EXIT_SUCCESS;
+    if (!Intro::showIfNeeded(*node, did_show_intro, prune)) return EXIT_SUCCESS;
 
     /// 6. Determine availability of data directory and parse bitcoin.conf
     /// - Do not call GetDataDir(true) before this step finishes
@@ -566,6 +567,11 @@ int GuiMain(int argc, char* argv[])
     app.parameterSetup();
     // Load GUI settings from QSettings
     app.createOptionsModel(gArgs.GetBoolArg("-resetguisettings", false));
+
+    if (did_show_intro) {
+        // Store intro dialog settings other than datadir (network specific)
+        app.SetPrune(prune, true);
+    }
 
     if (gArgs.GetBoolArg("-splash", DEFAULT_SPLASHSCREEN) && !gArgs.GetBoolArg("-min", false))
         app.createSplashScreen(networkStyle.data());

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -491,8 +491,9 @@ int GuiMain(int argc, char* argv[])
 
     /// 5. Now that settings and translations are available, ask user for data directory
     // User language is set up: pick a data directory
-    if (!Intro::pickDataDirectory(*node))
-        return EXIT_SUCCESS;
+    bool did_show_intro = false;
+    // Gracefully exit if the user cancels
+    if (!Intro::showIfNeeded(*node, did_show_intro)) return EXIT_SUCCESS;
 
     /// 6. Determine availability of data directory and parse bitcoin.conf
     /// - Do not call GetDataDir(true) before this step finishes

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -67,6 +67,8 @@ public:
     void parameterSetup();
     /// Create options model
     void createOptionsModel(bool resetSettings);
+    /// Update prune value
+    void SetPrune(bool prune, bool force = false);
     /// Create main window
     void createWindow(const NetworkStyle *networkStyle);
     /// Create splash screen

--- a/src/qt/forms/intro.ui
+++ b/src/qt/forms/intro.ui
@@ -211,6 +211,16 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="prune">
+     <property name="toolTip">
+      <string>Reverting this setting requires re-downloading the entire blockchain. It is faster to download the full chain first and prune it later. Disables some advanced features.</string>
+     </property>
+     <property name="text">
+      <string></string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QLabel" name="lblExplanation2">
      <property name="text">
       <string>This initial synchronisation is very demanding, and may expose hardware problems with your computer that had previously gone unnoticed. Each time you run %1, it will continue downloading where it left off.</string>

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -131,6 +131,11 @@ Intro::Intro(QWidget *parent, uint64_t blockchain_size, uint64_t chain_state_siz
     ui->lblExplanation2->setText(ui->lblExplanation2->text().arg(PACKAGE_NAME));
 
     uint64_t pruneTarget = std::max<int64_t>(0, gArgs.GetArg("-prune", 0));
+    if (pruneTarget > 1) { // -prune=1 means enabled, above that it's a size in MB
+        ui->prune->setChecked(true);
+        ui->prune->setEnabled(false);
+    }
+    ui->prune->setText(tr("Discard blocks after verification, except most recent %1 GB (prune)").arg(pruneTarget ? pruneTarget / 1000 : 2));
     requiredSpace = m_blockchain_size;
     QString storageRequiresMsg = tr("At least %1 GB of data will be stored in this directory, and it will grow over time.");
     if (pruneTarget) {
@@ -180,7 +185,7 @@ void Intro::setDataDirectory(const QString &dataDir)
     }
 }
 
-bool Intro::showIfNeeded(interfaces::Node& node, bool& did_show_intro)
+bool Intro::showIfNeeded(interfaces::Node& node, bool& did_show_intro, bool& prune)
 {
     did_show_intro = false;
 
@@ -229,6 +234,9 @@ bool Intro::showIfNeeded(interfaces::Node& node, bool& did_show_intro)
                 /* fall through, back to choosing screen */
             }
         }
+
+        // Additional preferences:
+        prune = intro.ui->prune->isChecked();
 
         settings.setValue("strDataDir", dataDir);
         settings.setValue("fReset", false);

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -180,8 +180,10 @@ void Intro::setDataDirectory(const QString &dataDir)
     }
 }
 
-bool Intro::pickDataDirectory(interfaces::Node& node)
+bool Intro::showIfNeeded(interfaces::Node& node, bool& did_show_intro)
 {
+    did_show_intro = false;
+
     QSettings settings;
     /* If data directory provided on command line, no need to look at settings
        or show a picking dialog */
@@ -205,6 +207,7 @@ bool Intro::pickDataDirectory(interfaces::Node& node)
         Intro intro(0, node.getAssumedBlockchainSize(), node.getAssumedChainStateSize());
         intro.setDataDirectory(dataDir);
         intro.setWindowIcon(QIcon(":icons/bitcoin"));
+        did_show_intro = true;
 
         while(true)
         {

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -274,6 +274,11 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
         {
             freeString += " " + tr("(of %n GB needed)", "", requiredSpace);
             ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
+            ui->prune->setChecked(true);
+        } else if (bytesAvailable / GB_BYTES - requiredSpace < 10) {
+            freeString += " " + tr("(%n GB needed for full chain)", "", requiredSpace);
+            ui->freeSpace->setStyleSheet("QLabel { color: #999900 }");
+            ui->prune->setChecked(true);
         } else {
             ui->freeSpace->setStyleSheet("");
         }

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -46,7 +46,7 @@ public:
      * @note do NOT call global GetDataDir() before calling this function, this
      * will cause the wrong path to be cached.
      */
-    static bool pickDataDirectory(interfaces::Node& node);
+    static bool showIfNeeded(interfaces::Node& node, bool& did_show_intro);
 
 Q_SIGNALS:
     void requestCheck();

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -39,6 +39,7 @@ public:
 
     /**
      * Determine data directory. Let the user choose if the current one doesn't exist.
+     * Let the user configure additional preferences such as pruning.
      *
      * @returns true if a data directory was selected, false if the user cancelled the selection
      * dialog.
@@ -46,7 +47,7 @@ public:
      * @note do NOT call global GetDataDir() before calling this function, this
      * will cause the wrong path to be cached.
      */
-    static bool showIfNeeded(interfaces::Node& node, bool& did_show_intro);
+    static bool showIfNeeded(interfaces::Node& node, bool& did_show_intro, bool& prune);
 
 Q_SIGNALS:
     void requestCheck();

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -77,6 +77,9 @@ public:
     bool getCoinControlFeatures() const { return fCoinControlFeatures; }
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
+    /* Explicit setters */
+    void SetPrune(bool prune, bool force = false);
+
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);
     bool isRestartRequired() const;


### PR DESCRIPTION
This adds a checkbox to the intro screen to enable pruning from the get go.

If the user has plenty of space, it's unchecked by default:

<img width="671" alt="big" src="https://user-images.githubusercontent.com/10217/63641289-10339000-c6ac-11e9-98d7-caf64dff0da6.png">

If the user has insufficient space it's checked by default:
<img width="897" alt="low" src="https://user-images.githubusercontent.com/10217/63641276-d4002f80-c6ab-11e9-9f5b-a53472f814ff.png">

When the user has barely enough space and is likely to need pruning in the near future, this is shown in yellow and we also check the prune box:

<img width="662" alt="medium" src="https://user-images.githubusercontent.com/10217/63641294-1c1f5200-c6ac-11e9-8ecb-6b69e42b1ece.png">

The cut-off for this 10 GB above `m_assumed_blockchain_size` (`=240` in `chainparams.cpp`). 

If the user launches the first time with `-prune=...` then we disable the check box and display the correct size (rounded to GB):
<img width="658" alt="Schermafbeelding 2019-08-24 om 20 23 14" src="https://user-images.githubusercontent.com/10217/63641351-09594d00-c6ad-11e9-94fe-fe5ed562e109.png">
 
The 2 GB default matches the settings default. The user can't change it in the intro screen, but can change it later. I'm tempted to increase that default to 10 GB, and then have the intro screen reduce it if space is really tight.

Tips for testing:
* move your existing data dir elsewhere
* wipe data dir at every restart (behavior is different if it exists)
* launch with `bitcoin-qt -resetguisettings -lang=en` (there's some space issues in different languages)
* fake your free space by changing `intro.cpp` line 90: `freeBytesAvailable = 5000000000; // 5 GB`
* try both testnet and mainnet, because settings are seperate. In particular note how step 7 in `GuiMain` switches where `QTSettings settings` points to; this had me thoroughly confused on testnet, because I was setting them too early.