### PR TITLE
test: Add shrinkdebugfile=0 to regtest bitcoin.conf

### DIFF
--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -316,6 +316,7 @@ def initialize_datadir(dirname, n, chain):
         f.write("listenonion=0\n")
         f.write("printtoconsole=0\n")
         f.write("upnp=0\n")
+        f.write("shrinkdebugfile=0\n")
         os.makedirs(os.path.join(datadir, 'stderr'), exist_ok=True)
         os.makedirs(os.path.join(datadir, 'stdout'), exist_ok=True)
     return datadir


### PR DESCRIPTION
This helps avoid accidentally truncating the debug.log while manually
debugging.