### PR TITLE
[0.19] cli: fix -getinfo output when compiled with no wallet

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -262,7 +262,7 @@ public:
         result.pushKV("proxy", batch[ID_NETWORKINFO]["result"]["networks"][0]["proxy"]);
         result.pushKV("difficulty", batch[ID_BLOCKCHAININFO]["result"]["difficulty"]);
         result.pushKV("chain", UniValue(batch[ID_BLOCKCHAININFO]["result"]["chain"]));
-        if (!batch[ID_WALLETINFO].isNull()) {
+        if (!batch[ID_WALLETINFO]["result"].isNull()) {
             result.pushKV("walletversion", batch[ID_WALLETINFO]["result"]["walletversion"]);
             result.pushKV("balance", batch[ID_WALLETINFO]["result"]["balance"]);
             result.pushKV("keypoololdest", batch[ID_WALLETINFO]["result"]["keypoololdest"]);


### PR DESCRIPTION
Backports #17368 to the 0.19 branch.