### PR TITLE
build: Add variable printing target to Makefiles

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,10 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+# Pattern rule to print variables, e.g. make print-top_srcdir
+print-%:
+	@echo $* = $($*)
+
 ACLOCAL_AMFLAGS = -I build-aux/m4
 SUBDIRS = src
 if ENABLE_MAN

--- a/depends/Makefile
+++ b/depends/Makefile
@@ -1,5 +1,9 @@
 .NOTPARALLEL :
 
+# Pattern rule to print variables, e.g. make print-top_srcdir
+print-%:
+	@echo $* = $($*)
+
 SOURCES_PATH ?= $(BASEDIR)/sources
 WORK_PATH = $(BASEDIR)/work
 BASE_CACHE ?= $(BASEDIR)/built


### PR DESCRIPTION
```
I kept finding myself needing these to debug our build system, since
they are innocuous and are very helpful they probably belong in the
codebase.

Source: John Graham-Cumming
https://www.cmcrossroads.com/article/printing-value-makefile-variable
```