### PR TITLE
test: Fix p2p_invalid_messages failing in Python 3.8 because of warning

### DIFF
--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -145,13 +145,13 @@ class InvalidMessagesTest(BitcoinTestFramework):
     def test_magic_bytes(self):
         conn = self.nodes[0].add_p2p_connection(P2PDataStore())
 
-        def swap_magic_bytes():
+        async def swap_magic_bytes():
             conn._on_data = lambda: None  # Need to ignore all incoming messages from now, since they come with "invalid" magic bytes
             conn.magic_bytes = b'\x00\x11\x22\x32'
 
         # Call .result() to block until the atomic swap is complete, otherwise
         # we might run into races later on
-        asyncio.run_coroutine_threadsafe(asyncio.coroutine(swap_magic_bytes)(), NetworkThread.network_event_loop).result()
+        asyncio.run_coroutine_threadsafe(swap_magic_bytes(), NetworkThread.network_event_loop).result()
 
         with self.nodes[0].assert_debug_log(['PROCESSMESSAGE: INVALID MESSAGESTART ping']):
             conn.send_message(messages.msg_ping(nonce=0xff))


### PR DESCRIPTION
In Python 3.8 `p2p_invalid_messages.py` fails because of the following warning python produce: 
```
2020-01-15T13:02:14.486000Z TestFramework (INFO): Initializing test directory /tmp/bitcoin_func_test_3xq0f6uh
./test/functional/p2p_invalid_messages.py:154: DeprecationWarning: "@coroutine" decorator is deprecated since Python 3.8, use "async def" instead
  asyncio.run_coroutine_threadsafe(asyncio.coroutine(swap_magic_bytes)(), NetworkThread.network_event_loop).result()
2020-01-15T13:02:15.306000Z TestFramework (INFO): Sending a bunch of large, junk messages to test memory exhaustion. May take a bit...
2020-01-15T13:02:17.971000Z TestFramework (INFO): Waiting for node to drop junk messages.
2020-01-15T13:02:18.042000Z TestFramework.mininode (WARNING): Connection lost to 127.0.0.1:12826 due to [Errno 104] Connection reset by peer
2020-01-15T13:02:18.141000Z TestFramework (INFO): Sending a message with incorrect size of 2
2020-01-15T13:02:18.293000Z TestFramework (INFO): Sending a message with incorrect size of 77
2020-01-15T13:02:18.344000Z TestFramework.mininode (WARNING): Connection lost to 127.0.0.1:12826 due to [Errno 104] Connection reset by peer
2020-01-15T13:02:18.445000Z TestFramework (INFO): Sending a message with incorrect size of 78
2020-01-15T13:02:18.597000Z TestFramework (INFO): Sending a message with incorrect size of 79
2020-01-15T13:02:18.902000Z TestFramework (INFO): Stopping nodes
2020-01-15T13:02:19.154000Z TestFramework (INFO): Cleaning up /tmp/bitcoin_func_test_3xq0f6uh on exit
2020-01-15T13:02:19.154000Z TestFramework (INFO): Tests successful
```

so as it says I replaced the co-routine with `async def` which IIUC is supported since Python 3.5, so this makes the test pass both on 3.5+ and on 3.8 
https://docs.python.org/3.5/library/asyncio-task.html ("The async def type of coroutine was added in Python 3.5, and is recommended if there is no need to support older Python versions")