### PR TITLE
depends: Add OpenSSL termios fix for musl libc

### DIFF
--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -3,6 +3,7 @@ $(package)_version=1.0.1k
 $(package)_download_path=https://www.openssl.org/source
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
+$(package)_patches=0001-Add-OpenSSL-termios-fix-for-musl-libc.patch
 
 define $(package)_set_vars
 $(package)_config_env=AR="$($(package)_ar)" RANLIB="$($(package)_ranlib)" CC="$($(package)_cc)"
@@ -60,6 +61,7 @@ $(package)_config_opts_i686_mingw32=mingw
 endef
 
 define $(package)_preprocess_cmds
+  patch -p1 < $($(package)_patch_dir)/0001-Add-OpenSSL-termios-fix-for-musl-libc.patch && \
   sed -i.old "/define DATE/d" util/mkbuildinf.pl && \
   sed -i.old "s|engines apps test|engines|" Makefile.org
 endef

--- a/depends/patches/openssl/0001-Add-OpenSSL-termios-fix-for-musl-libc.patch
+++ b/depends/patches/openssl/0001-Add-OpenSSL-termios-fix-for-musl-libc.patch
@@ -1,0 +1,17 @@
+diff --git a/crypto/ui/ui_openssl.c b/crypto/ui/ui_openssl.c
+index a38c758..d99edc2 100644
+--- a/crypto/ui/ui_openssl.c
++++ b/crypto/ui/ui_openssl.c
+@@ -190,9 +190,9 @@
+ # undef  SGTTY
+ #endif
+ 
+-#if defined(linux) && !defined(TERMIO)
+-# undef  TERMIOS
+-# define TERMIO
++#if defined(linux)
++# define TERMIOS
++# undef  TERMIO
+ # undef  SGTTY
+ #endif
+ 


### PR DESCRIPTION
Currently the version of OpenSSL included in the depends system won't build on musl based systems because `termio.h` does not exist. The proper header named `termios.h` does exist.

This PR adds a patch for OpenSSL to replace the `termio.h` header with `termios.h`, which is the proper POSIX header as I understand it.

This is a known issue as `TERMIOS` (not `TERMIO`) should be the default, and is fixed in later versions of OpenSSL. There is discussion on the OpenSSL repo here: openssl/openssl#163

This has been [fixed in OpenSSL](https://github.com/openssl/openssl/commit/64e6bf64b36136d487e2fbf907f09612e69ae911).

This partly fixes #16925 and allows building Bitcoin on Alpine using the depends system.