### PR TITLE
Remove redundant class file include from test_bitcoin msvc project

### DIFF
--- a/build_msvc/test_bitcoin/test_bitcoin.vcxproj
+++ b/build_msvc/test_bitcoin/test_bitcoin.vcxproj
@@ -9,15 +9,13 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\test\*_tests.cpp" />
     <ClCompile Include="..\..\src\test\*_properties.cpp" />
+    <ClCompile Include="..\..\src\test\*_tests.cpp" />
     <ClCompile Include="..\..\src\test\gen\*_gen.cpp" />
-    <ClCompile Include="..\..\src\wallet\test\*_tests.cpp" />
-    <ClCompile Include="..\..\src\test\util\*.cpp" />
-    <ClCompile Include="..\..\src\test\util\setup_common.cpp" />
     <ClCompile Include="..\..\src\test\main.cpp" />
-    <ClCompile Include="..\..\src\wallet\test\*_fixture.cpp" />
     <ClCompile Include="..\..\src\test\util\*.cpp" />
+    <ClCompile Include="..\..\src\wallet\test\*_fixture.cpp" />
+    <ClCompile Include="..\..\src\wallet\test\*_tests.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">


### PR DESCRIPTION
#17364 & #17384 overlapped and both added the same line of `..\..\src\test\util\*.cpp` to `test_bitcoin.vcxproj`. This didn't break the build but does result in duplicate symbol warnings. This PR cleans it up and removes the additional redundant line of `..\..\src\test\util\setup_common.cpp` which will also be covered by the wildcard include.