### PR TITLE
gui: remove OpenSSL PRNG seeding (Windows, Qt only)

### DIFF
--- a/src/qt/winshutdownmonitor.cpp
+++ b/src/qt/winshutdownmonitor.cpp
@@ -6,13 +6,10 @@
 
 #if defined(Q_OS_WIN)
 #include <shutdown.h>
-#include <util/system.h>
 
 #include <windows.h>
 
 #include <QDebug>
-
-#include <openssl/rand.h>
 
 // If we don't want a message to be processed by Qt, return true and set result to
 // the value that the window procedure should return. Otherwise return false.
@@ -21,16 +18,6 @@ bool WinShutdownMonitor::nativeEventFilter(const QByteArray &eventType, void *pM
        Q_UNUSED(eventType);
 
        MSG *pMsg = static_cast<MSG *>(pMessage);
-
-       // Seed OpenSSL PRNG with Windows event data (e.g.  mouse movements and other user interactions)
-       if (RAND_event(pMsg->message, pMsg->wParam, pMsg->lParam) == 0) {
-            // Warn only once as this is performance-critical
-            static bool warned = false;
-            if (!warned) {
-                LogPrintf("%s: OpenSSL RAND_event() failed to seed OpenSSL PRNG with enough data.\n", __func__);
-                warned = true;
-            }
-       }
 
        switch(pMsg->message)
        {


### PR DESCRIPTION
This removes the code introduced in [#4399](https://github.com/bitcoin/bitcoin/pull/4399) that attempts to add additional entroy to the OpenSSL PRNG using `RAND_event()`. This is specific to bitcoin-qt running on Windows.

```
RAND_event() collects the entropy from Windows events such as mouse movements and other user interaction.
It should be called with the iMsg, wParam and lParam arguments of all messages sent to the window procedure.
It will estimate the entropy contained in the event message (if any), and add it to the PRNG.
The program can then process the messages as usual.
```

Besides BIP70, this is the last place we are directly using OpenSSL in the GUI code. All other OpenSSL usage is in [random.cpp](https://github.com/bitcoin/bitcoin/blob/master/src/random.cpp).

Note that we are still also still doing other Windows specific gathering using [RandAddSeedPerfmon](https://github.com/bitcoin/bitcoin/blob/master/src/random.cpp#L268) and [RAND_screen()](https://github.com/bitcoin/bitcoin/blob/master/src/random.cpp#L600) on top of the other generation we do.

Also note that if RAND_event returns `0` here (PRNG has **NOT** been seeded with enough data), we're just logging a single message and continuing, which also seems less than ideal.