### PR TITLE
[moveonly] Extract CWallet::CompactDatabase

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -688,13 +688,12 @@ public:
      */
     mutable CCriticalSection cs_wallet;
 
+    /** Compact the wallet database */
+    void CompactDatabase();
+
     /** Get database handle used by this wallet. Ideally this function would
      * not be necessary.
      */
-    WalletDatabase& GetDBHandle()
-    {
-        return *database;
-    }
     WalletDatabase& GetDatabase() override { return *database; }
 
     /**

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -670,20 +670,7 @@ void MaybeCompactWalletDB()
     }
 
     for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
-        WalletDatabase& dbh = pwallet->GetDBHandle();
-
-        unsigned int nUpdateCounter = dbh.nUpdateCounter;
-
-        if (dbh.nLastSeen != nUpdateCounter) {
-            dbh.nLastSeen = nUpdateCounter;
-            dbh.nLastWalletUpdate = GetTime();
-        }
-
-        if (dbh.nLastFlushed != nUpdateCounter && GetTime() - dbh.nLastWalletUpdate >= 2) {
-            if (BerkeleyBatch::PeriodicFlush(dbh)) {
-                dbh.nLastFlushed = nUpdateCounter;
-            }
-        }
+        pwallet->CompactDatabase();
     }
 
     fOneThread = false;


### PR DESCRIPTION
This removes the last use of `CWallet::GetDBHandle`, which is a layer violation (breaking encapsulation of CWallet::database) whose own comments call for its removal.

After this, the only remaining external users of `database` is `LegacyScriptPubKeyMan` via `CWallet::GetDatabase`, extracted in #17260.