### PR TITLE
prevector: avoid misaligned member accesses

### DIFF
--- a/src/prevector.h
+++ b/src/prevector.h
@@ -15,7 +15,6 @@
 #include <type_traits>
 #include <utility>
 
-#pragma pack(push, 1)
 /** Implements a drop-in replacement for std::vector<T> which stores up to N
  *  elements directly (without heap allocation). The types Size and Diff are
  *  used to store element counts, and can be any unsigned + signed type.
@@ -147,14 +146,20 @@ public:
     };
 
 private:
-    size_type _size = 0;
+#pragma pack(push, 1)
     union direct_or_indirect {
         char direct[sizeof(T) * N];
         struct {
-            size_type capacity;
             char* indirect;
+            size_type capacity;
         };
-    } _union = {};
+    };
+#pragma pack(pop)
+    alignas(char*) direct_or_indirect _union = {};
+    size_type _size = 0;
+
+    static_assert(alignof(char*) % alignof(size_type) == 0 && sizeof(char*) % alignof(size_type) == 0, "size_type cannot have more restrictive alignment requirement than pointer");
+    static_assert(alignof(char*) % alignof(T) == 0, "value_type T cannot have more restrictive alignment requirement than pointer");
 
     T* direct_ptr(difference_type pos) { return reinterpret_cast<T*>(_union.direct) + pos; }
     const T* direct_ptr(difference_type pos) const { return reinterpret_cast<const T*>(_union.direct) + pos; }
@@ -523,6 +528,5 @@ public:
         return item_ptr(0);
     }
 };
-#pragma pack(pop)
 
 #endif // BITCOIN_PREVECTOR_H

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -1,7 +1,5 @@
 # -fsanitize=undefined suppressions
 # =================================
-alignment:move.h
-alignment:prevector.h
 float-divide-by-zero:policy/fees.cpp
 float-divide-by-zero:validation.cpp
 float-divide-by-zero:wallet/wallet.cpp


### PR DESCRIPTION
Ensure prevector data is appropriately aligned. Earlier discussion in #17530.

**Edit laanwj**: In contrast to #17530, it does this without increase in size of any of the coin cache data structures (x86_64, clang)

| Struct        | (size,align) before           | (size,align) after  |
| ------------- | ------------- | ------- |
| Coin | 48, 8        |     48, 8   |
| CCoinsCacheEntry | 56, 8    |   56, 8  |
| CScript | 32, 1       |      32, 8  |
