### PR TITLE
Use natural alignment for prevector

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -14,7 +14,6 @@
 #include <cstddef>
 #include <type_traits>
 
-#pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
  *  elements directly (without heap allocation). The types Size and Diff are
  *  used to store element counts, and can be any unsigned + signed type.
@@ -522,6 +521,5 @@ public:
         return item_ptr(0);
     }
 };
-#pragma pack(pop)
 
 #endif // BITCOIN_PREVECTOR_H

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,7 +1,5 @@
 # -fsanitize=undefined suppressions
 # =================================
-alignment:move.h
-alignment:prevector.h
 float-divide-by-zero:policy/fees.cpp
 float-divide-by-zero:validation.cpp
 float-divide-by-zero:wallet/wallet.cpp


### PR DESCRIPTION
`#pragma pack(1)` prevents aligning the struct and its members to their required alignment. This can result in code that performs non-aligned reads and writes to integers and pointers, which is problematic on some architectures.

It also triggers UBsan — see https://github.com/bitcoin/bitcoin/pull/17156#issuecomment-543123631 and #17510.

So remove the pragmas.