### PR TITLE
contrib: Bump gitian descriptors for 0.20

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-core-linux-0.19"
+name: "bitcoin-core-linux-0.20"
 enable_cache: true
 distro: "ubuntu"
 suites:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-core-osx-0.19"
+name: "bitcoin-core-osx-0.20"
 enable_cache: true
 distro: "ubuntu"
 suites:

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "bitcoin-core-win-0.19"
+name: "bitcoin-core-win-0.20"
 enable_cache: true
 distro: "ubuntu"
 suites:


### PR DESCRIPTION
Bump the gitian descriptor versions as a follow-up to #17007.

Also fixes #17027 with a cherry-pick, and bump the manpages.