### PR TITLE
build: make Travis catch unused variables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -329,6 +329,7 @@ if test "x$enable_werror" = "xyes"; then
   AX_CHECK_COMPILE_FLAG([-Werror=vla],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=vla"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=switch],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=switch"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=thread-safety-analysis],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=thread-safety-analysis"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Werror=unused-variable],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=unused-variable"],,[[$CXXFLAG_WERROR]])
 fi
 
 if test "x$CXXFLAGS_overridden" = "xno"; then
@@ -341,6 +342,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wthread-safety-analysis],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wthread-safety-analysis"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wrange-loop-analysis],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wrange-loop-analysis"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wredundant-decls],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wredundant-decls"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wunused-variable],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wunused-variable"],,[[$CXXFLAG_WERROR]])
 
   ## Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   ## unknown options if any other warning is produced. Test the -Wfoo case, and


### PR DESCRIPTION
The two macOS Travis machines run with `--enable-werror`. This PR adds `-Werror=unused-variable` to the existing `vla`, `switch` and `thread-safety-analysis` checks. This should prevent the need for fixes like b07b07cd8779355ba1dd16e7eb4af42e0ae1c587, 26a93bce29fd813e1402b013f402869c25b656d1, dd777f3e1220dd1a76e8a29cafdd4fe6244c5c0f, 99be644966c63e9917161f97574905551e44360f, fa39f674aed8f2dc5a9bde6a84b0ec52fc49e695, 16bcc1b8237698c96b8ced2fa7eb76388c7ba85e, bb079a0e2c20beb22456c91ad9e11beeae7cdc34, bdaed4755846e8b1e533c14485faa5f9fd1cf18b and ecf9b25a03d8a29f16005ca4485b6533db6efc82 with minimal nuisance.

Thoughts for followups: 
* Travis starts these macOS machines fairly late, so we should consider setting `--enable-werror` on earlier machines as well.
* We should encourage the use of `--enable-werror` by developers. Maybe switch it on by default for `--enable-debug`?
* See practicalswift's overview of other checks to consider in #17344