### PR TITLE
qt: Change default size of intro frame

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -154,6 +154,7 @@ Intro::Intro(QWidget *parent, uint64_t blockchain_size, uint64_t chain_state_siz
         storageRequiresMsg.arg(requiredSpace) + " " +
         tr("The wallet will also be stored in this directory.")
     );
+    this->adjustSize();
     startThread();
 }
 


### PR DESCRIPTION
Because of the new pruning feature in the intro frame, the size of the intro frame is too small.
Like you see, some text is not visible completely.

### Before
![Before](https://i.imgur.com/ppZ3Gf9.png)
### After
![After](https://i.imgur.com/wcElqLA.png)

Update: I changed it so it adjusts the size dynamically