### PR TITLE
Epoch Mempool

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -301,7 +301,7 @@ public:
     {
         LockPoints lp;
         CTxMemPoolEntry entry(tx, 0, 0, 0, false, 0, lp);
-        CTxMemPool::setEntries ancestors;
+        CTxMemPool::vecEntries ancestors;
         auto limit_ancestor_count = gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
         auto limit_ancestor_size = gArgs.GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
         auto limit_descendant_count = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -237,8 +237,10 @@ int BlockAssembler::UpdatePackagesForAdded(const Iterable& alreadyAdded,
         // can't use external epoch to loop because we want to update
         // all descendants
         // No need to add self (it) because we would filter it from the loop
-        m_mempool.GetFreshEpoch();
-        m_mempool.CalculateDescendantsVec(it, descendants);
+        {
+            const auto epoch = m_mempool.GetFreshEpoch();
+            m_mempool.CalculateDescendantsVec(it, descendants);
+        } // release epoch guard just in case predicate uses epochs (it doesn't)
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
             if (predicate(desc)) continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -178,16 +178,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
 
 void BlockAssembler::onlyUnconfirmed(CTxMemPool::vecEntries& testSet)
 {
-    size_t max_element = testSet.size(), i = 0;
-    while (i < max_element) {
-        bool not_in_block = !inBlock.count(testSet[i]);
-        // if !not_in_block, set testSet[i] to testSet[max_element-1]
-        max_element -= !not_in_block;
-        testSet[i] = testSet[!not_in_block*max_element + not_in_block*i];
-        i += not_in_block;
-    }
-    // drop erased elements
-    testSet.resize(max_element);
+    testSet.erase(std::remove_if(testSet.begin(), testSet.end(),
+                [this](CTxMemPool::txiter t){return inBlock.count(t);}), testSet.end());
 }
 
 bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -239,9 +239,13 @@ int BlockAssembler::UpdatePackagesForAdded(const SortedIterable& alreadyAdded,
         indexed_modified_transaction_set &mapModifiedTx)
 {
     int nDescendantsUpdated = 0;
+    CTxMemPool::vecEntries descendants;
     for (CTxMemPool::txiter it : alreadyAdded) {
-        CTxMemPool::setEntries descendants;
-        m_mempool.CalculateDescendants(it, descendants);
+        descendants.clear();
+        // can't use external epoch to loop because we want to update
+        // all descendants
+        // No need to add self (it) because we would filter it from the loop
+        m_mempool.CalculateDescendantsVec(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
             if (std::binary_search(alreadyAdded.cbegin(), alreadyAdded.cend(), desc, CTxMemPool::CompareIteratorByHash()))

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -237,6 +237,7 @@ int BlockAssembler::UpdatePackagesForAdded(const Iterable& alreadyAdded,
         // can't use external epoch to loop because we want to update
         // all descendants
         // No need to add self (it) because we would filter it from the loop
+        m_mempool.GetFreshEpoch();
         m_mempool.CalculateDescendantsVec(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -388,10 +388,11 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
-        CTxMemPool::setEntries ancestors;
+        std::vector<CTxMemPool::txiter> vec_ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        m_mempool.CalculateMemPoolAncestors(*iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        m_mempool.CalculateMemPoolAncestors(*iter, vec_ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
+        CTxMemPool::setEntries ancestors{vec_ancestors.begin(), vec_ancestors.end()};
 
         onlyUnconfirmed(ancestors);
         ancestors.insert(iter);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -176,17 +176,18 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     return std::move(pblocktemplate);
 }
 
-void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
+void BlockAssembler::onlyUnconfirmed(CTxMemPool::vecEntries& testSet)
 {
-    for (CTxMemPool::setEntries::iterator iit = testSet.begin(); iit != testSet.end(); ) {
-        // Only test txs not already in the block
-        if (inBlock.count(*iit)) {
-            testSet.erase(iit++);
-        }
-        else {
-            iit++;
-        }
+    size_t max_element = testSet.size(), i = 0;
+    while (i < max_element) {
+        bool not_in_block = !inBlock.count(testSet[i]);
+        // if !not_in_block, set testSet[i] to testSet[max_element-1]
+        max_element -= !not_in_block;
+        testSet[i] = testSet[!not_in_block*max_element + not_in_block*i];
+        i += not_in_block;
     }
+    // drop erased elements
+    testSet.resize(max_element);
 }
 
 bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const
@@ -203,7 +204,7 @@ bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost
 // - transaction finality (locktime)
 // - premature witness (in case segwit transactions are added to mempool before
 //   segwit activation)
-bool BlockAssembler::TestPackageTransactions(const CTxMemPool::setEntries& package)
+bool BlockAssembler::TestPackageTransactions(const CTxMemPool::vecEntries& package)
 {
     for (CTxMemPool::txiter it : package) {
         if (!IsFinalTx(it->GetTx(), nHeight, nLockTimeCutoff))
@@ -233,7 +234,8 @@ void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
     }
 }
 
-int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded,
+template<typename SortedIterable>
+int BlockAssembler::UpdatePackagesForAdded(const SortedIterable& alreadyAdded,
         indexed_modified_transaction_set &mapModifiedTx)
 {
     int nDescendantsUpdated = 0;
@@ -242,7 +244,7 @@ int BlockAssembler::UpdatePackagesForAdded(const CTxMemPool::setEntries& already
         m_mempool.CalculateDescendants(it, descendants);
         // Insert all descendants (not yet in block) into the modified set
         for (CTxMemPool::txiter desc : descendants) {
-            if (alreadyAdded.count(desc))
+            if (std::binary_search(alreadyAdded.cbegin(), alreadyAdded.cend(), desc, CTxMemPool::CompareIteratorByHash()))
                 continue;
             ++nDescendantsUpdated;
             modtxiter mit = mapModifiedTx.find(desc);
@@ -275,15 +277,13 @@ bool BlockAssembler::SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_tran
     return mapModifiedTx.count(it) || inBlock.count(it) || failedTx.count(it);
 }
 
-void BlockAssembler::SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries)
+void BlockAssembler::SortForBlock(CTxMemPool::vecEntries& unsorted_entries)
 {
     // Sort package by ancestor count
     // If a transaction A depends on transaction B, then A's ancestor count
     // must be greater than B's.  So this is sufficient to validly order the
     // transactions for block inclusion.
-    sortedEntries.clear();
-    sortedEntries.insert(sortedEntries.begin(), package.begin(), package.end());
-    std::sort(sortedEntries.begin(), sortedEntries.end(), CompareTxIterByAncestorCount());
+    std::sort(unsorted_entries.begin(), unsorted_entries.end(), CompareTxIterByAncestorCount());
 }
 
 // This transaction selection algorithm orders the mempool based
@@ -388,14 +388,13 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
             continue;
         }
 
-        std::vector<CTxMemPool::txiter> vec_ancestors;
+        CTxMemPool::vecEntries ancestors;
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
         std::string dummy;
-        m_mempool.CalculateMemPoolAncestors(*iter, vec_ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
-        CTxMemPool::setEntries ancestors{vec_ancestors.begin(), vec_ancestors.end()};
+        m_mempool.CalculateMemPoolAncestors(*iter, ancestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
 
         onlyUnconfirmed(ancestors);
-        ancestors.insert(iter);
+        ancestors.push_back(iter);
 
         // Test if all tx's are Final
         if (!TestPackageTransactions(ancestors)) {
@@ -410,18 +409,20 @@ void BlockAssembler::addPackageTxs(int &nPackagesSelected, int &nDescendantsUpda
         nConsecutiveFailed = 0;
 
         // Package can be added. Sort the entries in a valid order.
-        std::vector<CTxMemPool::txiter> sortedEntries;
-        SortForBlock(ancestors, sortedEntries);
+        SortForBlock(ancestors);
 
-        for (size_t i=0; i<sortedEntries.size(); ++i) {
-            AddToBlock(sortedEntries[i]);
+        for (CTxMemPool::txiter ancestor : ancestors) {
+            AddToBlock(ancestor);
             // Erase from the modified set, if present
-            mapModifiedTx.erase(sortedEntries[i]);
+            mapModifiedTx.erase(ancestor);
         }
 
         ++nPackagesSelected;
 
         // Update transactions that depend on each of these
+        // Sort before passing in
+        // TODO: unclear if hash order is needed or if txiter would suffice
+        std::sort(ancestors.begin(), ancestors.end(), CTxMemPool::CompareIteratorByHash());
         nDescendantsUpdated += UpdatePackagesForAdded(ancestors, mapModifiedTx);
     }
 }

--- a/src/miner.h
+++ b/src/miner.h
@@ -195,9 +195,9 @@ private:
     void SortForBlock(CTxMemPool::vecEntries& package);
     /** Add descendants of given transactions to mapModifiedTx with ancestor
       * state updated assuming given transactions are inBlock. Returns number
-      * of updated descendants. */
-    template<typename SortedIterable>
-    int UpdatePackagesForAdded(const SortedIterable& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
+      * of updated descendants. Param predicate tests if a child is in alreadyAdded.*/
+    template<typename Iterable, typename BinPred>
+    int UpdatePackagesForAdded(const Iterable& alreadyAdded, BinPred&& predicate, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 };
 
 /** Modify the extranonce in a block */

--- a/src/miner.h
+++ b/src/miner.h
@@ -180,23 +180,24 @@ private:
 
     // helper functions for addPackageTxs()
     /** Remove confirmed (inBlock) entries from given set */
-    void onlyUnconfirmed(CTxMemPool::setEntries& testSet);
+    void onlyUnconfirmed(CTxMemPool::vecEntries& testSet);
     /** Test if a new package would "fit" in the block */
     bool TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const;
     /** Perform checks on each transaction in a package:
       * locktime, premature-witness, serialized size (if necessary)
       * These checks should always succeed, and they're here
       * only as an extra check in case of suboptimal node configuration */
-    bool TestPackageTransactions(const CTxMemPool::setEntries& package);
+    bool TestPackageTransactions(const CTxMemPool::vecEntries& package);
     /** Return true if given transaction from mapTx has already been evaluated,
       * or if the transaction's cached data in mapTx is incorrect. */
     bool SkipMapTxEntry(CTxMemPool::txiter it, indexed_modified_transaction_set& mapModifiedTx, CTxMemPool::setEntries& failedTx) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
     /** Sort the package in an order that is valid to appear in a block */
-    void SortForBlock(const CTxMemPool::setEntries& package, std::vector<CTxMemPool::txiter>& sortedEntries);
+    void SortForBlock(CTxMemPool::vecEntries& package);
     /** Add descendants of given transactions to mapModifiedTx with ancestor
       * state updated assuming given transactions are inBlock. Returns number
       * of updated descendants. */
-    int UpdatePackagesForAdded(const CTxMemPool::setEntries& alreadyAdded, indexed_modified_transaction_set& mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(m_mempool.cs);
+    template<typename SortedIterable>
+    int UpdatePackagesForAdded(const SortedIterable& alreadyAdded, indexed_modified_transaction_set &mapModifiedTx) EXCLUSIVE_LOCKS_REQUIRED(mempool.cs);
 };
 
 /** Modify the extranonce in a block */

--- a/src/policy/rbf.cpp
+++ b/src/policy/rbf.cpp
@@ -9,7 +9,7 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
 {
     AssertLockHeld(pool.cs);
 
-    CTxMemPool::setEntries setAncestors;
+    CTxMemPool::vecEntries ancestors;
 
     // First check the transaction itself.
     if (SignalsOptInRBF(tx)) {
@@ -27,9 +27,9 @@ RBFTransactionState IsRBFOptIn(const CTransaction& tx, const CTxMemPool& pool)
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
     CTxMemPoolEntry entry = *pool.mapTx.find(tx.GetHash());
-    pool.CalculateMemPoolAncestors(entry, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    pool.CalculateMemPoolAncestors(entry, ancestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
 
-    for (CTxMemPool::txiter it : setAncestors) {
+    for (CTxMemPool::txiter it : ancestors) {
         if (SignalsOptInRBF(it->GetTx())) {
             return RBFTransactionState::REPLACEABLE_BIP125;
         }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -642,6 +642,7 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
+    mempool.GetFreshEpoch();
     CTxMemPool::vecEntries setDescendants;
     mempool.CalculateDescendantsVec(it, setDescendants);
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -574,7 +574,7 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    CTxMemPool::setEntries setAncestors;
+    CTxMemPool::vecEntries setAncestors;
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
     mempool.CalculateMemPoolAncestors(*it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -574,21 +574,21 @@ static UniValue getmempoolancestors(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    CTxMemPool::vecEntries setAncestors;
+    CTxMemPool::vecEntries ancestors;
     uint64_t noLimit = std::numeric_limits<uint64_t>::max();
     std::string dummy;
-    mempool.CalculateMemPoolAncestors(*it, setAncestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
+    mempool.CalculateMemPoolAncestors(*it, ancestors, noLimit, noLimit, noLimit, noLimit, dummy, false);
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);
-        for (CTxMemPool::txiter ancestorIt : setAncestors) {
+        for (CTxMemPool::txiter ancestorIt : ancestors) {
             o.push_back(ancestorIt->GetTx().GetHash().ToString());
         }
 
         return o;
     } else {
         UniValue o(UniValue::VOBJ);
-        for (CTxMemPool::txiter ancestorIt : setAncestors) {
+        for (CTxMemPool::txiter ancestorIt : ancestors) {
             const CTxMemPoolEntry &e = *ancestorIt;
             const uint256& _hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -642,9 +642,11 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    mempool.GetFreshEpoch();
     CTxMemPool::vecEntries setDescendants;
-    mempool.CalculateDescendantsVec(it, setDescendants);
+    {
+        const auto epoch = mempool.GetFreshEpoch();
+        mempool.CalculateDescendantsVec(it, setDescendants);
+    } // release epoch guard because entryToJSON below calls IsRBFOptIn
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -642,10 +642,8 @@ static UniValue getmempooldescendants(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Transaction not in mempool");
     }
 
-    CTxMemPool::setEntries setDescendants;
-    mempool.CalculateDescendants(it, setDescendants);
-    // CTxMemPool::CalculateDescendants will include the given tx
-    setDescendants.erase(it);
+    CTxMemPool::vecEntries setDescendants;
+    mempool.CalculateDescendantsVec(it, setDescendants);
 
     if (!fVerbose) {
         UniValue o(UniValue::VARR);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -123,7 +123,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     // UpdateForDescendants.
     for (const uint256 &hash : reverse_iterate(vHashesToUpdate)) {
         // we cache the in-mempool children to avoid duplicate updates
-        setEntries setChildren;
+        uint64_t epoch = GetFreshEpoch();
         // calculate children from mapNextTx
         txiter it = mapTx.find(hash);
         if (it == mapTx.end()) {
@@ -138,7 +138,7 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
             assert(childIter != mapTx.end());
             // We can skip updating entries we've encountered before or that
             // are in the block (which are already accounted for).
-            if (setChildren.insert(childIter).second && !setAlreadyIncluded.count(childHash)) {
+            if (!childIter->already_touched(epoch) && !setAlreadyIncluded.count(childHash)) {
                 UpdateChild(it, childIter, true);
                 UpdateParent(childIter, it, true);
             }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -468,34 +468,8 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-void CTxMemPool::CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
-{
-        for (txiter childiter : GetMemPoolChildren(it)) {
-            if (childiter->already_touched(epoch)) continue;
-            if (!setDescendants.insert(childiter).second) continue;
-            if (limit > 0) CalculateDescendants(childiter, setDescendants, stack, epoch, limit-1);
-            else stack.push_back(childiter);
-        }
-}
-
-void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants) const
-{
-    CalculateDescendants(entryit, setDescendants, GetFreshEpoch());
-}
-
-void CTxMemPool::CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const
-{
-    if (!setDescendants.insert(entryit).second) return;
-    // Traverse down the children of entry, only adding children that are not
-    // accounted for in setDescendants already (because those children have either
-    // already been walked, or will be walked in this iteration).
-    txiter it = entryit;
-    std::vector<txiter> stack;
-    do {
-        CalculateDescendants(it, setDescendants, stack, cached_epoch);
-    } while (!stack.empty() && (it = stack.back(), stack.pop_back(), true));
-
-}
+//
+// Note: it does not get inserted into the vector
 
 void CTxMemPool::CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack, const uint64_t epoch, const uint8_t limit) const
 {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -80,7 +80,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     // Update and add to cached descendant map
     auto main_it = updateIt;
     bool first_pass = true;
-    do {
+    auto func = [&] (txiter param_it) {
         auto& direct_children = GetMemPoolChildren(main_it);
         for (txiter cit : direct_children) {
             if (first_pass) cit->already_touched(epoch);
@@ -106,6 +106,9 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
             }
         }
         first_pass = false;
+    };
+    do {
+        func(main_it);
     } while (!stack.empty() && (main_it = stack.back(), stack.pop_back(), true));
     mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
 }

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -23,7 +23,7 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
                                  int64_t _nTime, unsigned int _entryHeight,
                                  bool _spendsCoinbase, int64_t _sigOpsCost, LockPoints lp)
     : tx(_tx), nFee(_nFee), nTxWeight(GetTransactionWeight(*tx)), nUsageSize(RecursiveDynamicUsage(tx)), nTime(_nTime), entryHeight(_entryHeight),
-    spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp)
+    spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp), m_epoch(0)
 {
     nCountWithDescendants = 1;
     nSizeWithDescendants = GetTxSize();
@@ -1103,6 +1103,11 @@ void CTxMemPool::SetIsLoaded(bool loaded)
 {
     LOCK(cs);
     m_is_loaded = loaded;
+}
+
+uint64_t CTxMemPool::GetFreshEpoch() const
+{
+    return ++m_epoch;
 }
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -106,7 +106,7 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
 {
     // Our children are natrually uniqueu
     vecEntries stack;
-    GetFreshEpoch();
+    const auto epoch = GetFreshEpoch();
 
     int64_t modifySize = 0;
     CAmount modifyFee = 0;
@@ -145,8 +145,6 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
     // setMemPoolChildren will be updated, an assumption made in
     // UpdateForDescendants.
     for (const uint256 &hash : reverse_iterate(vHashesToUpdate)) {
-        // we cache the in-mempool children to avoid duplicate updates
-        GetFreshEpoch();
         // calculate children from mapNextTx
         txiter it = mapTx.find(hash);
         if (it == mapTx.end()) {
@@ -155,17 +153,21 @@ void CTxMemPool::UpdateTransactionsFromBlock(const std::vector<uint256> &vHashes
         auto iter = mapNextTx.lower_bound(COutPoint(hash, 0));
         // First calculate the children, and update setMemPoolChildren to
         // include them, and update their setMemPoolParents to include this tx.
-        for (; iter != mapNextTx.end() && iter->first->hash == hash; ++iter) {
-            const uint256 &childHash = iter->second->GetHash();
-            txiter childIter = mapTx.find(childHash);
-            assert(childIter != mapTx.end());
-            // We can skip updating entries we've encountered before or that
-            // are in the block (which are already accounted for).
-            if (!already_touched(childIter) && !setAlreadyIncluded.count(childHash)) {
-                UpdateChild(it, childIter, true);
-                UpdateParent(childIter, it, true);
+        // we cache the in-mempool children to avoid duplicate updates
+        {
+            const auto epoch = GetFreshEpoch();
+            for (; iter != mapNextTx.end() && iter->first->hash == hash; ++iter) {
+                const uint256 &childHash = iter->second->GetHash();
+                txiter childIter = mapTx.find(childHash);
+                assert(childIter != mapTx.end());
+                // We can skip updating entries we've encountered before or that
+                // are in the block (which are already accounted for).
+                if (!already_touched(childIter) && !setAlreadyIncluded.count(childHash)) {
+                    UpdateChild(it, childIter, true);
+                    UpdateParent(childIter, it, true);
+                }
             }
-        }
+        } // release epoch guard for UpdateForDescendants
         UpdateForDescendants(it, mapMemPoolDescendantsToUpdate, setAlreadyIncluded);
     }
 }
@@ -174,7 +176,7 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, vecEntr
 {
     assert(ancestors.size() == 0);
     const CTransaction &tx = entry.GetTx();
-    GetFreshEpoch();
+    const auto epoch = GetFreshEpoch();
     if (fSearchForParents) {
         // Get parents of this transaction that are in the mempool
         // GetMemPoolParents() is only valid for entries in the mempool, so we
@@ -285,7 +287,7 @@ void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, b
         // need to traverse the mempool).
         for (txiter removeIt : entriesToRemove) {
             vecEntries descendants;
-            GetFreshEpoch();
+            const auto epoch = GetFreshEpoch();
             CalculateDescendantsVec(removeIt, descendants);
             int64_t modifySize = -((int64_t)removeIt->GetTxSize());
             CAmount modifyFee = -removeIt->GetModifiedFee();
@@ -400,13 +402,16 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, vecEntries &ancestor
     cachedInnerUsage += entry.DynamicMemoryUsage();
 
     const CTransaction& tx = newit->GetTx();
-    GetFreshEpoch();
-    for (unsigned int i = 0; i < tx.vin.size(); i++) {
-        mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, &tx));
-        // Update ancestors with information about this tx
-        auto maybe_it = GetIter(tx.vin[i].prevout.hash);
-        if (!already_touched(maybe_it)) UpdateParent(newit, *maybe_it, true);
-    }
+    {
+        const auto epoch = GetFreshEpoch();
+        for (unsigned int i = 0; i < tx.vin.size(); i++) {
+            mapNextTx.insert(std::make_pair(&tx.vin[i].prevout, &tx));
+            // Update ancestors with information about this tx
+            auto maybe_it = GetIter(tx.vin[i].prevout.hash);
+            if (!already_touched(maybe_it)) UpdateParent(newit, *maybe_it, true);
+        }
+    } // releasing epoch guard is uneccessary but we don't need it past here
+
     // Don't bother worrying about child transactions of this one.
     // Normal case of a new transaction arriving is that there can't be any
     // children, because such children would be orphans.
@@ -490,8 +495,9 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
 {
     // Remove transaction from memory pool
     AssertLockHeld(cs);
-        GetFreshEpoch();
-        vecEntries txToRemove;
+    vecEntries txToRemove;
+    {
+        const auto epoch = GetFreshEpoch();
         txiter origit = mapTx.find(origTx.GetHash());
         // All txToRemove will be touched, this guarantees txToRemove gets no duplicates
         if (origit != mapTx.end()) {
@@ -517,8 +523,9 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
         for (size_t idx = 0; idx < max_idx; ++idx) {
             CalculateDescendantsVec(txToRemove[idx], txToRemove);
         }
+    } // release epoch guard for RemoveStaged
 
-        RemoveStaged(txToRemove, false, reason);
+    RemoveStaged(txToRemove, false, reason);
 }
 
 void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags)
@@ -553,18 +560,20 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         }
     }
 
-    GetFreshEpoch();
-    // touch all txToRemove first to force CalculateDescendantsVec
-    // to not recurse if we're going to call it later.
-    // This guarantees txToRemove gets no duplicates
-    for (txiter it : txToRemove) {
-        already_touched(it);
-    }
-    // max_idx is used rather than iterator because txToRemove may grow
-    const size_t max_idx = txToRemove.size();
-    for (size_t idx = 0; idx < max_idx; ++idx) {
-        CalculateDescendantsVec(txToRemove[idx], txToRemove);
-    }
+    {
+        const auto epoch = GetFreshEpoch();
+        // touch all txToRemove first to force CalculateDescendantsVec
+        // to not recurse if we're going to call it later.
+        // This guarantees txToRemove gets no duplicates
+        for (txiter it : txToRemove) {
+            already_touched(it);
+        }
+        // max_idx is used rather than iterator because txToRemove may grow
+        const size_t max_idx = txToRemove.size();
+        for (size_t idx = 0; idx < max_idx; ++idx) {
+            CalculateDescendantsVec(txToRemove[idx], txToRemove);
+        }
+    } // release epoch guard for RemoveStaged
     RemoveStaged(txToRemove, false, MemPoolRemovalReason::REORG);
 
 }
@@ -628,6 +637,8 @@ void CTxMemPool::_clear()
     blockSinceLastRollingFeeBump = false;
     rollingMinimumFeeRate = 0;
     ++nTransactionsUpdated;
+    has_epoch_guard = false;
+    m_epoch = 0;
 }
 
 void CTxMemPool::clear()
@@ -874,7 +885,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             }
             // Now update all descendants' modified fees with ancestors
             vecEntries descendants;
-            GetFreshEpoch();
+            const auto epoch = GetFreshEpoch();
             CalculateDescendantsVec(it, descendants);
             for (txiter descendantIt : descendants) {
                 mapTx.modify(descendantIt, update_ancestor_state(0, nFeeDelta, 0, 0));
@@ -974,12 +985,14 @@ int CTxMemPool::Expire(std::chrono::seconds time)
         it++;
     }
     vecEntries stage;
-    GetFreshEpoch();
-    for (txiter removeit : toremove) {
-        CalculateDescendantsVec(removeit, stage);
-        if (!already_touched(removeit))
+    {
+        const auto epoch = GetFreshEpoch();
+        for (txiter removeit : toremove) {
+            CalculateDescendantsVec(removeit, stage);
+            if (!already_touched(removeit))
                 stage.push_back(removeit);
-    }
+        }
+    } // release epoch guard for RemoveStaged
     RemoveStaged(stage, false, MemPoolRemovalReason::EXPIRY);
     return stage.size();
 }
@@ -1079,8 +1092,10 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpends
         maxFeeRateRemoved = std::max(maxFeeRateRemoved, removed);
 
         vecEntries stage;
-        GetFreshEpoch();
-        CalculateDescendantsVec(mapTx.project<0>(it), stage);
+        {
+            const auto epoch = GetFreshEpoch();
+            CalculateDescendantsVec(mapTx.project<0>(it), stage);
+        } // release epoch guard because RemoveStaged
         stage.push_back(mapTx.project<0>(it));
         nTxnRemoved += stage.size();
 
@@ -1150,9 +1165,22 @@ void CTxMemPool::SetIsLoaded(bool loaded)
     m_is_loaded = loaded;
 }
 
-uint64_t CTxMemPool::GetFreshEpoch() const
+CTxMemPool::EpochGuard CTxMemPool::GetFreshEpoch() const
 {
-    return ++m_epoch;
+    return EpochGuard(*this);
+}
+CTxMemPool::EpochGuard::EpochGuard(const CTxMemPool& in) : pool(in)
+{
+    assert(!pool.has_epoch_guard);
+    ++pool.m_epoch;
+    pool.has_epoch_guard = true;
+}
+
+CTxMemPool::EpochGuard::~EpochGuard()
+{
+    // prevents stale results being used
+    ++pool.m_epoch;
+    pool.has_epoch_guard = false;
 }
 
 SaltedTxidHasher::SaltedTxidHasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -270,9 +270,7 @@ void CTxMemPool::UpdateChildrenForRemoval(txiter it)
     }
 }
 
-template <typename T>
-void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants)
-{
+void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, bool updateDescendants) {
     // For each entry, walk back all ancestors and decrement size associated with this
     // transaction
     const uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
@@ -326,13 +324,6 @@ void CTxMemPool::UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool u
     for (txiter removeIt : entriesToRemove) {
         UpdateChildrenForRemoval(removeIt);
     }
-}
-void CTxMemPool::UpdateForRemoveFromMempool(const vecEntries &entriesToRemove, bool updateDescendants) {
-    UpdateForRemoveFromMempoolImpl(entriesToRemove, updateDescendants);
-}
-
-void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) {
-    UpdateForRemoveFromMempoolImpl(entriesToRemove, updateDescendants);
 }
 
 void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
@@ -971,20 +962,12 @@ size_t CTxMemPool::DynamicMemoryUsage() const {
     return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
 }
 
-template<typename T>
-void CTxMemPool::RemoveStagedImpl(T &stage, bool updateDescendants, MemPoolRemovalReason reason) {
+void CTxMemPool::RemoveStaged(vecEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
     AssertLockHeld(cs);
     UpdateForRemoveFromMempool(stage, updateDescendants);
     for (txiter it : stage) {
         removeUnchecked(it, reason);
     }
-}
-
-void CTxMemPool::RemoveStaged(vecEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
-    RemoveStagedImpl(stage, updateDescendants, reason);
-}
-void CTxMemPool::RemoveStaged(setEntries &stage, bool updateDescendants, MemPoolRemovalReason reason) {
-    RemoveStagedImpl(stage, updateDescendants, reason);
 }
 
 int CTxMemPool::Expire(std::chrono::seconds time)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -522,9 +522,9 @@ void CTxMemPool::removeRecursive(const CTransaction &origTx, MemPoolRemovalReaso
         vecEntries all_removes;
         const uint64_t epoch = GetFreshEpoch();
         for (txiter it : txToRemove) {
+            if (it->already_touched(epoch)) continue;
             CalculateDescendantsVec(it, all_removes, epoch);
-            if (!it->already_touched(epoch))
-                all_removes.push_back(it);
+            all_removes.push_back(it);
         }
 
         RemoveStaged(all_removes, false, reason);
@@ -563,9 +563,9 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
     vecEntries all_removes;
     const uint64_t epoch = GetFreshEpoch();
     for (txiter it : txToRemove) {
+        if (it->already_touched(epoch)) continue;
         CalculateDescendantsVec(it, all_removes, epoch);
-        if (!it->already_touched(epoch))
-                all_removes.push_back(it);
+        all_removes.push_back(it);
     }
     RemoveStaged(all_removes, false, MemPoolRemovalReason::REORG);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -656,6 +656,14 @@ public:
     void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
+    /* Assumes empty descendants vector. Useful when we are just going to iterate over them
+     *
+     * unlike CalculateDescendants, CalculateDescendantsVec does not include self*/
+    void CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack,
+            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendantsVec(txiter it, std::vector<txiter>& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendantsVec(txiter entryit, std::vector<txiter>& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.
       *  The incrementalRelayFee policy variable is used to bound the time it

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -650,6 +650,9 @@ public:
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
      *  already in it.  */
+
+    void CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack,
+            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -623,10 +623,7 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
-    template <typename T>
-    void RemoveStagedImpl(T& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void RemoveStaged(vecEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
      *  new mempool entries may have children in the mempool (which is generally
@@ -749,10 +746,7 @@ private:
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
-    template <typename T>
-    void UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForRemoveFromMempool(const vecEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -762,21 +762,13 @@ public:
     };
     EpochGuard GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    bool already_touched(txiter it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
-        assert(has_epoch_guard);
-        bool ret = it->m_epoch >= during;
-        it->m_epoch = std::max(it->m_epoch, during);
-        return ret;
-    }
-    bool already_touched(Optional<txiter> it, uint64_t during) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
-        return !it || already_touched(*it, during);
-    }
     bool already_touched(txiter it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
         assert(has_epoch_guard);
         bool ret = it->m_epoch >= m_epoch;
         it->m_epoch = std::max(it->m_epoch, m_epoch);
         return ret;
     }
+
     bool already_touched(Optional<txiter> it) const EXCLUSIVE_LOCKS_REQUIRED(cs) {
         return !it || already_touched(*it);
     }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -654,6 +654,7 @@ public:
     void CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack,
             const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -536,6 +536,7 @@ public:
         }
     };
     typedef std::set<txiter, CompareIteratorByHash> setEntries;
+    typedef std::vector<txiter> vecEntries;
 
     const setEntries & GetMemPoolParents(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     const setEntries & GetMemPoolChildren(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -581,7 +582,7 @@ public:
     // and any other callers may break wallet's in-mempool tracking (due to
     // lack of CValidationInterface::TransactionAddedToMempool callbacks).
     void addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void addUnchecked(const CTxMemPoolEntry& entry, setEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
+    void addUnchecked(const CTxMemPoolEntry& entry, vecEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
@@ -648,7 +649,7 @@ public:
      *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
      *    look up parents from mapLinks. Must be true for entries not in the mempool
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, setEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
@@ -744,9 +745,9 @@ private:
             int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
             stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
-    void UpdateAncestorsOf(bool add, txiter hash, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateAncestorsOf(bool add, txiter hash, vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
-    void UpdateEntryForAncestors(txiter it, const setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateEntryForAncestors(txiter it, const vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -725,6 +725,9 @@ private:
     void UpdateForDescendants(txiter updateIt,
             cacheMap &cachedDescendants,
             const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount& fee,
+            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
+            stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, setEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -437,7 +437,7 @@ public:
  * in-block transactions by calling UpdateTransactionsFromBlock().  Note that
  * until this is called, the mempool state is not consistent, and in particular
  * mapLinks may not be correct (and therefore functions like
- * CalculateMemPoolAncestors() and CalculateDescendants() that rely
+ * CalculateMemPoolAncestors() and CalculateDescendantsVec() that rely
  * on them to walk the mempool are not generally safe to use).
  *
  * Computational limits:
@@ -651,20 +651,18 @@ public:
      */
     bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& ancestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
-    /** Populate setDescendants with all in-mempool descendants of hash.
-     *  Assumes that setDescendants includes all in-mempool descendants of anything
-     *  already in it.  */
-
-    void CalculateDescendants(txiter it, setEntries& setDescendants, std::vector<txiter>& stack,
-            const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendants(txiter it, setEntries& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendants(txiter entryit, setEntries& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-
-    /* Assumes empty descendants vector. Useful when we are just going to iterate over them
+    /** Populate descendants with all in-mempool descendants of hash.
      *
-     * unlike CalculateDescendants, CalculateDescendantsVec does not include self*/
+     *  Assumes that if descendants includes a txiter T, then all in-mempool descendants of T are
+     *  already in it and T->already_touched(cached_epoch)
+     *
+     *  Assumes empty descendants vector. Useful when we are just going to
+     *  iterate over them and don't care about order
+     *
+     * CalculateDescendantsVec does not include self (it)*/
     void CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack,
             const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    /** Assumes setDescednants is empty */
     void CalculateDescendantsVec(txiter it, std::vector<txiter>& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     void CalculateDescendantsVec(txiter entryit, std::vector<txiter>& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -651,9 +651,6 @@ public:
      *  iterate over them and don't care about order
      *
      * CalculateDescendantsVec does not include self (it)*/
-    void CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack,
-            const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    /** Assumes descednants is empty */
     void CalculateDescendantsVec(txiter it, vecEntries& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -129,6 +129,14 @@ public:
     int64_t GetSigOpCostWithAncestors() const { return nSigOpCostWithAncestors; }
 
     mutable size_t vTxHashesIdx; //!< Index in mempool's vTxHashes
+private:
+    mutable uint64_t m_epoch; //!< epoch when last touched, useful for graph algorithms
+public:
+    bool already_touched(uint64_t during) const {
+        bool ret = m_epoch >= during;
+        m_epoch = std::max(m_epoch, during);
+        return ret;
+    }
 };
 
 // Helpers for modifying CTxMemPool::mapTx, which is a boost multi_index.
@@ -453,6 +461,7 @@ private:
     mutable int64_t lastRollingFeeUpdate;
     mutable bool blockSinceLastRollingFeeBump;
     mutable double rollingMinimumFeeRate; //!< minimum fee to get into the pool, decreases exponentially
+    mutable uint64_t m_epoch;
 
     void trackPackageRemoved(const CFeeRate& rate) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
@@ -736,6 +745,9 @@ private:
      *  removal.
      */
     void removeUnchecked(txiter entry, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+public:
+    // This function mutates mutable state!
+    uint64_t GetFreshEpoch() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 };
 
 /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -582,7 +582,7 @@ public:
     // and any other callers may break wallet's in-mempool tracking (due to
     // lack of CValidationInterface::TransactionAddedToMempool callbacks).
     void addUnchecked(const CTxMemPoolEntry& entry, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
-    void addUnchecked(const CTxMemPoolEntry& entry, vecEntries& setAncestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
+    void addUnchecked(const CTxMemPoolEntry& entry, vecEntries& ancestors, bool validFeeEstimate = true) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
 
     void removeRecursive(const CTransaction& tx, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void removeForReorg(const CCoinsViewCache* pcoins, unsigned int nMemPoolHeight, int flags) EXCLUSIVE_LOCKS_REQUIRED(cs, cs_main);
@@ -649,7 +649,7 @@ public:
      *  fSearchForParents = whether to search a tx's vin for in-mempool parents, or
      *    look up parents from mapLinks. Must be true for entries not in the mempool
      */
-    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& setAncestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    bool CalculateMemPoolAncestors(const CTxMemPoolEntry& entry, vecEntries& ancestors, uint64_t limitAncestorCount, uint64_t limitAncestorSize, uint64_t limitDescendantCount, uint64_t limitDescendantSize, std::string& errString, bool fSearchForParents = true) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** Populate setDescendants with all in-mempool descendants of hash.
      *  Assumes that setDescendants includes all in-mempool descendants of anything
@@ -745,9 +745,9 @@ private:
             int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
             stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
-    void UpdateAncestorsOf(bool add, txiter hash, vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateAncestorsOf(bool add, txiter hash, vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Set ancestor state for an entry */
-    void UpdateEntryForAncestors(txiter it, const vecEntries &setAncestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateEntryForAncestors(txiter it, const vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -625,7 +625,7 @@ public:
      */
     template <typename T>
     void RemoveStagedImpl(T& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void RemoveStaged(std::vector<txiter>& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(vecEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
@@ -660,11 +660,11 @@ public:
      *  iterate over them and don't care about order
      *
      * CalculateDescendantsVec does not include self (it)*/
-    void CalculateDescendantsVec(txiter it, std::vector<txiter>& descendants, std::vector<txiter>& stack,
+    void CalculateDescendantsVec(txiter it, vecEntries& descendants, vecEntries& stack,
             const uint64_t epoch, const uint8_t limit=25) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    /** Assumes setDescednants is empty */
-    void CalculateDescendantsVec(txiter it, std::vector<txiter>& setDescendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void CalculateDescendantsVec(txiter entryit, std::vector<txiter>& setDescendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    /** Assumes descednants is empty */
+    void CalculateDescendantsVec(txiter it, vecEntries& descendants) const EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void CalculateDescendantsVec(txiter entryit, vecEntries& descendants, const uint64_t cached_epoch) const EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** The minimum fee to get into the mempool, which may itself not be enough
       *  for larger-sized transactions.
@@ -740,7 +740,7 @@ private:
             cacheMap &cachedDescendants,
             const std::set<uint256> &setExclude) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForDescendantsInner(txiter param_it, txiter update_it, int64_t&size, CAmount& fee,
-            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, std::vector<txiter>&
+            int64_t& count, cacheMap& cache, const std::set<uint256>& exclude, vecEntries&
             stack, bool update_child_epochs, const uint64_t epoch, const uint8_t limit = 25) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Update ancestors of hash to add/remove it as a descendant transaction. */
     void UpdateAncestorsOf(bool add, txiter hash, vecEntries &ancestors) EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -751,8 +751,8 @@ private:
       * ancestor state. */
     template <typename T>
     void UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForRemoveFromMempool(const std::vector<txiter> &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
-    void UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const vecEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const setEntries& entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -622,6 +622,9 @@ public:
      *  Set updateDescendants to true when removing a tx that was in a block, so
      *  that any in-mempool descendants have their ancestor state updated.
      */
+    template <typename T>
+    void RemoveStagedImpl(T& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void RemoveStaged(std::vector<txiter>& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void RemoveStaged(setEntries& stage, bool updateDescendants, MemPoolRemovalReason reason) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     /** When adding transactions from a disconnected block back to the mempool,
@@ -747,6 +750,9 @@ private:
     /** For each transaction being removed, update ancestors and any direct children.
       * If updateDescendants is true, then also update in-mempool descendants'
       * ancestor state. */
+    template <typename T>
+    void UpdateForRemoveFromMempoolImpl(const T &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateForRemoveFromMempool(const std::vector<txiter> &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     void UpdateForRemoveFromMempool(const setEntries &entriesToRemove, bool updateDescendants) EXCLUSIVE_LOCKS_REQUIRED(cs);
     /** Sever link between specified transaction and direct children. */
     void UpdateChildrenForRemoval(txiter entry) EXCLUSIVE_LOCKS_REQUIRED(cs);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -466,7 +466,7 @@ private:
         Workspace(const CTransactionRef& ptx) : m_ptx(ptx), m_hash(ptx->GetHash()) {}
         std::set<uint256> m_conflicts;
         CTxMemPool::setEntries m_all_conflicting;
-        CTxMemPool::setEntries m_ancestors;
+        CTxMemPool::vecEntries m_ancestors;
         std::unique_ptr<CTxMemPoolEntry> m_entry;
 
         bool m_replacement_transaction;
@@ -544,7 +544,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
     // Alias what we need out of ws
     std::set<uint256>& setConflicts = ws.m_conflicts;
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
+    CTxMemPool::vecEntries& setAncestors = ws.m_ancestors;
+    assert(setAncestors.empty());
     std::unique_ptr<CTxMemPoolEntry>& entry = ws.m_entry;
     bool& fReplacementTransaction = ws.m_replacement_transaction;
     CAmount& nModifiedFees = ws.m_modified_fees;
@@ -965,7 +966,7 @@ bool MemPoolAccept::Finalize(ATMPArgs& args, Workspace& ws)
     const bool bypass_limits = args.m_bypass_limits;
 
     CTxMemPool::setEntries& allConflicting = ws.m_all_conflicting;
-    CTxMemPool::setEntries& setAncestors = ws.m_ancestors;
+    CTxMemPool::vecEntries& setAncestors = ws.m_ancestors;
     const CAmount& nModifiedFees = ws.m_modified_fees;
     const CAmount& nConflictingFees = ws.m_conflicting_fees;
     const size_t& nConflictingSize = ws.m_conflicting_size;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -835,10 +835,10 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         if (nConflictingCount <= maxDescendantsToVisit) {
             // If not too many to replace, then calculate the set of
             // transactions that would have to be evicted
-            const uint64_t epoch = m_pool.GetFreshEpoch();
+            m_pool.GetFreshEpoch();
             for (CTxMemPool::txiter it : setIterConflicting) {
-                if (it->already_touched(epoch)) continue;
-                m_pool.CalculateDescendantsVec(it, all_conflicting, epoch);
+                if (m_pool.already_touched(it)) continue;
+                m_pool.CalculateDescendantsVec(it, all_conflicting);
                 all_conflicting.push_back(it);
             }
             for (CTxMemPool::txiter it : all_conflicting) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -835,7 +835,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
         if (nConflictingCount <= maxDescendantsToVisit) {
             // If not too many to replace, then calculate the set of
             // transactions that would have to be evicted
-            m_pool.GetFreshEpoch();
+            const auto epoch = m_pool.GetFreshEpoch();
             for (CTxMemPool::txiter it : setIterConflicting) {
                 if (m_pool.already_touched(it)) continue;
                 m_pool.CalculateDescendantsVec(it, all_conflicting);


### PR DESCRIPTION
_Hansel and Gretel
left bread crumb trails as they went
but birds ate them all._

This Pull Request improves the asymptotic complexity of many of the mempool's algorithms as well as makes them more performant in practice.

In the mempool we have a lot of algorithms which depend on rather computationally expensive state tracking. The state tracking algorithms we use make a lot of algorithms inefficient because we're inserting into various sets that grow with the number of ancestors and descendants, or we may have to iterate multiple times of data we've already seen.

To address these inefficiencies, we can closely limit the maximum possible data we iterate and reject transactions above the limits.

However, a rational miner/user will purchase faster hardware and raise these limits to be able to collect more fee revenue or process more transactions. Further, changes coming from around the ecosystem (lightning, OP_SECURETHEBAG) have critical use cases which benefit when the mempool has fewer limitations.

Rather than use expensive state tracking, we can do something simpler. Like Hansel and Gretel, we can leave breadcrumbs in the mempool as we traverse it, so we can know if we are going somewhere we've already been. Luckily, in bitcoind there are no birds!

These breadcrumbs are a uint64_t epoch per CTxMemPoolEntry. (64 bits is enough that it will *never* overflow). The mempool also has a counter.

Every time we begin traversing the mempool, and we need some help tracking state, we increment the mempool's counter. Any CTxMemPoolEntry with an epoch less than the MemPools has not yet been touched, and should be traversed and have it's epoch set higher.

Given the one-to-one mapping between CTxMemPool entries and transactions, this is a safe way to cache data.

Using these bread-crumbs allows us to get rid of many of the std::set accumulators in favor of a std::vector as we no longer rely on the de-duplicative properties of std::set.

We can also improve many of the related algorithms to no longer make heavy use of heapstack based processing.

The overall changes are not that big. It's 302 additions and 208 deletions. You could review it all at once, especially for a Concept Ack. But I've carefully done them in small steps to permit careful analysis of the changes. So I'd recommend giving the final state of the PR a read over first to get familiar with the end-goal (it won't take long), and then step through commit-by-commit so you can be convinced of the correctness for more thorough code reviewers.

**But is it good in practice?** Yes! Basic benchmarks show it being 5% faster on the AssembleBlock benchmark, and 14.5% faster on MempoolEviction, but they aren't that tough. Tougher benchmarks, as described below, show a **>2x speedup**. 

> PR #17292, adds a motivating benchmark for the Epoch Mempool.
> 
> ./src/bench/bench_bitcoin --filter=ComplexMemPool --scaling=5
> 
> Before:
> 
>     # Benchmark, evals, iterations, total, min, max, median
>     ComplexMemPool, 5, 5, 6.62715, 0.264409, 0.265441, 0.2654
> 
> After:
> 
>     # Benchmark, evals, iterations, total, min, max, median
>     ComplexMemPool, 5, 5, 3.07116, 0.122246, 0.12351, 0.122783
> 
> This shows a > 2x speedup on this difficult benchmark (~2.15x across total, min, max, median).
> 
> Note: For scientific purity, I created it "single shot blind". That is, I did not modify the test at all after running it on the new branch (I had to run it on master to fix bugs / adjust the expected iters for a second parameter, and then adjust the internal params to get it to be about a second).

**What's the catch?** The specific downsides of this approach are twofold:

1) We need to store an extra 8 bytes per CTxMemPoolEntry
2) Some of the algorithms are a little bit less obvious & are "less safe" to call concurrently (e.g., from a recursive call, not necessarily in parallel)

But for these two specific downsides:

1) The 8 bytes could be reduced to 4 (with code to reset all CTxMemPoolEntries near overflow, but then we would need to more carefully check that we won't overflow the epoch in a recursive call.
2) The 8 bytes could be a 4 byte index into a table of 8 (or 4, or even fewer) Byte epochs + back pointer, at expense of indirection like vTxHashes. Then we would only ever need as many epochs as the things we walk per-epoch.
3) We can replace the epoch with an atomic<epoch>, which would allow for new parallel graph traversal algorithms to build descendants more quickly
4) Some algorithms benefit from recursive epoch use

So overall, I felt the potential benefits outweigh the risks.


**What's next?**
I've submitted this a bit early for review to gain concept acks on the approach, independent testing, and feedback on methodologies for testing, as well as to collect more worst-case edge conditions to put into benchmarks. It's not quite a WIP -- the code passes tests and is "clean", but it should receive intense scrutiny before accepting.