### PR TITLE
test: Add RegTestingSetup to setup_common

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -56,8 +56,10 @@ RAW_TEST_FILES =
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 
 BITCOIN_TEST_SUITE = \
-  test/lib/transaction_utils.h \
+  test/lib/blockfilter.cpp \
+  test/lib/blockfilter.h \
   test/lib/transaction_utils.cpp \
+  test/lib/transaction_utils.h \
   test/main.cpp \
   test/setup_common.h \
   test/setup_common.cpp

--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -112,7 +112,7 @@ void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double
     printer.header();
 
     for (const auto& p : benchmarks()) {
-        TestingSetup test{CBaseChainParams::REGTEST};
+        RegTestingSetup test{};
         {
             LOCK(cs_main);
             assert(::ChainActive().Height() == 0);

--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -3,8 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blockencodings.h>
-#include <consensus/merkle.h>
 #include <chainparams.h>
+#include <consensus/merkle.h>
 #include <pow.h>
 #include <streams.h>
 
@@ -14,11 +14,7 @@
 
 std::vector<std::pair<uint256, CTransactionRef>> extra_txn;
 
-struct RegtestingSetup : public TestingSetup {
-    RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
-};
-
-BOOST_FIXTURE_TEST_SUITE(blockencodings_tests, RegtestingSetup)
+BOOST_FIXTURE_TEST_SUITE(blockencodings_tests, RegTestingSetup)
 
 static CBlock BuildBlockTestCase() {
     CBlock block;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -8,31 +8,15 @@
 #include <index/blockfilterindex.h>
 #include <miner.h>
 #include <pow.h>
-#include <test/setup_common.h>
 #include <script/standard.h>
+#include <test/lib/blockfilter.h>
+#include <test/setup_common.h>
 #include <util/time.h>
 #include <validation.h>
 
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_SUITE(blockfilter_index_tests)
-
-static bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index,
-                          BlockFilter& filter)
-{
-    CBlock block;
-    if (!ReadBlockFromDisk(block, block_index->GetBlockPos(), Params().GetConsensus())) {
-        return false;
-    }
-
-    CBlockUndo block_undo;
-    if (block_index->nHeight > 0 && !UndoReadFromDisk(block_undo, block_index)) {
-        return false;
-    }
-
-    filter = BlockFilter(filter_type, block, block_undo);
-    return true;
-}
 
 static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex* block_index,
                                uint256& last_header)

--- a/src/test/lib/blockfilter.cpp
+++ b/src/test/lib/blockfilter.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/lib/blockfilter.h>
+
+#include <chainparams.h>
+#include <validation.h>
+
+
+bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter)
+{
+    CBlock block;
+    if (!ReadBlockFromDisk(block, block_index->GetBlockPos(), Params().GetConsensus())) {
+        return false;
+    }
+
+    CBlockUndo block_undo;
+    if (block_index->nHeight > 0 && !UndoReadFromDisk(block_undo, block_index)) {
+        return false;
+    }
+
+    filter = BlockFilter(filter_type, block, block_undo);
+    return true;
+}
+

--- a/src/test/lib/blockfilter.h
+++ b/src/test/lib/blockfilter.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_LIB_BLOCKFILTER_H
+#define BITCOIN_TEST_LIB_BLOCKFILTER_H
+
+#include <blockfilter.h>
+class CBlockIndex;
+
+bool ComputeFilter(BlockFilterType filter_type, const CBlockIndex* block_index, BlockFilter& filter);
+
+#endif // BITCOIN_TEST_LIB_BLOCKFILTER_H

--- a/src/test/setup_common.cpp
+++ b/src/test/setup_common.cpp
@@ -124,7 +124,7 @@ TestingSetup::~TestingSetup()
     pblocktree.reset();
 }
 
-TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
+TestChain100Setup::TestChain100Setup()
 {
     // CreateAndProcessBlock() does not support building SegWit blocks, so don't activate in these tests.
     // TODO: fix the code to support SegWit blocks.

--- a/src/test/setup_common.h
+++ b/src/test/setup_common.h
@@ -76,6 +76,12 @@ struct TestingSetup : public BasicTestingSetup {
     ~TestingSetup();
 };
 
+/** Identical to TestingSetup, but chain set to regtest */
+struct RegTestingSetup : public TestingSetup {
+    RegTestingSetup()
+        : TestingSetup{CBaseChainParams::REGTEST} {}
+};
+
 class CBlock;
 struct CMutableTransaction;
 class CScript;
@@ -84,7 +90,7 @@ class CScript;
 // Testing fixture that pre-creates a
 // 100-block REGTEST-mode block chain
 //
-struct TestChain100Setup : public TestingSetup {
+struct TestChain100Setup : public RegTestingSetup {
     TestChain100Setup();
 
     // Create a new block with just given transactions, coinbase paying to

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -18,13 +18,9 @@
 
 #include <thread>
 
-struct RegtestingSetup : public TestingSetup {
-    RegtestingSetup() : TestingSetup(CBaseChainParams::REGTEST) {}
-};
-
 static const std::vector<unsigned char> V_OP_TRUE{OP_TRUE};
 
-BOOST_FIXTURE_TEST_SUITE(validation_block_tests, RegtestingSetup)
+BOOST_FIXTURE_TEST_SUITE(validation_block_tests, RegTestingSetup)
 
 struct TestSubscriber : public CValidationInterface {
     uint256 m_expected_tip;


### PR DESCRIPTION
The default chain for `TestingSetup` is the main chain. However, any test that wants to mine blocks on demand needs to switch to regtest. This is done manually and in-line right now.

Fix that by creating an explicit `RegTestingSetup` and use it where appropriate.

Also, add a move-only commit to move `ComputeFilter` into the newly created unit test library.

Both commits are part of #15845, but split up because they are useful on their own.