### PR TITLE
faster & less memory for sync: bulk pool allocator for node based containers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -191,6 +191,7 @@ BITCOIN_CORE_H = \
   script/standard.h \
   shutdown.h \
   streams.h \
+  support/allocators/bulk_pool.h \
   support/allocators/secure.h \
   support/allocators/zeroafterfree.h \
   support/cleanse.h \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -16,6 +16,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.cpp \
   bench/bench.h \
   bench/block_assemble.cpp \
+  bench/bulk_pool.cpp \
   bench/checkblock.cpp \
   bench/checkqueue.cpp \
   bench/data.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -102,6 +102,7 @@ BITCOIN_TESTS =\
   test/blockfilter_tests.cpp \
   test/blockfilter_index_tests.cpp \
   test/bloom_tests.cpp \
+  test/bulk_pool_tests.cpp \
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \

--- a/src/bench/bulk_pool.cpp
+++ b/src/bench/bulk_pool.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <coins.h>
+#include <support/allocators/bulk_pool.h>
+
+#include <unordered_map>
+
+template <typename Map>
+void BenchFillClearMap(benchmark::State& state, Map& map)
+{
+    COutPoint p;
+    while (state.KeepRunning()) {
+        // modify hash. We don't need to check if big/little endian, just modify.
+        ++*reinterpret_cast<uint64_t*>(p.hash.begin());
+        map[p];
+        if (map.size() > 50000) {
+            map.clear();
+        }
+    }
+}
+
+static void BulkPool_StdUnorderedMap(benchmark::State& state)
+{
+    using Map = std::unordered_map<COutPoint, CCoinsCacheEntry, SaltedOutpointHasher>;
+    Map map;
+    BenchFillClearMap(state, map);
+}
+
+static void BulkPool_StdMap(benchmark::State& state)
+{
+    using Map = std::map<COutPoint, CCoinsCacheEntry>;
+    Map map;
+    BenchFillClearMap(state, map);
+}
+
+static void BulkPool_StdUnorderedMap_Enabled(benchmark::State& state)
+{
+    using Map = std::unordered_map<COutPoint, CCoinsCacheEntry, SaltedOutpointHasher, std::equal_to<COutPoint>, bulk_pool::Allocator<std::pair<const COutPoint, CCoinsCacheEntry>>>;
+    bulk_pool::Pool pool;
+    Map map(0, Map::hasher{}, Map::key_equal{}, Map::allocator_type{&pool});
+    BenchFillClearMap(state, map);
+}
+
+static void BulkPool_StdMap_Enabled(benchmark::State& state)
+{
+    using Map = std::map<COutPoint, CCoinsCacheEntry, std::less<COutPoint>, bulk_pool::Allocator<std::pair<const COutPoint, CCoinsCacheEntry>>>;
+    bulk_pool::Pool pool;
+    Map map(Map::key_compare{}, Map::allocator_type{&pool});
+    BenchFillClearMap(state, map);
+}
+
+BENCHMARK(BulkPool_StdUnorderedMap, 5000000);
+BENCHMARK(BulkPool_StdMap, 5000000);
+BENCHMARK(BulkPool_StdUnorderedMap_Enabled, 5000000);
+BENCHMARK(BulkPool_StdMap_Enabled, 5000000);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -33,7 +33,7 @@ size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 
 SaltedOutpointHasher::SaltedOutpointHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), cachedCoinsUsage(0) {}
+CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn) {}
 
 size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -159,8 +159,8 @@ static inline size_t DynamicUsage(const std::unordered_set<X, Y>& s)
     return MallocUsage(sizeof(unordered_node<X>)) * s.size() + MallocUsage(sizeof(void*) * s.bucket_count());
 }
 
-template<typename X, typename Y, typename Z>
-static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z>& m)
+template<typename X, typename Y, typename Z, typename E, typename A>
+static inline size_t DynamicUsage(const std::unordered_map<X, Y, Z, E, A>& m)
 {
     return MallocUsage(sizeof(unordered_node<std::pair<const X, Y> >)) * m.size() + MallocUsage(sizeof(void*) * m.bucket_count());
 }

