### PR TITLE
test: speed up wallet_address_types by whitelisting peers (immediate tx relay)

### DIFF
--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -80,6 +80,9 @@ class AddressTypeTest(BitcoinTestFramework):
             ["-changetype=p2sh-segwit"],
             [],
         ]
+        # whitelist all peers to speed up tx relay / mempool sync
+        for args in self.extra_args:
+            args.append("-whitelist=127.0.0.1")
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()


### PR DESCRIPTION
approaches another part of #16613 ("Functional test suite bottlenecks")

As for `wallet_backup.py` (Commit 581c9be0d8bff46cd68bd6a3bf72f22d11c09aea), the
bottleneck is in relaying transactions. By whitelisting the peers, the
inventory is transmissioned immediately rather than on average every 5 seconds,
speeding up the test significantly:

before:
```
$ time ./wallet_address_types.py
real    1m30.072s
user    0m6.478s
sys     0m2.298s
```

with this PR:
```
$ time ./wallet_address_types.py
real    0m26.785s
user    0m5.525s
sys     0m1.888s
```