### PR TITLE
test: Make PORT_MIN in test runner configurable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,6 +9,7 @@ task:
     MAKEJOBS: "-j9"
     CONFIGURE_OPTS: "--disable-dependency-tracking"
     GOAL: "install"
+    TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
     CCACHE_SIZE: "200M"
     CCACHE_COMPRESS: 1
     CCACHE_DIR: "/tmp/ccache_dir"
@@ -37,6 +38,7 @@ task:
   env:
     MAKEJOBS: "-j9"
     RUN_CI_ON_HOST: "1"
+    TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
     CCACHE_SIZE: "200M"
     CCACHE_DIR: "/tmp/ccache_dir"
   ccache_cache:

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -7,13 +7,13 @@
 from base64 import b64encode
 from binascii import unhexlify
 from decimal import Decimal, ROUND_DOWN
+from subprocess import CalledProcessError
 import inspect
 import json
 import logging
 import os
 import random
 import re
-from subprocess import CalledProcessError
 import time
 
 from . import coverage
@@ -228,9 +228,10 @@ def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=N
 # The maximum number of nodes a single test can spawn
 MAX_NODES = 12
 # Don't assign rpc or p2p ports lower than this
-PORT_MIN = 11000
+PORT_MIN = int(os.getenv('TEST_RUNNER_PORT_MIN', default=11000))
 # The number of ports to "reserve" for p2p and rpc, each
 PORT_RANGE = 5000
+
 
 class PortSeed:
     # Must be initialized with a unique integer for each process


### PR DESCRIPTION
This is needed when some ports in the port range are used by other processes. Note that simply assigning the ports dynamically does not work:

* We spin up several nodes per test (each node gets its own port)
* We run several tests in parallel

So to avoid nodes from different tests colliding on ports, the port assignment must be deterministic (can not be dynamic).

Fixes: #10869