### PR TITLE
travis: Disable feature_block in tsan run due to OOM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ jobs:
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs, sanitizers: thread (TSan), no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_amd64_tsan.sh"
+        TEST_RUNNER_EXTRA="--exclude feature_block"  # Not enough memory on travis machines
 
     - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs, sanitizers: address/leak (ASan + LSan) + undefined (UBSan) + integer]'


### PR DESCRIPTION
The `feature_block` test causes the travis machine to OOM, when run with the thread sanitizer.

The stderr says:

```
==27237==ERROR: ThreadSanitizer failed to allocate 0xf6000 (1007616) bytes of LargeMmapAllocator (error code: 12)
...
FATAL: ThreadSanitizer CHECK failed: /build/llvm-toolchain-3.8-_PD09B/llvm-toolchain-3.8-3.8/projects/compiler-rt/lib/sanitizer_common/sanitizer_common.cc:183 "((0 && "unable to mmap")) != (0)" (0x0, 0x0)

ERROR: Failed to mmap
```
(from https://travis-ci.org/bitcoin/bitcoin/jobs/588194563#L10505)

Fix this by disabling `feature_block` on travis. Longer term, I'd like to move away from travis, but I'll leave this for a follow-up.