### PR TITLE
Fix first last_op_finish_ is unpredictable value

### DIFF
--- a/src/leveldb/db/db_bench.cc
+++ b/src/leveldb/db/db_bench.cc
@@ -175,7 +175,7 @@ static void AppendWithSpace(std::string* str, Slice msg) {
 
 class Stats {
  private:
-  double start_;
+  double start_ = 0.0;
   double finish_;
   double seconds_;
   int done_;


### PR DESCRIPTION
last_op_finish_  use uninitialized variable “start_” to initialize. This will lead to last_op_finish_ is unpredictable value.