### PR TITLE
Remove UBSan suppressions for CTxMemPool*

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -217,10 +217,11 @@ void CTxMemPool::UpdateAncestorsOf(bool add, txiter it, setEntries &setAncestors
         UpdateChild(piter, it, add);
     }
     const int64_t updateCount = (add ? 1 : -1);
-    const int64_t updateSize = updateCount * it->GetTxSize();
+    const int64_t updateSize = it->GetTxSize();
+    assert(updateSize >= 0);
     const CAmount updateFee = updateCount * it->GetModifiedFee();
     for (txiter ancestorIt : setAncestors) {
-        mapTx.modify(ancestorIt, update_descendant_state(updateSize, updateFee, updateCount));
+        mapTx.modify(ancestorIt, update_descendant_state(updateCount * updateSize, updateFee, updateCount));
     }
 }
 
@@ -307,19 +308,19 @@ void CTxMemPool::UpdateForRemoveFromMempool(const setEntries &entriesToRemove, b
 void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount)
 {
     nSizeWithDescendants += modifySize;
-    assert(int64_t(nSizeWithDescendants) > 0);
+    assert(nSizeWithDescendants > 0);
     nModFeesWithDescendants += modifyFee;
     nCountWithDescendants += modifyCount;
-    assert(int64_t(nCountWithDescendants) > 0);
+    assert(nCountWithDescendants > 0);
 }
 
 void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int64_t modifySigOps)
 {
     nSizeWithAncestors += modifySize;
-    assert(int64_t(nSizeWithAncestors) > 0);
+    assert(nSizeWithAncestors > 0);
     nModFeesWithAncestors += modifyFee;
     nCountWithAncestors += modifyCount;
-    assert(int64_t(nCountWithAncestors) > 0);
+    assert(nCountWithAncestors > 0);
     nSigOpCostWithAncestors += modifySigOps;
     assert(int(nSigOpCostWithAncestors) >= 0);
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -79,13 +79,13 @@ private:
     // Information about descendants of this transaction that are in the
     // mempool; if we remove this transaction we must remove all of these
     // descendants as well.
-    uint64_t nCountWithDescendants;  //!< number of descendant transactions
-    uint64_t nSizeWithDescendants;   //!< ... and size
+    int64_t nCountWithDescendants;   //!< number of descendant transactions
+    int64_t nSizeWithDescendants;    //!< ... and size
     CAmount nModFeesWithDescendants; //!< ... and total fees (all including us)
 
     // Analogous statistics for ancestor transactions
-    uint64_t nCountWithAncestors;
-    uint64_t nSizeWithAncestors;
+    int64_t nCountWithAncestors;
+    int64_t nSizeWithAncestors;
     CAmount nModFeesWithAncestors;
     int64_t nSigOpCostWithAncestors;
 

--- a/test/sanitizer_suppressions/ubsan
+++ b/test/sanitizer_suppressions/ubsan
@@ -39,7 +39,6 @@ unsigned-integer-overflow:policy/fees.cpp
 unsigned-integer-overflow:prevector.h
 unsigned-integer-overflow:script/interpreter.cpp
 unsigned-integer-overflow:stl_bvector.h
-unsigned-integer-overflow:txmempool.cpp
 unsigned-integer-overflow:util/strencodings.cpp
 unsigned-integer-overflow:validation.cpp
 
@@ -68,7 +67,6 @@ implicit-integer-sign-change:test/prevector_tests.cpp
 implicit-integer-sign-change:test/sighash_tests.cpp
 implicit-integer-sign-change:test/streams_tests.cpp
 implicit-integer-sign-change:test/transaction_tests.cpp
-implicit-integer-sign-change:txmempool.cpp
 implicit-integer-sign-change:util/strencodings.*
 implicit-integer-sign-change:validation.cpp
 implicit-integer-sign-change:zmq/zmqpublishnotifier.cpp


### PR DESCRIPTION
In `CTxMemPoolEntry` class the type of four data members has been changed from `uint64_t` to `int64_t`. The type of getters, `uint64_t`, remains unchanged.

In `CTxMemPool::UpdateAncestorsOf()` the only expression was needed to be reworked (the result looks a bit ugly, I'm still open for suggestions).