### PR TITLE
github: Add warning for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report to help us improve (use this for suspected bugs only, if not sure, open a regular issue below)
 title: ''
 labels: Bug
 assignees: ''


### PR DESCRIPTION
I've noticed the "Bug" label being added redundantly fairly frequently. I think this might be due to github's templates.

All in all, the link in https://github.com/bitcoin/bitcoin/issues/new/choose to open a regular issue is a bit hidden from sight. Direct people's attention to it.