### PR TITLE
wallet: Rename 'decode' argument in gettransaction method to 'verbose'

### DIFF
--- a/doc/release-notes-16185.md
+++ b/doc/release-notes-16185.md
@@ -1,3 +1,3 @@
 RPC changes
 -----------
-The `gettransaction` RPC now accepts a third (boolean) argument `decode`. If set to `true`, a new `decoded` field will be added to the response containing the decoded transaction.
+The `gettransaction` RPC now accepts a third (boolean) argument `verbose`. If set to `true`, a new `details` field will be added to the response containing additional transaction details.

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -85,7 +85,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getblockheader", 1, "verbose" },
     { "getchaintxstats", 0, "nblocks" },
     { "gettransaction", 1, "include_watchonly" },
-    { "gettransaction", 2, "decode" },
+    { "gettransaction", 2, "verbose" },
     { "getrawtransaction", 1, "verbose" },
     { "createrawtransaction", 0, "inputs" },
     { "createrawtransaction", 1, "outputs" },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1649,7 +1649,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
                 {
                     {"txid", RPCArg::Type::STR, RPCArg::Optional::NO, "The transaction id"},
                     {"include_watchonly", RPCArg::Type::BOOL, /* default */ "true for watch-only wallets, otherwise false", "Whether to include watch-only addresses in balance calculation and details[]"},
-                    {"decode", RPCArg::Type::BOOL, /* default */ "false", "Whether to add a field with the decoded transaction"},
+                    {"verbose", RPCArg::Type::BOOL, /* default */ "false", "Whether to add a field with additional transaction details"},
                 },
                 RPCResult{
             "{\n"
@@ -1685,7 +1685,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
             "    ,...\n"
             "  ],\n"
             "  \"hex\" : \"data\"         (string) Raw data for transaction\n"
-            "  \"decoded\" : transaction         (json object) Optional, the decoded transaction\n"
+            "  \"details\" : transaction         (json object) Optional, additional transaction details. This object contains the same transaction details as the `getrawtransaction` RPC method\n"
             "}\n"
                 },
                 RPCExamples{
@@ -1711,7 +1711,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
         filter |= ISMINE_WATCH_ONLY;
     }
 
-    bool decode_tx = request.params[2].isNull() ? false : request.params[2].get_bool();
+    bool verbose = request.params[2].isNull() ? false : request.params[2].get_bool();
 
     UniValue entry(UniValue::VOBJ);
     auto it = pwallet->mapWallet.find(hash);
@@ -1738,10 +1738,10 @@ static UniValue gettransaction(const JSONRPCRequest& request)
     std::string strHex = EncodeHexTx(*wtx.tx, pwallet->chain().rpcSerializationFlags());
     entry.pushKV("hex", strHex);
 
-    if (decode_tx) {
-        UniValue decoded(UniValue::VOBJ);
-        TxToUniv(*wtx.tx, uint256(), decoded, false);
-        entry.pushKV("decoded", decoded);
+    if (verbose) {
+        UniValue details(UniValue::VOBJ);
+        TxToUniv(*wtx.tx, uint256(), details, false);
+        entry.pushKV("details", details);
     }
 
     return entry;
@@ -4189,7 +4189,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "getrawchangeaddress",              &getrawchangeaddress,           {"address_type"} },
     { "wallet",             "getreceivedbyaddress",             &getreceivedbyaddress,          {"address","minconf"} },
     { "wallet",             "getreceivedbylabel",               &getreceivedbylabel,            {"label","minconf"} },
-    { "wallet",             "gettransaction",                   &gettransaction,                {"txid","include_watchonly","decode"} },
+    { "wallet",             "gettransaction",                   &gettransaction,                {"txid","include_watchonly","verbose"} },
     { "wallet",             "getunconfirmedbalance",            &getunconfirmedbalance,         {} },
     { "wallet",             "getbalances",                      &getbalances,                   {} },
     { "wallet",             "getwalletinfo",                    &getwalletinfo,                 {} },

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -499,10 +499,10 @@ class WalletTest(BitcoinTestFramework):
         self.nodes[0].setlabel(change, 'foobar')
         assert_equal(self.nodes[0].getaddressinfo(change)['ischange'], False)
 
-        # Test "decoded" field value in gettransaction response
-        self.log.info("Testing gettransaction decoding...")
-        tx = self.nodes[0].gettransaction(txid=txid, decode=True)
-        assert_equal(tx["decoded"], self.nodes[0].decoderawtransaction(tx["hex"]))
+        # Test "verbose" field value in gettransaction response
+        self.log.info("Testing verbose gettransaction...")
+        tx = self.nodes[0].gettransaction(txid=txid, verbose=True)
+        assert_equal(tx["details"], self.nodes[0].decoderawtransaction(tx["hex"]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes the RPC method consistent with other RPC methods that have a
'verbose' option.

Change the name of the return object from 'decoded' to details.

Update help text.