### PR TITLE
Replace assert with ASSERT

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -314,7 +314,7 @@ void SetRPCWarmupStatus(const std::string& newStatus)
 void SetRPCWarmupFinished()
 {
     LOCK(cs_rpcWarmup);
-    assert(fRPCInWarmup);
+    ASSERT(fRPCInWarmup);
     fRPCInWarmup = false;
 }
 

--- a/src/util/check.h
+++ b/src/util/check.h
@@ -9,6 +9,30 @@
 
 #include <stdexcept>
 
+/**
+ * Abort the program when the condition evaluates to false
+ *
+ * This should only be used
+ * - where the condition is assumed to be true, not for error handling or validating user input
+ * - where a failure to fulfill the condition is NOT recoverable and needs to ABORT the program
+ *
+ * For example in script validation, where any further action after a logic error could lead to a consensus failure, it
+ * is better to abort the program and not proceed with validation.
+ */
+#define ASSERT(condition)                                                  \
+    do {                                                                   \
+        if (!(condition)) {                                                \
+            tfm::format(std::cerr, "%s:%d (%s)\n"                          \
+                                   "Internal bug detected: '%s'\n"         \
+                                   "Aborting!\n"                           \
+                                   "You may report this issue here: %s\n", \
+                __FILE__, __LINE__, __func__,                              \
+                (#condition),                                              \
+                PACKAGE_BUGREPORT);                                        \
+            std::abort();                                                  \
+        }                                                                  \
+    } while (false)
+
 class NonFatalCheckError : public std::runtime_error
 {
     using std::runtime_error::runtime_error;

--- a/test/lint/lint-assertions.sh
+++ b/test/lint/lint-assertions.sh
@@ -20,12 +20,9 @@ if [[ ${OUTPUT} != "" ]]; then
     EXIT_CODE=1
 fi
 
-# Macro CHECK_NONFATAL(condition) should be used instead of assert for RPC code, where it
-# is undesirable to crash the whole program. See: src/util/check.h
-# src/rpc/server.cpp is excluded from this check since it's mostly meta-code.
-OUTPUT=$(git grep -nE 'assert *\(.*\);' -- "src/rpc/" "src/wallet/rpc*" ":(exclude)src/rpc/server.cpp")
+OUTPUT=$(git grep -nE 'assert *\(.*\);' -- "src/rpc/" "src/wallet/rpc*")
 if [[ ${OUTPUT} != "" ]]; then
-    echo "CHECK_NONFATAL(condition) should be used instead of assert for RPC code."
+    echo "CHECK_NONFATAL(condition) or ASSERT(condition) should be used instead of assert for RPC code. See src/util/check.h"
     echo
     echo "${OUTPUT}"
     EXIT_CODE=1


### PR DESCRIPTION
`ASSERT` does the same as the current `assert` in Bitcoin Core, with the only difference of printing a bug report to stderr. Also, it comes with documentation when to use it.