### PR TITLE
utils: Use fallback for macOS in AllocateFileRange

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -972,19 +972,6 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
     nFileSize.u.HighPart = nEndPos >> 32;
     SetFilePointerEx(hFile, nFileSize, 0, FILE_BEGIN);
     SetEndOfFile(hFile);
-#elif defined(MAC_OSX)
-    // OSX specific version
-    fstore_t fst;
-    fst.fst_flags = F_ALLOCATECONTIG;
-    fst.fst_posmode = F_PEOFPOSMODE;
-    fst.fst_offset = 0;
-    fst.fst_length = (off_t)offset + length;
-    fst.fst_bytesalloc = 0;
-    if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
-        fst.fst_flags = F_ALLOCATEALL;
-        fcntl(fileno(file), F_PREALLOCATE, &fst);
-    }
-    ftruncate(fileno(file), fst.fst_length);
 #else
     #if defined(__linux__)
     // Version using posix_fallocate


### PR DESCRIPTION
Following the findings collected in issue #17827 this PR removes the specific macOS code in favor of the generic fallback. Hence, APFS volumes with just enough free space can still complete the IBD.

ftruncate behaves erratically when used in an APFS volume, generating rev*.data files with a size considerably bigger than expected.

Using the generic method solves the problem and works for both APFS and HFS+.

