### PR TITLE
tests: Add test_fuzzing_harnesses.sh for quick testing/verification of fuzzing harness coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_amd64_asan.sh"
 
     - stage: test
-      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs, sanitizers: fuzzer,address]'
+      name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs, sanitizers: fuzzer,address,undefined]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_amd64_fuzz.sh"
 

--- a/ci/test/00_setup_env_amd64_fuzz.sh
+++ b/ci/test/00_setup_env_amd64_fuzz.sh
@@ -13,4 +13,4 @@ export RUN_UNIT_TESTS=false
 export RUN_FUNCTIONAL_TESTS=false
 export RUN_FUZZ_TESTS=true
 export GOAL="install"
-export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer,address CC=clang CXX=clang++"
+export BITCOIN_CONFIG="--enable-fuzz --with-sanitizers=fuzzer,address,undefined CC=clang CXX=clang++"

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -24,6 +24,9 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   BEGIN_FOLD fuzz-tests
   DOCKER_EXEC test/fuzz/test_runner.py -l DEBUG ${DIR_FUZZ_IN}
   END_FOLD
+  BEGIN_FOLD fuzz-tests-verify-coverage
+  DOCKER_EXEC ${BASE_BUILD_DIR}/contrib/devtools/test_fuzzing_harnesses.sh
+  END_FOLD
 fi
 
 cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)

--- a/contrib/devtools/test_fuzzing_harnesses.sh
+++ b/contrib/devtools/test_fuzzing_harnesses.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+export LC_ALL=C
+
+set -e
+set -o pipefail
+
+TEST_REGEXP="${1:-}"
+RUNNING_TIME="${2:-1}"
+
+FUZZER_DIR="src/test/fuzz/"
+N_FUZZERS=$(find "${FUZZER_DIR}" -type f -executable |  wc -l)
+if [[ ${N_FUZZERS} == 0 ]]; then
+    echo "Error: Could not find any compiled fuzz harnesses in ${FUZZER_DIR}"
+    echo
+    echo "Enable and build the fuzzers using:"
+    echo "    \$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined"
+    echo "    \$ make"
+    exit 1
+fi
+
+if [[ ${TEST_REGEXP} == "" ]]; then
+    echo "Found ${N_FUZZERS} fuzz harnesses to test."
+    echo
+fi
+
+N_RUNS=0
+for FUZZER_PATH in $(find "${FUZZER_DIR}" -type f -executable | sort); do
+    FUZZER=$(basename "${FUZZER_PATH}")
+    if [[ ! ${FUZZER} =~ ${TEST_REGEXP} ]]; then
+        continue
+    fi
+    CORPUS_DIR=$(mktemp -d)
+    echo "Testing fuzzer ${FUZZER} during ${RUNNING_TIME} second(s)"
+    echo "A subset of reached functions:"
+    ${FUZZER_PATH} -verbosity=0 -detect_leaks=0 -print_funcs=20 -timeout="${RUNNING_TIME}" -max_total_time="${RUNNING_TIME}" -print_final_stats=1 "${CORPUS_DIR}" 2>&1 | grep -vE '^(INFO: .*(files found in|max_len is not provided|seed corpus: files|A corpus is not provided)|#|"|.*/include/)' | sed "s%$(pwd)/%%g"
+    N_RUNS=$((N_RUNS + 1))
+    COVERED_CODE_PATHS=$(find "${CORPUS_DIR}" -type f | wc -l)
+    echo "Number of unique code paths taken during fuzzing round: ${COVERED_CODE_PATHS}"
+    if [[ ${COVERED_CODE_PATHS} == 0 ]]; then
+        echo "No taken code paths recorded during the fuzzing round. The fuzzing setup for ${FUZZER} seems broken. Aborting."
+        exit 1
+    fi
+    if [[ ${COVERED_CODE_PATHS} == 1 ]]; then
+        echo "Only one unique code path was taken when executing ${FUZZING} during ${RUNNING_TIME} second(s) with varying inputs. Investigate how you can make more code paths reachable for the fuzzer. Aborting."
+        exit 1
+    fi
+    rm -r "${CORPUS_DIR}"
+    echo
+done
+
+if [[ ${N_RUNS} == 0 ]]; then
+    echo "Could not find any fuzzers matching regexp \"${TEST_REGEXP}\"."
+else
+    echo "Tested fuzz harnesses seem to work as expected."
+fi


### PR DESCRIPTION
Add `test_fuzzing_harnesses.sh` for easy verification that our fuzz harnesses work the way we expect them to work. One thing tested is that we are able to reach different unique code paths when varying input.

