### PR TITLE
msbuild: adds bench_bitcoin to auto generated project files

### DIFF
--- a/build_msvc/bench_bitcoin/bench_bitcoin.vcxproj.in
+++ b/build_msvc/bench_bitcoin/bench_bitcoin.vcxproj.in
@@ -9,27 +9,7 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\test\util.cpp" />
-    <ClCompile Include="..\..\src\test\setup_common.cpp" />
-    <ClCompile Include="..\..\src\bench\base58.cpp" />
-    <ClCompile Include="..\..\src\bench\bech32.cpp" />
-    <ClCompile Include="..\..\src\bench\bench.cpp" />
-    <ClCompile Include="..\..\src\bench\bench_bitcoin.cpp" />
-    <ClCompile Include="..\..\src\bench\ccoins_caching.cpp" />
-    <ClCompile Include="..\..\src\bench\checkblock.cpp" />
-    <ClCompile Include="..\..\src\bench\checkqueue.cpp" />
-    <ClCompile Include="..\..\src\bench\coin_selection.cpp" />
-    <ClCompile Include="..\..\src\bench\crypto_hash.cpp" />
-    <ClCompile Include="..\..\src\bench\data.cpp" />
-    <ClCompile Include="..\..\src\bench\examples.cpp" />
-    <ClCompile Include="..\..\src\bench\lockedpool.cpp" />
-    <ClCompile Include="..\..\src\bench\mempool_eviction.cpp" />
-    <ClCompile Include="..\..\src\bench\rpc_blockchain.cpp" />
-    <ClCompile Include="..\..\src\bench\rpc_mempool.cpp" />
-    <ClCompile Include="..\..\src\bench\merkle_root.cpp" />
-    <ClCompile Include="..\..\src\bench\rollingbloom.cpp" />
-    <ClCompile Include="..\..\src\bench\wallet_balance.cpp" />
-    <ClCompile Include="..\..\src\bench\verify_script.cpp" />
+@SOURCE_FILES@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">

--- a/build_msvc/msvc-autogen.py
+++ b/build_msvc/msvc-autogen.py
@@ -17,6 +17,7 @@ libs = [
     'libbitcoin_wallet_tool',
     'libbitcoin_wallet',
     'libbitcoin_zmq',
+    'bench_bitcoin',
 ]
 
 ignore_list = [


### PR DESCRIPTION
As discussed in #16747.

The msbuild bench_bitcoin project is currently missing a number of classes. Rather than add them manually this PR adds bench_bitcoin to the list of project files that are auto generated from the main make files.
