### PR TITLE
doc: Added running functional tests in valgrind

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -250,6 +250,7 @@ $ valgrind --suppressions=contrib/valgrind.supp src/test/test_bitcoin
 $ valgrind --suppressions=contrib/valgrind.supp --leak-check=full \
       --show-leak-kinds=all src/test/test_bitcoin --log_level=test_suite
 $ valgrind -v --leak-check=full src/bitcoind -printtoconsole
+$ ./test/functional/test_runner.py --valgrind
 ```
 
 ### Compiling for test coverage


### PR DESCRIPTION
Technically the notes only show an "example" of how to run valgrind with the suppression file,
but now that https://github.com/bitcoin/bitcoin/pull/17633 is merged then maybe this can encourage more people to run also the functional tests in valgrind