### PR TITLE
build: depends macOS: hide linker visibility warnings

### DIFF
--- a/depends/builders/darwin.mk
+++ b/depends/builders/darwin.mk
@@ -10,8 +10,8 @@ build_darwin_SHA256SUM=shasum -a 256
 build_darwin_DOWNLOAD=curl --location --fail --connect-timeout $(DOWNLOAD_CONNECT_TIMEOUT) --retry $(DOWNLOAD_RETRIES) -o
 
 #darwin host on darwin builder. overrides darwin host preferences.
-darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION) --sysroot $(shell xcrun --show-sdk-path)
-darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -stdlib=libc++ --sysroot $(shell xcrun --show-sdk-path)
+darwin_CC=$(shell xcrun -f clang) -mmacosx-version-min=$(OSX_MIN_VERSION) -fvisibility=hidden -fvisibility-inlines-hidden --sysroot $(shell xcrun --show-sdk-path)
+darwin_CXX:=$(shell xcrun -f clang++) -mmacosx-version-min=$(OSX_MIN_VERSION) -fvisibility=hidden -fvisibility-inlines-hidden -stdlib=libc++ --sysroot $(shell xcrun --show-sdk-path)
 darwin_AR:=$(shell xcrun -f ar)
 darwin_RANLIB:=$(shell xcrun -f ranlib)
 darwin_STRIP:=$(shell xcrun -f strip)


### PR DESCRIPTION
Removes 3167 linker warnings when compiling for macOS.

Warnings like this one:
```
ld: warning: direct access in function 'boost::filesystem::detail::create_directories(boost::filesystem::path const&, boost::system::error_code*)' from file '/Users/rex/bitcoin/depends/x86_64-apple-darwin19.0.0/lib/libboost_filesystem-mt-x64.a(operations.o)' to global weak symbol 'boost::system::generic_category()::generic_category_instance' from file 'libbitcoin_util.a(libbitcoin_util_a-time.o)' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```