### PR TITLE
ui: make send a wizard 

### DIFF
--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -42,7 +42,7 @@
     <ClCompile Include="..\..\src\qt\receiverequestdialog.cpp" />
     <ClCompile Include="..\..\src\qt\recentrequeststablemodel.cpp" />
     <ClCompile Include="..\..\src\qt\rpcconsole.cpp" />
-    <ClCompile Include="..\..\src\qt\sendcoinsdialog.cpp" />
+    <ClCompile Include="..\..\src\qt\sendcompose.cpp" />
     <ClCompile Include="..\..\src\qt\sendcoinsentry.cpp" />
     <ClCompile Include="..\..\src\qt\signverifymessagedialog.cpp" />
     <ClCompile Include="..\..\src\qt\splashscreen.cpp" />
@@ -94,7 +94,7 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_receiverequestdialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_recentrequeststablemodel.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcconsole.cpp" />
-    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcoinsdialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcompose.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcoinsentry.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_signverifymessagedialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_splashscreen.cpp" />

--- a/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
+++ b/build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj
@@ -43,7 +43,10 @@
     <ClCompile Include="..\..\src\qt\recentrequeststablemodel.cpp" />
     <ClCompile Include="..\..\src\qt\rpcconsole.cpp" />
     <ClCompile Include="..\..\src\qt\sendcompose.cpp" />
+    <ClCompile Include="..\..\src\qt\senddialog.cpp" />
+    <ClCompile Include="..\..\src\qt\sendfinish.cpp" />
     <ClCompile Include="..\..\src\qt\sendcoinsentry.cpp" />
+    <ClCompile Include="..\..\src\qt\sendsign.cpp" />
     <ClCompile Include="..\..\src\qt\signverifymessagedialog.cpp" />
     <ClCompile Include="..\..\src\qt\splashscreen.cpp" />
     <ClCompile Include="..\..\src\qt\trafficgraphwidget.cpp" />
@@ -96,6 +99,9 @@
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_rpcconsole.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcompose.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendcoinsentry.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_senddialog.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendfinish.cpp" />
+    <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_sendsign.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_signverifymessagedialog.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_splashscreen.cpp" />
     <ClCompile Include="$(GeneratedFilesOutDir)\moc\moc_trafficgraphwidget.cpp" />

--- a/contrib/bitcoin-qt.pro
+++ b/contrib/bitcoin-qt.pro
@@ -14,7 +14,10 @@ FORMS += \
     ../src/qt/forms/debugwindow.ui \
     ../src/qt/forms/sendcompose.ui \
     ../src/qt/forms/sendcoinsentry.ui \
+    ../src/qt/forms/sendsign.ui \
+    ../src/qt/forms/sendfinish.ui \
     ../src/qt/forms/signverifymessagedialog.ui \
+    ../src/qt/forms/senddialog.ui \
     ../src/qt/forms/transactiondescdialog.ui \
     ../src/qt/forms/createwalletdialog.ui
 

--- a/contrib/bitcoin-qt.pro
+++ b/contrib/bitcoin-qt.pro
@@ -12,7 +12,7 @@ FORMS += \
     ../src/qt/forms/receivecoinsdialog.ui \
     ../src/qt/forms/receiverequestdialog.ui \
     ../src/qt/forms/debugwindow.ui \
-    ../src/qt/forms/sendcoinsdialog.ui \
+    ../src/qt/forms/sendcompose.ui \
     ../src/qt/forms/sendcoinsentry.ui \
     ../src/qt/forms/signverifymessagedialog.ui \
     ../src/qt/forms/transactiondescdialog.ui \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -25,7 +25,10 @@ QT_FORMS_UI = \
   qt/forms/debugwindow.ui \
   qt/forms/sendcompose.ui \
   qt/forms/sendcoinsentry.ui \
+  qt/forms/sendsign.ui \
+  qt/forms/sendfinish.ui \
   qt/forms/signverifymessagedialog.ui \
+  qt/forms/senddialog.ui \
   qt/forms/transactiondescdialog.ui
 
 QT_MOC_CPP = \
@@ -64,12 +67,15 @@ QT_MOC_CPP = \
   qt/moc_recentrequeststablemodel.cpp \
   qt/moc_rpcconsole.cpp \
   qt/moc_sendcompose.cpp \
+  qt/moc_sendsign.cpp \
   qt/moc_sendcoinsentry.cpp \
+  qt/moc_sendfinish.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
   qt/moc_trafficgraphwidget.cpp \
   qt/moc_transactiondesc.cpp \
   qt/moc_transactiondescdialog.cpp \
+  qt/moc_senddialog.cpp \
   qt/moc_transactionfilterproxy.cpp \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
@@ -146,7 +152,10 @@ BITCOIN_QT_H = \
   qt/recentrequeststablemodel.h \
   qt/rpcconsole.h \
   qt/sendcompose.h \
+  qt/sendsign.h \
   qt/sendcoinsentry.h \
+  qt/senddialog.h \
+  qt/sendfinish.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
   qt/trafficgraphwidget.h \
@@ -255,9 +264,12 @@ BITCOIN_QT_WALLET_CPP = \
   qt/receiverequestdialog.cpp \
   qt/recentrequeststablemodel.cpp \
   qt/sendcompose.cpp \
+  qt/sendsign.cpp \
   qt/sendcoinsentry.cpp \
+  qt/sendfinish.cpp \
   qt/signverifymessagedialog.cpp \
   qt/transactiondesc.cpp \
+  qt/senddialog.cpp \
   qt/transactiondescdialog.cpp \
   qt/transactionfilterproxy.cpp \
   qt/transactionrecord.cpp \

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -23,7 +23,7 @@ QT_FORMS_UI = \
   qt/forms/receivecoinsdialog.ui \
   qt/forms/receiverequestdialog.ui \
   qt/forms/debugwindow.ui \
-  qt/forms/sendcoinsdialog.ui \
+  qt/forms/sendcompose.ui \
   qt/forms/sendcoinsentry.ui \
   qt/forms/signverifymessagedialog.ui \
   qt/forms/transactiondescdialog.ui
@@ -63,7 +63,7 @@ QT_MOC_CPP = \
   qt/moc_receiverequestdialog.cpp \
   qt/moc_recentrequeststablemodel.cpp \
   qt/moc_rpcconsole.cpp \
-  qt/moc_sendcoinsdialog.cpp \
+  qt/moc_sendcompose.cpp \
   qt/moc_sendcoinsentry.cpp \
   qt/moc_signverifymessagedialog.cpp \
   qt/moc_splashscreen.cpp \
@@ -145,7 +145,7 @@ BITCOIN_QT_H = \
   qt/receiverequestdialog.h \
   qt/recentrequeststablemodel.h \
   qt/rpcconsole.h \
-  qt/sendcoinsdialog.h \
+  qt/sendcompose.h \
   qt/sendcoinsentry.h \
   qt/signverifymessagedialog.h \
   qt/splashscreen.h \
@@ -254,7 +254,7 @@ BITCOIN_QT_WALLET_CPP = \
   qt/receivecoinsdialog.cpp \
   qt/receiverequestdialog.cpp \
   qt/recentrequeststablemodel.cpp \
-  qt/sendcoinsdialog.cpp \
+  qt/sendcompose.cpp \
   qt/sendcoinsentry.cpp \
   qt/signverifymessagedialog.cpp \
   qt/transactiondesc.cpp \

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -20,8 +20,9 @@
 #include <wallet/feebumper.h>
 #include <wallet/fees.h>
 #include <wallet/ismine.h>
-#include <wallet/rpcwallet.h>
 #include <wallet/load.h>
+#include <wallet/psbtwallet.h>
+#include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 #include <wallet/walletutil.h>
 
@@ -343,6 +344,14 @@ public:
             return MakeWalletTx(*locked_chain, *m_wallet, mi->second);
         }
         return {};
+    }
+    TransactionError fillPSBT(PartiallySignedTransaction& psbtx,
+        bool& complete,
+        int sighash_type = 1 /* SIGHASH_ALL */,
+        bool sign = true,
+        bool bip32derivs = false) override
+    {
+            return FillPSBT(m_wallet.get(), psbtx, complete, sighash_type, sign, bip32derivs);
     }
     WalletBalances getBalances() override
     {

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <psbt.h>
 #include <stdint.h>
 #include <string>
 #include <tuple>
@@ -194,6 +195,13 @@ public:
         WalletOrderForm& order_form,
         bool& in_mempool,
         int& num_blocks) = 0;
+
+    //! Fill PSBT
+    virtual TransactionError fillPSBT(PartiallySignedTransaction& psbtx,
+        bool& complete,
+        int sighash_type = 1 /* SIGHASH_ALL */,
+        bool sign = true,
+        bool bip32derivs = false) = 0;
 
     //! Get balances.
     virtual WalletBalances getBalances() = 0;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -403,7 +403,7 @@ void CoinControlDialog::updateLabelLocked()
     else ui->labelLocked->setVisible(false);
 }
 
