### PR TITLE
test: update fuzz directory in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ src/bitcoind
 src/bitcoin-cli
 src/bitcoin-tx
 src/bitcoin-wallet
+src/test/fuzz
+!src/test/fuzz/*.*
 src/test/test_bitcoin
-src/test/test_bitcoin_fuzzy
 src/qt/test/test_bitcoin-qt
 
 # autoreconf


### PR DESCRIPTION
The fuzzing gitignores haven't been updated since a4153e2 in 2016 that added an initial simple fuzzing framework.

This commit:
- removes `src/test/test_bitcoin_fuzzy` which is no longer used in favor of `src/test/fuzz`
- ignores the `src/test/fuzz` directory, then un-ignores files in it with an extension, to de-clutter the git status from all the generated binary files.

Co-authored-by: Karl-Johan Alm <karljohan-alm@garage.co.jp>