### PR TITLE
Cache 26% more coins: Reduce CCoinsMap::value_type from 96 to 76 bytes

### DIFF
--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -23,7 +23,7 @@ static void ApplyStats(CCoinsStats &stats, CHashWriter& ss, const uint256& hash,
     for (const auto& output : outputs) {
         ss << VARINT(output.first + 1);
         ss << output.second.out.scriptPubKey;
-        ss << VARINT(output.second.out.nValue, VarIntMode::NONNEGATIVE_SIGNED);
+        ss << VARINT((CAmount)output.second.out.nValue, VarIntMode::NONNEGATIVE_SIGNED);
         stats.nTransactionOutputs++;
         stats.nTotalAmount += output.second.out.nValue;
         stats.nBogoSize += 32 /* txid */ + 4 /* vout index */ + 4 /* height + coinbase */ + 8 /* amount */ +

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -21,13 +21,14 @@
  *
  *  Storage layout is either:
  *  - Direct allocation:
- *    - Size _size: the number of used elements (between 0 and N)
  *    - T direct[N]: an array of N elements of type T
- *      (only the first _size are initialized).
+ *    - unsigned char _size_direct: the number of used elements
+ *      between 0 and N. 0xFF means indirect allocation.
+ *      (only the first _size_direct are initialized).
  *  - Indirect allocation:
- *    - Size _size: the number of used elements plus N + 1
- *    - Size capacity: the number of allocated elements
- *    - T* indirect: a pointer to an array of capacity elements of type T
+ *    - size_type _size: the number of used elements
+ *    - size_type capacity: the number of allocated elements
+ *    - char* indirect: a pointer to an array of capacity elements of type T
  *      (only the first _size are initialized).
  *
  *  The data type T must be movable by memmove/realloc(). Once we switch to C++,
@@ -35,6 +36,8 @@
  */
 template<unsigned int N, typename T, typename Size = uint32_t, typename Diff = int32_t>
 class prevector {
+    static_assert(N < 0xff, "can't directly allocate more than 254 elements");
+
 public:
     typedef Size size_type;
     typedef Diff difference_type;
@@ -146,30 +149,31 @@ public:
     };
 
 private:
-    size_type _size = 0;
     union direct_or_indirect {
         char direct[sizeof(T) * N];
         struct {
+            size_type size;
             size_type capacity;
             char* indirect;
         };
     } _union = {};
+    unsigned char _size_direct = 0;
 
     T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
     const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
     T* indirect_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.indirect) + pos; }
     const T* indirect_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.indirect) + pos; }
-    bool is_direct() const { return _size <= N; }
+    bool is_direct() const { return _size_direct != 0xFF; }
 
     void change_capacity(size_type new_capacity) {
         if (new_capacity <= N) {
             if (!is_direct()) {
+                _size_direct = static_cast<unsigned char>(_union.size);
                 T* indirect = indirect_ptr(0);
                 T* src = indirect;
                 T* dst = direct_ptr(0);
-                memcpy(dst, src, size() * sizeof(T));
+                memcpy(dst, src, _size_direct * sizeof(T));
                 free(indirect);
-                _size -= N + 1;
             }
         } else {
             if (!is_direct()) {
@@ -187,7 +191,8 @@ private:
                 memcpy(dst, src, size() * sizeof(T));
                 _union.indirect = new_indirect;
                 _union.capacity = new_capacity;
-                _size += N + 1;
+                _union.size = _size_direct;
+                _size_direct = 0xff;
             }
         }
     }
@@ -208,13 +213,21 @@ private:
         }
     }
 
+    void change_size_by(Diff diff) {
+        if (is_direct()) {
+            _size_direct += diff;
+        } else {
+            _union.size += diff;
+        }
+    }
+
 public:
     void assign(size_type n, const T& val) {
         clear();
         if (capacity() < n) {
             change_capacity(n);
         }
-        _size += n;
+        change_size_by(n);
         fill(item_ptr(0), n, val);
     }
 
@@ -225,7 +238,7 @@ public:
         if (capacity() < n) {
             change_capacity(n);
         }
-        _size += n;
+        change_size_by(n);
         fill(item_ptr(0), first, last);
     }
 
@@ -237,7 +250,7 @@ public:
 
     explicit prevector(size_type n, const T& val) {
         change_capacity(n);
-        _size += n;
+        change_size_by(n);
         fill(item_ptr(0), n, val);
     }
 
@@ -245,14 +258,14 @@ public:
     prevector(InputIterator first, InputIterator last) {
         size_type n = last - first;
         change_capacity(n);
-        _size += n;
+        change_size_by(n);
         fill(item_ptr(0), first, last);
     }
 
     prevector(const prevector<N, T, Size, Diff>& other) {
         size_type n = other.size();
         change_capacity(n);
-        _size += n;
+        change_size_by(n);
         fill(item_ptr(0), other.begin(),  other.end());
     }
 
