### PR TITLE
test: add rpc_fundrawtransaction logging

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -91,7 +91,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.test_option_subtract_fee_from_outputs()
 
     def test_change_position(self):
-        # ensure that setting changePosition in fundraw with an exact match is handled properly
+        """Ensure setting changePosition in fundraw with an exact match is handled properly."""
         self.log.info("Test fundrawtxn changePosition option")
         rawmatch = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():50})
         rawmatch = self.nodes[2].fundrawtransaction(rawmatch, {"changePosition":1, "subtractFeeFromOutputs":[0]})
@@ -117,9 +117,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
     def test_simple(self):
-        ###############
-        # simple test #
-        ###############
         self.log.info("Test fundrawtxn")
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 1.0 }
@@ -130,9 +127,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert len(dec_tx['vin']) > 0  #test that we have enough inputs
 
     def test_simple_two_coins(self):
-        ##############################
-        # simple test with two coins #
-        ##############################
         self.log.info("Test fundrawtxn with 2 coins")
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 2.2 }
@@ -145,9 +139,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
     def test_simple_two_outputs(self):
-        ################################
-        # simple test with two outputs #
-        ################################
         self.log.info("Test fundrawtxn with 2 outputs")
 
         inputs  = [ ]
@@ -165,9 +156,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(dec_tx['vin'][0]['scriptSig']['hex'], '')
 
     def test_change(self):
-        #########################################################################
-        # test a fundrawtransaction with a VIN greater than the required amount #
-        #########################################################################
         self.log.info("Test fundrawtxn with a vin > required amount")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -188,9 +176,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(fee + totalOut, utx['amount']) #compare vin total and totalout+fee
 
     def test_no_change(self):
-        #####################################################################
-        # test a fundrawtransaction with which will not get a change output #
-        #####################################################################
         self.log.info("Test fundrawtxn not having a change output")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -211,9 +196,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(fee + totalOut, utx['amount']) #compare vin total and totalout+fee
 
     def test_invalid_option(self):
-        ####################################################
-        # test a fundrawtransaction with an invalid option #
-        ####################################################
         self.log.info("Test fundrawtxn with an invalid option")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -229,9 +211,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-3, "Unexpected key reserveChangeKey", lambda: self.nodes[2].fundrawtransaction(hexstring=rawtx, options={'reserveChangeKey': True}))
 
     def test_invalid_change_address(self):
-        ############################################################
-        # test a fundrawtransaction with an invalid change address #
-        ############################################################
         self.log.info("Test fundrawtxn with an invalid change address")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -244,9 +223,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, "changeAddress must be a valid bitcoin address", self.nodes[2].fundrawtransaction, rawtx, {'changeAddress':'foobar'})
 
     def test_valid_change_address(self):
-        ############################################################
-        # test a fundrawtransaction with a provided change address #
-        ############################################################
         self.log.info("Test fundrawtxn with a provided change address")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -264,9 +240,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(change, out['scriptPubKey']['addresses'][0])
 
     def test_change_type(self):
-        #########################################################
-        # test a fundrawtransaction with a provided change type #
-        #########################################################
         self.log.info("Test fundrawtxn with a provided change type")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -280,9 +253,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal('witness_v0_keyhash', dec_tx['vout'][rawtx['changepos']]['scriptPubKey']['type'])
 
     def test_coin_selection(self):
-        #########################################################################
-        # test a fundrawtransaction with a VIN smaller than the required amount #
-        #########################################################################
         self.log.info("Test fundrawtxn with a vin < required amount")
         utx = get_unspent(self.nodes[2].listunspent(), 1)
 
@@ -315,9 +285,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(len(dec_tx['vout']), 2)
 
     def test_two_vin(self):
-        ###########################################
-        # test a fundrawtransaction with two VINs #
-        ###########################################
         self.log.info("Test fundrawtxn with 2 vins")
         utx = get_unspent(self.nodes[2].listunspent(), 1)
         utx2 = get_unspent(self.nodes[2].listunspent(), 5)
