### PR TITLE
test: speedup wallet_backup by whitelisting peers (immediate tx relay)

### DIFF
--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -48,7 +48,13 @@ class WalletBackupTest(BitcoinTestFramework):
         self.num_nodes = 4
         self.setup_clean_chain = True
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
-        self.extra_args = [["-keypool=100"], ["-keypool=100"], ["-keypool=100"], []]
+        # whitelist all peers to speed up tx relay / mempool sync
+        self.extra_args = [
+            ["-keypool=100", "-whitelist=127.0.0.1"],
+            ["-keypool=100", "-whitelist=127.0.0.1"],
+            ["-keypool=100", "-whitelist=127.0.0.1"],
+            ["-whitelist=127.0.0.1"]
+        ]
         self.rpc_timeout = 120
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
approaches part of #16613 ("Functional test suite bottlenecks")

The majority of the test time is spent in `sync_mempools()` after sending to
addresses, i.e. the bottleneck is in relaying transactions. By whitelisting the
peers via `-whitelist`, the inventory is transmissioned immediately rather than
on average every 5 seconds, speeding up the test by at least a factor of two:

before:
```
$ time ./wallet_backup.py
real    2m2.523s
user    0m6.093s
sys 0m2.454s
```
with this PR:
```
$ time ./wallet_backup_with_whitelist.py
real    0m36.570s
user    0m5.365s
sys 0m1.696s
```
Note that the test is not deterministic (the `sendtoaddress` RPC in function
`one_send()` is executed with a probability of 50%), hence the times could vary
between individual runs.