### PR TITLE
move-only: PASTE macros to util/macros.h

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -209,6 +209,7 @@ BITCOIN_CORE_H = \
   util/error.h \
   util/fees.h \
   util/system.h \
+  util/macros.h \
   util/memory.h \
   util/moneystr.h \
   util/rbf.h \

--- a/src/sync.h
+++ b/src/sync.h
@@ -7,6 +7,7 @@
 #define BITCOIN_SYNC_H
 
 #include <threadsafety.h>
+#include <util/macros.h>
 
 #include <condition_variable>
 #include <thread>
@@ -175,9 +176,6 @@ public:
 
 template<typename MutexArg>
 using DebugLock = UniqueLock<typename std::remove_reference<typename std::remove_pointer<MutexArg>::type>::type>;
-
-#define PASTE(x, y) x ## y
-#define PASTE2(x, y) PASTE(x, y)
 
 #define LOCK(cs) DebugLock<decltype(cs)> PASTE2(criticalblock, __COUNTER__)(cs, #cs, __FILE__, __LINE__)
 #define LOCK2(cs1, cs2)                                               \

--- a/src/util/macros.h
+++ b/src/util/macros.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_MACROS_H
+#define BITCOIN_UTIL_MACROS_H
+
+#define PASTE(x, y) x ## y
+#define PASTE2(x, y) PASTE(x, y)
+
+#endif // BITCOIN_UTIL_MACROS_H


### PR DESCRIPTION
Really dumb move-only stolen from #16805. Some of my pull requests also depend on this, so I split it up to not depend on #16805.