### PR TITLE
gui: increases default GraphRange of Network Traffic to 12 hours.

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -695,7 +695,7 @@
               <number>12</number>
              </property>
              <property name="value">
-              <number>6</number>
+              <number>144</number>
              </property>
              <property name="orientation">
               <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
1. A graph range of `12 h` shows a more informative overview of the daily traffic. 
2. It's annoying to increase this range after every reboot; 12 hours is right in the middle, so users who want to change it have to drag the slider less compared to the original value.

Value `6` = 30 minutes (6 * 5 m), value `144` = 12 hours (144 * 5 m).