### PR TITLE
tests: Add fuzzing harnesses for various Base{32,58,64} and hex related functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -28,6 +28,7 @@ FUZZ_TARGETS = \
   test/fuzz/eval_script \
   test/fuzz/fee_rate_deserialize \
   test/fuzz/flat_file_pos_deserialize \
+  test/fuzz/hex \
   test/fuzz/integer \
   test/fuzz/inv_deserialize \
   test/fuzz/key_origin_info_deserialize \
@@ -362,6 +363,12 @@ test_fuzz_address_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DAD
 test_fuzz_address_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_address_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_address_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_hex_SOURCES = $(FUZZ_SUITE) test/fuzz/hex.cpp
+test_fuzz_hex_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_hex_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_hex_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_hex_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_inv_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_inv_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DINV_DESERIALIZE=1

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -8,6 +8,7 @@ FUZZ_TARGETS = \
   test/fuzz/address_deserialize \
   test/fuzz/addrman_deserialize \
   test/fuzz/banentry_deserialize \
+  test/fuzz/base_encode_decode \
   test/fuzz/bech32 \
   test/fuzz/block \
   test/fuzz/block_deserialize \
@@ -277,6 +278,12 @@ test_fuzz_bech32_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_bech32_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_bech32_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_bech32_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_base_encode_decode_SOURCES = $(FUZZ_SUITE) test/fuzz/base_encode_decode.cpp
+test_fuzz_base_encode_decode_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_base_encode_decode_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_base_encode_decode_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_base_encode_decode_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_txundo_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_txundo_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTXUNDO_DESERIALIZE=1

--- a/src/test/fuzz/base_encode_decode.cpp
+++ b/src/test/fuzz/base_encode_decode.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/fuzz.h>
+
+#include <base58.h>
+#include <util/string.h>
+#include <util/strencodings.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    const std::string random_encoded_string(buffer.begin(), buffer.end());
+
+    std::vector<unsigned char> decoded;
+    if (DecodeBase58(random_encoded_string, decoded, 100)) {
+        const std::string encoded_string = EncodeBase58(decoded);
+        assert(encoded_string == TrimString(encoded_string));
+        assert(ToLower(encoded_string) == ToLower(TrimString(random_encoded_string)));
+    }
+
+    if (DecodeBase58Check(random_encoded_string, decoded, 100)) {
+        const std::string encoded_string = EncodeBase58Check(decoded);
+        assert(encoded_string == TrimString(encoded_string));
+        assert(ToLower(encoded_string) == ToLower(TrimString(random_encoded_string)));
+    }
+
+    bool pf_invalid;
+    std::string decoded_string = DecodeBase32(random_encoded_string, &pf_invalid);
+    if (!pf_invalid) {
+        const std::string encoded_string = EncodeBase32(decoded_string);
+        assert(encoded_string == TrimString(encoded_string));
+        assert(ToLower(encoded_string) == ToLower(TrimString(random_encoded_string)));
+    }
+
+    decoded_string = DecodeBase64(random_encoded_string, &pf_invalid);
+    if (!pf_invalid) {
+        const std::string encoded_string = EncodeBase64(decoded_string);
+        assert(encoded_string == TrimString(encoded_string));
+        assert(ToLower(encoded_string) == ToLower(TrimString(random_encoded_string)));
+    }
+}

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/fuzz.h>
+
+#include <util/strencodings.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    const std::string random_hex_string(buffer.begin(), buffer.end());
+    const std::vector<unsigned char> data = ParseHex(random_hex_string);
+    const std::string hex_data = HexStr(data);
+    if (IsHex(random_hex_string)) {
+        assert(ToLower(random_hex_string) == hex_data);
+    }
+}

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -11,6 +11,16 @@
 #include <string>
 #include <vector>
 
+NODISCARD inline std::string TrimString(const std::string& str, const std::string& pattern = " \f\n\r\t\v")
+{
+    std::string::size_type front = str.find_first_not_of(pattern);
+    if (front == std::string::npos) {
+        return std::string();
+    }
+    std::string::size_type end = str.find_last_not_of(pattern);
+    return str.substr(front, end - front + 1);
+}
+
 /**
  * Join a list of items
  *

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -7,6 +7,7 @@
 
 #include <chainparamsbase.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/translation.h>
 
 
@@ -677,16 +678,6 @@ void ClearDatadirCache()
 fs::path GetConfigFile(const std::string& confPath)
 {
     return AbsPathForConfigVal(fs::path(confPath), false);
-}
-
-static std::string TrimString(const std::string& str, const std::string& pattern)
-{
-    std::string::size_type front = str.find_first_not_of(pattern);
-    if (front == std::string::npos) {
-        return std::string();
-    }
-    std::string::size_type end = str.find_last_not_of(pattern);
-    return str.substr(front, end - front + 1);
 }
 
 static bool GetConfigOptions(std::istream& stream, const std::string& filepath, std::string& error, std::vector<std::pair<std::string, std::string>>& options, std::list<SectionInfo>& sections)

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -15,12 +15,14 @@ import logging
 # Fuzzers known to lack a seed corpus in https://github.com/bitcoin-core/qa-assets/tree/master/fuzz_seed_corpus
 FUZZERS_MISSING_CORPORA = [
     "addr_info_deserialize",
+    "base_encode_decode",
     "block",
     "block_file_info_deserialize",
     "block_filter_deserialize",
     "block_header_and_short_txids_deserialize",
     "fee_rate_deserialize",
     "flat_file_pos_deserialize",
+    "hex",
     "integer",
     "key_origin_info_deserialize",
     "merkle_block_deserialize",


### PR DESCRIPTION
Add fuzzing harnesses for various Base{32,58,64} and hex related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/base_encode_decode
…
$ src/test/fuzz/hex
…
```