### PR TITLE
build: Fix --with-gui configure option without argument

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -212,7 +212,7 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
 
 
   dnl enable qt support
-  AC_MSG_CHECKING(whether to build ]AC_PACKAGE_NAME[ GUI)
+  AC_MSG_CHECKING([whether to build ]AC_PACKAGE_NAME[ GUI])
   BITCOIN_QT_CHECK([
     bitcoin_enable_qt=yes
     bitcoin_enable_qt_test=yes

--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -5,7 +5,7 @@ dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
 dnl Helper for cases where a qt dependency is not met.
 dnl Output: If qt version is auto, set bitcoin_enable_qt to false. Else, exit.
 AC_DEFUN([BITCOIN_QT_FAIL],[
-  if test "x$bitcoin_qt_want_version" = xauto && test "x$bitcoin_qt_force" != xyes; then
+  if test "x$bitcoin_qt_want_version" = xauto; then
     if test "x$bitcoin_enable_qt" != xno; then
       AC_MSG_WARN([$1; bitcoin-qt frontend will not be built])
     fi
@@ -58,7 +58,6 @@ AC_DEFUN([BITCOIN_QT_INIT],[
     [
      bitcoin_qt_want_version=$withval
      if test "x$bitcoin_qt_want_version" = xyes; then
-       bitcoin_qt_force=yes
        bitcoin_qt_want_version=auto
      fi
     ],


### PR DESCRIPTION
It is expected that `--with-gui` behaves the same as `--with-gui=auto`.

But if Qt dependencies not found, `configure --with-gui` fails rather than warns. See: #17813 

Ref: **laanwj**'s [comment](https://github.com/bitcoin/bitcoin/pull/6938#issuecomment-153757477) from #6938

This PR:
- fixes #17813 
- fixes m4 escaping