### PR TITLE
bench: Fix negative values and zero for -evals flag

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -51,6 +51,13 @@ int main(int argc, char** argv)
     std::string scaling_str = gArgs.GetArg("-scaling", DEFAULT_BENCH_SCALING);
     bool is_list_only = gArgs.GetBoolArg("-list", false);
 
+    if (evaluations == 0) {
+        return EXIT_SUCCESS;
+    } else if (evaluations < 0) {
+        tfm::format(std::cerr, "Error parsing evaluations argument: %d\n", evaluations);
+        return EXIT_FAILURE;
+    }
+
     double scaling_factor;
     if (!ParseDouble(scaling_str, &scaling_factor)) {
         tfm::format(std::cerr, "Error parsing scaling factor as double: %s\n", scaling_str.c_str());


### PR DESCRIPTION
This PR makes `bench_bitcoin -evals=0` evaluate at once and throws when `-evals` is a negative integer.

---

Currently when you run `bench_bitcoin -evals=0`, it'll get stuck at
```
# Benchmark, evals, iterations, total, min, max, median
```
. This is not intuitively expected and should instead evaluate instantly as it's set to zero. Negative integers for `-evals` does not make sense either and should throw if set.