### PR TITLE
build: make building protobuf optional in depends

### DIFF
--- a/ci/test/00_setup_env_i686.sh
+++ b/ci/test/00_setup_env_i686.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export HOST=i686-pc-linux-gnu
+export DEP_OPTS="PROTOBUF=1"
 export PACKAGES="g++-multilib python3-zmq"
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 --enable-bip70 --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -5,6 +5,7 @@ WORK_PATH = $(BASEDIR)/work
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
+PROTOBUF ?=
 RAPIDCHECK ?=
 NO_WALLET ?=
 NO_ZMQ ?=
@@ -96,13 +97,15 @@ wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
 zmq_packages_$(NO_ZMQ) = $(zmq_packages)
 
+protobuf_packages_$(PROTOBUF) = $(protobuf_packages)
 rapidcheck_packages_$(RAPIDCHECK) = $(rapidcheck_packages)
 
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
-ifneq ($(qt_packages_),)
-native_packages += $(qt_native_packages)
+ifeq ($(protobuf_packages_),)
+native_packages += $(protobuf_native_packages)
+packages += $(protobuf_packages)
 endif
 
 ifneq ($(zmq_packages_),)
@@ -150,6 +153,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@no_qt@|$(NO_QT)|' \
             -e 's|@no_zmq@|$(NO_ZMQ)|' \
+            -e 's|@enable_bip70@|$(PROTOBUF)|' \
             -e 's|@no_wallet@|$(NO_WALLET)|' \
             -e 's|@no_upnp@|$(NO_UPNP)|' \
             -e 's|@debug@|$(DEBUG)|' \

--- a/depends/README.md
+++ b/depends/README.md
@@ -77,6 +77,7 @@ The following can be set when running make: make FOO=bar
     NO_UPNP: Don't download/build/cache packages needed for enabling upnp
     DEBUG: disable some optimizations and enable more runtime checking
     RAPIDCHECK: build rapidcheck (experimental, requires cmake)
+    PROTOBUF: build protobuf (used for deprecated BIP70 support)
     HOST_ID_SALT: Optional salt to use when generating host package ids
     BUILD_ID_SALT: Optional salt to use when generating build package ids
 

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -37,6 +37,10 @@ if test -z $enable_zmq && test -n "@no_zmq@"; then
   enable_zmq=no
 fi
 
+if test -n $enable_bip70 && test -n "@enable_bip70@"; then
+  enable_bip70=yes
+fi
+
 if test x@host_os@ = xdarwin; then
   BREW=no
   PORT=no

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,7 +1,9 @@
 packages:=boost openssl libevent
 
-qt_native_packages = native_protobuf
-qt_packages = qrencode protobuf zlib
+protobuf_native_packages = native_protobuf
+protobuf_packages = protobuf
+
+qt_packages = qrencode zlib
 
 qt_linux_packages:=qt expat libxcb xcb_proto libXau xproto freetype fontconfig
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -44,7 +44,7 @@ Optional dependencies:
  miniupnpc   | UPnP Support     | Firewall-jumping support
  libdb4.8    | Berkeley DB      | Wallet storage (only needed when wallet enabled)
  qt          | GUI              | GUI toolkit (only needed when GUI enabled)
- protobuf    | Payments in GUI  | Data interchange format used for payment protocol (only needed when GUI enabled)
+ protobuf    | Payments in GUI  | Data interchange format used for payment protocol (only needed when BIP70 enabled)
  libqrencode | QR codes in GUI  | Optional for generating QR codes (only needed when GUI enabled)
  univalue    | Utility          | JSON parsing and encoding (bundled version will be used unless --with-system-univalue passed to configure)
  libzmq3     | ZMQ notification | Optional, allows generating ZMQ notifications (requires ZMQ version >= 4.0.0)

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -35,7 +35,7 @@ Some dependencies are not needed in all configurations. The following are some f
 #### Options passed to `./configure`
 * MiniUPnPc is not needed with  `--with-miniupnpc=no`.
 * Berkeley DB is not needed with `--disable-wallet`.
-* protobuf is not needed with `--disable-bip70`.
+* protobuf is only needed with `--enable-bip70`.
 * Qt is not needed with `--without-gui`.
 * If the qrencode dependency is absent, QR support won't be added. To force an error when that happens, pass `--with-qrencode`.
 * ZeroMQ is needed only with the `--with-zmq` option.


### PR DESCRIPTION
As mentioned by dongcarl in https://github.com/bitcoin/bitcoin/pull/15584#issuecomment-521780972, make building `protobuf` optional in depends. With this change it will only be built if you pass `PROTOBUF=1`.