### PR TITLE
doc: Added regtest config for linearize script

### DIFF
--- a/contrib/linearize/example-linearize.cfg
+++ b/contrib/linearize/example-linearize.cfg
@@ -28,6 +28,11 @@ input=/home/example/.bitcoin/blocks
 #genesis=000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943
 #input=/home/example/.bitcoin/testnet3/blocks
 
+# regtest
+#netmagic=fabfb5da
+#genesis=0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
+#input=/home/example/.bitcoin/regtest/blocks
+
 # "output" option causes blockchain files to be written to the given location,
 # with "output_file" ignored. If not used, "output_file" is used instead.
 # output=/home/example/blockchain_directory


### PR DESCRIPTION
Updated the example-linearize.cfg file to include support for the regtest chain network config which is used by the ./linearize-data.py

Problem:
Without the regtest magic, genesis hash and path config, the `linearize-data.py` script cannot generate a bootstrap.dat file.

Example:

./linearize-data.py ./linearize.cfg
Read 102 hashes
Genesis block not found in hashlist

Solution: 

Added netmagic, genesis and input example parameters to file. 

Resolution

1. Starting bitcoind in regtest mode 
2. bitcoin-cli generatetoaddress 101 $(bitcoin-cli getnewaddress)
3. ./linearize-hashes.py ./linearize.cfg > ./hashlist.txt
4. ./linearize-data.py ./linearize.cfg

```
$ ./linearize-data.py ./linearize.cfg
Read 102 hashes
Input file /Users/gr0kchain/.bitcoin/regtest/blocks/blk00000.dat
Output file /Users/gr0kchain/Downloads/bootstrap.dat
Done (102 blocks written)
```