### PR TITLE
gui: grey out used address in address book

### DIFF
--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -133,6 +133,9 @@ public:
     //! List locked coins.
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 
+    //! Whether this address has been used.
+    virtual bool isUsedAddress(const CTxDestination& dst) = 0;
+
     //! Create transaction.
     virtual CTransactionRef createTransaction(const std::vector<CRecipient>& recipients,
         const CCoinControl& coin_control,
@@ -341,9 +344,10 @@ struct WalletAddress
     isminetype is_mine;
     std::string name;
     std::string purpose;
+    bool is_used;
 
-    WalletAddress(CTxDestination dest, isminetype is_mine, std::string name, std::string purpose)
-        : dest(std::move(dest)), is_mine(is_mine), name(std::move(name)), purpose(std::move(purpose))
+    WalletAddress(CTxDestination dest, isminetype is_mine, std::string name, std::string purpose, bool is_used)
+        : dest(std::move(dest)), is_mine(is_mine), name(std::move(name)), purpose(std::move(purpose)), is_used(is_used)
     {
     }
 };

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -133,8 +133,8 @@ public:
     //! List locked coins.
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 
-    //! Whether this address has been used.
-    virtual bool isUsedAddress(const CTxDestination& dst) = 0;
+    //! Whether this address has been used (has received).
+    virtual bool hasAddressReceived(const CTxDestination& dst) = 0;
 
     //! Create transaction.
     virtual CTransactionRef createTransaction(const std::vector<CRecipient>& recipients,

--- a/src/qt/addresstablemodel.h
+++ b/src/qt/addresstablemodel.h
@@ -97,7 +97,7 @@ private:
 public Q_SLOTS:
     /* Update address list from core.
      */
-    void updateEntry(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
+    void updateEntry(const QString &address, const QString &label, bool isMine, const QString &purpose, int status, bool is_used);
 
     friend class AddressTablePriv;
 };

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -372,7 +372,7 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel,
                               Q_ARG(bool, isMine),
                               Q_ARG(QString, strPurpose),
                               Q_ARG(int, status),
-                              Q_ARG(bool, walletmodel->wallet().isUsedAddress(address)));
+                              Q_ARG(bool, walletmodel->wallet().hasAddressReceived(address)));
     assert(invoked);
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -130,10 +130,10 @@ void WalletModel::updateTransaction()
 }
 
 void WalletModel::updateAddressBook(const QString &address, const QString &label,
-        bool isMine, const QString &purpose, int status)
+        bool isMine, const QString &purpose, int status, bool is_used)
 {
     if(addressTableModel)
-        addressTableModel->updateEntry(address, label, isMine, purpose, status);
+        addressTableModel->updateEntry(address, label, isMine, purpose, status, is_used);
 }
 
 void WalletModel::updateWatchOnlyFlag(bool fHaveWatchonly)
@@ -371,7 +371,8 @@ static void NotifyAddressBookChanged(WalletModel *walletmodel,
                               Q_ARG(QString, strLabel),
                               Q_ARG(bool, isMine),
                               Q_ARG(QString, strPurpose),
-                              Q_ARG(int, status));
+                              Q_ARG(int, status),
+                              Q_ARG(bool, walletmodel->wallet().isUsedAddress(address)));
     assert(invoked);
 }
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -232,7 +232,7 @@ public Q_SLOTS:
     /* New transaction, or transaction changed status */
     void updateTransaction();
     /* New, updated or removed address book entry */
-    void updateAddressBook(const QString &address, const QString &label, bool isMine, const QString &purpose, int status);
+    void updateAddressBook(const QString &address, const QString &label, bool isMine, const QString &purpose, int status, bool is_used);
     /* Watch-only added */
     void updateWatchOnlyFlag(bool fHaveWatchonly);
     /* Current, immature or unconfirmed balance might have changed - emit 'balanceChanged' if so */

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -193,7 +193,7 @@ public:
         std::vector<WalletAddress> result;
         for (const auto& item : m_wallet->m_address_book) {
             if (item.second.IsChange()) continue;
-            result.emplace_back(item.first, m_wallet->IsMine(item.first), item.second.GetLabel(), item.second.purpose);
+            result.emplace_back(item.first, m_wallet->IsMine(item.first), item.second.GetLabel(), item.second.purpose, m_wallet->IsUsedAddress(item.first));
         }
         return result;
     }
@@ -230,6 +230,11 @@ public:
     {
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins(outputs);
+    }
+    bool isUsedAddress(const CTxDestination& dst) override
+    {
+        LOCK(m_wallet->cs_wallet);
+        return m_wallet->IsUsedAddress(dst);
     }
     CTransactionRef createTransaction(const std::vector<CRecipient>& recipients,
         const CCoinControl& coin_control,

--- a/src/wallet/interfaces.cpp
+++ b/src/wallet/interfaces.cpp
@@ -193,7 +193,7 @@ public:
         std::vector<WalletAddress> result;
         for (const auto& item : m_wallet->m_address_book) {
             if (item.second.IsChange()) continue;
-            result.emplace_back(item.first, m_wallet->IsMine(item.first), item.second.GetLabel(), item.second.purpose, m_wallet->IsUsedAddress(item.first));
+            result.emplace_back(item.first, m_wallet->IsMine(item.first), item.second.GetLabel(), item.second.purpose, m_wallet->HasAddressReceived(item.first));
         }
         return result;
     }
