### PR TITLE
Validation: Move CheckBlock() mutation guard to AcceptBlock()

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -693,7 +693,7 @@ public:
         const CChainParams& chainparams,
         std::shared_ptr<const CBlock> pblock) LOCKS_EXCLUDED(cs_main);
 
-    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+    bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     // Block (dis)connection on a given view:
     DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view);


### PR DESCRIPTION
We do not mark any blocks that fail `CheckBlock()` as `BLOCK_FAILED_VALID`
since they could have been mutated and marking a valid-but-mutated block
as invalid would prevent us from ever syncing to that chain. See
https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2019-February/016697.html
for full details.

The current guard against marking `CheckBlock()` failed blocks as invalid
is by calling `CheckBlock()` prior to `AcceptBlock()` in `ProcessNewBlock()`.
That is brittle since `AcceptBlock()` has an implicit assumption that any
block submitted has been checked for mutation. A future change to
`ProcessNewBlock()` could overlook that implicit assumption and introduce
a consensus failure.

Move the mutation guard logic into `AcceptBlock()` and
add comments to explain why we never mark `CheckBlock()` failed blocks as
invalid.
