### PR TITLE
[WIP] Add an update checker

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,7 +4,7 @@
 
 DIST_SUBDIRS = secp256k1 univalue
 
-AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS) $(GPROF_LDFLAGS) $(SANITIZER_LDFLAGS)
+AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS) $(GPROF_LDFLAGS) $(SANITIZER_LDFLAGS) -lcurl
 AM_CXXFLAGS = $(DEBUG_CXXFLAGS) $(HARDENED_CXXFLAGS) $(WARN_CXXFLAGS) $(NOWARN_CXXFLAGS) $(ERROR_CXXFLAGS) $(GPROF_CXXFLAGS) $(SANITIZER_CXXFLAGS)
 AM_CPPFLAGS = $(DEBUG_CPPFLAGS) $(HARDENED_CPPFLAGS)
 AM_LIBTOOLFLAGS = --preserve-dup-deps
@@ -220,6 +220,7 @@ BITCOIN_CORE_H = \
   util/translation.h \
   util/url.h \
   util/validation.h \
+  update.h \
   validation.h \
   validationinterface.h \
   versionbits.h \
@@ -303,6 +304,7 @@ libbitcoin_server_a_SOURCES = \
   txdb.cpp \
   txmempool.cpp \
   ui_interface.cpp \
+  update.cpp \
   validation.cpp \
   validationinterface.cpp \
   versionbits.cpp \

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -14,6 +14,7 @@
 #include <util/system.h>
 #include <util/strencodings.h>
 #include <util/validation.h>
+#include <update.h>
 
 #include <stdint.h>
 #include <tuple>
@@ -552,12 +553,29 @@ static UniValue echo(const JSONRPCRequest& request)
     return request.params;
 }
 
+static UniValue check_update(const JSONRPCRequest& request)
+{
+    if (request.fHelp)
+        throw std::runtime_error(
+            RPCHelpMan{"check-update",
+            "\nCheck if a newer version of Bitcoin Core is available.\n"
+            "\nIt will never update Bitcoin Core.",
+            {},
+            RPCResults{},
+            RPCExamples{""},
+            }.ToString()
+        );
+    UpdateManager updater;
+    return updater.checkUpdate();
+}
+
 // clang-format off
 static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
     { "control",            "getmemoryinfo",          &getmemoryinfo,          {"mode"} },
     { "control",            "logging",                &logging,                {"include", "exclude"}},
+    { "util",               "check-update",           &check_update,           {}, },
     { "util",               "validateaddress",        &validateaddress,        {"address"} },
     { "util",               "createmultisig",         &createmultisig,         {"nrequired","keys","address_type"} },
     { "util",               "deriveaddresses",        &deriveaddresses,        {"descriptor", "range"} },

