### PR TITLE
wallet: add cached m_is_ibd to remove Chain::isInitialBlockDownload

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -339,8 +339,7 @@ public:
         LOCK(cs_main);
         return ::fHavePruned;
     }
-    bool isReadyToBroadcast() override { return !::fImporting && !::fReindex && !isInitialBlockDownload(); }
-    bool isInitialBlockDownload() override { return ::ChainstateActive().IsInitialBlockDownload(); }
+    bool isReadyToBroadcast() override { return !::fImporting && !::fReindex; }
     bool shutdownRequested() override { return ShutdownRequested(); }
     int64_t getAdjustedTime() override { return GetAdjustedTime(); }
     void initMessage(const std::string& message) override { ::uiInterface.InitMessage(message); }

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -77,7 +77,7 @@ public:
     }
     void UpdatedBlockTip(const CBlockIndex* index, const CBlockIndex* fork_index, bool is_ibd) override
     {
-        m_notifications->updatedBlockTip();
+        m_notifications->updatedBlockTip(is_ibd);
     }
     void ChainStateFlushed(const CBlockLocator& locator) override { m_notifications->chainStateFlushed(locator); }
     std::shared_ptr<Chain::Notifications> m_notifications;

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -243,7 +243,7 @@ public:
         virtual void transactionRemovedFromMempool(const CTransactionRef& tx, MemPoolRemovalReason reason) {}
         virtual void blockConnected(const CBlock& block, int height) {}
         virtual void blockDisconnected(const CBlock& block, int height) {}
-        virtual void updatedBlockTip() {}
+        virtual void updatedBlockTip(bool is_ibd) {}
         virtual void chainStateFlushed(const CBlockLocator& locator) {}
     };
 

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -213,9 +213,6 @@ public:
     //! Check if the node is ready to broadcast transactions.
     virtual bool isReadyToBroadcast() = 0;
 
-    //! Check if in IBD.
-    virtual bool isInitialBlockDownload() = 0;
-
     //! Check if shutdown requested.
     virtual bool shutdownRequested() = 0;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1177,7 +1177,7 @@ void CWallet::blockDisconnected(const CBlock& block, int height)
     }
 }
 
-void CWallet::updatedBlockTip()
+void CWallet::updatedBlockTip(bool is_ibd)
 {
     m_best_block_time = GetTime();
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -902,7 +902,7 @@ public:
     void transactionAddedToMempool(const CTransactionRef& tx) override;
     void blockConnected(const CBlock& block, int height) override;
     void blockDisconnected(const CBlock& block, int height) override;
-    void updatedBlockTip() override;
+    void updatedBlockTip(bool is_ibd) override;
     int64_t RescanFromTime(int64_t startTime, const WalletRescanReserver& reserver, bool update);
 
     struct ScanResult {

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -723,6 +723,12 @@ private:
     // ScriptPubKeyMan::GetID. In many cases it will be the hash of an internal structure
     std::map<uint256, std::unique_ptr<ScriptPubKeyMan>> m_spk_managers;
 
+    /* Flag to indicate chain is still in initial block download. Initialized to false,
+     * latched to updateBlockTip if node evaluates being out of IBD. This method MUST be
+     * called by rescanning code while boostraping the wallet.
+     */
+    bool m_is_ibd GUARDED_BY(cs_wallet) = false;
+
 public:
     /*
      * Main wallet lock.


### PR DESCRIPTION
**Dependency on #15719** 

Actually we lock the chain every-time a resend or transaction is broadcast to evaluate if node is currently in-or-out of IBD. This PR proposes instead to rely on `updatedBlockTip` to refresh IBD status, therefore increasing asynchronicity between wallet-node and should be a slight performance improvement.
