### PR TITLE
build: fix kerning issue with macOS .dmg background image

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -27,7 +27,7 @@ packages:
 - "python3"
 - "python3-dev"
 - "python3-setuptools"
-- "fonts-tuffy"
+- "fonts-liberation"
 remotes:
 - "url": "https://github.com/bitcoin/bitcoin.git"
   "dir": "bitcoin"

--- a/contrib/macdeploy/background.svg
+++ b/contrib/macdeploy/background.svg
@@ -9,8 +9,11 @@
 	-->
 	<style type="text/css"><![CDATA[
 		text {
-			font-family: "Tuffy";
-			font-size: 86px;
+			font-family: "Liberation Mono",monospace;
+			font-weight:bold;
+			font-kerning: none;
+			letter-spacing:0.8em;
+			font-size: 3.3em;
 			fill: gray;
 			text-anchor: middle;
 		}
@@ -28,7 +31,9 @@
 		<text x="0" y="114">PACKAGE_NAME</text>
 	</g>
 	<g transform="translate(0.000000,640.000000) scale(0.100000,-0.100000)"
-	fill="#000000" stroke="none">
+	fill="#808080" stroke="none">
 		<path d="M4995 3705 c-24 -23 -25 -29 -25 -165 l0 -140 -306 0 -306 0 -29 -29 c-29 -29 -29 -31 -29 -141 0 -110 0 -112 29 -141 l29 -29 306 0 306 0 0 -140 c0 -136 1 -142 25 -165 16 -17 35 -25 57 -25 29 0 72 32 306 226 180 149 274 233 278 250 13 53 -2 70 -278 299 -235 194 -277 225 -306 225 -22 0 -41 -8 -57 -25z" fixlter="url(#glow)"/>
 	</g>
 </svg>
+
+

--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -13,7 +13,7 @@ package_name_ns = sys.argv[2]
 ds = DSStore.open(output_file, 'w+')
 ds['.']['bwsp'] = {
     'ShowStatusBar': False,
-    'WindowBounds': '{{300, 280}, {500, 343}}',
+    'WindowBounds': '{{0, 0}, {0, 0}}',
     'ContainerShowSidebar': False,
     'SidebarWidth': 0,
     'ShowTabView': False,
@@ -52,8 +52,8 @@ ds['.']['icvp'] = icvp
 
 ds['.']['vSrn'] = ('long', 1)
 
-ds['Applications']['Iloc'] = (370, 156)
-ds['Bitcoin-Qt.app']['Iloc'] = (128, 156)
+ds['Applications']['Iloc'] = (0, 0)
+ds['Bitcoin-Qt.app']['Iloc'] = (0, 0)
 
 ds.flush()
 ds.close()

--- a/contrib/macdeploy/fancy.plist
+++ b/contrib/macdeploy/fancy.plist
@@ -22,10 +22,20 @@
 			<integer>370</integer>
 			<integer>156</integer>
 		</array>
+		<key>.fseventsd</key>
+		<array>
+			<integer>370</integer>
+			<integer>1</integer>
+		</array>
 		<key>Bitcoin-Qt.app</key>
 		<array>
 			<integer>128</integer>
 			<integer>156</integer>
+		</array>
+		<key>.background</key>
+		<array>
+			<integer>128</integer>
+			<integer>1</integer>
 		</array>
 	</dict>
 </dict>

--- a/contrib/macdeploy/macdeployqtplus
+++ b/contrib/macdeploy/macdeployqtplus
@@ -863,7 +863,7 @@ if config.dmg is not None:
 
         params = {
             "disk" : volname,
-            "window_bounds" : "300,300,800,620",
+            "window_bounds" : "0,0,0,0",
             "icon_size" : "96",
             "background_commands" : "",
             "items_positions" : "\n                   ".join(items_positions)


### PR DESCRIPTION
Fixes: #16836

The kerning issue for the .dmg background image originates in the css styling that is embedded in the background.svg file itself.

This commit also updates the font family to Arial Black which is a common font on Macs.
This commit was tested on macOS Mojave 10.14.6 (18G103). The change uses standard CSS styling. The change enables normal font kerning but the fix is actually accomplish with the letter-spacing attribute. 

![Screen Shot 2019-10-14 at 7 01 27 PM](https://user-images.githubusercontent.com/152159/66788296-1593a680-eeb5-11e9-9e34-764f3c766533.png)