### PR TITLE
depends: add ability to skip building qrencode

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -9,6 +9,7 @@ WORK_PATH = $(BASEDIR)/work
 BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
+NO_QR ?=
 RAPIDCHECK ?=
 NO_WALLET ?=
 NO_ZMQ ?=
@@ -100,7 +101,10 @@ $(host_arch)_$(host_os)_id_string+=$(shell $(host_CXX) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_RANLIB) --version 2>/dev/null)
 $(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
 
-qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
+qrencode_packages_$(NO_QR) = $(qrencode_packages)
+
+qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages) $(qrencode_packages_)
+
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
 zmq_packages_$(NO_ZMQ) = $(zmq_packages)
@@ -154,6 +158,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@no_qt@|$(NO_QT)|' \
+            -e 's|@no_qr@|$(NO_QR)|' \
             -e 's|@no_zmq@|$(NO_ZMQ)|' \
             -e 's|@no_wallet@|$(NO_WALLET)|' \
             -e 's|@no_upnp@|$(NO_UPNP)|' \

--- a/depends/README.md
+++ b/depends/README.md
@@ -76,6 +76,7 @@ The following can be set when running make: make FOO=bar
     SDK_PATH: Path where sdk's can be found (used by macOS)
     FALLBACK_DOWNLOAD_PATH: If a source file can't be fetched, try here before giving up
     NO_QT: Don't download/build/cache qt and its dependencies
+    NO_QR: Don't download/build/cache packages needed for enabling qrencode
     NO_ZMQ: Don't download/build/cache packages needed for enabling zeromq
     NO_WALLET: Don't download/build/cache libs needed to enable the wallet
     NO_UPNP: Don't download/build/cache packages needed for enabling upnp

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -17,6 +17,10 @@ if test -z $with_qt_bindir && test -z "@no_qt@"; then
   with_qt_bindir=$depends_prefix/native/bin
 fi
 
+if test -z $with_qrencode && test -n "@no_qr@"; then
+  with_qrencode=no
+fi
+
 if test -z $enable_wallet && test -n "@no_wallet@"; then
   enable_wallet=no
 fi

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,6 +1,8 @@
 packages:=boost libevent
 
-qt_packages = qrencode zlib
+qt_packages = zlib
+
+qrencode_packages = qrencode
 
 qt_linux_packages:=qt expat libxcb xcb_proto libXau xproto freetype fontconfig
 qt_android_packages=qt


### PR DESCRIPTION
Similar to other depends packages, add the ability to skip building `qrencode` by passing `NO_QR=1`. Same as #16089.