### PR TITLE
rpc: query general daemon information via RPC 

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -14,6 +14,8 @@
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/validation.h>
+#include <clientversion.h>
+#include <net.h>
 
 #include <stdint.h>
 #include <tuple>
@@ -449,6 +451,36 @@ static UniValue getmemoryinfo(const JSONRPCRequest& request)
     }
 }
 
+static UniValue getgeneralinfo(const JSONRPCRequest& request)
+{
+    RPCHelpMan{"getgeneralinfo",
+                "\nReturns data about the bitcoin daemon.\n",
+                {},
+                RPCResult{
+                "  {\n"
+                "    \"clientversion\": \"string\",     (string) Client version\n"
+                "    \"useragent\":\"string\",          (string) Client name\n"
+                "    \"datadir\":\"path\",              (string) Data directory path\n"
+                "    \"blocksdir\":\"path\",            (string) Blocks directory path\n"
+                "    \"startuptime\":\"number\",      (number) Startup time\n"
+                "  }\n"
+                },
+                RPCExamples{
+                    HelpExampleCli("getgeneralinfo", "")
+            + HelpExampleRpc("getgeneralinfo", "")
+                },
+            }.Check(request);
+
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("clientversion", FormatFullVersion());
+        obj.pushKV("useragent", strSubVersion);
+        obj.pushKV("datadir", GetDataDir().string());
+        obj.pushKV("blocksdir", GetBlocksDir().string());
+        obj.pushKV("startuptime", GetStartupTime());
+        return obj;
+
+}
+
 static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     cats = cats.get_array();
     for (unsigned int i = 0; i < cats.size(); ++i) {
@@ -560,6 +592,7 @@ static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         argNames
   //  --------------------- ------------------------  -----------------------  ----------
     { "control",            "getmemoryinfo",          &getmemoryinfo,          {"mode"} },
+    { "control",            "getgeneralinfo",         &getgeneralinfo,         {} },
     { "control",            "logging",                &logging,                {"include", "exclude"}},
     { "util",               "validateaddress",        &validateaddress,        {"address"} },
     { "util",               "createmultisig",         &createmultisig,         {"nrequired","keys","address_type"} },

--- a/test/functional/rpc_getgeneralinfo.py
+++ b/test/functional/rpc_getgeneralinfo.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the getgeneralinfo RPC."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_equal, try_rpc
+
+class GetGeneralInfoTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_cli()
+
+    def run_test(self):
+        """Test getgeneralinfo."""
+        """Check if 'getgeneralinfo' is callable."""
+        try_rpc(None, None, self.nodes[0].getgeneralinfo, None, None)
+        """Check if 'getgeneralinfo' is idempotent (multiple requests return same data)."""
+        json1 = self.nodes[0].getgeneralinfo()
+        json2 = self.nodes[0].getgeneralinfo()
+        assert_equal(json1, json2)
+
+if __name__ == '__main__':
+    GetGeneralInfoTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -213,6 +213,7 @@ BASE_SCRIPTS = [
     'feature_blocksdir.py',
     'feature_config_args.py',
     'rpc_getaddressinfo_labels_purpose_deprecation.py',
+    'rpc_getgeneralinfo.py',
     'rpc_help.py',
     'feature_help.py',
     'feature_shutdown.py',


### PR DESCRIPTION
This PR implements a new feature requested in #17952 

A new call *getgeneralinfo* is now available for sending general daemon information back to clients. Currently, this data is only available via GUI (debug window / information tab).

The RPC execution looks like this:

**bitcoin-cli -regtest getgeneralinfo**
```shell
{
  "clientversion": "v0.19.99.0-a654626f0-dirty",
  "useragent": "/Satoshi:0.19.99/",
  "datadir": "/Users/brakmic/Library/Application Support/Bitcoin/regtest",
  "blocksdir": "/Users/brakmic/Library/Application Support/Bitcoin/regtest/blocks",
  "startuptime": "2020-01-18T17:49:50Z"
}
```

**bitcoin-cli -regtest help getgeneralinfo**
```shell
getgeneralnfo

Returns data about the bitcoin daemon.

Result:
  {
    "clientversion": "v0.19.99.0-a654626f0",       (string) Client version
    "useragent":"/Satoshi:0.19.99/",               (string) Client name
    "datadir":"/home/user/.bitcoin",               (string) Data directory path
    "blocksdir":"/home/user/.bitcoin/blocks",      (string) Blocks directory path
    "startuptime":"2020-01-18T17:49:50Z",          (string) Startup time
  }

Examples:
> bitcoin-cli getgeneralinfo 
> curl --user myusername --data-binary '{"jsonrpc": "1.0", "id":"curltest", "method": "getgeneralinfo", "params": [] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/
```

However, I am not sure if the current format in "startuptime" field is acceptable. Maybe there is a better function that should be used? Currently I am using the **FormatISO8601DateTime** function.

**Test**
A new functional test *rpc_getgeneralinfo.py* is available.

Regards,