### PR TITLE
gui: disable font antialiasing for QR image address

### DIFF
--- a/src/qt/qrimagewidget.cpp
+++ b/src/qt/qrimagewidget.cpp
@@ -71,6 +71,7 @@ bool QRImageWidget::setQR(const QString& data, const QString& text)
 
     if (!text.isEmpty()) {
         QFont font = GUIUtil::fixedPitchFont();
+        font.setStyleStrategy(QFont::NoAntialias);
         QRect paddedRect = qrAddrImage.rect();
 
         // calculate ideal font size


### PR DESCRIPTION
The address text inside the QR code is currently fairly blurry / unreadable. Explicitly disabling font antialiasing improves that somewhat.

master (693e40090ae7af52585ce1a6136a4bd56318fac7):
![macOS_master](https://user-images.githubusercontent.com/863730/67591414-644e0580-f72b-11e9-8399-2cd0584e7d62.png)

PR (e156b9d8b974f57253306b693a03aa80322ebc6c):
![macOS_pr](https://user-images.githubusercontent.com/863730/67591424-6dd76d80-f72b-11e9-86b6-b3911f8e07e6.png)
