### PR TITLE
cli: add -generate option

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -49,7 +49,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-generate=[nblocks] [maxtries]", strprintf("Generate blocks immediately (default nblocks: %s, maxtries: %s)", DEFAULT_GENERATED_NBLOCKS, DEFAULT_GENERATED_MAXTRIES), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-generate=nblocks maxtries", strprintf("Generate blocks immediately (default nblocks: %s, maxtries: %s)", DEFAULT_GENERATED_NBLOCKS, DEFAULT_GENERATED_MAXTRIES), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     SetupChainParamsBaseOptions();
     gArgs.AddArg("-named", strprintf("Pass named instead of positional arguments (default: %s)", DEFAULT_NAMED), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -513,10 +513,6 @@ static int CommandLineRPC(int argc, char *argv[])
             method = "";
         } else if (gArgs.GetBoolArg("-generate", false)) {
             //-generate is special as it executes two RPC calls:
-            // 1) "getnewaddress" without any parameters
-            // 2) "generatetoaddress" with three params: numblocks, address and maxtries
-            // If no args are given the args-vector will be extended with DEFAULT_GENERATED_NBLOCKS
-            // and DEFAULT_GENERATED_MAXTRIES.
             // In any case, the address will be generated internally and put into args vector as well.
             rh.reset(new GetNewAddressRequestHandler());
             method = "";
@@ -539,8 +535,8 @@ static int CommandLineRPC(int argc, char *argv[])
                     args.push_back(std::move(address));
                 }
                 else if (args.size() == 2) {
-                    const std::string nblocks = args[0];
-                    const std::string maxtries = args[1];
+                    const std::string nblocks = args.at(0);
+                    const std::string maxtries = args.at(1);
                     args.clear();
                     args.push_back(std::move(nblocks));
                     args.push_back(std::move(address));

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -34,7 +34,6 @@ static const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 static const bool DEFAULT_NAMED=false;
 static const int DEFAULT_GENERATED_NBLOCKS=1;
-static const int DEFAULT_GENERATED_MAXTRIES=100000;
 static const int CONTINUE_EXECUTION=-1;
 
 static void SetupCliArgs()

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -247,14 +247,20 @@ public:
 
     UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) override
     {
+        addr = args.at(1);
         UniValue paramsObj = RPCConvertValues("generatetoaddress", args);
         return JSONRPCRequestObj("generatetoaddress", paramsObj, ID_GENERATETOADDRESS);
     }
 
     UniValue ProcessReply(const UniValue &result) override
     {
-        return JSONRPCReplyObj(result, NullUniValue, 1);
+        UniValue res(UniValue::VOBJ);
+        res.pushKV("address", addr);
+        res.pushKV("blocks", result.get_obj()["result"]);
+        return JSONRPCReplyObj(res, NullUniValue, 1);
     }
