### PR TITLE
Switch to weight units for all feerates computation

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -158,5 +158,9 @@ static inline int64_t GetTransactionInputWeight(const CTxIn& txin)
     // scriptWitness size is added here because witnesses and txins are split up in segwit serialization.
     return ::GetSerializeSize(txin, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txin, PROTOCOL_VERSION) + ::GetSerializeSize(txin.scriptWitness.stack, PROTOCOL_VERSION);
 }
+static inline int64_t GetTransactionOutputWeight(const CTxOut& txout)
+{
+    return ::GetSerializeSize(txout, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR - 1) + ::GetSerializeSize(txout, PROTOCOL_VERSION);
+}
 
 #endif // BITCOIN_CONSENSUS_VALIDATION_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1044,7 +1044,7 @@ bool AppInitParameterInteraction()
         CAmount n = 0;
         if (!ParseMoney(gArgs.GetArg("-incrementalrelayfee", ""), n))
             return InitError(AmountErrMsg("incrementalrelayfee", gArgs.GetArg("-incrementalrelayfee", "")).translated);
-        incrementalRelayFee = CFeeRate(n);
+        incrementalRelayFee = CFeeRate(n / WITNESS_SCALE_FACTOR);
     }
 
     // block pruning; get the amount of disk space (in MiB) to allot for block & undo files
@@ -1081,7 +1081,7 @@ bool AppInitParameterInteraction()
             return InitError(AmountErrMsg("minrelaytxfee", gArgs.GetArg("-minrelaytxfee", "")).translated);
         }
         // High fee check is done afterward in CWallet::CreateWalletFromFile()
-        ::minRelayTxFee = CFeeRate(n);
+        ::minRelayTxFee = CFeeRate(n / WITNESS_SCALE_FACTOR);
     } else if (incrementalRelayFee > ::minRelayTxFee) {
         // Allow only setting incrementalRelayFee to control both
         ::minRelayTxFee = incrementalRelayFee;
@@ -1104,7 +1104,7 @@ bool AppInitParameterInteraction()
         CAmount n = 0;
         if (!ParseMoney(gArgs.GetArg("-dustrelayfee", ""), n))
             return InitError(AmountErrMsg("dustrelayfee", gArgs.GetArg("-dustrelayfee", "")).translated);
-        dustRelayFee = CFeeRate(n);
+        dustRelayFee = CFeeRate(n / WITNESS_SCALE_FACTOR);
     }
 
     fRequireStandard = !gArgs.GetBoolArg("-acceptnonstdtxn", !chainparams.RequireStandard());

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1033,8 +1033,8 @@ bool AppInitParameterInteraction()
     }
 
     // mempool limits
-    int64_t nMempoolSizeMax = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
-    int64_t nMempoolSizeMin = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40;
+    int64_t nMempoolSizeMax = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000 * WITNESS_SCALE_FACTOR;
+    int64_t nMempoolSizeMin = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * 40 * WITNESS_SCALE_FACTOR;
     if (nMempoolSizeMax < 0 || nMempoolSizeMax < nMempoolSizeMin)
         return InitError(strprintf(_("-maxmempool must be at least %d MB").translated, std::ceil(nMempoolSizeMin / 1000000.0)));
     // incremental relay fee sets the minimum feerate increase necessary for BIP 125 replacement in the mempool
@@ -1440,6 +1440,7 @@ bool AppInitMain(NodeContext& node)
     nCoinDBCache = std::min(nCoinDBCache, nMaxCoinsDBCache << 20); // cap total coins db cache
     nTotalCache -= nCoinDBCache;
     nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
+    // We use weight units to measure size, but this variable is only used for printing usage statistics in bytes.
     int64_t nMempoolSizeMax = gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     LogPrintf("Cache configuration:\n");
     LogPrintf("* Using %.1f MiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -303,9 +303,9 @@ public:
         CTxMemPoolEntry entry(tx, 0, 0, 0, false, 0, lp);
         CTxMemPool::setEntries ancestors;
         auto limit_ancestor_count = gArgs.GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
-        auto limit_ancestor_size = gArgs.GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
+        auto limit_ancestor_size = gArgs.GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000 * WITNESS_SCALE_FACTOR;
         auto limit_descendant_count = gArgs.GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
-        auto limit_descendant_size = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
+        auto limit_descendant_size = gArgs.GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000 * WITNESS_SCALE_FACTOR;
         std::string unused_error_string;
         LOCK(::mempool.cs);
         return ::mempool.CalculateMemPoolAncestors(entry, ancestors, limit_ancestor_count, limit_ancestor_size,
@@ -321,7 +321,7 @@ public:
     }
     CFeeRate mempoolMinFee() override
     {
-        return ::mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000);
+        return ::mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000 * WITNESS_SCALE_FACTOR);
     }
     CFeeRate relayMinFee() override { return ::minRelayTxFee; }
     CFeeRate relayIncrementalFee() override { return ::incrementalRelayFee; }

