### PR TITLE
Bugfix: GUI: Recognise NETWORK_LIMITED in formatServicesStr

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -245,6 +245,7 @@ const std::vector<std::string> &getAllNetMessageTypes();
 
 /** nServices flags */
 enum ServiceFlags : uint64_t {
+    // NOTE: When adding here, be sure to update qt/guiutil.cpp's formatServicesStr too
     // Nothing
     NODE_NONE = 0,
     // NODE_NETWORK means that the node is capable of serving the complete block chain. It is currently

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -815,6 +815,24 @@ QString formatDurationStr(int secs)
     return strList.join(" ");
 }
 
+QString serviceFlagToStr(const quint64 mask, const int bit)
+{
+    switch (ServiceFlags(mask)) {
+    case NODE_NONE: abort();  // impossible
+    case NODE_NETWORK:         return "NETWORK";
+    case NODE_GETUTXO:         return "GETUTXO";
+    case NODE_BLOOM:           return "BLOOM";
+    case NODE_WITNESS:         return "WITNESS";
+    case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
+    // Not using default, so we get warned when a case is missing
+    }
+    if (bit < 8) {
+        return QString("%1[%2]").arg("UNKNOWN").arg(mask);
+    } else {
+        return QString("%1[2^%2]").arg("UNKNOWN").arg(bit);
+    }
+}
+
 QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
@@ -823,30 +841,7 @@ QString formatServicesStr(quint64 mask)
         uint64_t check = 1LL << i;
         if (mask & check)
         {
-            switch (check)
-            {
-            case NODE_NETWORK:
-                strList.append("NETWORK");
-                break;
-            case NODE_GETUTXO:
-                strList.append("GETUTXO");
-                break;
-            case NODE_BLOOM:
-                strList.append("BLOOM");
-                break;
-            case NODE_WITNESS:
-                strList.append("WITNESS");
-                break;
-            case NODE_NETWORK_LIMITED:
-                strList.append("NETWORK_LIMITED");
-                break;
-            default:
-                if (i < 8) {
-                    strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
-                } else {
-                    strList.append(QString("%1[2^%2]").arg("UNKNOWN").arg(i));
-                }
-            }
+            strList.append(serviceFlagToStr(check, i));
         }
     }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -819,9 +819,8 @@ QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
 
-    // Just scan the last 8 bits for now.
-    for (int i = 0; i < 8; i++) {
-        uint64_t check = 1 << i;
+    for (int i = 0; i < 64; i++) {
+        uint64_t check = 1LL << i;
         if (mask & check)
         {
             switch (check)
@@ -838,8 +837,15 @@ QString formatServicesStr(quint64 mask)
             case NODE_WITNESS:
                 strList.append("WITNESS");
                 break;
+            case NODE_NETWORK_LIMITED:
+                strList.append("NETWORK_LIMITED");
+                break;
             default:
-                strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
+                if (i < 8) {
+                    strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
+                } else {
+                    strList.append(QString("%1[2^%2]").arg("UNKNOWN").arg(i));
+                }
             }
         }
     }


### PR DESCRIPTION
Currently, only the bottom 8 service bits are shown in the GUI peer details view.

`NODE_NETWORK_LIMITED` is the 11th bit (2^10).

The first commit expands the range to cover the full 64 bits, and properly label `"NETWORK_LIMITED"`.
The second commit refactors the code so that any future omitted service bits will trigger a compile warning.