### PR TITLE
Unbreak build with Boost 1.72.0

### DIFF
--- a/src/fs.h
+++ b/src/fs.h
@@ -11,7 +11,6 @@
 #include <ext/stdio_filebuf.h>
 #endif
 
-#define BOOST_FILESYSTEM_NO_DEPRECATED
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 


### PR DESCRIPTION
Regressed by https://github.com/boostorg/filesystem/commit/9a14c37d6f95. See [error log](http://package22.nyi.freebsd.org/data/113amd64-default-PR241449/2019-11-27_11h48m22s/logs/bitcoin-0.19.0.1.log).
https://github.com/bitcoin/bitcoin/blob/35eda631ed3bd23d4a41761a85a96f925d4a6337/src/fs.h#L14
