### PR TITLE
[0.18] scripts: fix check-symbols & check-security argument passing

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -638,13 +638,13 @@ clean-local:
 check-symbols: $(bin_PROGRAMS)
 if GLIBC_BACK_COMPAT
 	@echo "Checking glibc back compat..."
-	$(AM_V_at) READELF=$(READELF) CPPFILT=$(CPPFILT) $(top_srcdir)/contrib/devtools/symbol-check.py < $(bin_PROGRAMS)
+	$(AM_V_at) READELF=$(READELF) CPPFILT=$(CPPFILT) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
 endif
 
 check-security: $(bin_PROGRAMS)
 if HARDEN
 	@echo "Checking binary security..."
-	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) $(top_srcdir)/contrib/devtools/security-check.py < $(bin_PROGRAMS)
+	$(AM_V_at) READELF=$(READELF) OBJDUMP=$(OBJDUMP) $(top_srcdir)/contrib/devtools/security-check.py $(bin_PROGRAMS)
 endif
 
 if ENABLE_BIP70


### PR DESCRIPTION
Backport of https://github.com/bitcoin/bitcoin/pull/17857.

The first argument in bin_PROGRAMS (bitcoind) was being silently
dropped and never passed into the check-security.py or check-symbols.py scripts.

This has been the case since the scripts were added to the makefile in
https://github.com/bitcoin/bitcoin/commit/f3d3eaf78eb51238d799d8f20a585550d1567719.

Example of the behavior:

```python
# touch a, touch b, touch c
# python3 args.py < a b c

import sys
if __name__ == '__main__':
    print(sys.argv)
    # ['args.py', 'b', 'c']

    # if you add some lines to "a",
    # you'll see them here..
    for line in sys.stdin:
        print(line)
```

Github-Pull: #17857
Rebased-From: 71af793512100ee7d508c3fb815af47925fe80ba