### PR TITLE
doc: Put PR template in comments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,14 @@
+<!--
+*** Please remove the following help text before submitting: ***
+
 Pull requests without a rationale and clear improvement may be closed
 immediately.
+-->
 
+<!--
 Please provide clear motivation for your patch and explain how it improves
 Bitcoin Core user experience or Bitcoin Core developer experience
-significantly.
+significantly:
 
 * Any test improvements or new tests that improve coverage are always welcome.
 * All other changes should have accompanying unit tests (see `src/test/`) or
@@ -24,8 +29,11 @@ significantly.
   is often a subjective matter. Unless they are explicitly mentioned to be
   preferred in the [developer notes](/doc/developer-notes.md), stylistic code
   changes are usually rejected.
+-->
 
+<!--
 Bitcoin Core has a thorough review process and even the most trivial change
 needs to pass a lot of eyes and requires non-zero or even substantial time
 effort to review. There is a huge lack of active reviewers on the project, so
 patches often sit for a long time.
+-->


### PR DESCRIPTION
This prevents the common annoyance of the text being included into PRs
accidentally.