### PR TITLE
Add permission whitelisting system

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -534,6 +534,8 @@ void SetupServerArgs()
     gArgs.AddArg("-rpcservertimeout=<n>", strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcthreads=<n>", strprintf("Set the number of threads to service RPC calls (default: %d)", DEFAULT_HTTP_THREADS), ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcuser=<user>", "Username for JSON-RPC connections", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcwhitelistenable", "Enable the whitelist feature", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
+    gArgs.AddArg("-rpcwhitelist=<whitelist>", "Give users speciic permissions, only works when -rpcwhitelistenable=1", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
     gArgs.AddArg("-rpcworkqueue=<n>", strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::RPC);
     gArgs.AddArg("-server", "Accept command line and JSON-RPC commands", ArgsManager::ALLOW_ANY, OptionsCategory::RPC);
 


### PR DESCRIPTION
Similar to #12763.

This adds a system to enable a whitelist and give certain RPC users certain permissions.
It works like that:
```
server=1
rpcauth=emil:9d4e28a0cdbce4e5440a0b26fe9bfbf1$50e12acc8b9ae3e55ad1b7f976b76e2e29c20d312358ce2004da937b8926b964
rpcwhitelistenable=1
rpcwhitelist=emil:getbestblockhash,getblock
```
With such a `bitcoin.conf`, `emil` would only be able to execute `getbestblockhash` and `getblock`.
This can be repeated as many as you want with as many users as possible.
If a `rpcwhitelist` is malformed it will be skipped.
Valid syntax is
```
rpcwhitelist=[command][,command2]
```
Commas are only necessary when there are multiple entries.

**Requested Reviewers**: JeremyRubin 