### PR TITLE
WIP: refactor: Use our own integer parsing/formatting everywhere

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -255,8 +255,11 @@ static void MutateTxAddInput(CMutableTransaction& tx, const std::string& strInpu
 
     // extract the optional sequence number
     uint32_t nSequenceIn = CTxIn::SEQUENCE_FINAL;
-    if (vStrInputParts.size() > 2)
-        nSequenceIn = std::stoul(vStrInputParts[2]);
+    if (vStrInputParts.size() > 2) {
+        if (!ParseUInt32(vStrInputParts[2], &nSequenceIn)) {
+            throw std::runtime_error("invalid sequence id '" + vStrInputParts[2] + "'");
+        }
+    }
 
     // append to transaction input list
     CTxIn txin(txid, vout, CScript(), nSequenceIn);

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -50,15 +50,14 @@ CScript ParseScript(const std::string& s)
 
     for (std::vector<std::string>::const_iterator w = words.begin(); w != words.end(); ++w)
     {
+        int64_t n;
         if (w->empty())
         {
             // Empty string, ignore. (boost::split given '' will return one word)
         }
-        else if (std::all_of(w->begin(), w->end(), ::IsDigit) ||
-            (w->front() == '-' && w->size() > 1 && std::all_of(w->begin()+1, w->end(), ::IsDigit)))
+        else if (ParseInt64(*w, &n))
         {
             // Number
-            int64_t n = atoi64(*w);
             result << n;
         }
         else if (w->substr(0,2) == "0x" && w->size() > 2 && IsHex(std::string(w->begin()+2, w->end())))

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -203,7 +203,12 @@ size_t CDBWrapper::DynamicMemoryUsage() const {
         LogPrint(BCLog::LEVELDB, "Failed to get approximate-memory-usage property\n");
         return 0;
     }
-    return stoul(memory);
+    uint64_t ret;
+    if (ParseUInt64(memory, &ret)) {
+        return ret;
+    } else {
+        return 0;
+    }
 }
 
 // Prefixed with null character to avoid collisions with other keys

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -644,9 +644,10 @@ static void CleanupBlockRevFiles()
     // zero by walking the ordered map (keys are block file indices) by
     // keeping a separate counter.  Once we hit a gap (or if 0 doesn't exist)
     // start removing block files.
-    int nContigCounter = 0;
+    uint32_t nContigCounter = 0;
     for (const std::pair<const std::string, fs::path>& item : mapBlockFiles) {
-        if (atoi(item.first) == nContigCounter) {
+        uint32_t value;
+        if (ParseUInt32(item.first, &value) && value == nContigCounter) {
             nContigCounter++;
             continue;
         }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -222,10 +222,12 @@ bool RPCConsole::RPCParseCommandLine(interfaces::Node* node, std::string &strRes
                                 UniValue subelement;
                                 if (lastResult.isArray())
                                 {
-                                    for(char argch: curarg)
-                                        if (!IsDigit(argch))
-                                            throw std::runtime_error("Invalid result query");
-                                    subelement = lastResult[atoi(curarg.c_str())];
+                                    uint32_t index;
+                                    if (ParseUInt32(curarg, &index)) {
+                                        subelement = lastResult[index];
+                                    } else {
+                                        throw std::runtime_error("Invalid result query");
+                                    }
                                 }
                                 else if (lastResult.isObject())
                                     subelement = find_value(lastResult, curarg);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -127,8 +127,8 @@ static bool rest_headers(HTTPRequest* req,
     if (path.size() != 2)
         return RESTERR(req, HTTP_BAD_REQUEST, "No header count specified. Use /rest/headers/<count>/<hash>.<ext>.");
 
-    long count = strtol(path[0].c_str(), nullptr, 10);
-    if (count < 1 || count > 2000)
+    uint32_t count;
+    if (!ParseUInt32(path[0], &count) || count < 1 || count > 2000)
         return RESTERR(req, HTTP_BAD_REQUEST, "Header count out of range: " + path[0]);
 
     std::string hashStr = path[1];

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -492,7 +492,11 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
             std::string lpstr = lpval.get_str();
 
             hashWatchedChain = ParseHashV(lpstr.substr(0, 64), "longpollid");
-            nTransactionsUpdatedLastLP = atoi64(lpstr.substr(64));
+            uint32_t temp;
+            if (!ParseUInt32(lpstr.substr(64), &temp)) {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "could not parse lpval");
+            }
+            nTransactionsUpdatedLastLP = temp;
         }
         else
         {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -355,14 +355,11 @@ struct StringContentsSerializer {
 
 BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 {
-    char buf[10];
-
     fs::path ph = GetDataDir() / "iterator_string_ordering";
     CDBWrapper dbw(ph, (1 << 20), true, false, false);
     for (int x=0x00; x<10; ++x) {
         for (int y = 0; y < 10; y++) {
-            snprintf(buf, sizeof(buf), "%d", x);
-            StringContentsSerializer key(buf);
+            StringContentsSerializer key(strprintf("%d", x));
             for (int z = 0; z < y; z++)
                 key += key;
             uint32_t value = x*x;
@@ -372,13 +369,11 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
 
     std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper&>(dbw).NewIterator());
     for (const int seek_start : {0, 5}) {
-        snprintf(buf, sizeof(buf), "%d", seek_start);
-        StringContentsSerializer seek_key(buf);
+        StringContentsSerializer seek_key(strprintf("%d", seek_start));
         it->Seek(seek_key);
         for (unsigned int x=seek_start; x<10; ++x) {
             for (int y = 0; y < 10; y++) {
-                snprintf(buf, sizeof(buf), "%d", x);
-                std::string exp_key(buf);
+                std::string exp_key = strprintf("%d", x);
                 for (int z = 0; z < y; z++)
                     exp_key += exp_key;
                 StringContentsSerializer key;

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -55,7 +55,7 @@ class TorControlReply
 public:
     TorControlReply() { Clear(); }
 
-    int code;
+    uint32_t code;
     std::vector<std::string> lines;
 
     void Clear()
@@ -146,7 +146,10 @@ void TorControlConnection::readcb(struct bufferevent *bev, void *ctx)
         if (s.size() < 4) // Short line
             continue;
         // <status>(-|+| )<data><CRLF>
-        self->message.code = atoi(s.substr(0,3));
+        if (!ParseUInt32(s.substr(0,3), &self->message.code)) {
+            // Could not parse reply code
+            continue;
+        }
         self->message.lines.push_back(s.substr(4));
         char ch = s[3]; // '-','+' or ' '
         if (ch == ' ') {

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -68,7 +68,10 @@ bool ParseMoney(const char* pszIn, CAmount& nRet)
         return false;
     if (nUnits < 0 || nUnits > COIN)
         return false;
-    int64_t nWhole = atoi64(strWhole);
+    int64_t nWhole;
+    if (!ParseInt64(strWhole, &nWhole)) {
+        return false;
+    }
     CAmount nValue = nWhole*COIN + nUnits;
 
     nRet = nValue;

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -422,11 +422,6 @@ int64_t atoi64(const std::string& str)
 #endif
 }
 
-int atoi(const std::string& str)
-{
-    return atoi(str.c_str());
-}
-
 /** Upper bound for mantissa.
  * 10^18-1 is the largest arbitrary decimal that will fit in a signed 64-bit integer.
  * Larger integers cannot consist of arbitrary combinations of 0-9:

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -404,24 +404,6 @@ std::string itostr(int n)
     return strprintf("%d", n);
 }
 
-int64_t atoi64(const char* psz)
-{
-#ifdef _MSC_VER
-    return _atoi64(psz);
-#else
-    return strtoll(psz, nullptr, 10);
-#endif
-}
-
-int64_t atoi64(const std::string& str)
-{
-#ifdef _MSC_VER
-    return _atoi64(str.c_str());
-#else
-    return strtoll(str.c_str(), nullptr, 10);
-#endif
-}
-
 /** Upper bound for mantissa.
  * 10^18-1 is the largest arbitrary decimal that will fit in a signed 64-bit integer.
  * Larger integers cannot consist of arbitrary combinations of 0-9:

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -57,8 +57,6 @@ std::string EncodeBase32(const std::string& str);
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
 std::string i64tostr(int64_t n);
 std::string itostr(int n);
-int64_t atoi64(const char* psz);
-int64_t atoi64(const std::string& str);
 
 /**
  * Tests if the given character is a decimal digit.

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -59,7 +59,6 @@ std::string i64tostr(int64_t n);
 std::string itostr(int n);
 int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
-int atoi(const std::string& str);
 
 /**
  * Tests if the given character is a decimal digit.

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -504,7 +504,15 @@ int64_t ArgsManager::GetArg(const std::string& strArg, int64_t nDefault) const
 {
     if (IsArgNegated(strArg)) return 0;
     std::pair<bool,std::string> found_res = ArgsManagerHelper::GetArg(*this, strArg);
-    if (found_res.first) return atoi64(found_res.second);
+    int64_t res;
+    // TODO: add a way to return a parse error
+    if (found_res.first) {
+        if (ParseInt64(found_res.second, &res)) {
+            return res;
+        } else {
+            return 0;
+        }
+    }
     return nDefault;
 }
 

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -140,25 +140,16 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
 /**
  * Interpret a string argument as a boolean.
  *
- * The definition of atoi() requires that non-numeric string values like "foo",
- * return 0. This means that if a user unintentionally supplies a non-integer
- * argument here, the return value is always false. This means that -foo=false
- * does what the user probably expects, but -foo=true is well defined but does
- * not do what they probably expected.
- *
- * The return value of atoi() is undefined when given input not representable as
- * an int. On most systems this means string value between "-2147483648" and
- * "2147483647" are well defined (this method will return true). Setting
- * -txindex=2147483648 on most systems, however, is probably undefined.
- *
- * For a more extensive discussion of this topic (and a wide range of opinions
- * on the Right Way to change this code), see PR12713.
+ * - If the value is empty, this returns true.
+ * - If the value could not be parsed as a 64-bit integer, return false.
+ * - If the value could be parsed as a 64-bit integer, and is not 0, return true.
  */
 static bool InterpretBool(const std::string& strValue)
 {
     if (strValue.empty())
         return true;
-    return (atoi(strValue) != 0);
+    int64_t value;
+    return ParseInt64(strValue, &value) && value != 0;
 }
 
 /** Internal helper functions for ArgsManager */

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -148,6 +148,7 @@ static bool InterpretBool(const std::string& strValue)
 {
     if (strValue.empty())
         return true;
+    // TODO: add a way to return a parse error
     int64_t value;
     return ParseInt64(strValue, &value) && value != 0;
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -414,7 +414,12 @@ public:
         }
 
         ReadOrderPos(nOrderPos, mapValue);
-        nTimeSmart = mapValue.count("timesmart") ? (unsigned int)atoi64(mapValue["timesmart"]) : 0;
+        uint64_t temp;
+        if (mapValue.count("timesmart") && ParseUInt64(mapValue["timesmart"], &temp)) {
+            nTimeSmart = temp;
+        } else {
+            nTimeSmart = 0;
+        }
 
         mapValue.erase("fromaccount");
         mapValue.erase("spent");

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -200,12 +200,10 @@ typedef std::map<std::string, std::string> mapValue_t;
 
 static inline void ReadOrderPos(int64_t& nOrderPos, mapValue_t& mapValue)
 {
-    if (!mapValue.count("n"))
+    if (!mapValue.count("n") || !ParseInt64(mapValue["n"], &nOrderPos))
     {
         nOrderPos = -1; // TODO: calculate elsewhere
-        return;
     }
-    nOrderPos = atoi64(mapValue["n"].c_str());
 }
 
 

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -11,7 +11,6 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtol"
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
-    "src/util/system.cpp:.*atoi"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -5,7 +5,6 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*trim_right"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
-    "src/init.cpp:.*atoi"
     "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -2,7 +2,6 @@
 
 export LC_ALL=C
 KNOWN_VIOLATIONS=(
-    "src/bitcoin-tx.cpp.*stoul"
     "src/bitcoin-tx.cpp.*trim_right"
     "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -6,7 +6,6 @@ KNOWN_VIOLATIONS=(
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
     "src/rest.cpp:.*strtol"
-    "src/test/dbwrapper_tests.cpp:.*snprintf"
     "src/torcontrol.cpp:.*atoi"
     "src/torcontrol.cpp:.*strtol"
     "src/util/strencodings.cpp:.*atoi"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -3,7 +3,6 @@
 export LC_ALL=C
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*trim_right"
-    "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
     "src/init.cpp:.*atoi"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -5,7 +5,6 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*trim_right"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
-    "src/torcontrol.cpp:.*atoi"
     "src/torcontrol.cpp:.*strtol"
     "src/util/strencodings.cpp:.*atoi"
     "src/util/strencodings.cpp:.*strtol"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -5,7 +5,6 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*trim_right"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
-    "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"
     "src/torcontrol.cpp:.*atoi"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -6,10 +6,8 @@ KNOWN_VIOLATIONS=(
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
     "src/torcontrol.cpp:.*strtol"
-    "src/util/strencodings.cpp:.*atoi"
     "src/util/strencodings.cpp:.*strtol"
     "src/util/strencodings.cpp:.*strtoul"
-    "src/util/strencodings.h:.*atoi"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -5,7 +5,6 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*trim_right"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
-    "src/rest.cpp:.*strtol"
     "src/torcontrol.cpp:.*atoi"
     "src/torcontrol.cpp:.*strtol"
     "src/util/strencodings.cpp:.*atoi"


### PR DESCRIPTION
Addresses comment https://github.com/bitcoin/bitcoin/issues/17379#issuecomment-549919186

This replaces direct use of (often locale dependent) C library functions with our own integer parsing and formatting functions., as the [developer notes](https://github.com/bitcoin/bitcoin/blob/master/doc/developer-notes.md#strings-and-formatting) recommend.

For parsing this introduces parse error checking that was not there before. In many cases it's clear what to do on failure, but sometimes it's not. It also adds explicitly sized types everywhere. Please pay attention to this while reviewing.

See individual commits for details.

This leaves the following "known violations":
- `"src/bitcoin-tx.cpp.*trim_right"` boost function, out of scope
- `"src/dbwrapper.cpp:.*vsnprintf"` copied function, the comment addresses this: https://github.com/bitcoin/bitcoin/blob/master/src/dbwrapper.cpp#L19
- `"src/httprpc.cpp.*trim"` another boost function, out of scope
- `"src/torcontrol.cpp:.*strtol"` **octal** parsing, out of scope
- `"src/util/strencodings.cpp:.*strtol"`  part of `ParseInt32` and `ParseUInt32`, gated by our own checks
- `"src/util/strencodings.cpp:.*strtoul"` part of `ParseInt64` and `ParseUInt64`