### PR TITLE
gui: Fix manual coin control with multiple wallets loaded

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -612,8 +612,7 @@ void CoinControlDialog::updateView()
     int nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 
     for (const auto& coins : model->wallet().listCoins()) {
-        CCoinControlWidgetItem *itemWalletAddress = new CCoinControlWidgetItem();
-        itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);
+        CCoinControlWidgetItem* itemWalletAddress{nullptr};
         QString sWalletAddress = QString::fromStdString(EncodeDestination(coins.first));
         QString sWalletLabel = model->getAddressTableModel()->labelForAddress(sWalletAddress);
         if (sWalletLabel.isEmpty())
@@ -622,7 +621,7 @@ void CoinControlDialog::updateView()
         if (treeMode)
         {
             // wallet address
-            ui->treeWidget->addTopLevelItem(itemWalletAddress);
+            itemWalletAddress = new CCoinControlWidgetItem(ui->treeWidget);
 
             itemWalletAddress->setFlags(flgTristate);
             itemWalletAddress->setCheckState(COLUMN_CHECKBOX, Qt::Unchecked);

--- a/src/qt/coincontroldialog.h
+++ b/src/qt/coincontroldialog.h
@@ -48,15 +48,15 @@ public:
 
     void setModel(WalletModel *model);
 
-    // static because also called from sendcoinsdialog
-    static void updateLabels(WalletModel*, QDialog*);
+    void updateLabels();
 
-    static QList<CAmount> payAmounts;
-    static CCoinControl *coinControl();
-    static bool fSubtractFeeFromAmount;
+    QList<CAmount> payAmounts;
+    CCoinControl* coinControl();
+    bool fSubtractFeeFromAmount{false};
 
 private:
     Ui::CoinControlDialog *ui;
+    CCoinControl* m_coin_control{nullptr};
     WalletModel *model;
     int sortColumn;
     Qt::SortOrder sortOrder;

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -691,6 +691,16 @@ void SendCoinsDialog::updateFeeMinimizedLabel()
     }
 }
 
+CoinControlDialog* SendCoinsDialog::coinControlDialog()
+{
+    if (!m_coin_control_dialog) {
+        m_coin_control_dialog = new CoinControlDialog(platformStyle, this);
+        m_coin_control_dialog->setModel(model);
+        connect(m_coin_control_dialog, &QDialog::finished, this, &SendCoinsDialog::coinControlUpdateLabels);
+    }
+    return m_coin_control_dialog;
+}
+
 void SendCoinsDialog::updateCoinControlState(CCoinControl& ctrl)
 {
     if (ui->radioCustomFee->isChecked()) {
@@ -794,10 +804,7 @@ void SendCoinsDialog::coinControlFeatureChanged(bool checked)
 // Coin Control: button inputs -> show actual coin control dialog
 void SendCoinsDialog::coinControlButtonClicked()
 {
-    CoinControlDialog dlg(platformStyle);
-    dlg.setModel(model);
-    dlg.exec();
-    coinControlUpdateLabels();
+    coinControlDialog()->open();
 }
 
 // Coin Control: checkbox custom change address

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -13,6 +13,7 @@
 #include <QTimer>
 
 class ClientModel;
+class CoinControlDialog;
 class PlatformStyle;
 class SendCoinsEntry;
 class SendCoinsRecipient;
@@ -60,6 +61,7 @@ private:
     Ui::SendCoinsDialog *ui;
     ClientModel *clientModel;
     WalletModel *model;
+    CoinControlDialog* m_coin_control_dialog{nullptr};
     bool fNewRecipientAllowed;
     bool fFeeMinimized;
     const PlatformStyle *platformStyle;
@@ -70,6 +72,8 @@ private:
     void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());
     void minimizeFeeSection(bool fMinimize);
     void updateFeeMinimizedLabel();
+    // Returns the coin control dialog, creating it on first call.
+    CoinControlDialog* coinControlDialog();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -74,6 +74,7 @@ private:
     void updateFeeMinimizedLabel();
     // Returns the coin control dialog, creating it on first call.
     CoinControlDialog* coinControlDialog();
+    void updateLabels();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
 

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -63,6 +63,8 @@ int main(int argc, char *argv[])
         setenv("QT_QPA_PLATFORM", "minimal", /* overwrite */ 0);
     #endif
 
+    qRegisterMetaType<size_t>("size_t");
+
     // Don't remove this, it's needed to access
     // QApplication:: and QCoreApplication:: in the tests
     BitcoinApplication app(*node);


### PR DESCRIPTION
This PR makes coin selection work when multiple wallets are loaded - each loaded wallet has it's own coin control dialog.

Closes #15725.