### PR TITLE
wallet: avoid knapsack when there's no change

### DIFF
--- a/src/bench/coin_selection.cpp
+++ b/src/bench/coin_selection.cpp
@@ -47,7 +47,7 @@ static void CoinSelection(benchmark::State& state)
     }
 
     const CoinEligibilityFilter filter_standard(1, 6, 0);
-    const CoinSelectionParams coin_selection_params(true, 34, 148, CFeeRate(0), 0);
+    const CoinSelectionParams coin_selection_params(/* use_bnb */ true, /* use_knapsack */ true, /* subtract_fee_from_outputs */ false, 34, 148, CFeeRate(0), 0);
     while (state.KeepRunning()) {
         std::set<CInputCoin> setCoinsRet;
         CAmount nValueRet;
@@ -98,7 +98,7 @@ static void BnBExhaustion(benchmark::State& state)
     while (state.KeepRunning()) {
         // Benchmark
         CAmount target = make_hard_case(17, utxo_pool);
-        SelectCoinsBnB(utxo_pool, target, 0, selection, value_ret, not_input_fees); // Should exhaust
+        SelectCoinsBnB(utxo_pool, target, 0, selection, value_ret, not_input_fees, /* subtract_fee_from_outputs */ false); // Should exhaust
 
         // Cleanup
         utxo_pool.clear();

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -62,14 +62,14 @@ struct {
 
 static const size_t TOTAL_TRIES = 100000;
 
-bool SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& target_value, const CAmount& cost_of_change, std::set<CInputCoin>& out_set, CAmount& value_ret, CAmount not_input_fees)
+bool SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& target_value, const CAmount& cost_of_change, std::set<CInputCoin>& out_set, CAmount& value_ret, CAmount not_input_fees, bool subtract_fee_from_outputs)
 {
     out_set.clear();
     CAmount curr_value = 0;
 
     std::vector<bool> curr_selection; // select the utxo at this index
     curr_selection.reserve(utxo_pool.size());
-    CAmount actual_target = not_input_fees + target_value;
+    CAmount actual_target = (subtract_fee_from_outputs ? 0 : not_input_fees) + target_value;
 
     // Calculate curr_available_value
     CAmount curr_available_value = 0;

--- a/src/wallet/coinselection.h
+++ b/src/wallet/coinselection.h
@@ -93,7 +93,7 @@ struct OutputGroup
     bool EligibleForSpending(const CoinEligibilityFilter& eligibility_filter) const;
 };
 
-bool SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& target_value, const CAmount& cost_of_change, std::set<CInputCoin>& out_set, CAmount& value_ret, CAmount not_input_fees);
+bool SelectCoinsBnB(std::vector<OutputGroup>& utxo_pool, const CAmount& target_value, const CAmount& cost_of_change, std::set<CInputCoin>& out_set, CAmount& value_ret, CAmount not_input_fees, bool subtract_fee_from_outputs);
 
 // Original coin selection algorithm as a fallback
 bool KnapsackSolver(const CAmount& nTargetValue, std::vector<OutputGroup>& groups, std::set<CInputCoin>& setCoinsRet, CAmount& nValueRet);

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -20,7 +20,7 @@ bool LegacyScriptPubKeyMan::GetNewDestination(const OutputType type, const std::
     // Generate a new key that is added to wallet
     CPubKey new_key;
     if (!GetKeyFromPool(new_key)) {
-        error = "Error: Keypool ran out, please call keypoolrefill first";
+        error = _("Error: Keypool ran out, please call keypoolrefill first").translated;
         return false;
     }
     LearnRelatedScripts(new_key, type);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2530,19 +2530,14 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                 //  post-backup change.
 
                 // Reserve a new key pair from key pool
-                if (!CanGetAddresses(true)) {
-                    strFailReason = _("Can't generate a change-address key. No keys in the internal keypool and can't generate any keys.").translated;
-                    return false;
-                }
                 CTxDestination dest;
                 const OutputType change_type = TransactionChangeType(coin_control.m_change_type ? *coin_control.m_change_type : m_default_change_type, vecSend);
-                bool ret = reservedest.GetReservedDestination(change_type, dest, true);
-                if (!ret)
-                {
-                    strFailReason = _("Keypool ran out, please call keypoolrefill first").translated;
+                if (reservedest.GetReservedDestination(change_type, dest, true)) {
+                    scriptChange = GetScriptForDestination(dest);
+                } else {
+                    strFailReason = _("Can't generate a change-address key. Please call keypoolrefill first.").translated;
                     return false;
                 }
-
                 scriptChange = GetScriptForDestination(dest);
             }
             CTxOut change_prototype_txout(0, scriptChange);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2539,7 +2539,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                 bool ret = reservedest.GetReservedDestination(change_type, dest, true);
                 if (!ret)
                 {
-                    strFailReason = "Keypool ran out, please call keypoolrefill first";
+                    strFailReason = _("Keypool ran out, please call keypoolrefill first").translated;
                     return false;
                 }
 
@@ -3055,7 +3055,7 @@ bool CWallet::GetNewChangeDestination(const OutputType type, CTxDestination& des
 
     ReserveDestination reservedest(this);
     if (!reservedest.GetReservedDestination(type, dest, true)) {
-        error = "Error: Keypool ran out, please call keypoolrefill first";
+        error = _("Error: Keypool ran out, please call keypoolrefill first").translated;
         return false;
     }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -571,12 +571,14 @@ public:
 struct CoinSelectionParams
 {
     bool use_bnb = true;
+    bool use_knapsack = true;
+    bool subtract_fee_from_outputs = false;
     size_t change_output_size = 0;
     size_t change_spend_size = 0;
     CFeeRate effective_fee = CFeeRate(0);
     size_t tx_noinputs_size = 0;
 
-    CoinSelectionParams(bool use_bnb, size_t change_output_size, size_t change_spend_size, CFeeRate effective_fee, size_t tx_noinputs_size) : use_bnb(use_bnb), change_output_size(change_output_size), change_spend_size(change_spend_size), effective_fee(effective_fee), tx_noinputs_size(tx_noinputs_size) {}
+    CoinSelectionParams(bool use_bnb, bool use_knapsack, bool subtract_fee_from_outputs, size_t change_output_size, size_t change_spend_size, CFeeRate effective_fee, size_t tx_noinputs_size) : use_bnb(use_bnb), change_output_size(change_output_size), change_spend_size(change_spend_size), effective_fee(effective_fee), tx_noinputs_size(tx_noinputs_size) {}
     CoinSelectionParams() {}
 };
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -521,11 +521,16 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].getnewaddress()
         self.nodes[1].getrawchangeaddress()
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():1.1}
+        outputs = {self.nodes[0].getnewaddress():1.09999500}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
+        # fund a transaction that does not require a new key for the change output
+        self.nodes[1].fundrawtransaction(rawtx)
+
         # fund a transaction that requires a new key for the change output
         # creating the key must be impossible because the wallet is locked
