### PR TITLE
tests: Add fuzzing harness for descriptor Span-parsing helpers

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -23,6 +23,7 @@ FUZZ_TARGETS = \
   test/fuzz/netaddr_deserialize \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
+  test/fuzz/spanparsing \
   test/fuzz/transaction \
   test/fuzz/txoutcompressor_deserialize \
   test/fuzz/txundo_deserialize
@@ -269,6 +270,12 @@ test_fuzz_service_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSE
 test_fuzz_service_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_service_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_service_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_spanparsing_SOURCES = $(FUZZ_SUITE) test/fuzz/spanparsing.cpp
+test_fuzz_spanparsing_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_spanparsing_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_spanparsing_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_spanparsing_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_messageheader_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_messageheader_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DMESSAGEHEADER_DESERIALIZE=1

--- a/src/test/fuzz/spanparsing.cpp
+++ b/src/test/fuzz/spanparsing.cpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/spanparsing.h>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const size_t query_size = fuzzed_data_provider.ConsumeIntegral<size_t>();
+    const std::string query = fuzzed_data_provider.ConsumeBytesAsString(std::min<size_t>(query_size, 1024 * 1024));
+    const std::string span_str = fuzzed_data_provider.ConsumeRemainingBytesAsString();
+    const Span<const char> const_span = MakeSpan(span_str);
+
+    Span<const char> mut_span = const_span;
+    (void)spanparsing::Const(query, mut_span);
+
+    mut_span = const_span;
+    (void)spanparsing::Func(query, mut_span);
+
+    mut_span = const_span;
+    (void)spanparsing::Expr(mut_span);
+
+    if (!query.empty()) {
+        mut_span = const_span;
+        (void)spanparsing::Split(mut_span, query.front());
+    }
+}


### PR DESCRIPTION
Add fuzzing harness for descriptor Span-parsing helpers (`spanparsing`).

As suggested by a fuzz testing enthusiast in https://github.com/bitcoin/bitcoin/pull/16887#issuecomment-540655816.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/spanparsing
```