### PR TITLE
Testschains: Many regtests with different genesis and default datadir

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -7,6 +7,7 @@
 
 #include <chainparamsseeds.h>
 #include <consensus/merkle.h>
+#include <hash.h>
 #include <tinyformat.h>
 #include <util/system.h>
 #include <util/strencodings.h>
@@ -17,13 +18,13 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
+static CBlock CreateGenesisBlock(const CScript& coinbase_sig, const CScript& genesisOutputScript, uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     CMutableTransaction txNew;
     txNew.nVersion = 1;
     txNew.vin.resize(1);
     txNew.vout.resize(1);
-    txNew.vin[0].scriptSig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+    txNew.vin[0].scriptSig = coinbase_sig;
     txNew.vout[0].nValue = genesisReward;
     txNew.vout[0].scriptPubKey = genesisOutputScript;
 
@@ -52,8 +53,10 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
 static CBlock CreateGenesisBlock(uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion, const CAmount& genesisReward)
 {
     const char* pszTimestamp = "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks";
+    const CScript coinbase_sig = CScript() << 486604799 << CScriptNum(4) << std::vector<unsigned char>((const unsigned char*)pszTimestamp, (const unsigned char*)pszTimestamp + strlen(pszTimestamp));
+
     const CScript genesisOutputScript = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
-    return CreateGenesisBlock(pszTimestamp, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
+    return CreateGenesisBlock(coinbase_sig, genesisOutputScript, nTime, nNonce, nBits, nVersion, genesisReward);
 }
 
 /**
@@ -388,6 +391,30 @@ void CRegTestParams::UpdateFromArgs(const ArgsManager& args)
     m_is_test_chain = args.GetBoolArg("-is_test_chain", true);
 }
 
+/**
+ * Custom params for creating many chains with different genesis blocks.
+ */
+class CCustomParams : public CRegTestParams {
+public:
+    CCustomParams(const std::string& chain, ArgsManager& args) : CRegTestParams(args)
+    {
+        strNetworkID = chain;
+        UpdateFromArgs(args);
+
+        CHashWriter h(SER_DISK, 0);
+        h << strNetworkID;
+        const uint256 hash = h.GetHash();
+        CScript coinbase_sig = CScript() << std::vector<uint8_t>(hash.begin(), hash.end());
+        genesis = CreateGenesisBlock(coinbase_sig, CScript(OP_RETURN), 1296688602, 2, 0x207fffff, 1, 50 * COIN);
+        consensus.hashGenesisBlock = genesis.GetHash();
+        checkpointData = {
+            {
+                {0, uint256S(consensus.hashGenesisBlock.GetHex())},
+            }
+        };
+    }
+};
+
 static std::unique_ptr<const CChainParams> globalChainParams;
 
 const CChainParams &Params() {
@@ -397,13 +424,15 @@ const CChainParams &Params() {
 
 std::unique_ptr<const CChainParams> CreateChainParams(const std::string& chain)
 {
+    // Reserved names for non-custom chains
     if (chain == CBaseChainParams::MAIN)
         return std::unique_ptr<CChainParams>(new CMainParams());
     else if (chain == CBaseChainParams::TESTNET)
         return std::unique_ptr<CChainParams>(new CTestNetParams());
     else if (chain == CBaseChainParams::REGTEST)
         return std::unique_ptr<CChainParams>(new CRegTestParams(gArgs));
-    throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+
+    return std::unique_ptr<CChainParams>(new CCustomParams(chain, gArgs));
 }
 
 void SelectParams(const std::string& network)

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -291,7 +291,7 @@ public:
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;
 
-        UpdateActivationParametersFromArgs(args);
+        UpdateFromArgs(args);
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -303,7 +303,6 @@ public:
 
         fDefaultConsistencyChecks = true;
         fRequireStandard = true;
-        m_is_test_chain = true;
         m_is_mockable_chain = true;
 
         checkpointData = {
@@ -336,6 +335,7 @@ public:
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
     void UpdateActivationParametersFromArgs(const ArgsManager& args);
+    void UpdateFromArgs(const ArgsManager& args);
 };
 
 void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
@@ -379,6 +379,13 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
             throw std::runtime_error(strprintf("Invalid deployment (%s)", vDeploymentParams[0]));
         }
     }
+}
+
+void CRegTestParams::UpdateFromArgs(const ArgsManager& args)
+{
+    UpdateActivationParametersFromArgs(args);
+
+    m_is_test_chain = args.GetBoolArg("-is_test_chain", true);
 }
 
 static std::unique_ptr<const CChainParams> globalChainParams;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -23,6 +23,7 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-segwitheight=<n>", "Set the activation height of segwit. -1 to disable. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-is_test_chain", "Whether it's allowed to set -acceptnonstdtxn=0 for this chain or not. Default: 1 (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
 }
 
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -17,7 +17,7 @@ const std::string CBaseChainParams::REGTEST = "regtest";
 
 void SetupChainParamsBaseOptions()
 {
-    gArgs.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Allowed values: main, test, regtest", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-chain=<chain>", "Use the chain <chain> (default: main). Reserved values: main, test, regtest. With any other value, a custom chain is used. All regtest-only options are available in custom chains too.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-regtest", "Enter regression test mode, which uses a special chain in which blocks can be solved instantly. "
                  "This is intended for regression testing tools and app development. Equivalent to -chain=regtest.", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-segwitheight=<n>", "Set the activation height of segwit. -1 to disable. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
@@ -42,8 +42,8 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         return MakeUnique<CBaseChainParams>("testnet3", 18332);
     else if (chain == CBaseChainParams::REGTEST)
         return MakeUnique<CBaseChainParams>("regtest", 18443);
-    else
-        throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
+
+    return MakeUnique<CBaseChainParams>(chain, 18553);
 }
 
 void SelectBaseParams(const std::string& chain)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -933,11 +933,6 @@ bool AppInitParameterInteraction()
         return InitError(strprintf(_("Config setting for %s only applied on %s network when in [%s] section.").translated, arg, network, network));
     }
 
