### PR TITLE
doc: Change doxygen URL to doxygen.bitcoincore.org

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -54,7 +54,7 @@ The Bitcoin repo's [root README](/README.md) contains relevant information on th
 - [Productivity Notes](productivity.md)
 - [Release Notes](release-notes.md)
 - [Release Process](release-process.md)
-- [Source Code Documentation (External Link)](https://dev.visucore.com/bitcoin/doxygen/)
+- [Source Code Documentation (External Link)](https://doxygen.bitcoincore.org/)
 - [Translation Process](translation_process.md)
 - [Translation Strings Policy](translation_strings_policy.md)
 - [JSON-RPC Interface](JSON-RPC-interface.md)


### PR DESCRIPTION
The bitcoin core doxygen documentation has moved to https://doxygen.bitcoincore.org, see bitcoin-core/bitcoincore.org#681

(the old URL still works as a redirect)