### PR TITLE
depends: Set default depends fallback url to drahtbot.space

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -42,7 +42,7 @@ NO_UPNP ?=
 NO_USDT ?=
 NO_NATPMP ?=
 MULTIPROCESS ?=
-FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
+FALLBACK_DOWNLOAD_PATH ?= https://drahtbot.space/depends_download_fallback
 
 BUILD = $(shell ./config.guess)
 HOST ?= $(BUILD)


### PR DESCRIPTION
`https://bitcoincore.org/depends-sources` seems unmaintained, as it is missing a lot of packages. So a failure to fetch the package from the original source will result in another error. Fix that by replacing the url with one that should have all packages.