### PR TITLE
build: Mark depends headers as -isystem

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -58,7 +58,7 @@ if test -z "@allow_host_packages@"; then
   export PKGCONFIG_LIBDIR=
 fi
 
-CPPFLAGS="-I$depends_prefix/include/ $CPPFLAGS"
+CPPFLAGS="-isystem$depends_prefix/include/ $CPPFLAGS"
 LDFLAGS="-L$depends_prefix/lib $LDFLAGS"
 
 if test -n "@CC@" -a -z "${CC}"; then


### PR DESCRIPTION
This prevents Travis from failing if any of the dependencies have e.g. unused variables: https://travis-ci.org/bitcoin/bitcoin/jobs/613924094#L10291 (I ran into this particular unused variable in #15382, and it has been fixed in Boost System 1.71)

https://stackoverflow.com/a/1900578/313633

Alternative is to revert #17486, but I'd rather not.