### PR TITLE
scripts: add MACHO PIE check to security-check.py

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -98,7 +98,7 @@ repository (requires pngcrush).
 security-check.py and test-security-check.py
 ============================================
 
-Perform basic ELF security checks on a series of executables.
+Perform basic security checks on a series of executables.
 
 symbol-check.py
 ===============

--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -188,6 +188,15 @@ def check_MACHO_PIE(executable) -> bool:
         return True
     return False
 
+def check_MACHO_NOUNDEFS(executable) -> bool:
+    '''
+    Check for no undefined references.
+    '''
+    flags = get_MACHO_executable_flags(executable)
+    if 'NOUNDEFS' in flags:
+        return True
+    return False
+
 CHECKS = {
 'ELF': [
     ('PIE', check_ELF_PIE),
@@ -202,6 +211,7 @@ CHECKS = {
 ],
 'MACHO': [
     ('PIE', check_MACHO_PIE),
+    ('NOUNDEFS', check_MACHO_NOUNDEFS),
 ]
 }
 

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -137,6 +137,7 @@ script: |
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
     make ${MAKEOPTS}
+    make ${MAKEOPTS} -C src check-security
     make install-strip DESTDIR=${INSTALLPATH}
 
     make osx_volname

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -710,7 +710,7 @@ endif
 check-security: $(bin_PROGRAMS)
 if HARDEN
 	@echo "Checking binary security..."
-	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py < $(bin_PROGRAMS)
+	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py < $(bin_PROGRAMS)
 endif
 
 if EMBEDDED_LEVELDB


### PR DESCRIPTION
This uses `otool -vh` to print the mach header and look for the `PIE` flag:
```bash
otool -vh src/bitcoind
Mach header
      magic cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
MH_MAGIC_64  X86_64        ALL LIB64     EXECUTE    24       2544   NOUNDEFS DYLDLINK TWOLEVEL WEAK_DEFINES BINDS_TO_WEAK PIE
```

From [`mach-o/loader.h`](https://opensource.apple.com/source/cctools/cctools-927.0.2/include/mach-o/loader.h.auto.html):
```c
#define	MH_PIE 0x200000			/* When this bit is set, the OS will
					   load the main executable at a
					   random address.  Only used in
					   MH_EXECUTE filetypes. */
```