### PR TITLE
gui: update description for default language

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -93,7 +93,7 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->openBitcoinConfButton->setToolTip(ui->openBitcoinConfButton->toolTip().arg(PACKAGE_NAME));
 
     ui->lang->setToolTip(ui->lang->toolTip().arg(PACKAGE_NAME));
-    ui->lang->addItem(QString("(") + tr("default") + QString(")"), QVariant(""));
+    ui->lang->addItem(QString("English (") + tr("default") + QString(")"), QVariant(""));
     for (const QString &langStr : translations.entryList())
     {
         QLocale locale(langStr);


### PR DESCRIPTION
Drop down menu in GUI now displays "English (default)" for the default language, where "English" is never translated, making it easier to find the default language