### PR TITLE
qt: Make bech32 opt out

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -189,7 +189,7 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="useBech32">
+           <widget class="QCheckBox" name="useP2SH">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -209,7 +209,7 @@
              <string>Native segwit addresses (aka Bech32 or BIP-173) reduce your transaction fees later on and offer better protection against typos, but old wallets don't support them. When unchecked, an address compatible with older wallets will be created instead.</string>
             </property>
             <property name="text">
-             <string>Generate native segwit (Bech32) address</string>
+             <string>Generate P2SH segwit address</string>
             </property>
            </widget>
           </item>
@@ -360,7 +360,7 @@
  <tabstops>
   <tabstop>reqLabel</tabstop>
   <tabstop>reqAmount</tabstop>
-  <tabstop>useBech32</tabstop>
+  <tabstop>useP2SH</tabstop>
   <tabstop>reqMessage</tabstop>
   <tabstop>receiveButton</tabstop>
   <tabstop>clearButton</tabstop>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -92,10 +92,10 @@ void ReceiveCoinsDialog::setModel(WalletModel *_model)
         // Last 2 columns are set by the columnResizingFixer, when the table geometry is ready.
         columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(tableView, AMOUNT_MINIMUM_COLUMN_WIDTH, DATE_COLUMN_WIDTH, this);
 
-        if (model->wallet().getDefaultAddressType() == OutputType::BECH32) {
-            ui->useBech32->setCheckState(Qt::Checked);
+        if (model->wallet().getDefaultAddressType() == OutputType::P2SH_SEGWIT) {
+            ui->useP2SH->setCheckState(Qt::Checked);
         } else {
-            ui->useBech32->setCheckState(Qt::Unchecked);
+            ui->useP2SH->setCheckState(Qt::Unchecked);
         }
 
         // Set the button to be enabled or disabled based on whether the wallet can give out new addresses.
@@ -148,7 +148,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     QString label = ui->reqLabel->text();
     /* Generate new receiving address */
     OutputType address_type;
-    if (ui->useBech32->isChecked()) {
+    if (!ui->useP2SH->isChecked()) {
         address_type = OutputType::BECH32;
     } else {
         address_type = model->wallet().getDefaultAddressType();


### PR DESCRIPTION
This pull requests makes the Bech32 checkbox to a P2SH segwit checkbox and makes it therefore a different kind of opt out.

Because Bech32 is standard now in Bitcoin-Qt, it shouldn't be extra mentioned IMO.
Although I'm not a marketing expert I still think it is better to use this approach because I personally unchecked all check boxes where I don't know what they do (you may accidentally sign up for a spam newsletter then).