### PR TITLE
Chainparams: Decouple AllowSetMockTime from MineBlocksOnDemand

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -132,6 +132,7 @@ public:
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_main, pnSeed6_main + ARRAYLEN(pnSeed6_main));
 
+        m_allow_set_mocktime = false;
         fDefaultConsistencyChecks = false;
         fRequireStandard = true;
         m_is_test_chain = false;
@@ -228,6 +229,7 @@ public:
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
+        m_allow_set_mocktime = false;
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
         m_is_test_chain = true;
@@ -300,6 +302,7 @@ public:
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
 
+        m_allow_set_mocktime = true;
         fDefaultConsistencyChecks = true;
         fRequireStandard = true;
         m_is_test_chain = true;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -229,7 +229,7 @@ public:
 
         vFixedSeeds = std::vector<SeedSpec6>(pnSeed6_test, pnSeed6_test + ARRAYLEN(pnSeed6_test));
 
-        m_allow_set_mocktime = false;
+        m_allow_set_mocktime = true;
         fDefaultConsistencyChecks = false;
         fRequireStandard = false;
         m_is_test_chain = true;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -292,7 +292,7 @@ public:
         m_assumed_blockchain_size = 0;
         m_assumed_chain_state_size = 0;
 
-        UpdateActivationParametersFromArgs(args);
+        UpdateFromArgs(args);
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -302,7 +302,6 @@ public:
         vFixedSeeds.clear(); //!< Regtest mode doesn't have any fixed seeds.
         vSeeds.clear();      //!< Regtest mode doesn't have any DNS seeds.
 
-        m_allow_set_mocktime = true;
         fDefaultConsistencyChecks = true;
         fRequireStandard = true;
         m_is_test_chain = true;
@@ -337,6 +336,7 @@ public:
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
     void UpdateActivationParametersFromArgs(const ArgsManager& args);
+    void UpdateFromArgs(const ArgsManager& args);
 };
 
 void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
@@ -380,6 +380,12 @@ void CRegTestParams::UpdateActivationParametersFromArgs(const ArgsManager& args)
             throw std::runtime_error(strprintf("Invalid deployment (%s)", vDeploymentParams[0]));
         }
     }
+}
+void CRegTestParams::UpdateFromArgs(const ArgsManager& args)
+{
+    UpdateActivationParametersFromArgs(args);
+
+    m_allow_set_mocktime = args.GetBoolArg("-allow_set_mocktime", true);
 }
 
 static std::unique_ptr<const CChainParams> globalChainParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -73,6 +73,8 @@ public:
     uint64_t AssumedBlockchainSize() const { return m_assumed_blockchain_size; }
     /** Minimum free space (in GB) needed for data directory when pruned; Does not include prune target*/
     uint64_t AssumedChainStateSize() const { return m_assumed_chain_state_size; }
+    /** Whether it is allowed set a mock time */
+    bool AllowSetMockTime() const { return m_allow_set_mocktime; }
     /** Whether it is possible to mine blocks on demand (no retargeting) */
     bool MineBlocksOnDemand() const { return consensus.fPowNoRetargeting; }
     /** Return the BIP70 network string (main, test or regtest) */
@@ -99,6 +101,7 @@ protected:
     std::string strNetworkID;
     CBlock genesis;
     std::vector<SeedSpec6> vFixedSeeds;
+    bool m_allow_set_mocktime;
     bool fDefaultConsistencyChecks;
     bool fRequireStandard;
     bool m_is_test_chain;

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -23,6 +23,7 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-segwitheight=<n>", "Set the activation height of segwit. -1 to disable. (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     gArgs.AddArg("-testnet", "Use the test chain. Equivalent to -chain=test.", ArgsManager::ALLOW_ANY, OptionsCategory::CHAINPARAMS);
     gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
+    gArgs.AddArg("-allow_set_mocktime", "Whether it is allowed to call rpc setmocktime or not. Default: 1 (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
 }
 
 static std::unique_ptr<CBaseChainParams> globalChainBaseParams;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -350,8 +350,8 @@ static UniValue setmocktime(const JSONRPCRequest& request)
                 RPCExamples{""},
             }.Check(request);
 
-    if (!Params().MineBlocksOnDemand())
-        throw std::runtime_error("setmocktime for regression testing (-regtest mode) only");
+    if (!Params().AllowSetMockTime())
+        throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("setmocktime is not allowed for chain %s", Params().NetworkIDString()));
 
     // For now, don't change mocktime if we're in the middle of validation, as
     // this could have an effect on mempool time-based eviction, as well as

--- a/test/functional/rpc_forbidden.py
+++ b/test/functional/rpc_forbidden.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test rpc calls can be forbidden for main chain
+
+Test the following RPCs:
+    - setmocktime
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+class RpcForbiddenTest(BitcoinTestFramework):
+
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [[
+            '-allow_set_mocktime=0',
+        ]]
+
+    def run_test(self):
+        assert_raises_rpc_error(-8, 'setmocktime is not allowed for chain %s' % self.chain, self.nodes[0].setmocktime, '1255227617')
+
+if __name__ == '__main__':
+    RpcForbiddenTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -202,6 +202,7 @@ BASE_SCRIPTS = [
     'feature_includeconf.py',
     'rpc_deriveaddresses.py',
     'rpc_deriveaddresses.py --usecli',
+    'rpc_forbidden.py',
     'rpc_scantxoutset.py',
     'feature_logging.py',
     'p2p_node_network_limited.py',


### PR DESCRIPTION
Even if a test chain doesn't MineBlocksOnDemand (aka consensus.fPowNoRetargeting = false), it may make sense to allow the rpc call setmocktime for that chain.

For example, it could be allowed by default for testnet3 (aka "test" on bip70).
Or at least this is what I think MarcoFalke wants from our last conversation on IRC.
For more context see https://github.com/bitcoin/bitcoin/pull/16770#issuecomment-537711517

As a bonus, unlike consensus.fPowNoRetargeting, the new field m_allow_set_mocktime gets fully out of consensus code in the sense that people "greping" from consensus/params.h don't need to necessarily look at rpc call setmocktime in rpc/misc.cpp if that's not what they're looking for.
One less read to Consensus::Params.
Not sure if that last part makes sense to anyone else but me as reasons to get this merged. 

