### PR TITLE
gui: Rename address checkbox back to bech32

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -189,7 +189,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="useLegacyAddress">
+           <widget class="QCheckBox" name="useBech32">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -206,10 +206,10 @@
              <enum>Qt::StrongFocus</enum>
             </property>
             <property name="toolTip">
-             <string>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When checked, an address compatible with older wallets will be created instead.</string>
+             <string>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</string>
             </property>
             <property name="text">
-             <string>Generate legacy address</string>
+             <string>Generate native segwit (Bech32) address</string>
             </property>
            </widget>
           </item>
@@ -360,7 +360,7 @@
  <tabstops>
   <tabstop>reqLabel</tabstop>
   <tabstop>reqAmount</tabstop>
-  <tabstop>useLegacyAddress</tabstop>
+  <tabstop>useBech32</tabstop>
   <tabstop>reqMessage</tabstop>
   <tabstop>receiveButton</tabstop>
   <tabstop>clearButton</tabstop>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -2696,17 +2696,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+136"/>
-        <source>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don&apos;t support them. When checked, an address compatible with older wallets will be created instead.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="+3"/>
-        <source>Generate legacy address</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location line="-178"/>
+        <location line="-39"/>
         <location line="+153"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"></translation>
@@ -2727,7 +2717,17 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location line="+142"/>
+        <location line="+78"/>
+        <source>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don&apos;t support them. When unchecked, an address compatible with older wallets will be created instead.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+3"/>
+        <source>Generate native segwit (Bech32) address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location line="+61"/>
         <source>Requested payments history</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -96,13 +96,13 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
         if (model->node().isAddressTypeSet()) {
             // user explicitly set the type, use it
             if (model->wallet().getDefaultAddressType() == OutputType::BECH32) {
-                ui->useLegacyAddress->setCheckState(Qt::Unchecked);
+                ui->useBech32->setCheckState(Qt::Checked);
             } else {
-                ui->useLegacyAddress->setCheckState(Qt::Checked);
+                ui->useBech32->setCheckState(Qt::Unchecked);
             }
         } else {
             // Always fall back to bech32 in the gui
-            ui->useLegacyAddress->setCheckState(Qt::Unchecked);
+            ui->useBech32->setCheckState(Qt::Checked);
         }
 
         // Set the button to be enabled or disabled based on whether the wallet can give out new addresses.
@@ -155,7 +155,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     QString label = ui->reqLabel->text();
     /* Generate new receiving address */
     OutputType address_type;
-    if (!ui->useLegacyAddress->isChecked()) {
+    if (ui->useBech32->isChecked()) {
         address_type = OutputType::BECH32;
     } else {
         address_type = model->wallet().getDefaultAddressType();


### PR DESCRIPTION
This is the wording that has been used in the previous release, so translations should still exist for it.

Fixes: #16924