### PR TITLE
qt: Do not block GUI thread in RPCConsole

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -324,8 +324,6 @@ void BitcoinApplication::requestShutdown()
     // for example the RPC console may still be executing a command.
     shutdownWindow.reset(ShutdownWindow::showShutdownWindow(window));
 
-    qDebug() << __func__ << ": Requesting shutdown";
-    startThread();
     window->clearGUI();
     // Must disconnect node signals otherwise current thread can deadlock since
     // no event loop is running.
@@ -341,8 +339,7 @@ void BitcoinApplication::requestShutdown()
     delete clientModel;
     clientModel = nullptr;
 
-    // Request shutdown from core thread
-    Q_EMIT requestedShutdown();
+    requestNodeShutdown();
 }
 
 void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info)
@@ -394,6 +391,14 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
         Q_EMIT splashFinished(); // Make sure splash screen doesn't stick around during shutdown
         requestShutdown();
     }
+}
+
+void BitcoinApplication::requestNodeShutdown()
+{
+    qDebug() << __func__ << ": Requesting shutdown";
+    startThread();
+    // Request shutdown from core thread
+    Q_EMIT requestedShutdown();
 }
 
 void BitcoinApplication::shutdownResult()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -253,6 +253,7 @@ void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 {
     window = new BitcoinGUI(m_node, platformStyle, networkStyle, nullptr);
     connect(window, &BitcoinGUI::quitClicked, this, &BitcoinApplication::requestShutdown);
+    connect(window, &BitcoinGUI::rpcExecutorThreadFinished, this, &BitcoinApplication::requestNodeShutdown);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, &QTimer::timeout, window, &BitcoinGUI::detectShutdown);
@@ -338,8 +339,6 @@ void BitcoinApplication::requestShutdown()
 
     delete clientModel;
     clientModel = nullptr;
-
-    requestNodeShutdown();
 }
 
 void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info)
@@ -389,7 +388,7 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
         pollShutdownTimer->start(200);
     } else {
         Q_EMIT splashFinished(); // Make sure splash screen doesn't stick around during shutdown
-        requestShutdown();
+        requestNodeShutdown();
     }
 }
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -325,7 +325,7 @@ void BitcoinApplication::requestShutdown()
 
     qDebug() << __func__ << ": Requesting shutdown";
     startThread();
-    window->hide();
+    window->clearGUI();
     // Must disconnect node signals otherwise current thread can deadlock since
     // no event loop is running.
     window->unsubscribeFromCoreSignals();

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -252,6 +252,7 @@ void BitcoinApplication::createOptionsModel(bool resetSettings)
 void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)
 {
     window = new BitcoinGUI(m_node, platformStyle, networkStyle, nullptr);
+    connect(window, &BitcoinGUI::quitClicked, this, &BitcoinApplication::requestShutdown);
 
     pollShutdownTimer = new QTimer(window);
     connect(pollShutdownTimer, &QTimer::timeout, window, &BitcoinGUI::detectShutdown);
@@ -391,13 +392,13 @@ void BitcoinApplication::initializeResult(bool success, interfaces::BlockAndHead
         pollShutdownTimer->start(200);
     } else {
         Q_EMIT splashFinished(); // Make sure splash screen doesn't stick around during shutdown
-        quit(); // Exit first main loop invocation
+        requestShutdown();
     }
 }
 
 void BitcoinApplication::shutdownResult()
 {
-    quit(); // Exit second main loop invocation after shutdown finished
+    quit();
 }
 
 void BitcoinApplication::handleRunawayException(const QString &message)
@@ -599,8 +600,6 @@ int GuiMain(int argc, char* argv[])
 #if defined(Q_OS_WIN)
             WinShutdownMonitor::registerShutdownBlockReason(QObject::tr("%1 didn't yet exit safely...").arg(PACKAGE_NAME), (HWND)app.getMainWinId());
 #endif
