### PR TITLE
test: Correct docstring param name.

### DIFF
--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -34,7 +34,7 @@ def assert_net_servicesnames(servicesflag, servicenames):
     `getpeerinfo` and `getnetworkinfo`.
 
     :param servicesflag: The services as an integer.
-    :param servicesnames: The list of decoded services names, as strings.
+    :param servicenames: The list of decoded services names, as strings.
     """
     if servicesflag & NODE_NETWORK:
         assert "NETWORK" in servicenames


### PR DESCRIPTION
Small fix to correct the Python docstring.  