### PR TITLE
tests: Avoid accumulating allocated memory in a global state if LogPrintf is called when fuzzing

### DIFF
--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -7,10 +7,14 @@
 #include <blockencodings.h>
 #include <blockfilter.h>
 #include <chain.h>
+#include <chainparams.h>
+#include <chainparamsbase.h>
 #include <coins.h>
 #include <compressor.h>
 #include <consensus/merkle.h>
 #include <key.h>
+#include <init.h>
+#include <logging.h>
 #include <merkleblock.h>
 #include <net.h>
 #include <primitives/block.h>
@@ -35,6 +39,17 @@ void initialize()
 {
     // Fuzzers using pubkey must hold an ECCVerifyHandle.
     static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+
+    // Enable logging. This avoids accumulating allocated memory in a global
+    // state (via m_msgs_before_open buffering) if LogPrintf is called when
+    // fuzzing. Log messages are written to standard output.
+    SelectParams(CBaseChainParams::REGTEST);
+    ::gArgs.ForceSetArg("-datadir", "/dev/null/subdir/does/not/exist");
+    ::gArgs.ForceSetArg("-debuglogfile", "/dev/null");
+    InitLogging();
+    LogInstance().m_print_to_console = false;
+    LogInstance().StartLogging();
+    LogInstance().m_print_to_console = true;
 }
 
 namespace {


### PR DESCRIPTION
Avoid accumulating allocated memory in a global state if `LogPrintf` is called when fuzzing.

The accumulation takes place via the `m_msgs_before_open` buffering.

Resolved by enabling logging and writing log messages to standard output.

This has the added benefit of making the fuzzing operator aware of any log printing caused by fuzzing which is likely to be an anomaly in itself (in the general case).

The only fuzzing harness in `master` that I've seen calling `LogPrintf` is `messageheader_deserialize` via the call to `CMessageHeader::IsValid()` which somewhat surprisingly does a `LogPrintf` in the case of `nMessageSize > MAX_SIZE` :)

Before:

```
$ src/test/fuzz/messageheader_deserialize corpus/
…
INFO: libFuzzer disabled leak detection after every mutation.
      Most likely the target function accumulates allocated
      memory in a global state w/o actually leaking it.
      You may try running this binary with -trace_malloc=[12]
      to get a trace of mallocs and frees.
      If LeakSanitizer is enabled in this process it will still
      run on the process shutdown.
…
```

After:

```
$ src/test/fuzz/messageheader_deserialize corpus/
…
2020-01-07T23:20:34Z CMessageHeader::IsValid(): (@, 4278190080 bytes) nMessageSize > MAX_SIZE
…
```

**How to test this PR**

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/messageheader_deserialize
…
```
