### PR TITLE
Fix unsigned integer overflow in LoadMempool

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4968,7 +4968,8 @@ bool LoadMempool(CTxMemPool& pool)
         }
         uint64_t num;
         file >> num;
-        while (num--) {
+        while (num > 0) {
+            --num;
             CTransactionRef tx;
             int64_t nTime;
             int64_t nFeeDelta;


### PR DESCRIPTION
As reported by UB sanitizer:
```
validation.cpp:4958:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'uint64_t' (aka 'unsigned long long')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior validation.cpp
```