@@ -349,9 +316,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(matchingIns, 2) #we now must see two vins identical to vins given as params
 
     def test_two_vin_two_vout(self):
-        #########################################################
-        # test a fundrawtransaction with two VINs and two vOUTs #
-        #########################################################
         self.log.info("Test fundrawtxn with 2 vins and 2 vouts")
         utx = get_unspent(self.nodes[2].listunspent(), 1)
         utx2 = get_unspent(self.nodes[2].listunspent(), 5)
@@ -375,9 +339,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(len(dec_tx['vout']), 3)
 
     def test_invalid_input(self):
-        ##############################################
-        # test a fundrawtransaction with invalid vin #
-        ##############################################
         self.log.info("Test fundrawtxn with an invalid vin")
         inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
         outputs = { self.nodes[0].getnewaddress() : 1.0}
@@ -385,26 +346,23 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, "Insufficient funds", self.nodes[2].fundrawtransaction, rawtx)
 
     def test_fee_p2pkh(self):
-        ############################################################
-        #compare fee of a standard pubkeyhash transaction
+        """Compare fee of a standard pubkeyhash transaction."""
         self.log.info("Test fundrawtxn p2pkh fee")
         inputs = []
         outputs = {self.nodes[1].getnewaddress():1.1}
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
 
-        #create same transaction over sendtoaddress
+        # Create same transaction over sendtoaddress.
         txId = self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1.1)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
-        #compare fee
+        # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
-        ############################################################
 
     def test_fee_p2pkh_multi_out(self):
-        ############################################################
-        #compare fee of a standard pubkeyhash transaction with multiple outputs
+        """Compare fee of a standard pubkeyhash transaction with multiple outputs."""
         self.log.info("Test fundrawtxn p2pkh fee with multiple outputs")
         inputs = []
         outputs = {
@@ -417,20 +375,18 @@ class RawTransactionsTest(BitcoinTestFramework):
         }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
-        #create same transaction over sendtoaddress
+
+        # Create same transaction over sendtoaddress.
         txId = self.nodes[0].sendmany("", outputs)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
-        #compare fee
+        # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
-        ############################################################
 
     def test_fee_p2sh(self):
-        ############################################################
-        #compare fee of a 2of2 multisig p2sh transaction
-
-        # create 2of2 addr
+        """Compare fee of a 2-of-2 multisig p2sh transaction."""
+        # Create 2-of-2 addr.
         addr1 = self.nodes[1].getnewaddress()
         addr2 = self.nodes[1].getnewaddress()
 
@@ -444,21 +400,19 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
 
-        #create same transaction over sendtoaddress
+        # Create same transaction over sendtoaddress.
         txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
-        #compare fee
+        # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
-        ############################################################
 
     def test_fee_4of5(self):
-        ############################################################
-        #compare fee of a standard pubkeyhash transaction
+        """Compare fee of a standard pubkeyhash transaction."""
         self.log.info("Test fundrawtxn fee with 4-of-5 addresses")
 
-        # create 4of5 addr
+        # Create 4-of-5 addr.
         addr1 = self.nodes[1].getnewaddress()
         addr2 = self.nodes[1].getnewaddress()
         addr3 = self.nodes[1].getnewaddress()
@@ -487,21 +441,19 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
 
-        #create same transaction over sendtoaddress
+        # Create same transaction over sendtoaddress.
         txId = self.nodes[0].sendtoaddress(mSigObj, 1.1)
         signedFee = self.nodes[0].getrawmempool(True)[txId]['fee']
 
-        #compare fee
+        # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
-        ############################################################
 
     def test_spend_2of2(self):
-        ############################################################
-        # spend a 2of2 multisig transaction over fundraw
+        """Spend a 2-of-2 multisig transaction over fundraw."""
         self.log.info("Test fundrawtxn spending 2-of-2 multisig")
 
-        # create 2of2 addr
+        # Create 2-of-2 addr.
         addr1 = self.nodes[2].getnewaddress()
         addr2 = self.nodes[2].getnewaddress()
 
@@ -516,7 +468,7 @@ class RawTransactionsTest(BitcoinTestFramework):
             ]
         )['address']
 
