### PR TITLE
test: Use assert_greater_than_or_equal helper method to aid debugging.

### DIFF
--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -363,7 +363,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_greater_than_or_equal(feeDelta, 0)
+        assert_greater_than_or_equal(self.fee_tolerance, feeDelta)
 
     def test_fee_p2pkh_multi_out(self):
         """Compare fee of a standard pubkeyhash transaction with multiple outputs."""
@@ -386,7 +387,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_greater_than_or_equal(feeDelta, 0)
+        assert_greater_than_or_equal(self.fee_tolerance, feeDelta)
 
     def test_fee_p2sh(self):
         """Compare fee of a 2-of-2 multisig p2sh transaction."""
@@ -410,7 +412,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_greater_than_or_equal(feeDelta, 0)
+        assert_greater_than_or_equal(self.fee_tolerance, feeDelta)
 
     def test_fee_4of5(self):
         """Compare fee of a standard pubkeyhash transaction."""
@@ -451,7 +454,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance
+        assert_greater_than_or_equal(feeDelta, 0)
+        assert_greater_than_or_equal(self.fee_tolerance, feeDelta)
 
     def test_spend_2of2(self):
         """Spend a 2-of-2 multisig transaction over fundraw."""
@@ -556,7 +560,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         # Compare fee.
         feeDelta = Decimal(fundedTx['fee']) - Decimal(signedFee)
-        assert feeDelta >= 0 and feeDelta <= self.fee_tolerance * 19  #~19 inputs
+        assert_greater_than_or_equal(feeDelta, 0)
+        assert_greater_than_or_equal(self.fee_tolerance * 19, feeDelta)  #~19 inputs
 
     def test_many_inputs_send(self):
         """Multiple (~19) inputs tx test | sign/send."""

--- a/test/functional/test_framework/key.py
+++ b/test/functional/test_framework/key.py
@@ -332,7 +332,7 @@ class ECKey():
         """Construct a private key object with given 32-byte secret and compressed flag."""
         assert(len(secret) == 32)
         secret = int.from_bytes(secret, 'big')
-        self.valid = (secret > 0 and secret < SECP256K1_ORDER)
+        self.valid = (0 < secret < SECP256K1_ORDER)
         if self.valid:
             self.secret = secret
             self.compressed = compressed


### PR DESCRIPTION
Comparisons can be chained arbitrarily, e.g., x < y <= z is equivalent to x < y and y <= z, except that y is evaluated only once (but in both cases z is not evaluated at all when x < y is found to be false).

