### PR TITLE
Move parsing from init.cpp to where values are needed

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1009,7 +1009,6 @@ bool AppInitParameterInteraction()
     if (ratio != 0) {
         mempool.setSanityCheck(1.0 / ratio);
     }
-    fCheckBlockIndex = gArgs.GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = gArgs.GetBoolArg("-checkpoints", DEFAULT_CHECKPOINTS_ENABLED);
 
     hashAssumeValid = uint256S(gArgs.GetArg("-assumevalid", chainparams.GetConsensus().defaultAssumeValid.GetHex()));
@@ -1132,6 +1131,8 @@ bool AppInitParameterInteraction()
         return InitError("unknown rpcserialversion requested.");
 
     nMaxTipAge = gArgs.GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
+
+    ValidationParameterInteraction(chainparams);
 
     return true;
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -68,6 +68,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     fs::create_directories(m_path_root);
     gArgs.ForceSetArg("-datadir", m_path_root.string());
     ClearDatadirCache();
+    gArgs.ForceSetArg("-checkblockindex", "1");
     SelectParams(chainName);
     SeedInsecureRand();
     gArgs.ForceSetArg("-printtoconsole", "0");
@@ -79,7 +80,6 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     SetupNetworking();
     InitSignatureCache();
     InitScriptExecutionCache();
-    fCheckBlockIndex = true;
     static bool noui_connected = false;
     if (!noui_connected) {
         noui_connect();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -180,6 +180,11 @@ CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& loc
 
 std::unique_ptr<CBlockTreeDB> pblocktree;
 
+void ValidationParameterInteraction(const CChainParams& chainparams)
+{
+    fCheckBlockIndex = gArgs.GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
+}
+
 // See definition for documentation
 static void FindFilesToPruneManual(std::set<int>& setFilesToPrune, int nManualPruneHeight);
 static void FindFilesToPrune(std::set<int>& setFilesToPrune, uint64_t nPruneAfterHeight);

--- a/src/validation.h
+++ b/src/validation.h
@@ -152,7 +152,6 @@ extern std::atomic_bool fReindex;
  */
 extern bool g_parallel_script_checks;
 extern bool fRequireStandard;
-extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
 extern size_t nCoinCacheUsage;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
@@ -292,6 +291,9 @@ int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::D
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction& tx, CCoinsViewCache& inputs, int nHeight);
+
+/** Parse and validate parameters only used in validation.cpp */
+void ValidationParameterInteraction(const CChainParams& chainparams);
 
 /** Transaction validation functions */
 


### PR DESCRIPTION
There appear to be a few more of these globals that are only used once. I could do more of them, if this sort of change is welcome.

Reference: https://github.com/bitcoin/bitcoin/pull/17383#issuecomment-550278607