### PR TITLE
ci: Fix brew python link

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -16,6 +16,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   git reset --hard origin/master
   popd || exit 1
   set -o errexit
+  ${CI_RETRY_EXE} brew unlink python@2
   ${CI_RETRY_EXE} brew update
   # brew upgrade returns an error if any of the packages is already up to date
   # Failure is safe to ignore, unless we really need an update.


### PR DESCRIPTION
During the native macOS build on Travis brew-version python update from 3.7.5 to 3.7.6_1 causes link failure:

```
==> Upgrading python3 
==> Downloading https://homebrew.bintray.com/bottles/python-3.7.6_1.mojave.bottl
==> Downloading from https://akamai.bintray.com/64/643d627c2b4fc03a3286c397d2992
######################################################################## 100.0%
==> Pouring python-3.7.6_1.mojave.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
```

Close #17848 