### PR TITLE
build: remove libanl.so.1 from ALLOWED_LIBRARIES

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -57,7 +57,6 @@ ALLOWED_LIBRARIES = {
 'libgcc_s.so.1', # GCC base support
 'libc.so.6', # C library
 'libpthread.so.0', # threading
-'libanl.so.1', # DNS resolve
 'libm.so.6', # math library
 'librt.so.1', # real-time (clock)
 'libatomic.so.1',


### PR DESCRIPTION
It should no longer be needed after: https://github.com/bitcoin/bitcoin/commit/10ae7a7b2316f8052ec58ef237ce6dd987300900.

Symbol checker output for the `0.19.0.1` gitian built Linux binaries:
```bash
aarch64  arm  i686-pc  risvc  symbol-check.py  x86_64
root@557096f567b5:/test# find aarch64/ -type f -executable | xargs python3 symbol-check.py
['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
['libpthread.so.0', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
root@557096f567b5:/test# find arm -type f -executable | xargs python3 symbol-check.py
['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
['libpthread.so.0', 'librt.so.1', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
root@557096f567b5:/test# find i686-pc -type f -executable | xargs python3 symbol-check.py
['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
['libpthread.so.0', 'librt.so.1', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
root@557096f567b5:/test# find risvc/ -type f -executable | xargs python3 symbol-check.py
['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1']
['libpthread.so.0', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1', 'libatomic.so.1']
root@557096f567b5:/test# find x86_64/ -type f -executable | xargs python3 symbol-check.py
['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
['libpthread.so.0', 'librt.so.1', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
```