### PR TITLE
p2p: add PoissonNextSend method that returns mockable time

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -762,7 +762,7 @@ public:
         bool fSendMempool GUARDED_BY(cs_tx_inventory){false};
         // Last time a "MEMPOOL" request was serviced.
         std::atomic<std::chrono::seconds> m_last_mempool_req{std::chrono::seconds{0}};
-        int64_t nNextInvSend{0};
+        std::chrono::microseconds nNextInvSend{0};
 
         CCriticalSection cs_feeFilter;
         // Minimum fee rate with which to filter inv's to this node

--- a/src/net.h
+++ b/src/net.h
@@ -943,11 +943,13 @@ public:
     void MaybeSetAddrName(const std::string& addrNameIn);
 };
 
-
-
-
-
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
 int64_t PoissonNextSend(int64_t now, int average_interval_seconds);
+
+/** Wrapper to return mockable type */
+inline std::chrono::microseconds PoissonNextSend(std::chrono::microseconds now, std::chrono::seconds average_interval)
+{
+    return std::chrono::microseconds{PoissonNextSend(now.count(), average_interval.count())};
+}
 
 #endif // BITCOIN_NET_H

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -303,5 +303,19 @@ BOOST_AUTO_TEST_CASE(LocalAddress_BasicLifecycle)
     BOOST_CHECK_EQUAL(IsLocal(addr), false);
 }
 
+BOOST_AUTO_TEST_CASE(PoissonNextSend)
+{
+    g_mock_deterministic_tests = true;
+
+    int64_t now = 5000;
+    int average_interval_seconds = 600;
+
+    auto poisson = ::PoissonNextSend(now, average_interval_seconds);
+    std::chrono::microseconds poisson_chrono = ::PoissonNextSend(std::chrono::microseconds{now}, std::chrono::seconds{average_interval_seconds});
+
+    BOOST_CHECK_EQUAL(poisson, poisson_chrono.count());
+
+    g_mock_deterministic_tests = false;
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Introduce a Poisson helper method that wraps the existing method to return `std::chrono::duration` type, which is mockable. 

Needed for https://github.com/bitcoin/bitcoin/pull/16698.