### PR TITLE
tests: Fix fs_tests for unknown locales

### DIFF
--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
     fs::path tmpfolder = GetDataDir();
     // tmpfile1 should be the same as tmpfile2
     fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
-    fs::path tmpfile2 = tmpfolder / L"fs_tests_₿_🏃";
+    fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";
     {
         fsbridge::ofstream file(tmpfile1);
         file << "bitcoin";


### PR DESCRIPTION
Fix by removing "L" as suggested by meeDamian in
https://github.com/bitcoin/bitcoin/issues/14948#issuecomment-522355441

```
# all in .../bitcoin/src/test
$ uname -m
x86_64
$ export LC_ALL=randomnonexistentlocale
$ ./test_bitcoin
Running 369 test cases...
unknown location(0): fatal error: in "fs_tests/fsbridge_fstream": boost::system::system_error: boost::filesystem::path codecvt to string: error
test/fs_tests.cpp(13): last checkpoint: "fsbridge_fstream" test entry

*** 1 failure is detected in the test module "Bitcoin Core Test Suite"
```

After the patch is applied, the same test under the same conditions runs fine.

```
$ export LC_ALL=randomnonexistentlocale
$ ./test_bitcoin
Running 369 test cases...

*** No errors detected
```

Co-Authored-By: bugs@meedamian.com