### PR TITLE
build: set AC_PREREQ to 2.69

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,4 @@
-dnl require autoconf 2.60 (AS_ECHO/AS_ECHO_N)
-AC_PREREQ([2.60])
+AC_PREREQ([2.69])
 define(_CLIENT_VERSION_MAJOR, 0)
 define(_CLIENT_VERSION_MINOR, 19)
 define(_CLIENT_VERSION_REVISION, 99)


### PR DESCRIPTION
We use build macros such as `AX_CHECK_LINK_FLAG`, that require >=2.64, so our configure should also require Autoconf >= 2.64. The build would already blow up if 2.64 wasn't available. i.e:
```bash
configure.ac:320: error: Autoconf version 2.64 or higher is required
build-aux/m4/ax_check_link_flag.m4:74: AX_CHECK_LINK_FLAG is expanded from...
```
For reference, Autoconf 2.69 was released in [April of 2012](https://lists.gnu.org/archive/html/autoconf/2012-04/msg00041.html).

See the [Autoconf Versioning docs](https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Versioning.html) for more info on `AC_PREREQ`.