### PR TITLE
test: Show debug log on unit test failure

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -16,6 +16,7 @@
 #include <regex>
 
 const RegTestingSetup* g_testing_setup = nullptr;
+const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 void benchmark::ConsolePrinter::header()
 {

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -37,6 +37,8 @@ Q_IMPORT_PLUGIN(QCocoaIntegrationPlugin);
 #endif
 #endif
 
+const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
+
 // This is all you need to run all the tests
 int main(int argc, char *argv[])
 {

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -4,9 +4,13 @@
 
 #include <test/fuzz/fuzz.h>
 
+#include <test/util/setup_common.h>
+
 #include <cstdint>
 #include <unistd.h>
 #include <vector>
+
+const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 static bool read_stdin(std::vector<uint8_t>& data)
 {

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -2,6 +2,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+/**
+ * See https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/link_references/link_boost_test_module_macro.html
+ */
 #define BOOST_TEST_MODULE Bitcoin Core Test Suite
 
 #include <boost/test/unit_test.hpp>
+
+#include <test/util/setup_common.h>
+
+/** Redirect debug log to boost log */
+const std::function<void(const std::string&)> G_TEST_LOG_FUN = [](const std::string& s) {
+    if (s.back() == '\n') {
+        // boost will insert the new line
+        BOOST_TEST_MESSAGE(s.substr(0, s.size() - 1));
+    } else {
+        BOOST_TEST_MESSAGE(s);
+    }
+};

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -71,6 +71,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     SelectParams(chainName);
     SeedInsecureRand();
     gArgs.ForceSetArg("-printtoconsole", "0");
+    if (G_TEST_LOG_FUN) LogInstance().PushBackCallback(G_TEST_LOG_FUN);
     InitLogging();
     LogInstance().StartLogging();
     SHA256AutoDetect();

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -18,6 +18,9 @@
 
 #include <boost/thread.hpp>
 
+/** This is connected to the logger. Can be used to redirect logs to any other log */
+extern const std::function<void(const std::string&)> G_TEST_LOG_FUN;
+
 // Enable BOOST_CHECK_EQUAL for enum class types
 template <typename T>
 std::ostream& operator<<(typename std::enable_if<std::is_enum<T>::value, std::ostream>::type& stream, const T& e)

--- a/test/sanitizer_suppressions/tsan
+++ b/test/sanitizer_suppressions/tsan
@@ -7,6 +7,14 @@ deadlock:WalletBatch
 # Intentional deadlock in tests
 deadlock:TestPotentialDeadLockDetected
 
+# Race due to unprotected calls to thread-unsafe BOOST_TEST_MESSAGE from different threads:
+# * G_TEST_LOG_FUN in the index thread
+# * boost test case invoker (entering a test case) in the main thread
+# TODO: get rid of BOOST_ macros, see also https://github.com/bitcoin/bitcoin/issues/8670
+race:blockfilter_index_initial_sync_invoker
+race:txindex_initial_sync_invoker
+race:validation_block_tests::TestSubscriber
+
 # Wildcard for all gui tests, should be replaced with non-wildcard suppressions
 race:src/qt/test/*
 deadlock:src/qt/test/*


### PR DESCRIPTION
Often, it is hard to debug unit test failures without the debug log. Especially when the failure happens remotely (e.g. on a ci system).

Fix that by printing the log on failure.