### PR TITLE
RPC: Internal named params

### DIFF
--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -24,7 +24,7 @@ static UniValue rpcNestedTest_rpc(const JSONRPCRequest& request)
 
 static const CRPCCommand vRPCCommands[] =
 {
-    { "test", "rpcNestedTest", &rpcNestedTest_rpc, {} },
+    { "test", "rpcNestedTest", &rpcNestedTest_rpc, {"a", "b", "c"} },
 };
 
 void RPCNestedTests::rpcNestedTests()

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -574,8 +574,9 @@ static UniValue setban(const JSONRPCRequest& request)
                 },
     };
     std::string strCommand;
-    if (!request.params[1].isNull())
-        strCommand = request.params[1].get_str();
+    if (!request.m_params["command"].isNull()) {
+        strCommand = request.m_params["command"].get_str();
+    }
     if (request.fHelp || !help.IsValidNumArgs(request.params.size()) || (strCommand != "add" && strCommand != "remove")) {
         throw std::runtime_error(help.ToString());
     }
@@ -588,16 +589,17 @@ static UniValue setban(const JSONRPCRequest& request)
     CNetAddr netAddr;
     bool isSubnet = false;
 
-    if (request.params[0].get_str().find('/') != std::string::npos)
+    if (request.m_params["subnet"].get_str().find('/') != std::string::npos) {
         isSubnet = true;
+    }
 
     if (!isSubnet) {
         CNetAddr resolved;
-        LookupHost(request.params[0].get_str(), resolved, false);
+        LookupHost(request.m_params["subnet"].get_str(), resolved, false);
         netAddr = resolved;
     }
     else
-        LookupSubNet(request.params[0].get_str(), subNet);
+        LookupSubNet(request.m_params["subnet"].get_str(), subNet);
 
     if (! (isSubnet ? subNet.IsValid() : netAddr.IsValid()) )
         throw JSONRPCError(RPC_CLIENT_INVALID_IP_OR_SUBNET, "Error: Invalid IP/Subnet");
@@ -609,12 +611,14 @@ static UniValue setban(const JSONRPCRequest& request)
         }
 
         int64_t banTime = 0; //use standard bantime if not specified
-        if (!request.params[2].isNull())
-            banTime = request.params[2].get_int64();
+        if (!request.m_params["bantime"].isNull()) {
+            banTime = request.m_params["bantime"].get_int64();
+        }
 
         bool absolute = false;
-        if (request.params[3].isTrue())
+        if (request.m_params["absolute"].isTrue()) {
             absolute = true;
+        }
 
         if (isSubnet) {
             node.banman->Ban(subNet, banTime, absolute);

--- a/src/rpc/request.h
+++ b/src/rpc/request.h
@@ -34,19 +34,21 @@ public:
     UniValue id;
     std::string strMethod;
     UniValue params;
+    UniValue m_params;
+    bool m_used_positional_args;
     bool fHelp;
     std::string URI;
     std::string authUser;
     std::string peerAddr;
     const util::Ref& context;
 
-    JSONRPCRequest(const util::Ref& context) : id(NullUniValue), params(NullUniValue), fHelp(false), context(context) {}
+    JSONRPCRequest(const util::Ref& context) : id(NullUniValue), params(NullUniValue), m_params(NullUniValue), m_used_positional_args(false), fHelp(false), context(context) {}
 
     //! Initializes request information from another request object and the
     //! given context. The implementation should be updated if any members are
     //! added or removed above.
     JSONRPCRequest(const JSONRPCRequest& other, const util::Ref& context)
-        : id(other.id), strMethod(other.strMethod), params(other.params), fHelp(other.fHelp), URI(other.URI),
+        : id(other.id), strMethod(other.strMethod), params(other.params), m_params(other.m_params), m_used_positional_args(other.m_used_positional_args), fHelp(other.fHelp), URI(other.URI),
           authUser(other.authUser), peerAddr(other.peerAddr), context(context)
     {
     }


### PR DESCRIPTION
Reworked #11660 to add a new `m_params` to `JSONRPCRequest` in parallel to the legacy `params` to ease the transition.

Dropped other unnecessary improvements and "options" handling for now to keep this PR smaller, those can go in later in other PRs.