--- a/src/miner.h
+++ b/src/miner.h
@@ -40,18 +40,22 @@ struct CTxMemPoolModifiedEntry {
     {
         iter = entry;
         nSizeWithAncestors = entry->GetSizeWithAncestors();
+        nWeightWithAncestors = entry->GetWeightWithAncestors();
         nModFeesWithAncestors = entry->GetModFeesWithAncestors();
         nSigOpCostWithAncestors = entry->GetSigOpCostWithAncestors();
     }
 
     int64_t GetModifiedFee() const { return iter->GetModifiedFee(); }
     uint64_t GetSizeWithAncestors() const { return nSizeWithAncestors; }
+    uint64_t GetWeightWithAncestors() const { return nWeightWithAncestors; }
     CAmount GetModFeesWithAncestors() const { return nModFeesWithAncestors; }
     size_t GetTxSize() const { return iter->GetTxSize(); }
+    size_t GetTxWeight() const { return iter->GetTxWeight(); }
     const CTransaction& GetTx() const { return iter->GetTx(); }
 
     CTxMemPool::txiter iter;
     uint64_t nSizeWithAncestors;
+    uint64_t nWeightWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 };
@@ -116,6 +120,7 @@ struct update_for_parent_inclusion
     {
         e.nModFeesWithAncestors -= iter->GetFee();
         e.nSizeWithAncestors -= iter->GetTxSize();
+        e.nWeightWithAncestors -= iter->GetTxWeight();
         e.nSigOpCostWithAncestors -= iter->GetSigOpCost();
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -4053,7 +4053,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
         // We don't want white listed peers to filter txs to us if we have -whitelistforcerelay
         if (pto->m_tx_relay != nullptr && pto->nVersion >= FEEFILTER_VERSION && gArgs.GetBoolArg("-feefilter", DEFAULT_FEEFILTER) &&
             !pto->HasPermission(PF_FORCERELAY)) {
-            CAmount currentFilter = mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFeePerK();
+            CAmount currentFilter = mempool.GetMinFee(gArgs.GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000 * WITNESS_SCALE_FACTOR).GetFeePerK();
             int64_t timeNow = GetTimeMicros();
             if (timeNow > pto->m_tx_relay->nextSendTimeFeeFilter) {
                 static CFeeRate default_feerate(DEFAULT_MIN_RELAY_TX_FEE);

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -122,7 +122,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
             size_t weight = GetTransactionWeight(ctx);
             result.estimated_weight = weight;
             // Estimate fee rate
-            CFeeRate feerate(fee, size);
+            CFeeRate feerate(fee, weight);
             result.estimated_feerate = feerate;
         }
 

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -4,6 +4,7 @@
 
 #include <coins.h>
 #include <consensus/tx_verify.h>
+#include <consensus/validation.h>
 #include <node/psbt.h>
 #include <policy/policy.h>
 #include <policy/settings.h>
@@ -116,8 +117,10 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
 
         if (success) {
             CTransaction ctx = CTransaction(mtx);
-            size_t size = GetVirtualTransactionSize(ctx, GetTransactionSigOpCost(ctx, view, STANDARD_SCRIPT_VERIFY_FLAGS));
-            result.estimated_vsize = size;
+            size_t vsize = GetVirtualTransactionSize(ctx, GetTransactionSigOpCost(ctx, view, STANDARD_SCRIPT_VERIFY_FLAGS));
+            result.estimated_vsize = vsize;
+            size_t weight = GetTransactionWeight(ctx);
+            result.estimated_weight = weight;
             // Estimate fee rate
             CFeeRate feerate(fee, size);
             result.estimated_feerate = feerate;

--- a/src/node/psbt.h
+++ b/src/node/psbt.h
@@ -25,8 +25,9 @@ struct PSBTInputAnalysis {
  * Holds the results of AnalyzePSBT (miscellaneous information about a PSBT)
  */
 struct PSBTAnalysis {
-    Optional<size_t> estimated_vsize;      //!< Estimated weight of the transaction
-    Optional<CFeeRate> estimated_feerate;  //!< Estimated feerate (fee / weight) of the transaction
+    Optional<size_t> estimated_vsize;      //!< Estimated size in virtual bytes of the transaction
+    Optional<size_t> estimated_weight;      //!< Estimated size in weight units of the transaction
+    Optional<CFeeRate> estimated_feerate;  //!< Estimated feerate (fee / virtual kbyte) of the transaction
     Optional<CAmount> fee;                 //!< Amount of fee being paid by the transaction
     std::vector<PSBTInputAnalysis> inputs; //!< More information about the individual inputs of the transaction
     PSBTRole next;                         //!< Which of the BIP 174 roles needs to handle the transaction next

--- a/src/policy/feerate.cpp
+++ b/src/policy/feerate.cpp
@@ -3,16 +3,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/consensus.h>
 #include <policy/feerate.h>
 
 #include <tinyformat.h>
 
 const std::string CURRENCY_UNIT = "BTC";
 
-CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nBytes_)
+CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nWeight)
 {
-    assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
-    int64_t nSize = int64_t(nBytes_);
+    assert(nWeight <= uint64_t(std::numeric_limits<int64_t>::max()));
+    int64_t nSize = int64_t(nWeight);
 
     if (nSize > 0)
         nSatoshisPerK = nFeePaid * 1000 / nSize;
@@ -20,10 +21,10 @@ CFeeRate::CFeeRate(const CAmount& nFeePaid, size_t nBytes_)
         nSatoshisPerK = 0;
 }
 
-CAmount CFeeRate::GetFee(size_t nBytes_) const
+CAmount CFeeRate::GetFee(size_t nWeight) const
 {
-    assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));
-    int64_t nSize = int64_t(nBytes_);
+    assert(nWeight <= uint64_t(std::numeric_limits<int64_t>::max()));
+    int64_t nSize = int64_t(nWeight);
 
     CAmount nFee = nSatoshisPerK * nSize / 1000;
 
@@ -39,5 +40,5 @@ CAmount CFeeRate::GetFee(size_t nBytes_) const
 
 std::string CFeeRate::ToString() const
 {
-    return strprintf("%d.%08d %s/kB", nSatoshisPerK / COIN, nSatoshisPerK % COIN, CURRENCY_UNIT);
+    return strprintf("%d.%08d %s/kB", nSatoshisPerK / COIN, nSatoshisPerK * WITNESS_SCALE_FACTOR % COIN, CURRENCY_UNIT);
 }

--- a/src/policy/feerate.h
+++ b/src/policy/feerate.h
@@ -14,29 +14,29 @@
 extern const std::string CURRENCY_UNIT;
 
 /**
- * Fee rate in satoshis per kilobyte: CAmount / kB
+ * Fee rate in satoshis per weight: CAmount / kW
  */
 class CFeeRate
 {
 private:
-    CAmount nSatoshisPerK; // unit is satoshis-per-1,000-bytes
+    CAmount nSatoshisPerK; // unit is satoshis-per-1,000-weightunit
 
 public:
-    /** Fee rate of 0 satoshis per kB */
+    /** Fee rate of 0 satoshis per kWU */
     CFeeRate() : nSatoshisPerK(0) { }
     template<typename I>
     explicit CFeeRate(const I _nSatoshisPerK): nSatoshisPerK(_nSatoshisPerK) {
         // We've previously had bugs creep in from silent double->int conversion...
         static_assert(std::is_integral<I>::value, "CFeeRate should be used without floats");
     }
-    /** Constructor for a fee rate in satoshis per kB. The size in bytes must not exceed (2^63 - 1)*/
-    CFeeRate(const CAmount& nFeePaid, size_t nBytes);
+    /** Constructor for a fee rate in satoshis per kW. The size in weight units must not exceed (2^63 - 1) */
+    CFeeRate(const CAmount& nFeePaid, size_t nWeight);
     /**
-     * Return the fee in satoshis for the given size in bytes.
+     * Return the fee in satoshis for the given size in weight units.
      */
-    CAmount GetFee(size_t nBytes) const;
+    CAmount GetFee(size_t nWeight) const;
     /**
-     * Return the fee in satoshis for a size of 1000 bytes
+     * Return the fee in satoshis for a size of 1000 weight units.
      */
     CAmount GetFeePerK() const { return GetFee(1000); }
     friend bool operator<(const CFeeRate& a, const CFeeRate& b) { return a.nSatoshisPerK < b.nSatoshisPerK; }

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -537,8 +537,8 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry& entry, boo
     }
     trackedTxs++;
 
-    // Feerates are stored and reported as BTC-per-kb:
-    CFeeRate feeRate(entry.GetFee(), entry.GetTxSize());
+    // Feerates are stored and reported as BTC-per-kWU:
+    CFeeRate feeRate(entry.GetFee(), entry.GetTxWeight());
 
     mapMemPoolTxs[hash].blockHeight = txHeight;
     unsigned int bucketIndex = feeStats->NewTx(txHeight, (double)feeRate.GetFeePerK());
@@ -567,8 +567,8 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxM
         return false;
     }
 
-    // Feerates are stored and reported as BTC-per-kb:
-    CFeeRate feeRate(entry->GetFee(), entry->GetTxSize());
+    // Feerates are stored and reported as BTC-per-kWU:
+    CFeeRate feeRate(entry->GetFee(), entry->GetTxWeight());
 
     feeStats->Record(blocksToConfirm, (double)feeRate.GetFeePerK());
     shortStats->Record(blocksToConfirm, (double)feeRate.GetFeePerK());
@@ -865,7 +865,7 @@ bool CBlockPolicyEstimator::Write(CAutoFile& fileout) const
 {
     try {
         LOCK(m_cs_fee_estimator);
-        fileout << 149900; // version required to read: 0.14.99 or later
+        fileout << 199900; // version required to read: 0.19.99 or later
         fileout << CLIENT_VERSION; // version that wrote the file
         fileout << nBestSeenHeight;
         if (BlockSpan() > HistoricalBlockSpan()/2) {
@@ -900,9 +900,9 @@ bool CBlockPolicyEstimator::Read(CAutoFile& filein)
         unsigned int nFileBestSeenHeight;
         filein >> nFileBestSeenHeight;
 
-        if (nVersionRequired < 149900) {
+        if (nVersionRequired < 199900) {
             LogPrintf("%s: incompatible old fee estimation data (non-fatal). Version: %d\n", __func__, nVersionRequired);
-        } else { // New format introduced in 149900
+        } else { // New format introduced in 199900
             unsigned int nFileHistoricalFirst, nFileHistoricalBest;
             filein >> nFileHistoricalFirst >> nFileHistoricalBest;
             if (nFileHistoricalFirst > nFileHistoricalBest || nFileHistoricalBest > nFileBestSeenHeight) {

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -169,7 +169,7 @@ private:
      * invalidates old estimates files. So leave it at 1000 unless it becomes
      * necessary to lower it, and then lower it substantially.
      */
-    static constexpr double MIN_BUCKET_FEERATE = 1000;
+    static constexpr double MIN_BUCKET_FEERATE = 250;
     static constexpr double MAX_BUCKET_FEERATE = 1e7;
 
     /** Spacing of FeeRate buckets

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -18,8 +18,8 @@ class CTxOut;
 
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = MAX_BLOCK_WEIGHT - 4000;
-/** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
-static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
+/** Default for -blockmintxfee, which sets the minimum feerate (sat/kWU) for a transaction in blocks created by mining code **/
+static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 250;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** The minimum non-witness size for transactions we're willing to relay/mine (1 segwit input + 1 P2WPKH output = 82 bytes) */
@@ -30,8 +30,8 @@ static const unsigned int MAX_P2SH_SIGOPS = 15;
 static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
-/** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
-static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
+/** Default for -incrementalrelayfee, which sets the minimum feerate in sat/kWU increase for mempool limiting or BIP 125 replacement **/
+static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 250;
 /** Default for -bytespersigop */
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 /** Default for -permitbaremultisig */
@@ -42,12 +42,12 @@ static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEMS = 100;
 static const unsigned int MAX_STANDARD_P2WSH_STACK_ITEM_SIZE = 80;
 /** The maximum size of a standard witnessScript */
 static const unsigned int MAX_STANDARD_P2WSH_SCRIPT_SIZE = 3600;
-/** Min feerate for defining dust. Historically this has been based on the
+/** Min feerate in sat/kWU for defining dust. Historically this has been based on the
  * minRelayTxFee, however changing the dust limit changes which transactions are
  * standard and should be done with care and ideally rarely. It makes sense to
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
-static const unsigned int DUST_RELAY_TX_FEE = 3000;
+static const unsigned int DUST_RELAY_TX_FEE = 750;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -121,6 +121,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "finalizepsbt", 1, "extract"},
     { "converttopsbt", 1, "permitsigdata"},
     { "converttopsbt", 2, "iswitness"},
+    { "analyzepsbt", 1, "feerate_kwu" },
     { "gettxout", 1, "n" },
     { "gettxout", 2, "include_mempool" },
     { "gettxoutproof", 0, "txids" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -137,6 +137,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
+    { "getblockstats", 2, "feerate_kwu" },
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -40,6 +40,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "sendtoaddress", 6 , "conf_target" },
     { "sendtoaddress", 8, "avoid_reuse" },
     { "settxfee", 0, "amount" },
+    { "settxfee", 1, "feerate_kwu" },
     { "sethdseed", 0, "newkeypool" },
     { "getreceivedbyaddress", 1, "minconf" },
     { "getreceivedbylabel", 1, "minconf" },

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -140,6 +140,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "keypoolrefill", 0, "newsize" },
     { "getrawmempool", 0, "verbose" },
     { "estimatesmartfee", 0, "conf_target" },
+    { "estimatesmartfee", 2, "feerate_kwu" },
     { "estimaterawfee", 0, "conf_target" },
     { "estimaterawfee", 1, "threshold" },
     { "prioritisetransaction", 1, "dummy" },

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -901,9 +901,8 @@ static UniValue estimaterawfee(const JSONRPCRequest& request)
                 "\nWARNING: This is an advanced API call that is tightly coupled to the specific\n"
                 "         implementation of fee estimation. The parameters it can be called with\n"
                 "         and the results it returns will change if the internal implementation changes.\n"
-                "\nEstimates the approximate fee per kilobyte needed for a transaction to begin\n"
-                "confirmation within conf_target blocks if possible. Uses virtual transaction size as\n"
-                "defined in BIP 141 (witness data is discounted).\n",
+                "\nEstimates the approximate fee per kilo weight unit needed for a transaction to begin\n"
+                "confirmation within conf_target blocks if possible.\n",
                 {
                     {"conf_target", RPCArg::Type::NUM, RPCArg::Optional::NO, "Confirmation target in blocks (1 - 1008)"},
                     {"threshold", RPCArg::Type::NUM, /* default */ "0.95", "The proportion of transactions in a given feerate range that must have been\n"
@@ -913,7 +912,7 @@ static UniValue estimaterawfee(const JSONRPCRequest& request)
                 RPCResult{
             "{\n"
             "  \"short\" : {            (json object, optional) estimate for short time horizon\n"
-            "      \"feerate\" : x.x,        (numeric, optional) estimate fee rate in " + CURRENCY_UNIT + "/kB\n"
+            "      \"feerate\" : x.x,        (numeric, optional) estimate fee rate in " + CURRENCY_UNIT + "/kWU\n"
             "      \"decay\" : x.x,          (numeric) exponential decay (per block) for historical moving average of confirmation data\n"
             "      \"scale\" : x,            (numeric) The resolution of confirmation targets at this time horizon\n"
             "      \"pass\" : {              (json object, optional) information about the lowest range of feerates to succeed in meeting the threshold\n"

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -191,7 +191,7 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             permissions.push_back(permission);
         }
         obj.pushKV("permissions", permissions);
-        obj.pushKV("minfeefilter", ValueFromAmount(stats.minFeeFilter));
+        obj.pushKV("minfeefilter", ValueFromAmount(stats.minFeeFilter * WITNESS_SCALE_FACTOR));
 
         UniValue sendPerMsgCmd(UniValue::VOBJ);
         for (const auto& i : stats.mapSendBytesPerMsgCmd) {
@@ -507,8 +507,8 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
         obj.pushKV("connections",   (int)g_rpc_node->connman->GetNodeCount(CConnman::CONNECTIONS_ALL));
     }
     obj.pushKV("networks",      GetNetworksInfo());
-    obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK()));
-    obj.pushKV("incrementalfee", ValueFromAmount(::incrementalRelayFee.GetFeePerK()));
+    obj.pushKV("relayfee",      ValueFromAmount(::minRelayTxFee.GetFee(1000 * WITNESS_SCALE_FACTOR)));
+    obj.pushKV("incrementalfee", ValueFromAmount(::incrementalRelayFee.GetFee(1000 * WITNESS_SCALE_FACTOR)));
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -43,7 +43,7 @@
  * By default, a transaction with a fee rate higher than this will be rejected
  * by the RPCs. This can be overridden with the maxfeerate argument.
  */
-static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
+static const CFeeRate DEFAULT_MAX_RAW_TX_FEERATE_VBYTE{COIN / 10};
 
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 {
@@ -779,7 +779,7 @@ static UniValue sendrawtransaction(const JSONRPCRequest& request)
                 "\nAlso see createrawtransaction and signrawtransactionwithkey calls.\n",
                 {
                     {"hexstring", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hex string of the raw transaction"},
-                    {"maxfeerate", RPCArg::Type::AMOUNT, /* default */ FormatMoney(DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK()),
+                    {"maxfeerate", RPCArg::Type::AMOUNT, /* default */ FormatMoney(DEFAULT_MAX_RAW_TX_FEERATE_VBYTE.GetFeePerK()),
                         "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT +
                             "/kB.\nSet to 0 to accept any fee rate.\n"},
                 },
@@ -809,7 +809,7 @@ static UniValue sendrawtransaction(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
     CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
 
-    CFeeRate max_raw_tx_fee_rate = DEFAULT_MAX_RAW_TX_FEE_RATE;
+    CFeeRate max_raw_tx_fee_rate = DEFAULT_MAX_RAW_TX_FEERATE_VBYTE;
     // TODO: temporary migration code for old clients. Remove in v0.20
     if (request.params[1].isBool()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Second argument must be numeric (maxfeerate) and no longer supports a boolean. To allow a transaction with high fees, set maxfeerate to 0.");
@@ -843,7 +843,7 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
                             {"rawtx", RPCArg::Type::STR_HEX, RPCArg::Optional::OMITTED, ""},
                         },
                         },
-                    {"maxfeerate", RPCArg::Type::AMOUNT, /* default */ FormatMoney(DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK()), "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT + "/kB\n"},
+                    {"maxfeerate", RPCArg::Type::AMOUNT, /* default */ FormatMoney(DEFAULT_MAX_RAW_TX_FEERATE_VBYTE.GetFeePerK()), "Reject transactions whose fee rate is higher than the specified value, expressed in " + CURRENCY_UNIT + "/kB\n"},
                 },
                 RPCResult{
             "[                   (array) The result of the mempool acceptance test for each raw transaction in the input array.\n"
@@ -883,7 +883,7 @@ static UniValue testmempoolaccept(const JSONRPCRequest& request)
     CTransactionRef tx(MakeTransactionRef(std::move(mtx)));
     const uint256& tx_hash = tx->GetHash();
 
-    CFeeRate max_raw_tx_fee_rate = DEFAULT_MAX_RAW_TX_FEE_RATE;
+    CFeeRate max_raw_tx_fee_rate = DEFAULT_MAX_RAW_TX_FEERATE_VBYTE;
     // TODO: temporary migration code for old clients. Remove in v0.20
     if (request.params[1].isBool()) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Second argument must be numeric (maxfeerate) and no longer supports a boolean. To allow a transaction with high fees, set maxfeerate to 0.");

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1673,7 +1673,8 @@ UniValue analyzepsbt(const JSONRPCRequest& request)
                 "    }\n"
                 "    ,...\n"
                 "  ]\n"
-                "  \"estimated_vsize\" : vsize       (numeric, optional) Estimated vsize of the final signed transaction\n"
+                "  \"estimated_vsize\" : vsize       (numeric, optional) Estimated size in virtual bytes of the final signed transaction\n"
+                "  \"estimated_weight\" : weight       (numeric, optional) Estimated size in weight units of the final signed transaction\n"
                 "  \"estimated_feerate\" : feerate   (numeric, optional) Estimated feerate of the final signed transaction in " + CURRENCY_UNIT + "/kB. Shown only if all UTXO slots in the PSBT have been filled.\n"
                 "  \"fee\" : fee                     (numeric, optional) The transaction fee paid. Shown only if all UTXO slots in the PSBT have been filled.\n"
                 "  \"next\" : \"role\"                 (string) Role of the next person that this psbt needs to go to\n"
@@ -1734,6 +1735,9 @@ UniValue analyzepsbt(const JSONRPCRequest& request)
 
     if (psbta.estimated_vsize != nullopt) {
         result.pushKV("estimated_vsize", (int)*psbta.estimated_vsize);
+    }
+    if (psbta.estimated_weight != nullopt) {
+        result.pushKV("estimated_weight", (int)*psbta.estimated_weight);
     }
     if (psbta.estimated_feerate != nullopt) {
         result.pushKV("estimated_feerate", ValueFromAmount(psbta.estimated_feerate->GetFeePerK()));

--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -106,8 +106,9 @@ BOOST_AUTO_TEST_CASE(BinaryOperatorTest)
 BOOST_AUTO_TEST_CASE(ToStringTest)
 {
     CFeeRate feeRate;
+    // 1 sat/kWU
     feeRate = CFeeRate(1);
-    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000001 BTC/kB");
+    BOOST_CHECK_EQUAL(feeRate.ToString(), "0.00000004 BTC/kB");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
+#include <consensus/validation.h>
 #include <miner.h>
 #include <policy/policy.h>
 #include <script/standard.h>
@@ -143,7 +144,7 @@ void MinerTestingSetup::TestPackageSelection(const CChainParams& chainparams, co
     tx.vout[0].nValue = 5000000000LL - 1000 - 50000; // 0 fee
     uint256 hashFreeTx = tx.GetHash();
     m_node.mempool->addUnchecked(entry.Fee(0).FromTx(tx));
-    size_t freeTxSize = ::GetSerializeSize(tx, PROTOCOL_VERSION);
+    size_t freeTxSize = GetTransactionWeight(CTransaction(tx));
 
     // Calculate a fee on child transaction that will put the package just
     // below the block min tx fee (assuming 1 child tx of the same size).

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/validation.h>
 #include <policy/policy.h>
 #include <policy/fees.h>
 #include <txmempool.h>
@@ -44,7 +45,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     tx.vin[0].scriptSig = garbage;
     tx.vout.resize(1);
     tx.vout[0].nValue=0LL;
-    CFeeRate baseRate(basefee, GetVirtualTransactionSize(CTransaction(tx)));
+    CFeeRate baseRate(basefee, GetTransactionWeight(CTransaction(tx)));
 
     // Create a fake block
     std::vector<CTransactionRef> block;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -702,7 +702,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
     // Check dust with default relay fee:
-    CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK()/1000;
+    CAmount nDustThreshold = 728 * dustRelayFee.GetFeePerK()/1000;
     BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
@@ -737,8 +737,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
     // Check dust with odd relay fee to verify rounding:
-    // nDustThreshold = 182 * 3702 / 1000
-    dustRelayFee = CFeeRate(3702);
+    // nDustThreshold = 728 * 3702/4 / 1000
+    // 728 * 3702/4 / 1000 == 182 * 3702 / 1000
+    dustRelayFee = CFeeRate(3702 / WITNESS_SCALE_FACTOR);
     // dust:
     t.vout[0].nValue = 673 - 1;
     reason.clear();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -26,13 +26,15 @@ CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef& _tx, const CAmount& _nFe
     spendsCoinbase(_spendsCoinbase), sigOpCost(_sigOpsCost), lockPoints(lp)
 {
     nCountWithDescendants = 1;
-    nSizeWithDescendants = GetTxSize();
+    nVirtualSizeWithDescendants = GetTxSize();
+    nWeightWithDescendants = GetTxWeight();
     nModFeesWithDescendants = nFee;
 
     feeDelta = 0;
 
     nCountWithAncestors = 1;
-    nSizeWithAncestors = GetTxSize();
+    nVirtualSizeWithAncestors = GetTxSize();
+    nWeightWithAncestors = GetTxWeight();
     nModFeesWithAncestors = nFee;
     nSigOpCostWithAncestors = sigOpCost;
 }
@@ -84,19 +86,21 @@ void CTxMemPool::UpdateForDescendants(txiter updateIt, cacheMap &cachedDescendan
     // setAllDescendants now contains all in-mempool descendants of updateIt.
     // Update and add to cached descendant map
     int64_t modifySize = 0;
+    int64_t modifyWeight = 0;
     CAmount modifyFee = 0;
     int64_t modifyCount = 0;
     for (txiter cit : setAllDescendants) {
         if (!setExclude.count(cit->GetTx().GetHash())) {
             modifySize += cit->GetTxSize();
+            modifyWeight += cit->GetTxWeight();
             modifyFee += cit->GetModifiedFee();
             modifyCount++;
             cachedDescendants[updateIt].insert(cit);
             // Update ancestor state for each descendant
-            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost()));
+            mapTx.modify(cit, update_ancestor_state(updateIt->GetTxSize(), updateIt->GetTxWeight(), updateIt->GetModifiedFee(), 1, updateIt->GetSigOpCost()));
         }
     }
-    mapTx.modify(updateIt, update_descendant_state(modifySize, modifyFee, modifyCount));
+    mapTx.modify(updateIt, update_descendant_state(modifySize, modifyWeight, modifyFee, modifyCount));
 }
 
 // vHashesToUpdate is the set of transaction hashes from a disconnected block
@@ -218,9 +222,10 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors
     }
     const int64_t updateCount = (add ? 1 : -1);
     const int64_t updateSize = updateCount * it->GetTxSize();
+    const int64_t updateWeight = updateCount * it->GetTxWeight();
     const CAmount updateFee = updateCount * it->GetModifiedFee();
     for (txiter ancestorIt : setAncestors) {
-        mapTx.modify(ancestorIt, update_descendant_state(updateSize, updateFee, updateCount));
+        mapTx.modify(ancestorIt, update_descendant_state(updateSize, updateWeight, updateFee, updateCount));
     }
 }
 
@@ -228,14 +233,16 @@ void CTxMemPool::UpdateEntryForAncestors(txiter it, const setEntries &setAncesto
 {
     int64_t updateCount = setAncestors.size();
     int64_t updateSize = 0;
+    int64_t updateWeight = 0;
     CAmount updateFee = 0;
     int64_t updateSigOpsCost = 0;
     for (txiter ancestorIt : setAncestors) {
         updateSize += ancestorIt->GetTxSize();
+        updateWeight += ancestorIt->GetTxWeight();
         updateFee += ancestorIt->GetModifiedFee();
         updateSigOpsCost += ancestorIt->GetSigOpCost();
     }
-    mapTx.modify(it, update_ancestor_state(updateSize, updateFee, updateCount, updateSigOpsCost));
+    mapTx.modify(it, update_ancestor_state(updateSize, updateWeight, updateFee, updateCount, updateSigOpsCost));
 }
 
 void CTxMemPool::UpdateChildrenForRemoval(txiter it)
@@ -263,10 +270,11 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
             CalculateDescendants(removeIt, setDescendants);
             setDescendants.erase(removeIt); // don't update state for self
             int64_t modifySize = -((int64_t)removeIt->GetTxSize());
+            int64_t modifyWeight = -((int64_t)removeIt->GetTxWeight());
             CAmount modifyFee = -removeIt->GetModifiedFee();
             int modifySigOps = -removeIt->GetSigOpCost();
             for (txiter dit : setDescendants) {
-                mapTx.modify(dit, update_ancestor_state(modifySize, modifyFee, -1, modifySigOps));
+                mapTx.modify(dit, update_ancestor_state(modifySize, modifyWeight, modifyFee, -1, modifySigOps));
             }
         }
     }
@@ -304,19 +312,23 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
     }
 }
 
-void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
+void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, int64_t modifyWeight, CAmount modifyFee, int64_t modifyCount)
 {
-    nSizeWithDescendants += modifySize;
-    assert(int64_t(nSizeWithDescendants) > 0);
+    nVirtualSizeWithDescendants += modifySize;
+    assert(int64_t(nVirtualSizeWithDescendants) > 0);
+    nWeightWithDescendants += modifyWeight;
+    assert(int64_t(nWeightWithDescendants) > 0);
     nModFeesWithDescendants += modifyFee;
     nCountWithDescendants += modifyCount;
     assert(int64_t(nCountWithDescendants) > 0);
 }
 
-void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
+void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, int64_t modifyWeight, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
 {
-    nSizeWithAncestors += modifySize;
-    assert(int64_t(nSizeWithAncestors) > 0);
+    nVirtualSizeWithAncestors += modifySize;
+    assert(int64_t(nVirtualSizeWithAncestors) > 0);
+    nWeightWithAncestors += modifyWeight;
+    assert(int64_t(nWeightWithAncestors) > 0);
     nModFeesWithAncestors += modifyFee;
     nCountWithAncestors += modifyCount;
     assert(int64_t(nCountWithAncestors) > 0);
@@ -395,7 +407,8 @@ void CTxMemPool::addUnchecked(const CTxMemPoolEntry &entry, setEntries &setAnces
     UpdateEntryForAncestors(newit, setAncestors);
 
     nTransactionsUpdated++;
-    totalTxSize += entry.GetTxSize();
+    totalTxVirtualSize += entry.GetTxSize();
+    totalTxWeight += entry.GetTxWeight();
     if (minerPolicyEstimator) {minerPolicyEstimator->processTransaction(entry, validFeeEstimate);}
 
     vTxHashes.emplace_back(tx.GetWitnessHash(), newit);
@@ -423,7 +436,8 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
     } else
         vTxHashes.clear();
 
-    totalTxSize -= it->GetTxSize();
+    totalTxVirtualSize -= it->GetTxSize();
+    totalTxWeight -= it->GetTxWeight();
     cachedInnerUsage -= it->DynamicMemoryUsage();
     cachedInnerUsage -= memusage::DynamicUsage(mapLinks[it].parents) + memusage::DynamicUsage(mapLinks[it].children);
     mapLinks.erase(it);
@@ -582,7 +596,8 @@ void CTxMemPool::_clear()
     mapLinks.clear();
     mapTx.clear();
     mapNextTx.clear();
-    totalTxSize = 0;
+    totalTxVirtualSize = 0;
+    totalTxWeight = 0;
     cachedInnerUsage = 0;
     lastRollingFeeUpdate = GetTime();
     blockSinceLastRollingFeeBump = false;
@@ -616,7 +631,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
 
     LogPrint(BCLog::MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(), (unsigned int)mapNextTx.size());
 
-    uint64_t checkTotal = 0;
+    uint64_t checkTotalVsize = 0;
+    uint64_t checkTotalWeight = 0;
     uint64_t innerUsage = 0;
 
     CCoinsViewCache mempoolDuplicate(const_cast<CCoinsViewCache*>(pcoins));
@@ -625,7 +641,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     std::list<const CTxMemPoolEntry*> waitingOnDependants;
     for (indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++) {
         unsigned int i = 0;
-        checkTotal += it->GetTxSize();
+        checkTotalVsize += it->GetTxSize();
+        checkTotalWeight += it->GetTxWeight();
         innerUsage += it->DynamicMemoryUsage();
         const CTransaction& tx = it->GetTx();
         txlinksMap::const_iterator linksiter = mapLinks.find(it);
@@ -660,35 +677,40 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
         uint64_t nCountCheck = setAncestors.size() + 1;
         uint64_t nSizeCheck = it->GetTxSize();
+        uint64_t nWeightCheck = it->GetTxWeight();
         CAmount nFeesCheck = it->GetModifiedFee();
         int64_t nSigOpCheck = it->GetSigOpCost();
 
         for (txiter ancestorIt : setAncestors) {
             nSizeCheck += ancestorIt->GetTxSize();
+            nWeightCheck += ancestorIt->GetTxWeight();
             nFeesCheck += ancestorIt->GetModifiedFee();
             nSigOpCheck += ancestorIt->GetSigOpCost();
         }
 
         assert(it->GetCountWithAncestors() == nCountCheck);
         assert(it->GetSizeWithAncestors() == nSizeCheck);
+        assert(it->GetWeightWithAncestors() == nWeightCheck);
         assert(it->GetSigOpCostWithAncestors() == nSigOpCheck);
         assert(it->GetModFeesWithAncestors() == nFeesCheck);
 
         // Check children against mapNextTx
         CTxMemPool::setEntries setChildrenCheck;
         auto iter = mapNextTx.lower_bound(COutPoint(it->GetTx().GetHash(), 0));
-        uint64_t child_sizes = 0;
+        uint64_t child_sizes = 0, child_weights = 0;
         for (; iter != mapNextTx.end() && iter->first->hash == it->GetTx().GetHash(); ++iter) {
             txiter childit = mapTx.find(iter->second->GetHash());
             assert(childit != mapTx.end()); // mapNextTx points to in-mempool transactions
             if (setChildrenCheck.insert(childit).second) {
                 child_sizes += childit->GetTxSize();
+                child_weights += childit->GetTxWeight();
             }
         }
         assert(setChildrenCheck == GetMemPoolChildren(it));
         // Also check to make sure size is greater than sum with immediate children.
         // just a sanity check, not definitive that this calc is correct...
         assert(it->GetSizeWithDescendants() >= child_sizes + it->GetTxSize());
+        assert(it->GetWeightWithDescendants() >= child_weights + it->GetTxWeight());
 
         if (fDependsWait)
             waitingOnDependants.push_back(&(*it));
@@ -717,7 +739,8 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         assert(&tx == it->second);
     }
 
-    assert(totalTxSize == checkTotal);
+    assert(totalTxVirtualSize == checkTotalVsize);
+    assert(totalTxWeight == checkTotalWeight);
     assert(innerUsage == cachedInnerUsage);
 }
 
@@ -780,7 +803,7 @@ void CTxMemPool::queryHashes(std::vector<uint256>& vtxid) const
 }
 
 static TxMempoolInfo GetInfo(CTxMemPool::indexed_transaction_set::const_iterator it) {
-    return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
+    return TxMempoolInfo{it->GetSharedTx(), it->GetTime(), it->GetFee(), it->GetTxWeight(), it->GetTxSize(), it->GetModifiedFee() - it->GetFee()};
 }
 
 std::vector<TxMempoolInfo> CTxMemPool::infoAll() const
@@ -830,14 +853,14 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
             std::string dummy;
             CalculateMemPoolAncestors(*it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, false);
             for (txiter ancestorIt : setAncestors) {
-                mapTx.modify(ancestorIt, update_descendant_state(0, nFeeDelta, 0));
+                mapTx.modify(ancestorIt, update_descendant_state(0, 0, nFeeDelta, 0));
             }
             // Now update all descendants' modified fees with ancestors
             setEntries setDescendants;
             CalculateDescendants(it, setDescendants);
             setDescendants.erase(it);
             for (txiter descendantIt : setDescendants) {
-                mapTx.modify(descendantIt, update_ancestor_state(0, nFeeDelta, 0, 0));
+                mapTx.modify(descendantIt, update_ancestor_state(0, 0, nFeeDelta, 0, 0));
             }
             ++nTransactionsUpdated;
         }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -233,15 +233,15 @@ public:
     {
         // Compare feerate with descendants to feerate of the transaction, and
         // return the fee/size for the max.
-        double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
-        double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxSize();
+        double f1 = (double)a.GetModifiedFee() * a.GetWeightWithDescendants();
+        double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxWeight();
 
         if (f2 > f1) {
             mod_fee = a.GetModFeesWithDescendants();
-            size = a.GetSizeWithDescendants();
+            size = a.GetWeightWithDescendants();
         } else {
             mod_fee = a.GetModifiedFee();
-            size = a.GetTxSize();
+            size = a.GetTxWeight();
         }
     }
 };
@@ -258,8 +258,8 @@ class CompareTxMemPoolEntryByScore
 public:
     bool operator()(const CTxMemPoolEntry& a, const CTxMemPoolEntry& b) const
     {
-        double f1 = (double)a.GetFee() * b.GetTxSize();
-        double f2 = (double)b.GetFee() * a.GetTxSize();
+        double f1 = (double)a.GetFee() * b.GetTxWeight();
+        double f2 = (double)b.GetFee() * a.GetTxWeight();
         if (f1 == f2) {
             return b.GetTx().GetHash() < a.GetTx().GetHash();
         }
@@ -307,15 +307,15 @@ public:
     {
         // Compare feerate with ancestors to feerate of the transaction, and
         // return the fee/size for the min.
-        double f1 = (double)a.GetModifiedFee() * a.GetSizeWithAncestors();
-        double f2 = (double)a.GetModFeesWithAncestors() * a.GetTxSize();
+        double f1 = (double)a.GetModifiedFee() * a.GetWeightWithAncestors();
+        double f2 = (double)a.GetModFeesWithAncestors() * a.GetTxWeight();
 
         if (f1 > f2) {
             mod_fee = a.GetModFeesWithAncestors();
-            size = a.GetSizeWithAncestors();
+            size = a.GetWeightWithAncestors();
         } else {
             mod_fee = a.GetModifiedFee();
-            size = a.GetTxSize();
+            size = a.GetTxWeight();
         }
     }
 };

--- a/src/validation.h
+++ b/src/validation.h
@@ -49,8 +49,8 @@ struct DisconnectedBlockTransactions;
 struct PrecomputedTransactionData;
 struct LockPoints;
 
-/** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 1000;
+/** Default for -minrelaytxfee, minimum relay feerate for transactions */
+static const unsigned int DEFAULT_MIN_RELAY_TX_FEE = 250;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
 static const unsigned int DEFAULT_ANCESTOR_LIMIT = 25;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */

--- a/src/validation.h
+++ b/src/validation.h
@@ -64,7 +64,7 @@ static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
  * ancestor and is no larger than this. Not really any reason to make this
  * configurable as it doesn't materially change DoS parameters.
  */
-static const unsigned int EXTRA_DESCENDANT_TX_SIZE_LIMIT = 10000;
+static const unsigned int EXTRA_DESCENDANT_TX_SIZE_LIMIT = 40000;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 336;
 /** Maximum kilobytes for transactions to store for processing during reorg */

--- a/src/wallet/feebumper.cpp
+++ b/src/wallet/feebumper.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <wallet/coincontrol.h>
 #include <wallet/feebumper.h>
@@ -81,7 +82,7 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CWalletTx& wt
     // Given old total fee and transaction size, calculate the old feeRate
     isminefilter filter = wallet.GetLegacyScriptPubKeyMan() && wallet.IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS) ? ISMINE_WATCH_ONLY : ISMINE_SPENDABLE;
     CAmount old_fee = wtx.GetDebit(filter) - wtx.tx->GetValueOut();
