### PR TITLE
doc: Fix doxygen comment for SignTransaction in rpc/rawtransaction_util

### DIFF
--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -268,7 +268,7 @@ void ParsePrevouts(const UniValue& prevTxsUnival, FillableSigningProvider* keyst
     }
 }
 
-UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, std::map<COutPoint, Coin>& coins, const UniValue& hashType)
+UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType)
 {
     int nHashType = ParseSighashString(hashType);
 

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -19,11 +19,11 @@ class SigningProvider;
  *
  * @param  mtx           The transaction to-be-signed
  * @param  keystore      Temporary keystore containing signing keys
- * @param  coins         Map of unspent outputs - coins in mempool and current chain UTXO set, may be extended by previous txns outputs after call
+ * @param  coins         Map of unspent outputs
  * @param  hashType      The signature hash type
  * @returns JSON object with details of signed transaction
  */
-UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, std::map<COutPoint, Coin>& coins, const UniValue& hashType);
+UniValue SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType);
 
 /**
   * Parse a prevtxs UniValue array and get the map of coins from it


### PR DESCRIPTION
The param `coins` to `SignTransaction` is final and can thus not be extended (as suggested by the doc).