### PR TITLE
depends: zlib: Move toolchain options to configure

### DIFF
--- a/depends/packages/zlib.mk
+++ b/depends/packages/zlib.mk
@@ -5,23 +5,26 @@ $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
 
 define $(package)_set_vars
-$(package)_build_opts= CC="$($(package)_cc)"
-$(package)_build_opts+=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
-$(package)_build_opts+=RANLIB="$($(package)_ranlib)"
-$(package)_build_opts+=AR="$($(package)_ar)"
-$(package)_build_opts_darwin+=AR="$($(package)_libtool)"
-$(package)_build_opts_darwin+=ARFLAGS="-o"
+$(package)_config_opts= CC="$($(package)_cc)"
+$(package)_config_opts+=CFLAGS="$($(package)_cflags) $($(package)_cppflags) -fPIC"
+$(package)_config_opts+=RANLIB="$($(package)_ranlib)"
+$(package)_config_opts+=AR="$($(package)_ar)"
+$(package)_config_opts_darwin+=AR="$($(package)_libtool)"
+$(package)_config_opts_darwin+=ARFLAGS="-o"
 endef
 
+# zlib has its own custom configure script that takes in options like CC,
+# CFLAGS, RANLIB, AR, and ARFLAGS from the environment rather than from
+# command-line arguments.
 define $(package)_config_cmds
-  ./configure --static --prefix=$(host_prefix)
+  env $($(package)_config_opts) ./configure --static --prefix=$(host_prefix)
 endef
 
 define $(package)_build_cmds
-  $(MAKE) $($(package)_build_opts) libz.a
+  $(MAKE) libz.a
 endef
 
 define $(package)_stage_cmds
-  $(MAKE) DESTDIR=$($(package)_staging_dir) install $($(package)_build_opts)
+  $(MAKE) DESTDIR=$($(package)_staging_dir) install
 endef
 


### PR DESCRIPTION
```
zlib has its own custom configure script, see comment in zlib.mk for
more details
```

Performed Guix cross-builds locally and everything worked as expected.