### PR TITLE
[rpc] Include immature coinbase in listunspent

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2447,7 +2447,7 @@ CAmount CWallet::GetAvailableBalance(const CCoinControl* coinControl) const
     return balance;
 }
 
-void CWallet::AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount) const
+void CWallet::AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe, const CCoinControl* coinControl, const CAmount& nMinimumAmount, const CAmount& nMaximumAmount, const CAmount& nMinimumSumAmount, const uint64_t nMaximumCount, const bool include_immature) const
 {
     AssertLockHeld(cs_wallet);
 
@@ -2468,7 +2468,7 @@ void CWallet::AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<
             continue;
         }
 
-        if (wtx.IsImmatureCoinBase(locked_chain))
+        if (!include_immature && wtx.IsImmatureCoinBase(locked_chain))
             continue;
 
         int nDepth = wtx.GetDepthInMainChain(locked_chain);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -978,7 +978,7 @@ public:
     /**
      * populate vCoins with vector of available COutputs.
      */
-    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void AvailableCoins(interfaces::Chain::Lock& locked_chain, std::vector<COutput>& vCoins, bool fOnlySafe = true, const CCoinControl* coinControl = nullptr, const CAmount& nMinimumAmount = 1, const CAmount& nMaximumAmount = MAX_MONEY, const CAmount& nMinimumSumAmount = MAX_MONEY, const uint64_t nMaximumCount = 0, const bool include_immature = false) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /**
      * Return list of available coins and locked coins grouped by non-change output address.

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -196,6 +196,7 @@ BASE_SCRIPTS = [
     'p2p_fingerprint.py',
     'feature_uacomment.py',
     'wallet_coinbase_category.py',
+    'wallet_listunspent.py',
     'feature_filelock.py',
     'p2p_dos_header_tree.py',
     'p2p_unrequested_blocks.py',

--- a/test/functional/wallet_listunspent.py
+++ b/test/functional/wallet_listunspent.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the listunspent API."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_array_result
+
+class ListUnspentTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        # Generate one block to an address
+        address = self.nodes[0].getnewaddress()
+        self.nodes[0].generatetoaddress(1, address)
+
+        # Immature coinbase transactions should not be safe
+        assert_array_result(self.nodes[0].listunspent(),
+                    {"address": address},
+                    {"safe": False})
+
+        assert_array_result(self.nodes[0].listunspent(include_unsafe=False),
+                    {"address": address},
+                    {}, True)
+
+        new_address = self.nodes[0].getnewaddress()
+        self.nodes[0].generatetoaddress(100, new_address)
+
+        # Mature coinbase transactions should be safe
+        assert_array_result(self.nodes[0].listunspent(),
+                    {"address": address},
+                    {"safe": True})
+
+        assert_array_result(self.nodes[0].listunspent(include_unsafe=False),
+                    {"address": address},
+                    {"safe": True})
+
+
+if __name__ == '__main__':
+    ListUnspentTest().main()


### PR DESCRIPTION
`listunspent` help text is
```
Returns array of unspent transaction outputs
with between minconf and maxconf (inclusive) confirmations.
Optionally filter to only include txouts paid to specified addresses.
```
Based on that it seems that not returning immature coinbase outputs is an error. They should be returned with the `safe` field being set to false.