-        # send 1.2 BTC to msig addr
+        # Send 1.2 BTC to msig addr.
         self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[1].generate(1)
@@ -534,12 +486,10 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[1].generate(1)
         self.sync_all()
 
-        # make sure funds are received at node1
+        # Make sure funds are received at node1.
         assert_equal(oldBalance+Decimal('1.10000000'), self.nodes[1].getbalance())
 
     def test_locked_wallet(self):
-        ############################################################
-        # locked wallet test
         self.log.info("Test fundrawtxn with locked wallet")
 
         self.nodes[1].encryptwallet("test")
@@ -547,7 +497,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         self.start_nodes()
         # This test is not meant to test fee estimation and we'd like
-        # to be sure all txs are sent at a consistent desired feerate
+        # to be sure all txns are sent at a consistent desired feerate.
         for node in self.nodes:
             node.settxfee(self.min_relay_tx_fee)
 
@@ -556,11 +506,11 @@ class RawTransactionsTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 2)
         connect_nodes(self.nodes[0], 3)
         # Again lock the watchonly UTXO or nodes[0] may spend it, because
-        # lockunspent is memory-only and thus lost on restart
+        # lockunspent is memory-only and thus lost on restart.
         self.nodes[0].lockunspent(False, [{"txid": self.watchonly_txid, "vout": self.watchonly_vout}])
         self.sync_all()
 
-        # drain the keypool
+        # Drain the keypool.
         self.nodes[1].getnewaddress()
         self.nodes[1].getrawchangeaddress()
         inputs = []
@@ -570,7 +520,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         # creating the key must be impossible because the wallet is locked
         assert_raises_rpc_error(-4, "Keypool ran out, please call keypoolrefill first", self.nodes[1].fundrawtransaction, rawtx)
 
-        #refill the keypool
+        # Refill the keypool.
         self.nodes[1].walletpassphrase("test", 100)
         self.nodes[1].keypoolrefill(8) #need to refill the keypool to get an internal change address
         self.nodes[1].walletlock()
@@ -584,23 +534,21 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
 
-        #now we need to unlock
+        # Now we need to unlock.
         self.nodes[1].walletpassphrase("test", 600)
         signedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
         self.nodes[1].sendrawtransaction(signedTx['hex'])
         self.nodes[1].generate(1)
         self.sync_all()
 
-        # make sure funds are received at node1
+        # Make sure funds are received at node1.
         assert_equal(oldBalance+Decimal('51.10000000'), self.nodes[0].getbalance())
 
     def test_many_inputs_fee(self):
-        ###############################################
-        # multiple (~19) inputs tx test | Compare fee #
-        ###############################################
+        """Multiple (~19) inputs tx test | Compare fee."""
         self.log.info("Test fundrawtxn fee with many inputs")
 
-        #empty node1, send some small coins from node0 to node1
+        # Empty node1, send some small coins from node0 to node1.
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
         self.sync_all()
         self.nodes[0].generate(1)
@@ -611,27 +559,25 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        #fund a tx with ~20 small inputs
+        # Fund a tx with ~20 small inputs.
         inputs = []
         outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
 
-        #create same transaction over sendtoaddress
+        # Create same transaction over sendtoaddress.
         txId = self.nodes[1].sendmany("", outputs)
         signedFee = self.nodes[1].getrawmempool(True)[txId]['fee']
 
-        #compare fee
+        # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
         assert feeDelta >= 0 and feeDelta <= self.fee_tolerance * 19  #~19 inputs
 
     def test_many_inputs_send(self):
-        #############################################
-        # multiple (~19) inputs tx test | sign/send #
-        #############################################
+        """Multiple (~19) inputs tx test | sign/send."""
         self.log.info("Test fundrawtxn sign+send with many inputs")
 
-        #again, empty node1, send some small coins from node0 to node1
+        # Again, empty node1, send some small coins from node0 to node1.
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
         self.sync_all()
         self.nodes[0].generate(1)
@@ -642,7 +588,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].generate(1)
         self.sync_all()
 
