### PR TITLE
gui: Fix intro dialog labels when the prune button is toggled

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -251,22 +251,29 @@ void Intro::setStatus(int status, const QString &message, quint64 bytesAvailable
     {
         ui->freeSpace->setText("");
     } else {
-        QString freeString = tr("%n GB of free space available", "", bytesAvailable/GB_BYTES);
-        if (bytesAvailable < m_required_space_gb * GB_BYTES) {
-            freeString += " " + tr("(of %n GB needed)", "", m_required_space_gb);
-            ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
-            ui->prune->setChecked(true);
-        } else if (bytesAvailable / GB_BYTES - m_required_space_gb < 10) {
-            freeString += " " + tr("(%n GB needed for full chain)", "", m_required_space_gb);
-            ui->freeSpace->setStyleSheet("QLabel { color: #999900 }");
-            ui->prune->setChecked(true);
-        } else {
-            ui->freeSpace->setStyleSheet("");
+        m_bytes_available = bytesAvailable;
+        if (ui->prune->isEnabled()) {
+            ui->prune->setChecked(m_bytes_available < (m_blockchain_size_gb + m_chain_state_size_gb + 10) * GB_BYTES);
         }
-        ui->freeSpace->setText(freeString + ".");
+        UpdateFreeSpaceLabel();
     }
     /* Don't allow confirm in ERROR state */
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(status != FreespaceChecker::ST_ERROR);
+}
+
+void Intro::UpdateFreeSpaceLabel()
+{
+    QString freeString = tr("%n GB of free space available", "", m_bytes_available / GB_BYTES);
+    if (m_bytes_available < m_required_space_gb * GB_BYTES) {
+        freeString += " " + tr("(of %n GB needed)", "", m_required_space_gb);
+        ui->freeSpace->setStyleSheet("QLabel { color: #800000 }");
+    } else if (m_bytes_available / GB_BYTES - m_required_space_gb < 10) {
+        freeString += " " + tr("(%n GB needed for full chain)", "", m_required_space_gb);
+        ui->freeSpace->setStyleSheet("QLabel { color: #999900 }");
+    } else {
+        ui->freeSpace->setStyleSheet("");
+    }
+    ui->freeSpace->setText(freeString + ".");
 }
 
 void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -135,19 +135,7 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     }
     const int prune_target_gb = PruneMiBtoGB(prune_target_mib);
     ui->prune->setText(tr("Discard blocks after verification, except most recent %1 GB (prune)").arg(prune_target_gb ? prune_target_gb : DEFAULT_PRUNE_TARGET_GB));
-    m_required_space_gb = m_blockchain_size_gb + m_chain_state_size_gb;
-    QString storageRequiresMsg = tr("At least %1 GB of data will be stored in this directory, and it will grow over time.");
-    if (0 < prune_target_gb && prune_target_gb <= m_blockchain_size_gb) {
-        m_required_space_gb = prune_target_gb + m_chain_state_size_gb;
-        storageRequiresMsg = tr("Approximately %1 GB of data will be stored in this directory.");
-    }
-    ui->lblExplanation3->setVisible(prune_target_gb > 0);
-    ui->sizeWarningLabel->setText(
-        tr("%1 will download and store a copy of the Bitcoin block chain.").arg(PACKAGE_NAME) + " " +
-        storageRequiresMsg.arg(m_required_space_gb) + " " +
-        tr("The wallet will also be stored in this directory.")
-    );
-    this->adjustSize();
+    UpdatePruneLabels(prune_target_gb);
     startThread();
 }
 
@@ -340,4 +328,21 @@ QString Intro::getPathToCheck()
     signalled = false; /* new request can be queued now */
     mutex.unlock();
     return retval;
+}
+
+void Intro::UpdatePruneLabels(int64_t prune_target_gb)
+{
+    m_required_space_gb = m_blockchain_size_gb + m_chain_state_size_gb;
+    QString storageRequiresMsg = tr("At least %1 GB of data will be stored in this directory, and it will grow over time.");
+    if (0 < prune_target_gb && prune_target_gb <= m_blockchain_size_gb) {
+        m_required_space_gb = prune_target_gb + m_chain_state_size_gb;
+        storageRequiresMsg = tr("Approximately %1 GB of data will be stored in this directory.");
+    }
+    ui->lblExplanation3->setVisible(prune_target_gb > 0);
+    ui->sizeWarningLabel->setText(
+        tr("%1 will download and store a copy of the Bitcoin block chain.").arg(PACKAGE_NAME) + " " +
+        storageRequiresMsg.arg(m_required_space_gb) + " " +
+        tr("The wallet will also be stored in this directory.")
+    );
+    this->adjustSize();
 }

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -71,11 +71,13 @@ private:
     const int64_t m_chain_state_size_gb;
     //! Total required space (in GB) depending on user choice (prune or not prune).
     int64_t m_required_space_gb{0};
+    uint64_t m_bytes_available{0};
 
     void startThread();
     void checkPath(const QString &dataDir);
     QString getPathToCheck();
     void UpdatePruneLabels(int64_t prune_target_gb);
