### PR TITLE
refactor: Remove Qt function to disable menu icons on macOS

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -436,9 +436,6 @@ int GuiMain(int argc, char* argv[])
 #if QT_VERSION >= 0x050600
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 #endif
-#ifdef Q_OS_MAC
-    QApplication::setAttribute(Qt::AA_DontShowIconsInMenus);
-#endif
 
     BitcoinApplication app(*node);
 


### PR DESCRIPTION
As menu icons were removed in #16612, this removes an unnecessary function for macOS
Could this get into v0.19.0?