### PR TITLE
build: Disable warnings for leveldb subtree by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -270,8 +270,15 @@ AC_ARG_ENABLE([werror],
     [enable_werror=$enableval],
     [enable_werror=no])
 
+AC_ARG_ENABLE([wleveldb],
+    [AS_HELP_STRING([--enable-wleveldb],
+                    [enable warnings for leveldb subtree (default is no)])],
+    [enable_wleveldb=$enableval],
+    [enable_wleveldb=no])
+
 AC_LANG_PUSH([C++])
 AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
+AX_CHECK_COMPILE_FLAG([-w],[CXXFLAG_w="-w"],[CXXFLAG_w=""])
 
 if test "x$enable_debug" = xyes; then
   # Clear default -g -O2 flags
@@ -994,10 +1001,16 @@ AC_LINK_IFELSE(
 AC_DEFINE([HAVE_SYSTEM], [HAVE_STD__SYSTEM || HAVE_WSYSTEM], [std::system or ::wsystem])
 
 LEVELDB_CPPFLAGS=
+LEVELDB_CXXFLAGS=
+if test "x$enable_wleveldb" != "xyes"; then
+  enable_wleveldb=no
+  LEVELDB_CXXFLAGS="$CXXFLAG_w"
+fi
 LIBLEVELDB=
 LIBMEMENV=
 AM_CONDITIONAL([EMBEDDED_LEVELDB],[true])
 AC_SUBST(LEVELDB_CPPFLAGS)
+AC_SUBST(LEVELDB_CXXFLAGS)
 AC_SUBST(LIBLEVELDB)
 AC_SUBST(LIBMEMENV)
 
@@ -1657,6 +1670,9 @@ echo "  sanitizers    = $use_sanitizers"
 echo "  debug enabled = $enable_debug"
 echo "  gprof enabled = $enable_gprof"
 echo "  werror        = $enable_werror"
+if test x$enable_wleveldb != xno; then
+    echo "  wleveldb      = $enable_wleveldb"
+fi
 echo
 echo "  target os     = $TARGET_OS"
 echo "  build os      = $BUILD_OS"

--- a/src/Makefile.leveldb.include
+++ b/src/Makefile.leveldb.include
@@ -30,7 +30,7 @@ LEVELDB_CPPFLAGS_INT += -DLEVELDB_PLATFORM_POSIX
 endif
 
 leveldb_libleveldb_a_CPPFLAGS = $(AM_CPPFLAGS) $(LEVELDB_CPPFLAGS_INT) $(LEVELDB_CPPFLAGS)
-leveldb_libleveldb_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+leveldb_libleveldb_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) $(LEVELDB_CXXFLAGS)
 
 leveldb_libleveldb_a_SOURCES=
 leveldb_libleveldb_a_SOURCES += leveldb/port/atomic_pointer.h


### PR DESCRIPTION
This PR adds `--enable-wleveldb` option to the `configure` script.

Here are some examples of usefulness:
- #15539 
- #15822 
- #16387 
- #16710 

Related to #14920.

Inspired by **practicalswift** and **promag**.