### PR TITLE
msvc: Change appveyor build image to previous visual studio 2019.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 5


### PR DESCRIPTION
Fixing the appveyor build with #17709 has turned into a bigger job than expected. As an interim measure setting the build image back to the previous version of Visual Studio 2019 will fix it immediately.