### PR TITLE
Appveyor install libevent[thread] vcpkg

### DIFF
--- a/build_msvc/vcpkg-packages.txt
+++ b/build_msvc/vcpkg-packages.txt
@@ -1,1 +1,1 @@
-berkeleydb boost-filesystem boost-multi-index boost-signals2 boost-test boost-thread libevent rapidcheck zeromq double-conversion
+berkeleydb boost-filesystem boost-multi-index boost-signals2 boost-test boost-thread libevent[thread] rapidcheck zeromq double-conversion


### PR DESCRIPTION
As per #17586 the default libevent vcpkg install now has thread disabled. This PR installs libevent with the thread feature enabled.