### PR TITLE
tests: Add fuzzing harness for various functions consuming only integrals

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -26,6 +26,7 @@ FUZZ_TARGETS = \
   test/fuzz/eval_script \
   test/fuzz/fee_rate_deserialize \
   test/fuzz/flat_file_pos_deserialize \
+  test/fuzz/integer \
   test/fuzz/inv_deserialize \
   test/fuzz/key_origin_info_deserialize \
   test/fuzz/merkle_block_deserialize \
@@ -364,6 +365,12 @@ test_fuzz_eval_script_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_eval_script_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_eval_script_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_eval_script_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_integer_SOURCES = $(FUZZ_SUITE) test/fuzz/integer.cpp
+test_fuzz_integer_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_integer_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_integer_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_integer_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_txoutcompressor_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_txoutcompressor_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTXOUTCOMPRESSOR_DESERIALIZE=1

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <arith_uint256.h>
+#include <compressor.h>
+#include <consensus/merkle.h>
+#include <core_io.h>
+#include <crypto/common.h>
+#include <crypto/siphash.h>
+#include <key_io.h>
+#include <memusage.h>
+#include <netbase.h>
+#include <policy/settings.h>
+#include <pow.h>
+#include <pubkey.h>
+#include <rpc/util.h>
+#include <script/signingprovider.h>
+#include <script/standard.h>
+#include <serialize.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <uint256.h>
+#include <util/strencodings.h>
+#include <util/system.h>
+#include <util/time.h>
+
+#include <cassert>
+#include <limits>
+#include <vector>
+
+void initialize()
+{
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    if (buffer.size() < sizeof(uint256) + sizeof(uint160)) {
+        return;
+    }
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const uint256 u256(fuzzed_data_provider.ConsumeBytes<unsigned char>(sizeof(uint256)));
+    const uint160 u160(fuzzed_data_provider.ConsumeBytes<unsigned char>(sizeof(uint160)));
+    const uint64_t u64 = fuzzed_data_provider.ConsumeIntegral<uint64_t>();
+    const int64_t i64 = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+    const uint32_t u32 = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+    const int32_t i32 = fuzzed_data_provider.ConsumeIntegral<int32_t>();
+    const uint16_t u16 = fuzzed_data_provider.ConsumeIntegral<uint16_t>();
+    const int16_t i16 = fuzzed_data_provider.ConsumeIntegral<int16_t>();
+    const uint8_t u8 = fuzzed_data_provider.ConsumeIntegral<uint8_t>();
+    const int8_t i8 = fuzzed_data_provider.ConsumeIntegral<int8_t>();
+    // We cannot assume a specific value of std::is_signed<char>::value:
+    // ConsumeIntegral<char>() instead of casting from {u,}int8_t.
+    const char ch = fuzzed_data_provider.ConsumeIntegral<char>();
+
+    const Consensus::Params& consensus_params = Params().GetConsensus();
+    (void)CheckProofOfWork(u256, u32, consensus_params);
+    (void)CompressAmount(u64);
+    static const uint256 u256_min(uint256S("0000000000000000000000000000000000000000000000000000000000000000"));
+    static const uint256 u256_max(uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+    const std::vector<uint256> v256{u256, u256_min, u256_max};
+    (void)ComputeMerkleRoot(v256);
+    (void)CountBits(u64);
+    (void)DecompressAmount(u64);
+    (void)FormatISO8601Date(i64);
+    (void)FormatISO8601DateTime(i64);
+    (void)GetSizeOfCompactSize(u64);
+    (void)GetSpecialScriptSize(u32);
+    // (void)GetVirtualTransactionSize(i64, i64); // function defined only for a subset of int64_t inputs
+    // (void)GetVirtualTransactionSize(i64, i64, u32); // function defined only for a subset of int64_t/uint32_t inputs
+    (void)HexDigit(ch);
+    (void)i64tostr(i64);
+    (void)IsDigit(ch);
+    (void)IsSpace(ch);
+    (void)IsSwitchChar(ch);
+    (void)itostr(i32);
+    (void)memusage::DynamicUsage(ch);
+    (void)memusage::DynamicUsage(i16);
+    (void)memusage::DynamicUsage(i32);
+    (void)memusage::DynamicUsage(i64);
+    (void)memusage::DynamicUsage(i8);
+    (void)memusage::DynamicUsage(u16);
+    (void)memusage::DynamicUsage(u32);
+    (void)memusage::DynamicUsage(u64);
+    (void)memusage::DynamicUsage(u8);
+    const unsigned char uch = static_cast<unsigned char>(u8);
+    (void)memusage::DynamicUsage(uch);
+    (void)MillisToTimeval(i64);
+    const double d = ser_uint64_to_double(u64);
+    assert(ser_double_to_uint64(d) == u64);
+    const float f = ser_uint32_to_float(u32);
+    assert(ser_float_to_uint32(f) == u32);
+    (void)SighashToStr(uch);
+    (void)SipHashUint256(u64, u64, u256);
+    (void)SipHashUint256Extra(u64, u64, u256, u32);
+    (void)ToLower(ch);
+
+    const arith_uint256 au256 = UintToArith256(u256);
+    assert(ArithToUint256(au256) == u256);
+    assert(uint256S(au256.GetHex()) == u256);
+    (void)au256.bits();
+    (void)au256.GetCompact(/* fNegative= */ false);
+    (void)au256.GetCompact(/* fNegative= */ true);
+    (void)au256.getdouble();
+    (void)au256.GetHex();
+    (void)au256.GetLow64();
+    (void)au256.size();
+    (void)au256.ToString();
+
+    const CKeyID key_id{u160};
+    const CScriptID script_id{u160};
+    // CTxDestination = CNoDestination ∪ PKHash ∪ ScriptHash ∪ WitnessV0ScriptHash ∪ WitnessV0KeyHash ∪ WitnessUnknown
+    const PKHash pk_hash{u160};
+    const ScriptHash script_hash{u160};
+    const WitnessV0KeyHash witness_v0_key_hash{u160};
+    const WitnessV0ScriptHash witness_v0_script_hash{u256};
+    const std::vector<CTxDestination> destinations{pk_hash, script_hash, witness_v0_key_hash, witness_v0_script_hash};
+    const SigningProvider store;
+    for (const CTxDestination& destination : destinations) {
+        (void)DescribeAddress(destination);
+        (void)EncodeDestination(destination);
+        (void)GetKeyForDestination(store, destination);
+        (void)GetScriptForDestination(destination);
+        (void)IsValidDestination(destination);
+    }
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -20,6 +20,7 @@ FUZZERS_MISSING_CORPORA = [
     "block_header_and_short_txids_deserialize",
     "fee_rate_deserialize",
     "flat_file_pos_deserialize",
+    "integer",
     "key_origin_info_deserialize",
     "merkle_block_deserialize",
     "out_point_deserialize",


### PR DESCRIPTION
Add fuzzing harness for various functions consuming only integrals.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/integer
```