-        #fund a tx with ~20 small inputs
+        # Fund a tx with ~20 small inputs.
         oldBalance = self.nodes[0].getbalance()
 
         inputs = []
@@ -657,9 +603,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(oldBalance+Decimal('50.19000000'), self.nodes[0].getbalance()) #0.19+block reward
 
     def test_op_return(self):
-        #####################################################
-        # test fundrawtransaction with OP_RETURN and no vin #
-        #####################################################
         self.log.info("Test fundrawtxn with OP_RETURN and no vin")
 
         rawtx   = "0100000000010000000000000000066a047465737400000000"
@@ -675,9 +618,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(len(dec_tx['vout']), 2) # one change output added
 
     def test_watchonly(self):
-        ##################################################
-        # test a fundrawtransaction using only watchonly #
-        ##################################################
         self.log.info("Test fundrawtxn using only watchonly")
 
         inputs = []
@@ -693,16 +633,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_greater_than(result["changepos"], -1)
 
     def test_all_watched_funds(self):
-        ###############################################################
-        # test fundrawtransaction using the entirety of watched funds #
-        ###############################################################
         self.log.info("Test fundrawtxn using entirety of watched funds")
 
         inputs = []
         outputs = {self.nodes[2].getnewaddress(): self.watchonly_amount}
         rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
 
-        # Backward compatibility test (2nd param is includeWatching)
+        # Backward compatibility test (2nd param is includeWatching).
         result = self.nodes[3].fundrawtransaction(rawtx, True)
         res_dec = self.nodes[0].decoderawtransaction(result["hex"])
         assert_equal(len(res_dec["vin"]), 2)
@@ -721,12 +658,9 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
 
     def test_option_feerate(self):
-        #######################
-        # Test feeRate option #
-        #######################
         self.log.info("Test fundrawtxn feeRate option")
 
-        # Make sure there is exactly one input so coin selection can't skew the result
+        # Make sure there is exactly one input so coin selection can't skew the result.
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
 
         inputs = []
@@ -741,9 +675,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_fee_amount(result3['fee'], count_bytes(result3['hex']), 10 * result_fee_rate)
 
     def test_address_reuse(self):
-        ################################
-        # Test no address reuse occurs #
-        ################################
+        """Test no address reuse occurs."""
         self.log.info("Test fundrawtxn does not reuse addresses")
 
         rawtx = self.nodes[3].createrawtransaction(inputs=[], outputs={self.nodes[3].getnewaddress(): 1})
@@ -755,16 +687,13 @@ class RawTransactionsTest(BitcoinTestFramework):
                 changeaddress += out['scriptPubKey']['addresses'][0]
         assert changeaddress != ""
         nextaddr = self.nodes[3].getnewaddress()
-        # Now the change address key should be removed from the keypool
+        # Now the change address key should be removed from the keypool.
         assert changeaddress != nextaddr
 
     def test_option_subtract_fee_from_outputs(self):
-        ######################################
-        # Test subtractFeeFromOutputs option #
-        ######################################
         self.log.info("Test fundrawtxn subtractFeeFromOutputs option")
 
-        # Make sure there is exactly one input so coin selection can't skew the result
+        # Make sure there is exactly one input so coin selection can't skew the result.
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
 
         inputs = []
@@ -795,38 +724,39 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
 
         result = [self.nodes[3].fundrawtransaction(rawtx),
-                  # split the fee between outputs 0, 2, and 3, but not output 1
+                  # Split the fee between outputs 0, 2, and 3, but not output 1.
                   self.nodes[3].fundrawtransaction(rawtx, {"subtractFeeFromOutputs": [0, 2, 3]})]
 
         dec_tx = [self.nodes[3].decoderawtransaction(result[0]['hex']),
                   self.nodes[3].decoderawtransaction(result[1]['hex'])]
 
-        # Nested list of non-change output amounts for each transaction
+        # Nested list of non-change output amounts for each transaction.
         output = [[out['value'] for i, out in enumerate(d['vout']) if i != r['changepos']]
                   for d, r in zip(dec_tx, result)]
 