@@ -231,10 +231,10 @@ public:
         LOCK(m_wallet->cs_wallet);
         return m_wallet->ListLockedCoins(outputs);
     }
-    bool isUsedAddress(const CTxDestination& dst) override
+    bool hasAddressReceived(const CTxDestination& dst) override
     {
         LOCK(m_wallet->cs_wallet);
-        return m_wallet->IsUsedAddress(dst);
+        return m_wallet->HasAddressReceived(dst);
     }
     CTransactionRef createTransaction(const std::vector<CRecipient>& recipients,
         const CCoinControl& coin_control,

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -875,20 +875,31 @@ bool CWallet::IsSpentKey(const uint256& hash, unsigned int n) const
     return false;
 }
 
-void CWallet::SetUsedAddressState(WalletBatch& batch, const CTxOut& cout, uint256 hash)
+void CWallet::SetAddressReceivedState(WalletBatch& batch, const CTxOut& cout, const uint256& hash)
 {
     AssertLockHeld(cs_wallet);
     CTxDestination dst;
     if (ExtractDestination(cout.scriptPubKey, dst) && IsMine(dst)) {
-        AddDestData(batch, dst, "first_txid", hash.ToString());
-        NotifyAddressBookChanged(this, dst, m_address_book[dst].GetLabel(), IsMine(dst) != ISMINE_NO, "receive", CT_UPDATED );
+
+        m_address_book[dst].destdata.insert(std::make_pair("first_txid", hash.ToString()));
+        NotifyAddressBookChanged(dst, m_address_book[dst].GetLabel(), IsMine(dst) != ISMINE_NO, "receive", CT_UPDATED);
     }
 }
 
-bool CWallet::IsUsedAddress(const CTxDestination& dst) const
+bool CWallet::HasAddressReceived(const CTxDestination& dst) const
 {
-    AssertLockHeld(cs_wallet);
-    return GetDestData(dst, "first_txid", nullptr);
+
+    const std::string key{"first_txid"};
+    std::map<CTxDestination, CAddressBookData>::const_iterator i = m_address_book.find(dst);
+    if(i != m_address_book.end())
+    {
+        CAddressBookData::StringMap::const_iterator j = i->second.destdata.find(key);
+        if(j != i->second.destdata.end())
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const CWalletTx::Confirmation& confirm, const UpdateWalletTxFn& update_wtx, bool fFlushOnClose)
@@ -909,7 +920,7 @@ CWalletTx* CWallet::AddToWallet(CTransactionRef tx, const CWalletTx::Confirmatio
         }
 
         for (const CTxOut& txout : tx->vout) {
-            SetUsedAddressState(batch, txout, hash);
+            SetAddressReceivedState(batch, txout, hash);
         }
 
         MarkDestinationsDirty(tx_destinations);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -456,6 +456,9 @@ public:
     void SetSpentKeyState(WalletBatch& batch, const uint256& hash, unsigned int n, bool used, std::set<CTxDestination>& tx_destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, const CoinSelectionParams& coin_sel_params, const CoinEligibilityFilter& filter, bool positive_only) const;
+    //! Whether this address has been used.
+    void SetUsedAddressState(WalletBatch& batch, const CTxOut& cout, uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool IsUsedAddress(const CTxDestination& dst) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Display address on an external signer. Returns false if external signer support is not compiled */
     bool DisplayAddress(const CTxDestination& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -456,9 +456,9 @@ public:
     void SetSpentKeyState(WalletBatch& batch, const uint256& hash, unsigned int n, bool used, std::set<CTxDestination>& tx_destinations) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::vector<OutputGroup> GroupOutputs(const std::vector<COutput>& outputs, const CoinSelectionParams& coin_sel_params, const CoinEligibilityFilter& filter, bool positive_only) const;
-    //! Whether this address has been used.
-    void SetUsedAddressState(WalletBatch& batch, const CTxOut& cout, uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
-    bool IsUsedAddress(const CTxDestination& dst) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    //! Whether this address has been used (has received).
+    void SetAddressReceivedState(WalletBatch& batch, const CTxOut& cout, const uint256& hash) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool HasAddressReceived(const CTxDestination& dst) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /** Display address on an external signer. Returns false if external signer support is not compiled */
     bool DisplayAddress(const CTxDestination& dest) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);


### PR DESCRIPTION
Implements issue #17174, to grey out used addresses in the address book when the wallet has the `avoid_reuse` flag set.

this commit brings the `IsUsedDestination` method into the `Wallet.h` interface. It is then called in `addresstablemodel.cpp` to determine whether the address has been used or not whilst setting the font colour

master
<img width="840" alt="Screenshot 2019-11-02 at 17 36 51" src="https://user-images.githubusercontent.com/31032215/68075122-897dec00-fd9b-11e9-95ac-4a8f36635cc9.png">

pr
<img width="836" alt="Screenshot 2019-11-02 at 17 33 41" src="https://user-images.githubusercontent.com/31032215/68075130-9e5a7f80-fd9b-11e9-93e3-6d687b982c34.png">

