### PR TITLE
script: Add Keyserver to verify-commits README

### DIFF
--- a/contrib/verify-commits/README.md
+++ b/contrib/verify-commits/README.md
@@ -40,7 +40,7 @@ Import trusted keys
 In order to check the commit signatures, you must add the trusted PGP keys to your machine. [GnuPG](https://gnupg.org/) may be used to import the trusted keys by running the following command:
 
 ```sh
-gpg --recv-keys $(<contrib/verify-commits/trusted-keys)
+gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $(<contrib/verify-commits/trusted-keys)
 ```
 
 Key expiry/revocation


### PR DESCRIPTION
When I use the option with the default keyserver on `gpg (GnuPG) 2.2.12` from the Debian repositories only the keys from meshcollider and fanquake are actually found. Using the ubuntu keyserver works without any problems and all keys are getting found.
As this keyserver is also suggested on [https://bitcoincore.org/en/download/](), it would be good to have a common keyserver.