### PR TITLE
gui: Drop calls to QCoreApplication::processEvents

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -440,7 +440,6 @@ SendCoinsEntry *SendCoinsDialog::addEntry()
     entry->clear();
     entry->setFocus();
     ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
-    qApp->processEvents();
     QScrollBar* bar = ui->scrollArea->verticalScrollBar();
     if(bar)
         bar->setSliderPosition(bar->maximum());

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -70,6 +70,7 @@ uint256 SendCoins(CWallet& wallet, SendCoinsDialog& sendCoinsDialog, const CTxDe
     ConfirmSend();
     bool invoked = QMetaObject::invokeMethod(&sendCoinsDialog, "on_sendButton_clicked");
     assert(invoked);
+    qApp->processEvents();
     return txid;
 }
 

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -437,8 +437,6 @@ void TransactionView::bumpFee()
         // Update the table
         transactionView->selectionModel()->clearSelection();
         model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, true);
-
-        qApp->processEvents();
         Q_EMIT bumpedFee(newHash);
     }
 }


### PR DESCRIPTION
Addresses #16875. For now just remove the calls.

These were introduced in #593 and #12818.