-    // Warn if unrecognized section name are present in the config file.
-    for (const auto& section : gArgs.GetUnrecognizedSections()) {
-        InitWarning(strprintf("%s:%i " + _("Section [%s] is not recognized.").translated, section.m_file, section.m_line, section.m_name));
-    }
-
     if (!fs::is_directory(GetBlocksDir())) {
         return InitError(strprintf(_("Specified blocks directory \"%s\" does not exist.").translated, gArgs.GetArg("-blocksdir", "")));
     }

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -47,6 +47,7 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
 #define QAPP_APP_NAME_REGTEST "Bitcoin-Qt-regtest"
+#define QAPP_APP_NAME_CUSTOM "Bitcoin-Qt-custom-chain"
 
 /* One gigabyte (GB) in bytes */
 static constexpr uint64_t GB_BYTES{1000000000};

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -91,5 +91,5 @@ const NetworkStyle* NetworkStyle::instantiate(const std::string& networkId)
                     titleAddText.c_str());
         }
     }
-    return nullptr;
+    return new NetworkStyle(strprintf("%s-%s", QAPP_APP_NAME_CUSTOM, networkId).c_str(), 250, 30, titleAddText.c_str());
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -275,9 +275,11 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, consensusParams))
-                    return error("%s: CheckProofOfWork failed: %s", __func__, pindexNew->ToString());
-
+                const uint256 block_hash = pindexNew->GetBlockHash();
+                if (!CheckProofOfWork(block_hash, pindexNew->nBits, consensusParams) &&
+                    block_hash != consensusParams.hashGenesisBlock) {
+                    return error("%s: CheckProofOfWork: %s, %s", __func__, block_hash.ToString(), pindexNew->ToString());
+                }
                 pcursor->Next();
             } else {
                 return error("%s: failed to read value", __func__);

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -251,21 +251,6 @@ const std::set<std::string> ArgsManager::GetUnsuitableSectionOnlyArgs() const
     return unsuitables;
 }
 
