### PR TITLE
build: macOS fix background.svg

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,10 @@ OSX_APP=Bitcoin-Qt.app
 OSX_VOLNAME = $(subst $(space),-,$(PACKAGE_NAME))
 OSX_DMG = $(OSX_VOLNAME).dmg
 OSX_BACKGROUND_SVG=background.svg
+OSX_BACKGROUND_2X_SVG=background@2x.svg
 OSX_BACKGROUND_IMAGE=background.tiff
+OSX_BACKGROUND_IMAGE_PNG=background.tiff.png
+OSX_BACKGROUND_IMAGE_2X_PNG=background.tiff@2x.png
 OSX_BACKGROUND_IMAGE_DPIS=36 72
 OSX_DSSTORE_GEN=$(top_srcdir)/contrib/macdeploy/custom_dsstore.py
 OSX_DEPLOY_SCRIPT=$(top_srcdir)/contrib/macdeploy/macdeployqtplus
@@ -119,11 +122,21 @@ if BUILD_DARWIN
 $(OSX_DMG): $(OSX_APP_BUILT) $(OSX_PACKAGING) $(OSX_BACKGROUND_IMAGE)
 	$(PYTHON) $(OSX_DEPLOY_SCRIPT) $(OSX_APP) -add-qt-tr $(OSX_QT_TRANSLATIONS) -translations-dir=$(QT_TRANSLATION_DIR) -dmg -fancy $(OSX_FANCY_PLIST) -verbose 2 -volname $(OSX_VOLNAME)
 
-$(OSX_BACKGROUND_IMAGE).png: contrib/macdeploy/$(OSX_BACKGROUND_SVG)
-	sed 's/PACKAGE_NAME/$(PACKAGE_NAME)/' < "$<" | $(RSVG_CONVERT) -f png -d 36 -p 36 -o $@
-$(OSX_BACKGROUND_IMAGE)@2x.png: contrib/macdeploy/$(OSX_BACKGROUND_SVG)
-	sed 's/PACKAGE_NAME/$(PACKAGE_NAME)/' < "$<" | $(RSVG_CONVERT) -f png -d 72 -p 72 -o $@
-$(OSX_BACKGROUND_IMAGE): $(OSX_BACKGROUND_IMAGE).png $(OSX_BACKGROUND_IMAGE)@2x.png
+$(OSX_BACKGROUND_IMAGE_PNG): contrib/macdeploy/$(OSX_BACKGROUND_SVG)
+	sed -e 's/PACKAGE_NAME/$(PACKAGE_NAME)/' \
+		-e 's/PACKAGE_VERSION/$(PACKAGE_VERSION)/' \
+		-e 's/COPYRIGHT_YEAR/$(COPYRIGHT_YEAR)/' \
+		-e 's/COPYRIGHT_HOLDERS_FINAL/$(COPYRIGHT_HOLDERS_FINAL)/' \
+		contrib/macdeploy/$(OSX_BACKGROUND_SVG) < "$<" | $(RSVG_CONVERT) -f png -h 320 -w 500 -d 144 -p 144 -o $@
+
+$(OSX_BACKGROUND_IMAGE_2X_PNG): contrib/macdeploy/$(OSX_BACKGROUND_2X_SVG)
+	sed -e 's/PACKAGE_NAME/$(PACKAGE_NAME)/' \
+		-e 's/PACKAGE_VERSION/$(PACKAGE_VERSION)/' \
+		-e 's/COPYRIGHT_YEAR/$(COPYRIGHT_YEAR)/' \
+		-e 's/COPYRIGHT_HOLDERS_FINAL/$(COPYRIGHT_HOLDERS_FINAL)/' \
+		contrib/macdeploy/$(OSX_BACKGROUND_2X_SVG) < "$<" | $(RSVG_CONVERT) -f png -h 640 -w 1000 -d 144 -p 144 -o $@
+
+$(OSX_BACKGROUND_IMAGE): $(OSX_BACKGROUND_IMAGE_PNG) $(OSX_BACKGROUND_IMAGE_2X_PNG)
 	tiffutil -cathidpicheck $^ -out $@
 
 deploydir: $(OSX_DMG)

