### PR TITLE
gui: Improved tooltip for send amount field

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -18,7 +18,7 @@
   </property>
   <widget class="QFrame" name="SendCoins">
    <property name="toolTip">
-    <string>This is a normal payment.</string>
+    <string>The amount to send in the selected unit</string>
    </property>
    <property name="frameShape">
     <enum>QFrame::NoFrame</enum>


### PR DESCRIPTION
I noticed that on Bitcoin sends the tooltip wasn't very clear for new users and I hope my PR is more concise. If it needs changing more will happily change too :+1: 
![IMG_20191017_192739](https://user-images.githubusercontent.com/46864828/67036925-75d45380-f114-11e9-88bf-bab58161f80a.jpg)
