### PR TITLE
[0.17] doc: Remove release note fragment from #16639

### DIFF
--- a/doc/release-notes-0.18.1-16257.md
+++ b/doc/release-notes-0.18.1-16257.md
@@ -1,6 +1,0 @@
-Wallet changes
---------------
-When creating a transaction with a fee above `-maxtxfee` (default 0.1 BTC),
-the RPC commands `walletcreatefundedpsbt` and  `fundrawtransaction` will now fail
-instead of rounding down the fee. Beware that the `feeRate` argument is specified
-in BTC per kilobyte, not satoshi per byte.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -71,6 +71,11 @@ Documentation
   implementations, and many other cases where two or more programs need
   to interact to generate a complete transaction.
 
+Wallet
+------
+
+- When creating a transaction with a fee above -maxtxfee (default 0.1 BTC), the RPC commands walletcreatefundedpsbt and fundrawtransaction will now fail instead of rounding down the fee. Be aware that the feeRate argument is specified in BTC per 1,000 vbytes, not satoshi per vbyte. (#16639)
+
 0.17.2 change log
 =================
 


### PR DESCRIPTION
This uses the wording from the release-notes currently [in master](https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes.md#wallet).