### PR TITLE
tests: Add descriptor Parse(...) fuzzing harness

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -16,6 +16,7 @@ FUZZ_TARGETS = \
   test/fuzz/blockundo_deserialize \
   test/fuzz/bloomfilter_deserialize \
   test/fuzz/coins_deserialize \
+  test/fuzz/descriptor_parse \
   test/fuzz/diskblockindex_deserialize \
   test/fuzz/eval_script \
   test/fuzz/inv_deserialize \
@@ -252,6 +253,12 @@ test_fuzz_coins_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DCOIN
 test_fuzz_coins_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_coins_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_coins_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_descriptor_parse_SOURCES = $(FUZZ_SUITE) test/fuzz/descriptor_parse.cpp
+test_fuzz_descriptor_parse_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_descriptor_parse_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_descriptor_parse_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_descriptor_parse_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_netaddr_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_netaddr_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DNETADDR_DESERIALIZE=1

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <script/descriptor.h>
+#include <test/fuzz/fuzz.h>
+
+void initialize()
+{
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    const std::string descriptor(buffer.begin(), buffer.end());
+    FlatSigningProvider signing_provider;
+    std::string error;
+    for (const bool require_checksum : {true, false}) {
+        Parse(descriptor, signing_provider, error, require_checksum);
+    }
+}

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -22,7 +22,9 @@ static bool read_stdin(std::vector<uint8_t>& data)
     return length == 0;
 }
 
-static void initialize()
+// Default initialization: Override using a non-weak initialize().
+__attribute__((weak))
+void initialize()
 {
     const static auto verify_handle = MakeUnique<ECCVerifyHandle>();
 }

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <vector>
 
-
+void initialize();
 void test_one_input(const std::vector<uint8_t>& buffer);
 
 #endif // BITCOIN_TEST_FUZZ_FUZZ_H


### PR DESCRIPTION
Add `Parse(...)` (descriptor) fuzzing harness.

To test this PR:

