### PR TITLE
ui: disable 3rd-party tx-urls when wallet disabled

### DIFF
--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -77,9 +77,11 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
     ui->verticalLayout_Main->removeItem(ui->horizontalSpacer_0_Main);
 #endif
 
-    /* remove Wallet tab in case of -disablewallet */
+    /* remove Wallet tab and 3rd party-URL textbox in case of -disablewallet */
     if (!enableWallet) {
         ui->tabWidget->removeTab(ui->tabWidget->indexOf(ui->tabWallet));
+        ui->thirdPartyTxUrlsLabel->setVisible(false);
+        ui->thirdPartyTxUrls->setVisible(false);
     }
 
     /* Display elements init */


### PR DESCRIPTION
This PR closes #17683 by removing 3rd-party Url-Label and -TextBox from Display Options in wallet-disabled mode.
 
