### PR TITLE
build: Set gitian arch back to amd64

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -5,7 +5,7 @@ distro: "ubuntu"
 suites:
 - "bionic"
 architectures:
-- "linux64"
+- "amd64"
 packages:
 - "curl"
 - "g++-aarch64-linux-gnu"

--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -4,7 +4,7 @@ distro: "ubuntu"
 suites:
 - "bionic"
 architectures:
-- "linux64"
+- "amd64"
 packages:
 - "faketime"
 remotes:

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -5,7 +5,7 @@ distro: "ubuntu"
 suites:
 - "bionic"
 architectures:
-- "linux64"
+- "amd64"
 packages:
 - "ca-certificates"
 - "curl"

--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -4,7 +4,7 @@ distro: "ubuntu"
 suites:
 - "bionic"
 architectures:
-- "linux64"
+- "amd64"
 packages:
 # Once osslsigncode supports openssl 1.1, we can change this back to libssl-dev
 - "libssl1.0-dev"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -5,7 +5,7 @@ distro: "ubuntu"
 suites:
 - "bionic"
 architectures:
-- "linux64"
+- "amd64"
 packages:
 - "curl"
 - "g++"


### PR DESCRIPTION
This was required to allow gitian builds on non-amd64 architecture, however, it seems to break the current builds (with lxc), see https://github.com/bitcoin/bitcoin/pull/17409#issuecomment-554099626

Also, the gititan builds wouldn't be deterministic across arches anyway, see #17468 

So instead of wasting more time on this, revert the change and hope that guix allows to compile on non-amd64 architectures.