### PR TITLE
build:lint eliminate some lint spelling alerts

### DIFF
--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -13,3 +13,4 @@ errorstring
 keyserver
 homogenous
 setban
+hist


### PR DESCRIPTION
Eliminates another linting alert in the linting sequence.
In this case it is a false positive. "hist" is used as a variable.
https://github.com/bitcoin/bitcoin/blob/6a7c40bee403cadedeecd4b1c6528575522094eb/contrib/seeds/makeseeds.py#L119