### PR TITLE
build: pass -fno-ident in Windows gitian descriptor

### DIFF
--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -34,8 +34,8 @@ script: |
   CONFIGFLAGS="--enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="ar ranlib nm windres strip objcopy"
   FAKETIME_PROGS="date makensis zip"
-  HOST_CFLAGS="-O2 -g"
-  HOST_CXXFLAGS="-O2 -g"
+  HOST_CFLAGS="-O2 -g -fno-ident"
+  HOST_CXXFLAGS="-O2 -g -fno-ident"
 
   export QT_RCC_TEST=1
   export QT_RCC_SOURCE_DATE_OVERRIDE=1


### PR DESCRIPTION
`-fno-ident` prevents compilers from emitting compiler name and version number information that can needlessly bloat binaries. 

For example, in the `v0.19.0.1` Windows release binaries, there are > 1000 GCC compiler version strings embedded: 
```bash
# GCC: (GNU) 7.3-posix 20180312... & GCC: (GNU) 6.3.0 20170415.......
strings bitcoind.exe | rg GCC | wc -l
    1021
```

They end up collected in the end of the`.rdata` section, and cannot be removed by `strip`. i.e:

```bash
objdump --section=.rdata --full-contents bitcoind.exe
...
 cfcc00 00000000 00000000 00000000 00000000  ................
 cfcc10 00000000 00000000 00000000 00000000  ................
 cfcc20 4743433a 2028474e 55292036 2e332e30  GCC: (GNU) 6.3.0
 cfcc30 20323031 37303431 35000000 00000000   20170415.......
 cfcc40 4743433a 2028474e 55292037 2e332d70  GCC: (GNU) 7.3-p
 cfcc50 6f736978 20323031 38303331 32000000  osix 20180312...
 cfcc60 4743433a 2028474e 55292037 2e332d70  GCC: (GNU) 7.3-p
 cfcc70 6f736978 20323031 38303331 32000000  osix 20180312...
```

The flag is available for [Clang](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-qn) and [GCC](https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html#index-fno-ident).

Relevant code in [GCC](https://github.com/gcc-mirror/gcc/blob/master/gcc/toplev.c#L565-L578):
```c
  /* Attach a special .ident directive to the end of the file to identify
     the version of GCC which compiled this code.  The format of the .ident
     string is patterned after the ones produced by native SVR4 compilers.  */
  if (!flag_no_ident)
    {
      const char *pkg_version = "(GNU) ";
      char *ident_str;


      if (strcmp ("(GCC) ", pkgversion_string))
	pkg_version = pkgversion_string;


      ident_str = ACONCAT (("GCC: ", pkg_version, version_string, NULL));
      targetm.asm_out.output_ident (ident_str);
    }
```