### PR TITLE
gui: Shortcut to close RPC Console

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -94,6 +94,7 @@ GUI changes
 -----------
 
 - The "Start Bitcoin Core on system login" option has been removed on macOS.
+- The RPC Console Window can be closed with Ctrl+D now (Ctrl+W on macOS).
 
 Wallet
 ------

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -469,6 +469,16 @@ RPCConsole::RPCConsole(interfaces::Node& node, const PlatformStyle *_platformSty
     ui->lineEdit->installEventFilter(this);
     ui->messagesWidget->installEventFilter(this);
 
+    QAction* eot_action = new QAction(this);
+    // We use Control+D because EOT is the 4th ASCII char and D the 4th char of the latin alphabet. macOS uses CTRL+W
+#ifdef Q_OS_MAC
+    eot_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_W));
+#else
+    eot_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_D));
+#endif
+    connect(eot_action, &QAction::triggered, this, &QWidget::close);
+    ui->tab_console->addAction(eot_action);
+
     connect(ui->clearButton, &QPushButton::clicked, this, &RPCConsole::clear);
     connect(ui->fontBiggerButton, &QPushButton::clicked, this, &RPCConsole::fontBigger);
     connect(ui->fontSmallerButton, &QPushButton::clicked, this, &RPCConsole::fontSmaller);


### PR DESCRIPTION
Credits to promag.
Similar to #16515 with a macOS addition.

This PR makes it possible to close the RPC Console (like a terminal) with Ctrl+D. On macOS it will close with Ctrl+W as it is a more common syntax there.