### PR TITLE
rpc: add missing newline in analyzepsbt RPCResult

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1674,7 +1674,7 @@ UniValue analyzepsbt(const JSONRPCRequest& request)
                 "  \"estimated_feerate\" : feerate   (numeric, optional) Estimated feerate of the final signed transaction in " + CURRENCY_UNIT + "/kB. Shown only if all UTXO slots in the PSBT have been filled.\n"
                 "  \"fee\" : fee                     (numeric, optional) The transaction fee paid. Shown only if all UTXO slots in the PSBT have been filled.\n"
                 "  \"next\" : \"role\"                 (string) Role of the next person that this psbt needs to go to\n"
-                "  \"error\" : \"error\"               (string) Error message if there is one"
+                "  \"error\" : \"error\"               (string) Error message if there is one\n"
                 "}\n"
             },
             RPCExamples {


### PR DESCRIPTION
follow-up to 638e40c in #17524

before
```
  "error" : "error"               (string) Error message if there is one}
```
after
```
  "error" : "error"               (string) Error message if there is one
}
```
