### PR TITLE
Abstract out some of the descriptor Span-parsing helpers

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -208,6 +208,7 @@ BITCOIN_CORE_H = \
   util/bytevectorhash.h \
   util/error.h \
   util/fees.h \
+  util/spanparsing.h \
   util/system.h \
   util/memory.h \
   util/moneystr.h \
@@ -503,6 +504,7 @@ libbitcoin_util_a_SOURCES = \
   util/moneystr.cpp \
   util/rbf.cpp \
   util/threadnames.cpp \
+  util/spanparsing.cpp \
   util/strencodings.cpp \
   util/string.cpp \
   util/time.cpp \

--- a/src/util/spanparsing.cpp
+++ b/src/util/spanparsing.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/spanparsing.h>
+
+#include <span.h>
+
+#include <string>
+#include <vector>
+
+namespace spanparsing {
+
+bool Const(const std::string& str, Span<const char>& sp)
+{
+    if ((size_t)sp.size() >= str.size() && std::equal(str.begin(), str.end(), sp.begin())) {
+        sp = sp.subspan(str.size());
+        return true;
+    }
+    return false;
+}
+
+bool Func(const std::string& str, Span<const char>& sp)
+{
+    if ((size_t)sp.size() >= str.size() + 2 && sp[str.size()] == '(' && sp[sp.size() - 1] == ')' && std::equal(str.begin(), str.end(), sp.begin())) {
+        sp = sp.subspan(str.size() + 1, sp.size() - str.size() - 2);
+        return true;
+    }
+    return false;
+}
+
+Span<const char> Expr(Span<const char>& sp)
+{
+    int level = 0;
+    auto it = sp.begin();
+    while (it != sp.end()) {
+        if (*it == '(') {
+            ++level;
+        } else if (level && *it == ')') {
+            --level;
+        } else if (level == 0 && (*it == ')' || *it == ',')) {
+            break;
+        }
+        ++it;
+    }
+    Span<const char> ret = sp.first(it - sp.begin());
+    sp = sp.subspan(it - sp.begin());
+    return ret;
+}
+
+std::vector<Span<const char>> Split(const Span<const char>& sp, char sep)
+{
+    std::vector<Span<const char>> ret;
+    auto it = sp.begin();
+    auto start = it;
+    while (it != sp.end()) {
+        if (*it == sep) {
+            ret.emplace_back(start, it);
+            start = it + 1;
+        }
+        ++it;
+    }
+    ret.emplace_back(start, it);
+    return ret;
+}
+
+} // namespace spanparsing

--- a/src/util/spanparsing.h
+++ b/src/util/spanparsing.h
@@ -12,16 +12,37 @@
 
 namespace spanparsing {
 
-/** Parse a constant. If successful, sp is updated to skip the constant and return true. */
+/** Parse a constant.
+ *
+ * If sp's initial part matches str, sp is updated to skip that part, and true is returned.
+ * Otherwise sp is unmodified and false is returned.
+ */
 bool Const(const std::string& str, Span<const char>& sp);
 
-/** Parse a function call. If successful, sp is updated to be the function's argument(s). */
+/** Parse a function call.
+ *
+ * If sp's initial part matches str + "(", and sp ends with ")", sp is updated to be the
+ * section between the braces, and true is returned. Otherwise sp is unmodified and false
+ * is returned.
+ */
 bool Func(const std::string& str, Span<const char>& sp);
 
-/** Return the expression that sp begins with, and update sp to skip it. */
+/** Extract the expression that sp begins with.
+ *
+ * This function will return the initial part of sp, up to (but not including) the first
+ * comma or closing brace, skipping ones that are surrounded by braces. So for example,
+ * for "foo(bar(1),2),3" the initial part "foo(bar(1),2)" will be returned. sp will be
+ * updated to skip the initial part that is returned.
+ */
 Span<const char> Expr(Span<const char>& sp);
 
-/** Split a string on every instance of sep, returning a vector. */
+/** Split a string on every instance of sep, returning a vector.
+ *
+ * If sep does not occur in sp, a singleton with the entirety of sp is returned.
+ *
+ * Note that this function does not care about braces, so splitting
+ * "foo(bar(1),2),3) on ',' will return {"foo(bar(1)", "2)", "3)"}.
+ */
 std::vector<Span<const char>> Split(const Span<const char>& sp, char sep);
 
 } // namespace spanparsing

--- a/src/util/spanparsing.h
+++ b/src/util/spanparsing.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2018 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_SPANPARSING_H
+#define BITCOIN_UTIL_SPANPARSING_H
+
+#include <span.h>
+
+#include <string>
+#include <vector>
+
+namespace spanparsing {
+
+/** Parse a constant. If successful, sp is updated to skip the constant and return true. */
+bool Const(const std::string& str, Span<const char>& sp);
+
+/** Parse a function call. If successful, sp is updated to be the function's argument(s). */
+bool Func(const std::string& str, Span<const char>& sp);
+
+/** Return the expression that sp begins with, and update sp to skip it. */
+Span<const char> Expr(Span<const char>& sp);
+
+/** Split a string on every instance of sep, returning a vector. */
+std::vector<Span<const char>> Split(const Span<const char>& sp, char sep);
+
+} // namespace spanparsing
+
+#endif // BITCOIN_UTIL_SPANPARSING_H


### PR DESCRIPTION
As suggested here: https://github.com/bitcoin/bitcoin/pull/16800#issuecomment-531605482.

This moves the Span parsing functions out of the descriptor module, making them more easily usable for other parsers (in particular, in preparation for miniscript parsing).