### PR TITLE
wallet: remove unused variable spk_man in import* RPCs

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -96,6 +96,12 @@ static LegacyScriptPubKeyMan& GetLegacyScriptPubKeyMan(CWallet& wallet)
     return *spk_man;
 }
 
+// Only check the presence of a LegacyScriptPubKeyMan, throw an error if it doesn't
+static void RequireLegacyScriptPubKeyMan(CWallet& wallet)
+{
+    (void)GetLegacyScriptPubKeyMan(wallet);
+}
+
 UniValue importprivkey(const JSONRPCRequest& request)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
@@ -134,7 +140,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_WALLET_ERROR, "Cannot import private keys to a wallet with private keys disabled");
     }
 
-    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
+    RequireLegacyScriptPubKeyMan(*wallet);
 
     WalletRescanReserver reserver(pwallet);
     bool fRescan = true;
@@ -262,7 +268,7 @@ UniValue importaddress(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*pwallet);
+    RequireLegacyScriptPubKeyMan(*pwallet);
 
     std::string strLabel;
     if (!request.params[1].isNull())
@@ -465,7 +471,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
+    RequireLegacyScriptPubKeyMan(*wallet);
 
     std::string strLabel;
     if (!request.params[1].isNull())
@@ -549,7 +555,7 @@ UniValue importwallet(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
+    RequireLegacyScriptPubKeyMan(*wallet);
 
     if (pwallet->chain().havePruned()) {
         // Exit early and print an error.
@@ -1346,7 +1352,7 @@ UniValue importmulti(const JSONRPCRequest& mainRequest)
 
     RPCTypeCheck(mainRequest.params, {UniValue::VARR, UniValue::VOBJ});
 
-    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
+    RequireLegacyScriptPubKeyMan(*wallet);
 
     const UniValue& requests = mainRequest.params[0];
 


### PR DESCRIPTION
Each of the following RPC functions 
- importprivkey
- importaddress
- importpubkey
- importwallet
- importmulti

define a variable reference `LegacyScriptPubKeyMan& spk_man` which is not used, leading to compiler warnings in the current master branch (bdda137878904e9401a84e308ac74c93c2ef87c1):
```
  CXX      wallet/libbitcoin_wallet_a-rpcdump.o
wallet/rpcdump.cpp:137:28: warning: unused variable 'spk_man' [-Wunused-variable]
    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
                           ^
wallet/rpcdump.cpp:265:28: warning: unused variable 'spk_man' [-Wunused-variable]
    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*pwallet);
                           ^
wallet/rpcdump.cpp:468:28: warning: unused variable 'spk_man' [-Wunused-variable]
    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
                           ^
wallet/rpcdump.cpp:552:28: warning: unused variable 'spk_man' [-Wunused-variable]
    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
                           ^
wallet/rpcdump.cpp:1349:28: warning: unused variable 'spk_man' [-Wunused-variable]
    LegacyScriptPubKeyMan& spk_man = GetLegacyScriptPubKeyMan(*wallet);
                           ^
5 warnings generated.
```

The call to `GetLegacyScriptPubKeyMan()` still serves the purpose to throw an error if the wallet doesn't have a LegacyScriptPubKeyMan instance (indicating that the command is not supported, as pointed out by the error message):
https://github.com/bitcoin/bitcoin/blob/bdda137878904e9401a84e308ac74c93c2ef87c1/src/wallet/rpcdump.cpp#L90-L97

This commit ~~casts the functions return value to `void` to point out that the value is thrown away, and adds a comment on why the function call is needed as well.~~ introduces a new function `RequireLegacyScriptPubKeyMan()` which in turn calls `GetLegacyScriptPubKeyMan()` but discards its return value.