### PR TITLE
test: Add python bech32 impl round-trip test

### DIFF
--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -64,7 +64,10 @@ from test_framework.util import (
     assert_raises_rpc_error,
     connect_nodes_bi,
 )
-
+from test_framework.segwit_addr import (
+    encode,
+    decode,
+)
 
 class AddressTypeTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -97,6 +100,13 @@ class AddressTypeTest(BitcoinTestFramework):
         else:
             return [self.nodes[i].getunconfirmedbalance() for i in range(4)]
 
+    # Quick test of python bech32 implementation
+    def test_python_bech32(self, addr):
+        hrp = addr[:4]
+        assert_equal(hrp, "bcrt")
+        (witver, witprog) = decode(hrp, addr)
+        assert_equal(encode(hrp, witver, witprog), addr)
+
     def test_address(self, node, address, multisig, typ):
         """Run sanity checks on an address."""
         info = self.nodes[node].getaddressinfo(address)
@@ -121,6 +131,7 @@ class AddressTypeTest(BitcoinTestFramework):
             assert_equal(info['witness_version'], 0)
             assert_equal(len(info['witness_program']), 40)
             assert 'pubkey' in info
+            self.test_python_bech32(info["address"])
         elif typ == 'legacy':
             # P2SH-multisig
             assert info['isscript']
@@ -146,6 +157,7 @@ class AddressTypeTest(BitcoinTestFramework):
             assert_equal(info['witness_version'], 0)
             assert_equal(len(info['witness_program']), 64)
             assert 'pubkeys' in info
+            self.test_python_bech32(info["address"])
         else:
             # Unknown type
             assert False


### PR DESCRIPTION
Currently there is a single use of `segwit_addr.encode`, and zero uses of `segwit_addr.decode` in the codebase.

This adds a simple round-trip test of the implementation to avoid future regressions.