### PR TITLE
util: Make thread names shorter

### DIFF
--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -57,6 +57,6 @@ static void SetInternalName(std::string name) { }
 
 void util::ThreadRename(std::string&& name)
 {
-    SetThreadName(("bitcoin-" + name).c_str());
+    SetThreadName(("b-" + name).c_str());
     SetInternalName(std::move(name));
 }


### PR DESCRIPTION
Thread names at the process level are limited by 15 characters:
https://github.com/bitcoin/bitcoin/blob/6b2210f1016c9ed96ce470e588e4cb12fa36a900/src/util/threadnames.cpp#L28-L29

This commit ensures that name `b-httpworker.42` will not be truncated.

On master (6b2210f1016c9ed96ce470e588e4cb12fa36a900):
```bash
hebasto@redcat:~$ ps -T -p $(cat /home/hebasto/.bitcoin/testnet3/bitcoind.pid)
  PID  SPID TTY          TIME CMD
32647 32647 pts/6    00:00:00 bitcoin-main
32647 32648 pts/6    00:00:00 QXcbEventReader
32647 32649 pts/6    00:00:00 bitcoin:disk$0
32647 32650 pts/6    00:00:00 QDBusConnection
32647 32651 pts/6    00:00:00 gmain
32647 32652 pts/6    00:00:00 gdbus
32647 32653 pts/6    00:00:07 bitcoin-qt-init
32647 32656 pts/6    00:00:00 bitcoin-scriptc
32647 32657 pts/6    00:00:00 bitcoin-scriptc
32647 32658 pts/6    00:00:00 bitcoin-scriptc
32647 32659 pts/6    00:00:00 bitcoin-schedul
32647 32660 pts/6    00:00:00 bitcoin-http
32647 32661 pts/6    00:00:00 bitcoin-httpwor
32647 32662 pts/6    00:00:00 bitcoin-httpwor
32647 32663 pts/6    00:00:00 bitcoin-httpwor
32647 32664 pts/6    00:00:00 bitcoin-httpwor
32647 32665 pts/6    00:00:00 bitcoin-qt-init
32647 32668 pts/6    00:00:00 bitcoin-torcont
32647 32669 pts/6    00:00:00 bitcoin-upnp
32647 32670 pts/6    00:00:00 bitcoin-net
32647 32671 pts/6    00:00:00 bitcoin-dnsseed
32647 32672 pts/6    00:00:00 bitcoin-addcon
32647 32673 pts/6    00:00:00 bitcoin-opencon
32647 32674 pts/6    00:00:00 bitcoin-msghand
32647 32675 pts/6    00:00:00 QThread
32647 32676 pts/6    00:00:00 QThread
```

With this PR:
```bash
hebasto@redcat:~$ ps -T -p $(cat /home/hebasto/.bitcoin/testnet3/bitcoind.pid)
  PID  SPID TTY          TIME CMD
25664 25664 pts/0    00:00:00 b-main
25664 25665 pts/0    00:00:00 QXcbEventReader
25664 25666 pts/0    00:00:00 bitcoin:disk$0
25664 25667 pts/0    00:00:00 QDBusConnection
25664 25668 pts/0    00:00:00 gmain
25664 25669 pts/0    00:00:00 gdbus
25664 25670 pts/0    00:00:07 b-qt-init
25664 25671 pts/0    00:00:00 b-scriptch.0
25664 25672 pts/0    00:00:00 b-scriptch.1
25664 25673 pts/0    00:00:00 b-scriptch.2
25664 25674 pts/0    00:00:00 b-scheduler
25664 25675 pts/0    00:00:00 b-http
25664 25676 pts/0    00:00:00 b-httpworker.0
25664 25677 pts/0    00:00:00 b-httpworker.1
25664 25678 pts/0    00:00:00 b-httpworker.2
25664 25679 pts/0    00:00:00 b-httpworker.3
25664 25680 pts/0    00:00:00 b-qt-init
25664 25682 pts/0    00:00:00 b-torcontrol
25664 25683 pts/0    00:00:00 b-upnp
25664 25684 pts/0    00:00:00 b-net
25664 25685 pts/0    00:00:00 b-dnsseed
25664 25686 pts/0    00:00:00 b-addcon
25664 25687 pts/0    00:00:00 b-opencon
25664 25688 pts/0    00:00:01 b-msghand
25664 25689 pts/0    00:00:00 QThread
25664 25690 pts/0    00:00:00 QThread
```