### PR TITLE
cli: fix -getinfo output when compiled with no wallet

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -265,7 +265,7 @@ public:
         result.pushKV("proxy", batch[ID_NETWORKINFO]["result"]["networks"][0]["proxy"]);
         result.pushKV("difficulty", batch[ID_BLOCKCHAININFO]["result"]["difficulty"]);
         result.pushKV("chain", UniValue(batch[ID_BLOCKCHAININFO]["result"]["chain"]));
-        if (!batch[ID_WALLETINFO].isNull()) {
+        if (!batch[ID_WALLETINFO]["result"].isNull()) {
             result.pushKV("walletversion", batch[ID_WALLETINFO]["result"]["walletversion"]);
             result.pushKV("balance", batch[ID_WALLETINFO]["result"]["balance"]);
             result.pushKV("keypoololdest", batch[ID_WALLETINFO]["result"]["keypoololdest"]);


### PR DESCRIPTION
master (33b155f28732487854cf0ca29ca17c50f8c6872e):
```bash
src/bitcoin-cli -getinfo
{
  "version": 199900,
  "protocolversion": 70015,
  "blocks": 602348,
  "headers": 602348,
  "verificationprogress": 0.9999995592310106,
  "timeoffset": 0,
  "connections": 10,
  "proxy": "",
  "difficulty": 13691480038694.45,
  "chain": "main",
  "walletversion": null,
  "balance": null,
  "keypoololdest": null,
  "keypoolsize": null,
  "paytxfee": null,
  "relayfee": 0.00001000,
  "warnings": "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications"
}
```

This PR (3d05d332693ec860626fc77e6ba50dec94e4e83c):
```bash
{
  "version": 199900,
  "protocolversion": 70015,
  "blocks": 602348,
  "headers": 602348,
  "verificationprogress": 0.9999996313568186,
  "timeoffset": 0,
  "connections": 10,
  "proxy": "",
  "difficulty": 13691480038694.45,
  "chain": "main",
  "relayfee": 0.00001000,
  "warnings": "This is a pre-release test build - use at your own risk - do not use for mining or merchant applications"
}
```