### PR TITLE
init: Change fallback locale to C.UTF-8

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1153,12 +1153,12 @@ void SetupEnvironment()
     }
 #endif
     // On most POSIX systems (e.g. Linux, but not BSD) the environment's locale
-    // may be invalid, in which case the "C" locale is used as fallback.
+    // may be invalid, in which case the "C.UTF-8" locale is used as fallback.
 #if !defined(WIN32) && !defined(MAC_OSX) && !defined(__FreeBSD__) && !defined(__OpenBSD__)
     try {
         std::locale(""); // Raises a runtime error if current locale is invalid
     } catch (const std::runtime_error&) {
-        setenv("LC_ALL", "C", 1);
+        setenv("LC_ALL", "C.UTF-8", 1);
     }
 #elif defined(WIN32)
     // Set the default input/output charset is utf-8


### PR DESCRIPTION
Much of our code assumes file system UTF-8 support, and this is a more realistic guess for modern systems anyway than the default character set (which would be ASCII only). So change the assumed fallback locale (if no locale is defined by the user or OS) to `C.UTF-8`.

related: https://github.com/bitcoin/bitcoin/issues/14948#issuecomment-488385462