### PR TITLE
Return BlockValidationState from ProcessNewBlock if CheckBlock/AcceptBlock fails

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3338,7 +3338,8 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
             // we have a chain with at least nMinimumChainWork), and we ignore
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
-            m_chainman.ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            BlockValidationState dos_state;
+            m_chainman.ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true, &fNewBlock);
             BlockProcessed(pfrom, *pblock, fNewBlock);
 
             LOCK(cs_main); // hold cs_main for CBlockIndex::IsValid()
@@ -3424,7 +3425,8 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
             // disk-space attacks), but this should be safe due to the
             // protections in the compact block handler -- see related comment
             // in compact block optimistic reconstruction handling.
-            m_chainman.ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            BlockValidationState dos_state;
+            m_chainman.ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true, &fNewBlock);
             BlockProcessed(pfrom, *pblock, fNewBlock);
         }
         return;
@@ -3482,7 +3484,8 @@ void PeerLogicValidation::ProcessMessage(CNode& pfrom, const std::string& msg_ty
             mapBlockSource.emplace(hash, std::make_pair(pfrom.GetId(), true));
         }
         bool fNewBlock = false;
-        m_chainman.ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        BlockValidationState dos_state;
+        m_chainman.ProcessNewBlock(chainparams, pblock, dos_state, forceProcessing, &fNewBlock);
         BlockProcessed(pfrom, *pblock, fNewBlock);
         return;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1385,8 +1385,11 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
 /**
  * Handle invalid block rejection and consequent peer discouragement, maintain which
  * peers announce compact blocks.
+ * Called both in case of cursory DoS checks failing (implying the peer is likely
+ * sending us bogus data) and after full validation of the block fails (which may
+ * be OK if it was sent over compact blocks).
  */
-void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidationState& state) {
+static void BlockChecked(const CBlock& block, const BlockValidationState& state, CConnman& connman) {
     LOCK(cs_main);
 
     const uint256 hash(block.GetHash());
@@ -1409,11 +1412,15 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidatio
              !::ChainstateActive().IsInitialBlockDownload() &&
              mapBlocksInFlight.count(hash) == mapBlocksInFlight.size()) {
         if (it != mapBlockSource.end()) {
-            MaybeSetPeerAsAnnouncingHeaderAndIDs(it->second.first, m_connman);
+            MaybeSetPeerAsAnnouncingHeaderAndIDs(it->second.first, connman);
         }
     }
     if (it != mapBlockSource.end())
         mapBlockSource.erase(it);
+}
+
+void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidationState& state) {
+    ::BlockChecked(block, state, m_connman);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -126,7 +126,8 @@ static bool GenerateBlock(ChainstateManager& chainman, CBlock& block, uint64_t& 
     }
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    if (!chainman.ProcessNewBlock(chainparams, shared_pblock, true, nullptr)) {
+    BlockValidationState state;
+    if (!chainman.ProcessNewBlock(chainparams, shared_pblock, state, true, nullptr)) {
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
     }
 
@@ -960,7 +961,8 @@ static UniValue submitblock(const JSONRPCRequest& request)
     bool new_block;
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
     RegisterSharedValidationInterface(sc);
-    bool accepted = EnsureChainman(request.context).ProcessNewBlock(Params(), blockptr, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
+    BlockValidationState dos_state;
+    bool accepted = EnsureChainman(request.context).ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
     UnregisterSharedValidationInterface(sc);
     if (!new_block && accepted) {
         return "duplicate";

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -967,6 +967,9 @@ static UniValue submitblock(const JSONRPCRequest& request)
     if (!new_block && accepted) {
         return "duplicate";
     }
+    if (!dos_state.IsValid()) {
+        return BIP22ValidationResult(dos_state);
+    }
     if (!sc->found) {
         return "inconclusive";
     }

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -173,6 +173,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const auto& block = chainA[i];
         BlockValidationState dos_state;
         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -192,6 +193,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const auto& block = chainB[i];
         BlockValidationState dos_state;
         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -224,6 +226,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const auto& block = chainA[i];
         BlockValidationState dos_state;
         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
     }
 
      // Check that chain A and B blocks can be retrieved.

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -171,7 +171,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
+        BlockValidationState dos_state;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr));
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -189,7 +190,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
+        BlockValidationState dos_state;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr));
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -218,10 +220,11 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     }
 
     // Reorg back to chain A.
-     for (size_t i = 2; i < 4; i++) {
-         const auto& block = chainA[i];
-         BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, true, nullptr));
-     }
+    for (size_t i = 2; i < 4; i++) {
+        const auto& block = chainA[i];
+        BlockValidationState dos_state;
+        BOOST_REQUIRE(Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+    }
 
      // Check that chain A and B blocks can be retrieved.
      chainA_last_header = last_header;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
+#include <consensus/validation.h>
 #include <miner.h>
 #include <policy/policy.h>
 #include <script/standard.h>
@@ -253,7 +254,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        BlockValidationState dos_state;
+        BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -256,6 +256,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BlockValidationState dos_state;
         BOOST_CHECK(Assert(m_node.chainman)->ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
+        BOOST_CHECK(dos_state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <consensus/validation.h>
 #include <key_io.h>
 #include <miner.h>
 #include <node/context.h>
@@ -32,7 +33,8 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
         assert(block->nNonce);
     }
 
-    bool processed{Assert(node.chainman)->ProcessNewBlock(Params(), block, true, nullptr)};
+    BlockValidationState dos_state;
+    bool processed{Assert(node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
     assert(processed);
 
     return CTxIn{block->vtx[0]->GetHash(), 0};

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -36,6 +36,7 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
     BlockValidationState dos_state;
     bool processed{Assert(node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
     assert(processed);
+    assert(dos_state.IsValid());
 
     return CTxIn{block->vtx[0]->GetHash(), 0};
 }

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -235,7 +235,8 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    Assert(m_node.chainman)->ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    BlockValidationState dos_state;
+    Assert(m_node.chainman)->ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr);
 
     CBlock result = block;
     return result;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -198,6 +198,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                     BlockValidationState dos_state;
                     bool processed = Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, true, &ignored);
                     assert(processed);
+                    assert(dos_state.IsValid());
                 }
             }
         });
