### PR TITLE
rpc: Add missing deque include to fix build

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -15,6 +15,7 @@
 #include <sync.h>
 #include <ui_interface.h>
 
+#include <deque>
 #include <memory>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Regressed by boostorg/filesystem@9a14c37d6f95. See [error log](https://github.com/bitcoin/bitcoin/files/3772177/bitcoin-0.18.1.log).

```c++
httpserver.cpp:74:10: error: no template named 'deque' in namespace 'std'
    std::deque<std::unique_ptr<WorkItem>> queue;
    ~~~~~^
```
