### PR TITLE
qt: Change uninstall icon on Windows

### DIFF
--- a/share/setup.nsi.in
+++ b/share/setup.nsi.in
@@ -101,7 +101,7 @@ Section -post SEC0001
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayVersion "@PACKAGE_VERSION@"
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" Publisher "${COMPANY}"
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" URLInfoAbout "${URL}"
-    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayIcon $INSTDIR\uninstall.exe
+    WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" DisplayIcon $INSTDIR\bitcoin-qt.exe
     WriteRegStr HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" UninstallString $INSTDIR\uninstall.exe
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoModify 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(^Name)" NoRepair 1


### PR DESCRIPTION
Change uninstall icon in Windows by changing a registry value.
Original uninstall.exe icon remains the same
Reason: almost no other modern program uses that uninstall icon in Windows.

before:
![before](https://user-images.githubusercontent.com/42591821/63967490-13a09000-ca8d-11e9-8f49-3884d33302ce.png)
after:
![after](https://user-images.githubusercontent.com/42591821/63967491-13a09000-ca8d-11e9-82f0-5adb74246a1e.png)


