### PR TITLE
tests: Pass fuzzing inputs as constant references

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -23,7 +23,7 @@
 
 #include <test/fuzz/fuzz.h>
 
-void test_one_input(std::vector<uint8_t> buffer)
+void test_one_input(const std::vector<uint8_t>& buffer)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
     try {

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -30,7 +30,8 @@ static void initialize()
 // This function is used by libFuzzer
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    test_one_input(std::vector<uint8_t>(data, data + size));
+    const std::vector<uint8_t> input(data, data + size);
+    test_one_input(input);
     return 0;
 }
 

--- a/src/test/fuzz/fuzz.h
+++ b/src/test/fuzz/fuzz.h
@@ -9,6 +9,6 @@
 #include <vector>
 
 
-void test_one_input(std::vector<uint8_t> buffer);
+void test_one_input(const std::vector<uint8_t>& buffer);
 
 #endif // BITCOIN_TEST_FUZZ_FUZZ_H

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -11,7 +11,7 @@
 /** Flags that are not forbidden by an assert */
 static bool IsValidFlagCombination(unsigned flags);
 
-void test_one_input(std::vector<uint8_t> buffer)
+void test_one_input(const std::vector<uint8_t>& buffer)
 {
     CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
     try {


### PR DESCRIPTION
Pass fuzzing inputs as constant references.

Split out from #17009 as suggested by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/17009#discussion_r331502028.