### PR TITLE
Bugfix: GUI: Restore SendConfirmationDialog button default to "Yes"

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -965,7 +965,7 @@ SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QStri
     yesButton = button(yes_button);
     removeButton(yesButton);
     addButton(yesButton, QMessageBox::YesRole);
-    if (yes_button_text.isEmpty()) m_yes_button_text = tr("Send");
+    if (yes_button_text.isEmpty()) m_yes_button_text = tr("Yes");
     updateYesButton();
     connect(&countDownTimer, &QTimer::timeout, this, &SendConfirmationDialog::countDown);
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -377,12 +377,8 @@ void SendCoinsDialog::on_sendButton_clicked()
 
     const QString confirmation = model->wallet().privateKeysDisabled() ? tr("Confirm transaction proposal") : tr("Confirm send coins");
     const QString confirmButtonText = model->wallet().privateKeysDisabled() ? tr("Create Unsigned") : tr("Send");
-    SendConfirmationDialog confirmationDialog(confirmation, question_string, informative_text, detailed_text, SEND_CONFIRM_DELAY, confirmButtonText, this);
-    confirmationDialog.exec();
-    QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
-
-    if(retval != QMessageBox::Yes)
-    {
+    SendConfirmationDialog confirmationDialog(confirmation, question_string, QMessageBox::Yes, confirmButtonText, QMessageBox::Cancel, informative_text, detailed_text, SEND_CONFIRM_DELAY, this);
+    if (!confirmationDialog.exec()) {
         fNewRecipientAllowed = true;
         return;
     }
@@ -947,17 +943,29 @@ void SendCoinsDialog::coinControlUpdateLabels()
     }
 }
 
-SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, const QString& yes_button_text, QWidget* parent)
-    : QMessageBox(parent), secDelay(_secDelay), m_yes_button_text(yes_button_text)
+SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QMessageBox::StandardButton yes_button, const QString &yes_button_text, const QMessageBox::StandardButton cancel_button, const QString& informative_text, const QString& detailed_text, int _secDelay, QWidget *parent)
+    : QMessageBox(parent),
+    secDelay(_secDelay),
+    m_yes_button_text(yes_button_text)
 {
     setIcon(QMessageBox::Question);
     setWindowTitle(title); // On macOS, the window title is ignored (as required by the macOS Guidelines).
     setText(text);
     setInformativeText(informative_text);
     setDetailedText(detailed_text);
-    setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
-    setDefaultButton(QMessageBox::Cancel);
-    yesButton = button(QMessageBox::Yes);
+    setStandardButtons(yes_button | cancel_button);
+
+    // We need to ensure the buttons have Yes/No roles, or they'll get ordered weird
+    QAbstractButton * const cancel_button_obj = button(cancel_button);
+    removeButton(cancel_button_obj);
+    addButton(cancel_button_obj, QMessageBox::NoRole);
+    setEscapeButton(cancel_button_obj);
+    setDefaultButton(cancel_button);
+
+    yesButton = button(yes_button);
+    removeButton(yesButton);
+    addButton(yesButton, QMessageBox::YesRole);
+    if (yes_button_text.isEmpty()) m_yes_button_text = tr("Send");
     updateYesButton();
     connect(&countDownTimer, &QTimer::timeout, this, &SendConfirmationDialog::countDown);
 }
@@ -966,7 +974,8 @@ int SendConfirmationDialog::exec()
 {
     updateYesButton();
     countDownTimer.start(1000);
-    return QMessageBox::exec();
+    QMessageBox::exec();
+    return (buttonRole(clickedButton()) == QMessageBox::YesRole);
 }
 
 void SendConfirmationDialog::countDown()

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -947,8 +947,8 @@ void SendCoinsDialog::coinControlUpdateLabels()
     }
 }
 
-SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, const QString& _confirmButtonText, QWidget* parent)
-    : QMessageBox(parent), secDelay(_secDelay), confirmButtonText(_confirmButtonText)
+SendConfirmationDialog::SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text, const QString& detailed_text, int _secDelay, const QString& yes_button_text, QWidget* parent)
+    : QMessageBox(parent), secDelay(_secDelay), m_yes_button_text(yes_button_text)
 {
     setIcon(QMessageBox::Question);
     setWindowTitle(title); // On macOS, the window title is ignored (as required by the macOS Guidelines).
@@ -985,11 +985,11 @@ void SendConfirmationDialog::updateYesButton()
     if(secDelay > 0)
     {
         yesButton->setEnabled(false);
-        yesButton->setText(confirmButtonText + " (" + QString::number(secDelay) + ")");
+        yesButton->setText(m_yes_button_text + " (" + QString::number(secDelay) + ")");
     }
     else
     {
         yesButton->setEnabled(true);
-        yesButton->setText(confirmButtonText);
+        yesButton->setText(m_yes_button_text);
     }
 }

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -124,7 +124,7 @@ private:
     QAbstractButton *yesButton;
     QTimer countDownTimer;
     int secDelay;
-    QString confirmButtonText;
+    QString m_yes_button_text;
 };
 
 #endif // BITCOIN_QT_SENDCOINSDIALOG_H

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -113,7 +113,7 @@ class SendConfirmationDialog : public QMessageBox
     Q_OBJECT
 
 public:
-    SendConfirmationDialog(const QString& title, const QString& text, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, const QString& confirmText = "Send", QWidget* parent = nullptr);
+    SendConfirmationDialog(const QString& title, const QString& text, QMessageBox::StandardButton yes_button = QMessageBox::Yes, const QString &yes_button_text = "", QMessageBox::StandardButton cancel_button = QMessageBox::Cancel, const QString& informative_text = "", const QString& detailed_text = "", int secDelay = SEND_CONFIRM_DELAY, QWidget* parent = nullptr);
     int exec() override;
 
 private Q_SLOTS:

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -49,7 +49,14 @@ void ConfirmSend(QString* text = nullptr, bool cancel = false)
             if (widget->inherits("SendConfirmationDialog")) {
                 SendConfirmationDialog* dialog = qobject_cast<SendConfirmationDialog*>(widget);
                 if (text) *text = dialog->text();
-                QAbstractButton* button = dialog->button(cancel ? QMessageBox::Cancel : QMessageBox::Yes);
+                QAbstractButton* button = nullptr;
+                auto desired_button_role = cancel ? QMessageBox::NoRole : QMessageBox::YesRole;
+                for (QAbstractButton* maybe_button : dialog->buttons()) {
+                    if (dialog->buttonRole(maybe_button) == desired_button_role) {
+                        button = maybe_button;
+                        break;
+                    }
+                }
                 button->setEnabled(true);
                 button->click();
             }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -517,12 +517,10 @@ bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
     questionString.append("</td><td>");
     questionString.append(BitcoinUnits::formatHtmlWithUnit(getOptionsModel()->getDisplayUnit(), new_fee));
     questionString.append("</td></tr></table>");
-    SendConfirmationDialog confirmationDialog(tr("Confirm fee bump"), questionString);
-    confirmationDialog.exec();
-    QMessageBox::StandardButton retval = static_cast<QMessageBox::StandardButton>(confirmationDialog.result());
 
+    SendConfirmationDialog confirmationDialog(tr("Confirm fee bump"), questionString);
     // cancel sign&broadcast if user doesn't want to bump the fee
-    if (retval != QMessageBox::Yes) {
+    if (!confirmationDialog.exec()) {
         return false;
     }
 


### PR DESCRIPTION
The SendConfirmationDialog is used for bumping the fee, where "Send" doesn't really make sense

Customisation of the dialog is also needed for #16944 and #15987 so might as well use it for this too.