+protected:
+    std::string addr;
 };
 
 /** Process getinfo requests */

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -49,7 +49,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-generate=nblocks maxtries", strprintf("Generate blocks immediately (default nblocks: %s, maxtries: %s)", DEFAULT_GENERATED_NBLOCKS, DEFAULT_GENERATED_MAXTRIES), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-generate", strprintf("Generate blocks immediately (default nblocks: %s, maxtries: %s)", DEFAULT_GENERATED_NBLOCKS, DEFAULT_GENERATED_MAXTRIES), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     SetupChainParamsBaseOptions();
     gArgs.AddArg("-named", strprintf("Pass named instead of positional arguments (default: %s)", DEFAULT_NAMED), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -227,9 +227,9 @@ public:
 class GetNewAddressRequestHandler: public BaseRequestHandler
 {
 public:
-   const int ID_GETNEWADDRESS = 0;
+    const int ID_GETNEWADDRESS = 0;
 
-   UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& /* args */) override
+    UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& /* args */) override
     {
         const UniValue& request = JSONRPCRequestObj("getnewaddress", NullUniValue, ID_GETNEWADDRESS);
         return request;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -47,8 +47,8 @@ static void SetupCliArgs()
     gArgs.AddArg("-version", "Print version and exit", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-generate", strprintf("[nblocks] [maxtries] Generate blocks immediately (default nblocks: %s, maxtries: Same default as the generatetoaddress RPC)", DEFAULT_GENERATED_NBLOCKS), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     SetupChainParamsBaseOptions();
     gArgs.AddArg("-named", strprintf("Pass named instead of positional arguments (default: %s)", DEFAULT_NAMED), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -513,7 +513,7 @@ static int CommandLineRPC(int argc, char *argv[])
             method = "";
         } else if (gArgs.GetBoolArg("-generate", false)) {
             //-generate is special as it executes two RPC calls:
-            // 1) "getnewaddress" without any parameters, which returns a bech32 address
+            // 1) "getnewaddress" without any parameters
             // 2) "generatetoaddress" with three params: numblocks, address and maxtries
             // If no args are given the args-vector will be extended with DEFAULT_GENERATED_NBLOCKS
             // and DEFAULT_GENERATED_MAXTRIES.

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -33,6 +33,8 @@ const std::function<std::string(const char*)> G_TRANSLATION_FUN = nullptr;
 static const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 static const int DEFAULT_HTTP_CLIENT_TIMEOUT=900;
 static const bool DEFAULT_NAMED=false;
+static const int DEFAULT_GENERATED_NBLOCKS=1;
+static const int DEFAULT_GENERATED_MAXTRIES=100000;
 static const int CONTINUE_EXECUTION=-1;
 
 static void SetupCliArgs()
@@ -47,6 +49,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-generate=[nblocks] [maxtries]", strprintf("Generate blocks immediately (default nblocks: %s, maxtries: %s)", DEFAULT_GENERATED_NBLOCKS, DEFAULT_GENERATED_MAXTRIES), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     SetupChainParamsBaseOptions();
     gArgs.AddArg("-named", strprintf("Pass named instead of positional arguments (default: %s)", DEFAULT_NAMED), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -219,6 +222,40 @@ public:
     virtual ~BaseRequestHandler() {}
     virtual UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) = 0;
     virtual UniValue ProcessReply(const UniValue &batch_in) = 0;
+};
+/** Get new address */
+class GetNewAddressRequestHandler: public BaseRequestHandler
+{
+public:
+   const int ID_GETNEWADDRESS = 0;
+
+   UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& /* args */) override
+    {
+        const UniValue& request = JSONRPCRequestObj("getnewaddress", NullUniValue, ID_GETNEWADDRESS);
+        return request;
+    }
+
+    UniValue ProcessReply(const UniValue &result) override
+    {
+        return JSONRPCReplyObj(result, NullUniValue, 1);
+    }
+};
+/** Generate blocks */
+class GenerateRequestHandler: public BaseRequestHandler
+{
+public:
+    const int ID_GENERATETOADDRESS = 0;
+
+    UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) override
+    {
+        UniValue paramsObj = RPCConvertValues("generatetoaddress", args);
+        return JSONRPCRequestObj("generatetoaddress", paramsObj, ID_GENERATETOADDRESS);
+    }
+
+    UniValue ProcessReply(const UniValue &result) override
+    {
+        return JSONRPCReplyObj(result, NullUniValue, 1);
+    }
 };
 
 /** Process getinfo requests */
