### PR TITLE
gui: Move static placeholder texts to forms

### DIFF
--- a/src/qt/forms/openuridialog.ui
+++ b/src/qt/forms/openuridialog.ui
@@ -24,7 +24,11 @@
       </widget>
      </item>
      <item>
-      <widget class="QValidatedLineEdit" name="uriEdit"/>
+      <widget class="QValidatedLineEdit" name="uriEdit">
+       <property name="placeholderText">
+        <string notr="true">bitcoin:</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -685,6 +685,9 @@
            <property name="toolTip">
             <string>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</string>
            </property>
+           <property name="placeholderText">
+            <string notr="true">https://example.com/tx/%s</string>
+           </property>
           </widget>
          </item>
         </layout>

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -144,6 +144,9 @@
       <property name="toolTip">
        <string>Enter a label for this address to add it to the list of used addresses</string>
       </property>
+      <property name="placeholderText">
+       <string>Enter a label for this address to add it to your address book</string>
+      </property>
      </widget>
     </item>
     <item row="2" column="0">

--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -145,7 +145,7 @@
        <string>Enter a label for this address to add it to the list of used addresses</string>
       </property>
       <property name="placeholderText">
-       <string>Enter a label for this address to add it to your address book</string>
+       <string>Enter a label for this address to add it to the list of used addresses</string>
       </property>
      </widget>
     </item>

--- a/src/qt/forms/signverifymessagedialog.ui
+++ b/src/qt/forms/signverifymessagedialog.ui
@@ -121,6 +121,9 @@
          </property>
          <item>
           <widget class="QLineEdit" name="signatureOut_SM">
+           <property name="placeholderText">
+            <string>Click "Sign Message" to generate signature</string>
+           </property>
            <property name="font">
             <font>
              <italic>true</italic>

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -15,7 +15,6 @@ OpenURIDialog::OpenURIDialog(QWidget *parent) :
     ui(new Ui::OpenURIDialog)
 {
     ui->setupUi(this);
-    ui->uriEdit->setPlaceholderText("bitcoin:");
 }
 
 OpenURIDialog::~OpenURIDialog()

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -108,8 +108,6 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet) :
             ui->lang->addItem(locale.nativeLanguageName() + QString(" (") + langStr + QString(")"), QVariant(langStr));
         }
     }
-    ui->thirdPartyTxUrls->setPlaceholderText("https://example.com/tx/%s");
-
     ui->unit->setModel(new BitcoinUnits(this));
 
     /* Widget-to-option mapper */

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -37,7 +37,6 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
 
     if (platformStyle->getUseExtraSpacing())
         ui->payToLayout->setSpacing(4);
-    ui->addAsLabel->setPlaceholderText(tr("Enter a label for this address to add it to your address book"));
 
     // normal bitcoin address field
     GUIUtil::setupAddressWidget(ui->payTo, this);

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -35,8 +35,6 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
     ui->verifyMessageButton_VM->setIcon(platformStyle->SingleColorIcon(":/icons/transaction_0"));
     ui->clearButton_VM->setIcon(platformStyle->SingleColorIcon(":/icons/remove"));
 
-    ui->signatureOut_SM->setPlaceholderText(tr("Click \"Sign Message\" to generate signature"));
-
     GUIUtil::setupAddressWidget(ui->addressIn_SM, this);
     GUIUtil::setupAddressWidget(ui->addressIn_VM, this);
 


### PR DESCRIPTION
There was an issue around the time of Qt 4.6 when placeholder text was introduced, that caused a compile failure when it was specified in the form.

As a workaround the placeholder texts were moved to the code.

Qt 4 hasn't been relevant to us for ages. So move all (non-parametrized) placeholder texts to the form files instead.

It's better to keep this kind of text content together. Translate/no-translate status is kept as it is.

Proof that they still work:
![win1](https://user-images.githubusercontent.com/126646/70428014-0e80b300-1a76-11ea-9a6d-be78a0bf14ed.png)

![win2](https://user-images.githubusercontent.com/126646/70428019-10e30d00-1a76-11ea-8016-ffa0c4eafe34.png)

![win3](https://user-images.githubusercontent.com/126646/70428021-13456700-1a76-11ea-9449-9413487e39f6.png)

![win4](https://user-images.githubusercontent.com/126646/70428025-150f2a80-1a76-11ea-92ad-be5f3c171c43.png)


