### PR TITLE
rpc: Fix casing in getblockchaininfo to be inline with other fields

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1159,7 +1159,7 @@ static void BIP9SoftForkDescPushBack(UniValue& softforks, const std::string &nam
     {
         bip9.pushKV("bit", consensusParams.vDeployments[id].bit);
     }
-    bip9.pushKV("startTime", consensusParams.vDeployments[id].nStartTime);
+    bip9.pushKV("start_time", consensusParams.vDeployments[id].nStartTime);
     bip9.pushKV("timeout", consensusParams.vDeployments[id].nTimeout);
     int64_t since_height = VersionBitsTipStateSinceHeight(consensusParams, id);
     bip9.pushKV("since", since_height);
@@ -1213,7 +1213,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
             "        \"bip9\": {               (object) status of bip9 softforks (only for \"bip9\" type)\n"
             "           \"status\": \"xxxx\",    (string) one of \"defined\", \"started\", \"locked_in\", \"active\", \"failed\"\n"
             "           \"bit\": xx,           (numeric) the bit (0-28) in the block version field used to signal this softfork (only for \"started\" status)\n"
-            "           \"startTime\": xx,     (numeric) the minimum median time past of a block at which the bit gains its meaning\n"
+            "           \"start_time\": xx,     (numeric) the minimum median time past of a block at which the bit gains its meaning\n"
             "           \"timeout\": xx,       (numeric) the median time past of a block at which the deployment is considered failed if not yet locked in\n"
             "           \"since\": xx,         (numeric) height of the first block to which the status applies\n"
             "           \"statistics\": {      (object) numeric statistics about BIP9 signalling for a softfork\n"

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -134,7 +134,7 @@ class BlockchainTest(BitcoinTestFramework):
                 'bip9': {
                     'status': 'started',
                     'bit': 28,
-                    'startTime': 0,
+                    'start_time': 0,
                     'timeout': 0x7fffffffffffffff,  # testdummy does not have a timeout so is set to the max int64 value
                     'since': 144,
                     'statistics': {


### PR DESCRIPTION
The response in the RPC result `startTime` is camel cased while the rest of the response seems to be lower cased.

If this was intentional please ignore and close this PR.

Note: RPC field case changes might break existing callers
