### PR TITLE
[WIP] qt: Make Information tab accessible via keyboard 

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -67,18 +67,18 @@
         </widget>
        </item>
        <item row="1" column="1" colspan="2">
-        <widget class="QLabel" name="clientVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="clientVersion">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -93,18 +93,18 @@
         </widget>
        </item>
        <item row="2" column="1" colspan="2">
-        <widget class="QLabel" name="clientUserAgent">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="clientUserAgent">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -119,18 +119,18 @@
         </widget>
        </item>
        <item row="3" column="1" colspan="2">
-        <widget class="QLabel" name="berkeleyDBVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="berkeleyDBVersion">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -142,24 +142,18 @@
         </widget>
        </item>
        <item row="4" column="1" colspan="2">
-        <widget class="QLabel" name="dataDir">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="toolTip">
-          <string>To specify a non-default location of the data directory use the '%1' option.</string>
+        <widget class="QLineEdit" name="dataDir">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="wordWrap">
+         <property name="readOnly">
           <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -171,24 +165,18 @@
         </widget>
        </item>
        <item row="5" column="1" colspan="2">
-        <widget class="QLabel" name="blocksDir">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="toolTip">
-          <string>To specify a non-default location of the blocks directory use the '%1' option.</string>
+        <widget class="QLineEdit" name="blocksDir">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="wordWrap">
+         <property name="readOnly">
           <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -200,18 +188,18 @@
         </widget>
        </item>
        <item row="6" column="1" colspan="2">
-        <widget class="QLabel" name="startupTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="startupTime">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -236,18 +224,18 @@
         </widget>
        </item>
        <item row="8" column="1" colspan="2">
-        <widget class="QLabel" name="networkName">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="networkName">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -259,18 +247,18 @@
         </widget>
        </item>
        <item row="9" column="1" colspan="2">
-        <widget class="QLabel" name="numberOfConnections">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="numberOfConnections">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -295,18 +283,18 @@
         </widget>
        </item>
        <item row="11" column="1" colspan="2">
-        <widget class="QLabel" name="numberOfBlocks">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="numberOfBlocks">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -318,18 +306,18 @@
         </widget>
        </item>
        <item row="12" column="1" colspan="2">
-        <widget class="QLabel" name="lastBlockTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="lastBlockTime">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -354,18 +342,18 @@
         </widget>
        </item>
        <item row="14" column="1">
-        <widget class="QLabel" name="mempoolNumberTxs">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="mempoolNumberTxs">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -377,18 +365,18 @@
         </widget>
        </item>
        <item row="15" column="1">
-        <widget class="QLabel" name="mempoolSize">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
+        <widget class="QLineEdit" name="mempoolSize">
+         <property name="styleSheet">
+          <string notr="true">background-color: rgba(0, 0, 0, 0);</string>
          </property>
          <property name="text">
           <string>N/A</string>
          </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
+         <property name="frame">
+          <bool>false</bool>
          </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         <property name="readOnly">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
-    <height>430</height>
+    <width>744</width>
+    <height>461</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -204,17 +204,17 @@
         </widget>
        </item>
        <item row="7" column="0">
-           <widget class="QLabel" name="labelNetwork">
-               <property name="font">
-                   <font>
-                       <weight>75</weight>
-                       <bold>true</bold>
-                   </font>
-               </property>
-               <property name="text">
-                   <string>Network</string>
-               </property>
-           </widget>
+        <widget class="QLabel" name="labelNetwork">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network</string>
+         </property>
+        </widget>
        </item>
        <item row="8" column="0">
         <widget class="QLabel" name="label_8">
@@ -491,9 +491,6 @@
              <height>24</height>
             </size>
            </property>
-           <property name="text">
-            <string/>
-           </property>
            <property name="toolTip">
             <string>Decrease font size</string>
            </property>
@@ -640,9 +637,6 @@
          </item>
          <item>
           <widget class="QLineEdit" name="lineEdit">
-           <property name="placeholderText">
-            <string/>
-           </property>
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -1063,7 +1057,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>300</width>
-                <height>426</height>
+                <height>432</height>
                </rect>
               </property>
               <property name="minimumSize">

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -904,4 +904,13 @@ void LogQtInfo()
     }
 }
 
+void SetTextPreservingSelection(QLineEdit* qlineedit_widget, const QString& new_text)
+{
+    const bool has_selected_text = qlineedit_widget->hasSelectedText();
+    qlineedit_widget->setText(new_text);
+    if (has_selected_text) {
+        qlineedit_widget->selectAll();
+    }
+}
+
 } // namespace GUIUtil

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -270,6 +270,11 @@ namespace GUIUtil
      * Writes to debug.log short info about the used Qt and the host system.
      */
     void LogQtInfo();
+
+    /**
+     * Calls QLineEdit::setText() and preserves text selection state.
+     */
+    void SetTextPreservingSelection(QLineEdit* qlineedit_widget, const QString& new_text);
 } // namespace GUIUtil
 
 #endif // BITCOIN_QT_GUIUTIL_H

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -11,6 +11,7 @@
 
 #include <qt/bantablemodel.h>
 #include <qt/clientmodel.h>
+#include <qt/guiutil.h>
 #include <qt/platformstyle.h>
 #include <qt/walletmodel.h>
 #include <chainparams.h>
@@ -849,7 +850,7 @@ void RPCConsole::updateNetworkState()
         connections += " (" + tr("Network activity disabled") + ")";
     }
 
-    ui->numberOfConnections->setText(connections);
+    GUIUtil::SetTextPreservingSelection(ui->numberOfConnections, connections);
 }
 
 void RPCConsole::setNumConnections(int count)
@@ -868,19 +869,19 @@ void RPCConsole::setNetworkActive(bool networkActive)
 void RPCConsole::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress, bool headers)
 {
     if (!headers) {
-        ui->numberOfBlocks->setText(QString::number(count));
-        ui->lastBlockTime->setText(blockDate.toString());
+        GUIUtil::SetTextPreservingSelection(ui->numberOfBlocks, QString::number(count));
+        GUIUtil::SetTextPreservingSelection(ui->lastBlockTime, blockDate.toString())    ;
     }
 }
 
 void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
 {
-    ui->mempoolNumberTxs->setText(QString::number(numberOfTxs));
+    GUIUtil::SetTextPreservingSelection(ui->mempoolNumberTxs, QString::number(numberOfTxs));
 
     if (dynUsage < 1000000)
-        ui->mempoolSize->setText(QString::number(dynUsage/1000.0, 'f', 2) + " KB");
+        GUIUtil::SetTextPreservingSelection(ui->mempoolSize, QString::number(dynUsage/1000.0, 'f', 2) + " KB");
     else
-        ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
+        GUIUtil::SetTextPreservingSelection(ui->mempoolSize, QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }
 
 void RPCConsole::on_lineEdit_returnPressed()


### PR DESCRIPTION
This is an alternative to #14810.
Used a **promag**'s [suggestion](https://github.com/bitcoin/bitcoin/pull/14810#issuecomment-487580715)

Also applied a style-fix from #15220.

Current drawbacks: context menu and tooltip background color inherits customized widget one instead of use system defaults.