### PR TITLE
qt: Replace QFontMetrics::width() with TextWidth()

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -947,7 +947,7 @@ void PolishProgressDialog(QProgressDialog* dialog)
 {
 #ifdef Q_OS_MAC
     // Workaround for macOS-only Qt bug; see: QTBUG-65750, QTBUG-70357.
-    const int margin = dialog->fontMetrics().width("X");
+    const int margin = TextWidth(dialog->fontMetrics(), ("X"));
     dialog->resize(dialog->width() + 2 * margin, dialog->height());
     dialog->show();
 #else


### PR DESCRIPTION
Compiling master (d8fc9979130a268cf55b12c223b20fd7d4b9f67f) on macOS Catalina (with a patch from #16720) reveals one more instance of `QFontMetrics::width()` which is supposed to be replaced with `TextWidth()` in the merged #16701.

Sorry for incomplete solution provided in #16701. It’s especially sad that the line I missed lies in only 7 lines from the code touched in #16701.