### PR TITLE
tests: Add fuzzing harness for Bech32 encoding/decoding

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -7,6 +7,7 @@ FUZZ_TARGETS = \
   test/fuzz/address_deserialize \
   test/fuzz/addrman_deserialize \
   test/fuzz/banentry_deserialize \
+  test/fuzz/bech32 \
   test/fuzz/block_deserialize \
   test/fuzz/blockheader_deserialize \
   test/fuzz/blocklocator_deserialize \
@@ -65,11 +66,13 @@ BITCOIN_TEST_SUITE = \
   test/util/str.cpp
 
 FUZZ_SUITE = \
-  test/setup_common.h \
-  test/setup_common.cpp \
   test/fuzz/fuzz.cpp \
   test/fuzz/fuzz.h \
-  test/fuzz/FuzzedDataProvider.h
+  test/fuzz/FuzzedDataProvider.h \
+  test/setup_common.cpp \
+  test/setup_common.h \
+  test/util/str.cpp \
+  test/util/str.h
 
 FUZZ_SUITE_LD_COMMON = \
  $(LIBBITCOIN_SERVER) \
@@ -241,6 +244,12 @@ test_fuzz_banentry_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DB
 test_fuzz_banentry_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_banentry_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_banentry_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+
+test_fuzz_bech32_SOURCES = $(FUZZ_SUITE) test/fuzz/bech32.cpp
+test_fuzz_bech32_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_bech32_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_bech32_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_bech32_LDADD = $(FUZZ_SUITE_LD_COMMON)
 
 test_fuzz_txundo_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 test_fuzz_txundo_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DTXUNDO_DESERIALIZE=1

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -60,7 +60,9 @@ BITCOIN_TEST_SUITE = \
   test/lib/transaction_utils.cpp \
   test/main.cpp \
   test/setup_common.h \
-  test/setup_common.cpp
+  test/setup_common.cpp \
+  test/util/str.h \
+  test/util/str.cpp
 
 FUZZ_SUITE = \
   test/setup_common.h \

--- a/src/test/bech32_tests.cpp
+++ b/src/test/bech32_tests.cpp
@@ -4,23 +4,11 @@
 
 #include <bech32.h>
 #include <test/setup_common.h>
+#include <test/util/str.h>
 
 #include <boost/test/unit_test.hpp>
 
 BOOST_FIXTURE_TEST_SUITE(bech32_tests, BasicTestingSetup)
-
-static bool CaseInsensitiveEqual(const std::string &s1, const std::string &s2)
-{
-    if (s1.size() != s2.size()) return false;
-    for (size_t i = 0; i < s1.size(); ++i) {
-        char c1 = s1[i];
-        if (c1 >= 'A' && c1 <= 'Z') c1 -= ('A' - 'a');
-        char c2 = s2[i];
-        if (c2 >= 'A' && c2 <= 'Z') c2 -= ('A' - 'a');
-        if (c1 != c2) return false;
-    }
-    return true;
-}
 
 BOOST_AUTO_TEST_CASE(bip173_testvectors_valid)
 {

--- a/src/test/fuzz/bech32.cpp
+++ b/src/test/fuzz/bech32.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bech32.h>
+#include <test/fuzz/fuzz.h>
+#include <test/util/str.h>
+#include <util/strencodings.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    const std::string random_string(buffer.begin(), buffer.end());
+    const std::pair<std::string, std::vector<uint8_t>> r1 = bech32::Decode(random_string);
+    if (r1.first.empty()) {
+        assert(r1.second.empty());
+    } else {
+        const std::string& hrp = r1.first;
+        const std::vector<uint8_t>& data = r1.second;
+        const std::string reencoded = bech32::Encode(hrp, data);
+        assert(CaseInsensitiveEqual(random_string, reencoded));
+    }
+
+    std::vector<unsigned char> input;
+    ConvertBits<8, 5, true>([&](unsigned char c) { input.push_back(c); }, buffer.begin(), buffer.end());
+    const std::string encoded = bech32::Encode("bc", input);
+    assert(!encoded.empty());
+
+    const std::pair<std::string, std::vector<uint8_t>> r2 = bech32::Decode(encoded);
+    if (r2.first.empty()) {
+        assert(r2.second.empty());
+    } else {
+        const std::string& hrp = r2.first;
+        const std::vector<uint8_t>& data = r2.second;
+        assert(hrp == "bc");
+        assert(data == input);
+    }
+}

--- a/src/test/util/str.cpp
+++ b/src/test/util/str.cpp
@@ -1,0 +1,21 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/str.h>
+
+#include <cstdint>
+#include <string>
+
+bool CaseInsensitiveEqual(const std::string& s1, const std::string& s2)
+{
+    if (s1.size() != s2.size()) return false;
+    for (size_t i = 0; i < s1.size(); ++i) {
+        char c1 = s1[i];
+        if (c1 >= 'A' && c1 <= 'Z') c1 -= ('A' - 'a');
+        char c2 = s2[i];
+        if (c2 >= 'A' && c2 <= 'Z') c2 -= ('A' - 'a');
+        if (c1 != c2) return false;
+    }
+    return true;
+}

--- a/src/test/util/str.h
+++ b/src/test/util/str.h
@@ -1,0 +1,12 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_STR_H
+#define BITCOIN_TEST_UTIL_STR_H
+
+#include <string>
+
+bool CaseInsensitiveEqual(const std::string& s1, const std::string& s2);
+
+#endif // BITCOIN_TEST_UTIL_STR_H


### PR DESCRIPTION
Add fuzzing harness for Bech32 encoding/decoding.

**Testing this PR**

Run:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/bech32 -max_total_time=60
…
```