### PR TITLE
depends: don't configure xcb_proto

### DIFF
--- a/depends/packages/xcb_proto.mk
+++ b/depends/packages/xcb_proto.mk
@@ -4,11 +4,6 @@ $(package)_download_path=https://xcb.freedesktop.org/dist
 $(package)_file_name=xcb-proto-$($(package)_version).tar.bz2
 $(package)_sha256_hash=7ef40ddd855b750bc597d2a435da21e55e502a0fefa85b274f2c922800baaf05
 
-define $(package)_set_vars
-  $(package)_config_opts=--disable-shared --enable-option-checking
-  $(package)_config_opts_linux=--with-pic
-endef
-
 define $(package)_config_cmds
   $($(package)_autoconf)
 endef


### PR DESCRIPTION
xcb_proto's configure doesn't understand `--disable-shared` or
`--with-pic`. All the package does it put a stack of XML files into
a directory to be used by libxcb.

Probably enough to close #16354.