### PR TITLE
refactor: rpc: Remove vector copy from listtransactions

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1491,23 +1491,10 @@ UniValue listtransactions(const JSONRPCRequest& request)
     if ((nFrom + nCount) > (int)ret.size())
         nCount = ret.size() - nFrom;
 
-    std::vector<UniValue> arrTmp = ret.getValues();
-
-    std::vector<UniValue>::iterator first = arrTmp.begin();
-    std::advance(first, nFrom);
-    std::vector<UniValue>::iterator last = arrTmp.begin();
-    std::advance(last, nFrom+nCount);
-
-    if (last != arrTmp.end()) arrTmp.erase(last, arrTmp.end());
-    if (first != arrTmp.begin()) arrTmp.erase(arrTmp.begin(), first);
-
-    std::reverse(arrTmp.begin(), arrTmp.end()); // Return oldest to newest
-
-    ret.clear();
-    ret.setArray();
-    ret.push_backV(arrTmp);
-
-    return ret;
+    const std::vector<UniValue>& txs = ret.getValues();
+    UniValue result{UniValue::VARR};
+    result.push_backV({ txs.rend() - nFrom - nCount, txs.rend() - nFrom }); // Return oldest to newest
+    return result;
 }
 
 static UniValue listsinceblock(const JSONRPCRequest& request)


### PR DESCRIPTION
Current approach
 - copy accumulated `ret` vector to `arrTmp`
 - drop unnecessary elements from `arrTmp`
 - reverse `arrTmp`
 - clear `ret`
 - copy `arrTmp` to the `ret`

New approach
 - create a vector from the accumulated `ret` with just the necessary elements already reversed
 - copy it to the result

This PR doesn't change behavior.