### PR TITLE
Restore English translation option

### DIFF
--- a/src/Makefile.qt_locale.include
+++ b/src/Makefile.qt_locale.include
@@ -10,6 +10,7 @@ QT_TS = \
   qt/locale/bitcoin_de_DE.ts \
   qt/locale/bitcoin_el.ts \
   qt/locale/bitcoin_el_GR.ts \
+  qt/locale/bitcoin_en.ts \
   qt/locale/bitcoin_en_AU.ts \
   qt/locale/bitcoin_en_GB.ts \
   qt/locale/bitcoin_eo.ts \

--- a/src/qt/bitcoin_locale.qrc
+++ b/src/qt/bitcoin_locale.qrc
@@ -11,6 +11,7 @@
         <file alias="de_DE">locale/bitcoin_de_DE.qm</file>
         <file alias="el">locale/bitcoin_el.qm</file>
         <file alias="el_GR">locale/bitcoin_el_GR.qm</file>
+        <file alias="en">locale/bitcoin_en.qm</file>
         <file alias="en_AU">locale/bitcoin_en_AU.qm</file>
         <file alias="en_GB">locale/bitcoin_en_GB.qm</file>
         <file alias="eo">locale/bitcoin_eo.qm</file>


### PR DESCRIPTION
It was [reported on Bitcointalk](https://bitcointalk.org/index.php?topic=5204167.msg53540137#msg53540137) that the normal English language option was lost in 0.19. This PR restores it. For some reason it was removed during the last periodic translation update.