### PR TITLE
gui: Changed tooltip for 'Label' & 'Message' text fields to be more clear

### DIFF
--- a/src/qt/forms/receivecoinsdialog.ui
+++ b/src/qt/forms/receivecoinsdialog.ui
@@ -63,7 +63,7 @@
         <item row="4" column="2">
          <widget class="QLineEdit" name="reqLabel">
           <property name="toolTip">
-           <string>An optional label to associate with the new receiving address.</string>
+           <string>An optional label to associate with the new receiving address (used by you to identify an invoice).  It is also attached to the payment request.</string>
           </property>
          </widget>
         </item>
@@ -93,7 +93,7 @@
         <item row="6" column="2">
          <widget class="QLineEdit" name="reqMessage">
           <property name="toolTip">
-           <string>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</string>
+           <string>An optional message that is attached to the payment request and may be displayed to the sender.</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
I have changed the tooltips for 'Label' & 'Message' text fields to be more clear, stating the difference between the two (#17173)