### PR TITLE
qt: Force set nPruneSize in QSettings after the intro dialog

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -281,8 +281,11 @@ void BitcoinApplication::parameterSetup()
     m_node.initParameterInteraction();
 }
 
-void BitcoinApplication::SetPrune(bool prune, bool force) {
-     optionsModel->SetPrune(prune, force);
+void BitcoinApplication::SetPrune(bool prune, bool force)
+{
+    // If prune is set, intentionally override existing prune size with
+    // the default size since this is called when choosing a new datadir.
+    optionsModel->SetPruneTargetGB(prune ? DEFAULT_PRUNE_TARGET_GB : 0, force);
 }
 
 void BitcoinApplication::requestInitialize()

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -281,11 +281,11 @@ void BitcoinApplication::parameterSetup()
     m_node.initParameterInteraction();
 }
 
-void BitcoinApplication::SetPrune(bool prune, bool force)
+void BitcoinApplication::SetPrune(bool prune)
 {
     // If prune is set, intentionally override existing prune size with
     // the default size since this is called when choosing a new datadir.
-    optionsModel->SetPruneTargetGB(prune ? DEFAULT_PRUNE_TARGET_GB : 0, force);
+    optionsModel->SetPruneTargetGB(prune ? DEFAULT_PRUNE_TARGET_GB : 0, true);
 }
 
 void BitcoinApplication::requestInitialize()
@@ -564,7 +564,7 @@ int GuiMain(int argc, char* argv[])
 
     if (did_show_intro) {
         // Store intro dialog settings other than datadir (network specific)
-        app.SetPrune(prune, true);
+        app.SetPrune(prune);
     }
 
     if (gArgs.GetBoolArg("-splash", DEFAULT_SPLASHSCREEN) && !gArgs.GetBoolArg("-min", false))

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -281,7 +281,7 @@ void BitcoinApplication::parameterSetup()
     m_node.initParameterInteraction();
 }
 
