### PR TITLE
wallet: Remove Boost from DecodeDumpTime

### DIFF
--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -111,3 +111,17 @@ std::string FormatISO8601Date(int64_t nTime) {
 #endif
     return strprintf("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
 }
+
+#ifdef WIN32
+#define timegm _mkgmtime
+#endif
+
+int64_t ParseISO8601DateTime(const std::string &str) {
+    std::istringstream iss(str);
+    std::tm t;
+    iss.imbue(std::locale::classic());
+    iss >> std::get_time(&t, "%Y-%m-%dT%H:%M:%SZ");
+    if (iss.fail())
+        return 0;
+    return timegm(&t);
+}

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -48,5 +48,6 @@ T GetTime();
  */
 std::string FormatISO8601DateTime(int64_t nTime);
 std::string FormatISO8601Date(int64_t nTime);
+int64_t ParseISO8601DateTime(const std::string &str);
 
 #endif // BITCOIN_UTIL_TIME_H

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -21,25 +21,26 @@
 
 #include <stdint.h>
 #include <tuple>
+#include <iomanip>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <univalue.h>
 
+#ifdef WIN32
+#define timegm _mkgmtime
+#endif
 
-int64_t static DecodeDumpTime(const std::string &str) {
-    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
-    static const std::locale loc(std::locale::classic(),
-        new boost::posix_time::time_input_facet("%Y-%m-%dT%H:%M:%SZ"));
+int64_t DecodeDumpTime(const std::string &str) {
     std::istringstream iss(str);
-    iss.imbue(loc);
-    boost::posix_time::ptime ptime(boost::date_time::not_a_date_time);
-    iss >> ptime;
-    if (ptime.is_not_a_date_time())
+    std::tm t;
+    iss.imbue(std::locale::classic());
+    iss >> std::get_time(&t, "%Y-%m-%dT%H:%M:%SZ");
+    if (iss.fail())
         return 0;
-    return (ptime - epoch).total_seconds();
+    return timegm(&t);
 }
+
 
 std::string static EncodeDumpString(const std::string &str) {
     std::stringstream ret;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -27,20 +27,6 @@
 
 #include <univalue.h>
 
-#ifdef WIN32
-#define timegm _mkgmtime
-#endif
-
-int64_t DecodeDumpTime(const std::string &str) {
-    std::istringstream iss(str);
-    std::tm t;
-    iss.imbue(std::locale::classic());
-    iss >> std::get_time(&t, "%Y-%m-%dT%H:%M:%SZ");
-    if (iss.fail())
-        return 0;
-    return timegm(&t);
-}
-
 
 std::string static EncodeDumpString(const std::string &str) {
     std::stringstream ret;
@@ -599,7 +585,7 @@ UniValue importwallet(const JSONRPCRequest& request)
                 continue;
             CKey key = DecodeSecret(vstr[0]);
             if (key.IsValid()) {
-                int64_t nTime = DecodeDumpTime(vstr[1]);
+                int64_t nTime = ParseISO8601DateTime(vstr[1]);
                 std::string strLabel;
                 bool fLabel = true;
                 for (unsigned int nStr = 2; nStr < vstr.size(); nStr++) {
@@ -618,7 +604,7 @@ UniValue importwallet(const JSONRPCRequest& request)
             } else if(IsHex(vstr[0])) {
                 std::vector<unsigned char> vData(ParseHex(vstr[0]));
                 CScript script = CScript(vData.begin(), vData.end());
-                int64_t birth_time = DecodeDumpTime(vstr[1]);
+                int64_t birth_time = ParseISO8601DateTime(vstr[1]);
                 scripts.push_back(std::pair<CScript, int64_t>(script, birth_time));
             }
         }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -15,6 +15,7 @@
 #include <validation.h>
 #include <wallet/coincontrol.h>
 #include <wallet/test/wallet_test_fixture.h>
+#include <util/time.h>
 
 #include <boost/test/unit_test.hpp>
 #include <boost/algorithm/string.hpp>
@@ -24,7 +25,6 @@
 extern UniValue importmulti(const JSONRPCRequest& request);
 extern UniValue dumpwallet(const JSONRPCRequest& request);
 extern UniValue importwallet(const JSONRPCRequest& request);
-int64_t DecodeDumpTime(const std::string &str);
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 
@@ -594,7 +594,7 @@ BOOST_FIXTURE_TEST_CASE(dummy_input_size_test, TestChain100Setup)
     BOOST_CHECK_EQUAL(CalculateNestedKeyhashInputSize(true), DUMMY_NESTED_P2WPKH_INPUT_SIZE);
 }
 
-int64_t static OldDecodeDumpTime(const std::string &str) {
+int64_t static OldParseISO8601DateTime(const std::string &str) {
     static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
     static const std::locale loc(std::locale::classic(),
         new boost::posix_time::time_input_facet("%Y-%m-%dT%H:%M:%SZ"));
@@ -607,11 +607,11 @@ int64_t static OldDecodeDumpTime(const std::string &str) {
     return (ptime - epoch).total_seconds();
 }
 
-BOOST_AUTO_TEST_CASE(DecodeDumpTimeTest)
+BOOST_AUTO_TEST_CASE(ParseISO8601DateTimeTest)
 {
     std::string first("2019-10-24T23:46:06Z");
     std::string zero("1970-01-01T00:00:00Z");
-    BOOST_CHECK_EQUAL(DecodeDumpTime(first), OldDecodeDumpTime(first));
+    BOOST_CHECK_EQUAL(ParseISO8601DateTime(first), OldParseISO8601DateTime(first));
 
     std::stringstream formatted_now;
     auto now = std::chrono::system_clock::now();
@@ -619,8 +619,8 @@ BOOST_AUTO_TEST_CASE(DecodeDumpTimeTest)
     auto tm = std::localtime(&now_time);
     formatted_now << std::put_time(tm, "%Y-%m-%dT%H:%M:%SZ");
 
-    BOOST_CHECK_EQUAL(DecodeDumpTime(formatted_now.str()), OldDecodeDumpTime(formatted_now.str()));
-    BOOST_CHECK_EQUAL(DecodeDumpTime(zero), 0);
+    BOOST_CHECK_EQUAL(ParseISO8601DateTime(formatted_now.str()), OldParseISO8601DateTime(formatted_now.str()));
+    BOOST_CHECK_EQUAL(ParseISO8601DateTime(zero), 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Utilizing C++11 and platform specific function(timegm) to replace the usage of boost in converting a timestamp in string to a unix epoch.

Moved the old function to the unit tests to check for consistency (in case there's some corner case in timezones)

Sadly C++11 doesn't have anything to handle timezones currently(C++20 seems to have  heh) so I had to use `timegm` from POSIX and `_mkgmtime` from windows.

Tested on linux only.