### PR TITLE
tests: Add fuzzing harness for various PSBT related functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -23,6 +23,7 @@ FUZZ_TARGETS = \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
   test/fuzz/parse_iso8601 \
+  test/fuzz/psbt \
   test/fuzz/script \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
@@ -275,6 +276,12 @@ test_fuzz_parse_iso8601_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_parse_iso8601_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_parse_iso8601_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_parse_iso8601_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_psbt_SOURCES = $(FUZZ_SUITE) test/fuzz/psbt.cpp
+test_fuzz_psbt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_psbt_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_psbt_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_psbt_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_script_SOURCES = $(FUZZ_SUITE) test/fuzz/script.cpp
 test_fuzz_script_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/fuzz.h>
+
+#include <node/psbt.h>
+#include <optional.h>
+#include <psbt.h>
+#include <pubkey.h>
+#include <script/script.h>
+#include <streams.h>
+#include <util/memory.h>
+#include <version.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    PartiallySignedTransaction psbt_mut;
+    const std::string raw_psbt{buffer.begin(), buffer.end()};
+    std::string error;
+    if (!DecodeRawPSBT(psbt_mut, raw_psbt, error)) {
+        return;
+    }
+    const PartiallySignedTransaction psbt = psbt_mut;
+
+    const PSBTAnalysis analysis = AnalyzePSBT(psbt);
+    (void)PSBTRoleName(analysis.next);
+    for (const PSBTInputAnalysis& input_analysis : analysis.inputs) {
+        (void)PSBTRoleName(input_analysis.next);
+    }
+
+    (void)psbt.IsNull();
+    (void)psbt.IsSane();
+
+    Optional<CMutableTransaction> tx = psbt.tx;
+    if (tx) {
+        const CMutableTransaction& mtx = *tx;
+        const PartiallySignedTransaction psbt_from_tx{mtx};
+    }
+
+    for (const PSBTInput& input : psbt.inputs) {
+        (void)PSBTInputSigned(input);
+        (void)input.IsNull();
+        (void)input.IsSane();
+    }
+
+    for (const PSBTOutput& output : psbt.outputs) {
+        (void)output.IsNull();
+    }
+
+    for (size_t i = 0; i < psbt.tx->vin.size(); ++i) {
+        CTxOut tx_out;
+        if (psbt.GetInputUTXO(tx_out, i)) {
+            (void)tx_out.IsNull();
+            (void)tx_out.ToString();
+        }
+    }
+
+    psbt_mut = psbt;
+    (void)FinalizePSBT(psbt_mut);
+
+    psbt_mut = psbt;
+    CMutableTransaction result;
+    if (FinalizeAndExtractPSBT(psbt_mut, result)) {
+        const PartiallySignedTransaction psbt_from_tx{result};
+    }
+
+    psbt_mut = psbt;
+    (void)psbt_mut.Merge(psbt);
+}


### PR DESCRIPTION
Add fuzzing harness for various PSBT related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/psbt
```