-            app.exec();
-            app.requestShutdown();
             app.exec();
             rv = app.getReturnValue();
         } else {

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -76,8 +76,6 @@ public:
 
     /// Request core initialization
     void requestInitialize();
-    /// Request core shutdown
-    void requestShutdown();
 
     /// Get process return value
     int getReturnValue() const { return returnValue; }
@@ -90,6 +88,8 @@ public:
 
 public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
+    /// Request core shutdown
+    void requestShutdown();
     void shutdownResult();
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString &message);

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -90,6 +90,7 @@ public Q_SLOTS:
     void initializeResult(bool success, interfaces::BlockAndHeaderTipInfo tip_info);
     /// Request core shutdown
     void requestShutdown();
+    void requestNodeShutdown();
     void shutdownResult();
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString &message);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -95,6 +95,8 @@ BitcoinGUI::BitcoinGUI(interfaces::Node& node, const PlatformStyle *_platformSty
     updateWindowTitle();
 
     rpcConsole = new RPCConsole(node, _platformStyle, nullptr);
+    connect(rpcConsole, &RPCConsole::executorThreadFinished, this, &BitcoinGUI::rpcExecutorThreadFinished);
+
     helpMessageDialog = new HelpMessageDialog(node, this, false);
 #ifdef ENABLE_WALLET
     if(enableWallet)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -225,8 +225,6 @@ BitcoinGUI::~BitcoinGUI()
 
     QSettings settings;
     settings.setValue("MainWindowGeometry", saveGeometry());
-    if(trayIcon) // Hide tray icon, as deleting will let it linger until quit (on Ubuntu)
-        trayIcon->hide();
 #ifdef Q_OS_MAC
     delete m_app_nap_inhibitor;
     delete appMenuBar;
@@ -373,8 +371,6 @@ void BitcoinGUI::createActions()
     connect(toggleHideAction, &QAction::triggered, this, &BitcoinGUI::toggleHidden);
     connect(showHelpMessageAction, &QAction::triggered, this, &BitcoinGUI::showHelpMessageClicked);
     connect(openRPCConsoleAction, &QAction::triggered, this, &BitcoinGUI::showDebugWindow);
-    // prevents an open debug window from becoming stuck/unusable on client shutdown
-    connect(quitAction, &QAction::triggered, rpcConsole, &QWidget::hide);
 
 #ifdef ENABLE_WALLET
     if(walletFrame)
@@ -623,11 +619,6 @@ void BitcoinGUI::setClientModel(ClientModel *_clientModel, interfaces::BlockAndH
     } else {
         // Disable possibility to show main window via action
         toggleHideAction->setEnabled(false);
-        if(trayIconMenu)
-        {
-            // Disable context menu on tray icon
-            trayIconMenu->clear();
-        }
         // Propagate cleared model to child objects
         rpcConsole->setClientModel(nullptr);
 #ifdef ENABLE_WALLET
@@ -1159,9 +1150,6 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
     {
         if(!clientModel->getOptionsModel()->getMinimizeOnClose())
         {
-            // close rpcConsole in case it was open to make some space for the shutdown window
-            rpcConsole->close();
-
             QApplication::quit();
         }
         else
@@ -1355,8 +1343,6 @@ void BitcoinGUI::detectShutdown()
 {
     if (m_node.shutdownRequested())
     {
-        if(rpcConsole)
-            rpcConsole->hide();
         qApp->quit();
     }
 }

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -364,7 +364,7 @@ void BitcoinGUI::createActions()
     m_mask_values_action->setStatusTip(tr("Mask the values in the Overview tab"));
     m_mask_values_action->setCheckable(true);
 
-    connect(quitAction, &QAction::triggered, qApp, QApplication::quit);
+    connect(quitAction, &QAction::triggered, this, &BitcoinGUI::quitClicked);
     connect(aboutAction, &QAction::triggered, this, &BitcoinGUI::aboutClicked);
     connect(aboutQtAction, &QAction::triggered, qApp, QApplication::aboutQt);
     connect(optionsAction, &QAction::triggered, this, &BitcoinGUI::optionsClicked);
@@ -938,6 +938,7 @@ void BitcoinGUI::openOptionsDialogWithTab(OptionsDialog::Tab tab)
     OptionsDialog dlg(this, enableWallet);
     dlg.setCurrentTab(tab);
     dlg.setModel(clientModel->getOptionsModel());
+    connect(&dlg, &OptionsDialog::quitOnReset, this, &BitcoinGUI::quitClicked);
     dlg.exec();
 }
 
@@ -1150,7 +1151,7 @@ void BitcoinGUI::closeEvent(QCloseEvent *event)
     {
         if(!clientModel->getOptionsModel()->getMinimizeOnClose())
         {
-            QApplication::quit();
+            Q_EMIT quitClicked();
         }
         else
         {
@@ -1343,7 +1344,7 @@ void BitcoinGUI::detectShutdown()
 {
     if (m_node.shutdownRequested())
     {
-        qApp->quit();
+        Q_EMIT quitClicked();
     }
 }
 

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1395,6 +1395,14 @@ void BitcoinGUI::showModalOverlay()
         modalOverlay->toggleVisibility();
 }
 
+void BitcoinGUI::clearGUI()
+{
+    trayIconMenu->clear();
+    setTrayIconVisible(false);
+    rpcConsole->hide();
+    hide();
+}
+
 static bool ThreadSafeMessageBox(BitcoinGUI* gui, const bilingual_str& message, const std::string& caption, unsigned int style)
 {
     bool modal = (style & CClientUIInterface::MODAL);

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -320,6 +320,9 @@ public Q_SLOTS:
     void setTrayIconVisible(bool);
 
     void showModalOverlay();
+
+    /** Hide all windows and tray icon. */
+    void clearGUI();
 };
 
 class UnitDisplayStatusBarControl : public QLabel

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -209,6 +209,7 @@ private:
     void openOptionsDialogWithTab(OptionsDialog::Tab tab);
 
 Q_SIGNALS:
+    void quitClicked();
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);
     /** Signal raised when RPC console shown */

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -210,6 +210,7 @@ private:
 
 Q_SIGNALS:
     void quitClicked();
+    void rpcExecutorThreadFinished();
     /** Signal raised when a URI was entered or dragged to the GUI */
     void receivedURI(const QString &uri);
     /** Signal raised when RPC console shown */

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -258,7 +258,8 @@ void OptionsDialog::on_resetButton_clicked()
 
         /* reset all options and close GUI */
         model->Reset();
-        QApplication::quit();
+        close();
+        Q_EMIT quitOnReset();
     }
 }
 

