### PR TITLE
CI: GitHub Action workflow which duplicates AppVeyor job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: bitcoin-core-ci
+
+on:
+  push:
+jobs:
+  build:
+    runs-on: windows-latest
+    env:
+        PYTHONUTF8: 1
+        QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.4/Qt5.9.8_x64_static_vs2019.zip'
+        QT_DOWNLOAD_HASH: 'f285cbb02bec3b3f3cc2621e3fa7d5edf0d6a66fa30c57859e583acda954ea80'
+        QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
+        VCPKG_INSTALL_PATH: "$env:VCPKG_INSTALLATION_ROOT/installed"
+        PLATFORM: x64
+    steps:
+    - uses: actions/checkout@v1
+
+    - uses: actions/cache@v1
+      id: vcpkgcache
+      with:
+       path: C:/vcpkg/installed
+       key: ${{ runner.os }}-vcpkg
+
+    - name: Update vcpkg and install packages
+      if: steps.vcpkgcache.outputs.cache-hit != 'true'
+      run: |
+        $env:PACKAGES = Get-Content -Path "$env:GITHUB_WORKSPACE/build_msvc/vcpkg-packages.txt"
+        Write-Host "vcpkg list: $env:PACKAGES"
+        cd $env:VCPKG_INSTALLATION_ROOT
+        git pull origin master
+        .\bootstrap-vcpkg.bat
+        .\vcpkg install --triplet $env:PLATFORM-windows-static $env:PACKAGES.split() > $null
+    - name: Install prebuilt Qt libraries
+      run: |
+       if(!(Test-Path -Path ($env:QT_LOCAL_PATH))) {
+          Write-Host "Downloading Qt binaries.";
+          Invoke-WebRequest -Uri $env:QT_DOWNLOAD_URL -Out qtdownload.zip;
+          Write-Host "Qt binaries successfully downloaded, checking hash against $env:QT_DOWNLOAD_HASH...";
+          if((Get-FileHash qtdownload.zip).Hash -eq $env:QT_DOWNLOAD_HASH) {
+            Expand-Archive qtdownload.zip -DestinationPath $env:QT_LOCAL_PATH;
+            Write-Host "Qt binary download matched the expected hash.";
+          }
+          else {
+            Write-Host "ERROR: Qt binary download did not match the expected hash.";
+            exit 1
+          }
+        }
+        else {
+           Write-Host "Qt binaries already present.";
+        }
+    - name: Generate project files
+      run: python build_msvc\msvc-autogen.py
+    - name: Setup MSBuild.exe
+      uses: warrenbuckley/Setup-MSBuild@v1
+    - name: vcpkg integration
+      run: C:/vcpkg/vcpkg.exe integrate install
+    - name: Build
+      run: msbuild build_msvc\bitcoin.sln /m /v:n /p:Configuration=Release
+    - name: Run test_bticoin
+      shell: cmd
+      run: src\test_bitcoin.exe -k stdout -e stdout 2> NUL
+    - name: Run bench_bitcoin
+      shell: cmd
+      run: src\bench_bitcoin.exe -evals=1 -scaling=0 > NUL
+    - name: bitcoin-util-test
+      run: python test\util\bitcoin-util-test.py
+    - name: rpcauth-test
+      shell: cmd
+      run: python test\util\rpcauth-test.py
+# This step fails due to character UTF encoding error. If anyone knows how Python deals with Unicode they might be
+# able to decipher the error message.
+#    - name: test_runner
+#      shell: cmd
+#      run: |
+#       python test\functional\test_runner.py --ansi --ci --quiet --combinedlogslen=4000 --failfast --exclude feature_fee_estimation
+


### PR DESCRIPTION
As discussed in #17594 this PR contains a GitHub Action workflow file that performs the same job as the current Appveyor CI task except for the Python functional tests. For the latter I've been unable to get them to execute successfully due to a Unicode error. I've tried on and off for a week to get it to work but with no joy. 

It may be that someone more proficient in Python will recognise the error and be able to provide a pointer on how to proceed. I've tried some obvious things like changing the Windows console code page.

To run this job it should just be a matter of clicking on the GitHub `Actions` tab and enabling workflows. It's also not required that the file is on the `master` branch for the job to run. If anyone else wants to run the job they can pull this PR into their own fork and enable `Actions` (it's free).