### PR TITLE
build: only pass --disable-dependency-tracking to packages that understand it

### DIFF
--- a/depends/funcs.mk
+++ b/depends/funcs.mk
@@ -133,7 +133,7 @@ $(1)_config_env+=PKG_CONFIG_PATH=$($($(1)_type)_prefix)/share/pkgconfig
 $(1)_config_env+=PATH=$(build_prefix)/bin:$(PATH)
 $(1)_build_env+=PATH=$(build_prefix)/bin:$(PATH)
 $(1)_stage_env+=PATH=$(build_prefix)/bin:$(PATH)
-$(1)_autoconf=./configure --host=$($($(1)_type)_host) --disable-dependency-tracking --prefix=$($($(1)_type)_prefix) $$($(1)_config_opts) CC="$$($(1)_cc)" CXX="$$($(1)_cxx)"
+$(1)_autoconf=./configure --host=$($($(1)_type)_host) --prefix=$($($(1)_type)_prefix) $$($(1)_config_opts) CC="$$($(1)_cc)" CXX="$$($(1)_cxx)"
 
 ifneq ($($(1)_nm),)
 $(1)_autoconf += NM="$$($(1)_nm)"

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b857327
 $(package)_build_subdir=build_unix
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-shared --enable-cxx --disable-replication
+$(package)_config_opts=--disable-shared --enable-cxx --disable-replication --enable-option-checking
 $(package)_config_opts_mingw32=--enable-mingw
 $(package)_config_opts_linux=--with-pic
 $(package)_cxxflags=-std=c++11

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -5,7 +5,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples --disable-dependency-tracking
+  $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/expat.mk
+++ b/depends/packages/expat.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples
+  $(package)_config_opts=--disable-shared --without-docbook --without-tests --without-examples --disable-dependency-tracking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f
 $(package)_dependencies=freetype expat
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
+  $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv --disable-dependency-tracking
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/fontconfig.mk
+++ b/depends/packages/fontconfig.mk
@@ -6,7 +6,8 @@ $(package)_sha256_hash=b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f
 $(package)_dependencies=freetype expat
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv --disable-dependency-tracking
+  $(package)_config_opts=--disable-docs --disable-static --disable-libxml2 --disable-iconv
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 
 define $(package)_config_cmds

--- a/depends/packages/freetype.mk
+++ b/depends/packages/freetype.mk
@@ -6,6 +6,7 @@ $(package)_sha256_hash=3a3bb2c4e15ffb433f2032f50a5b5a92558206822e22bfe8cbe339af4
 
 define $(package)_set_vars
   $(package)_config_opts=--without-zlib --without-png --without-harfbuzz --without-bzip2 --disable-static
+  $(package)_config_opts += --enable-option-checking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -8,7 +8,8 @@ $(package)_dependencies=xproto
 # When updating this package, check the default value of
 # --disable-xthreads. It is currently enabled.
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint --disable-dependency-tracking
+  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/libXau.mk
+++ b/depends/packages/libXau.mk
@@ -8,7 +8,7 @@ $(package)_dependencies=xproto
 # When updating this package, check the default value of
 # --disable-xthreads. It is currently enabled.
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint
+  $(package)_config_opts=--disable-shared --disable-lint-library --without-lint --disable-dependency-tracking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -9,7 +9,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
+  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples --disable-dependency-tracking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
 endef

