### PR TITLE
build: remove linking librt for backwards compatibility

### DIFF
--- a/build_msvc/bitcoin_config.h
+++ b/build_msvc/bitcoin_config.h
@@ -218,9 +218,6 @@
 /* Define to 1 if you have the `rpcrt4' library (-lrpcrt4). */
 #define HAVE_LIBRPCRT4 1
 
-/* Define to 1 if you have the `rt' library (-lrt). */
-/* #undef HAVE_LIBRT */
-
 /* Define to 1 if you have the `shell32' library (-lshell32). */
 #define HAVE_LIBSHELL32 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -693,10 +693,6 @@ AX_GCC_FUNC_ATTRIBUTE([dllimport])
 
 if test x$use_glibc_compat != xno; then
 
-  dnl glibc absorbed clock_gettime in 2.17. librt (its previous location) is safe to link
-  dnl in anyway for back-compat.
-  AC_CHECK_LIB([rt],[clock_gettime],, AC_MSG_ERROR(librt missing))
-
   dnl __fdelt_chk's params and return type have changed from long unsigned int to long int.
   dnl See which one is present here.
   AC_MSG_CHECKING(__fdelt_chk type)


### PR DESCRIPTION
Now that we require glibc 2.17+, see #17538, we can remove linking librt
for backwards compatibility purposes. The `clock_*` functions from librt
were merged into glibc as part of the [2.17 release](https://sourceware.org/ml/libc-announce/2012/msg00001.html):

* The `clock_*` suite of functions (declared in <time.h>) is now available
  directly in the main C library.  Previously it was necessary to link with
  -lrt to use these functions.  This change has the effect that a
  single-threaded program that uses a function such as `clock_gettime' (and
  is not linked with -lrt) will no longer implicitly load the pthreads
  library at runtime and so will not suffer the overheads associated with
  multi-thread support in other code such as the C++ runtime library.

Note that `librt` is already unused by the RISC-V and AARCH64 binaries as their librts don't export any `clock_*` functions. As an example, you can find a diff of the arm32 vs arm64 librt symbols [here](https://gist.github.com/fanquake/b08cb1f0d14df3133395d7796ebf030c).

Below is the library usage for the `v0.19.0.1` release (can delete these tables pre-merge).

#### RISC-V
```bash
riscv/bin/bitcoin-cli: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1']
riscv/bin/bitcoin-qt: ['libpthread.so.0', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1', 'libatomic.so.1']
riscv/bin/bitcoin-wallet: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1', 'libatomic.so.1']
riscv/bin/bitcoind: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1', 'libatomic.so.1']
riscv/bin/bitcoin-tx: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1']
riscv/bin/test_bitcoin: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-riscv64-lp64d.so.1', 'libatomic.so.1']
```

#### AARCH64
```bash
aarch64/bin/bitcoin-cli: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
aarch64/bin/bitcoin-qt: ['libpthread.so.0', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
aarch64/bin/bitcoin-wallet: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
aarch64/bin/bitcoind: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
aarch64/bin/bitcoin-tx: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
aarch64/bin/test_bitcoin: ['libpthread.so.0', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-aarch64.so.1']
```

#### ARM LINUX GNUEABIHF
```bash
arm32/bin/bitcoin-cli: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
arm32/bin/bitcoin-qt: ['libpthread.so.0', 'librt.so.1', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
arm32/bin/bitcoin-wallet: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
arm32/bin/bitcoind: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
arm32/bin/bitcoin-tx: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
arm32/bin/test_bitcoin: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-armhf.so.3']
```

#### LINUX X86_64
```bash
x86_64/bin/bitcoin-cli: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
x86_64/bin/bitcoin-qt: ['libpthread.so.0', 'librt.so.1', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
x86_64/bin/bitcoin-wallet: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
x86_64/bin/bitcoind: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
x86_64/bin/bitcoin-tx: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
x86_64/bin/test_bitcoin: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux-x86-64.so.2']
```

#### LINUX i686
```bash
i686/bin/bitcoin-cli: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
i686/bin/bitcoin-qt: ['libpthread.so.0', 'librt.so.1', 'libfontconfig.so.1', 'libfreetype.so.6', 'libxcb.so.1', 'libdl.so.2', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
i686/bin/bitcoin-wallet: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
i686/bin/bitcoind: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
i686/bin/bitcoin-tx: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
i686/bin/test_bitcoin: ['libpthread.so.0', 'librt.so.1', 'libm.so.6', 'libgcc_s.so.1', 'libc.so.6', 'ld-linux.so.2']
```