### PR TITLE
doc: Add markdownlint rules & apply formatting

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,44 @@
+# github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#rules
+---
+MD001: true
+MD003: false
+MD004:
+  style: consistent
+MD005: true
+MD006: true
+MD007: false
+MD009: true
+MD010: true
+MD011: true
+MD012: true
+MD013: false
+MD014: true
+MD018: true
+MD019: true
+MD022: 0
+MD023: true
+MD024: false
+MD025: true
+MD026: false
+MD027: true
+MD028: true
+MD029:
+  style: ordered
+MD030: true
+MD031: false
+MD032: false
+MD033: false
+MD034: false
+MD035:
+  style: "---"
+MD036: true
+MD037: true
+MD038: true
+MD039: true
+MD040: false
+MD041: true
+MD042: true
+MD045: true
+MD046: false
+MD047: true
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,20 +22,19 @@ Communication Channels
 ----------------------
 
 Most communication about Bitcoin Core development happens on IRC, in the
-#bitcoin-core-dev channel on Freenode. The easiest way to participate on IRC is
+\#bitcoin-core-dev channel on Freenode. The easiest way to participate on IRC is
 with the web client, [webchat.freenode.net](https://webchat.freenode.net/). Chat
 history logs can be found
 on [http://www.erisian.com.au/bitcoin-core-dev/](http://www.erisian.com.au/bitcoin-core-dev/)
 and [http://gnusha.org/bitcoin-core-dev/](http://gnusha.org/bitcoin-core-dev/).
 
-Discussion about code base improvements happens in GitHub issues and on pull
+Discussion about codebase improvements happens in GitHub issues and on pull
 requests.
 
 The developer
 [mailing list](https://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev)
 should be used to discuss complicated or controversial changes before working on
 a patch set.
-
 
 Contributor Workflow
 --------------------
@@ -46,9 +45,9 @@ facilitates social contribution, easy testing and peer review.
 
 To contribute a patch, the workflow is as follows:
 
-  1. Fork repository
-  1. Create topic branch
-  1. Commit patches
+1. Fork repository
+2. Create topic branch
+3. Commit patches
 
 The project coding conventions in the [developer notes](doc/developer-notes.md)
 must be adhered to.
@@ -73,31 +72,34 @@ Commit messages should never contain any `@` mentions.
 Please refer to the [Git manual](https://git-scm.com/doc) for more information
 about Git.
 
-  - Push changes to your fork
-  - Create pull request
+- Push changes to your fork
+- Create pull request
 
 The title of the pull request should be prefixed by the component or area that
-the pull request affects. Valid areas as:
+the pull request affects. Valid areas are:
 
-  - `consensus` for changes to consensus critical code
-  - `doc` for changes to the documentation
-  - `qt` or `gui` for changes to bitcoin-qt
-  - `log` for changes to log messages
-  - `mining` for changes to the mining code
-  - `net` or `p2p` for changes to the peer-to-peer network code
-  - `refactor` for structural changes that do not change behavior
-  - `rpc`, `rest` or `zmq` for changes to the RPC, REST or ZMQ APIs
-  - `script` for changes to the scripts and tools
-  - `test` for changes to the bitcoin unit tests or QA tests
-  - `util` or `lib` for changes to the utils or libraries
-  - `wallet` for changes to the wallet code
-  - `build` for changes to the GNU Autotools, reproducible builds or CI code
+- `consensus` for changes to consensus critical code
+- `doc` for changes to the documentation
+- `qt` or `gui` for changes to bitcoin-qt
+- `log` for changes to log messages
+- `mining` for changes to the mining code
+- `net` or `p2p` for changes to the peer-to-peer network code
+- `refactor` for structural changes that do not change behavior
+- `rpc`, `rest` or `zmq` for changes to the RPC, REST or ZMQ APIs
+- `script` for changes to the scripts and tools
+- `test` for changes to the bitcoin unit tests or QA tests
+- `util` or `lib` for changes to the utils or libraries
+- `wallet` for changes to the wallet code
+- `build` for changes to the GNU Autotools, reproducible builds or CI code
 
 Examples:
 
     consensus: Add new opcode for BIP-XXXX OP_CHECKAWESOMESIG
+
     net: Automatically create hidden service, listen on Tor
+
     qt: Add feed bump button
+
     log: Fix typo in log message
 
 Note that translations should not be submitted as pull requests, please see
@@ -149,7 +151,6 @@ the respective change set.
 The length of time required for peer review is unpredictable and will vary from
 pull request to pull request.
 
-
 Pull Request Philosophy
 -----------------------
 
@@ -158,7 +159,6 @@ feature, fix a bug, or refactor code; but not a mixture. Please also avoid super
 pull requests which attempt to do too much, are overly large, or overly complex
 as this makes review difficult.
 
-
 ### Features
 
 When adding a new feature, thought must be given to the long term technical debt
@@ -166,7 +166,6 @@ and maintenance that feature may require after inclusion. Before proposing a new
 feature that will require maintenance, please consider if you are willing to
 maintain it (including bug fixing). If features get orphaned with no maintainer
 in the future, they may be removed by the Repository Maintainer.
-
 
 ### Refactoring
 
@@ -190,7 +189,6 @@ Trivial pull requests or pull requests that refactor the code with no clear
 benefits may be immediately closed by the maintainers to reduce unnecessary
 workload on reviewing.
 
-
 "Decision Making" Process
 -------------------------
 
@@ -207,15 +205,15 @@ judge the general consensus of contributors.
 
 In general, all pull requests must:
 
-  - Have a clear use case, fix a demonstrable bug or serve the greater good of
-    the project (for example refactoring for modularisation);
-  - Be well peer reviewed;
-  - Have unit tests and functional tests where appropriate;
-  - Follow code style guidelines ([C++](doc/developer-notes.md), [functional tests](test/functional/README.md));
-  - Not break the existing test suite;
-  - Where bugs are fixed, where possible, there should be unit tests
-    demonstrating the bug and also proving the fix. This helps prevent regression.
-  - Change relevant comments and documentation when behaviour of code changes.
+- Have a clear use case, fix a demonstrable bug or serve the greater good of
+  the project (for example refactoring for modularisation);
+- Be well peer reviewed;
+- Have unit tests and functional tests where appropriate;
+- Follow code style guidelines ([C++](doc/developer-notes.md), [functional tests](test/functional/README.md));
+- Not break the existing test suite;
+- Where bugs are fixed, where possible, there should be unit tests
+  demonstrating the bug and also proving the fix. This helps prevent regression.
+- Change relevant comments and documentation when behaviour of code changes.
 
 Patches that change Bitcoin consensus rules are considerably more involved than
 normal because they affect the entire ecosystem and so must be preceded by
@@ -223,7 +221,6 @@ extensive mailing list discussions and have a numbered BIP. While each case will
 be different, one should be prepared to expend more time and effort than for
 other kinds of patches because of increased peer review and consensus building
 requirements.
-
 
 ### Peer Review
 
@@ -236,10 +233,11 @@ spread out over GitHub, mailing list and IRC discussions).
 
 #### Conceptual Review
 
-A review can be a conceptual review, where the reviewer leaves a comment
- * `Concept (N)ACK`, meaning "I do (not) agree in the general goal of this pull
+A review can be a conceptual review, where the reviewer leaves a comment:
+
+- `Concept (N)ACK`, meaning "I do (not) agree in the general goal of this pull
    request",
- * `Approach (N)ACK`, meaning `Concept ACK`, but "I do (not) agree with the
+- `Approach (N)ACK`, meaning `Concept ACK`, but "I do (not) agree with the
    approach of this change".
 
 A `NACK` needs to include a rationale why the change is not worthwhile.
@@ -253,13 +251,13 @@ topic branch. The review is followed by a description of how the reviewer did
 the review. The following
 language is used within pull-request comments:
 
-  - "I have tested the code", involving
-    change-specific manual testing in addition to running the unit and functional
-    tests, and in case it is not obvious how the manual testing was done, it should
-    be described;
-  - "I have not tested the code, but I have reviewed it and it looks
-    OK, I agree it can be merged";
-  - Nit refers to trivial, often non-blocking issues.
+- "I have tested the code", involving
+  change-specific manual testing in addition to running the unit and functional
+  tests, and in case it is not obvious how the manual testing was done, it should
+  be described;
+- "I have not tested the code, but I have reviewed it and it looks
+  OK, I agree it can be merged";
+- Nit refers to trivial, often non-blocking issues.
 
 Project maintainers reserve the right to weigh the opinions of peer reviewers
 using common sense judgement and also may weight based on meritocracy: Those
@@ -285,29 +283,31 @@ that you've been waiting for a pull request to be given attention for several
 months, there may be a number of reasons for this, some of which you can do something
 about:
 
-  - It may be because of a feature freeze due to an upcoming release. During this time,
-    only bug fixes are taken into consideration. If your pull request is a new feature,
-    it will not be prioritized until the release is over. Wait for release.
-  - It may be because the changes you are suggesting do not appeal to people. Rather than
-    nits and critique, which require effort and means they care enough to spend time on your
-    contribution, thundering silence is a good sign of widespread (mild) dislike of a given change
-    (because people don't assume *others* won't actually like the proposal). Don't take
-    that personally, though! Instead, take another critical look at what you are suggesting
-    and see if it: changes too much, is too broad, doesn't adhere to the
-    [developer notes](doc/developer-notes.md), is dangerous or insecure, is messily written, etc.
-    Identify and address any of the issues you find. Then ask e.g. on IRC if someone could give
-    their opinion on the concept itself.
-  - It may be because your code is too complex for all but a few people. And those people
-    may not have realized your pull request even exists. A great way to find people who
-    are qualified and care about the code you are touching is the
-    [Git Blame feature](https://help.github.com/articles/tracing-changes-in-a-file/). Simply
-    find the person touching the code you are touching before you and see if you can find
-    them and give them a nudge. Don't be incessant about the nudging though.
-  - Finally, if all else fails, ask on IRC or elsewhere for someone to give your pull request
-    a look. If you think you've been waiting an unreasonably long amount of time (month+) for
-    no particular reason (few lines changed, etc), this is totally fine. Try to return the favor
-    when someone else is asking for feedback on their code, and universe balances out.
+- It may be because of a feature freeze due to an upcoming release. During this time,
+  only bug fixes are taken into consideration. If your pull request is a new feature,
+  it will not be prioritized until the release is over. Wait for release.
 
+- It may be because the changes you are suggesting do not appeal to people. Rather than
+  nits and critique, which require effort and means they care enough to spend time on your
+  contribution, thundering silence is a good sign of widespread (mild) dislike of a given change
+  (because people don't assume *others* won't actually like the proposal). Don't take
+  that personally, though! Instead, take another critical look at what you are suggesting
+  and see if it: changes too much, is too broad, doesn't adhere to the
+  [developer notes](doc/developer-notes.md), is dangerous or insecure, is messily written, etc.
+  Identify and address any of the issues you find. Then ask e.g. on IRC if someone could give
+  their opinion on the concept itself.
+
+- It may be because your code is too complex for all but a few people. And those people
+  may not have realized your pull request even exists. A great way to find people who
+  are qualified and care about the code you are touching is the
+  [Git Blame feature](https://help.github.com/articles/tracing-changes-in-a-file/). Simply
+  find the person touching the code you are touching before you and see if you can find
+  them and give them a nudge. Don't be incessant about the nudging though.
+
+- Finally, if all else fails, ask on IRC or elsewhere for someone to give your pull request
+  a look. If you think you've been waiting an unreasonably long amount of time (month+) for
+  no particular reason (few lines changed, etc), this is totally fine. Try to return the favor
+  when someone else is asking for feedback on their code, and universe balances out.
 
 Release Policy
 --------------

--- a/ci/README.md
+++ b/ci/README.md
@@ -1,4 +1,4 @@
-## ci scripts
+# CI Scripts
 
 This directory contains scripts for each build step in each build stage.
 
@@ -6,7 +6,7 @@ Currently three stages `lint`, `extended_lint` and `test` are defined. Each stag
 [Travis CI lifecycle](https://docs.travis-ci.com/user/job-lifecycle#the-job-lifecycle). Every script in here is named
 and numbered according to which stage and lifecycle step it belongs to.
 
-### Running a stage locally
+## Running a stage locally
 
 To allow for a wide range of tested environments, but also ensure reproducibility to some extent, the test stage
 requires `docker` to be installed. To install all requirements on Ubuntu, run

--- a/ci/retry/README.md
+++ b/ci/retry/README.md
@@ -1,9 +1,8 @@
-retry - The command line retry tool
-------------------------------------------
+# retry - The command line retry tool
 
 Retry any shell command with exponential backoff or constant delay.
 
-### Instructions
+## Instructions
 
 Install:
 
@@ -21,7 +20,7 @@ brew install retry
 ```
 Not popular enough for homebrew-core. Please star this project to help.
 
-### Usage
+## Usage
 
 Help:
 
@@ -32,8 +31,8 @@ Help:
         -v, --verbose                    Verbose output
         -t, --tries=#                    Set max retries: Default 10
         -s, --sleep=secs                 Constant sleep amount (seconds)
-        -m, --min=secs                   Exponenetial Backoff: minimum sleep amount (seconds): Default 0.3
-        -x, --max=secs                   Exponenetial Backoff: maximum sleep amount (seconds): Default 60
+        -m, --min=secs                   Exponential Backoff: minimum sleep amount (seconds): Default 0.3
+        -x, --max=secs                   Exponential Backoff: maximum sleep amount (seconds): Default 60
         -f, --fail="script +cmds"        Fail Script: run in case of final failure
 
 ### Examples

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,48 +1,48 @@
 Repository Tools
----------------------
+================
 
-### [Developer tools](/contrib/devtools) ###
+## [Developer tools](/contrib/devtools)
 Specific tools for developers working on this repository.
 Additional tools, including the `github-merge.py` script, are available in the [maintainer-tools](https://github.com/bitcoin-core/bitcoin-maintainer-tools) repository.
 
-### [Verify-Commits](/contrib/verify-commits) ###
+## [verify-commits](/contrib/verify-commits)
 Tool to verify that every merge commit was signed by a developer using the `github-merge.py` script.
 
-### [Linearize](/contrib/linearize) ###
+## [linearize](/contrib/linearize)
 Construct a linear, no-fork, best version of the blockchain.
 
-### [Qos](/contrib/qos) ###
+## [qos](/contrib/qos)
 
 A Linux bash script that will set up traffic control (tc) to limit the outgoing bandwidth for connections to the Bitcoin network. This means one can have an always-on bitcoind instance running, and another local bitcoind/bitcoin-qt instance which connects to this node and receives blocks from it.
 
-### [Seeds](/contrib/seeds) ###
+## [seeds](/contrib/seeds)
 Utility to generate the pnSeed[] array that is compiled into the client.
 
 Build Tools and Keys
 ---------------------
 
-### Packaging ###
+### Packaging
 The [Debian](/contrib/debian) subfolder contains the copyright file.
 
-All other packaging related files can be found in the [bitcoin-core/packaging](https://github.com/bitcoin-core/packaging) repository.
+All other packaging-related files can be found in the [bitcoin-core/packaging](https://github.com/bitcoin-core/packaging) repository.
 
-### [Gitian-descriptors](/contrib/gitian-descriptors) ###
+### [gitian-build.py](/contrib/gitian-build.py)
+Script for running full Gitian builds.
+
+### [gitian-descriptors](/contrib/gitian-descriptors)
 Files used during the gitian build process. For more information about gitian, see the [the Bitcoin Core documentation repository](https://github.com/bitcoin-core/docs).
 
-### [Gitian-keys](/contrib/gitian-keys)
+### [gitian-keys](/contrib/gitian-keys)
 PGP keys used for signing Bitcoin Core [Gitian release](/doc/release-process.md) results.
 
-### [MacDeploy](/contrib/macdeploy) ###
+### [macdeploy](/contrib/macdeploy)
 Scripts and notes for Mac builds.
-
-### [Gitian-build](/contrib/gitian-build.py) ###
-Script for running full Gitian builds.
 
 Test and Verify Tools
 ---------------------
 
-### [TestGen](/contrib/testgen) ###
+### [TestGen](/contrib/testgen)
 Utilities to generate test vectors for the data-driven Bitcoin tests.
 
-### [Verify Binaries](/contrib/verifybinaries) ###
+### [Verify Binaries](/contrib/verifybinaries)
 This script attempts to download and verify the signature file SHA256SUMS.asc from bitcoin.org.

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -1,43 +1,44 @@
-Contents
-========
+# Devtools
+
 This directory contains tools for developers working on this repository.
 
-clang-format-diff.py
-===================
+## clang-format-diff.py
 
 A script to format unified git diffs according to [.clang-format](../../src/.clang-format).
 
 Requires `clang-format`, installed e.g. via `brew install clang-format` on macOS.
 
 For instance, to format the last commit with 0 lines of context,
-the script should be called from the git root folder as follows.
+the script should be called from the git root folder as follows:
 
 ```
 git diff -U0 HEAD~1.. | ./contrib/devtools/clang-format-diff.py -p1 -i -v
 ```
 
-copyright\_header.py
-====================
+## copyright\_header.py
 
 Provides utilities for managing copyright headers of `The Bitcoin Core
 developers` in repository source files. It has three subcommands:
 
 ```
-$ ./copyright_header.py report <base_directory> [verbose]
-$ ./copyright_header.py update <base_directory>
-$ ./copyright_header.py insert <file>
+./copyright_header.py report <base_directory> [verbose]
+```
+```
+./copyright_header.py update <base_directory>
+```
+```
+./copyright_header.py insert <file>
 ```
 Running these subcommands without arguments displays a usage string.
 
-copyright\_header.py report \<base\_directory\> [verbose]
----------------------------------------------------------
+### copyright\_header.py report \<base\_directory\> [verbose]
 
 Produces a report of all copyright header notices found inside the source files
 of a repository. Useful to quickly visualize the state of the headers.
 Specifying `verbose` will list the full filenames of files of each category.
 
-copyright\_header.py update \<base\_directory\> [verbose]
----------------------------------------------------------
+### copyright\_header.py update \<base\_directory\> [verbose]
+
 Updates all the copyright headers of `The Bitcoin Core developers` which were
 changed in a year more recent than is listed. For example:
 ```
@@ -60,8 +61,8 @@ will be updated to:
 ```
 where the update is appropriate.
 
-copyright\_header.py insert \<file\>
-------------------------------------
+### copyright\_header.py insert \<file\>
+
 Inserts a copyright header for `The Bitcoin Core developers` at the top of the
 file in either Python or C++ style as determined by the file extension. If the
 file is a Python file and it has  `#!` starting the first line, the header is
@@ -75,8 +76,7 @@ year rather than two hyphenated years.
 If the file already has a copyright for `The Bitcoin Core developers`, the
 script will exit.
 
-gen-manpages.sh
-===============
+## gen-manpages.sh
 
 A small script to automatically create manpages in ../../doc/man by running the release binaries with the -help option.
 This requires help2man which can be found at: https://www.gnu.org/software/help2man/
@@ -89,19 +89,16 @@ example:
 BUILDDIR=$PWD/build contrib/devtools/gen-manpages.sh
 ```
 
-optimize-pngs.py
-================
+## optimize-pngs.py
 
 A script to optimize png files in the bitcoin
 repository (requires pngcrush).
 
-security-check.py and test-security-check.py
-============================================
+## security-check.py and test-security-check.py
 
 Perform basic ELF security checks on a series of executables.
 
-symbol-check.py
-===============
+## symbol-check.py
 
 A script to check that the (Linux) executables produced by gitian only contain
 allowed gcc, glibc and libstdc++ version symbols. This makes sure they are
@@ -120,8 +117,7 @@ If there are 'unsupported' symbols, the return value will be 1 a list like this 
     .../64/test_bitcoin: symbol std::out_of_range::~out_of_range() from unsupported version GLIBCXX_3.4.15
     .../64/test_bitcoin: symbol _ZNSt8__detail15_List_nod from unsupported version GLIBCXX_3.4.15
 
-circular-dependencies.py
-========================
+## circular-dependencies.py
 
 Run this script from the root of the source tree (`src/`) to find circular dependencies in the source code.
 This looks only at which files include other files, treating the `.cpp` and `.h` file as one unit.

--- a/contrib/gitian-keys/README.md
+++ b/contrib/gitian-keys/README.md
@@ -1,4 +1,4 @@
-## PGP keys of Gitian builders and Developers
+# PGP keys of Gitian builders and Developers
 
 The file `keys.txt` contains fingerprints of the public keys of Gitian builders
 and active developers.

--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -113,7 +113,7 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
 
 #### Recognized environment variables
 
-* _**HOSTS**_
+- _**HOSTS**_
 
   Override the space-separated list of platform triples for which to perform a
   bootstrappable build. _(defaults to "i686-linux-gnu x86\_64-linux-gnu
@@ -121,31 +121,31 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
 
   > Windows and OS X platform triplet support are WIP.
 
-* _**SOURCES_PATH**_
+- _**SOURCES_PATH**_
 
   Set the depends tree download cache for sources. This is passed through to the
   depends tree. Setting this to the same directory across multiple builds of the
   depends tree can eliminate unnecessary redownloading of package sources.
 
-* _**MAX_JOBS**_
+- _**MAX_JOBS**_
 
   Override the maximum number of jobs to run simultaneously, you might want to
   do so on a memory-limited machine. This may be passed to `make` as in `make
   --jobs="$MAX_JOBS"` or `xargs` as in `xargs -P"$MAX_JOBS"`. _(defaults to the
   value of `nproc` outside the container)_
 
-* _**SOURCE_DATE_EPOCH**_
+- _**SOURCE_DATE_EPOCH**_
 
   Override the reference UNIX timestamp used for bit-for-bit reproducibility,
   the variable name conforms to [standard][r12e/source-date-epoch]. _(defaults
   to the output of `$(git log --format=%at -1)`)_
 
-* _**V**_
+- _**V**_
 
   If non-empty, will pass `V=1` to all `make` invocations, making `make` output
   verbose.
 
-* _**ADDITIONAL_GUIX_ENVIRONMENT_FLAGS**_
+- _**ADDITIONAL_GUIX_ENVIRONMENT_FLAGS**_
 
   Additional flags to be passed to `guix environment`. For a fully-bootstrapped
   build, set this to `--bootstrap --no-substitutes` (refer to the [security

--- a/contrib/init/README.md
+++ b/contrib/init/README.md
@@ -1,3 +1,5 @@
+# Init
+
 Sample configuration files for:
 ```
 SystemD: bitcoind.service
@@ -9,4 +11,4 @@ macOS:   org.bitcoin.bitcoind.plist
 ```
 have been made available to assist packagers in creating node packages here.
 
-See doc/init.md for more information.
+See [/doc/init.md](/doc/init.md) for more information.

--- a/contrib/linearize/README.md
+++ b/contrib/linearize/README.md
@@ -3,7 +3,7 @@ Construct a linear, no-fork, best version of the Bitcoin blockchain.
 
 ## Step 1: Download hash list
 
-    $ ./linearize-hashes.py linearize.cfg > hashlist.txt
+    ./linearize-hashes.py linearize.cfg > hashlist.txt
 
 Required configuration file settings for linearize-hashes:
 * RPC: `datadir` (Required if `rpcuser` and `rpcpassword` are not specified)
@@ -24,7 +24,7 @@ JSON-RPC server. Running `bitcoind` or `bitcoin-qt -server` will be sufficient.
 
 ## Step 2: Copy local block data
 
-    $ ./linearize-data.py linearize.cfg
+    ./linearize-data.py linearize.cfg
 
 Required configuration file settings:
 * `output_file`: The file that will contain the final blockchain.

--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -1,15 +1,14 @@
-### MacDeploy ###
+# MacDeploy
 
 For Snow Leopard (which uses [Python 2.6](http://www.python.org/download/releases/2.6/)), you will need the param_parser package:
 
-	sudo easy_install argparse
+    sudo easy_install argparse
 
 This script should not be run manually, instead, after building as usual:
 
-	make deploy
+    make deploy
 
 During the process, the disk image window will pop up briefly where the fancy
 settings are applied. This is normal, please do not interfere.
 
 When finished, it will produce `Bitcoin-Core.dmg`.
-

--- a/contrib/qos/README.md
+++ b/contrib/qos/README.md
@@ -1,4 +1,4 @@
-### QoS (Quality of service) ###
+# QoS (Quality of Service)
 
 This is a Linux bash script that will set up tc to limit the outgoing bandwidth for connections to the Bitcoin network. It limits outbound TCP traffic with a source or destination port of 8333, but not if the destination IP is within a LAN.
 

--- a/contrib/testgen/README.md
+++ b/contrib/testgen/README.md
@@ -1,4 +1,4 @@
-### TestGen ###
+# TestGen
 
 Utilities to generate test vectors for the data-driven Bitcoin tests.
 

--- a/contrib/verify-commits/README.md
+++ b/contrib/verify-commits/README.md
@@ -1,11 +1,10 @@
 Tooling for verification of PGP signed commits
-----------------------------------------------
+==============================================
 
 This is an incomplete work in progress, but currently includes a pre-push hook
 script (`pre-push-hook.sh`) for maintainers to ensure that their own commits
 are PGP signed (nearly always merge commits), as well as a Python 3 script to verify
 commits against a trusted keys list.
-
 
 Using verify-commits.py safely
 ------------------------------

--- a/contrib/verifybinaries/README.md
+++ b/contrib/verifybinaries/README.md
@@ -1,6 +1,6 @@
-### Verify Binaries
+# Verify Binaries
 
-#### Preparation:
+## Preparation:
 
 Make sure you obtain the proper release signing key and verify the fingerprint with several independent sources.
 
@@ -11,14 +11,13 @@ pub   4096R/36C2E964 2015-06-24 [expires: YYYY-MM-DD]
 uid                  Wladimir J. van der Laan (Bitcoin Core binary release signing key) <laanwj@gmail.com>
 ```
 
-#### Usage:
+## Usage:
 
 This script attempts to download the signature file `SHA256SUMS.asc` from https://bitcoin.org.
 
 It first checks if the signature passes, and then downloads the files specified in the file, and checks if the hashes of these files match those that are specified in the signature file.
 
 The script returns 0 if everything passes the checks. It returns 1 if either the signature check or the hash check doesn't pass. If an error occurs the return value is 2.
-
 
 ```sh
 ./verify.sh bitcoin-core-0.11.2

--- a/depends/README.md
+++ b/depends/README.md
@@ -1,4 +1,6 @@
-### Usage
+# Dependencies
+
+## Usage
 
 To build dependencies for the current arch+OS:
 
@@ -33,17 +35,17 @@ Common `host-platform-triplets` for cross compilation are:
 
 No other options are needed, the paths are automatically configured.
 
-### Install the required dependencies: Ubuntu & Debian
+## Install the required dependencies: Ubuntu & Debian
 
-#### For macOS cross compilation
+### For macOS cross compilation
 
     sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python3-setuptools
 
-#### For Win32/Win64 cross compilation
+### For Win32/Win64 cross compilation
 
-- see [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)
+See [build-windows.md](../doc/build-windows.md#cross-compilation-for-ubuntu-and-windows-subsystem-for-linux)
 
-#### For linux (including i386, ARM) cross compilation
+### For linux (including i386, ARM) cross compilation
 
 Common linux dependencies:
 
@@ -95,4 +97,3 @@ options will be passed to bitcoin's configure. In this case, `--disable-wallet`.
 
 - [description.md](description.md): General description of the depends system
 - [packages.md](packages.md): Steps for adding packages
-

--- a/depends/description.md
+++ b/depends/description.md
@@ -1,7 +1,9 @@
+# Dependencies - Overview
+
 This is a system of building and caching dependencies necessary for building Bitcoin.
 There are several features that make it different from most similar systems:
 
-### It is designed to be builder and host agnostic
+## It is designed to be builder and host agnostic
 
 In theory, binaries for any target OS/architecture can be created, from a
 builder running any OS/architecture. In practice, build-side tools must be
@@ -9,18 +11,18 @@ specified when the defaults don't fit, and packages must be amended to work
 on new hosts. For now, a build architecture of x86_64 is assumed, either on
 Linux or macOS.
 
-### No reliance on timestamps
+## No reliance on timestamps
 
 File presence is used to determine what needs to be built. This makes the
 results distributable and easily digestable by automated builders.
 
-### Each build only has its specified dependencies available at build-time.
+## Each build only has its specified dependencies available at build-time
 
 For each build, the sysroot is wiped and the (recursive) dependencies are
 installed. This makes each build deterministic, since there will never be any
 unknown files available to cause side-effects.
 
-### Each package is cached and only rebuilt as needed.
+## Each package is cached and only rebuilt as needed
 
 Before building, a unique build-id is generated for each package. This id
 consists of a hash of all files used to build the package (Makefiles, packages,
@@ -30,7 +32,7 @@ any other package that depends on it. If any of the main makefiles (Makefile,
 funcs.mk, etc) are changed, all packages will be rebuilt. After building, the
 results are cached into a tarball that can be re-used and distributed.
 
-### Package build results are (relatively) deterministic.
+## Package build results are (relatively) deterministic
 
 Each package is configured and patched so that it will yield the same
 build-results with each consequent build, within a reasonable set of
@@ -39,13 +41,13 @@ beyond the scope of this system. Additionally, the toolchain itself must be
 capable of deterministic results. When revisions are properly bumped, a cached
 build should represent an exact single payload.
 
-### Sources are fetched and verified automatically
+## Sources are fetched and verified automatically
 
 Each package must define its source location and checksum. The build will fail
 if the fetched source does not match. Sources may be pre-seeded and/or cached
 as desired.
 
-### Self-cleaning
+## Self-cleaning
 
 Build and staging dirs are wiped after use, and any previous version of a
 cached result is removed following a successful build. Automated builders

--- a/depends/packages.md
+++ b/depends/packages.md
@@ -1,3 +1,5 @@
+# Dependencies - Packages
+
 Each recipe consists of 3 main parts: defining identifiers, setting build
 variables, and defining build commands.
 
@@ -48,7 +50,6 @@ These variables are optional:
     Any extra files that will be fetched via $(package)_fetch_cmds. These are
     specified so that they can be fetched and verified via 'make download'.
 
-
 ## Build Variables:
 After defining the main identifiers, build variables may be added or customized
 before running the build commands. They should be added to a function called
@@ -61,10 +62,10 @@ $(package)_set_vars. For example:
 Most variables can be prefixed with the host, architecture, or both, to make
 the modifications specific to that case. For example:
 
-    Universal:     $(package)_cc=gcc
-    Linux only:    $(package)_linux_cc=gcc
-    x86_64 only:       $(package)_x86_64_cc = gcc
-    x86_64 linux only: $(package)_x86_64_linux_cc = gcc
+    Universal:         $(package)_cc=gcc
+    Linux only:        $(package)_linux_cc=gcc
+    x86_64 only:       $(package)_x86_64_cc=gcc
+    x86_64 linux only: $(package)_x86_64_linux_cc=gcc
 
 These variables may be set to override or append their default values.
 
@@ -159,9 +160,9 @@ possible.
 
 From the [Gentoo Wiki entry](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Handling_Libtool_Archives):
 
->  Libtool pulls in all direct and indirect dependencies into the .la files it
->  creates. This leads to massive overlinking, which is toxic to the Gentoo
->  ecosystem, as it leads to a massive number of unnecessary rebuilds.
+> Libtool pulls in all direct and indirect dependencies into the .la files it
+> creates. This leads to massive overlinking, which is toxic to the Gentoo
+> ecosystem, as it leads to a massive number of unnecessary rebuilds.
 
 ## Secondary dependencies:
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -28,10 +28,10 @@ Drag Bitcoin Core to your applications folder, and then run Bitcoin Core.
 
 ### Need Help?
 
-* See the documentation at the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
+- See the documentation at the [Bitcoin Wiki](https://en.bitcoin.it/wiki/Main_Page)
 for help and more information.
-* Ask for help on [#bitcoin](http://webchat.freenode.net?channels=bitcoin) on Freenode. If you don't have an IRC client, use [webchat here](http://webchat.freenode.net?channels=bitcoin).
-* Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
+- Ask for help on [#bitcoin](http://webchat.freenode.net?channels=bitcoin) on Freenode. If you don't have an IRC client, use [webchat here](http://webchat.freenode.net?channels=bitcoin).
+- Ask for help on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Technical Support board](https://bitcointalk.org/index.php?board=4.0).
 
 Building
 ---------------------
@@ -65,9 +65,9 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Benchmarking](benchmarking.md)
 
 ### Resources
-* Discuss on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Development & Technical Discussion board](https://bitcointalk.org/index.php?board=6.0).
-* Discuss project-specific development on #bitcoin-core-dev on Freenode. If you don't have an IRC client, use [webchat here](http://webchat.freenode.net/?channels=bitcoin-core-dev).
-* Discuss general Bitcoin development on #bitcoin-dev on Freenode. If you don't have an IRC client, use [webchat here](http://webchat.freenode.net/?channels=bitcoin-dev).
+- Discuss on the [BitcoinTalk](https://bitcointalk.org/) forums, in the [Development & Technical Discussion board](https://bitcointalk.org/index.php?board=6.0).
+- Discuss project-specific development on #bitcoin-core-dev on Freenode. If you don't have an IRC client, use [webchat here](http://webchat.freenode.net/?channels=bitcoin-core-dev).
+- Discuss general Bitcoin development on #bitcoin-dev on Freenode. If you don't have an IRC client, use [webchat here](http://webchat.freenode.net/?channels=bitcoin-dev).
 
 ### Miscellaneous
 - [Assets Attribution](assets-attribution.md)

--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -15,7 +15,7 @@ apply.
 Supported API
 -------------
 
-#### Transactions
+### Transactions
 `GET /rest/tx/<TX-HASH>.<bin|hex|json>`
 
 Given a transaction hash: returns a transaction in binary, hex-encoded binary, or JSON formats.
@@ -23,7 +23,7 @@ Given a transaction hash: returns a transaction in binary, hex-encoded binary, o
 By default, this endpoint will only search the mempool.
 To query for a confirmed transaction, enable the transaction index via "txindex=1" command line / configuration option.
 
-#### Blocks
+### Blocks
 `GET /rest/block/<BLOCK-HASH>.<bin|hex|json>`
 `GET /rest/block/notxdetails/<BLOCK-HASH>.<bin|hex|json>`
 
@@ -34,18 +34,18 @@ The HTTP request and response are both handled entirely in-memory, thus making m
 
 With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response.
 
-#### Blockheaders
+### Blockheaders
 `GET /rest/headers/<COUNT>/<BLOCK-HASH>.<bin|hex|json>`
 
-Given a block hash: returns <COUNT> amount of blockheaders in upward direction.
+Given a block hash: returns `<COUNT>` amount of blockheaders in upward direction.
 Returns empty if the block doesn't exist or it isn't in the active chain.
 
-#### Blockhash by height
+### Blockhash by height
 `GET /rest/blockhashbyheight/<HEIGHT>.<bin|hex|json>`
 
 Given a height: returns hash of block in best-block-chain at height provided.
 
-#### Chaininfos
+### Chaininfos
 `GET /rest/chaininfo.json`
 
 Returns various state info regarding block chain processing.
@@ -63,7 +63,7 @@ Only supports JSON as output format.
 * softforks : (array) status of softforks in progress
 * bip9_softforks : (object) status of BIP9 softforks in progress
 
-#### Query UTXO set
+### Query UTXO set
 `GET /rest/getutxos/<checkmempool>/<txid>-<n>/<txid>-<n>/.../<txid>-<n>.<bin|hex|json>`
 
 The getutxo command allows querying of the UTXO set given a set of outpoints.
@@ -96,7 +96,7 @@ $ curl localhost:18332/rest/getutxos/checkmempool/b2cdfd7b89def827ff8af7cd9bff76
 }
 ```
 
-#### Memory pool
+### Memory pool
 `GET /rest/mempool/info.json`
 
 Returns various information about the TX mempool.

--- a/doc/assets-attribution.md
+++ b/doc/assets-attribution.md
@@ -1,1 +1,3 @@
+# Assets Attribution
+
 The list of assets used in the bitcoin source and their attribution can now be found in [contrib/debian/copyright](../contrib/debian/copyright).

--- a/doc/bips.md
+++ b/doc/bips.md
@@ -1,3 +1,5 @@
+# Implemented BIPs
+
 BIPs that are implemented by Bitcoin Core (up-to-date up to **v0.18.0**):
 
 * [`BIP 9`](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki): The changes allowing multiple soft-forks to be deployed in parallel have been implemented since **v0.12.1**  ([PR #7575](https://github.com/bitcoin/bitcoin/pull/7575))

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -103,4 +103,3 @@ If your user is in the `staff` group the limit can be raised with:
 The change will only affect the current shell and processes spawned by it. To
 make the change system-wide, change `datasize-cur` and `datasize-max` in
 `/etc/login.conf`, and reboot.
-

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,4 +1,4 @@
-# macOS Build Instructions and Notes
+# MacOS Build Guide and Notes
 
 The commands in this guide should be executed in a Terminal application.
 The built-in one is located in
@@ -50,7 +50,7 @@ from the root of the repository.
     cd bitcoin
     ```
 
-2.  Build Bitcoin Core:
+2. Build Bitcoin Core:
 
     Configure and build the headless Bitcoin Core binaries as well as the GUI (if Qt is found).
 
@@ -61,12 +61,12 @@ from the root of the repository.
     make
     ```
 
-3.  It is recommended to build and run the unit tests:
+3. It is recommended to build and run the unit tests:
     ```shell
     make check
     ```
 
-4.  You can also create a  `.dmg` that contains the `.app` bundle (optional):
+4. You can also create a  `.dmg` that contains the `.app` bundle (optional):
     ```shell
     make deploy
     ```
@@ -197,12 +197,11 @@ order to satisfy the new Gatekeeper requirements. Because this private key canno
 shared, we'll have to be a bit creative in order for the build process to remain somewhat
 deterministic. Here's how it works:
 
-- Builders use Gitian to create an unsigned release. This outputs an unsigned DMG which
+* Builders use Gitian to create an unsigned release. This outputs an unsigned DMG which
   users may choose to bless and run. It also outputs an unsigned app structure in the form
   of a tarball, which also contains all of the tools that have been previously (deterministically)
   built in order to create a final DMG.
-- The Apple keyholder uses this unsigned app to create a detached signature, using the
+* The Apple keyholder uses this unsigned app to create a detached signature, using the
   script that is also included there. Detached signatures are available from this [repository](https://github.com/bitcoin-core/bitcoin-detached-sigs).
-- Builders feed the unsigned app + detached signature back into Gitian. It uses the
+* Builders feed the unsigned app + detached signature back into Gitian. It uses the
   pre-built tools to recombine the pieces into a deterministic DMG.
-

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -1,4 +1,4 @@
-UNIX BUILD NOTES
+Unix Build Notes
 ====================
 Some notes on how to build Bitcoin Core in Unix.
 
@@ -9,7 +9,7 @@ Note
 Always use absolute paths to configure and compile Bitcoin Core and the dependencies.
 For example, when specifying the path of the dependency:
 
-	../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+    ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
 
 Here BDB_PREFIX must be an absolute path - it is defined using $(pwd) which ensures
 the usage of the absolute path.
@@ -58,7 +58,6 @@ C++ compilers are memory-hungry. It is recommended to have at least 1.5 GB of
 memory available when compiling Bitcoin Core. On systems with less, gcc can be
 tuned to conserve memory with additional CXXFLAGS:
 
-
     ./configure CXXFLAGS="--param ggc-min-expand=1 --param ggc-min-heapsize=32768"
 
 Alternatively, or in addition, debugging information can be skipped for compilation. The default compile flags are
@@ -95,8 +94,7 @@ Otherwise, you can build from self-compiled `depends` (see above).
 
 To build Bitcoin Core without wallet, see [*Disable-wallet mode*](/doc/build-unix.md#disable-wallet-mode)
 
-
-Optional (see `--with-miniupnpc` and `--enable-upnp-default`):
+Optionally (see `--with-miniupnpc` and `--enable-upnp-default`):
 
     sudo apt-get install libminiupnpc-dev
 
@@ -124,7 +122,6 @@ protobuf (optional) can be installed with:
 
 Once these are installed, they will be found by configure and a bitcoin-qt executable will be
 built by default.
-
 
 ### Fedora
 
@@ -159,7 +156,6 @@ Notes
 The release is built with GCC and then "strip bitcoind" to strip the debug
 symbols, which reduces the executable size by about 90%.
 
-
 miniupnpc
 ---------
 
@@ -167,10 +163,9 @@ miniupnpc
 http://miniupnp.tuxfamily.org/files/).  UPnP support is compiled in and
 turned off by default.  See the configure options for upnp behavior desired:
 
-	--without-miniupnpc      No UPnP support miniupnp not required
-	--disable-upnp-default   (the default) UPnP support turned off by default at runtime
-	--enable-upnp-default    UPnP support turned on by default at runtime
-
+    --without-miniupnpc      No UPnP support miniupnp not required
+    --disable-upnp-default   (the default) UPnP support turned off by default at runtime
+    --enable-upnp-default    UPnP support turned on by default at runtime
 
 Berkeley DB
 -----------
@@ -190,10 +185,9 @@ Boost
 -----
 If you need to build Boost yourself:
 
-	sudo su
-	./bootstrap.sh
-	./bjam install
-
+    sudo su
+    ./bootstrap.sh
+    ./bjam install
 
 Security
 --------
@@ -203,9 +197,8 @@ This can be disabled with:
 
 Hardening Flags:
 
-	./configure --enable-hardening
-	./configure --disable-hardening
-
+    ./configure --enable-hardening
+    ./configure --disable-hardening
 
 Hardening enables the following features:
 * _Position Independent Executable_: Build position independent code to take advantage of Address Space Layout Randomization
@@ -219,7 +212,7 @@ Hardening enables the following features:
 
     To test that you have built PIE executable, install scanelf, part of paxutils, and use:
 
-    	scanelf -e ./bitcoin
+        scanelf -e ./bitcoin
 
     The output should contain:
 
@@ -236,8 +229,9 @@ Hardening enables the following features:
     `scanelf -e ./bitcoin`
 
     The output should contain:
-	STK/REL/PTL
-	RW- R-- RW-
+
+        STK/REL/PTL
+        RW- R-- RW-
 
     The STK RW- means that the stack is readable and writeable but not executable.
 
@@ -258,7 +252,6 @@ A list of additional configure flags can be displayed with:
 
     ./configure --help
 
-
 Setup and Build Example: Arch Linux
 -----------------------------------
 This example lists the steps necessary to setup and build a command line only, non-wallet distribution of the latest changes on Arch Linux:
@@ -276,7 +269,6 @@ or building and depending on a local version of Berkeley DB 4.8. The readily ava
 `--with-incompatible-bdb` according to the [PKGBUILD](https://projects.archlinux.org/svntogit/community.git/tree/bitcoin/trunk/PKGBUILD).
 As mentioned above, when maintaining portability of the wallet between the standard Bitcoin Core distributions and independently built
 node software is desired, Berkeley DB 4.8 must be used.
-
 
 ARM Cross-compilation
 -------------------
@@ -297,6 +289,5 @@ To build executables for ARM:
     ./autogen.sh
     ./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
     make
-
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,4 +1,4 @@
-WINDOWS BUILD NOTES
+Windows Build Notes
 ====================
 
 Below are some notes on how to build Bitcoin Core for Windows.
@@ -34,18 +34,18 @@ Full instructions to install WSL are available on the above link.
 To install WSL on Windows 10 with Fall Creators Update installed (version >= 16215.0) do the following:
 
 1. Enable the Windows Subsystem for Linux feature
-  * Open the Windows Features dialog (`OptionalFeatures.exe`)
-  * Enable 'Windows Subsystem for Linux'
-  * Click 'OK' and restart if necessary
+   * Open the Windows Features dialog (`OptionalFeatures.exe`)
+   * Enable 'Windows Subsystem for Linux'
+   * Click 'OK' and restart if necessary
 2. Install Ubuntu
-  * Open Microsoft Store and search for "Ubuntu 18.04" or use [this link](https://www.microsoft.com/store/productId/9N9TNGVNDL3Q)
-  * Click Install
+   * Open Microsoft Store and search for "Ubuntu 18.04" or use [this link](https://www.microsoft.com/store/productId/9N9TNGVNDL3Q)
+   * Click Install
 3. Complete Installation
-  * Open a cmd prompt and type "Ubuntu1804"
-  * Create a new UNIX user account (this is a separate account from your Windows account)
+   * Open a cmd prompt and type `Ubuntu1804`
+   * Create a new UNIX user account (this is a separate account from your Windows account)
 
 After the bash shell is active, you can follow the instructions below, starting
-with the "Cross-compilation" section. Compiling the 64-bit version is
+with the cross-compilation section. Compiling the 64-bit version is
 recommended, but it is possible to compile the 32-bit version.
 
 Cross-compilation for Ubuntu and Windows Subsystem for Linux

--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -32,7 +32,7 @@ Controlling dependencies
 ------------------------
 Some dependencies are not needed in all configurations. The following are some factors that affect the dependency list.
 
-#### Options passed to `./configure`
+### Options passed to `./configure`
 * MiniUPnPc is not needed with  `--with-miniupnpc=no`.
 * Berkeley DB is not needed with `--disable-wallet`.
 * protobuf is only needed with `--enable-bip70`.
@@ -40,5 +40,5 @@ Some dependencies are not needed in all configurations. The following are some f
 * If the qrencode dependency is absent, QR support won't be added. To force an error when that happens, pass `--with-qrencode`.
 * ZeroMQ is needed only with the `--with-zmq` option.
 
-#### Other
+### Other
 * librsvg is only needed if you need to run `make deploy` on (cross-compilation to) macOS.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -2,41 +2,47 @@ Developer Notes
 ===============
 
 <!-- markdown-toc start -->
+<!-- markdownlint-disable no-emphasis-as-header -->
 **Table of Contents**
+<!-- markdownlint-enable no-emphasis-as-header -->
 
 - [Developer Notes](#developer-notes)
-    - [Coding Style (General)](#coding-style-general)
-    - [Coding Style (C++)](#coding-style-c)
-    - [Coding Style (Python)](#coding-style-python)
-    - [Coding Style (Doxygen-compatible comments)](#coding-style-doxygen-compatible-comments)
-    - [Development tips and tricks](#development-tips-and-tricks)
-        - [Compiling for debugging](#compiling-for-debugging)
-        - [Compiling for gprof profiling](#compiling-for-gprof-profiling)
-        - [debug.log](#debuglog)
-        - [Testnet and Regtest modes](#testnet-and-regtest-modes)
-        - [DEBUG_LOCKORDER](#debug_lockorder)
-        - [Valgrind suppressions file](#valgrind-suppressions-file)
-        - [Compiling for test coverage](#compiling-for-test-coverage)
-        - [Performance profiling with perf](#performance-profiling-with-perf)
-    - [Locking/mutex usage notes](#lockingmutex-usage-notes)
-    - [Threads](#threads)
-    - [Ignoring IDE/editor files](#ignoring-ideeditor-files)
-- [Development guidelines](#development-guidelines)
-    - [General Bitcoin Core](#general-bitcoin-core)
-    - [Wallet](#wallet)
-    - [General C++](#general-c)
-    - [C++ data structures](#c-data-structures)
-    - [Strings and formatting](#strings-and-formatting)
-    - [Shadowing](#shadowing)
-    - [Threads and synchronization](#threads-and-synchronization)
-    - [Scripts](#scripts)
-        - [Shebang](#shebang)
-    - [Source code organization](#source-code-organization)
-    - [GUI](#gui)
-    - [Subtrees](#subtrees)
-    - [Scripted diffs](#scripted-diffs)
-    - [Release notes](#release-notes)
-    - [RPC interface guidelines](#rpc-interface-guidelines)
+  - [Coding Style (General)](#coding-style-general)
+  - [Coding Style (C++)](#coding-style-c)
+  - [Coding Style (Python)](#coding-style-python)
+  - [Coding Style (Doxygen-compatible comments)](#coding-style-doxygen-compatible-comments)
+  - [Development tips and tricks](#development-tips-and-tricks)
+    - [Compiling for debugging](#compiling-for-debugging)
+    - [Compiling for gprof profiling](#compiling-for-gprof-profiling)
+    - [debug.log](#debuglog)
+    - [Testnet and Regtest modes](#testnet-and-regtest-modes)
+    - [DEBUG_LOCKORDER](#debuglockorder)
+    - [Valgrind suppressions file](#valgrind-suppressions-file)
+    - [Compiling for test coverage](#compiling-for-test-coverage)
+    - [Performance profiling with perf](#performance-profiling-with-perf)
+      - [Sanitizers](#sanitizers)
+  - [Locking/mutex usage notes](#lockingmutex-usage-notes)
+  - [Threads](#threads)
+  - [Ignoring IDE/editor files](#ignoring-ideeditor-files)
+- [Development Guidelines](#development-guidelines)
+  - [General Bitcoin Core](#general-bitcoin-core)
+  - [Wallet](#wallet)
+  - [General C++](#general-c)
+  - [C++ data structures](#c-data-structures)
+  - [Strings and formatting](#strings-and-formatting)
+  - [Shadowing](#shadowing)
+  - [Threads and synchronization](#threads-and-synchronization)
+  - [Scripts](#scripts)
+    - [Shebang](#shebang)
+  - [Source code organization](#source-code-organization)
+  - [GUI](#gui)
+  - [Subtrees](#subtrees)
+  - [Upgrading LevelDB](#upgrading-leveldb)
+    - [File Descriptor Counts](#file-descriptor-counts)
+    - [Consensus Compatibility](#consensus-compatibility)
+  - [Scripted diffs](#scripted-diffs)
+  - [Release notes](#release-notes)
+  - [RPC interface guidelines](#rpc-interface-guidelines)
 
 <!-- markdown-toc end -->
 
@@ -284,8 +290,8 @@ Certain kernel parameters may need to be set for perf to be able to inspect the
 running process's stack.
 
 ```sh
-$ sudo sysctl -w kernel.perf_event_paranoid=-1
-$ sudo sysctl -w kernel.kptr_restrict=0
+sudo sysctl -w kernel.perf_event_paranoid=-1
+sudo sysctl -w kernel.kptr_restrict=0
 ```
 
 Make sure you [understand the security
@@ -311,8 +317,7 @@ or using a graphical tool like [Hotspot](https://github.com/KDAB/hotspot).
 
 See the functional test documentation for how to invoke perf within tests.
 
-
-**Sanitizers**
+#### Sanitizers
 
 Bitcoin Core can be compiled with various "sanitizers" enabled, which add
 instrumentation for issues regarding things like memory safety, thread race
@@ -354,14 +359,14 @@ compiler.
 
 Additional resources:
 
- * [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
- * [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html)
- * [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html)
- * [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html)
- * [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
- * [GCC Instrumentation Options](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html)
- * [Google Sanitizers Wiki](https://github.com/google/sanitizers/wiki)
- * [Issue #12691: Enable -fsanitize flags in Travis](https://github.com/bitcoin/bitcoin/issues/12691)
+- [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
+- [LeakSanitizer](https://clang.llvm.org/docs/LeakSanitizer.html)
+- [MemorySanitizer](https://clang.llvm.org/docs/MemorySanitizer.html)
+- [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html)
+- [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html)
+- [GCC Instrumentation Options](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html)
+- [Google Sanitizers Wiki](https://github.com/google/sanitizers/wiki)
+- [Issue #12691: Enable -fsanitize flags in Travis](https://github.com/bitcoin/bitcoin/issues/12691)
 
 Locking/mutex usage notes
 -------------------------
@@ -420,7 +425,7 @@ to do this is thus to create your local gitignore. Add this to `~/.gitconfig`:
 
 ```
 [core]
-        excludesfile = /home/.../.gitignore_global
+    excludesfile = /home/.../.gitignore_global
 ```
 
 (alternatively, type the command `git config --global core.excludesfile ~/.gitignore_global`
@@ -439,8 +444,10 @@ If a set of tools is used by the build system or scripts the repository (for
 example, lcov) it is perfectly acceptable to add its files to `.gitignore`
 and commit them.
 
-Development guidelines
-============================
+<!-- markdownlint-disable single-h1 -->
+Development Guidelines
+======================
+<!-- markdownlint-enable single-h1 -->
 
 A few non-style-related recommendations for developers, as well as points to
 pay attention to for reviewers of Bitcoin Core code.
@@ -539,12 +546,12 @@ C++ data structures
     Initializing the members in the declaration makes it easy to
     spot uninitialized ones.
 
-```cpp
-class A
-{
-    uint32_t m_count{0};
-}
-```
+  ```cpp
+  class A
+  {
+      uint32_t m_count{0};
+  }
+  ```
 
 - By default, declare single-argument constructors `explicit`.
 
@@ -634,7 +641,7 @@ Threads and synchronization
   the current scope, so surround the statement and the code that needs the lock
   with braces.
 
-  OK:
+OK:
 ```c++
 {
     TRY_LOCK(cs_vNodes, lockNodes);
@@ -642,7 +649,7 @@ Threads and synchronization
 }
 ```
 
-  Wrong:
+Wrong:
 ```c++
 TRY_LOCK(cs_vNodes, lockNodes);
 {
@@ -663,12 +670,12 @@ Scripts
 
     `#!/usr/bin/env bash` searches the user's PATH to find the bash binary.
 
-  OK:
+OK:
 ```bash
 #!/usr/bin/env bash
 ```
 
-  Wrong:
+Wrong:
 ```bash
 #!/bin/bash
 ```
@@ -702,15 +709,15 @@ Source code organization
 - Terminate namespaces with a comment (`// namespace mynamespace`). The comment
   should be placed on the same line as the brace closing the namespace, e.g.
 
-```c++
-namespace mynamespace {
-...
-} // namespace mynamespace
+  ```c++
+  namespace mynamespace {
+  ...
+  } // namespace mynamespace
 
-namespace {
-...
-} // namespace
-```
+  namespace {
+  ...
+  } // namespace
+  ```
 
   - *Rationale*: Avoids confusion about the namespace context.
 
@@ -725,12 +732,12 @@ namespace {
 - Use include guards to avoid the problem of double inclusion. The header file
   `foo/bar.h` should use the include guard identifier `BITCOIN_FOO_BAR_H`, e.g.
 
-```c++
-#ifndef BITCOIN_FOO_BAR_H
-#define BITCOIN_FOO_BAR_H
-...
-#endif // BITCOIN_FOO_BAR_H
-```
+  ```c++
+  #ifndef BITCOIN_FOO_BAR_H
+  #define BITCOIN_FOO_BAR_H
+  ...
+  #endif // BITCOIN_FOO_BAR_H
+  ```
 
 GUI
 -----

--- a/doc/dnsseed-policy.md
+++ b/doc/dnsseed-policy.md
@@ -10,35 +10,35 @@ Other implementations of Bitcoin software may also use the same
 seeds and may be more exposed. In light of this exposure, this
 document establishes some basic expectations for operating dnsseeds.
 
-0. A DNS seed operating organization or person is expected to follow good
+1. A DNS seed operating organization or person is expected to follow good
 host security practices, maintain control of applicable infrastructure,
 and not sell or transfer control of the DNS seed. Any hosting services
 contracted by the operator are equally expected to uphold these expectations.
 
-1. The DNS seed results must consist exclusively of fairly selected and
+2. The DNS seed results must consist exclusively of fairly selected and
 functioning Bitcoin nodes from the public network to the best of the
 operator's understanding and capability.
 
-2. For the avoidance of doubt, the results may be randomized but must not
+3. For the avoidance of doubt, the results may be randomized but must not
 single-out any group of hosts to receive different results unless due to an
 urgent technical necessity and disclosed.
 
-3. The results may not be served with a DNS TTL of less than one minute.
+4. The results may not be served with a DNS TTL of less than one minute.
 
-4. Any logging of DNS queries should be only that which is necessary
+5. Any logging of DNS queries should be only that which is necessary
 for the operation of the service or urgent health of the Bitcoin
 network and must not be retained longer than necessary nor disclosed
 to any third party.
 
-5. Information gathered as a result of the operators node-spidering
+6. Information gathered as a result of the operators node-spidering
 (not from DNS queries) may be freely published or retained, but only
 if this data was not made more complete by biasing node connectivity
 (a violation of expectation (1)).
 
-6. Operators are encouraged, but not required, to publicly document the
+7. Operators are encouraged, but not required, to publicly document the
 details of their operating practices.
 
-7. A reachable email contact address must be published for inquiries
+8. A reachable email contact address must be published for inquiries
 related to the DNS seed operation.
 
 If these expectations cannot be satisfied the operator should

--- a/doc/files.md
+++ b/doc/files.md
@@ -1,3 +1,5 @@
+# Bitcoin Data Files
+
 Filename            | Description
 --------------------|----------------------------------------------------------------------------------------------------------------------------
 banlist.dat         | stores the IPs/Subnets of banned nodes

--- a/doc/init.md
+++ b/doc/init.md
@@ -30,13 +30,13 @@ file, however it is recommended that a strong and secure password be used
 as this password is security critical to securing the wallet should the
 wallet be enabled.
 
-If bitcoind is run with the "-server" flag (set by default), and no rpcpassword is set,
+If bitcoind is run with the `-server` flag (set by default), and no rpcpassword is set,
 it will use a special cookie file for authentication. The cookie is generated with random
 content when the daemon starts, and deleted when it exits. Read access to this file
 controls who can access it through RPC.
 
 By default the cookie is stored in the data directory, but it's location can be overridden
-with the option '-rpccookiefile'.
+with the option `-rpccookiefile`.
 
 This allows for running bitcoind without having to do any manual configuration.
 
@@ -53,11 +53,11 @@ Paths
 
 All three configurations assume several paths that might need to be adjusted.
 
-Binary:              `/usr/bin/bitcoind`
-Configuration file:  `/etc/bitcoin/bitcoin.conf`
-Data directory:      `/var/lib/bitcoind`
-PID file:            `/var/run/bitcoind/bitcoind.pid` (OpenRC and Upstart) or `/run/bitcoind/bitcoind.pid` (systemd)
-Lock file:           `/var/lock/subsys/bitcoind` (CentOS)
+- Binary:              `/usr/bin/bitcoind`
+- Configuration file:  `/etc/bitcoin/bitcoin.conf`
+- Data directory:      `/var/lib/bitcoind`
+- PID file:            `/var/run/bitcoind/bitcoind.pid` (OpenRC and Upstart) or `/run/bitcoind/bitcoind.pid` (systemd)
+- Lock file:           `/var/lock/subsys/bitcoind` (CentOS)
 
 The PID directory (if applicable) and data directory should both be owned by the
 bitcoin user and group. It is advised for security reasons to make the
@@ -81,12 +81,12 @@ configuration mechanisms that would allow for overriding the command line
 options specified in the init files (e.g. setting `BITCOIND_DATADIR` for
 OpenRC).
 
-### macOS
+### MacOS
 
-Binary:              `/usr/local/bin/bitcoind`
-Configuration file:  `~/Library/Application Support/Bitcoin/bitcoin.conf`
-Data directory:      `~/Library/Application Support/Bitcoin`
-Lock file:           `~/Library/Application Support/Bitcoin/.lock`
+- Binary:              `/usr/local/bin/bitcoind`
+- Configuration file:  `~/Library/Application Support/Bitcoin/bitcoin.conf`
+- Data directory:      `~/Library/Application Support/Bitcoin`
+- Lock file:           `~/Library/Application Support/Bitcoin/.lock`
 
 Installing Service Configuration
 -----------------------------------

--- a/doc/productivity.md
+++ b/doc/productivity.md
@@ -4,25 +4,27 @@ Productivity Notes
 Table of Contents
 -----------------
 
-* [General](#general)
-   * [Cache compilations with `ccache`](#cache-compilations-with-ccache)
-   * [Disable features with `./configure`](#disable-features-with-configure)
-   * [Make use of your threads with `make -j`](#make-use-of-your-threads-with-make--j)
-   * [Only build what you need](#only-build-what-you-need)
-   * [Multiple working directories with `git worktrees`](#multiple-working-directories-with-git-worktrees)
-   * [Interactive "dummy rebases" for fixups and execs with `git merge-base`](#interactive-dummy-rebases-for-fixups-and-execs-with-git-merge-base)
-* [Writing code](#writing-code)
-   * [Format C/C++/Protobuf diffs with `clang-format-diff.py`](#format-ccprotobuf-diffs-with-clang-format-diffpy)
-   * [Format Python diffs with `yapf-diff.py`](#format-python-diffs-with-yapf-diffpy)
-* [Rebasing/Merging code](#rebasingmerging-code)
-   * [More conflict context with `merge.conflictstyle diff3`](#more-conflict-context-with-mergeconflictstyle-diff3)
-* [Reviewing code](#reviewing-code)
-   * [Reduce mental load with `git diff` options](#reduce-mental-load-with-git-diff-options)
-   * [Reference PRs easily with `refspec`s](#reference-prs-easily-with-refspecs)
-   * [Diff the diffs with `git range-diff`](#diff-the-diffs-with-git-range-diff)
+- [Productivity Notes](#productivity-notes)
+  - [Table of Contents](#table-of-contents)
+  - [General](#general)
+    - [Cache compilations with `ccache`](#cache-compilations-with-ccache)
+    - [Disable features with `./configure`](#disable-features-with-configure)
+    - [Make use of your threads with `make -j`](#make-use-of-your-threads-with-make--j)
+    - [Only build what you need](#only-build-what-you-need)
+    - [Multiple working directories with `git worktrees`](#multiple-working-directories-with-git-worktrees)
+    - [Interactive "dummy rebases" for fixups and execs with `git merge-base`](#interactive-%22dummy-rebases%22-for-fixups-and-execs-with-git-merge-base)
+  - [Writing code](#writing-code)
+    - [Format C/C++/Protobuf diffs with `clang-format-diff.py`](#format-ccprotobuf-diffs-with-clang-format-diffpy)
+    - [Format Python diffs with `yapf-diff.py`](#format-python-diffs-with-yapf-diffpy)
+  - [Rebasing/Merging code](#rebasingmerging-code)
+    - [More conflict context with `merge.conflictstyle diff3`](#more-conflict-context-with-mergeconflictstyle-diff3)
+  - [Reviewing code](#reviewing-code)
+    - [Reduce mental load with `git diff` options](#reduce-mental-load-with-git-diff-options)
+    - [Reference PRs easily with `refspec`s](#reference-prs-easily-with-refspecs)
+    - [Diff the diffs with `git range-diff`](#diff-the-diffs-with-git-range-diff)
 
 General
-------
+-------
 
 ### Cache compilations with `ccache`
 
@@ -109,7 +111,7 @@ To execute `make check` on every commit since last diverged from master, but wit
 git rebase -i --exec "make check" "$(git merge-base master HEAD)"
 ```
 
------
+---
 
 This synergizes well with [`ccache`](#cache-compilations-with-ccache) as objects resulting from unchanged code will most likely hit the cache and won't need to be recompiled.
 
@@ -127,7 +129,7 @@ See [contrib/devtools/README.md](/contrib/devtools/README.md#clang-format-diff.p
 Usage is exactly the same as [`clang-format-diff.py`](#format-ccprotobuf-diffs-with-clang-format-diffpy). You can get it [here](https://github.com/MarcoFalke/yapf-diff).
 
 Rebasing/Merging code
--------------
+---------------------
 
 ### More conflict context with `merge.conflictstyle diff3`
 
@@ -210,7 +212,7 @@ PREV=P5 N=4 && git range-diff `git merge-base --all HEAD $PREV`...$PREV HEAD~$N.
 
 Where `P5` is the commit you last reviewed and `4` is the number of commits in the new version.
 
------
+---
 
 `git range-diff` also accepts normal `git diff` options, see [Reduce mental load with `git diff` options](#reduce-mental-load-with-git-diff-options) for useful `git diff` options.
 

--- a/doc/psbt.md
+++ b/doc/psbt.md
@@ -87,7 +87,6 @@ hardware implementations will typically implement multiple roles simultaneously.
   possible, computes the fee of the resulting transaction and estimates the
   final weight and feerate.
 
-
 ### Workflows
 
 #### Multisig with multiple Bitcoin Core instances

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -372,5 +372,4 @@ Credits
 
 Thanks to everyone who directly contributed to this release:
 
-
 As well as everyone that helped translating on [Transifex](https://www.transifex.com/bitcoin/bitcoin/).

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -5,17 +5,17 @@ Release Process
 
 ### Before every release candidate
 
-* Update translations (ping wumpus on IRC) see [translation_process.md](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md#synchronising-translations).
-* Update manpages, see [gen-manpages.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md#gen-manpagessh).
-* Update release candidate version in `configure.ac` (`CLIENT_VERSION_RC`).
+- Update translations (ping wumpus on IRC) see [translation_process.md](https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md#synchronising-translations).
+- Update manpages, see [gen-manpages.sh](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/README.md#gen-manpagessh).
+- Update release candidate version in `configure.ac` (`CLIENT_VERSION_RC`).
 
 ### Before every major and minor release
 
-* Update [bips.md](bips.md) to account for changes since the last release.
-* Update version in `configure.ac` (don't forget to set `CLIENT_VERSION_RC` to `0`).
-* Write release notes (see "Write the release notes" below).
-* Update `src/chainparams.cpp` nMinimumChainWork with information from the getblockchaininfo rpc.
-* Update `src/chainparams.cpp` defaultAssumeValid with information from the getblockhash rpc.
+- Update [bips.md](bips.md) to account for changes since the last release.
+- Update version in `configure.ac` (don't forget to set `CLIENT_VERSION_RC` to `0`).
+- Write release notes (see "Write the release notes" below).
+- Update `src/chainparams.cpp` nMinimumChainWork with information from the getblockchaininfo rpc.
+- Update `src/chainparams.cpp` defaultAssumeValid with information from the getblockhash rpc.
   - The selected value must not be orphaned so it may be useful to set the value two blocks back from the tip.
   - Testnet should be set some tens of thousands back from the tip due to reorgs there.
   - This update should be reviewed with a reindex-chainstate with assumevalid=0 to catch any defect
@@ -23,14 +23,14 @@ Release Process
 
 ### Before every major release
 
-* Update hardcoded [seeds](/contrib/seeds/README.md), see [this pull request](https://github.com/bitcoin/bitcoin/pull/7415) for an example.
-* Update [`src/chainparams.cpp`](/src/chainparams.cpp) m_assumed_blockchain_size and m_assumed_chain_state_size with the current size plus some overhead.
-* Update `src/chainparams.cpp` chainTxData with statistics about the transaction count and rate. Use the output of the RPC `getchaintxstats`, see
+- Update hardcoded [seeds](/contrib/seeds/README.md), see [this pull request](https://github.com/bitcoin/bitcoin/pull/7415) for an example.
+- Update [`src/chainparams.cpp`](/src/chainparams.cpp) m_assumed_blockchain_size and m_assumed_chain_state_size with the current size plus some overhead.
+- Update `src/chainparams.cpp` chainTxData with statistics about the transaction count and rate. Use the output of the RPC `getchaintxstats`, see
   [this pull request](https://github.com/bitcoin/bitcoin/pull/12270) for an example. Reviewers can verify the results by running `getchaintxstats <window_block_count> <window_last_block_hash>` with the `window_block_count` and `window_last_block_hash` from your output.
-* On both the master branch and the new release branch:
+- On both the master branch and the new release branch:
   - update `CLIENT_VERSION_MINOR` in [`configure.ac`](../configure.ac)
   - update `CLIENT_VERSION_MINOR`, `PACKAGE_VERSION`, and `PACKAGE_STRING` in [`build_msvc/bitcoin_config.h`](/build_msvc/bitcoin_config.h)
-* On the new release branch in [`configure.ac`](../configure.ac) and [`build_msvc/bitcoin_config.h`](/build_msvc/bitcoin_config.h) (see [this commit](https://github.com/bitcoin/bitcoin/commit/742f7dd)):
+- On the new release branch in [`configure.ac`](../configure.ac) and [`build_msvc/bitcoin_config.h`](/build_msvc/bitcoin_config.h) (see [this commit](https://github.com/bitcoin/bitcoin/commit/742f7dd)):
   - set `CLIENT_VERSION_REVISION` to `0`
   - set `CLIENT_VERSION_IS_RELEASE` to `true`
 
@@ -50,7 +50,6 @@ Release Process
 
 - Merge the release notes from the wiki into the branch.
 - Ensure the "Needs release note" label is removed from all relevant pull requests and issues.
-
 
 ## Building
 

--- a/doc/tor.md
+++ b/doc/tor.md
@@ -1,41 +1,39 @@
-# TOR SUPPORT IN BITCOIN
+# Tor Support
 
 It is possible to run Bitcoin Core as a Tor hidden service, and connect to such services.
 
 The following directions assume you have a Tor proxy running on port 9050. Many distributions default to having a SOCKS proxy listening on port 9050, but others may not. In particular, the Tor Browser Bundle defaults to listening on port 9150. See [Tor Project FAQ:TBBSocksPort](https://www.torproject.org/docs/faq.html.en#TBBSocksPort) for how to properly
 configure Tor.
 
-
 ## 1. Run Bitcoin Core behind a Tor proxy
 
 The first step is running Bitcoin Core behind a Tor proxy. This will already anonymize all
 outgoing connections, but more is possible.
 
-	-proxy=ip:port  Set the proxy server. If SOCKS5 is selected (default), this proxy
-	                server will be used to try to reach .onion addresses as well.
+    -proxy=ip:port  Set the proxy server. If SOCKS5 is selected (default), this proxy
+                    server will be used to try to reach .onion addresses as well.
 
-	-onion=ip:port  Set the proxy server to use for Tor hidden services. You do not
-	                need to set this if it's the same as -proxy. You can use -noonion
-	                to explicitly disable access to hidden services.
+    -onion=ip:port  Set the proxy server to use for Tor hidden services. You do not
+                    need to set this if it's the same as -proxy. You can use -noonion
+                    to explicitly disable access to hidden services.
 
-	-listen         When using -proxy, listening is disabled by default. If you want
-	                to run a hidden service (see next section), you'll need to enable
-	                it explicitly.
+    -listen         When using -proxy, listening is disabled by default. If you want
+                    to run a hidden service (see next section), you'll need to enable
+                    it explicitly.
 
-	-connect=X      When behind a Tor proxy, you can specify .onion addresses instead
-	-addnode=X      of IP addresses or hostnames in these parameters. It requires
-	-seednode=X     SOCKS5. In Tor mode, such addresses can also be exchanged with
-	                other P2P nodes.
+    -connect=X      When behind a Tor proxy, you can specify .onion addresses instead
+    -addnode=X      of IP addresses or hostnames in these parameters. It requires
+    -seednode=X     SOCKS5. In Tor mode, such addresses can also be exchanged with
+                    other P2P nodes.
 
-	-onlynet=onion  Make outgoing connections only to .onion addresses. Incoming
-	                connections are not affected by this option. This option can be
-	                specified multiple times to allow multiple network types, e.g.
-	                ipv4, ipv6, or onion.
+    -onlynet=onion  Make outgoing connections only to .onion addresses. Incoming
+                    connections are not affected by this option. This option can be
+                    specified multiple times to allow multiple network types, e.g.
+                    ipv4, ipv6, or onion.
 
 In a typical situation, this suffices to run behind a Tor proxy:
 
-	./bitcoind -proxy=127.0.0.1:9050
-
+    ./bitcoind -proxy=127.0.0.1:9050
 
 ## 2. Run a Bitcoin Core hidden server
 
@@ -44,52 +42,52 @@ reachable from the Tor network. Add these lines to your /etc/tor/torrc (or equiv
 config file): *Needed for Tor version 0.2.7.0 and older versions of Tor only. For newer
 versions of Tor see [Section 3](#3-automatically-listen-on-tor).*
 
-	HiddenServiceDir /var/lib/tor/bitcoin-service/
-	HiddenServicePort 8333 127.0.0.1:8333
-	HiddenServicePort 18333 127.0.0.1:18333
+    HiddenServiceDir /var/lib/tor/bitcoin-service/
+    HiddenServicePort 8333 127.0.0.1:8333
+    HiddenServicePort 18333 127.0.0.1:18333
 
 The directory can be different of course, but (both) port numbers should be equal to
 your bitcoind's P2P listen port (8333 by default).
 
-	-externalip=X   You can tell bitcoin about its publicly reachable address using
-	                this option, and this can be a .onion address. Given the above
-	                configuration, you can find your .onion address in
-	                /var/lib/tor/bitcoin-service/hostname. For connections
-	                coming from unroutable addresses (such as 127.0.0.1, where the
-	                Tor proxy typically runs), .onion addresses are given
-	                preference for your node to advertise itself with.
+    -externalip=X   You can tell bitcoin about its publicly reachable address using
+                    this option, and this can be a .onion address. Given the above
+                    configuration, you can find your .onion address in
+                    /var/lib/tor/bitcoin-service/hostname. For connections
+                    coming from unroutable addresses (such as 127.0.0.1, where the
+                    Tor proxy typically runs), .onion addresses are given
+                    preference for your node to advertise itself with.
 
-	-listen         You'll need to enable listening for incoming connections, as this
-	                is off by default behind a proxy.
+    -listen         You'll need to enable listening for incoming connections, as this
+                    is off by default behind a proxy.
 
-	-discover       When -externalip is specified, no attempt is made to discover local
-	                IPv4 or IPv6 addresses. If you want to run a dual stack, reachable
-	                from both Tor and IPv4 (or IPv6), you'll need to either pass your
-	                other addresses using -externalip, or explicitly enable -discover.
-	                Note that both addresses of a dual-stack system may be easily
-	                linkable using traffic analysis.
+    -discover       When -externalip is specified, no attempt is made to discover local
+                    IPv4 or IPv6 addresses. If you want to run a dual stack, reachable
+                    from both Tor and IPv4 (or IPv6), you'll need to either pass your
+                    other addresses using -externalip, or explicitly enable -discover.
+                    Note that both addresses of a dual-stack system may be easily
+                    linkable using traffic analysis.
 
 In a typical situation, where you're only reachable via Tor, this should suffice:
 
-	./bitcoind -proxy=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -listen
+    ./bitcoind -proxy=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -listen
 
 (obviously, replace the .onion address with your own). It should be noted that you still
 listen on all devices and another node could establish a clearnet connection, when knowing
 your address. To mitigate this, additionally bind the address of your Tor proxy:
 
-	./bitcoind ... -bind=127.0.0.1
+    ./bitcoind ... -bind=127.0.0.1
 
 If you don't care too much about hiding your node, and want to be reachable on IPv4
 as well, use `discover` instead:
 
-	./bitcoind ... -discover
+    ./bitcoind ... -discover
 
 and open port 8333 on your firewall (or use -upnp).
 
 If you only want to use Tor to reach .onion addresses, but not use it as a proxy
 for normal IPv4/IPv6 communication, use:
 
-	./bitcoind -onion=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -discover
+    ./bitcoind -onion=127.0.0.1:9050 -externalip=57qr3yd1nyntf5k.onion -discover
 
 ## 3. Automatically listen on Tor
 

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -3,14 +3,14 @@ Translations
 
 The Bitcoin-Core project has been designed to support multiple localisations. This makes adding new phrases, and completely new languages easily achievable. For managing all application translations, Bitcoin-Core makes use of the Transifex online translation management tool.
 
-### Helping to translate (using Transifex)
+## Helping to translate (using Transifex)
 Transifex is setup to monitor the GitHub repo for updates, and when code containing new translations is found, Transifex will process any changes. It may take several hours after a pull-request has been merged, to appear in the Transifex web interface.
 
 Multiple language support is critical in assisting Bitcoin’s global adoption, and growth. One of Bitcoin’s greatest strengths is cross-border money transfers, any help making that easier is greatly appreciated.
 
 See the [Transifex Bitcoin project](https://www.transifex.com/bitcoin/bitcoin/) to assist in translations. You should also join the translation mailing list for announcements - see details below.
 
-### Writing code with translations
+## Writing code with translations
 We use automated scripts to help extract translations in both Qt, and non-Qt source files. It is rarely necessary to manually edit the files in `src/qt/locale/`. The translation source files must adhere to the following format:
 `bitcoin_xx_YY.ts or bitcoin_xx.ts`
 
@@ -24,12 +24,12 @@ make translate
 
 `contrib/bitcoin-qt.pro` takes care of generating `.qm` (binary compiled) files from `.ts` (source files) files. It’s mostly automated, and you shouldn’t need to worry about it.
 
-**Example Qt translation**
+### Example Qt translation
 ```cpp
 QToolBar *toolbar = addToolBar(tr("Tabs toolbar"));
 ```
 
-### Creating a pull-request
+## Creating a pull-request
 For general PRs, you shouldn’t include any updates to the translation source files. They will be updated periodically, primarily around pre-releases, allowing time for any new phrases to be translated before public releases. This is also important in avoiding translation related merge conflicts.
 
 When an updated source file is merged into the GitHub repo, Transifex will automatically detect it (although it can take several hours). Once processed, the new strings will show up as "Remaining" in the Transifex web interface and are ready for translators.
@@ -40,17 +40,17 @@ git add src/qt/bitcoinstrings.cpp src/qt/locale/bitcoin_en.ts
 git commit
 ```
 
-### Creating a Transifex account
+## Creating a Transifex account
 Visit the [Transifex Signup](https://www.transifex.com/signup/) page to create an account. Take note of your username and password, as they will be required to configure the command-line tool.
 
 You can find the Bitcoin translation project at [https://www.transifex.com/bitcoin/bitcoin/](https://www.transifex.com/bitcoin/bitcoin/).
 
-### Installing the Transifex client command-line tool
+## Installing the Transifex client command-line tool
 The client is used to fetch updated translations. If you are having problems, or need more details, see [https://docs.transifex.com/client/installing-the-client](https://docs.transifex.com/client/installing-the-client)
 
 `pip install transifex-client`
 
-Setup your Transifex client config as follows. Please *ignore the token field*.
+Setup your Transifex client config as follows (**ignore the token field**):
 
 ```ini
 nano ~/.transifexrc
@@ -70,19 +70,19 @@ To assist in updating translations, a helper script is available in the [maintai
 1. `python3 ../bitcoin-maintainer-tools/update-translations.py`
 2. `git add` new translations from `src/qt/locale/`
 3. Update `src/qt/bitcoin_locale.qrc` manually or via
-```bash
-git ls-files src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/        <file alias="\2">locale\/\1.qm<\/file>/'
-```
+   ```bash
+   git ls-files src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/        <file alias="\2">locale\/\1.qm<\/file>/'
+   ```
 4. Update `src/Makefile.qt.include` manually or via
-```bash
-git ls-files src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/  qt\/locale\/\1.ts \\/'
-```
+   ```bash
+   git ls-files src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/  qt\/locale\/\1.ts \\/'
+   ```
 5. Update `build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj` or via
-```bash
-git ls-files src/qt/locale/*ts|xargs -n1 basename |
-  sed 's/@/%40/' |
-  sed 's/\(bitcoin_\(.*\)\).ts/    <None Include="..\\..\\src\\qt\\locale\\\1.ts">\n      <DeploymentContent>true<\/DeploymentContent>\n    <\/None>/'
-```
+   ```bash
+   git ls-files src/qt/locale/*ts|xargs -n1 basename |
+     sed 's/@/%40/' |
+     sed 's/\(bitcoin_\(.*\)\).ts/    <None Include="..\\..\\src\\qt\\locale\\\1.ts">\n      <DeploymentContent>true<\/DeploymentContent>\n    <\/None>/'
+   ```
 
 **Do not directly download translations** one by one from the Transifex website, as we do a few post-processing steps before committing the translations.
 

--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -49,7 +49,7 @@ By default, the ZeroMQ feature is automatically compiled in if the
 necessary prerequisites are found.  To disable, use --disable-zmq
 during the *configure* step of building bitcoind:
 
-    $ ./configure --disable-zmq (other options)
+    ./configure --disable-zmq (other options)
 
 To actually enable operation, one must set the appropriate options on
 the command line or in the configuration file.

--- a/share/rpcauth/README.md
+++ b/share/rpcauth/README.md
@@ -1,12 +1,12 @@
 RPC Tools
----------------------
+=========
 
-### [RPCAuth](/share/rpcauth) ###
+## [RPCAuth](/share/rpcauth.py)
 
 ```
-usage: rpcauth.py [-h] username [password]
+Usage: rpcauth.py [-h] username [password]
 
-Create login credentials for a JSON-RPC user
+Create login credentials for a JSON-RPC user.
 
 positional arguments:
   username    the username for authentication

--- a/src/qt/README.md
+++ b/src/qt/README.md
@@ -1,4 +1,6 @@
-This directory contains the BitcoinQT graphical user interface (GUI). It uses the cross-platform framework [Qt](https://www1.qt.io/developers/).
+# Qt
+
+This directory contains the Bitcoin-Qt graphical user interface (GUI). It uses the cross-platform framework [Qt](https://www1.qt.io/developers/).
 
 The current precise version for Qt 5 is specified in [qt.mk](/depends/packages/qt.mk).
 

--- a/src/test/README.md
+++ b/src/test/README.md
@@ -1,4 +1,4 @@
-### Compiling/running unit tests
+# Compiling/running unit tests
 
 Unit tests will be automatically compiled if dependencies were met in `./configure`
 and tests weren't explicitly disabled.
@@ -12,14 +12,14 @@ to run the bitcoind tests.
 
 To add more bitcoind tests, add `BOOST_AUTO_TEST_CASE` functions to the existing
 .cpp files in the `test/` directory or add new .cpp files that
-implement new BOOST_AUTO_TEST_SUITE sections.
+implement new `BOOST_AUTO_TEST_SUITE` sections.
 
 To run the bitcoin-qt tests manually, launch `src/qt/test/test_bitcoin-qt`
 
 To add more bitcoin-qt tests, add them to the `src/qt/test/` directory and
 the `src/qt/test/test_main.cpp` file.
 
-### Running individual tests
+## Running individual tests
 
 test_bitcoin has some built-in command-line arguments; for
 example, to run just the getarg_tests verbosely:
@@ -32,7 +32,7 @@ example, to run just the getarg_tests verbosely:
 
 Run `test_bitcoin --help` for the full list.
 
-### Note on adding test cases
+## Note on adding test cases
 
 The sources in this directory are unit test cases.  Boost includes a
 unit testing framework, and since bitcoin already uses boost, it makes

--- a/src/test/data/README.md
+++ b/src/test/data/README.md
@@ -1,5 +1,5 @@
 Description
-------------
+===========
 
 This directory contains data-driven tests for various aspects of Bitcoin.
 
@@ -9,4 +9,3 @@ License
 The data files in this directory are distributed under the MIT software
 license, see the accompanying file COPYING or
 http://www.opensource.org/licenses/mit-license.php.
-

--- a/test/README.md
+++ b/test/README.md
@@ -1,3 +1,5 @@
+# Integration Tests
+
 This directory contains integration tests that test bitcoind and its
 utilities in their entirety. It does not contain unit tests, which
 can be found in [/src/test](/src/test), [/src/wallet/test](/src/wallet/test),
@@ -15,10 +17,9 @@ bitcoin-tx.
 The util tests are run as part of `make check` target. The functional
 tests and lint scripts can be run as explained in the sections below.
 
-# Running tests locally
+## Running tests locally
 
 Before tests can be run locally, Bitcoin Core must be built.  See the [building instructions](/doc#building) for help.
-
 
 ### Functional tests
 
@@ -118,7 +119,6 @@ or
 ```bash
 pkill -9 bitcoind
 ```
-
 
 ##### Data directory cache
 
@@ -245,7 +245,7 @@ You can run all the shell-based lint tests by running:
 test/lint/lint-all.sh
 ```
 
-# Writing functional tests
+## Writing functional tests
 
 You are encouraged to write functional tests for new or existing features.
 Further information about the functional test framework and individual

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -1,21 +1,21 @@
 # Functional tests
 
-### Writing Functional Tests
+## Writing Functional Tests
 
-#### Example test
+### Example test
 
 The [example_test.py](example_test.py) is a heavily commented example of a test case that uses both
 the RPC and P2P interfaces. If you are writing your first test, copy that file
 and modify to fit your needs.
 
-#### Coverage
+### Coverage
 
 Running `test_runner.py` with the `--coverage` argument tracks which RPCs are
 called by the tests and prints a report of uncovered RPCs in the summary. This
 can be used (along with the `--extended` argument) to find out which RPCs we
 don't have test cases for.
 
-#### Style guidelines
+### Style guidelines
 
 - Where possible, try to adhere to [PEP-8 guidelines](https://www.python.org/dev/peps/pep-0008/)
 - Use a python linter like flake8 before submitting PRs to catch common style
@@ -34,7 +34,7 @@ don't have test cases for.
   the subclass, then locally-defined helper methods, then the `run_test()` method.
 - Use `'{}'.format(x)` for string formatting, not `'%s' % x`.
 
-#### Naming guidelines
+### Naming guidelines
 
 - Name the test `<area>_test.py`, where area can be one of the following:
     - `feature` for tests for full features that aren't wallet/mining/mempool, eg `feature_rbf.py`
@@ -49,7 +49,7 @@ don't have test cases for.
     - exception: for tests for specific RPCs or command line options which don't include underscores, name the test after the exact RPC or argument name, eg `rpc_decodescript.py`, not `rpc_decode_script.py`
 - Don't use the redundant word `test` in the name, eg `interface_zmq.py`, not `interface_zmq_test.py`
 
-#### General test-writing advice
+### General test-writing advice
 
 - Set `self.num_nodes` to the minimum number of nodes necessary for the test.
   Having additional unrequired nodes adds to the execution time of the test as
@@ -71,7 +71,7 @@ don't have test cases for.
   from typographical errors or usage of the objects outside of their intended
   purpose.
 
-#### RPC and P2P definitions
+### RPC and P2P definitions
 
 Test writers may find it helpful to refer to the definitions for the RPC and
 P2P messages. These can be found in the following source files:
@@ -80,7 +80,7 @@ P2P messages. These can be found in the following source files:
 - `/src/wallet/rpc*` for wallet RPCs
 - `ProcessMessage()` in `/src/net_processing.cpp` for parsing P2P messages
 
-#### Using the P2P interface
+### Using the P2P interface
 
 - `messages.py` contains all the definitions for objects that pass
 over the network (`CBlock`, `CTransaction`, etc, along with the network-level
@@ -98,33 +98,33 @@ P2PInterface object and override the callback methods.
 - Can be used to write tests where specific P2P protocol behavior is tested.
 Examples tests are `p2p_unrequested_blocks.py`, `p2p_compactblocks.py`.
 
-### test-framework modules
+## test-framework modules
 
-#### [test_framework/authproxy.py](test_framework/authproxy.py)
+## [test_framework/authproxy.py](test_framework/authproxy.py)
 Taken from the [python-bitcoinrpc repository](https://github.com/jgarzik/python-bitcoinrpc).
 
-#### [test_framework/test_framework.py](test_framework/test_framework.py)
+### [test_framework/test_framework.py](test_framework/test_framework.py)
 Base class for functional tests.
 
-#### [test_framework/util.py](test_framework/util.py)
+### [test_framework/util.py](test_framework/util.py)
 Generally useful functions.
 
-#### [test_framework/mininode.py](test_framework/mininode.py)
+### [test_framework/mininode.py](test_framework/mininode.py)
 Basic code to support P2P connectivity to a bitcoind.
 
-#### [test_framework/script.py](test_framework/script.py)
+### [test_framework/script.py](test_framework/script.py)
 Utilities for manipulating transaction scripts (originally from python-bitcoinlib)
 
-#### [test_framework/key.py](test_framework/key.py)
+### [test_framework/key.py](test_framework/key.py)
 Wrapper around OpenSSL EC_Key (originally from python-bitcoinlib)
 
-#### [test_framework/bignum.py](test_framework/bignum.py)
+### [test_framework/bignum.py](test_framework/bignum.py)
 Helpers for script.py
 
-#### [test_framework/blocktools.py](test_framework/blocktools.py)
+### [test_framework/blocktools.py](test_framework/blocktools.py)
 Helper functions for creating blocks and transactions.
 
-### Benchmarking with perf
+## Benchmarking with perf
 
 An easy way to profile node performance during functional tests is provided
 for Linux platforms using `perf`.
@@ -151,7 +151,7 @@ To see useful textual output, run
 perf report -i /path/to/datadir/send-big-msgs.perf.data.xxxx --stdio | c++filt | less
 ```
 
-#### See also:
+### See also:
 
 - [Installing perf](https://askubuntu.com/q/50145)
 - [Perf examples](http://www.brendangregg.com/perf.html)

--- a/test/functional/data/wallets/high_minversion/generate.md
+++ b/test/functional/data/wallets/high_minversion/generate.md
@@ -1,3 +1,5 @@
+# Generating the `high_minversion` wallet
+
 The wallet has been created by starting Bitcoin Core with the options
 `-regtest -datadir=/tmp -nowallet -walletdir=$(pwd)/test/functional/data/wallets/`.
 

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -1,15 +1,15 @@
-This folder contains lint scripts.
+# Lint Scripts
 
-check-doc.py
-============
+## check-doc.py
+
 Check for missing documentation of command line options.
 
-commit-script-check.sh
-======================
+## commit-script-check.sh
+
 Verification of [scripted diffs](/doc/developer-notes.md#scripted-diffs).
 
-git-subtree-check.sh
-====================
+## git-subtree-check.sh
+
 Run this script from the root of the repository to verify that a subtree matches the contents of
 the commit it claims to have been updated to.
 
@@ -24,6 +24,6 @@ Usage: `git-subtree-check.sh DIR (COMMIT)`
 
 `COMMIT` may be omitted, in which case `HEAD` is used.
 
-lint-all.sh
-===========
+## lint-all.sh
+
 Calls other scripts with the `lint-` prefix.


### PR DESCRIPTION
This PR introduces a rules file called `.markdownlint.yml`, and a sizeable amount of documentation formatting from having applied these rules.

`.markdownlint.yml` can be used by running npm package `markdownlint` from the repo root. In this case, I ran:

```
markdownlint . --ignore "doc/release-notes*" --ignore "doc/release-notes/*" --ignore "src/leveldb/*" --ignore "src/leveldb/**/*" --ignore "src/univalue/*" --ignore "src/univalue/**/*" --ignore "src/secp256k1/*" --ignore "src/secp256k1/**/*" --ignore "src/crypto/**/*" --ignore "ci/retry/*"
```

A few advantages come from adding this linter:

- Consistent formatting and improved readability, both rendered and as plaintext.
- `.markdownlint.yml` automatically offers warnings in VSCode if plugin `markdownlint` installed.
- Could be used to lint Doxygen comments.