### PR TITLE
util: Make -help more Unix and grep friendly

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -444,7 +444,7 @@ void SetupServerArgs()
         "and mempool (allow requesting BIP35 mempool contents). "
         "Specify multiple permissions separated by commas (default: noban,mempool,relay). Can be specified multiple times.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
 
-    gArgs.AddArg("-whitelist=<[permissions@]IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or "
+    gArgs.AddArg("-whitelist=<[permissions@]addr>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or "
         "CIDR notated network(e.g. 1.2.3.0/24). Uses same permissions as "
         "-whitebind. Can be specified multiple times." , ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
 

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -368,6 +368,7 @@ bool ParseDouble(const std::string& str, double *out)
 
 std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
 {
+#ifdef _WIN32
     std::stringstream out;
     size_t ptr = 0;
     size_t indented = 0;
@@ -405,6 +406,29 @@ std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
         }
     }
     return out.str();
+#else
+    std::istringstream iss(in);
+    std::vector<std::string> lines_splitted((std::istream_iterator<std::string>(iss)), std::istream_iterator<std::string>());
+    std::vector<std::string> lines_formatted = {""};    // Initialize with empty string
+    for(long unsigned int i = 0; i < lines_splitted.size(); i++) {
+        if(std::string(lines_formatted[lines_formatted.size() - 1] + lines_splitted[i] + " ").size() > width) {
+            lines_formatted.push_back(lines_splitted[i] + " ");
+        }
+        else {
+            lines_formatted[lines_formatted.size() - 1] += lines_splitted[i] + " ";
+        }
+    }
+    // Make it a string
+    std::string retstr;
+    for(long unsigned int i = 0; i < lines_formatted.size(); i++) {
+        // Do not do the indent on line 1
+        if(i == 0)
+            retstr += lines_formatted[0] + "\n";
+        else
+            retstr += std::string(indent, ' ') + lines_formatted[i] + "\n";
+    }
+    return retstr;
+#endif
 }
 
 std::string i64tostr(int64_t n)

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -518,17 +518,28 @@ void SetupHelpOptions(ArgsManager& args)
 
 static const int screenWidth = 79;
 static const int optIndent = 2;
+#ifdef _WIN32
 static const int msgIndent = 7;
+#else
+static const int msgIndent = 41;
+#endif
 
 std::string HelpMessageGroup(const std::string &message) {
     return std::string(message) + std::string("\n\n");
 }
 
 std::string HelpMessageOpt(const std::string &option, const std::string &message) {
+#ifdef _WIN32
     return std::string(optIndent,' ') + std::string(option) +
            std::string("\n") + std::string(msgIndent,' ') +
            FormatParagraph(message, screenWidth - msgIndent, msgIndent) +
            std::string("\n\n");
+#else
+    return std::string(optIndent,' ') + std::string(option) +
+           std::string(msgIndent - option.size() - optIndent,' ') +
+           FormatParagraph(message, screenWidth - msgIndent, msgIndent) +
+           std::string("\n\n");
+#endif
 }
 
 static std::string FormatException(const std::exception* pex, const char* pszThread)


### PR DESCRIPTION
**This does not affect the Windows platform**
The current `--help` overview is ugly and pretty uncommon for the GNU (and probably unix userland).
The biggest difference is that at Bitcoin Cores approach, there is a new line after every command. This isn't really friendly when using grep to get more informations about a command. Honestly IMO the current help page looks from its format more like a man rather than a help page.

As an example:
Current:
```
Chain selection options:

  -chain=<chain>
       Use the chain <chain> (default: main). Allowed values: main, test,
       regtest

  -testnet
       Use the test chain. Equivalent to -chain=test.

```
This PR:
```
Chain selection options:

  -chain=<chain>                         Use the chain <chain> (default: 
                                         main). Allowed values: main, test, 
                                         regtest 


  -testnet                               Use the test chain. Equivalent to 
                                         -chain=test. 


```

It also adds a limit of 41 characters per arg name. That's why I also changed the parameter description of `-whitelist`