### PR TITLE
rpc: Add generateblock to mine a custom set of transactions

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -32,6 +32,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "generatetoaddress", 2, "maxtries" },
     { "generatetodescriptor", 0, "num_blocks" },
     { "generatetodescriptor", 2, "maxtries" },
+    { "generatecustomblock", 1, "transactions" },
     { "getnetworkhashps", 0, "nblocks" },
     { "getnetworkhashps", 1, "height" },
     { "sendtoaddress", 1, "amount" },

--- a/test/functional/rpc_generatecustomblock.py
+++ b/test/functional/rpc_generatecustomblock.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test generatecustomblock rpc.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR
+
+class GenerateCustomBlockTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        # Generate an empty block to address
+        address = node.getnewaddress()
+        node.generatecustomblock(address, [])
+
+        # Generate an empty block to a descriptor
+        node.generatecustomblock(ADDRESS_BCRT1_UNSPENDABLE_DESCRIPTOR, [])
+
+        # Generate 110 blocks to spend
+        node.generatetoaddress(110, address)
+
+        # Generate some extra mempool transactions to verify they don't get mined
+        for i in range(10):
+            node.sendtoaddress(address, 0.001)
+
+        # Generate custom block with raw tx
+        utxos = node.listunspent(addresses=[address])
+        raw = node.createrawtransaction([{"txid":utxos[0]["txid"], "vout":utxos[0]["vout"]}],[{address:1}])
+        signed_raw = node.signrawtransactionwithwallet(raw)['hex']
+        hash = node.generatecustomblock(address, [signed_raw])
+        block = node.getblock(hash, 1)
+        assert len(block['tx']) == 2
+        txid = block['tx'][1]
+        assert node.gettransaction(txid)['hex'] == signed_raw
+
+        # Generate custom block with txid
+        txid = node.sendtoaddress(address, 1)
+        hash = node.generatecustomblock(address, [txid])
+        block = node.getblock(hash, 1)
+        assert len(block['tx']) == 2
+        assert block['tx'][1] == txid
+
+if __name__ == '__main__':
+    GenerateCustomBlockTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -170,6 +170,7 @@ BASE_SCRIPTS = [
     'wallet_importprunedfunds.py',
     'p2p_leak_tx.py',
     'rpc_signmessage.py',
+    'rpc_generatecustomblock.py',
     'wallet_balance.py',
     'feature_nulldummy.py',
     'mempool_accept.py',


### PR DESCRIPTION
The existing block generation rpcs for regtest, `generatetoaddress` and `generatetodescriptor`, mine everything in the mempool up to the block weight limit. This makes it difficult to test a system for several scenarios where a different set of transactions are mined. For example:
- Testing the common scenario where a transaction is replaced in the mempool but the replaced transaction is mined instead.
- Testing for a double-spent transaction where a transaction that conflicts with the mempool is mined.
- Testing for non-standard transactions that are mined.
- Testing the scenario where several blocks are mined without a specific transaction in the mempool being included in a block.

This PR introduces a new rpc, `generateblock`, that takes an array of raw transactions and txids and mines only those and the coinbase. Any txids must be in the mempool, but the raw txs can be anything conforming to consensus rules. The coinbase can be specified as either an address or descriptor.

There is some relevant conversation [here](https://github.com/bitcoin/bitcoin/pull/15873#issuecomment-485993758). 