### PR TITLE
util: Replace itostr/i64tostr with c++11 to_string

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -35,6 +35,7 @@
 #include <warnings.h>
 
 #include <memory>
+#include <string>
 #include <stdint.h>
 
 /**
@@ -677,7 +678,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
-    result.pushKV("longpollid", ::ChainActive().Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
+    result.pushKV("longpollid", ::ChainActive().Tip()->GetBlockHash().GetHex() + std::to_string(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
     result.pushKV("mutable", aMutable);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -10,7 +10,6 @@
 #include <tinyformat.h>
 
 #include <logging.h>
-#include <util/strencodings.h>
 #include <util/threadnames.h>
 
 
@@ -56,8 +55,8 @@ struct CLockLocation {
     std::string ToString() const
     {
         return strprintf(
-            "%s %s:%s%s (in thread %s)",
-            mutexName, sourceFile, itostr(sourceLine), (fTry ? " (TRY)" : ""), m_thread_name);
+            "%s %s:%d%s (in thread %s)",
+            mutexName, sourceFile, sourceLine, (fTry ? " (TRY)" : ""), m_thread_name);
     }
 
 private:

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -70,11 +70,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     // (void)GetVirtualTransactionSize(i64, i64); // function defined only for a subset of int64_t inputs
     // (void)GetVirtualTransactionSize(i64, i64, u32); // function defined only for a subset of int64_t/uint32_t inputs
     (void)HexDigit(ch);
-    (void)i64tostr(i64);
     (void)IsDigit(ch);
     (void)IsSpace(ch);
     (void)IsSwitchChar(ch);
-    (void)itostr(i32);
     (void)memusage::DynamicUsage(ch);
     (void)memusage::DynamicUsage(i16);
     (void)memusage::DynamicUsage(i32);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -407,16 +407,6 @@ std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
     return out.str();
 }
 
-std::string i64tostr(int64_t n)
-{
-    return strprintf("%d", n);
-}
-
-std::string itostr(int n)
-{
-    return strprintf("%d", n);
-}
-
 int64_t atoi64(const char* psz)
 {
 #ifdef _MSC_VER

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -55,8 +55,6 @@ std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
-std::string i64tostr(int64_t n);
-std::string itostr(int n);
 int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -210,7 +210,7 @@ static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (nOrderPos == -1)
         return;
-    mapValue["n"] = i64tostr(nOrderPos);
+    mapValue["n"] = std::to_string(nOrderPos);
 }
 
 struct COutputEntry


### PR DESCRIPTION
C++11 introduced to_string methods for a variety of POD types, including int and int64_t. These are already used in a few places in the repo. This patch removes the ad-hoc functions in strencodings in favor of the new std versions.