-void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
+void CoinControlDialog::updateLabels(WalletModel *model, QWidget* dialog)
 {
     if (!model)
         return;

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -49,7 +49,7 @@ public:
     void setModel(WalletModel *model);
 
     // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, QDialog*);
+    static void updateLabels(WalletModel*, QWidget*);
 
     static QList<CAmount> payAmounts;
     static CCoinControl *coinControl();

--- a/src/qt/forms/sendcompose.ui
+++ b/src/qt/forms/sendcompose.ui
@@ -1,18 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>SendCompose</class>
- <widget class="QDialog" name="SendCompose">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>850</width>
-    <height>526</height>
-   </rect>
-  </property>
-  <property name="windowTitle">
-   <string>Send Coins</string>
-  </property>
+ <widget class="QWidget" name="SendCompose">
   <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0,0">
    <property name="bottomMargin">
     <number>8</number>

--- a/src/qt/forms/sendcompose.ui
+++ b/src/qt/forms/sendcompose.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>SendCoinsDialog</class>
- <widget class="QDialog" name="SendCoinsDialog">
+ <class>SendCompose</class>
+ <widget class="QDialog" name="SendCompose">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/src/qt/forms/senddialog.ui
+++ b/src/qt/forms/senddialog.ui
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SendDialog</class>
+  <widget class="QTabWidget" name="SendDialog">
+   <property name="currentIndex">
+    <number>0</number>
+   </property>
+  </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/sendfinish.ui
+++ b/src/qt/forms/sendfinish.ui
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SendFinish</class>
+ <widget class="QWidget" name="SendFinish">
+  <layout class="QVBoxLayout" name="verticalLayoutPage" stretch="0,1,0,0">
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
+   <item>
+     <widget class="QFrame" name="frameTransaction">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayoutFrame">
+       <property name="alignment">
+         <enum>Qt::AlignTop</enum>
+       </property>
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>6</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayoutTransaction" stretch="0,0,0,0,0">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayoutConfirmTransaction">
+           <item>
+            <widget class="QLabel" name="labelTransactionFinish">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string></string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+           <widget class="QLabel" name="labelTransaction">
+             <property name="text">
+               <string></string>
+             </property>
+           </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalSectionControls" stretch="0,0,0,0">
+           <property name="spacing">
+            <number>8</number>
+           </property>
+           <property name="bottomMargin">
+            <number>10</number>
+           </property>
+            <item>
+             <widget class="QLabel" name="questionLabel">
+             </widget>
+            </item>
+          </layout>
+         </item>
+       </layout>
+     </item>
+     </layout>
+     </widget>
+   </item>
+   <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="showTransaction">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Show in transaction history</string>
+        </property>
+        <property name="text">
+         <string>S&amp;how</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/eye</normaloff>:/icons/eye</iconset>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="newTransactionButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Create a new transaction.</string>
+        </property>
+        <property name="text">
+         <string>&amp;New</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+ </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/forms/sendsign.ui
+++ b/src/qt/forms/sendsign.ui
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SendSign</class>
+ <widget class="QWidget" name="SendSign">
+  <layout class="QVBoxLayout" name="verticalLayoutPage" stretch="0,1,0,0">
+   <property name="bottomMargin">
+    <number>8</number>
+   </property>
+   <item>
+     <widget class="QFrame" name="frameConfirmTransaction">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::StyledPanel</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Sunken</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayoutFrame">
+       <property name="alignment">
+         <enum>Qt::AlignTop</enum>
+       </property>
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>6</number>
+       </property>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayoutConfirmTransaction" stretch="0,0,0,0,0">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="topMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayoutConfirmTransaction">
+           <item>
+            <widget class="QLabel" name="labelConfirmTransaction">
+             <property name="font">
+              <font>
+               <weight>75</weight>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Confirm Transaction</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+           <widget class="QLabel" name="labelAreYouSure">
+             <property name="text">
+               <string></string>
+             </property>
+           </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="explanation">
+           <property name="text">
+            <string></string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalSectionControls" stretch="0,0,0,0">
+           <property name="spacing">
+            <number>8</number>
+           </property>
+           <property name="bottomMargin">
+            <number>10</number>
+           </property>
+            <item>
+             <widget class="QLabel" name="questionLabel">
+             </widget>
+            </item>
+          </layout>
+         </item>
+       </layout>
+     </item>
+     </layout>
+     </widget>
+   </item>
+   <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="sendButton">
+        <property name="minimumSize">
+         <size>
+          <width>150</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string></string>
+        </property>
+        <property name="text">
+         <string></string>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/send</normaloff>:/icons/send</iconset>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="editButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Edit transaction</string>
+        </property>
+        <property name="text">
+         <string>&amp;Edit</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/editcopy</normaloff>:/icons/editcopy</iconset>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="cancelButton">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Abort fee bump</string>
+        </property>
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../bitcoin.qrc">
+          <normaloff>:/icons/remove</normaloff>:/icons/remove</iconset>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+ </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -197,7 +197,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -191,7 +191,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     </context>
 <context>
     <name>SendCoinsEntry</name>

--- a/src/qt/locale/bitcoin_be_BY.ts
+++ b/src/qt/locale/bitcoin_be_BY.ts
@@ -811,7 +811,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Даслаць Манеты</translation>

--- a/src/qt/locale/bitcoin_be_BY.ts
+++ b/src/qt/locale/bitcoin_be_BY.ts
@@ -937,7 +937,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -419,7 +419,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -429,7 +429,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -2465,7 +2465,7 @@ Poznámka: Jelikož je poplatek počítaný za bajt, poplatek o hodnotě "100 sa
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ano</translation>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -2095,7 +2095,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Pošli mince</translation>

--- a/src/qt/locale/bitcoin_cs_CZ.ts
+++ b/src/qt/locale/bitcoin_cs_CZ.ts
@@ -429,7 +429,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Amount:</source>
         <translation>Množství:</translation>

--- a/src/qt/locale/bitcoin_cs_CZ.ts
+++ b/src/qt/locale/bitcoin_cs_CZ.ts
@@ -459,7 +459,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -793,7 +793,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Anfon arian</translation>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -875,7 +875,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -2223,7 +2223,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Send bitcoins</translation>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -2605,7 +2605,7 @@ Note: Siden gebyret er kalkuleret på en per-byte basis, et gebyr på "100 satos
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ja</translation>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -2493,7 +2493,7 @@ Hinweis: Eine Gebühr von "100 Satoshis pro kB" bei einer Größe der Transaktio
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ja</translation>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -2123,7 +2123,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Bitcoins überweisen</translation>

--- a/src/qt/locale/bitcoin_de_DE.ts
+++ b/src/qt/locale/bitcoin_de_DE.ts
@@ -757,7 +757,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_de_DE.ts
+++ b/src/qt/locale/bitcoin_de_DE.ts
@@ -715,7 +715,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>Anzahl:</translation>

--- a/src/qt/locale/bitcoin_el.ts
+++ b/src/qt/locale/bitcoin_el.ts
@@ -1673,7 +1673,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ναι</translation>

--- a/src/qt/locale/bitcoin_el.ts
+++ b/src/qt/locale/bitcoin_el.ts
@@ -1479,7 +1479,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Αποστολή νομισμάτων</translation>

--- a/src/qt/locale/bitcoin_el_GR.ts
+++ b/src/qt/locale/bitcoin_el_GR.ts
@@ -1699,7 +1699,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ναι</translation>

--- a/src/qt/locale/bitcoin_el_GR.ts
+++ b/src/qt/locale/bitcoin_el_GR.ts
@@ -1505,7 +1505,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Αποστολή νομισμάτων</translation>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -2876,8 +2876,8 @@
 <context>
     <name>SendCompose</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+601"/>
+        <location filename="../forms/sendcompose.ui" line="+14"/>
+        <location filename="../sendcompose.cpp" line="+601"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -3064,7 +3064,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-513"/>
+        <location filename="../sendcompose.cpp" line="-513"/>
         <source>Copy quantity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3359,9 +3359,9 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satos
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="+88"/>
+        <location filename="../sendcompose.cpp" line="+88"/>
         <location line="+5"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>

--- a/src/qt/locale/bitcoin_en.ts
+++ b/src/qt/locale/bitcoin_en.ts
@@ -2874,7 +2874,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
         <location filename="../sendcoinsdialog.cpp" line="+601"/>

--- a/src/qt/locale/bitcoin_en_AU.ts
+++ b/src/qt/locale/bitcoin_en_AU.ts
@@ -127,7 +127,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_en_AU.ts
+++ b/src/qt/locale/bitcoin_en_AU.ts
@@ -113,7 +113,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(Smart fee not initialized yet. This usually takes a few blocks...)</source>
         <translation>(Smart fee not initialised yet. This usually takes a few blocks...)</translation>

--- a/src/qt/locale/bitcoin_en_GB.ts
+++ b/src/qt/locale/bitcoin_en_GB.ts
@@ -2095,7 +2095,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Send Coins</translation>

--- a/src/qt/locale/bitcoin_en_GB.ts
+++ b/src/qt/locale/bitcoin_en_GB.ts
@@ -2465,7 +2465,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Yes</translation>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -1383,7 +1383,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -1173,7 +1173,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Sendi Bitmonon</translation>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -2484,7 +2484,7 @@ Nota: Dado que la comisión se calcula por byte, una comisión de "100 satoshis 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Sí</translation>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -2106,7 +2106,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar bitcoins</translation>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -1964,7 +1964,7 @@ Exportar los datos en la pestaña actual a un archivo</translation>
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -2263,7 +2263,7 @@ Tarifa de copia</translation>
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Si </translation>

--- a/src/qt/locale/bitcoin_es_CO.ts
+++ b/src/qt/locale/bitcoin_es_CO.ts
@@ -1962,7 +1962,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>

--- a/src/qt/locale/bitcoin_es_CO.ts
+++ b/src/qt/locale/bitcoin_es_CO.ts
@@ -2261,7 +2261,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Si</translation>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -1195,7 +1195,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -1025,7 +1025,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>

--- a/src/qt/locale/bitcoin_es_ES.ts
+++ b/src/qt/locale/bitcoin_es_ES.ts
@@ -1855,7 +1855,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar bitcoins</translation>

--- a/src/qt/locale/bitcoin_es_ES.ts
+++ b/src/qt/locale/bitcoin_es_ES.ts
@@ -2177,7 +2177,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Sí</translation>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -643,7 +643,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -733,7 +733,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_es_VE.ts
+++ b/src/qt/locale/bitcoin_es_VE.ts
@@ -1181,7 +1181,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_es_VE.ts
+++ b/src/qt/locale/bitcoin_es_VE.ts
@@ -1011,7 +1011,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -1411,7 +1411,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Jah</translation>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -1201,7 +1201,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Müntide saatmine</translation>

--- a/src/qt/locale/bitcoin_et_EE.ts
+++ b/src/qt/locale/bitcoin_et_EE.ts
@@ -555,7 +555,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Jah</translation>

--- a/src/qt/locale/bitcoin_et_EE.ts
+++ b/src/qt/locale/bitcoin_et_EE.ts
@@ -525,7 +525,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Amount:</source>
         <translation>Kogus</translation>

--- a/src/qt/locale/bitcoin_eu.ts
+++ b/src/qt/locale/bitcoin_eu.ts
@@ -565,7 +565,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_eu.ts
+++ b/src/qt/locale/bitcoin_eu.ts
@@ -491,7 +491,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Txanponak bidali</translation>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -2059,7 +2059,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>بله</translation>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -1737,7 +1737,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>سکه های ارسالی</translation>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -2437,7 +2437,7 @@ Huom: Koska siirtomaksu lasketaan tavujen mukaan, niin määrittelemällä 500 t
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Kyllä</translation>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -2071,7 +2071,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Lähetä kolikoita</translation>

--- a/src/qt/locale/bitcoin_fil.ts
+++ b/src/qt/locale/bitcoin_fil.ts
@@ -2449,7 +2449,7 @@ Tandaan: Dahil ang bayad  ay kinakalkula sa bawat-byte na batayan, ang bayad ng 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Oo</translation>

--- a/src/qt/locale/bitcoin_fil.ts
+++ b/src/qt/locale/bitcoin_fil.ts
@@ -2079,7 +2079,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Magpadala ng Coins</translation>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -2223,7 +2223,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Envoyer des pièces</translation>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -2605,7 +2605,7 @@ Note : Les frais étant calculés par octet, des frais de « 100 satoshis par
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Oui</translation>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -115,7 +115,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -109,7 +109,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     </context>
 <context>
     <name>SendCoinsEntry</name>

--- a/src/qt/locale/bitcoin_fr_FR.ts
+++ b/src/qt/locale/bitcoin_fr_FR.ts
@@ -1519,7 +1519,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Envoyer des pièces</translation>

--- a/src/qt/locale/bitcoin_fr_FR.ts
+++ b/src/qt/locale/bitcoin_fr_FR.ts
@@ -1741,7 +1741,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Oui</translation>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -1085,7 +1085,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -959,7 +959,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Moedas Enviadas</translation>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -2095,7 +2095,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>שליחת מטבעות</translation>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -2465,7 +2465,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>כן</translation>

--- a/src/qt/locale/bitcoin_he_IL.ts
+++ b/src/qt/locale/bitcoin_he_IL.ts
@@ -165,7 +165,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Copy quantity</source>
         <translation>העתק כמות</translation>

--- a/src/qt/locale/bitcoin_he_IL.ts
+++ b/src/qt/locale/bitcoin_he_IL.ts
@@ -179,7 +179,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_hi.ts
+++ b/src/qt/locale/bitcoin_hi.ts
@@ -528,7 +528,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_hi.ts
+++ b/src/qt/locale/bitcoin_hi.ts
@@ -470,7 +470,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>सिक्के भेजें|</translation>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -2468,7 +2468,7 @@ Napomena: Budući da se naknada računa po bajtu, naknada od "100 satošija po k
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Da</translation>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -2098,7 +2098,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Slanje novca</translation>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -2010,7 +2010,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Érmék küldése</translation>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -2324,7 +2324,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Igen</translation>

--- a/src/qt/locale/bitcoin_hu_HU.ts
+++ b/src/qt/locale/bitcoin_hu_HU.ts
@@ -1951,7 +1951,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Érmék küldése</translation>

--- a/src/qt/locale/bitcoin_hu_HU.ts
+++ b/src/qt/locale/bitcoin_hu_HU.ts
@@ -2177,7 +2177,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Igen</translation>

--- a/src/qt/locale/bitcoin_id.ts
+++ b/src/qt/locale/bitcoin_id.ts
@@ -1989,7 +1989,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Kirim Koin</translation>

--- a/src/qt/locale/bitcoin_id.ts
+++ b/src/qt/locale/bitcoin_id.ts
@@ -2183,7 +2183,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ya</translation>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -1865,7 +1865,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -1671,7 +1671,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Kirim Koin</translation>

--- a/src/qt/locale/bitcoin_is.ts
+++ b/src/qt/locale/bitcoin_is.ts
@@ -797,7 +797,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>Magn:</translation>

--- a/src/qt/locale/bitcoin_is.ts
+++ b/src/qt/locale/bitcoin_is.ts
@@ -843,7 +843,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -2606,7 +2606,7 @@ Nota: poiché la commissione è calcolata su base per byte, una commissione di "
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Si</translation>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -2224,7 +2224,7 @@ Per specificare più URL separarli con una barra verticale "|".</translation>
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Invia Bitcoin</translation>

--- a/src/qt/locale/bitcoin_it_IT.ts
+++ b/src/qt/locale/bitcoin_it_IT.ts
@@ -965,7 +965,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_it_IT.ts
+++ b/src/qt/locale/bitcoin_it_IT.ts
@@ -907,7 +907,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>Quantità:</translation>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -2095,7 +2095,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>コインの送金</translation>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -2465,7 +2465,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>はい</translation>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -1187,7 +1187,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>მონეტების გაგზავნა</translation>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -1353,7 +1353,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_kk.ts
+++ b/src/qt/locale/bitcoin_kk.ts
@@ -251,7 +251,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Amount:</source>
         <translation>Саны</translation>

--- a/src/qt/locale/bitcoin_kk.ts
+++ b/src/qt/locale/bitcoin_kk.ts
@@ -277,7 +277,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_km.ts
+++ b/src/qt/locale/bitcoin_km.ts
@@ -236,7 +236,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(no label)</source>
         <translation>(គ្មាន​ឡាបែល)</translation>

--- a/src/qt/locale/bitcoin_km.ts
+++ b/src/qt/locale/bitcoin_km.ts
@@ -246,7 +246,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ko.ts
+++ b/src/qt/locale/bitcoin_ko.ts
@@ -2095,7 +2095,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>코인 전송내기</translation>

--- a/src/qt/locale/bitcoin_ko.ts
+++ b/src/qt/locale/bitcoin_ko.ts
@@ -2465,7 +2465,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>예</translation>

--- a/src/qt/locale/bitcoin_ku_IQ.ts
+++ b/src/qt/locale/bitcoin_ku_IQ.ts
@@ -313,7 +313,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>بەڵێ</translation>

--- a/src/qt/locale/bitcoin_ku_IQ.ts
+++ b/src/qt/locale/bitcoin_ku_IQ.ts
@@ -295,7 +295,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Amount:</source>
         <translation>کۆ:</translation>

--- a/src/qt/locale/bitcoin_ky.ts
+++ b/src/qt/locale/bitcoin_ky.ts
@@ -243,7 +243,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Clear &amp;All</source>
         <translation>&amp;Бардыгын тазалоо</translation>

--- a/src/qt/locale/bitcoin_ky.ts
+++ b/src/qt/locale/bitcoin_ky.ts
@@ -269,7 +269,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -575,7 +575,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Mitte Nummos</translation>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -657,7 +657,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -2457,7 +2457,7 @@ Pastaba: Kadangi mokestis apskaičiuojamas pagal baitą, mokestis už „100 sat
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Taip</translation>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -2091,7 +2091,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Siųsti monetas</translation>

--- a/src/qt/locale/bitcoin_lv.ts
+++ b/src/qt/locale/bitcoin_lv.ts
@@ -1049,7 +1049,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_lv.ts
+++ b/src/qt/locale/bitcoin_lv.ts
@@ -907,7 +907,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Sūtīt Bitkoinus</translation>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -1063,7 +1063,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -921,7 +921,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Sūtīt Bitkoinus</translation>

--- a/src/qt/locale/bitcoin_mk.ts
+++ b/src/qt/locale/bitcoin_mk.ts
@@ -547,7 +547,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_mk.ts
+++ b/src/qt/locale/bitcoin_mk.ts
@@ -505,7 +505,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Bytes:</source>
         <translation>Бајти:</translation>

--- a/src/qt/locale/bitcoin_ml.ts
+++ b/src/qt/locale/bitcoin_ml.ts
@@ -258,7 +258,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ml.ts
+++ b/src/qt/locale/bitcoin_ml.ts
@@ -248,7 +248,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(no label)</source>
         <translation>(ലേബൽ ഇല്ല)</translation>

--- a/src/qt/locale/bitcoin_mn.ts
+++ b/src/qt/locale/bitcoin_mn.ts
@@ -411,7 +411,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Зоос явуулах</translation>

--- a/src/qt/locale/bitcoin_mn.ts
+++ b/src/qt/locale/bitcoin_mn.ts
@@ -493,7 +493,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_mr_IN.ts
+++ b/src/qt/locale/bitcoin_mr_IN.ts
@@ -151,7 +151,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     </context>
 <context>
     <name>SendCoinsEntry</name>

--- a/src/qt/locale/bitcoin_mr_IN.ts
+++ b/src/qt/locale/bitcoin_mr_IN.ts
@@ -157,7 +157,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ms.ts
+++ b/src/qt/locale/bitcoin_ms.ts
@@ -564,7 +564,7 @@ Alihkan fail data ke dalam tab semasa</translation>
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ms.ts
+++ b/src/qt/locale/bitcoin_ms.ts
@@ -550,7 +550,7 @@ Alihkan fail data ke dalam tab semasa</translation>
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Balance:</source>
         <translation>Baki</translation>

--- a/src/qt/locale/bitcoin_ms_MY.ts
+++ b/src/qt/locale/bitcoin_ms_MY.ts
@@ -545,7 +545,7 @@ Alihkan fail data ke dalam tab semasa</translation>
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Balance:</source>
         <translation>Baki</translation>

--- a/src/qt/locale/bitcoin_ms_MY.ts
+++ b/src/qt/locale/bitcoin_ms_MY.ts
@@ -559,7 +559,7 @@ Alihkan fail data ke dalam tab semasa</translation>
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -2031,7 +2031,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Send Bitcoins</translation>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -2385,7 +2385,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ja</translation>

--- a/src/qt/locale/bitcoin_ne.ts
+++ b/src/qt/locale/bitcoin_ne.ts
@@ -363,7 +363,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ne.ts
+++ b/src/qt/locale/bitcoin_ne.ts
@@ -337,7 +337,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Choose...</source>
         <translation>छनौट गर्नुहोस्...</translation>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -2557,7 +2557,7 @@ Notitie: Omdat de vergoeding per byte wordt gerekend, zal een vergoeding van "10
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ja</translation>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -2179,7 +2179,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Verstuurde munten</translation>

--- a/src/qt/locale/bitcoin_nl_NL.ts
+++ b/src/qt/locale/bitcoin_nl_NL.ts
@@ -905,7 +905,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_nl_NL.ts
+++ b/src/qt/locale/bitcoin_nl_NL.ts
@@ -839,7 +839,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>Hoeveelheid:</translation>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -629,7 +629,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -547,7 +547,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Magpadalang Barya</translation>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -2223,7 +2223,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Wyślij monety</translation>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -2606,7 +2606,7 @@ Uwaga: Ponieważ opłata jest naliczana za każdy bajt, opłata "100 satoshi za 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Tak</translation>

--- a/src/qt/locale/bitcoin_pt.ts
+++ b/src/qt/locale/bitcoin_pt.ts
@@ -2467,7 +2467,7 @@ Nota: como a taxa é calculada por byte, uma taxa de "100 satoshis por kB" por u
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Sim</translation>

--- a/src/qt/locale/bitcoin_pt.ts
+++ b/src/qt/locale/bitcoin_pt.ts
@@ -2096,7 +2096,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar Moedas</translation>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -2469,7 +2469,7 @@ Nota:  Como a taxa é calculada por byte, uma taxa de "100 satoshis por kB" por 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Sim</translation>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -2099,7 +2099,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar moedas</translation>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -2034,7 +2034,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Enviar Moedas</translation>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -2381,7 +2381,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Sim</translation>

--- a/src/qt/locale/bitcoin_ro.ts
+++ b/src/qt/locale/bitcoin_ro.ts
@@ -2381,7 +2381,7 @@ Nota: Cum taxa este calculata per byte, o taxa de "100 satoshi per kB" pentru o 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Da</translation>

--- a/src/qt/locale/bitcoin_ro.ts
+++ b/src/qt/locale/bitcoin_ro.ts
@@ -2019,7 +2019,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Trimite monede</translation>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -2435,7 +2435,7 @@ Nota: Cum taxa este calculata per byte, o taxa de "100 satoshi per kB" pentru o 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Da</translation>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -2057,7 +2057,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Trimite monede</translation>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -2485,7 +2485,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Да</translation>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -2111,7 +2111,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Отправить монеты</translation>

--- a/src/qt/locale/bitcoin_ru_RU.ts
+++ b/src/qt/locale/bitcoin_ru_RU.ts
@@ -1867,7 +1867,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Да</translation>

--- a/src/qt/locale/bitcoin_ru_RU.ts
+++ b/src/qt/locale/bitcoin_ru_RU.ts
@@ -1633,7 +1633,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Отправить монеты</translation>

--- a/src/qt/locale/bitcoin_si.ts
+++ b/src/qt/locale/bitcoin_si.ts
@@ -237,7 +237,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_si.ts
+++ b/src/qt/locale/bitcoin_si.ts
@@ -211,7 +211,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>ප්‍රමාණය:</translation>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -2100,7 +2100,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Poslať Bitcoins</translation>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -2474,7 +2474,7 @@ Poznámka: Keďže poplatok je počítaný za bajt, poplatok o hodnote "100 sato
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>áno</translation>

--- a/src/qt/locale/bitcoin_sk_SK.ts
+++ b/src/qt/locale/bitcoin_sk_SK.ts
@@ -2045,7 +2045,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Poslať mince</translation>

--- a/src/qt/locale/bitcoin_sk_SK.ts
+++ b/src/qt/locale/bitcoin_sk_SK.ts
@@ -2423,7 +2423,7 @@ Zapamätajte si: Keďže cena poplatku je počítaná za bajt, tak poplatok o ho
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Áno</translation>

--- a/src/qt/locale/bitcoin_sl.ts
+++ b/src/qt/locale/bitcoin_sl.ts
@@ -2175,7 +2175,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Pošlji</translation>

--- a/src/qt/locale/bitcoin_sl.ts
+++ b/src/qt/locale/bitcoin_sl.ts
@@ -2552,7 +2552,7 @@ Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kB" 
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Da</translation>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -1387,7 +1387,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Pošlji</translation>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -1601,7 +1601,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_sn.ts
+++ b/src/qt/locale/bitcoin_sn.ts
@@ -263,7 +263,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(no label)</source>
         <translation>(hapana zita)</translation>

--- a/src/qt/locale/bitcoin_sn.ts
+++ b/src/qt/locale/bitcoin_sn.ts
@@ -273,7 +273,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -1115,7 +1115,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Da</translation>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -1013,7 +1013,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Слање новца</translation>

--- a/src/qt/locale/bitcoin_sr@latin.ts
+++ b/src/qt/locale/bitcoin_sr@latin.ts
@@ -577,7 +577,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>Količina:</translation>

--- a/src/qt/locale/bitcoin_sr@latin.ts
+++ b/src/qt/locale/bitcoin_sr@latin.ts
@@ -607,7 +607,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -2100,7 +2100,7 @@ Försök igen.</translation>
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Skicka pengar</translation>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -2470,7 +2470,7 @@ Notera: Då avgiften beräknas per byte kommer en avgift på 50 satoshi tas ut f
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ja</translation>

--- a/src/qt/locale/bitcoin_szl.ts
+++ b/src/qt/locale/bitcoin_szl.ts
@@ -1685,7 +1685,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ja</translation>

--- a/src/qt/locale/bitcoin_szl.ts
+++ b/src/qt/locale/bitcoin_szl.ts
@@ -1535,7 +1535,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Poślij mōnety</translation>

--- a/src/qt/locale/bitcoin_ta.ts
+++ b/src/qt/locale/bitcoin_ta.ts
@@ -2003,7 +2003,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>நாணயங்களை அனுப்பவும்</translation>

--- a/src/qt/locale/bitcoin_ta.ts
+++ b/src/qt/locale/bitcoin_ta.ts
@@ -2197,7 +2197,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>ஆம்</translation>

--- a/src/qt/locale/bitcoin_te.ts
+++ b/src/qt/locale/bitcoin_te.ts
@@ -325,7 +325,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_te.ts
+++ b/src/qt/locale/bitcoin_te.ts
@@ -311,7 +311,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Quantity:</source>
         <translation>పరిమాణం</translation>

--- a/src/qt/locale/bitcoin_th.ts
+++ b/src/qt/locale/bitcoin_th.ts
@@ -907,7 +907,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_th.ts
+++ b/src/qt/locale/bitcoin_th.ts
@@ -861,7 +861,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>ส่งเหรียญ</translation>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -2365,7 +2365,7 @@
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Evet</translation>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -2031,7 +2031,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Coin gönder</translation>

--- a/src/qt/locale/bitcoin_tr_TR.ts
+++ b/src/qt/locale/bitcoin_tr_TR.ts
@@ -1130,7 +1130,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Evet</translation>

--- a/src/qt/locale/bitcoin_tr_TR.ts
+++ b/src/qt/locale/bitcoin_tr_TR.ts
@@ -1028,7 +1028,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Coin gönder</translation>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -2471,7 +2471,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Так</translation>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -2101,7 +2101,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Відправити</translation>

--- a/src/qt/locale/bitcoin_uk_UA.ts
+++ b/src/qt/locale/bitcoin_uk_UA.ts
@@ -187,7 +187,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_uk_UA.ts
+++ b/src/qt/locale/bitcoin_uk_UA.ts
@@ -181,7 +181,7 @@
     <name>RecentRequestsTableModel</name>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     </context>
 <context>
     <name>SendCoinsEntry</name>

--- a/src/qt/locale/bitcoin_ur.ts
+++ b/src/qt/locale/bitcoin_ur.ts
@@ -261,7 +261,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_ur.ts
+++ b/src/qt/locale/bitcoin_ur.ts
@@ -243,7 +243,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Insufficient funds!</source>
         <translation>ناکافی فنڈز</translation>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -1097,7 +1097,7 @@
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Ҳа</translation>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -955,7 +955,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Тангаларни жунат</translation>

--- a/src/qt/locale/bitcoin_vi.ts
+++ b/src/qt/locale/bitcoin_vi.ts
@@ -2091,7 +2091,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Gửi Coins</translation>

--- a/src/qt/locale/bitcoin_vi.ts
+++ b/src/qt/locale/bitcoin_vi.ts
@@ -2473,7 +2473,7 @@ Lưu ý: Vì phí được tính trên cơ sở mỗi byte, nên phí "100 satos
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Yes</translation>

--- a/src/qt/locale/bitcoin_vi_VN.ts
+++ b/src/qt/locale/bitcoin_vi_VN.ts
@@ -992,7 +992,7 @@ Ví của bạn chưa được mã hóa.</translation>
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>Gửi Coins</translation>

--- a/src/qt/locale/bitcoin_vi_VN.ts
+++ b/src/qt/locale/bitcoin_vi_VN.ts
@@ -1114,7 +1114,7 @@ Ví của bạn chưa được mã hóa.</translation>
     </message>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>Đồng ý</translation>

--- a/src/qt/locale/bitcoin_yo.ts
+++ b/src/qt/locale/bitcoin_yo.ts
@@ -137,7 +137,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_yo.ts
+++ b/src/qt/locale/bitcoin_yo.ts
@@ -131,7 +131,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     </context>
 <context>
     <name>SendCoinsEntry</name>

--- a/src/qt/locale/bitcoin_zh-Hans.ts
+++ b/src/qt/locale/bitcoin_zh-Hans.ts
@@ -203,7 +203,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(no label)</source>
         <translation>(无标签)</translation>

--- a/src/qt/locale/bitcoin_zh-Hans.ts
+++ b/src/qt/locale/bitcoin_zh-Hans.ts
@@ -213,7 +213,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -2223,7 +2223,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>发币</translation>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -2605,7 +2605,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>是</translation>

--- a/src/qt/locale/bitcoin_zh_HK.ts
+++ b/src/qt/locale/bitcoin_zh_HK.ts
@@ -573,7 +573,7 @@
     </message>
     </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>(no label)</source>
         <translation>(無標記)</translation>

--- a/src/qt/locale/bitcoin_zh_HK.ts
+++ b/src/qt/locale/bitcoin_zh_HK.ts
@@ -583,7 +583,7 @@
     <name>SendCoinsEntry</name>
     </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     </context>
 <context>
     <name>ShutdownWindow</name>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -2497,7 +2497,7 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
     </message>
 </context>
 <context>
-    <name>SendConfirmationDialog</name>
+    <name>SendSign</name>
     <message>
         <source>Yes</source>
         <translation>是</translation>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -2115,7 +2115,7 @@
     </message>
 </context>
 <context>
-    <name>SendCoinsDialog</name>
+    <name>SendCompose</name>
     <message>
         <source>Send Coins</source>
         <translation>发送</translation>

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -630,6 +630,9 @@ void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)
         coin_control = *CoinControlDialog::coinControl();
     }
 