+    void UpdateFreeSpaceLabel();
 
     friend class FreespaceChecker;
 };

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -72,11 +72,12 @@ private:
     //! Total required space (in GB) depending on user choice (prune or not prune).
     int64_t m_required_space_gb{0};
     uint64_t m_bytes_available{0};
+    const int64_t m_prune_target_gb;
 
     void startThread();
     void checkPath(const QString &dataDir);
     QString getPathToCheck();
-    void UpdatePruneLabels(int64_t prune_target_gb);
+    void UpdatePruneLabels(bool prune_checked);
     void UpdateFreeSpaceLabel();
 
     friend class FreespaceChecker;

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -31,7 +31,7 @@ class Intro : public QDialog
 
 public:
     explicit Intro(QWidget *parent = nullptr,
-                   uint64_t blockchain_size = 0, uint64_t chain_state_size = 0);
+                   int64_t blockchain_size_gb = 0, int64_t chain_state_size_gb = 0);
     ~Intro();
 
     QString getDataDirectory();
@@ -67,8 +67,10 @@ private:
     QMutex mutex;
     bool signalled;
     QString pathToCheck;
-    uint64_t m_blockchain_size;
-    uint64_t m_chain_state_size;
+    const int64_t m_blockchain_size_gb;
+    const int64_t m_chain_state_size_gb;
+    //! Total required space (in GB) depending on user choice (prune or not prune).
+    int64_t m_required_space_gb{0};
 
     void startThread();
     void checkPath(const QString &dataDir);

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -75,6 +75,7 @@ private:
     void startThread();
     void checkPath(const QString &dataDir);
     QString getPathToCheck();
+    void UpdatePruneLabels(int64_t prune_target_gb);
 
     friend class FreespaceChecker;
 };

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -240,9 +240,8 @@ void OptionsModel::SetPruneEnabled(bool prune, bool force)
 {
     QSettings settings;
     settings.setValue("bPrune", prune);
-    // Convert prune size from GB to MiB:
-    const uint64_t nPruneSizeMiB = (settings.value("nPruneSize").toInt() * GB_BYTES) >> 20;
-    std::string prune_val = prune ? std::to_string(nPruneSizeMiB) : "0";
+    const int64_t prune_target_mib = PruneGBtoMiB(settings.value("nPruneSize").toInt());
+    std::string prune_val = prune ? std::to_string(prune_target_mib) : "0";
     if (force) {
         m_node.forceSetArg("-prune", prune_val);
         return;

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_OPTIONSMODEL_H
 
 #include <amount.h>
+#include <qt/guiconstants.h>
 
 #include <QAbstractListModel>
 
@@ -15,6 +16,11 @@ class Node;
 
 extern const char *DEFAULT_GUI_PROXY_HOST;
 static constexpr unsigned short DEFAULT_GUI_PROXY_PORT = 9050;
+
+/**
+ * Convert configured prune target MiB to displayed GB. Round up to avoid underestimating max disk usage.
+ */
+static inline int PruneMiBtoGB(int64_t mib) { return (mib * 1024 * 1024 + GB_BYTES - 1) / GB_BYTES; }
 
 /** Interface from Qt to configuration data structure for Bitcoin client.
    To Qt, the options are presented as a list with the different options

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -22,6 +22,11 @@ static constexpr unsigned short DEFAULT_GUI_PROXY_PORT = 9050;
  */
 static inline int PruneMiBtoGB(int64_t mib) { return (mib * 1024 * 1024 + GB_BYTES - 1) / GB_BYTES; }
 
+/**
+ * Convert displayed prune target GB to configured MiB. Round down so roundtrip GB -> MiB -> GB conversion is stable.
+ */
+static inline int64_t PruneGBtoMiB(int gb) { return gb * GB_BYTES / 1024 / 1024; }
+
 /** Interface from Qt to configuration data structure for Bitcoin client.
    To Qt, the options are presented as a list with the different options
    laid out vertically.


### PR DESCRIPTION
On master (a6f6333ba253cda83221ee529810cacf930e413f) and on 0.19.0.1 the intro dialog with prune enabled (checkbox "Discard blocks..." is checked) provides a user with wrong info about the required disk space:

![DeepinScreenshot_bitcoin-qt_20191208112228](https://user-images.githubusercontent.com/32963518/70387510-8daab400-19ae-11ea-9338-29add9c31118.png)

Also the paragraph "If you have chosen to limit..." is missed.

---

With this PR when prune checkbox is toggled, the related text labels and the amount of required space shown are updated (previously they were only updated when the data directory was updated):
![Screenshot from 2019-12-08 11-34-53](https://user-images.githubusercontent.com/32963518/70387542-eed28780-19ae-11ea-9565-49d8a64b2f33.png)

---

This PR is an alternative to #17035.

**ryanofsky**'s [suggestion](https://github.com/bitcoin/bitcoin/pull/17035#discussion_r337594268) also has been implemented.