### PR TITLE
test: add unit test for non-standard txs w/ too large tx size

### DIFF
--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -799,12 +799,12 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK_EQUAL(reason, "scriptsig-size");
 
     // Check tx-size (non-standard if transaction size is > MAX_STANDARD_TX_WEIGHT)
-    t.vin.resize(2397); // transaction weight = 399904
+    t.vin.resize(1);
     t.vin[0].scriptSig = CScript();
     reason.clear();
     BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
 
-    t.vin.resize(2398); // transaction weight = 400068
+    t.vin.resize(10000);
     reason.clear();
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
     BOOST_CHECK_EQUAL(reason, "tx-size");

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -797,6 +797,17 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     reason.clear();
     BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
     BOOST_CHECK_EQUAL(reason, "scriptsig-size");
+
+    // Check tx-size (non-standard if transaction size is > MAX_STANDARD_TX_WEIGHT)
+    t.vin.resize(2397); // transaction weight = 399904
+    t.vin[0].scriptSig = CScript();
+    reason.clear();
+    BOOST_CHECK(IsStandardTx(CTransaction(t), reason));
+
+    t.vin.resize(2398); // transaction weight = 400068
+    reason.clear();
+    BOOST_CHECK(!IsStandardTx(CTransaction(t), reason));
+    BOOST_CHECK_EQUAL(reason, "tx-size");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds one of the missing tests of issue #17394: the function IsStandardTx() returns rejection reason `tx-size` if the transaction's size is larger than MAX_STANDARD_TX_WEIGHT, which is as of now defined as 400000.

Simply increasing the size of `vin` seemed the easiest way to test this case. 

Heavily inspired by #17480