### PR TITLE
Updates to appveyor config for VS2019 and Qt5.9.8 + msvc project fixes

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,31 +1,56 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 5
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   CLCACHE_SERVER: 1
-  PACKAGES: berkeleydb boost-filesystem boost-signals2 boost-test libevent openssl rapidcheck zeromq double-conversion
+  PACKAGES: berkeleydb boost-filesystem boost-multi-index boost-signals2 boost-test boost-thread libevent openssl rapidcheck zeromq double-conversion
   PATH: 'C:\Python37-x64;C:\Python37-x64\Scripts;%PATH%'
   PYTHONUTF8: 1
-  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.0/Qt5.9.7_ssl_x64_static_vs2017.zip'
-  QT_DOWNLOAD_HASH: 'D4D35B8112302B67E5610A03421BB3E43FE13F14D9A5F637C22AE60DCEC0E0F5'
-  QT_LOCAL_PATH: 'C:\Qt5.9.7_ssl_x64_static_vs2017'
+  QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.4/Qt5.9.8_x64_static_vs2019.zip'
+  QT_DOWNLOAD_HASH: 'f285cbb02bec3b3f3cc2621e3fa7d5edf0d6a66fa30c57859e583acda954ea80'
+  QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
+  VCPKG_INSTALL_PATH: 'C:\tools\vcpkg\installed'
 cache:
 - C:\tools\vcpkg\installed
 - C:\Users\appveyor\clcache -> .appveyor.yml, build_msvc\**, **\Makefile.am, **\*.vcxproj.in
-- C:\Qt5.9.7_ssl_x64_static_vs2017
+- C:\Qt5.9.8_x64_static_vs2019
 install:
 - cmd: pip install --quiet git+https://github.com/frerich/clcache.git@v4.2.0
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.
 # - cmd: pip install zmq
-- cmd: echo set(VCPKG_BUILD_TYPE release) >> C:\tools\vcpkg\triplets\%PLATFORM%-windows-static.cmake
-- cmd: vcpkg remove --outdated --recurse
-- cmd: vcpkg install --triplet %PLATFORM%-windows-static %PACKAGES% > NUL
+# Powershell block below is to install the c++ dependencies via vcpkg. The pseudo code is:
+# 1. If the vcpkg install directory exists assume dependencies are installed and do nothing. To
+#    force a fresh install of the packages delete the job's appveyor cache.
+# 2. Otherwise:
+#    a. Update the vcpkg source (including port files) and build the vcpkg binary,
+#    b. Install the required packages.
+- ps: |
+      cd c:\tools\vcpkg
+      if(!(Test-Path -Path ($env:VCPKG_INSTALL_PATH))) {
+          $env:GIT_REDIRECT_STDERR = '2>&1' # git is writing non-errors to STDERR when doing git pull. Send to STDOUT instead.
+          Add-Content "C:\tools\vcpkg\triplets\$env:PLATFORM-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
+          git pull origin master
+          .\bootstrap-vcpkg.bat
+          .\vcpkg install --triplet $env:PLATFORM-windows-static $env:PACKAGES.split() > $null
+      }
+      else {
+        Write-Host "vcpkg packages already installed (to reinstall purge appveyor job's cache)."
+      }
+      .\vcpkg integrate install
+      cd "$env:APPVEYOR_BUILD_FOLDER"
 before_build:
 - ps:  clcache -M 536870912
+# Powershell block below is to download and extract the Qt static libraries. The pseudo code is:
+# 1. If the Qt destination directory exists assume it is correct and do nothing. To
+#    force a fresh install of the packages delete the job's appveyor cache.
+# 2. Otherwise:
+#    a. Download the zip file with the prebuilt Qt static libraries.
+#    b. Check that the downloaded file matches the expected hash.
+#    c. Extract the zip file to the specific destination path expected by the msbuild projects.
 - ps: |
       if(!(Test-Path -Path ($env:QT_LOCAL_PATH))) {
         Write-Host "Downloading Qt binaries.";
@@ -44,17 +69,10 @@ before_build:
          Write-Host "Qt binaries already present.";
       }
 - cmd: python build_msvc\msvc-autogen.py
-- ps:  $files = (Get-ChildItem -Recurse | where {$_.extension -eq ".vcxproj"}).FullName
-- ps:  for (${i} = 0; ${i} -lt ${files}.length; ${i}++) {
-           ${content} = (Get-Content ${files}[${i}]);
-           ${content} = ${content}.Replace("</RuntimeLibrary>", "</RuntimeLibrary><DebugInformationFormat>None</DebugInformationFormat>");
-           ${content} = ${content}.Replace("<WholeProgramOptimization>true", "<WholeProgramOptimization>false");
-           Set-Content ${files}[${i}] ${content};
-       }
 - ps:  Start-Process clcache-server
 - ps:  fsutil behavior set disablelastaccess 0 # Enable Access time feature on Windows (for clcache)
 build_script:
