### PR TITLE
p2p: Stop relaying non-mempool txs, improve tx privacy slightly

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -823,7 +823,10 @@ public:
         bool fSendMempool GUARDED_BY(cs_tx_inventory){false};
         // Last time a "MEMPOOL" request was serviced.
         std::atomic<std::chrono::seconds> m_last_mempool_req{std::chrono::seconds{0}};
+        /** When to send the next batch of invs to this peer */
         std::chrono::microseconds nNextInvSend{0};
+        /** When the last batch of invs was sent to this peer */
+        std::chrono::microseconds m_last_inv_sent{0};
 
         RecursiveMutex cs_feeFilter;
         // Minimum fee rate with which to filter inv's to this node

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1622,8 +1622,9 @@ CTransactionRef static FindTxForGetData(const uint256& txid, const std::chrono::
     if (txinfo.tx) {
         // To protect privacy, do not answer getdata using the mempool when
         // that TX couldn't have been INVed in reply to a MEMPOOL request,
-        // or when it's too recent to have expired from mapRelay.
-        if ((mempool_req.count() && txinfo.m_time <= mempool_req) || txinfo.m_time <= longlived_mempool_time) {
+        // and when it's not marked for relay,
+        // and when it's too recent to have expired from mapRelay.
+        if ((mempool_req.count() && txinfo.m_time <= mempool_req) || (mapRelay.find(inv.hash) != mapRelay.end() || txinfo.m_time <= longlived_mempool_time) {
             return txinfo.tx;
         }
     }

--- a/test/functional/p2p_leak_tx.py
+++ b/test/functional/p2p_leak_tx.py
@@ -49,7 +49,12 @@ class P2PLeakTxTest(BitcoinTestFramework):
                 break
             else:
                 self.log.debug('tx {} was already announced to us. Try test again.'.format(txid))
-                assert int(txid, 16) in [inv.hash for inv in inbound_peer.last_message['inv'].inv]
+                if 'inv' in inbound_peer.last_message:
+                    assert int(txid, 16) in [inv.hash for inv in inbound_peer.last_message['inv'].inv]
+                    inbound_peer.last_message.pop('inv')
+                if 'tx' in inbound_peer.last_message:
+                    assert_equal(txid, inbound_peer.last_message['tx'].tx.rehash())
+                    inbound_peer.last_message.pop('tx')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is no reason to relay transactions that have been, but are no longer, in the mempool at the time of the getdata request for the transaction.

Possible reasons for mempool removal, and my thinking why it is safe to not relay

Reason | | Rationale
-- | -- | --
`EXPIRY` | Expired from mempool | Mempool expiry is 2 weeks, so does not interfere with relay at all.
`SIZELIMIT` | Removed in size limiting | A low fee transaction, which will be relayed by a different peer after `GETDATA_TX_INTERVAL`. Assuming it ever made it to another peer.
`REORG` | Removed for reorganization | Block races are rare, so reorgs should be rarer. Also the tx will be reaccepted from the `disconnectpool` later on and then relayed (TODO), so this should never be observable in practise.
`BLOCK` | Removed for block | The other peer will eventually receive the (filtered)block with the tx in it.
`CONFLICT` | Removed for conflict with in-block transaction | The peer won't be able to add the tx to the mempool anyway. No need to waste bandwidth.
`REPLACED` | Removed for replacement | Same as above, send them the higher fee tx instead.


This should also improve transaction relay privacy slightly. Previously any peer (even inbounds) could ask for transactions in `mapRelay`, even if they were never announced to them via an `inv` message. After my changes, the peer can only request transactions that were added to the mempool before the last `inv` message was sent to that peer.