--- a/src/update.cpp
+++ b/src/update.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <update.h>
+
+UpdateManager::UpdateManager()
+{
+    // Add sources from where to fetch the current version
+    addSource("https://www.emilengler.com/bitcoin/version.txt");
+    // Add keys to verify the current version (needs to be legacy)
+    addKey("14RdN6xBjrrqx5y4nH7VXYgtyRVRvBQeF1"); // Emil Engler (@emilengler)
+}
+
+void UpdateManager::addSource(std::string url)
+{
+    sources.push_back(url);
+}
+
+void UpdateManager::addKey(std::string key)
+{
+    keys.push_back(key);
+}
+
+// Function to check if an item is in a string vector
+bool VectorContains(std::vector<std::string> &v, std::string &s) {
+    if (std::find(v.begin(), v.end(), s) != v.end()) {
+        // Item is in vector
+        return true;
+    }
+    return false;
+}
+
+// Checks for a new version and returns the newest version. If no new version is available or the source is not reachable it will return "false"
+std::string UpdateManager::checkUpdate()
+{
+    // Ignore if the build isn't a release (needs to be activated before merge)
+    /*if(!CLIENT_VERSION_IS_RELEASE)
+        return "false";*/
+
+    // For security use a pseudo random source
+    srand(time(NULL));
+    std::string source = sources[rand() % sources.size()];
+    std::string upstreamVersion = download(source);
+
+    // Repeat until a valid source was fetched
+    std::vector<std::string> tried;                         // Sources that were already tried
+    while (upstreamVersion == "ERROR") {
+        tried.push_back(source);
+        // Return "false" if no source is reachable
+        if (tried.size() == sources.size())
+            return "false";
+        while (VectorContains(tried, source)) {
+            source = sources[rand() % sources.size()];
+        }
+        upstreamVersion = download(source);
+    }
+
+    // Split upstreamVersion into "version" and "signature"
+    std::vector<std::string> versionDetails;
+    std::string line;
+    std::istringstream lineStream(upstreamVersion);
+    while (std::getline(lineStream, line, '\n')) {
+        versionDetails.push_back(line);
+    }
+
+    // Verify authentity
+    if (versionDetails.size() < 2)
+        return "false";
+    // Verify signature
+    if (!verify(versionDetails[1], versionDetails[0])) {
+        return "false";
+    }
+
+    // Check if the current version is the upstream version
+    if (versionDetails[0] == FormatFullVersion())
+        return "false";
+
+    // Check for invalid characters (only dots and numbers are permitted)
+    std::string legalChars = "v.0123456789";
+    for(long unsigned int i = 0; i < versionDetails[0].size(); ++i) {
+        if (legalChars.find(versionDetails[0][i]) == std::string::npos)
+            return "false";
+    }
+
+    // Check if the version is newer (probably useless because of line 76)
+    /*std::string currentVersion = FormatFullVersion();
+    std::regex r("v0\.(.+?)$");
+    std::smatch matches;
+    while(std::regex_search(currentVersion, matches, r)) {
+        // IF the current version is the same or higher, false
+        if (atof(matches[1].str().c_str()) < atof(currentVersion.c_str()))
+            return "false";
+    }*/
+
+    // If no errors, return the newest version
+    return versionDetails[0];
+}
+
+// Just an internal function for making downloads possible
+size_t write_data(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    std::string data((const char*) ptr, (size_t) size * nmemb);
+    *((std::stringstream*) stream) << data;
+    return size * nmemb;
+}
+
+
+std::string UpdateManager::download(std::string url)
+{
+    CURL *curl = curl_easy_init();
+
+    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+    std::stringstream out;
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &out);
+    CURLcode res = curl_easy_perform(curl);
+    if (res != CURLE_OK)
+        return "ERROR";
+
+    curl_easy_cleanup(curl);
+    return out.str();
+}
+
+bool UpdateManager::verify(std::string strSign, std::string strMessage)
+{
+    for(unsigned long int i = 0; i < keys.size(); ++i)
+    {
+        std::string strAddress = keys[i];
+
+        CTxDestination destination = DecodeDestination(strAddress);
+        if (!IsValidDestination(destination)) {
+            continue;
+        }
+
+        const PKHash *pkhash = boost::get<PKHash>(&destination);
+        if (!pkhash) {
+            continue;
+        }
+
+        bool fInvalid = false;
+        std::vector<unsigned char> vchSig = DecodeBase64(strSign.c_str(), &fInvalid);
+
+        if (fInvalid)
+            continue;
+
+        CHashWriter ss(SER_GETHASH, 0);
+        ss << strMessageMagic;
+        ss << strMessage;
+
+        CPubKey pubkey;
+        if (!pubkey.RecoverCompact(ss.GetHash(), vchSig))
+            continue;
+
+        if (pubkey.GetID() == *pkhash)
+            return true;
+    }
+    return false;
+}

--- a/src/update.h
+++ b/src/update.h
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UPDATE_H
+#define BITCOIN_UPDATE_H
+
+#include <vector>
+#include <string>
+#include <sstream>
+#include <algorithm>
+#include <curl/curl.h>
+#include <clientversion.h>
+#include <key_io.h>
+#include <outputtype.h>
+#include <script/descriptor.h>
+#include <util/system.h>
+#include <util/strencodings.h>
+#include <util/validation.h>
+#include <stdlib.h>
+#include <time.h>
+#include <regex>
+
+class UpdateManager {
+public:
+    void addSource(std::string url);
+    void addKey(std::string pubKey);
+    std::string checkUpdate();
+    UpdateManager();
+private:
+    std::vector<std::string> sources;
+    std::vector<std::string> keys;
+    std::string download(std::string url);
+    bool verify(std::string strSign, std::string strMessage);
+};
+
+#endif

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -8,6 +8,7 @@
 #include <sync.h>
 #include <util/system.h>
 #include <util/translation.h>
