### PR TITLE
tests: Add deserialization fuzzing harnesses

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -4,11 +4,15 @@
 
 
 FUZZ_TARGETS = \
+  test/fuzz/addr_info_deserialize \
   test/fuzz/address_deserialize \
   test/fuzz/addrman_deserialize \
   test/fuzz/banentry_deserialize \
   test/fuzz/bech32 \
   test/fuzz/block_deserialize \
+  test/fuzz/block_file_info_deserialize \
+  test/fuzz/block_filter_deserialize \
+  test/fuzz/block_header_and_short_txids_deserialize \
   test/fuzz/blockheader_deserialize \
   test/fuzz/blocklocator_deserialize \
   test/fuzz/blockmerkleroot \
@@ -20,16 +24,30 @@ FUZZ_TARGETS = \
   test/fuzz/descriptor_parse \
   test/fuzz/diskblockindex_deserialize \
   test/fuzz/eval_script \
+  test/fuzz/fee_rate_deserialize \
+  test/fuzz/flat_file_pos_deserialize \
   test/fuzz/inv_deserialize \
+  test/fuzz/key_origin_info_deserialize \
+  test/fuzz/merkle_block_deserialize \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
+  test/fuzz/out_point_deserialize \
   test/fuzz/parse_iso8601 \
+  test/fuzz/partial_merkle_tree_deserialize \
+  test/fuzz/partially_signed_transaction_deserialize \
+  test/fuzz/prefilled_transaction_deserialize \
   test/fuzz/psbt \
+  test/fuzz/psbt_input_deserialize \
+  test/fuzz/psbt_output_deserialize \
+  test/fuzz/pub_key_deserialize \
   test/fuzz/script \
+  test/fuzz/script_deserialize \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
   test/fuzz/spanparsing \
+  test/fuzz/sub_net_deserialize \
   test/fuzz/transaction \
+  test/fuzz/tx_in_deserialize \
   test/fuzz/txoutcompressor_deserialize \
   test/fuzz/txundo_deserialize
 
@@ -382,6 +400,114 @@ test_fuzz_transaction_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_transaction_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_transaction_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_transaction_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_addr_info_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_addr_info_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DADDR_INFO_DESERIALIZE=1
+test_fuzz_addr_info_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_addr_info_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_addr_info_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_block_file_info_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_block_file_info_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCK_FILE_INFO_DESERIALIZE=1
+test_fuzz_block_file_info_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_block_file_info_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_block_file_info_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_block_filter_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_block_filter_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCK_FILTER_DESERIALIZE=1
+test_fuzz_block_filter_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_block_filter_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_block_filter_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_block_header_and_short_txids_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_block_header_and_short_txids_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCK_HEADER_AND_SHORT_TXIDS_DESERIALIZE=1
+test_fuzz_block_header_and_short_txids_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_block_header_and_short_txids_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_block_header_and_short_txids_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_fee_rate_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_fee_rate_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DFEE_RATE_DESERIALIZE=1
+test_fuzz_fee_rate_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_fee_rate_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_fee_rate_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_flat_file_pos_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_flat_file_pos_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DFLAT_FILE_POS_DESERIALIZE=1
+test_fuzz_flat_file_pos_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_flat_file_pos_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_flat_file_pos_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_key_origin_info_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_key_origin_info_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DKEY_ORIGIN_INFO_DESERIALIZE=1
+test_fuzz_key_origin_info_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_key_origin_info_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_key_origin_info_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_merkle_block_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_merkle_block_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DMERKLE_BLOCK_DESERIALIZE=1
+test_fuzz_merkle_block_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_merkle_block_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_merkle_block_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_out_point_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_out_point_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DOUT_POINT_DESERIALIZE=1
+test_fuzz_out_point_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_out_point_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_out_point_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_partially_signed_transaction_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_partially_signed_transaction_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DPARTIALLY_SIGNED_TRANSACTION_DESERIALIZE=1
+test_fuzz_partially_signed_transaction_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_partially_signed_transaction_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_partially_signed_transaction_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_partial_merkle_tree_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_partial_merkle_tree_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DPARTIAL_MERKLE_TREE_DESERIALIZE=1
+test_fuzz_partial_merkle_tree_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_partial_merkle_tree_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_partial_merkle_tree_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_prefilled_transaction_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_prefilled_transaction_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DPREFILLED_TRANSACTION_DESERIALIZE=1
+test_fuzz_prefilled_transaction_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_prefilled_transaction_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_prefilled_transaction_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_psbt_input_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_psbt_input_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DPSBT_INPUT_DESERIALIZE=1
+test_fuzz_psbt_input_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_psbt_input_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_psbt_input_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_psbt_output_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_psbt_output_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DPSBT_OUTPUT_DESERIALIZE=1
+test_fuzz_psbt_output_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_psbt_output_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_psbt_output_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_pub_key_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_pub_key_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DPUB_KEY_DESERIALIZE=1
+test_fuzz_pub_key_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_pub_key_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_pub_key_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_script_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_script_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSCRIPT_DESERIALIZE=1
+test_fuzz_script_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_sub_net_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_sub_net_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSUB_NET_DESERIALIZE=1
+test_fuzz_sub_net_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_sub_net_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_sub_net_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_tx_in_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+test_fuzz_tx_in_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTX_IN_DESERIALIZE=1
+test_fuzz_tx_in_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_tx_in_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_tx_in_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 endif # ENABLE_FUZZ
 

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -5,18 +5,24 @@
 #include <addrdb.h>
 #include <addrman.h>
 #include <blockencodings.h>
