### PR TITLE
gui: Fix payAmount tooltip in SendCoinsEntry

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -17,9 +17,6 @@
    <bool>false</bool>
   </property>
   <widget class="QFrame" name="SendCoins">
-   <property name="toolTip">
-    <string>The amount to send in the selected unit</string>
-   </property>
    <property name="frameShape">
     <enum>QFrame::NoFrame</enum>
    </property>
@@ -165,7 +162,11 @@
     <item row="2" column="1">
      <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,1,0">
       <item>
-       <widget class="BitcoinAmountField" name="payAmount"/>
+       <widget class="BitcoinAmountField" name="payAmount">
+         <property name="toolTip">
+          <string>The amount to send in the selected unit</string>
+         </property>
+       </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="checkboxSubtractFeeFromAmount">


### PR DESCRIPTION
Before the tooltip shows in wrong places:

![Screenshot 2019-10-23 at 11 33 49](https://user-images.githubusercontent.com/3534524/67384904-f6b6a380-f589-11e9-832c-ec1643014b96.png)
![Screenshot 2019-10-23 at 11 33 23](https://user-images.githubusercontent.com/3534524/67384905-f74f3a00-f589-11e9-9944-a52fee097e02.png)

Now only shows in the amount field:

![Screenshot 2019-10-23 at 11 35 30](https://user-images.githubusercontent.com/3534524/67384919-ff0ede80-f589-11e9-8ce4-c122e11fe885.png)