### PR TITLE
util: Simplify path argument for CBlockTreeDB ctor

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -145,7 +145,7 @@ size_t CCoinsViewDB::EstimateSize() const
     return db.EstimateSize(DB_COIN, (char)(DB_COIN+1));
 }
 
-CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(gArgs.IsArgSet("-blocksdir") ? GetDataDir() / "blocks" / "index" : GetBlocksDir() / "index", nCacheSize, fMemory, fWipe) {
+CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe) : CDBWrapper(GetDataDir() / "blocks" / "index", nCacheSize, fMemory, fWipe) {
 }
 
 bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info) {


### PR DESCRIPTION
This PR:
- simplifies path argument (`datadir/blocks/index`) for `CBlockTreeDB`  constructor
- does not change behavior as `GetBlocksDir()` with unset "-blocksdir" returns the same path
- improves code readability