### PR TITLE
doc: Update homebrew instruction for doxygen

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -193,7 +193,7 @@ Documentation can be generated with `make docs` and cleaned up with `make clean-
 
 Before running `make docs`, you will need to install dependencies `doxygen` and `dot`. For example, on macOS via Homebrew:
 ```
-brew install doxygen --with-graphviz
+brew install graphviz doxygen
 ```
 
 Development tips and tricks


### PR DESCRIPTION
I noticed while testing #16912 that `brew install doxygen --with-graphviz` no long works. Instead you need to use `brew install graphviz doxygen`.