### PR TITLE
net: Remove unnecessary portability typedef

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -82,12 +82,6 @@ typedef int32_t ssize_t;
 size_t strnlen( const char *start, size_t max_len);
 #endif // HAVE_DECL_STRNLEN
 
-#ifndef WIN32
-typedef void* sockopt_arg_type;
-#else
-typedef char* sockopt_arg_type;
-#endif
-
 // Note these both should work with the current usage of poll, but best to be safe
 // WIN32 poll is broken https://daniel.haxx.se/blog/2012/10/10/wsapoll-is-broken/
 // __APPLE__ poll is broke https://github.com/bitcoin/bitcoin/pull/14336#issuecomment-437384408

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2078,13 +2078,13 @@ bool CConnman::BindListenPort(const CService& addrBind, std::string& strError, N
 
     // Allow binding if the port is still in TIME_WAIT state after
     // the program was closed and restarted.
-    setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (sockopt_arg_type)&nOne, sizeof(int));
+    setsockopt(hListenSocket, SOL_SOCKET, SO_REUSEADDR, (char*)&nOne, sizeof(int));
 
     // some systems don't have IPV6_V6ONLY but are always v6only; others do have the option
     // and enable it by default or not. Try to enable it, if possible.
     if (addrBind.IsIPv6()) {
 #ifdef IPV6_V6ONLY
-        setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (sockopt_arg_type)&nOne, sizeof(int));
+        setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (char*)&nOne, sizeof(int));
 #endif
 #ifdef WIN32
         int nProtLevel = PROTECTION_LEVEL_UNRESTRICTED;

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -665,7 +665,7 @@ bool ConnectSocketDirectly(const CService &addrConnect, const SOCKET& hSocket, i
             // in the SO_ERROR for the socket in modern systems. We read it into
             // nRet here.
             socklen_t nRetSize = sizeof(nRet);
-            if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, (sockopt_arg_type)&nRet, &nRetSize) == SOCKET_ERROR)
+            if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, (char*)&nRet, &nRetSize) == SOCKET_ERROR)
             {
                 LogPrintf("getsockopt() for %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
                 return false;


### PR DESCRIPTION
On Linux, any type of pointer may be passed as a void* argument. As such, this platform-specific typedef switch is unnecessary.

Note, there is already one usage of setsockopt that directly uses a char*: [src/netbase.cpp:926](https://github.com/bitcoin/bitcoin/blob/ac831339cbfa65b1f7576c53b5d9a94841db9868/src/netbase.cpp#L926)