### PR TITLE
doc: Remove Doxygen intro from src/bitcoind.cpp

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -790,7 +790,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = src
+INPUT                  = src doc/README_doxygen.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -974,7 +974,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = doc/README_doxygen.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/doc/README_doxygen.md
+++ b/doc/README_doxygen.md
@@ -1,0 +1,15 @@
+\mainpage notitle
+
+\section intro_sec Introduction
+
+This is the developer documentation of the reference client for an experimental new digital currency called Bitcoin,
+which enables instant payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
+with no central authority: managing transactions and issuing money are carried out collectively by the network.
+
+The software is a community-driven open source project, released under the MIT license.
+
+See https://github.com/bitcoin/bitcoin and https://bitcoincore.org/ for further information about the project.
+
+\section Navigation
+Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
+

--- a/doc/README_doxygen.md
+++ b/doc/README_doxygen.md
@@ -11,5 +11,5 @@ The software is a community-driven open source project, released under the MIT l
 See https://github.com/bitcoin/bitcoin and https://bitcoincore.org/ for further information about the project.
 
 \section Navigation
-Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
+Use <a href="modules.html"><code>Modules</code></a>, <a href="namespaces.html"><code>Namespaces</code></a>, <a href="classes.html"><code>Classes</code></a>, or <a href="files.html"><code>Files</code></a> at the top of the page to start navigating the code.
 

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -25,24 +25,6 @@
 
 const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 
-/* Introduction text for doxygen: */
-
-/*! \mainpage Developer documentation
- *
- * \section intro_sec Introduction
- *
- * This is the developer documentation of the reference client for an experimental new digital currency called Bitcoin,
- * which enables instant payments to anyone, anywhere in the world. Bitcoin uses peer-to-peer technology to operate
- * with no central authority: managing transactions and issuing money are carried out collectively by the network.
- *
- * The software is a community-driven open source project, released under the MIT license.
- *
- * See https://github.com/bitcoin/bitcoin and https://bitcoincore.org/ for further information about the project.
- *
- * \section Navigation
- * Use the buttons <code>Namespaces</code>, <code>Classes</code> or <code>Files</code> at the top of the page to start navigating the code.
- */
-
 static void WaitForShutdown()
 {
     while (!ShutdownRequested())


### PR DESCRIPTION
With `USE_MDFILE_AS_MAINPAGE`, this moves the introductory Doxygen comment to its own file. This makes `bitcoind.cpp` cleaner.

It also removes the `\mainpage` header text, which was smaller than the section titles, and improves the Navigation section.