### PR TITLE
Add specific envvar system

### DIFF
--- a/doc/bitcoin-conf.md
+++ b/doc/bitcoin-conf.md
@@ -60,3 +60,15 @@ Linux | `$HOME/.bitcoin/` | `/home/username/.bitcoin/bitcoin.conf`
 macOS | `$HOME/Library/Application Support/Bitcoin/` | `/Users/username/Library/Application Support/Bitcoin/bitcoin.conf`
 
 You can find an example bitcoin.conf file in [share/examples/bitcoin.conf](../share/examples/bitcoin.conf).
+
+## Environment variables
+If an environment variable is set, it will be used unless it is set in the config file or provided as a command line argument.
+The order is:
+```
+Environment variable < Config file < Command line arguments
+```
+
+Name | Option equivalent
+-- | --
+BITCOIN_DATADIR | -datadir
+BITCOIN_CONF	| -conf

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -128,6 +128,7 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
+  envvar.h \
   flatfile.h \
   fs.h \
   httprpc.h \
@@ -487,6 +488,7 @@ libbitcoin_util_a_SOURCES = \
   compat/glibc_sanity.cpp \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
+  envvar.cpp \
   fs.cpp \
   interfaces/handler.cpp \
   logging.cpp \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -9,6 +9,7 @@
 
 #include <chainparamsbase.h>
 #include <clientversion.h>
+#include <envvar.h>
 #include <fs.h>
 #include <rpc/client.h>
 #include <rpc/protocol.h>
@@ -107,6 +108,8 @@ static int AppInitRPC(int argc, char* argv[])
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error.c_str());
         return EXIT_FAILURE;
     }
+    // Install envvars
+    InstallEnvVars(gArgs);
     if (argc < 2 || HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
         std::string strUsage = PACKAGE_NAME " RPC client version " + FormatFullVersion() + "\n";
         if (!gArgs.IsArgSet("-version")) {

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -8,6 +8,7 @@
 
 #include <chainparams.h>
 #include <chainparamsbase.h>
+#include <envvar.h>
 #include <logging.h>
 #include <util/strencodings.h>
 #include <util/system.h>
@@ -41,6 +42,8 @@ static bool WalletAppInit(int argc, char* argv[])
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error_message.c_str());
         return false;
     }
+    // Install envvars
+    InstallEnvVars(gArgs);
     if (argc < 2 || HelpRequested(gArgs)) {
         std::string usage = strprintf("%s bitcoin-wallet version", PACKAGE_NAME) + " " + FormatFullVersion() + "\n\n" +
                                       "wallet-tool is an offline tool for creating and interacting with Bitcoin Core wallet files.\n" +

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -10,6 +10,7 @@
 #include <chainparams.h>
 #include <clientversion.h>
 #include <compat.h>
+#include <envvar.h>
 #include <fs.h>
 #include <init.h>
 #include <interfaces/chain.h>
@@ -74,6 +75,9 @@ static bool AppInit(int argc, char* argv[])
     if (!gArgs.ParseParameters(argc, argv, error)) {
         return InitError(strprintf("Error parsing command line arguments: %s\n", error));
     }
+
+    // Install envvars
+    InstallEnvVars(gArgs);
 
     // Process help and version before taking care about datadir
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {

--- a/src/envvar.cpp
+++ b/src/envvar.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include <envvar.h>
+
+void InstallEnvVars(ArgsManager& am)
+{
+    // Append other envvars here
+    std::vector<std::string> vars = {
+        "datadir",
+        "conf"
+    };
+
+    for (unsigned int i = 0; i < vars.size(); ++i)
+    {
+        std::string element = "BITCOIN_";   // Prefix
+        for (auto &c: vars[i]) {
+            element += toupper(c);
+        }
+        const char *envvar = getenv(element.c_str());
+        if (envvar != NULL)
+        {
+            if (!gArgs.IsArgSet("-" + vars[i])) {
+                LogPrintf("Using environment variable %s=%s\n", element, envvar);
+                am.SoftSetArg("-" + vars[i], std::string(envvar));
+            }
+        }
+    }
+}

--- a/src/envvar.h
+++ b/src/envvar.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_ENVVAR_H
+#define BITCOIN_ENVVAR_H
+
+#include <vector>
+#include <string>
+#include <util/system.h>
+
+void InstallEnvVars(ArgsManager &am);
+#endif

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -96,6 +96,7 @@ public:
         }
     }
     void setupServerArgs() override { return SetupServerArgs(); }
+    void installEnvVars(ArgsManager& am) { return InstallEnvVars(am); }
     bool getProxy(Network net, proxyType& proxy_info) override { return GetProxy(net, proxy_info); }
     size_t getNodeCount(CConnman::NumConnections flags) override
     {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -10,6 +10,7 @@
 #include <net.h>        // For CConnman::NumConnections
 #include <netaddress.h> // For Network
 #include <support/allocators/secure.h> // For SecureString
+#include <envvar.h> // For InstallEnvVars
 
 #include <functional>
 #include <memory>
@@ -99,6 +100,9 @@ public:
 
     //! Setup arguments
     virtual void setupServerArgs() = 0;
+
+    //! Install envvars
+    virtual void installEnvVars(ArgsManager& am) = 0;
 
     //! Map port.
     virtual void mapPort(bool use_upnp) = 0;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -466,6 +466,9 @@ int GuiMain(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
+    // Install envvars
+    node->installEnvVars(gArgs);
+
     // Now that the QApplication is setup and we have parsed our parameters, we can set the platform style
     app.setupPlatformStyle();
 

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -18,6 +18,7 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
     "src/util/system.cpp:.*atoi"
+    "src/envvar.cpp:.*toupper"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"


### PR DESCRIPTION
See #16829
### Description
This PR adds a way to set **some** CLI args with an environment variable.
The syntax for the envvars are `BITCOIN_<ARGNAME>=<VALUE>`
E.g `BITCOIN_DATADIR=/home/emil/bitcoin/`
Console arguments override setted envvars.
The envvars are always uppercase.
### Testing
Set some envvars
On Unix:
```
export BITCOIN_DATADIR=/path/to/your/datadir
export BITCOIN_CONF=/path/to/your/conf
./bitcoin-qt
```
This will start Bitcoin-Qt using the datadir path with an english overlay.
### List of supported envvars

- datadir
- conf
- <s>blocksdir</s>
- <s>debuclogfile</s>
- <s>includeconf</s>
- <s>loadblock</s>
- <s>pid</s>
- Others can be added by changing one line of code