-        # List of differences in output amounts between normal and subtractFee transactions
+        # List of differences in output amounts between normal and subtractFee transactions.
         share = [o0 - o1 for o0, o1 in zip(output[0], output[1])]
 
-        # output 1 is the same in both transactions
+        # Output 1 is the same in both transactions.
         assert_equal(share[1], 0)
 
-        # the other 3 outputs are smaller as a result of subtractFeeFromOutputs
+        # The other 3 outputs are smaller as a result of subtractFeeFromOutputs.
         assert_greater_than(share[0], 0)
         assert_greater_than(share[2], 0)
         assert_greater_than(share[3], 0)
 
-        # outputs 2 and 3 take the same share of the fee
+        # Outputs 2 and 3 take the same share of the fee.
         assert_equal(share[2], share[3])
 
-        # output 0 takes at least as much share of the fee, and no more than 2 satoshis more, than outputs 2 and 3
+        # Output 0 takes at least as much share of the fee, and no more than 2
+        # satoshis more, than outputs 2 and 3.
         assert_greater_than_or_equal(share[0], share[2])
         assert_greater_than_or_equal(share[2] + Decimal(2e-8), share[0])
 
-        # the fee is the same in both transactions
+        # The fee is the same in both transactions.
         assert_equal(result[0]['fee'], result[1]['fee'])
 
-        # the total subtracted from the outputs is equal to the fee
+        # The total subtracted from the outputs is equal to the fee.
         assert_equal(share[0] + share[2] + share[3], result[0]['fee'])
 
 if __name__ == '__main__':

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -41,6 +41,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         connect_nodes(self.nodes[0], 3)
 
     def run_test(self):
+        self.log.info("Connect nodes, set fees, generate blocks, and sync")
         self.min_relay_tx_fee = self.nodes[0].getnetworkinfo()['relayfee']
         # This test is not meant to test fee estimation and we'd like
         # to be sure all txs are sent at a consistent desired feerate
@@ -91,6 +92,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
     def test_change_position(self):
         # ensure that setting changePosition in fundraw with an exact match is handled properly
+        self.log.info("Test fundrawtxn changePosition option")
         rawmatch = self.nodes[2].createrawtransaction([], {self.nodes[2].getnewaddress():50})
         rawmatch = self.nodes[2].fundrawtransaction(rawmatch, {"changePosition":1, "subtractFeeFromOutputs":[0]})
         assert_equal(rawmatch["changepos"], -1)
@@ -118,6 +120,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###############
         # simple test #
         ###############
+        self.log.info("Test fundrawtxn")
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 1.0 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
@@ -130,6 +133,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ##############################
         # simple test with two coins #
         ##############################
+        self.log.info("Test fundrawtxn with 2 coins")
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 2.2 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
@@ -144,6 +148,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         ################################
         # simple test with two outputs #
         ################################
+        self.log.info("Test fundrawtxn with 2 outputs")
+
         inputs  = [ ]
         outputs = { self.nodes[0].getnewaddress() : 2.6, self.nodes[1].getnewaddress() : 2.5 }
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
@@ -162,6 +168,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################################
         # test a fundrawtransaction with a VIN greater than the required amount #
         #########################################################################
+        self.log.info("Test fundrawtxn with a vin > required amount")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
@@ -184,6 +191,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #####################################################################
         # test a fundrawtransaction with which will not get a change output #
         #####################################################################
+        self.log.info("Test fundrawtxn not having a change output")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
@@ -206,6 +214,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ####################################################
         # test a fundrawtransaction with an invalid option #
         ####################################################
+        self.log.info("Test fundrawtxn with an invalid option")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
@@ -223,6 +232,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         # test a fundrawtransaction with an invalid change address #
         ############################################################
+        self.log.info("Test fundrawtxn with an invalid change address")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
@@ -237,6 +247,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ############################################################
         # test a fundrawtransaction with a provided change address #
         ############################################################
+        self.log.info("Test fundrawtxn with a provided change address")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
@@ -256,6 +267,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################
         # test a fundrawtransaction with a provided change type #
         #########################################################
