### PR TITLE
Feed environment data into RNG initializers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -788,7 +788,7 @@ if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
 fi
 
-AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h])
+AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])
 
 # FD_ZERO may be dependent on a declaration of memcpy, e.g. in SmartOS
 # check that it fails to build without memcpy, then that it builds with
@@ -945,6 +945,18 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
  #include <sys/random.h>]],
  [[ getentropy(nullptr, 32) ]])],
  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GETENTROPY_RAND, 1,[Define this symbol if the BSD getentropy system call is available with sys/random.h]) ],
+ [ AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING(for sysctl)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
+  #include <sys/sysctl.h>]],
+ [[ static const int name[2] = {CTL_KERN, KERN_VERSION};
+    #ifdef __linux__
+    #error "Don't use sysctl on Linux, it's deprecated even when it works"
+    #endif
+    sysctl(name, 2, nullptr, nullptr, nullptr, 0); ]])],
+ [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCTL, 1,[Define this symbol if the BSD sysctl() is available]) ],
  [ AC_MSG_RESULT(no)]
 )
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -119,6 +119,7 @@ BITCOIN_CORE_H = \
   compat.h \
   compat/assumptions.h \
   compat/byteswap.h \
+  compat/cpuid.h \
   compat/endian.h \
   compat/sanity.h \
   compressor.h \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -175,6 +175,7 @@ BITCOIN_CORE_H = \
   protocol.h \
   psbt.h \
   random.h \
+  randomenv.h \
   reverse_iterator.h \
   reverselock.h \
   rpc/blockchain.h \
@@ -502,6 +503,7 @@ libbitcoin_util_a_SOURCES = \
   interfaces/handler.cpp \
   logging.cpp \
   random.cpp \
+  randomenv.cpp \
   rpc/request.cpp \
   support/cleanse.cpp \
   sync.cpp \

