### PR TITLE
wallet: Do not turn OP_1NEGATE in scriptSig into 0x0181 in signing code (sipa)

### DIFF
--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -186,6 +186,8 @@ static CScript PushAll(const std::vector<valtype>& values)
             result << OP_0;
         } else if (v.size() == 1 && v[0] >= 1 && v[0] <= 16) {
             result << CScript::EncodeOP_N(v[0]);
+        } else if (v.size() == 1 && v[0] == 0x81) {
+            result << OP_1NEGATE;
         } else {
             result << v;
         }

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -361,6 +361,8 @@ static CScript PushAll(const std::vector<valtype>& values)
             result << OP_0;
         } else if (v.size() == 1 && v[0] >= 1 && v[0] <= 16) {
             result << CScript::EncodeOP_N(v[0]);
+        } else if (v.size() == 1 && v[0] == 0x81) {
+            result << OP_1NEGATE;
         } else {
             result << v;
         }

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -198,10 +198,30 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         assert_equal(spending_tx_signed['complete'], True)
         self.nodes[0].sendrawtransaction(spending_tx_signed['hex'])
 
+    def OP_1NEGATE_test(self):
+        self.log.info("Test OP_1NEGATE (0x4f) satisfies BIP62 minimal push standardness rule")
+        hex_str = (
+            "0200000001FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+            "FFFFFFFF00000000044F024F9CFDFFFFFF01F0B9F5050000000023210277777777"
+            "77777777777777777777777777777777777777777777777777777777AC66030000"
+        )
+        prev_txs = [
+            {
+                "txid": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+                "vout": 0,
+                "scriptPubKey": "A914AE44AB6E9AA0B71F1CD2B453B69340E9BFBAEF6087",
+                "redeemScript": "4F9C",
+                "amount": 1,
+            }
+        ]
+        txn = self.nodes[0].signrawtransactionwithwallet(hex_str, prev_txs)
+        assert txn["complete"]
+
     def run_test(self):
         self.successful_signing_test()
         self.script_verification_error_test()
         self.witness_script_test()
+        self.OP_1NEGATE_test()
         self.test_with_lock_outputs()
 
 


### PR DESCRIPTION
A rebase of #13084 which additionally modifies the test code (unaddressed in the original, assuming sipa is too busy to deal with this at the moment).

Relatively simple bugfix so it'd be good to have merged soon.

Turning OP_1NEGATE into 0x0181 results in a larger-than-necessary data push instead of just actually using the OP_1NEGATE opcode (0x4f). This fails the minimal push rule of BIP 62 and makes the result non-standard.