### PR TITLE
tests: Add EvalScript(...) fuzzing harness

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -59,7 +59,8 @@ FUZZ_SUITE = \
   test/setup_common.h \
   test/setup_common.cpp \
   test/fuzz/fuzz.cpp \
-  test/fuzz/fuzz.h
+  test/fuzz/fuzz.h \
+  test/fuzz/FuzzedDataProvider.h
 
 FUZZ_SUITE_LD_COMMON = \
  $(LIBBITCOIN_SERVER) \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -17,6 +17,7 @@ FUZZ_TARGETS = \
   test/fuzz/bloomfilter_deserialize \
   test/fuzz/coins_deserialize \
   test/fuzz/diskblockindex_deserialize \
+  test/fuzz/eval_script \
   test/fuzz/inv_deserialize \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
@@ -298,6 +299,12 @@ test_fuzz_diskblockindex_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDE
 test_fuzz_diskblockindex_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_diskblockindex_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_diskblockindex_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_eval_script_SOURCES = $(FUZZ_SUITE) test/fuzz/eval_script.cpp
+test_fuzz_eval_script_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_eval_script_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_eval_script_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_eval_script_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_txoutcompressor_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_txoutcompressor_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTXOUTCOMPRESSOR_DESERIALIZE=1

--- a/src/test/fuzz/FuzzedDataProvider.h
+++ b/src/test/fuzz/FuzzedDataProvider.h
@@ -1,0 +1,245 @@
+//===- FuzzedDataProvider.h - Utility header for fuzz targets ---*- C++ -* ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// A single header library providing an utility class to break up an array of
+// bytes. Whenever run on the same input, provides the same output, as long as
+// its methods are called in the same order, with the same arguments.
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_FUZZER_FUZZED_DATA_PROVIDER_H_
+#define LLVM_FUZZER_FUZZED_DATA_PROVIDER_H_
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <algorithm>
+#include <cstring>
+#include <initializer_list>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+class FuzzedDataProvider {
+public:
+  // |data| is an array of length |size| that the FuzzedDataProvider wraps to
+  // provide more granular access. |data| must outlive the FuzzedDataProvider.
+  FuzzedDataProvider(const uint8_t *data, size_t size)
+      : data_ptr_(data), remaining_bytes_(size) {}
+  ~FuzzedDataProvider() = default;
+
+  // Returns a std::vector containing |num_bytes| of input data. If fewer than
+  // |num_bytes| of data remain, returns a shorter std::vector containing all
+  // of the data that's left. Can be used with any byte sized type, such as
+  // char, unsigned char, uint8_t, etc.
+  template <typename T> std::vector<T> ConsumeBytes(size_t num_bytes) {
+    num_bytes = std::min(num_bytes, remaining_bytes_);
+    return ConsumeBytes<T>(num_bytes, num_bytes);
+  }
+
+  // Similar to |ConsumeBytes|, but also appends the terminator value at the end
+  // of the resulting vector. Useful, when a mutable null-terminated C-string is
+  // needed, for example. But that is a rare case. Better avoid it, if possible,
+  // and prefer using |ConsumeBytes| or |ConsumeBytesAsString| methods.
+  template <typename T>
+  std::vector<T> ConsumeBytesWithTerminator(size_t num_bytes,
+                                            T terminator = 0) {
+    num_bytes = std::min(num_bytes, remaining_bytes_);
+    std::vector<T> result = ConsumeBytes<T>(num_bytes + 1, num_bytes);
+    result.back() = terminator;
+    return result;
+  }
+
+  // Returns a std::string containing |num_bytes| of input data. Using this and
+  // |.c_str()| on the resulting string is the best way to get an immutable
+  // null-terminated C string. If fewer than |num_bytes| of data remain, returns
+  // a shorter std::string containing all of the data that's left.
+  std::string ConsumeBytesAsString(size_t num_bytes) {
+    static_assert(sizeof(std::string::value_type) == sizeof(uint8_t),
+                  "ConsumeBytesAsString cannot convert the data to a string.");
+
+    num_bytes = std::min(num_bytes, remaining_bytes_);
+    std::string result(
+        reinterpret_cast<const std::string::value_type *>(data_ptr_),
+        num_bytes);
+    Advance(num_bytes);
+    return result;
+  }
+
+  // Returns a number in the range [min, max] by consuming bytes from the
+  // input data. The value might not be uniformly distributed in the given
+  // range. If there's no input data left, always returns |min|. |min| must
+  // be less than or equal to |max|.
+  template <typename T> T ConsumeIntegralInRange(T min, T max) {
+    static_assert(std::is_integral<T>::value, "An integral type is required.");
+    static_assert(sizeof(T) <= sizeof(uint64_t), "Unsupported integral type.");
+
+    if (min > max)
+      abort();
+
+    // Use the biggest type possible to hold the range and the result.
+    uint64_t range = static_cast<uint64_t>(max) - min;
+    uint64_t result = 0;
+    size_t offset = 0;
+
+    while (offset < sizeof(T) * CHAR_BIT && (range >> offset) > 0 &&
+           remaining_bytes_ != 0) {
+      // Pull bytes off the end of the seed data. Experimentally, this seems to
+      // allow the fuzzer to more easily explore the input space. This makes
+      // sense, since it works by modifying inputs that caused new code to run,
+      // and this data is often used to encode length of data read by
+      // |ConsumeBytes|. Separating out read lengths makes it easier modify the
+      // contents of the data that is actually read.
+      --remaining_bytes_;
+      result = (result << CHAR_BIT) | data_ptr_[remaining_bytes_];
+      offset += CHAR_BIT;
+    }
+
+    // Avoid division by 0, in case |range + 1| results in overflow.
+    if (range != std::numeric_limits<decltype(range)>::max())
+      result = result % (range + 1);
+
+    return static_cast<T>(min + result);
+  }
+
+  // Returns a std::string of length from 0 to |max_length|. When it runs out of
+  // input data, returns what remains of the input. Designed to be more stable
+  // with respect to a fuzzer inserting characters than just picking a random
+  // length and then consuming that many bytes with |ConsumeBytes|.
+  std::string ConsumeRandomLengthString(size_t max_length) {
+    // Reads bytes from the start of |data_ptr_|. Maps "\\" to "\", and maps "\"
+    // followed by anything else to the end of the string. As a result of this
+    // logic, a fuzzer can insert characters into the string, and the string
+    // will be lengthened to include those new characters, resulting in a more
+    // stable fuzzer than picking the length of a string independently from
+    // picking its contents.
+    std::string result;
+
+    // Reserve the anticipated capaticity to prevent several reallocations.
+    result.reserve(std::min(max_length, remaining_bytes_));
+    for (size_t i = 0; i < max_length && remaining_bytes_ != 0; ++i) {
+      char next = ConvertUnsignedToSigned<char>(data_ptr_[0]);
+      Advance(1);
+      if (next == '\\' && remaining_bytes_ != 0) {
+        next = ConvertUnsignedToSigned<char>(data_ptr_[0]);
+        Advance(1);
+        if (next != '\\')
+          break;
+      }
+      result += next;
+    }
+
+    result.shrink_to_fit();
+    return result;
+  }
+
+  // Returns a std::vector containing all remaining bytes of the input data.
+  template <typename T> std::vector<T> ConsumeRemainingBytes() {
+    return ConsumeBytes<T>(remaining_bytes_);
+  }
+
+  // Prefer using |ConsumeRemainingBytes| unless you actually need a std::string
+  // object.
+  // Returns a std::vector containing all remaining bytes of the input data.
+  std::string ConsumeRemainingBytesAsString() {
+    return ConsumeBytesAsString(remaining_bytes_);
+  }
+
+  // Returns a number in the range [Type's min, Type's max]. The value might
+  // not be uniformly distributed in the given range. If there's no input data
+  // left, always returns |min|.
+  template <typename T> T ConsumeIntegral() {
+    return ConsumeIntegralInRange(std::numeric_limits<T>::min(),
+                                  std::numeric_limits<T>::max());
+  }
+
+  // Reads one byte and returns a bool, or false when no data remains.
+  bool ConsumeBool() { return 1 & ConsumeIntegral<uint8_t>(); }
+
+  // Returns a copy of a value selected from a fixed-size |array|.
+  template <typename T, size_t size>
+  T PickValueInArray(const T (&array)[size]) {
+    static_assert(size > 0, "The array must be non empty.");
+    return array[ConsumeIntegralInRange<size_t>(0, size - 1)];
+  }
+
+  template <typename T>
+  T PickValueInArray(std::initializer_list<const T> list) {
+    // static_assert(list.size() > 0, "The array must be non empty.");
+    return *(list.begin() + ConsumeIntegralInRange<size_t>(0, list.size() - 1));
+  }
+
+  // Return an enum value. The enum must start at 0 and be contiguous. It must
+  // also contain |kMaxValue| aliased to its largest (inclusive) value. Such as:
+  // enum class Foo { SomeValue, OtherValue, kMaxValue = OtherValue };
+  template <typename T> T ConsumeEnum() {
+    static_assert(std::is_enum<T>::value, "|T| must be an enum type.");
+    return static_cast<T>(ConsumeIntegralInRange<uint32_t>(
+        0, static_cast<uint32_t>(T::kMaxValue)));
+  }
+
+  // Reports the remaining bytes available for fuzzed input.
+  size_t remaining_bytes() { return remaining_bytes_; }
+
+private:
+  FuzzedDataProvider(const FuzzedDataProvider &) = delete;
+  FuzzedDataProvider &operator=(const FuzzedDataProvider &) = delete;
+
+  void Advance(size_t num_bytes) {
+    if (num_bytes > remaining_bytes_)
+      abort();
+
+    data_ptr_ += num_bytes;
+    remaining_bytes_ -= num_bytes;
+  }
+
+  template <typename T>
+  std::vector<T> ConsumeBytes(size_t size, size_t num_bytes_to_consume) {
+    static_assert(sizeof(T) == sizeof(uint8_t), "Incompatible data type.");
+
+    // The point of using the size-based constructor below is to increase the
+    // odds of having a vector object with capacity being equal to the length.
+    // That part is always implementation specific, but at least both libc++ and
+    // libstdc++ allocate the requested number of bytes in that constructor,
+    // which seems to be a natural choice for other implementations as well.
+    // To increase the odds even more, we also call |shrink_to_fit| below.
+    std::vector<T> result(size);
+    std::memcpy(result.data(), data_ptr_, num_bytes_to_consume);
+    Advance(num_bytes_to_consume);
+
+    // Even though |shrink_to_fit| is also implementation specific, we expect it
+    // to provide an additional assurance in case vector's constructor allocated
+    // a buffer which is larger than the actual amount of data we put inside it.
+    result.shrink_to_fit();
+    return result;
+  }
+
+  template <typename TS, typename TU> TS ConvertUnsignedToSigned(TU value) {
+    static_assert(sizeof(TS) == sizeof(TU), "Incompatible data types.");
+    static_assert(!std::numeric_limits<TU>::is_signed,
+                  "Source type must be unsigned.");
+
+    // TODO(Dor1s): change to `if constexpr` once C++17 becomes mainstream.
+    if (std::numeric_limits<TS>::is_modulo)
+      return static_cast<TS>(value);
+
+    // Avoid using implementation-defined unsigned to signer conversions.
+    // To learn more, see https://stackoverflow.com/questions/13150449.
+    if (value <= std::numeric_limits<TS>::max())
+      return static_cast<TS>(value);
+    else {
+      constexpr auto TS_min = std::numeric_limits<TS>::min();
+      return TS_min + static_cast<char>(value - TS_min);
+    }
+  }
+
+  const uint8_t *data_ptr_;
+  size_t remaining_bytes_;
+};
+
+#endif // LLVM_FUZZER_FUZZED_DATA_PROVIDER_H_

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/interpreter.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+
+#include <limits>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const unsigned int flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const std::vector<uint8_t> script_bytes = [&] {
+        if (fuzzed_data_provider.remaining_bytes() != 0) {
+            return fuzzed_data_provider.ConsumeRemainingBytes<uint8_t>();
+        } else {
+            // Avoid UBSan warning:
+            //   test/fuzz/FuzzedDataProvider.h:212:17: runtime error: null pointer passed as argument 1, which is declared to never be null
+            //   /usr/include/string.h:43:28: note: nonnull attribute specified here
+            return std::vector<uint8_t>();
+        }
+    }();
+    const CScript script(script_bytes.begin(), script_bytes.end());
+    for (const auto sig_version : {SigVersion::BASE, SigVersion::WITNESS_V0}) {
+        std::vector<std::vector<unsigned char>> stack;
+        (void)EvalScript(stack, script, flags, BaseSignatureChecker(), sig_version, nullptr);
+    }
+}