@@ -274,7 +287,7 @@ public:
     }
 
     size_type size() const {
-        return is_direct() ? _size : _size - N - 1;
+        return is_direct() ? _size_direct : _union.size;
     }
 
     bool empty() const {
@@ -321,7 +334,7 @@ public:
         }
         ptrdiff_t increase = new_size - cur_size;
         fill(item_ptr(cur_size), increase);
-        _size += increase;
+        change_size_by(increase);
     }
 
     void reserve(size_type new_capacity) {
@@ -346,7 +359,7 @@ public:
         }
         T* ptr = item_ptr(p);
         memmove(ptr + 1, ptr, (size() - p) * sizeof(T));
-        _size++;
+        change_size_by(1);
         new(static_cast<void*>(ptr)) T(value);
         return iterator(ptr);
     }
@@ -359,7 +372,7 @@ public:
         }
         T* ptr = item_ptr(p);
         memmove(ptr + count, ptr, (size() - p) * sizeof(T));
-        _size += count;
+        change_size_by(count);
         fill(item_ptr(p), count, value);
     }
 
@@ -373,7 +386,7 @@ public:
         }
         T* ptr = item_ptr(p);
         memmove(ptr + count, ptr, (size() - p) * sizeof(T));
-        _size += count;
+        change_size_by(count);
         fill(ptr, first, last);
     }
 
@@ -382,13 +395,13 @@ public:
         // If size < new_size, the added elements must be initialized explicitly.
         if (capacity() < new_size) {
             change_capacity(new_size);
-            _size += new_size - size();
+            change_size_by(new_size - size());
             return;
         }
         if (new_size < size()) {
             erase(item_ptr(new_size), end());
         } else {
-            _size += new_size - size();
+            change_size_by(new_size - size());
         }
     }
 
@@ -408,11 +421,11 @@ public:
         if (!std::is_trivially_destructible<T>::value) {
             while (p != last) {
                 (*p).~T();
-                _size--;
+                change_size_by(-1);
                 ++p;
             }
         } else {
-            _size -= last - p;
+            change_size_by(-(last - p));
         }
         memmove(&(*first), &(*last), endp - ((char*)(&(*last))));
         return first;
@@ -424,7 +437,7 @@ public:
             change_capacity(new_size + (new_size >> 1));
         }
         new(item_ptr(size())) T(value);