--- a/src/support/allocators/bulk_pool.h
+++ b/src/support/allocators/bulk_pool.h
@@ -1,0 +1,351 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_SUPPORT_ALLOCATORS_BULK_POOL_H
+#define BITCOIN_SUPPORT_ALLOCATORS_BULK_POOL_H
+
+#include <cstddef>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace bulk_pool {
+
+/// This pool allocates one object (memory block) at a time. The first call to allocate determine
+/// the size of chunks in the pool. Subsequent calls with other types of different size will
+/// return nullptr. It is designed for use in node-based container like std::unordered_map or
+/// std::list, where most allocations are for 1 element. It allocates increasingly large blocks
+/// of memory, and only deallocates at destruction.
+///
+/// The size of the allocated blocks are doubled until NUM_CHUNKS_ALLOC_MAX is reached. This way we
+/// don't have too large an overhead for small pool usage, and still get efficiency for lots of
+/// elements since number of mallocs() are very reduced. Also, less bookkeeping is necessary, so
+/// it's more space efficient than allocating one chunk at a time.
+///
+/// Deallocate() does not actually free memory, but puts the data into a linked list which can then
+/// be used for allocate() calls when 1 element is requested. The linked list is in place, reusing
+/// the memory of the chunks.
+///
+/// Memory layout
+///
+///  m_blocks
+///        v
+///    [ BlockNode, chunk0, chunk1, ... chunk3] // block 0
+///        v
+///    [ BlockNode, chunk0, chunk1, ... chunk7] // block 1
+///        :
+///    [ BlockNode, chunk0, chunk1, ... chunk16383] // block 12
+///        v
+///    [ BlockNode, chunk0, chunk1, ... chunk16383] // block 13
+///        v
+///      nullptr
+///
+/// m_free_chunks represents a singly linked list of all T's that have been deallocated.
+class Pool
+{
+public:
+    // Inplace linked list of all allocated blocks. Make sure it is aligned in such a way that whatever comes
+    // after a BlockNode is correctly aligned.
+    struct alignas(alignof(::max_align_t)) BlockNode {
+        // make sure to align
+        BlockNode* next;
+    };
+
+    // Inplace linked list of the allocation chunks
+    struct ChunkNode {
+        ChunkNode* next;
+    };
+
+    /// Explicitly specify the Pool's chunk size. It will only allocate chunks of this size, returning
+    /// nullptr if a type of different size is specified. If set to 0, the first Allocate() call will
+    /// determine the chunk size of the pool.
+    explicit Pool(size_t chunk_size) noexcept
+        : m_chunk_size(chunk_size)
+    {
+    }
+
+    /// Doesn't specify the chunk size, so it's determined by the first call to Allocate.
+    Pool() = default;
+
+    // Don't allow moving/copying a pool, it's dangerous
+    Pool(Pool&&) = delete;
+    Pool& operator=(Pool&&) = delete;
+    Pool(const Pool&) = delete;
+    Pool& operator=(const Pool&) = delete;
+
+    /// Deallocates all allocated memory, even when Deallocate() was not yet called.
+    ~Pool() noexcept
+    {
+        Destroy();
+    }
+
+    /// Don't allow allocation for types that are smaller than a Node. This does not make sense
+    /// because we need to fit a pointer into the memory.
+    /// We return nullptr instead of producing a compile error so bulk_pool::Allocator<T>::allocate(size_t n)
+    /// does not need any special handling.
+    template <typename T, typename std::enable_if<sizeof(T) < sizeof(ChunkNode), int>::type = 0>
+    T* Allocate() noexcept
+    {
+        return nullptr;
+    }
+
+    /// As with Allocate(), don't allow for types that are smaller than a Node.
+    template <typename T, typename std::enable_if<sizeof(T) < sizeof(ChunkNode), int>::type = 0>
+    bool Deallocate() noexcept
+    {
+        return false;
+    }
+
+    /// Tries to allocate one T. If allocation is not possible, returns nullptr and the callee
+    /// has to do something else to get memory. First caller decides the size of the pool's data.
+    template <typename T, typename std::enable_if<sizeof(T) >= sizeof(ChunkNode), int>::type = 0>
+    T* Allocate()
+    {
+        if (m_chunk_size == 0) {
+            // allocator not yet used, so this type determines the size.
+            m_chunk_size = sizeof(T);
+        } else if (m_chunk_size != sizeof(T)) {
+            // allocator's size does not match sizeof(T), don't allocate.
+            return nullptr;
+        }
+
+        // Make sure we have memory available
+        if (m_free_chunks == nullptr) {
+            AllocateAndCreateFreelist();
+        }
+
+        // pop one element from the linked list, returning previous head
+        auto old_head = m_free_chunks;
+        m_free_chunks = old_head->next;
+        return reinterpret_cast<T*>(old_head);
+    }
+
+    /// Puts p back into the freelist, if it was the correct size. Only allowed with objects
+    /// that were allocated with this pool!
+    template <typename T, typename std::enable_if<sizeof(T) >= sizeof(ChunkNode), int>::type = 0>
+    bool Deallocate(T* p) noexcept
+    {
+        if (m_chunk_size != sizeof(T)) {
+            // allocation didn't happen with this allocator
+            return false;
+        }
+
+        // put it into the linked list
+        auto n = reinterpret_cast<ChunkNode*>(p);
+        n->next = m_free_chunks;
+        m_free_chunks = n;
+        return true;
+    }
+
+    /// Deallocates all allocated memory, even when Deallocate() was not yet called. Use with care!
+    void Destroy() noexcept
+    {
+        while (m_blocks != nullptr) {
+            auto old_head = m_blocks;
+            m_blocks = m_blocks->next;
+            ::operator delete(old_head);
+        }
+        m_free_chunks = nullptr;
+    }
+
+    /// Counts number of free entries in the freelist. This is an O(n) operation. Mostly for debugging / logging / testing.
+    size_t NumFreeChunks() const
+    {
+        return CountNodes(m_free_chunks);
+    }
+
+    /// Counts number of allocated blocks. This is an O(n) operation. Mostly for debugging / logging / testing.
+    size_t NumBlocks() const
+    {
+        return CountNodes(m_blocks);
+    }
+
+    /// Size per chunk
+    size_t ChunkSize() const
+    {
+        return m_chunk_size;
+    }
+
+private:
+    //! Minimum number of chunks to allocate for the first block
+    static constexpr size_t NUM_CHUNKS_ALLOC_MIN = 4;
+
+    //! Maximum number of chunks to allocate in one block
+    static constexpr size_t NUM_CHUNKS_ALLOC_MAX = 16384;
+
+    // Counts list length by iterating until nullptr is reached.
+    template <typename N>
+    size_t CountNodes(N* node) const
+    {
+        size_t length = 0;
+        while (node != nullptr) {
+            node = node->next;
+            ++length;
+        }
+        return length;
+    }
+
+    /// Called when no memory is available (m_free_chunks == nullptr).
+    void AllocateAndCreateFreelist()
+    {
+        auto num_chunks = CalcNumChunksToAlloc();
+        auto data = ::operator new(sizeof(BlockNode) + m_chunk_size * num_chunks);
+
+        // link block into blocklist
+        auto block = reinterpret_cast<BlockNode*>(data);
+        block->next = m_blocks;
+        m_blocks = block;
+
+        m_free_chunks = MakeFreelist(block, num_chunks);
+    }
+
+    /// Doubles number of elements to alloc until max is reached.
+    size_t CalcNumChunksToAlloc() noexcept
+    {
+        if (m_num_chunks_alloc >= NUM_CHUNKS_ALLOC_MAX) {
+            return NUM_CHUNKS_ALLOC_MAX;
+        }
+        auto prev = m_num_chunks_alloc;
+        m_num_chunks_alloc *= 2;
+        return prev;
+    }
+
+    /// Integrates a previously allocated block of memory (where n > 1) into the linked list
+    ChunkNode* MakeFreelist(BlockNode* block, const size_t num_elements) noexcept
+    {
+        // skip BlockNode to get to the chunks
+        auto const data = reinterpret_cast<char*>(block + 1);
+
+        // interlink all chunks
+        for (size_t i = 0; i < num_elements; ++i) {
+            reinterpret_cast<ChunkNode*>(data + i * m_chunk_size)->next = reinterpret_cast<ChunkNode*>(data + (i + 1) * m_chunk_size);
+        }
+
+        // last one points nullptr
+        reinterpret_cast<ChunkNode*>(data + (num_elements - 1) * m_chunk_size)->next = nullptr;
+        return reinterpret_cast<ChunkNode*>(data);
+    }
+
+    //! A single linked list of all data available in the pool. This list is used for allocations of single elements.
+    ChunkNode* m_free_chunks{nullptr};
+
+    //! A single linked list of all allocated blocks of memory, used to free the data in the destructor.
+    BlockNode* m_blocks{nullptr};
+
+    //! The pool's size for the memory blocks. First call to Allocate() determines the used size.
+    size_t m_chunk_size{0};
+
+    //! Number of elements to allocate in bulk. Doubles each time, until m_max_num_allocs is reached.
+    size_t m_num_chunks_alloc{NUM_CHUNKS_ALLOC_MIN};
+};
+
+/// Allocator that's usable for node-based containers like std::unorderd_map or std::list. It requires a Pool
+/// which will be used for allocations of n==1. The pool's memory is only actually freed when the pool's
+/// destructor is called, otherwise previously allocated memory will be put back into the pool for further use.
+///
+/// Be aware that this allocator assumes that the containers will call allocate(1) to allocate nodes, otherwise
+/// the pool won't be used. Also, it assumes that the *first* call to allocate(1) is done with the actual node
+/// size. Only subsequent allocate(1) calls with the same sizeof(T) will make use of the allocator.
+template <typename T>
+class Allocator
+{
+    template <typename U>
+    friend class Allocator;
+
+    template <typename X, typename Y>
+    friend bool operator==(const Allocator<X>& a, const Allocator<Y>& b) noexcept;
+
+public:
+    using value_type = T;
+
+    //! Note: when two containers a and b have different pools and a=b is called, we replace a's allocator with b's.
+    using propagate_on_container_copy_assignment = std::true_type;
+    using propagate_on_container_move_assignment = std::true_type;
+    using propagate_on_container_swap = std::true_type;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = size_t;
+    using difference_type = std::ptrdiff_t;
+
+    template <typename U>
+    struct rebind {
+        using other = Allocator<U>;
+    };
+
+    explicit Allocator(Pool* pool) noexcept
+        : m_pool(pool)
+    {
+    }
+
+    /// Conversion constructor, all Allocators use the same pool.
+    template <typename U>
+    Allocator(const Allocator<U>& other) noexcept
+        : m_pool(other.m_pool)
+    {
+    }
+
+    /// Allocates n entries. When n==1, the pool is used. The pool might return nullptr if sizeof(T)
+    /// does not match the pool's chunk size. In that case, we fall back to new().
+    /// This method should be kept short so it's easily inlineable.
+    T* allocate(size_t n)
+    {
+        if (n == 1) {
+            auto r = m_pool->Allocate<T>();
+            if (r != nullptr) {
+                return r;
+            }
+        }
+        return reinterpret_cast<T*>(::operator new(n * sizeof(T)));
+    }
+
+    /// If n==1, we might have gotten the object from the pool. This is not the case when sizeof(T) does
+    /// not match the pool's chunk size. In that case, we fall back to delete().
+    void deallocate(T* p, std::size_t n)
+    {
+        if (n == 1 && m_pool->Deallocate(p)) {
+            return;
+        }
+        ::operator delete(p);
+    }
+
+    /// According to the standard, destroy() is an optional Allocator requirement since C++11.
+    /// It seems only g++4.8 requires that this method is present, that's why it is here. It
+    /// is deprecated in C++17 and removed in C++20.
+    ///
+    /// Calls p->~U().
+    /// see https://en.cppreference.com/w/cpp/memory/allocator/destroy
+    template <typename U>
+    void destroy(U* p)
+    {
+        p->~U();
+    }
+
+    template <class U, class... Args>
+    void construct(U* p, Args&&... args)
+    {
+        ::new ((void*)p) U(std::forward<Args>(args)...);
+    }
+
+private:
+    Pool* m_pool;
+};
+
+/// Since Allocator is stateful, comparison with another one only returns true if it uses the same pool.
+template <typename T, typename U>
+bool operator==(const Allocator<T>& a, const Allocator<U>& b) noexcept
+{
+    return a.m_pool == b.m_pool;
+}
+
+template <typename T, typename U>
+bool operator!=(const Allocator<T>& a, const Allocator<U>& b) noexcept
+{
+    return !(a == b);
+}
+
+} // namespace bulk_pool
+
+#endif // BITCOIN_SUPPORT_ALLOCATORS_BULK_POOL_H

