### PR TITLE
tests: Add std::to_string to list of locale dependent functions

### DIFF
--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -3,15 +3,30 @@
 export LC_ALL=C
 KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
+    "src/bitcoin-tx.cpp.*std::to_string"
     "src/bitcoin-tx.cpp.*trim_right"
     "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
     "src/init.cpp:.*atoi"
+    "src/qt/optionsmodel.cpp.*std::to_string"
     "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"
+    "src/rpc/net.cpp.*std::to_string"
+    "src/rpc/rawtransaction.cpp.*std::to_string"
+    "src/rpc/util.cpp.*std::to_string"
+    "src/test/addrman_tests.cpp.*std::to_string"
+    "src/test/blockchain_tests.cpp.*std::to_string"
     "src/test/dbwrapper_tests.cpp:.*snprintf"
+    "src/test/denialofservice_tests.cpp.*std::to_string"
     "src/test/fuzz/parse_numbers.cpp:.*atoi"
+    "src/test/key_tests.cpp.*std::to_string"
+    "src/test/net_tests.cpp.*std::to_string"
+    "src/test/settings_tests.cpp.*std::to_string"
+    "src/test/timedata_tests.cpp.*std::to_string"
+    "src/test/util/setup_common.cpp.*std::to_string"
+    "src/test/util_tests.cpp.*std::to_string"
+    "src/test/util_threadnames_tests.cpp.*std::to_string"
     "src/torcontrol.cpp:.*atoi"
     "src/torcontrol.cpp:.*strtol"
     "src/util/strencodings.cpp:.*atoi"
@@ -19,6 +34,7 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
     "src/util/system.cpp:.*atoi"
+    "src/wallet/scriptpubkeyman.cpp.*std::to_string"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"
@@ -93,6 +109,7 @@ LOCALE_DEPENDENT_FUNCTIONS=(
     snprintf
     sprintf
     sscanf
+    std::to_string
     stod
     stof
     stoi


### PR DESCRIPTION
Add `std::to_string` to list of locale dependent functions:

> `std::to_string` relies on the current locale for formatting purposes […]

Context https://github.com/bitcoin/bitcoin/pull/17808#issuecomment-570329665

