### PR TITLE
Update build-openbsd.md

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -12,7 +12,7 @@ Preparation
 Run the following as root to install the base dependencies for building:
 
 ```bash
-pkg_add git gmake libevent libtool boost
+pkg_add git gmake libevent libtool boost openssl
 pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.16)
 pkg_add python # (select highest version, e.g. 3.6)


### PR DESCRIPTION
add openSSL to base dependencies, it is required for secp256k1
