### PR TITLE
Remove redundant copy constructors

### DIFF
--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -23,12 +23,6 @@ struct Available {
     size_t vin_left{0};
     size_t tx_count;
     Available(CTransactionRef& ref, size_t tx_count) : ref(ref), tx_count(tx_count){}
-    Available& operator=(Available other) {
-        ref = other.ref;
-        vin_left = other.vin_left;
-        tx_count = other.tx_count;
-        return *this;
-    }
 };
 
 static void ComplexMemPool(benchmark::State& state)
@@ -66,7 +60,7 @@ static void ComplexMemPool(benchmark::State& state)
                 tx.vin.back().scriptSig = CScript() << coin.tx_count;
                 tx.vin.back().scriptWitness.stack.push_back(CScriptNum(coin.tx_count).getvch());
             }
-            if  (coin.vin_left == coin.ref->vin.size()) {
+            if (coin.vin_left == coin.ref->vin.size()) {
                 coin = available_coins.back();
                 available_coins.pop_back();
             }

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -401,7 +401,6 @@ struct PartiallySignedTransaction
     bool AddInput(const CTxIn& txin, PSBTInput& psbtin);
     bool AddOutput(const CTxOut& txout, const PSBTOutput& psbtout);
     PartiallySignedTransaction() {}
-    PartiallySignedTransaction(const PartiallySignedTransaction& psbt_in) : tx(psbt_in.tx), inputs(psbt_in.inputs), outputs(psbt_in.outputs), unknown(psbt_in.unknown) {}
     explicit PartiallySignedTransaction(const CMutableTransaction& tx);
     /**
      * Finds the UTXO for a given input index


### PR DESCRIPTION
I fail to see why people add these copy constructors manually without explanation, when the compiler can generate them at least as good automatically with less code.