### PR TITLE
random: mark RandAddPeriodic and SeedPeriodic as noexcept

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -450,17 +450,7 @@ void LockingCallbackOpenSSL(int mode, int i, const char* file, int line) NO_THRE
 
 /* A note on the use of noexcept in the seeding functions below:
  *
- * None of the RNG code should ever throw any exception, with the sole exception
- * of MilliSleep in SeedSleep, which can (and does) support interruptions which
- * cause a boost::thread_interrupted to be thrown.
- *
- * This means that SeedSleep, and all functions that invoke it are throwing.
- * However, we know that GetRandBytes() and GetStrongRandBytes() never trigger
- * this sleeping logic, so they are noexcept. The same is true for all the
- * GetRand*() functions that use GetRandBytes() indirectly.
- *
- * TODO: After moving away from interruptible boost-based thread management,
- * everything can become noexcept here.
+ * None of the RNG code should ever throw any exception.
  */
 
 static void SeedTimestamp(CSHA512& hasher) noexcept
@@ -516,7 +506,7 @@ static void SeedStrengthen(CSHA512& hasher, RNGState& rng, int microseconds) noe
     Strengthen(strengthen_seed, microseconds, hasher);
 }
 
-static void SeedPeriodic(CSHA512& hasher, RNGState& rng)
+static void SeedPeriodic(CSHA512& hasher, RNGState& rng) noexcept
 {
     // Everything that the 'fast' seeder includes
     SeedFast(hasher);
@@ -598,7 +588,7 @@ static void ProcRand(unsigned char* out, int num, RNGLevel level)
 
 void GetRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::FAST); }
 void GetStrongRandBytes(unsigned char* buf, int num) noexcept { ProcRand(buf, num, RNGLevel::SLOW); }
-void RandAddPeriodic() { ProcRand(nullptr, 0, RNGLevel::PERIODIC); }
+void RandAddPeriodic() noexcept { ProcRand(nullptr, 0, RNGLevel::PERIODIC); }
 
 bool g_mock_deterministic_tests{false};
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -182,7 +182,7 @@ static uint64_t GetRdSeed() noexcept
 /* Access to other hardware random number generators could be added here later,
  * assuming it is sufficiently fast (in the order of a few hundred CPU cycles).
  * Slower sources should probably be invoked separately, and/or only from
- * RandAddSeedSleep (which is called during idle background operation).
+ * RandAddPeriodic (which is called once a minute).
  */
 static void InitHardwareRand() {}
 static void ReportHardwareRand() {}

--- a/src/random.h
+++ b/src/random.h
@@ -88,7 +88,7 @@ void GetStrongRandBytes(unsigned char* buf, int num) noexcept;
  *
  * Thread-safe.
  */
-void RandAddPeriodic();
+void RandAddPeriodic() noexcept;
 
 /**
  * Fast randomness source. This is seeded once with secure random data, but

--- a/src/random.h
+++ b/src/random.h
@@ -41,17 +41,17 @@
  *   These entropy sources are slower, but designed to make sure the RNG state contains
  *   fresh data that is unpredictable to attackers.
  *
- * - RandAddSeedSleep() seeds everything that fast seeding includes, but additionally:
- *   - A high-precision timestamp before and after sleeping 1ms.
- *   - (On Windows) Once every 10 minutes, performance monitoring data from the OS.
- -   - Once every minute, strengthen the entropy for 10 ms using repeated SHA512.
- *   These just exploit the fact the system is idle to improve the quality of the RNG
- *   slightly.
+ * - RandAddPeriodic() seeds everything that fast seeding includes, but additionally:
+ *   - A high-precision timestamp
+ *   - Dynamic environment data (performance monitoring, ...)
+ *   - Strengthen the entropy for 10 ms using repeated SHA512.
+ *   This is run once every minute.
  *
  * On first use of the RNG (regardless of what function is called first), all entropy
  * sources used in the 'slow' seeder are included, but also:
  * - 256 bits from the hardware RNG (rdseed or rdrand) when available.
- * - (On Windows) Performance monitoring data from the OS.
+ * - Dynamic environment data (performance monitoring, ...)
+ * - Static environment data
  * - Strengthen the entropy for 100 ms using repeated SHA512.
  *
  * When mixing in new entropy, H = SHA512(entropy || old_rng_state) is computed, and


### PR DESCRIPTION
The usage of `MilliSleep()` in SeedPeriodic (previously SeedSleep) was
[removed](https://github.com/bitcoin/bitcoin/pull/17270/commits/d61f2bb076d8f17840a8e79f1583d7f6e3e6d09a) in #17270, meaning it, and its users can now be marked `noexcept`.

This also corrects the docs in random.h for some of the changes in #17270.