### PR TITLE
refactor: Abstract boost::variant out

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -231,6 +231,7 @@ BITCOIN_CORE_H = \
   util/vector.h \
   validation.h \
   validationinterface.h \
+  variant.h \
   versionbits.h \
   versionbitsinfo.h \
   walletinitinterface.h \

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -254,7 +254,7 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
         } else if(index.column() == Address) {
             CTxDestination newAddress = DecodeDestination(value.toString().toStdString());
             // Refuse to set invalid address, set error status and return false
-            if(boost::get<CNoDestination>(&newAddress))
+            if(newAddress.get_if<CNoDestination>())
             {
                 editStatus = INVALID_ADDRESS;
                 return false;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -467,7 +467,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog* dialog)
         else if(ExtractDestination(out.txout.scriptPubKey, address))
         {
             CPubKey pubkey;
-            PKHash *pkhash = boost::get<PKHash>(&address);
+            PKHash *pkhash = address.get_if<PKHash>();
             if (pkhash && model->wallet().getPubKey(out.txout.scriptPubKey, CKeyID(*pkhash), pubkey))
             {
                 nBytesInputs += (pubkey.IsCompressed() ? 148 : 180);

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -117,7 +117,7 @@ void SignVerifyMessageDialog::on_signMessageButton_SM_clicked()
         ui->statusLabel_SM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
-    const PKHash* pkhash = boost::get<PKHash>(&destination);
+    const PKHash* pkhash = destination.get_if<PKHash>();
     if (!pkhash) {
         ui->addressIn_SM->setValid(false);
         ui->statusLabel_SM->setStyleSheet("QLabel { color: red; }");
@@ -195,7 +195,7 @@ void SignVerifyMessageDialog::on_verifyMessageButton_VM_clicked()
         ui->statusLabel_VM->setText(tr("The entered address is invalid.") + QString(" ") + tr("Please check the address and try again."));
         return;
     }
-    if (!boost::get<PKHash>(&destination)) {
+    if (!destination.get_if<PKHash>()) {
         ui->addressIn_VM->setValid(false);
         ui->statusLabel_VM->setStyleSheet("QLabel { color: red; }");
         ui->statusLabel_VM->setText(tr("The entered address does not refer to a key.") + QString(" ") + tr("Please check the address and try again."));

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -124,7 +124,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const interface
                     continue;
                 }
 
-                if (!boost::get<CNoDestination>(&wtx.txout_address[nOut]))
+                if (!wtx.txout_address[nOut].get_if<CNoDestination>())
                 {
                     // Sent to Bitcoin Address
                     sub.type = TransactionRecord::SendToAddress;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -276,7 +276,7 @@ static UniValue verifymessage(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
     }
 
-    const PKHash *pkhash = boost::get<PKHash>(&destination);
+    const PKHash *pkhash = destination.get_if<PKHash>();
     if (!pkhash) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
     }

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -519,7 +519,7 @@ bool RPCArg::IsOptional() const
     if (m_fallback.which() == 1) {
         return true;
     } else {
-        return RPCArg::Optional::NO != boost::get<RPCArg::Optional>(m_fallback);
+        return RPCArg::Optional::NO != m_fallback.get<RPCArg::Optional>();
     }
 }
 
@@ -566,9 +566,9 @@ std::string RPCArg::ToDescriptionString() const
         }
     }
     if (m_fallback.which() == 1) {
-        ret += ", optional, default=" + boost::get<std::string>(m_fallback);
+        ret += ", optional, default=" + m_fallback.get<std::string>();
     } else {
-        switch (boost::get<RPCArg::Optional>(m_fallback)) {
+        switch (m_fallback.get<RPCArg::Optional>()) {
         case RPCArg::Optional::OMITTED: {
             // nothing to do. Element is treated as if not present and has no default value
             break;

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -7,6 +7,7 @@
 
 #include <node/transaction.h>
 #include <outputtype.h>
+#include <variant.h>
 #include <protocol.h>
 #include <pubkey.h>
 #include <rpc/protocol.h>
@@ -19,8 +20,6 @@
 
 #include <string>
 #include <vector>
-
-#include <boost/variant.hpp>
 
 /**
  * String used to describe UNIX epoch time in documentation, factored out to a
@@ -124,7 +123,7 @@ struct RPCArg {
          */
         OMITTED,
     };
-    using Fallback = boost::variant<Optional, /* default value for optional args */ std::string>;
+    using Fallback = Variant<Optional, /* default value for optional args */ std::string>;
     const std::string m_name; //!< The name of the arg (can be empty for inner args)
     const Type m_type;
     const std::vector<RPCArg> m_inner; //!< Only used for arrays or dicts

--- a/src/script/signingprovider.cpp
+++ b/src/script/signingprovider.cpp
@@ -179,18 +179,18 @@ CKeyID GetKeyForDestination(const SigningProvider& store, const CTxDestination& 
 {
     // Only supports destinations which map to single public keys, i.e. P2PKH,
     // P2WPKH, and P2SH-P2WPKH.
-    if (auto id = boost::get<PKHash>(&dest)) {
+    if (auto id = dest.get_if<PKHash>()) {
         return CKeyID(*id);
     }
-    if (auto witness_id = boost::get<WitnessV0KeyHash>(&dest)) {
+    if (auto witness_id = dest.get_if<WitnessV0KeyHash>()) {
         return CKeyID(*witness_id);
     }
-    if (auto script_hash = boost::get<ScriptHash>(&dest)) {
+    if (auto script_hash = dest.get_if<ScriptHash>()) {
         CScript script;
         CScriptID script_id(*script_hash);
         CTxDestination inner_dest;
         if (store.GetCScript(script_id, script) && ExtractDestination(script, inner_dest)) {
-            if (auto inner_witness_id = boost::get<WitnessV0KeyHash>(&inner_dest)) {
+            if (auto inner_witness_id = inner_dest.get_if<WitnessV0KeyHash>()) {
                 return CKeyID(*inner_witness_id);
             }
         }

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -8,8 +8,7 @@
 
 #include <script/interpreter.h>
 #include <uint256.h>
-
-#include <boost/variant.hpp>
+#include <variant.h>
 
 
 static const bool DEFAULT_ACCEPT_DATACARRIER = true;
@@ -140,7 +139,7 @@ struct WitnessUnknown
  *  * WitnessUnknown: TX_WITNESS_UNKNOWN destination (P2W???)
  *  A CTxDestination is the internal data type encoded in a bitcoin address
  */
-typedef boost::variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown> CTxDestination;
+typedef Variant<CNoDestination, PKHash, ScriptHash, WitnessV0ScriptHash, WitnessV0KeyHash, WitnessUnknown> CTxDestination;
 
 /** Check whether a CTxDestination is a CNoDestination. */
 bool IsValidDestination(const CTxDestination& dest);

--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -177,23 +177,23 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     s.clear();
     s << ToByteVector(pubkey) << OP_CHECKSIG;
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<PKHash>(&address) &&
-                *boost::get<PKHash>(&address) == PKHash(pubkey));
+    BOOST_CHECK(address.get_if<PKHash>() &&
+                *address.get_if<PKHash>() == PKHash(pubkey));
 
     // TX_PUBKEYHASH
     s.clear();
     s << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<PKHash>(&address) &&
-                *boost::get<PKHash>(&address) == PKHash(pubkey));
+    BOOST_CHECK(address.get_if<PKHash>() &&
+                *address.get_if<PKHash>() == PKHash(pubkey));
 
     // TX_SCRIPTHASH
     CScript redeemScript(s); // initialize with leftover P2PKH script
     s.clear();
     s << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<ScriptHash>(&address) &&
-                *boost::get<ScriptHash>(&address) == ScriptHash(redeemScript));
+    BOOST_CHECK(address.get_if<ScriptHash>() &&
+                *address.get_if<ScriptHash>() == ScriptHash(redeemScript));
 
     // TX_MULTISIG
     s.clear();
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     BOOST_CHECK(ExtractDestination(s, address));
     WitnessV0KeyHash keyhash;
     CHash160().Write(pubkey.begin(), pubkey.size()).Finalize(keyhash.begin());
-    BOOST_CHECK(boost::get<WitnessV0KeyHash>(&address) && *boost::get<WitnessV0KeyHash>(&address) == keyhash);
+    BOOST_CHECK(address.get_if<WitnessV0KeyHash>() && *address.get_if<WitnessV0KeyHash>() == keyhash);
 
     // TX_WITNESS_V0_SCRIPTHASH
     s.clear();
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     CSHA256().Write(redeemScript.data(), redeemScript.size()).Finalize(scripthash.begin());
     s << OP_0 << ToByteVector(scripthash);
     BOOST_CHECK(ExtractDestination(s, address));
-    BOOST_CHECK(boost::get<WitnessV0ScriptHash>(&address) && *boost::get<WitnessV0ScriptHash>(&address) == scripthash);
+    BOOST_CHECK(address.get_if<WitnessV0ScriptHash>() && *address.get_if<WitnessV0ScriptHash>() == scripthash);
 
     // TX_WITNESS with unknown version
     s.clear();
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestination)
     unk.length = 33;
     unk.version = 1;
     std::copy(pubkey.begin(), pubkey.end(), unk.program);
-    BOOST_CHECK(boost::get<WitnessUnknown>(&address) && *boost::get<WitnessUnknown>(&address) == unk);
+    BOOST_CHECK(address.get_if<WitnessUnknown>() && *address.get_if<WitnessUnknown>() == unk);
 }
 
 BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
@@ -253,8 +253,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_PUBKEY);
     BOOST_CHECK_EQUAL(addresses.size(), 1U);
     BOOST_CHECK_EQUAL(nRequired, 1);
-    BOOST_CHECK(boost::get<PKHash>(&addresses[0]) &&
-                *boost::get<PKHash>(&addresses[0]) == PKHash(pubkeys[0]));
+    BOOST_CHECK(addresses[0].get_if<PKHash>() &&
+                *addresses[0].get_if<PKHash>() == PKHash(pubkeys[0]));
 
     // TX_PUBKEYHASH
     s.clear();
@@ -263,8 +263,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_PUBKEYHASH);
     BOOST_CHECK_EQUAL(addresses.size(), 1U);
     BOOST_CHECK_EQUAL(nRequired, 1);
-    BOOST_CHECK(boost::get<PKHash>(&addresses[0]) &&
-                *boost::get<PKHash>(&addresses[0]) == PKHash(pubkeys[0]));
+    BOOST_CHECK(addresses[0].get_if<PKHash>() &&
+                *addresses[0].get_if<PKHash>() == PKHash(pubkeys[0]));
 
     // TX_SCRIPTHASH
     CScript redeemScript(s); // initialize with leftover P2PKH script
@@ -274,8 +274,8 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_SCRIPTHASH);
     BOOST_CHECK_EQUAL(addresses.size(), 1U);
     BOOST_CHECK_EQUAL(nRequired, 1);
-    BOOST_CHECK(boost::get<ScriptHash>(&addresses[0]) &&
-                *boost::get<ScriptHash>(&addresses[0]) == ScriptHash(redeemScript));
+    BOOST_CHECK(addresses[0].get_if<ScriptHash>() &&
+                *addresses[0].get_if<ScriptHash>() == ScriptHash(redeemScript));
 
     // TX_MULTISIG
     s.clear();
@@ -287,10 +287,10 @@ BOOST_AUTO_TEST_CASE(script_standard_ExtractDestinations)
     BOOST_CHECK_EQUAL(whichType, TX_MULTISIG);
     BOOST_CHECK_EQUAL(addresses.size(), 2U);
     BOOST_CHECK_EQUAL(nRequired, 2);
-    BOOST_CHECK(boost::get<PKHash>(&addresses[0]) &&
-                *boost::get<PKHash>(&addresses[0]) == PKHash(pubkeys[0]));
-    BOOST_CHECK(boost::get<PKHash>(&addresses[1]) &&
-                *boost::get<PKHash>(&addresses[1]) == PKHash(pubkeys[1]));
+    BOOST_CHECK(addresses[0].get_if<PKHash>() &&
+                *addresses[0].get_if<PKHash>() == PKHash(pubkeys[0]));
+    BOOST_CHECK(addresses[1].get_if<PKHash>() &&
+                *addresses[1].get_if<PKHash>() == PKHash(pubkeys[1]));
 
     // TX_NULL_DATA
     s.clear();

--- a/src/variant.h
+++ b/src/variant.h
@@ -1,0 +1,153 @@
+// Copyright (c) 2017-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_VARIANT_H
+#define BITCOIN_VARIANT_H
+
+#include <utility>
+#include <type_traits>
+
+#include <boost/variant.hpp>
+
+//! Substitute for C++17 std::variant
+template <class... Types>
+class Variant
+{
+private:
+    boost::variant<Types...> m_var;
+
+public:
+    Variant()
+    {
+        m_var = {};
+    }
+    Variant(const Variant& other)
+    {
+        m_var = other.m_var;
+    }
+    Variant(Variant&& other)
+    {
+        m_var = std::move(other.m_var);
+    }
+    // Require that typeof(T) != Variant. to prevent wrong template instantiations
+    template <class T, typename = typename std::enable_if<!std::is_same<typename std::decay<T>::type, Variant>::value>::type>
+    Variant(T&& value)
+    {
+        m_var = std::forward<T>(value);
+    }
+
+    int which() const
+    {
+        return m_var.which();
+    }
+
+    template <class T>
+    T* get_if()
+    {
+        return boost::get<T>(&m_var);
+    }
+    template <class T>
+    const T* get_if() const
+    {
+        return boost::get<T>(&m_var);
+    }
+    template <class T>
+    T& get()
+    {
+        return boost::get<T>(m_var);
+    }
+    template <class T>
+    const T& get() const
+    {
+        return boost::get<T>(m_var);
+    }
+
+    Variant& operator=(const Variant& other)
+    {
+        m_var = other.m_var;
+        return *this;
+    }
+    Variant& operator=(Variant&& other)
+    {
+        m_var = std::move(other.m_var);
+        return *this;
+    }
+    // Require that typeof(T) != Variant. to prevent wrong template instantiations
+    template <class T, typename = typename std::enable_if<!std::is_same<typename std::decay<T>::type, Variant>::value>::type>
+    Variant& operator=(T&& value)
+    {
+        m_var = std::forward<T>(value);
+        return *this;
+    }
+
+    // Allow support for boost::Variant
+    template <class Visitor>
+    typename Visitor::result_type apply_visitor(Visitor& visitor) const
+    {
+        return boost::apply_visitor(visitor, m_var);
+    }
+    template <class Visitor>
+    typename Visitor::result_type apply_visitor(const Visitor& visitor) const
+    {
+        return boost::apply_visitor(visitor, m_var);
+    }
+
+    bool operator==(const Variant& other) const
+    {
+        return m_var == other.m_var;
+    }
+    bool operator!=(const Variant& other) const
+    {
+        return m_var != other.m_var;
+    }
+    bool operator<(const Variant& other) const
+    {
+        return m_var < other.m_var;
+    }
+    bool operator>(const Variant& other) const
+    {
+        return m_var > other.m_var;
+    }
+    bool operator<=(const Variant& other) const
+    {
+        return m_var <= other.m_var;
+    }
+    bool operator>=(const Variant& other) const
+    {
+        return m_var >= other.m_var;
+    }
+    // This are here to prevent implicit conversion to Variant and throw a compile time error.
+    template <typename T>
+    void operator==(const T&) const
+    {
+        static_assert(false && sizeof(T), "Compared a Variant directly with type T. this prevented an implicit conversion");
+    }
+    template <typename T>
+    void operator!=(const T&) const
+    {
+        static_assert(false && sizeof(T), "Compared a Variant directly with type T. this prevented an implicit conversion");
+    }
+    template <typename T>
+    void operator<(const T&) const
+    {
+        static_assert(false && sizeof(T), "Compared a Variant directly with type T. this prevented an implicit conversion");
+    }
+    template <typename T>
+    void operator>(const T&) const
+    {
+        static_assert(false && sizeof(T), "Compared a Variant directly with type T. this prevented an implicit conversion");
+    }
+    template <typename T>
+    void operator<=(const T&) const
+    {
+        static_assert(false && sizeof(T), "Compared a Variant directly with type T. this prevented an implicit conversion");
+    }
+    template <typename T>
+    void operator>=(const T&) const
+    {
+        static_assert(false && sizeof(T), "Compared a Variant directly with type T. this prevented an implicit conversion");
+    }
+};
+
+#endif // BITCOIN_VARIANT_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -555,7 +555,7 @@ static UniValue signmessage(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid address");
     }
 
-    const PKHash *pkhash = boost::get<PKHash>(&dest);
+    const PKHash *pkhash = dest.get_if<PKHash>();
     if (!pkhash) {
         throw JSONRPCError(RPC_TYPE_ERROR, "Address does not refer to key");
     }
@@ -2947,7 +2947,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
             const SigningProvider* provider = pwallet->GetSigningProvider(scriptPubKey);
             if (provider) {
                 if (scriptPubKey.IsPayToScriptHash()) {
-                    const CScriptID& hash = CScriptID(boost::get<ScriptHash>(address));
+                    const CScriptID& hash = CScriptID(address.get<ScriptHash>());
                     CScript redeemScript;
                     if (provider->GetCScript(hash, redeemScript)) {
                         entry.pushKV("redeemScript", HexStr(redeemScript.begin(), redeemScript.end()));
@@ -2957,7 +2957,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
                             bool extracted = ExtractDestination(redeemScript, witness_destination);
                             CHECK_NONFATAL(extracted);
                             // Also return the witness script
-                            const WitnessV0ScriptHash& whash = boost::get<WitnessV0ScriptHash>(witness_destination);
+                            const WitnessV0ScriptHash& whash = witness_destination.get<WitnessV0ScriptHash>();
                             CScriptID id;
                             CRIPEMD160().Write(whash.begin(), whash.size()).Finalize(id.begin());
                             CScript witnessScript;
@@ -2967,7 +2967,7 @@ static UniValue listunspent(const JSONRPCRequest& request)
                         }
                     }
                 } else if (scriptPubKey.IsPayToWitnessScriptHash()) {
-                    const WitnessV0ScriptHash& whash = boost::get<WitnessV0ScriptHash>(address);
+                    const WitnessV0ScriptHash& whash = address.get<WitnessV0ScriptHash>();
                     CScriptID id;
                     CRIPEMD160().Write(whash.begin(), whash.size()).Finalize(id.begin());
                     CScript witnessScript;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -523,7 +523,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
         list = wallet->ListCoins(*locked_chain);
     }
     BOOST_CHECK_EQUAL(list.size(), 1U);
-    BOOST_CHECK_EQUAL(boost::get<PKHash>(list.begin()->first).ToString(), coinbaseAddress);
+    BOOST_CHECK_EQUAL(list.begin()->first.get<PKHash>().ToString(), coinbaseAddress);
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 1U);
 
     // Check initial balance from one mature coinbase transaction.
@@ -540,7 +540,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
         list = wallet->ListCoins(*locked_chain);
     }
     BOOST_CHECK_EQUAL(list.size(), 1U);
