### PR TITLE
test: Check for codespell in lint-spelling.sh

### DIFF
--- a/test/lint/lint-spelling.sh
+++ b/test/lint/lint-spelling.sh
@@ -9,6 +9,11 @@
 
 export LC_ALL=C
 
+if ! command -v codespell > /dev/null; then
+    echo "Skipping spell check linting since codespell is not installed."
+    exit 0
+fi
+
 IGNORE_WORDS_FILE=test/lint/lint-spelling.ignore-words.txt
 if ! codespell --check-filenames --disable-colors --quiet-level=7 --ignore-words=${IGNORE_WORDS_FILE} $(git ls-files -- ":(exclude)build-aux/m4/" ":(exclude)contrib/seeds/*.txt" ":(exclude)depends/" ":(exclude)doc/release-notes/" ":(exclude)src/leveldb/" ":(exclude)src/qt/locale/" ":(exclude)src/secp256k1/" ":(exclude)src/univalue/"); then
     echo "^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in ${IGNORE_WORDS_FILE}"


### PR DESCRIPTION
Similar check for `spellcheck` already exists in `lint-shell.sh`