### PR TITLE
Travis CI bug in macOS environment #17178 workaround

### DIFF
--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -23,7 +23,7 @@ mkdir -p build
 
 # Temporarily disable errexit, because Travis macOS fails without error message
 set +o errexit
-cd build || (echo "could not enter build directory"; exit 1)
+type cd build || (echo "could not enter build directory"; exit 1)
 set -o errexit
 
 BEGIN_FOLD configure
@@ -35,7 +35,7 @@ DOCKER_EXEC make distdir VERSION=$HOST
 END_FOLD
 
 set +o errexit
-cd "bitcoin-$HOST" || (echo "could not enter distdir bitcoin-$HOST"; exit 1)
+type cd "bitcoin-$HOST" || (echo "could not enter distdir bitcoin-$HOST"; exit 1)
 set -o errexit
 
 BEGIN_FOLD configure
@@ -50,5 +50,5 @@ DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows
 END_FOLD
 
 set +o errexit
-cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
+type cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
 set -o errexit

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -6,11 +6,13 @@
 
 export LC_ALL=C.UTF-8
 
+#cd command is misunderstanded by cd Travis built-in command in some macOS
 lcd='cd'
 if [[ "$OSTYPE" == "darwin"* ]]; then
   lcd='type cd'
 fi
 
+#Avoid repeating this block several places in code
 safe_cd()
 {
   set +o errexit

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -11,8 +11,6 @@ export LC_ALL=C.UTF-8
 #if [[ "$OSTYPE" == "darwin"* ]]; then
 #  lcd='type cd'
 #fi
-
-command +V cd
 type cd
 #Avoid repeating this block several places in code
 safe_cd()

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -6,6 +6,13 @@
 
 export LC_ALL=C.UTF-8
 
+safe_cd()
+{
+  set +o errexit
+  type cd $1 || (echo $2; exit 1)
+  set -o errexit
+}
+
 BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$BASE_BUILD_DIR/depends/$HOST --bindir=$BASE_OUTDIR/bin --libdir=$BASE_OUTDIR/lib"
 if [ -z "$NO_DEPENDS" ]; then
   DOCKER_EXEC ccache --max-size=$CCACHE_SIZE
@@ -22,9 +29,7 @@ END_FOLD
 mkdir -p build
 
 # Temporarily disable errexit, because Travis macOS fails without error message
-set +o errexit
-type cd build || (echo "could not enter build directory"; exit 1)
-set -o errexit
+safe_cd build "could not enter build directory"
 
 BEGIN_FOLD configure
 DOCKER_EXEC ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
@@ -34,9 +39,7 @@ BEGIN_FOLD distdir
 DOCKER_EXEC make distdir VERSION=$HOST
 END_FOLD
 
-set +o errexit
-type cd "bitcoin-$HOST" || (echo "could not enter distdir bitcoin-$HOST"; exit 1)
-set -o errexit
+safe_cd "bitcoin-$HOST" "could not enter distdir bitcoin-$HOST"
 
 BEGIN_FOLD configure
 DOCKER_EXEC ./configure --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
@@ -49,6 +52,4 @@ BEGIN_FOLD build
 DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false )
 END_FOLD
 
-set +o errexit
-type cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
-set -o errexit
+safe_cd ${BASE_BUILD_DIR} "could not enter travis build dir $BASE_BUILD_DIR"

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -12,11 +12,11 @@ export LC_ALL=C.UTF-8
 #  lcd='type cd'
 #fi
 
