### PR TITLE
gui: Add placeholder text to the sign message field

### DIFF
--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -99,6 +99,9 @@
          <property name="toolTip">
           <string>Enter the message you want to sign here</string>
          </property>
+         <property name="placeholderText">
+          <string>Enter the message you want to sign here</string>
+         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
When using the sign message functionality I noticed the "message" field had no label or placeholder text to highlight what it's for. 

I've added the placeholder text to match the tool tip to help it be more user friendly.