### PR TITLE
refactor: test/bench: dedup Build{Crediting,Spending}Transaction()

### DIFF
--- a/build_msvc/test_bitcoin/test_bitcoin.vcxproj
+++ b/build_msvc/test_bitcoin/test_bitcoin.vcxproj
@@ -13,6 +13,7 @@
     <ClCompile Include="..\..\src\test\*_properties.cpp" />
     <ClCompile Include="..\..\src\test\gen\*_gen.cpp" />
     <ClCompile Include="..\..\src\wallet\test\*_tests.cpp" />
+    <ClCompile Include="..\..\src\test\lib\*.cpp" />
     <ClCompile Include="..\..\src\test\setup_common.cpp" />
     <ClCompile Include="..\..\src\test\main.cpp" />
     <ClCompile Include="..\..\src\wallet\test\*_fixture.cpp" />

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -39,6 +39,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/lockedpool.cpp \
   bench/poly1305.cpp \
   bench/prevector.cpp \
+  test/lib/transaction_utils.h \
+  test/lib/transaction_utils.cpp \
   test/setup_common.h \
   test/setup_common.cpp \
   test/util.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -53,6 +53,8 @@ RAW_TEST_FILES =
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 
 BITCOIN_TEST_SUITE = \
+  test/lib/transaction_utils.h \
+  test/lib/transaction_utils.cpp \
   test/main.cpp \
   test/setup_common.h \
   test/setup_common.cpp

--- a/src/test/lib/transaction_utils.cpp
+++ b/src/test/lib/transaction_utils.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/lib/transaction_utils.h>
+
+CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue)
+{
+    CMutableTransaction txCredit;
+    txCredit.nVersion = 1;
+    txCredit.nLockTime = 0;
+    txCredit.vin.resize(1);
+    txCredit.vout.resize(1);
+    txCredit.vin[0].prevout.SetNull();
+    txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
+    txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txCredit.vout[0].scriptPubKey = scriptPubKey;
+    txCredit.vout[0].nValue = nValue;
+
+    return txCredit;
+}
+
+CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CScriptWitness& scriptWitness, const CTransaction& txCredit)
+{
+    CMutableTransaction txSpend;
+    txSpend.nVersion = 1;
+    txSpend.nLockTime = 0;
+    txSpend.vin.resize(1);
+    txSpend.vout.resize(1);
+    txSpend.vin[0].scriptWitness = scriptWitness;
+    txSpend.vin[0].prevout.hash = txCredit.GetHash();
+    txSpend.vin[0].prevout.n = 0;
+    txSpend.vin[0].scriptSig = scriptSig;
+    txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    txSpend.vout[0].scriptPubKey = CScript();
+    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
+
+    return txSpend;
+}

--- a/src/test/lib/transaction_utils.h
+++ b/src/test/lib/transaction_utils.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_LIB_TRANSACTION_UTILS_H
+#define BITCOIN_TEST_LIB_TRANSACTION_UTILS_H
+
+#include <primitives/transaction.h>
+
+// create crediting transaction
+// [1 coinbase input => 1 output with given scriptPubkey and value]
+CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue = 0);
+
+// create spending transaction
+// [1 input with referenced transaction outpoint, scriptSig, scriptWitness =>
+//  1 output with empty scriptPubKey, full value of referenced transaction]
+CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CScriptWitness& scriptWitness, const CTransaction& txCredit);
+
+#endif // BITCOIN_TEST_LIB_TRANSACTION_UTILS_H

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -12,6 +12,7 @@
 #include <script/signingprovider.h>
 #include <util/system.h>
 #include <util/strencodings.h>
+#include <test/lib/transaction_utils.h>
 #include <test/setup_common.h>
 #include <rpc/util.h>
 #include <streams.h>
@@ -120,40 +121,6 @@ static ScriptError_t ParseScriptError(const std::string &name)
 }
 
 BOOST_FIXTURE_TEST_SUITE(script_tests, BasicTestingSetup)
-
-CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue = 0)
-{
-    CMutableTransaction txCredit;
-    txCredit.nVersion = 1;
-    txCredit.nLockTime = 0;
-    txCredit.vin.resize(1);
-    txCredit.vout.resize(1);
-    txCredit.vin[0].prevout.SetNull();
-    txCredit.vin[0].scriptSig = CScript() << CScriptNum(0) << CScriptNum(0);
-    txCredit.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
-    txCredit.vout[0].scriptPubKey = scriptPubKey;
-    txCredit.vout[0].nValue = nValue;
-
-    return txCredit;
-}
-
-CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CScriptWitness& scriptWitness, const CTransaction& txCredit)
-{
-    CMutableTransaction txSpend;
-    txSpend.nVersion = 1;
-    txSpend.nLockTime = 0;
-    txSpend.vin.resize(1);
-    txSpend.vout.resize(1);
-    txSpend.vin[0].scriptWitness = scriptWitness;
-    txSpend.vin[0].prevout.hash = txCredit.GetHash();
-    txSpend.vin[0].prevout.n = 0;
-    txSpend.vin[0].scriptSig = scriptSig;
-    txSpend.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
-    txSpend.vout[0].scriptPubKey = CScript();
-    txSpend.vout[0].nValue = txCredit.vout[0].nValue;
-
-    return txSpend;
-}
 
 void DoTest(const CScript& scriptPubKey, const CScript& scriptSig, const CScriptWitness& scriptWitness, int flags, const std::string& message, int scriptError, CAmount nValue = 0)
 {


### PR DESCRIPTION
prototypes used in `src/test/script_tests.cpp`:
- `CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey, int nValue = 0);`
- `CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CScriptWitness& scriptWitness, const CTransaction& txCredit);`

prototypes used in `bench/verify_script.cpp`:
- `CMutableTransaction BuildCreditingTransaction(const CScript& scriptPubKey);`
- `CMutableTransaction BuildSpendingTransaction(const CScript& scriptSig, const CMutableTransaction& txCredit);`

The more generic versions from the script tests are moved into `setup_common.cpp` and the calls are adapted accordingly in the verify_script benchmark (passing the nValue of 1 explicitely for `BuildCreditingTransaction()`, passing empty scriptWitness explicitely and converting txCredit parameter to CTransaction in `BuildSpendingTransaction()`).
