### PR TITLE
build: Create test utility library from src/test/util/

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -717,6 +717,8 @@ if EMBEDDED_LEVELDB
 include Makefile.leveldb.include
 endif
 
+include Makefile.test_util.include
+
 if ENABLE_TESTS
 include Makefile.test.include
 endif

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -40,10 +40,6 @@ bench_bench_bitcoin_SOURCES = \
   bench/lockedpool.cpp \
   bench/poly1305.cpp \
   bench/prevector.cpp \
-  test/util/transaction_utils.h \
-  test/util/transaction_utils.cpp \
-  test/util/setup_common.h \
-  test/util/setup_common.cpp \
   test/util.h \
   test/util.cpp
 
@@ -59,6 +55,7 @@ bench_bench_bitcoin_LDADD = \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_CRYPTO) \
+  $(LIBTEST_UTIL) \
   $(LIBLEVELDB) \
   $(LIBLEVELDB_SSE42) \
   $(LIBMEMENV) \

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -26,12 +26,6 @@ TEST_QT_H = \
   qt/test/util.h \
   qt/test/wallettests.h
 
-TEST_BITCOIN_CPP = \
-  test/util/setup_common.cpp
-
-TEST_BITCOIN_H = \
-  test/util/setup_common.h
-
 qt_test_test_bitcoin_qt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_QT_INCLUDES) \
   $(QT_INCLUDES) $(QT_TEST_INCLUDES)
 
@@ -42,9 +36,7 @@ qt_test_test_bitcoin_qt_SOURCES = \
   qt/test/test_main.cpp \
   qt/test/uritests.cpp \
   qt/test/util.cpp \
-  $(TEST_QT_H) \
-  $(TEST_BITCOIN_CPP) \
-  $(TEST_BITCOIN_H)
+  $(TEST_QT_H)
 if ENABLE_WALLET
 qt_test_test_bitcoin_qt_SOURCES += \
   qt/test/addressbooktests.cpp \
@@ -54,7 +46,7 @@ endif # ENABLE_WALLET
 
 nodist_qt_test_test_bitcoin_qt_SOURCES = $(TEST_QT_MOC_CPP)
 
-qt_test_test_bitcoin_qt_LDADD = $(LIBBITCOINQT) $(LIBBITCOIN_SERVER)
+qt_test_test_bitcoin_qt_LDADD = $(LIBBITCOINQT) $(LIBBITCOIN_SERVER) $(LIBTEST_UTIL)
 if ENABLE_WALLET
 qt_test_test_bitcoin_qt_LDADD += $(LIBBITCOIN_UTIL) $(LIBBITCOIN_WALLET)
 endif

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -58,31 +58,19 @@ RAW_TEST_FILES =
 GENERATED_TEST_FILES = $(JSON_TEST_FILES:.json=.json.h) $(RAW_TEST_FILES:.raw=.raw.h)
 
 BITCOIN_TEST_SUITE = \
-  test/util/blockfilter.cpp \
-  test/util/blockfilter.h \
-  test/util/logging.cpp \
-  test/util/logging.h \
-  test/util/transaction_utils.cpp \
-  test/util/transaction_utils.h \
   test/main.cpp \
-  test/util/setup_common.h \
-  test/util/setup_common.cpp \
-  test/util/str.h \
-  test/util/str.cpp
+  $(TEST_UTIL_H)
 
 FUZZ_SUITE = \
   test/fuzz/fuzz.cpp \
   test/fuzz/fuzz.h \
-  test/fuzz/FuzzedDataProvider.h \
-  test/util/setup_common.cpp \
-  test/util/setup_common.h \
-  test/util/str.cpp \
-  test/util/str.h
+  test/fuzz/FuzzedDataProvider.h
 
 FUZZ_SUITE_LD_COMMON = \
  $(LIBBITCOIN_SERVER) \
  $(LIBBITCOIN_COMMON) \
  $(LIBBITCOIN_UTIL) \
+ $(LIBTEST_UTIL) \
  $(LIBBITCOIN_CONSENSUS) \
  $(LIBBITCOIN_CRYPTO) \
  $(LIBUNIVALUE) \
@@ -198,7 +186,7 @@ endif
 
 test_test_bitcoin_SOURCES = $(BITCOIN_TEST_SUITE) $(BITCOIN_TESTS) $(JSON_TEST_FILES) $(RAW_TEST_FILES)
 test_test_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(TESTDEFS) $(EVENT_CFLAGS)
-test_test_bitcoin_LDADD =
+test_test_bitcoin_LDADD = $(LIBTEST_UTIL)
 if ENABLE_WALLET
 test_test_bitcoin_LDADD += $(LIBBITCOIN_WALLET)
 endif

--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -1,0 +1,31 @@
+# Copyright (c) 2013-2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+LIBTEST_UTIL=libtest_util.a
+
+EXTRA_LIBRARIES += \
+    $(LIBTEST_UTIL)
+
+TEST_UTIL_H = \
+    test/util/blockfilter.h \
+    test/util/logging.h \
+    test/util/setup_common.h \
+    test/util/str.h \
+    test/util/transaction_utils.h
+
+libtest_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
+libtest_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+libtest_util_a_SOURCES = \
+  test/util/blockfilter.cpp \
+  test/util/logging.cpp \
+  test/util/setup_common.cpp \
+  test/util/str.cpp \
+  test/util/transaction_utils.cpp \
+  $(TEST_UTIL_H)
+
+LIBTEST_UTIL += $(LIBBITCOIN_SERVER)
+LIBTEST_UTIL += $(LIBBITCOIN_COMMON)
+LIBTEST_UTIL += $(LIBBITCOIN_UTIL)
+LIBTEST_UTIL += $(LIBBITCOIN_CRYPTO_BASE)
+


### PR DESCRIPTION
This PR creates a static **test utility library** that replaces repetitive compilations of sources from *src/test/util* in **unit**, **gui** and **bench** **tests**.

The original issue is here: https://github.com/bitcoin/bitcoin/issues/17401 

The changes are:

* a new *Makefile.test_util.include*
* a new entry in *Makefile.am* that includes *Makefile.test_util.include* when testing is enabled
* removal of all *src/test/util* headers & sources from unit, gui and bench Makefiles
* addition of *libtest_util.a* at LDADD's of every test

