### PR TITLE
rpc: gettxoutsetinfo locks m_cs_chainstate 

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -993,6 +993,9 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
     UniValue ret(UniValue::VOBJ);
 
     CCoinsStats stats;
+
+    LOCK(::ChainstateActive().m_cs_chainstate);
+
     ::ChainstateActive().ForceFlushStateToDisk();
 
     CCoinsView* coins_view = WITH_LOCK(cs_main, return &ChainstateActive().CoinsDB());

--- a/src/validation.h
+++ b/src/validation.h
@@ -562,12 +562,6 @@ private:
     arith_uint256 nLastPreciousChainwork = 0;
 
     /**
-     * the ChainState CriticalSection
-     * A lock that must be held when modifying this ChainState - held in ActivateBestChain()
-     */
-    CCriticalSection m_cs_chainstate;
-
-    /**
      * Whether this chainstate is undergoing initial block download.
      *
      * Mutable because we need to be able to mark IsInitialBlockDownload()
@@ -586,6 +580,12 @@ private:
 public:
     CChainState(BlockManager& blockman) : m_blockman(blockman) {}
     CChainState();
+
+    /**
+     * the ChainState CriticalSection
+     * A lock that must be held when modifying this ChainState - held in ActivateBestChain()
+     */
+    CCriticalSection m_cs_chainstate;
 
     /**
      * Initialize the CoinsViews UTXO set database management data structures. The in-memory


### PR DESCRIPTION
It seems unsafe to connect / disconnect / activate blocks while collecting stats about the current chain state.

Making a UTXO snapshot in #16899 relies on invaliding a early block to roll back to the chain, calling `gettxoutsetinfo` and then calling `reconsiderblock` to return to the tip. I managed to end up with a corrupt chainstate doing this. Perhaps this was a result of #16444, but I also noticed that  `gettxoutsetinfo` only returned once it reached the tip.

I'm not sure if this is the right approach though.

This might also help with #16979