### PR TITLE
doc: Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,25 @@
+# Nonspecific maintainers
+#   @laanwj
+#   @sipa
+#   @fanquake
+
+# Build system maintainer
+/configure.ac         @theuni
+/build-aux/           @theuni
+/depends/             @theuni
+*.am                  @theuni
+Makefile.*            @theuni
+
+# Test framework maintainer
+/src/test/            @marcofalke
+/test/                @marcofalke
+/ci/                  @marcofalke
+
+# GUI maintainer
+/src/qt/              @jonasschnelli
+
+# Wallet maintainer
+/src/wallet/          @meshcollider
+
+# MSVC build system maintainer
+/build_msvc/          @sipsorcery


### PR DESCRIPTION
Code owners (maintainers) will be added automatically to the "Reviewers" list for a PR and notified when a PR is opened.

See https://help.github.com/en/articles/about-code-owners for syntax.

Let me know if you want to be added for a specific path or file wildcard.