### PR TITLE
Update Copyright Date

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
-// Copyright (c) 2009-2018 The Bitcoin Core developers
+// Copyright (c) 2009-2020 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 


### PR DESCRIPTION
Updating the copyright date to 2020 for 0.19, if you think it should be included based on the release expectation, or 0.20.