--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -9,7 +9,8 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples --disable-dependency-tracking
+  $(package)_config_opts=--disable-shared --disable-openssl --disable-libevent-regress --disable-samples
+  $(package)_config_opts += --disable-dependency-tracking --enable-option-checking
   $(package)_config_opts_release=--disable-debug-mode
   $(package)_config_opts_linux=--with-pic
 endef

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c
 $(package)_dependencies=xcb_proto libXau
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd
+$(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd --disable-dependency-tracking
 # Because we pass -qt-xcb to Qt, it will compile in a set of xcb helper libraries and extensions,
 # so we skip building all of the extensions here.
 # More info is available from: https://doc.qt.io/qt-5.9/linux-requirements.html

--- a/depends/packages/libxcb.mk
+++ b/depends/packages/libxcb.mk
@@ -6,7 +6,8 @@ $(package)_sha256_hash=98d9ab05b636dd088603b64229dd1ab2d2cc02ab807892e107d674f9c
 $(package)_dependencies=xcb_proto libXau
 
 define $(package)_set_vars
-$(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd --disable-dependency-tracking
+$(package)_config_opts=--disable-static --disable-build-docs --without-doxygen --without-launchd
+$(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 # Because we pass -qt-xcb to Qt, it will compile in a set of xcb helper libraries and extensions,
 # so we skip building all of the extensions here.
 # More info is available from: https://doc.qt.io/qt-5.9/linux-requirements.html

--- a/depends/packages/protobuf.mk
+++ b/depends/packages/protobuf.mk
@@ -7,7 +7,7 @@ $(package)_dependencies=native_$(package)
 $(package)_cxxflags=-std=c++11
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --with-protoc=$(build_prefix)/bin/protoc
+  $(package)_config_opts=--disable-shared --with-protoc=$(build_prefix)/bin/protoc --disable-dependency-tracking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -6,7 +6,7 @@ $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest
-$(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
+$(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap --disable-dependency-tracking
 $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -6,7 +6,8 @@ $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19
 
 define $(package)_set_vars
 $(package)_config_opts=--disable-shared --without-tools --without-tests --disable-sdltest
-$(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap --disable-dependency-tracking
+$(package)_config_opts += --disable-gprof --disable-gcov --disable-mudflap
+$(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -5,7 +5,7 @@ $(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
 $(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
 
 define $(package)_set_vars
-  $(package)_config_opts=--disable-shared
+  $(package)_config_opts=--disable-shared --enable-option-checking
   $(package)_config_opts_linux=--with-pic
 endef
 

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -5,7 +5,8 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e046514f
 
 define $(package)_set_vars
-$(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs --disable-dependency-tracking
+$(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
+$(package)_config_opts += --disable-dependency-tracking --enable-option-checking
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/xproto.mk
+++ b/depends/packages/xproto.mk
@@ -5,7 +5,7 @@ $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=636162c1759805a5a0114a369dffdeccb8af8c859ef6e1445f26a4e6e046514f
 
 define $(package)_set_vars
-$(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs
+$(package)_config_opts=--without-fop --without-xmlto --without-xsltproc --disable-specs --disable-dependency-tracking
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -6,9 +6,10 @@ $(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d83
 $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
-  $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf --disable-Werror --disable-drafts
+  $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
   $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
+  $(package)_config_opts += --disable-Werror --disable-drafts --enable-option-checking
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
 endef

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -8,7 +8,7 @@ $(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_
 define $(package)_set_vars
   $(package)_config_opts=--without-docs --disable-shared --disable-curve --disable-curve-keygen --disable-perf --disable-Werror --disable-drafts
   $(package)_config_opts += --without-libsodium --without-libgssapi_krb5 --without-pgm --without-norm --without-vmci
-  $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov
+  $(package)_config_opts += --disable-libunwind --disable-radix-tree --without-gcov --disable-dependency-tracking
   $(package)_config_opts_linux=--with-pic
   $(package)_cxxflags=-std=c++11
 endef


### PR DESCRIPTION
By blanket passing `--disable-dependency-tracking` to all depends packages we end up with warnings (i.e in `bdb` or `freetype`) like:
```bash
configure: WARNING: unrecognized options: --disable-dependency-tracking
```
Instead, only pass it to packages that actually understand it. Related to https://github.com/bitcoin/bitcoin/issues/16354.

More info on `--disable-dependency-tracking` available [here](https://www.gnu.org/software/automake/manual/html_node/Dependency-Tracking.html).

This PR also adds `--enable-option-checking` as a configure option to all applicable packages.