+command +V cd
+type cd
 #Avoid repeating this block several places in code
 safe_cd()
 {
-  command +V cd
-  type cd
   set +o errexit
   #$lcd $1 || (echo $2; exit 1)
   set -o errexit

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-lcd = cd
+lcd=cd
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  lcd = type cd
+  lcd=type cd
 fi
 
 safe_cd()

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -7,16 +7,16 @@
 export LC_ALL=C.UTF-8
 
 #cd command is misunderstanded by cd Travis built-in command in some macOS
-lcd='cd'
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  lcd='type cd'
-fi
+#lcd='cd'
+#if [[ "$OSTYPE" == "darwin"* ]]; then
+#  lcd='type cd'
+#fi
 
 #Avoid repeating this block several places in code
 safe_cd()
 {
-  which cd
   command +V cd
+  type cd
   set +o errexit
   #$lcd $1 || (echo $2; exit 1)
   set -o errexit

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -15,8 +15,10 @@ fi
 #Avoid repeating this block several places in code
 safe_cd()
 {
+  which cd
+  type cd
   set +o errexit
-  $lcd $1 || (echo $2; exit 1)
+  #$lcd $1 || (echo $2; exit 1)
   set -o errexit
 }
 

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -6,10 +6,15 @@
 
 export LC_ALL=C.UTF-8
 
+lcd = cd
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  lcd = type cd
+fi
+
 safe_cd()
 {
   set +o errexit
-  type cd $1 || (echo $2; exit 1)
+  $lcd $1 || (echo $2; exit 1)
   set -o errexit
 }
 

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-lcd=cd
+lcd='cd'
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  lcd=type cd
+  lcd='type cd'
 fi
 
 safe_cd()

--- a/ci/test/06_script_a.sh
+++ b/ci/test/06_script_a.sh
@@ -16,7 +16,7 @@ fi
 safe_cd()
 {
   which cd
-  type cd
+  command +V cd
   set +o errexit
   #$lcd $1 || (echo $2; exit 1)
   set -o errexit

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -15,8 +15,10 @@ fi
 #Avoid repeating this block several places in code
 safe_cd()
 {
+  type cd
+  which cd
   set +o errexit
-  $lcd $1 || (echo $2; exit 1)
+  #$lcd $1 || (echo $2; exit 1)
   set -o errexit
 }
 

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -16,7 +16,7 @@ fi
 safe_cd()
 {
   type cd
-  which cd
+  command +V cd
   set +o errexit
   #$lcd $1 || (echo $2; exit 1)
   set -o errexit

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -7,10 +7,10 @@
 export LC_ALL=C.UTF-8
 
 #cd command is misunderstanded by cd Travis built-in command in some macOS
-lcd='cd'
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  lcd='type cd'
-fi
+#lcd='cd'
+#if [[ "$OSTYPE" == "darwin"* ]]; then
+#  lcd='type cd'
+#fi
 
 #Avoid repeating this block several places in code
 safe_cd()

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -12,7 +12,6 @@ export LC_ALL=C.UTF-8
 #  lcd='type cd'
 #fi
 type cd
-command +V cd
 #Avoid repeating this block several places in code
 safe_cd()
 {

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -6,11 +6,13 @@
 
 export LC_ALL=C.UTF-8
 
+#cd command is misunderstanded by cd Travis built-in command in some macOS
 lcd='cd'
 if [[ "$OSTYPE" == "darwin"* ]]; then
   lcd='type cd'
 fi
 
+#Avoid repeating this block several places in code
 safe_cd()
 {
   set +o errexit

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -8,7 +8,7 @@ export LC_ALL=C.UTF-8
 
 # Temporarily disable errexit, because Travis macOS fails without error message
 set +o errexit
-cd "build/bitcoin-$HOST" || (echo "could not enter distdir build/bitcoin-$HOST"; exit 1)
+type cd "build/bitcoin-$HOST" || (echo "could not enter distdir build/bitcoin-$HOST"; exit 1)
 set -o errexit
 
 if [ -n "$QEMU_USER_CMD" ]; then
@@ -50,5 +50,5 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
 fi
 
 set +o errexit
-cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
+type cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
 set -o errexit

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -11,12 +11,11 @@ export LC_ALL=C.UTF-8
 #if [[ "$OSTYPE" == "darwin"* ]]; then
 #  lcd='type cd'
 #fi
-
+type cd
+command +V cd
 #Avoid repeating this block several places in code
 safe_cd()
 {
-  type cd
-  command +V cd
   set +o errexit
   #$lcd $1 || (echo $2; exit 1)
   set -o errexit

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-lcd = cd
+lcd=cd
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  lcd = type cd
+  lcd=type cd
 fi
 
 safe_cd()

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -6,10 +6,15 @@
 
 export LC_ALL=C.UTF-8
 
+safe_cd()
+{
+  set +o errexit
+  type cd $1 || (echo $2; exit 1)
+  set -o errexit
+}
+
 # Temporarily disable errexit, because Travis macOS fails without error message
-set +o errexit
-type cd "build/bitcoin-$HOST" || (echo "could not enter distdir build/bitcoin-$HOST"; exit 1)
-set -o errexit
+safe_cd "build/bitcoin-$HOST" "could not enter distdir build/bitcoin-$HOST"
 
 if [ -n "$QEMU_USER_CMD" ]; then
   BEGIN_FOLD wrap-qemu
@@ -49,6 +54,4 @@ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   END_FOLD
 fi
 
-set +o errexit
-type cd ${BASE_BUILD_DIR} || (echo "could not enter travis build dir $BASE_BUILD_DIR"; exit 1)
-set -o errexit
+safe_cd ${BASE_BUILD_DIR} "could not enter travis build dir $BASE_BUILD_DIR"

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -6,10 +6,15 @@
 
 export LC_ALL=C.UTF-8
 
+lcd = cd
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  lcd = type cd
+fi
+
 safe_cd()
 {
   set +o errexit
-  type cd $1 || (echo $2; exit 1)
+  $lcd $1 || (echo $2; exit 1)
   set -o errexit
 }
 

--- a/ci/test/06_script_b.sh
+++ b/ci/test/06_script_b.sh
@@ -6,9 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-lcd=cd
+lcd='cd'
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  lcd=type cd
+  lcd='type cd'
 fi
 
 safe_cd()


### PR DESCRIPTION
According to #17178 by MarcoFalke, `cd` command (using for changing directory) has some conflicts with Travis builtin command with similar name in some environments (like macOS).

In this PR :
1. I tried to solve this issue by replacing `cd` by `type cd` in `ci/test/06_script_a.sh` and `ci/test/06_script_b.sh` .
2. I added function called `safe_cd` as commented in [here](https://github.com/bitcoin/bitcoin/pull/16597/files#r336052676) to avoid duplication in code.