### PR TITLE
replace deprecated method of recursive_directory_iterator with the st…

### DIFF
--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -74,7 +74,7 @@ std::vector<fs::path> ListWalletDir()
         if (it->status().type() == fs::directory_file && IsBerkeleyBtree(it->path() / "wallet.dat")) {
             // Found a directory which contains wallet.dat btree file, add it as a wallet.
             paths.emplace_back(path);
-        } else if (it.level() == 0 && it->symlink_status().type() == fs::regular_file && IsBerkeleyBtree(it->path())) {
+        } else if (it.depth() == 0 && it->symlink_status().type() == fs::regular_file && IsBerkeleyBtree(it->path())) {
             if (it->path().filename() == "wallet.dat") {
                 // Found top-level wallet.dat btree file, add top level directory ""
                 // as a wallet.


### PR DESCRIPTION
The update of boost 1.72.0 deprecated the method level() of the recursive_directory_iterator.

See: https://www.boost.org/doc/libs/1_72_0/libs/filesystem/doc/release_history.html

This commit fixes this by replacing the member with the standard counterpart.

