### PR TITLE
refactor, qt: Nuke walletframe circular dependency

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -98,7 +98,7 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     if(enableWallet)
     {
         /** Create wallet frame and make it the central widget */
-        walletFrame = new WalletFrame(_platformStyle, this);
+        walletFrame = new WalletFrame(_platformStyle, this, this);
         setCentralWidget(walletFrame);
     } else
 #endif // ENABLE_WALLET

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -3,9 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <qt/walletframe.h>
-#include <qt/walletmodel.h>
 
-#include <qt/bitcoingui.h>
+#include <qt/walletmodel.h>
 #include <qt/walletview.h>
 
 #include <cassert>
@@ -13,10 +12,10 @@
 #include <QHBoxLayout>
 #include <QLabel>
 
-WalletFrame::WalletFrame(const PlatformStyle *_platformStyle, BitcoinGUI *_gui) :
-    QFrame(_gui),
-    gui(_gui),
-    platformStyle(_platformStyle)
+WalletFrame::WalletFrame(const PlatformStyle* _platformStyle, BitcoinGUI* _gui, QWidget* parent)
+    : QFrame(parent),
+      gui(_gui),
+      platformStyle(_platformStyle)
 {
     // Leave HBox hook for adding a list view later
     QHBoxLayout *walletFrameLayout = new QHBoxLayout(this);

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -17,6 +17,7 @@ class WalletView;
 
 QT_BEGIN_NAMESPACE
 class QStackedWidget;
+class QWidget;
 QT_END_NAMESPACE
 
 /**
@@ -31,7 +32,7 @@ class WalletFrame : public QFrame
     Q_OBJECT
 
 public:
-    explicit WalletFrame(const PlatformStyle *platformStyle, BitcoinGUI *_gui = nullptr);
+    explicit WalletFrame(const PlatformStyle* platformStyle, BitcoinGUI* _gui, QWidget* parent);
     ~WalletFrame();
 
     void setClientModel(ClientModel *clientModel);

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -15,7 +15,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"
     "qt/bantablemodel -> qt/clientmodel -> qt/bantablemodel"
     "qt/bitcoingui -> qt/utilitydialog -> qt/bitcoingui"
-    "qt/bitcoingui -> qt/walletframe -> qt/bitcoingui"
     "qt/bitcoingui -> qt/walletview -> qt/bitcoingui"
     "qt/clientmodel -> qt/peertablemodel -> qt/clientmodel"
     "qt/paymentserver -> qt/walletmodel -> qt/paymentserver"


### PR DESCRIPTION
This PR:
- gets rid of `qt/bitcoingui` -> `qt/walletframe` -> `qt/bitcoingui` circular dependency
- ~is based on top of #17499 (as a prerequisite)~ (merged)