-    BOOST_CHECK_EQUAL(boost::get<PKHash>(list.begin()->first).ToString(), coinbaseAddress);
+    BOOST_CHECK_EQUAL(list.begin()->first.get<PKHash>().ToString(), coinbaseAddress);
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 2U);
 
     // Lock both coins. Confirm number of available coins drops to 0.
@@ -572,7 +572,7 @@ BOOST_FIXTURE_TEST_CASE(ListCoins, ListCoinsTestingSetup)
         list = wallet->ListCoins(*locked_chain);
     }
     BOOST_CHECK_EQUAL(list.size(), 1U);
-    BOOST_CHECK_EQUAL(boost::get<PKHash>(list.begin()->first).ToString(), coinbaseAddress);
+    BOOST_CHECK_EQUAL(list.begin()->first.get<PKHash>().ToString(), coinbaseAddress);
     BOOST_CHECK_EQUAL(list.begin()->second.size(), 2U);
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2612,7 +2612,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
             CScript scriptChange;
 
             // coin control: send change to custom address
-            if (!boost::get<CNoDestination>(&coin_control.destChange)) {
+            if (!coin_control.destChange.get_if<CNoDestination>()) {
                 scriptChange = GetScriptForDestination(coin_control.destChange);
             } else { // no coin control: send change to newly generated address
                 // Note: We use a new key here to keep it from being obvious which side is the change.
@@ -3523,7 +3523,7 @@ unsigned int CWallet::ComputeTimeSmart(const CWalletTx& wtx) const
 
 bool CWallet::AddDestData(WalletBatch& batch, const CTxDestination &dest, const std::string &key, const std::string &value)
 {
-    if (boost::get<CNoDestination>(&dest))
+    if (dest.get_if<CNoDestination>())
         return false;
 
     mapAddressBook[dest].destdata.insert(std::make_pair(key, value));


### PR DESCRIPTION
Hi,
This introduces a level of abstractions for `boost::variant` such that when we switch to C++17 we can drop in `std::variant` instead and everything should work modulo the visitors.

The reason I went for a class and not a typedef/using like with `Optional` is because I want to add the `get` function so "users" won't need to still include `boost/variant/get.hpp` and because I wanted to make it more explicit when `get` is throwing and when not (by splitting to `get` and `get_if` like stl does).

~I also replaced the generic `boost/variant.hpp` with `boost/variant/get.hpp` and `boost/variant/variant.hpp` which are just 2 out of the 7 headers in `boost/variant.hpp`(https://www.boost.org/doc/libs/1_71_0/boost/variant.hpp)~ (Had to remove this since it broke a build, not sure if it's because a specific boost version or a clang version https://travis-ci.org/bitcoin/bitcoin/jobs/638552502)

