### PR TITLE
gui: uncheck encrypt by default when creating wallet

### DIFF
--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -68,12 +68,12 @@
     <string>Encrypt Wallet</string>
    </property>
    <property name="checked">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
   </widget>
   <widget class="QCheckBox" name="disable_privkeys_checkbox">
    <property name="enabled">
-    <bool>false</bool>
+    <bool>true</bool>
    </property>
    <property name="geometry">
     <rect>


### PR DESCRIPTION
Sorry for bike-shedding, but I find this default confusing:
<img width="367" alt="Schermafbeelding 2020-01-06 om 12 49 15" src="https://user-images.githubusercontent.com/10217/71795996-b395a800-3083-11ea-8119-8930f096715f.png">

We don't encrypt the default wallet by default, so I don't think we should do it with new wallets. When creating a watch-only wallet - which I suspect is a more common use case than a second regular wallet - you have to uncheck the box first before you can check the watch-only box.

This PR unchecks the encryption box by default:
<img width="368" alt="Schermafbeelding 2020-01-06 om 12 56 10" src="https://user-images.githubusercontent.com/10217/71796048-f192cc00-3083-11ea-8e83-d136b77d49fc.png">

