### PR TITLE
doc: Remove MSVC update step from translation process

### DIFF
--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -77,12 +77,6 @@ git ls-files src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/ 
 ```bash
 git ls-files src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/  qt\/locale\/\1.ts \\/'
 ```
-5. Update `build_msvc/libbitcoin_qt/libbitcoin_qt.vcxproj` or via
-```bash
-git ls-files src/qt/locale/*ts|xargs -n1 basename |
-  sed 's/@/%40/' |
-  sed 's/\(bitcoin_\(.*\)\).ts/    <None Include="..\\..\\src\\qt\\locale\\\1.ts">\n      <DeploymentContent>true<\/DeploymentContent>\n    <\/None>/'
-```
 
 **Do not directly download translations** one by one from the Transifex website, as we do a few post-processing steps before committing the translations.
 


### PR DESCRIPTION
This part of the build system has been removed in #15529 and thus no longer needs to be updated.