### PR TITLE
test: check custom descendant limit in mempool_packages.py

### DIFF
--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -12,6 +12,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     satoshi_round,
+    wait_until,
 )
 
 # default limits
@@ -19,13 +20,22 @@ MAX_ANCESTORS = 25
 MAX_DESCENDANTS = 25
 # custom limits for node1
 MAX_ANCESTORS_CUSTOM = 5
+MAX_DESCENDANTS_CUSTOM = 10
+assert MAX_DESCENDANTS_CUSTOM >= MAX_ANCESTORS_CUSTOM
 
 class MempoolPackagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [
-            ["-maxorphantx=1000"],
-            ["-maxorphantx=1000", "-limitancestorcount={}".format(MAX_ANCESTORS_CUSTOM)],
+            [
+                "-maxorphantx=1000",
+                "-whitelist=noban@127.0.0.1",  # immediate tx relay
+            ],
+            [
+                "-maxorphantx=1000",
+                "-limitancestorcount={}".format(MAX_ANCESTORS_CUSTOM),
+                "-limitdescendantcount={}".format(MAX_DESCENDANTS_CUSTOM),
+            ],
         ]
 
     def skip_test_if_missing_module(self):
@@ -219,9 +229,11 @@ class MempoolPackagesTest(BitcoinTestFramework):
             transaction_package.append({'txid': txid, 'vout': i, 'amount': sent_value})
 
         # Sign and send up to MAX_DESCENDANT transactions chained off the parent tx
+        chain = [] # save sent txs for the purpose of checking node1's mempool later (see below)
         for i in range(MAX_DESCENDANTS - 1):
             utxo = transaction_package.pop(0)
             (txid, sent_value) = self.chain_transaction(self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
+            chain.append(txid)
             if utxo['txid'] is parent_transaction:
                 tx_children.append(txid)
             for j in range(10):
@@ -238,7 +250,21 @@ class MempoolPackagesTest(BitcoinTestFramework):
         utxo = transaction_package.pop(0)
         assert_raises_rpc_error(-26, "too-long-mempool-chain", self.chain_transaction, self.nodes[0], utxo['txid'], utxo['vout'], utxo['amount'], fee, 10)
 
-        # TODO: check that node1's mempool is as expected
+        # Check that node1's mempool is as expected, containing:
+        # - txs from previous ancestor test (-> custom ancestor limit)
+        # - parent tx for descendant test
+        # - txs chained off parent tx (-> custom descendant limit)
+        wait_until(lambda: len(self.nodes[1].getrawmempool(False)) ==
+                           MAX_ANCESTORS_CUSTOM + 1 + MAX_DESCENDANTS_CUSTOM, timeout=10)
+        mempool0 = self.nodes[0].getrawmempool(False)
+        mempool1 = self.nodes[1].getrawmempool(False)
+        assert set(mempool1).issubset(set(mempool0))
+        assert parent_transaction in mempool1
+        for tx in chain[:MAX_DESCENDANTS_CUSTOM]:
+            assert tx in mempool1
+        for tx in chain[MAX_DESCENDANTS_CUSTOM:]:
+            assert tx not in mempool1
+        # TODO: more detailed check of node1's mempool (fees etc.)
 
         # TODO: test descendant size limits
 


### PR DESCRIPTION
This is a follow-up PR to #17435, testing the custom descendant limit, passed by the argument `-limitdescendantcount`. ~~It was more tricky than expected, mainly because we don't know for sure at which point node1 has got all the transactions broadcasted from node0 (for the ancestor test this wasn't a problem since the txs were immediately available through `invalidateblock`) -- a simple `sync_mempools()` doesn't work here since the mempool contents are not equal due to different ancestor/descendant limits. Hence I came up with a "hacky manual sync":~~
1. ~~wait until the mempool has the _expected_ tx count (see conditions below)~~
2. ~~after that, wait some time and get sure that the mempool contents haven't changed in-between~~

~~Like for~~ Similar to the ancestor test, we overall check for ~~three~~ four conditions:
- the # of txs in the node1 mempool is equal to the descendant limit (plus 1 for the parent tx, plus the # txs from the previous ancestor test which are still in) ~~(done by the hacky sync above)~~
- all txs in node1 mempool are a subset of txs in node0 mempool
- part of the constructed descendant-chain (the first ones up to the limit) are contained in node1 mempool
- the remaining part of the constructed descendant-chain (all after the first ones up to the limit) is *not* contained in node1 mempool