### PR TITLE
test: add block height test to listsinceblock.py 

### DIFF
--- a/doc/release-notes-17437.md
+++ b/doc/release-notes-17437.md
@@ -1,5 +1,5 @@
 Low-level RPC Changes
 ===
 
-- The RPC gettransaction, listtransactions and listsinceblock responses now also
-includes the height of the block that contains the wallet transaction, if any.
+- The RPC gettransaction, listtransactions and listsinceblock responses now
+include the height of the block that contains the wallet transaction, if any.

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -81,8 +81,9 @@ Updated settings
 Updated RPCs
 ------------
 
-Note: some low-level RPC changes mainly useful for testing are described in the
-Low-level Changes section below.
+Please refer to the help of the relevant RPC for more details on an update
+below. Some low-level RPC changes mainly useful for testing are described
+in the "Low-level changes" section further down.
 
 GUI changes
 -----------

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2017-2019 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-"""Test the listsincelast RPC."""
+"""Test the listsinceblock RPC."""
 
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.messages import BIP125_SEQUENCE_NUMBER
@@ -111,23 +111,22 @@ class ListSinceBlockTest(BitcoinTestFramework):
         senttx = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 1)
 
         # generate on both sides
-        lastblockhash = self.nodes[1].generate(6)[5]
-        self.nodes[2].generate(7)
-        self.log.info('lastblockhash=%s' % (lastblockhash))
+        nodes1_last_blockhash = self.nodes[1].generate(6)[-1]
+        nodes2_first_blockhash = self.nodes[2].generate(7)[0]
+        self.log.debug("nodes[1] last blockhash = {}".format(nodes1_last_blockhash))
+        self.log.debug("nodes[2] first blockhash = {}".format(nodes2_first_blockhash))
 
         self.sync_all(self.nodes[:2])
         self.sync_all(self.nodes[2:])
 
         self.join_network()
 
-        # listsinceblock(lastblockhash) should now include tx, as seen from nodes[0]
-        lsbres = self.nodes[0].listsinceblock(lastblockhash)
-        found = False
-        for tx in lsbres['transactions']:
-            if tx['txid'] == senttx:
-                found = True
-                break
-        assert found
+        # listsinceblock(nodes1_last_blockhash) should now include tx as seen from nodes[0]
+        # and return the block height which listsinceblock now exposes since a5e7795.
+        transactions = self.nodes[0].listsinceblock(nodes1_last_blockhash)['transactions']
+        found = next(tx for tx in transactions if tx['txid'] == senttx)
+        assert_equal(found['blockheight'],
+                     self.nodes[0].getblockheader(nodes2_first_blockhash)['height'])
 
     def test_double_spend(self):
         '''

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -38,6 +38,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         self.double_spends_filtered()
 
     def test_no_blockhash(self):
+        self.log.info("Test no blockhash")
         txid = self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), 1)
         blockhash, = self.nodes[2].generate(1)
         blockheight = self.nodes[2].getblockheader(blockhash)['height']
@@ -63,6 +64,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
              "transactions": txs})
 
     def test_invalid_blockhash(self):
+        self.log.info("Test invalid blockhash")
         assert_raises_rpc_error(-5, "Block not found", self.nodes[0].listsinceblock,
                                 "42759cde25462784395a337460bde75f58e73d3f08bd31fdc3507cbac856a2c4")
         assert_raises_rpc_error(-5, "Block not found", self.nodes[0].listsinceblock,
@@ -100,6 +102,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
 
         This test only checks that [tx0] is present.
         '''
+        self.log.info("Test reorg")
 
         # Split network into two
         self.split_network()
@@ -155,6 +158,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         until the fork point, and to include all transactions that relate to the
         node wallet.
         '''
+        self.log.info("Test double spend")
 
         self.sync_all()
 
@@ -234,6 +238,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         3. It is listed with a confirmation count of 2 (bb3, bb4), not
            3 (aa1, aa2, aa3).
         '''
+        self.log.info("Test double send")
 
         self.sync_all()
 
@@ -302,6 +307,7 @@ class ListSinceBlockTest(BitcoinTestFramework):
         `listsinceblock` was returning conflicted transactions even if they
         occurred before the specified cutoff blockhash
         '''
+        self.log.info("Test spends filtered")
         spending_node = self.nodes[2]
         dest_address = spending_node.getnewaddress()
 


### PR DESCRIPTION
Follow-up to PR #17437.

Add block height test, expected fields tests, logging, and correct header docstring in `listsinceblock.py`, and improve the release notes.