+        self.log.info("Test fundrawtxn with a provided change type")
         utx = get_unspent(self.nodes[2].listunspent(), 5)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']} ]
@@ -271,6 +283,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################################
         # test a fundrawtransaction with a VIN smaller than the required amount #
         #########################################################################
+        self.log.info("Test fundrawtxn with a vin < required amount")
         utx = get_unspent(self.nodes[2].listunspent(), 1)
 
         inputs  = [ {'txid' : utx['txid'], 'vout' : utx['vout']}]
@@ -305,6 +318,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###########################################
         # test a fundrawtransaction with two VINs #
         ###########################################
+        self.log.info("Test fundrawtxn with 2 vins")
         utx = get_unspent(self.nodes[2].listunspent(), 1)
         utx2 = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -338,6 +352,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #########################################################
         # test a fundrawtransaction with two VINs and two vOUTs #
         #########################################################
+        self.log.info("Test fundrawtxn with 2 vins and 2 vouts")
         utx = get_unspent(self.nodes[2].listunspent(), 1)
         utx2 = get_unspent(self.nodes[2].listunspent(), 5)
 
@@ -363,6 +378,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ##############################################
         # test a fundrawtransaction with invalid vin #
         ##############################################
+        self.log.info("Test fundrawtxn with an invalid vin")
         inputs  = [ {'txid' : "1c7f966dab21119bac53213a2bc7532bff1fa844c124fd750a7d0b1332440bd1", 'vout' : 0} ] #invalid vin!
         outputs = { self.nodes[0].getnewaddress() : 1.0}
         rawtx   = self.nodes[2].createrawtransaction(inputs, outputs)
@@ -371,6 +387,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_fee_p2pkh(self):
         ############################################################
         #compare fee of a standard pubkeyhash transaction
+        self.log.info("Test fundrawtxn p2pkh fee")
         inputs = []
         outputs = {self.nodes[1].getnewaddress():1.1}
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
@@ -388,8 +405,16 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_fee_p2pkh_multi_out(self):
         ############################################################
         #compare fee of a standard pubkeyhash transaction with multiple outputs
+        self.log.info("Test fundrawtxn p2pkh fee with multiple outputs")
         inputs = []
-        outputs = {self.nodes[1].getnewaddress():1.1,self.nodes[1].getnewaddress():1.2,self.nodes[1].getnewaddress():0.1,self.nodes[1].getnewaddress():1.3,self.nodes[1].getnewaddress():0.2,self.nodes[1].getnewaddress():0.3}
+        outputs = {
+            self.nodes[1].getnewaddress():1.1,
+            self.nodes[1].getnewaddress():1.2,
+            self.nodes[1].getnewaddress():0.1,
+            self.nodes[1].getnewaddress():1.3,
+            self.nodes[1].getnewaddress():0.2,
+            self.nodes[1].getnewaddress():0.3,
+        }
         rawtx = self.nodes[0].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[0].fundrawtransaction(rawtx)
         #create same transaction over sendtoaddress
@@ -431,6 +456,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_fee_4of5(self):
         ############################################################
         #compare fee of a standard pubkeyhash transaction
+        self.log.info("Test fundrawtxn fee with 4-of-5 addresses")
 
         # create 4of5 addr
         addr1 = self.nodes[1].getnewaddress()
@@ -445,7 +471,16 @@ class RawTransactionsTest(BitcoinTestFramework):
         addr4Obj = self.nodes[1].getaddressinfo(addr4)
         addr5Obj = self.nodes[1].getaddressinfo(addr5)
 
-        mSigObj = self.nodes[1].addmultisigaddress(4, [addr1Obj['pubkey'], addr2Obj['pubkey'], addr3Obj['pubkey'], addr4Obj['pubkey'], addr5Obj['pubkey']])['address']
+        mSigObj = self.nodes[1].addmultisigaddress(
+            4,
+            [
+                addr1Obj['pubkey'],
+                addr2Obj['pubkey'],
+                addr3Obj['pubkey'],
+                addr4Obj['pubkey'],
+                addr5Obj['pubkey'],
+            ]
+        )['address']
 
         inputs = []
         outputs = {mSigObj:1.1}
