### PR TITLE
test: move more utility functions into test utility library

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -39,9 +39,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/bech32.cpp \
   bench/lockedpool.cpp \
   bench/poly1305.cpp \
-  bench/prevector.cpp \
-  test/util.h \
-  test/util.cpp
+  bench/prevector.cpp
 
 nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_BENCH_FILES)
 

--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -10,6 +10,7 @@ EXTRA_LIBRARIES += \
 TEST_UTIL_H = \
     test/util/blockfilter.h \
     test/util/logging.h \
+    test/util/mining.h \
     test/util/setup_common.h \
     test/util/str.h \
     test/util/transaction_utils.h
@@ -19,6 +20,7 @@ libtest_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libtest_util_a_SOURCES = \
   test/util/blockfilter.cpp \
   test/util/logging.cpp \
+  test/util/mining.cpp \
   test/util/setup_common.cpp \
   test/util/str.cpp \
   test/util/transaction_utils.cpp \
@@ -28,4 +30,3 @@ LIBTEST_UTIL += $(LIBBITCOIN_SERVER)
 LIBTEST_UTIL += $(LIBBITCOIN_COMMON)
 LIBTEST_UTIL += $(LIBBITCOIN_UTIL)
 LIBTEST_UTIL += $(LIBBITCOIN_CRYPTO_BASE)
-

--- a/src/Makefile.test_util.include
+++ b/src/Makefile.test_util.include
@@ -13,7 +13,8 @@ TEST_UTIL_H = \
     test/util/mining.h \
     test/util/setup_common.h \
     test/util/str.h \
-    test/util/transaction_utils.h
+    test/util/transaction_utils.h \
+    test/util/wallet.h
 
 libtest_util_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
 libtest_util_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -24,6 +25,7 @@ libtest_util_a_SOURCES = \
   test/util/setup_common.cpp \
   test/util/str.cpp \
   test/util/transaction_utils.cpp \
+  test/util/wallet.cpp \
   $(TEST_UTIL_H)
 
 LIBTEST_UTIL += $(LIBBITCOIN_SERVER)

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -5,8 +5,8 @@
 #include <bench/bench.h>
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
-#include <test/util.h>
 #include <test/util/mining.h>
+#include <test/util/wallet.h>
 #include <txmempool.h>
 #include <validation.h>
 

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -6,6 +6,7 @@
 #include <consensus/validation.h>
 #include <crypto/sha256.h>
 #include <test/util.h>
+#include <test/util/mining.h>
 #include <txmempool.h>
 #include <validation.h>
 

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -7,6 +7,7 @@
 #include <node/context.h>
 #include <optional.h>
 #include <test/util.h>
+#include <test/util/mining.h>
 #include <validationinterface.h>
 #include <wallet/wallet.h>
 

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -6,8 +6,8 @@
 #include <interfaces/chain.h>
 #include <node/context.h>
 #include <optional.h>
-#include <test/util.h>
 #include <test/util/mining.h>
+#include <test/util/wallet.h>
 #include <validationinterface.h>
 #include <wallet/wallet.h>
 

--- a/src/test/settings_tests.cpp
+++ b/src/test/settings_tests.cpp
@@ -4,8 +4,9 @@
 
 #include <util/settings.h>
 
-#include <test/util.h>
 #include <test/util/setup_common.h>
+#include <test/util/str.h>
+
 
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -34,37 +34,4 @@ std::string getnewaddress(CWallet& w);
 /** Returns the generated coin */
 CTxIn generatetoaddress(const std::string& address);
 
-/**
- * Increment a string. Useful to enumerate all fixed length strings with
- * characters in [min_char, max_char].
- */
-template <typename CharType, size_t StringLength>
-bool NextString(CharType (&string)[StringLength], CharType min_char, CharType max_char)
-{
-    for (CharType& elem : string) {
-        bool has_next = elem != max_char;
-        elem = elem < min_char || elem >= max_char ? min_char : CharType(elem + 1);
-        if (has_next) return true;
-    }
-    return false;
-}
-
-/**
- * Iterate over string values and call function for each string without
- * successive duplicate characters.
- */
-template <typename CharType, size_t StringLength, typename Fn>
-void ForEachNoDup(CharType (&string)[StringLength], CharType min_char, CharType max_char, Fn&& fn) {
-    for (bool has_next = true; has_next; has_next = NextString(string, min_char, max_char)) {
-        int prev = -1;
-        bool skip_string = false;
-        for (CharType c : string) {
-            if (c == prev) skip_string = true;
-            if (skip_string || c < min_char || c > max_char) break;
-            prev = c;
-        }
-        if (!skip_string) fn();
-    }
-}
-
 #endif // BITCOIN_TEST_UTIL_H

--- a/src/test/util.h
+++ b/src/test/util.h
@@ -5,25 +5,13 @@
 #ifndef BITCOIN_TEST_UTIL_H
 #define BITCOIN_TEST_UTIL_H
 
-#include <memory>
 #include <string>
 
-class CBlock;
-class CScript;
-class CTxIn;
 class CWallet;
 
 // Constants //
 
 extern const std::string ADDRESS_BCRT1_UNSPENDABLE;
-
-// Lower-level utils //
-
-/** Returns the generated coin */
-CTxIn MineBlock(const CScript& coinbase_scriptPubKey);
-/** Prepare a block to be mined */
-std::shared_ptr<CBlock> PrepareBlock(const CScript& coinbase_scriptPubKey);
-
 
 // RPC-like //
 
