### PR TITLE
tests: Add fuzzing harness for CheckBlock(...) and other CBlock related functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -9,6 +9,7 @@ FUZZ_TARGETS = \
   test/fuzz/addrman_deserialize \
   test/fuzz/banentry_deserialize \
   test/fuzz/bech32 \
+  test/fuzz/block \
   test/fuzz/block_deserialize \
   test/fuzz/block_file_info_deserialize \
   test/fuzz/block_filter_deserialize \
@@ -229,6 +230,12 @@ test_test_bitcoin_LDADD += $(LIBBITCOIN_ZMQ) $(ZMQ_LIBS)
 endif
 
 if ENABLE_FUZZ
+test_fuzz_block_SOURCES = $(FUZZ_SUITE) test/fuzz/block.cpp
+test_fuzz_block_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_block_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_block_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_block_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
 test_fuzz_block_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_block_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCK_DESERIALIZE=1
 test_fuzz_block_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <consensus/merkle.h>
+#include <consensus/validation.h>
+#include <core_io.h>
+#include <core_memusage.h>
+#include <pubkey.h>
+#include <primitives/block.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+#include <validation.h>
+#include <version.h>
+
+#include <cassert>
+#include <string>
+
+void initialize()
+{
+    const static auto verify_handle = MakeUnique<ECCVerifyHandle>();
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    CBlock block;
+    try {
+        int nVersion;
+        ds >> nVersion;
+        ds.SetVersion(nVersion);
+        ds >> block;
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+    const Consensus::Params& consensus_params = Params().GetConsensus();
+    BlockValidationState validation_state_pow_and_merkle;
+    const bool valid_incl_pow_and_merkle = CheckBlock(block, validation_state_pow_and_merkle, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true);
+    BlockValidationState validation_state_pow;
+    const bool valid_incl_pow = CheckBlock(block, validation_state_pow, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false);
+    BlockValidationState validation_state_merkle;
+    const bool valid_incl_merkle = CheckBlock(block, validation_state_merkle, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true);
+    BlockValidationState validation_state_none;
+    const bool valid_incl_none = CheckBlock(block, validation_state_none, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false);
+    if (valid_incl_pow_and_merkle) {
+        assert(valid_incl_pow && valid_incl_merkle && valid_incl_none);
+    } else if (valid_incl_merkle || valid_incl_pow) {
+        assert(valid_incl_none);
+    }
+    (void)block.GetHash();
+    (void)block.ToString();
+    (void)BlockMerkleRoot(block);
+    if (!block.vtx.empty()) {
+        // TODO: Avoid array index out of bounds error in BlockWitnessMerkleRoot
+        //       when block.vtx.empty().
+        (void)BlockWitnessMerkleRoot(block);
+    }
+    (void)GetBlockWeight(block);
+    (void)GetWitnessCommitmentIndex(block);
+    (void)RecursiveDynamicUsage(block);
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -15,6 +15,7 @@ import logging
 # Fuzzers known to lack a seed corpus in https://github.com/bitcoin-core/qa-assets/tree/master/fuzz_seed_corpus
 FUZZERS_MISSING_CORPORA = [
     "addr_info_deserialize",
+    "block",
     "block_file_info_deserialize",
     "block_filter_deserialize",
     "block_header_and_short_txids_deserialize",


### PR DESCRIPTION
Add fuzzing harness for `CheckBlock(...)` and other `CBlock` related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/block
…
# And to to quickly verify that the relevant code regions are triggered, that the
# fuzzing throughput seems reasonable, etc.
$ contrib/devtools/test_fuzzing_harnesses.sh '^block$'
```

`test_fuzzing_harnesses.sh` can be found in PR #17000.