### PR TITLE
gitian: fixed SC2001 regex

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -36,6 +36,6 @@ script: |
   make
   find ${UNSIGNED_DIR} -name "*-unsigned.exe" | while read i; do
     INFILE="$(basename "${i}")"
-    OUTFILE="${INFILE/%-unsigned}"
+    OUTFILE="${INFILE/-unsigned}"
     ./osslsigncode attach-signature -in "${i}" -out "${OUTDIR}/${OUTFILE}" -sigin "${SIGDIR}/${INFILE}.pem"
   done


### PR DESCRIPTION
Currently the gitian-win-signer.yml produces OUTFILE names without `-unsigned` stripped out
This is due to regex having an`%` in front of it
```
$ INFILE="bitcoin-0.19.0-win64-setup-unsigned.exe"
$ echo "${INFILE/%-unsigned}"
bitcoin-0.19.0-win64-setup-unsigned.exe
$ echo "${INFILE/-unsigned}"
bitcoin-0.19.0-win64-setup.exe
```

Fixes #17361