--- a/contrib/macdeploy/background.svg
+++ b/contrib/macdeploy/background.svg
@@ -1,34 +1,30 @@
-<?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 20010904//EN"
- "http://www.w3.org/TR/2001/REC-SVG-20010904/DTD/svg10.dtd">
-<svg version="1.0" xmlns="http://www.w3.org/2000/svg" width="1000pt" height="640pt" viewBox="0 0 1000 640" preserveAspectRatio="xMidYMid meet">
-	<!-- kate: space-indent off;
-	Copyright (c) 2015 The Bitcoin Core developers
-	Distributed under the MIT software license, see the accompanying
-	file COPYING or http://www.opensource.org/licenses/mit-license.php.
-	-->
-	<style type="text/css"><![CDATA[
-		text {
-			font-family: "Tuffy";
-			font-size: 86px;
-			fill: gray;
-			text-anchor: middle;
-		}
-	]]></style>
-	<defs>
-		<linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-			<stop offset="0%" style="stop-color:rgb(239,239,239);stop-opacity:1" />
-			<stop offset="33%" style="stop-color:rgb(239,239,239);stop-opacity:1" />
-			<stop offset="80%" style="stop-color:rgb(205,205,205);stop-opacity:1" />
-			<stop offset="100%" style="stop-color:rgb(204,204,204);stop-opacity:1" />
-		</linearGradient>
-	</defs>
-	<rect width="1000" height="640" style="fill:url(#gradient);stroke-width:0" />
-	<g transform="translate(500,0) scale(0.9, 1)">
-		<text x="0" y="114">PACKAGE_NAME</text>
-	</g>
-	<g transform="translate(0.000000,640.000000) scale(0.100000,-0.100000)"
-	fill="#000000" stroke="none">
-		<path d="M4995 3705 c-24 -23 -25 -29 -25 -165 l0 -140 -306 0 -306 0 -29 -29 c-29 -29 -29 -31 -29 -141 0 -110 0 -112 29 -141 l29 -29 306 0 306 0 0 -140 c0 -136 1 -142 25 -165 16 -17 35 -25 57 -25 29 0 72 32 306 226 180 149 274 233 278 250 13 53 -2 70 -278 299 -235 194 -277 225 -306 225 -22 0 -41 -8 -57 -25z" fixlter="url(#glow)"/>
-	</g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2013-2020 The Bitcoin Core developers -->
+<!-- Distributed under the MIT software license -->
+<!-- Reference http://www.opensource.org/licenses/mit-license.php -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 500 320" style="enable-background:new 0 0 500 320;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#808080;}
+	.st2{font-family:'Tuffy-Bold';}
+	.st3{font-size:10px;}
+	.st4{font-size:40px;}
+	.st5{font-size:10px;}
+</style>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-1494.4189" y1="317.4891" x2="-1493.9189" y2="317.4891" gradientTransform="matrix(1000 0 0 -640 1494419 203353)">
+	<stop  offset="0" style="stop-color:#EFEFEF"/>
+	<stop  offset="0.5" style="stop-color:#EFEFEF"/>
+	<stop  offset="1" style="stop-color:#CDCDCD"/>
+	<stop  offset="1" style="stop-color:#CCCCCC"/>
+</linearGradient>
+<rect class="st0" width="500" height="320"/>
+<path class="st1" d="M251.2,136.2c-1.2,1.1-1.2,1.4-1.2,8.2v7h-14.8h-14.9l-1.4,1.4c-1.4,1.4-1.4,1.6-1.4,7.1s0,5.6,1.4,7.1l1.4,1.4
+	h14.8H250v7c0,6.8,0.1,7.1,1.2,8.2c0.8,0.9,1.7,1.2,2.8,1.2c1.4,0,3.5-1.6,14.9-11.3c8.7-7.4,13.3-11.6,13.5-12.5
+	c0.6-2.6-0.1-3.5-13.5-14.9c-11.4-9.7-13.4-11.2-14.9-11.2C252.9,135,252,135.4,251.2,136.2z"/>
+<g>
+	<text transform="matrix(1 0 0 1 130 50)" class="st1 st2 st4">PACKAGE_NAME</text>
+	<text transform="matrix(1 0 0 1 300 60)" class="st1 st2 st5">vPACKAGE_VERSION</text>
+	<text transform="matrix(1 0 0 1 150 290)" class="st1 st2 st3">Copyright &#169; COPYRIGHT_YEAR COPYRIGHT_HOLDERS_FINAL</text>
+</g>
 </svg>