@@ -236,7 +237,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
     bool ignored;
     auto ProcessBlock = [&](std::shared_ptr<const CBlock> block) -> bool {
         BlockValidationState dos_state;
-        return Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
+        return Assert(m_node.chainman)->ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &ignored) && dos_state.IsValid();
     };
 
     // Process all mined blocks

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3848,7 +3848,6 @@ bool ChainstateManager::ProcessNewBlock(const CChainParams& chainparams, const s
             ret = ::ChainstateActive().AcceptBlock(pblock, dos_state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
         }
         if (!ret) {
-            GetMainSignals().BlockChecked(*pblock, dos_state);
             return error("%s: AcceptBlock FAILED (%s)", __func__, dos_state.ToString());
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3854,9 +3854,9 @@ bool ChainstateManager::ProcessNewBlock(const CChainParams& chainparams, const s
 
     NotifyHeaderTip();
 
-    BlockValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!::ChainstateActive().ActivateBestChain(state, chainparams, pblock))
-        return error("%s: ActivateBestChain failed (%s)", __func__, state.ToString());
+    BlockValidationState dummy_state; // Only used to report errors, not invalidity - ignore it
+    if (!::ChainstateActive().ActivateBestChain(dummy_state, chainparams, pblock))
+        return error("%s: ActivateBestChain failed (%s)", __func__, dummy_state.ToString());
 
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -862,18 +862,29 @@ public:
      * block is made active. Note that it does not, however, guarantee that the
      * specific block passed to it has been checked for validity!
      *
-     * If you want to *possibly* get feedback on whether pblock is valid, you must
-     * install a CValidationInterface (see validationinterface.h) - this will have
-     * its BlockChecked method called whenever *any* block completes validation.
+     * Performs initial sanity checks using the provided BlockValidationState before
+     * connecting any block(s). If you want to *possibly* get feedback on whether
+     * pblock is valid beyond just cursory mutation/DoS checks, you must install
+     * a CValidationInterface (see validationinterface.h) - this will have its
+     * BlockChecked method called whenever *any* block completes validation (note
+     * that any invalidity returned via state will *not* also be provided via
+     * BlockChecked). There is, of course, no guarantee that any given block which
+     * is not a part of the eventual best chain will ever be checked.
      *
-     * Note that we guarantee that either the proof-of-work is valid on pblock, or
-     * (and possibly also) BlockChecked will have been called.
+     * If the block pblock is built on is in our header tree, and pblock is a
+     * candidate for accepting to disk (either because it is a candidate for the
+     * best chain soon, or fForceProcessing is set), but pblock has been mutated,
+     * state is guaranteed to be some non-IsValid() state.
      *
-     * May not be called in a
-     * validationinterface callback.
+     * If fForceProcessing is set (or fNewBlock returns true), and state.IsValid(),
+     * barring pruning and a desire to re-download a pruned block, there should
+     * never be any reason to re-ProcessNewBlock any block with the same hash.
+     *
+     * May not be called in a validationinterface callback.
      *
      * @param[in]   pblock            The block we want to process.
-     * @param[out]  state             Currently unused.
+     * @param[out]  state             Only used for failures in CheckBlock/AcceptBlock. For failure in block connection,
+     *                                a CValidationInterface BlockChecked callback is used to notify clients of validity.
      * @param[in]   fForceProcessing  This block was requested from the peer or came from a non-network source.
      * @param[out]  fNewBlock         A boolean which is set to indicate if the block was first received via this call
      * @returns     bool              If the block was processed, independently of block validity

--- a/src/validation.h
+++ b/src/validation.h
@@ -872,12 +872,13 @@ public:
      * May not be called in a
      * validationinterface callback.
      *
-     * @param[in]   pblock  The block we want to process.
-     * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources.
-     * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
-     * @returns     If the block was processed, independently of block validity
+     * @param[in]   pblock            The block we want to process.
+     * @param[out]  state             Currently unused.
+     * @param[in]   fForceProcessing  This block was requested from the peer or came from a non-network source.
+     * @param[out]  fNewBlock         A boolean which is set to indicate if the block was first received via this call
+     * @returns     bool              If the block was processed, independently of block validity
      */
-    bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+    bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, BlockValidationState& state, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
 
     /**
      * Process incoming block headers.


### PR DESCRIPTION
Net processing now passes a `BlockValidationState` object into `ProcessNewBlock()`. If `CheckBlock()` or `AcceptBlock()` fails, then PNB returns to net processing without calling the (asynchronous) `BlockChecked` Validation Interface method. net processing can use the invalid `BlockValidationState` returned to punish peers.

`CheckBlock()` and `AcceptBlock()` represent the DoS checks on a block (ie PoW and malleability). Net processing wants to know about those failed checks immediately and shouldn't have to wait on a callback. Other validation interface clients don't care about net processing submitting bogus malleated blocks to validation, so they don't need to be notified of `BlockChecked`.

Furthermore, if PNB returns a valid `BlockValidationState`, we never need to try to process (non-malleated) copies of the block from other peers. That makes it much easier to move the best chain activation logic to a background thread in future work.