### PR TITLE
p2p: Unify Send and Receive protocol versions

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -621,32 +621,6 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete
     return true;
 }
 
-void CNode::SetSendVersion(int nVersionIn)
-{
-    // Send version may only be changed in the version message, and
-    // only one version message is allowed per session. We can therefore
-    // treat this value as const and even atomic as long as it's only used
-    // once a version message has been successfully processed. Any attempt to
-    // set this twice is an error.
-    if (nSendVersion != 0) {
-        error("Send version already set for node: %i. Refusing to change from %i to %i", id, nSendVersion, nVersionIn);
-    } else {
-        nSendVersion = nVersionIn;
-    }
-}
-
-int CNode::GetSendVersion() const
-{
-    // The send version should always be explicitly set to
-    // INIT_PROTO_VERSION rather than using this value until SetSendVersion
-    // has been called.
-    if (nSendVersion == 0) {
-        error("Requesting unset send version for node: %i. Using %i", id, INIT_PROTO_VERSION);
-        return INIT_PROTO_VERSION;
-    }
-    return nSendVersion;
-}
-
 int V1TransportDeserializer::readHeader(const char *pch, unsigned int nBytes)
 {
     // copy data to temporary parsing buffer

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1167,7 +1167,7 @@ void CConnman::InactivityCheck(CNode *pnode)
             LogPrintf("socket sending timeout: %is\n", nTime - pnode->nLastSend);
             pnode->fDisconnect = true;
         }
-        else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
+        else if (nTime - pnode->nLastRecv > (pnode->GetCommonVersion() > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90*60))
         {
             LogPrintf("socket receive timeout: %is\n", nTime - pnode->nLastRecv);
             pnode->fDisconnect = true;

--- a/src/net.h
+++ b/src/net.h
@@ -827,7 +827,6 @@ public:
 
     std::deque<CInv> vRecvGetData;
     uint64_t nRecvBytes GUARDED_BY(cs_vRecv){0};
-    std::atomic<int> nRecvVersion{INIT_PROTO_VERSION};
 
     std::atomic<int64_t> nLastSend{0};
     std::atomic<int64_t> nLastRecv{0};
@@ -1014,6 +1013,7 @@ private:
     const NodeId id;
     const uint64_t nLocalHostNonce;
     const ConnectionType m_conn_type;
+    std::atomic<int> m_greatest_common_version{INIT_PROTO_VERSION};
 
     //! Services offered to this peer.
     //!
@@ -1033,7 +1033,6 @@ private:
     const ServiceFlags nLocalServices;
 
     const int nMyStartingHeight;
-    int nSendVersion{0};
     NetPermissionFlags m_permissionFlags{ PF_NONE };
     std::list<CNetMessage> vRecvMsg;  // Used only by SocketHandler thread
 
@@ -1065,16 +1064,14 @@ public:
 
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete);
 
-    void SetRecvVersion(int nVersionIn)
+    void SetCommonVersion(int greatest_common_version)
     {
-        nRecvVersion = nVersionIn;
+        m_greatest_common_version = greatest_common_version;
     }
-    int GetRecvVersion() const
+    int GetCommonVersion() const
     {
-        return nRecvVersion;
+        return m_greatest_common_version;
     }
