### PR TITLE
test: added test for RPCConvertNamedValues in rpc_tests

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -335,6 +335,18 @@ BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
     BOOST_CHECK_EQUAL(result[2].get_int(), 9);
 }
 
+BOOST_AUTO_TEST_CASE(rpc_convert_named_values_generatetoaddress)
+{
+    UniValue result;
+
+    BOOST_CHECK_NO_THROW(result = RPCConvertNamedValues("generatetoaddress", { "nblocks=10", "address=2N7xz1EnWubTbQmWFcVpCvT2RwKeDuzWr5g", "maxtries=50" }));
+    BOOST_CHECK_EQUAL(result[0].get_int(), 10);
+    BOOST_CHECK_EQUAL(result[1].get_str(), "2N7xz1EnWubTbQmWFcVpCvT2RwKeDuzWr5g");
+    BOOST_CHECK_EQUAL(result[2].get_int(), 50);
+    // Throws an exception when the receiving address is missing.
+    BOOST_CHECK_THROW(RPCConvertNamedValues("generatetoaddress", { "nblocks=10", "address" }), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(rpc_getblockstats_calculate_percentiles_by_weight)
 {
     int64_t total_weight = 200;


### PR DESCRIPTION
This PR adds a test for function *RPCConvertNamedValues* from rpc/client.cpp. As there's already a test for *RPCConvertValues*, I thought, it would be appropriate to add this one too.

The test comprises of two checks: 

* proper conversions
* throwing of exceptions when bad data is given, for example arguments without the madatory **=**. According to function description, the **=** must be present even if there is no data.

I am using this website to check for missing test coverages: https://marcofalke.github.io/btc_cov/test_bitcoin.coverage/src/rpc/client.cpp.gcov.html

I read about it here: https://github.com/bitcoin/bitcoin/issues/16450, which is also the reason why I started searching for missing test coverages.

My test results:

```shell
Entering test module "Bitcoin Core Test Suite"
test/rpc_tests.cpp:43: Entering test suite "rpc_tests"
test/rpc_tests.cpp:342: Entering test case "rpc_convert_named_values_generatetoaddress"
test/rpc_tests.cpp:351: info: check 'no exceptions thrown by result = RPCConvertNamedValues("generatetoaddress", valid_named_values)' has passed
test/rpc_tests.cpp:352: info: check result[0].get_int() == 10 has passed
test/rpc_tests.cpp:353: info: check result[1].get_str() == "2N7xz1EnWubTbQmWFcVpCvT2RwKeDuzWr5g" has passed
test/rpc_tests.cpp:354: info: check result[2].get_int() == 50 has passed
test/rpc_tests.cpp:362: info: check 'exception "std::runtime_error" raised as expected' has passed
test/rpc_tests.cpp:342: Leaving test case "rpc_convert_named_values_generatetoaddress"; testing time: 78684us
test/rpc_tests.cpp:43: Leaving test suite "rpc_tests"; testing time: 78740us
Leaving test module "Bitcoin Core Test Suite"; testing time: 78943us
```