### PR TITLE
build: Qt version appears only if GUI is being built

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -228,7 +228,11 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
   ],[
     bitcoin_enable_qt=no
   ])
-  AC_MSG_RESULT([$bitcoin_enable_qt (Qt5)])
+  if test x$bitcoin_enable_qt = xyes; then
+    AC_MSG_RESULT([$bitcoin_enable_qt ($QT_LIB_PREFIX)])
+  else
+    AC_MSG_RESULT([$bitcoin_enable_qt])
+  fi
 
   AC_SUBST(QT_PIE_FLAGS)
   AC_SUBST(QT_INCLUDES)


### PR DESCRIPTION
Closes #16989.

Simplifies `./configure` output for `x$bitcoin_enable_qt`.

Now:
`checking whether to build Bitcoin Core GUI... no`
`checking whether to build Bitcoin Core GUI... yes (Qt5)`