### PR TITLE
test: Establish only one connection between nodes in rpc_invalidateblock

### DIFF
--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -8,7 +8,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE
 from test_framework.util import (
     assert_equal,
-    connect_nodes_bi,
+    connect_nodes,
     wait_until,
 )
 
@@ -33,7 +33,7 @@ class InvalidateTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getblockcount(), 6)
 
         self.log.info("Connect nodes to force a reorg")
-        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes(self.nodes[0], 1)
         self.sync_blocks(self.nodes[0:2])
         assert_equal(self.nodes[0].getblockcount(), 6)
         badhash = self.nodes[1].getblockhash(2)
@@ -44,7 +44,7 @@ class InvalidateTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), besthash_n0)
 
         self.log.info("Make sure we won't reorg to a lower work chain:")
-        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes(self.nodes[1], 2)
         self.log.info("Sync node 2 to node 1 so both have 6 blocks")
         self.sync_blocks(self.nodes[1:3])
         assert_equal(self.nodes[2].getblockcount(), 6)


### PR DESCRIPTION
Headers and block sync should eventually converge to the same result, regardless of whether the peers treat each other as "inbound" or "outbound".

`connect_nodes_bi` has been introduced as a (temporary?) workaround for bug #5113 and #5138, which has long been fixed in #5157 and #5662.

Thus remove the `connect_nodes_bi` workaround from the rpc_invalidateblock test.

Conveniently, this also closes #16453. See https://github.com/bitcoin/bitcoin/issues/16444#issuecomment-514801708 for rationale