### PR TITLE
Add unit test for leveldb creation with unicode path

### DIFF
--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -397,6 +397,18 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
     }
 }
 
+BOOST_AUTO_TEST_CASE(unicodepath)
+{
+    // Attempt to create a database with a utf8 character in the path.
+    // On Windows this test will fail if the directory is created using
+    // the ANSI CreateDirectoryA  call and the code page isn't UTF8.
+    // It will succeed if the created with  CreateDirectoryW.
+    fs::path ph = GetDataDir() / "test_runner_₿_🏃_20191128_104644";
+    CDBWrapper dbw(ph, (1 << 20));
+
+    fs::path lockPath = ph / "LOCK";
+    BOOST_CHECK(boost::filesystem::exists(lockPath));
+}
 
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
An issue arose when attempting to switch back to the main repo version of leveldb when the bitcoin data directory uses a unicode path. The leveldb windows file IO wrapper was using the *A ANSI win32 calls instead of the Unicode *W ones. This unit test will catch if the path created by leveldb doesn't match what we're expecting. For more info see https://github.com/google/leveldb/issues/755.