### PR TITLE
qt: Fix comparison function signature

### DIFF
--- a/src/cuckoocache.h
+++ b/src/cuckoocache.h
@@ -6,11 +6,11 @@
 #define BITCOIN_CUCKOOCACHE_H
 
 #include <array>
-#include <algorithm>
 #include <atomic>
-#include <cstring>
 #include <cmath>
+#include <cstring>
 #include <memory>
+#include <utility>
 #include <vector>
 
 

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <type_traits>
+#include <utility>
 
 #pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -8,7 +8,7 @@
 #include <net_types.h> // For banmap_t
 #include <qt/clientmodel.h>
 
-#include <algorithm>
+#include <utility>
 
 #include <QDebug>
 #include <QList>

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -10,7 +10,7 @@
 
 #include <interfaces/node.h>
 
-#include <algorithm>
+#include <utility>
 
 #include <QDebug>
 #include <QList>

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -12,8 +12,7 @@
 #include <clientversion.h>
 #include <streams.h>
 
-#include <algorithm>
-
+#include <utility>
 
 RecentRequestsTableModel::RecentRequestsTableModel(WalletModel *parent) :
     QAbstractTableModel(parent), walletModel(parent)
@@ -214,10 +213,10 @@ void RecentRequestsTableModel::updateDisplayUnit()
     updateAmountColumnTitle();
 }
 
-bool RecentRequestEntryLessThan::operator()(RecentRequestEntry &left, RecentRequestEntry &right) const
+bool RecentRequestEntryLessThan::operator()(const RecentRequestEntry& left, const RecentRequestEntry& right) const
 {
-    RecentRequestEntry *pLeft = &left;
-    RecentRequestEntry *pRight = &right;
+    const RecentRequestEntry* pLeft = &left;
+    const RecentRequestEntry* pRight = &right;
     if (order == Qt::DescendingOrder)
         std::swap(pLeft, pRight);
 

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -45,7 +45,7 @@ class RecentRequestEntryLessThan
 public:
     RecentRequestEntryLessThan(int nColumn, Qt::SortOrder fOrder):
         column(nColumn), order(fOrder) {}
-    bool operator()(RecentRequestEntry &left, RecentRequestEntry &right) const;
+    bool operator()(const RecentRequestEntry& left, const RecentRequestEntry& right) const;
 
 private:
     int column;

--- a/src/test/checkqueue_tests.cpp
+++ b/src/test/checkqueue_tests.cpp
@@ -17,6 +17,7 @@
 #include <condition_variable>
 
 #include <unordered_set>
+#include <utility>
 
 BOOST_FIXTURE_TEST_SUITE(checkqueue_tests, TestingSetup)
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -23,7 +23,6 @@
 #include <versionbits.h>
 #include <serialize.h>
 
-#include <algorithm>
 #include <atomic>
 #include <map>
 #include <memory>


### PR DESCRIPTION
This PR fixes build on CentOS 7 with GCC 4.8.5:

```
...
In file included from /usr/include/c++/4.8.2/algorithm:62:0,
                 from ./serialize.h:11,
                 from ./qt/sendcoinsrecipient.h:13,
                 from ./qt/recentrequeststablemodel.h:8,
                 from qt/recentrequeststablemodel.cpp:5:
/usr/include/c++/4.8.2/bits/stl_algo.h: In instantiation of ‘_RandomAccessIterator std::__unguarded_partition(_RandomAccessIterator, _RandomAccessIterator, const _Tp&, _Compare) [with _RandomAccessIterator = QList<RecentRequestEntry>::iterator; _Tp = RecentRequestEntry; _Compare = RecentRequestEntryLessThan]’:
/usr/include/c++/4.8.2/bits/stl_algo.h:2296:78:   required from ‘_RandomAccessIterator std::__unguarded_partition_pivot(_RandomAccessIterator, _RandomAccessIterator, _Compare) [with _RandomAccessIterator = QList<RecentRequestEntry>::iterator; _Compare = RecentRequestEntryLessThan]’
/usr/include/c++/4.8.2/bits/stl_algo.h:2337:62:   required from ‘void std::__introsort_loop(_RandomAccessIterator, _RandomAccessIterator, _Size, _Compare) [with _RandomAccessIterator = QList<RecentRequestEntry>::iterator; _Size = int; _Compare = RecentRequestEntryLessThan]’
/usr/include/c++/4.8.2/bits/stl_algo.h:5499:44:   required from ‘void std::sort(_RAIter, _RAIter, _Compare) [with _RAIter = QList<RecentRequestEntry>::iterator; _Compare = RecentRequestEntryLessThan]’
qt/recentrequeststablemodel.cpp:208:82:   required from here
/usr/include/c++/4.8.2/bits/stl_algo.h:2263:35: error: no match for call to ‘(RecentRequestEntryLessThan) (RecentRequestEntry&, const RecentRequestEntry&)’
    while (__comp(*__first, __pivot))
                                   ^
In file included from qt/recentrequeststablemodel.cpp:5:0:
./qt/recentrequeststablemodel.h:43:7: note: candidate is:
 class RecentRequestEntryLessThan
       ^
qt/recentrequeststablemodel.cpp:217:6: note: bool RecentRequestEntryLessThan::operator()(RecentRequestEntry&, RecentRequestEntry&) const
 bool RecentRequestEntryLessThan::operator()(RecentRequestEntry &left, RecentRequestEntry &right) const
      ^
qt/recentrequeststablemodel.cpp:217:6: note:   no known conversion for argument 2 from ‘const RecentRequestEntry’ to ‘RecentRequestEntry&’
In file included from /usr/include/c++/4.8.2/algorithm:62:0,
                 from ./serialize.h:11,
                 from ./qt/sendcoinsrecipient.h:13,
                 from ./qt/recentrequeststablemodel.h:8,
                 from qt/recentrequeststablemodel.cpp:5:
/usr/include/c++/4.8.2/bits/stl_algo.h:2266:34: error: no match for call to ‘(RecentRequestEntryLessThan) (const RecentRequestEntry&, RecentRequestEntry&)’
    while (__comp(__pivot, *__last))
                                  ^
In file included from qt/recentrequeststablemodel.cpp:5:0:
./qt/recentrequeststablemodel.h:43:7: note: candidate is:
 class RecentRequestEntryLessThan
       ^
qt/recentrequeststablemodel.cpp:217:6: note: bool RecentRequestEntryLessThan::operator()(RecentRequestEntry&, RecentRequestEntry&) const
 bool RecentRequestEntryLessThan::operator()(RecentRequestEntry &left, RecentRequestEntry &right) const
      ^
qt/recentrequeststablemodel.cpp:217:6: note:   no known conversion for argument 1 from ‘const RecentRequestEntry’ to ‘RecentRequestEntry&’
  CXX      qt/qt_libbitcoinqt_a-sendcoinsentry.o
make[2]: *** [qt/qt_libbitcoinqt_a-recentrequeststablemodel.o] Error 1
```

Also for `std::swap()` header `<algorithm>` is replaced with `<utility>` one.
Refs:
- [`std::swap()`](https://en.cppreference.com/w/cpp/algorithm/swap)
- [standard library header `<utility>`](https://en.cppreference.com/w/cpp/header/utility)