### PR TITLE
wip: zmq: Support -zmqpubwallettx

### DIFF
--- a/contrib/zmq/zmq_sub.py
+++ b/contrib/zmq/zmq_sub.py
@@ -47,6 +47,7 @@ class ZMQHandler():
         self.zmqSubSocket.setsockopt_string(zmq.SUBSCRIBE, "hashtx")
         self.zmqSubSocket.setsockopt_string(zmq.SUBSCRIBE, "rawblock")
         self.zmqSubSocket.setsockopt_string(zmq.SUBSCRIBE, "rawtx")
+        self.zmqSubSocket.setsockopt_string(zmq.SUBSCRIBE, "wallettx")
         self.zmqSubSocket.connect("tcp://127.0.0.1:%i" % port)
 
     async def handle(self) :
@@ -68,6 +69,9 @@ class ZMQHandler():
             print(binascii.hexlify(body[:80]))
         elif topic == b"rawtx":
             print('- RAW TX ('+sequence+') -')
+            print(binascii.hexlify(body))
+        elif topic == b"wallettx":
+            print('- WALLET TX ('+sequence+') -')
             print(binascii.hexlify(body))
         # schedule ourselves to receive the next message
         asyncio.ensure_future(self.handle())

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -48,6 +48,8 @@ static const size_t OUTPUT_GROUP_MAX_ENTRIES = 10;
 static CCriticalSection cs_wallets;
 static std::vector<std::shared_ptr<CWallet>> vpwallets GUARDED_BY(cs_wallets);
 
+boost::signals2::signal<void (CWallet *wallet, const uint256 &hash, ChangeType status)> g_wallet_transaction_changed;
+
 bool AddWallet(const std::shared_ptr<CWallet>& wallet)
 {
     LOCK(cs_wallets);
@@ -55,6 +57,7 @@ bool AddWallet(const std::shared_ptr<CWallet>& wallet)
     std::vector<std::shared_ptr<CWallet>>::const_iterator i = std::find(vpwallets.begin(), vpwallets.end(), wallet);
     if (i != vpwallets.end()) return false;
     vpwallets.push_back(wallet);
+    wallet->NotifyTransactionChanged.connect(g_wallet_transaction_changed);
     return true;
 }
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -49,6 +49,8 @@ std::vector<std::shared_ptr<CWallet>> GetWallets();
 std::shared_ptr<CWallet> GetWallet(const std::string& name);
 std::shared_ptr<CWallet> LoadWallet(interfaces::Chain& chain, const WalletLocation& location, std::string& error, std::vector<std::string>& warnings);
 
+extern boost::signals2::signal<void (CWallet *wallet, const uint256 &hash, ChangeType status)> g_wallet_transaction_changed;
+
 enum class WalletCreationStatus {
     SUCCESS,
     CREATION_FAILED,

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -20,3 +20,8 @@ bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction &/*transaction*/
 {
     return true;
 }
+
+bool CZMQAbstractNotifier::WalletTransactionChanged(CWallet* /*wallet*/, const uint256& /*hashTx*/, ChangeType /*status*/)
+{
+    return true;
+}

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -5,9 +5,12 @@
 #ifndef BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 #define BITCOIN_ZMQ_ZMQABSTRACTNOTIFIER_H
 
+#include <ui_interface.h>
+#include <uint256.h>
 #include <zmq/zmqconfig.h>
 
 class CBlockIndex;
+class CWallet;
 class CZMQAbstractNotifier;
 
 typedef CZMQAbstractNotifier* (*CZMQNotifierFactory)();
@@ -42,6 +45,7 @@ public:
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
     virtual bool NotifyTransaction(const CTransaction &transaction);
+    virtual bool WalletTransactionChanged(CWallet* wallet, const uint256& hashTx, ChangeType status);
 
 protected:
     void *psocket;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -5,10 +5,13 @@
 #ifndef BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 #define BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H
 
+#include <ui_interface.h>
+#include <uint256.h>
 #include <validationinterface.h>
 #include <list>
 
 class CBlockIndex;
+class CWallet;
 class CZMQAbstractNotifier;
 
 class CZMQNotificationInterface final : public CValidationInterface
@@ -19,6 +22,8 @@ public:
     std::list<const CZMQAbstractNotifier*> GetActiveNotifiers() const;
 
     static CZMQNotificationInterface* Create();
+
+    void WalletTransactionChanged(CWallet* wallet, const uint256& hashTx, ChangeType status);
 
 protected:
     bool Initialize();

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -216,7 +216,7 @@ bool CZMQPublishWalletTransactionNotifier::WalletTransactionChanged(CWallet* wal
     uint32_t name_size = htonl(wallet->GetName().size());
     oss.write((const char*)&name_size, sizeof(name_size));
     oss << wallet->GetName();
-    oss.write(hash, 32);
+    oss.write((const char*) hash.begin(), 32);
     std::string s = oss.str();
     return SendMessage(MSG_WALLETTX, s.c_str(), s.size());
 }

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -52,4 +52,10 @@ public:
     bool NotifyTransaction(const CTransaction &transaction) override;
 };
 
+class CZMQPublishWalletTransactionNotifier : public CZMQAbstractPublishNotifier
+{
+public:
+    bool WalletTransactionChanged(CWallet* wallet, const uint256& hashTx, ChangeType status);
+};
+
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
This is an alternative to `-walletnotify` which has the advantage of publishing the wallet name. This is essential in a multi-wallet setup.

I'm submitting to seek concept ACK and/or suggestions.

Currently the published message contains the wallet name (lengh + bytes) followed by 32 bytes of the wallet transaction. Also considering to include the change (added, updated, removed) but I'm open for suggestions.

Currently working on extending the test `test/functional/interface_zmq.py` as well as `contrib/zmq/zmq_sub.py` and relevant documentation.
