### PR TITLE
tests: Add fuzzing harness for CheckTransaction(...), IsStandardTx(...) and other CTransaction related functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -23,7 +23,6 @@ FUZZ_TARGETS = \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
   test/fuzz/transaction \
-  test/fuzz/transaction_deserialize \
   test/fuzz/txoutcompressor_deserialize \
   test/fuzz/txundo_deserialize
 
@@ -202,12 +201,6 @@ test_fuzz_block_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOC
 test_fuzz_block_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_block_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_block_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
-
-test_fuzz_transaction_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
-test_fuzz_transaction_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTRANSACTION_DESERIALIZE=1
-test_fuzz_transaction_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-test_fuzz_transaction_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
-test_fuzz_transaction_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_blocklocator_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_blocklocator_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCKLOCATOR_DESERIALIZE=1

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -22,6 +22,7 @@ FUZZ_TARGETS = \
   test/fuzz/netaddr_deserialize \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
+  test/fuzz/transaction \
   test/fuzz/transaction_deserialize \
   test/fuzz/txoutcompressor_deserialize \
   test/fuzz/txundo_deserialize
@@ -321,6 +322,13 @@ test_fuzz_blocktransactionsrequest_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCO
 test_fuzz_blocktransactionsrequest_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_blocktransactionsrequest_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_blocktransactionsrequest_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_transaction_SOURCES = $(FUZZ_SUITE) test/fuzz/transaction.cpp
+test_fuzz_transaction_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_transaction_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_transaction_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_transaction_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
 endif # ENABLE_FUZZ
 
 nodist_test_test_bitcoin_SOURCES = $(GENERATED_TEST_FILES)

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -40,11 +40,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 CBlock block;
                 ds >> block;
             } catch (const std::ios_base::failure& e) {return;}
-#elif TRANSACTION_DESERIALIZE
-            try
-            {
-                CTransaction tx(deserialize, ds);
-            } catch (const std::ios_base::failure& e) {return;}
 #elif BLOCKLOCATOR_DESERIALIZE
             try
             {

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <coins.h>
+#include <consensus/tx_check.h>
+#include <consensus/tx_verify.h>
+#include <consensus/validation.h>
+#include <core_io.h>
+#include <core_memusage.h>
+#include <policy/policy.h>
+#include <policy/settings.h>
+#include <primitives/transaction.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+#include <util/rbf.h>
+#include <validation.h>
+#include <version.h>
+
+#include <cassert>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    try {
+        int nVersion;
+        ds >> nVersion;
+        ds.SetVersion(nVersion);
+    } catch (const std::ios_base::failure& e) {
+        return;
+    }
+    bool valid = true;
+    const CTransaction tx = [&] {
+        try {
+            return CTransaction(deserialize, ds);
+        } catch (const std::ios_base::failure& e) {
+            valid = false;
+            return CTransaction();
+        }
+    }();
+    if (!valid) {
+        return;
+    }
+
+    CValidationState state_with_dupe_check;
+    const bool valid_with_dupe_check = CheckTransaction(tx, state_with_dupe_check, /* fCheckDuplicateInputs= */ true);
+    CValidationState state_without_dupe_check;
+    const bool valid_without_dupe_check = CheckTransaction(tx, state_without_dupe_check, /* fCheckDuplicateInputs= */ false);
+    if (valid_with_dupe_check) {
+        assert(valid_without_dupe_check);
+    }
+
+    const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
+    std::string reason;
+    const bool is_standard_with_permit_bare_multisig = IsStandardTx(tx, /* permit_bare_multisig= */ true, dust_relay_fee, reason);
+    const bool is_standard_without_permit_bare_multisig = IsStandardTx(tx, /* permit_bare_multisig= */ false, dust_relay_fee, reason);
+    if (is_standard_without_permit_bare_multisig) {
+        assert(is_standard_with_permit_bare_multisig);
+    }
+
+    (void)tx.GetHash();
+    (void)tx.GetTotalSize();
+    try {
+        (void)tx.GetValueOut();
+    } catch (const std::runtime_error&) {
+    }
+    (void)tx.GetWitnessHash();
+    (void)tx.HasWitness();
+    (void)tx.IsCoinBase();
+    (void)tx.IsNull();
+    (void)tx.ToString();
+
+    (void)EncodeHexTx(tx);
+    (void)GetLegacySigOpCount(tx);
+    (void)GetTransactionWeight(tx);
+    (void)GetVirtualTransactionSize(tx);
+    (void)IsFinalTx(tx, /* nBlockHeight= */ 1024, /* nBlockTime= */ 1024);
+    (void)IsStandardTx(tx, reason);
+    (void)RecursiveDynamicUsage(tx);
+    (void)SignalsOptInRBF(tx);
+}


### PR DESCRIPTION
Add fuzzing harness for `CheckTransaction(...)`, `IsStandardTx(...)` and other `CTransaction` related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/transaction
…
# And to to quickly verify that the relevant code regions are triggered, that the
# fuzzing throughput seems reasonable, etc.
$ contrib/devtools/test_fuzzing_harnesses.sh '^transaction$'
```

`test_fuzzing_harnesses.sh` can be found in PR #17000.