### PR TITLE
p2p: Avoid forwarding ADDR messages to SPV nodes 

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1497,7 +1497,7 @@ static void RelayAddress(const CAddress& addr, bool fReachable, const CConnman& 
     assert(nRelayNodes <= best.size());
 
     auto sortfunc = [&best, &hasher, nRelayNodes](CNode* pnode) {
-        if (pnode->IsAddrRelayPeer()) {
+        if (pnode->IsAddrRelayPeer() && MayHaveUsefulAddressDB(pnode->nServices)) {
             uint64_t hashKey = CSipHasher(hasher).Write(pnode->GetId()).Finalize();
             for (unsigned int i = 0; i < nRelayNodes; i++) {
                  if (hashKey > best[i].first) {


### PR DESCRIPTION
### Background

The primary method of relaying node addresses across the network is daily self-announcement and forwarding self-announcements of other nodes.
To rate-limit those, we relay them only to 1 or 2 peers (depending on whether the address is reachable for us).
Unfortunately, in current implementation there is a chance of choosing SPV nodes, which, to the best of my knowledge, currently do not forward those announcements.

### Discussion

During the [meeting](http://www.erisian.com.au/bitcoin-core-dev/log-2019-10-17.html) we reached a soft consensus that address relay participation should not be coupled to SPV/full node definition, but rather have an explicit flag (e.g. service flag).
Until that’s getting resolved, I’m suggesting a tiny patch that prevent forwarding (they still can request and learn) these announcements to SPV nodes.

### Analysis

To justify the change, I decided to measure how does this relay perform in different conditions (see my [script](https://github.com/naumenkogs/bitcoin_network_analysis/blob/master/addr_relay/forward_to_spv.py)).
I measured how many nodes know about the new address relayed through this protocol (omitting batching <10 rule) within 120 “waves” of relay, each happening every 30 seconds (which is roughly 1 hour).

Let’s see what if the address is reachable to 5% of the network (I guess pretty fair assumption for Onion addresses, for example). Let's call those "exotic".
Let's also simulate having 10% of black holes, which are indistinguishable from real nodes, but don't forward anything.

|  non-forwarding SPV nodes                                   | 5%  | 10%  | 20%  | 30% |
|--|--|--|--|--|
| All nodes knowing addr (before the change) | 56% | 48% | 30% | 22% |
| All nodes knowing addr (after the change)  | 55% | 54% | 58%  | 40% |
|  |
| Exotic nodes knowing addr (before the change) | 80% | 75% | 55% | 50% |
| Exotic nodes knowing addr (after the change)  | 76% | 77% | 75%  | 75% |

If you don't believe it's that bad, please make your own simulation to validate mine :)

It will become worse and worse with the growth of SPV.

These numbers can also be used to motivate the high-level change (see [discussion](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-October/017428.html)).

### Questions
1. Would we make SPVs more vulnerable to addrman injections? Like, would it be easier for an attacker to fill their addrmans with malicious sybil nodes? (I guess we are already vulnerable it assuming some capabilities of an attacker, but would it be noticeably worse? EthanHeilman)
2. Does the same apply to the old pruned nodes? (achow101 I think you mentioned that older nodes would also be excluded here). Should we forward these announcements to them, if this makes them noticeably more vulnerable?

We can forward it to these two groups IN ADDITION to forwarding to (1 or 2) peers, if there is a belief that this is might affect their security. The bandwidth overhead would be obviously very low.


#### P.S.
~~This experiment also means that we're very vulnerable to just black holes when relaying exotic addresses, but I will write about it in a separate issue.~~
Imrpoved the script to consider black holes.

#### P.P.S.
~~I guess the biggest inaccuracy in my little experiment is that in practice, those exotic semi-reachable nodes are well-interconnected, so once the address makes it to one of those — it should be relayed a bit better. Maybe, I will try to measure.
Anyway, this does not disregard the problem.~~
Improved the script to take exotic inter-connectivity into account and updated the measurements.