### PR TITLE
rpc: Faster getblock using PureBlock

### DIFF
--- a/src/bench/checkblock.cpp
+++ b/src/bench/checkblock.cpp
@@ -15,6 +15,20 @@
 // a block off the wire, but before we can relay the block on to peers using
 // compact block relay.
 
+static void DeserializePureBlockTest(benchmark::Bench& state)
+{
+    CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
+    char a = '\0';
+    stream.write(&a, 1); // Prevent compaction
+
+    while (state.KeepRunning()) {
+        PureBlock block;
+        stream >> block;
+        bool rewound = stream.Rewind(benchmark::data::block413567.size());
+        assert(rewound);
+    }
+}
+
 static void DeserializeBlockTest(benchmark::Bench& bench)
 {
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
@@ -50,5 +64,6 @@ static void DeserializeAndCheckBlockTest(benchmark::Bench& bench)
     });
 }
 
+BENCHMARK(DeserializePureBlockTest);
 BENCHMARK(DeserializeBlockTest);
 BENCHMARK(DeserializeAndCheckBlockTest);

--- a/src/core_io.h
+++ b/src/core_io.h
@@ -6,11 +6,11 @@
 #define BITCOIN_CORE_IO_H
 
 #include <consensus/amount.h>
+#include <primitives/types.h>
 
 #include <string>
 #include <vector>
 
-class CBlock;
 class CBlockHeader;
 class CScript;
 class CTransaction;

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -9,8 +9,8 @@
 #include <interfaces/chain.h>
 #include <threadinterrupt.h>
 #include <validationinterface.h>
+#include <primitives/types.h>
 
