### PR TITLE
linter: Strip trailing / in path for git-subtree-check

### DIFF
--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -4,7 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 export LC_ALL=C
-DIR="$1"
+# Strip trailing / from directory path (in case it was added by autocomplete)
+DIR="${1%/}"
 COMMIT="$2"
 if [ -z "$COMMIT" ]; then
     COMMIT=HEAD


### PR DESCRIPTION
git-subtree-check fails if the directory is given with a trailing slash,
eg:

```
> test/lint/git-subtree-check.sh src/univalue/
ERROR: src/univalue/ is not a subtree
```

Shell autocompletes will add the trailing slash when autofilling the
path name, which will therefore cause the script to fail.

Just ignore any trailing slash.