### PR TITLE
build: organize tests by goal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,8 @@ before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 stages:
   - lint
-  - test
+  - deploy
+  - install
   - extended-lint
 env:
   global:
@@ -95,60 +96,60 @@ jobs:
       script:
         - set -o errexit; source ./ci/extended_lint/06_script.sh
 
-    - stage: test
+    - stage: install
       name: 'ARM  [GOAL: install]  [unit tests, functional tests]'
       arch: arm64
       env: >-
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
         QEMU_USER_CMD=""  # Can run the tests natively without qemu
 
-    - stage: test
+    - stage: deploy
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_win64.sh"
 
-    - stage: test
+    - stage: install
       name: '32-bit + dash  [GOAL: install]  [gui]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_i686.sh"
 
-    - stage: test
+    - stage: install
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [uses qt5 dev package instead of depends Qt to speed up build and avoid timeout] [unsigned char]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_qt5.sh"
 
-    - stage: test
+    - stage: install
       name: 'x86_64 Linux  [GOAL: install]  [trusty]  [no functional tests, no depends, only system libs]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_trusty.sh"
 
-    - stage: test
+    - stage: install
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no depends, only system libs, sanitizers: thread (TSan), no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_tsan.sh"
         TEST_RUNNER_EXTRA="--exclude feature_block"  # Not enough memory on travis machines
 
-    - stage: test
+    - stage: install
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs, sanitizers: address/leak (ASan + LSan) + undefined (UBSan) + integer]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_asan.sh"
 
-    - stage: test
+    - stage: install
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no depends, only system libs, sanitizers: fuzzer,address,undefined]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_fuzz.sh"
 
-    - stage: test
+    - stage: install
       name: 'x86_64 Linux  [GOAL: install]  [bionic]  [no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_nowallet.sh"
 
-    - stage: test
+    - stage: deploy
       name: 'macOS 10.10  [GOAL: deploy] [no functional tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_mac.sh"
 
-    - stage: test
+    - stage: install
       name: 'macOS 10.14 native [GOAL: install] [GUI] [no depends]'
       os: osx
       # Use the most recent version:


### PR DESCRIPTION
The tests can be organized by goal for efficiency and clarity.

```deploy``` is before ```install``` because this stage is faster
and if it fails - it eliminates the need to continue - which is a
positive for jobs waiting in the cue.

There are other ways to improve efficiency but this one seemed easy
to implement with minimal changes to the .travis.yml configuration.  
