### PR TITLE
doc: Fix doxygen errors

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -990,7 +990,7 @@ static bool TxRelayMayResultInDisconnect(const TxValidationState& state) {
 /**
  * Potentially ban a node based on the contents of a BlockValidationState object
  *
- * @param[in] via_compact_block: this bool is passed in because net_processing should
+ * @param[in] via_compact_block this bool is passed in because net_processing should
  * punish peers differently depending on whether the data was provided in a compact
  * block message or not. If the compact block had a valid header, but contained invalid
  * txs, the peer should not be punished. See BIP 152.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -763,7 +763,7 @@ bool IsProxy(const CNetAddr &addr) {
  * @param hSocket The socket on which to connect to the SOCKS5 proxy.
  * @param nTimeout Wait this many milliseconds for the connection to the SOCKS5
  *                 proxy to be established.
- * @param outProxyConnectionFailed[out] Whether or not the connection to the
+ * @param[out] outProxyConnectionFailed Whether or not the connection to the
  *                                      SOCKS5 proxy failed.
  *
  * @returns Whether or not the operation succeeded.

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -22,10 +22,10 @@ struct NodeContext;
  *
  * @param[in]  node reference to node context
  * @param[in]  tx the transaction to broadcast
- * @param[out] &err_string reference to std::string to fill with error string if available
+ * @param[out] err_string reference to std::string to fill with error string if available
  * @param[in]  max_tx_fee reject txs with fees higher than this (if 0, accept any fee)
  * @param[in]  relay flag if both mempool insertion and p2p relay are requested
- * @param[in]  wait_callback, wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
+ * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
 NODISCARD TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -584,7 +584,7 @@ void UpdatePSBTOutput(const SigningProvider& provider, PartiallySignedTransactio
 /**
  * Finalizes a PSBT if possible, combining partial signatures.
  *
- * @param[in,out] &psbtx reference to PartiallySignedTransaction to finalize
+ * @param[in,out] psbtx PartiallySignedTransaction to finalize
  * return True if the PSBT is now complete, false otherwise
  */
 bool FinalizePSBT(PartiallySignedTransaction& psbtx);
@@ -592,7 +592,7 @@ bool FinalizePSBT(PartiallySignedTransaction& psbtx);
 /**
  * Finalizes a PSBT if possible, and extracts it to a CMutableTransaction if it could be finalized.
  *
- * @param[in]  &psbtx reference to PartiallySignedTransaction
+ * @param[in]  psbtx PartiallySignedTransaction
  * @param[out] result CMutableTransaction representing the complete transaction, if successful
  * @return True if we successfully extracted the transaction, false otherwise
  */
@@ -601,7 +601,7 @@ bool FinalizeAndExtractPSBT(PartiallySignedTransaction& psbtx, CMutableTransacti
 /**
  * Combines PSBTs with the same underlying transaction, resulting in a single PSBT with all partial signatures from each input.
  *
- * @param[out] &out   the combined PSBT, if successful
+ * @param[out] out   the combined PSBT, if successful
  * @param[in]  psbtxs the PSBTs to combine
  * @return error (OK if we successfully combined the transactions, other error if they were not compatible)
  */

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -28,7 +28,7 @@ void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
 /**
   * Parse a prevtxs UniValue array and get the map of coins from it
   *
-  * @param  prevTxs       Array of previous txns outputs that tx depends on but may not yet be in the block chain
+  * @param  prevTxsUnival Array of previous txns outputs that tx depends on but may not yet be in the block chain
   * @param  keystore      A pointer to the temporary keystore if there is one
   * @param  coins         Map of unspent outputs - coins in mempool and current chain UTXO set, may be extended by previous txns outputs after call
   */

--- a/src/script/descriptor.h
+++ b/src/script/descriptor.h
@@ -47,28 +47,28 @@ struct Descriptor {
 
     /** Expand a descriptor at a specified position.
      *
-     * @param[in] pos: The position at which to expand the descriptor. If IsRange() is false, this is ignored.
-     * @param[in] provider: The provider to query for private keys in case of hardened derivation.
-     * @param[out] output_scripts: The expanded scriptPubKeys.
-     * @param[out] out: Scripts and public keys necessary for solving the expanded scriptPubKeys (may be equal to `provider`).
-     * @param[out] cache: Cache data necessary to evaluate the descriptor at this point without access to private keys.
+     * @param[in] pos The position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * @param[in] provider The provider to query for private keys in case of hardened derivation.
+     * @param[out] output_scripts The expanded scriptPubKeys.
+     * @param[out] out Scripts and public keys necessary for solving the expanded scriptPubKeys (may be equal to `provider`).
+     * @param[out] cache Cache data necessary to evaluate the descriptor at this point without access to private keys.
      */
     virtual bool Expand(int pos, const SigningProvider& provider, std::vector<CScript>& output_scripts, FlatSigningProvider& out, std::vector<unsigned char>* cache = nullptr) const = 0;
 
     /** Expand a descriptor at a specified position using cached expansion data.
      *
-     * @param[in] pos: The position at which to expand the descriptor. If IsRange() is false, this is ignored.
-     * @param[in] cache: Cached expansion data.
-     * @param[out] output_scripts: The expanded scriptPubKeys.
-     * @param[out] out: Scripts and public keys necessary for solving the expanded scriptPubKeys (may be equal to `provider`).
+     * @param[in] pos The position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * @param[in] cache Cached expansion data.
+     * @param[out] output_scripts The expanded scriptPubKeys.
+     * @param[out] out Scripts and public keys necessary for solving the expanded scriptPubKeys (may be equal to `provider`).
      */
     virtual bool ExpandFromCache(int pos, const std::vector<unsigned char>& cache, std::vector<CScript>& output_scripts, FlatSigningProvider& out) const = 0;
 
     /** Expand the private key for a descriptor at a specified position, if possible.
      *
-     * @param[in] pos: The position at which to expand the descriptor. If IsRange() is false, this is ignored.
-     * @param[in] provider: The provider to query for the private keys.
-     * @param[out] out: Any private keys available for the specified `pos`.
+     * @param[in] pos The position at which to expand the descriptor. If IsRange() is false, this is ignored.
+     * @param[in] provider The provider to query for the private keys.
+     * @param[out] out Any private keys available for the specified `pos`.
      */
     virtual void ExpandPrivate(int pos, const SigningProvider& provider, FlatSigningProvider& out) const = 0;
 };

--- a/src/wallet/psbtwallet.h
+++ b/src/wallet/psbtwallet.h
@@ -15,8 +15,8 @@
  * finalize.) Sets `error` and returns false if something goes wrong.
  *
  * @param[in]  pwallet pointer to a wallet
- * @param[in]  &psbtx reference to PartiallySignedTransaction to fill in
- * @param[out] &complete indicates whether the PSBT is now complete
+ * @param[in]  psbtx PartiallySignedTransaction to fill in
+ * @param[out] complete indicates whether the PSBT is now complete
  * @param[in]  sighash_type the sighash type to use when signing (if PSBT does not specify)
  * @param[in]  sign whether to sign or not
  * @param[in]  bip32derivs whether to fill in bip32 derivation information if available

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -915,9 +915,9 @@ public:
      * Should be called after CreateTransaction unless you want to abort
      * broadcasting the transaction.
      *
-     * @param tx[in] The transaction to be broadcast.
-     * @param mapValue[in] key-values to be set on the transaction.
-     * @param orderForm[in] BIP 70 / BIP 21 order form details to be set on the transaction.
+     * @param[in] tx The transaction to be broadcast.
+     * @param[in] mapValue key-values to be set on the transaction.
+     * @param[in] orderForm BIP 70 / BIP 21 order form details to be set on the transaction.
      */
     void CommitTransaction(CTransactionRef tx, mapValue_t mapValue, std::vector<std::pair<std::string, std::string>> orderForm);
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -124,7 +124,7 @@ public:
     std::string hdKeypath; //optional HD/bip32 keypath. Still used to determine whether a key is a seed. Also kept for backwards compatibility
     CKeyID hd_seed_id; //id of the HD seed used to derive this key
     KeyOriginInfo key_origin; // Key origin info with path and fingerprint
-    bool has_key_origin = false; //< Whether the key_origin is useful
+    bool has_key_origin = false; //!< Whether the key_origin is useful
 
     CKeyMetadata()
     {


### PR DESCRIPTION
These are all the remaining errors identified via -Werror=documentation, e.g.:
```
  ./rpc/rawtransaction_util.h:31:13: error: parameter 'prevTxs' not found in the function declaration [-Werror,-Wdocumentation]
    * @param  prevTxs       Array of previous txns outputs that tx depends on but may not yet be in the block chain
              ^~~~~~~
  ./rpc/rawtransaction_util.h:31:13: note: did you mean 'prevTxsUnival'?
    * @param  prevTxs       Array of previous txns outputs that tx depends on but may not yet be in the block chain
              ^~~~~~~
              prevTxsUnival

  netbase.cpp:766:11: error: parameter 'outProxyConnectionFailed[out]' not found in the function declaration [-Werror,-Wdocumentation]
   * @param outProxyConnectionFailed[out] Whether or not the connection to the
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  netbase.cpp:766:11: note: did you mean 'outProxyConnectionFailed'?
   * @param outProxyConnectionFailed[out] Whether or not the connection to the
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
            outProxyConnectionFailed
```

You can use this to run with `-Wdocumentation` yourself: #14920