### PR TITLE
doc: Update tx-size-small comment with relevant CVE disclosure

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -461,7 +461,8 @@ static bool AcceptToMemoryPoolWorker(const CChainParams& chainparams, CTxMemPool
 
     // Do not work on transactions that are too small.
     // A transaction with 1 segwit input and 1 P2WPHK output has non-witness size of 82 bytes.
-    // Transactions smaller than this are not relayed to reduce unnecessary malloc overhead.
+    // Transactions smaller than this are not relayed to mitigate CVE-2017-12842 by not relaying
+    // 64-byte transactions.
     if (::GetSerializeSize(tx, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) < MIN_STANDARD_TX_NONWITNESS_SIZE)
         return state.Invalid(ValidationInvalidReason::TX_NOT_STANDARD, false, REJECT_NONSTANDARD, "tx-size-small");
 

--- a/test/functional/data/invalid_txs.py
+++ b/test/functional/data/invalid_txs.py
@@ -82,6 +82,8 @@ class InputMissing(BadTxTemplate):
         return tx
 
 
+# The following check prevents exploit of lack of merkle
+# tree depth commitment (CVE-2017-12842)
 class SizeTooSmall(BadTxTemplate):
     reject_reason = "tx-size-small"
     expect_disconnect = False


### PR DESCRIPTION
Code first introduced under https://github.com/bitcoin/bitcoin/pull/11423 with essentially no description and no discussion.