### PR TITLE
doc: Update comment describing CheckInputs in validation.cpp

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1282,7 +1282,7 @@ void InitScriptExecutionCache() {
 }
 
 /**
- * Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)
+ * Check whether all inputs of this transaction are valid (scripts & sigs)
  * This does not modify the UTXO set.
  *
  * If pvChecks is not nullptr, script checks are pushed onto it instead of being performed inline. Any


### PR DESCRIPTION
In the [Bitcoin Core PR review club](https://bitcoin-core-review-club.github.io/15169.html) @jnewbery noted that the comment describing the CheckInputs() function is no longer accurate.

13:10 < jnewbery> Note that the CheckInputs function is slightly confusingly named (and the comment above is incorrect in parts)
13:11 < jnewbery> The comment says "Check whether all inputs of this transaction are valid (no double spends, scripts & sigs, amounts)
13:11 < jnewbery> historically, that was true (it'd check amounts and doublespends). Now it only checks scripts and sigs.

CheckInputs() no longer checks amounts and double spends and so I have deleted double spends and amounts from the comment.

@jnewbery also noted that CheckInputs() is confusingly named and so the function name should be replaced. 

If there is an obvious function name replacement then perhaps replacing the function name should be included in this PR. For now I thought it best to just change the comment and open an issue on what this function name replacement should be. I don't know if there is an obvious replacement. If that is a suboptimal approach please comment below.


