### PR TITLE
ci: Disable functional tests on mac host

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,4 +152,4 @@ jobs:
       # https://docs.travis-ci.com/user/reference/osx/#macos-version
       osx_image: xcode11
       env: >-
-        FILE_ENV="./ci/test/00_setup_env_mac_functional.sh"
+        FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/ci/test/00_setup_env_mac_host.sh
+++ b/ci/test/00_setup_env_mac_host.sh
@@ -11,7 +11,7 @@ export BREW_PACKAGES="automake berkeley-db4 libtool boost miniupnpc pkg-config p
 export PIP_PACKAGES="zmq"
 export RUN_CI_ON_HOST=true
 export RUN_UNIT_TESTS=true
-export RUN_FUNCTIONAL_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false
 export GOAL="install"
 export BITCOIN_CONFIG="--enable-gui --enable-bip70 --enable-reduce-exports --enable-werror"
 # Run without depends


### PR DESCRIPTION
Judging from the lack of responses to https://github.com/bitcoin/bitcoin/issues/15400#issuecomment-543745053, no one can reproduce the failures locally. Thus, disable the tests on the ci mac host. Otherwise they cause ci failures to be ignored or overwritten by a blind re-run.