### PR TITLE
rpc: Don't allow to 'estimatesmartfee' in blocksonly mode

### DIFF
--- a/doc/release-notes-16890.md
+++ b/doc/release-notes-16890.md
@@ -1,0 +1,3 @@
+RPC changes
+-----------
+The `estimatesmartfee` command does not return an estimation anymore if don't relay transactions.

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -830,6 +830,9 @@ static UniValue estimatesmartfee(const JSONRPCRequest& request)
         if (fee_mode == FeeEstimateMode::ECONOMICAL) conservative = false;
     }
 
+    if (!g_relay_txes)
+        throw JSONRPCError(RPC_MISC_ERROR, "Can not estimate fees if not relaying transactions.");
+
     UniValue result(UniValue::VOBJ);
     UniValue errors(UniValue::VARR);
     FeeCalculation feeCalc;

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -7,7 +7,7 @@
 from test_framework.messages import msg_tx, CTransaction, FromHex
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal
+from test_framework.util import assert_equal, assert_raises_rpc_error
 
 
 class P2PBlocksOnly(BitcoinTestFramework):
@@ -56,6 +56,11 @@ class P2PBlocksOnly(BitcoinTestFramework):
             self.nodes[0].sendrawtransaction(sigtx)
             self.nodes[0].p2p.wait_for_tx(txid)
             assert_equal(self.nodes[0].getmempoolinfo()['size'], 1)
+
+        # Test that we cant `estimatesmartfee` in blocksonly mode.
+        assert_raises_rpc_error(-1, "Can not estimate fees if not relaying "
+                                "transactions.",
+                                self.nodes[0].estimatesmartfee, 6)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #16840.

EDIT: some context from the issue: `estimatesmartfee` will return bad (outdated) fee estimation if ran in `blocksonly` mode. Seems better for it to fail instead of succeeding with potentially harmful (in the case of a lightning penalty tx for example) values.