--- a/test/lint/lint-filenames.sh
+++ b/test/lint/lint-filenames.sh
@@ -12,7 +12,7 @@ export LC_ALL=C
 EXIT_CODE=0
 OUTPUT=$(git ls-files --full-name -- "*.[cC][pP][pP]" "*.[hH]" "*.[pP][yY]" "*.[sS][hH]" | \
     grep -vE '^[a-z0-9_./-]+$' | \
-    grep -vE '^src/(secp256k1|univalue)/')
+    grep -vE '^src/(secp256k1/|univalue/|test/fuzz/FuzzedDataProvider.h)')
 
 if [[ ${OUTPUT} != "" ]]; then
     echo "Use only lowercase alphanumerics (a-z0-9), underscores (_), hyphens (-) and dots (.)"

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -10,7 +10,7 @@ export LC_ALL=C
 HEADER_ID_PREFIX="BITCOIN_"
 HEADER_ID_SUFFIX="_H"
 
-REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"
+REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|secp256k1/|test/fuzz/FuzzedDataProvider.h|tinyformat.h|univalue/)"
 
 EXIT_CODE=0
 for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")


### PR DESCRIPTION
Add `EvalScript(...)` fuzzing harness.

To test this PR:

We can run `contrib/devtools/test_fuzzing_harnesses.sh` (#17000) during five seconds to quickly verify that the newly added  fuzz harness seem to hit relevant code regions, that the fuzzing throughput seems reasonable, etc.

`test_fuzzing_harnesses.sh eval 5` runs all fuzzers matching the regexp `eval` giving them five seconds of runtime each.

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ contrib/devtools/test_fuzzing_harnesses.sh eval 5
Testing fuzzer eval_script during 5 second(s)
A subset of reached functions:
        NEW_FUNC[1/24]: 0x557b808742e0 in prevector<28u, unsigned char, unsigned int, int>::indirect_ptr(int) src/./prevector.h:161
        NEW_FUNC[2/24]: 0x557b80875460 in prevector<28u, unsigned char, unsigned int, int>::indirect_ptr(int) const src/./prevector.h:162
        NEW_FUNC[6/9]: 0x557b81acdaa0 in popstack(std::vector<std::vector<unsigned char, std::allocator<unsigned char> >, std::allocator<std::vector<unsigned char, std::allocator<unsigned char> > > >&) src/script/interpreter.cpp:57
        NEW_FUNC[5/16]: 0x557b809f1bf0 in CScriptNum::serialize(long const&) src/./script/script.h:326
        NEW_FUNC[4/6]: 0x557b817c93d0 in CScriptNum::CScriptNum(std::vector<unsigned char, std::allocator<unsigned char> > const&, bool, unsigned long) src/./script/script.h:225
        NEW_FUNC[5/6]: 0x557b817cbb80 in CScriptNum::set_vch(std::vector<unsigned char, std::allocator<unsigned char> > const&) src/./script/script.h:360
        NEW_FUNC[0/11]: 0x557b80a88170 in CHash256::Write(unsigned char const*, unsigned long) src/./hash.h:34
        NEW_FUNC[1/11]: 0x557b80a88270 in CHash256::Finalize(unsigned char*) src/./hash.h:28
        NEW_FUNC[5/11]: 0x557b81affdb0 in CSHA256::CSHA256() src/crypto/sha256.cpp:644
        NEW_FUNC[6/11]: 0x557b81affe80 in (anonymous namespace)::sha256::Initialize(unsigned int*) src/crypto/sha256.cpp:66
        NEW_FUNC[7/11]: 0x557b81b00460 in CSHA256::Write(unsigned char const*, unsigned long) src/crypto/sha256.cpp:649
        NEW_FUNC[8/11]: 0x557b81b009a0 in CSHA256::Finalize(unsigned char*) src/crypto/sha256.cpp:675
        NEW_FUNC[9/11]: 0x557b81b015e0 in CSHA256::Reset() src/crypto/sha256.cpp:692
        NEW_FUNC[10/11]: 0x557b81b01d90 in (anonymous namespace)::sha256::Transform(unsigned int*, unsigned char const*, unsigned long) src/crypto/sha256.cpp:79
        NEW_FUNC[0/1]: 0x557b808cc180 in BaseSignatureChecker::CheckLockTime(CScriptNum const&) const src/./script/interpreter.h:153
        NEW_FUNC[0/2]: 0x557b81ab5640 in CastToBool(std::vector<unsigned char, std::allocator<unsigned char> > const&) src/script/interpreter.cpp:36
        NEW_FUNC[0/1]: 0x557b817c9c30 in CScriptNum::getint() const src/./script/script.h:312
        NEW_FUNC[0/1]: 0x557b81ae1df0 in CScriptNum::operator-=(long const&) src/./script/script.h:298
        NEW_FUNC[0/5]: 0x557b81af5670 in CRIPEMD160::CRIPEMD160() src/crypto/ripemd160.cpp:243
        NEW_FUNC[1/5]: 0x557b81af5740 in (anonymous namespace)::ripemd160::Initialize(unsigned int*) src/crypto/ripemd160.cpp:25
        NEW_FUNC[2/5]: 0x557b81af5b00 in CRIPEMD160::Write(unsigned char const*, unsigned long) src/crypto/ripemd160.cpp:248
        NEW_FUNC[3/5]: 0x557b81af5fa0 in (anonymous namespace)::ripemd160::Transform(unsigned int*, unsigned char const*) src/crypto/ripemd160.cpp:55
        NEW_FUNC[4/5]: 0x557b81af8d60 in CRIPEMD160::Finalize(unsigned char*) src/crypto/ripemd160.cpp:274
        NEW_FUNC[0/16]: 0x557b80857a30 in CScript::operator<<(std::vector<unsigned char, std::allocator<unsigned char> > const&) src/./script/script.h:462
        NEW_FUNC[1/16]: 0x557b80872670 in prevector<28u, unsigned char, unsigned int, int>::insert(prevector<28u, unsigned char, unsigned int, int>::iterator, unsigned char const&) src/./prevector.h:342
        NEW_FUNC[2/16]: 0x557b80872e00 in void prevector<28u, unsigned char, unsigned int, int>::insert<__gnu_cxx::__normal_iterator<unsigned char const*, std::vector<unsigned char, std::allocator<unsigned char> > > >(prevector<28u, unsigned char, unsigned int, int>::iterator, __gnu_cxx::__normal_iterator<unsigned char const*, std::vector<unsigned char, std::allocator<unsigned char> > >, __gnu_cxx::__normal_iterator<unsigned char const*, std::vector<unsigned char, std::allocator<unsigned char> > >) src/./prevector.h:368
        NEW_FUNC[3/16]: 0x557b80873630 in prevector<28u, unsigned char, unsigned int, int>::capacity() const src/./prevector.h:295
        NEW_FUNC[4/16]: 0x557b80874ed0 in void prevector<28u, unsigned char, unsigned int, int>::fill<prevector<28u, unsigned char, unsigned int, int>::const_iterator>(unsigned char*, prevector<28u, unsigned char, unsigned int, int>::const_iterator, prevector<28u, unsigned char, unsigned int, int>::const_iterator) src/./prevector.h:204
        NEW_FUNC[5/16]: 0x557b808cc0f0 in BaseSignatureChecker::CheckSig(std::vector<unsigned char, std::allocator<unsigned char> > const&, std::vector<unsigned char, std::allocator<unsigned char> > const&, CScript const&, SigVersion) const src/./script/interpreter.h:148
        NEW_FUNC[6/16]: 0x557b809edb10 in CScript::operator=(CScript&&) src/./script/script.h:390
        NEW_FUNC[7/16]: 0x557b809f8ec0 in void prevector<28u, unsigned char, unsigned int, int>::insert<prevector<28u, unsigned char, unsigned int, int>::const_iterator>(prevector<28u, unsigned char, unsigned int, int>::iterator, prevector<28u, unsigned char, unsigned int, int>::const_iterator, prevector<28u, unsigned char, unsigned int, int>::const_iterator) src/./prevector.h:368
        NEW_FUNC[8/16]: 0x557b809f9260 in prevector<28u, unsigned char, unsigned int, int>::swap(prevector<28u, unsigned char, unsigned int, int>&) src/./prevector.h:451
        NEW_FUNC[9/16]: 0x557b81ab58c0 in CheckSignatureEncoding(std::vector<unsigned char, std::allocator<unsigned char> > const&, unsigned int, ScriptError_t*) src/script/interpreter.cpp:200
        NEW_FUNC[10/16]: 0x557b81ab6f30 in FindAndDelete(CScript&, CScript const&) src/script/interpreter.cpp:254
        NEW_FUNC[11/16]: 0x557b81acdc20 in CheckPubKeyEncoding(std::vector<unsigned char, std::allocator<unsigned char> > const&, unsigned int, SigVersion const&, ScriptError_t*) src/script/interpreter.cpp:217
        NEW_FUNC[12/16]: 0x557b81ad3890 in IsCompressedOrUncompressedPubKey(std::vector<unsigned char, std::allocator<unsigned char> > const&) src/script/interpreter.cpp:63
        NEW_FUNC[13/16]: 0x557b81ad8830 in CScript::GetOp(prevector<28u, unsigned char, unsigned int, int>::const_iterator&, opcodetype&) const src/./script/script.h:505
        NEW_FUNC[14/16]: 0x557b81ae21a0 in prevector<28u, unsigned char, unsigned int, int>::prevector<prevector<28u, unsigned char, unsigned int, int>::const_iterator>(prevector<28u, unsigned char, unsigned int, int>::const_iterator, prevector<28u, unsigned char, unsigned int, int>::const_iterator) src/./prevector.h:246
        NEW_FUNC[0/1]: 0x557b81ae1a40 in CScriptNum::operator+=(long const&) src/./script/script.h:290
        NEW_FUNC[0/5]: 0x557b81af9760 in CSHA1::CSHA1() src/crypto/sha1.cpp:150
        NEW_FUNC[1/5]: 0x557b81af9830 in (anonymous namespace)::sha1::Initialize(unsigned int*) src/crypto/sha1.cpp:32
        NEW_FUNC[2/5]: 0x557b81af9bf0 in CSHA1::Write(unsigned char const*, unsigned long) src/crypto/sha1.cpp:155
        NEW_FUNC[3/5]: 0x557b81afa090 in (anonymous namespace)::sha1::Transform(unsigned int*, unsigned char const*) src/crypto/sha1.cpp:47
        NEW_FUNC[4/5]: 0x557b81afc5e0 in CSHA1::Finalize(unsigned char*) src/crypto/sha1.cpp:181
        NEW_FUNC[0/1]: 0x557b81ada4f0 in CScriptNum::operator-() const src/./script/script.h:278
        NEW_FUNC[0/1]: 0x557b808cc210 in BaseSignatureChecker::CheckSequence(CScriptNum const&) const src/./script/interpreter.h:158
        NEW_FUNC[0/1]: 0x557b81ab5c00 in IsValidSignatureEncoding(std::vector<unsigned char, std::allocator<unsigned char> > const&) src/script/interpreter.cpp:107
stat::number_of_executed_units: 9728
stat::average_exec_per_sec:     1621
stat::new_units_added:          844
stat::slowest_unit_time_sec:    0
stat::peak_rss_mb:              326
Number of unique code paths taken during fuzzing round: 583

Tested fuzz harnesses seem to work as expected.
```