### PR TITLE
doc: Doxygen-friendly script/descriptor.h comments

### DIFF
--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -11,22 +11,24 @@
 
 #include <vector>
 
-// Descriptors are strings that describe a set of scriptPubKeys, together with
-// all information necessary to solve them. By combining all information into
-// one, they avoid the need to separately import keys and scripts.
-//
-// Descriptors may be ranged, which occurs when the public keys inside are
-// specified in the form of HD chains (xpubs).
-//
-// Descriptors always represent public information - public keys and scripts -
-// but in cases where private keys need to be conveyed along with a descriptor,
-// they can be included inside by changing public keys to private keys (WIF
-// format), and changing xpubs by xprvs.
-//
-// Reference documentation about the descriptor language can be found in
-// doc/descriptors.md.
 
-/** Interface for parsed descriptor objects. */
+/** \brief Interface for parsed descriptor objects.
+ *
+ * Descriptors are strings that describe a set of scriptPubKeys, together with
+ * all information necessary to solve them. By combining all information into
+ * one, they avoid the need to separately import keys and scripts.
+ *
+ * Descriptors may be ranged, which occurs when the public keys inside are
+ * specified in the form of HD chains (xpubs).
+ *
+ * Descriptors always represent public information - public keys and scripts -
+ * but in cases where private keys need to be conveyed along with a descriptor,
+ * they can be included inside by changing public keys to private keys (WIF
+ * format), and changing xpubs by xprvs.
+ *
+ * Reference documentation about the descriptor language can be found in
+ * doc/descriptors.md.
+ */
 struct Descriptor {
     virtual ~Descriptor() = default;
 
@@ -45,51 +47,51 @@ struct Descriptor {
 
     /** Expand a descriptor at a specified position.
      *
-     * pos: the position at which to expand the descriptor. If IsRange() is false, this is ignored.
-     * provider: the provider to query for private keys in case of hardened derivation.
-     * output_scripts: the expanded scriptPubKeys will be put here.
-     * out: scripts and public keys necessary for solving the expanded scriptPubKeys will be put here (may be equal to provider).
-     * cache: vector which will be overwritten with cache data necessary to evaluate the descriptor at this point without access to private keys.
+     * @param[in] pos: The position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * @param[in] provider: The provider to query for private keys in case of hardened derivation.
+     * @param[out] output_scripts: The expanded scriptPubKeys.
+     * @param[out] out: Scripts and public keys necessary for solving the expanded scriptPubKeys (may be equal to `provider`).
+     * @param[out] cache: Cache data necessary to evaluate the descriptor at this point without access to private keys.
      */
     virtual bool Expand(int pos, const SigningProvider& provider, std::vector<CScript>& output_scripts, FlatSigningProvider& out, std::vector<unsigned char>* cache = nullptr) const = 0;
 
     /** Expand a descriptor at a specified position using cached expansion data.
      *
-     * pos: the position at which to expand the descriptor. If IsRange() is false, this is ignored.
-     * cache: vector from which cached expansion data will be read.
-     * output_scripts: the expanded scriptPubKeys will be put here.
-     * out: scripts and public keys necessary for solving the expanded scriptPubKeys will be put here (may be equal to provider).
+     * @param[in] pos: The position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * @param[in] cache: Cached expansion data.
+     * @param[out] output_scripts: The expanded scriptPubKeys.
+     * @param[out] out: Scripts and public keys necessary for solving the expanded scriptPubKeys (may be equal to `provider`).
      */
     virtual bool ExpandFromCache(int pos, const std::vector<unsigned char>& cache, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const = 0;
 
     /** Expand the private key for a descriptor at a specified position, if possible.
      *
-     * pos: the position at which to expand the descriptor. If IsRange() is false, this is ignored.
-     * provider: the provider to query for the private keys.
-     * out: any private keys available for the specified pos will be placed here.
+     * @param[in] pos: The position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * @param[in] provider: The provider to query for the private keys.
+     * @param[out] out: Any private keys available for the specified `pos`.
      */
     virtual void ExpandPrivate(int pos, const SigningProvider& provider, FlatSigningProvider& out) const = 0;
 };
 
-/** Parse a descriptor string. Included private keys are put in out.
+/** Parse a `descriptor` string. Included private keys are put in `out`.
  *
- * If the descriptor has a checksum, it must be valid. If require_checksum
+ * If the descriptor has a checksum, it must be valid. If `require_checksum`
  * is set, the checksum is mandatory - otherwise it is optional.
  *
  * If a parse error occurs, or the checksum is missing/invalid, or anything
- * else is wrong, nullptr is returned.
+ * else is wrong, `nullptr` is returned.
  */
 std::unique_ptr<Descriptor> Parse(const std::string& descriptor, FlatSigningProvider& out, std::string& error, bool require_checksum = false);
 
-/** Get the checksum for a descriptor.
+/** Get the checksum for a `descriptor`.
  *
- * If it already has one, and it is correct, return the checksum in the input.
- * If it already has one that is wrong, return "".
- * If it does not already have one, return the checksum that would need to be added.
+ * - If it already has one, and it is correct, return the checksum in the input.
+ * - If it already has one that is wrong, return "".
+ * - If it does not already have one, return the checksum that would need to be added.
  */
 std::string GetDescriptorChecksum(const std::string& descriptor);
 
-/** Find a descriptor for the specified script, using information from provider where possible.
+/** Find a descriptor for the specified `script`, using information from `provider` where possible.
  *
  * A non-ranged descriptor which only generates the specified script will be returned in all
  * circumstances.
@@ -98,9 +100,9 @@ std::string GetDescriptorChecksum(const std::string& descriptor);
  * descriptor.
  *
  * - If all information for solving `script` is present in `provider`, a descriptor will be returned
- *   which is `IsSolvable()` and encapsulates said information.
+ *   which is IsSolvable() and encapsulates said information.
  * - Failing that, if `script` corresponds to a known address type, an "addr()" descriptor will be
- *   returned (which is not `IsSolvable()`).
+ *   returned (which is not IsSolvable()).
  * - Failing that, a "raw()" descriptor is returned.
  */
 std::unique_ptr<Descriptor> InferDescriptor(const CScript& script, const SigningProvider& provider);


### PR DESCRIPTION
Closes #16942.

- Make `Descriptor` overview subtext of `Interface for parsed descriptor objects.`
- Conform to `@param[in, out] argname: Info` in parameter comments. Present in code: https://github.com/bitcoin/bitcoin/blob/feb162d500273040c8a2e5cdd3393edf34dff45b/src/net_processing.cpp#L1001
- Remove redundant argument type, `in` vs `out` mentions
- Removed unnecessary backticks around `IsSolvable()`, since Doxygen builds a link to the known function's docs
- Add backticks to refer to `argname`s

`descriptor.cpp` has more documentation, but Doxygen's output doesn't include anything inside unnamed namespaces for some reason. Tried to access them via searchbar.