### PR TITLE
tests: Add fuzzing harness for various CTx{In,Out} related functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -47,6 +47,7 @@ FUZZ_TARGETS = \
   test/fuzz/spanparsing \
   test/fuzz/sub_net_deserialize \
   test/fuzz/transaction \
+  test/fuzz/tx_in \
   test/fuzz/tx_in_deserialize \
   test/fuzz/txoutcompressor_deserialize \
   test/fuzz/txundo_deserialize
@@ -496,6 +497,12 @@ test_fuzz_tx_in_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTX_I
 test_fuzz_tx_in_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_tx_in_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_tx_in_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_tx_in_SOURCES = $(FUZZ_SUITE) test/fuzz/tx_in.cpp
+test_fuzz_tx_in_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_tx_in_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_tx_in_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_tx_in_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 endif # ENABLE_FUZZ
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -49,6 +49,7 @@ FUZZ_TARGETS = \
   test/fuzz/transaction \
   test/fuzz/tx_in \
   test/fuzz/tx_in_deserialize \
+  test/fuzz/tx_out \
   test/fuzz/txoutcompressor_deserialize \
   test/fuzz/txundo_deserialize
 
@@ -503,6 +504,12 @@ test_fuzz_tx_in_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_tx_in_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_tx_in_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_tx_in_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_tx_out_SOURCES = $(FUZZ_SUITE) test/fuzz/tx_out.cpp
+test_fuzz_tx_out_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_tx_out_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_tx_out_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_tx_out_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 endif # ENABLE_FUZZ
 

--- a/src/test/fuzz/tx_in.cpp
+++ b/src/test/fuzz/tx_in.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/validation.h>
+#include <core_memusage.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+#include <version.h>
+
+#include <cassert>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    CTxIn tx_in;
+    try {
+        int version;
+        ds >> version;
+        ds.SetVersion(version);
+        ds >> tx_in;
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+
+    (void)GetTransactionInputWeight(tx_in);
+    (void)GetVirtualTransactionInputSize(tx_in);
+    (void)RecursiveDynamicUsage(tx_in);
+
+    (void)tx_in.ToString();
+}

--- a/src/test/fuzz/tx_out.cpp
+++ b/src/test/fuzz/tx_out.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <consensus/validation.h>
+#include <core_memusage.h>
+#include <policy/policy.h>
+#include <primitives/transaction.h>
+#include <streams.h>
+#include <test/fuzz/fuzz.h>
+#include <version.h>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+    CTxOut tx_out;
+    try {
+        int version;
+        ds >> version;
+        ds.SetVersion(version);
+        ds >> tx_out;
+    } catch (const std::ios_base::failure&) {
+        return;
+    }
+
+    const CFeeRate dust_relay_fee{DUST_RELAY_TX_FEE};
+    (void)GetDustThreshold(tx_out, dust_relay_fee);
+    (void)IsDust(tx_out, dust_relay_fee);
+    (void)RecursiveDynamicUsage(tx_out);
+
+    (void)tx_out.ToString();
+    (void)tx_out.IsNull();
+    tx_out.SetNull();
+    assert(tx_out.IsNull());
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -32,6 +32,8 @@ FUZZERS_MISSING_CORPORA = [
     "script_deserialize",
     "sub_net_deserialize",
     "tx_in_deserialize",
+    "tx_in",
+    "tx_out",
 ]
 
 def main():


### PR DESCRIPTION
Add fuzzing harness for various `CTx{In,Out}` related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/tx_in
…
$ src/test/fuzz/tx_out
…
# And to to quickly verify that the relevant code regions are triggered, that the
# fuzzing throughput seems reasonable, etc.
$ contrib/devtools/test_fuzzing_harnesses.sh '^tx_'
```

`test_fuzzing_harnesses.sh` can be found in PR #17000.