--- a/src/qt/optionsdialog.h
+++ b/src/qt/optionsdialog.h
@@ -68,6 +68,7 @@ private Q_SLOTS:
 
 Q_SIGNALS:
     void proxyIpChecks(QValidatedLineEdit *pUiProxyIp, int nProxyPort);
+    void quitOnReset();
 
 private:
     Ui::OptionsDialog *ui;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -690,8 +690,8 @@ void RPCConsole::setClientModel(ClientModel *model, int bestblock_height, int64_
     }
     if (!model) {
         // Client model is being set to 0, this means shutdown() is about to be called.
+        connect(&thread, &QThread::finished, this, &RPCConsole::executorThreadFinished);
         thread.quit();
-        thread.wait();
     }
 }
 

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -133,6 +133,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     // For RPC command executor
     void cmdRequest(const QString &command, const WalletModel* wallet_model);
+    void executorThreadFinished();
 
 private:
     void startExecutor();


### PR DESCRIPTION
On master (35eda631ed3bd23d4a41761a85a96f925d4a6337) the GUI thread is blocked with [`QThread::wait()`](https://doc.qt.io/qt-5/qthread.html#wait) during `bitcoin-qt` shutdown routine. This causes unresponsive GUI if some commands are passed to the RPC console (#13217) before shutdown initiating.

This PR:
- removes blocking call and uses additional signal-to-slot connections.
- makes `bitcoin-qt` shutdown routine more streamlined: the only [`QApplication::exec()`](https://doc.qt.io/qt-5/qapplication.html#exec) is used in `bitcoin-qt`. Therefore, the main event loop never interrupts until shutdown, unlike master and alternative #13674.

Refs:
- #10504
- #17145 

This PR is an alternative to #13674.

Fix #13217