### PR TITLE
util: Use try_lock return value in UniqueLock::TryEnter

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -136,10 +136,10 @@ private:
     bool TryEnter(const char* pszName, const char* pszFile, int nLine)
     {
         EnterCritical(pszName, pszFile, nLine, (void*)(Base::mutex()), true);
-        Base::try_lock();
-        if (!Base::owns_lock())
+        bool successful = Base::try_lock();
+        if (!successful)
             LeaveCritical();
-        return Base::owns_lock();
+        return successful;
     }
 
 public:


### PR DESCRIPTION
If I understand http://www.cplusplus.com/reference/mutex/unique_lock/try_lock/ and https://en.cppreference.com/w/cpp/thread/mutex/try_lock correctly, the return value if `try_lock` already signifies whether the locking was succesful, there is no need to call `Base::owns_lock` (http://www.cplusplus.com/reference/mutex/unique_lock/owns_lock/) to check.

Should get rid of the following MSVC warning in AppVeyor: "warning C4834: discarding return value of function with 'nodiscard' attribute"