### PR TITLE
qt: Ensure that ModalOverlay is resized properly

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -5,12 +5,12 @@
 #include <qt/modaloverlay.h>
 #include <qt/forms/ui_modaloverlay.h>
 
+#include <chainparams.h>
 #include <qt/guiutil.h>
 
-#include <chainparams.h>
-
-#include <QResizeEvent>
+#include <QEasingCurve>
 #include <QPropertyAnimation>
+#include <QResizeEvent>
 
 ModalOverlay::ModalOverlay(bool enable_wallet, QWidget *parent) :
 QWidget(parent),
@@ -33,6 +33,11 @@ userClosed(false)
         ui->infoText->setVisible(false);
         ui->infoTextStrong->setText(tr("%1 is currently syncing.  It will download headers and blocks from peers and validate them until reaching the tip of the block chain.").arg(PACKAGE_NAME));
     }
+
+    m_animation.setTargetObject(this);
+    m_animation.setPropertyName("pos");
+    m_animation.setDuration(300 /* ms */);
+    m_animation.setEasingCurve(QEasingCurve::OutQuad);
 }
 
 ModalOverlay::~ModalOverlay()
@@ -48,6 +53,9 @@ bool ModalOverlay::eventFilter(QObject * obj, QEvent * ev) {
             if (!layerIsVisible)
                 setGeometry(0, height(), width(), height());
 
+            if (m_animation.endValue().toPoint().y() > 0) {
+                m_animation.setEndValue(QPoint(0, height()));
+            }
         }
         else if (ev->type() == QEvent::ChildAdded) {
             raise();
@@ -166,14 +174,10 @@ void ModalOverlay::showHide(bool hide, bool userRequested)
     if (!isVisible() && !hide)
         setVisible(true);
 
-    setGeometry(0, hide ? 0 : height(), width(), height());
-
-    QPropertyAnimation* animation = new QPropertyAnimation(this, "pos");
-    animation->setDuration(300);
-    animation->setStartValue(QPoint(0, hide ? 0 : this->height()));
-    animation->setEndValue(QPoint(0, hide ? this->height() : 0));
-    animation->setEasingCurve(QEasingCurve::OutQuad);
-    animation->start(QAbstractAnimation::DeleteWhenStopped);
+    m_animation.setStartValue(QPoint(0, hide ? 0 : height()));
+    // The eventFilter() updates the endValue if it is required for QEvent::Resize.
+    m_animation.setEndValue(QPoint(0, hide ? height() : 0));
+    m_animation.start(QAbstractAnimation::KeepWhenStopped);
     layerIsVisible = !hide;
 }
 

--- a/src/qt/modaloverlay.h
+++ b/src/qt/modaloverlay.h
@@ -6,6 +6,7 @@
 #define BITCOIN_QT_MODALOVERLAY_H
 
 #include <QDateTime>
+#include <QPropertyAnimation>
 #include <QWidget>
 
 //! The required delta of headers to the estimated number of available headers until we show the IBD progress
@@ -45,6 +46,7 @@ private:
     QVector<QPair<qint64, double> > blockProcessTime;
     bool layerIsVisible;
     bool userClosed;
+    QPropertyAnimation m_animation;
     void UpdateHeaderSyncLabel();
 };
 


### PR DESCRIPTION
In certain circumstances the `ModalOverlay` widget is not sized properly:
- #17269
- #17967 
- https://github.com/bitcoin/bitcoin/pull/17968#pullrequestreview-350753107

On master (f018d0c9cd7f408dac016b6bfc873670de713d27) this bug looks like this:
![DeepinScreenshot_bitcoin-qt_20200120193402](https://user-images.githubusercontent.com/32963518/72748165-298b2a80-3bbf-11ea-810d-2966f08e496a.png)

With this PR the wallet frame looks ok:
![DeepinScreenshot_bitcoin-qt_20200120195241](https://user-images.githubusercontent.com/32963518/72748388-c64dc800-3bbf-11ea-8875-1ba1899b3513.png)

Fix #17269
Fix #17967 