### PR TITLE
random: remove call to RAND_screen() (Windows only)

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -594,10 +594,6 @@ static void SeedSleep(CSHA512& hasher, RNGState& rng)
 
 static void SeedStartup(CSHA512& hasher, RNGState& rng) noexcept
 {
-#ifdef WIN32
-    RAND_screen();
-#endif
-
     // Gather 256 bits of hardware randomness, if available
     SeedHardwareSlow(hasher);
 


### PR DESCRIPTION
Follow up to https://github.com/bitcoin/bitcoin/pull/17151 where there were multiple calls to also remove our call to RAND_screen().