### PR TITLE
Optimize ToLower() and ToUpper()

### DIFF
--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -205,9 +205,9 @@ bool ConvertBits(const O& outfn, I it, I end) {
  * @return          the lowercase equivalent of c; or the argument
  *                  if no conversion is possible.
  */
-constexpr char ToLower(char c)
+constexpr char ToLower(const char c)
 {
-    return (c >= 'A' && c <= 'Z' ? (c - 'A') + 'a' : c);
+    return (c >= 'A' && c <= 'Z' ? c | 0x20 : c);
 }
 
 /**
@@ -231,9 +231,9 @@ std::string ToLower(const std::string& str);
  * @return          the uppercase equivalent of c; or the argument
  *                  if no conversion is possible.
  */
-constexpr char ToUpper(char c)
+constexpr char ToUpper(const char c)
 {
-    return (c >= 'a' && c <= 'z' ? (c - 'a') + 'A' : c);
+    return (c >= 'a' && c <= 'z' ? c & ~0x20 : c);
 }
 
 /**


### PR DESCRIPTION
Not the most important optimization, as these functions aren't used much, but came across this when reviewing #17808 and as I had this already implemented years ago when developing my own embedded / real-time libc, decided why not to send a PR here.

ASCII was designed clever enough so that you can convert from lowercase to uppercase and vice versa by just flipping a single bit instead of doing addition and subtraction. Maybe some comment could be added about this, but I think it's a well known bit hack. In addition, adding `const` to parameter will not hurt, at least in my tests it made code smaller.

Also noticed that `ToUpper()` is only used in unit tests and nowhere else, but it makes sense to keep both functions, probably it will be useful someday in future.