### PR TITLE
[WIP] Add support for addrv2 (BIP155)

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -120,13 +120,14 @@ private:
     CHash256 ctx;
 
     const int nType;
-    const int nVersion;
+    int nVersion;
 public:
 
     CHashWriter(int nTypeIn, int nVersionIn) : nType(nTypeIn), nVersion(nVersionIn) {}
 
     int GetType() const { return nType; }
     int GetVersion() const { return nVersion; }
+    void SetVersion(int n)       { nVersion = n; }
 
     void write(const char *pch, size_t size) {
         ctx.Write((const unsigned char*)pch, size);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -113,6 +113,17 @@ CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope) : scop
     }
 }
 
+bool CNetAddr::IsStandardV2Deserialization() const
+{
+    if (IsIPv6()) {
+        return (memcmp(ip.data(), pchOnionCat, sizeof(pchOnionCat)) != 0) &&
+            (memcmp(ip.data(), pchIPv4, sizeof(pchIPv4)) != 0) &&
+            ip.at(0) != 0xfc;
+    } else {
+        return true;
+    }
+}
+
 unsigned int CNetAddr::GetByte(int n) const
 {
     return ip.at(ip.size()-1-n);
@@ -253,6 +264,10 @@ bool CNetAddr::IsLocal() const
  */
 bool CNetAddr::IsValid() const
 {
+    if (m_network_id == NetworkID::INVALID) {
+        return false;
+    }
+
     // Cleanup 3-byte shifted addresses caused by garbage in size field
     // of addr messages from versions before 0.2.9 checksum.
     // Two consecutive addr messages look like this:

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -16,7 +16,8 @@ static const unsigned char g_internal_prefix[] = { 0xFD, 0x6B, 0x88, 0xC0, 0x87,
 
 void CNetAddr::SetIP(const CNetAddr& ipIn)
 {
-    memcpy(ip, ipIn.ip, sizeof(ip));
+    m_network_id = ipIn.m_network_id;
+    ip = ipIn.ip;
 }
 
 void CNetAddr::SetRaw(Network network, const uint8_t *ip_in)
@@ -24,11 +25,12 @@ void CNetAddr::SetRaw(Network network, const uint8_t *ip_in)
     switch(network)
     {
         case NET_IPV4:
-            memcpy(ip, pchIPv4, 12);
-            memcpy(ip+12, ip_in, 4);
+            ip.assign(ip_in, ip_in+4);
+            m_network_id = NetworkID::IPV4;
             break;
         case NET_IPV6:
-            memcpy(ip, ip_in, 16);
+            ip.assign(ip_in, ip_in+16);
+            m_network_id = NetworkID::IPV6;
             break;
         default:
             assert(!"invalid network");
@@ -56,8 +58,8 @@ bool CNetAddr::SetInternal(const std::string &name)
     }
     unsigned char hash[32] = {};
     CSHA256().Write((const unsigned char*)name.data(), name.size()).Finalize(hash);
-    memcpy(ip, g_internal_prefix, sizeof(g_internal_prefix));
-    memcpy(ip + sizeof(g_internal_prefix), hash, sizeof(ip) - sizeof(g_internal_prefix));
+    ip.assign(hash, hash+16-sizeof(g_internal_prefix));
+    m_network_id = NetworkID::NAME;
     return true;
 }
 
@@ -75,12 +77,11 @@ bool CNetAddr::SetSpecial(const std::string &strName)
 {
     if (strName.size()>6 && strName.substr(strName.size() - 6, 6) == ".onion") {
         std::vector<unsigned char> vchAddr = DecodeBase32(strName.substr(0, strName.size() - 6).c_str());
-        if (vchAddr.size() != 16-sizeof(pchOnionCat))
-            return false;
-        memcpy(ip, pchOnionCat, sizeof(pchOnionCat));
-        for (unsigned int i=0; i<16-sizeof(pchOnionCat); i++)
-            ip[i + sizeof(pchOnionCat)] = vchAddr[i];
-        return true;
+        if (vchAddr.size() == 10) {
+            m_network_id = NetworkID::TORV2;
+            ip.assign(vchAddr.begin(), vchAddr.end());
+            return true;
+        }
     }
     return false;
 }
@@ -92,12 +93,12 @@ CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
 
 CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope) : scopeId(scope)
 {
-    SetRaw(NET_IPV6, (const uint8_t*)&ipv6Addr);
+    FromV1Serialization((unsigned char *)&ipv6Addr);
 }
 
 unsigned int CNetAddr::GetByte(int n) const
 {
-    return ip[15-n];
+    return ip.at(ip.size()-1-n);
 }
 
 bool CNetAddr::IsBindAny() const
@@ -112,12 +113,12 @@ bool CNetAddr::IsBindAny() const
 
 bool CNetAddr::IsIPv4() const
 {
-    return (memcmp(ip, pchIPv4, sizeof(pchIPv4)) == 0);
+    return m_network_id == NetworkID::IPV4;
 }
 
 bool CNetAddr::IsIPv6() const
 {
-    return (!IsIPv4() && !IsTor() && !IsInternal());
+    return m_network_id == NetworkID::IPV6;
 }
 
 bool CNetAddr::IsRFC1918() const
@@ -152,50 +153,50 @@ bool CNetAddr::IsRFC5737() const
 
 bool CNetAddr::IsRFC3849() const
 {
-    return GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x0D && GetByte(12) == 0xB8;
+    return IsIPv6() && (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x0D && GetByte(12) == 0xB8);
 }
 
 bool CNetAddr::IsRFC3964() const
 {
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x02);
+    return IsIPv6() && (GetByte(15) == 0x20 && GetByte(14) == 0x02);
 }
 
 bool CNetAddr::IsRFC6052() const
 {
     static const unsigned char pchRFC6052[] = {0,0x64,0xFF,0x9B,0,0,0,0,0,0,0,0};
-    return (memcmp(ip, pchRFC6052, sizeof(pchRFC6052)) == 0);
+    return IsIPv6() && (memcmp(ip.data(), pchRFC6052, sizeof(pchRFC6052)) == 0);
 }
 
 bool CNetAddr::IsRFC4380() const
 {
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0 && GetByte(12) == 0);
+    return IsIPv6() && (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0 && GetByte(12) == 0);
 }
 
 bool CNetAddr::IsRFC4862() const
 {
     static const unsigned char pchRFC4862[] = {0xFE,0x80,0,0,0,0,0,0};
-    return (memcmp(ip, pchRFC4862, sizeof(pchRFC4862)) == 0);
+    return IsIPv6() && (memcmp(ip.data(), pchRFC4862, sizeof(pchRFC4862)) == 0);
 }
 
 bool CNetAddr::IsRFC4193() const
 {
-    return ((GetByte(15) & 0xFE) == 0xFC);
+    return (IsIPv6() && ((GetByte(15) & 0xFE) == 0xFC));
 }
 
 bool CNetAddr::IsRFC6145() const
 {
     static const unsigned char pchRFC6145[] = {0,0,0,0,0,0,0,0,0xFF,0xFF,0,0};
-    return (memcmp(ip, pchRFC6145, sizeof(pchRFC6145)) == 0);
+    return IsIPv6() && (memcmp(ip.data(), pchRFC6145, sizeof(pchRFC6145)) == 0);
 }
 
 bool CNetAddr::IsRFC4843() const
 {
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && (GetByte(12) & 0xF0) == 0x10);
+    return IsIPv6() && (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && (GetByte(12) & 0xF0) == 0x10);
 }
 
 bool CNetAddr::IsRFC7343() const
 {
-    return (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && (GetByte(12) & 0xF0) == 0x20);
+    return IsIPv6() && (GetByte(15) == 0x20 && GetByte(14) == 0x01 && GetByte(13) == 0x00 && (GetByte(12) & 0xF0) == 0x20);
 }
 
 /**
@@ -206,7 +207,7 @@ bool CNetAddr::IsRFC7343() const
  */
 bool CNetAddr::IsTor() const
 {
-    return (memcmp(ip, pchOnionCat, sizeof(pchOnionCat)) == 0);
+    return m_network_id == NetworkID::TORV2;
 }
 
 bool CNetAddr::IsLocal() const
