### PR TITLE
gui: make sure to update the UI when deleting a transaction

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3376,6 +3376,7 @@ DBErrors CWallet::ZapSelectTx(std::vector<uint256>& vHashIn, std::vector<uint256
         const auto& it = mapWallet.find(hash);
         wtxOrdered.erase(it->second.m_it_wtxOrdered);
         mapWallet.erase(it);
+        NotifyTransactionChanged(this, hash, CT_DELETED);
     }
 
     if (nZapSelectTxRet == DBErrors::NEED_REWRITE)


### PR DESCRIPTION
`CWallet::ZapSelectTx` removes transactions from the internal model, but leaves the UI in the dark.
Adding a `NotifyTransactionChanged()` should avoid having invalid transactions in the GUI.

Fixes #16950