### PR TITLE
test: Fix combine_logs.py for AppVeyor build

### DIFF
--- a/test/functional/combine_logs.py
+++ b/test/functional/combine_logs.py
@@ -8,7 +8,6 @@ If no argument is provided, the most recent test directory will be used."""
 
 import argparse
 from collections import defaultdict, namedtuple
-import glob
 import heapq
 import itertools
 import os
@@ -78,10 +77,11 @@ def read_logs(tmp_dir):
     for each of the input log files."""
 
     # Find out what the folder is called that holds the debug.log file
-    chain = glob.glob("{}/node0/*/debug.log".format(tmp_dir))
-    if chain:
-        chain = chain[0]  # pick the first one if more than one chain was found (should never happen)
-        chain = re.search(r'node0/(.+?)/debug\.log$', chain).group(1)  # extract the chain name
+    glob = pathlib.Path(tmp_dir).glob('node0/**/debug.log')
+    path = next(glob, None)
+    if path:
+        assert next(glob, None) is None #  more than one debug.log, should never happen
+        chain = re.search(r'node0/(.+?)/debug\.log$', path.as_posix()).group(1)  # extract the chain name
     else:
         chain = 'regtest'  # fallback to regtest (should only happen when none exists)
 


### PR DESCRIPTION
Fixes #16894

This fixes the problem of AppVeyor builds not showing `debug.log` if a functional test fails, because the windows separator `\` doesn't work together with the regex in `combine_logs.py`.

A fix was already attempted in  #16896, however, that PR became inactive and was marked "up for grabs", plus it's a really small change.

As suggested by jamesob, this PR uses `pathlib`: For the glob and to convert the path to a posix-style string, it leaves the regex as is (in contrast to #16896 which adjusted the regex).

I tested this locally on Windows and Ubuntu.
