### PR TITLE
doc: Add ShellCheck to lint tests dependencies

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -254,7 +254,13 @@ Use the `-v` option for verbose output.
 
 #### Dependencies
 
-The lint tests require codespell and flake8. To install: `pip3 install codespell flake8`.
+| Lint test | Dependency | Version [used by CI](../ci/lint/04_install.sh) | Installation
+|-----------|:----------:|:-------------------------------------------:|--------------
+| [`lint-python.sh`](lint/lint-python.sh) | [flake8](https://gitlab.com/pycqa/flake8) | [3.7.8](https://github.com/bitcoin/bitcoin/pull/15257) | `pip3 install flake8==3.7.8`
+| [`lint-shell.sh`](lint/lint-shell.sh) | [ShellCheck](https://github.com/koalaman/shellcheck) | [0.6.0](https://github.com/bitcoin/bitcoin/pull/15166) | [details...](https://github.com/koalaman/shellcheck#installing)
+| [`lint-spelling.sh`](lint/lint-spelling.sh) | [codespell](https://github.com/codespell-project/codespell) | [1.15.0](https://github.com/bitcoin/bitcoin/pull/16186) | `pip3 install codespell==1.15.0`
+
+Please be aware that on Linux distributions all dependencies are usually available as packages, but could be outdated.
 
 #### Running the tests
 

--- a/test/lint/lint-python.sh
+++ b/test/lint/lint-python.sh
@@ -82,10 +82,10 @@ enabled=(
 )
 
 if ! command -v flake8 > /dev/null; then
-    echo "Skipping Python linting since flake8 is not installed. Install by running \"pip3 install flake8\""
+    echo "Skipping Python linting since flake8 is not installed."
     exit 0
 elif PYTHONWARNINGS="ignore" flake8 --version | grep -q "Python 2"; then
-    echo "Skipping Python linting since flake8 is running under Python 2. Install the Python 3 version of flake8 by running \"pip3 install flake8\""
+    echo "Skipping Python linting since flake8 is running under Python 2. Install the Python 3 version of flake8."
     exit 0
 fi
 


### PR DESCRIPTION
In master (9641366950276da88af626d0898676195df8d83a) the lint tests dependencies list lacks ShellCheck. This PR fixes it.

Also `lint-python.sh` is slightly improved.