### PR TITLE
Suppress false positive warning about uninitialized entropy buffers

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -142,7 +142,7 @@ void AddFile(CSHA512& hasher, const char *path)
     int f = open(path, O_RDONLY);
     size_t total = 0;
     if (f != -1) {
-        unsigned char fbuf[4096];
+        unsigned char fbuf[4096]; // intentionally not initialized, see https://github.com/bitcoin/bitcoin/pull/17627
         int n;
         hasher.Write((const unsigned char*)&f, sizeof(f));
         if (fstat(f, &sb) == 0) hasher << sb;
@@ -171,7 +171,7 @@ template<int... S>
 void AddSysctl(CSHA512& hasher)
 {
     int CTL[sizeof...(S)] = {S...};
-    unsigned char buffer[65536];
+    unsigned char buffer[65536]; // intentionally not initialized
     size_t siz = 65536;
     int ret = sysctl(CTL, sizeof...(S), buffer, &siz, nullptr, 0);
     if (ret == 0 || (ret == -1 && errno == ENOMEM)) {


### PR DESCRIPTION
The memory sanitizer cannot see through `syscall` (see https://github.com/google/sanitizers/issues/852). This caused a false
positive `use-of-uninitialized-value` error for `SYS_getrandom`.

Given recent problematic real issues with uninitialized variables, I think it's worth getting rid of the false positives so developers, and maybe Travis, can run the sanitizer.

```
==18287==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x561f1c40bfc8 in ReadBE64(unsigned char const*) /home/dev/bitcoin/src/./crypto/common.h:67:12
    #1 0x561f1c3fe1d3 in (anonymous namespace)::sha512::Transform(unsigned long*, unsigned char const*) /home/dev/bitcoin/src/crypto/sha512.cpp:59:63
    #2 0x561f1c3fcb77 in CSHA512::Write(unsigned char const*, unsigned long) /home/dev/bitcoin/src/crypto/sha512.cpp:168:9
    #3 0x561f1c2d102d in CSHA512& (anonymous namespace)::operator<<<timespec>(CSHA512&, timespec const&) /home/dev/bitcoin/src/randomenv.cpp:119:12
    #4 0x561f1c2d07e8 in RandAddDynamicEnv(CSHA512&) /home/dev/bitcoin/src/randomenv.cpp:249:12
    #5 0x561f1c2cbfb9 in SeedStartup(CSHA512&, (anonymous namespace)::RNGState&) /home/dev/bitcoin/src/random.cpp:513:5
    #6 0x561f1c2c933e in ProcRand(unsigned char*, int, RNGLevel) /home/dev/bitcoin/src/random.cpp:553:9
    #7 0x561f1c2c8f98 in GetRandBytes(unsigned char*, int) /home/dev/bitcoin/src/random.cpp:558:59
    #8 0x561f1baa521e in (anonymous namespace)::CSignatureCache::CSignatureCache() /home/dev/bitcoin/src/script/sigcache.cpp:34:9
    #9 0x561f1b3bcdf9 in __cxx_global_var_init.3 /home/dev/bitcoin/src/script/sigcache.cpp:67:24
    #10 0x561f1b3bce88 in _GLOBAL__sub_I_sigcache.cpp /home/dev/bitcoin/src/script/sigcache.cpp
    #11 0x561f1c60107c in __libc_csu_init (/home/dev/bitcoin/src/bitcoind+0x129507c)
    #12 0x7fc924a8fb27 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:266
    #13 0x561f1b3c3659 in _start (/home/dev/bitcoin/src/bitcoind+0x57659)

  Uninitialized value was stored to memory at
    #0 0x561f1b3c9316 in __msan_memcpy (/home/dev/bitcoin/src/bitcoind+0x5d316)
    #1 0x561f1c3fcc8c in CSHA512::Write(unsigned char const*, unsigned long) /home/dev/bitcoin/src/crypto/sha512.cpp:179:9
    #2 0x561f1c2cbc50 in SeedSlow(CSHA512&) /home/dev/bitcoin/src/random.cpp:467:12
    #3 0x561f1c2cbf65 in SeedStartup(CSHA512&, (anonymous namespace)::RNGState&) /home/dev/bitcoin/src/random.cpp:509:5
    #4 0x561f1c2c933e in ProcRand(unsigned char*, int, RNGLevel) /home/dev/bitcoin/src/random.cpp:553:9
    #5 0x561f1c2c8f98 in GetRandBytes(unsigned char*, int) /home/dev/bitcoin/src/random.cpp:558:59
    #6 0x561f1baa521e in (anonymous namespace)::CSignatureCache::CSignatureCache() /home/dev/bitcoin/src/script/sigcache.cpp:34:9
    #7 0x561f1b3bcdf9 in __cxx_global_var_init.3 /home/dev/bitcoin/src/script/sigcache.cpp:67:24
    #8 0x561f1b3bce88 in _GLOBAL__sub_I_sigcache.cpp /home/dev/bitcoin/src/script/sigcache.cpp
    #9 0x561f1c60107c in __libc_csu_init (/home/dev/bitcoin/src/bitcoind+0x129507c)

  Uninitialized value was created by an allocation of 'buffer' in the stack frame of function '_ZL8SeedSlowR7CSHA512'
    #0 0x561f1c2cbb80 in SeedSlow(CSHA512&) /home/dev/bitcoin/src/random.cpp:459

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/dev/bitcoin/src/./crypto/common.h:67:12 in ReadBE64(unsigned char const*)
Exiting
```

See #17620 for how to use the memory sanitizer.