### PR TITLE
rpc: add extensive file checks for dumptxoutset and dumpwallet

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2265,16 +2265,11 @@ UniValue dumptxoutset(const JSONRPCRequest& request)
     }.Check(request);
 
     fs::path path = fs::absolute(request.params[0].get_str(), GetDataDir());
+    EnsureFileWritable(path);
+
     // Write to a temporary path and then move into `path` on completion
     // to avoid confusion due to an interruption.
     fs::path temppath = fs::absolute(request.params[0].get_str() + ".incomplete", GetDataDir());
-
-    if (fs::exists(path)) {
-        throw JSONRPCError(
-            RPC_INVALID_PARAMETER,
-            path.string() + " already exists. If you are sure this is what you want, "
-            "move it out of the way first");
-    }
 
     FILE* file{fsbridge::fopen(temppath, "wb")};
     CAutoFile afile{file, SER_DISK, CLIENT_VERSION};

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include <boost/variant.hpp>
+#include <fs.h>
 
 /**
  * String used to describe UNIX epoch time in documentation, factored out to a
@@ -101,6 +102,8 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
 
 /** Returns, given services flags, a list of humanly readable (known) network services */
 UniValue GetServicesNames(ServiceFlags services);
+/** Check file and directory validity, availability and accessibility. Throws JSONRPCError */
+void EnsureFileWritable(const fs::path& filepath);
 
 /**
  * Serializing JSON objects depends on the outer type. Only arrays and

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -750,8 +750,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     EnsureWalletIsUnlocked(&wallet);
 
-    fs::path filepath = request.params[0].get_str();
-    filepath = fs::absolute(filepath);
+    fs::path filepath = fs::absolute(request.params[0].get_str());
+    EnsureFileWritable(filepath);
 
     /* Prevent arbitrary files from being overwritten. There have been reports
      * that users have overwritten wallet files this way:

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -47,5 +47,10 @@ class DumptxoutsetTest(BitcoinTestFramework):
         assert_raises_rpc_error(
             -8, '{} already exists'.format(FILENAME),  node.dumptxoutset, FILENAME)
 
+        # Specifying an irregular file path will fail.
+        irregular_file = " utxo.dat"
+        assert_raises_rpc_error(
+            -8, '{} is invalid'.format(irregular_file),  node.dumptxoutset, irregular_file)
+
 if __name__ == '__main__':
     DumptxoutsetTest().main()


### PR DESCRIPTION
This PR fixes the problem with handling of irregular file names described in https://github.com/bitcoin/bitcoin/issues/17612

It also defines a helper function EnsureFileWritable that is used by dumptxoutset and dumpwallet. 

This function checks for:

* file name existence (if only a dir-path was given the execution stops with a corresponding JSON error)
* file name validity for the current OS 
* write permissions
* file existence (if a file already exists the dump* operation stops, like it was done in previous versions)

The already existing JSON objects and their messages have been preserved to prevent failing of tests and/or 3rd party tools whose parsers maybe rely on them.

A functional test was added in test/functional/rpc_dumptxoutset.py

Closes: #17612

**Notice**: the original PR was #17615 but due to an error at squashing changes it got automatically closed by GitHub and could not be reopened again.
