### PR TITLE
build: `make dist` uses `git archive`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/bitcoin-*
 *.tar.gz
 
 *.exe

--- a/Makefile.am
+++ b/Makefile.am
@@ -14,7 +14,7 @@ if ENABLE_MAN
 SUBDIRS += doc/man
 endif
 
-.PHONY: deploy FORCE
+.PHONY: dist deploy FORCE
 
 export PYTHONPATH
 
@@ -63,8 +63,16 @@ COVERAGE_INFO = baseline.info \
   baseline_filtered.info functional_test.info functional_test_filtered.info \
   test_bitcoin_coverage.info test_bitcoin.info
 
-dist-hook:
-	- $(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_distdir) -xf -
+dist:
+	$(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_builddir) -xf -
+	$(GIT) add -f \
+	aclocal.m4 configure build-aux Makefile.in src/Makefile.in src/config/bitcoin-config.h.in \
+	src/univalue/aclocal.m4 src/univalue/configure src/univalue/build-aux src/univalue/Makefile.in src/univalue/univalue-config.h.in \
+	src/secp256k1/aclocal.m4 src/secp256k1/configure src/secp256k1/build-aux src/secp256k1/Makefile.in src/secp256k1/src/libsecp256k1-config.h.in \
+	doc/man/Makefile.in
+	$(GIT) reset -- build-aux/m4 src/univalue/build-aux/m4 src/secp256k1/build-aux/m4
+	$(GIT) stash --all && $(GIT) archive --format=tar --prefix=$(top_distdir)/ stash@{0} > $(top_builddir)/$(top_distdir).tar && gzip $(top_distdir).tar
+	$(GIT) stash pop --quiet && $(GIT) reset && $(GIT) checkout -- src/clientversion.cpp
 
 # Begin Windows rules
 $(WIN_INSTALLER): all-recursive

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,14 +7,12 @@ print-%:
 	@echo $* = $($*)
 
 ACLOCAL_AMFLAGS = -I build-aux/m4
+.PHONY: deploy FORCE
 
 SUBDIRS = src
-
 if ENABLE_MAN
 SUBDIRS += doc/man
 endif
-
-.PHONY: dist deploy FORCE
 
 export PYTHONPATH
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,10 +7,13 @@ print-%:
 	@echo $* = $($*)
 
 ACLOCAL_AMFLAGS = -I build-aux/m4
+
 SUBDIRS = src
+
 if ENABLE_MAN
 SUBDIRS += doc/man
 endif
+
 .PHONY: deploy FORCE
 
 export PYTHONPATH
@@ -25,10 +28,16 @@ BITCOIN_QT_BIN=$(top_builddir)/src/qt/$(BITCOIN_GUI_NAME)$(EXEEXT)
 BITCOIN_CLI_BIN=$(top_builddir)/src/$(BITCOIN_CLI_NAME)$(EXEEXT)
 BITCOIN_TX_BIN=$(top_builddir)/src/$(BITCOIN_TX_NAME)$(EXEEXT)
 BITCOIN_WALLET_BIN=$(top_builddir)/src/$(BITCOIN_WALLET_TOOL_NAME)$(EXEEXT)
-BITCOIN_WIN_INSTALLER=$(PACKAGE)-$(PACKAGE_VERSION)-win$(WINDOWS_BITS)-setup$(EXEEXT)
 
 empty :=
 space := $(empty) $(empty)
+
+WIN_INSTALLER=$(PACKAGE)-$(PACKAGE_VERSION)-win$(WINDOWS_BITS)-setup$(EXEEXT)
+
+WIN_PACKAGING = $(top_srcdir)/share/pixmaps/bitcoin.ico \
+  $(top_srcdir)/share/pixmaps/nsis-header.bmp \
+  $(top_srcdir)/share/pixmaps/nsis-wizard.bmp \
+  $(top_srcdir)/doc/README_windows.txt
 
 OSX_APP=Bitcoin-Qt.app
 OSX_VOLNAME = $(subst $(space),-,$(PACKAGE_NAME))
@@ -40,30 +49,8 @@ OSX_DSSTORE_GEN=$(top_srcdir)/contrib/macdeploy/custom_dsstore.py
 OSX_DEPLOY_SCRIPT=$(top_srcdir)/contrib/macdeploy/macdeployqtplus
 OSX_FANCY_PLIST=$(top_srcdir)/contrib/macdeploy/fancy.plist
 OSX_INSTALLER_ICONS=$(top_srcdir)/src/qt/res/icons/bitcoin.icns
-OSX_PLIST=$(top_builddir)/share/qt/Info.plist #not installed
+OSX_PLIST=$(top_builddir)/share/qt/Info.plist # not installed
 OSX_QT_TRANSLATIONS = da,de,es,hu,ru,uk,zh_CN,zh_TW