+#include <update.h>
 
 static RecursiveMutex cs_warnings;
 static std::string strMiscWarning GUARDED_BY(cs_warnings);
@@ -43,12 +44,19 @@ std::string GetWarnings(const std::string& strFor)
     std::string strStatusBar;
     std::string strGUI;
     const std::string uiAlertSeperator = "<hr />";
+    UpdateManager manager;
 
     LOCK(cs_warnings);
 
     if (!CLIENT_VERSION_IS_RELEASE) {
         strStatusBar = "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications";
         strGUI = _("This is a pre-release test build - use at your own risk - do not use for mining or merchant applications").translated;
+    }
+
+    // If a newer version is available
+    if (manager.checkUpdate() != "false") {
+        strStatusBar = "A newer version of Bitcoin Core is available, you may want to update";
+        strGUI = _("A newer version of Bitcoin Core is available, you may want to update").translated;
     }
 
     // Misc warnings like out of disk space and clock is wrong


### PR DESCRIPTION
### About
This adds a cryptography system to check for newer versions of Bitcoin Core. It will never update binaries itself.
It adds a new RPC command called `check-update` and displays a message in the GUI if a new version is available.
### How does this work
There is a list of sources where a file is hosted which says the newest version + a digital signature of it. When checking for a new version it does the following steps:

1. Checks if the client is a release and not a dirty build (disabled right now for testing purpose)
2. It will choose a random source from where to get the versions file
3. It will try to download the versions file, if it fails it will select a new source. If no source is found, it will fail
4. It will parse the downloaded file
5. It will verify if the signature matches one of the hard coded public keys
6. It will check if the version is newer than the current one (disabled because of testing)
7. It will check if the new version string only contains numbers, dots and 'v'

### Q&A
**Q:** Alert Key system remastered?
**A:** No, the alert key system was a bitcoin specific thing which happened over the protocol, this happens over HTTP and is only related to Bitcoin Core and will only give a new version (or anything that can be done with just numbers and dots)
**Q:** What happens if someone gets a public version signing key?
**A:** Nothing. Unless he does not control a source, he can't do anything with it. If he controls a source he could give a message with just numbers, dots and 'v' and it would be only visible to these peers who randomly select his source
**Q:** What happens when an attacker gets the control over a source?
**A:** Nothing, as long as he doesn't have the private key of a version signing address. He could just remove the version or install an older
**Q:** Is it centralization?
**A:** Well yes, but Bitcoin Core is a centralized project (it has maintainers, governance, etc.). Like I said, the system has nothing to do with Bitcoin directly

### Version Signing Address
A Version Signing Address needs to be legacy to create and verify signatures

### Source
The source is just a txt file hosted on a web server. It needs to be exactly two lines long. The first line contains the text and the second one the message.
Example:
```
v0.99.0
IEHPu8Bc609G9wxc0TPOfGlnSbtEcvoZA68e/pi5pEZqeqegvovwqcNtXfU50ju+hD5OIJWsuOTjHISLV+KprVs=
```

### Testing
Because it uses libcurl and I am a complete disaster when it comes to build systems it only works with libcurl installed and I only tested it on (g++ (Debian 8.3.0-6) 8.3.0)

First install libcurl
On Debian 10
```
apt install libcurl4-openssl
```

When you build this PR and run check-update you will get
```
v0.99.0
```
When you run bitcoin-qt you will get
![](https://i.imgur.com/oiKVVJk.png)
It will use a source on my webserver with a public key that only I have
(The server might be down around 4am german time every day)

### Testing with own source or address
#### Source
1. Setup a web server
2. Copy a valid source file (you can use mine) to the webserver
3. Add the URL of the file to the class constructor with adding the function `addSource("http://yourhost");`
#### Address
1. Create a new legacy address (can be done over getnewaddress)
2. Copy this address to the class contructor with `addKey("YOURADDRESS");`
3. Create a source file with signing the version text from line 1

### To-Do before merging
* Get address from laanwj and others (just as backups)
* Integrate libcurl better to the build system and if it's not available disable this feature.
* Setup multiple sources for the case that one is down and to add decentralization.
* Add options to the RPC call to use a custom source and address (for testing)

**Because this PR uses new dependencies a compilation might not work**
**Contact me whenever you have questions or problems of any kind**