### PR TITLE
Add feature to get specific help

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv)
     }
 
     if (HelpRequested(gArgs)) {
-        std::cout << gArgs.GetHelpMessage();
+        std::cout << gArgs.GetSpecificHelpMessage();
 
         return EXIT_SUCCESS;
     }

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -116,7 +116,7 @@ static int AppInitRPC(int argc, char* argv[])
                 "or:     bitcoin-cli [options] -named <command> [name=value]...  Send command to " PACKAGE_NAME " (with named arguments)\n"
                 "or:     bitcoin-cli [options] help                List commands\n"
                 "or:     bitcoin-cli [options] help <command>      Get help for a command\n";
-            strUsage += "\n" + gArgs.GetHelpMessage();
+            strUsage += "\n" + gArgs.GetSpecificHelpMessage();
         }
 
         tfm::format(std::cout, "%s", strUsage);

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -103,7 +103,7 @@ static int AppInitRawTx(int argc, char* argv[])
             "Usage:  bitcoin-tx [options] <hex-tx> [commands]  Update hex-encoded bitcoin transaction\n" +
             "or:     bitcoin-tx [options] -create [commands]   Create hex-encoded bitcoin transaction\n" +
             "\n";
-        strUsage += gArgs.GetHelpMessage();
+        strUsage += gArgs.GetSpecificHelpMessage();
 
         tfm::format(std::cout, "%s", strUsage);
 

--- a/src/bitcoin-wallet.cpp
+++ b/src/bitcoin-wallet.cpp
@@ -46,7 +46,7 @@ static bool WalletAppInit(int argc, char* argv[])
                                       "To change the target wallet, use the -datadir, -wallet and -testnet/-regtest arguments.\n\n" +
                                       "Usage:\n" +
                                      "  bitcoin-wallet [options] <command>\n\n" +
-                                     gArgs.GetHelpMessage();
+                                     gArgs.GetSpecificHelpMessage();
 
         tfm::format(std::cout, "%s", usage);
         return false;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -68,7 +68,7 @@ static bool AppInit(int argc, char* argv[])
         else
         {
             strUsage += "\nUsage:  bitcoind [options]                     Start " PACKAGE_NAME "\n";
-            strUsage += "\n" + gArgs.GetHelpMessage();
+            strUsage += "\n" + gArgs.GetSpecificHelpMessage();
         }
 
         tfm::format(std::cout, "%s", strUsage);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -478,7 +478,9 @@ int GuiMain(int argc, char* argv[])
     // Show help message immediately after parsing command-line options (for "-lang") and setting locale,
     // but before showing splash screen.
     if (HelpRequested(gArgs) || gArgs.IsArgSet("-version")) {
-        HelpMessageDialog help(*node, nullptr, gArgs.IsArgSet("-version"));
+        std::string helpArg = gArgs.GetArg("-help", "");
+        bool specialHelp = (helpArg != "");
+        HelpMessageDialog help(*node, nullptr, gArgs.IsArgSet("-version"), specialHelp);
         help.showOrPrint();
         return EXIT_SUCCESS;
     }

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -27,7 +27,7 @@
 #include <QVBoxLayout>
 
 /** "Help message" or "About" dialog box */
-HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bool about) :
+HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bool about, bool specificHelp) :
     QDialog(parent),
     ui(new Ui::HelpMessageDialog)
 {
@@ -102,6 +102,10 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
         ui->helpMessage->moveCursor(QTextCursor::Start);
         ui->scrollArea->setVisible(false);
         ui->aboutLogo->setVisible(false);
+        if (specificHelp) {
+            coreOptions = QString::fromStdString(gArgs.GetSpecificHelpMessage());
+            text = version + "\n\n" + header + "\n" + coreOptions;
+        }
     }
 }
 

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -24,7 +24,7 @@ class HelpMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit HelpMessageDialog(interfaces::Node& node, QWidget *parent, bool about);
+    explicit HelpMessageDialog(interfaces::Node& node, QWidget *parent, bool about, bool specificHelp = false);
     ~HelpMessageDialog();
 
     void printToConsole();

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -314,6 +314,11 @@ public:
     std::string GetHelpMessage() const;
 
     /**
+     * Get a filtered help string
+     */
+    std::string GetSpecificHelpMessage();
+
+    /**
      * Return Flags for known arg.
      * Return nullopt for unknown arg.
      */


### PR DESCRIPTION
This PR makes it possible to get a more specific help about just one CMD.
Example:
```
$ bitcoind --help=server
Bitcoin Core version v0.19.99.0-6fdf7dda6

Usage:  bitcoind [options]                     Start Bitcoin Core

  -server
       Accept command line and JSON-RPC commands

```
If no arg was given or the arg doesn't exist, it will return the normal full help.