--- a/src/compat/cpuid.h
+++ b/src/compat/cpuid.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_COMPAT_CPUID_H
+#define BITCOIN_COMPAT_CPUID_H
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#define HAVE_GETCPUID
+
+#include <cpuid.h>
+
+// We can't use cpuid.h's __get_cpuid as it does not support subleafs.
+void static inline GetCPUID(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
+{
+#ifdef __GNUC__
+    __cpuid_count(leaf, subleaf, a, b, c, d);
+#else
+  __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
+#endif
+}
+
+#endif // defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
+#endif // BITCOIN_COMPAT_CPUID_H

--- a/src/crypto/sha256.cpp
+++ b/src/crypto/sha256.cpp
@@ -8,9 +8,10 @@
 #include <assert.h>
 #include <string.h>
 
+#include <compat/cpuid.h>
+
 #if defined(__x86_64__) || defined(__amd64__) || defined(__i386__)
 #if defined(USE_ASM)
-#include <cpuid.h>
 namespace sha256_sse4
 {
 void Transform(uint32_t* s, const unsigned char* chunk, size_t blocks);
@@ -546,18 +547,7 @@ bool SelfTest() {
     return true;
 }
 
-
 #if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
-// We can't use cpuid.h's __get_cpuid as it does not support subleafs.
-void inline cpuid(uint32_t leaf, uint32_t subleaf, uint32_t& a, uint32_t& b, uint32_t& c, uint32_t& d)
-{
-#ifdef __GNUC__
-    __cpuid_count(leaf, subleaf, a, b, c, d);
-#else
-  __asm__ ("cpuid" : "=a"(a), "=b"(b), "=c"(c), "=d"(d) : "0"(leaf), "2"(subleaf));
-#endif
-}
-
 /** Check whether the OS has enabled AVX registers. */
 bool AVXEnabled()
 {
@@ -572,7 +562,7 @@ bool AVXEnabled()
 std::string SHA256AutoDetect()
 {
     std::string ret = "standard";
-#if defined(USE_ASM) && (defined(__x86_64__) || defined(__amd64__) || defined(__i386__))
+#if defined(USE_ASM) && defined(HAVE_GETCPUID)
     bool have_sse4 = false;
     bool have_xsave = false;
     bool have_avx = false;
@@ -589,7 +579,7 @@ std::string SHA256AutoDetect()
     (void)enabled_avx;
 
     uint32_t eax, ebx, ecx, edx;
-    cpuid(1, 0, eax, ebx, ecx, edx);
+    GetCPUID(1, 0, eax, ebx, ecx, edx);
     have_sse4 = (ecx >> 19) & 1;
     have_xsave = (ecx >> 27) & 1;
     have_avx = (ecx >> 28) & 1;
@@ -597,7 +587,7 @@ std::string SHA256AutoDetect()
         enabled_avx = AVXEnabled();
     }
     if (have_sse4) {
-        cpuid(7, 0, eax, ebx, ecx, edx);
+        GetCPUID(7, 0, eax, ebx, ecx, edx);
         have_avx2 = (ebx >> 5) & 1;
         have_shani = (ebx >> 29) & 1;
     }

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -23,6 +23,7 @@ public:
     CSHA512& Write(const unsigned char* data, size_t len);
     void Finalize(unsigned char hash[OUTPUT_SIZE]);
     CSHA512& Reset();
+    uint64_t Size() const { return bytes; }
 };
 
 #endif // BITCOIN_CRYPTO_SHA512_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1258,6 +1258,11 @@ bool AppInitMain(NodeContext& node)
     CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
     threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
 
+    // Gather some entropy once per minute.
+    scheduler.scheduleEvery([]{
+        RandAddPeriodic();
+    }, 60000);
+
     GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
     GetMainSignals().RegisterWithMempoolSignals(mempool);
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -11,8 +11,8 @@
 #include <compat.h> // for Windows API
 #include <wincrypt.h>
 #endif
-#include <logging.h>  // for LogPrint()
-#include <sync.h>     // for WAIT_LOCK
+#include <logging.h>  // for LogPrintf()
+#include <sync.h>     // for Mutex
 #include <util/time.h> // for GetTime()
 
 #include <stdlib.h>
@@ -716,7 +716,7 @@ bool Random_SanityCheck()
     uint64_t start = GetPerformanceCounter();
 
     /* This does not measure the quality of randomness, but it does test that
-     * OSRandom() overwrites all 32 bytes of the output given a maximum
+     * GetOSRand() overwrites all 32 bytes of the output given a maximum
      * number of tries.
      */
     static const ssize_t MAX_TRIES = 1024;

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -525,7 +525,9 @@ static void SeedPeriodic(CSHA512& hasher, RNGState& rng)
     SeedTimestamp(hasher);
 
     // Dynamic environment data (performance monitoring, ...)
+    auto old_size = hasher.Size();
     RandAddDynamicEnv(hasher);
+    LogPrintf("Feeding %i bytes of dynamic environment data into RNG\n", hasher.Size() - old_size);
 
     // Strengthen for 10 ms
     SeedStrengthen(hasher, rng, 10000);
@@ -540,10 +542,12 @@ static void SeedStartup(CSHA512& hasher, RNGState& rng) noexcept
     SeedSlow(hasher);
 
     // Dynamic environment data (performance monitoring, ...)
+    auto old_size = hasher.Size();
     RandAddDynamicEnv(hasher);
 
     // Static environment data
     RandAddStaticEnv(hasher);
+    LogPrintf("Feeding %i bytes of environment data into RNG\n", hasher.Size() - old_size);
 
     // Strengthen for 100 ms
     SeedStrengthen(hasher, rng, 100000);

--- a/src/random.h
+++ b/src/random.h
@@ -52,7 +52,6 @@
  * sources used in the 'slow' seeder are included, but also:
  * - 256 bits from the hardware RNG (rdseed or rdrand) when available.
  * - (On Windows) Performance monitoring data from the OS.
- * - (On Windows) Through OpenSSL, the screen contents.
  * - Strengthen the entropy for 100 ms using repeated SHA512.
  *
  * When mixing in new entropy, H = SHA512(entropy || old_rng_state) is computed, and

--- a/src/random.h
+++ b/src/random.h
@@ -84,11 +84,11 @@ uint256 GetRandHash() noexcept;
 void GetStrongRandBytes(unsigned char* buf, int num) noexcept;
 
 /**
- * Sleep for 1ms, gather entropy from various sources, and feed them to the PRNG state.
+ * Gather entropy from various expensive sources, and feed them to the PRNG state.
  *
  * Thread-safe.
  */
-void RandAddSeedSleep();
+void RandAddPeriodic();
 
 /**
  * Fast randomness source. This is seeded once with secure random data, but

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <randomenv.h>
+
+#include <crypto/sha512.h>
+#include <support/cleanse.h>
+#include <util/time.h> // for GetTime()
+#ifdef WIN32
+#include <compat.h> // for Windows API
+#endif
+
+#include <algorithm>
+#include <vector>
+
+#include <stdint.h>
+
+namespace {
+
+void RandAddSeedPerfmon(CSHA512& hasher)
+{
+#ifdef WIN32
+    // Don't need this on Linux, OpenSSL automatically uses /dev/urandom
+    // Seed with the entire set of perfmon data
+
+    // This can take up to 2 seconds, so only do it every 10 minutes
+    static int64_t nLastPerfmon;
+    if (GetTime() < nLastPerfmon + 10 * 60)
+        return;
+    nLastPerfmon = GetTime();
+
+    std::vector<unsigned char> vData(250000, 0);
+    long ret = 0;
+    unsigned long nSize = 0;
+    const size_t nMaxSize = 10000000; // Bail out at more than 10MB of performance data
+    while (true) {
+        nSize = vData.size();
+        ret = RegQueryValueExA(HKEY_PERFORMANCE_DATA, "Global", nullptr, nullptr, vData.data(), &nSize);
+        if (ret != ERROR_MORE_DATA || vData.size() >= nMaxSize)
+            break;
+        vData.resize(std::max((vData.size() * 3) / 2, nMaxSize)); // Grow size of buffer exponentially
+    }
+    RegCloseKey(HKEY_PERFORMANCE_DATA);
+    if (ret == ERROR_SUCCESS) {
+        hasher.Write(vData.data(), nSize);
+        memory_cleanse(vData.data(), nSize);
+    } else {
+        // Performance data is only a best-effort attempt at improving the
+        // situation when the OS randomness (and other sources) aren't
+        // adequate. As a result, failure to read it is isn't considered critical,
+        // so we don't call RandFailure().
+        // TODO: Add logging when the logger is made functional before global
+        // constructors have been invoked.
+    }
+#endif
+}
+
+} // namespace
+
+void RandAddDynamicEnv(CSHA512& hasher)
+{
+    RandAddSeedPerfmon(hasher);
+}
+
+void RandAddStaticEnv(CSHA512& hasher)
+{
+}

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -19,6 +19,7 @@
 #endif
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <climits>
 #include <thread>
@@ -73,10 +74,11 @@ void RandAddSeedPerfmon(CSHA512& hasher)
     // Seed with the entire set of perfmon data
 
     // This can take up to 2 seconds, so only do it every 10 minutes
-    static int64_t nLastPerfmon;
-    if (GetTime() < nLastPerfmon + 10 * 60)
-        return;
-    nLastPerfmon = GetTime();
+    static std::atomic<std::chrono::seconds> last_perfmon{std::chrono::seconds{0}};
+    auto last_time = last_perfmon.load();
+    auto current_time = GetTime<std::chrono::seconds>();
+    if (current_time < last_time + std::chrono::minutes{10}) return;
+    last_perfmon = current_time;
 
     std::vector<unsigned char> vData(250000, 0);
     long ret = 0;

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -3,8 +3,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
 #include <randomenv.h>
 
+#include <clientversion.h>
 #include <crypto/sha512.h>
 #include <support/cleanse.h>
 #include <util/time.h> // for GetTime()
@@ -14,14 +19,21 @@
 
 #include <algorithm>
 #include <chrono>
+#include <climits>
 #include <thread>
 #include <vector>
 
 #include <stdint.h>
 #include <string.h>
 #ifndef WIN32
+#include <sys/types.h> // must go before a number of other headers
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/resource.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/types.h>
+#include <sys/utsname.h>
 #include <unistd.h>
 #endif
 #ifdef __MACH__
@@ -29,6 +41,12 @@
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 #endif
+#if HAVE_DECL_GETIFADDRS
+#include <ifaddrs.h>
+#endif
+
+//! Necessary on some platforms
+extern char** environ;
 
 namespace {
 
@@ -85,6 +103,53 @@ CSHA512& operator<<(CSHA512& hasher, const T& data) {
     return hasher;
 }
 
+#ifndef WIN32
+void AddSockaddr(CSHA512& hasher, const struct sockaddr *addr)
+{
+    if (addr == nullptr) return;
+    switch (addr->sa_family) {
+    case AF_INET:
+        hasher.Write((const unsigned char*)addr, sizeof(sockaddr_in));
+        break;
+    case AF_INET6:
+        hasher.Write((const unsigned char*)addr, sizeof(sockaddr_in6));
+        break;
+    default:
+        hasher.Write((const unsigned char*)&addr->sa_family, sizeof(addr->sa_family));
+    }
+}
+
+void AddFile(CSHA512& hasher, const char *path)
+{
+    struct stat sb = {};
+    int f = open(path, O_RDONLY);
+    size_t total = 0;
+    if (f != -1) {
+        unsigned char fbuf[4096];
+        int n;
+        hasher.Write((const unsigned char*)&f, sizeof(f));
+        if (fstat(f, &sb) == 0) hasher << sb;
+        do {
+            n = read(f, fbuf, sizeof(fbuf));
+            if (n > 0) hasher.Write(fbuf, n);
+            total += n;
+            /* not bothering with EINTR handling. */
+        } while (n == sizeof(fbuf) && total < 1048576); // Read only the first 1 Mbyte
+        close(f);
+    }
+}
+
+void AddPath(CSHA512& hasher, const char *path)
+{
+    struct stat sb = {};
+    if (stat(path, &sb) == 0) {
+        hasher.Write((const unsigned char*)path, strlen(path) + 1);
+        hasher << sb;
+    }
+}
+#endif
+
+
 } // namespace
 
 void RandAddDynamicEnv(CSHA512& hasher)