-        assert_raises_rpc_error(-4, "Can't generate a change-address key. Please call keypoolrefill first.", self.nodes[1].fundrawtransaction, rawtx)
+        outputs = {self.nodes[0].getnewaddress():1.1}
+        rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
+        assert_raises_rpc_error(-4, "Can't generate a transaction without change. Please call keypoolrefill first.", self.nodes[1].fundrawtransaction, rawtx)
 
         #refill the keypool
         self.nodes[1].walletpassphrase("test", 100)

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -525,7 +525,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         # fund a transaction that requires a new key for the change output
         # creating the key must be impossible because the wallet is locked
-        assert_raises_rpc_error(-4, "Keypool ran out, please call keypoolrefill first", self.nodes[1].fundrawtransaction, rawtx)
+        assert_raises_rpc_error(-4, "Can't generate a change-address key. Please call keypoolrefill first.", self.nodes[1].fundrawtransaction, rawtx)
 
         #refill the keypool
         self.nodes[1].walletpassphrase("test", 100)

--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -5,6 +5,7 @@
 """Test the wallet keypool and interaction with wallet encryption/locking."""
 
 import time
+from decimal import Decimal
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
@@ -53,12 +54,12 @@ class KeyPoolTest(BitcoinTestFramework):
         assert_raises_rpc_error(-12, "Keypool ran out", nodes[0].getrawchangeaddress)
 
         # drain the external keys
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
-        addr.add(nodes[0].getnewaddress())
+        addr.add(nodes[0].getnewaddress(address_type="bech32"))
+        addr.add(nodes[0].getnewaddress(address_type="bech32"))
+        addr.add(nodes[0].getnewaddress(address_type="bech32"))
+        addr.add(nodes[0].getnewaddress(address_type="bech32"))
+        addr.add(nodes[0].getnewaddress(address_type="bech32"))
+        addr.add(nodes[0].getnewaddress(address_type="bech32"))
         assert len(addr) == 6
         # the next one should fail
         assert_raises_rpc_error(-12, "Error: Keypool ran out, please call keypoolrefill first", nodes[0].getnewaddress)
