### PR TITLE
wallet: LearnRelatedScripts only if KeepDestination

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3256,7 +3256,6 @@ bool ReserveDestination::GetReservedDestination(CTxDestination& dest, bool inter
         fInternal = keypool.fInternal;
     }
     assert(vchPubKey.IsValid());
-    m_spk_man->LearnRelatedScripts(vchPubKey, type);
     address = GetDestinationForKey(vchPubKey, type);
     dest = address;
     return true;
@@ -3264,8 +3263,10 @@ bool ReserveDestination::GetReservedDestination(CTxDestination& dest, bool inter
 
 void ReserveDestination::KeepDestination()
 {
-    if (nIndex != -1)
+    if (nIndex != -1) {
         m_spk_man->KeepDestination(nIndex);
+        m_spk_man->LearnRelatedScripts(vchPubKey, type);
+    }
     nIndex = -1;
     vchPubKey = CPubKey();
     address = CNoDestination();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -140,8 +140,9 @@ class ReserveDestination
 {
 protected:
     //! The wallet to reserve from
-    CWallet* pwallet;
+    CWallet* const pwallet;
     LegacyScriptPubKeyMan* m_spk_man{nullptr};
+    OutputType const type;
     //! The index of the address's key in the keypool
     int64_t nIndex{-1};
     //! The public key for the address
@@ -153,10 +154,9 @@ protected:
 
 public:
     //! Construct a ReserveDestination object. This does NOT reserve an address yet
-    explicit ReserveDestination(CWallet* pwalletIn)
-    {
-        pwallet = pwalletIn;
-    }
+    explicit ReserveDestination(CWallet* pwallet, OutputType type)
+      : pwallet(pwallet)
+      , type(type) { }
 
     ReserveDestination(const ReserveDestination&) = delete;
     ReserveDestination& operator=(const ReserveDestination&) = delete;
@@ -168,7 +168,7 @@ public:
     }
 
     //! Reserve an address
-    bool GetReservedDestination(const OutputType type, CTxDestination& pubkey, bool internal);
+    bool GetReservedDestination(CTxDestination& pubkey, bool internal);
     //! Return reserved address
     void ReturnDestination();
     //! Keep the address. Do not return it's key to the keypool when this object goes out of scope


### PR DESCRIPTION
Only mutates the wallet if the reserved key is kept.

First commit is a refactor that makes the address type a class member.

The second commit moves `LearnRelatedScripts` from `GetReservedDestination` to `KeepDestination` to avoid an unnecessary call to `AddCScript` - which in turn prevents multiple entries of the same script in the wallet DB.