### PR TITLE
Build: add REPO_SLUG to fix errors in forked builds

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -18,7 +18,7 @@ test/lint/check-doc.py
 test/lint/check-rpc-mappings.py .
 test/lint/lint-all.sh
 
-if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" ] && [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
+if [ "$TRAVIS_REPO_SLUG" = "$REPO_SLUG" ] && [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
     travis_retry gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $(<contrib/verify-commits/trusted-keys) &&
     ./contrib/verify-commits/verify-commits.py --clean-merge=2;

--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -15,7 +15,9 @@ fi
 
 BASE_ROOT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../../ >/dev/null 2>&1 && pwd )
 export BASE_ROOT_DIR
-
+REPO_SLUG=$(git config user.name)/$(basename $(git rev-parse --show-toplevel))
+echo "REPO_SLUG=$REPO_SLUG"
+export REPO_SLUG
 echo "Fallback to default values in env (if not yet set)"
 # The number of parallel jobs to pass down to make and test_runner.py
 export MAKEJOBS=${MAKEJOBS:--j4}


### PR DESCRIPTION
This small change enables forks to use the TravisCI tests.