### PR TITLE
doc: Fix table syntax

### DIFF
--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -53,10 +53,10 @@ The `includeconf=<file>` option in the `bitcoin.conf` file can be used to includ
 
 ### Default configuration file locations
 
-Operating System | Data Directory | Example Path
--- | -- | --
-Windows | `%APPDATA%\Bitcoin\` | `C:\Users\username\AppData\Roaming\Bitcoin\bitcoin.conf`
-Linux | `$HOME/.bitcoin/` | `/home/username/.bitcoin/bitcoin.conf`
-macOS | `$HOME/Library/Application Support/Bitcoin/` | `/Users/username/Library/Application Support/Bitcoin/bitcoin.conf`
+Operating System | Data Directory                              | Example Path
+--               | --                                          | --
+Windows          | `%APPDATA%\Bitcoin\`                        |`C:\Users\username\AppData\Roaming\Bitcoin\bitcoin.conf`
+Linux            |`$HOME/.bitcoin/`                            |`/home/username/.bitcoin/bitcoin.conf`
+macOS            |`$HOME/Library/Application Support/Bitcoin/` |`/Users/username/Library/Application Support/Bitcoin/bitcoin.conf`
 
 You can find an example bitcoin.conf file in [share/examples/bitcoin.conf](../share/examples/bitcoin.conf).


### PR DESCRIPTION
Adjustment with whitespaces to other tables in the docs.
See 9b51b158fc42f2d5ad4fe161053e44e667d42fd6