### PR TITLE
tests: Fix fuzzers eval_script and script_flags by re-adding ECCVerifyHandle dependency

### DIFF
--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -2,11 +2,18 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <pubkey.h>
 #include <script/interpreter.h>
-#include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <util/memory.h>
 
 #include <limits>
+
+void initialize()
+{
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+}
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -2,14 +2,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <pubkey.h>
 #include <script/interpreter.h>
 #include <streams.h>
+#include <util/memory.h>
 #include <version.h>
 
 #include <test/fuzz/fuzz.h>
 
 /** Flags that are not forbidden by an assert */
 static bool IsValidFlagCombination(unsigned flags);
+
+void initialize()
+{
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+}
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {


### PR DESCRIPTION
The fuzzers `eval_script` and `script_flags` require holding `ECCVerifyHandle`. 

This is a follow-up to #17235 which accidentally broke those two fuzzers.

Sorry about the temporary breakage my fuzzing friends: it took a while to fuzz before reaching these code paths. That's why this wasn't immediately caught. Sorry.