### PR TITLE
util: Don't allow Base32/64-decoding or ParseMoney(…) on strings with embedded NUL characters. Add tests.

### DIFF
--- a/src/test/base32_tests.cpp
+++ b/src/test/base32_tests.cpp
@@ -20,6 +20,17 @@ BOOST_AUTO_TEST_CASE(base32_testvectors)
         std::string strDec = DecodeBase32(vstrOut[i]);
         BOOST_CHECK_EQUAL(strDec, vstrIn[i]);
     }
+
+    // Decoding strings with embedded NUL characters should fail
+    bool failure;
+    (void)DecodeBase32(std::string("invalid", 7), &failure);
+    BOOST_CHECK_EQUAL(failure, true);
+    (void)DecodeBase32(std::string("AWSX3VPP", 8), &failure);
+    BOOST_CHECK_EQUAL(failure, false);
+    (void)DecodeBase32(std::string("AWSX3VPP\0invalid", 16), &failure);
+    BOOST_CHECK_EQUAL(failure, true);
+    (void)DecodeBase32(std::string("AWSX3VPPinvalid", 15), &failure);
+    BOOST_CHECK_EQUAL(failure, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/base64_tests.cpp
+++ b/src/test/base64_tests.cpp
@@ -20,6 +20,17 @@ BOOST_AUTO_TEST_CASE(base64_testvectors)
         std::string strDec = DecodeBase64(strEnc);
         BOOST_CHECK_EQUAL(strDec, vstrIn[i]);
     }
+
+    // Decoding strings with embedded NUL characters should fail
+    bool failure;
+    (void)DecodeBase64(std::string("invalid", 7), &failure);
+    BOOST_CHECK_EQUAL(failure, true);
+    (void)DecodeBase64(std::string("nQB/pZw=", 8), &failure);
+    BOOST_CHECK_EQUAL(failure, false);
+    (void)DecodeBase64(std::string("nQB/pZw=\0invalid", 16), &failure);
+    BOOST_CHECK_EQUAL(failure, true);
+    (void)DecodeBase64(std::string("nQB/pZw=invalid", 15), &failure);
+    BOOST_CHECK_EQUAL(failure, true);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1069,6 +1069,11 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
 
     // Parsing negative amounts must fail
     BOOST_CHECK(!ParseMoney("-1", ret));
+
+    // Parsing strings with embedded NUL characters should fail
+    BOOST_CHECK(!ParseMoney(std::string("\0-1", 3), ret));
+    BOOST_CHECK(!ParseMoney(std::string("\01", 2), ret));
+    BOOST_CHECK(!ParseMoney(std::string("1\0", 2), ret));
 }
 
 BOOST_AUTO_TEST_CASE(util_IsHex)

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -7,6 +7,7 @@
 
 #include <tinyformat.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 
 std::string FormatMoney(const CAmount& n)
 {
@@ -32,6 +33,9 @@ std::string FormatMoney(const CAmount& n)
 
 bool ParseMoney(const std::string& str, CAmount& nRet)
 {
+    if (!ValidAsCString(str)) {
+        return false;
+    }
     return ParseMoney(str.c_str(), nRet);
 }
 

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -191,6 +191,12 @@ std::vector<unsigned char> DecodeBase64(const char* p, bool* pf_invalid)
 
 std::string DecodeBase64(const std::string& str, bool* pf_invalid)
 {
+    if (!ValidAsCString(str)) {
+        if (pf_invalid) {
+            *pf_invalid = true;
+        }
+        return {};
+    }
     std::vector<unsigned char> vchRet = DecodeBase64(str.c_str(), pf_invalid);
     return std::string((const char*)vchRet.data(), vchRet.size());
 }

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -266,6 +266,12 @@ std::vector<unsigned char> DecodeBase32(const char* p, bool* pf_invalid)
 
 std::string DecodeBase32(const std::string& str, bool* pf_invalid)
 {
+    if (!ValidAsCString(str)) {
+        if (pf_invalid) {
+            *pf_invalid = true;
+        }
+        return {};
+    }
     std::vector<unsigned char> vchRet = DecodeBase32(str.c_str(), pf_invalid);
     return std::string((const char*)vchRet.data(), vchRet.size());
 }


### PR DESCRIPTION
Don't allow Base32/64-decoding or `ParseMoney(…)` on strings with embedded `NUL` characters. Add tests.

Added tests before:

```
$ src/test/test_bitcoin
Running 385 test cases...
test/base32_tests.cpp(31): error: in "base32_tests/base32_testvectors":
    check failure == true has failed [false != true]
test/base64_tests.cpp(31): error: in "base64_tests/base64_testvectors":
    check failure == true has failed [false != true]
test/util_tests.cpp(1074): error: in "util_tests/util_ParseMoney":
    check !ParseMoney(std::string("\0-1", 3), ret) has failed
test/util_tests.cpp(1076): error: in "util_tests/util_ParseMoney":
    check !ParseMoney(std::string("1\0", 2), ret) has failed

*** 4 failures are detected in the test module "Bitcoin Core Test Suite"
```

Added tests after:

```
$ src/test/test_bitcoin
Running 385 test cases...

*** No errors detected
```