### PR TITLE
Chainparams: Rename IsTestChain() to AllowAcceptNonstd()

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -134,7 +134,7 @@ public:
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
-        m_is_test_chain = false;
+        m_allow_accept_nonstd = false;
         m_is_mockable_chain = false;
 
         checkpointData = {
@@ -231,7 +231,7 @@ public:
 
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
-        m_is_test_chain = true;
+        m_allow_accept_nonstd = true;
         m_is_mockable_chain = false;
 
         checkpointData = {
@@ -303,7 +303,7 @@ public:
 
         fDefaultConsistencyChecks = true;
         fRequireStandard = true;
-        m_is_test_chain = true;
+        m_allow_accept_nonstd = true;
         m_is_mockable_chain = true;
 
         checkpointData = {

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -66,8 +66,8 @@ public:
     bool DefaultConsistencyChecks() const { return fDefaultConsistencyChecks; }
     /** Policy: Filter transactions that do not match well-defined patterns */
     bool RequireStandard() const { return fRequireStandard; }
-    /** If this chain is exclusively used for testing */
-    bool IsTestChain() const { return m_is_test_chain; }
+    /** If it is allowed to set -acceptnonstdtxn=1 for this chain or not */
+    bool AllowAcceptNonstd() const { return m_allow_accept_nonstd; }
     /** If this chain allows time to be mocked */
     bool IsMockableChain() const { return m_is_mockable_chain; }
     uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
@@ -103,7 +103,7 @@ protected:
     std::vector<SeedSpec6> vFixedSeeds;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
-    bool m_is_test_chain;
+    bool m_allow_accept_nonstd;
     bool m_is_mockable_chain;
     CCheckpointData checkpointData;
     ChainTxData chainTxData;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1119,7 +1119,7 @@ bool AppInitParameterInteraction()
     }
 
     fRequireStandard = !gArgs.GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());
-    if (!chainparams.IsTestChain() && !fRequireStandard) {
+    if (!chainparams.AllowAcceptNonstd() && !fRequireStandard) {
         return InitError(strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
     }
     nBytesPerSigOp = gArgs.GetArg("-bytespersigop", nBytesPerSigOp);


### PR DESCRIPTION
Refactor, this shouldn't change functionality.

This is a step to get rid of Params().IsTestChain() which is currently used for 2 unrelated things.

Rename related to https://github.com/bitcoin/bitcoin/pull/16526