### PR TITLE
tests: Add unit testing for the CompressScript function

### DIFF
--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -4,6 +4,7 @@
 
 #include <compressor.h>
 #include <test/setup_common.h>
+#include <script/standard.h>
 
 #include <stdint.h>
 
@@ -59,6 +60,78 @@ BOOST_AUTO_TEST_CASE(compress_amounts)
 
     for (uint64_t i = 0; i < 100000; i++)
         BOOST_CHECK(TestDecode(i));
+}
+
+BOOST_AUTO_TEST_CASE(compress_script_to_ckey_id)
+{
+    // case CKeyID
+    CKey key;
+    key.MakeNewKey(true);
+    CPubKey pubkey = key.GetPubKey();
+
+    CScript script = CScript() << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
+    BOOST_CHECK_EQUAL(script.size(), 25);
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 21);
+    BOOST_CHECK_EQUAL(out[0], 0x00);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[3], 20), 0); // compare the 20 relevant chars of the CKeyId in the script
+}
+
+BOOST_AUTO_TEST_CASE(compress_script_to_cscript_id)
+{
+    // case CScriptID
+    CScript script, redeemScript;
+    script << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
+    BOOST_CHECK_EQUAL(script.size(), 23);
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 21);
+    BOOST_CHECK_EQUAL(out[0], 0x01);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 20), 0); // compare the 20 relevant chars of the CScriptId in the script
+}
+
+BOOST_AUTO_TEST_CASE(compress_script_to_compressed_pubkey_id)
+{
+    CKey key;
+    key.MakeNewKey(true); // case compressed PubKeyID
+
+    CScript script = CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG; // COMPRESSED_PUBLIC_KEY_SIZE (33)
+    BOOST_CHECK_EQUAL(script.size(), 35);
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 33);
+    BOOST_CHECK_EQUAL(memcmp(&out[0], &script[1], 1), 0);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 32), 0); // compare the 32 chars of the compressed CPubKey
+}
+
+BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
+{
+    CKey key;
+    key.MakeNewKey(false); // case uncompressed PubKeyID
+    CScript script =  CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG; // PUBLIC_KEY_SIZE (65)
+    BOOST_CHECK_EQUAL(script.size(), 67);                   // 1 char code + 65 char pubkey + OP_CHECKSIG
+
+    std::vector<unsigned char> out;
+    bool done = CompressScript(script, out);
+    BOOST_CHECK_EQUAL(done, true);
+
+    // Check compressed script
+    BOOST_CHECK_EQUAL(out.size(), 33);
+    BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 32), 0); // first 32 chars of CPubKey are copied into out[1:]
+    BOOST_CHECK_EQUAL(out[0], 0x04 | (script[65] & 0x01)); // least significant bit (lsb) of last char of pubkey is mapped into out[0]
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Salvaging #15104 which adds unit tests for CompressScript function in `compressor.cpp`

Tested following cases for the CScript:
  - CKeyID
  - CScriptID
  - Uncompressed CPubKey (of size: 65)
  - Compressed CPubKey (of size: 32)