### PR TITLE
doc: correct function name in ReportHardwareRand()

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -111,7 +111,7 @@ static void InitHardwareRand()
 
 static void ReportHardwareRand()
 {
-    // This must be done in a separate function, as HWRandInit() may be indirectly called
+    // This must be done in a separate function, as InitHardwareRand() may be indirectly called
     // from global constructors, before logging is initialized.
     if (g_rdseed_supported) {
         LogPrintf("Using RdSeed as additional entropy source\n");


### PR DESCRIPTION
The function is `InitHardwareRand` not `HWRandInit`.

https://github.com/bitcoin/bitcoin/blob/46d6930f8c7ba7cbcd7d86dd5d0117642fcbc819/src/random.cpp#L99