### PR TITLE
qt: Fix text display when state of prune button is changed

### DIFF
--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -69,10 +69,13 @@ private:
     QString pathToCheck;
     uint64_t m_blockchain_size;
     uint64_t m_chain_state_size;
+    bool m_prune_set{false};
+    uint64_t m_prune_target{0};
 
     void startThread();
     void checkPath(const QString &dataDir);
     QString getPathToCheck();
+    void setSizeWarningLabel();
 
     friend class FreespaceChecker;
 };


### PR DESCRIPTION
Currently there is [this bug ](https://www.youtube.com/watch?v=Xr78eYiOfQE&feature=youtu.be)when enabling and disabling pruning: The intro screen isn't updated when something is changing.

This fixes the storage message in the top.
[Here](https://www.youtube.com/watch?v=Wq2nSlmbVQk&feature=youtu.be) is a video of this fix
<s>Unfortunately it doesn't fix the required storage amount, I will be working on this next.</s> Done!
This needs to get into 0.19 as well