### PR TITLE
Add copy constructor and copy operator= to CScript to remove ubsan suppression

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -412,6 +412,9 @@ public:
     CScript(std::vector<unsigned char>::const_iterator pbegin, std::vector<unsigned char>::const_iterator pend) : CScriptBase(pbegin, pend) { }
     CScript(const unsigned char* pbegin, const unsigned char* pend) : CScriptBase(pbegin, pend) { }
 
+    // Define a copy constructor so that operator= is a copy instead of a move to avoid undefined behavior
+    CScript(const CScript& a) : CScript(a.begin(), a.end()) {}
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -495,6 +498,7 @@ public:
         return *this;
     }
 
+    CScript& operator=(const CScript&) = default;
 
     bool GetOp(const_iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>& vchRet) const
     {

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,7 +1,5 @@
 # -fsanitize=undefined suppressions
 # =================================
-alignment:move.h
-alignment:prevector.h
 float-divide-by-zero:policy/fees.cpp
 float-divide-by-zero:validation.cpp
 float-divide-by-zero:wallet/wallet.cpp


### PR DESCRIPTION
As noted in https://github.com/bitcoin/bitcoin/pull/17156#issuecomment-543123631, the PSBT fuzzer is triggering a UBSan condition which is fixed by this PR. Additionally, by fixing this, some UBSan suppressions can be removed.

Split from #17156 