### PR TITLE
ci: Travis support for PowerPC64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -101,6 +101,12 @@ jobs:
         QEMU_USER_CMD=""  # Can run the tests natively without qemu
 
     - stage: test
+      name: 'PowerPC64  [GOAL: install]  [unit tests, functional tests]'
+      os: linux-ppc64le
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_powerpc64.sh"
+
+    - stage: test
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_win64.sh"

--- a/ci/test/00_setup_env_powerpc64.sh
+++ b/ci/test/00_setup_env_powerpc64.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# set -x
+
+export LC_ALL=C.UTF-8
+
+export HOST=powerpc64le-unknown-linux-gnu
+export DOCKER_NAME_TAG=ppc64le/ubuntu:18.04
+export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
+export NO_DEPENDS=1
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL="install"
+export BITCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb"


### PR DESCRIPTION
Apparently travis has powerpc64 support even though it's undocumented.
 
I found a couple of caveats though:
1. Compact glibc support doesn't work (should be solved in #14066 )
2. it fails building OpneSSL from `depends` (fanquake tried debugging and it looks like it can't recognize the platform).
3. Docker doesn't recognize the platform correctly, so I had to use `ppc64le/ubuntu:18.04` instead of `library/ubuntu:18.04` (this is also maintained by Docker themselves https://github.com/docker-library/official-images#architectures-other-than-amd64)
4. functional tests are timing out.