### PR TITLE
tests: Fix bug in the descriptor parsing fuzzing harness (descriptor_parse)

### DIFF
--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -3,11 +3,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chainparams.h>
+#include <pubkey.h>
 #include <script/descriptor.h>
 #include <test/fuzz/fuzz.h>
+#include <util/memory.h>
 
 void initialize()
 {
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
     SelectParams(CBaseChainParams::REGTEST);
 }
 


### PR DESCRIPTION
Fix bug in the descriptor parsing fuzzing harness (`descriptor_parse`) by making sure `secp256k1_context_verify` is properly initialized (via `ECCVerifyHandle`).

Background:

When fuzzing `Parse(…)` with `libFuzzer` I eventually reached the test case `combo(020000000000000000000000000000000000000000000000000000000000000000)`. That input triggers a call to `CPubKey::IsFullyValid()` which in turns requires an initialized `secp256k1_context_verify`.

The fuzzing harness did not fulfil that pre-condition prior to this commit (sorry, my fault!) :)

Before:

```
$ mkdir descriptors/
$ echo -n 'combo(020000000000000000000000000000000000000000000000000000000000000000)' > descriptors/input
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" src/test/fuzz/descriptor_parse -runs=1 descriptors/
…
pubkey.cpp:210:38: runtime error: null pointer passed as argument 1, which is declared to never be null
secp256k1/include/secp256k1.h:305:3: note: nonnull attribute specified here
    #0 0x561c032ccf25 in CPubKey::IsFullyValid() const src/pubkey.cpp:210:12
    #1 0x561c022139c3 in (anonymous namespace)::ParsePubkeyInner(Span<char const> const&, bool, FlatSigningProvider&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) src/script/descriptor.cpp:674:24
    #2 0x561c02207680 in (anonymous namespace)::ParsePubkey(Span<char const> const&, bool, FlatSigningProvider&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) src/script/descriptor.cpp:730:42
    #3 0x561c0220080e in (anonymous namespace)::ParseScript(Span<char const>&, (anonymous namespace)::ParseScriptContext, FlatSigningProvider&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) src/script/descriptor.cpp:774:23
    #4 0x561c021ffb07 in Parse(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, FlatSigningProvider&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, bool) src/script/descriptor.cpp:994:16
    #5 0x561c0218d5d4 in test_one_input(std::vector<unsigned char, std::allocator<unsigned char> > const&) src/test/fuzz/descriptor_parse.cpp:20:9
…
$
```

After:

```
$ mkdir descriptors/
$ echo -n 'combo(020000000000000000000000000000000000000000000000000000000000000000)' > descriptors/input
$ UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=1" src/test/fuzz/descriptor_parse -runs=1 descriptors/
…
Done 2 runs in 0 second(s)
$
```