### PR TITLE
Avoid unused call to GuessVerificationProgress in NotifyHeaderTip

### DIFF
--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -312,7 +312,7 @@ public:
         return MakeHandler(
             ::uiInterface.NotifyHeaderTip_connect([fn](bool initial_download, const CBlockIndex* block) {
                 fn(initial_download, block->nHeight, block->GetBlockTime(),
-                    GuessVerificationProgress(Params().TxData(), block));
+                    /* verification progress is unused when a header was received */ 0);
             }));
     }
     InitInterfaces m_interfaces;


### PR DESCRIPTION
`GuessVerificationProgress` for a header (not a block) is always 0 because the number of txs in the block can not be determined from the header alone. Anyway, this result was never used, so we can optimize this call by hardcoding 0.

This is the next commit in a series of changes toward removing nChainTx (see #14863, #13875)