-class CBlock;
 class CBlockIndex;
 class CChainState;
 namespace interfaces {

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -7,6 +7,7 @@
 
 #include <primitives/transaction.h> // For CTransactionRef
 #include <util/settings.h>          // For util::SettingsValue
+#include <primitives/types.h>
 
 #include <functional>
 #include <memory>
@@ -17,7 +18,6 @@
 #include <vector>
 
 class ArgsManager;
-class CBlock;
 class CBlockUndo;
 class CFeeRate;
 class CRPCCommand;

--- a/src/kernel/chain.cpp
+++ b/src/kernel/chain.cpp
@@ -6,8 +6,7 @@
 #include <interfaces/chain.h>
 #include <sync.h>
 #include <uint256.h>
-
-class CBlock;
+#include <primitives/types.h>
 
 namespace kernel {
 interfaces::BlockInfo MakeBlockInfo(const CBlockIndex* index, const CBlock* data)

--- a/src/kernel/chain.h
+++ b/src/kernel/chain.h
@@ -5,7 +5,8 @@
 #ifndef BITCOIN_KERNEL_CHAIN_H
 #define BITCOIN_KERNEL_CHAIN_H
 
-class CBlock;
+#include <primitives/types.h>
+
 class CBlockIndex;
 namespace interfaces {
 struct BlockInfo;

--- a/src/node/blockstorage.cpp
+++ b/src/node/blockstorage.cpp
@@ -709,7 +709,8 @@ bool BlockManager::WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValid
     return true;
 }
 
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const FlatFilePos& pos, const Consensus::Params& consensusParams)
 {
     block.SetNull();
 
@@ -738,8 +739,11 @@ bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::P
 
     return true;
 }
+template bool ReadBlockFromDisk<PureBlock>(PureBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
+template bool ReadBlockFromDisk<CBlock>(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
 
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams)
 {
     const FlatFilePos block_pos{WITH_LOCK(cs_main, return pindex->GetBlockPos())};
 
@@ -752,6 +756,8 @@ bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus
     }
     return true;
 }
+template bool ReadBlockFromDisk<PureBlock>(PureBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+template bool ReadBlockFromDisk<CBlock>(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start)
 {

--- a/src/node/blockstorage.h
+++ b/src/node/blockstorage.h
@@ -8,6 +8,7 @@
 #include <attributes.h>
 #include <chain.h>
 #include <fs.h>
+#include <primitives/types.h>
 #include <protocol.h>
 #include <sync.h>
 #include <txdb.h>
@@ -21,7 +22,6 @@ extern RecursiveMutex cs_main;
 
 class ArgsManager;
 class BlockValidationState;
-class CBlock;
 class CBlockFileInfo;
 class CBlockUndo;
 class CChain;
@@ -205,8 +205,10 @@ fs::path GetBlockPosFilename(const FlatFilePos& pos);
 void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Functions for disk access for blocks */
-bool ReadBlockFromDisk(CBlock& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
-bool ReadBlockFromDisk(CBlock& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const FlatFilePos& pos, const Consensus::Params& consensusParams);
+template <typename Block>
+bool ReadBlockFromDisk(Block& block, const CBlockIndex* pindex, const Consensus::Params& consensusParams);
 bool ReadRawBlockFromDisk(std::vector<uint8_t>& block, const FlatFilePos& pos, const CMessageHeader::MessageStartChars& message_start);
 
 bool UndoReadFromDisk(CBlockUndo& blockundo, const CBlockIndex* pindex);

--- a/src/node/chainstate.cpp
+++ b/src/node/chainstate.cpp
@@ -11,11 +11,9 @@
 #include <node/caches.h>
 #include <sync.h>
 #include <threadsafety.h>
-#include <tinyformat.h>
 #include <txdb.h>
 #include <uint256.h>
 #include <util/time.h>
-#include <util/translation.h>
 #include <validation.h>
 
 #include <algorithm>

--- a/src/node/chainstate.h
+++ b/src/node/chainstate.h
@@ -5,13 +5,13 @@
 #ifndef BITCOIN_NODE_CHAINSTATE_H
 #define BITCOIN_NODE_CHAINSTATE_H
 
-#include <util/translation.h>
 #include <validation.h>
 
 #include <cstdint>
 #include <functional>
-#include <tuple>
+#include <optional>
 
+class ChainstateManager;
 class CTxMemPool;
 
 namespace node {

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -13,6 +13,7 @@ uint256 CBlockHeader::GetHash() const
     return SerializeHash(*this);
 }
 
+template<>
 std::string CBlock::ToString() const
 {
     std::stringstream s;

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -59,27 +59,28 @@ public:
 };
 
 
-class CBlock : public CBlockHeader
+template <typename TxRef>
+class Block : public CBlockHeader
 {
 public:
     // network and disk
-    std::vector<CTransactionRef> vtx;
+    std::vector<TxRef> vtx;
 
     // memory only
     mutable bool fChecked;
 
-    CBlock()
+    Block()
     {
         SetNull();
     }
 
-    CBlock(const CBlockHeader &header)
+    Block(const CBlockHeader& header)
     {
         SetNull();
         *(static_cast<CBlockHeader*>(this)) = header;
     }
 
-    SERIALIZE_METHODS(CBlock, obj)
+    SERIALIZE_METHODS(Block, obj)
     {
         READWRITEAS(CBlockHeader, obj);
         READWRITE(obj.vtx);
@@ -106,6 +107,9 @@ public:
 
     std::string ToString() const;
 };
+
+using PureBlock = Block<PureTransactionRef>;
+using CBlock = Block<CTransactionRef>;
 
 /** Describes a place in the block chain to another node such that if the
  * other node doesn't have the same branch, it can find a recent common trunk.

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -78,8 +78,10 @@ uint256 CTransaction::ComputeWitnessHash() const
     return SerializeHash(*this, SER_GETHASH, 0);
 }
 
-CTransaction::CTransaction(const CMutableTransaction& tx) : vin(tx.vin), vout(tx.vout), nVersion(tx.nVersion), nLockTime(tx.nLockTime), hash{ComputeHash()}, m_witness_hash{ComputeWitnessHash()} {}
-CTransaction::CTransaction(CMutableTransaction&& tx) : vin(std::move(tx.vin)), vout(std::move(tx.vout)), nVersion(tx.nVersion), nLockTime(tx.nLockTime), hash{ComputeHash()}, m_witness_hash{ComputeWitnessHash()} {}
+CTransaction::CTransaction(const CMutableTransaction& tx) : PureTransaction{tx}, hash{ComputeHash()}, m_witness_hash{ComputeWitnessHash()} {}
+PureTransaction::PureTransaction(const CMutableTransaction& tx) : vin{tx.vin}, vout{tx.vout}, nVersion{tx.nVersion}, nLockTime{tx.nLockTime} {}
+CTransaction::CTransaction(CMutableTransaction&& tx) : PureTransaction{std::move(tx)}, hash{ComputeHash()}, m_witness_hash{ComputeWitnessHash()} {}
+PureTransaction::PureTransaction(CMutableTransaction&& tx) : vin{std::move(tx.vin)}, vout{std::move(tx.vout)}, nVersion{tx.nVersion}, nLockTime{tx.nLockTime} {}
 
 CAmount CTransaction::GetValueOut() const
 {

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -11,6 +11,7 @@
 #include <streams.h>
 #include <sync.h>
 #include <validation.h>
+#include <primitives/types.h>
 
 #include <any>
 #include <stdint.h>
@@ -18,7 +19,6 @@
 
 extern RecursiveMutex cs_main;
 
-class CBlock;
 class CBlockIndex;
 class CChainState;
 class UniValue;

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -5,11 +5,12 @@
 #ifndef BITCOIN_TEST_UTIL_MINING_H
 #define BITCOIN_TEST_UTIL_MINING_H
 
+#include <primitives/types.h>
+
 #include <memory>
 #include <string>
 #include <vector>
 
-class CBlock;
 class CChainParams;
 class CScript;
 class CTxIn;

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -12,6 +12,7 @@
 #include <node/caches.h>
 #include <node/context.h>
 #include <pubkey.h>
+#include <primitives/types.h>
 #include <random.h>
 #include <stdexcept>
 #include <txmempool.h>
@@ -116,7 +117,6 @@ struct RegTestingSetup : public TestingSetup {
         : TestingSetup{CBaseChainParams::REGTEST} {}
 };
 
-class CBlock;
 struct CMutableTransaction;
 class CScript;
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -6,15 +6,14 @@
 #ifndef BITCOIN_VALIDATIONINTERFACE_H
 #define BITCOIN_VALIDATIONINTERFACE_H
 
-#include <primitives/transaction.h> // CTransaction(Ref)
 #include <sync.h>
+#include <primitives/types.h>
 
 #include <functional>
 #include <memory>
 
 extern RecursiveMutex cs_main;
 class BlockValidationState;
-class CBlock;
 class CBlockIndex;
 struct CBlockLocator;
 class CValidationInterface;

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -235,9 +235,8 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION | RPCSerializationFlags());
     {
         LOCK(cs_main);
-        CBlock block;
-        if(!ReadBlockFromDisk(block, pindex, consensusParams))
-        {
+        PureBlock block;
+        if (!ReadBlockFromDisk(block, pindex, consensusParams)) {
             zmqError("Can't read block from disk");
             return false;
         }


### PR DESCRIPTION
This adds and uses a new transaction type `PureTransaction`.
The underlying class has no transaction hash compiled in. So
it is safe to use (and faster) wherever it compiles.
    
The existing CMutableTransaction retains the behavior to calculate the
tx hash on demand. Use of CMutableTransaction makes compile-time
complexity analysis impossible.
    
The existing CTransaction retains the behavior to cache the hash on
initialization.
