### PR TITLE
tests: Add key_io fuzzing harness. Fuzz additional functions in existing fuzzing harnesses.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -36,6 +36,7 @@ FUZZ_TARGETS = \
   test/fuzz/integer \
   test/fuzz/inv_deserialize \
   test/fuzz/key \
+  test/fuzz/key_io \
   test/fuzz/key_origin_info_deserialize \
   test/fuzz/locale \
   test/fuzz/merkle_block_deserialize \
@@ -437,6 +438,12 @@ test_fuzz_key_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_key_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_key_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_key_SOURCES = $(FUZZ_SUITE) test/fuzz/key.cpp
+
+test_fuzz_key_io_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_key_io_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_key_io_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_key_io_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_key_io_SOURCES = $(FUZZ_SUITE) test/fuzz/key_io.cpp
 
 test_fuzz_key_origin_info_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DKEY_ORIGIN_INFO_DESERIALIZE=1
 test_fuzz_key_origin_info_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -2,8 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <core_io.h>
+#include <primitives/block.h>
+#include <rpc/util.h>
 #include <test/fuzz/fuzz.h>
-
+#include <uint256.h>
+#include <univalue.h>
 #include <util/strencodings.h>
 
 #include <cassert>
@@ -19,4 +23,14 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     if (IsHex(random_hex_string)) {
         assert(ToLower(random_hex_string) == hex_data);
     }
+    (void)IsHexNumber(random_hex_string);
+    uint256 result;
+    (void)ParseHashStr(random_hex_string, result);
+    (void)uint256S(random_hex_string);
+    try {
+        (void)HexToPubKey(random_hex_string);
+    } catch (const UniValue&) {
+    }
+    CBlockHeader block_header;
+    (void)DecodeHexBlockHeader(block_header, random_hex_string);
 }

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -23,6 +23,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <uint256.h>
+#include <util/moneystr.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/time.h>
@@ -76,11 +77,19 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     (void)DecompressAmount(u64);
     (void)FormatISO8601Date(i64);
     (void)FormatISO8601DateTime(i64);
+    // FormatMoney(i) not defined when i == std::numeric_limits<int64_t>::min()
+    if (i64 != std::numeric_limits<int64_t>::min()) {
+        int64_t parsed_money;
+        if (ParseMoney(FormatMoney(i64), parsed_money)) {
+            assert(parsed_money == i64);
+        }
+    }
     (void)GetSizeOfCompactSize(u64);
     (void)GetSpecialScriptSize(u32);
     // (void)GetVirtualTransactionSize(i64, i64); // function defined only for a subset of int64_t inputs
     // (void)GetVirtualTransactionSize(i64, i64, u32); // function defined only for a subset of int64_t/uint32_t inputs
     (void)HexDigit(ch);
+    (void)MoneyRange(i64);
     (void)i64tostr(i64);
     (void)IsDigit(ch);
     (void)IsSpace(ch);
@@ -106,6 +115,14 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     (void)SipHashUint256(u64, u64, u256);
     (void)SipHashUint256Extra(u64, u64, u256, u32);
     (void)ToLower(ch);
+    (void)ToUpper(ch);
+    // ValueFromAmount(i) not defined when i == std::numeric_limits<int64_t>::min()
+    if (i64 != std::numeric_limits<int64_t>::min()) {
+        int64_t parsed_money;
+        if (ParseMoney(ValueFromAmount(i64).getValStr(), parsed_money)) {
+            assert(parsed_money == i64);
+        }
+    }
 
     const arith_uint256 au256 = UintToArith256(u256);
     assert(ArithToUint256(au256) == u256);

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <key_io.h>
+#include <rpc/util.h>
+#include <script/signingprovider.h>
+#include <script/standard.h>
+#include <test/fuzz/fuzz.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    const std::string random_string(buffer.begin(), buffer.end());
+
+    const CKey key = DecodeSecret(random_string);
+    if (key.IsValid()) {
+        assert(key == DecodeSecret(EncodeSecret(key)));
+    }
+
+    const CExtKey ext_key = DecodeExtKey(random_string);
+    if (ext_key.key.size() == 32) {
+        assert(ext_key == DecodeExtKey(EncodeExtKey(ext_key)));
+    }
+
+    const CExtPubKey ext_pub_key = DecodeExtPubKey(random_string);
+    if (ext_pub_key.pubkey.size() == CPubKey::COMPRESSED_SIZE) {
+        assert(ext_pub_key == DecodeExtPubKey(EncodeExtPubKey(ext_pub_key)));
+    }
+
+    const CTxDestination tx_destination = DecodeDestination(random_string);
+    (void)DescribeAddress(tx_destination);
+    (void)GetKeyForDestination(/* store */ {}, tx_destination);
+    (void)GetScriptForDestination(tx_destination);
+    (void)IsValidDestination(tx_destination);
+
+    (void)IsValidDestinationString(random_string);
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -27,6 +27,7 @@ FUZZERS_MISSING_CORPORA = [
     "flat_file_pos_deserialize",
     "float",
     "hex",
+    "key_io",
     "integer",
     "key",
     "key_origin_info_deserialize",


### PR DESCRIPTION
Add `key_io` fuzzing harness.

Fuzz additional functions in the `hex` fuzzing harness.

Fuzz additional functions in the `integer` fuzzing harness.

Fuzz additional functions in the `script` fuzzing harness.

Fuzz additional functions in the `transaction` fuzzing harness.

**How to test this PR**

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/key_io
…
```