### PR TITLE
contrib: replace deprecated PermissionsStartOnly in systemd init

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -20,8 +20,7 @@ ExecStart=/usr/bin/bitcoind -daemon \
                             -datadir=/var/lib/bitcoind
 
 # Make sure the config directory is readable by the service user
-PermissionsStartOnly=true
-ExecStartPre=/bin/chgrp bitcoin /etc/bitcoin
+ExecStartPre=!/bin/chgrp bitcoin /etc/bitcoin
 
 # Process management
 ####################


### PR DESCRIPTION
`PermissionsStartOnly` is deprecated (but not yet removed); its
functionality replaced by special executable prefixes. The `!` prefix
allows the prefixed command to be run with unrestricted User and Group.
This is necessary to ensure group ownership is set correctly to the
configuration directory.

Followup on @hebasto's comment on #16556 