### PR TITLE
Make compiler warn about tautological run-time comparisons

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wvla],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wvla"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wswitch],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wswitch"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wformat-security],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wformat-security"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wtautological-constant-in-range-compare],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wtautological-constant-in-range-compare"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wthread-safety-analysis],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wthread-safety-analysis"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wrange-loop-analysis],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wrange-loop-analysis"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wredundant-decls],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wredundant-decls"],,[[$CXXFLAG_WERROR]])

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -97,7 +97,8 @@ std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDeco
             str += "[error]";
             return str;
         }
-        if (0 <= opcode && opcode <= OP_PUSHDATA4) {
+        static_assert(std::numeric_limits<decltype(opcode)>::min() >= 0, "Assumption: 0 <= opcode");
+        if (opcode <= OP_PUSHDATA4) {
             if (vch.size() <= static_cast<std::vector<unsigned char>::size_type>(4)) {
                 str += strprintf("%d", CScriptNum(vch, false).getint());
             } else {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -227,7 +227,8 @@ bool static CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, co
 
 bool static CheckMinimalPush(const valtype& data, opcodetype opcode) {
     // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal
-    assert(0 <= opcode && opcode <= OP_PUSHDATA4);
+    static_assert(std::numeric_limits<decltype(opcode)>::min() >= 0, "Assumption: 0 <= opcode");
+    assert(opcode <= OP_PUSHDATA4);
     if (data.size() == 0) {
         // Should have used OP_0.
         return opcode == OP_0;
@@ -340,7 +341,8 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
             if (opcode == OP_CODESEPARATOR && sigversion == SigVersion::BASE && (flags & SCRIPT_VERIFY_CONST_SCRIPTCODE))
                 return set_error(serror, SCRIPT_ERR_OP_CODESEPARATOR);
 
-            if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4) {
+            static_assert(std::numeric_limits<decltype(opcode)>::min() >= 0, "Assumption: 0 <= opcode");
+            if (fExec && opcode <= OP_PUSHDATA4) {
                 if (fRequireMinimal && !CheckMinimalPush(vchPushValue, opcode)) {
                     return set_error(serror, SCRIPT_ERR_MINIMALDATA);
                 }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -446,8 +446,7 @@ public:
 
     CScript& operator<<(opcodetype opcode)
     {
-        if (opcode < 0 || opcode > 0xff)
-            throw std::runtime_error("CScript::operator<<(): invalid opcode");
+        static_assert(std::numeric_limits<decltype(opcode)>::min() >= 0 && std::numeric_limits<decltype(opcode)>::max() <= 0xff, "Assumption: !(opcode < 0 || opcode > 0xff)");
         insert(end(), (unsigned char)opcode);
         return *this;
     }

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -300,9 +300,9 @@ bool ParseInt64(const std::string& str, int64_t *out)
     if(out) *out = (int64_t)n;
     // Note that strtoll returns a *long long int*, so even if strtol doesn't report an over/underflow
     // we still have to check that the returned value is within the range of an *int64_t*.
-    return endp && *endp == 0 && !errno &&
-        n >= std::numeric_limits<int64_t>::min() &&
-        n <= std::numeric_limits<int64_t>::max();
+    static_assert(std::numeric_limits<decltype(n)>::min() >= std::numeric_limits<int64_t>::min(), "Assumption: n >= std::numeric_limits<int64_t>::min()");
+    static_assert(std::numeric_limits<decltype(n)>::max() <= std::numeric_limits<int64_t>::max(), "Assumption: n <= std::numeric_limits<int64_t>::max()");
+    return endp && *endp == 0 && !errno;
 }
 
 bool ParseUInt32(const std::string& str, uint32_t *out)
@@ -334,8 +334,8 @@ bool ParseUInt64(const std::string& str, uint64_t *out)
     if(out) *out = (uint64_t)n;
     // Note that strtoull returns a *unsigned long long int*, so even if it doesn't report an over/underflow
     // we still have to check that the returned value is within the range of an *uint64_t*.
-    return endp && *endp == 0 && !errno &&
-        n <= std::numeric_limits<uint64_t>::max();
+    static_assert(std::numeric_limits<decltype(n)>::max() <= std::numeric_limits<uint64_t>::max(), "Assumption: n <= std::numeric_limits<uint64_t>::max()");
+    return endp && *endp == 0 && !errno;
 }
 
 


### PR DESCRIPTION
_Submitting as draft pull request: seeking Concept ACK:s._

Tautological run-time checks may be an indication of incorrect logic. Enabling compiler warnings for tautological checks can help identify such issues early in the development cycle.

If it is clear already at compile-time that a run-time check is tautological it is better to make it a compile-time check using `static_assert` (if possible and assuming the check should be kept).

Compile-time checking is preferred over run-time checking as noted in the developer notes:

> `static_assert` is preferred over `assert` where possible. Generally; compile-time checking is preferred over run-time checking.

Suggested changes in this PR:
* Commit 1. Make compiler warn about tautological comparisons (`-Wtautological-constant-in-range-compare` in Clang)
* Commit 2. Get rid of current warnings by replacing the run-time tautological comparisons with equivalent compile-time assertions (`static_assert`)

---

Compiler output given `-Wtautological-constant-in-range-compare` before this PR:

```
$ make
util/strencodings.cpp:304:11: warning: result of comparison 'long long' >= -9223372036854775808 is always true [-Wtautological-type-limit-compare]
        n >= std::numeric_limits<int64_t>::min() &&
        ~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
util/strencodings.cpp:305:11: warning: result of comparison 'long long' <= 9223372036854775807 is always true [-Wtautological-type-limit-compare]
        n <= std::numeric_limits<int64_t>::max();
        ~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
util/strencodings.cpp:338:11: warning: result of comparison 'unsigned long long' <= 18446744073709551615 is always true [-Wtautological-type-limit-compare]
        n <= std::numeric_limits<uint64_t>::max();
        ~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
core_write.cpp:100:15: warning: result of comparison of 0 <= unsigned enum expression is always true [-Wtautological-unsigned-enum-zero-compare]
        if (0 <= opcode && opcode <= OP_PUSHDATA4) {
            ~ ^  ~~~~~~
script/script.h:449:20: warning: result of comparison of unsigned enum expression < 0 is always false [-Wtautological-unsigned-enum-zero-compare]
        if (opcode < 0 || opcode > 0xff)
            ~~~~~~ ^ ~
script/script.h:449:34: warning: result of comparison 'opcodetype' > 255 is always false [-Wtautological-type-limit-compare]
        if (opcode < 0 || opcode > 0xff)
                          ~~~~~~ ^ ~~~~
script/interpreter.cpp:343:28: warning: result of comparison of 0 <= unsigned enum expression is always true [-Wtautological-unsigned-enum-zero-compare]
            if (fExec && 0 <= opcode && opcode <= OP_PUSHDATA4) {
                         ~ ^  ~~~~~~
$
```

Compiler output given `-Wtautological-constant-in-range-compare` after this PR:

```
$ make
$
```