### PR TITLE
tests: Add amount compression/decompression fuzzing to existing fuzzing harness

### DIFF
--- a/src/compressor.h
+++ b/src/compressor.h
@@ -19,7 +19,17 @@ bool CompressScript(const CScript& script, std::vector<unsigned char> &out);
 unsigned int GetSpecialScriptSize(unsigned int nSize);
 bool DecompressScript(CScript& script, unsigned int nSize, const std::vector<unsigned char> &out);
 
+/**
+ * Compress amount.
+ *
+ * nAmount is of type uint64_t and thus cannot be negative. If you're passing in
+ * a CAmount (int64_t), make sure to properly handle the case where the amount
+ * is negative before calling CompressAmount(...).
+ *
+ * @pre Function defined only for 0 <= nAmount <= MAX_MONEY.
+ */
 uint64_t CompressAmount(uint64_t nAmount);
+
 uint64_t DecompressAmount(uint64_t nAmount);
 
 /** Compact serializer for scripts.

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <amount.h>
 #include <arith_uint256.h>
 #include <compressor.h>
 #include <consensus/merkle.h>
@@ -56,7 +57,14 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
     const Consensus::Params& consensus_params = Params().GetConsensus();
     (void)CheckProofOfWork(u256, u32, consensus_params);
-    (void)CompressAmount(u64);
+    if (u64 <= MAX_MONEY) {
+        const uint64_t compressed_money_amount = CompressAmount(u64);
+        assert(u64 == DecompressAmount(compressed_money_amount));
+        static const uint64_t compressed_money_amount_max = CompressAmount(MAX_MONEY - 1);
+        assert(compressed_money_amount <= compressed_money_amount_max);
+    } else {
+        (void)CompressAmount(u64);
+    }
     static const uint256 u256_min(uint256S("0000000000000000000000000000000000000000000000000000000000000000"));
     static const uint256 u256_max(uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
     const std::vector<uint256> v256{u256, u256_min, u256_max};


### PR DESCRIPTION
Small fuzzing improvement:

Add amount compression/decompression fuzzing to existing fuzzing harness: test compression round-trip (`DecompressAmount(CompressAmount(…))`).

Make the domain of `CompressAmount(…)` explicit.

Amount compression primer:

```
    Compact serialization for amounts

    Special serializer/deserializer for amount values. It is optimized for
    values which have few non-zero digits in decimal representation. Most
    amounts currently in the txout set take only 1 or 2 bytes to
    represent.
```

**How to test this PR**

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/integer
…
```
