### PR TITLE
gui: Change sendcoins dialogue Yes to Send

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -927,11 +927,11 @@ void SendConfirmationDialog::updateYesButton()
     if(secDelay > 0)
     {
         yesButton->setEnabled(false);
-        yesButton->setText(tr("Yes") + " (" + QString::number(secDelay) + ")");
+        yesButton->setText(tr("Send") + " (" + QString::number(secDelay) + ")");
     }
     else
     {
         yesButton->setEnabled(true);
-        yesButton->setText(tr("Yes"));
+        yesButton->setText(tr("Send"));
     }
 }


### PR DESCRIPTION
It's more self-explanatory, matches "cancel" better, and makes future extensions such as https://github.com/bitcoin/bitcoin/pull/16944 more directly understandable to the user.