### PR TITLE
tests: Skip unnecessary fuzzer initialisation. Hold ECCVerifyHandle only when needed.

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -12,6 +12,7 @@
 #include <net.h>
 #include <primitives/block.h>
 #include <protocol.h>
+#include <pubkey.h>
 #include <streams.h>
 #include <undo.h>
 #include <version.h>
@@ -22,6 +23,12 @@
 #include <vector>
 
 #include <test/fuzz/fuzz.h>
+
+void initialize()
+{
+    // Fuzzers using pubkey must hold an ECCVerifyHandle.
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+}
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -4,11 +4,9 @@
 
 #include <test/fuzz/fuzz.h>
 
+#include <cstdint>
 #include <unistd.h>
-
-#include <pubkey.h>
-#include <util/memory.h>
-
+#include <vector>
 
 static bool read_stdin(std::vector<uint8_t>& data)
 {
@@ -23,10 +21,8 @@ static bool read_stdin(std::vector<uint8_t>& data)
 }
 
 // Default initialization: Override using a non-weak initialize().
-__attribute__((weak))
-void initialize()
+__attribute__((weak)) void initialize()
 {
-    const static auto verify_handle = MakeUnique<ECCVerifyHandle>();
 }
 
 // This function is used by libFuzzer
@@ -50,7 +46,8 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
 // the main(...) function.
 __attribute__((weak))
 #endif
-int main(int argc, char **argv)
+int
+main(int argc, char** argv)
 {
     initialize();
 #ifdef __AFL_INIT

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -40,14 +40,9 @@ extern "C" int LLVMFuzzerInitialize(int* argc, char*** argv)
     return 0;
 }
 
-// Disabled under WIN32 due to clash with Cygwin's WinMain.
-#ifndef WIN32
 // Declare main(...) "weak" to allow for libFuzzer linking. libFuzzer provides
 // the main(...) function.
-__attribute__((weak))
-#endif
-int
-main(int argc, char** argv)
+__attribute__((weak)) int main(int argc, char** argv)
 {
     initialize();
 #ifdef __AFL_INIT


### PR DESCRIPTION
Skip unnecessary fuzzer initialisation. Hold `ECCVerifyHandle` only when needed.

As suggested by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/17018#discussion_r336645391.