### PR TITLE
doc: Document MemPoolAccept::Finalize(...) precondition

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -465,7 +465,8 @@ public:
 
 private:
     // All the intermediate state that gets passed between the various levels
-    // of checking a given transaction.
+    // of checking a given transaction. Initialization of the members is done
+    // in PreChecks(ATMPArgs& args, Workspace& ws).
     struct Workspace {
         Workspace(const CTransactionRef& ptx) : m_ptx(ptx), m_hash(ptx->GetHash()) {}
         std::set<uint256> m_conflicts;


### PR DESCRIPTION
Document `MemPoolAccept::Finalize(...)` precondition.

Context: A quick look at ...

```
$ git grep m_conflicting_size
src/validation.cpp:        size_t m_conflicting_size;
src/validation.cpp:    size_t& nConflictingSize = ws.m_conflicting_size;
src/validation.cpp:    const size_t& nConflictingSize = ws.m_conflicting_size;
```

... might look like an uninitialized read (which it is not) :)