+#include <blockfilter.h>
 #include <chain.h>
 #include <coins.h>
 #include <compressor.h>
 #include <consensus/merkle.h>
+#include <key.h>
+#include <merkleblock.h>
 #include <net.h>
 #include <primitives/block.h>
 #include <protocol.h>
+#include <psbt.h>
 #include <pubkey.h>
+#include <script/keyorigin.h>
 #include <streams.h>
 #include <undo.h>
 #include <version.h>
 
+#include <stdexcept>
 #include <stdint.h>
 #include <unistd.h>
 
@@ -37,129 +43,237 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         int nVersion;
         ds >> nVersion;
         ds.SetVersion(nVersion);
-    } catch (const std::ios_base::failure& e) {
+    } catch (const std::ios_base::failure&) {
         return;
     }
 
-#if BLOCK_DESERIALIZE
-            try
-            {
-                CBlock block;
-                ds >> block;
-            } catch (const std::ios_base::failure& e) {return;}
+#if BLOCK_FILTER_DESERIALIZE
+    try {
+        BlockFilter block_filter;
+        ds >> block_filter;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif ADDR_INFO_DESERIALIZE
+    try {
+        CAddrInfo addr_info;
+        ds >> addr_info;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif BLOCK_FILE_INFO_DESERIALIZE
+    try {
+        CBlockFileInfo block_file_info;
+        ds >> block_file_info;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif BLOCK_HEADER_AND_SHORT_TXIDS_DESERIALIZE
+    try {
+        CBlockHeaderAndShortTxIDs block_header_and_short_txids;
+        ds >> block_header_and_short_txids;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif FEE_RATE_DESERIALIZE
+    try {
+        CFeeRate fee_rate;
+        ds >> fee_rate;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif MERKLE_BLOCK_DESERIALIZE
+    try {
+        CMerkleBlock merkle_block;
+        ds >> merkle_block;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif OUT_POINT_DESERIALIZE
+    try {
+        COutPoint out_point;
+        ds >> out_point;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif PARTIAL_MERKLE_TREE_DESERIALIZE
+    try {
+        CPartialMerkleTree partial_merkle_tree;
+        ds >> partial_merkle_tree;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif PUB_KEY_DESERIALIZE
+    try {
+        CPubKey pub_key;
+        ds >> pub_key;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif SCRIPT_DESERIALIZE
+    try {
+        CScript script;
+        ds >> script;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif SUB_NET_DESERIALIZE
+    try {
+        CSubNet sub_net;
+        ds >> sub_net;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif TX_IN_DESERIALIZE
+    try {
+        CTxIn tx_in;
+        ds >> tx_in;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif FLAT_FILE_POS_DESERIALIZE
+    try {
+        FlatFilePos flat_file_pos;
+        ds >> flat_file_pos;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif KEY_ORIGIN_INFO_DESERIALIZE
+    try {
+        KeyOriginInfo key_origin_info;
+        ds >> key_origin_info;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif PARTIALLY_SIGNED_TRANSACTION_DESERIALIZE
+    try {
+        PartiallySignedTransaction partially_signed_transaction;
+        ds >> partially_signed_transaction;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif PREFILLED_TRANSACTION_DESERIALIZE
+    try {
+        PrefilledTransaction prefilled_transaction;
+        ds >> prefilled_transaction;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif PSBT_INPUT_DESERIALIZE
+    try {
+        PSBTInput psbt_input;
+        ds >> psbt_input;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif PSBT_OUTPUT_DESERIALIZE
+    try {
+        PSBTOutput psbt_output;
+        ds >> psbt_output;
+    } catch (const std::ios_base::failure&) {
+    }
+#elif BLOCK_DESERIALIZE
+    try {
+        CBlock block;
+        ds >> block;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOCKLOCATOR_DESERIALIZE
-            try
-            {
-                CBlockLocator bl;
-                ds >> bl;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CBlockLocator bl;
+        ds >> bl;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOCKMERKLEROOT
-            try
-            {
-                CBlock block;
-                ds >> block;
-                bool mutated;
-                BlockMerkleRoot(block, &mutated);
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CBlock block;
+        ds >> block;
+        bool mutated;
+        BlockMerkleRoot(block, &mutated);
+    } catch (const std::ios_base::failure&) {
+    }
 #elif ADDRMAN_DESERIALIZE
-            try
-            {
-                CAddrMan am;
-                ds >> am;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CAddrMan am;
+        ds >> am;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOCKHEADER_DESERIALIZE
-            try
-            {
-                CBlockHeader bh;
-                ds >> bh;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CBlockHeader bh;
+        ds >> bh;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BANENTRY_DESERIALIZE
-            try
-            {
-                CBanEntry be;
-                ds >> be;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CBanEntry be;
+        ds >> be;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif TXUNDO_DESERIALIZE
-            try
-            {
-                CTxUndo tu;
-                ds >> tu;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CTxUndo tu;
+        ds >> tu;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOCKUNDO_DESERIALIZE
-            try
-            {
-                CBlockUndo bu;
-                ds >> bu;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CBlockUndo bu;
+        ds >> bu;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif COINS_DESERIALIZE
-            try
-            {
-                Coin coin;
-                ds >> coin;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        Coin coin;
+        ds >> coin;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif NETADDR_DESERIALIZE
-            try
-            {
-                CNetAddr na;
-                ds >> na;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CNetAddr na;
+        ds >> na;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif SERVICE_DESERIALIZE
-            try
-            {
-                CService s;
-                ds >> s;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CService s;
+        ds >> s;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif MESSAGEHEADER_DESERIALIZE
-            CMessageHeader::MessageStartChars pchMessageStart = {0x00, 0x00, 0x00, 0x00};
-            try
-            {
-                CMessageHeader mh(pchMessageStart);
-                ds >> mh;
-                if (!mh.IsValid(pchMessageStart)) {return;}
-            } catch (const std::ios_base::failure& e) {return;}
+    CMessageHeader::MessageStartChars pchMessageStart = {0x00, 0x00, 0x00, 0x00};
+    try {
+        CMessageHeader mh(pchMessageStart);
+        ds >> mh;
+        (void)mh.IsValid(pchMessageStart);
+    } catch (const std::ios_base::failure&) {
+    }
 #elif ADDRESS_DESERIALIZE
-            try
-            {
-                CAddress a;
-                ds >> a;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CAddress a;
+        ds >> a;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif INV_DESERIALIZE
-            try
-            {
-                CInv i;
-                ds >> i;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CInv i;
+        ds >> i;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOOMFILTER_DESERIALIZE
-            try
-            {
-                CBloomFilter bf;
-                ds >> bf;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CBloomFilter bf;
+        ds >> bf;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif DISKBLOCKINDEX_DESERIALIZE
-            try
-            {
-                CDiskBlockIndex dbi;
-                ds >> dbi;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        CDiskBlockIndex dbi;
+        ds >> dbi;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif TXOUTCOMPRESSOR_DESERIALIZE
-            CTxOut to;
-            CTxOutCompressor toc(to);
-            try
-            {
-                ds >> toc;
-            } catch (const std::ios_base::failure& e) {return;}
+    CTxOut to;
+    CTxOutCompressor toc(to);
+    try {
+        ds >> toc;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOCKTRANSACTIONS_DESERIALIZE
-            try
-            {
-                BlockTransactions bt;
-                ds >> bt;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        BlockTransactions bt;
+        ds >> bt;
+    } catch (const std::ios_base::failure&) {
+    }
 #elif BLOCKTRANSACTIONSREQUEST_DESERIALIZE
-            try
-            {
-                BlockTransactionsRequest btr;
-                ds >> btr;
-            } catch (const std::ios_base::failure& e) {return;}
+    try {
+        BlockTransactionsRequest btr;
+        ds >> btr;
+    } catch (const std::ios_base::failure&) {
+    }
 #else
 #error Need at least one fuzz target to compile
 #endif

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -26,19 +26,31 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         int nVersion;
         ds >> nVersion;
         ds.SetVersion(nVersion);
-    } catch (const std::ios_base::failure& e) {
+    } catch (const std::ios_base::failure&) {
         return;
     }
-    bool valid = true;
+    bool valid_tx = true;
     const CTransaction tx = [&] {
         try {
             return CTransaction(deserialize, ds);
-        } catch (const std::ios_base::failure& e) {
-            valid = false;
+        } catch (const std::ios_base::failure&) {
+            valid_tx = false;
             return CTransaction();
         }
     }();
-    if (!valid) {
+    bool valid_mutable_tx = true;
+    CDataStream ds_mtx(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    CMutableTransaction mutable_tx;
+    try {
+        int nVersion;
+        ds_mtx >> nVersion;
+        ds_mtx.SetVersion(nVersion);
+        ds_mtx >> mutable_tx;
+    } catch (const std::ios_base::failure&) {
+        valid_mutable_tx = false;
+    }
+    assert(valid_tx == valid_mutable_tx);
+    if (!valid_tx) {
         return;
     }
 

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -22,7 +22,6 @@ FUZZERS_MISSING_CORPORA = [
     "flat_file_pos_deserialize",
     "key_origin_info_deserialize",
     "merkle_block_deserialize",
-    "mutable_transaction_deserialize",
     "out_point_deserialize",
     "partial_merkle_tree_deserialize",
     "partially_signed_transaction_deserialize",

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -12,6 +12,28 @@ import sys
 import subprocess
 import logging
 
+# Fuzzers known to lack a seed corpus in https://github.com/bitcoin-core/qa-assets/tree/master/fuzz_seed_corpus
+FUZZERS_MISSING_CORPORA = [
+    "addr_info_deserialize",
+    "block_file_info_deserialize",
+    "block_filter_deserialize",
+    "block_header_and_short_txids_deserialize",
+    "fee_rate_deserialize",
+    "flat_file_pos_deserialize",
+    "key_origin_info_deserialize",
+    "merkle_block_deserialize",
+    "mutable_transaction_deserialize",
+    "out_point_deserialize",
+    "partial_merkle_tree_deserialize",
+    "partially_signed_transaction_deserialize",
+    "prefilled_transaction_deserialize",
+    "psbt_input_deserialize",
+    "psbt_output_deserialize",
+    "pub_key_deserialize",
+    "script_deserialize",
+    "sub_net_deserialize",
+    "tx_in_deserialize",
+]
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -100,10 +122,14 @@ def main():
 
 def run_once(*, corpus, test_list, build_dir, export_coverage):
     for t in test_list:
+        corpus_path = os.path.join(corpus, t)
+        if t in FUZZERS_MISSING_CORPORA:
+            os.makedirs(corpus_path, exist_ok=True)
         args = [
             os.path.join(build_dir, 'src', 'test', 'fuzz', t),
             '-runs=1',
-            os.path.join(corpus, t),
+            '-detect_leaks=0',
+            corpus_path,
         ]
         logging.debug('Run {} with args {}'.format(t, args))
         result = subprocess.run(args, stderr=subprocess.PIPE, universal_newlines=True)


### PR DESCRIPTION
Add deserialization fuzzing harnesses.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ contrib/devtools/test_fuzzing_harnesses.sh 'addr_info|block_file_info|block_filter|block_header|ext_key|ext_pub_key|fee_rate|flat_file|key_origin|merkle_block|mutable_transaction|out_point|partial_merkle_tree|partially_signed_transaction|prefilled_transaction|psbt_input|psbt_output|pub_key|script_deserialize|sub_net|tx_in' 10
```

`test_fuzzing_harnesses.sh` can be found in PR #17000.