### PR TITLE
travis: Run unit and functional tests on native arm

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -45,8 +45,6 @@ task:
     folder: "/tmp/ccache_dir"
   depends_built_cache:
     folder: "/tmp/cirrus-ci-build/depends/built"
-  depends_sdk_cache:
-    folder: "/tmp/cirrus-ci-build/depends/sdk-sources"
   install_script:
     - apt-get update
     - apt-get -y install git bash ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,9 +94,11 @@ jobs:
         - set -o errexit; source ./ci/extended_lint/06_script.sh
 
     - stage: test
-      name: 'ARM  [GOAL: install]  [unit tests, no functional tests]'
+      name: 'ARM  [GOAL: install]  [unit tests, functional tests]'
+      arch: arm64
       env: >-
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
+        QEMU_USER_CMD=""  # Can run the tests natively without qemu
 
     - stage: test
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'

--- a/ci/README.md
+++ b/ci/README.md
@@ -12,7 +12,7 @@ To allow for a wide range of tested environments, but also ensure reproducibilit
 requires `docker` to be installed. To install all requirements on Ubuntu, run
 
 ```
-sudo apt install docker.io ccache bash git
+sudo apt install docker.io bash git
 ```
 
 To run the default test stage,

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -7,11 +7,16 @@
 export LC_ALL=C.UTF-8
 
 export HOST=arm-linux-gnueabihf
-export QEMU_USER_CMD="qemu-arm -L /usr/arm-linux-gnueabihf/"
-export PACKAGES="python3 g++-arm-linux-gnueabihf busybox qemu-user"
+# The host arch is unknown, so we run the tests through qemu.
+# If the host is arm and wants to run the tests natively, it can set QEMU_USER_CMD to the empty string.
+export QEMU_USER_CMD="${QEMU_USER_CMD:"qemu-arm -L /usr/arm-linux-gnueabihf/"}"
+# We don't know whether the host can run the cross compiled binaries. To run them, either qemu-user or libc6:armhf for
+# the target is required, so install both.
+export DPKG_ADD_ARCH="armhf"
+export PACKAGES="python3 g++-arm-linux-gnueabihf busybox qemu-user libc6:armhf libstdc++6:armhf libfontconfig1:armhf libxcb1:armhf"
 export USE_BUSY_BOX=true
 export RUN_UNIT_TESTS=true
-export RUN_FUNCTIONAL_TESTS=false
+export RUN_FUNCTIONAL_TESTS=true
 export GOAL="install"
 # -Wno-psabi is to disable ABI warnings: "note: parameter passing for argument of type ... changed in GCC 7.1"
 # This could be removed once the ABI change warning does not show up by default

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -76,6 +76,9 @@ else
   DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
 fi
 
+if [ -n "$DPKG_ADD_ARCH" ]; then
+  DOCKER_EXEC dpkg --add-architecture "$DPKG_ADD_ARCH"
+fi
 
 if [ "$TRAVIS_OS_NAME" != "osx" ]; then
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get update

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -33,7 +33,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 fi
 
 mkdir -p "${BASE_SCRATCH_DIR}"
-ccache echo "Creating ccache dir if it didn't already exist"
+mkdir -p "${CCACHE_DIR}"
 
 if [ ! -d ${DIR_QA_ASSETS} ]; then
   git clone https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}


### PR DESCRIPTION
This keeps the cross-compilation to make it easy to run the ci on non-arm hardware. To run this locally in qemu-user as it used to be, just `export QEMU_USER_CMD="qemu-arm -L /usr/arm-linux-gnueabihf/"`.