### PR TITLE
Update Qt binaries for GitHub Action CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,12 @@ jobs:
     runs-on: windows-latest
     env:
         PYTHONUTF8: 1
-        QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.4/Qt5.9.8_x64_static_vs2019.zip'
-        QT_DOWNLOAD_HASH: 'f285cbb02bec3b3f3cc2621e3fa7d5edf0d6a66fa30c57859e583acda954ea80'
+        QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.6/Qt5.9.8_x64_static_vs2019.zip'
+        QT_DOWNLOAD_HASH: '9a8c6eb20967873785057fdcd329a657c7f922b0af08c5fde105cc597dd37e21'
         QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
         VCPKG_INSTALL_PATH: "$env:VCPKG_INSTALLATION_ROOT/installed"
         PLATFORM: x64
+        JOB_VERSION: 1
     steps:
     - uses: actions/checkout@v1
 
@@ -19,14 +20,27 @@ jobs:
       with:
         python-version: '3.7'  # Needed for PEP 540
 
+    # Bump the JOB_VERSION number anytime the cached vcpkg dependencies need to be re-installed.
+    - uses: actions/cache@v1
+      id: jobversion
+      with:
+       path: C:/jobversion/$JOB_VERSION
+       key: ${{ runner.os }}-jobversion
+
+    - name: Make job version directory
+      if: steps.jobversion.outputs.cache-hit != 'true'
+      shell: cmd
+      run: mkdir C:\jobversion\%JOB_VERSION%
+
     - uses: actions/cache@v1
       id: vcpkgcache
+      if: steps.jobversion.outputs.cache-hit == 'true'
       with:
        path: C:/vcpkg/installed
        key: ${{ runner.os }}-vcpkg
 
     - name: Update vcpkg and install packages
-      if: steps.vcpkgcache.outputs.cache-hit != 'true'
+      if: steps.vcpkgcache.outputs.cache-hit != 'true' || steps.jobversion.outputs.cache-hit != 'true'
       run: |
         $env:PACKAGES = Get-Content -Path "$env:GITHUB_WORKSPACE/build_msvc/vcpkg-packages.txt"
         Write-Host "vcpkg list: $env:PACKAGES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,25 +22,25 @@ jobs:
 
     # Bump the JOB_VERSION number anytime the cached vcpkg dependencies need to be re-installed.
     - uses: actions/cache@v1
-      id: jobversion
+      id: jobversioncache
       with:
-       path: C:/jobversion/$JOB_VERSION
-       key: ${{ runner.os }}-jobversion
+       path: C:/jobversion/${{ env.JOB_VERSION }}
+       key: jobversion
 
     - name: Make job version directory
-      if: steps.jobversion.outputs.cache-hit != 'true'
+      if: steps.jobversioncache.outputs.cache-hit != 'true'
       shell: cmd
       run: mkdir C:\jobversion\%JOB_VERSION%
 
     - uses: actions/cache@v1
       id: vcpkgcache
-      if: steps.jobversion.outputs.cache-hit == 'true'
+      if: steps.jobversioncache.outputs.cache-hit == 'true'
       with:
        path: C:/vcpkg/installed
        key: ${{ runner.os }}-vcpkg
 
     - name: Update vcpkg and install packages
-      if: steps.vcpkgcache.outputs.cache-hit != 'true' || steps.jobversion.outputs.cache-hit != 'true'
+      if: steps.vcpkgcache.outputs.cache-hit != 'true' || steps.jobversioncache.outputs.cache-hit != 'true'
       run: |
         $env:PACKAGES = Get-Content -Path "$env:GITHUB_WORKSPACE/build_msvc/vcpkg-packages.txt"
         Write-Host "vcpkg list: $env:PACKAGES"


### PR DESCRIPTION
Also add new job version flag to allow vcpkg dependencies to be reinstalled whenever the job version flag is bumped.

Fix for #17788.