@@ -474,6 +511,46 @@ static int CommandLineRPC(int argc, char *argv[])
         if (gArgs.GetBoolArg("-getinfo", false)) {
             rh.reset(new GetinfoRequestHandler());
             method = "";
+        } else if (gArgs.GetBoolArg("-generate", false)) {
+            //-generate is special as it executes two RPC calls:
+            // 1) "getnewaddress" without any parameters, which returns a bech32 address
+            // 2) "generatetoaddress" with three params: numblocks, address and maxtries
+            // If no args are given the args-vector will be extended with DEFAULT_GENERATED_NBLOCKS
+            // and DEFAULT_GENERATED_MAXTRIES.
+            // In any case, the address will be generated internally and put into args vector as well.
+            rh.reset(new GetNewAddressRequestHandler());
+            method = "";
+            const UniValue reply = CallRPC(rh.get(), method, args);
+            const UniValue& result = find_value(reply, "result");
+            const UniValue& error  = find_value(reply, "error");
+            if (error.empty()) {
+                const std::string address = result.get_obj()["result"].getValStr();
+                // Take care of different situations:
+                // a) no arguments given
+                // b) only "nblocks"
+                // c) "nblocks" & "maxtries"
+                // --------------------------
+                // "address" must be the 2nd arg in the vector before calling generatetoaddress.
+                if (args.size() == 0) {
+                    args.push_back(std::to_string(DEFAULT_GENERATED_NBLOCKS));
+                    args.push_back(std::move(address));
+                }
+                else if (args.size() < 2) {
+                    args.push_back(std::move(address));
+                }
+                else if (args.size() == 2) {
+                    const std::string nblocks = args[0];
+                    const std::string maxtries = args[1];
+                    args.clear();
+                    args.push_back(std::move(nblocks));
+                    args.push_back(std::move(address));
+                    args.push_back(std::move(maxtries));
+                }
+                rh.reset(new GenerateRequestHandler());
+                method = "";
+            } else {
+                throw std::runtime_error(error.get_obj()["error"].getValStr());
+            }
         } else {
             rh.reset(new DefaultRequestHandler());
             if (args.size() < 1) {

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -49,7 +49,7 @@ static void SetupCliArgs()
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-getinfo", "Get general information from the remote server. Note that unlike server-side RPC calls, the results of -getinfo is the result of multiple non-atomic requests. Some entries in the result may represent results from different states (e.g. wallet balance may be as of a different block from the chain state reported)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-generate", strprintf("Generate blocks immediately (default nblocks: %s, maxtries: %s)", DEFAULT_GENERATED_NBLOCKS, DEFAULT_GENERATED_MAXTRIES), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
+    gArgs.AddArg("-generate", strprintf("[nblocks] [maxtries] Generate blocks immediately (default nblocks: %s, maxtries: Same default as the generatetoaddress RPC)", DEFAULT_GENERATED_NBLOCKS), ArgsManager::ALLOW_ANY, OptionsCategory::BLOCK_CREATION);
     SetupChainParamsBaseOptions();
     gArgs.AddArg("-named", strprintf("Pass named instead of positional arguments (default: %s)", DEFAULT_NAMED), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-rpcclienttimeout=<n>", strprintf("Timeout in seconds during HTTP requests, or 0 for no timeout. (default: %d)", DEFAULT_HTTP_CLIENT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -11,7 +11,7 @@ from test_framework.util import assert_equal, assert_raises_process_error
 class GenerateRpcTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.setup_clean_chain = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -7,7 +7,6 @@
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_process_error
 
-
 class GenerateRpcTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
@@ -17,23 +16,20 @@ class GenerateRpcTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        self.generate_blocks()
-
-    def generate_blocks(self):
         starting_blockcount = self.nodes[0].getblockcount()
-        # check that "generate 1" returns a single block hash
+        """check that "generate 1" returns a single block hash"""
         assert_equal(len(self.nodes[0].cli.send_cli("-generate")["blocks"]), 1)
-        # check that "generate 1" also moved the chain for one block
+        """check that "generate 1" also moved the chain for one block"""
         assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 1)
-        # check that "generate 3" returns three blocks
+        """check that "generate 3" returns three blocks"""
         assert_equal(len(self.nodes[0].cli.send_cli("-generate", 3)['blocks']), 3)
-        # check that "generate 3" moved the chain for three more blocks
+        """check that "generate 3" moved the chain for three more blocks"""
         assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 4)
-        # check that "generate 1 100000" generates one block with 10,000 max. tries
+        """check that "generate 1 100000" generates one block with 10,000 max. tries"""
         assert_equal(len(self.nodes[0].cli.send_cli("-generate", 5, 100000)['blocks']), 5)
-        # check that "generate 5 100000" moved the chain for five more blocks
+        """check that "generate 5 100000" moved the chain for five more blocks"""
         assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 9)
