### PR TITLE
gui: Add toolTip and placeholderText to sign message fields

### DIFF
--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -285,10 +285,24 @@
         </layout>
        </item>
        <item>
-        <widget class="QPlainTextEdit" name="messageIn_VM"/>
+        <widget class="QPlainTextEdit" name="messageIn_VM">
+          <property name="toolTip">
+            <string>The signed message to verify</string>
+          </property>
+          <property name="placeholderText">
+            <string>The signed message to verify</string>
+          </property>
+        </widget>
        </item>
        <item>
-        <widget class="QValidatedLineEdit" name="signatureIn_VM"/>
+        <widget class="QValidatedLineEdit" name="signatureIn_VM">
+          <property name="toolTip">
+            <string>The signature given when the message was signed</string>
+          </property>
+          <property name="placeholderText">
+            <string>The signature given when the message was signed</string>
+          </property>
+        </widget>
        </item>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_2_VM">


### PR DESCRIPTION
When using the Verify Message functionality, I found the input boxes to be rather confusing as they had no guidance for their purpose.

I have added tooltips and labels to aid users when verifying messages in future