-const std::list<SectionInfo> ArgsManager::GetUnrecognizedSections() const
-{
-    // Section names to be recognized in the config file.
-    static const std::set<std::string> available_sections{
-        CBaseChainParams::REGTEST,
-        CBaseChainParams::TESTNET,
-        CBaseChainParams::MAIN
-    };
-
-    LOCK(cs_args);
-    std::list<SectionInfo> unrecognized = m_config_sections;
-    unrecognized.remove_if([](const SectionInfo& appeared){ return available_sections.find(appeared.m_name) != available_sections.end(); });
-    return unrecognized;
-}
-
 void ArgsManager::SelectConfigNetwork(const std::string& network)
 {
     LOCK(cs_args);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -210,11 +210,6 @@ public:
     const std::set<std::string> GetUnsuitableSectionOnlyArgs() const;
 
     /**
-     * Log warnings for unrecognized section names in the config file.
-     */
-    const std::list<SectionInfo> GetUnrecognizedSections() const;
-
-    /**
      * Return a vector of strings of the given argument
      *
      * @param strArg Argument to get (e.g. "-foo")

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -42,9 +42,9 @@ class ConfArgsTest(BitcoinTestFramework):
             self.nodes[0].assert_start_raises_init_error(expected_msg='Error: Config setting for -wallet only applied on %s network when in [%s] section.' % (self.chain, self.chain))
 
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
-            conf.write('regtest=0\n') # mainnet
+            conf.write('is_test_chain=0\n') # like mainnet
             conf.write('acceptnonstdtxn=1\n')
-        self.nodes[0].assert_start_raises_init_error(expected_msg='Error: acceptnonstdtxn is not currently supported for main chain')
+        self.nodes[0].assert_start_raises_init_error(expected_msg='Error: acceptnonstdtxn is not currently supported for %s chain' % self.chain)
 
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
             conf.write('nono\n')

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -80,7 +80,7 @@ class ConfArgsTest(BitcoinTestFramework):
                     'Command-line arg: rpcpassword=****',
                     'Command-line arg: rpcuser=****',
                     'Command-line arg: torpassword=****',
-                    'Config file arg: %s="1"' % self.chain,
+                    'Config file arg: chain="%s"' % self.chain,
                     'Config file arg: [%s] server="1"' % self.chain,
                 ],
                 unexpected_msgs=[

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -62,20 +62,7 @@ class ConfArgsTest(BitcoinTestFramework):
             conf.write('server=1\nrpcuser=someuser\n[main]\nrpcpassword=some#pass')
         self.nodes[0].assert_start_raises_init_error(expected_msg='Error: Error reading configuration file: parse error on line 4, using # in rpcpassword can be ambiguous and should be avoided')
 
-        inc_conf_file2_path = os.path.join(self.nodes[0].datadir, 'include2.conf')
-        with open(os.path.join(self.nodes[0].datadir, 'bitcoin.conf'), 'a', encoding='utf-8') as conf:
-            conf.write('includeconf={}\n'.format(inc_conf_file2_path))
-
         with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
-            conf.write('testnot.datadir=1\n')
-        with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
-            conf.write('[testnet]\n')
-        self.restart_node(0)
-        self.nodes[0].stop_node(expected_stderr='Warning: ' + inc_conf_file_path + ':1 Section [testnot] is not recognized.' + os.linesep + 'Warning: ' + inc_conf_file2_path + ':1 Section [testnet] is not recognized.')
-
-        with open(inc_conf_file_path, 'w', encoding='utf-8') as conf:
-            conf.write('')  # clear
-        with open(inc_conf_file2_path, 'w', encoding='utf-8') as conf:
             conf.write('')  # clear
 
     def test_log_buffer(self):

--- a/test/functional/feature_custom_chain.py
+++ b/test/functional/feature_custom_chain.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test running bitcoind with multiple custom chains with different genesis blocks
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal
+
+EXPECTED_GENESIS_HASH = {
+    'regtest': '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+    'chain_1': '58ebd25d25b128530d4d462c65a7e679b7e053e6f25ffb8ac63bc68832fda201',
+    'chain_2': 'e07d79a4f8f1525814e421eb71aa9527fe8a25091fe1b9c5c312939c887aadc7',
+    'chain_3': 'de650213b96a541df3bd9ee530cc3da4e9424d3617f95e6b2a0d5452e23412b9',
+    'chain_4': '075e818d62bbe049a715856344987294ea2b4ff636b857911966e7fc9fee637c',
+    'chain_5': '54a435af6a093f145769b138c20d5f72b35395e7057a89d36a0b8e954031b04c',
+}
+
+class CustomChainTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        assert_equal(EXPECTED_GENESIS_HASH[self.chain], self.nodes[0].getblockhash(0))
+        self.nodes[0].generatetoaddress(1, self.nodes[0].get_deterministic_priv_key().address)
+        self.log.info("Success")
+
+if __name__ == '__main__':
+    for chain_name in EXPECTED_GENESIS_HASH.keys():
+        CustomChainTest(chain=chain_name).main()

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -90,9 +90,9 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
     This class also contains various public and private helper methods."""
 
-    def __init__(self):
+    def __init__(self, chain='regtest'):
         """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
-        self.chain = 'regtest'
+        self.chain = chain
         self.setup_clean_chain = False
         self.nodes = []
         self.network_thread = None

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -301,16 +301,14 @@ def initialize_datadir(dirname, n, chain):
     datadir = get_datadir_path(dirname, n)
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
-    # Translate chain name to config name
+
+    # Translate datadir name to chain bip70 name
     if chain == 'testnet3':
-        chain_name_conf_arg = 'testnet'
-        chain_name_conf_section = 'test'
-    else:
-        chain_name_conf_arg = chain
-        chain_name_conf_section = chain
+        chain = 'test'
+
     with open(os.path.join(datadir, "bitcoin.conf"), 'w', encoding='utf8') as f:
-        f.write("{}=1\n".format(chain_name_conf_arg))
-        f.write("[{}]\n".format(chain_name_conf_section))
+        f.write("chain={}\n".format(chain))
+        f.write("[{}]\n".format(chain))
         f.write("port=" + str(p2p_port(n)) + "\n")
         f.write("rpcport=" + str(rpc_port(n)) + "\n")
         f.write("fallbackfee=0.0002\n")

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'p2p_permissions.py',
     'feature_blocksdir.py',
     'feature_config_args.py',
+    'feature_custom_chain.py',
     'rpc_getaddressinfo_labels_purpose_deprecation.py',
     'rpc_getaddressinfo_label_deprecation.py',
     'rpc_help.py',


### PR DESCRIPTION
And bip70 name.
And on demand (meaning you don't have to mine a genesis block for it to pass minimal pow).

This allows the daemon to create a new regtest-like chains on demand.
The hash of the genesis block is dependent on the "petname" of the chain.
Examples: "regtest2, custom, chain_2, aaa, bbbb"

The hash of the genesis block could depend on more things.
For example, for signet chains, it could depend on the signet_blockscript in the case of BIP325 (signet) https://github.com/bitcoin/bitcoin/pull/16411/

In fact, #16411 could be simplified if this was merged first, for the genesis block wouldn't need to be mined anymore (which requires a special case in grindblock which in turn requires CreateSignetGenesisBlock to be exposed in chainparams). So I guess perhaps signet could be counted as a use case, or perhaps only part of this.

But why would somebody want more than one regtest?

I'm personally using it for doing cross-chain payments in lightning, see https://github.com/jtimon/multi-ln-demo/blob/master/conf/bitcoind.conf
I would like to work on what I call "cross chain trampoline payments" and I plan to keep using it for that too.

I imagine other developers could find this useful for other developments involving bitcoin-like chains.
For example atomic swaps or submarine swaps.

Of course, an alternative for these use cases is to use other regtests from other bitcoin-like networks, for example litecoin regtest or liquid regtest.

Another use case is creating temporal testnets for testing upcoming features.
For example, had this been in place before segwit, when "segwitnet" (was that its name) was created, it could have simply been some shared configuration instead of an additional hardoced chainparams.
Something like:

```
[segwitnet]
segwitheight=0
rpcport=18555
port=18556
...
```

We're not going to use it for a segwitnet now, obviously, but perhaps for a taprootnet or something.
Perhaps #17032 would be needed too for this use case in particular to be more useful though, or at least make that for some of the fields that are different between testnet3 and regtest.