@@ -464,6 +499,7 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_spend_2of2(self):
         ############################################################
         # spend a 2of2 multisig transaction over fundraw
+        self.log.info("Test fundrawtxn spending 2-of-2 multisig")
 
         # create 2of2 addr
         addr1 = self.nodes[2].getnewaddress()
@@ -472,8 +508,13 @@ class RawTransactionsTest(BitcoinTestFramework):
         addr1Obj = self.nodes[2].getaddressinfo(addr1)
         addr2Obj = self.nodes[2].getaddressinfo(addr2)
 
-        mSigObj = self.nodes[2].addmultisigaddress(2, [addr1Obj['pubkey'], addr2Obj['pubkey']])['address']
-
+        mSigObj = self.nodes[2].addmultisigaddress(
+            2,
+            [
+                addr1Obj['pubkey'],
+                addr2Obj['pubkey'],
+            ]
+        )['address']
 
         # send 1.2 BTC to msig addr
         self.nodes[0].sendtoaddress(mSigObj, 1.2)
@@ -499,6 +540,8 @@ class RawTransactionsTest(BitcoinTestFramework):
     def test_locked_wallet(self):
         ############################################################
         # locked wallet test
+        self.log.info("Test fundrawtxn with locked wallet")
+
         self.nodes[1].encryptwallet("test")
         self.stop_nodes()
 
@@ -555,6 +598,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###############################################
         # multiple (~19) inputs tx test | Compare fee #
         ###############################################
+        self.log.info("Test fundrawtxn fee with many inputs")
 
         #empty node1, send some small coins from node0 to node1
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
@@ -585,6 +629,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #############################################
         # multiple (~19) inputs tx test | sign/send #
         #############################################
+        self.log.info("Test fundrawtxn sign+send with many inputs")
 
         #again, empty node1, send some small coins from node0 to node1
         self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), self.nodes[1].getbalance(), "", "", True)
@@ -615,6 +660,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #####################################################
         # test fundrawtransaction with OP_RETURN and no vin #
         #####################################################
+        self.log.info("Test fundrawtxn with OP_RETURN and no vin")
 
         rawtx   = "0100000000010000000000000000066a047465737400000000"
         dec_tx  = self.nodes[2].decoderawtransaction(rawtx)
@@ -632,6 +678,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ##################################################
         # test a fundrawtransaction using only watchonly #
         ##################################################
+        self.log.info("Test fundrawtxn using only watchonly")
 
         inputs = []
         outputs = {self.nodes[2].getnewaddress(): self.watchonly_amount / 2}
@@ -649,6 +696,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ###############################################################
         # test fundrawtransaction using the entirety of watched funds #
         ###############################################################
+        self.log.info("Test fundrawtxn using entirety of watched funds")
 
         inputs = []
         outputs = {self.nodes[2].getnewaddress(): self.watchonly_amount}
@@ -676,6 +724,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #######################
         # Test feeRate option #
         #######################
+        self.log.info("Test fundrawtxn feeRate option")
 
         # Make sure there is exactly one input so coin selection can't skew the result
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
@@ -695,6 +744,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ################################
         # Test no address reuse occurs #
         ################################
+        self.log.info("Test fundrawtxn does not reuse addresses")
 
         rawtx = self.nodes[3].createrawtransaction(inputs=[], outputs={self.nodes[3].getnewaddress(): 1})
         result3 = self.nodes[3].fundrawtransaction(rawtx)
@@ -712,6 +762,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         ######################################
         # Test subtractFeeFromOutputs option #
         ######################################
+        self.log.info("Test fundrawtxn subtractFeeFromOutputs option")
 
         # Make sure there is exactly one input so coin selection can't skew the result
         assert_equal(len(self.nodes[3].listunspent(1)), 1)


### PR DESCRIPTION
`test/functional/rpc_fundrawtransaction.py` is fairly slow to run and has no logging, so it can appear to be stalled.

This commit adds info logging at each test to provide feedback on the test run.