+    // Include watch-only for wallets without private key
+    coin_control.fAllowWatchOnly = model->privateKeysDisabled();
+
     // Calculate available amount to send.
     CAmount amount = model->wallet().getAvailableBalance(coin_control);
     for (int i = 0; i < ui->entries->count(); ++i) {
@@ -682,6 +685,8 @@ void SendCoinsDialog::updateCoinControlState(CCoinControl& ctrl)
     // Either custom fee will be used or if not selected, the confirmation target from dropdown box
     ctrl.m_confirm_target = getConfTargetForIndex(ui->confTargetSelector->currentIndex());
     ctrl.m_signal_bip125_rbf = ui->optInRBF->isChecked();
+    // Include watch-only for wallets without private key
+    ctrl.fAllowWatchOnly = model->privateKeysDisabled();
 }
 
 void SendCoinsDialog::updateSmartFeeLabel()

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -21,6 +21,7 @@
 #include <chainparams.h>
 #include <interfaces/node.h>
 #include <key_io.h>
+#include <wallet/psbtwallet.h>
 #include <wallet/coincontrol.h>
 #include <ui_interface.h>
 #include <txmempool.h>
@@ -186,6 +187,13 @@ void SendCoinsDialog::setModel(WalletModel *_model)
         // set default rbf checkbox state
         ui->optInRBF->setCheckState(Qt::Checked);
 
