### PR TITLE
build: add linker optimisation flags to gitian & guix (Linux)

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -46,7 +46,7 @@ script: |
   FAKETIME_PROGS="date ar ranlib nm"
   HOST_CFLAGS="-O2 -g"
   HOST_CXXFLAGS="-O2 -g"
-  HOST_LDFLAGS_BASE="-static-libstdc++"
+  HOST_LDFLAGS_BASE="-static-libstdc++ -Wl,-O2"
 
   export QT_RCC_TEST=1
   export QT_RCC_SOURCE_DATE_OVERRIDE=1

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -177,7 +177,7 @@ HOST_CXXFLAGS="$HOST_CFLAGS"
 
 # LDFLAGS
 case "$HOST" in
-    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++" ;;
+    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++ -Wl,-O2" ;;
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 


### PR DESCRIPTION
This PR adds `-Wl,O2` to our gitian and guix LDFLAGS. This makes the linker perform certain optimisations (and is different from LTO).

Any -O argument will enable optimizations in GNU ld. We can use -O2 here, as this matches our compile flags. Note that this would also enable additional optimizations if using the lld or gold linkers, when compared to -O0.

A nice writeup + diagrams of some of these optimizations is  available here: http://lwn.net/Articles/192624/.

#### master
```bash
# bitcoind
Histogram for `.gnu.hash' bucket list length (total of 3 buckets)
 Length  Number     % of total  Coverage
      0  1          ( 33.3%)       0.0%
      1  0          (  0.0%)       0.0%
      2  1          ( 33.3%)      40.0%
      3  1          ( 33.3%)     100.0%
```
```bash
# bitcoin-qt 
Histogram for `.gnu.hash' bucket list length (total of 3 buckets)
 Length  Number     % of total  Coverage
      0  0          (  0.0%)       0.0%
      1  1          ( 33.3%)      10.0%
      2  0          (  0.0%)      10.0%
      3  0          (  0.0%)      10.0%
      4  1          ( 33.3%)      50.0%
      5  1          ( 33.3%)     100.0%
```

#### this PR:
```bash
# bitcoind
Histogram for `.gnu.hash' bucket list length (total of 8 buckets)
 Length  Number     % of total  Coverage
      0  3          ( 37.5%)       0.0%
      1  5          ( 62.5%)     100.0%
```
```bash
# bitcoin-qt
Histogram for `.gnu.hash' bucket list length (total of 19 buckets)
 Length  Number     % of total  Coverage
      0  9          ( 47.4%)       0.0%
      1  10         ( 52.6%)     100.0%
```

#### GNU ld -O

> If level is a numeric values greater than zero ld optimizes the output. This might take significantly longer and therefore probably should only be enabled for the final binary. At the moment this option only affects ELF shared library generation. Future releases of the linker may make more use of this option. Also currently there is no difference in the linker’s behaviour for different non-zero values of this option. Again this may change with future releases.

#### lld -O

> Optimize output file size
