### PR TITLE
[RFC] Tests: use boost test framework for benchmarks

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,6 +94,7 @@ BITCOIN_TESTS =\
   test/blockfilter_tests.cpp \
   test/blockfilter_index_tests.cpp \
   test/bloom_tests.cpp \
+  test/boost_bench.h \
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \

--- a/src/test/boost_bench.h
+++ b/src/test/boost_bench.h
@@ -1,0 +1,53 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_BOOST_BENCH_H
+#define BITCOIN_TEST_BOOST_BENCH_H
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#define BENCHMARK(testname) BOOST_AUTO_TEST_CASE(testname, *::boost::unit_test::label("benchmark") * ::boost::unit_test::disabled())
+
+class Benchmark
+{
+    using Clock = std::chrono::high_resolution_clock;
+
+    std::string m_name;
+    size_t m_batch{1};
+    size_t m_iters{1};
+
+public:
+    explicit Benchmark(std::string name)
+        : m_name(std::move(name)) {}
+
+    Benchmark& Batch(size_t batch)
+    {
+        m_batch = batch;
+        return *this;
+    }
+
+    Benchmark& Iters(size_t iters)
+    {
+        m_iters = iters;
+        return *this;
+    }
+
+    template <typename Op>
+    void Run(Op op) const
+    {
+        size_t n = m_iters;
+        auto before = Clock::now();
+        while (n > 0) {
+            op();
+            --n;
+        }
+        auto after = Clock::now();
+        auto elapsed = std::chrono::duration_cast<std::chrono::duration<double>>(after - before).count();
+        std::cout << (1e9 * elapsed / (m_batch * m_iters)) << " ns for " << m_name << " (" << elapsed << " s total)" << std::endl;
+    }
+};
+
+#endif

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -13,6 +13,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <test/boost_bench.h>
+
 BOOST_FIXTURE_TEST_SUITE(prevector_tests, TestingSetup)
 
 template<unsigned int N, typename T>
@@ -290,6 +292,26 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             }
         }
     }
+}
+
+// This is just a boost test with the label "benchmark", and defaults to disabled.
+BENCHMARK(prevector_resize)
+{
+    // Run a benchmark called "resize", where each iteration consists of a batch of 1000*4 operations.
+    // Perform a total of 20000 iterations. Once the loop has finish, show timing results.
+    Benchmark("resize").Batch(1000 * 4).Iters(20000).Run([] {
+        prevector<28, int> t0;
+        prevector<28, int> t1;
+        for (auto x = 0; x < 1000; ++x) {
+            t0.resize(28);
+            t0.resize(0);
+            t1.resize(29);
+            t1.resize(0);
+        }
+    });
+
+    // When the loop has finished, it prints the benchmark results, something like this:
+    // 4.35599 ns for resize (0.348479 s total)
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR is a brainstorming to gather opinions if there is interest in rewrite the benchmarking framework, to make it more usable and extensible. I currently have a quick hack to test a new API. It shows a few ideas:

* Move benchmarking code into tests: the macro `BENCHMARK` creates a boost test with the label `benchmark`, that is disabled by default. To run all benchmarks, execute `./test_bitcoin --run_test=@benchmark`. 
* Configuration & running of a benchmark is one place:
   ```cpp
   Benchmark("resize").Iters(1000).Run([] {
      // code
   });
   ```
   The configuration can be easily extended with other attributes, e.g. output configuration, automatic runtime configuration, etc.

Please have a look at my change to prevector_tests.cpp which shows a working example. 

If there is interest in such a refactoring, I can spend some time on it