### PR TITLE
tests: Add fuzzing harness for ISO-8601 related functions

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -77,13 +77,13 @@ will print an error and suggestion if so.
 
 ## libFuzzer
 
-A recent version of `clang`, the address sanitizer and libFuzzer is needed (all
+A recent version of `clang`, the address/undefined sanitizers (ASan/UBSan) and libFuzzer is needed (all
 found in the `compiler-rt` runtime libraries package).
 
 To build all fuzz targets with libFuzzer, run
 
 ```
-./configure --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address CC=clang CXX=clang++
+./configure --disable-ccache --enable-fuzz --with-sanitizers=fuzzer,address,undefined CC=clang CXX=clang++
 make
 ```
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -22,6 +22,7 @@ FUZZ_TARGETS = \
   test/fuzz/inv_deserialize \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
+  test/fuzz/parse_iso8601 \
   test/fuzz/script \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
@@ -268,6 +269,12 @@ test_fuzz_netaddr_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DNE
 test_fuzz_netaddr_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_netaddr_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_netaddr_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_parse_iso8601_SOURCES = $(FUZZ_SUITE) test/fuzz/parse_iso8601.cpp
+test_fuzz_parse_iso8601_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_parse_iso8601_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_parse_iso8601_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_parse_iso8601_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_script_SOURCES = $(FUZZ_SUITE) test/fuzz/script.cpp
 test_fuzz_script_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)

--- a/src/test/fuzz/parse_iso8601.cpp
+++ b/src/test/fuzz/parse_iso8601.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/time.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const int64_t random_time = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+    const std::string random_string = fuzzed_data_provider.ConsumeRemainingBytesAsString();
+
+    const std::string iso8601_datetime = FormatISO8601DateTime(random_time);
+    const int64_t parsed_time_1 = ParseISO8601DateTime(iso8601_datetime);
+    if (random_time >= 0) {
+        assert(parsed_time_1 >= 0);
+        if (iso8601_datetime.length() == 20) {
+            assert(parsed_time_1 == random_time);
+        }
+    }
+
+    const int64_t parsed_time_2 = ParseISO8601DateTime(random_string);
+    assert(parsed_time_2 >= 0);
+}


### PR DESCRIPTION
Add fuzzing harness for ISO-8601 related functions.

**Testing this PR**

Run:

```
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/parse_iso8601
…
```