### PR TITLE
ci: Enable address sanitizer (ASan) stack-use-after-return checking

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -41,7 +41,7 @@ fi
 export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
 
 mkdir -p "${BASE_BUILD_DIR}/sanitizer-output/"
-export ASAN_OPTIONS=""
+export ASAN_OPTIONS="detect_stack_use_after_return=1"
 export LSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/tsan:log_path=${BASE_BUILD_DIR}/sanitizer-output/tsan"
 export UBSAN_OPTIONS="suppressions=${BASE_BUILD_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1"


### PR DESCRIPTION
Enable address sanitizer (ASan) stack-use-after-return checking (`detect_stack_use_after_return=1`).

Example:

```
#include <iostream>
#include <string>

const std::string& get_string(int i) {
    return std::to_string(i);
}

int main() {
    std::cout << get_string(41) << "\n";
}
```

Without address sanitizer (ASan) stack-use-after-return checking:

```
$ ./stack-use-after-return

$
```

With address sanitizer (ASan) stack-use-after-return checking:

```
$ ASAN_OPTIONS="detect_stack_use_after_return=1" ./stack-use-after-return
=================================================================
==10400==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f7fa0400030 at pc 0x00000049d2cc bp 0x7ffcbd617070 sp 0x7ffcbd616820
READ of size 2 at 0x7f7abbecd030 thread T0
    #0 0x439781 in fwrite
    #1 0x7f7ac0504cb3 in std::basic_ostream<char, std::char_traits<char> >& std::__ostream_insert<char, std::char_traits<char> >(std::basic_ostream<char, std::char_traits<char> >&, char const*, long) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0x113cb3)
    #2 0x4f9b5f in main stack-use-after-return.cpp:9:15
    #3 0x7f7abf440b96 in __libc_start_main
    #4 0x41bbc9 in _start
…
$
```