### PR TITLE
utils: Use GetProcessWorkingSetSizeEx to get limit for Win32LockedPageAllocator

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -200,8 +200,11 @@ void Win32LockedPageAllocator::FreeLocked(void* addr, size_t len)
 
 size_t Win32LockedPageAllocator::GetLimit()
 {
-    // TODO is there a limit on Windows, how to get it?
-    return std::numeric_limits<size_t>::max();
+    size_t minSet;
+    size_t maxSet;
+    DWORD flags;
+    GetProcessWorkingSetSizeEx(GetCurrentProcess(), &minSet, &maxSet, &flags);
+    return maxSet;
 }
 #endif
 


### PR DESCRIPTION
This returns `1413120` in the virtual machine I've been using for testing.

More info: https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-getprocessworkingsetsizeex.