### PR TITLE
util: Make logging noexcept

### DIFF
--- a/src/fs.cpp
+++ b/src/fs.cpp
@@ -12,7 +12,7 @@
 
 namespace fsbridge {
 
-FILE *fopen(const fs::path& p, const char *mode)
+FILE *fopen(const fs::path& p, const char *mode) noexcept
 {
 #ifndef WIN32
     return ::fopen(p.string().c_str(), mode);

--- a/src/fs.h
+++ b/src/fs.h
@@ -20,7 +20,7 @@ namespace fs = boost::filesystem;
 
 /** Bridge operations to C stdio */
 namespace fsbridge {
-    FILE *fopen(const fs::path& p, const char *mode);
+    FILE *fopen(const fs::path& p, const char *mode) noexcept;
 
     class FileLock
     {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -11,7 +11,7 @@
 
 const char * const DEFAULT_DEBUGLOGFILE = "debug.log";
 
-BCLog::Logger& LogInstance()
+BCLog::Logger& LogInstance() noexcept
 {
 /**
  * NOTE: the logger instances is leaked on exit. This is ugly, but will be

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -244,14 +244,14 @@ namespace BCLog {
      * It escapes instead of removes them to still allow for troubleshooting
      * issues where they accidentally end up in strings.
      */
-    std::string LogEscapeMessage(const std::string& str) {
+    std::string LogEscapeMessage(const std::string& str) noexcept {
         std::string ret;
         for (char ch_in : str) {
             uint8_t ch = (uint8_t)ch_in;
             if ((ch >= 32 || ch == '\n') && ch != '\x7f') {
                 ret += ch_in;
             } else {
-                ret += strprintf("\\x%02x", ch);
+                ret += tfm::format_noexcept("\\x%02x", ch);
             }
         }
         return ret;

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -211,7 +211,7 @@ std::vector<CLogCategoryActive> ListActiveLogCategories()
     return ret;
 }
 
-std::string BCLog::Logger::LogTimestampStr(const std::string& str)
+std::string BCLog::Logger::LogTimestampStr(const std::string& str) noexcept
 {
     std::string strStamped;
 
@@ -223,7 +223,7 @@ std::string BCLog::Logger::LogTimestampStr(const std::string& str)
         strStamped = FormatISO8601DateTime(nTimeMicros/1000000);
         if (m_log_time_micros) {
             strStamped.pop_back();
-            strStamped += strprintf(".%06dZ", nTimeMicros%1000000);
+            strStamped += tfm::format_noexcept(".%06dZ", nTimeMicros%1000000);
         }
         int64_t mocktime = GetMockTime();
         if (mocktime) {

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -258,7 +258,7 @@ namespace BCLog {
     }
 }
 
-void BCLog::Logger::LogPrintStr(const std::string& str)
+void BCLog::Logger::LogPrintStr(const std::string& str) noexcept
 {
     std::lock_guard<std::mutex> scoped_lock(m_cs);
     std::string str_prefixed = LogEscapeMessage(str);

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -121,7 +121,7 @@ bool BCLog::Logger::DisableCategory(const std::string& str)
     return true;
 }
 
-bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const
+bool BCLog::Logger::WillLogCategory(BCLog::LogFlags category) const noexcept
 {
     return (m_categories.load(std::memory_order_relaxed) & category) != 0;
 }

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -34,7 +34,7 @@ BCLog::Logger& LogInstance() noexcept
 
 bool fLogIPs = DEFAULT_LOGIPS;
 
-static int FileWriteStr(const std::string &str, FILE *fp)
+static int FileWriteStr(const std::string &str, FILE *fp) noexcept
 {
     return fwrite(str.data(), 1, str.size(), fp);
 }

--- a/src/logging.h
+++ b/src/logging.h
@@ -75,7 +75,7 @@ namespace BCLog {
         /** Log categories bitfield. */
         std::atomic<uint32_t> m_categories{0};
 
-        std::string LogTimestampStr(const std::string& str);
+        std::string LogTimestampStr(const std::string& str) noexcept;
 
         /** Slots that connect to the print signal */
         std::list<std::function<void(const std::string&)>> m_print_callbacks /* GUARDED_BY(m_cs) */ {};

--- a/src/logging.h
+++ b/src/logging.h
@@ -95,7 +95,7 @@ namespace BCLog {
         void LogPrintStr(const std::string& str);
 
         /** Returns whether logs will be written to any output */
-        bool Enabled() const
+        bool Enabled() const noexcept
         {
             std::lock_guard<std::mutex> scoped_lock(m_cs);
             return m_buffering || m_print_to_console || m_print_to_file || !m_print_callbacks.empty();

--- a/src/logging.h
+++ b/src/logging.h
@@ -137,7 +137,7 @@ namespace BCLog {
 
 } // namespace BCLog
 
-BCLog::Logger& LogInstance();
+BCLog::Logger& LogInstance() noexcept;
 
 /** Return true if log accepts specified category */
 static inline bool LogAcceptCategory(BCLog::LogFlags category)

--- a/src/logging.h
+++ b/src/logging.h
@@ -92,7 +92,7 @@ namespace BCLog {
         std::atomic<bool> m_reopen_file{false};
 
         /** Send a string to the log output */
-        void LogPrintStr(const std::string& str);
+        void LogPrintStr(const std::string& str) noexcept;
 
         /** Returns whether logs will be written to any output */
         bool Enabled() const noexcept
@@ -159,7 +159,7 @@ bool GetLogCategory(BCLog::LogFlags& flag, const std::string& str);
 // peer can fill up a user's disk with debug.log entries.
 
 template <typename... Args>
-static inline void LogPrintf(const char* fmt, const Args&... args)
+static inline void LogPrintf(const char* fmt, const Args&... args) noexcept
 {
     if (LogInstance().Enabled()) {
         std::string log_msg;

--- a/src/logging.h
+++ b/src/logging.h
@@ -130,7 +130,7 @@ namespace BCLog {
         void DisableCategory(LogFlags flag);
         bool DisableCategory(const std::string& str);
 
-        bool WillLogCategory(LogFlags category) const;
+        bool WillLogCategory(LogFlags category) const noexcept;
 
         bool DefaultShrinkDebugFile() const;
     };
@@ -140,7 +140,7 @@ namespace BCLog {
 BCLog::Logger& LogInstance() noexcept;
 
 /** Return true if log accepts specified category */
-static inline bool LogAcceptCategory(BCLog::LogFlags category)
+static inline bool LogAcceptCategory(BCLog::LogFlags category) noexcept
 {
     return LogInstance().WillLogCategory(category);
 }

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -1061,6 +1061,24 @@ std::string format(const std::string &fmt, const Args&... args)
     return oss.str();
 }
 
+/** Variant of tfm::format that aborts when an formatting exception happens instead
+ * of raising an exception.
+ *
+ * Use this function in no-except context, when you are 100% sure that the
+ * format string contains no errors. Only errors in the format string and inconsistencies
+ * between the format string and the type or number of arguments passed in cause tinyformat
+ * exceptions. It does not depend on the value of the arguments.
+ */
+template<typename... Args>
+std::string format_noexcept(const std::string &fmt, const Args&... args) noexcept
+{
+    // The C++ standard ensures that any exception raised here will call std::terminate,
+    // even if a terminate handler is set that does not abort.
+    std::ostringstream oss;
+    format(oss, fmt.c_str(), args...);
+    return oss.str();
+}
+
 } // namespace tinyformat
 
 /** Format arguments and return the string or write to given std::ostream (see tinyformat::format doc for details) */

--- a/src/util/threadnames.cpp
+++ b/src/util/threadnames.cpp
@@ -41,7 +41,7 @@ static void SetThreadName(const char* name)
 #if defined(HAVE_THREAD_LOCAL)
 
 static thread_local std::string g_thread_name;
-const std::string& util::ThreadGetInternalName() { return g_thread_name; }
+const std::string& util::ThreadGetInternalName() noexcept { return g_thread_name; }
 //! Set the in-memory internal name for this thread. Does not affect the process
 //! name.
 static void SetInternalName(std::string name) { g_thread_name = std::move(name); }
@@ -50,7 +50,7 @@ static void SetInternalName(std::string name) { g_thread_name = std::move(name);
 #else
 
 static const std::string empty_string;
-const std::string& util::ThreadGetInternalName() { return empty_string; }
+const std::string& util::ThreadGetInternalName() noexcept { return empty_string; }
 static void SetInternalName(std::string name) { }
 #endif
 

--- a/src/util/threadnames.h
+++ b/src/util/threadnames.h
@@ -19,7 +19,7 @@ void ThreadSetInternalName(std::string&&);
 
 //! Get the thread's internal (in-memory) name; used e.g. for identification in
 //! logging.
-const std::string& ThreadGetInternalName();
+const std::string& ThreadGetInternalName() noexcept;
 
 } // namespace util
 

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -51,18 +51,20 @@ int64_t GetMockTime() noexcept
     return nMockTime.load(std::memory_order_relaxed);
 }
 
-int64_t GetTimeMillis()
+int64_t GetTimeMillis() noexcept
 {
+    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
-                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_milliseconds();
+                   epoch).total_milliseconds();
     assert(now > 0);
     return now;
 }
 
-int64_t GetTimeMicros()
+int64_t GetTimeMicros() noexcept
 {
+    static const boost::posix_time::ptime epoch = boost::posix_time::from_time_t(0);
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
-                   boost::posix_time::ptime(boost::gregorian::date(1970,1,1))).total_microseconds();
+                   epoch).total_microseconds();
     assert(now > 0);
     return now;
 }

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -46,7 +46,7 @@ void SetMockTime(int64_t nMockTimeIn)
     nMockTime.store(nMockTimeIn, std::memory_order_relaxed);
 }
 
-int64_t GetMockTime()
+int64_t GetMockTime() noexcept
 {
     return nMockTime.load(std::memory_order_relaxed);
 }

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -90,7 +90,7 @@ void MilliSleep(int64_t n)
 #endif
 }
 
-std::string FormatISO8601DateTime(int64_t nTime) {
+std::string FormatISO8601DateTime(int64_t nTime) noexcept {
     struct tm ts;
     time_t time_val = nTime;
 #ifdef _MSC_VER
@@ -98,10 +98,10 @@ std::string FormatISO8601DateTime(int64_t nTime) {
 #else
     gmtime_r(&time_val, &ts);
 #endif
-    return strprintf("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
+    return tfm::format_noexcept("%04i-%02i-%02iT%02i:%02i:%02iZ", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday, ts.tm_hour, ts.tm_min, ts.tm_sec);
 }
 
-std::string FormatISO8601Date(int64_t nTime) {
+std::string FormatISO8601Date(int64_t nTime) noexcept {
     struct tm ts;
     time_t time_val = nTime;
 #ifdef _MSC_VER
@@ -109,7 +109,7 @@ std::string FormatISO8601Date(int64_t nTime) {
 #else
     gmtime_r(&time_val, &ts);
 #endif
-    return strprintf("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
+    return tfm::format_noexcept("%04i-%02i-%02i", ts.tm_year + 1900, ts.tm_mon + 1, ts.tm_mday);
 }
 
 int64_t ParseISO8601DateTime(const std::string& str)

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -25,9 +25,9 @@ inline int64_t count_seconds(std::chrono::seconds t) { return t.count(); }
 int64_t GetTime();
 
 /** Returns the system time (not mockable) */
-int64_t GetTimeMillis();
+int64_t GetTimeMillis() noexcept;
 /** Returns the system time (not mockable) */
-int64_t GetTimeMicros();
+int64_t GetTimeMicros() noexcept;
 /** Returns the system time (not mockable) */
 int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -34,7 +34,7 @@ int64_t GetSystemTimeInSeconds(); // Like GetTime(), but not mockable
 /** For testing. Set e.g. with the setmocktime rpc, or -mocktime argument */
 void SetMockTime(int64_t nMockTimeIn);
 /** For testing */
-int64_t GetMockTime();
+int64_t GetMockTime() noexcept;
 
 void MilliSleep(int64_t n);
 

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -46,8 +46,8 @@ T GetTime();
  * ISO 8601 formatting is preferred. Use the FormatISO8601{DateTime,Date}
  * helper functions if possible.
  */
-std::string FormatISO8601DateTime(int64_t nTime);
-std::string FormatISO8601Date(int64_t nTime);
+std::string FormatISO8601DateTime(int64_t nTime) noexcept;
+std::string FormatISO8601Date(int64_t nTime) noexcept;
 int64_t ParseISO8601DateTime(const std::string& str);
 
 #endif // BITCOIN_UTIL_TIME_H


### PR DESCRIPTION
Make the logging subsystem noexcept. This facilitates changes such as #17507 by making
it possible to log in noexcept context.

First, adds a function `tfm::format_noexcept` that works like `tfm::format` for use in noexcept context if the format string and number of arguments are guaranteed to be correct (for example, if it is trivial like "%02x"). It will abort on any tinyformat error. This is used in utility functions, not for the logging strings itself, as formatting exceptions there are internally caught and logged in LogPrintf (for better troubleshooting of the complex arbitrary formatting expressions used there).

Then, go through the call hierarchy and make functions noexcept after checking them (see individual commits):
```
LogInstance
LogAcceptCategory
  Logger::WillLogCategory
LogPrintf
  Logger::Enabled
  LogPrintStr
    LogEscapeMessage
    util::ThreadGetInternalName()
    LogTimestampStr
      GetTimeMicros
      FormatISO8601DateTime
      GetMockTime
    fsbridge::fopen
    FileWriteStr
```

Though I've checked these functions carefully, it is possible that I missed a function down the call tree. Please let me know if so.

~~The only functions I'm slightly uncertain about are the boost posix_time functions in
GetTimeMicros/GetTimeMillis, but I could not find any documented exceptions in
https://www.boost.org/doc/libs/1_71_0/doc/html/date_time/posix_time.html~~ (fixed, thanks to practicalswift)

(I know the m_print_callbacks can potentially throw, there is as far as I saw no way
to guarantee std::function as noexcept. I leave this as an responsibility to who registers it.
FWIW, this functionality is only used as part of the test framework.)

(Also, thinking of it, any kind of allocation in C++ can except with `bad_alloc&`, including inside string manipulation, which is almost 100% of the code here. If that's an issue, I'm no longer convinced this is possible at all)