### PR TITLE
Add blockpause setting

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1249,6 +1249,11 @@ bool AppInitMain(InitInterfaces& interfaces)
     }
 
     if (gArgs.IsArgSet("-blockpause")) {
+        bool IsRegtest;
+        if (Params().NetworkIDString() != "regtest")
+            IsRegtest = false;
+        else
+            IsRegtest = true;
         blockpause = gArgs.GetArg("-blockpause", DEFAULT_BLOCKPAUSE);
         LogPrintf("Blockpause: %d\n", blockpause);
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -154,6 +154,8 @@ static std::unique_ptr<ECCVerifyHandle> globalVerifyHandle;
 static boost::thread_group threadGroup;
 static CScheduler scheduler;
 
+unsigned int blockpause;
+
 void Interrupt()
 {
     InterruptHTTPServer();
@@ -365,6 +367,7 @@ void SetupServerArgs()
 #if HAVE_SYSTEM
     gArgs.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
+    gArgs.AddArg("-blockpause=<miliseconds>", "Set a delay between the blocks at the initial sync (default: 0)", ArgsManager::ALLOW_INT, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blockreconstructionextratxn=<n>", strprintf("Extra transactions to keep in memory for compact block reconstructions (default: %u)", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-blocksonly", strprintf("Whether to reject transactions from network peers. Transactions from the wallet, RPC and relay whitelisted inbound peers are not affected. (default: %u)", DEFAULT_BLOCKSONLY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -1243,6 +1246,11 @@ bool AppInitMain(InitInterfaces& interfaces)
     } else {
         // Not categorizing as "Warning" because it's the default behavior
         LogPrintf("Config file: %s (not found, skipping)\n", config_file_path.string());
+    }
+
+    if (gArgs.IsArgSet("-blockpause")) {
+        blockpause = gArgs.GetArg("-blockpause", DEFAULT_BLOCKPAUSE);
+        LogPrintf("Blockpause: %d\n", blockpause);
     }
 
     LogPrintf("Using at most %i automatic connections (%i file descriptors available)\n", nMaxConnections, nFD);

--- a/src/init.h
+++ b/src/init.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <util/system.h>
+#include <chainparams.h> // For Params().NetworkIDString()
 
 namespace interfaces {
 class Chain;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3426,6 +3426,11 @@ static FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, const CChai
 /** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
 bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock)
 {
+    // Ignore blockpause in regtest
+    if (Params().NetworkIDString() != "regtest")
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(blockpause));
+    }
     const CBlock& block = *pblock;
 
     if (fNewBlock) *fNewBlock = false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3427,7 +3427,8 @@ static FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, const CChai
 bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock)
 {
     // Ignore blockpause in regtest
-    if (Params().NetworkIDString() != "regtest")
+    bool IsRegtest;
+    if (!IsRegtest)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(blockpause));
     }

--- a/src/validation.h
+++ b/src/validation.h
@@ -21,7 +21,6 @@
 #include <txmempool.h> // For CTxMemPool::cs
 #include <txdb.h>
 #include <versionbits.h>
-#include <chainparams.h> // For Params().NetworkIDString()
 
 #include <algorithm>
 #include <atomic>
@@ -790,5 +789,7 @@ inline bool IsBlockPruned(const CBlockIndex* pblockindex)
 {
     return (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0);
 }
+
+extern bool IsRegtest;
 
 #endif // BITCOIN_VALIDATION_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -21,6 +21,7 @@
 #include <txmempool.h> // For CTxMemPool::cs
 #include <txdb.h>
 #include <versionbits.h>
+#include <chainparams.h> // For Params().NetworkIDString()
 
 #include <algorithm>
 #include <atomic>
@@ -32,6 +33,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <chrono>
+#include <thread>
 
 class CChainState;
 class CBlockIndex;
@@ -98,6 +101,8 @@ static const int MAX_BLOCKTXN_DEPTH = 10;
  *  degree of disordering of blocks on disk (which make reindexing and pruning harder). We'll probably
  *  want to make this a per-peer adaptive value at some point. */
 static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
+/** Blockpause */
+static const unsigned int DEFAULT_BLOCKPAUSE = 0;
 /** Time to wait (in seconds) between writing blocks/block index to disk. */
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
@@ -167,6 +172,9 @@ extern arith_uint256 nMinimumChainWork;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;
+
+/** Time to wait between blocks */
+extern unsigned int blockpause;
 
 /** Pruning-related variables and constants */
 /** True if any block files have ever been pruned. */


### PR DESCRIPTION
# What is this?
This adds a feature to set a delay between the blocks at the initial download.
# Why?
A few weeks ago I was downloading the blockchain on my systems drive (which is an SSD).
I usually download the blockchain on an external drive which is an HDD.
During the sync on my SSD my Computer was completely unusable because there were too many read and write operations. This PR adds a feature to throttle the block downlad to make the Computer usable during that time.
# Testing
Just add a `-blockpause=1000` to add a pause of ten seconds. The default is 0 miliseconds
# Notes
This is being ignored if the regtest chain is in use
# Log
Running `./bitcoind --blockpause=10000`
```
2019-08-29T19:42:43Z UpdateTip: new best=00000000faac558a7a5266c3c678e53b53b88a619b00dd825395b8e4ca44cdd9 height=9511 version=0x00000001 log2_work=45.215555 tx=9602 date='2009-04-02T02:23:37Z' progress=0.000022 cache=0.0MiB(1txo)
2019-08-29T19:42:53Z UpdateTip: new best=000000009be075c2742955e8cad5aa09390e2e7feffdfecc371bdcae0fb60951 height=9512 version=0x00000001 log2_work=45.215707 tx=9603 date='2009-04-02T02:27:04Z' progress=0.000022 cache=0.0MiB(2txo)
2019-08-29T19:43:03Z UpdateTip: new best=00000000c60596cdb860839242211d9a17ba734e397636135e7744303d189a0b height=9513 version=0x00000001 log2_work=45.215858 tx=9604 date='2009-04-02T01:41:48Z' progress=0.000022 cache=0.0MiB(3txo)
2019-08-29T19:43:13Z UpdateTip: new best=0000000052ab68c20deabfd537a4f40ce88bbd29bdc91b86fb791a701a7af723 height=9514 version=0x00000001 log2_work=45.21601 tx=9605 date='2009-04-02T01:59:40Z' progress=0.000022 cache=0.0MiB(4txo)
```
See timestamps