### PR TITLE
build: pass -dead_strip_dylibs to ld on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -783,6 +783,7 @@ fi
 dnl this flag screws up non-darwin gcc even when the check fails. special-case it.
 if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
+  AX_CHECK_LINK_FLAG([[-Wl,-dead_strip_dylibs]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip_dylibs"])
 fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])


### PR DESCRIPTION
This strips some unused dylibs from bitcoin-qt.

```diff
otool -L src/qt/bitcoin-qt
  /usr/lib/libSystem.B.dylib
- /System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration
  /System/Library/Frameworks/IOKit.framework/Versions/A/IOKit
  /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation
  /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices
  /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
  /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation 
-/System/Library/Frameworks/Security.framework/Versions/A/Security 
  /System/Library/Frameworks/SystemConfiguration.framework/Versions/A/SystemConfiguration 
  /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics 
  /System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL 
-/System/Library/Frameworks/AGL.framework/Versions/A/AGL 
  /System/Library/Frameworks/Carbon.framework/Versions/A/Carbon 
  /usr/lib/libc++.1.dylib 
  /System/Library/Frameworks/CFNetwork.framework/Versions/A/CFNetwork 
  /System/Library/Frameworks/CoreText.framework/Versions/A/CoreText 
  /System/Library/Frameworks/ImageIO.framework/Versions/A/ImageIO
  /usr/lib/libobjc.A.dylib
```

`AGL` - ObjC wrapper for OpenGL.
`DiskArbitration` - mount/unmount notifications and events.
`Security` - low level security operations, authentication services.

From `man ld`:
```
Remove dylibs that are unreachable by the entry point or exported symbols. 
That is, suppresses the generation of load command commands for dylibs 
which supplied no symbols during the link. This option should not be 
used when linking against a dylib which is required at runtime for 
some indirect reason such as the dylib has an important initializer.
```