### PR TITLE
tests: Update valgrind suppressions

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -6,7 +6,14 @@
 # Example use:
 # $ valgrind --suppressions=contrib/valgrind.supp src/test/test_bitcoin
 # $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
-#       --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite
+#       --show-leak-kinds=all src/test/test_bitcoin
+#
+# To create suppressions for found issues, use the --gen-suppressions=all option:
+# $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
+#       --show-leak-kinds=all --gen-suppressions=all --show-reachable=yes \
+#       --error-limit=no src/test/test_bitcoin
+#
+# Note that suppressions may depend on OS and/or library versions.
 {
    Suppress libstdc++ warning - https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65434
    Memcheck:Leak
@@ -27,6 +34,14 @@
    fun:__log_put_record
 }
 {
+   Suppress libdb warning
+   Memcheck:Param
+   pwrite64(buf)
+   fun:pwrite
+   fun:__os_io
+   obj:*/libdb_cxx-*.so
+}
+{
    Suppress leveldb warning (leveldb::InitModule()) - https://github.com/google/leveldb/issues/113
    Memcheck:Leak
    match-leak-kinds: reachable
@@ -40,4 +55,58 @@
    fun:_Znwm
    ...
    fun:_ZN7leveldbL14InitDefaultEnvEv
+}
+{
+   Suppress wcsnrtombs glibc SSE4 warning (could be related: https://stroika.atlassian.net/browse/STK-626)
+   Memcheck:Addr16
+   fun:__wcsnlen_sse4_1
+   fun:wcsnrtombs
+}
+{
+   Suppress boost::filesystem warning (fixed in boost 1.70: https://github.com/boostorg/filesystem/commit/bbe9d1771e5d679b3f10c42a58fc81f7e8c024a9)
+   Memcheck:Cond
+   fun:_ZN5boost10filesystem6detail28directory_iterator_incrementERNS0_18directory_iteratorEPNS_6system10error_codeE
+   fun:_ZN5boost10filesystem6detail28directory_iterator_constructERNS0_18directory_iteratorERKNS0_4pathEPNS_6system10error_codeE
+   obj:*/libboost_filesystem.so.*
+}
+{
+   Suppress boost::filesystem warning (could be related: https://stackoverflow.com/questions/9830182/function-boostfilesystemcomplete-being-reported-as-possible-memory-leak-by-v)
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN5boost10filesystem8absoluteERKNS0_4pathES3_
+}
+{
+   Suppress boost still reachable memory warning
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   ...
+   fun:_M_construct_aux<char*>
+   fun:_M_construct<char*>
+   fun:basic_string
+   fun:path
+}
+{
+   Suppress LogInstance still reachable memory warning
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_Z11LogInstancev
+}
+{
+   Suppress secp256k1_context_create still reachable memory warning
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:secp256k1_context_create
+}
+{
+   Suppress BCLog::Logger::StartLogging() still reachable memory warning
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:_ZN5BCLog6Logger12StartLoggingEv
 }


### PR DESCRIPTION
Update `valgrind` suppressions.

To test this PR:

```
$ valgrind --suppressions=contrib/valgrind.supp src/test/test_bitcoin
$ valgrind --suppressions=contrib/valgrind.supp src/bench/bench_bitcoin -evals=1 \
      -scaling=0.0
```