### PR TITLE
gui: Create wallet menu option follow-ups

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -44,7 +44,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent, SecureStri
     switch(mode)
     {
         case Encrypt: // Ask passphrase x2
-            ui->warningLabel->setText(tr("Enter the new passphrase to the wallet.<br/>Please use a passphrase of <b>ten or more random characters</b>, or <b>eight or more words</b>."));
+            ui->warningLabel->setText(tr("Enter the new passphrase for the wallet.<br/>Please use a passphrase of <b>ten or more random characters</b>, or <b>eight or more words</b>."));
             ui->passLabel1->hide();
             ui->passEdit1->hide();
             setWindowTitle(tr("Encrypt wallet"));
@@ -67,7 +67,7 @@ AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent, SecureStri
             break;
         case ChangePass: // Ask old passphrase + new passphrase x2
             setWindowTitle(tr("Change passphrase"));
-            ui->warningLabel->setText(tr("Enter the old passphrase and new passphrase to the wallet."));
+            ui->warningLabel->setText(tr("Enter the old passphrase and new passphrase for the wallet."));
             break;
     }
     textChanged();

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -375,7 +375,9 @@ void BitcoinGUI::createActions()
             for (const std::pair<const std::string, bool>& i : m_wallet_controller->listWalletDir()) {
                 const std::string& path = i.first;
                 QString name = path.empty() ? QString("["+tr("default wallet")+"]") : QString::fromStdString(path);
-                // Menu items remove single &. Single & are shown when && is in the string, but only the first occurrence. So replace only the first & with &&
+                // Menu items remove single &. Single & are shown when && is in
+                // the string, but only the first occurrence. So replace only
+                // the first & with &&.
                 name.replace(name.indexOf(QChar('&')), 1, QString("&&"));
                 QAction* action = m_open_wallet_menu->addAction(name);
 

--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -25,7 +25,8 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
     });
 
     connect(ui->encrypt_wallet_checkbox, &QCheckBox::toggled, [this](bool checked) {
-        // Disable disable_privkeys_checkbox when encrypt is set to true, enable it when encrypt is false
+        // Disable the disable_privkeys_checkbox when isEncryptWalletChecked is
+        // set to true, enable it when isEncryptWalletChecked is false.
         ui->disable_privkeys_checkbox->setEnabled(!checked);
 
         // When the disable_privkeys_checkbox is disabled, uncheck it.
@@ -45,17 +46,17 @@ QString CreateWalletDialog::walletName() const
     return ui->wallet_name_line_edit->text();
 }
 
-bool CreateWalletDialog::encrypt() const
+bool CreateWalletDialog::isEncryptWalletChecked() const
 {
     return ui->encrypt_wallet_checkbox->isChecked();
 }
 
-bool CreateWalletDialog::disablePrivateKeys() const
+bool CreateWalletDialog::isDisablePrivateKeysChecked() const
 {
     return ui->disable_privkeys_checkbox->isChecked();
 }
 
-bool CreateWalletDialog::blank() const
+bool CreateWalletDialog::isMakeBlankWalletChecked() const
 {
     return ui->blank_wallet_checkbox->isChecked();
 }

--- a/src/qt/createwalletdialog.h
+++ b/src/qt/createwalletdialog.h
@@ -24,9 +24,9 @@ public:
     virtual ~CreateWalletDialog();
 
     QString walletName() const;
-    bool encrypt() const;
-    bool disablePrivateKeys() const;
-    bool blank() const;
+    bool isEncryptWalletChecked() const;
+    bool isDisablePrivateKeysChecked() const;
+    bool isMakeBlankWalletChecked() const;
 
 private:
     Ui::CreateWalletDialog *ui;

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -95,7 +95,7 @@
      <item row="3" column="1">
       <widget class="QCheckBox" name="toggleShowPasswordButton">
        <property name="text">
-        <string>Show password</string>
+        <string>Show passphrase</string>
        </property>
       </widget>
      </item>

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -62,7 +62,7 @@
     </rect>
    </property>
    <property name="toolTip">
-    <string>Encrypt the wallet. The wallet will be encrypted with a password of your choice.</string>
+    <string>Encrypt the wallet. The wallet will be encrypted with a passphrase of your choice.</string>
    </property>
    <property name="text">
     <string>Encrypt Wallet</string>

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -182,6 +182,7 @@ CreateWalletActivity::~CreateWalletActivity()
 void CreateWalletActivity::askPassphrase()
 {
     m_passphrase_dialog = new AskPassphraseDialog(AskPassphraseDialog::Encrypt, m_parent_widget, &m_passphrase);
+    m_passphrase_dialog->setWindowModality(Qt::ApplicationModal);
     m_passphrase_dialog->show();
 
     connect(m_passphrase_dialog, &QObject::destroyed, [this] {

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -179,7 +179,7 @@ CreateWalletActivity::~CreateWalletActivity()
     delete m_passphrase_dialog;
 }
 
-void CreateWalletActivity::askPasshprase()
+void CreateWalletActivity::askPassphrase()
 {
     m_passphrase_dialog = new AskPassphraseDialog(AskPassphraseDialog::Encrypt, m_parent_widget, &m_passphrase);
     m_passphrase_dialog->show();
@@ -201,10 +201,10 @@ void CreateWalletActivity::createWallet()
 
     std::string name = m_create_wallet_dialog->walletName().toStdString();
     uint64_t flags = 0;
-    if (m_create_wallet_dialog->disablePrivateKeys()) {
+    if (m_create_wallet_dialog->isDisablePrivateKeysChecked()) {
         flags |= WALLET_FLAG_DISABLE_PRIVATE_KEYS;
     }
-    if (m_create_wallet_dialog->blank()) {
+    if (m_create_wallet_dialog->isMakeBlankWalletChecked()) {
         flags |= WALLET_FLAG_BLANK_WALLET;
     }
 
@@ -246,8 +246,8 @@ void CreateWalletActivity::create()
         Q_EMIT finished();
     });
     connect(m_create_wallet_dialog, &QDialog::accepted, [this] {
-        if (m_create_wallet_dialog->encrypt()) {
-            askPasshprase();
+        if (m_create_wallet_dialog->isEncryptWalletChecked()) {
+            askPassphrase();
         } else {
             createWallet();
         }

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -75,7 +75,7 @@ void WalletController::closeWallet(WalletModel* wallet_model, QWidget* parent)
 {
     QMessageBox box(parent);
     box.setWindowTitle(tr("Close wallet"));
-    box.setText(tr("Are you sure you wish to close wallet <i>%1</i>?").arg(GUIUtil::HtmlEscape(wallet_model->getDisplayName())));
+    box.setText(tr("Are you sure you wish to close the wallet <i>%1</i>?").arg(GUIUtil::HtmlEscape(wallet_model->getDisplayName())));
     box.setInformativeText(tr("Closing the wallet for too long can result in having to resync the entire chain if pruning is enabled."));
     box.setStandardButtons(QMessageBox::Yes|QMessageBox::Cancel);
     box.setDefaultButton(QMessageBox::Yes);

--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -118,7 +118,7 @@ Q_SIGNALS:
     void created(WalletModel* wallet_model);
 
 private:
-    void askPasshprase();
+    void askPassphrase();
     void createWallet();
     void finish();
 


### PR DESCRIPTION
Closes #16820. The wallet [name escaping issue](https://github.com/bitcoin/bitcoin/pull/15450#pullrequestreview-282297760) in that issue predates #15450 and is fixed by #16826.

- [x]  rename encrypt() to encryptWallet(), and blank() to makeBlankWallet() // EDIT: updated to
        isEncryptWalletChecked()
        isDisablePrivateKeysChecked()
        isMakeBlankWalletChecked()
- [x]  fix naming of askPasshprase() to askPassphrase()
- [x]  fix passphrase labels and tooltip in createwalletdialog.ui and askpassphrasedialog.ui
- [x]  fix grammar of labels in askpassphrase dialog and WalletController::closeWallet
- [x]  fix autofocus in CreateWalletActivity::askPassphrase()

Squashed down to three commits.

Reviewers, to test manually: build, launch the gui wallet, and look at labels/tooltips/focus with the create wallet, encrypt wallet, change password, and close wallet commands.
