### PR TITLE
gui: Remove needless GCC diagnostic pragma

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -54,9 +54,6 @@
 #include <QUrlQuery>
 
 #if defined(Q_OS_MAC)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
 #include <CoreServices/CoreServices.h>
 #include <QProcess>
 
@@ -771,7 +768,6 @@ bool SetStartOnSystemStartup(bool fAutoStart)
     CFRelease(listSnapshot);
     return true;
 }
-#pragma GCC diagnostic pop
 #else
 
 bool GetStartOnSystemStartup() { return false; }


### PR DESCRIPTION
Some tests on different platforms make me believe that some GCC diagnostic pragmas are needless: no additional warnings are generated with this PR.