### PR TITLE
docs: Update macdeploy README to include all files produced by `make deploy`

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -11,5 +11,5 @@ This script should not be run manually, instead, after building as usual:
 During the process, the disk image window will pop up briefly where the fancy
 settings are applied. This is normal, please do not interfere.
 
-When finished, it will produce `Bitcoin-Core.dmg`.
+When finished, it will produce `Bitcoin-Qt.dmg`.
 


### PR DESCRIPTION
Fixes issue #16909 to update the `contrib/macdeploy/README.md` to match the files produced from `make deploy`

The files produced from `make deploy` are as follows:

- `Bitcoin-Qt.dmg`
- `Bitcoin Core.app`
- `dist/Bitcoin Core.app`