### PR TITLE
gui: Check the strength of an encryption password

### DIFF
--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_ASKPASSPHRASEDIALOG_H
 
 #include <QDialog>
+#include <QLineEdit>
 
 #include <support/allocators/secure.h>
 
@@ -45,6 +46,7 @@ private:
 
 private Q_SLOTS:
     void textChanged();
+    void updatePasswordStrengthIndicator(QLineEdit* lineedit);
     void secureClearPassFields();
     void toggleShowPassword(bool);
 

--- a/src/qt/forms/askpassphrasedialog.ui
+++ b/src/qt/forms/askpassphrasedialog.ui
@@ -99,7 +99,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QLabel" name="capsLabel">
        <property name="font">
         <font>
@@ -112,6 +112,16 @@
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QLabel" name="labelSecurityLevel">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string></string>
        </property>
       </widget>
      </item>

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -18,6 +18,9 @@ static const int STATUSBAR_ICONSIZE = 16;
 
 static const bool DEFAULT_SPLASHSCREEN = true;
 
+/* Recommend length of a password */
+static const int RECOMMEND_LENGTH = 10;
+
 /* Invalid field background style */
 #define STYLE_INVALID "background:#FF8080"
 


### PR DESCRIPTION
Fixes: #5278

[Video Demo](https://www.youtube.com/watch?v=hnYICfbd19o&feature=youtu.be)

This PR checks the strength of a password when encrypting or changing the passphrase of a wallet. If someone has some suggestions in terms of password security let me so I can add them to the different levels of strength