+        if (model->privateKeysDisabled()) {
+            ui->sendButton->setText(tr("Create Unsigned"));
+            ui->sendButton->setToolTip(tr("Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline Bitcoin Core wallet, or a PSBT-compatible hardware wallet."));
+        } else {
+            ui->sendButton->setText(tr("Send"));
+        }
+
         // set the smartfee-sliders default value (wallets default conf.target or last stored value)
         QSettings settings;
         if (settings.value("nSmartFeeSliderPosition").toInt() != 0) {
@@ -319,9 +327,21 @@ void SendCoinsDialog::on_sendButton_clicked()
         formatted.append(recipientElement);
     }
 
-    QString questionString = tr("Are you sure you want to send?");
+    QString questionString;
+    if (!model->privateKeysDisabled()) {
+        questionString.append(tr("Are you sure you want to send?"));
+    } else {
+        questionString.append(tr("Do you want to draft this transaction?"));
+    }
+
     questionString.append("<br /><span style='font-size:10pt;'>");
-    questionString.append(tr("Please, review your transaction."));
+    QString pleaseReview;
+    if (!model->privateKeysDisabled()) {
+        pleaseReview = tr("Please, review your transaction.");
+    } else {
+        pleaseReview = tr("Please, review your transaction proposal. This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can copy and then sign with e.g. an offline Bitcoin Core wallet, or a PSBT-compatible hardware wallet.");
+    }
+    questionString.append(pleaseReview);
     questionString.append("</span>%1");
 
     if(txFee > 0)
@@ -373,7 +393,12 @@ void SendCoinsDialog::on_sendButton_clicked()
         questionString = questionString.arg("<br /><br />" + formatted.at(0));
     }
 
-    SendConfirmationDialog confirmationDialog(tr("Confirm send coins"), questionString, informative_text, detailed_text, SEND_CONFIRM_DELAY, this);
+    const QString confirmation = model->privateKeysDisabled() ? tr("Confirm transaction proposal") : tr("Confirm send coins");
+    QString confirmButtonText = tr("Send");
+    if (model->privateKeysDisabled()) {
+        confirmButtonText = tr("Copy PSBT to clipboard");
+    }
+    SendConfirmationDialog confirmationDialog(confirmation, questionString, informative_text, detailed_text, SEND_CONFIRM_DELAY, confirmButtonText, this);
     confirmationDialog.exec();
     QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
 
@@ -383,17 +408,35 @@ void SendCoinsDialog::on_sendButton_clicked()
         return;
     }
 
-    // now send the prepared transaction
-    WalletModel::SendCoinsReturn sendStatus = model->sendCoins(currentTransaction);
-    // process sendStatus and on error generate message shown to user
-    processSendCoinsReturn(sendStatus);
+    bool send_failure = false;
+    if (model->privateKeysDisabled()) {
+        CMutableTransaction mtx = CMutableTransaction{*(currentTransaction.getWtx())};
+        PartiallySignedTransaction psbtx(mtx);
+        bool complete = false;
+        const TransactionError err = model->wallet().fillPSBT(psbtx, complete, SIGHASH_ALL, false /* sign */, true /* bip32derivs */);
+        assert(!complete);
+        assert(err == TransactionError::OK);
+        // Serialize the PSBT
+        CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+        ssTx << psbtx;
+        GUIUtil::setClipboard(EncodeBase64(ssTx.str()).c_str());
+        Q_EMIT message(tr("PSBT copied"), "Copied to clipboard", CClientUIInterface::MSG_INFORMATION);
+    } else {
+        // now send the prepared transaction
+        WalletModel::SendCoinsReturn sendStatus = model->sendCoins(currentTransaction);
+        // process sendStatus and on error generate message shown to user
+        processSendCoinsReturn(sendStatus);
 
-    if (sendStatus.status == WalletModel::OK)
-    {
+        if (sendStatus.status == WalletModel::OK) {
+            Q_EMIT coinsSent(currentTransaction.getWtx()->GetHash());
+        } else {
+            send_failure = true;
+        }
+    }
+    if (!send_failure) {
         accept();
         CoinControlDialog::coinControl()->UnSelectAll();
         coinControlUpdateLabels();
-        Q_EMIT coinsSent(currentTransaction.getWtx()->GetHash());
     }
     fNewRecipientAllowed = true;
 }
@@ -894,8 +937,8 @@ void SendCoinsDialog::coinControlUpdateLabels()
     }
 }
 
-SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, QWidget* parent)
-    : QMessageBox(parent), secDelay(_secDelay)
+SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, const QString& _confirmButtonText, QWidget* parent)
+    : QMessageBox(parent), secDelay(_secDelay), confirmButtonText(_confirmButtonText)
 {
     setIcon(QMessageBox::Question);
     setWindowTitle(title); // On macOS, the window title is ignored (as required by the macOS Guidelines).
@@ -932,11 +975,11 @@ void SendConfirmationDialog::updateYesButton()
     if(secDelay > 0)
     {
         yesButton->setEnabled(false);
-        yesButton->setText(tr("Send") + " (" + QString::number(secDelay) + ")");
+        yesButton->setText(confirmButtonText + " (" + QString::number(secDelay) + ")");
     }
     else
     {
         yesButton->setEnabled(true);
-        yesButton->setText(tr("Send"));
+        yesButton->setText(confirmButtonText);
     }
 }

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -108,7 +108,7 @@ class SendConfirmationDialog : public QMessageBox
     Q_OBJECT
 
 public:
-    SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, QWidget* parent = nullptr);
+    SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, const QString& confirmText = "Send", QWidget* parent = nullptr);
     int exec();
 
 private Q_SLOTS:
@@ -119,6 +119,7 @@ private:
     QAbstractButton *yesButton;
     QTimer countDownTimer;
     int secDelay;
+    QString confirmButtonText;
 };
 
 #endif // BITCOIN_QT_SENDCOINSDIALOG_H

--- a/src/qt/sendcompose.cpp
+++ b/src/qt/sendcompose.cpp
@@ -398,7 +398,7 @@ void SendCompose::on_sendButton_clicked()
     if (model->privateKeysDisabled()) {
         confirmButtonText = tr("Copy PSBT to clipboard");
     }
-    SendConfirmationDialog confirmationDialog(confirmation, questionString, informative_text, detailed_text, SEND_CONFIRM_DELAY, confirmButtonText, this);
+    SendSign confirmationDialog(confirmation, questionString, informative_text, detailed_text, SEND_CONFIRM_DELAY, confirmButtonText, this);
     confirmationDialog.exec();
     QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
 
@@ -937,7 +937,7 @@ void SendCompose::coinControlUpdateLabels()
     }
 }
 
-SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, const QString& _confirmButtonText, QWidget* parent)
+SendSign::SendSign(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, const QString& _confirmButtonText, QWidget* parent)
     : QMessageBox(parent), secDelay(_secDelay), confirmButtonText(_confirmButtonText)
 {
     setIcon(QMessageBox::Question);
@@ -949,17 +949,17 @@ SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QStri
     setDefaultButton(QMessageBox::Cancel);
     yesButton = button(QMessageBox::Yes);
     updateYesButton();
-    connect(&countDownTimer, &QTimer::timeout, this, &SendConfirmationDialog::countDown);
+    connect(&countDownTimer, &QTimer::timeout, this, &SendSign::countDown);
 }
 
-int SendConfirmationDialog::exec()
+int SendSign::exec()
 {
     updateYesButton();
     countDownTimer.start(1000);
     return QMessageBox::exec();
 }
 
-void SendConfirmationDialog::countDown()
+void SendSign::countDown()
 {
     secDelay--;
     updateYesButton();
@@ -970,7 +970,7 @@ void SendConfirmationDialog::countDown()
     }
 }
 
