### PR TITLE
wallet: extract PubKey from P2PK script with Solver

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -523,18 +523,9 @@ bool CWallet::LoadCScript(const CScript& redeemScript)
 
 static bool ExtractPubKey(const CScript &dest, CPubKey& pubKeyOut)
 {
-    //TODO: Use Solver to extract this?
-    CScript::const_iterator pc = dest.begin();
-    opcodetype opcode;
-    std::vector<unsigned char> vch;
-    if (!dest.GetOp(pc, opcode, vch) || !CPubKey::ValidSize(vch))
-        return false;
-    pubKeyOut = CPubKey(vch);
-    if (!pubKeyOut.IsFullyValid())
-        return false;
-    if (!dest.GetOp(pc, opcode, vch) || opcode != OP_CHECKSIG || dest.GetOp(pc, opcode, vch))
-        return false;
-    return true;
+    std::vector<std::vector<unsigned char>> solutions;
+    return Solver(dest, solutions) == TX_PUBKEY &&
+        (pubKeyOut = CPubKey(solutions[0])).IsFullyValid();
 }
 
 bool CWallet::AddWatchOnlyInMem(const CScript &dest)


### PR DESCRIPTION
The function `ExtractPubKey()` checks if a given script matches the P2PK pattern
(`<PubKey> OP_CHECKSIG`), extracts the PubKey and additionally checks if it is
cryptographically valid (full validation with ECC library via `CPubKey::IsFullyValid()`).

Currently this is done manually in the following order:
1. check if first script OP is data push with valid PubKey length (first part of pattern match), extract PubKey
2. create `CPubKey` object with extracted PubKey
3. fully validate public key
4. check if last script OP is `OP_CHECKSIG` (second part of pattern match)

Using Solver, the pattern matching and PubKey extraction can be done via a
single step, leading to the following simplified order with shorter code:
1. check if given script matches P2PK pattern with Solver (also contains valid PubKey length check), extracts Pubkey
2. create `CPubKey` object with extracted Pubkey
3. fully validate public key