### PR TITLE
qt: Remove connection for unused accepted() signal in ReceiveRequestDialog

### DIFF
--- a/src/qt/forms/receiverequestdialog.ui
+++ b/src/qt/forms/receiverequestdialog.ui
@@ -148,21 +148,5 @@
     </hint>
    </hints>
   </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ReceiveRequestDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>452</x>
-     <y>573</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>243</x>
-     <y>298</y>
-    </hint>
-   </hints>
-  </connection>
  </connections>
 </ui>


### PR DESCRIPTION
`ReceiveRequestDialog` has only "Close" button in `QDialogButtonBox`, therefore nothing could emit [`QDialogButtonBox::accepted()`](https://doc.qt.io/qt-5/qdialogbuttonbox.html#accepted) signal.