### PR TITLE
netaddress: Simplify reachability logic

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -101,7 +101,18 @@ unsigned short GetListenPort()
     return (unsigned short)(gArgs.GetArg("-port", Params().GetDefaultPort()));
 }
 
-// find 'best' local address for a particular peer
+/**
+ * Find the local service with the best reachability from a particular peer,
+ * breaking ties by their scores.
+ *
+ * @param[out] addr The local service, if found.
+ * @param paddrPeer The peer from which to evaluate reachability.
+ *
+ * @returns Whether or not a local service was found.
+ *
+ * @see CNetAddr::GetReachabilityFrom(const CNetAddr *) for how reachability is
+ *      scored.
+ */
 bool GetLocal(CService& addr, const CNetAddr *paddrPeer)
 {
     if (!fListen)


### PR DESCRIPTION
```
Our reachability logic was overly complicated, and most likely
incorrect. In particular, we would prefer advertising our IPv4 services
for peers on Toredo, which would most likely just result in us sending
packets to their Toredo provider.

The new logic is a bit simpler:

- Assume all peers can reach us through IPv4 (same as before)
- If peer is unknown or unroutable, assume they can reach through every
  network (same as before)
- IPv6 peers can reach through IPv6
- Onion peers can reach through Onion
```

-----

What I need help on:
1. Is the "If peer is unknown or unroutable, assume they can reach through every network" rule reasonable? I suspect I'm misunderstanding the original intention.
2. Since the unknown and unroutable cases seem to follow the same logic, can we just make them one thing and eliminate the awkward re-purposing of `NET_MAX`?