We can run `test_fuzzing_harnesses.sh` (#17000) during ten seconds to quickly verify that the newly added  fuzz harness seem to hit relevant code regions, that the fuzzing throughput seems reasonable, etc.

`test_fuzzing_harnesses.sh descriptor 10` runs all fuzzers matching the regexp `descriptor` giving them ten seconds of runtime each.

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ contrib/devtools/test_fuzzing_harnesses.sh descriptor 10
Testing fuzzer descriptor_parse during 10 second(s)
A subset of reached functions:
        NEW_FUNC[0/17]: 0x55ec8a240c90 in tinyformat::detail::formatImpl(std::ostream&, char const*, tinyformat::detail::FormatArg const*, int) src/./tinyformat.h:791
        NEW_FUNC[4/17]: 0x55ec8a2435f0 in tinyformat::detail::printFormatStringLiteral(std::ostream&, char const*) src/./tinyformat.h:564
        NEW_FUNC[5/17]: 0x55ec8a2439d0 in tinyformat::detail::streamStateFromFormat(std::ostream&, bool&, int&, char const*, tinyformat::detail::FormatArg const*, int&, int) src/./tinyformat.h:601
        NEW_FUNC[6/17]: 0x55ec8a24a3d0 in tinyformat::detail::FormatArg::format(std::ostream&, char const*, char const*, int) const src/./tinyformat.h:513
        NEW_FUNC[12/17]: 0x55ec8a29cd70 in void tinyformat::detail::FormatArg::formatImpl<long>(std::ostream&, char const*, char const*, int, void const*) src/./tinyformat.h:530
        NEW_FUNC[13/17]: 0x55ec8a29cf50 in void tinyformat::formatValue<long>(std::ostream&, char const*, char const*, int, long const&) src/./tinyformat.h:317
        NEW_FUNC[14/17]: 0x55ec8a2ea450 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > tinyformat::format<long>(char const*, long const&) src/./tinyformat.h:976
        NEW_FUNC[15/17]: 0x55ec8a346ac0 in void tinyformat::format<long>(std::ostream&, char const*, long const&) src/./tinyformat.h:968
        NEW_FUNC[16/17]: 0x55ec8a346d80 in tinyformat::detail::FormatListN<1>::FormatListN<long>(long const&) src/./tinyformat.h:885
        NEW_FUNC[0/16]: 0x55ec8a210c90 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > tinyformat::format<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/./tinyformat.h:976
        NEW_FUNC[2/16]: 0x55ec8a25c3e0 in void tinyformat::format<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::ostream&, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/./tinyformat.h:968
        NEW_FUNC[3/16]: 0x55ec8a25c6a0 in tinyformat::detail::FormatListN<1>::FormatListN<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/./tinyformat.h:885
        NEW_FUNC[4/16]: 0x55ec8a25c980 in void tinyformat::detail::FormatArg::formatImpl<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::ostream&, char const*, char const*, int, void const*) src/./tinyformat.h:530
        NEW_FUNC[6/16]: 0x55ec8b29cc60 in (anonymous namespace)::ParseScript(Span<char const>&, (anonymous namespace)::ParseScriptContext, FlatSigningProvider&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) src/script/descriptor.cpp:810
        NEW_FUNC[8/16]: 0x55ec8b2a4710 in (anonymous namespace)::Expr(Span<char const>&) src/script/descriptor.cpp:657
        NEW_FUNC[9/16]: 0x55ec8b2a4d40 in (anonymous namespace)::Func(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Span<char const>&) src/script/descriptor.cpp:647
        NEW_FUNC[15/16]: 0x55ec8b2d7dd0 in Span<char const>::subspan(long) const src/./span.h:33
        NEW_FUNC[0/1]: 0x55ec8b2d7830 in Span<char const>::operator[](long) const src/./span.h:31
        NEW_FUNC[0/10]: 0x55ec8a2ea090 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > tinyformat::format<char const*>(char const*, char const* const&) src/./tinyformat.h:976
        NEW_FUNC[1/10]: 0x55ec8a345d40 in void tinyformat::format<char const*>(std::ostream&, char const*, char const* const&) src/./tinyformat.h:968
        NEW_FUNC[2/10]: 0x55ec8a346000 in tinyformat::detail::FormatListN<1>::FormatListN<char const*>(char const* const&) src/./tinyformat.h:885
        NEW_FUNC[3/10]: 0x55ec8a3462e0 in void tinyformat::detail::FormatArg::formatImpl<char const*>(std::ostream&, char const*, char const*, int, void const*) src/./tinyformat.h:530
        NEW_FUNC[4/10]: 0x55ec8a3464b0 in void tinyformat::formatValue<char const*>(std::ostream&, char const*, char const*, int, char const* const&) src/./tinyformat.h:317
        NEW_FUNC[8/10]: 0x55ec8b438ef0 in ParsePrechecks(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/util/strencodings.cpp:267
        NEW_FUNC[9/10]: 0x55ec8b4398b0 in ParseUInt32(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int*) src/util/strencodings.cpp:309
        NEW_FUNC[0/3]: 0x55ec8a2e9430 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > tinyformat::format<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/./tinyformat.h:976
        NEW_FUNC[1/3]: 0x55ec8a33a6f0 in void tinyformat::format<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::ostream&, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/./tinyformat.h:968
        NEW_FUNC[2/3]: 0x55ec8a33aa40 in tinyformat::detail::FormatListN<2>::FormatListN<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/./tinyformat.h:885
        NEW_FUNC[1/2]: 0x55ec8b4331b0 in IsHex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/util/strencodings.cpp:61
        NEW_FUNC[13/24]: 0x55ec8b126eb0 in Params() src/chainparams.cpp:384
        NEW_FUNC[14/24]: 0x55ec8b19a500 in DecodeDestination(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) src/key_io.cpp:217
        NEW_FUNC[15/24]: 0x55ec8b19a610 in (anonymous namespace)::DecodeDestination(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, CChainParams const&) src/key_io.cpp:74
        NEW_FUNC[18/24]: 0x55ec8b357160 in IsValidDestination(boost::variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown> const&) src/script/standard.cpp:325
        NEW_FUNC[19/24]: 0x55ec8b36fe40 in DecodeBase58(char const*, std::vector<unsigned char, std::allocator<unsigned char> >&) src/base58.cpp:36
stat::number_of_executed_units: 54900
stat::average_exec_per_sec:     4990
stat::new_units_added:          421
stat::slowest_unit_time_sec:    0
stat::peak_rss_mb:              412
Number of unique code paths taken during fuzzing round: 93

Tested fuzz harnesses seem to work as expected.
```