@@ -99,18 +164,18 @@ void RandAddDynamicEnv(CSHA512& hasher)
 #else
 #  ifndef __MACH__
     // On non-MacOS systems, use various clock_gettime() calls.
-    struct timespec ts;
+    struct timespec ts = {};
 #    ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    hasher << ts.tv_sec << ts.tv_nsec;
+    hasher << ts;
 #    endif
 #    ifdef CLOCK_REALTIME
     clock_gettime(CLOCK_REALTIME, &ts);
-    hasher << ts.tv_sec << ts.tv_nsec;
+    hasher << ts;
 #    endif
 #    ifdef CLOCK_BOOTTIME
     clock_gettime(CLOCK_BOOTTIME, &ts);
-    hasher << ts.tv_sec << ts.tv_nsec;
+    hasher << ts;
 #    endif
 #  else
     // On MacOS use mach_absolute_time (number of CPU ticks since boot) as a replacement for CLOCK_MONOTONIC,
@@ -118,29 +183,138 @@ void RandAddDynamicEnv(CSHA512& hasher)
     hasher << mach_absolute_time();
     // From https://gist.github.com/jbenet/1087739
     clock_serv_t cclock;
-    mach_timespec_t mts;
+    mach_timespec_t mts = {};
     if (host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock) == KERN_SUCCESS && clock_get_time(cclock, &mts) == KERN_SUCCESS) {
-        hasher << mts.tv_sec << mts.tv_nsec;
+        hasher << mts;
         mach_port_deallocate(mach_task_self(), cclock);
     }
 #  endif
     // gettimeofday is available on all UNIX systems, but only has microsecond precision.