-void SendConfirmationDialog::updateYesButton()
+void SendSign::updateYesButton()
 {
     if(secDelay > 0)
     {

--- a/src/qt/sendcompose.cpp
+++ b/src/qt/sendcompose.cpp
@@ -336,7 +336,6 @@ SendCoinsEntry *SendCompose::addEntry()
     entry->clear();
     entry->setFocus();
     ui->scrollAreaWidgetContents->resize(ui->scrollAreaWidgetContents->sizeHint());
-    qApp->processEvents();
     QScrollBar* bar = ui->scrollArea->verticalScrollBar();
     if(bar)
         bar->setSliderPosition(bar->maximum());

--- a/src/qt/sendcompose.h
+++ b/src/qt/sendcompose.h
@@ -103,12 +103,12 @@ Q_SIGNALS:
 
 #define SEND_CONFIRM_DELAY   3
 
-class SendConfirmationDialog : public QMessageBox
+class SendSign : public QMessageBox
 {
     Q_OBJECT
 
 public:
-    SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, const QString& confirmText = "Send", QWidget* parent = nullptr);
+    SendSign(const QString& title, const QString& text, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, const QString& confirmText = "Send", QWidget* parent = nullptr);
     int exec();
 
 private Q_SLOTS:

--- a/src/qt/sendcompose.h
+++ b/src/qt/sendcompose.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_QT_SENDCOINSDIALOG_H
-#define BITCOIN_QT_SENDCOINSDIALOG_H
+#ifndef BITCOIN_QT_SENDCOMPOSE_H
+#define BITCOIN_QT_SENDCOMPOSE_H
 
 #include <qt/walletmodel.h>
 
@@ -18,7 +18,7 @@ class SendCoinsEntry;
 class SendCoinsRecipient;
 
 namespace Ui {
-    class SendCoinsDialog;
+    class SendCompose;
 }
 
 QT_BEGIN_NAMESPACE
@@ -26,13 +26,13 @@ class QUrl;
 QT_END_NAMESPACE
 
 /** Dialog for sending bitcoins */
-class SendCoinsDialog : public QDialog
+class SendCompose : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit SendCoinsDialog(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
-    ~SendCoinsDialog();
+    explicit SendCompose(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    ~SendCompose();
 
     void setClientModel(ClientModel *clientModel);
     void setModel(WalletModel *model);
@@ -57,7 +57,7 @@ Q_SIGNALS:
     void coinsSent(const uint256& txid);
 
 private:
-    Ui::SendCoinsDialog *ui;
+    Ui::SendCompose *ui;
     ClientModel *clientModel;
     WalletModel *model;
     bool fNewRecipientAllowed;
@@ -122,4 +122,4 @@ private:
     QString confirmButtonText;
 };
 
-#endif // BITCOIN_QT_SENDCOINSDIALOG_H
+#endif // BITCOIN_QT_SENDCOMPOSE_H

--- a/src/qt/senddialog.cpp
+++ b/src/qt/senddialog.cpp
@@ -1,0 +1,158 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <qt/senddialog.h>
+#include <qt/sendcompose.h>
+#include <qt/sendsign.h>
+#include <qt/sendfinish.h>
+
+#include <qt/forms/ui_senddialog.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+
+#include <util/memory.h>
+#include <wallet/coincontrol.h>
+
+SendDialog::SendDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
+    QTabWidget(parent),
+    ui(new Ui::SendDialog),
+    platformStyle(_platformStyle),
+    walletModel(nullptr),
+    clientModel(nullptr)
+{
+    ui->setupUi(this);
+    draftWidget = new SendCompose(platformStyle);
+    signWidget = new SendSign(platformStyle);
+    finishWidget = new SendFinish(platformStyle);
+
+    addTab(draftWidget, "(1) Draft");
+    addTab(signWidget, "(2) Sign");
+    addTab(finishWidget, "(3) Finish");
+
+    setWorkflowState(WorkflowState::Draft);
+
+    // Provide draft widget with coin control
+    draftWidget->coinControl = MakeUnique<CCoinControl>();
+
+    // Pass through messages from tabs
+    connect(draftWidget, &SendCompose::message, this, &SendDialog::message);
+    connect(signWidget, &SendSign::message, this, &SendDialog::message);
+    connect(finishWidget, &SendFinish::message, this, &SendDialog::message);
+
+    // Sign button in Draft tab hands over to gotoSign()
+    connect(draftWidget, &SendCompose::gotoSign, this, &SendDialog::gotoSign);
+
+    // Handle cancelled signing
+    connect(signWidget, &SendSign::signCancelled, this, &SendDialog::signCancelled);
+
+    // Handle confirmed signing
+    connect(signWidget, &SendSign::signConfirmed, this, &SendDialog::signConfirmed);
+
+    // Handle go to transactions page
+    connect(finishWidget, &SendFinish::showTransaction, this, &SendDialog::showTransaction);
+
+    // Handle start new transaction
+    connect(finishWidget, &SendFinish::goNewTransaction, this, &SendDialog::goNewTransaction);
+
+}
+
+SendDialog::~SendDialog()
+{
+    delete ui;
+}
+
+void SendDialog::setWorkflowState(enum SendDialog::WorkflowState state)
+{
+    m_workflow_state = state;
+    setCurrentIndex(state);
+    for (auto i = 0; i < count(); ++i) {
+        setTabEnabled(i, i == currentIndex());
+    }
+    this->draftWidget->setActiveWidget(state == WorkflowState::Draft);
+    this->signWidget->setActiveWidget(state == WorkflowState::Sign);
+    this->finishWidget->setActiveWidget(state == WorkflowState::Finish);
+}
+
+void SendDialog::setClientModel(ClientModel *_clientModel)
+{
+    this->clientModel = _clientModel;
+    this->draftWidget->setClientModel(_clientModel);
+}
+
+void SendDialog::setModel(WalletModel *_model)
+{
+    this->walletModel = _model;
+    this->draftWidget->setModel(_model);
+    this->signWidget->setModel(_model);
+    this->finishWidget->setModel(_model);
+}
+
+void SendDialog::setAddress(const QString &address) {
+    setWorkflowState(WorkflowState::Draft);
+    this->draftWidget->setAddress(address);
+}
+
+bool SendDialog::handlePaymentRequest(const SendCoinsRecipient &rv)
+{
+    setWorkflowState(WorkflowState::Draft);
+    return this->draftWidget->handlePaymentRequest(rv);
+}
+
+void SendDialog::signCancelled() {
+    assert(m_workflow_state == WorkflowState::Sign);
+    // Clear transaction and coin control; draft widget will provide new ones:
+    signWidget->transaction.reset();
+    signWidget->coinControl.reset();
+
+    setWorkflowState(WorkflowState::Draft);
+    draftWidget->signCancelled();
+}
+
+void SendDialog::signConfirmed() {
+    // Pass transaction to finish widget:
+    finishWidget->transaction = std::move(signWidget->transaction);
+
+    // Discard coin cointrol:
+    signWidget->coinControl.reset();
+
+    if (!walletModel->privateKeysDisabled()) {
+        finishWidget->broadcastTransaction();
+    } else {
+        finishWidget->createPsbt();
+    }
+    setWorkflowState(WorkflowState::Finish);
+}
+
+
+void SendDialog::sendFailed() {
+    assert(m_workflow_state == WorkflowState::Finish);
+    // Clear transaction; draft widget will provide new one:
+    finishWidget->transaction.reset();
+
+    setWorkflowState(WorkflowState::Draft);
+    draftWidget->signCancelled();
+}
+
+void SendDialog::sendCompleted() {
+    draftWidget->signCompleted();
+}
+
+void SendDialog::gotoSign()
+{
+    signWidget->transaction = std::move(draftWidget->transaction);
+    signWidget->coinControl = std::move(draftWidget->coinControl);
+    setWorkflowState(WorkflowState::Sign);
+    signWidget->prepareTransaction();
+}
+
+void SendDialog::goNewTransaction() {
+    assert(m_workflow_state == WorkflowState::Finish);
+    // Clear transaction; draft widget will provide new one:
+    finishWidget->transaction.reset();
+    setWorkflowState(WorkflowState::Draft);
+}

--- a/src/qt/senddialog.h
+++ b/src/qt/senddialog.h
@@ -50,13 +50,17 @@ public:
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
     void signCancelled();
     void signConfirmed();
+    void rbfCancelled(uint256 txid);
+    void rbfConfirmed(uint256 txid, CMutableTransaction mtx);
     void sendFailed();
     void sendCompleted();
+    void rbfSendFailed(uint256 txid);
 
     // Also called when creating a PSBT in a watch-only wallet:
     void gotoSign();
 
     void goNewTransaction();
+    void gotoBumpFee(const uint256& txid);
 
 // public Q_SLOTS:
 

--- a/src/qt/senddialog.h
+++ b/src/qt/senddialog.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SENDDIALOG_H
+#define BITCOIN_QT_SENDDIALOG_H
+
+#include <QtWidgets/QTabWidget>
+
+#include <qt/clientmodel.h>
+#include <qt/walletmodel.h>
+
+class CCoinControl;
+class PlatformStyle;
+class SendCompose;
+class SendSign;
+class SendFinish;
+
+namespace Ui {
+class SendDialog;
+}
+
+QT_BEGIN_NAMESPACE
+class QModelIndex;
+QT_END_NAMESPACE
+
+/** Dialog showing transaction details. */
+class SendDialog : public QTabWidget
+{
+    Q_OBJECT
+
+public:
+    QTabWidget *tabWidget;
+
+    // Correspond 1:1 to tab IDs
+    enum WorkflowState {
+        Draft = 0,
+        Sign = 1,
+        Finish = 2,
+    };
+
+    explicit SendDialog(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    ~SendDialog();
+
+    void setWorkflowState(enum WorkflowState);
+
+    void setClientModel(ClientModel *clientModel);
+    void setModel(WalletModel *model);
+    void setAddress(const QString &address);
+    bool handlePaymentRequest(const SendCoinsRecipient &recipient);
+    void signCancelled();
+    void signConfirmed();
+    void sendFailed();
+    void sendCompleted();
+
+    // Also called when creating a PSBT in a watch-only wallet:
+    void gotoSign();
+
+    void goNewTransaction();
+
+// public Q_SLOTS:
+
+
+    SendCompose *draftWidget;
+    SendSign *signWidget;
+    SendFinish *finishWidget;
+
+private:
+    WorkflowState m_workflow_state;
+    Ui::SendDialog* ui;
+    const PlatformStyle *platformStyle;
+    WalletModel* walletModel;
+    ClientModel* clientModel;
+
+    // std::unique_ptr<WalletModelTransaction> transaction;
+    // std::unique_ptr<CCoinControl> coinControl;
+
+Q_SIGNALS:
+    // Fired when a message should be reported to the user
+    void message(const QString &title, const QString &message, unsigned int style);
+
+    void showTransaction(const uint256& txid);
+};
+
+#endif // BITCOIN_QT_SENDDIALOG_H

--- a/src/qt/sendfinish.cpp
+++ b/src/qt/sendfinish.cpp
@@ -1,0 +1,144 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <qt/sendfinish.h>
+#include <qt/forms/ui_sendfinish.h>
+
+#include <qt/guiutil.h>
+#include <qt/platformstyle.h>
+
+#include <wallet/psbtwallet.h>
+
+SendFinish::SendFinish(const PlatformStyle *platformStyle, QWidget* parent)
+    : QWidget(parent),
+    ui(new Ui::SendFinish)
+{
+    ui->setupUi(this);
+    ui->labelTransaction->setTextInteractionFlags(Qt::TextSelectableByMouse | Qt::TextSelectableByKeyboard);
+    connect(ui->showTransaction, &QPushButton::clicked, this, &SendFinish::showTransactionClicked);
+    connect(ui->newTransactionButton, &QPushButton::clicked, this, &SendFinish::newTransactionClicked);
+}
+
+SendFinish::~SendFinish()
+{
+    delete ui;
+}
+
+bool SendFinish::isActiveWidget()
+{
+    return m_is_active_widget;
+}
+
+void SendFinish::setActiveWidget(bool active)
+{
+    m_is_active_widget = active;
+}
+
+void SendFinish::setModel(WalletModel *_walletModel)
+{
+    this->walletModel = _walletModel;
+}
+
+void SendFinish::prepareForm() {
+    ui->labelTransactionFinish->setText("Transaction sent");
+    switch (mode) {
+    case Mode::FinishTransaction:
+        ui->showTransaction->setVisible(true);
+        break;
+    case Mode::FinishPsbt:
+        ui->showTransaction->setVisible(false);
+        ui->labelTransactionFinish->setText("PSBT created");
+        break;
+    }
+}
+
+void SendFinish::processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg)
+{
+    assert(mode == Mode::FinishTransaction);
+    QPair<QString, CClientUIInterface::MessageBoxFlags> msgParams;
+    // Default to a warning message, override if error message is needed
+    msgParams.second = CClientUIInterface::MSG_WARNING;
+
+    // This comment is specific to SendCompose usage of WalletModel::SendCoinsReturn.
+    // WalletModel::TransactionCommitFailed is used only in WalletModel::sendCoins()
+    // all others are used only in WalletModel::prepareTransaction()
+    switch(sendCoinsReturn.status)
+    {
+    case WalletModel::TransactionCommitFailed:
+        msgParams.first = tr("The transaction was rejected with the following reason: %1").arg(sendCoinsReturn.reasonCommitFailed);
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    // included to prevent a compiler warning.
+    case WalletModel::InvalidAddress:
+    case WalletModel::InvalidAmount:
+    case WalletModel::AmountExceedsBalance:
+    case WalletModel::AmountWithFeeExceedsBalance:
+    case WalletModel::DuplicateAddress:
+    case WalletModel::TransactionCreationFailed:
+    case WalletModel::AbsurdFee:
+    case WalletModel::PaymentRequestExpired:
+    case WalletModel::OK:
+    default:
+        return;
+    }
+
+    Q_EMIT message(tr("Send Coins"), msgParams.first, msgParams.second);
+}
+
+void SendFinish::createPsbt() {
+    mode = Mode::FinishPsbt;
+    prepareForm();
+
+    assert(walletModel->privateKeysDisabled());
+
+    CMutableTransaction mtx = CMutableTransaction{*(transaction->getWtx())};
+    PartiallySignedTransaction psbtx(mtx);
+    bool complete = false;
+    const TransactionError err = walletModel->wallet().fillPSBT(psbtx, complete, SIGHASH_ALL, false /* sign */, true /* bip32derivs */);
+    assert(!complete);
+    assert(err == TransactionError::OK);
+    // Serialize the PSBT
+    CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+    ssTx << psbtx;
+    GUIUtil::setClipboard(EncodeBase64(ssTx.str()).c_str());
+    ui->labelTransaction->setText("The Partially Signed Bitcoin Transaction (PSBT) has been copied to the clipboard.");
+    Q_EMIT message(tr("PSBT copied"), "Copied to clipboard", CClientUIInterface::MSG_INFORMATION);
+}
+
+void SendFinish::broadcastTransaction() {
+    mode = Mode::FinishTransaction;
+    prepareForm();
+
+    WalletModel::SendCoinsReturn sendStatus = walletModel->sendCoins(*transaction);
+    // process sendStatus and on error generate message shown to user
+    processSendCoinsReturn(sendStatus);
+
+    if (sendStatus.status == WalletModel::OK)
+    {
+        ui->labelTransaction->setText(tr("Transaction identifier: %1").arg(QString::fromStdString(transaction->getWtx()->GetHash().GetHex())));
+        sendCompleted();
+    } else {
+        sendFailed();
+    }
+}
+
+void SendFinish::showTransactionClicked() {
+    switch (mode) {
+    case Mode::FinishTransaction:
+        assert(transaction != nullptr);
+        Q_EMIT showTransaction(transaction->getWtx()->GetHash());
+        break;
+    case Mode::FinishPsbt:
+        assert(false);
+        break;
+    }
+}
+
+void SendFinish::newTransactionClicked() {
+    Q_EMIT goNewTransaction();
+}

--- a/src/qt/sendfinish.h
+++ b/src/qt/sendfinish.h
@@ -30,6 +30,7 @@ public:
     void setModel(WalletModel *walletModel);
     void broadcastTransaction();
     void createPsbt();
+    void broadcastRbf(uint256 txid, CMutableTransaction mtx);
 
 private Q_SLOTS:
     void showTransactionClicked();
@@ -45,6 +46,12 @@ Q_SIGNALS:
     // Fired when send succeeds
     void sendCompleted();
 
+    // Fired when RBF send fails
+    void rbfSendFailed(uint256 txid);
+
+    // Fired when RBF send succeeds
+    void rbfCompleted();
+
     // Fired when user asks to see transaction
     void showTransaction(uint256 txid);
 
@@ -56,11 +63,17 @@ private:
     enum Mode {
         FinishTransaction = 0,
         FinishPsbt = 1,
+        FinishRbf = 2
     };
 
     Ui::SendFinish *ui;
     Mode mode;
     WalletModel *walletModel;
+
+    // RBF:
+    std::shared_ptr<CMutableTransaction> mtx;
+    uint256 txid;
+    uint256 new_hash;
 
     void prepareForm();
 

--- a/src/qt/sendfinish.h
+++ b/src/qt/sendfinish.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SENDFINISH_H
+#define BITCOIN_QT_SENDFINISH_H
+
+#include <qt/walletmodel.h>
+
+#include <QWidget>
+
+class WalletModelTransaction;
+
+namespace Ui {
+    class SendFinish;
+}
+
+class SendFinish : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SendFinish(const PlatformStyle *platformStyle, QWidget* parent = nullptr);
+    ~SendFinish();
+    bool isActiveWidget();
+    void setActiveWidget(bool active);
+
+    std::unique_ptr<WalletModelTransaction> transaction;
+
+    void setModel(WalletModel *walletModel);
+    void broadcastTransaction();
+    void createPsbt();
+
+private Q_SLOTS:
+    void showTransactionClicked();
+    void newTransactionClicked();
+
+Q_SIGNALS:
+    // Fired when a message should be reported to the user
+    void message(const QString &title, const QString &message, unsigned int style);
+
+    // Fired when send fails
+    void sendFailed();
+
+    // Fired when send succeeds
+    void sendCompleted();
+
+    // Fired when user asks to see transaction
+    void showTransaction(uint256 txid);
+
+    // Fired when user wants to create a new transaction
+    void goNewTransaction();
+
+private:
+    bool m_is_active_widget{false};
+    enum Mode {
+        FinishTransaction = 0,
+        FinishPsbt = 1,
+    };
+
+    Ui::SendFinish *ui;
+    Mode mode;
+    WalletModel *walletModel;
+
+    void prepareForm();
+
+    // Process WalletModel::SendCoinsReturn and generate a pair consisting
+    // of a message and message flags for use in Q_EMIT message().
+    // Additional parameter msgArg can be used via .arg(msgArg).
+    void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());
+};
+
+#endif // BITCOIN_QT_SENDFINISH_H

--- a/src/qt/sendsign.cpp
+++ b/src/qt/sendsign.cpp
@@ -1,0 +1,281 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <qt/sendsign.h>
+#include <qt/forms/ui_sendsign.h>
+
+#include <qt/bitcoinunits.h>
+#include <qt/guiutil.h>
+#include <qt/optionsmodel.h>
+#include <qt/platformstyle.h>
+
+#include <wallet/coincontrol.h>
+
+SendSign::SendSign(const PlatformStyle *platformStyle, QWidget* parent)
+    : QWidget(parent),
+    ui(new Ui::SendSign)
+{
+    ui->setupUi(this);
+    connect(&countDownTimer, &QTimer::timeout, this, &SendSign::countDown);
+    connect(ui->editButton, &QPushButton::clicked, this, &SendSign::cancel);
+    connect(ui->cancelButton, &QPushButton::clicked, this, &SendSign::cancel);
+    connect(ui->sendButton, &QPushButton::clicked, this, &SendSign::confirm);
+}
+
+SendSign::~SendSign()
+{
+    delete ui;
+}
+
+bool SendSign::isActiveWidget()
+{
+    return m_is_active_widget;
+}
+
+void SendSign::setActiveWidget(bool active)
+{
+    m_is_active_widget = active;
+}
+
+void SendSign::setModel(WalletModel *_walletModel)
+{
+    this->walletModel = _walletModel;
+}
+
+void SendSign::processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg)
+{
+    QPair<QString, CClientUIInterface::MessageBoxFlags> msgParams;
+    // Default to a warning message, override if error message is needed
+    msgParams.second = CClientUIInterface::MSG_WARNING;
+
+    // This comment is specific to SendCompose usage of WalletModel::SendCoinsReturn.
+    // WalletModel::TransactionCommitFailed is used only in WalletModel::sendCoins()
+    // all others are used only in WalletModel::prepareTransaction()
+    switch(sendCoinsReturn.status)
+    {
+    case WalletModel::InvalidAddress:
+        msgParams.first = tr("The recipient address is not valid. Please recheck.");
+        break;
+    case WalletModel::InvalidAmount:
+        msgParams.first = tr("The amount to pay must be larger than 0.");
+        break;
+    case WalletModel::AmountExceedsBalance:
+        msgParams.first = tr("The amount exceeds your balance.");
+        break;
+    case WalletModel::AmountWithFeeExceedsBalance:
+        msgParams.first = tr("The total exceeds your balance when the %1 transaction fee is included.").arg(msgArg);
+        break;
+    case WalletModel::DuplicateAddress:
+        msgParams.first = tr("Duplicate address found: addresses should only be used once each.");
+        break;
+    case WalletModel::TransactionCreationFailed:
+        msgParams.first = tr("Transaction creation failed!");
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    case WalletModel::AbsurdFee:
+        msgParams.first = tr("A fee higher than %1 is considered an absurdly high fee.").arg(BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), walletModel->wallet().getDefaultMaxTxFee()));
+        break;
+    case WalletModel::PaymentRequestExpired:
+        msgParams.first = tr("Payment request expired.");
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
+    // included to prevent a compiler warning.
+    case WalletModel::TransactionCommitFailed:
+    case WalletModel::OK:
+    default:
+        return;
+    }
+
+    Q_EMIT message(tr("Send Coins"), msgParams.first, msgParams.second);
+}
+
+void SendSign::renderForm() {
+    QString areYouSure = tr("Are you sure you want to send?");
+    QString send = tr("Send");
+    QString sendTooltip = tr("Confirm the send action");
+    switch (mode) {
+    case Mode::SignTransaction:
+        ui->editButton->setVisible(true);
+        ui->cancelButton->setVisible(false);
+        break;
+    case Mode::CreatePsbt:
+        ui->editButton->setVisible(true);
+        ui->cancelButton->setVisible(false);
+        ui->explanation->setVisible(true);
+        areYouSure = tr("Do you want to draft this transaction? This will produce a Partially Signed Bitcoin Transaction (PSBT) which you can copy and then sign with e.g. an offline Bitcoin Core wallet, or a PSBT-compatible hardware wallet.");
+        send = tr("Copy PSBT to clipboard");
+        break;
+    }
+    ui->labelAreYouSure->setText(areYouSure);
+    ui->labelAreYouSure->setWordWrap(true);
+    if(secDelay > 0)
+    {
+        ui->sendButton->setEnabled(false);
+        ui->sendButton->setText(send + " (" + QString::number(secDelay) + ")");
+    } else {
+        ui->sendButton->setEnabled(true);
+        ui->sendButton->setText(send);
+    }
+    ui->sendButton->setToolTip(sendTooltip);
+}
+
+void SendSign::prepareTransaction()
+{
+    assert(m_is_active_widget);
+    mode = !walletModel->privateKeysDisabled() ? Mode::SignTransaction : Mode::CreatePsbt;
+    if (mode == Mode::SignTransaction) {
+        secDelay = SEND_CONFIRM_DELAY;
+        countDownTimer.start(1000);
+    }
+    renderForm();
+
+    WalletModel::UnlockContext ctx(walletModel->requestUnlock());
+    if(!ctx.isValid())
+    {
+        // Unlock wallet was cancelled
+        Q_EMIT signCancelled();
+        return;
+    }
+
+    WalletModel::SendCoinsReturn prepareStatus;
+    prepareStatus = walletModel->prepareTransaction(*transaction, *coinControl);
+
+    // process prepareStatus and on error generate message shown to user
+    processSendCoinsReturn(prepareStatus,
+        BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), transaction->getTransactionFee()));
+
+    if(prepareStatus.status != WalletModel::OK) {
+        Q_EMIT signCancelled();
+        return;
+    }
+
+    CAmount txFee = transaction->getTransactionFee();
+
+    // Format confirmation message
+    QStringList formatted;
+    for (const SendCoinsRecipient &rcp : transaction->getRecipients())
+    {
+        // generate amount string with wallet name in case of multiwallet
+        QString amount = BitcoinUnits::formatWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), rcp.amount);
+        if (walletModel->isMultiwallet()) {
+            amount.append(tr(" from wallet '%1'").arg(GUIUtil::HtmlEscape(walletModel->getWalletName())));
+        }
+
+        // generate address string
+        QString address = rcp.address;
+
+        QString recipientElement;
+
+#ifdef ENABLE_BIP70
+        if (!rcp.paymentRequest.IsInitialized()) // normal payment
+#endif
+        {
+            if(rcp.label.length() > 0) // label with address
+            {
+                recipientElement.append(tr("%1 to '%2'").arg(amount, GUIUtil::HtmlEscape(rcp.label)));
+                recipientElement.append(QString(" (%1)").arg(address));
+            }
+            else // just address
+            {
+                recipientElement.append(tr("%1 to %2").arg(amount, address));
+            }
+        }
+#ifdef ENABLE_BIP70
+        else if(!rcp.authenticatedMerchant.isEmpty()) // authenticated payment request
+        {
+            recipientElement.append(tr("%1 to '%2'").arg(amount, rcp.authenticatedMerchant));
+        }
+        else // unauthenticated payment request
+        {
+            recipientElement.append(tr("%1 to %2").arg(amount, address));
+        }
+#endif
+
+        formatted.append(recipientElement);
+    }
+
+    QString questionString = QString("<b>%1</b>").arg(tr("Recipients"));
+    questionString = questionString.append("<br />");
+    questionString = questionString.append(formatted.join("<br />"));
+
+    if(txFee > 0)
+    {
+        // append fee string if a fee is required
+        questionString.append("<hr /><b>");
+        questionString.append(tr("Transaction fee"));
+        questionString.append("</b>");
+
+        // append transaction size
+        questionString.append(" (" + QString::number((double)transaction->getTransactionSize() / 1000) + " kB): ");
+
+        // append transaction fee value
+        questionString.append("<span style='color:#aa0000; font-weight:bold;'>");
+        questionString.append(BitcoinUnits::formatHtmlWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), txFee));
+        questionString.append("</span><br />");
+
+        // append RBF message according to transaction's signalling
+        questionString.append("<span style='font-size:10pt; font-weight:normal;'>");
+        assert(coinControl->m_signal_bip125_rbf); // SendCompose always sets this boost::optional
+        if (*coinControl->m_signal_bip125_rbf) {
+            questionString.append(tr("You can increase the fee later (signals Replace-By-Fee, BIP-125)."));
+        } else {
+            questionString.append(tr("Not signalling Replace-By-Fee, BIP-125."));
+        }
+        questionString.append("</span>");
+    }
+
+    // add total amount in all subdivision units
+    questionString.append("<hr />");
+    CAmount totalAmount = transaction->getTotalTransactionAmount() + txFee;
+    QStringList alternativeUnits;
+    for (const BitcoinUnits::Unit u : BitcoinUnits::availableUnits())
+    {
+        if(u != walletModel->getOptionsModel()->getDisplayUnit())
+            alternativeUnits.append(BitcoinUnits::formatHtmlWithUnit(u, totalAmount));
+    }
+    questionString.append(QString("<b>%1</b>: <b>%2</b>").arg(tr("Total Amount"))
+        .arg(BitcoinUnits::formatHtmlWithUnit(walletModel->getOptionsModel()->getDisplayUnit(), totalAmount)));
+    questionString.append(QString("<br /><span style='font-size:10pt; font-weight:normal;'>(=%1)</span>")
+        .arg(alternativeUnits.join(" " + tr("or") + " ")));
+
+    ui->questionLabel->setText(questionString);
+}
+
+void SendSign::countDown()
+{
+    secDelay--;
+    renderForm();
+
+    if(secDelay <= 0)
+    {
+        countDownTimer.stop();
+    }
+}
+
+void SendSign::cancel()
+{
+    assert(m_is_active_widget);
+    switch (mode) {
+    case Mode::SignTransaction:
+    case Mode::CreatePsbt:
+        Q_EMIT signCancelled();
+        break;
+    }
+
+}
+
+void SendSign::confirm()
+{
+    assert(m_is_active_widget);
+    switch (mode) {
+    case Mode::SignTransaction:
+    case Mode::CreatePsbt:
+        Q_EMIT signConfirmed();
+        break;
+    }
+}

