### PR TITLE
gui: enable RPC server by default

### DIFF
--- a/doc/release-notes-17301.md
+++ b/doc/release-notes-17301.md
@@ -1,0 +1,7 @@
+Graphical User Interface (GUI)
+------------------------------
+
+- The RPC server is enabled by default (can be disabled with `-server=0`). This
+  enables the use of external tools without a configuration change. For example
+  the Hardware Wallet Interaction ([HWI](https://github.com/bitcoin-core/HWI#readme))
+  scripts.

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -96,8 +96,6 @@ static bool AppInit(int argc, char* argv[])
             }
         }
 
-        // -server defaults to true for bitcoind but not for the GUI so do this here
-        gArgs.SoftSetBoolArg("-server", true);
         // Set this early so that parameter interactions go to console
         InitLogging();
         InitParameterInteraction();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1294,7 +1294,7 @@ bool AppInitMain(InitInterfaces& interfaces)
      * that the server is there and will be ready later).  Warmup mode will
      * be disabled when initialisation is finished.
      */
-    if (gArgs.GetBoolArg("-server", false))
+    if (gArgs.GetBoolArg("-server", true))
     {
         uiInterface.InitMessage_connect(SetRPCWarmupStatus);
         if (!AppInitServers())


### PR DESCRIPTION
This PR enables the RPC server by default for GUI users (with cookie based authentication).

Alternatively I could add GUI setting.