### PR TITLE
refactor: call getDisplayUnit() once instead of three times

### DIFF
--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -265,10 +265,11 @@ void SendCoinsEntry::updateDisplayUnit()
 {
     if(model && model->getOptionsModel())
     {
-        // Update payAmount with the current unit
-        ui->payAmount->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
-        ui->payAmount_is->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
-        ui->payAmount_s->setDisplayUnit(model->getOptionsModel()->getDisplayUnit());
+        // Update payAmount with the current 
+        int unit = model->getOptionsModel()->getDisplayUnit();
+        ui->payAmount->setDisplayUnit(unit);
+        ui->payAmount_is->setDisplayUnit(unit);
+        ui->payAmount_s->setDisplayUnit(unit);
     }
 }
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -265,7 +265,7 @@ void SendCoinsEntry::updateDisplayUnit()
 {
     if(model && model->getOptionsModel())
     {
-        // Update payAmount with the current 
+        // Update payAmount with the current unit
         int unit = model->getOptionsModel()->getDisplayUnit();
         ui->payAmount->setDisplayUnit(unit);
         ui->payAmount_is->setDisplayUnit(unit);


### PR DESCRIPTION
Noticed that getDisplayUnit() was being called 3 times but can be made more efficient if we store the value on the function once as a variable for reuse instead