### PR TITLE
ci: Cleanup macOS runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ cache:
     - /usr/local/Homebrew
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
-  # Cache only .git files under "/usr/local/Homebrew" so "brew update" does not take 5min every build
-  # - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then find /usr/local/Homebrew \! -regex ".+\.git.+" -delete; fi
 stages:
   - lint
   - test
@@ -94,28 +92,6 @@ jobs:
         - set -o errexit; source ./ci/lint/05_before_script.sh
       script:
         - set -o errexit; source ./ci/extended_lint/06_script.sh
-
-    - stage: extended-lint
-      name: 'lint macOS 10.12 (compat)'
-      os: osx
-      # Use the earliest macOS that can build our lint dependencies:
-      # Xcode 8.3.3, macOS 10.12, JDK 1.8.0_112-b16
-      # https://docs.travis-ci.com/user/reference/osx/#macos-version
-      osx_image: xcode8.3
-      # TODO: if you're updating osx_image, try using "rvm:" to supply the
-      # version of ruby required by homebrew. Despite this "rvm:" declaration,
-      # brew update installs ruby 2.3.7 as its first action.
-      language: ruby
-      rvm:
-        - 2.3.7
-      env:
-      cache: false
-      install:
-        - set -o errexit; source ./ci/lint/04_install.sh
-      before_script:
-        - set -o errexit; source ./ci/lint/05_before_script.sh
-      script:
-        - set -o errexit; source ./ci/lint/06_script.sh
 
     - stage: test
       name: 'ARM  [GOAL: install]  [unit tests, no functional tests]'

--- a/ci/lint/04_install.sh
+++ b/ci/lint/04_install.sh
@@ -6,22 +6,9 @@
 
 export LC_ALL=C
 
-if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-  # update first to install required ruby dependency
-  travis_retry brew update
-  travis_retry brew reinstall git -- --with-pcre2 # for  --perl-regexp
-  travis_retry brew install grep # gnu grep for --perl-regexp support
-  PATH="$(brew --prefix grep)/libexec/gnubin:$PATH"
-  travis_retry brew install shellcheck
-  travis_retry brew upgrade python
-  PATH="$(brew --prefix python)/bin:$PATH"
-  export PATH
-else
-  SHELLCHECK_VERSION=v0.6.0
-  travis_retry curl --silent "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
-  PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"
-  export PATH
-fi
-
 travis_retry pip3 install codespell==1.15.0
 travis_retry pip3 install flake8==3.7.8
+
+SHELLCHECK_VERSION=v0.6.0
+curl -s "https://storage.googleapis.com/shellcheck/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar --xz -xf - --directory /tmp/
+export PATH="/tmp/shellcheck-${SHELLCHECK_VERSION}:${PATH}"

--- a/ci/test/00_setup_env_mac_functional.sh
+++ b/ci/test/00_setup_env_mac_functional.sh
@@ -9,10 +9,11 @@ export LC_ALL=C.UTF-8
 export HOST=x86_64-apple-darwin14
 export BREW_PACKAGES="automake berkeley-db4 libtool boost miniupnpc pkg-config protobuf qt qrencode python3 ccache zeromq"
 export PIP_PACKAGES="zmq"
-export OSX_SDK=10.11
 export RUN_CI_ON_HOST=true
 export RUN_UNIT_TESTS=true
 export RUN_FUNCTIONAL_TESTS=true
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-gui --enable-bip70 --enable-reduce-exports --enable-werror"
+# Run without depends
 export NO_DEPENDS=1
+export OSX_SDK=""

--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -13,21 +13,17 @@ else
   DOCKER_EXEC echo \> \$HOME/.bitcoin
 fi
 
-if [ "$TRAVIS_OS_NAME" != "osx" ]; then
+mkdir -p depends/SDKs depends/sdk-sources
 
-  mkdir -p depends/SDKs depends/sdk-sources
-
-  if [ -n "$OSX_SDK" ] && [ ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
-    curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
-  fi
-  if [ -n "$OSX_SDK" ] && [ -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
-    tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
-  fi
-  if [[ $HOST = *-mingw32 ]]; then
-    DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
-  fi
-  if [ -z "$NO_DEPENDS" ]; then
-    DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
-  fi
-
+if [ -n "$OSX_SDK" ] && [ ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
+  curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
+fi
+if [ -n "$OSX_SDK" ] && [ -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then
+  tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz
+fi
+if [[ $HOST = *-mingw32 ]]; then
+  DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\)
+fi
+if [ -z "$NO_DEPENDS" ]; then
+  DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
 fi

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -7,6 +7,8 @@ Check for missing documentation of command line options.
 commit-script-check.sh
 ======================
 Verification of [scripted diffs](/doc/developer-notes.md#scripted-diffs).
+Scripted diffs are only assumed to run on the latest LTS release of Ubuntu. Running them on other operating systems
+might require installing GNU tools, such as GNU sed.
 
 git-subtree-check.sh
 ====================


### PR DESCRIPTION
* Remove a commented out cleanup task in `before_cache`
* Remove the linter run on macOS, and document that GNU tools are required to run the linters