### PR TITLE
random: don't special case clock usage on macOS

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -237,8 +237,6 @@ void RandAddDynamicEnv(CSHA512& hasher)
     GetSystemTimeAsFileTime(&ftime);
     hasher << ftime;
 #else
-#  ifndef __MACH__
-    // On non-MacOS systems, use various clock_gettime() calls.
     struct timespec ts = {};
 #    ifdef CLOCK_MONOTONIC
     clock_gettime(CLOCK_MONOTONIC, &ts);
@@ -252,18 +250,6 @@ void RandAddDynamicEnv(CSHA512& hasher)
     clock_gettime(CLOCK_BOOTTIME, &ts);
     hasher << ts;
 #    endif
-#  else
-    // On MacOS use mach_absolute_time (number of CPU ticks since boot) as a replacement for CLOCK_MONOTONIC,
-    // and clock_get_time for CALENDAR_CLOCK as a replacement for CLOCK_REALTIME.
-    hasher << mach_absolute_time();
-    // From https://gist.github.com/jbenet/1087739
-    clock_serv_t cclock;
-    mach_timespec_t mts = {};
-    if (host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock) == KERN_SUCCESS && clock_get_time(cclock, &mts) == KERN_SUCCESS) {
-        hasher << mts;
-        mach_port_deallocate(mach_task_self(), cclock);
-    }
-#  endif
     // gettimeofday is available on all UNIX systems, but only has microsecond precision.
     struct timeval tv = {};
     gettimeofday(&tv, nullptr);


### PR DESCRIPTION
`clock_gettime()`, `CLOCK_MONOTONIC` and `CLOCK_REALTIME` are all available for use on
macOS (now that we require macOS >=10.12 and build against 10.14). Use them rather than the [deprecated](https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/KernelProgramming/Mach/Mach.html) `mach_timespec_t` time API.

I mentioned the possibility for this change [in #17270](https://github.com/bitcoin/bitcoin/pull/17270#discussion_r346090606).

[master](1dbf3350c683f93d7fc9b861400724f6fd2b2f1d):
```bash
2019-12-23T20:49:43Z Feeding 216 bytes of dynamic environment data into RNG
2019-12-23T20:50:43Z Feeding 216 bytes of dynamic environment data into RNG
```

This PR:
```bash
2019-12-23T20:32:41Z Feeding 232 bytes of dynamic environment data into RNG
2019-12-23T20:33:42Z Feeding 232 bytes of dynamic environment data into RNG
```

~~Depends on #16392.~~ Merged.