### PR TITLE
Add envvar system

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -92,6 +92,25 @@ public:
 
 };
 
+void BitcoinCliInstallEnvVars(ArgsManager &am)
+{
+    // Set args based on their environment variable
+    std::vector<std::string> args = am.GetAddedArgs();
+    for (long unsigned int i = 0; i < args.size(); ++i)
+    {
+        std::string element;
+        for(auto &c: args[i]) {
+            element += toupper(c);
+        }
+        // Schema = BITCOIND_<ARG>
+        std::string envname = "BITCOIND_" + element.substr(1, element.size());
+        const char *envvar = getenv(envname.c_str());
+        // Check if envvar is set
+        if (envvar != NULL)
+            am.SoftSetArg(args[i], std::string(envvar));
+    }
+}
+
 //
 // This function returns either one of EXIT_ codes when it's expected to stop the process or
 // CONTINUE_EXECUTION when it's expected to continue further.
@@ -107,6 +126,7 @@ static int AppInitRPC(int argc, char* argv[])
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error.c_str());
         return EXIT_FAILURE;
     }
+    BitcoinCliInstallEnvVars(gArgs);
     if (argc < 2 || HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
         std::string strUsage = PACKAGE_NAME " RPC client version " + FormatFullVersion() + "\n";
         if (!gArgs.IsArgSet("-version")) {

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -75,6 +75,8 @@ static bool AppInit(int argc, char* argv[])
         return InitError(strprintf("Error parsing command line arguments: %s\n", error));
     }
 
+    InstallEnvVars(gArgs);
+
     // Process help and version before taking care about datadir
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
         std::string strUsage = PACKAGE_NAME " Daemon version " + FormatFullVersion() + "\n";

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -57,6 +57,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 #ifndef WIN32
 #include <attributes.h>
@@ -548,6 +549,32 @@ void SetupServerArgs()
 
     // Add the hidden options
     gArgs.AddHiddenArgs(hidden_args);
+}
+
+void InstallEnvVars(ArgsManager &am)
+{
+    // Set args based on their environment variable
+    std::vector<std::string> args = am.GetAddedArgs();
+    for (long unsigned int i = 0; i < args.size(); ++i)
+    {
+        std::string element;
+        for(auto &c: args[i]) {
+            element += toupper(c);
+        }
+        // Schema = BITCOIND_<ARG>
+        std::string envname = "BITCOIND_" + element.substr(1, element.size()); 
+        const char *envvar = getenv(envname.c_str());
+        // Check if envvar is set
+        if (envvar != NULL)
+        {
+            if (gArgs.IsArgSet(args[i]))
+                LogPrintf("Envvar %s is set but is not being used\n", envname);
+            else
+                LogPrintf("Envvar %s is set and used\n", envname);
+            
+            am.SoftSetArg(args[i], std::string(envvar));
+        }
+    }
 }
 
 std::string LicenseInfo()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -562,7 +562,7 @@ void InstallEnvVars(ArgsManager &am)
             element += toupper(c);
         }
         // Schema = BITCOIND_<ARG>
-        std::string envname = "BITCOIND_" + element.substr(1, element.size()); 
+        std::string envname = "BITCOIND_" + element.substr(1, element.size());
         const char *envvar = getenv(envname.c_str());
         // Check if envvar is set
         if (envvar != NULL)
@@ -571,7 +571,7 @@ void InstallEnvVars(ArgsManager &am)
                 LogPrintf("Envvar %s is set but is not being used\n", envname);
             else
                 LogPrintf("Envvar %s is set and used\n", envname);
-            
+
             am.SoftSetArg(args[i], std::string(envvar));
         }
     }

--- a/src/init.h
+++ b/src/init.h
@@ -70,6 +70,8 @@ bool AppInitMain(InitInterfaces& interfaces);
  */
 void SetupServerArgs();
 
+void InstallEnvVars(ArgsManager &am);
+
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();
 

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -93,6 +93,7 @@ public:
         }
     }
     void setupServerArgs() override { return SetupServerArgs(); }
+    void installEnvvars(ArgsManager &am) { return InstallEnvVars(am); }
     bool getProxy(Network net, proxyType& proxy_info) override { return GetProxy(net, proxy_info); }
     size_t getNodeCount(CConnman::NumConnections flags) override
     {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -95,6 +95,9 @@ public:
     //! Setup arguments
     virtual void setupServerArgs() = 0;
 
+    //! Install Envvars
+    virtual void installEnvvars(ArgsManager &am) = 0;
+
     //! Map port.
     virtual void mapPort(bool use_upnp) = 0;
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -461,6 +461,8 @@ int GuiMain(int argc, char* argv[])
             QString::fromStdString("Error parsing command line arguments: %1.").arg(QString::fromStdString(error)));
         return EXIT_FAILURE;
     }
+    // Setup env vars
+    node->installEnvvars(gArgs);
 
     // Now that the QApplication is setup and we have parsed our parameters, we can set the platform style
     app.setupPlatformStyle();

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -469,6 +469,21 @@ std::vector<std::string> ArgsManager::GetArgs(const std::string& strArg) const
     return result;
 }
 
+std::vector<std::string> ArgsManager::GetAddedArgs() const
+{
+    std::vector<std::string> ret;
+    LOCK(cs_args);
+    for (auto const& x : m_available_args)
+    {
+        for(auto const& y : x.second)
+        {
+            ret.push_back(y.first);
+        }
+    }
+
+    return ret;
+}
+
 bool ArgsManager::IsArgSet(const std::string& strArg) const
 {
     if (IsArgNegated(strArg)) return true; // special case

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -199,6 +199,13 @@ public:
     std::vector<std::string> GetArgs(const std::string& strArg) const;
 
     /**
+     * Return list of all args
+     * 
+     * @return Return list of all args
+    */
+   std::vector<std::string> GetAddedArgs() const;
+
+    /**
      * Return true if the given argument has been manually set
      *
      * @param strArg Argument to get (e.g. "-foo")

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -200,7 +200,7 @@ public:
 
     /**
      * Return list of all args
-     * 
+     *
      * @return Return list of all args
     */
    std::vector<std::string> GetAddedArgs() const;


### PR DESCRIPTION
### Description
This PR adds a way to set CLI args with an environment variable.
The syntax for the envvars are `BITCOIND_<ARGNAME>=<VALUE>`
E.g `BITCOIND_DATADIR=/home/emil/bitcoin/`
Console arguments override setted envvars.
The envvars are always uppercase.
### Testing
Set some envvars
On Unix:
```
BITCOIND_DATADIR=/path/to/your/datadir
BITCOIND_LANG=en
export BITCOIND_DATADIR
export BITCOIND_LANG

./bitcoin-qt
```
This will start Bitcoin-Qt using the datadir path with an english overlay.

### Notes
This also adds a function to ArgsManager to get all added args in a vector.