### PR TITLE
Don't rename main thread at process level

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -45,7 +45,7 @@ static bool AppInit(int argc, char* argv[])
 
     bool fRet = false;
 
-    util::ThreadRename("init");
+    util::ThreadSetInternalName("init");
 
     //
     // Parameters

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -416,7 +416,7 @@ int GuiMain(int argc, char* argv[])
     std::tie(argc, argv) = winArgs.get();
 #endif
     SetupEnvironment();
-    util::ThreadRename("main");
+    util::ThreadSetInternalName("main");
 
     std::unique_ptr<interfaces::Node> node = interfaces::MakeNode();
 

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -60,3 +60,8 @@ void util::ThreadRename(std::string&& name)
     SetThreadName(("b-" + name).c_str());
     SetInternalName(std::move(name));
 }
+
+void util::ThreadSetInternalName(std::string&& name)
+{
+    SetInternalName(std::move(name));
+}

--- a/src/util/threadnames.h
+++ b/src/util/threadnames.h
@@ -10,7 +10,12 @@
 namespace util {
 //! Rename a thread both in terms of an internal (in-memory) name as well
 //! as its system thread name.
+//! @note Do not call this for the main thread, as this will interfere with
+//! UNIX utilities such as top and killall. Use ThreadSetInternalName instead.
 void ThreadRename(std::string&&);
+
+//! Set the internal (in-memory) name of the current thread only.
+void ThreadSetInternalName(std::string&&);
 
 //! Get the thread's internal (in-memory) name; used e.g. for identification in
 //! logging.


### PR DESCRIPTION
Set only the internal name for the main threads.

Fixes #17036 for both `bitcoind` and `bitcoin-qt`.

After this, e.g. `killall` works again for either.