### PR TITLE
refactor: wallet: Cleanup walletinitinterface.h

### DIFF
--- a/src/walletinitinterface.h
+++ b/src/walletinitinterface.h
@@ -5,10 +5,6 @@
 #ifndef BITCOIN_WALLETINITINTERFACE_H
 #define BITCOIN_WALLETINITINTERFACE_H
 
-#include <string>
-
-class CScheduler;
-class CRPCTable;
 struct InitInterfaces;
 
 class WalletInitInterface {


### PR DESCRIPTION
Forward declarations of `CScheduler` and `CRPCTable` classes are no longer needed after ea961c3d7256c66146b4976ab1293db4a628c0de (#14437) commit.

Including `<string>` is no longer needed after 4d4185a4f0e40c033a587871839a47cb3f89ee93 (#13190) commit.