### PR TITLE
Add asymptotes for benchmarking framework

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -80,6 +80,7 @@ public:
 };
 
 typedef std::function<void(State&)> BenchFunction;
+typedef std::function<void(State&, const std::vector<size_t>*)> BenchAsymptoteFunction;
 
 class BenchRunner
 {
@@ -87,13 +88,19 @@ class BenchRunner
         BenchFunction func;
         uint64_t num_iters_for_one_second;
     };
+    struct BenchAsymptote {
+        BenchAsymptoteFunction func;
+    };
     typedef std::map<std::string, Bench> BenchmarkMap;
     static BenchmarkMap& benchmarks();
+    typedef std::map<std::string, BenchAsymptote> BenchmarkAsymptoteMap;
+    static BenchmarkAsymptoteMap& asymptotic_benchmarks();
 
 public:
     BenchRunner(std::string name, BenchFunction func, uint64_t num_iters_for_one_second);
+    BenchRunner(std::string name, BenchAsymptoteFunction func);
 
-    static void RunAll(Printer& printer, uint64_t num_evals, double scaling, const std::string& filter, bool is_list_only);
+    static void RunAll(Printer& printer, uint64_t num_evals, double scaling, const std::string& filter, bool is_list_only, const std::vector<size_t>& asymptotic_factors);
 };
 
 // interface to output benchmark results.
@@ -137,5 +144,9 @@ private:
 // the same time, and scaling factor can be used that the total time is appropriate for your system.
 #define BENCHMARK(n, num_iters_for_one_second) \
     benchmark::BenchRunner BOOST_PP_CAT(bench_, BOOST_PP_CAT(__LINE__, n))(BOOST_PP_STRINGIZE(n), n, (num_iters_for_one_second));
+
+#define BENCHMARK_ASYMPTOTE(n) \
+    benchmark::BenchRunner BOOST_PP_CAT(asymptote_bench_, BOOST_PP_CAT(__LINE__, n))(BOOST_PP_STRINGIZE(n), n);
+
 
 #endif // BITCOIN_BENCH_BENCH_H

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -16,6 +16,7 @@ static const char* DEFAULT_BENCH_PRINTER = "console";
 static const char* DEFAULT_PLOT_PLOTLYURL = "https://cdn.plot.ly/plotly-latest.min.js";
 static const int64_t DEFAULT_PLOT_WIDTH = 1024;
 static const int64_t DEFAULT_PLOT_HEIGHT = 768;
+static const std::vector<size_t> DEFAULT_ASYMPTOTIC_FACTORS;
 
 static void SetupBenchArgs()
 {
@@ -25,6 +26,14 @@ static void SetupBenchArgs()
     gArgs.AddArg("-evals=<n>", strprintf("Number of measurement evaluations to perform. (default: %u)", DEFAULT_BENCH_EVALUATIONS), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-filter=<regex>", strprintf("Regular expression filter to select benchmark by name (default: %s)", DEFAULT_BENCH_FILTER), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-scaling=<n>", strprintf("Scaling factor for benchmark's runtime (default: %u)", DEFAULT_BENCH_SCALING), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-asymptote=n", 
+            strprintf("Certain benchmarks can have tunable parameters (e.g, number of transactions) to test the "
+                      "asymptotic growth of the runtime of an algorithm easily. "
+                      "These arguments are positional and are defined differently per benchmark. "
+                      "Thus asymptote should be used with a narrowly scoped filter to a single test case. "
+                      "For example, this script tests ComplexMemPoolAsymptotic's max descendants per tx parameter "
+                      "growing by powers of 2 and prints out the median: "
+                      "`for x in {1..10}; do ./src/bench/bench_bitcoin -filter=ComplexMemPoolAsymptotic -asymptote=100 -asymptote=100 -asymptote=$((2**$x)); done | grep ComplexMemPoolAsymptotic --line-buffered | cut -d, -f7`"), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-printer=(console|plot)", strprintf("Choose printer format. console: print data to console. plot: Print results as HTML graph (default: %s)", DEFAULT_BENCH_PRINTER), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-plot-plotlyurl=<uri>", strprintf("URL to use for plotly.js (default: %s)", DEFAULT_PLOT_PLOTLYURL), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-plot-width=<x>", strprintf("Plot width in pixel (default: %u)", DEFAULT_PLOT_WIDTH), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -50,6 +59,7 @@ int main(int argc, char** argv)
     std::string regex_filter = gArgs.GetArg("-filter", DEFAULT_BENCH_FILTER);
     std::string scaling_str = gArgs.GetArg("-scaling", DEFAULT_BENCH_SCALING);
     bool is_list_only = gArgs.GetBoolArg("-list", false);
+    std::vector<std::string> asymptotes = gArgs.GetArgs("-asymptote");
 
     if (evaluations == 0) {
         return EXIT_SUCCESS;
@@ -73,7 +83,17 @@ int main(int argc, char** argv)
             gArgs.GetArg("-plot-height", DEFAULT_PLOT_HEIGHT)));
     }
 
-    benchmark::BenchRunner::RunAll(*printer, evaluations, scaling_factor, regex_filter, is_list_only);
+    std::vector<size_t> asymptotic_factors;
+    for (auto& s: asymptotes) {
+        uint64_t arg;
+        if (!ParseUInt64(s, &arg))
+            tfm::format(std::cerr, "Error parsing scaling factor as double: %s\n", s);
+        if (arg > std::numeric_limits<size_t>::max())
+            tfm::format(std::cerr, "Error parsing scaling factor as size_t: %s\n", s);
+        asymptotic_factors.emplace_back((size_t)arg);
+    }
+
+    benchmark::BenchRunner::RunAll(*printer, evaluations, scaling_factor, regex_filter, is_list_only, asymptotic_factors);
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
It can be pretty convenient for certain classes of benchmark to be able to run it with dynamic parameters, to generate curves of magnitudes runtimes.

This PR adds this functionality and shows an example using it.

This functionality is a bit useless unless you also combine it with a filter to ensure the params are meaningful for the target asymptotic benchmark.