### PR TITLE
test: Remove unused try-block in assert_debug_log

### DIFF
--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -26,7 +26,7 @@ class SetBanTests(BitcoinTestFramework):
         self.nodes[1].setban("127.0.0.1", "add")
 
         # Node 0 should not be able to reconnect
-        with self.nodes[1].assert_debug_log(expected_msgs=['dropped (banned)\n'],timeout=5):
+        with self.nodes[1].assert_debug_log(expected_msgs=['dropped (banned)\n'], timeout=5):
             self.restart_node(1, [])
             self.nodes[0].addnode("127.0.0.1:" + str(p2p_port(1)), "onetry")
 

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -313,24 +313,24 @@ class TestNode():
         with open(debug_log, encoding='utf-8') as dl:
             dl.seek(0, 2)
             prev_size = dl.tell()
-        try:
-            yield
-        finally:
-            while True:
-                found = True
-                with open(debug_log, encoding='utf-8') as dl:
-                    dl.seek(prev_size)
-                    log = dl.read()
-                print_log = " - " + "\n - ".join(log.splitlines())
-                for expected_msg in expected_msgs:
-                    if re.search(re.escape(expected_msg), log, flags=re.MULTILINE) is None:
-                        found = False
-                if found:
-                    return
-                if time.time() >= time_end:
-                    break
-                time.sleep(0.05)
-            self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
+
+        yield
+
+        while True:
+            found = True
+            with open(debug_log, encoding='utf-8') as dl:
+                dl.seek(prev_size)
+                log = dl.read()
+            print_log = " - " + "\n - ".join(log.splitlines())
+            for expected_msg in expected_msgs:
+                if re.search(re.escape(expected_msg), log, flags=re.MULTILINE) is None:
+                    found = False
+            if found:
+                return
+            if time.time() >= time_end:
+                break
+            time.sleep(0.05)
+        self._raise_assertion_error('Expected messages "{}" does not partially match log:\n\n{}\n\n'.format(str(expected_msgs), print_log))
 
     @contextlib.contextmanager
     def assert_memory_usage_stable(self, *, increase_allowed=0.03):


### PR DESCRIPTION
This try block has accidentally been added by me in fa3e9f7627784ee00980590e5bf044a0e1249999.
It was unused all the time, but commit 6011c9d72d1df5c2cd09de6f85c21eb4f7eb1ba8 added a `return` in the finally block, muting all exceptions.

This can be tested by adding an `assert False` after any `with ...assert_debug_log...:` line.