### PR TITLE
tests: Fix fs_tests for unknown locales

### DIFF
--- a/src/test/fs_tests.cpp
+++ b/src/test/fs_tests.cpp
@@ -15,7 +15,7 @@ BOOST_AUTO_TEST_CASE(fsbridge_fstream)
     fs::path tmpfolder = GetDataDir();
     // tmpfile1 should be the same as tmpfile2
     fs::path tmpfile1 = tmpfolder / "fs_tests_₿_🏃";
-    fs::path tmpfile2 = tmpfolder / L"fs_tests_₿_🏃";
+    fs::path tmpfile2 = tmpfolder / "fs_tests_₿_🏃";
     {
         fsbridge::ofstream file(tmpfile1);
         file << "bitcoin";


### PR DESCRIPTION
Backporting to `0.19` as suggested in https://github.com/bitcoin/bitcoin/pull/17086#issuecomment-542297344

Fix by removing "L" as suggested by meeDamian in
https://github.com/bitcoin/bitcoin/issues/14948#issuecomment-522355441

Co-Authored-By: bugs@meedamian.com