### PR TITLE
gui: remove unnecessary shortcuts in bitcoingui files

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -411,7 +411,6 @@ void BitcoinGUI::createActions()
     }
 #endif // ENABLE_WALLET
 
-    connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_C), this), &QShortcut::activated, this, &BitcoinGUI::showDebugWindowActivateConsole);
     connect(new QShortcut(QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_D), this), &QShortcut::activated, this, &BitcoinGUI::showDebugWindow);
 }
 
@@ -792,12 +791,6 @@ void BitcoinGUI::showDebugWindow()
 {
     GUIUtil::bringToFront(rpcConsole);
     Q_EMIT consoleShown(rpcConsole);
-}
-
-void BitcoinGUI::showDebugWindowActivateConsole()
-{
-    rpcConsole->setTabFocus(RPCConsole::TabTypes::CONSOLE);
-    showDebugWindow();
 }
 
 void BitcoinGUI::showHelpMessageClicked()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -280,8 +280,6 @@ public Q_SLOTS:
     void aboutClicked();
     /** Show debug window */
     void showDebugWindow();
-    /** Show debug window and set focus to the console */
-    void showDebugWindowActivateConsole();
     /** Show help message dialog */
     void showHelpMessageClicked();
 #ifndef Q_OS_MAC


### PR DESCRIPTION
This commit removes 2 shortcuts which are now unnecessary (see  new shortcuts which were introduced in 091747b). Also removes some related unnecessary code.