### PR TITLE
tests: Add initialization order fiasco detection in Travis

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -33,7 +33,7 @@ fi
 mkdir -p "${BASE_SCRATCH_DIR}"
 mkdir -p "${CCACHE_DIR}"
 
-export ASAN_OPTIONS="detect_stack_use_after_return=1"
+export ASAN_OPTIONS="detect_stack_use_after_return=1:check_initialization_order=1:strict_init_order=1"
 export LSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/lsan"
 export TSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/tsan:log_path=${BASE_SCRATCH_DIR}/sanitizer-output/tsan"
 export UBSAN_OPTIONS="suppressions=${BASE_ROOT_DIR}/test/sanitizer_suppressions/ubsan:print_stacktrace=1:halt_on_error=1:report_error_type=1"


### PR DESCRIPTION
Add initialization order fiasco detection in Travis :)

Context: https://github.com/bitcoin/bitcoin/pull/17670#issuecomment-562035813

This would have caught the `events_hasher` initialization order issue introduced in #17573  and fixed in #17670.

Output in case of an initialization order fiasco:

```
==7934==ERROR: AddressSanitizer: initialization-order-fiasco on address 0x557098d79200 at pc 0x55709796b9a3 bp 0x7ffde524dc30 sp 0x7ffde524dc28
READ of size 8 at 0x557098d79200 thread T0
    #0 0x55709796b9a2 in CSHA256::Finalize(unsigned char*) src/crypto/sha256.cpp:667:25
    #1 0x5570978150e9 in SeedEvents(CSHA512&) src/random.cpp:462:19
    #2 0x5570978145e1 in SeedSlow(CSHA512&) src/random.cpp:482:5
    #3 0x5570978149a3 in SeedStartup(CSHA512&, (anonymous namespace)::RNGState&) src/random.cpp:527:5
    #4 0x55709781102d in ProcRand(unsigned char*, int, RNGLevel) src/random.cpp:571:9
    #5 0x557097810d19 in GetRandBytes(unsigned char*, int) src/random.cpp:576:59
    #6 0x557096c2f9d5 in (anonymous namespace)::CSignatureCache::CSignatureCache() src/script/sigcache.cpp:34:9
    #7 0x557096511977 in __cxx_global_var_init.7 src/script/sigcache.cpp:67:24
    #8 0x5570965119f8 in _GLOBAL__sub_I_sigcache.cpp src/script/sigcache.cpp
    #9 0x557097bba4ac in __libc_csu_init (src/bitcoind+0x18554ac)
    #10 0x7f214b1c2b27 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:266
    #11 0x5570965347d9 in _start (src/bitcoind+0x1cf7d9)

0x557098d79200 is located 96 bytes inside of global variable 'events_hasher' defined in 'random.cpp:456:16' (0x557098d791a0) of size 104
  registered at:
    #0 0x557096545dfd in __asan_register_globals compiler-rt/lib/asan/asan_globals.cpp:360:3
    #1 0x557097817f8b in asan.module_ctor (src/bitcoind+0x14b2f8b)

SUMMARY: AddressSanitizer: initialization-order-fiasco src/crypto/sha256.cpp:667:25 in CSHA256::Finalize(unsigned char*)
```