### PR TITLE
refactor, qt: Remove unused signal from WalletView class

### DIFF
--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -61,11 +61,6 @@ void WalletFrame::addWallet(WalletModel *walletModel)
     walletStack->addWidget(walletView);
     mapWalletViews[walletModel] = walletView;
 
-    // Ensure a walletView is able to show the main window
-    connect(walletView, &WalletView::showNormalIfMinimized, [this]{
-      gui->showNormalIfMinimized();
-    });
-
     connect(walletView, &WalletView::outOfSyncWarningClicked, this, &WalletFrame::outOfSyncWarningClicked);
 }
 

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -115,8 +115,6 @@ public Q_SLOTS:
     void requestedSyncWarningInfo();
 
 Q_SIGNALS:
-    /** Signal that we want to show the main window */
-    void showNormalIfMinimized();
     /**  Fired when a message should be reported to the user */
     void message(const QString &title, const QString &message, unsigned int style);
     /** Encryption status of wallet changed */


### PR DESCRIPTION
`WalletView::showNormalIfMinimized()` signal was introduced in #2872 (dbc0a6aba2cf94aa1b167145a18e0b9c671aef5b).

The only signal emit command was removed in #3144 (2384a2864b6a0b29eec6410057aefe1fd8e7e585)