### PR TITLE
doc: Change apt-get to apt

### DIFF
--- a/contrib/seeds/README.md
+++ b/contrib/seeds/README.md
@@ -18,4 +18,4 @@ The seeds compiled into the release are created from sipa's DNS seed data, like 
 
 Ubuntu:
 
-    sudo apt-get install python3-dnspython
+    sudo apt install python3-dnspython

--- a/depends/README.md
+++ b/depends/README.md
@@ -37,7 +37,7 @@ No other options are needed, the paths are automatically configured.
 
 #### For macOS cross compilation
 
-    sudo apt-get install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python3-setuptools
+    sudo apt install curl librsvg2-bin libtiff-tools bsdmainutils cmake imagemagick libcap-dev libz-dev libbz2-dev python3-setuptools
 
 #### For Win32/Win64 cross compilation
 
@@ -47,19 +47,19 @@ No other options are needed, the paths are automatically configured.
 
 Common linux dependencies:
 
-    sudo apt-get install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch
+    sudo apt install make automake cmake curl g++-multilib libtool binutils-gold bsdmainutils pkg-config python3 patch
 
 For linux ARM cross compilation:
 
-    sudo apt-get install g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
+    sudo apt install g++-arm-linux-gnueabihf binutils-arm-linux-gnueabihf
 
 For linux AARCH64 cross compilation:
 
-    sudo apt-get install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
+    sudo apt install g++-aarch64-linux-gnu binutils-aarch64-linux-gnu
 
 For linux RISC-V 64-bit cross compilation (there are no packages for 32-bit):
 
-    sudo apt-get install g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
+    sudo apt install g++-riscv64-linux-gnu binutils-riscv64-linux-gnu
 
 RISC-V known issue: gcc-7.3.0 and gcc-7.3.1 result in a broken `test_bitcoin` executable (see https://github.com/bitcoin/bitcoin/pull/13543),
 this is apparently fixed in gcc-8.1.0.

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -163,7 +163,7 @@ delete the `intermediate 5.hfs` file and `MacOSX10.11.sdk` (the directory) when 
 confirmed the extraction succeeded.
 
 ```shell
-apt-get install p7zip-full sleuthkit
+apt install p7zip-full sleuthkit
 contrib/macdeploy/extract-osx-sdk.sh
 rm -rf 5.hfs MacOSX10.11.sdk
 ```

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -78,11 +78,11 @@ Finally, clang (often less resource hungry) can be used instead of gcc, which is
 
 Build requirements:
 
-    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
+    sudo apt install build-essential libtool autotools-dev automake pkg-config bsdmainutils python3
 
 Now, you can either build from self-compiled [depends](/depends/README.md) or install the required dependencies:
 
-    sudo apt-get install libssl-dev libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
+    sudo apt install libssl-dev libevent-dev libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev
 
 BerkeleyDB is required for the wallet.
 
@@ -98,11 +98,11 @@ To build Bitcoin Core without wallet, see [*Disable-wallet mode*](/doc/build-uni
 
 Optional (see `--with-miniupnpc` and `--enable-upnp-default`):
 
-    sudo apt-get install libminiupnpc-dev
+    sudo apt install libminiupnpc-dev
 
 ZMQ dependencies (provides ZMQ API):
 
-    sudo apt-get install libzmq3-dev
+    sudo apt install libzmq3-dev
 
 GUI dependencies:
 
@@ -112,15 +112,15 @@ To build without GUI pass `--without-gui`.
 
 To build with Qt 5 you need the following:
 
-    sudo apt-get install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
+    sudo apt install libqt5gui5 libqt5core5a libqt5dbus5 qttools5-dev qttools5-dev-tools
 
 libqrencode (optional) can be installed with:
 
-    sudo apt-get install libqrencode-dev
+    sudo apt install libqrencode-dev
 
 protobuf (optional) can be installed with:
 
-    sudo apt-get install libprotobuf-dev protobuf-compiler
+    sudo apt install libprotobuf-dev protobuf-compiler
 
 Once these are installed, they will be found by configure and a bitcoin-qt executable will be
 built by default.
@@ -287,7 +287,7 @@ installing the toolchain will be different.
 Make sure you install the build requirements mentioned above.
 Then, install the toolchain and curl:
 
-    sudo apt-get install g++-arm-linux-gnueabihf curl
+    sudo apt install g++-arm-linux-gnueabihf curl
 
 To build executables for ARM:
 

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -14,7 +14,7 @@ See the [Transifex Bitcoin project](https://www.transifex.com/bitcoin/bitcoin/) 
 We use automated scripts to help extract translations in both Qt, and non-Qt source files. It is rarely necessary to manually edit the files in `src/qt/locale/`. The translation source files must adhere to the following format:
 `bitcoin_xx_YY.ts or bitcoin_xx.ts`
 
-`src/qt/locale/bitcoin_en.ts` is treated in a special way. It is used as the source for all other translations. Whenever a string in the source code is changed, this file must be updated to reflect those changes. A custom script is used to extract strings from the non-Qt parts. This script makes use of `gettext`, so make sure that utility is installed (ie, `apt-get install gettext` on Ubuntu/Debian). Once this has been updated, `lupdate` (included in the Qt SDK) is used to update `bitcoin_en.ts`.
+`src/qt/locale/bitcoin_en.ts` is treated in a special way. It is used as the source for all other translations. Whenever a string in the source code is changed, this file must be updated to reflect those changes. A custom script is used to extract strings from the non-Qt parts. This script makes use of `gettext`, so make sure that utility is installed (ie, `apt install gettext` on Ubuntu/Debian). Once this has been updated, `lupdate` (included in the Qt SDK) is used to update `bitcoin_en.ts`.
 
 To automatically regenerate the `bitcoin_en.ts` file, run the following commands:
 ```sh

--- a/test/README.md
+++ b/test/README.md
@@ -26,7 +26,7 @@ Before tests can be run locally, Bitcoin Core must be built.  See the [building 
 
 The ZMQ functional test requires a python ZMQ library. To install it:
 
-- on Unix, run `sudo apt-get install python3-zmq`
+- on Unix, run `sudo apt install python3-zmq`
 - on mac OS, run `pip3 install pyzmq`
 
 #### Running the tests


### PR DESCRIPTION
As all major dpkg distributions now support apt, and all who doesn't reached EOL, it would be better to switch to apt instead of the legacy apt-get.

I haven't modified testing scripts because they might need apt-get because apt is not available there.

If you don't now the difference, here is a [short](https://itsfoss.com/apt-vs-apt-get-difference/) article which explains it.