### PR TITLE
 refactor: Remove addrdb.h dependency from node.h 

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -152,6 +152,7 @@ BITCOIN_CORE_H = \
   net.h \
   net_permissions.h \
   net_processing.h \
+  net_types.h \
   netaddress.h \
   netbase.h \
   netmessagemaker.h \

--- a/src/addrdb.h
+++ b/src/addrdb.h
@@ -7,6 +7,7 @@
 #define BITCOIN_ADDRDB_H
 
 #include <fs.h>
+#include <net_types.h> // For banmap_t
 #include <serialize.h>
 
 #include <string>
@@ -78,8 +79,6 @@ public:
         }
     }
 };
-
-typedef std::map<CSubNet, CBanEntry> banmap_t;
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/banman.h
+++ b/src/banman.h
@@ -10,6 +10,7 @@
 
 #include <addrdb.h>
 #include <fs.h>
+#include <net_types.h> // For banmap_t
 #include <sync.h>
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -5,9 +5,9 @@
 #ifndef BITCOIN_INTERFACES_NODE_H
 #define BITCOIN_INTERFACES_NODE_H
 
-#include <addrdb.h>     // For banmap_t
 #include <amount.h>     // For CAmount
 #include <net.h>        // For CConnman::NumConnections
+#include <net_types.h>  // For banmap_t
 #include <netaddress.h> // For Network
 #include <support/allocators/secure.h> // For SecureString
 

--- a/src/net_types.h
+++ b/src/net_types.h
@@ -1,0 +1,15 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NET_TYPES_H
+#define BITCOIN_NET_TYPES_H
+
+#include <map>
+
+class CBanEntry;
+class CSubNet;
+
+using banmap_t = std::map<CSubNet, CBanEntry>;
+
+#endif // BITCOIN_NET_TYPES_H

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -4,9 +4,9 @@
 
 #include <qt/bantablemodel.h>
 
-#include <qt/clientmodel.h>
-
 #include <interfaces/node.h>
+#include <net_types.h> // For banmap_t
+#include <qt/clientmodel.h>
 
 #include <algorithm>
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -8,8 +8,9 @@
 #include <clientversion.h>
 #include <core_io.h>
 #include <net.h>
-#include <net_processing.h>
 #include <net_permissions.h>
+#include <net_processing.h>
+#include <net_types.h> // For banmap_t
 #include <netbase.h>
 #include <policy/settings.h>
 #include <rpc/protocol.h>


### PR DESCRIPTION
`node.h` includes `addrdb.h` just for the sake of `banmap_t` type.
This PR makes dependencies simpler and explicit.

~Also needless `typedef` has been removed from `enum BanReason`.~