-
-DIST_DOCS = \
-  README.md \
-  $(wildcard doc/*.md) \
-  $(wildcard doc/release-notes/*.md)
-DIST_CONTRIB = $(top_srcdir)/contrib/bitcoin-cli.bash-completion \
-	       $(top_srcdir)/contrib/bitcoin-tx.bash-completion \
-	       $(top_srcdir)/contrib/bitcoind.bash-completion \
-	       $(top_srcdir)/contrib/debian/copyright \
-	       $(top_srcdir)/contrib/init \
-	       $(top_srcdir)/contrib/install_db4.sh
-DIST_SHARE = \
-  $(top_srcdir)/share/genbuild.sh \
-  $(top_srcdir)/share/rpcauth
-
-BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py \
-           $(top_srcdir)/contrib/devtools/security-check.py
-
-WINDOWS_PACKAGING = $(top_srcdir)/share/pixmaps/bitcoin.ico \
-  $(top_srcdir)/share/pixmaps/nsis-header.bmp \
-  $(top_srcdir)/share/pixmaps/nsis-wizard.bmp \
-  $(top_srcdir)/doc/README_windows.txt
 
 OSX_PACKAGING = $(OSX_DEPLOY_SCRIPT) $(OSX_FANCY_PLIST) $(OSX_INSTALLER_ICONS) \
   $(top_srcdir)/contrib/macdeploy/$(OSX_BACKGROUND_SVG) \
@@ -77,9 +64,10 @@ COVERAGE_INFO = baseline.info \
   test_bitcoin_coverage.info test_bitcoin.info
 
 dist-hook:
-	-$(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_distdir) -xf -
+	- $(GIT) archive --format=tar HEAD -- src/clientversion.cpp | $(AMTAR) -C $(top_distdir) -xf -
 
-$(BITCOIN_WIN_INSTALLER): all-recursive
+# Begin Windows rules
+$(WIN_INSTALLER): all-recursive
 	$(MKDIR_P) $(top_builddir)/release
 	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM) $(BITCOIND_BIN) $(top_builddir)/release
 	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM) $(BITCOIN_QT_BIN) $(top_builddir)/release
@@ -88,15 +76,17 @@ $(BITCOIN_WIN_INSTALLER): all-recursive
 	STRIPPROG="$(STRIP)" $(INSTALL_STRIP_PROGRAM) $(BITCOIN_WALLET_BIN) $(top_builddir)/release
 	@test -f $(MAKENSIS) && $(MAKENSIS) -V2 $(top_builddir)/share/setup.nsi || \
 	  echo error: could not build $@
-	@echo built $@
+	@echo built: $@
+# End Windows rules
 
+# Begin MacOS rules
 $(OSX_APP)/Contents/PkgInfo:
 	$(MKDIR_P) $(@D)
 	@echo "APPL????" > $@
 
 $(OSX_APP)/Contents/Resources/empty.lproj:
 	$(MKDIR_P) $(@D)
-	@touch $@ 
+	@touch $@
 
 $(OSX_APP)/Contents/Info.plist: $(OSX_PLIST)
 	$(MKDIR_P) $(@D)
@@ -161,13 +151,15 @@ $(APP_DIST_DIR)/$(OSX_APP)/Contents/MacOS/Bitcoin-Qt: $(OSX_APP_BUILT) $(OSX_PAC
 
 deploydir: $(APP_DIST_EXTRAS)
 endif
+# End MacOS rules
 
 if TARGET_DARWIN
 appbundle: $(OSX_APP_BUILT)
 deploy: $(OSX_DMG)
 endif
+
 if TARGET_WINDOWS
-deploy: $(BITCOIN_WIN_INSTALLER)
+deploy: $(WIN_INSTALLER)
 endif
 
 $(BITCOIN_QT_BIN): FORCE
@@ -228,72 +220,11 @@ total.coverage/.dirstamp: total_coverage.info
 	@touch $@
 
 cov: test_bitcoin.coverage/.dirstamp total.coverage/.dirstamp
-
 endif
 
 dist_noinst_SCRIPTS = autogen.sh
 
-EXTRA_DIST = $(DIST_SHARE) $(DIST_CONTRIB) $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
-
-EXTRA_DIST += \
-    test/functional \
-    test/fuzz
-
-EXTRA_DIST += \
-    test/util/bitcoin-util-test.py \
-    test/util/data/bitcoin-util-test.json \
-    test/util/data/blanktxv1.hex \
-    test/util/data/blanktxv1.json \
-    test/util/data/blanktxv2.hex \
-    test/util/data/blanktxv2.json \
-    test/util/data/tt-delin1-out.hex \
-    test/util/data/tt-delin1-out.json \
-    test/util/data/tt-delout1-out.hex \
-    test/util/data/tt-delout1-out.json \
-    test/util/data/tt-locktime317000-out.hex \
-    test/util/data/tt-locktime317000-out.json \
-    test/util/data/tx394b54bb.hex \
-    test/util/data/txcreate1.hex \
-    test/util/data/txcreate1.json \
-    test/util/data/txcreate2.hex \
-    test/util/data/txcreate2.json \
-    test/util/data/txcreatedata1.hex \
-    test/util/data/txcreatedata1.json \
-    test/util/data/txcreatedata2.hex \
-    test/util/data/txcreatedata2.json \
-    test/util/data/txcreatedata_seq0.hex \
-    test/util/data/txcreatedata_seq0.json \
-    test/util/data/txcreatedata_seq1.hex \
-    test/util/data/txcreatedata_seq1.json \
-    test/util/data/txcreatemultisig1.hex \
-    test/util/data/txcreatemultisig1.json \
-    test/util/data/txcreatemultisig2.hex \
-    test/util/data/txcreatemultisig2.json \
-    test/util/data/txcreatemultisig3.hex \
-    test/util/data/txcreatemultisig3.json \
-    test/util/data/txcreatemultisig4.hex \
-    test/util/data/txcreatemultisig4.json \
-    test/util/data/txcreatemultisig5.json \
-    test/util/data/txcreateoutpubkey1.hex \
-    test/util/data/txcreateoutpubkey1.json \
-    test/util/data/txcreateoutpubkey2.hex \
-    test/util/data/txcreateoutpubkey2.json \
-    test/util/data/txcreateoutpubkey3.hex \
-    test/util/data/txcreateoutpubkey3.json \
-    test/util/data/txcreatescript1.hex \
-    test/util/data/txcreatescript1.json \
-    test/util/data/txcreatescript2.hex \
-    test/util/data/txcreatescript2.json \
-    test/util/data/txcreatescript3.hex \
-    test/util/data/txcreatescript3.json \
-    test/util/data/txcreatescript4.hex \
-    test/util/data/txcreatescript4.json \
-    test/util/data/txcreatesignv1.hex \
-    test/util/data/txcreatesignv1.json \
-    test/util/data/txcreatesignv2.hex \
-    test/util/rpcauth-test.py
-
-CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
+CLEANFILES = $(OSX_DMG) $(WIN_INSTALLER)
 
 .INTERMEDIATE: $(COVERAGE_INFO)
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -250,7 +250,7 @@ BITCOIN_CORE_H = \
 
 obj/build.h: FORCE
 	@$(MKDIR_P) $(builddir)/obj
-	@"$(abs_top_srcdir)/share/genbuild.sh" "$(abs_top_builddir)/src/obj/build.h" \
+	@"$(abs_top_builddir)/share/genbuild.sh" "$(abs_top_builddir)/src/obj/build.h" \
 	  "$(abs_top_srcdir)"
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
@@ -674,7 +674,7 @@ config/bitcoin-config.h: config/stamp-h1
 	@$(MAKE) -C $(top_builddir) $(subdir)/$(@)
 config/stamp-h1: $(top_srcdir)/$(subdir)/config/bitcoin-config.h.in $(top_builddir)/config.status
 	$(AM_V_at)$(MAKE) -C $(top_builddir) $(subdir)/$(@)
-$(top_srcdir)/$(subdir)/config/bitcoin-config.h.in:  $(am__configure_deps)
+$(top_srcdir)/$(subdir)/config/bitcoin-config.h.in: $(am__configure_deps)
 	$(AM_V_at)$(MAKE) -C $(top_srcdir) $(subdir)/config/bitcoin-config.h.in
 
 clean-local:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -250,7 +250,7 @@ BITCOIN_CORE_H = \
 
 obj/build.h: FORCE
 	@$(MKDIR_P) $(builddir)/obj
-	@$(top_srcdir)/share/genbuild.sh "$(abs_top_builddir)/src/obj/build.h" \
+	@"$(abs_top_srcdir)/share/genbuild.sh" "$(abs_top_builddir)/src/obj/build.h" \
 	  "$(abs_top_srcdir)"
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 


### PR DESCRIPTION
Changes `make dist` to use `git archive` instead of its default approach ,`EXTRA_DIST`.

The clientversion.cpp version suffix is set to the commit hash of `HEAD`. There are additional files that are appended beyond this, namely configure and other autotools generated files. The .git directory is not included. Target `dist:` is used without a `dist-hook:`.

```
./autogen.sh && ./configure && make dist
```

Lastly, simplifies the layout of Makefile.am.

Note - MacOS would need `gtar` to use `tar --transform` for appending the autotools generated files in a prefixed way (an alternate approach). This PR uses `git add -f` instead.