### PR TITLE
doc: Fix whitespace errs in .md files, bitcoin.conf, and Info.plist.in

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb48.m4
+++ b/build-aux/m4/bitcoin_find_bdb48.m4
@@ -61,7 +61,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
     BDB_CPPFLAGS=${BDB_CFLAGS}
   fi
   AC_SUBST(BDB_CPPFLAGS)
-  
+
   if test "x$BDB_LIBS" = "x"; then
     # TODO: Ideally this could find the library version and make sure it matches the headers being used
     for searchlib in db_cxx-4.8 db_cxx db4_cxx; do

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -33,12 +33,12 @@ Files used during the gitian build process. For more information about gitian, s
 PGP keys used for signing Bitcoin Core [Gitian release](/doc/release-process.md) results.
 
 ### [MacDeploy](/contrib/macdeploy) ###
-Scripts and notes for Mac builds. 
+Scripts and notes for Mac builds.
 
 ### [Gitian-build](/contrib/gitian-build.py) ###
 Script for running full Gitian builds.
 
-Test and Verify Tools 
+Test and Verify Tools
 ---------------------
 
 ### [TestGen](/contrib/testgen) ###

--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -1,7 +1,7 @@
 ### MacDeploy ###
 
 For Snow Leopard (which uses [Python 2.6](http://www.python.org/download/releases/2.6/)), you will need the param_parser package:
-	
+
 	sudo easy_install argparse
 
 This script should not be run manually, instead, after building as usual:

--- a/contrib/testgen/README.md
+++ b/contrib/testgen/README.md
@@ -2,7 +2,7 @@
 
 Utilities to generate test vectors for the data-driven Bitcoin tests.
 
-Usage: 
+Usage:
 
     PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py valid 50 > ../../src/test/data/key_io_keys_valid.json
     PYTHONPATH=../../test/functional/test_framework ./gen_key_io_test_vectors.py invalid 50 > ../../src/test/data/key_io_keys_invalid.json

--- a/depends/description.md
+++ b/depends/description.md
@@ -1,4 +1,4 @@
-This is a system of building and caching dependencies necessary for building Bitcoin. 
+This is a system of building and caching dependencies necessary for building Bitcoin.
 There are several features that make it different from most similar systems:
 
 ### It is designed to be builder and host agnostic
@@ -26,7 +26,7 @@ Before building, a unique build-id is generated for each package. This id
 consists of a hash of all files used to build the package (Makefiles, packages,
 etc), and as well as a hash of the same data for each recursive dependency. If
 any portion of a package's build recipe changes, it will be rebuilt as well as
-any other package that depends on it. If any of the main makefiles (Makefile, 
+any other package that depends on it. If any of the main makefiles (Makefile,
 funcs.mk, etc) are changed, all packages will be rebuilt. After building, the
 results are cached into a tarball that can be re-used and distributed.
 

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -32,15 +32,15 @@ These variables are optional:
 
     $(package)_build_subdir:
     cd to this dir before running configure/build/stage commands.
-    
+
     $(package)_download_file:
     The file-name of the upstream source if it differs from how it should be
     stored locally. This can be used to avoid storing file-names with strange
     characters.
-    
+
     $(package)_dependencies:
     Names of any other packages that this one depends on.
-    
+
     $(package)_patches:
     Filenames of any patches needed to build the package
 
@@ -134,7 +134,7 @@ the user. Other variables may be defined as needed.
     Stage the build results. If undefined, does nothing.
 
   The following variables are available for each recipe:
-    
+
     $(1)_staging_dir: package's destination sysroot path
     $(1)_staging_prefix_dir: prefix path inside of the package's staging dir
     $(1)_extract_dir: path to the package's extracted sources

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -81,7 +81,7 @@ $ curl localhost:18332/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff76
       {
          "txvers" : 1
          "height" : 2147483647,
-         "value" : 8.8687,		 
+         "value" : 8.8687,
          "scriptPubKey" : {
             "asm" : "OP_DUP OP_HASH160 1c7cebb529b86a04c683dfa87be49de35bcf589e OP_EQUALVERIFY OP_CHECKSIG",
             "hex" : "76a9141c7cebb529b86a04c683dfa87be49de35bcf589e88ac",

--- a/doc/init.md
+++ b/doc/init.md
@@ -53,11 +53,11 @@ Paths
 
 All three configurations assume several paths that might need to be adjusted.
 
-Binary:              `/usr/bin/bitcoind`  
-Configuration file:  `/etc/bitcoin/bitcoin.conf`  
-Data directory:      `/var/lib/bitcoind`  
+Binary:              `/usr/bin/bitcoind`
+Configuration file:  `/etc/bitcoin/bitcoin.conf`
+Data directory:      `/var/lib/bitcoind`
 PID file:            `/var/run/bitcoind/bitcoind.pid` (OpenRC and Upstart) or `/run/bitcoind/bitcoind.pid` (systemd)
-Lock file:           `/var/lock/subsys/bitcoind` (CentOS)  
+Lock file:           `/var/lock/subsys/bitcoind` (CentOS)
 
 The PID directory (if applicable) and data directory should both be owned by the
 bitcoin user and group. It is advised for security reasons to make the
@@ -83,10 +83,10 @@ OpenRC).
 
 ### macOS
 
-Binary:              `/usr/local/bin/bitcoind`  
-Configuration file:  `~/Library/Application Support/Bitcoin/bitcoin.conf`  
-Data directory:      `~/Library/Application Support/Bitcoin`  
-Lock file:           `~/Library/Application Support/Bitcoin/.lock`  
+Binary:              `/usr/local/bin/bitcoind`
+Configuration file:  `~/Library/Application Support/Bitcoin/bitcoin.conf`
+Data directory:      `~/Library/Application Support/Bitcoin`
+Lock file:           `~/Library/Application Support/Bitcoin/.lock`
 
 Installing Service Configuration
 -----------------------------------

--- a/share/examples/bitcoin.conf
+++ b/share/examples/bitcoin.conf
@@ -1,7 +1,7 @@
 ##
 ## bitcoin.conf configuration file. Lines beginning with # are comments.
 ##
- 
+
 # Network-related settings:
 
 # Note that if you use testnet or regtest, particularly with the options
@@ -97,7 +97,7 @@
 # rpcauth=bob:b2dd077cb54591a2f3139e69a897ac$4e71f08d48b4347cf8eff3815c0e25ae2e9a4340474079f55705f40574f4ec99
 
 # How many seconds bitcoin will wait for a complete RPC HTTP request.
-# after the HTTP connection is established. 
+# after the HTTP connection is established.
 #rpcclienttimeout=30
 
 # By default, only RPC connections from localhost are allowed.
@@ -108,7 +108,7 @@
 # because the rpcpassword is transmitted over the network unencrypted.
 
 # server=1 tells Bitcoin-Qt to accept JSON-RPC commands.
-# it is also read by bitcoind to determine if RPC should be enabled 
+# it is also read by bitcoind to determine if RPC should be enabled
 #rpcallowip=10.1.1.34/255.255.255.0
 #rpcallowip=1.2.3.4/24
 #rpcallowip=2001:db8:85a3:0:0:8a2e:370:7334/96
@@ -139,11 +139,11 @@
 # both prior transactions and several dozen future transactions.
 #keypool=100
 
-# Enable pruning to reduce storage requirements by deleting old blocks. 
+# Enable pruning to reduce storage requirements by deleting old blocks.
 # This mode is incompatible with -txindex and -rescan.
 # 0 = default (no pruning).
 # 1 = allows manual pruning via RPC.
-# >=550 = target to stay under in MiB. 
+# >=550 = target to stay under in MiB.
 #prune=550
 
 # User interface options

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -30,7 +30,7 @@
 
   <key>CFBundleExecutable</key>
   <string>Bitcoin-Qt</string>
-  
+
   <key>CFBundleName</key>
   <string>Bitcoin-Qt</string>
 
@@ -99,7 +99,7 @@
 
   <key>NSRequiresAquaSystemAppearance</key>
     <string>True</string>
-  
+
   <key>LSApplicationCategoryType</key>
     <string>public.app-category.finance</string>
 </dict>


### PR DESCRIPTION
Although there is an existing `test/lint/lint-whitespace.sh` linter, it only prevents new errors from being introduced. This commit removes all existing whitespace errors from Core markdown files (skips `src/crypto/ctaes/`, `leveldb/`, and `doc/release-notes/`), `bitcoin.conf`, and `Info.plist.in`.

Further formatting could be done on the markdown documents, but seeing as there several coexisting styles that break a few `markdownlint` rules, a first step would be to define and add a linter to Travis. For now, the small fix is made.