### PR TITLE
scripts: fix symbol-check & security-check argument passing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -704,13 +704,13 @@ clean-local:
 check-symbols: $(bin_PROGRAMS)
 if GLIBC_BACK_COMPAT
 	@echo "Checking glibc back compat..."
-	$(AM_V_at) READELF=$(READELF) CPPFILT=$(CPPFILT) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py < $(bin_PROGRAMS)
+	$(AM_V_at) READELF=$(READELF) CPPFILT=$(CPPFILT) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
 endif
 
 check-security: $(bin_PROGRAMS)
 if HARDEN
 	@echo "Checking binary security..."
-	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py < $(bin_PROGRAMS)
+	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py $(bin_PROGRAMS)
 endif
 
 if EMBEDDED_LEVELDB


### PR DESCRIPTION
The first argument in `bin_PROGRAMS` (`bitcoind`) was being silently consumed and never passed into the [`security-check.py`](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/security-check.py) or [`symbol-check.py`](https://github.com/bitcoin/bitcoin/blob/master/contrib/devtools/symbol-check.py) scripts.

This seems to have been the case since the scripts were added to the makefile in https://github.com/bitcoin/bitcoin/commit/f3d3eaf78eb51238d799d8f20a585550d1567719.

Example of the behavior:

```python
# touch a, touch b, touch c
# python3 args.py < a b c

import sys
if __name__ == '__main__':
    print(sys.argv)
    # ['args.py', 'b', 'c']

    # if you add some lines to "a",
    # you'll see them here..
    for line in sys.stdin:
        print(line)
```