-void BitcoinApplication::SetPrune(bool prune)
+void BitcoinApplication::InitializePruneSetting(bool prune)
 {
     // If prune is set, intentionally override existing prune size with
     // the default size since this is called when choosing a new datadir.
@@ -564,7 +564,7 @@ int GuiMain(int argc, char* argv[])
 
     if (did_show_intro) {
         // Store intro dialog settings other than datadir (network specific)
-        app.SetPrune(prune);
+        app.InitializePruneSetting(prune);
     }
 
     if (gArgs.GetBoolArg("-splash", DEFAULT_SPLASHSCREEN) && !gArgs.GetBoolArg("-min", false))

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -67,8 +67,8 @@ public:
     void parameterSetup();
     /// Create options model
     void createOptionsModel(bool resetSettings);
-    /// Update prune value
-    void SetPrune(bool prune);
+    /// Initialize prune setting
+    void InitializePruneSetting(bool prune);
     /// Create main window
     void createWindow(const NetworkStyle *networkStyle);
     /// Create splash screen

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -68,7 +68,7 @@ public:
     /// Create options model
     void createOptionsModel(bool resetSettings);
     /// Update prune value
-    void SetPrune(bool prune, bool force = false);
+    void SetPrune(bool prune);
     /// Create main window
     void createWindow(const NetworkStyle *networkStyle);
     /// Create splash screen

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -51,4 +51,7 @@ static const int TOOLTIP_WRAP_THRESHOLD = 80;
 /* One gigabyte (GB) in bytes */
 static constexpr uint64_t GB_BYTES{1000000000};
 
+// Default prune target displayed in GUI.
+static constexpr int DEFAULT_PRUNE_TARGET_GB{2};
+
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -135,7 +135,7 @@ Intro::Intro(QWidget *parent, uint64_t blockchain_size, uint64_t chain_state_siz
         ui->prune->setChecked(true);
         ui->prune->setEnabled(false);
     }
-    ui->prune->setText(tr("Discard blocks after verification, except most recent %1 GB (prune)").arg(pruneTarget ? pruneTarget / 1000 : 2));
+    ui->prune->setText(tr("Discard blocks after verification, except most recent %1 GB (prune)").arg(pruneTarget ? pruneTarget / 1000 : DEFAULT_PRUNE_TARGET_GB));
     requiredSpace = m_blockchain_size;
     QString storageRequiresMsg = tr("At least %1 GB of data will be stored in this directory, and it will grow over time.");
     if (pruneTarget) {

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -92,7 +92,7 @@ void OptionsModel::Init(bool resetSettings)
         settings.setValue("bPrune", false);
     if (!settings.contains("nPruneSize"))
         settings.setValue("nPruneSize", DEFAULT_PRUNE_TARGET_GB);
-    SetPrune(settings.value("bPrune").toBool());
+    SetPruneEnabled(settings.value("bPrune").toBool());
 
     if (!settings.contains("nDatabaseCache"))
         settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
@@ -236,7 +236,7 @@ static const QString GetDefaultProxyAddress()
     return QString("%1:%2").arg(DEFAULT_GUI_PROXY_HOST).arg(DEFAULT_GUI_PROXY_PORT);
 }
 
-void OptionsModel::SetPrune(bool prune, bool force)
+void OptionsModel::SetPruneEnabled(bool prune, bool force)
 {
     QSettings settings;
     settings.setValue("bPrune", prune);
@@ -250,6 +250,16 @@ void OptionsModel::SetPrune(bool prune, bool force)
     if (!m_node.softSetArg("-prune", prune_val)) {
         addOverriddenOption("-prune");
     }
+}
+
+void OptionsModel::SetPruneTargetGB(int prune_target_gb, bool force)
+{
+    const bool prune = prune_target_gb > 0;
+    if (prune) {
+        QSettings settings;
+        settings.setValue("nPruneSize", prune_target_gb);
+    }
+    SetPruneEnabled(prune, force);
 }
 
 // read QSettings values and return them

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -91,7 +91,7 @@ void OptionsModel::Init(bool resetSettings)
     if (!settings.contains("bPrune"))
         settings.setValue("bPrune", false);
     if (!settings.contains("nPruneSize"))
-        settings.setValue("nPruneSize", 2);
+        settings.setValue("nPruneSize", DEFAULT_PRUNE_TARGET_GB);
     SetPrune(settings.value("bPrune").toBool());
 
     if (!settings.contains("nDatabaseCache"))

--- a/src/qt/optionsmodel.h
+++ b/src/qt/optionsmodel.h
@@ -73,7 +73,8 @@ public:
     const QString& getOverriddenByCommandLine() { return strOverriddenByCommandLine; }
 
     /* Explicit setters */
-    void SetPrune(bool prune, bool force = false);
+    void SetPruneEnabled(bool prune, bool force = false);
+    void SetPruneTargetGB(int prune_target_gb, bool force = false);
 
     /* Restart flag helper */
     void setRestartRequired(bool fRequired);


### PR DESCRIPTION
On master (5622d8f3156a293e61d0964c33d4b21d8c9fd5e0), having `QSettings` set already
```
$ grep nPruneSize ~/.config/Bitcoin/Bitcoin-Qt-testnet.conf
nPruneSize=6
```

enabling prune option in the intro dialog

```
$ ./src/qt/bitcoin-qt -choosedatadir -testnet
```
![DeepinScreenshot_select-area_20191208120425](https://user-images.githubusercontent.com/32963518/70388183-eed68580-19b6-11ea-9aa1-f9ad9aaa68a6.png)

has no effect:
```
$ grep Prune ~/.bitcoin/testnet3/debug.log
2019-12-08T10:04:41Z Prune configured to target 5722 MiB on disk for block and undo files.
```

---

With this PR:
```
$ grep Prune ~/.bitcoin/testnet3/debug.log 
2019-12-08T10:20:35Z Prune configured to target 1907 MiB on disk for block and undo files.
```

This PR has been split of #17453 (the first two commits) as it fixes an orthogonal bug.

Refs:
- https://github.com/bitcoin/bitcoin/pull/17453#discussion_r345424240
- https://github.com/bitcoin/bitcoin/pull/17453#discussion_r350960201
