### PR TITLE
rpc: Human readable network services

### DIFF
--- a/doc/release-notes-16787.md
+++ b/doc/release-notes-16787.md
@@ -1,0 +1,3 @@
+RPC changes
+-----------
+The `getnetworkinfo` and `getpeerinfo` commands now contain a new field with decoded network service flags.

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -82,6 +82,10 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             "    \"addrbind\":\"ip:port\",    (string) Bind address of the connection to the peer\n"
             "    \"addrlocal\":\"ip:port\",   (string) Local address as reported by the peer\n"
             "    \"services\":\"xxxxxxxxxxxxxxxx\",   (string) The services offered\n"
+            "    \"servicesnames\":[              (array) the services offered, in human-readable form\n"
+            "        \"SERVICE_NAME\",         (string) the service name if it is recognised\n"
+            "         ...\n"
+            "     ],\n"
             "    \"relaytxes\":true|false,    (boolean) Whether peer has asked us to relay transactions to it\n"
             "    \"lastsend\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last send\n"
             "    \"lastrecv\": ttt,           (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the last receive\n"
@@ -147,6 +151,7 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         if (stats.addrBind.IsValid())
             obj.pushKV("addrbind", stats.addrBind.ToString());
         obj.pushKV("services", strprintf("%016x", stats.nServices));
+        obj.pushKV("servicesnames", GetServicesNames(stats.nServices));
         obj.pushKV("relaytxes", stats.fRelayTxes);
         obj.pushKV("lastsend", stats.nLastSend);
         obj.pushKV("lastrecv", stats.nLastRecv);
@@ -446,6 +451,10 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
             "  \"subversion\": \"/Satoshi:x.x.x/\",     (string) the server subversion string\n"
             "  \"protocolversion\": xxxxx,              (numeric) the protocol version\n"
             "  \"localservices\": \"xxxxxxxxxxxxxxxx\", (string) the services we offer to the network\n"
+            "  \"localservicesnames\": [                (array) the services we offer to the network, in human-readable form\n"
+            "      \"SERVICE_NAME\",                    (string) the service name\n"
+            "       ...\n"
+            "   ],\n"
             "  \"localrelay\": true|false,              (bool) true if transaction relay is requested from peers\n"
             "  \"timeoffset\": xxxxx,                   (numeric) the time offset\n"
             "  \"connections\": xxxxx,                  (numeric) the number of connections\n"
@@ -484,8 +493,11 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
     obj.pushKV("version",       CLIENT_VERSION);
     obj.pushKV("subversion",    strSubVersion);
     obj.pushKV("protocolversion",PROTOCOL_VERSION);
-    if(g_connman)
-        obj.pushKV("localservices", strprintf("%016x", g_connman->GetLocalServices()));
+    if (g_connman) {
+        ServiceFlags services = g_connman->GetLocalServices();
+        obj.pushKV("localservices", strprintf("%016x", services));
+        obj.pushKV("localservicesnames", GetServicesNames(services));
+    }
     obj.pushKV("localrelay", g_relay_txes);
     obj.pushKV("timeoffset",    GetTimeOffset());
     if (g_connman) {

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -733,3 +733,21 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
     }
     return ret;
 }
+
+UniValue GetServicesNames(ServiceFlags services)
+{
+    UniValue servicesNames(UniValue::VARR);
+
+    if (services & NODE_NETWORK)
+        servicesNames.push_back("NETWORK");
+    if (services & NODE_GETUTXO)
+        servicesNames.push_back("GETUTXO");
+    if (services & NODE_BLOOM)
+        servicesNames.push_back("BLOOM");
+    if (services & NODE_WITNESS)
+        servicesNames.push_back("WITNESS");
+    if (services & NODE_NETWORK_LIMITED)
+        servicesNames.push_back("NETWORK_LIMITED");
+
+    return servicesNames;
+}

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -8,6 +8,7 @@
 #include <node/transaction.h>
 #include <outputtype.h>
 #include <pubkey.h>
+#include <protocol.h>
 #include <rpc/protocol.h>
 #include <rpc/request.h>
 #include <script/script.h>
@@ -89,6 +90,9 @@ std::pair<int64_t, int64_t> ParseDescriptorRange(const UniValue& value);
 
 /** Evaluate a descriptor given as a string, or as a {"desc":...,"range":...} object, with default range of 1000. */
 std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, FlatSigningProvider& provider);
+
+/** Returns, given services flags, a list of humanly readable (known) network services */
+UniValue GetServicesNames(ServiceFlags services);
 
 struct RPCArg {
     enum class Type {


### PR DESCRIPTION
This is a reopen of https://github.com/bitcoin/bitcoin/pull/15511#issuecomment-527087370 since there have been concept ACKs from sdaftuar and Sjors.

This adds a new entry to `getpeerinfo` and `getnetworkinfo` which decodes the network services flags.

Here is a truncated output of `getpeerinfo`:
```
"services": "000000000000040d",
"servicesnames": "NETWORK | BLOOM | WITNESS | NETWORK_LIMITED",
"relaytxes": true,
```
And one of `getnetworkinfo`:
```
"localservices": "0000000000000409",
"localservicesnames": "NETWORK | WITNESS | NETWORK_LIMITED",
"localrelay": true,
```

Fixes #16780.