### PR TITLE
build:fix "make clean" darwin build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ empty :=
 space := $(empty) $(empty)
 
 OSX_APP=Bitcoin-Qt.app
-OSX_VOLNAME = $(subst $(space),-,$(PACKAGE_NAME))
+OSX_VOLNAME = Bitcoin-Qt
 OSX_DMG = $(OSX_VOLNAME).dmg
 OSX_BACKGROUND_SVG=background.svg
 OSX_BACKGROUND_IMAGE=background.tiff
@@ -296,7 +296,7 @@ EXTRA_DIST += \
     test/util/data/txcreatesignv2.hex \
     test/util/rpcauth-test.py
 
-CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
+CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER) $(OSX_BACKGROUND_IMAGE) $(OSX_BACKGROUND_IMAGE).png $(OSX_BACKGROUND_IMAGE)@2x.png
 
 .INTERMEDIATE: $(COVERAGE_INFO)
 


### PR DESCRIPTION
This PR corrects an issue where ```make clean``` was not removing the .dmg

$```make clean``` now works as expected.
$```make deploy``` still works as expected.

cleans  Bitcoin-Qt.dmg, background.tiff
        bachground.png, background@2x.png
        as expected.

***old config***
![Screen Shot 2019-11-09 at 1 16 23 AM](https://user-images.githubusercontent.com/152159/68537092-7f746400-032c-11ea-9f29-4d2eb000ceba.png)
***new config***
![Screen Shot 2019-11-09 at 1 47 01 AM](https://user-images.githubusercontent.com/152159/68537093-8307eb00-032c-11ea-9107-2b30d42c454a.png)


The change was added to documentation but ```make clean``` needed to be updated.
https://github.com/bitcoin/bitcoin/commit/4441e58497513cc55cfebfdcaaeee340f62f8062#diff-9de36befe13356841c2699ee0eff4a0aR14

The old config named the Bitcoin-Core.dmg based on the PACKAGE_NAME variable (which is still used for naming the Bitcoin Core.app (with space)).
