### PR TITLE
Replace the LogPrint function with a macro

### DIFF
--- a/src/logging.h
+++ b/src/logging.h
@@ -155,12 +155,13 @@ static inline void LogPrintf(const char* fmt, const Args&... args)
     }
 }
 
-template <typename... Args>
-static inline void LogPrint(const BCLog::LogFlags& category, const Args&... args)
-{
-    if (LogAcceptCategory((category))) {
-        LogPrintf(args...);
-    }
-}
+// Use a macro instead of a function for conditional logging to prevent
+// evaluating arguments when logging for the category is not enabled.
+#define LogPrint(category, ...)              \
+    do {                                     \
+        if (LogAcceptCategory((category))) { \
+            LogPrintf(__VA_ARGS__);          \
+        }                                    \
+    } while (0)
 
 #endif // BITCOIN_LOGGING_H


### PR DESCRIPTION
Calling `LogPrint` with a category that is not enabled results in
evaluating the remaining function arguments, which may be arbitrarily
complex (and possibly expensive) expressions. Defining `LogPrint` as a
macro prevents this unnecessary expression evaluation.

This is a partial revert of #14209. The decision to revert is discussed
in #16688, which adds verbose logging for validation event notification.