### PR TITLE
test: `servicesnames` field in `getpeerinfo` and `getnetworkinfo`

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -56,7 +56,7 @@ class NetTest(BitcoinTestFramework):
     def run_test(self):
         self._test_connection_count()
         self._test_getnettotals()
-        self._test_getnetworkinginfo()
+        self._test_getnetworkinfo()
         self._test_getaddednodeinfo()
         self._test_getpeerinfo()
         self._test_getnodeaddresses()
@@ -95,7 +95,7 @@ class NetTest(BitcoinTestFramework):
             assert_greater_than_or_equal(after['bytesrecv_per_msg'].get('pong', 0), before['bytesrecv_per_msg'].get('pong', 0) + 32)
             assert_greater_than_or_equal(after['bytessent_per_msg'].get('ping', 0), before['bytessent_per_msg'].get('ping', 0) + 32)
 
-    def _test_getnetworkinginfo(self):
+    def _test_getnetworkinfo(self):
         assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)
         assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
 

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -20,7 +20,32 @@ from test_framework.util import (
     wait_until,
 )
 from test_framework.mininode import P2PInterface
-from test_framework.messages import CAddress, msg_addr, NODE_NETWORK, NODE_WITNESS
+from test_framework.messages import (
+    CAddress,
+    msg_addr,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    NODE_GETUTXO,NODE_BLOOM,
+    NODE_NETWORK_LIMITED,
+)
+
+def assert_net_servicesnames(servicesflag, servicenames):
+    """Utility that checks if all flags are correctly decoded in
+    `getpeerinfo` and `getnetworkinfo`.
+
+    :param servicesflag: The services as an integer.
+    :param servicesnames: The list of decoded services names, as strings.
+    """
+    if servicesflag & NODE_NETWORK:
+        assert "NETWORK" in servicenames
+    if servicesflag & NODE_GETUTXO:
+        assert "GETUTXO" in servicenames
+    if servicesflag & NODE_BLOOM:
+        assert "BLOOM" in servicenames
+    if servicesflag & NODE_WITNESS:
+        assert "WITNESS" in servicenames
+    if servicesflag & NODE_NETWORK_LIMITED:
+        assert "NETWORK_LIMITED" in servicenames
 
 class NetTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -84,6 +109,11 @@ class NetTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getnetworkinfo()['networkactive'], True)
         assert_equal(self.nodes[0].getnetworkinfo()['connections'], 2)
 
+        # check the `servicesnames` field
+        network_info = [node.getnetworkinfo() for node in self.nodes]
+        for info in network_info:
+            assert_net_servicesnames(int(info["localservices"]), info["localservicesnames"])
+
     def _test_getaddednodeinfo(self):
         assert_equal(self.nodes[0].getaddednodeinfo(), [])
         # add a node (node2) to node0
@@ -104,6 +134,9 @@ class NetTest(BitcoinTestFramework):
         assert_equal(peer_info[1][0]['addrbind'], peer_info[0][0]['addr'])
         assert_equal(peer_info[0][0]['minfeefilter'], Decimal("0.00000500"))
         assert_equal(peer_info[1][0]['minfeefilter'], Decimal("0.00001000"))
+        # check the `servicesnames` field
+        for info in peer_info:
+            assert_net_servicesnames(int(info[0]["services"]), info[0]["servicesnames"])
 
     def _test_getnodeaddresses(self):
         self.nodes[0].add_p2p_connection(P2PInterface())

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -43,8 +43,8 @@ COIN = 100000000  # 1 btc in satoshis
 BIP125_SEQUENCE_NUMBER = 0xfffffffd  # Sequence number that is BIP 125 opt-in and BIP 68-opt-out
 
 NODE_NETWORK = (1 << 0)
-# NODE_GETUTXO = (1 << 1)
-# NODE_BLOOM = (1 << 2)
+NODE_GETUTXO = (1 << 1)
+NODE_BLOOM = (1 << 2)
 NODE_WITNESS = (1 << 3)
 NODE_NETWORK_LIMITED = (1 << 10)
 


### PR DESCRIPTION
As per https://github.com/bitcoin/bitcoin/pull/16787#issuecomment-529801457, fixes #16844.

This adds a test for both commands in the first commit and renames the test for `getnetworkinfo` in the second commit.