### PR TITLE
ci: Make apt-get more verbose, to debug travis timeouts

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -46,5 +46,5 @@ DOCKER_EXEC free -m -h
 DOCKER_EXEC echo "Number of CPUs \(nproc\): $(nproc)"
 
 ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
-${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES $DOCKER_PACKAGES
+${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
 


### PR DESCRIPTION
See issue #16148 