--- a/src/qt/sendsign.h
+++ b/src/qt/sendsign.h
@@ -25,6 +25,7 @@ namespace Ui {
 enum Mode {
     SignTransaction = 0,
     CreatePsbt = 1,
+    SignRbf = 2
 };
 
 class SendSign : public QWidget
@@ -44,6 +45,8 @@ public:
     // Prepares an usigned transaction, to be signed or turned into a PSBT
     void prepareTransaction();
 
+    void prepareSignRbf(uint256 txid, CMutableTransaction mtx, CAmount old_fee, CAmount new_fee);
+
 public Q_SLOTS:
     void cancel();
     void confirm();
@@ -61,6 +64,12 @@ Q_SIGNALS:
     // Fired when user confirms sign
     void signConfirmed();
 
+    // Fired when user cancels RBF
+    void rbfCancelled(uint256 txid);
+
+    // Fired when user confirms RBF
+    void rbfConfirmed(uint256 txid, CMutableTransaction mtx);
+
 private:
     Ui::SendSign *ui;
     bool m_is_active_widget{false};
@@ -68,6 +77,10 @@ private:
     QTimer countDownTimer;
     int secDelay;
     WalletModel *walletModel;
+
+    // RBF:
+    uint256 txid; // Original transaction
+    CMutableTransaction mtx;
 
     void renderForm();
     void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());

