### PR TITLE
gui: Prevent processing duplicate payment requests

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -82,7 +82,7 @@ static QString ipcServerName()
 // the main GUI window is up and ready to ask the user
 // to send payment.
 
-static QList<QString> savedPaymentRequests;
+static QSet<QString> savedPaymentRequests;
 
 //
 // Sending to the server is done synchronously, at startup.
@@ -107,7 +107,8 @@ void PaymentServer::ipcParseCommandLine(interfaces::Node& node, int argc, char* 
         // will start a mainnet instance and throw a "wrong network" error.
         if (arg.startsWith(BITCOIN_IPC_PREFIX, Qt::CaseInsensitive)) // bitcoin: URI
         {
-            savedPaymentRequests.append(arg);
+            if (savedPaymentRequests.contains(arg)) continue;
+            savedPaymentRequests.insert(arg);
 
             SendCoinsRecipient r;
             if (GUIUtil::parseBitcoinURI(arg, &r) && !r.address.isEmpty())
@@ -127,7 +128,8 @@ void PaymentServer::ipcParseCommandLine(interfaces::Node& node, int argc, char* 
 #ifdef ENABLE_BIP70
         else if (QFile::exists(arg)) // Filename
         {
-            savedPaymentRequests.append(arg);
+            if (savedPaymentRequests.contains(arg)) continue;
+            savedPaymentRequests.insert(arg);
 
             PaymentRequestPlus request;
             if (readPaymentRequestFromFile(arg, request))
@@ -280,7 +282,7 @@ void PaymentServer::handleURIOrFile(const QString& s)
 {
     if (saveURIs)
     {
-        savedPaymentRequests.append(s);
+        savedPaymentRequests.insert(s);
         return;
     }
 


### PR DESCRIPTION
Considering the following from Qt [src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm#L267](https://github.com/qt/qtbase/blob/13e0a36626bd75e631dd9536e795a494432b1945/src/plugins/platforms/cocoa/qcocoaapplicationdelegate.mm#L267)

```cpp
- (void)application:(NSApplication *)sender openFiles:(NSArray *)filenames
{
    Q_UNUSED(filenames);
    Q_UNUSED(sender);

    for (NSString *fileName in filenames) {
        QString qtFileName = QString::fromNSString(fileName);
        if (inLaunch) {
            // We need to be careful because Cocoa will be nice enough to take
            // command line arguments and send them to us as events. Given the history
            // of Qt Applications, this will result in behavior people don't want, as
            // they might be doing the opening themselves with the command line parsing.
            if (qApp->arguments().contains(qtFileName))
                continue;
        }
        QWindowSystemInterface::handleFileOpenEvent(qtFileName);
    }
```

And that a2714a5c69f0b0506689af04c3e785f71ee0915d was merged, now Qt isn't able to filter out the above notifications, and then a [QFileOpenEvent](https://doc.qt.io/qt-5/qfileopenevent.html) event is delivered to `PaymentServer::eventFilter`, which in turn (re)adds the payment request.

This change fixes #17025, but makes sense regardless of the issue.