@@ -217,7 +218,7 @@ bool CNetAddr::IsLocal() const
 
     // IPv6 loopback (::1/128)
     static const unsigned char pchLocal[16] = {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1};
-    if (memcmp(ip, pchLocal, 16) == 0)
+    if (IsIPv6() && memcmp(ip.data(), pchLocal, 16) == 0)
         return true;
 
     return false;
@@ -241,13 +242,15 @@ bool CNetAddr::IsValid() const
     // header20 vectorlen3 addr26 addr26 addr26 header20 vectorlen3 addr26 addr26 addr26...
     // so if the first length field is garbled, it reads the second batch
     // of addr misaligned by 3 bytes.
-    if (memcmp(ip, pchIPv4+3, sizeof(pchIPv4)-3) == 0)
+    if (IsIPv6() && memcmp(ip.data(), pchIPv4+3, sizeof(pchIPv4)-3) == 0) {
         return false;
+    }
 
     // unspecified IPv6 address (::/128)
     unsigned char ipNone6[16] = {};
-    if (memcmp(ip, ipNone6, 16) == 0)
+    if (IsIPv6() && memcmp(ip.data(), ipNone6, 16) == 0) {
         return false;
+    }
 
     // documentation IPv6 address
     if (IsRFC3849())
@@ -260,13 +263,15 @@ bool CNetAddr::IsValid() const
     {
         // INADDR_NONE
         uint32_t ipNone = INADDR_NONE;
-        if (memcmp(ip+12, &ipNone, 4) == 0)
+        if (memcmp(ip.data(), &ipNone, 4) == 0) {
             return false;
+        }
 
         // 0
         ipNone = 0;
-        if (memcmp(ip+12, &ipNone, 4) == 0)
+        if (memcmp(ip.data(), &ipNone, 4) == 0) {
             return false;
+        }
     }
 
     return true;
