### PR TITLE
tests: Add fuzzing harness for V1TransportDeserializer (P2P transport)

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -37,6 +37,7 @@ FUZZ_TARGETS = \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
   test/fuzz/out_point_deserialize \
+  test/fuzz/p2p_transport_deserializer \
   test/fuzz/parse_hd_keypath \
   test/fuzz/parse_iso8601 \
   test/fuzz/parse_numbers \
@@ -432,6 +433,12 @@ test_fuzz_out_point_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_out_point_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_out_point_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_out_point_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_p2p_transport_deserializer_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_p2p_transport_deserializer_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_p2p_transport_deserializer_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_p2p_transport_deserializer_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_p2p_transport_deserializer_SOURCES = $(FUZZ_SUITE) test/fuzz/p2p_transport_deserializer.cpp
 
 test_fuzz_parse_hd_keypath_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_parse_hd_keypath_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/p2p_transport_deserializer.cpp
+++ b/src/test/fuzz/p2p_transport_deserializer.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <net.h>
+#include <protocol.h>
+#include <test/fuzz/fuzz.h>
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+void initialize()
+{
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    V1TransportDeserializer deserializer{Params().MessageStart(), SER_NETWORK, INIT_PROTO_VERSION};
+    const char* pch = (const char*)buffer.data();
+    size_t n_bytes = buffer.size();
+    while (n_bytes > 0) {
+        const int handled = deserializer.Read(pch, n_bytes);
+        if (handled < 0) {
+            break;
+        }
+        pch += handled;
+        n_bytes -= handled;
+        if (deserializer.Complete()) {
+            const int64_t m_time = std::numeric_limits<int64_t>::max();
+            const CNetMessage msg = deserializer.GetMessage(Params().MessageStart(), m_time);
+            assert(msg.m_command.size() <= CMessageHeader::COMMAND_SIZE);
+            assert(msg.m_raw_message_size <= buffer.size());
+            assert(msg.m_raw_message_size == CMessageHeader::HEADER_SIZE + msg.m_message_size);
+            assert(msg.m_time == m_time);
+            if (msg.m_valid_header) {
+                assert(msg.m_valid_netmagic);
+            }
+            if (!msg.m_valid_netmagic) {
+                assert(!msg.m_valid_header);
+            }
+        }
+    }
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -28,6 +28,7 @@ FUZZERS_MISSING_CORPORA = [
     "key_origin_info_deserialize",
     "merkle_block_deserialize",
     "out_point_deserialize",
+    "p2p_transport_deserializer",
     "parse_hd_keypath",
     "parse_numbers",
     "parse_script",


### PR DESCRIPTION
Add fuzzing harness for `V1TransportDeserializer` (P2P transport).

**Testing this PR**

Run:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/p2p_transport_deserializer
…
```