### PR TITLE
gui: disable File->CreateWallet during startup

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -341,6 +341,7 @@ void BitcoinGUI::createActions()
     m_close_wallet_action->setStatusTip(tr("Close wallet"));
 
     m_create_wallet_action = new QAction(tr("Create Wallet..."), this);
+    m_create_wallet_action->setEnabled(false);
     m_create_wallet_action->setStatusTip(tr("Create a new wallet"));
 
     showHelpMessageAction = new QAction(tr("&Command-line options"), this);
@@ -618,6 +619,7 @@ void BitcoinGUI::setWalletController(WalletController* wallet_controller)
 
     m_wallet_controller = wallet_controller;
 
+    m_create_wallet_action->setEnabled(true);
     m_open_wallet_action->setEnabled(true);
     m_open_wallet_action->setMenu(m_open_wallet_menu);
 


### PR DESCRIPTION
Same as #16118. Early calls to Create Wallet will crash bitcoin-qt.

```bash
lldb /Applications/Bitcoin-Qt.app/Contents/MacOS/Bitcoin-Qt -- --regtest -debug

Process 18143 launched: '/Users/michael/github/bitcoin/src/qt/bitcoin-qt' (x86_64)
2019-12-07 15:49:37.823867-0500 bitcoin-qt[18143:5696499] MessageTracer: Falling back to default whitelist
Process 18143 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x18)
    frame #0: 0x00000001000d2d9d bitcoin-qt`CreateWalletActivity::createWallet() + 381
bitcoin-qt`CreateWalletActivity::createWallet:
->  0x1000d2d9d <+381>: movq   0x18(%rax), %r14
    0x1000d2da1 <+385>: movq   %r15, -0xa8(%rbp)
    0x1000d2da8 <+392>: leaq   -0xa0(%rbp), %r12
    0x1000d2daf <+399>: leaq   -0x80(%rbp), %rsi
Target 0: (bitcoin-qt) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x18)
  * frame #0: 0x00000001000d2d9d bitcoin-qt`CreateWalletActivity::createWallet() + 381
    frame #1: 0x0000000100833e6f bitcoin-qt`QMetaObject::activate(QObject*, int, int, void**) + 1631
    frame #2: 0x0000000100a1fc47 bitcoin-qt`QDialog::done(int) + 247
    frame #3: 0x0000000100833ef5 bitcoin-qt`QMetaObject::activate(QObject*, int, int, void**) + 1765
    frame #4: 0x00000001009e04c2 bitcoin-qt`QDialogButtonBoxPrivate::_q_handleButtonClicked() + 786
```