-    void SetSendVersion(int nVersionIn);
-    int GetSendVersion() const;
 
     CService GetAddrLocal() const;
     //! May not be called more than once

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2523,8 +2523,6 @@ void PeerManager::ProcessMessage(CNode& pfrom, const std::string& msg_type, CDat
 
     if (msg_type == NetMsgType::VERACK)
     {
-        pfrom.SetCommonVersion(std::min(pfrom.nVersion.load(), PROTOCOL_VERSION));
-
         if (!pfrom.IsInboundConn()) {
             // Mark this node as currently connected, so we update its timestamp later.
             LOCK(cs_main);

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Mock an outbound peer
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(id++, ServiceFlags(NODE_NETWORK | NODE_WITNESS), 0, INVALID_SOCKET, addr1, 0, 0, CAddress(), "", ConnectionType::OUTBOUND_FULL_RELAY);
-    dummyNode1.SetSendVersion(PROTOCOL_VERSION);
+    dummyNode1.SetCommonVersion(PROTOCOL_VERSION);
 
     peerLogic->InitializeNode(&dummyNode1);
     dummyNode1.nVersion = 1;
@@ -138,7 +138,7 @@ static void AddRandomOutboundPeer(std::vector<CNode *> &vNodes, PeerManager &pee
     CAddress addr(ip(g_insecure_rand_ctx.randbits(32)), NODE_NONE);
     vNodes.emplace_back(new CNode(id++, ServiceFlags(NODE_NETWORK | NODE_WITNESS), 0, INVALID_SOCKET, addr, 0, 0, CAddress(), "", ConnectionType::OUTBOUND_FULL_RELAY));
     CNode &node = *vNodes.back();
-    node.SetSendVersion(PROTOCOL_VERSION);
+    node.SetCommonVersion(PROTOCOL_VERSION);
 
     peerLogic.InitializeNode(&node);
     node.nVersion = 1;
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
     banman->ClearBanned();
     CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr1, 0, 0, CAddress(), "", ConnectionType::INBOUND);
-    dummyNode1.SetSendVersion(PROTOCOL_VERSION);
+    dummyNode1.SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(&dummyNode1);
     dummyNode1.nVersion = 1;
     dummyNode1.fSuccessfullyConnected = true;
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(peer_discouragement)
 
     CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr2, 1, 1, CAddress(), "", ConnectionType::INBOUND);
-    dummyNode2.SetSendVersion(PROTOCOL_VERSION);
+    dummyNode2.SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(&dummyNode2);
     dummyNode2.nVersion = 1;
     dummyNode2.fSuccessfullyConnected = true;
@@ -281,7 +281,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     CAddress addr(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode(id++, NODE_NETWORK, 0, INVALID_SOCKET, addr, 4, 4, CAddress(), "", ConnectionType::INBOUND);
-    dummyNode.SetSendVersion(PROTOCOL_VERSION);
+    dummyNode.SetCommonVersion(PROTOCOL_VERSION);
     peerLogic->InitializeNode(&dummyNode);
     dummyNode.nVersion = 1;
     dummyNode.fSuccessfullyConnected = true;

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -48,7 +48,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                fuzzed_data_provider.ConsumeRandomLengthString(32),
                fuzzed_data_provider.PickValueInArray({ConnectionType::INBOUND, ConnectionType::OUTBOUND_FULL_RELAY, ConnectionType::MANUAL, ConnectionType::FEELER, ConnectionType::BLOCK_RELAY, ConnectionType::ADDR_FETCH})};
     while (fuzzed_data_provider.ConsumeBool()) {
-        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 12)) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 11)) {
         case 0: {
             node.CloseSocketDisconnect();
             break;
@@ -58,7 +58,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 2: {
-            node.SetSendVersion(fuzzed_data_provider.ConsumeIntegral<int>());
+            node.SetCommonVersion(fuzzed_data_provider.ConsumeIntegral<int>());
             break;
         }
         case 3: {
@@ -71,21 +71,17 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 4: {
-            node.SetRecvVersion(fuzzed_data_provider.ConsumeIntegral<int>());
-            break;
-        }
-        case 5: {
             const CNode* add_ref_node = node.AddRef();
             assert(add_ref_node == &node);
             break;
         }
-        case 6: {
+        case 5: {
             if (node.GetRefCount() > 0) {
                 node.Release();
             }
             break;
         }
-        case 7: {
+        case 6: {
             if (node.m_addr_known == nullptr) {
                 break;
             }
@@ -96,7 +92,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             node.AddAddressKnown(*addr_opt);
             break;
         }
-        case 8: {
+        case 7: {
             if (node.m_addr_known == nullptr) {
                 break;
             }
@@ -108,7 +104,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             node.PushAddress(*addr_opt, fast_random_context);
             break;
         }
-        case 9: {
+        case 8: {
             const std::optional<CInv> inv_opt = ConsumeDeserializable<CInv>(fuzzed_data_provider);
             if (!inv_opt) {
                 break;
@@ -116,11 +112,11 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             node.AddKnownTx(inv_opt->hash);
             break;
         }
-        case 10: {
+        case 9: {
             node.PushTxInventory(ConsumeUInt256(fuzzed_data_provider));
             break;
         }
-        case 11: {
+        case 10: {
             const std::optional<CService> service_opt = ConsumeDeserializable<CService>(fuzzed_data_provider);
             if (!service_opt) {
                 break;
@@ -128,7 +124,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             node.SetAddrLocal(*service_opt);
             break;
         }
-        case 12: {
+        case 11: {
             const std::vector<uint8_t> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
             bool complete;
             node.ReceiveMsgBytes((const char*)b.data(), b.size(), complete);
@@ -143,10 +139,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     (void)node.GetLocalNonce();
     (void)node.GetLocalServices();
     (void)node.GetMyStartingHeight();
-    (void)node.GetRecvVersion();
     const int ref_count = node.GetRefCount();
     assert(ref_count >= 0);
-    (void)node.GetSendVersion();
+    (void)node.GetCommonVersion();
     (void)node.RelayAddrsWithConn();
 
     const NetPermissionFlags net_permission_flags = fuzzed_data_provider.ConsumeBool() ?

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -71,7 +71,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     CNode& p2p_node = *MakeUnique<CNode>(0, ServiceFlags(NODE_NETWORK | NODE_WITNESS | NODE_BLOOM), 0, INVALID_SOCKET, CAddress{CService{in_addr{0x0100007f}, 7777}, NODE_NETWORK}, 0, 0, CAddress{}, std::string{}, ConnectionType::OUTBOUND_FULL_RELAY).release();
     p2p_node.fSuccessfullyConnected = true;
     p2p_node.nVersion = PROTOCOL_VERSION;
-    p2p_node.SetSendVersion(PROTOCOL_VERSION);
+    p2p_node.SetCommonVersion(PROTOCOL_VERSION);
     connman.AddTestNode(p2p_node);
     g_setup->m_node.peerman->InitializeNode(&p2p_node);
     try {

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -51,7 +51,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         p2p_node.fSuccessfullyConnected = true;
         p2p_node.fPauseSend = false;
         p2p_node.nVersion = PROTOCOL_VERSION;
-        p2p_node.SetSendVersion(PROTOCOL_VERSION);
+        p2p_node.SetCommonVersion(PROTOCOL_VERSION);
         g_setup->m_node.peerman->InitializeNode(&p2p_node);
 
         connman.AddTestNode(p2p_node);


### PR DESCRIPTION
On master (6fef85bfa3cd7f76e83b8b57f9e4acd63eb664ec) `CNode` has two members to keep protocol version:
- `nRecvVersion` for received messages
- `nSendVersion` for messages to send

After exchanging with `VERSION` and `VERACK` messages via protocol version `INIT_PROTO_VERSION`, both nodes set `nRecvVersion` _and_ `nSendVersion` to _the same_ value which is the greatest common protocol version.

This PR:
- replaces two `CNode` members, `nRecvVersion` `nSendVersion`, with `m_greatest_common_version`
- removes duplicated getter and setter

There is no change in behavior on the P2P network.