-- cmd: msbuild /p:TrackFileAccess=false /p:CLToolExe=clcache.exe build_msvc\bitcoin.sln /m /v:n /nologo
+- cmd: msbuild /p:TrackFileAccess=false /p:CLToolExe=clcache.exe build_msvc\bitcoin.sln /m /v:q /nologo
 after_build:
 - ps:  fsutil behavior set disablelastaccess 1 # Disable Access time feature on Windows (better performance)
 - ps:  clcache -z
@@ -64,7 +82,8 @@ test_script:
 - cmd: src\bench_bitcoin.exe -evals=1 -scaling=0 > NUL
 - ps:  python test\util\bitcoin-util-test.py
 - cmd: python test\util\rpcauth-test.py
-- cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast
+# Fee estimation test failing on appveyor with: WinError 10048] Only one usage of each socket address (protocol/network address/port) is normally permitted.
+- cmd: python test\functional\test_runner.py --ci --quiet --combinedlogslen=4000 --failfast --exclude feature_fee_estimation
 artifacts:
 #- path: bitcoin-%APPVEYOR_BUILD_VERSION%.zip
 deploy: off

--- a/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
+++ b/build_msvc/bitcoin-qt/bitcoin-qt.vcxproj
@@ -56,6 +56,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(QtReleaseLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4206</AdditionalOptions>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>..\..\src;</AdditionalIncludeDirectories>
@@ -69,6 +70,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(QtDebugLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>/ignore:4206</AdditionalOptions>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>..\..\src;</AdditionalIncludeDirectories>

--- a/build_msvc/common.init.vcxproj
+++ b/build_msvc/common.init.vcxproj
@@ -39,7 +39,7 @@
     <LinkIncremental>true</LinkIncremental>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>
@@ -48,7 +48,7 @@
     <LinkIncremental>false</LinkIncremental>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\$(ProjectName)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\$(ProjectName)\</IntDir>

--- a/build_msvc/common.qt.init.vcxproj
+++ b/build_msvc/common.qt.init.vcxproj
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup Label="QtGlobals">
-    <QtBaseDir>C:\Qt5.9.7_ssl_x64_static_vs2017</QtBaseDir>
+    <QtBaseDir>C:\Qt5.9.8_x64_static_vs2019</QtBaseDir>
     <QtPluginsLibraryDir>$(QtBaseDir)\plugins</QtPluginsLibraryDir>
     <QtLibraryDir>$(QtBaseDir)\lib</QtLibraryDir>
     <QtIncludeDir>$(QtBaseDir)\include</QtIncludeDir>

--- a/build_msvc/test_bitcoin/test_bitcoin.vcxproj
+++ b/build_msvc/test_bitcoin/test_bitcoin.vcxproj
@@ -17,6 +17,7 @@
     <ClCompile Include="..\..\src\test\setup_common.cpp" />
     <ClCompile Include="..\..\src\test\main.cpp" />
     <ClCompile Include="..\..\src\wallet\test\*_fixture.cpp" />
+    <ClCompile Include="..\..\src\test\util\*.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">


### PR DESCRIPTION
Updates to appveyor config:
 - Update build image from Visual Studio 2017 to Visual Studio 2019.
 - Updated Qt static library from Qt5.9.7 to Qt5.9.8.
 - Added commands to update vcpkg port files (this does not update already installed packages).
 - Updated vcpkg package list as per #17309.
 - Removed commands setting common project file options. Now done via common.init.vcxproj include.
 - Changed msbuild verbosity from normal to quiet. Normal writes a LOT of logs and impacts appveyor job duration.

Updates to msvc project configs:
 - Updated platform toolset from v141 to v142.
 - Updated Qt static library from Qt5.9.7 to Qt5.9.8.
 - Added ignore for linker warning building bitcoin-qt program.
 - Added missing util/str.cpp class file to test_bitcoin project file.

In order for an existing appveyor job based on the new config to work the cache must be purged. The steps to do this are shown below. The specific appveyor project path will need to be adjusted.

````
export APPVEYOR_TOKEN="<your-api-token>"
curl -H "Authorization: Bearer $APPVEYOR_TOKEN" -X DELETE https://ci.appveyor.com/api/projects/bitcoin/bitcoin-9ql6k/buildcache
````