--- a/src/test/bulk_pool_tests.cpp
+++ b/src/test/bulk_pool_tests.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <support/allocators/bulk_pool.h>
+
+#include <test/setup_common.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <list>
+#include <map>
+#include <string>
+#include <unordered_map>
+
+BOOST_FIXTURE_TEST_SUITE(bulk_pool_tests, BasicTestingSetup)
+
+void check(const bulk_pool::Pool& pool, size_t chunk_size, size_t num_free_chunks, size_t num_blocks)
+{
+    BOOST_CHECK_EQUAL(chunk_size, pool.ChunkSize());
+    BOOST_CHECK_EQUAL(num_free_chunks, pool.NumFreeChunks());
+    BOOST_CHECK_EQUAL(num_blocks, pool.NumBlocks());
+}
+
+BOOST_AUTO_TEST_CASE(specified_size)
+{
+    auto constexpr s = sizeof(std::string);
+    bulk_pool::Pool pool(s);
+    check(pool, s, 0, 0);
+
+    // can't allocate something of the wrong size
+    BOOST_CHECK(nullptr == pool.Allocate<int>());
+    check(pool, s, 0, 0);
+
+    std::string* data = pool.Allocate<std::string>();
+    BOOST_CHECK(nullptr != data);
+    // Block of 4 chunks allocated, one is returned => 3 remaining free
+    check(pool, s, 3, 1);
+
+    pool.Deallocate(data);
+    check(pool, s, 4, 1);
+
+    BOOST_CHECK(nullptr != pool.Allocate<std::string>());
+    check(pool, s, 3, 1);
+    BOOST_CHECK(nullptr != pool.Allocate<std::string>());
+    check(pool, s, 2, 1);
+    BOOST_CHECK(nullptr != pool.Allocate<std::string>());
+    check(pool, s, 1, 1);
+    BOOST_CHECK(nullptr != pool.Allocate<std::string>());
+    check(pool, s, 0, 1);
+    // another block of 8 chunks is allocated, and one returned
+    BOOST_CHECK(nullptr != pool.Allocate<std::string>());
+    check(pool, s, 7, 2);
+}
+
+BOOST_AUTO_TEST_CASE(too_small)
+{
+    bulk_pool::Pool pool;
+    BOOST_CHECK(nullptr == pool.Allocate<char>());
+    check(pool, 0, 0, 0);
+
+    BOOST_CHECK(nullptr != pool.Allocate<void*>());
+    check(pool, sizeof(void*), 3, 1);
+}
+
+BOOST_AUTO_TEST_CASE(std_unordered_map)
+{
+    using Map = std::unordered_map<uint64_t, uint64_t, std::hash<uint64_t>, std::equal_to<uint64_t>, bulk_pool::Allocator<std::pair<const uint64_t, uint64_t>>>;
+
+    bulk_pool::Pool pool;
+    Map m(0, Map::hasher{}, Map::key_equal{}, Map::allocator_type{&pool});
+    size_t num_free_chunks = 0;
+    {
+        Map a(0, Map::hasher{}, Map::key_equal{}, Map::allocator_type{&pool});
+        for (uint64_t i = 0; i < 1000; ++i) {
+            a[i] = i;
+        }
+
+        num_free_chunks = pool.NumFreeChunks();
+
+        // create a copy of the map, destroy the map => now a lot more free chunks should be available
+        {
+            Map b = a;
+        }
+
+        BOOST_CHECK(pool.NumFreeChunks() > num_free_chunks);
+        num_free_chunks = pool.NumFreeChunks();
+
+        // creating another copy, and then destroying everything should reuse all the chunks
+        {
+            Map b = a;
+        }
+        BOOST_CHECK_EQUAL(pool.NumFreeChunks(), num_free_chunks);
+
+        // moving the map should not create new nodes
+        m = std::move(a);
+        BOOST_CHECK_EQUAL(pool.NumFreeChunks(), num_free_chunks);
+    }
+    // a is destroyed, still all chunks should stay roughly the same.
+    BOOST_CHECK(pool.NumFreeChunks() <= num_free_chunks + 5);
+
+    m = Map(0, Map::hasher{}, Map::key_equal{}, Map::allocator_type{&pool});
+
+    // now we got everything free
+    BOOST_CHECK(pool.NumFreeChunks() > num_free_chunks + 50);
+}
+
+BOOST_AUTO_TEST_CASE(std_unordered_map_different_pool)
+{
+    using Map = std::unordered_map<uint64_t, uint64_t, std::hash<uint64_t>, std::equal_to<uint64_t>, bulk_pool::Allocator<std::pair<const uint64_t, uint64_t>>>;
+
+    bulk_pool::Pool pool_a;
+    bulk_pool::Pool pool_b;
+
+    Map map_a(0, Map::hasher{}, Map::key_equal{}, Map::allocator_type{&pool_a});
+    Map map_b(0, Map::hasher{}, Map::key_equal{}, Map::allocator_type{&pool_b});
+
+    for (int i = 0; i < 100; ++i) {
+        map_a[i] = i;
+        map_b[i] = i;
+    }
+
+    // all the same, so far.
+    BOOST_CHECK_EQUAL(pool_a.NumFreeChunks(), pool_b.NumFreeChunks());
+    map_a = map_b;
+    // note that map_a now uses pool_b, since propagate_on_container_copy_assignment is std::true_type!
+    // pool_a is not needed any more and can be destroyed.
+    pool_a.Destroy();
+
+    // add some more data to a, should be fine
+    for (int i = 100; i < 200; ++i) {
+        map_a[i] = i;
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -592,7 +592,8 @@ void GetCoinsMapEntry(const CCoinsMap& map, CAmount& value, char& flags)
 
 void WriteCoinsViewEntry(CCoinsView& view, CAmount value, char flags)
 {
-    CCoinsMap map;
+    bulk_pool::Pool pool;
+    CCoinsMap map(0, CCoinsMap::hasher{}, CCoinsMap::key_equal{}, CCoinsMap::allocator_type{&pool});
     InsertCoinsMapEntry(map, value, flags);
     BOOST_CHECK(view.BatchWrite(map, {}));
 }


### PR DESCRIPTION
This is a custom allocator for node based containers, as described in https://github.com/bitcoin/bitcoin/pull/16718#issuecomment-525878177. Hopefully, this is a less controversial change and easier to review than https://github.com/bitcoin/bitcoin/pull/16718.

The allocator retains memory of nodes, and allocates them in bulk. In my benchmarks, using this pool allocator for `CCoinsMap` gives about 16% faster `-reindex-chainstate`, and decreases memory usage by ~8%. The allocator is potentially useful for all node-based containers like `std::list`, `std::map`, `std::unordered_map`, etc. I believe this is especially useful on systems where malloc() and free() are relatively expensive operations, since this allocator will dramatically reduce these calls.

Some noteworthy properties about this allocator:

* It relies on the fact that node based containers allocate nodes one at a time. If a container doesn't behave like this, the allocator will still work but won't be any faster.

* The allocator determines the size of the nodes, which will then be used throughout the pool, by the first call to allocate(1). So if the container would not allocate something with the size of a node in its first call to allocate(1), the pool won't be usable for nodes since it was set up with a different size. With C++17 it would be possible to use a containers type `node_type` to correctly initialize the pool's size, but for now we have to rely on this heuristic.

* Copying / moving / swapping a map propagates the allocator. So if two different pools are used for two containers a and b, calling `a = b` will from now on use b's pool in a.

* The pool is not threadsafe. Two containers which use the same pool in different threads won't work.

* A pool's memory is only actually destroyed in the pool's destructor.

I've added a benchmark to compare std::map, std::unordered_map with and without the pool allocator for the `CCoinsMap`. 