### PR TITLE
gui: Improve "Hide" button tool-tip message

### DIFF
--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -797,7 +797,7 @@
           <item>
            <widget class="QPushButton" name="buttonMinimizeFee">
             <property name="toolTip">
-             <string>collapse fee-settings</string>
+             <string>Hide transaction fee settings</string>
             </property>
             <property name="text">
              <string>Hide</string>


### PR DESCRIPTION
Cleaned up the tool tip text, it looks as though it just got included back in 2014 when the whole section was added.

Changed hide button tool tip within transaction fee settings area from "collapse fee-settings" to "Hide transaction fee settings" to be more user friendly and fit with other tool tips.

![hide-transaction-fee-tool-tip](https://user-images.githubusercontent.com/17258195/68086415-b7b70680-fe43-11e9-82cb-567b9730c1b9.png)
