### PR TITLE
ci: Add big endian platform - s390x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,12 @@ jobs:
         QEMU_USER_CMD=""  # Can run the tests natively without qemu
 
     - stage: test
+      name: 'S390x  [GOAL: install]  [unit tests, functional tests]'
+      arch: s390x
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_s390x.sh"
+
+    - stage: test
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_win64.sh"

--- a/ci/test/00_setup_env_s390x.sh
+++ b/ci/test/00_setup_env_s390x.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+export LC_ALL=C.UTF-8
+
+export HOST=s390x-unknown-linux-gnu
+export DOCKER_NAME_TAG=s390x/ubuntu:18.04
+export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
+export NO_DEPENDS=1
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=false
+export GOAL="install"
+export BITCOIN_CONFIG="--enable-reduce-exports --with-incompatible-bdb"
+
+lscpu


### PR DESCRIPTION
Discovered this as part of #17402 and a conversation with gmaxwell.

You can see here that the platform is indeed BE: https://travis-ci.org/elichai/bitcoin/jobs/616656410#L36

This closes https://github.com/bitcoin/bitcoin/issues/6466