### PR TITLE
doc: fix directory path for secp256k1 subtree in developer-notes

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -820,7 +820,7 @@ Current subtrees include:
   - **Note**: Follow the instructions in [Upgrading LevelDB](#upgrading-leveldb) when
     merging upstream changes to the LevelDB subtree.
 
-- src/libsecp256k1
+- src/secp256k1
   - Upstream at https://github.com/bitcoin-core/secp256k1/ ; actively maintained by Core contributors.
 
 - src/crypto/ctaes


### PR DESCRIPTION
Documentation update to fix the directory path of the `secp256k1` subtree in the developer notes