-    const int64_t txSize = GetVirtualTransactionSize(*(wtx.tx));
+    const int64_t txSize = GetTransactionWeight(*(wtx.tx));
     CFeeRate nOldFeeRate(old_fee, txSize);
     // Min total fee is old fee + relay fee
     CAmount minTotalFee = nOldFeeRate.GetFee(maxTxSize) + incrementalRelayFee.GetFee(maxTxSize);
@@ -112,12 +113,9 @@ static feebumper::Result CheckFeeRate(const CWallet& wallet, const CWalletTx& wt
 
 static CFeeRate EstimateFeeRate(const CWallet& wallet, const CWalletTx& wtx, const CAmount old_fee, CCoinControl& coin_control)
 {
-    // Get the fee rate of the original transaction. This is calculated from
-    // the tx fee/vsize, so it may have been rounded down. Add 1 satoshi to the
-    // result.
-    int64_t txSize = GetVirtualTransactionSize(*(wtx.tx));
+    // Get the fee rate of the original transaction.
+    int64_t txSize = GetTransactionWeight(*(wtx.tx));
     CFeeRate feerate(old_fee, txSize);
-    feerate += CFeeRate(1);
 
     // The node has a configurable incremental relay fee. Increment the fee by
     // the minimum of that and the wallet's conservative
@@ -189,7 +187,7 @@ Result CreateTotalBumpTransaction(const CWallet* wallet, const uint256& txid, co
     }
 
     // Calculate the expected size of the new transaction.
-    int64_t txSize = GetVirtualTransactionSize(*(wtx.tx));
+    int64_t txSize = GetTransactionWeight(*(wtx.tx));
     const int64_t maxNewTxSize = CalculateMaximumSignedTxSize(*wtx.tx, wallet);
     if (maxNewTxSize < 0) {
         errors.push_back("Transaction contains inputs that cannot be signed");

--- a/src/wallet/fees.cpp
+++ b/src/wallet/fees.cpp
@@ -15,9 +15,15 @@ CAmount GetRequiredFee(const CWallet& wallet, unsigned int nTxBytes)
 }
 
 
-CAmount GetMinimumFee(const CWallet& wallet, unsigned int nTxBytes, const CCoinControl& coin_control, FeeCalculation* feeCalc)
+CAmount GetMinimumFee(const CWallet& wallet, unsigned int nTxWeight, const CCoinControl& coin_control, FeeCalculation* feeCalc)
 {
-    return GetMinimumFeeRate(wallet, coin_control, feeCalc).GetFee(nTxBytes);
+    CFeeRate min_feerate = GetMinimumFeeRate(wallet, coin_control, feeCalc);
+    CAmount fees = min_feerate.GetFee(nTxWeight);
+    // Avoid fees below minimum treshold because of truncation
+    if (fees * 1000 / nTxWeight < min_feerate.GetFee(1000)) {
+        fees++;
+    }
+    return fees;
 }
 
 CFeeRate GetRequiredFeeRate(const CWallet& wallet)

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2329,7 +2329,7 @@ static UniValue settxfee(const JSONRPCRequest& request)
     LOCK(pwallet->cs_wallet);
 
     CAmount nAmount = AmountFromValue(request.params[0]);
-    CFeeRate tx_fee_rate(nAmount, 1000);
+    CFeeRate tx_fee_rate(nAmount / WITNESS_SCALE_FACTOR, 1000);
     if (tx_fee_rate == CFeeRate(0)) {
         // automatic selection
     } else if (tx_fee_rate < pwallet->chain().relayMinFee()) {
@@ -2483,7 +2483,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     if (pwallet->IsCrypted()) {
         obj.pushKV("unlocked_until", pwallet->nRelockTime);
     }
-    obj.pushKV("paytxfee", ValueFromAmount(pwallet->m_pay_tx_fee.GetFeePerK()));
+    obj.pushKV("paytxfee", ValueFromAmount(pwallet->m_pay_tx_fee.GetFee(1000 * WITNESS_SCALE_FACTOR)));
     obj.pushKV("private_keys_enabled", !pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS));
     obj.pushKV("avoid_reuse", pwallet->IsWalletFlagSet(WALLET_FLAG_AVOID_REUSE));
     if (pwallet->IsScanning()) {
@@ -3062,7 +3062,7 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
 
         if (options.exists("feeRate"))
         {
-            coinControl.m_feerate = CFeeRate(AmountFromValue(options["feeRate"]));
+            coinControl.m_feerate = CFeeRate(AmountFromValue(options["feeRate"]) / WITNESS_SCALE_FACTOR);
             coinControl.fOverrideFeeRate = true;
         }
 
@@ -3413,7 +3413,7 @@ static UniValue bumpfee(const JSONRPCRequest& request)
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid totalFee %s (must be greater than 0)", FormatMoney(totalFee)));
             }
         } else if (options.exists("fee_rate")) {
-            CFeeRate fee_rate(AmountFromValue(options["fee_rate"]));
+            CFeeRate fee_rate(AmountFromValue(options["fee_rate"]) / WITNESS_SCALE_FACTOR);
             if (fee_rate <= CFeeRate(0)) {
                 throw JSONRPCError(RPC_INVALID_PARAMETER, strprintf("Invalid fee_rate %s (must be greater than 0)", fee_rate.ToString()));
             }

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <vector>
 
+#include <consensus/validation.h>
 #include <interfaces/chain.h>
 #include <node/context.h>
 #include <policy/policy.h>
@@ -623,12 +624,12 @@ static size_t CalculateNestedKeyhashInputSize(bool use_max_sig)
 
     CTxIn tx_in;
     UpdateInput(tx_in, sig_data);
-    return (size_t)GetVirtualTransactionInputSize(tx_in);
+    return (size_t)GetTransactionInputWeight(tx_in);
 }
 
 BOOST_FIXTURE_TEST_CASE(dummy_input_size_test, TestChain100Setup)
 {
-    BOOST_CHECK_EQUAL(CalculateNestedKeyhashInputSize(false), DUMMY_NESTED_P2WPKH_INPUT_SIZE);
+    BOOST_CHECK_EQUAL(CalculateNestedKeyhashInputSize(false), DUMMY_NESTED_P2WPKH_INPUT_SIZE - 1);
     BOOST_CHECK_EQUAL(CalculateNestedKeyhashInputSize(true), DUMMY_NESTED_P2WPKH_INPUT_SIZE);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1496,7 +1496,7 @@ int64_t CalculateMaximumSignedTxSize(const CTransaction &tx, const CWallet *wall
     if (!wallet->DummySignTx(txNew, txouts, use_max_sig)) {
         return -1;
     }
-    return GetVirtualTransactionSize(CTransaction(txNew));
+    return GetTransactionWeight(CTransaction(txNew));
 }
 
 int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* wallet, bool use_max_sig)
@@ -1506,7 +1506,7 @@ int CalculateMaximumSignedInputSize(const CTxOut& txout, const CWallet* wallet, 
     if (!wallet->DummySignInput(txn.vin[0], txout, use_max_sig)) {
         return -1;
     }
-    return GetVirtualTransactionInputSize(txn.vin[0]);
+    return GetTransactionInputWeight(txn.vin[0]);
 }
 
 void CWalletTx::GetAmounts(std::list<COutputEntry>& listReceived,
@@ -2596,7 +2596,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
 
     FeeCalculation feeCalc;
     CAmount nFeeNeeded;
-    int nBytes;
+    int nWeightUnits;
     {
         std::set<CInputCoin> setCoins;
         auto locked_chain = chain().lock();
@@ -2638,7 +2638,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                 scriptChange = GetScriptForDestination(dest);
             }
             CTxOut change_prototype_txout(0, scriptChange);
-            coin_selection_params.change_output_size = GetSerializeSize(change_prototype_txout);
+            coin_selection_params.change_output_size = GetTransactionOutputWeight(change_prototype_txout);
 
             CFeeRate discard_rate = GetDiscardRate(*this);
 
@@ -2667,7 +2667,8 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
 
                 // vouts to the payees
                 if (!coin_selection_params.m_subtract_fee_outputs) {
-                    coin_selection_params.tx_noinputs_size = 11; // Static vsize overhead + outputs vsize. 4 nVersion, 4 nLocktime, 1 input count, 1 output count, 1 witness overhead (dummy, flag, stack size)
+                    // Static weight overhead + outputs size. 4*4 nVersion, 4*4 nLocktime, 1*4 input count, 1*4 output count, 1 witness overhead (dummy, flag, stack size)
+                    coin_selection_params.tx_noinputs_size = (4 + 4 + 1 + 1) * WITNESS_SCALE_FACTOR + 1;
                 }
                 for (const auto& recipient : vecSend)
                 {
@@ -2686,7 +2687,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     }
                     // Include the fee cost for outputs. Note this is only used for BnB right now
                     if (!coin_selection_params.m_subtract_fee_outputs) {
-                        coin_selection_params.tx_noinputs_size += ::GetSerializeSize(txout, PROTOCOL_VERSION);
+                        coin_selection_params.tx_noinputs_size += GetTransactionOutputWeight(txout);
                     }
 
                     if (IsDust(txout, chain().relayDustFee()))
@@ -2775,13 +2776,13 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     txNew.vin.push_back(CTxIn(coin.outpoint,CScript()));
                 }
 
-                nBytes = CalculateMaximumSignedTxSize(CTransaction(txNew), this, coin_control.fAllowWatchOnly);
-                if (nBytes < 0) {
+                nWeightUnits = CalculateMaximumSignedTxSize(CTransaction(txNew), this, coin_control.fAllowWatchOnly);
+                if (nWeightUnits < 0) {
                     strFailReason = _("Signing transaction failed").translated;
                     return false;
                 }
 
-                nFeeNeeded = GetMinimumFee(*this, nBytes, coin_control, &feeCalc);
+                nFeeNeeded = GetMinimumFee(*this, nWeightUnits, coin_control, &feeCalc);
                 if (feeCalc.reason == FeeReason::FALLBACK && !m_allow_fallback_fee) {
                     // eventually allow a fallback fee
                     strFailReason = _("Fee estimation failed. Fallbackfee is disabled. Wait a few blocks or enable -fallbackfee.").translated;
@@ -2800,7 +2801,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     // (because of reduced tx size) and so we should add a
                     // change output. Only try this once.
                     if (nChangePosInOut == -1 && nSubtractFeeFromAmount == 0 && pick_new_inputs) {
-                        unsigned int tx_size_with_change = nBytes + coin_selection_params.change_output_size + 2; // Add 2 as a buffer in case increasing # of outputs changes compact size
+                        unsigned int tx_size_with_change = nWeightUnits + coin_selection_params.change_output_size + 2; // Add 2 as a buffer in case increasing # of outputs changes compact size
                         CAmount fee_needed_with_change = GetMinimumFee(*this, tx_size_with_change, coin_control, nullptr);
                         CAmount minimum_value_for_change = GetDustThreshold(change_prototype_txout, discard_rate);
                         if (nFeeRet >= fee_needed_with_change + minimum_value_for_change) {
@@ -2920,8 +2921,8 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
     // accidental re-use.
     reservedest.KeepDestination();
 
-    WalletLogPrintf("Fee Calculation: Fee:%d Bytes:%u Needed:%d Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
-              nFeeRet, nBytes, nFeeNeeded, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
+    WalletLogPrintf("Fee Calculation: Fee:%d Weight units:%u Needed:%d Tgt:%d (requested %d) Reason:\"%s\" Decay %.5f: Estimation: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out) Fail: (%g - %g) %.2f%% %.1f/(%.1f %d mem %.1f out)\n",
+              nFeeRet, nWeightUnits, nFeeNeeded, feeCalc.returnedTarget, feeCalc.desiredTarget, StringForFeeReason(feeCalc.reason), feeCalc.est.decay,
               feeCalc.est.pass.start, feeCalc.est.pass.end,
               100 * feeCalc.est.pass.withinTarget / (feeCalc.est.pass.totalConfirmed + feeCalc.est.pass.inMempool + feeCalc.est.pass.leftMempool),
               feeCalc.est.pass.withinTarget, feeCalc.est.pass.totalConfirmed, feeCalc.est.pass.inMempool, feeCalc.est.pass.leftMempool,
@@ -3763,11 +3764,11 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
             error = AmountErrMsg("mintxfee", gArgs.GetArg("-mintxfee", "")).translated;
             return nullptr;
         }
-        if (n > HIGH_TX_FEE_PER_KB) {
+        if (n / WITNESS_SCALE_FACTOR > HIGH_TX_FEERATE_PER_WU) {
             warnings.push_back(AmountHighWarn("-mintxfee").translated + " " +
                               _("This is the minimum transaction fee you pay on every transaction.").translated);
         }
-        walletInstance->m_min_fee = CFeeRate(n);
+        walletInstance->m_min_fee = CFeeRate(n / WITNESS_SCALE_FACTOR);
     }
 
     if (gArgs.IsArgSet("-fallbackfee")) {
@@ -3776,11 +3777,11 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
             error = strprintf(_("Invalid amount for -fallbackfee=<amount>: '%s'").translated, gArgs.GetArg("-fallbackfee", ""));
             return nullptr;
         }
-        if (nFeePerK > HIGH_TX_FEE_PER_KB) {
+        if (nFeePerK / WITNESS_SCALE_FACTOR > HIGH_TX_FEERATE_PER_WU) {
             warnings.push_back(AmountHighWarn("-fallbackfee").translated + " " +
                               _("This is the transaction fee you may pay when fee estimates are not available.").translated);
         }
-        walletInstance->m_fallback_fee = CFeeRate(nFeePerK);
+        walletInstance->m_fallback_fee = CFeeRate(nFeePerK / WITNESS_SCALE_FACTOR);
     }
     // Disable fallback fee in case value was set to 0, enable if non-null value
     walletInstance->m_allow_fallback_fee = walletInstance->m_fallback_fee.GetFeePerK() != 0;
@@ -3791,11 +3792,11 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
             error = strprintf(_("Invalid amount for -discardfee=<amount>: '%s'").translated, gArgs.GetArg("-discardfee", ""));
             return nullptr;
         }
-        if (nFeePerK > HIGH_TX_FEE_PER_KB) {
+        if (nFeePerK / WITNESS_SCALE_FACTOR > HIGH_TX_FEERATE_PER_WU) {
             warnings.push_back(AmountHighWarn("-discardfee").translated + " " +
                               _("This is the transaction fee you may discard if change is smaller than dust at this level").translated);
         }
-        walletInstance->m_discard_rate = CFeeRate(nFeePerK);
+        walletInstance->m_discard_rate = CFeeRate(nFeePerK / WITNESS_SCALE_FACTOR);
     }
     if (gArgs.IsArgSet("-paytxfee")) {
         CAmount nFeePerK = 0;
@@ -3803,11 +3804,11 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
             error = AmountErrMsg("paytxfee", gArgs.GetArg("-paytxfee", "")).translated;
             return nullptr;
         }
-        if (nFeePerK > HIGH_TX_FEE_PER_KB) {
+        if (nFeePerK / WITNESS_SCALE_FACTOR > HIGH_TX_FEERATE_PER_WU) {
             warnings.push_back(AmountHighWarn("-paytxfee").translated + " " +
                               _("This is the transaction fee you will pay if you send a transaction.").translated);
         }
-        walletInstance->m_pay_tx_fee = CFeeRate(nFeePerK, 1000);
+        walletInstance->m_pay_tx_fee = CFeeRate(nFeePerK / WITNESS_SCALE_FACTOR, 1000);
         if (walletInstance->m_pay_tx_fee < chain.relayMinFee()) {
             error = strprintf(_("Invalid amount for -paytxfee=<amount>: '%s' (must be at least %s)").translated,
                 gArgs.GetArg("-paytxfee", ""), chain.relayMinFee().ToString());
@@ -3821,18 +3822,18 @@ std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain,
             error = AmountErrMsg("maxtxfee", gArgs.GetArg("-maxtxfee", "")).translated;
             return nullptr;
         }
-        if (nMaxFee > HIGH_MAX_TX_FEE) {
+        if (nMaxFee / WITNESS_SCALE_FACTOR > HIGH_MAX_TX_FEE) {
             warnings.push_back(_("-maxtxfee is set very high! Fees this large could be paid on a single transaction.").translated);
         }
-        if (CFeeRate(nMaxFee, 1000) < chain.relayMinFee()) {
+        if (CFeeRate(nMaxFee / WITNESS_SCALE_FACTOR, 1000) < chain.relayMinFee()) {
             error = strprintf(_("Invalid amount for -maxtxfee=<amount>: '%s' (must be at least the minrelay fee of %s to prevent stuck transactions)").translated,
                                        gArgs.GetArg("-maxtxfee", ""), chain.relayMinFee().ToString());
             return nullptr;
         }
-        walletInstance->m_default_max_tx_fee = nMaxFee;
+        walletInstance->m_default_max_tx_fee = nMaxFee / WITNESS_SCALE_FACTOR;
     }
 
-    if (chain.relayMinFee().GetFeePerK() > HIGH_TX_FEE_PER_KB) {
+    if (chain.relayMinFee().GetFeePerK() > HIGH_TX_FEERATE_PER_WU) {
         warnings.push_back(AmountHighWarn("-minrelaytxfee").translated + " " +
                     _("The wallet will avoid paying less than the minimum relay fee.").translated);
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -7,6 +7,7 @@
 #define BITCOIN_WALLET_WALLET_H
 
 #include <amount.h>
+#include <consensus/consensus.h>
 #include <interfaces/chain.h>
 #include <interfaces/handler.h>
 #include <outputtype.h>
@@ -65,11 +66,11 @@ constexpr CAmount DEFAULT_PAY_TX_FEE = 0;
 //! -fallbackfee default
 static const CAmount DEFAULT_FALLBACK_FEE = 0;
 //! -discardfee default
-static const CAmount DEFAULT_DISCARD_FEE = 10000;
+static const CAmount DEFAULT_DISCARD_FEE = 2500;
 //! -mintxfee default
-static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
+static const CAmount DEFAULT_TRANSACTION_MINFEE = 250;
 //! minimum recommended increment for BIP 125 replacement txs
-static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 5000;
+static const CAmount WALLET_INCREMENTAL_RELAY_FEE = 1250;
 //! Default for -spendzeroconfchange
 static const bool DEFAULT_SPEND_ZEROCONF_CHANGE = true;
 //! Default for -walletrejectlongchains
@@ -82,13 +83,13 @@ static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 //! -maxtxfee default
 constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{COIN / 10};
-//! Discourage users to set fees higher than this amount (in satoshis) per kB
-constexpr CAmount HIGH_TX_FEE_PER_KB{COIN / 100};
+//! Discourage users to set fees higher than this amount (in satoshis) per weight unit
+constexpr CAmount HIGH_TX_FEERATE_PER_WU{COIN / 100 / WITNESS_SCALE_FACTOR};
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
-constexpr CAmount HIGH_MAX_TX_FEE{100 * HIGH_TX_FEE_PER_KB};
+constexpr CAmount HIGH_MAX_TX_FEE{100 * HIGH_TX_FEERATE_PER_WU};
 
-//! Pre-calculated constants for input size estimation in *virtual size*
-static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 91;
+//! Pre-calculated constants for input size estimation in *weight units*
+static constexpr size_t DUMMY_NESTED_P2WPKH_INPUT_SIZE = 364;
 
 class CCoinControl;
 class COutput;

--- a/test/functional/mempool_feerate.py
+++ b/test/functional/mempool_feerate.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+from decimal import Decimal, getcontext
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_raises_rpc_error,
+    connect_nodes,
+    create_confirmed_utxos
+)
+
+
+def get_signed_tx(node, inputs, feerate, value_out, type):
+    """
+    Generates a transaction to a {node}'s address, using speicified
+    {inputs}, {feerate}, {value_out} and {type} of address.
+    Returns the signed raw transaction.
+    """
+    address = node.getnewaddress(address_type=type)
+    output = {address: Decimal(value_out)}
+    tx = node.createrawtransaction(inputs, output)
+    tx = node.signrawtransactionwithwallet(tx)
+    tx_size = node.decoderawtransaction(tx["hex"])["weight"]
+    output[address] -= Decimal(tx_size) * feerate / Decimal(1000)
+    tx = node.createrawtransaction(inputs, output)
+    return node.signrawtransactionwithwallet(tx)["hex"]
+
+
+class FeerateTest(BitcoinTestFramework):
+    """
+    Sanity checks for the minimum relay feerate in weight units.
+    """
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        getcontext().prec = 10
+        connect_nodes(self.nodes[0], 1)
+        connect_nodes(self.nodes[1], 2)
+
+        self.log.info("Generate some fresh utxos..")
+        min_feerate = Decimal(250) * Decimal(10**-8)
+        utxos = create_confirmed_utxos(min_feerate,
+                                       self.nodes[0], 4)
+
+        self.log.info("A transaction which pays exactly {} btc/kWU"
+                      " should propagate".format(min_feerate))
+        utxo = utxos.pop()
+        inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]}]
+        amount = utxo["amount"]
+        # Test all address types. `bech32` would be relayed on old versions,
+        # but not `legacy` nor `p2sh-segwit`.
+        for addr_type in ["legacy", "p2sh-segwit", "bech32"]:
+            tx = get_signed_tx(self.nodes[0], inputs, min_feerate,
+                               amount, addr_type)
+            txid = self.nodes[0].sendrawtransaction(tx)
+            dec = self.nodes[0].decoderawtransaction(tx)
+            self.sync_mempools(wait=.2)
+            assert txid in self.nodes[1].getrawmempool()
+            inputs[0] = {"txid": txid, "vout": 0}
+            amount -= dec["weight"] * min_feerate / Decimal(1000)
+
+        self.log.info("A transaction below {} btc/kWU should not"
+                      " propagate".format(min_feerate))
+        for addr_type in ["legacy", "p2sh-segwit", "bech32"]:
+            utxo = utxos.pop()
+            inputs = [{"txid": utxo["txid"], "vout": utxo["vout"]}]
+            tx = get_signed_tx(self.nodes[0], inputs,
+                               min_feerate - Decimal(2 * 10**-8),
+                               utxo["amount"], addr_type)
+            # We should not be able to even send the transaction..
+            assert_raises_rpc_error(-26, "min relay fee not met",
+                                    self.nodes[0].sendrawtransaction, tx)
+            # .. But if we try anyway ..
+            self.stop_node(0)
+            self.start_node(0, ["-minrelaytxfee=0.00000001"])
+            txid = self.nodes[0].sendrawtransaction(tx)
+            dec = self.nodes[0].decoderawtransaction(tx)
+            # .. Our peer should not accept it.
+            try:
+                self.sync_mempools(wait=.2, timeout=2)
+            except AssertionError:
+                # The node #1 did not accept it (as expected)
+                pass
+            else:
+                raise AssertionError("Transaction below minimum relay fee "
+                                     "accepted by remote peer.")
+            assert txid not in self.nodes[1].getrawmempool()
+            self.stop_node(0)
+            self.start_node(0)
+
+
+if __name__ == '__main__':
+    FeerateTest().main()

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -69,8 +69,10 @@ class MempoolPackagesTest(BitcoinTestFramework):
         descendant_count = 1
         descendant_fees = 0
         descendant_vsize = 0
+        descendant_weight = 0
 
         ancestor_vsize = sum([mempool[tx]['vsize'] for tx in mempool])
+        ancestor_weight = sum([mempool[tx]['weight'] for tx in mempool])
         ancestor_count = MAX_ANCESTORS
         ancestor_fees = sum([mempool[tx]['fee'] for tx in mempool])
 
@@ -90,14 +92,18 @@ class MempoolPackagesTest(BitcoinTestFramework):
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN)
             assert_equal(mempool[x]['fees']['descendant'], descendant_fees)
             descendant_vsize += mempool[x]['vsize']
+            descendant_weight += mempool[x]['weight']
             assert_equal(mempool[x]['descendantsize'], descendant_vsize)
+            assert_equal(mempool[x]['descendantweight'], descendant_weight)
             descendant_count += 1
 
             # Check that ancestor calculations are correct
             assert_equal(mempool[x]['ancestorcount'], ancestor_count)
             assert_equal(mempool[x]['ancestorfees'], ancestor_fees * COIN)
             assert_equal(mempool[x]['ancestorsize'], ancestor_vsize)
+            assert_equal(mempool[x]['ancestorweight'], ancestor_weight)
             ancestor_vsize -= mempool[x]['vsize']
+            ancestor_weight -= mempool[x]['weight']
             ancestor_fees -= mempool[x]['fee']
             ancestor_count -= 1
 

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -130,6 +130,20 @@ class GetblockstatsTest(BitcoinTestFramework):
         stats = self.nodes[0].getblockstats(hash_or_height=1, stats=list(some_stats))
         assert_equal(set(stats.keys()), some_stats)
 
+        # Sanity check for the 'feerate_kwu' parameter
+        feerate_vbyte = self.nodes[0].getblockstats(hash_or_height=103,
+                                                    stats=["minfeerate",
+                                                           "avgfeerate"])
+        feerate_weight = self.nodes[0].getblockstats(hash_or_height=103,
+                                                     stats=["minfeerate",
+                                                            "avgfeerate"],
+                                                     feerate_kwu=True)
+        # For getblockstats, we don't round up for vbyte computation !
+        assert_equal(feerate_weight["avgfeerate"],
+                     feerate_vbyte["avgfeerate"] // 4)
+        assert_equal(feerate_weight["minfeerate"],
+                     feerate_vbyte["minfeerate"] // 4)
+
         # Test invalid parameters raise the proper json exceptions
         tip = self.start_height + self.max_stat_pos
         assert_raises_rpc_error(-8, 'Target block height %d after current tip %d' % (tip+1, tip),
@@ -157,8 +171,10 @@ class GetblockstatsTest(BitcoinTestFramework):
                                 hash_or_height='000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f')
 
         # Invalid number of args
-        assert_raises_rpc_error(-1, 'getblockstats hash_or_height ( stats )', self.nodes[0].getblockstats, '00', 1, 2)
-        assert_raises_rpc_error(-1, 'getblockstats hash_or_height ( stats )', self.nodes[0].getblockstats)
+        assert_raises_rpc_error(-1, 'getblockstats hash_or_height ( stats feerate_kwu )',
+                                self.nodes[0].getblockstats, '00', 1, True, 2)
+        assert_raises_rpc_error(-1, 'getblockstats hash_or_height ( stats feerate_kwu )',
+                                self.nodes[0].getblockstats)
 
 
 if __name__ == '__main__':

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -411,6 +411,8 @@ class PSBTTest(BitcoinTestFramework):
 
         # Check fee and size things
         assert analyzed['fee'] == Decimal('0.001') and analyzed['estimated_vsize'] == 134 and analyzed['estimated_feerate'] == Decimal('0.00746268')
+        # vsize = (weight + 3) // 4
+        assert analyzed['estimated_weight'] == 533
 
         # After signing and finalizing, needs extracting
         signed = self.nodes[1].walletprocesspsbt(updated)['psbt']

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -125,6 +125,7 @@ BASE_SCRIPTS = [
     'wallet_avoidreuse.py',
     'mempool_reorg.py',
     'mempool_persist.py',
+    'mempool_feerate.py',
     'wallet_multiwallet.py',
     'wallet_multiwallet.py --usecli',
     'wallet_createwallet.py',

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -541,6 +541,13 @@ class WalletTest(BitcoinTestFramework):
         assert_array_result(tx["details"], {"category": "receive"}, expected_receive_vout)
         assert_equal(tx[verbose_field], self.nodes[0].decoderawtransaction(tx["hex"]))
 
+        # Sanity check for 'settxfee' second parameter
+        feerate_set_wu = Decimal("0.0000025")
+        self.nodes[0].settxfee(feerate_set_wu * Decimal(4))
+        feerate = self.nodes[0].getwalletinfo()["paytxfee"]
+        self.nodes[0].settxfee(feerate_set_wu, True)
+        assert_equal(self.nodes[0].getwalletinfo()["paytxfee"], feerate)
+
 
 if __name__ == '__main__':
     WalletTest().main()


### PR DESCRIPTION
This changes the current feerate computation from using virtual bytes to weight units for transaction size.

The transaction size being stored and used as virtual bytes introduced some non-negligible rounding and approximations *(See https://github.com/bitcoin/bitcoin/issues/13283 for an example.)*. This patch set is an attempt to switch to using weight units in place of virtual bytes internally for a more accurate feerate computation, while leaving intact the vbyte interface.

There is, I think, a big cleanup needed (for example renaming feerate constants as `xx_FEERATE` would really improve readability) but I wanted to keep changes as minimal as possible.

 Fixes #13283.