### PR TITLE
Fix input size assertion in wallet_bumpfee.py

### DIFF
--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -211,15 +211,15 @@ def test_small_output_with_feerate_succeeds(rbf_node, dest_address):
     # Make sure additional inputs exist
     rbf_node.generatetoaddress(101, rbf_node.getnewaddress())
     rbfid = spend_one_input(rbf_node, dest_address)
-    original_input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
-    assert_equal(len(original_input_list), 1)
-    original_txin = original_input_list[0]
+    input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
+    assert_equal(len(input_list), 1)
+    original_txin = input_list[0]
     # Keep bumping until we out-spend change output
     tx_fee = 0
     while tx_fee < Decimal("0.0005"):
-        new_input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
-        new_item = list(new_input_list)[0]
-        assert_equal(len(original_input_list), 1)
+        input_list = rbf_node.getrawtransaction(rbfid, 1)["vin"]
+        new_item = list(input_list)[0]
+        assert_equal(len(input_list), 1)
         assert_equal(original_txin["txid"], new_item["txid"])
         assert_equal(original_txin["vout"], new_item["vout"])
         rbfid_new_details = rbf_node.bumpfee(rbfid)


### PR DESCRIPTION
I was investigating a curious error for https://github.com/bitcoin/bitcoin/pull/17290 and realized that this check should have caught that error earlier in the test.

The loop is intended to ensure that only a single input exists the entire time until the change output disappears, a single additional bump occurs, then it leaves the loop. 