### PR TITLE
tests: Add fuzzing harness for various CScript related functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -22,6 +22,7 @@ FUZZ_TARGETS = \
   test/fuzz/inv_deserialize \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
+  test/fuzz/script \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
   test/fuzz/spanparsing \
@@ -267,6 +268,12 @@ test_fuzz_netaddr_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DNE
 test_fuzz_netaddr_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_netaddr_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_netaddr_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_script_SOURCES = $(FUZZ_SUITE) test/fuzz/script.cpp
+test_fuzz_script_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_script_flags_SOURCES = $(FUZZ_SUITE) test/fuzz/script_flags.cpp
 test_fuzz_script_flags_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <compressor.h>
+#include <core_io.h>
+#include <core_memusage.h>
+#include <policy/policy.h>
+#include <pubkey.h>
+#include <script/descriptor.h>
+#include <script/script.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
+#include <script/standard.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+#include <util/memory.h>
+
+void initialize()
+{
+    // Fuzzers using pubkey must hold an ECCVerifyHandle.
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    const CScript script(buffer.begin(), buffer.end());
+
+    std::vector<unsigned char> compressed;
+    (void)CompressScript(script, compressed);
+
+    CTxDestination address;
+    (void)ExtractDestination(script, address);
+
+    txnouttype type_ret;
+    std::vector<CTxDestination> addresses;
+    int required_ret;
+    (void)ExtractDestinations(script, type_ret, addresses, required_ret);
+
+    (void)GetScriptForWitness(script);
+
+    const FlatSigningProvider signing_provider;
+    (void)InferDescriptor(script, signing_provider);
+
+    (void)IsSegWitOutput(signing_provider, script);
+
+    (void)IsSolvable(signing_provider, script);
+
+    txnouttype which_type;
+    (void)IsStandard(script, which_type);
+
+    (void)RecursiveDynamicUsage(script);
+
+    std::vector<std::vector<unsigned char>> solutions;
+    (void)Solver(script, solutions);
+
+    (void)script.HasValidOps();
+    (void)script.IsPayToScriptHash();
+    (void)script.IsPayToWitnessScriptHash();
+    (void)script.IsPushOnly();
+    (void)script.IsUnspendable();
+    (void)script.GetSigOpCount(/* fAccurate= */ false);
+}


### PR DESCRIPTION
Add fuzzing harness for various `CScript` related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/script
…
# And to to quickly verify that the relevant code regions are triggered, that the
# fuzzing throughput seems reasonable, etc.
$ contrib/devtools/test_fuzzing_harnesses.sh '^script$'
```

`test_fuzzing_harnesses.sh` can be found in PR #17000.