-    struct timeval tv;
+    struct timeval tv = {};
     gettimeofday(&tv, nullptr);
-    hasher << tv.tv_sec << tv.tv_usec;
+    hasher << tv;
 #endif
     // Probably redundant, but also use all the clocks C++11 provides:
     hasher << std::chrono::system_clock::now().time_since_epoch().count();
     hasher << std::chrono::steady_clock::now().time_since_epoch().count();
     hasher << std::chrono::high_resolution_clock::now().time_since_epoch().count();
+
+#ifndef WIN32
+    // Current resource usage.
+    struct rusage usage = {};
+    if (getrusage(RUSAGE_SELF, &usage) == 0) hasher << usage;
+#endif
+
+#ifdef __linux__
+    AddFile(hasher, "/proc/diskstats");
+    AddFile(hasher, "/proc/vmstat");
+    AddFile(hasher, "/proc/schedstat");
+    AddFile(hasher, "/proc/zoneinfo");
+    AddFile(hasher, "/proc/meminfo");
+    AddFile(hasher, "/proc/softirqs");
+    AddFile(hasher, "/proc/stat");
+    AddFile(hasher, "/proc/self/schedstat");
+    AddFile(hasher, "/proc/self/status");
+#endif
+
+    // Stack and heap location
+    void* addr = malloc(4097);
+    hasher << &addr << addr;
+    free(addr);
 }
 
 void RandAddStaticEnv(CSHA512& hasher)
 {
+    // Some compile-time static properties
+    hasher << (CHAR_MIN < 0) << sizeof(void*) << sizeof(long) << sizeof(int);
+#if defined(__GNUC__) && defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+    hasher << __GNUC__ << __GNUC_MINOR__ << __GNUC_PATCHLEVEL__;
+#endif
+#ifdef _MSC_VER
+    hasher << _MSC_VER;
+#endif
+    hasher << __cplusplus;
+#ifdef _XOPEN_VERSION
+    hasher << _XOPEN_VERSION;
+#endif
+#ifdef __VERSION__
+    const char* COMPILER_VERSION = __VERSION__;
+    hasher.Write((const unsigned char*)COMPILER_VERSION, strlen(COMPILER_VERSION) + 1);
+#endif
+
+    // Bitcoin client version
+    hasher << CLIENT_VERSION;
+
+    // Memory locations
+    hasher << &hasher << &RandAddStaticEnv << &malloc << &errno << &environ;
+
+    // Hostname
+    char hname[256];
+    if (gethostname(hname, 256) == 0) {
+        hasher.Write((const unsigned char*)hname, strnlen(hname, 256));
+    }
+
+#if HAVE_DECL_GETIFADDRS
+    // Network interfaces
+    struct ifaddrs *ifad = NULL;
+    getifaddrs(&ifad);
+    struct ifaddrs *ifit = ifad;
+    while (ifit != NULL) {
+        hasher.Write((const unsigned char*)&ifit, sizeof(ifit));
+        hasher.Write((const unsigned char*)ifit->ifa_name, strlen(ifit->ifa_name) + 1);
+        hasher.Write((const unsigned char*)&ifit->ifa_flags, sizeof(ifit->ifa_flags));
+        AddSockaddr(hasher, ifit->ifa_addr);
+        AddSockaddr(hasher, ifit->ifa_netmask);
+        AddSockaddr(hasher, ifit->ifa_dstaddr);
+        ifit = ifit->ifa_next;
+    }
+    freeifaddrs(ifad);
+#endif
+
+#ifndef WIN32
+    // UNIX kernel information
+    struct utsname name;
+    if (uname(&name) != -1) {
+        hasher.Write((const unsigned char*)&name.sysname, strlen(name.sysname) + 1);
+        hasher.Write((const unsigned char*)&name.nodename, strlen(name.nodename) + 1);
+        hasher.Write((const unsigned char*)&name.release, strlen(name.release) + 1);
+        hasher.Write((const unsigned char*)&name.version, strlen(name.version) + 1);
+        hasher.Write((const unsigned char*)&name.machine, strlen(name.machine) + 1);
+    }
+
+    /* Path and filesystem provided data */
+    AddPath(hasher, "/");
+    AddPath(hasher, ".");
+    AddPath(hasher, "/tmp");
+    AddPath(hasher, "/home");
+    AddPath(hasher, "/proc");
+#ifdef __linux__
+    AddFile(hasher, "/proc/cmdline");
+    AddFile(hasher, "/proc/cpuinfo");
+    AddFile(hasher, "/proc/version");
+#endif
+    AddFile(hasher, "/etc/passwd");
+    AddFile(hasher, "/etc/group");
+    AddFile(hasher, "/etc/hosts");
+    AddFile(hasher, "/etc/resolv.conf");
+    AddFile(hasher, "/etc/timezone");
+    AddFile(hasher, "/etc/localtime");
+
+    /* TODO: sysctl's for OSX to fetch information not available from /proc */
+#endif
+
+    // Env variables
+    if (environ) {
+        for (size_t i = 0; environ[i]; ++i) {
+            hasher.Write((const unsigned char*)environ[i], strlen(environ[i]));
+        }
+    }
+
+    // Process, thread, user, session, group, ... ids.
 #ifdef WIN32
     hasher << GetCurrentProcessId() << GetCurrentThreadId();
 #else
-    hasher << getpid();
+    hasher << getpid() << getppid() << getsid(0) << getpgid(0) << getuid() << geteuid() << getgid() << getegid();
 #endif
     hasher << std::this_thread::get_id();
 }

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -57,6 +57,9 @@
 #include <sys/vmmeter.h>
 #endif
 #endif
