### PR TITLE
6% faster, 6% less memory: more tightly pack CCoinMap::value_type

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -129,7 +129,12 @@ public:
 
 /** An output of a transaction.  It contains the public key that the next input
  * must be able to sign with to claim it.
+ *
+ * We align the struct to 4 bytes: that way, CTxOut will have 36 bytes: 8 for
+ * CAmount, and 28 for CScript. As a member of Coin, this leaves 4 bytes for
+ * Coin's nHeight without the need for any padding.
  */
+#pragma pack(push, 4)
 class CTxOut
 {
 public:
@@ -175,6 +180,7 @@ public:
 
     std::string ToString() const;
 };
+#pragma pack(pop)
 
 struct CMutableTransaction;
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -381,8 +381,11 @@ private:
  *  of vectors in cases where they normally contain a small number of small elements.
  * Tests in October 2015 showed use of this reduced dbcache memory usage by 23%
  *  and made an initial sync 13% faster.
+ *
+ * Most scripts seem to have <= 25 bytes. So with 27 entries + 1 byte for size(),
+ * the prevector will have a size of 28 bytes.
  */
-typedef prevector<28, unsigned char> CScriptBase;
+typedef prevector<27, unsigned char> CScriptBase;
 
 bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet);
 


### PR DESCRIPTION
This change reduces `CCoinMap::value_type` from 96 bytes to 80 bytes by more tightly packing it's data. This allows to cache a lot more transactions in the cache. I've achieved this with these changes:

* Refactored `prevector` so it uses a single byte to determine its size when in direct mode
* Reduce `CScriptBase` from 28 to 27 indirect bytes
* align `CTxOut` to 4 bytes to prevent padding when used as a member in `Coin`

This tighter packing means more data can be stored in the `coinsCache` before it is full and has to be flushed to disk. In my benchmark, `-reindex-chainstate` was 6% faster and used 6% less memory. The cache could fit 14% more txo's before it had to resize.

Some numbers: 

|                                       | runtime h:mm:ss | max RSS kbyte |
|---------------------------------------|-----------------|--------------|
| master  -dbcache=5000                                |         4:13:59 |      7696728 |
| 2019-09-more-compact-Coin  -dbcache=5000 |         3:57:59 |      7192772 |
| change                                |          -6.30% |       -6.55% |

The graph shows nicely that the cache is able to be used a lot longer before it is full and flushed to the disk:
![out](https://user-images.githubusercontent.com/14386/65710655-bbf94280-e093-11e9-820a-067e8c5c143b.png)

I've tried this change in combination with #16957 to not cache hash), and then additionally in combination with #16801 :

|                                       | runtime h:mm:ss | max RSS kbyte |
|---------------------------------------|-----------------|--------------|
| master  -dbcache=5000                                |         4:13:59 |      7696728 |
| 2019-09-more-compact-Coin  -dbcache=5000 |         3:57:59 |      7192772 |
| 2019-09-more-compact-Coin & #16957 -dbcache=5500 |         3:51:04 |      6600548 |
| 2019-09-more-compact-Coin & #16957 & #16801 -dbcache=5500 | 3:38:44 | 6164380 |

![out](https://user-images.githubusercontent.com/14386/65711422-278fdf80-e095-11e9-8095-faca6dc1edc2.png)

With all 3 PR's applied, reindex was 14% faster and used 20% less memory