### PR TITLE
build: add -bind_at_load to macOS hardened LDFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -784,6 +784,7 @@ dnl this flag screws up non-darwin gcc even when the check fails. special-case i
 if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip_dylibs]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip_dylibs"])
+  AX_CHECK_LINK_FLAG([[-Wl,-bind_at_load]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-bind_at_load"])
 fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])


### PR DESCRIPTION
This performs the same function as `-Wl,-z,now`, except for ld on macOS.

You can check the binaries using `otool -l`, and looking for the `LC_DYLD_INFO_ONLY` section; `lazy_bind_off` and `lazy_bind_size` should both be 0.

This seems to be the case with our current release binaries. However we can make the check, and applying the flag explicit in configure.

man ld:
```bash
-bind_at_load
Sets a bit in the mach header of the resulting binary which tells dyld
to bind all symbols when the binary is loaded, rather than lazily.
```
TODO:
- [ ] Follow up with `MH_BINDATLOAD` flag.
