### PR TITLE
depends: don't use OpenGL in Qt on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -783,6 +783,7 @@ fi
 dnl this flag screws up non-darwin gcc even when the check fails. special-case it.
 if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
+  AX_CHECK_LINK_FLAG([[-Wl,-dead_strip_dylibs]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip_dylibs"])
 fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])

--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -105,6 +105,7 @@ $(package)_config_opts += -no-feature-wizard
 $(package)_config_opts += -no-feature-xml
 
 $(package)_config_opts_darwin = -no-dbus
+$(package)_config_opts_darwin += -no-opengl
 
 ifneq ($(build_os),darwin)
 $(package)_config_opts_darwin += -xplatform macx-clang-linux


### PR DESCRIPTION
Based on #17663. OpenGL on macOS was also deprecated in 10.14.

This also removes the `/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL` dylib from `bitcoin-qt`.