### PR TITLE
build: remove deprecated key from macOS Info.plist

### DIFF
--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -16,7 +16,7 @@
   <key>CFBundlePackageType</key>
   <string>APPL</string>
 
-  <key>CFBundleGetInfoString</key>
+  <key>NSHumanReadableCopyright</key>
   <string>@CLIENT_VERSION_MAJOR@.@CLIENT_VERSION_MINOR@.@CLIENT_VERSION_REVISION@.@CLIENT_VERSION_BUILD@, Copyright © 2009-@COPYRIGHT_YEAR@ @COPYRIGHT_HOLDERS_FINAL@</string>
 
   <key>CFBundleShortVersionString</key>


### PR DESCRIPTION
Note that the current release binaries show correct version numbers everywhere in the GUI and macOS info dialogs (except for when you "space" click the app, shown in screenshots), and we haven't reintroduced the issue that #14701 fixed. This is just swapping a deprecated field for a newer one, as well as using the entire version string in two fields that we hadn't been previously.

Follows up discussion in #14701.

0.19.0.1
![0 19 0 1](https://user-images.githubusercontent.com/863730/70089170-a0576e80-15e5-11ea-975c-a6902a1ed95a.png)

This PR.
![master](https://user-images.githubusercontent.com/863730/70089178-a3525f00-15e5-11ea-9d63-7db67de014a5.png)

