### PR TITLE
ci: Update GitHub Actions CI vcpkg cache on MSBuild update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: windows-latest
     env:
         PYTHONUTF8: 1
-        QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.4/Qt5.9.8_x64_static_vs2019.zip'
-        QT_DOWNLOAD_HASH: 'f285cbb02bec3b3f3cc2621e3fa7d5edf0d6a66fa30c57859e583acda954ea80'
+        QT_DOWNLOAD_URL: 'https://github.com/sipsorcery/qt_win_binary/releases/download/v1.6/Qt5.9.8_x64_static_vs2019.zip'
+        QT_DOWNLOAD_HASH: '9a8c6eb20967873785057fdcd329a657c7f922b0af08c5fde105cc597dd37e21'
         QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
         VCPKG_INSTALL_PATH: "$env:VCPKG_INSTALLATION_ROOT/installed"
         PLATFORM: x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,17 @@ jobs:
       with:
         python-version: '3.7'  # Needed for PEP 540
 
+    - name: Setup MSBuild.exe
+      uses: warrenbuckley/Setup-MSBuild@v1
+
+    - name: Check MSBuild.exe
+      run: MSBuild.exe -version | Out-File -FilePath $env:GITHUB_WORKSPACE\MSBuild_version
+
     - uses: actions/cache@v1
       id: vcpkgcache
       with:
        path: C:/vcpkg/installed
-       key: ${{ runner.os }}-vcpkg
+       key: ${{ runner.os }}-vcpkg-${{ hashFiles('MSBuild_version') }}
 
     - name: Update vcpkg and install packages
       if: steps.vcpkgcache.outputs.cache-hit != 'true'
@@ -54,8 +60,6 @@ jobs:
         }
     - name: Generate project files
       run: python build_msvc\msvc-autogen.py
-    - name: Setup MSBuild.exe
-      uses: warrenbuckley/Setup-MSBuild@v1
     - name: vcpkg integration
       run: C:/vcpkg/vcpkg.exe integrate install
     - name: Build


### PR DESCRIPTION
On master (0cda5573405d75d695aba417e8f22f1301ded001) Visual Studio update in GitHub Actions CI virtual environment could break a build as the `vcpkg` cache is not updated accordingly (see #17788).

This PR:
- force vcpkg cache update on MSBuild update
- is an alternative to #17789
- fixes #17788