### PR TITLE
Remove redundant NDEBUG preprocessor checks

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -30,10 +30,6 @@
 
 #include <memory>
 
-#if defined(NDEBUG)
-# error "Bitcoin cannot be compiled without assertions."
-#endif
-
 /** Expiration time for orphan transactions in seconds */
 static constexpr int64_t ORPHAN_TX_EXPIRE_TIME = 20 * 60;
 /** Minimum time between orphan transactions expire time checks in seconds */

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -52,10 +52,6 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 
-#if defined(NDEBUG)
-# error "Bitcoin cannot be compiled without assertions."
-#endif
-
 #define MICRO 0.000001
 #define MILLI 0.001
 


### PR DESCRIPTION
Since commit 7cee85807c4db679003c6659d247a2fe74c2464a (_"Add compile time verification of assumptions we're currently making implicitly/tacitly"_, PR #15391), this check is done in `compat/assumptions.h`:
https://github.com/bitcoin/bitcoin/blob/8237889e8d0fb7542669a9098516c96da91913f0/src/compat/assumptions.h#L13-L18
This header is included by `util/system.h`, which is in turn included by most .cpp files, including the ones this commit modifies (`validation.cpp` and `net_processing.cpp`).