### PR TITLE
[POLICY] Make multiple OP_RETURNS in a single TX standard

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -109,7 +109,6 @@ bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeR
         }
     }
 
-    unsigned int nDataOut = 0;
     txnouttype whichType;
     for (const CTxOut& txout : tx.vout) {
         if (!::IsStandard(txout.scriptPubKey, whichType)) {
@@ -117,21 +116,13 @@ bool IsStandardTx(const CTransaction& tx, bool permit_bare_multisig, const CFeeR
             return false;
         }
 
-        if (whichType == TX_NULL_DATA)
-            nDataOut++;
-        else if ((whichType == TX_MULTISIG) && (!permit_bare_multisig)) {
+        if ((whichType == TX_MULTISIG) && (!permit_bare_multisig)) {
             reason = "bare-multisig";
             return false;
-        } else if (IsDust(txout, dust_relay_fee)) {
+        } else if (whichType != TX_NULL_DATA && IsDust(txout, dust_relay_fee)) {
             reason = "dust";
             return false;
         }
-    }
-
-    // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
-        reason = "multi-op-return";
-        return false;
     }
 
     return true;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -765,25 +765,6 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
-    // Only one TX_NULL_DATA permitted in all cases
-    t.vout.resize(2);
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "multi-op-return");
-
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "multi-op-return");
-
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN;
-    t.vout[1].scriptPubKey = CScript() << OP_RETURN;
-    reason.clear();
-    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
-    BOOST_CHECK_EQUAL(reason, "multi-op-return");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/functional/mempool_accept.py
+++ b/test/functional/mempool_accept.py
@@ -22,7 +22,6 @@ from test_framework.script import (
     OP_0,
     OP_EQUAL,
     OP_HASH160,
-    OP_RETURN,
 )
 from test_framework.util import (
     assert_equal,
@@ -279,13 +278,6 @@ class MempoolAcceptanceTest(BitcoinTestFramework):
         tx.vout[0].nValue -= 1  # Make output smaller, such that it is dust for our policy
         self.check_mempool_result(
             result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'dust'}],
-            rawtxs=[tx.serialize().hex()],
-        )
-        tx.deserialize(BytesIO(hex_str_to_bytes(raw_tx_reference)))
-        tx.vout[0].scriptPubKey = CScript([OP_RETURN, b'\xff'])
-        tx.vout = [tx.vout[0]] * 2
-        self.check_mempool_result(
-            result_expected=[{'txid': tx.rehash(), 'allowed': False, 'reject-reason': 'multi-op-return'}],
             rawtxs=[tx.serialize().hex()],
         )
 


### PR DESCRIPTION
This proposed policy change would allow multiple OP_RETURN outputs per transaction, the Bitcoin protocol allows for multiple of these opcodes per transaction but the current policy does not. We are seeing an inefficient use of OP_RETURN for systems that rely on this feature. For example, an asset layer solution making use of OP_RETURN currently has to create multiple transactions when sending to multiple recipients.

There are several regular sources of these types of transactions on the network making up a significant proportion of daily transaction, OmniLayer, one successful and popular asset layer, on the 21st Oct 2019 was responsible for 8% of transactions that day (Omni 28,313 TXs [[1](#-1)] / Bitcoin 351,632 TXs [2]). Allowing multiple OP_RETURN opcodes would enable asset layer solutions to move multiple assets to multiple recipients in a single transaction, this would result in an overall reduced data size for the movement of those assets reducing transaction load on the network.

The original Pull Request to add OP_RETURN linked below bemusingly set the fail reason for multiple instances of it to “mucho-data”, the opposite is now true, single OP_RETURN per transaction only result in more data, not less.

https://github.com/bitcoin/bitcoin/pull/2738/files

A service bit could be added to show whether a node would accept and relay a transaction with multiple OP_RETURN opcodes, such transactions would then only be relayed to nodes indicating support. If this change warrants such a thing I’d be happy to update this PR to include it.

1. https://omniexplorer.info/
2. https://bitinfocharts.com/comparison/bitcoin-transactions.html#3m