+#ifdef __linux__
+#include <sys/auxv.h>
+#endif
 
 //! Necessary on some platforms
 extern char** environ;
@@ -328,6 +331,28 @@ void RandAddStaticEnv(CSHA512& hasher)
 
     // Bitcoin client version
     hasher << CLIENT_VERSION;
+
+#ifdef __linux__
+    // Information available through getauxval()
+#  ifdef AT_HWCAP
+    hasher << getauxval(AT_HWCAP);
+#  endif
+#  ifdef AT_HWCAP2
+    hasher << getauxval(AT_HWCAP2);
+#  endif
+#  ifdef AT_RANDOM
+    const unsigned char* random_aux = (const unsigned char*)getauxval(AT_RANDOM);
+    if (random_aux) hasher.Write(random_aux, 16);
+#  endif
+#  ifdef AT_PLATFORM
+    const char* platform_str = (const char*)getauxval(AT_PLATFORM);
+    if (platform_str) hasher.Write((const unsigned char*)platform_str, strlen(platform_str) + 1);
+#  endif
+#  ifdef AT_EXECFN
+    const char* exec_str = (const char*)getauxval(AT_EXECFN);
+    if (exec_str) hasher.Write((const unsigned char*)exec_str, strlen(exec_str) + 1);
+#  endif
+#endif // __linux__
 
 #ifdef HAVE_GETCPUID
     AddAllCPUID(hasher);

