### PR TITLE
doc: Fix improper Doxygen inline comments

### DIFF
--- a/src/util/settings.h
+++ b/src/util/settings.h
@@ -71,11 +71,11 @@ struct SettingsSpan {
     explicit SettingsSpan(const SettingsValue& value) noexcept : SettingsSpan(&value, 1) {}
     explicit SettingsSpan(const SettingsValue* data, size_t size) noexcept : data(data), size(size) {}
     explicit SettingsSpan(const std::vector<SettingsValue>& vec) noexcept;
-    const SettingsValue* begin() const; //<! Pointer to first non-negated value.
-    const SettingsValue* end() const;   //<! Pointer to end of values.
-    bool empty() const;                 //<! True if there are any non-negated values.
-    bool last_negated() const;          //<! True if the last value is negated.
-    size_t negated() const;             //<! Number of negated values.
+    const SettingsValue* begin() const; //!< Pointer to first non-negated value.
+    const SettingsValue* end() const;   //!< Pointer to end of values.
+    bool empty() const;                 //!< True if there are any non-negated values.
+    bool last_negated() const;          //!< True if the last value is negated.
+    size_t negated() const;             //!< Number of negated values.
 
     const SettingsValue* data = nullptr;
     size_t size = 0;


### PR DESCRIPTION
The proper syntax is `//!<`
http://www.doxygen.nl/manual/docblocks.html#memberdoc

Identified via `-Wdocumentation`:

```
In file included from ./util/system.h:26:
./util/settings.h:74:41: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
    const SettingsValue* begin() const; //<! Pointer to first non-negated value.
                                        ^~~~
                                        ///<
./util/settings.h:75:41: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
    const SettingsValue* end() const;   //<! Pointer to end of values.
                                        ^~~~
                                        ///<
./util/settings.h:76:41: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
    bool empty() const;                 //<! True if there are any non-negated values.
                                        ^~~~
                                        ///<
./util/settings.h:77:41: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
    bool last_negated() const;          //<! True if the last value is negated.
                                        ^~~~
                                        ///<
./util/settings.h:78:41: error: not a Doxygen trailing comment [-Werror,-Wdocumentation]
    size_t negated() const;             //<! Number of negated values.
                                        ^~~~
                                        ///<
```