### PR TITLE
qa: Fix double-negative arg test

### DIFF
--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -79,7 +79,7 @@ class ConfArgsTest(BitcoinTestFramework):
             conf.write('')  # clear
 
     def test_log_buffer(self):
-        with self.nodes[0].assert_debug_log(expected_msgs=['Warning: parsed potentially confusing double-negative -connect=0']):
+        with self.nodes[0].assert_debug_log(expected_msgs=['Warning: parsed potentially confusing double-negative -connect=0\n']):
             self.start_node(0, extra_args=['-noconnect=0'])
         self.stop_node(0)
 


### PR DESCRIPTION
Commit 67518f7cc61bf59ddfa0fd7c8dbbdec3653b9556 tests do not catch that a pointer is returned instead of a value.

This PR makes test to not accept trailing characters after 0.

From [IRC](http://www.erisian.com.au/bitcoin-core-dev/log-2020-01-07.html#l-358):
>  \<hebasto\> ryanofsky: hmm, why test/functional/feature_config_args.py passed on 67518f7cc61bf59ddfa0fd7c8dbbdec3653b9556 ?
>  \<hebasto\> I see now: test is broken.
>  \<ryanofsky\> test should be unaffected by that change, do you see a break somewhere?
>  \<hebasto\> yes: "-connect=0x7fff50369968" != "-connect=0"
> ...
>  \<ryanofsky\> Oh I see how that would happen, it should not be a problem in the current PR.
>  \<hebasto\> going to submit a pr to fix test
>  \<ryanofsky\> in the commit you mentioned, value is a pointer to a string, and it was printing the pointer address instead of the string on: LogPrintf("Warning: parsed potentially confusing double-negative -%s=%s\n", key, value);
>  \<hebasto\> correct
>  \<ryanofsky\> oh I see, test could be fixed to more robust and not accept trailing characters after 0
