### PR TITLE
utils: Remove boost from time.cpp

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1110,6 +1110,18 @@ BOOST_AUTO_TEST_CASE(strprintf_numbers)
 BOOST_AUTO_TEST_CASE(gettime)
 {
     BOOST_CHECK((GetTime() & ~0xFFFFFFFFLL) == 0);
+
+}
+
+BOOST_AUTO_TEST_CASE(test_boost_c11)
+{
+    int64_t boost_now_millis = (boost::posix_time::microsec_clock::universal_time() -
+                boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+    BOOST_CHECK_EQUAL(GetTimeMillis() - boost_now_millis <= 1); // Make sure the diff is less or equal then 1 millisecond, in case it's just changed.
+
+    int64_t boost_now_micros = (boost::posix_time::microsec_clock::universal_time() -
+                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
+    BOOST_CHECK(GetTimeMicros() - boost_now_micros < 50); // Make sure that the diff between them is small enough as they probably won't be the same.
 }
 
 BOOST_AUTO_TEST_CASE(util_time_GetTime)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1117,11 +1117,17 @@ BOOST_AUTO_TEST_CASE(test_boost_c11)
 {
     int64_t boost_now_millis = (boost::posix_time::microsec_clock::universal_time() -
                 boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
-    BOOST_CHECK_EQUAL(GetTimeMillis() - boost_now_millis <= 1); // Make sure the diff is less or equal then 1 millisecond, in case it's just changed.
+    BOOST_CHECK(GetTimeMillis() - boost_now_millis <= 1); // Make sure the diff is less or equal then 1 millisecond, in case it's just changed.
 
     int64_t boost_now_micros = (boost::posix_time::microsec_clock::universal_time() -
                    boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
     BOOST_CHECK(GetTimeMicros() - boost_now_micros < 50); // Make sure that the diff between them is small enough as they probably won't be the same.
+
+
+    int64_t before = GetTimeMillis();
+    MilliSleep(2);
+    auto diff = GetTimeMillis() - before;
+    BOOST_CHECK(2 <= diff && diff <= 3);
 }
 
 BOOST_AUTO_TEST_CASE(util_time_GetTime)

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -53,16 +53,16 @@ int64_t GetMockTime()
 
 int64_t GetTimeMillis()
 {
-    int64_t now = (boost::posix_time::microsec_clock::universal_time() -
-                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+    auto now_clock = std::chrono::system_clock::now();
+    int64_t now = std::chrono::duration_cast<std::chrono::milliseconds>(now_clock.time_since_epoch()).count();
     assert(now > 0);
     return now;
 }
 
 int64_t GetTimeMicros()
 {
-    int64_t now = (boost::posix_time::microsec_clock::universal_time() -
-                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
+    auto now_clock = std::chrono::system_clock::now();
+    int64_t now = std::chrono::duration_cast<std::chrono::microseconds>(now_clock.time_since_epoch()).count();
     assert(now > 0);
     return now;
 }


### PR DESCRIPTION
Hi,
I'm trying to slowly replace simple boost usages with C++11.
replaced in time.cpp the functions that return time from boost to sltl.
and replaced `boost::this_thread_sleep*` with `std::this_thread_sleep_for()`

Bonus: This removes logic from the build system :)