### PR TITLE
Update .level() to .depth()

### DIFF
--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -74,7 +74,7 @@ std::vector<fs::path> ListWalletDir()
         if (it->status().type() == fs::directory_file && IsBerkeleyBtree(it->path() / "wallet.dat")) {
             // Found a directory which contains wallet.dat btree file, add it as a wallet.
             paths.emplace_back(path);
-        } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && IsBerkeleyBtree(it->path())) {
+        } else if (it.depth() == 0 && it->symlink_status().type() == fs::regular_file && IsBerkeleyBtree(it->path())) {
             if (it->path().filename() == "wallet.dat") {
                 // Found top-level wallet.dat btree file, add top level directory ""
                 // as a wallet.


### PR DESCRIPTION
recursive_directory_iterator.level() has been marked as deprecated in boost-libs 1.72.0 and since BOOST_FILESYSTEM_NO_DEPRECATED is defined in fs.h this results in a build error. recursive_directory_iterator.depth() should be used instead.

