### PR TITLE
cli: fix Fatal LevelDB error when specifying -blockfilterindex=basic twice

### DIFF
--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -4,6 +4,7 @@
 
 #include <mutex>
 #include <sstream>
+#include <set>
 
 #include <blockfilter.h>
 #include <crypto/siphash.h>
@@ -221,15 +222,14 @@ bool BlockFilterTypeByName(const std::string& name, BlockFilterType& filter_type
     return false;
 }
 
-const std::vector<BlockFilterType>& AllBlockFilterTypes()
+const std::set<BlockFilterType>& AllBlockFilterTypes()
 {
-    static std::vector<BlockFilterType> types;
+    static std::set<BlockFilterType> types;
 
     static std::once_flag flag;
     std::call_once(flag, []() {
-            types.reserve(g_filter_types.size());
             for (auto entry : g_filter_types) {
-                types.push_back(entry.first);
+                types.insert(entry.first);
             }
         });
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 #include <string>
+#include <set>
 #include <unordered_set>
 #include <vector>
 
@@ -97,7 +98,7 @@ const std::string& BlockFilterTypeName(BlockFilterType filter_type);
 bool BlockFilterTypeByName(const std::string& name, BlockFilterType& filter_type);
 
 /** Get a list of known filter types. */
-const std::vector<BlockFilterType>& AllBlockFilterTypes();
+const std::set<BlockFilterType>& AllBlockFilterTypes();
 
 /** Get a comma-separated list of known filter type names. */
 const std::string& ListBlockFilterTypes();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -58,6 +58,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <set>
 
 #ifndef WIN32
 #include <attributes.h>
@@ -846,7 +847,7 @@ int nUserMaxConnections;
 int nFD;
 ServiceFlags nLocalServices = ServiceFlags(NODE_NETWORK | NODE_NETWORK_LIMITED);
 int64_t peer_connect_timeout;
-std::vector<BlockFilterType> g_enabled_filter_types;
+std::set<BlockFilterType> g_enabled_filter_types;
 
 } // namespace
 
@@ -934,13 +935,12 @@ bool AppInitParameterInteraction()
         g_enabled_filter_types = AllBlockFilterTypes();
     } else if (blockfilterindex_value != "0") {
         const std::vector<std::string> names = gArgs.GetArgs("-blockfilterindex");
-        g_enabled_filter_types.reserve(names.size());
         for (const auto& name : names) {
             BlockFilterType filter_type;
             if (!BlockFilterTypeByName(name, filter_type)) {
                 return InitError(strprintf(_("Unknown -blockfilterindex value %s.").translated, name));
             }
-            g_enabled_filter_types.push_back(filter_type);
+            g_enabled_filter_types.insert(filter_type);
         }
     }
 


### PR DESCRIPTION
This PR fixes #17679 by replacing BlockFilterType-vector with a set of the same type to make sure that only unique filter types get inserted.