@@ -31,7 +19,5 @@ std::shared_ptr<CBlock> PrepareBlock(const CScript& coinbase_scriptPubKey);
 void importaddress(CWallet& wallet, const std::string& address);
 /** Returns a new address from the wallet */
 std::string getnewaddress(CWallet& w);
-/** Returns the generated coin */
-CTxIn generatetoaddress(const std::string& address);
 
 #endif // BITCOIN_TEST_UTIL_H

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/util/mining.h>
+
+#include <chainparams.h>
+#include <consensus/merkle.h>
+#include <key_io.h>
+#include <miner.h>
+#include <pow.h>
+#include <script/standard.h>
+#include <validation.h>
+
+CTxIn generatetoaddress(const std::string& address)
+{
+    const auto dest = DecodeDestination(address);
+    assert(IsValidDestination(dest));
+    const auto coinbase_script = GetScriptForDestination(dest);
+
+    return MineBlock(coinbase_script);
+}
+
+CTxIn MineBlock(const CScript& coinbase_scriptPubKey)
+{
+    auto block = PrepareBlock(coinbase_scriptPubKey);
+
+    while (!CheckProofOfWork(block->GetHash(), block->nBits, Params().GetConsensus())) {
+        ++block->nNonce;
+        assert(block->nNonce);
+    }
+
+    bool processed{ProcessNewBlock(Params(), block, true, nullptr)};
+    assert(processed);
+
+    return CTxIn{block->vtx[0]->GetHash(), 0};
+}
+
+std::shared_ptr<CBlock> PrepareBlock(const CScript& coinbase_scriptPubKey)
+{
+    auto block = std::make_shared<CBlock>(
+        BlockAssembler{Params()}
+            .CreateNewBlock(coinbase_scriptPubKey)
+            ->block);
+
+    LOCK(cs_main);
+    block->nTime = ::ChainActive().Tip()->GetMedianTimePast() + 1;
+    block->hashMerkleRoot = BlockMerkleRoot(*block);
+
+    return block;
+}

--- a/src/test/util/mining.h
+++ b/src/test/util/mining.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_UTIL_MINING_H
+#define BITCOIN_TEST_UTIL_MINING_H
+
+#include <memory>
+#include <string>
+
+class CBlock;
+class CScript;
+class CTxIn;
+
+/** Returns the generated coin */
+CTxIn MineBlock(const CScript& coinbase_scriptPubKey);
+
+/** Prepare a block to be mined */
+std::shared_ptr<CBlock> PrepareBlock(const CScript& coinbase_scriptPubKey);
+
+/** RPC-like helper function, returns the generated coin */
+CTxIn generatetoaddress(const std::string& address);
+
+#endif // BITCOIN_TEST_UTIL_MINING_H

--- a/src/test/util/str.h
+++ b/src/test/util/str.h
@@ -9,4 +9,37 @@
 
 bool CaseInsensitiveEqual(const std::string& s1, const std::string& s2);
 
+/**
+ * Increment a string. Useful to enumerate all fixed length strings with
+ * characters in [min_char, max_char].
+ */
+template <typename CharType, size_t StringLength>
+bool NextString(CharType (&string)[StringLength], CharType min_char, CharType max_char)
+{
+    for (CharType& elem : string) {
+        bool has_next = elem != max_char;
+        elem = elem < min_char || elem >= max_char ? min_char : CharType(elem + 1);
+        if (has_next) return true;
+    }
+    return false;
+}
+
+/**
+ * Iterate over string values and call function for each string without
+ * successive duplicate characters.
+ */
+template <typename CharType, size_t StringLength, typename Fn>
+void ForEachNoDup(CharType (&string)[StringLength], CharType min_char, CharType max_char, Fn&& fn) {
+    for (bool has_next = true; has_next; has_next = NextString(string, min_char, max_char)) {
+        int prev = -1;
+        bool skip_string = false;
+        for (CharType c : string) {
+            if (c == prev) skip_string = true;
+            if (skip_string || c < min_char || c > max_char) break;
+            prev = c;
+        }
+        if (!skip_string) fn();
+    }
+}
+
 #endif // BITCOIN_TEST_UTIL_STR_H

--- a/src/test/util/wallet.cpp
+++ b/src/test/util/wallet.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/util.h>
+#include <test/util/wallet.h>
 
 #include <key_io.h>
 #include <outputtype.h>

--- a/src/test/util/wallet.h
+++ b/src/test/util/wallet.h
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#ifndef BITCOIN_TEST_UTIL_H
-#define BITCOIN_TEST_UTIL_H
+#ifndef BITCOIN_TEST_UTIL_WALLET_H
+#define BITCOIN_TEST_UTIL_WALLET_H
 
 #include <string>
 
@@ -20,4 +20,5 @@ void importaddress(CWallet& wallet, const std::string& address);
 /** Returns a new address from the wallet */
 std::string getnewaddress(CWallet& w);
 
-#endif // BITCOIN_TEST_UTIL_H
+
+#endif // BITCOIN_TEST_UTIL_WALLET_H

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -7,7 +7,7 @@
 #include <clientversion.h>
 #include <sync.h>
 #include <test/util/setup_common.h>
-#include <test/util.h>
+#include <test/util/str.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/string.h>


### PR DESCRIPTION
This disbands `test/util.h` and `test/util.cpp` and moves the content into the test utility library recently created in #17542, so that all test utility functions are in one place.

The content of the original files are split into three modules:
1) string helper functions go to `test/util/str`
2) mining helper functions go to the newly created `test/util/mining`
3) wallet helper functions go to the newly created `test/util/wallet`
