### PR TITLE
Improve tracethread usability and trace loadblk thread

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -309,8 +309,7 @@ void BaseIndex::Start()
         return;
     }
 
-    m_thread_sync = std::thread(&TraceThread<std::function<void()>>, GetName(),
-                                std::bind(&BaseIndex::ThreadSync, this));
+    m_thread_sync = std::thread(TracedThread(GetName(), [this] { this->ThreadSync(); }));
 }
 
 void BaseIndex::Stop()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1263,8 +1263,7 @@ bool AppInitMain(NodeContext& node)
     }
 
     // Start the lightweight task scheduler thread
-    CScheduler::Function serviceLoop = std::bind(&CScheduler::serviceQueue, &scheduler);
-    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
+    threadGroup.create_thread(TracedThread("scheduler", []{ scheduler.serviceQueue(); }));
 
     GetMainSignals().RegisterBackgroundSignalScheduler(scheduler);
     GetMainSignals().RegisterWithMempoolSignals(mempool);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -657,7 +657,6 @@ static void CleanupBlockRevFiles()
 static void ThreadImport(std::vector<fs::path> vImportFiles)
 {
     const CChainParams& chainparams = Params();
-    util::ThreadRename("loadblk");
     ScheduleBatchPriority();
 
     {
@@ -1713,7 +1712,7 @@ bool AppInitMain(NodeContext& node)
         vImportFiles.push_back(strFile);
     }
 
-    threadGroup.create_thread(std::bind(&ThreadImport, vImportFiles));
+    threadGroup.create_thread(TracedThread("loadblk", [vImportFiles] { ThreadImport(vImportFiles); }));
 
     // Wait for genesis block to be processed
     {

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -752,7 +752,7 @@ void StartTorControl()
         return;
     }
 
-    torControlThread = std::thread(std::bind(&TraceThread<void (*)()>, "torcontrol", &TorControlThread));
+    torControlThread = std::thread(TracedThread("torcontrol", TorControlThread));
 }
 
 void InterruptTorControl()

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -668,7 +668,7 @@ std::string HelpMessageOpt(const std::string &option, const std::string &message
            std::string("\n\n");
 }
 
-static std::string FormatException(const std::exception* pex, const char* pszThread)
+static std::string FormatException(const std::exception* pex, const std::string& pszThread)
 {
 #ifdef WIN32
     char pszModule[MAX_PATH] = "";
@@ -684,7 +684,7 @@ static std::string FormatException(const std::exception* pex, const char* pszThr
             "UNKNOWN EXCEPTION       \n%s in %s       \n", pszModule, pszThread);
 }
 
-void PrintExceptionContinue(const std::exception* pex, const char* pszThread)
+void PrintExceptionContinue(const std::exception* pex, const std::string& pszThread)
 {
     std::string message = FormatException(pex, pszThread);
     LogPrintf("\n\n************************\n%s\n", message);
@@ -1258,11 +1258,11 @@ std::function<void()> TracedThread(const std::string name, std::function<void()>
             throw;
         }
         catch (const std::exception& e) {
-            PrintExceptionContinue(&e, name.c_str());
+            PrintExceptionContinue(&e, name);
             throw;
         }
         catch (...) {
-            PrintExceptionContinue(nullptr, name.c_str());
+            PrintExceptionContinue(nullptr, name);
             throw;
         }
     };

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1242,6 +1242,32 @@ int ScheduleBatchPriority()
 #endif
 }
 
+std::function<void()> TracedThread(const std::string name, std::function<void()> func)
+{
+    return [name, func]() {
+        util::ThreadRename(std::string(name));
+        try
+        {
+            LogPrintf("%s thread start\n", name);
+            func();
+            LogPrintf("%s thread exit\n", name);
+        }
+        catch (const boost::thread_interrupted&)
+        {
+            LogPrintf("%s thread interrupt\n", name);
+            throw;
+        }
+        catch (const std::exception& e) {
+            PrintExceptionContinue(&e, name.c_str());
+            throw;
+        }
+        catch (...) {
+            PrintExceptionContinue(nullptr, name.c_str());
+            throw;
+        }
+    };
+}
+
 namespace util {
 #ifdef WIN32
 WinCmdLineArgs::WinCmdLineArgs()

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -50,7 +50,7 @@ bool error(const char* fmt, const Args&... args)
     return false;
 }
 
-void PrintExceptionContinue(const std::exception *pex, const char* pszThread);
+void PrintExceptionContinue(const std::exception *pex, const std::string& pszThread);
 bool FileCommit(FILE *file);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -335,31 +335,10 @@ std::string HelpMessageOpt(const std::string& option, const std::string& message
 int GetNumCores();
 
 /**
- * .. and a wrapper that just calls func once
+ * Create a wrapper around a thread function that sets the thread name and logs
+ * start and exit. It also catches and logs exceptions on the way out.
  */
-template <typename Callable> void TraceThread(const char* name,  Callable func)
-{
-    util::ThreadRename(name);
-    try
-    {
-        LogPrintf("%s thread start\n", name);
-        func();
-        LogPrintf("%s thread exit\n", name);
-    }
-    catch (const boost::thread_interrupted&)
-    {
-        LogPrintf("%s thread interrupt\n", name);
-        throw;
-    }
-    catch (const std::exception& e) {
-        PrintExceptionContinue(&e, name);
-        throw;
-    }
-    catch (...) {
-        PrintExceptionContinue(nullptr, name);
-        throw;
-    }
-}
+std::function<void()> TracedThread(const std::string name, std::function<void()> func);
 
 std::string CopyrightHolders(const std::string& strPrefix);
 


### PR DESCRIPTION
This consists of three commits, the first has the most overall code change but is a refactor. The second adds tracing around the `loadblk` thread. The third is a simple refactor to get rid again of two `c_str()`.

(yes, I considered making `TracedThread` return a `std::thread`, but this isn't possible because it's passed to `threadGroup.create_thread` in two places)