### PR TITLE
consensus refactor: range based for loops

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -184,9 +184,9 @@ bool Consensus::CheckTxInputs(const CTransaction& tx, TxValidationState& state, 
     }
 
     const CAmount value_out = tx.GetValueOut();
-    if (nValueIn < value_out) {
+    if (value_in < value_out) {
         return state.Invalid(TxValidationResult::TX_CONSENSUS, "bad-txns-in-belowout",
-            strprintf("value in (%s) < value out (%s)", FormatMoney(nValueIn), FormatMoney(value_out)));
+            strprintf("value in (%s) < value out (%s)", FormatMoney(value_in), FormatMoney(value_out)));
     }
 
     // Tally transaction fees


### PR DESCRIPTION
Modernized for loops (range based for loops were introduced in C++11). Range based for loops were used in this file earlier, not sure why they weren't used for the entire file. 