### PR TITLE
wallet: undo conflicts properly in case of blocks disconnection

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -851,15 +851,6 @@ void CWallet::LoadToWallet(CWalletTx& wtxIn)
         wtx.m_it_wtxOrdered = wtxOrdered.insert(std::make_pair(wtx.nOrderPos, &wtx));
     }
     AddToSpends(hash);
-    for (const CTxIn& txin : wtx.tx->vin) {
-        auto it = mapWallet.find(txin.prevout.hash);
-        if (it != mapWallet.end()) {
-            CWalletTx& prevtx = it->second;
-            if (prevtx.isConflicted()) {
-                MarkConflicted(prevtx.m_confirm.hashBlock, prevtx.m_confirm.block_height, wtx.GetHash());
-            }
-        }
-    }
 }
 
 bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, CWalletTx::Confirmation confirm, bool fUpdate)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -653,7 +653,8 @@ private:
     bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, CWalletTx::Confirmation confirm, bool fUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
-    void MarkConflicted(const uint256& hashBlock, int conflicting_height, const uint256& hashTx);
+    template <typename Fn>
+    void UpdateConflicts(const uint256& hashTx, Fn&& fn);
 
     /* Mark a transaction's inputs dirty, thus forcing the outputs to be recomputed */
     void MarkInputsDirty(const CTransactionRef& tx) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -650,7 +650,7 @@ private:
      * Abandoned state should probably be more carefully tracked via different
      * posInBlock signals or by checking mempool presence when necessary.
      */
-    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, CWalletTx::Confirmation confirm, bool fUpdate) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef& tx, CWalletTx::Confirmation confirm, bool fUpdate, int height) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     /* Mark a transaction (and its in-wallet descendants) as conflicting with a particular block. */
     template <typename Fn>
@@ -663,7 +663,7 @@ private:
 
     /* Used by TransactionAddedToMemorypool/BlockConnected/Disconnected/ScanForWalletTransactions.
      * Should be called with non-zero block_hash and posInBlock if this is for a transaction that is included in a block. */