-        _size++;
+        change_size_by(1);
     }
 
     void pop_back() {
@@ -449,7 +462,7 @@ public:
 
     void swap(prevector<N, T, Size, Diff>& other) {
         std::swap(_union, other._union);
-        std::swap(_size, other._size);
+        std::swap(_size_direct, other._size_direct);
     }
 
     ~prevector() {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -130,9 +130,9 @@ public:
 
 /**
  * CAmount is an int64_t, which requires alignment of 8. This wrapper stores the data
- * in a memory array and packs/unpacks it whenever needed, regarldess of alignment.
+ * in a memory array and packs/unpacks it whenever needed, regardless of alignment.
  *
- * Since CAmount's size is know, the compiler should be able to optimize the std::memcpy away
+ * Since CAmount's size is known, the compiler should be able to optimize the std::memcpy away
  * in most cases.
  */
 class PackableCAmount
@@ -140,9 +140,9 @@ class PackableCAmount
     uint8_t m_data[sizeof(CAmount)];
 
 public:
-    PackableCAmount(CAmount val) noexcept
+    explicit PackableCAmount(CAmount val) noexcept
     {
-        std::memcpy(m_data, &val, sizeof(CAmount));
+        *this = val;
     }
 
     PackableCAmount() noexcept
@@ -157,13 +157,17 @@ public:
 
     PackableCAmount& operator-=(CAmount other) noexcept
     {
-        *this = ((CAmount) * this) - other;
-        return *this;
+        return *this = static_cast<CAmount>(*this) - other;
     }
 
     PackableCAmount& operator+=(CAmount other) noexcept
     {
-        *this = ((CAmount) * this) + other;
+        return *this = static_cast<CAmount>(*this) + other;
+    }
+
+    PackableCAmount& operator=(CAmount other) noexcept
+    {
+        std::memcpy(m_data, &other, sizeof(CAmount));
         return *this;
     }
 
@@ -178,7 +182,7 @@ public:
     template <typename Stream>
     void Serialize(Stream& s) const
     {
-        ::Serialize(s, (CAmount) * this);
+        ::Serialize(s, static_cast<CAmount>(*this));
     }
 };
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -381,8 +381,11 @@ private:
  *  of vectors in cases where they normally contain a small number of small elements.
  * Tests in October 2015 showed use of this reduced dbcache memory usage by 23%
  *  and made an initial sync 13% faster.
+ *
+ * Most scripts seem to have <= 25 bytes. So with 27 entries + 1 byte for size(),
+ * the prevector will have a size of 28 bytes.
  */
-typedef prevector<28, unsigned char> CScriptBase;
+typedef prevector<27, unsigned char> CScriptBase;
 
 bool GetScriptOp(CScriptBase::const_iterator& pc, CScriptBase::const_iterator end, opcodetype& opcodeRet, std::vector<unsigned char>* pvchRet);
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -106,7 +106,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock) {
     batch.Write(DB_HEAD_BLOCKS, Vector(hashBlock, old_tip));
 
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();) {
-        if (it->second.flags & CCoinsCacheEntry::DIRTY) {
+        if (it->second.coin.dirty) {
             CoinEntry entry(&it->first);
             if (it->second.coin.IsSpent())
                 batch.Erase(entry);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -33,7 +33,7 @@ class CBlockIndex;
 extern CCriticalSection cs_main;
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
-static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
+static const uint32_t MEMPOOL_HEIGHT = (1 << COIN_NHEIGHT_BITS) - 1;
 
 struct LockPoints
 {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1175,7 +1175,7 @@ CAmount CWallet::GetCredit(const CTxOut& txout, const isminefilter& filter) cons
 {
     if (!MoneyRange(txout.nValue))
         throw std::runtime_error(std::string(__func__) + ": value out of range");
-    return ((IsMine(txout) & filter) ? txout.nValue : 0);
+    return ((IsMine(txout) & filter) ? (CAmount)txout.nValue : 0);
 }
 
 bool CWallet::IsChange(const CTxOut& txout) const
@@ -1209,7 +1209,7 @@ CAmount CWallet::GetChange(const CTxOut& txout) const
 {
     if (!MoneyRange(txout.nValue))
         throw std::runtime_error(std::string(__func__) + ": value out of range");
-    return (IsChange(txout) ? txout.nValue : 0);
+    return (IsChange(txout) ? (CAmount)txout.nValue : 0);
 }
 
 bool CWallet::IsMine(const CTransaction& tx) const
@@ -3146,7 +3146,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances(interfaces::Chain:
                 if(!ExtractDestination(wtx.tx->vout[i].scriptPubKey, addr))
                     continue;
 
-                CAmount n = IsSpent(walletEntry.first, i) ? 0 : wtx.tx->vout[i].nValue;
+                CAmount n = IsSpent(walletEntry.first, i) ? 0 : (CAmount)wtx.tx->vout[i].nValue;
 
                 if (!balances.count(addr))
                     balances[addr] = 0;


### PR DESCRIPTION
This is an attempt to more tightly pack the data inside `CCoinsMap`. (replaces #16970, done after my investigations on #16957) Currently, there is quite a bit of overhead involved in the `CCoinsMap::value_type` data structure (total bytes to the left):

```
96 CCoinsMap::value_type
    36 COutPoint
        32 uint256
         4 uint32_t
     4 >>> PADDING <<<
    56 CCoinsCacheEntry
        48 Coin
            40 CTxOut
                8 nValue
                32 CScript
             4 fCoinBase & nHeight
             4 >>> PADDING <<<
         1 flags (dirty & fresh)
         7 >>> PADDING <<< 
```

So there is quite a bit of padding data. In my experiements I've noticed that the compiler is forced to use a padding size >=8 only because `nValue`'s `CAmount` type is `int64_t` which has to be 8-byte aligned. When replacing nValue with a 4-byte aligned data structure, the whole `CCoinsMap::value_type` will be aligned to 4 bytes, reducing padding.

Another 4 bytes can be saved by refactoring `prevector` to only use a single byte for direct size information, and reducing CScript's size from 28  to 27 bytes. It is still able to directly cache most scripts as most are <= 25 bytes long.

The remaining 4 bytes due to the 1 byte flag + 3 bytes padding in `CCoinsCacheEntry` can be removed by moving the flags into `Coin`, stealing another 2 bits from `nHeight`. 

Finally, the resulting data structure is 20 bytes smaller:

```
76 CCoinsMap::value_type
    36 COutPoint
        32 uint256
         4 uint32_t
    40 CCoinsCacheEntry
        40 Coin
            36 CTxOut
                 8 nValue
                28 CScript
            4 fCoinBase & nHeight & flags (dirty & fresh)
```

So we can store about 26% more data into dbcache's memory. I have evalued this on my Intel i7-8700, 32GB RAM, external SSD, for `-reindex-chainstate` with both `-dbcache=500` and `-dbcache=5000`:

![out2](https://user-images.githubusercontent.com/14386/66253968-18352400-e770-11e9-9cf3-7ca5b5099054.png)

  |   | time | max resident set size
-- | -- | -- | --
master | -dbcache=500 | 05:57:20 | 2957532
2019-09-more-compact-Coin | -dbcache=500 | 05:33:37 | 2919312
Improvement |   | 6,64% | 1,29%


  |   | time | max resident set size
-- | -- | -- | --
master | -dbcache=5000 | 04:22:42 | 7072612
2019-09-more-compact-Coin | -dbcache=5000 | 04:09:16 | 6533132
Improvement |   | 5,11% | 7,63%

So on my machine there is definitive an improvement, but honestly I am not sure if this ~6% improvement is worth the change. Maybe the improvement is bigger with slower disk, as ~26% more transaction can be cached.