### PR TITLE
Bug: IsUsedDestination shouldn't use key id as script id for ScriptHash

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -80,9 +80,14 @@ struct PKHash : public uint160
     using uint160::uint160;
 };
 
+struct WitnessV0KeyHash;
 struct ScriptHash : public uint160
 {
     ScriptHash() : uint160() {}
+    // These don't do what you'd expect.
+    // Use ScriptHash(GetScriptForDestination(...)) instead.
+    explicit ScriptHash(const WitnessV0KeyHash& hash) = delete;
+    explicit ScriptHash(const PKHash& hash) = delete;
     explicit ScriptHash(const uint160& hash) : uint160(hash) {}
     explicit ScriptHash(const CScript& script);
     using uint160::uint160;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -734,7 +734,7 @@ bool CWallet::IsUsedDestination(const uint256& hash, unsigned int n) const
             if (GetDestData(wpkh_dest, "used", nullptr)) {
                 return true;
             }
-            ScriptHash sh_wpkh_dest(wpkh_dest);
+            ScriptHash sh_wpkh_dest(GetScriptForDestination(wpkh_dest));
             if (GetDestData(sh_wpkh_dest, "used", nullptr)) {
                 return true;
             }


### PR DESCRIPTION
Regression introduced in https://github.com/bitcoin/bitcoin/pull/17621 which causes p2sh-segwit addresses to be erroneously missed.

Tests are only failing in 0.19 branch, likely because that release still uses p2sh-segwit addresses rather than bech32 by default.

I'll devise a test case to catch this going forward.