-        # check for error response when param is a non-numerical value
+        """check for error response when param is a non-numerical value"""
         wrong_nblocks = "foo"
         assert_raises_process_error(1, "error: Error parsing JSON:{}".format(wrong_nblocks),
                                   self.nodes[0].cli("-generate", wrong_nblocks).echo)

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test RPC generate output."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, assert_raises_process_error
+
+
+class GenerateRpcTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self.generate_blocks()
+
+    def generate_blocks(self):
+        starting_blockcount = self.nodes[0].getblockcount()
+        # check that "generate 1" returns a single block hash
+        assert_equal(len(self.nodes[0].cli.send_cli("-generate")["result"]), 1)
+        # check that "generate 1" also moved the chain for one block
+        assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 1)
+        # check that "generate 3" returns three blocks
+        assert_equal(len(self.nodes[0].cli.send_cli("-generate", 3)['result']), 3)
+        # check that "generate 3" moved the chain for three more blocks
+        assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 4)
+        # check that "generate 1 100000" generates one block with 10,000 max. tries
+        assert_equal(len(self.nodes[0].cli.send_cli("-generate", 5, 100000)['result']), 5)
+        # check that "generate 5 100000" moved the chain for five more blocks
+        assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 9)
+        # check for error response when param is a non-numerical value
+        wrong_nblocks = "foo"
+        assert_raises_process_error(1, "error: Error parsing JSON:{}".format(wrong_nblocks),
+                                  self.nodes[0].cli("-generate", wrong_nblocks).echo)
+
+if __name__ == '__main__':
+    GenerateRpcTest().main()

--- a/test/functional/rpc_generate.py
+++ b/test/functional/rpc_generate.py
@@ -22,15 +22,15 @@ class GenerateRpcTest(BitcoinTestFramework):
     def generate_blocks(self):
         starting_blockcount = self.nodes[0].getblockcount()
         # check that "generate 1" returns a single block hash
-        assert_equal(len(self.nodes[0].cli.send_cli("-generate")["result"]), 1)
+        assert_equal(len(self.nodes[0].cli.send_cli("-generate")["blocks"]), 1)
         # check that "generate 1" also moved the chain for one block
         assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 1)
         # check that "generate 3" returns three blocks
-        assert_equal(len(self.nodes[0].cli.send_cli("-generate", 3)['result']), 3)
+        assert_equal(len(self.nodes[0].cli.send_cli("-generate", 3)['blocks']), 3)
         # check that "generate 3" moved the chain for three more blocks
         assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 4)
         # check that "generate 1 100000" generates one block with 10,000 max. tries
-        assert_equal(len(self.nodes[0].cli.send_cli("-generate", 5, 100000)['result']), 5)
+        assert_equal(len(self.nodes[0].cli.send_cli("-generate", 5, 100000)['blocks']), 5)
         # check that "generate 5 100000" moved the chain for five more blocks
         assert_equal(self.nodes[0].getblockcount(), starting_blockcount + 9)
         # check for error response when param is a non-numerical value

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -192,6 +192,7 @@ BASE_SCRIPTS = [
     'wallet_resendwallettransactions.py',
     'wallet_fallbackfee.py',
     'rpc_dumptxoutset.py',
+    'rpc_generate.py',
     'feature_minchainwork.py',
     'rpc_getblockstats.py',
     'wallet_create_tx.py',


### PR DESCRIPTION
This PR is related to #16000 and should "bring back" the *generate* call.


bitcoin-cli would get a new option *-generate* that mimics the original API. 

The allowed (optional) parameters are *nblocks* and *maxtries*. 
For example:

* bitcoin-cli -generate

* bitcoin-cli -generate 2

* bitcoin-cli -generate 3 10000
