### PR TITLE
test: check custom ancestor limit in mempool_packages.py

### DIFF
--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -14,13 +14,19 @@ from test_framework.util import (
     satoshi_round,
 )
 
+# default limits
 MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
+# custom limits for node1
+MAX_ANCESTORS_CUSTOM = 5
 
 class MempoolPackagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.extra_args = [["-maxorphantx=1000"], ["-maxorphantx=1000", "-limitancestorcount=5"]]
+        self.extra_args = [
+            ["-maxorphantx=1000"],
+            ["-maxorphantx=1000", "-limitancestorcount={}".format(MAX_ANCESTORS_CUSTOM)],
+        ]
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -188,7 +194,14 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN + 2000)
             assert_equal(mempool[x]['fees']['descendant'], descendant_fees+satoshi_round(0.00002))
 
-        # TODO: check that node1's mempool is as expected
+        # Check that node1's mempool is as expected (-> custom ancestor limit)
+        mempool0 = self.nodes[0].getrawmempool(False)
+        mempool1 = self.nodes[1].getrawmempool(False)
+        assert_equal(len(mempool1), MAX_ANCESTORS_CUSTOM)
+        assert set(mempool1).issubset(set(mempool0))
+        for tx in chain[:MAX_ANCESTORS_CUSTOM]:
+            assert tx in mempool1
+        # TODO: more detailed check of node1's mempool (fees etc.)
 
         # TODO: test ancestor size limits
 


### PR DESCRIPTION
The functional test `mempool_packages.py` starts one node with default ancestor/descendant limit settings and one with a custom, reduced ancestor limit (currently `-limitancestorcount=5`). The effect of the latter had not been tested yet though. This is approached in this PR by checking on the expected mempool contents of node1 after the node0 ancestor tests are done, via the following three conditions:
- the # of txs in the node1 mempool is equal to the the limit
- all txs in node1 mempool are a subset of txs in node0 mempool
- the node1 mempool txs match the start of the constructed tx-chain

Note that this still doesn't *fully* check the expected mempool of node1 (e.g. that it isn't influenced by `prioritisetransaction` RPC on node0), hence I add another TODO. In the future it would make sense to also set a custom descendant limit when the second TODO about checking node1's mempool is approached: https://github.com/bitcoin/bitcoin/blob/89e93135aedf984f7a98771f047e2beb6cdbdb8e/test/functional/mempool_packages.py#L228