--- a/contrib/macdeploy/background@2x.svg
+++ b/contrib/macdeploy/background@2x.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2013-2020 The Bitcoin Core developers -->
+<!-- Distributed under the MIT software license -->
+<!-- Reference http://www.opensource.org/licenses/mit-license.php -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 1000 640" style="enable-background:new 0 0 1000 640;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:url(#SVGID_1_);}
+	.st1{fill:#808080;}
+	.st2{font-family:'Tuffy-Bold';}
+	.st3{font-size:20px;}
+	.st4{font-size:80px;}
+	.st5{font-size:20px;}
+</style>
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-1493.42" y1="323.7594" x2="-1492.42" y2="323.7594" gradientTransform="matrix(1000 0 0 640 1493420 -206886)">
+	<stop  offset="0" style="stop-color:#EFEFEF"/>
+	<stop  offset="0.5" style="stop-color:#EFEFEF"/>
+	<stop  offset="1" style="stop-color:#CDCDCD"/>
+	<stop  offset="1" style="stop-color:#CCCCCC"/>
+</linearGradient>
+<rect class="st0" width="1000" height="640"/>
+<path class="st1" d="M502.4,272.4c-2.4,2.2-2.4,2.8-2.4,16.4v14h-29.6h-29.8l-2.8,2.8c-2.8,2.8-2.8,3.2-2.8,14.2s0,11.2,2.8,14.2
+	l2.8,2.8h29.6H500v14c0,13.6,0.2,14.2,2.4,16.4c1.6,1.8,3.4,2.4,5.6,2.4c2.8,0,7-3.2,29.8-22.6c17.4-14.8,26.6-23.2,27-25
+	c1.2-5.2-0.2-7-27-29.8C515,272.8,511,269.8,508,269.8C505.8,270,504,270.8,502.4,272.4z"/>
+<g>
+	<text transform="matrix(1 0 0 1 260 100)" class="st1 st2 st4">PACKAGE_NAME</text>
+	<text transform="matrix(1 0 0 1 600 120)" class="st1 st2 st5">vPACKAGE_VERSION</text>
+	<text transform="matrix(1 0 0 1 300 580)" class="st1 st2 st3">Copyright &#169; COPYRIGHT_YEAR COPYRIGHT_HOLDERS_FINAL</text>
+</g>
+</svg>

--- a/contrib/macdeploy/custom_dsstore.py
+++ b/contrib/macdeploy/custom_dsstore.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2013-2018 The Bitcoin Core developers
+# Copyright (c) 2013-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 import biplist
@@ -13,7 +13,7 @@ package_name_ns = sys.argv[2]
 ds = DSStore.open(output_file, 'w+')
 ds['.']['bwsp'] = {
     'ShowStatusBar': False,
-    'WindowBounds': '{{300, 280}, {500, 343}}',
+    'WindowBounds': '{{300, 300}, {800, 642}}',
     'ContainerShowSidebar': False,
     'SidebarWidth': 0,
     'ShowTabView': False,

--- a/contrib/macdeploy/fancy.plist
+++ b/contrib/macdeploy/fancy.plist
@@ -7,7 +7,7 @@
 		<integer>300</integer>
 		<integer>300</integer>
 		<integer>800</integer>
-		<integer>620</integer>
+		<integer>642</integer>
 	</array>
 	<key>background_picture</key>
 	<string>background.tiff</string>


### PR DESCRIPTION
FIXES: #16836
- Valid SVG & this config doesn't require scaling. 
- New presentation - added copyright and version info to the background image. 
- Dynamic year in the copyright notice - dynamic version number as well.
- The result (IMO) is a good presentation that is easy to maintain
and improve upon in a future version. 
- High Res background image working.
  
***Normal Res***
![Screen Shot 2019-11-07 at 4 54 34 AM](https://user-images.githubusercontent.com/152159/68378951-fdf9b780-011a-11ea-9ece-fce1c5a262e0.png)
***Hi Res***
<img width="509" alt="Screen Shot 2019-11-07 at 4 55 16 AM" src="https://user-images.githubusercontent.com/152159/68378954-fdf9b780-011a-11ea-9524-6f0aa598408c.png">


![Screen Shot 2019-11-08 at 1 53 56 PM](https://user-images.githubusercontent.com/152159/68502812-55894780-022f-11ea-95cf-f0593976312a.png)
![Screen Shot 2019-11-08 at 1 54 04 PM](https://user-images.githubusercontent.com/152159/68502813-55894780-022f-11ea-8508-16ec6b5a23af.png)

The svg files are valid markup. If the linter ignores these files - maybe we can re-add svg files back to the linter? 