### PR TITLE
zmq: Fix due to invalid argument and multiple notifiers

### DIFF
--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -112,7 +112,8 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 
 void CZMQAbstractPublishNotifier::Shutdown()
 {
-    assert(psocket);
+    // Early return if Initialize was not called
+    if (!psocket) return;
 
     int count = mapPublishNotifiers.count(address);
 

--- a/test/functional/interface_zmq.py
+++ b/test/functional/interface_zmq.py
@@ -59,6 +59,10 @@ class ZMQTest (BitcoinTestFramework):
         # Note that the publishing order is not defined in the documentation and
         # is subject to change.
         import zmq
+
+        # Invalid zmq arguments don't take down the node, see #17185.
+        self.restart_node(0, ["-zmqpubrawtx=foo", "-zmqpubhashtx=bar"])
+
         address = 'tcp://127.0.0.1:28332'
         socket = self.ctx.socket(zmq.SUB)
         socket.set(zmq.RCVTIMEO, 60000)


### PR DESCRIPTION
ZMQ initialization is interrupted if any notifier fails, and in that case all notifiers are destroyed. The notifier shutdown assumes that the initialization had occurred. This is not valid when there are multiple notifiers and any except the last fails to initialize.

Can be tested by running test/functional/interface_zmq.py from this branch with bitcoind from master.

Closes #17185.