### PR TITLE
bitcoin-tx: fix comment about pay-to-witness script type ("addoutpubkey" command)

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -320,7 +320,7 @@ static void MutateTxAddOutPubKey(CMutableTransaction& tx, const std::string& str
         if (!pubkey.IsCompressed()) {
             throw std::runtime_error("Uncompressed pubkeys are not useable for SegWit outputs");
         }
-        // Call GetScriptForWitness() to build a P2WSH scriptPubKey
+        // Call GetScriptForWitness() to build a P2WPKH scriptPubKey
         scriptPubKey = GetScriptForWitness(scriptPubKey);
     }
     if (bScriptHash) {

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -320,7 +320,7 @@ static void MutateTxAddOutPubKey(CMutableTransaction& tx, const std::string& str
         if (!pubkey.IsCompressed()) {
             throw std::runtime_error("Uncompressed pubkeys are not useable for SegWit outputs");
         }
-        // Call GetScriptForWitness() to build a P2WPKH scriptPubKey
+        // Build a P2WPKH script
         scriptPubKey = GetScriptForWitness(scriptPubKey);
     }
     if (bScriptHash) {
@@ -390,7 +390,7 @@ static void MutateTxAddOutMultiSig(CMutableTransaction& tx, const std::string& s
                 throw std::runtime_error("Uncompressed pubkeys are not useable for SegWit outputs");
             }
         }
-        // Call GetScriptForWitness() to build a P2WSH scriptPubKey
+        // Build a P2WSH script
         scriptPubKey = GetScriptForWitness(scriptPubKey);
     }
     if (bScriptHash) {


### PR DESCRIPTION
The function `GetScriptForWitness()` returns a P2WPKH script if the
passed redeem script is P2PK or P2PKH, otherwise it returns a P2WSH.
Since we pass a P2PK script here (constructed a few lines above
through `GetScriptForRawPubKey()`) the result is rather P2WPKH than
P2WSH and the comment is adapted accordingly.