### PR TITLE
qt: Add -guisettingsdir option

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -85,6 +85,7 @@ Subdirectory | File(s)           | Description
 ## GUI settings
 
 `bitcoin-qt` uses [`QSettings`](https://doc.qt.io/qt-5/qsettings.html) class; this implies platform-specific [locations where application settings are stored](https://doc.qt.io/qt-5/qsettings.html#locations-where-application-settings-are-stored).
+You can change this with the `-guisettingsdir=<path>` option. It will use the cross-platform ini format then. `<path>` is where the `.ini` file is stored.
 
 ## Legacy subdirectories and files
 


### PR DESCRIPTION
## Short Description
This PR makes it possible to change the Qt relevant config files in a custom directory
## Motivation
There are multiple usecases where it could be useful, for example when you use Bitcoin Core on a USB stick, you can keep the config files there as well. My motivation was that I don't need to move my production bitcoin-qt config file to a different place because I don't want that an unstable bulid corrupts my datadir. Currently I need to delete my config or reset the datadir path every time I switch between productive to development. With this I can have a config directory for my productive use and one for my development use.
## Showcase
Having a directory called `/home/emil/testconf` and running bitcoin-qt will result in this hier: `/home/emil/testconf/Bitcoin/Bitcoin-Qt.conf`. The Bitcoin subdirectory is a feature, not a bug to make it possible to keep other Qt config files there without colliding. If the the user has no permissions, it won't save anything, if the dir does not exists it will be created.