### PR TITLE
Make all tests pass UBSan without using any UBSan suppressions

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -338,13 +338,11 @@ double TxConfirmStats::EstimateMedianVal(int confTarget, double sufficientTxVal,
         failBucket.leftMempool = failNum;
     }
 
-    LogPrint(BCLog::ESTIMATEFEE, "FeeEst: %d %s%.0f%% decay %.5f: feerate: %g from (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
+    LogPrint(BCLog::ESTIMATEFEE, "FeeEst: %d %s%.0f%% decay %.5f: feerate: %g from (%g - %g) %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.1f/(%.1f %d mem %.1f out)\n",
              confTarget, requireGreater ? ">" : "<", 100.0 * successBreakPoint, decay,
              median, passBucket.start, passBucket.end,
-             100 * passBucket.withinTarget / (passBucket.totalConfirmed + passBucket.inMempool + passBucket.leftMempool),
              passBucket.withinTarget, passBucket.totalConfirmed, passBucket.inMempool, passBucket.leftMempool,
              failBucket.start, failBucket.end,
-             100 * failBucket.withinTarget / (failBucket.totalConfirmed + failBucket.inMempool + failBucket.leftMempool),
              failBucket.withinTarget, failBucket.totalConfirmed, failBucket.inMempool, failBucket.leftMempool);
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1888,7 +1888,7 @@ static int64_t nTimeConnect = 0;
 static int64_t nTimeIndex = 0;
 static int64_t nTimeCallbacks = 0;
 static int64_t nTimeTotal = 0;
-static int64_t nBlocksTotal = 0;
+static int64_t nBlocksTotal = 1;
 
 /** Apply the effects of this block (with given index) on the UTXO set represented by coins.
  *  Validity checks that depend on the UTXO set are also done; ConnectBlock()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1658,7 +1658,9 @@ CWallet::ScanResult CWallet::ScanForWalletTransactions(const uint256& start_bloc
     }
     double progress_current = progress_begin;
     while (block_height && !fAbortRescan && !chain().shutdownRequested()) {
-        m_scanning_progress = (progress_current - progress_begin) / (progress_end - progress_begin);
+        if (progress_end - progress_begin > 0.0) {
+            m_scanning_progress = (progress_current - progress_begin) / (progress_end - progress_begin);
+        }
         if (*block_height % 100 == 0 && progress_end - progress_begin > 0.0) {
             ShowProgress(strprintf("%s " + _("Rescanning...").translated, GetDisplayName()), std::max(1, std::min(99, (int)(m_scanning_progress * 100))));
         }
@@ -2928,13 +2930,11 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
     // accidental re-use.
     reservedest.KeepDestination();
 
-    WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Needed:%d Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
+    WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Needed:%d Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.1f/(%.1f %d mem %.1f out)\n",
               nFeeRet, nBytes, nFeeNeeded, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
               feeCalc.est.pass.start, feeCalc.est.pass.end,
-              100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool),
               feeCalc.est.pass.withinTarget, feeCalc.est.pass.totalConfirmed, feeCalc.est.pass.inMempool, feeCalc.est.pass.leftMempool,
               feeCalc.est.fail.start, feeCalc.est.fail.end,
-              100 * feeCalc.est.fail.withinTarget / (feeCalc.est.fail.totalConfirmed + feeCalc.est.fail.inMempool + feeCalc.est.fail.leftMempool),
               feeCalc.est.fail.withinTarget, feeCalc.est.fail.totalConfirmed, feeCalc.est.fail.inMempool, feeCalc.est.fail.leftMempool);
     return true;
 }

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,9 +1,3 @@
-# -fsanitize=undefined suppressions
-# =================================
-float-divide-by-zero:policy/fees.cpp
-float-divide-by-zero:validation.cpp
-float-divide-by-zero:wallet/wallet.cpp
-
 # -fsanitize=integer suppressions
 # ===============================
 # Unsigned integer overflow occurs when the result of an unsigned integer


### PR DESCRIPTION
Make all tests pass UBSan (`-fsanitize=undefined`) without using any UBSan suppressions.

From a fuzzing perspective it would be really nice to be able to run UBSan without having to deal with suppression files :)

Note that the commit c8c393b149f975f13e3ac7e4be17196d7c482b69 needs to be cherry-picked in from PR #17156 to get rid of the two alignment related suppressions :)

Before this PR:

```
$ ./configure --with-sanitizers=undefined
$ make
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" src/test/test_bitcoin
…
validation.cpp:2563:164: runtime error: division by zero
validation.cpp:2568:138: runtime error: division by zero
validation.cpp:2573:161: runtime error: division by zero
validation.cpp:2582:164: runtime error: division by zero
validation.cpp:2583:144: runtime error: division by zero
policy/fees.cpp:347:44: runtime error: division by zero
policy/fees.cpp:344:44: runtime error: division by zero
wallet/wallet.cpp:2049:67: runtime error: division by zero
wallet/wallet.cpp:3280:51: runtime error: division by zero
wallet/wallet.cpp:3283:51: runtime error: division by zero
…
$ echo $?
1
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" test/functional/test_runner.py
…
AssertionError: Unexpected stderr validation.cpp:2563:164: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior validation.cpp:2563:164 in
validation.cpp:2568:138: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior validation.cpp:2568:138 in
validation.cpp:2573:161: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior validation.cpp:2573:161 in
validation.cpp:2582:164: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior validation.cpp:2582:164 in
validation.cpp:2583:144: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior validation.cpp:2583:144 in !=
…
$ echo $?
1
```

After this PR (with cherry-pick as described above):

```
$ ./configure --with-sanitizers=undefined
$ make
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" src/test/test_bitcoin
$ echo $?
0
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" test/functional/test_runner.py
$ echo $?
0
```

Note: This PR is not a bug fix (there is no bug to fix!). We assume the floating-point types to fulfil the requirements of IEC 559 (IEEE 754) standard: floating-point division by zero is thus well-defined.

The IEC 559 (IEEE 754) assumption is made explicitly in `assumptions.h` and also checked at compile-time:

https://github.com/bitcoin/bitcoin/blob/a22b62481aae95747830bd3c0db3227860b12d8e/src/compat/assumptions.h#L31-L36

However, UBSan is not aware of that assumption we're making.