### PR TITLE
scripts: Add convenience script for committing scripted-diffs from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/*.sh
 *.tar.gz
 
 *.exe

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -3,7 +3,7 @@ Contents
 This directory contains tools for developers working on this repository.
 
 clang-format-diff.py
-===================
+====================
 
 A script to format unified git diffs according to [.clang-format](../../src/.clang-format).
 
@@ -15,6 +15,18 @@ the script should be called from the git root folder as follows.
 ```
 git diff -U0 HEAD~1.. | ./contrib/devtools/clang-format-diff.py -p1 -i -v
 ```
+
+commit-scripted-diff.sh
+=======================
+
+Commits a [scripted-diff](/doc/developer-notes.md#scripted-diffs) from a script or text file.
+This avoids manually copying the script when building the commit. To use from a clean `git status`:
+
+1. Run the script to apply changes (`sed` or similar)
+2. `git add -A` to stage all changes
+3. `./contrib/devtools/commit-scripted-diff.sh <script_filename> <commit_message> [commit_description]`
+
+To further customize the commit message, `git commit --amend`.
 
 copyright\_header.py
 ====================

--- a/contrib/devtools/commit-scripted-diff.sh
+++ b/contrib/devtools/commit-scripted-diff.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Commits a scripted-diff from a script or text file.
+
+export LC_ALL=C
+
+SCRIPT_FILE=$1
+TITLE=$2
+DESCRIPTION=$3
+
+git commit -m "scripted-diff: $TITLE" \
+-m "$DESCRIPTION" \
+-m "
+-BEGIN VERIFY SCRIPT-
+$(cat $SCRIPT_FILE)
+-END VERIFY SCRIPT-
+"
+
+# You may now clean up the script file.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -843,16 +843,18 @@ the result of the script is identical to the commit. This aids reviewers since t
 does exactly what it's supposed to do. It is also helpful for rebasing (since the same script can just be re-run
 on the new master commit).
 
-To create a scripted-diff:
+To create a scripted-diff, use [`commit-scripted-diff.sh`](/contrib/devtools/README.md#commit-scripted-diff.sh).
 
-- start the commit message with `scripted-diff:` (and then a description of the diff on the same line)
-- in the commit message include the bash script between lines containing just the following text:
+This will automatically:
+
+- start the commit message with `scripted-diff: `
+- in the commit message, include the bash script between two lines:
     - `-BEGIN VERIFY SCRIPT-`
     - `-END VERIFY SCRIPT-`
 
-The scripted-diff is verified by the tool `test/lint/commit-script-check.sh`. The tool's default behavior, when supplied
-with a commit is to verify all scripted-diffs from the beginning of time up to said commit. Internally, the tool passes
-the first supplied argument to `git rev-list --reverse` to determine which commits to verify script-diffs for, ignoring
+The scripted-diff can be verified by running `./test/lint/commit-script-check.sh <commit>`. The tool's default behavior
+is to verify all scripted-diffs from the beginning of time up to said commit. Internally, the tool passes
+the first supplied argument to `git rev-list --reverse` to determine which commits should be verified, ignoring
 commits that don't conform to the commit message format described above.
 
 For development, it might be more convenient to verify all scripted-diffs in a range `A..B`, for example:


### PR DESCRIPTION
#### When creating a `scripted-diff` commit, a developer currently needs to:
- Locate and read the [Developer Notes on scripted-diffs](https://github.com/bitcoin/bitcoin/tree/master/doc/developer-notes.md#scripted-diffs)
- Write a script
- Debug it, possibly over multiple attempts
- Add `scripted-diff: ` to the beginning of the commit message & PR title
- Add the script(s) to the commit body
- Add `-BEGIN VERIFY SCRIPT-` and `-END VERIFY SCRIPT-` around the script

I found copying the above text into the editor during `git commit` to be a manual and repetitive part of building these commits.

#### This approach allows a simpler workflow for testing, applying, and committing these scripts. A developer can now:
- Create a working script file, e.g. `0.sh`
- Run `0.sh` to apply the changes, `git diff` to examine them, and perhaps `git checkout` to refresh and retry over multiple attempts. When desired, `git add` the changes.
- Run ```./contrib/devtools/commit-scripted-diff 0.sh "docs: Rename X to x globally"```

#### Improvements that could be made to this script:
- Further input validation
- Run `test/lint/commit-script-check.sh` against the most recent commit(s)
- Use `git commit -t <template_file>`, which would instead drop the user off in the editor at `COMMIT_EDITMSG` with pre-filled text. We would need to create `template_file` on the fly.
- ~Add to Developer Notes and Devtools~
- ~Copyright info~

Feedback appreciated; thank you!