@@ -293,7 +298,7 @@ bool CNetAddr::IsRoutable() const
  */
 bool CNetAddr::IsInternal() const
 {
-   return memcmp(ip, g_internal_prefix, sizeof(g_internal_prefix)) == 0;
+    return m_network_id == NetworkID::NAME;
 }
 
 enum Network CNetAddr::GetNetwork() const
@@ -316,9 +321,9 @@ enum Network CNetAddr::GetNetwork() const
 std::string CNetAddr::ToStringIP() const
 {
     if (IsTor())
-        return EncodeBase32(&ip[6], 10) + ".onion";
+        return EncodeBase32(ip.data(), 10) + ".onion";
     if (IsInternal())
-        return EncodeBase32(ip + sizeof(g_internal_prefix), sizeof(ip) - sizeof(g_internal_prefix)) + ".internal";
+        return EncodeBase32(ip.data(), 16 - sizeof(g_internal_prefix)) + ".internal";
     CService serv(*this, 0);
     struct sockaddr_storage sockaddr;
     socklen_t socklen = sizeof(sockaddr);
@@ -344,12 +349,16 @@ std::string CNetAddr::ToString() const
 
 bool operator==(const CNetAddr& a, const CNetAddr& b)
 {
-    return (memcmp(a.ip, b.ip, 16) == 0);
+    return a.m_network_id == b.m_network_id && a.ip == b.ip;
 }
 
 bool operator<(const CNetAddr& a, const CNetAddr& b)
 {
-    return (memcmp(a.ip, b.ip, 16) < 0);
+    if (a.m_network_id == b.m_network_id) {
+        return a.ip < b.ip;
+    } else {
+        return a.m_network_id < b.m_network_id;
+    }
 }
 
 /**
@@ -366,7 +375,7 @@ bool CNetAddr::GetInAddr(struct in_addr* pipv4Addr) const
 {
     if (!IsIPv4())
         return false;
-    memcpy(pipv4Addr, ip+12, 4);
+    memcpy(pipv4Addr, ip.data(), 4);
     return true;
 }
 
@@ -385,9 +394,49 @@ bool CNetAddr::GetIn6Addr(struct in6_addr* pipv6Addr) const
     if (!IsIPv6()) {
         return false;
     }
-    memcpy(pipv6Addr, ip, 16);
+    memcpy(pipv6Addr, ip.data(), 16);
     return true;
 }
+
+void CNetAddr::FromV1Serialization(unsigned char *buff) {
+    if (memcmp(buff, pchIPv4, sizeof(pchIPv4)) == 0) {
+        // IPv4-in-IPv6
+        SetRaw(NET_IPV4, (const uint8_t *)buff+sizeof(pchIPv4));
+    } else if (memcmp(buff, pchOnionCat, sizeof(pchOnionCat)) == 0) {
+        // OnionCat
+        ip.assign(buff+sizeof(pchOnionCat), buff+16);
+        m_network_id = NetworkID::TORV2;
+    } else if (memcmp(buff, g_internal_prefix, sizeof(g_internal_prefix)) == 0) {
+        // Custom Internal
+        ip.assign(buff+sizeof(g_internal_prefix), buff+16);
+        m_network_id = NetworkID::NAME;
+    } else { // Actually IPv6
+        SetRaw(NET_IPV6, (const uint8_t*)buff);
+    }
+}
+
+bool CNetAddr::GetV1Serialization(unsigned char *buff) const {
+    switch (m_network_id) {
+    case NetworkID::IPV4:
+        memcpy(buff, pchIPv4, sizeof(pchIPv4));
+        memcpy(buff+sizeof(pchIPv4), ip.data(), 16-sizeof(pchIPv4));
+        return true;
+    case NetworkID::TORV2:
+        memcpy(buff, pchOnionCat, sizeof(pchOnionCat));
+        memcpy(buff+sizeof(pchOnionCat), ip.data(), 16-sizeof(pchOnionCat));
+        return true;
+    case NetworkID::NAME:
+        memcpy(buff, g_internal_prefix, sizeof(g_internal_prefix));
+        memcpy(buff+sizeof(g_internal_prefix), ip.data(), 16-sizeof(g_internal_prefix));
+        return true;
+    case NetworkID::IPV6:
+        memcpy(buff, ip.data(), 16);
+        return true;
+    default:
+        return false;
+    }
+}
+
 
 /**
  * Get the canonical identifier of our network group
@@ -416,8 +465,7 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
     if (IsInternal())
     {
         nClass = NET_INTERNAL;
-        nStartByte = sizeof(g_internal_prefix);
-        nBits = (sizeof(ip) - sizeof(g_internal_prefix)) * 8;
+        nBits = (16 - sizeof(g_internal_prefix)) * 8;
     }
     // all other unroutable addresses belong to the same group
     else if (!IsRoutable())
@@ -427,7 +475,11 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
     }
     // for IPv4 addresses, '1' + the 16 higher-order bits of the IP
     // includes mapped IPv4, SIIT translated IPv4, and the well-known prefix
-    else if (IsIPv4() || IsRFC6145() || IsRFC6052())
+    else if (IsIPv4())
+    {
+        nClass = NET_IPV4;
+    }
+    else if (IsRFC6145() || IsRFC6052())
     {
         nClass = NET_IPV4;
         nStartByte = 12;
@@ -449,7 +501,6 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
     else if (IsTor())
     {
         nClass = NET_ONION;
-        nStartByte = 6;
         nBits = 4;
     }
     // for he.net, use /36 groups
@@ -464,20 +515,20 @@ std::vector<unsigned char> CNetAddr::GetGroup() const
     // push our ip onto vchRet byte by byte...
     while (nBits >= 8)
     {
-        vchRet.push_back(GetByte(15 - nStartByte));
+        vchRet.push_back(ip.at(nStartByte));
         nStartByte++;
         nBits -= 8;
     }
     // ...for the last byte, push nBits and for the rest of the byte push 1's
     if (nBits > 0)
-        vchRet.push_back(GetByte(15 - nStartByte) | ((1 << (8 - nBits)) - 1));
+        vchRet.push_back(ip.at(nStartByte) | ((1 << (8 - nBits)) - 1));
 
     return vchRet;
 }
 
 uint64_t CNetAddr::GetHash() const
 {
-    uint256 hash = Hash(&ip[0], &ip[16]);
+    uint256 hash = Hash(ip.begin(), ip.end());
     uint64_t nRet;
     memcpy(&nRet, &hash, sizeof(nRet));
     return nRet;
@@ -658,10 +709,12 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
 std::vector<unsigned char> CService::GetKey() const
 {
      std::vector<unsigned char> vKey;
-     vKey.resize(18);
-     memcpy(vKey.data(), ip, 16);
-     vKey[16] = port / 0x100; // most significant byte of our port
-     vKey[17] = port & 0x0FF; // least significant byte of our port
+     vKey.resize(16);
+     if (!GetV1Serialization(vKey.data())) {
+         vKey.assign(ip.begin(), ip.end());
+     }
+     vKey.push_back(port / 0x100);
+     vKey.push_back(port & 0x0FF);
      return vKey;
 }
 
@@ -692,51 +745,57 @@ CSubNet::CSubNet():
 
 CSubNet::CSubNet(const CNetAddr &addr, int32_t mask)
 {
-    valid = true;
+    valid = (addr.m_network_id == NetworkID::IPV4 || addr.m_network_id == NetworkID::IPV6);
     network = addr;
     // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
     memset(netmask, 255, sizeof(netmask));
 
     // IPv4 addresses start at offset 12, and first 12 bytes must match, so just offset n
-    const int astartofs = network.IsIPv4() ? 12 : 0;
+    const int alens = network.ip.size();
 
     int32_t n = mask;
-    if(n >= 0 && n <= (128 - astartofs*8)) // Only valid if in range of bits of address
+    if(n >= 0 && n <= (alens*8)) // Only valid if in range of bits of address
     {
-        n += astartofs*8;
         // Clear bits [n..127]
         for (; n < 128; ++n)
             netmask[n>>3] &= ~(1<<(7-(n&7)));
-    } else
+    } else {
         valid = false;
+    }
 
     // Normalize network according to netmask
-    for(int x=0; x<16; ++x)
-        network.ip[x] &= netmask[x];
+    for(size_t x=0; x<alens; ++x)
+        network.ip.at(x) &= netmask[x];
 }
 
 CSubNet::CSubNet(const CNetAddr &addr, const CNetAddr &mask)
 {
-    valid = true;
+    valid = (addr.m_network_id == NetworkID::IPV4 || addr.m_network_id == NetworkID::IPV6);
     network = addr;
     // Default to /32 (IPv4) or /128 (IPv6), i.e. match single address
     memset(netmask, 255, sizeof(netmask));
 
     // IPv4 addresses start at offset 12, and first 12 bytes must match, so just offset n
-    const int astartofs = network.IsIPv4() ? 12 : 0;
+    const int alens = network.ip.size();
 
-    for(int x=astartofs; x<16; ++x)
-        netmask[x] = mask.ip[x];
+    for(int x=0; x<alens; ++x)
+        netmask[x] = mask.ip.at(x);
+    for(int x=alens; x<16; ++x)
+        netmask[x] = 0;
 
     // Normalize network according to netmask
-    for(int x=0; x<16; ++x)
-        network.ip[x] &= netmask[x];
+    for(size_t x=0; x<network.ip.size(); ++x)
+        network.ip.at(x) &= netmask[x];
 }
 
 CSubNet::CSubNet(const CNetAddr &addr):
     valid(addr.IsValid())
 {
-    memset(netmask, 255, sizeof(netmask));
+    valid &= (addr.m_network_id == NetworkID::IPV4 || addr.m_network_id == NetworkID::IPV6);
+
+    memset(netmask, 0, sizeof(netmask));
+    memset(netmask, 255, addr.ip.size());
+
     network = addr;
 }
 
@@ -746,10 +805,21 @@ CSubNet::CSubNet(const CNetAddr &addr):
  */
 bool CSubNet::Match(const CNetAddr &addr) const
 {
-    if (!valid || !addr.IsValid())
+    // Construct a ::FFFF:0:0 with NetworkID::IPV6 as m_network_id
+    std::vector<unsigned char> blank_ipv4_mapped(std::begin(pchIPv4), std::end(pchIPv4));
+    blank_ipv4_mapped.resize(16, 0);
+    CNetAddr blank_ipv4_mapped_address;
+    blank_ipv4_mapped_address.SetRaw(NET_IPV6, blank_ipv4_mapped.data());
+
+    // We consider IPv4 as a subnet of IPv6. Therefore, any IPv6 subnet that
+    // contains ::FFFF:0:0 also contains all of IPv4.
+    if (network.IsIPv6() && addr.IsIPv4() && Match(blank_ipv4_mapped_address)) {
+        return true;
+    }
+    if (!valid || !addr.IsValid() || addr.m_network_id != network.m_network_id)
         return false;
-    for(int x=0; x<16; ++x)
-        if ((addr.ip[x] & netmask[x]) != network.ip[x])
+    for(size_t x=0; x<addr.ip.size(); ++x)
+        if ((addr.ip.at(x) & netmask[x]) != network.ip.at(x))
             return false;
     return true;
 }
@@ -779,7 +849,7 @@ std::string CSubNet::ToString() const
     /* Parse binary 1{n}0{N-n} to see if mask can be represented as /n */
     int cidr = 0;
     bool valid_cidr = true;
-    int n = network.IsIPv4() ? 12 : 0;
+    int n = 0;
     for (; n < 16 && netmask[n] == 0xff; ++n)
         cidr += 8;
     if (n < 16) {
@@ -800,7 +870,7 @@ std::string CSubNet::ToString() const
         strNetmask = strprintf("%u", cidr);
     } else {
         if (network.IsIPv4())
-            strNetmask = strprintf("%u.%u.%u.%u", netmask[12], netmask[13], netmask[14], netmask[15]);
+            strNetmask = strprintf("%u.%u.%u.%u", netmask[0], netmask[1], netmask[2], netmask[3]);
         else
             strNetmask = strprintf("%x:%x:%x:%x:%x:%x:%x:%x",
                              netmask[0] << 8 | netmask[1], netmask[2] << 8 | netmask[3],

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -14,16 +14,6 @@ static const unsigned char pchOnionCat[] = {0xFD,0x87,0xD8,0x7E,0xEB,0x43};
 // 0xFD + sha256("bitcoin")[0:5]
 static const unsigned char g_internal_prefix[] = { 0xFD, 0x6B, 0x88, 0xC0, 0x87, 0x24 };
 
-/**
- * Construct an unspecified IPv6 network address (::/128).
- *
- * @note This address is considered invalid by CNetAddr::IsValid()
- */
-CNetAddr::CNetAddr()
-{
-    memset(ip, 0, sizeof(ip));
-}
-
 void CNetAddr::SetIP(const CNetAddr& ipIn)
 {
     memcpy(ip, ipIn.ip, sizeof(ip));
@@ -100,10 +90,9 @@ CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
     SetRaw(NET_IPV4, (const uint8_t*)&ipv4Addr);
 }
 
-CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
+CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope) : scopeId(scope)
 {
     SetRaw(NET_IPV6, (const uint8_t*)&ipv6Addr);
-    scopeId = scope;
 }
 
 unsigned int CNetAddr::GetByte(int n) const

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -34,6 +34,9 @@ enum class NetworkID : uint8_t
     IPV4 = 1,
     IPV6,
     TORV2,
+    TORV3,
+    I2P,
+    CJDNS,
 };
 
 /** IP address (IPv6, or IPv4 using mapped IPv6 range (::FFFF:0:0/96)) */

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -170,7 +170,7 @@ class CService : public CNetAddr
 
         template <typename Stream, typename Operation>
         inline void SerializationOp(Stream& s, Operation ser_action) {
-            READWRITE(ip);
+            READWRITEAS(CNetAddr, *this);
             READWRITE(WrapBigEndian(port));
         }
 };

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -32,11 +32,16 @@ enum Network
 class CNetAddr
 {
     protected:
-        unsigned char ip[16]; // in network byte order
+        unsigned char ip[16]{}; // in network byte order
         uint32_t scopeId{0}; // for scoped/link-local ipv6 addresses
 
     public:
-        CNetAddr();
+        /**
+         * Construct an unspecified IPv6 network address (::/128).
+         *
+         * @note This address is considered invalid by CNetAddr::IsValid()
+         */
+        CNetAddr() = default;
         explicit CNetAddr(const struct in_addr& ipv4Addr);
         void SetIP(const CNetAddr& ip);
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -18,6 +18,8 @@ namespace NetMsgType {
 const char *VERSION="version";
 const char *VERACK="verack";
 const char *ADDR="addr";
+const char *ADDRv2="addrv2";
+const char *SENDADDRv2="sendaddrv2";
 const char *INV="inv";
 const char *GETDATA="getdata";
 const char *MERKLEBLOCK="merkleblock";
@@ -50,6 +52,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::VERSION,
     NetMsgType::VERACK,
     NetMsgType::ADDR,
+    NetMsgType::ADDRv2,
+    NetMsgType::SENDADDRv2,
     NetMsgType::INV,
     NetMsgType::GETDATA,
     NetMsgType::MERKLEBLOCK,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -85,6 +85,17 @@ extern const char *VERACK;
  */
 extern const char *ADDR;
 /**
+ * The addrv2 (IP address) message relays connection information for peers on
+ * the network just like the addr message, but is extended to allow gossipping
+ * of longer node addresses.
+ */
+extern const char *ADDRv2;
+/**
+ * Indicates that a node prefers to receive connection information for peers via
+ * an "addrv2" message rather than an "addr" message.
+ */
+extern const char *SENDADDRv2;
+/**
  * The inv message (inventory message) transmits one or more inventories of
  * objects known to the transmitting peer.
  * @see https://bitcoin.org/en/developer-reference#inv

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -341,10 +341,19 @@ public:
         if (s.GetType() & SER_DISK)
             READWRITE(nVersion);
         if ((s.GetType() & SER_DISK) ||
-            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH)))
-            READWRITE(nTime);
+            (nVersion >= CADDR_TIME_VERSION && !(s.GetType() & SER_GETHASH))) {
+            if (s.GetVersion() & SERIALIZE_ADDR_AS_V2) {
+                READWRITE(VARINT(nTime));
+            } else {
+                READWRITE(nTime);
+            }
+        }
         uint64_t nServicesInt = nServices;
-        READWRITE(nServicesInt);
+        if (s.GetVersion() & SERIALIZE_ADDR_AS_V2) {
+            READWRITE(VARINT(nServicesInt));
+        } else {
+            READWRITE(nServicesInt);
+        }
         nServices = static_cast<ServiceFlags>(nServicesInt);
         READWRITEAS(CService, *this);
     }

--- a/src/streams.h
+++ b/src/streams.h
@@ -604,7 +604,7 @@ class CAutoFile
 {
 private:
     const int nType;
-    const int nVersion;
+    int nVersion;
 
     FILE* file;
 
@@ -652,6 +652,7 @@ public:
     //
     int GetType() const          { return nType; }
     int GetVersion() const       { return nVersion; }
+    void SetVersion(int n)       { nVersion = n; }
 
     void read(char* pch, size_t nSize)
     {

--- a/test/functional/p2p_leak.py
+++ b/test/functional/p2p_leak.py
@@ -49,6 +49,7 @@ class CLazyNode(P2PInterface):
     def on_pong(self, message): self.bad_message(message)
     def on_feefilter(self, message): self.bad_message(message)
     def on_sendheaders(self, message): self.bad_message(message)
+    def on_sendaddrv2(self, message): self.bad_message(message)
     def on_sendcmpct(self, message): self.bad_message(message)
     def on_cmpctblock(self, message): self.bad_message(message)
     def on_getblocktxn(self, message): self.bad_message(message)

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1264,6 +1264,22 @@ class msg_sendheaders:
         return "msg_sendheaders()"
 
 
+class msg_sendaddrv2:
+    __slots__ = ()
+    command = b"sendaddrv2"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_sendaddrv2()"
+
 # getheaders message has
 # number of entries
 # vector of hashes

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -44,6 +44,7 @@ from test_framework.messages import (
     msg_reject,
     msg_sendcmpct,
     msg_sendheaders,
+    msg_sendaddrv2,
     msg_tx,
     MSG_TX,
     MSG_TYPE_MASK,
@@ -77,6 +78,7 @@ MESSAGEMAP = {
     b"reject": msg_reject,
     b"sendcmpct": msg_sendcmpct,
     b"sendheaders": msg_sendheaders,
+    b"sendaddrv2": msg_sendaddrv2,
     b"tx": msg_tx,
     b"verack": msg_verack,
     b"version": msg_version,
@@ -332,6 +334,7 @@ class P2PInterface(P2PConnection):
     def on_reject(self, message): pass
     def on_sendcmpct(self, message): pass
     def on_sendheaders(self, message): pass
+    def on_sendaddrv2(self, message): pass
     def on_tx(self, message): pass
 
     def on_inv(self, message):


### PR DESCRIPTION
Original BIP: https://github.com/bitcoin/bips/blob/master/bip-0155.mediawiki
Followup discussions after the BIP was merged: https://github.com/bitcoin/bips/pull/766

This rough WIP PR aims to allow propagating addresses with `addrv2` messages, and signaling support for `addrv2` messages with `sendaddrv2` message.

The commits are structured such that every single commit should compile and pass tests.

TODO:
- [ ] Wayyyyyyy more tests.

Things I'd like feedback on:
- What would be the best way to split up https://github.com/bitcoin/bitcoin/commit/e6009922077ce330bc76b82b9c3aa1e813e40356? I've tried to split it up in multiple ways but every time I attempt to do it, it just increases the total diff.
- In https://github.com/bitcoin/bitcoin/commit/fb78590939ff2d8c008cfd68f2f7df816389ac01, we introduce `CJDNS` as a new supported network. `CJDNS` addresses are simple IPv6 addresses under a certain prefix, 
- In https://github.com/bitcoin/bitcoin/commit/e10f8bfcaec44cf1e7b73c390225b80644e8367f, I'm wondering if there are better ways of structuring the code for ignoring single `addr` entries, and the entire message.

-----

Things that surprised me:
- `addrMe` was deprecated and no one seemed to remember: https://github.com/bitcoin/bips/pull/766#issuecomment-524444473
