### PR TITLE
doc: Update list of valid PR areas

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,19 +79,22 @@ about Git.
 The title of the pull request should be prefixed by the component or area that
 the pull request affects. Valid areas as:
 
-  - `consensus` for changes to consensus critical code
   - `doc` for changes to the documentation
-  - `qt` or `gui` for changes to bitcoin-qt
   - `log` for changes to log messages
-  - `mining` for changes to the mining code
-  - `net` or `p2p` for changes to the peer-to-peer network code
   - `refactor` for structural changes that do not change behavior
+  - `gui` or `qt` for changes to bitcoin-qt
+  - `cli` for changes to command-line parameters
+  - `init` for changes to daemon startup
+  - `net` or `p2p` for changes to the peer-to-peer network code
   - `rpc`, `rest` or `zmq` for changes to the RPC, REST or ZMQ APIs
-  - `script` for changes to the scripts and tools
-  - `test` for changes to the bitcoin unit tests or QA tests
-  - `util` or `lib` for changes to the utils or libraries
   - `wallet` for changes to the wallet code
-  - `build` for changes to the GNU Autotools, reproducible builds or CI code
+  - `mining` for changes to the mining code
+  - `consensus` for changes to consensus critical code
+  - `util` for changes to utility code
+  - `test` for changes to the bitcoin unit tests or QA tests
+  - `build` or `depends` for changes to the GNU Autotools, reproducible builds or CI code
+  - `scripts` or `contrib` for changes to the helper scripts and tools
+
 
 Examples:
 


### PR DESCRIPTION
 Updates list of Pull Request areas / prefixes in `CONTRIBUTING.md`:

- Adds `init`, `cli`, `depends`, `contrib`
- Removes `lib`
- Changes `script` to `scripts`