--- a/src/qt/sendsign.h
+++ b/src/qt/sendsign.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2011-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_SENDSIGN_H
+#define BITCOIN_QT_SENDSIGN_H
+
+#include <qt/walletmodel.h>
+
+#include <QDialog>
+#include <QMessageBox>
+#include <QAbstractButton>
+#include <QTimer>
+
+class CCoinControl;
+struct CMutableTransaction;
+class WalletModelTransaction;
+
+namespace Ui {
+    class SendSign;
+}
+
+#define SEND_CONFIRM_DELAY   3
+
+enum Mode {
+    SignTransaction = 0,
+    CreatePsbt = 1,
+};
+
+class SendSign : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit SendSign(const PlatformStyle *platformStyle, QWidget* parent = nullptr);
+    ~SendSign();
+    bool isActiveWidget();
+    void setActiveWidget(bool active);
+    void setModel(WalletModel *walletModel);
+
+    std::unique_ptr<WalletModelTransaction> transaction;
+    std::unique_ptr<CCoinControl> coinControl;
+
+    // Prepares an usigned transaction, to be signed or turned into a PSBT
+    void prepareTransaction();
+
+public Q_SLOTS:
+    void cancel();
+    void confirm();
+
+private Q_SLOTS:
+    void countDown();
+
+Q_SIGNALS:
+    // Fired when a message should be reported to the user
+    void message(const QString &title, const QString &message, unsigned int style);
+
+    // Fired when user cancels sign
+    void signCancelled();
+
+    // Fired when user confirms sign
+    void signConfirmed();
+
+private:
+    Ui::SendSign *ui;
+    bool m_is_active_widget{false};
+    Mode mode;
+    QTimer countDownTimer;
+    int secDelay;
+    WalletModel *walletModel;
+
+    void renderForm();
+    void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());
+};
+
+#endif // BITCOIN_QT_SENDSIGN_H

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -41,8 +41,8 @@ void ConfirmSend(QString* text = nullptr, bool cancel = false)
 {
     QTimer::singleShot(0, [text, cancel]() {
         for (QWidget* widget : QApplication::topLevelWidgets()) {
-            if (widget->inherits("SendConfirmationDialog")) {
-                SendConfirmationDialog* dialog = qobject_cast<SendConfirmationDialog*>(widget);
+            if (widget->inherits("SendSign")) {
+                SendSign* dialog = qobject_cast<SendSign*>(widget);
                 if (text) *text = dialog->text();
                 QAbstractButton* button = dialog->button(cancel ? QMessageBox::Cancel : QMessageBox::Yes);
                 button->setEnabled(true);

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -58,6 +58,7 @@ void SendCoins(uint256& txid, CWallet& wallet, SendDialog& sendDialog, const CTx
     }));
     bool invoked = QMetaObject::invokeMethod(sendDialog.draftWidget, "on_sendButton_clicked");
     assert(invoked);
+    qApp->processEvents();
     QVERIFY(sendDialog.signWidget->isActiveWidget());
     sendDialog.signWidget->confirm();
     // NotifyTransactionChanged in WalletModel calls "updateTransaction" using a Qt::QueuedConnection

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -7,7 +7,7 @@
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/qvalidatedlineedit.h>
-#include <qt/sendcoinsdialog.h>
+#include <qt/sendcompose.h>
 #include <qt/sendcoinsentry.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
@@ -53,7 +53,7 @@ void ConfirmSend(QString* text = nullptr, bool cancel = false)
 }
 
 //! Send coins to address and return txid.
-uint256 SendCoins(CWallet& wallet, SendCoinsDialog& sendCoinsDialog, const CTxDestination& address, CAmount amount, bool rbf)
+uint256 SendCoins(CWallet& wallet, SendCompose& sendCoinsDialog, const CTxDestination& address, CAmount amount, bool rbf)
 {
     QVBoxLayout* entries = sendCoinsDialog.findChild<QVBoxLayout*>("entries");
     SendCoinsEntry* entry = qobject_cast<SendCoinsEntry*>(entries->itemAt(0)->widget());
@@ -157,7 +157,7 @@ void TestGUI()
 
     // Create widgets for sending coins and listing transactions.
     std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
-    SendCoinsDialog sendCoinsDialog(platformStyle.get());
+    SendCompose sendCoinsDialog(platformStyle.get());
     TransactionView transactionView(platformStyle.get());
     auto node = interfaces::MakeNode();
     OptionsModel optionsModel(*node);

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -427,6 +427,9 @@ void TransactionView::bumpFee()
     QString hashQStr = selection.at(0).data(TransactionTableModel::TxHashRole).toString();
     hash.SetHex(hashQStr.toStdString());
 
+    // Go to send screen to handle fee bump
+    Q_EMIT gotoBumpFee(hash);
+    Q_EMIT gotoSendCoinsPage();
 }
 
 void TransactionView::copyAddress()

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -198,10 +198,6 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     connect(showDetailsAction, &QAction::triggered, this, &TransactionView::showDetails);
     // Double-clicking on a transaction on the transaction history page shows details
     connect(this, &TransactionView::doubleClicked, this, &TransactionView::showDetails);
-    // Highlight transaction after fee bump
-    connect(this, &TransactionView::bumpedFee, [this](const uint256& txid) {
-      focusTransaction(txid);
-    });
 }
 
 void TransactionView::setModel(WalletModel *_model)
@@ -431,16 +427,6 @@ void TransactionView::bumpFee()
     QString hashQStr = selection.at(0).data(TransactionTableModel::TxHashRole).toString();
     hash.SetHex(hashQStr.toStdString());
 
-    // Bump tx fee over the walletModel
-    uint256 newHash;
-    if (model->bumpFee(hash, newHash)) {
-        // Update the table
-        transactionView->selectionModel()->clearSelection();
-        model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, true);
-
-        qApp->processEvents();
-        Q_EMIT bumpedFee(newHash);
-    }
 }
 
 void TransactionView::copyAddress()

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -108,6 +108,7 @@ Q_SIGNALS:
     /**  Fired when a message should be reported to the user */
     void message(const QString &title, const QString &message, unsigned int style);
 
+    void gotoSendCoinsPage(QString addr = "");
 
 public Q_SLOTS:
     void chooseDate(int idx);

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -108,6 +108,7 @@ Q_SIGNALS:
     /**  Fired when a message should be reported to the user */
     void message(const QString &title, const QString &message, unsigned int style);
 
+    void gotoBumpFee(const uint256& txid);
     void gotoSendCoinsPage(QString addr = "");
 
 public Q_SLOTS:

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -108,7 +108,6 @@ Q_SIGNALS:
     /**  Fired when a message should be reported to the user */
     void message(const QString &title, const QString &message, unsigned int style);
 
-    void bumpedFee(const uint256& txid);
 
 public Q_SLOTS:
     void chooseDate(int idx);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -205,7 +205,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         std::string strFailReason;
 
         auto& newTx = transaction.getWtx();
-        newTx = m_wallet->createTransaction(vecSend, coinControl, true /* sign */, nChangePosRet, nFeeRequired, strFailReason);
+        newTx = m_wallet->createTransaction(vecSend, coinControl, !privateKeysDisabled() /* sign */, nChangePosRet, nFeeRequired, strFailReason);
         transaction.setTransactionFee(nFeeRequired);
         if (fSubtractFeeFromAmount && newTx)
             transaction.reassignAmounts(nChangePosRet);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -547,7 +547,7 @@ bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
     questionString.append("</td><td>");
     questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee));
     questionString.append("</td></tr></table>");
-    SendConfirmationDialog confirmationDialog(tr("Confirm fee bump"), questionString);
+    SendSign confirmationDialog(tr("Confirm fee bump"), questionString);
     confirmationDialog.exec();
     QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -13,7 +13,7 @@
 #include <qt/optionsmodel.h>
 #include <qt/paymentserver.h>
 #include <qt/recentrequeststablemodel.h>
-#include <qt/sendcoinsdialog.h>
+#include <qt/sendcompose.h>
 #include <qt/transactiontablemodel.h>
 
 #include <interfaces/handler.h>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -13,7 +13,6 @@
 #include <qt/optionsmodel.h>
 #include <qt/paymentserver.h>
 #include <qt/recentrequeststablemodel.h>
-#include <qt/sendcompose.h>
 #include <qt/transactiontablemodel.h>
 
 #include <interfaces/handler.h>

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -213,8 +213,6 @@ public:
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string &sAddress, const int64_t nId, const std::string &sRequest);
 
-    bool bumpFee(uint256 hash, uint256& new_hash);
-
     static bool isWalletEnabled();
     bool privateKeysDisabled() const;
     bool canGetAddresses() const;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -76,6 +76,9 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     // Clicking on "Export" allows to export the transaction list
     connect(exportButton, &QPushButton::clicked, transactionView, &TransactionView::exportClicked);
 
+    // Bump transaction fee
+    connect(transactionView, &TransactionView::gotoBumpFee, sendCoinsPage, &SendDialog::gotoBumpFee);
+
     // Pass through messages from send dialog
     connect(sendCoinsPage, &SendDialog::message, this, &WalletView::message);
     // Pass through messages from transactionView
@@ -95,6 +98,9 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
 
         // Navigate to transaction history page after send
         connect(sendCoinsPage, &SendDialog::showTransaction, gui, &BitcoinGUI::gotoHistoryPage);
