### PR TITLE
wallet: Remove unused boost::this_thread::interruption_point

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -166,10 +166,9 @@ BerkeleyEnvironment::~BerkeleyEnvironment()
 
 bool BerkeleyEnvironment::Open(bool retry)
 {
-    if (fDbEnvInit)
+    if (fDbEnvInit) {
         return true;
-
-    boost::this_thread::interruption_point();
+    }
 
     fs::path pathIn = strPath;
     TryCreateDirectories(pathIn);
@@ -238,12 +237,10 @@ bool BerkeleyEnvironment::Open(bool retry)
     return true;
 }
 
-//! Construct an in-memory mock Berkeley environment for testing and as a place-holder for g_dbenvs emplace
+//! Construct an in-memory mock Berkeley environment for testing
 BerkeleyEnvironment::BerkeleyEnvironment()
 {
     Reset();
-
-    boost::this_thread::interruption_point();
 
     LogPrint(BCLog::DB, "BerkeleyEnvironment::MakeMock\n");
 
@@ -263,8 +260,9 @@ BerkeleyEnvironment::BerkeleyEnvironment()
                              DB_THREAD |
                              DB_PRIVATE,
                          S_IRUSR | S_IWUSR);
-    if (ret > 0)
+    if (ret > 0) {
         throw std::runtime_error(strprintf("BerkeleyEnvironment::MakeMock: Error %d opening database environment.", ret));
+    }
 
     fDbEnvInit = true;
     fMockDb = true;


### PR DESCRIPTION
`BerkeleyEnvironment::Open` is only called from the main thread (init) or an http rpc thread, neither of which can be interrupted, so remove the useless interruption point.

`BerkeleyEnvironment{}` is only used in tests, which run in a single process/thread, so remove the useless interruption point.