### PR TITLE
Default to 2 additional blocks-only connections over Tor (+ bump default max conns to 150)

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1761,7 +1761,11 @@ bool AppInitMain(InitInterfaces& interfaces)
     connOptions.nLocalServices = nLocalServices;
     connOptions.nMaxConnections = nMaxConnections;
     connOptions.m_max_outbound_full_relay = std::min(MAX_OUTBOUND_FULL_RELAY_CONNECTIONS, connOptions.nMaxConnections);
-    connOptions.m_max_outbound_block_relay = std::min(MAX_BLOCKS_ONLY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
+    if (IsReachable(NET_ONION) && (IsReachable(NET_IPV4) || IsReachable(NET_IPV6))) {
+        connOptions.m_max_outbound_block_relay = std::min(MAX_BLOCKS_ONLY_CONNECTIONS + MAX_EXTRA_TOR_BLOCKS_ONLY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
+    } else {
+        connOptions.m_max_outbound_block_relay = std::min(MAX_BLOCKS_ONLY_CONNECTIONS, connOptions.nMaxConnections-connOptions.m_max_outbound_full_relay);
+    }
     connOptions.nMaxAddnode = MAX_ADDNODE_CONNECTIONS;
     connOptions.nMaxFeeler = 1;
     connOptions.nBestHeight = chain_active_height;

--- a/src/net.h
+++ b/src/net.h
@@ -67,6 +67,8 @@ static const int MAX_OUTBOUND_FULL_RELAY_CONNECTIONS = 8;
 static const int MAX_ADDNODE_CONNECTIONS = 8;
 /** Maximum number of block-relay-only outgoing connections */
 static const int MAX_BLOCKS_ONLY_CONNECTIONS = 2;
+/** Maximum number of block-relay-only outgoing connections made only to Tor nodes */
+static const int MAX_EXTRA_TOR_BLOCKS_ONLY_CONNECTIONS = 2;
 /** -listen default */
 static const bool DEFAULT_LISTEN = true;
 /** -upnp default */

--- a/src/net.h
+++ b/src/net.h
@@ -78,7 +78,7 @@ static const bool DEFAULT_UPNP = USE_UPNP;
 static const bool DEFAULT_UPNP = false;
 #endif
 /** The maximum number of peer connections to maintain. */
-static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
+static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 150;
 /** The default for -maxuploadtarget. 0 = Unlimited */
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** The default timeframe for -maxuploadtarget. 1 day. */


### PR DESCRIPTION
This adds the 2 tor-only blocks-only outbound connections to the
new 2 blocks-only outbound connections we added recently. This is a
naive fix for the issue where we fail to attempt any outbound Tor
connections when our regular network is being censored, but should
also stand on its own.

Also bumps max connections to 150 which I don't think should be controversial, but may be important due to the relative fewer number of onion-listening nodes.