### PR TITLE
gitignore: add fuzz binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# fuzzer binaries (we want these at top, because later on we re-ignore things like *.o, .deps, etc)
+# first ignore all
+src/test/fuzz/*
+# then unignore anything with a file extension
+!src/test/fuzz/*.*
+
+# general
 *.tar.gz
 
 *.exe


### PR DESCRIPTION
Building with `--enable-fuzz` results in `git status` showing all the fuzz binaries as untracked files. This adds rules to
1. ignore everything in `src/test/fuzz/`,
2. unignore everything with an extension in `src/test/fuzz/`.

The rules are added at the top to not overrule things like `*.o` ignores.