### PR TITLE
build: update boost macros to latest upstream for improved error reporting

### DIFF
--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 45
+#serial 47
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -113,6 +113,7 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
     dnl are found, e.g. when only header-only libraries are installed!
     AS_CASE([${host_cpu}],
       [x86_64],[libsubdirs="lib64 libx32 lib lib64"],
+      [mips*64*],[libsubdirs="lib64 lib32 lib lib64"],
       [ppc64|powerpc64|s390x|sparc64|aarch64|ppc64le|powerpc64le|riscv64],[libsubdirs="lib64 lib lib64"],
       [libsubdirs="lib"]
     )

--- a/build-aux/m4/ax_boost_chrono.m4
+++ b/build-aux/m4/ax_boost_chrono.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 5
 
 AC_DEFUN([AX_BOOST_CHRONO],
 [
@@ -105,7 +105,7 @@ AC_DEFUN([AX_BOOST_CHRONO],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Chrono library!)
             fi
 			if test "x$link_chrono" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_filesystem.m4
+++ b/build-aux/m4/ax_boost_filesystem.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#    http://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
+#   https://www.gnu.org/software/autoconf-archive/ax_boost_filesystem.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 26
+#serial 28
 
 AC_DEFUN([AX_BOOST_FILESYSTEM],
 [
@@ -80,7 +80,6 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 		if test "x$ax_cv_boost_filesystem" = "xyes"; then
 			AC_DEFINE(HAVE_BOOST_FILESYSTEM,,[define if the Boost::Filesystem library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
-            ax_lib=
             if test "x$ax_boost_user_filesystem_lib" = "x"; then
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_filesystem* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'` ; do
                      ax_lib=${libextension}
@@ -105,7 +104,7 @@ AC_DEFUN([AX_BOOST_FILESYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_filesystem library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Filesystem library!)
             fi
 			if test "x$link_filesystem" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_system.m4
+++ b/build-aux/m4/ax_boost_system.m4
@@ -31,7 +31,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 19
+#serial 20
 
 AC_DEFUN([AX_BOOST_SYSTEM],
 [
@@ -108,7 +108,7 @@ AC_DEFUN([AX_BOOST_SYSTEM],
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::System library!)
             fi
 			if test "x$link_system" = "xno"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)

--- a/build-aux/m4/ax_boost_thread.m4
+++ b/build-aux/m4/ax_boost_thread.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#      http://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
+#     https://www.gnu.org/software/autoconf-archive/ax_boost_thread.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -30,73 +30,75 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 27
+#serial 32
 
 AC_DEFUN([AX_BOOST_THREAD],
 [
-	AC_ARG_WITH([boost-thread],
-	AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
-                   [use the Thread library from boost - it is possible to specify a certain library for the linker
-                        e.g. --with-boost-thread=boost_thread-gcc-mt ]),
+    AC_ARG_WITH([boost-thread],
+    AS_HELP_STRING([--with-boost-thread@<:@=special-lib@:>@],
+                   [use the Thread library from boost -
+                    it is possible to specify a certain library for the linker
+                    e.g. --with-boost-thread=boost_thread-gcc-mt ]),
         [
-        if test "$withval" = "no"; then
-			want_boost="no"
-        elif test "$withval" = "yes"; then
+        if test "$withval" = "yes"; then
             want_boost="yes"
             ax_boost_user_thread_lib=""
         else
-		    want_boost="yes"
-		ax_boost_user_thread_lib="$withval"
-		fi
+            want_boost="yes"
+            ax_boost_user_thread_lib="$withval"
+        fi
         ],
         [want_boost="yes"]
-	)
+    )
 
-	if test "x$want_boost" = "xyes"; then
+    if test "x$want_boost" = "xyes"; then
         AC_REQUIRE([AC_PROG_CC])
         AC_REQUIRE([AC_CANONICAL_BUILD])
-		CPPFLAGS_SAVED="$CPPFLAGS"
-		CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
-		export CPPFLAGS
+        CPPFLAGS_SAVED="$CPPFLAGS"
+        CPPFLAGS="$CPPFLAGS $BOOST_CPPFLAGS"
+        export CPPFLAGS
 
-		LDFLAGS_SAVED="$LDFLAGS"
-		LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
-		export LDFLAGS
+        LDFLAGS_SAVED="$LDFLAGS"
+        LDFLAGS="$LDFLAGS $BOOST_LDFLAGS"
+        export LDFLAGS
 
         AC_CACHE_CHECK(whether the Boost::Thread library is available,
-					   ax_cv_boost_thread,
+                       ax_cv_boost_thread,
         [AC_LANG_PUSH([C++])
-			 CXXFLAGS_SAVE=$CXXFLAGS
+             CXXFLAGS_SAVE=$CXXFLAGS
 
-			 if test "x$host_os" = "xsolaris" ; then
-				 CXXFLAGS="-pthreads $CXXFLAGS"
-			 elif test "x$host_os" = "xmingw32" ; then
-				 CXXFLAGS="-mthreads $CXXFLAGS"
-			 else
-				CXXFLAGS="-pthread $CXXFLAGS"
-			 fi
-			 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[@%:@include <boost/thread/thread.hpp>]],
-                                   [[boost::thread_group thrds;
-                                   return 0;]])],
-                   ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
-			 CXXFLAGS=$CXXFLAGS_SAVE
+             if test "x$host_os" = "xsolaris" ; then
+                 CXXFLAGS="-pthreads $CXXFLAGS"
+             elif test "x$host_os" = "xmingw32" ; then
+                 CXXFLAGS="-mthreads $CXXFLAGS"
+             else
+                CXXFLAGS="-pthread $CXXFLAGS"
+             fi
+             AC_COMPILE_IFELSE([
+                 AC_LANG_PROGRAM(
+                     [[@%:@include <boost/thread/thread.hpp>]],
+                     [[boost::thread_group thrds;
+                       return 0;]])],
+                 ax_cv_boost_thread=yes, ax_cv_boost_thread=no)
+             CXXFLAGS=$CXXFLAGS_SAVE
              AC_LANG_POP([C++])
-		])
-		if test "x$ax_cv_boost_thread" = "xyes"; then
+        ])
+        if test "x$ax_cv_boost_thread" = "xyes"; then
            if test "x$host_os" = "xsolaris" ; then
-			  BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
-		   elif test "x$host_os" = "xmingw32" ; then
-			  BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
-		   else
-			  BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
-		   fi
+              BOOST_CPPFLAGS="-pthreads $BOOST_CPPFLAGS"
+           elif test "x$host_os" = "xmingw32" ; then
+              BOOST_CPPFLAGS="-mthreads $BOOST_CPPFLAGS"
+           else
+              BOOST_CPPFLAGS="-pthread $BOOST_CPPFLAGS"
+           fi
 
-			AC_SUBST(BOOST_CPPFLAGS)
+            AC_SUBST(BOOST_CPPFLAGS)
 
-			AC_DEFINE(HAVE_BOOST_THREAD,,[define if the Boost::Thread library is available])
+            AC_DEFINE(HAVE_BOOST_THREAD,,
+                      [define if the Boost::Thread library is available])
             BOOSTLIBDIR=`echo $BOOST_LDFLAGS | sed -e 's/@<:@^\/@:>@*//'`
 
-			LDFLAGS_SAVE=$LDFLAGS
+            LDFLAGS_SAVE=$LDFLAGS
                         case "x$host_os" in
                           *bsd* )
                                LDFLAGS="-pthread $LDFLAGS"
@@ -104,47 +106,58 @@ AC_DEFUN([AX_BOOST_THREAD],
                           ;;
                         esac
             if test "x$ax_boost_user_thread_lib" = "x"; then
-                ax_lib=
                 for libextension in `ls -r $BOOSTLIBDIR/libboost_thread* 2>/dev/null | sed 's,.*/lib,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                    AC_CHECK_LIB($ax_lib, exit,
+                                 [link_thread="yes"; break],
                                  [link_thread="no"])
-				done
+                done
                 if test "x$link_thread" != "xyes"; then
                 for libextension in `ls -r $BOOSTLIBDIR/boost_thread* 2>/dev/null | sed 's,.*/,,' | sed 's,\..*,,'`; do
                      ax_lib=${libextension}
-				    AC_CHECK_LIB($ax_lib, exit,
-                                 [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                    AC_CHECK_LIB($ax_lib, exit,
+                                 [link_thread="yes"; break],
                                  [link_thread="no"])
-				done
+                done
                 fi
 
             else
                for ax_lib in $ax_boost_user_thread_lib boost_thread-$ax_boost_user_thread_lib; do
-				      AC_CHECK_LIB($ax_lib, exit,
-                                   [BOOST_THREAD_LIB="-l$ax_lib"; AC_SUBST(BOOST_THREAD_LIB) link_thread="yes"; break],
+                      AC_CHECK_LIB($ax_lib, exit,
+                                   [link_thread="yes"; break],
                                    [link_thread="no"])
                   done
 
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the boost_thread library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Thread library!)
             fi
-			if test "x$link_thread" = "xno"; then
-				AC_MSG_ERROR(Could not link against $ax_lib !)
-                        else
-                           case "x$host_os" in
-                              *bsd* )
-				BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
-                              break;
-                              ;;
-                           esac
+            if test "x$link_thread" = "xno"; then
+                AC_MSG_ERROR(Could not link against $ax_lib !)
+            else
+                BOOST_THREAD_LIB="-l$ax_lib"
+                case "x$host_os" in
+                    *bsd* )
+                        BOOST_LDFLAGS="-pthread $BOOST_LDFLAGS"
+                        break;
+                        ;;
+                    xsolaris )
+                        BOOST_THREAD_LIB="$BOOST_THREAD_LIB -lpthread"
+                        break;
+                        ;;
+                    xmingw32 )
+                        break;
+                        ;;
+                    * )
+                        BOOST_THREAD_LIB="$BOOST_THREAD_LIB -lpthread"
+                        break;
+                        ;;
+                esac
+                AC_SUBST(BOOST_THREAD_LIB)
+            fi
+        fi
 
-			fi
-		fi
-
-		CPPFLAGS="$CPPFLAGS_SAVED"
-	LDFLAGS="$LDFLAGS_SAVED"
-	fi
+        CPPFLAGS="$CPPFLAGS_SAVED"
+        LDFLAGS="$LDFLAGS_SAVED"
+    fi
 ])

--- a/build-aux/m4/ax_boost_unit_test_framework.m4
+++ b/build-aux/m4/ax_boost_unit_test_framework.m4
@@ -29,7 +29,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 21
+#serial 22
 
 AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
 [
@@ -124,7 +124,7 @@ AC_DEFUN([AX_BOOST_UNIT_TEST_FRAMEWORK],
                done
             fi
             if test "x$ax_lib" = "x"; then
-                AC_MSG_ERROR(Could not find a version of the library!)
+                AC_MSG_ERROR(Could not find a version of the Boost::Unit_Test_Framework library!)
             fi
 			if test "x$link_unit_test_framework" != "xyes"; then
 				AC_MSG_ERROR(Could not link against $ax_lib !)


### PR DESCRIPTION
Fixes: #16803

I opened an [upstream PR](https://github.com/autoconf-archive/autoconf-archive/pull/197) to improve the Boost error reporting, so pull the latest macros.