### PR TITLE
gui: Set CConnman byte counters earlier to avoid uninitialized reads

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -386,8 +386,8 @@ private:
     // Network usage totals
     CCriticalSection cs_totalBytesRecv;
     CCriticalSection cs_totalBytesSent;
-    uint64_t nTotalBytesRecv GUARDED_BY(cs_totalBytesRecv);
-    uint64_t nTotalBytesSent GUARDED_BY(cs_totalBytesSent);
+    uint64_t nTotalBytesRecv GUARDED_BY(cs_totalBytesRecv) {0};
+    uint64_t nTotalBytesSent GUARDED_BY(cs_totalBytesSent) {0};
 
     // outbound limit & stats
     uint64_t nMaxOutboundTotalBytesSentInCycle GUARDED_BY(cs_totalBytesSent);


### PR DESCRIPTION
Initialize CConnman byte counters during construction, so GetTotalBytesRecv() and GetTotalBytesSent() methods don't return garbage before Start() is called.

Change shouldn't have any effect outside of the GUI. It just fixes a race condition during a qt test that was observed on travis: https://travis-ci.org/bitcoin/bitcoin/jobs/634989685