### PR TITLE
break loop early on undefined version bits

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1618,7 +1618,7 @@ private:
 public:
     explicit WarningBitsConditionChecker(int bitIn) : bit(bitIn) {}
 
-    int64_t BeginTime(const Consensus::Params& params) const override { return 0; }
+    int64_t BeginTime(const Consensus::Params& params) const override { return std::numeric_limits<int64_t>::max(); }
     int64_t EndTime(const Consensus::Params& params) const override { return std::numeric_limits<int64_t>::max(); }
     int Period(const Consensus::Params& params) const override { return params.nMinerConfirmationWindow; }
     int Threshold(const Consensus::Params& params) const override { return params.nRuleChangeActivationThreshold; }


### PR DESCRIPTION
Addresses #16697 as a light alternative to #16704 

This will set all states to DEFINED instead of STARTED and there for skip counting blocks and computing down.
