### PR TITLE
refactor: Remove redundant conditional

### DIFF
--- a/src/checkqueue.h
+++ b/src/checkqueue.h
@@ -90,8 +90,7 @@ private:
                         nTotal--;
                         bool fRet = fAllOk;
                         // reset the status for new work later
-                        if (fMaster)
-                            fAllOk = true;
+                        fAllOk = true;
                         // return the current status
                         return fRet;
                     }


### PR DESCRIPTION
Conditional check against fMaster is now redundant as it is already checked as true. This originally made sense as the outer conditional was:

https://github.com/bitcoin/bitcoin/blob/f9cae832e6f56c6abe89b3bf05d1f176c2a7c913/src/checkqueue.h#L86

Removal of fQuit happened in the commit below.

https://github.com/bitcoin/bitcoin/commit/30ded3e3d888f75b6fa8b2e55a3883f799e00775#diff-88316c9aa9514c038c9304297e672da5