-    void SyncTransaction(const CTransactionRef& tx, CWalletTx::Confirmation confirm, bool update_tx = true) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void SyncTransaction(const CTransactionRef& tx, CWalletTx::Confirmation confirm, int height, bool update_tx = true) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     std::atomic<uint64_t> m_wallet_flags{0};
 

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -132,6 +132,7 @@ BASE_SCRIPTS = [
     'wallet_watchonly.py',
     'wallet_watchonly.py --usecli',
     'wallet_reorgsrestore.py',
+    'wallet_conflicts.py',
     'interface_http.py',
     'interface_rpc.py',
     'rpc_psbt.py',

--- a/test/functional/wallet_conflicts.py
+++ b/test/functional/wallet_conflicts.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""Test conflicts tracking with multilple txn conflicting a conflicted tx."""
+
+from decimal import Decimal
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+        assert_equal,
+        connect_nodes,
+        disconnect_nodes,
+)
+
+class TxConflicts(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 3
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        # Send tx from which to conflict outputs later
+        txid_conflict_from_1 = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        txid_conflict_from_2 = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), Decimal("10"))
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        # Disconnect to broadcast conflicts on their respective chains
+        disconnect_nodes(self.nodes[0], 1)
+        disconnect_nodes(self.nodes[2], 1)
+        disconnect_nodes(self.nodes[2], 0)
+
+        # Create txn, with conflicted txn spending outpoint A & B, A is going to be spent by conflicting_tx_A and B is going to be spent by conflicting_tx_B
+        nA = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txid_conflict_from_1)["details"] if tx_out["amount"] == Decimal("10"))
+        nB = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txid_conflict_from_2)["details"] if tx_out["amount"] == Decimal("10"))
+        inputs_conflicted_tx = []
+        inputs_conflicted_tx.append({"txid": txid_conflict_from_1, "vout": nA})
+        inputs_conflicted_tx.append({"txid": txid_conflict_from_2, "vout": nB})
+        inputs_conflicting_tx_A = []
+        inputs_conflicting_tx_A.append({"txid": txid_conflict_from_1, "vout": nA})
+        inputs_conflicting_tx_B = []
+        inputs_conflicting_tx_B.append({"txid": txid_conflict_from_2, "vout": nB})
+
+        outputs_conflicted_tx = {}
+        outputs_conflicted_tx[self.nodes[0].getnewaddress()] = Decimal("19.99998")
+        outputs_conflicting_tx_A = {}
+        outputs_conflicting_tx_A[self.nodes[0].getnewaddress()] = Decimal("9.99998")
+        outputs_conflicting_tx_B = {}
+        outputs_conflicting_tx_B[self.nodes[0].getnewaddress()] = Decimal("9.99998")
+
+        conflicted = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs_conflicted_tx, outputs_conflicted_tx))
+        conflicting_tx_A = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs_conflicting_tx_A, outputs_conflicting_tx_A))
+        conflicting_tx_B = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs_conflicting_tx_B, outputs_conflicting_tx_B))
+
+        # Broadcast conflicted tx
+        conflicted_txid = self.nodes[0].sendrawtransaction(conflicted["hex"])
+        self.nodes[0].generate(1)
+
+        # Build child conflicted tx
+        nA = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(conflicted_txid)["details"] if tx_out["amount"] == Decimal("19.99998"))
+        inputs_child_conflicted = []
+        inputs_child_conflicted.append({"txid": conflicted_txid, "vout": nA})
+        outputs_child_conflicted = {}
+        outputs_child_conflicted[self.nodes[0].getnewaddress()] = Decimal("19.99996")
+        child_conflicted = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs_child_conflicted, outputs_child_conflicted))
+        child_conflicted_txid = self.nodes[0].sendrawtransaction(child_conflicted["hex"])
+        self.nodes[0].generate(1)
+
+        # Broadcast conflicting txn on node1 chain
+        conflicting_txid_A = self.nodes[1].sendrawtransaction(conflicting_tx_A["hex"])
+        self.nodes[1].generate(4)
+        self.nodes[1].sendrawtransaction(conflicting_tx_B["hex"])
+        self.nodes[1].generate(4)
+
+        # Reconnect node0 and node1 and check that conflicted_txid is effectively conflicted
+        connect_nodes(self.nodes[0], 1)
+        self.sync_blocks([self.nodes[0], self.nodes[1]])
+        conflicted = self.nodes[0].gettransaction(conflicted_txid)
+        child_conflicted = self.nodes[0].gettransaction(child_conflicted_txid)
+        conflicting = self.nodes[0].gettransaction(conflicting_txid_A)
+        # Conflicted tx should have confirmations set to the confirmations of the most conflicting tx
+        assert_equal(conflicted["confirmations"], -conflicting["confirmations"])
+        # Child should inherit conflicted state from parent
+        assert_equal(child_conflicted["confirmations"], -conflicting["confirmations"])
+
+        # Node2 chain without conflicts
+        self.nodes[2].generate(15)
+
+        # Connect node0 and node2 and wait reorg
+        connect_nodes(self.nodes[0], 2)
+        self.sync_blocks([self.nodes[0], self.nodes[2]])
+        conflicted = self.nodes[0].gettransaction(conflicted_txid)
+        child_conflicted = self.nodes[0].gettransaction(child_conflicted_txid)
+        # Former conflicted tx should be unoncifmred as it hasn't been yet rebroadcast
+        assert_equal(conflicted["confirmations"], 0)
+        # Former conflicted child tx should be unconfirmed as it hasn't been rebroadcast
+        assert_equal(child_conflicted["confirmations"], 0)
+        # Rebroadcast former conflicted tx and check it confirms smoothly
+        self.nodes[2].sendrawtransaction(conflicted["hex"])
+        self.nodes[2].generate(1)
+        self.sync_blocks([self.nodes[0], self.nodes[2]])
+        former_conflicted = self.nodes[0].gettransaction(conflicted_txid)
+        assert_equal(former_conflicted["confirmations"], 1)
+        assert_equal(former_conflicted["blockheight"], 217)
+
+if __name__ == '__main__':
+    TxConflicts().main()


### PR DESCRIPTION
At the moment, in case of block disconnection, if any conflicting transaction was inside, we don't undo conflicts on wallet transactions, i.e they stay in state `CONFLICTED` instead of being marked again as `UNCONFIRMED`. This shortcoming causes inaccurate balance computation and blocks the user from re-submitting the tx back to the mempool. 

Currently, if conflicted transaction was later confirmed, the status is updated accordingly and nothing changes. This PR undoes conflict(s) and also cleans up some of `MarkConflicted` which is renamed `UpdatedConflicts` to cover both instances of unconfirmed to conflicted and conflicted to unconfirmed cases. 

Lambda is used, but I'm open to other approaches.