--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -44,6 +44,18 @@
 #if HAVE_DECL_GETIFADDRS
 #include <ifaddrs.h>
 #endif
+#if HAVE_SYSCTL
+#include <sys/sysctl.h>
+#if HAVE_VM_VM_PARAM_H
+#include <vm/vm_param.h>
+#endif
+#if HAVE_SYS_RESOURCES_H
+#include <sys/resources.h>
+#endif
+#if HAVE_SYS_VMMETER_H
+#include <sys/vmmeter.h>
+#endif
+#endif
 
 //! Necessary on some platforms
 extern char** environ;
@@ -149,6 +161,23 @@ void AddPath(CSHA512& hasher, const char *path)
 }
 #endif
 
+#if HAVE_SYSCTL
+template<int... S>
+void AddSysctl(CSHA512& hasher)
+{
+    int CTL[sizeof...(S)] = {S...};
+    unsigned char buffer[65536];
+    size_t siz = 65536;
+    int ret = sysctl(CTL, sizeof...(S), buffer, &siz, nullptr, 0);
+    if (ret == 0 || (ret == -1 && errno == ENOMEM)) {
+        hasher << sizeof(CTL);
+        hasher.Write((const unsigned char*)CTL, sizeof(CTL));
+        if (siz > sizeof(buffer)) siz = sizeof(buffer);
+        hasher << siz;
+        hasher.Write(buffer, siz);
+    }
+}
+#endif
 
 } // namespace
 
