### PR TITLE
net: SocketHandler logs peer id for close and disconnect

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1361,7 +1361,7 @@ void CConnman::SocketHandler()
             {
                 // socket closed gracefully
                 if (!pnode->fDisconnect) {
-                    LogPrint(BCLog::NET, "socket closed\n");
+                    LogPrint(BCLog::NET, "socket closed for peer=%d\n", pnode->GetId());
                 }
                 pnode->CloseSocketDisconnect();
             }
@@ -1371,8 +1371,9 @@ void CConnman::SocketHandler()
                 int nErr = WSAGetLastError();
                 if (nErr != WSAEWOULDBLOCK && nErr != WSAEMSGSIZE && nErr != WSAEINTR && nErr != WSAEINPROGRESS)
                 {
-                    if (!pnode->fDisconnect)
-                        LogPrintf("socket recv error %s\n", NetworkErrorString(nErr));
+                    if (!pnode->fDisconnect) {
+                        LogPrint(BCLog::NET, "socket recv error for peer=%d: %s\n", pnode->GetId(), NetworkErrorString(nErr));
+                    }
                     pnode->CloseSocketDisconnect();
                 }
             }


### PR DESCRIPTION
When combined with `-logips` this makes it easier to diagnose disconnects.

To test on macOS, find a connection you want to disrupt:

```
lsof -nP -iTCP:8333 -sTCP:ESTABLISHED
```

To shut it down gracefully you can use tcpkill or this Python script: https://github.com/google/tcp_killer

The log should say:

```
2019-10-25T13:26:55Z socket closed for peer=1
2019-10-25T13:26:55Z disconnecting peer=1
2019-10-25T13:26:55Z Cleared nodestate for peer=1
```

To shut it down ungracefully I made a patch to the above script, adding a `-force` argument. _Careful, this may result in data corruption_. Then the log should say:

```
2019-10-25T13:39:57Z socket select error Bad file descriptor (9)
2019-10-25T13:39:57Z socket recv error for peer=0: Bad file descriptor (9)
2019-10-25T13:39:57Z disconnecting peer=0
2019-10-25T13:39:57Z Socket close failed: 35. Error: Bad file descriptor (9)
2019-10-25T13:39:57Z Cleared nodestate for peer=0
```