### PR TITLE
wallet: Avoid showing GUI popups on RPC errors (take 2)

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3651,9 +3651,7 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
         }
 
         if (auto spk_man = walletInstance->m_spk_man.get()) {
-            std::string error;
             if (!spk_man->Upgrade(prev_version, error)) {
-                chain.initError(error);
                 return nullptr;
             }
         }


### PR DESCRIPTION
Commit 8b0d82bb428de9e7f1da7c61574e7a8376a62d43 claims "This commit does not change behavior." However, it re-introduced the bug I tried to fix in #17070