@@ -215,6 +244,30 @@ void RandAddDynamicEnv(CSHA512& hasher)
     AddFile(hasher, "/proc/stat");
     AddFile(hasher, "/proc/self/schedstat");
     AddFile(hasher, "/proc/self/status");
+#endif
+
+#if HAVE_SYSCTL
+#  ifdef CTL_KERN
+#    if defined(KERN_PROC) && defined(KERN_PROC_ALL)
+    AddSysctl<CTL_KERN, KERN_PROC, KERN_PROC_ALL>(hasher);
+#    endif
+#  endif
+#  ifdef CTL_HW
+#    ifdef HW_DISKSTATS
+    AddSysctl<CTL_HW, HW_DISKSTATS>(hasher);
+#    endif
+#  endif
+#  ifdef CTL_VM
+#    ifdef VM_LOADAVG
+    AddSysctl<CTL_VM, VM_LOADAVG>(hasher);
+#    endif
+#    ifdef VM_TOTAL
+    AddSysctl<CTL_VM, VM_TOTAL>(hasher);
+#    endif
+#    ifdef VM_METER
+    AddSysctl<CTL_VM, VM_METER>(hasher);
+#    endif
+#  endif
 #endif
 
     // Stack and heap location
@@ -299,8 +352,81 @@ void RandAddStaticEnv(CSHA512& hasher)
     AddFile(hasher, "/etc/resolv.conf");
     AddFile(hasher, "/etc/timezone");
     AddFile(hasher, "/etc/localtime");
+#endif
 