@@ -81,6 +82,53 @@ class KeyPoolTest(BitcoinTestFramework):
         wi = nodes[0].getwalletinfo()
         assert_equal(wi['keypoolsize_hd_internal'], 100)
         assert_equal(wi['keypoolsize'], 100)
+
+        # create a blank wallet
+        nodes[0].createwallet(wallet_name='w2', blank=True)
+        w2 = nodes[0].get_wallet_rpc('w2')
+
+        # refer to initial wallet as w1
+        w1 = nodes[0].get_wallet_rpc('')
+
+        # import private key and fund it
+        address = addr.pop()
+        privkey = w1.dumpprivkey(address)
+        res = w2.importmulti([{'scriptPubKey': {'address': address}, 'keys': [privkey], 'timestamp': 'now'}])
+        assert_equal(res[0]['success'], True)
+        w1.walletpassphrase('test', 100)
+
+        res = w1.sendtoaddress(address=address, amount=0.00010000)
+        nodes[0].generate(1)
+        destination = addr.pop()
+
+        # Using a fee rate (10 sat / byte) well above the minimum relay rate
+        # creating a 5,000 sat transaction with change should not be possible
+        assert_raises_rpc_error(-4, "Can't generate a transaction without change. Please call keypoolrefill first.", w2.walletcreatefundedpsbt, inputs=[], outputs=[{addr.pop(): 0.00005000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010})
+
+        # creating a 10,000 sat transaction without change, with a manual input, should still be possible
+        res = w2.walletcreatefundedpsbt(inputs=w2.listunspent(), outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010})
+        assert_equal("psbt" in res, True)
+
+        # creating a 10,000 sat transaction without change should still be possible
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010})
+        assert_equal("psbt" in res, True)
+        # should work without subtractFeeFromOutputs if the exact fee is subtracted from the amount
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008900}], options={"feeRate": 0.00010})
+        assert_equal("psbt" in res, True)
+
+        # dust change should be removed
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00008800}], options={"feeRate": 0.00010})
+        assert_equal("psbt" in res, True)
+
+        # create a transaction without change at the maximum fee rate, such that the output is still spendable:
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.0008824})
+        assert_equal("psbt" in res, True)
+        assert_equal(res["fee"], Decimal("0.00009706"))
+
+        # creating a 10,000 sat transaction with a manual change address should be possible
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010, "changeAddress": addr.pop()})
+        assert_equal("psbt" in res, True)
+
 
 if __name__ == '__main__':
     KeyPoolTest().main()


### PR DESCRIPTION
Builds on top of #17219

Avoid knapsack when there's no change, by enabling BnB when subtracting fees from outputs. Gotchas:
1. when coins are pre-selected, it still uses knapsack
2. it still excludes dust inputs based on their value minus the fees needed to spend them, but it does not use their effective value in BnB. I don't think this matters in practice, because `subtractFeesFromOutputs` is generally used to spend either _all_ coins or a selected bunch. But there is an edge case where e.g. it can choose between two 0.01 BTC inputs, one SegWit and one legacy, and it won't care.