+
+        // Navigate to send page for RBF
+        connect(transactionView, &TransactionView::gotoSendCoinsPage, gui, &BitcoinGUI::gotoSendCoinsPage);
 
         // Receive and report messages
         connect(this, &WalletView::message, [gui](const QString &title, const QString &message, unsigned int style) {

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -13,7 +13,7 @@
 #include <qt/overviewpage.h>
 #include <qt/platformstyle.h>
 #include <qt/receivecoinsdialog.h>
-#include <qt/sendcoinsdialog.h>
+#include <qt/sendcompose.h>
 #include <qt/signverifymessagedialog.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
@@ -55,7 +55,7 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     transactionsPage->setLayout(vbox);
 
     receiveCoinsPage = new ReceiveCoinsDialog(platformStyle);
-    sendCoinsPage = new SendCoinsDialog(platformStyle);
+    sendCoinsPage = new SendCompose(platformStyle);
 
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedReceivingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
@@ -71,13 +71,13 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     connect(overviewPage, &OverviewPage::outOfSyncWarningClicked, this, &WalletView::requestedSyncWarningInfo);
 
     // Highlight transaction after send
-    connect(sendCoinsPage, &SendCoinsDialog::coinsSent, transactionView, static_cast<void (TransactionView::*)(const uint256&)>(&TransactionView::focusTransaction));
+    connect(sendCoinsPage, &SendCompose::coinsSent, transactionView, static_cast<void (TransactionView::*)(const uint256&)>(&TransactionView::focusTransaction));
 
     // Clicking on "Export" allows to export the transaction list
     connect(exportButton, &QPushButton::clicked, transactionView, &TransactionView::exportClicked);
 
     // Pass through messages from sendCoinsPage
-    connect(sendCoinsPage, &SendCoinsDialog::message, this, &WalletView::message);
+    connect(sendCoinsPage, &SendCompose::message, this, &WalletView::message);
     // Pass through messages from transactionView
     connect(transactionView, &TransactionView::message, this, &WalletView::message);
 }
@@ -94,7 +94,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         connect(overviewPage, &OverviewPage::transactionClicked, gui, &BitcoinGUI::gotoHistoryPage);
 
         // Navigate to transaction history page after send
-        connect(sendCoinsPage, &SendCoinsDialog::coinsSent, gui, &BitcoinGUI::gotoHistoryPage);
+        connect(sendCoinsPage, &SendCompose::coinsSent, gui, &BitcoinGUI::gotoHistoryPage);
 
         // Receive and report messages
         connect(this, &WalletView::message, [gui](const QString &title, const QString &message, unsigned int style) {

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -13,7 +13,7 @@
 #include <qt/overviewpage.h>
 #include <qt/platformstyle.h>
 #include <qt/receivecoinsdialog.h>
-#include <qt/sendcompose.h>
+#include <qt/senddialog.h>
 #include <qt/signverifymessagedialog.h>
 #include <qt/transactiontablemodel.h>
 #include <qt/transactionview.h>
@@ -55,7 +55,7 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     transactionsPage->setLayout(vbox);
 
     receiveCoinsPage = new ReceiveCoinsDialog(platformStyle);
-    sendCoinsPage = new SendCompose(platformStyle);
+    sendCoinsPage = new SendDialog(platformStyle);
 
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedReceivingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
@@ -71,13 +71,13 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     connect(overviewPage, &OverviewPage::outOfSyncWarningClicked, this, &WalletView::requestedSyncWarningInfo);
 
     // Highlight transaction after send
-    connect(sendCoinsPage, &SendCompose::coinsSent, transactionView, static_cast<void (TransactionView::*)(const uint256&)>(&TransactionView::focusTransaction));
+    connect(sendCoinsPage, &SendDialog::showTransaction, transactionView, static_cast<void (TransactionView::*)(const uint256&)>(&TransactionView::focusTransaction));
 
     // Clicking on "Export" allows to export the transaction list
     connect(exportButton, &QPushButton::clicked, transactionView, &TransactionView::exportClicked);
 
-    // Pass through messages from sendCoinsPage
-    connect(sendCoinsPage, &SendCompose::message, this, &WalletView::message);
+    // Pass through messages from send dialog
+    connect(sendCoinsPage, &SendDialog::message, this, &WalletView::message);
     // Pass through messages from transactionView
     connect(transactionView, &TransactionView::message, this, &WalletView::message);
 }
@@ -94,7 +94,7 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         connect(overviewPage, &OverviewPage::transactionClicked, gui, &BitcoinGUI::gotoHistoryPage);
 
         // Navigate to transaction history page after send
-        connect(sendCoinsPage, &SendCompose::coinsSent, gui, &BitcoinGUI::gotoHistoryPage);
+        connect(sendCoinsPage, &SendDialog::showTransaction, gui, &BitcoinGUI::gotoHistoryPage);
 
         // Receive and report messages
         connect(this, &WalletView::message, [gui](const QString &title, const QString &message, unsigned int style) {
@@ -194,8 +194,7 @@ void WalletView::gotoSendCoinsPage(QString addr)
 {
     setCurrentWidget(sendCoinsPage);
 
-    if (!addr.isEmpty())
-        sendCoinsPage->setAddress(addr);
+    if (!addr.isEmpty()) sendCoinsPage->setAddress(addr);
 }
 
 void WalletView::gotoSignMessageTab(QString addr)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -16,6 +16,7 @@ class PlatformStyle;
 class ReceiveCoinsDialog;
 class SendCompose;
 class SendCoinsRecipient;
+class SendDialog;
 class TransactionView;
 class WalletModel;
 class AddressBookPage;
@@ -62,7 +63,7 @@ private:
     OverviewPage *overviewPage;
     QWidget *transactionsPage;
     ReceiveCoinsDialog *receiveCoinsPage;
-    SendCompose *sendCoinsPage;
+    SendDialog *sendCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -14,7 +14,7 @@ class ClientModel;
 class OverviewPage;
 class PlatformStyle;
 class ReceiveCoinsDialog;
-class SendCoinsDialog;
+class SendCompose;
 class SendCoinsRecipient;
 class TransactionView;
 class WalletModel;
@@ -62,7 +62,7 @@ private:
     OverviewPage *overviewPage;
     QWidget *transactionsPage;
     ReceiveCoinsDialog *receiveCoinsPage;
-    SendCoinsDialog *sendCoinsPage;
+    SendCompose *sendCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
 

--- a/src/wallet/coincontrol.cpp
+++ b/src/wallet/coincontrol.cpp
@@ -6,6 +6,24 @@
 
 #include <util/system.h>
 
+CCoinControl::CCoinControl(const CCoinControl &obj) {
+    destChange = obj.destChange;
+    m_change_type = obj.m_change_type;
+    fAllowOtherInputs = obj.fAllowOtherInputs;
+    fAllowWatchOnly = obj.fAllowWatchOnly;
+    m_avoid_partial_spends = obj.m_avoid_partial_spends;
+    m_avoid_address_reuse = obj.m_avoid_address_reuse;
+    setSelected = obj.setSelected;
+    m_feerate = obj.m_feerate;
+    fOverrideFeeRate = obj.fOverrideFeeRate;
+    m_confirm_target = obj.m_confirm_target;
+    m_signal_bip125_rbf = obj.m_signal_bip125_rbf;
+    m_fee_mode = obj.m_fee_mode;
+    m_min_depth = obj.m_min_depth;
+    m_max_depth = obj.m_max_depth;
+}
+
+
 void CCoinControl::SetNull()
 {
     destChange = CNoDestination();
@@ -23,4 +41,3 @@ void CCoinControl::SetNull()
     m_min_depth = DEFAULT_MIN_DEPTH;
     m_max_depth = DEFAULT_MAX_DEPTH;
 }
-

--- a/src/wallet/coincontrol.h
+++ b/src/wallet/coincontrol.h
@@ -51,6 +51,8 @@ public:
         SetNull();
     }
 
+    CCoinControl(const CCoinControl &obj);
+
     void SetNull();
 
     bool HasSelected() const

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2577,7 +2577,7 @@ std::map<CTxDestination, std::vector<COutput>> CWallet::ListCoins(interfaces::Ch
 
     for (const COutput& coin : availableCoins) {
         CTxDestination address;
-        if (coin.fSpendable &&
+        if ((coin.fSpendable || (IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) && coin.fSolvable)) &&
             ExtractDestination(FindNonChangeParentOutput(*coin.tx->tx, coin.i).scriptPubKey, address)) {
             result[address].emplace_back(std::move(coin));
         }
@@ -2590,7 +2590,9 @@ std::map<CTxDestination, std::vector<COutput>> CWallet::ListCoins(interfaces::Ch
         if (it != mapWallet.end()) {
             int depth = it->second.GetDepthInMainChain(locked_chain);
             if (depth >= 0 && output.n < it->second.tx->vout.size() &&
-                IsMine(it->second.tx->vout[output.n]) == ISMINE_SPENDABLE) {
+                IsMine(it->second.tx->vout[output.n]) ==
+                  (IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) ?
+                  ISMINE_WATCH_ONLY : ISMINE_SPENDABLE)) {
                 CTxDestination address;
                 if (ExtractDestination(FindNonChangeParentOutput(*it->second.tx, output.n).scriptPubKey, address)) {
                     result[address].emplace_back(

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -20,7 +20,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "qt/clientmodel -> qt/peertablemodel -> qt/clientmodel"
     "qt/paymentserver -> qt/walletmodel -> qt/paymentserver"
     "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel"
-    "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog"
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel"
     "qt/walletmodel -> qt/walletmodeltransaction -> qt/walletmodel"
     "txmempool -> validation -> txmempool"


### PR DESCRIPTION
Implements #16954 for the current functionality + #16944 (`gui: create PSBT with watch-only wallet`). This PR splits the send screen into three tabs, like a wizard.

This frees up UI real estate where we can add support for PSBT, hardware wallets and education.

I renamed `SendCoinsDialog` to `SendCompose` and `SendConfirmationDialog` to `SendSign`for clarity, which ended up (trivially) touching lots of `src/qt/locale/bitcoin_##.ts` files. This is contained in two move-only commits.

**Tab 1: Draft**

<img width="926" alt="Schermafbeelding 2019-09-26 om 15 59 16" src="https://user-images.githubusercontent.com/10217/65695736-606d8b80-e078-11e9-84d9-fe2d37f932e8.png">

Same as the current send screen: enter destination, do coin selection, set fee etc. This can be split further in future PRs for a less cluttered experience, e.g. one tab for coin selection (if enabled), one for destination(s) and one for fees. Having a separate tab for fees also provides an entry point for RBF, which currently doesn't let the user pick an amount. 

**Tab 2: Sign**

This asks to unlock the wallet if needed.

<img width="931" alt="Schermafbeelding 2019-09-26 om 16 14 42" src="https://user-images.githubusercontent.com/10217/65695992-c9ed9a00-e078-11e9-9ee7-4d60d0499049.png">

Display transaction details like the current popup does. 

<img width="933" alt="Schermafbeelding 2019-09-26 om 15 59 35" src="https://user-images.githubusercontent.com/10217/65695773-6fecd480-e078-11e9-95fa-498f844c5eb1.png">

Edit jumps back to Draft. Send jumps to Finish, unless something goes wrong.

Bump fee jumps straight to this tab:
<img width="855" alt="sign" src="https://user-images.githubusercontent.com/10217/65713022-89057d80-e098-11e9-80d5-0a2abdde0871.png">

For watch-only wallets it displays the same text as #16944.

**Tab 3: Finish**

<img width="932" alt="Schermafbeelding 2019-09-26 om 16 08 21" src="https://user-images.githubusercontent.com/10217/65695799-7b400000-e078-11e9-967a-7581f15ecdd5.png">

This is where the actual broadcast takes place, or where the PSBT is copied to the clipboard. In a followup we can add support for saving the PSBT to disk, or for copying a signed transaction hex to clipboard if the user wants to broadcast that elsewhere. 

Bump fee shows both the previous and new transaction index:
<img width="847" alt="sent" src="https://user-images.githubusercontent.com/10217/65713060-9c184d80-e098-11e9-879a-f10822d4ad2b.png">

The manual "Show" button has the nice side-effect of fixing #16875 / #16876 in two out of three places. 

---

Todo:
- [ ] clean up WalletModelTransaction and CoinControl object passing mess
- [x] restore test

Followups:
* add PSBT export to Sign tab (extract from gwillen's branch https://github.com/gwillen/bitcoin/tree/feature-offline-v2, i.e. redo #16944)
* add Load PSBT menu option, jump to Broadcast tab if complete, otherwise to Sign tab
* list connected hardware wallets in Sign tab (redo #16549 
* split fee selection into its own tab
* allow custom RBF amounts: bump fee should jump to fee selection tab 