-    /* TODO: sysctl's for OSX to fetch information not available from /proc */
+    // For MacOS/BSDs, gather data through sysctl instead of /proc. Not all of these
+    // will exist on every system.
+#if HAVE_SYSCTL
+#  ifdef CTL_HW
+#    ifdef HW_MACHINE
+    AddSysctl<CTL_HW, HW_MACHINE>(hasher);
+#    endif
+#    ifdef HW_MODEL
+    AddSysctl<CTL_HW, HW_MODEL>(hasher);
+#    endif
+#    ifdef HW_NCPU
+    AddSysctl<CTL_HW, HW_NCPU>(hasher);
+#    endif
+#    ifdef HW_PHYSMEM
+    AddSysctl<CTL_HW, HW_PHYSMEM>(hasher);
+#    endif
+#    ifdef HW_USERMEM
+    AddSysctl<CTL_HW, HW_USERMEM>(hasher);
+#    endif
+#    ifdef HW_MACHINE_ARCH
+    AddSysctl<CTL_HW, HW_MACHINE_ARCH>(hasher);
+#    endif
+#    ifdef HW_REALMEM
+    AddSysctl<CTL_HW, HW_REALMEM>(hasher);
+#    endif
+#    ifdef HW_CPU_FREQ
+    AddSysctl<CTL_HW, HW_CPU_FREQ>(hasher);
+#    endif
+#    ifdef HW_BUS_FREQ
+    AddSysctl<CTL_HW, HW_BUS_FREQ>(hasher);
+#    endif
+#    ifdef HW_CACHELINE
+    AddSysctl<CTL_HW, HW_CACHELINE>(hasher);
+#    endif
+#  endif
+#  ifdef CTL_KERN
+#    ifdef KERN_BOOTFILE
+     AddSysctl<CTL_KERN, KERN_BOOTFILE>(hasher);
+#    endif
+#    ifdef KERN_BOOTTIME
+     AddSysctl<CTL_KERN, KERN_BOOTTIME>(hasher);
+#    endif
+#    ifdef KERN_CLOCKRATE
+     AddSysctl<CTL_KERN, KERN_CLOCKRATE>(hasher);
+#    endif
+#    ifdef KERN_HOSTID
+     AddSysctl<CTL_KERN, KERN_HOSTID>(hasher);
+#    endif
+#    ifdef KERN_HOSTUUID
+     AddSysctl<CTL_KERN, KERN_HOSTUUID>(hasher);
+#    endif
+#    ifdef KERN_HOSTNAME
+     AddSysctl<CTL_KERN, KERN_HOSTNAME>(hasher);
+#    endif
+#    ifdef KERN_OSRELDATE
+     AddSysctl<CTL_KERN, KERN_OSRELDATE>(hasher);
+#    endif
+#    ifdef KERN_OSRELEASE
+     AddSysctl<CTL_KERN, KERN_OSRELEASE>(hasher);
+#    endif
+#    ifdef KERN_OSREV
+     AddSysctl<CTL_KERN, KERN_OSREV>(hasher);
+#    endif
+#    ifdef KERN_OSTYPE
+     AddSysctl<CTL_KERN, KERN_OSTYPE>(hasher);
+#    endif
+#    ifdef KERN_POSIX1
+     AddSysctl<CTL_KERN, KERN_OSREV>(hasher);
+#    endif
+#    ifdef KERN_VERSION
+     AddSysctl<CTL_KERN, KERN_VERSION>(hasher);
+#    endif
+#  endif
 #endif
 
     // Env variables

--- a/src/randomenv.h
+++ b/src/randomenv.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RANDOMENV_H
+#define BITCOIN_RANDOMENV_H
+
+#include <crypto/sha512.h>
+
+/** Gather non-cryptographic environment data that changes over time. */
+void RandAddDynamicEnv(CSHA512& hasher);
+
+/** Gather non-cryptographic environment data that does not change over time. */
+void RandAddStaticEnv(CSHA512& hasher);
+
+#endif

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -41,8 +41,6 @@ void CScheduler::serviceQueue()
         try {
             if (!shouldStop() && taskQueue.empty()) {
                 reverse_lock<boost::unique_lock<boost::mutex> > rlock(lock);
-                // Use this chance to get more entropy
-                RandAddSeedSleep();
             }
             while (!shouldStop() && taskQueue.empty()) {
                 // Wait until there is something to do.


### PR DESCRIPTION
This introduces a new `randomenv` module that queries varies non-cryptographic (and non-RNG) sources of entropy available on the system; things like user IDs, system configuration, time, statistics, CPUID data.

The idea is that these provide a fallback in scenarios where system entropy is somehow broken (note that if system entropy *fails* we will abort regardless; this is only meant to function as a last resort against undetected failure). It includes some data sources OpenSSL currently uses, and more.

The separation between random and randomenv is a bit arbitrary, but I felt that all this "non-essential" functionality deserved to be separated from the core random module.