Each fuzz target is given one second of running time after which coverage is evaluated.

Intentionally running without a starting corpus to make sure the fuzzers can evolve from thin air :)

The total running time of `test_fuzzing_harnesses.sh` is less than a minute.

Example output:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ contrib/devtools/test_fuzzing_harnesses.sh
Found 21 fuzz harnesses to test.

Testing fuzzer address_deserialize during 1 second(s)
A subset of reached functions:
	NEW_FUNC[1/6]: 0x5592a0fa3430 in CDataStream& CDataStream::operator>><CAddress&>(CAddress&) src/./streams.h:460
	NEW_FUNC[2/6]: 0x5592a0fa4950 in void CAddress::SerializationOp<CDataStream, CSerActionUnserialize>(CDataStream&, CSerActionUnserialize) src/./protocol.h:337
	NEW_FUNC[3/6]: 0x5592a1ed2360 in CService::CService() src/netaddress.cpp:570
	NEW_FUNC[4/6]: 0x5592a1f03670 in CAddress::CAddress() src/protocol.cpp:145
	NEW_FUNC[5/6]: 0x5592a1f03780 in CAddress::Init() src/protocol.cpp:156
	NEW_FUNC[0/3]: 0x5592a0fa5440 in void SerReadWriteMany<CDataStream, CService&>(CDataStream&, CSerActionUnserialize, CService&) src/./serialize.h:989
	NEW_FUNC[1/3]: 0x5592a0fa5670 in void CService::SerializationOp<CDataStream, CSerActionUnserialize>(CDataStream&, CSerActionUnserialize) src/./netaddress.h:167
	NEW_FUNC[2/3]: 0x5592a0fa5ac0 in void BigEndian<unsigned short>::Unserialize<CDataStream>(CDataStream&) src/./serialize.h:474
stat::number_of_executed_units: 10343
stat::average_exec_per_sec:     5171
stat::new_units_added:          41
stat::slowest_unit_time_sec:    0
stat::peak_rss_mb:              147
Number of unique code paths reached during fuzzing round: 13

Testing fuzzer addrman_deserialize during 1 second(s)
A subset of reached functions:
	NEW_FUNC[0/61]: 0x55c567eabaa0 in UniqueLock<AnnotatedMixin<std::recursive_mutex>, std::unique_lock<std::recursive_mutex> >::UniqueLock(AnnotatedMixin<std::recursive_mutex>&, char const*, char const*, int, bool) src/./sync.h:146
	NEW_FUNC[1/61]: 0x55c567eabf00 in UniqueLock<AnnotatedMixin<std::recursive_mutex>, std::unique_lock<std::recursive_mutex> >::~UniqueLock() src/./sync.h:165
	NEW_FUNC[2/61]: 0x55c567eae5b0 in FastRandomContext::FillByteBuffer() src/./random.h:114
	NEW_FUNC[3/61]: 0x55c567eca850 in uint256::uint256() src/./uint256.h:123
	NEW_FUNC[4/61]: 0x55c567ed4f50 in UniqueLock<AnnotatedMixin<std::recursive_mutex>, std::unique_lock<std::recursive_mutex> >::Enter(char const*, char const*, int) src/./sync.h:123
	NEW_FUNC[12/61]: 0x55c567f07320 in CDataStream& CDataStream::operator>><unsigned char&>(unsigned char&) src/./streams.h:460
	NEW_FUNC[13/61]: 0x55c567f1d750 in CAddrMan::CAddrMan() src/./addrman.h:481
	NEW_FUNC[14/61]: 0x55c567f1dec0 in CDataStream& CDataStream::operator>><CAddrMan&>(CAddrMan&) src/./streams.h:460
	NEW_FUNC[15/61]: 0x55c567f1e050 in CAddrMan::~CAddrMan() src/./addrman.h:486
	NEW_FUNC[16/61]: 0x55c567f1e250 in CAddrMan::Clear() src/./addrman.h:457
stat::number_of_executed_units: 394
stat::average_exec_per_sec:     197
stat::new_units_added:          14
stat::slowest_unit_time_sec:    0
stat::peak_rss_mb:              111
Number of unique code paths reached during fuzzing round: 12

…

All fuzz harnesses seem to work as expected.
```

Commits:

* Add `contrib/devtools/test_fuzzing_harnesses.sh`
* Run `test_fuzzing_harnesses.sh` as part of `RUN_FUZZ_TESTS` in Travis
* Enable UBSan for Travis fuzzer job