### PR TITLE
doc: warn that ranged multi() descriptors are not BIP67 compatible

### DIFF
--- a/doc/descriptors.md
+++ b/doc/descriptors.md
@@ -114,6 +114,10 @@ or `*'`, the `multi()` expression only matches multisig scripts with the `i`th
 child key from each wildcard path in lockstep, rather than scripts with any
 combination of child keys from each wildcard path.
 
+Ranged multi() descriptors are incompatible with
+[BIP67](https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki), because
+public keys are not canonically ordered for each index.
+
 ### BIP32 derived keys and chains
 
 Most modern wallet software and hardware uses keys that are derived using

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -170,10 +170,11 @@ UniValue deriveaddresses(const JSONRPCRequest& request)
             RPCHelpMan{"deriveaddresses",
             {"\nDerives one or more addresses corresponding to an output descriptor.\n"
             "Examples of output descriptors are:\n"
-            "    pkh(<pubkey>)                        P2PKH outputs for the given pubkey\n"
-            "    wpkh(<pubkey>)                       Native segwit P2PKH outputs for the given pubkey\n"
-            "    sh(multi(<n>,<pubkey>,<pubkey>,...)) P2SH-multisig outputs for the given threshold and pubkeys\n"
-            "    raw(<hex script>)                    Outputs whose scriptPubKey equals the specified hex scripts\n"
+            "    pkh(<pubkey>)                             P2PKH outputs for the given pubkey\n"
+            "    wpkh(<pubkey>)                            Native segwit P2PKH outputs for the given pubkey\n"
+            "    sh(multi(<n>,<pubkey>,<pubkey>,...))      P2SH-multisig outputs for the given threshold and pubkeys\n"
+            "    wsh(multi(<n>,<xpub>/0/*,<xpub>/0/*,...)) Native segwit multisig output range (incompatible with BIP67)\n"
+            "    raw(<hex script>)                         Outputs whose scriptPubKey equals the specified hex scripts\n"
             "\nIn the above, <pubkey> either refers to a fixed public key in hexadecimal notation, or to an xpub/xprv optionally followed by one\n"
             "or more path elements separated by \"/\", where \"h\" represents a hardened child key.\n"
             "For more information on output descriptors, see the documentation in the doc/descriptors.md file.\n"},


### PR DESCRIPTION
This adds a quick warning to the `deriveaddresses` RPC help, and a more detailed explanation to `descriptors.md`.

<img width="764" alt="Schermafbeelding 2019-10-02 om 17 00 44" src="https://user-images.githubusercontent.com/10217/66055907-9908db80-e536-11e9-8dd5-efc02550ce87.png">

Personally I'm not a huge fan of [BIP67](https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki) as it is. It results in a different ordering for each deriviation index, depending on the public keys at that index. I would prefer to order all derived addresses by BIP32 master fingerprint.