### PR TITLE
doc: Add template for good first issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.md
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.md
@@ -1,0 +1,20 @@
+---
+name: Good first issue
+about: '(Regular devs only): Suggest a new good first issue'
+title: ''
+labels: good first issue
+assignees: ''
+
+---
+
+The purpose of the `good first issue` label is to highlight which issues are suitable for a new contributor without a deep understanding of the codebase.
+
+Useful skills:
+
+(For example, “C++11 std::thread”, “Qt5 GUI and async GUI design” or “basic understanding of Bitcoin mining and the Bitcoin Core RPC interface”.)
+
+Want to work on this issue?
+
+You do not need to request permission to start working on this. You are encouraged to comment on the issue if you are planning to work on it. This will help other contributors monitor which issues are actively being addressed and is also an effective way to request assistance if and when you need it.
+
+For guidance on contributing, please read [CONTRIBUTING.md](https://github.com/bitcoin/bitcoin/blob/master/CONTRIBUTING.md) before opening your pull request.


### PR DESCRIPTION
closes #17317 

Attempted to address everyone's suggestions in #17317 without making it too long. The first half is for the benefit of the individual opening the issue and the second half is for the benefit of the new contributor. Ideally we don't want the second half to be deleted by the individual opening the issue but whether they delete the first half or not isn't really a concern