### PR TITLE
Prevent UpdateTip log message from being broken up

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2240,14 +2240,12 @@ void static UpdateTip(const CBlockIndex* pindexNew, const CChainParams& chainPar
         if (nUpgraded > 0)
             AppendWarning(warningMessages, strprintf(_("%d of last 100 blocks have unexpected version").translated, nUpgraded));
     }
-    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)", __func__, /* Continued */
+    LogPrintf("%s: new best=%s height=%d version=0x%08x log2_work=%.8g tx=%lu date='%s' progress=%f cache=%.1fMiB(%utxo)%s\n", __func__,
       pindexNew->GetBlockHash().ToString(), pindexNew->nHeight, pindexNew->nVersion,
       log(pindexNew->nChainWork.getdouble())/log(2.0), (unsigned long)pindexNew->nChainTx,
       FormatISO8601DateTime(pindexNew->GetBlockTime()),
-      GuessVerificationProgress(chainParams.TxData(), pindexNew), ::ChainstateActive().CoinsTip().DynamicMemoryUsage() * (1.0 / (1<<20)), ::ChainstateActive().CoinsTip().GetCacheSize());
-    if (!warningMessages.empty())
-        LogPrintf(" warning='%s'", warningMessages); /* Continued */
-    LogPrintf("\n");
+      GuessVerificationProgress(chainParams.TxData(), pindexNew), ::ChainstateActive().CoinsTip().DynamicMemoryUsage() * (1.0 / (1<<20)), ::ChainstateActive().CoinsTip().GetCacheSize(),
+      !warningMessages.empty() ? strprintf(" warning='%s'", warningMessages) : "");
 
 }
 


### PR DESCRIPTION
We had some occurrences of log messages colliding:
```
$ grep ThreadRPC $(find . -type f -name debug.log -print | grep bitcoind.datadir ) | awk '{$1=""; print $0}' | sort -u                                                                     
 ThreadRPCServer method=sendrawtransaction user=bitcoinrpc
 ThreadRPCServer method=sendtoaddress user=bitcoinrpc
 ThreadRPCServer method=signrawtransactionwithkey user=bitcoinrpc
 UpdateTip: new best=0026711b58616e8d4db7d9bc9f46b746ec535521feb3e0f077e83925e45daa8a height=630 version=0x20000000 log2_work=10.301496 tx=633 date='2019-09-10T00:43:41Z' progress=1.000000 cache=0.1MiB(811txo)ThreadRPCServer method=getblockheader user=bitcoinrpc
 UpdateTip: new best=466304b9c3ed652373d30207f0d99551c568c2dbc648518c077cb40826039e5f height=643 version=0x20000000 log2_work=10.330917 tx=647 date='2019-09-10T00:43:43Z' progress=1.000000 cache=0.1MiB(915txo)ThreadRPCServer method=getblockheader user=bitcoinrpc
```