### PR TITLE
TestShell: Fix typos & implement cleanups

### DIFF
--- a/test/functional/test-shell.md
+++ b/test/functional/test-shell.md
@@ -31,7 +31,7 @@ importing the `TestShell` class from the `test_shell` sub-package.
 ```
 >>> import sys
 >>> sys.path.insert(0, "/path/to/bitcoin/test/functional")
->>> from test_framework.test_shell import `TestShell`
+>>> from test_framework.test_shell import TestShell
 ```
 
 The following `TestShell` methods manage the lifetime of the underlying bitcoind

--- a/test/functional/test-shell.md
+++ b/test/functional/test-shell.md
@@ -51,8 +51,7 @@ The following sections demonstrate how to initialize, run, and shut down a
 ## 3. Initializing a `TestShell` object
 
 ```
->>> test = TestShell()
->>> test.setup(num_nodes=2, setup_clean_chain=True)
+>>> test = TestShell().setup(num_nodes=2, setup_clean_chain=True)
 20XX-XX-XXTXX:XX:XX.XXXXXXX TestFramework (INFO): Initializing test directory /path/to/bitcoin_func_test_XXXXXXX
 ```
 The `TestShell` forwards all functional test parameters of the parent
@@ -66,8 +65,7 @@ temporary folder. If you need more bitcoind nodes than set by default (1),
 simply increase the `num_nodes` parameter during setup.
 
 ```
->>> test2 = TestShell()
->>> test2.setup()
+>>> test2 = TestShell().setup()
 TestShell is already running!
 ```
 

--- a/test/functional/test_framework/test_shell.py
+++ b/test/functional/test_framework/test_shell.py
@@ -53,7 +53,7 @@ class TestShell:
 
         def reset(self):
             if self.running:
-                print("Shutdown TestWrapper before resetting!")
+                print("Shutdown TestShell before resetting!")
             else:
                 self.num_nodes = None
                 super().__init__()

--- a/test/functional/test_framework/test_shell.py
+++ b/test/functional/test_framework/test_shell.py
@@ -29,8 +29,7 @@ class TestShell:
 
             # Num_nodes parameter must be set
             # by BitcoinTestFramework child class.
-            self.num_nodes = kwargs.get('num_nodes', 1)
-            kwargs.pop('num_nodes', None)
+            self.num_nodes = 1
 
             # User parameters override default values.
             for key, value in kwargs.items():

--- a/test/functional/test_framework/test_shell.py
+++ b/test/functional/test_framework/test_shell.py
@@ -42,6 +42,7 @@ class TestShell:
 
             super().setup()
             self.running = True
+            return self
 
         def shutdown(self):
             if not self.running:


### PR DESCRIPTION
This PR follows up on #17288 and fixes typos and implements code clean-ups suggested by reviewers of 19139ee.

- Typo in `test_shell.py` warning
- Typo in `test-shell.md` code block
- Simplified default setting of `num_nodes` in `TestShell.setup()`
- Enable initializer chaining: `TestShell().setup()`
