### PR TITLE
TestFramework: Add Python Miniscript Support

### DIFF
--- a/test/functional/feature_miniscript.py
+++ b/test/functional/feature_miniscript.py
@@ -4,13 +4,17 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test miniscript implementation."""
 
-from test_framework.key import ECKey
-from test_framework.miniscript import Node
-from test_framework.messages import hash256, sha256
-from test_framework.script import hash160
-from test_framework.test_framework import BitcoinTestFramework
-
 import hashlib
+from io import BytesIO
+
+from test_framework.address import script_to_p2wsh
+from test_framework.key import ECKey
+from test_framework.miniscript import Node, SatType
+from test_framework.messages import CTransaction, CTxInWitness, COutPoint, \
+    CTxIn, CTxOut, hash256, sha256
+from test_framework.script import CScript, hash160, \
+    SegwitV0SignatureHash, SIGHASH_ALL
+from test_framework.test_framework import BitcoinTestFramework
 
 
 class MiniscriptTest(BitcoinTestFramework):
@@ -33,6 +37,99 @@ class MiniscriptTest(BitcoinTestFramework):
             assert(node_from_script.desc == alt_desc_str)
         return node
 
+    def test_miniscript_satisfaction(self, node, keyhash_dict, sha256_dict,
+                                     hash256_dict, ripemd160_dict,
+                                     hash160_dict):
+        # Send funds to p2wsh(miniscript.script).
+        v0_address = script_to_p2wsh(node.script)
+        tx = self.generate_and_send_coin(v0_address)
+        # Construct spending transaction.
+        minfee_sat = int(self.nodes[0].getmempoolinfo()[
+            'mempoolminfee'] * 100000000)
+        spending_tx = self.create_spending_transaction(
+            tx.hash, amount=tx.vout[0].nValue-minfee_sat)
+        spending_tx.wit.vtxinwit = [CTxInWitness()]
+        node_script = CScript(node.script)
+        sig_hash = SegwitV0SignatureHash(node_script,
+                                               spending_tx, 0,
+                                               SIGHASH_ALL,
+                                               tx.vout[0].nValue)
+        # Test each canonical AND non-canonical
+        # satisfying witness for spending transaction.
+        for wit_sat in node.sat:
+            witness_arr = []
+            for sat_element in wit_sat:
+                # Set sequence for input at index 0.
+                if sat_element[0] is SatType.OLDER:
+                    delay = max(spending_tx.vin[0].nSequence, sat_element[1])
+                    spending_tx.vin[0].nSequence = delay
+                    # Recompute sighash.
+                    sig_hash = SegwitV0SignatureHash(node_script,
+                                                           spending_tx, 0,
+                                                           SIGHASH_ALL,
+                                                           tx.vout[0].nValue)
+                # Set locktime.
+                if sat_element[0] is SatType.AFTER:
+                    locktime = max(spending_tx.nLockTime, sat_element[1])
+                    spending_tx.nLockTime = locktime
+                    # Recompute sighash.
+                    sig_hash = SegwitV0SignatureHash(node_script,
+                                                           spending_tx, 0,
+                                                           SIGHASH_ALL,
+                                                           tx.vout[0].nValue)
+                # Add signature witness element.
+                if sat_element[0] is SatType.SIGNATURE:
+                    # Value: 33B Pubkey
+                    if len(sat_element[1]) == 33:
+                        pkhash = hash160(sat_element[1])
+                        signature = keyhash_dict[pkhash].sign_ecdsa(
+                            sig_hash)+b'\x01'
+                        witness_arr.append(signature)
+                    # Value: 20B Pubkeyhash
+                    elif len(sat_element[1]) == 20:
+                        signature = keyhash_dict[sat_element[1]].sign_ecdsa(
+                            sig_hash) + b'\x01'
+                        witness_arr.append(signature)
+                # Add public key witness element.
+                elif sat_element[0] is SatType.KEY_AND_HASH160_PREIMAGE:
+                    secret_key = keyhash_dict[sat_element[1]]
+                    witness_arr.append(secret_key.get_pubkey().get_bytes())
+                # Add sha256 preimage witness element.
+                elif sat_element[0] is SatType.SHA256_PREIMAGE:
+                    sha256_preimage = sha256_dict[sat_element[1]]
+                    witness_arr.append(sha256_preimage)
+                # Add hash256 preimage witness element.
+                elif sat_element[0] is SatType.HASH256_PREIMAGE:
+                    hash256_preimage = hash256_dict[sat_element[1]]
+                    witness_arr.append(hash256_preimage)
+                # Add ripemd160 preimage witness element.
+                elif sat_element[0] is SatType.RIPEMD160_PREIMAGE:
+                    ripemd160_preimage = ripemd160_dict[sat_element[1]]
+                    witness_arr.append(ripemd160_preimage)
+                # Add hash160 preimage witness element.
+                elif sat_element[0] is SatType.HASH160_PREIMAGE:
+                    hash160_preimage = hash160_dict[sat_element[1]]
+                    witness_arr.append(hash160_preimage)
+                # Add data witness element
+                elif sat_element[0] is SatType.DATA:
+                    witness_arr.append(sat_element[1])
+            # Set witness and test mempool acceptance.
+            spending_tx.wit.vtxinwit[0].scriptWitness.stack = witness_arr + [
+                node_script]
+            spending_tx.rehash()
+            tx_str = spending_tx.serialize().hex()
+            # Mine if delay or timelock.
+            if spending_tx.vin[0].nSequence > 0 or spending_tx.nLockTime > 0:
+                height = self.nodes[0].getblockchaininfo()['blocks']
+                blocks_required = max(spending_tx.nLockTime-height,
+                                      spending_tx.vin[0].nSequence)
+                self.nodes[0].generate(blocks_required)
+            # Test mempool acceptance.
+            ret = self.nodes[0].testmempoolaccept(rawtxs=[tx_str],
+                                                  maxfeerate=0)[0]
+            assert(ret['allowed'])
+
+    # Test Utility Methods.
     def generate_key_pair(self, keyhash_dict):
         privkey = ECKey()
         privkey.generate()
@@ -45,6 +142,53 @@ class MiniscriptTest(BitcoinTestFramework):
             pk_hex = keyhash_dict[pkh].get_pubkey().get_bytes().hex()
             key_hex_list.append(pk_hex)
         return key_hex_list
+
+    def generate_and_send_coin(self, address):
+        if self.nodes[0].getblockchaininfo()['blocks'] == 0:
+            self.coinbase_address = self.nodes[0].getnewaddress(
+                address_type="bech32")
+            self.nodes[0].generatetoaddress(101, self.coinbase_address)
+
+        balance = self.nodes[0].getbalance()
+
+        while balance < 1:
+            self.nodes[0].generatetoaddress(1, self.coinbase_address)
+            balance = self.nodes[0].getbalance()
+
+        unspent_txid = self.nodes[0].listunspent(1)[-1]["txid"]
+        inputs = [{"txid": unspent_txid, "vout": 0}]
+
+        # Send funds to address.
+        tx_hex = self.nodes[0].createrawtransaction(inputs=inputs,
+                                                    outputs=[{address: 1}])
+        res = self.nodes[0].signrawtransactionwithwallet(hexstring=tx_hex)
+        tx_hex = res["hex"]
+        assert res["complete"]
+        assert 'errors' not in res
+
+        # Max feerate set to 0 since no change output created.
+        txid = self.nodes[0].sendrawtransaction(hexstring=tx_hex, maxfeerate=0)
+        tx_hex = self.nodes[0].getrawtransaction(txid)
+        tx = CTransaction()
+        tx.deserialize(BytesIO(bytes.fromhex(tx_hex)))
+        tx.rehash()
+        return tx
+
+    def create_spending_transaction(self, txid, amount=0, version=2,
+                                    nSequence=0, nLocktime=0):
+        spending_tx = CTransaction()
+        spending_tx.nVersion = version
+        spending_tx.nLockTime = nLocktime
+        outpoint = COutPoint(int(txid, 16), 0)
+        spending_tx_in = CTxIn(outpoint=outpoint, nSequence=nSequence)
+        spending_tx.vin = [spending_tx_in]
+        dest_addr = self.nodes[0].getnewaddress(address_type="bech32")
+        scriptpubkey = bytes.fromhex(self.nodes[0].getaddressinfo(dest_addr)[
+            'scriptPubKey'])
+        amount_sat = amount
+        dest_output = CTxOut(nValue=amount_sat, scriptPubKey=scriptpubkey)
+        spending_tx.vout = [dest_output]
+        return spending_tx
 
     def run_test(self):
         # Generate key pairs.
@@ -116,49 +260,53 @@ class MiniscriptTest(BitcoinTestFramework):
                                                  pk_hex_list[2])
         self.test_miniscript_expr(desc9, "Bnduesm")
 
-        # Test (de)serialization of composable expressions.
+        # Test (de)serialization and (dis)satisfaction
+        # of composable expressions.
+
+        # Append miniscript nodes for satisfaction tests.
+        miniscript_list = []
 
         # c:pkh(key)
         pkh = list(keyhash_dict)[0]
         desc10 = "c:pk_h({})".format(pkh.hex())
-        self.test_miniscript_expr(desc10, "Bndemus")
+        miniscript_list.append(self.test_miniscript_expr(desc10, "Bndemus"))
 
         # and_v(vc:pk_h(key), c:pk_h(key)) expression.
         pkh0 = list(keyhash_dict)[0]
         pkh1 = list(keyhash_dict)[1]
         desc11 = "and_v(vc:pk_h({}),c:pk_h({}))".format(pkh0.hex(), pkh1.hex())
-        self.test_miniscript_expr(desc11, "Bnfmus")
+        miniscript_list.append(self.test_miniscript_expr(desc11, "Bnfmus"))
 
         # and_v(vc:pk_h(key),older(delay))) expression.
         pkh0 = list(keyhash_dict)[0]
         delay = 10
         desc12 = "and_v(vc:pk_h({}),older({}))".format(
             pkh0.hex(), delay)
-        self.test_miniscript_expr(desc12, "Bnfms")
+        miniscript_list.append(self.test_miniscript_expr(desc12, "Bnfms"))
 
         # or_b(c:pk(key),a:and_b(c:pk_h(key),sc:pk(key)))
         pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
         pkh0 = list(keyhash_dict)[0]
         desc13 = "or_b(c:pk({}),a:and_b(c:pk_h({}),sc:pk({})))".format(
             pk_hex_list[0], pkh0.hex(), pk_hex_list[1])
-        self.test_miniscript_expr(desc13, "Bdemus")
+        miniscript_list.append(self.test_miniscript_expr(desc13, "Bdemus"))
 
         # or_b(c:pk(key),a:and_n(c:pk(key),c:pk_h(key)))
         pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
         pkh0 = list(keyhash_dict)[0]
         desc14 = "or_b(c:pk({}),a:and_n(c:pk({}),c:pk_h({})))".format(
             *pk_hex_list, pkh0.hex())
-        self.test_miniscript_expr(desc14, "Bdemus")
+        miniscript_list.append(self.test_miniscript_expr(desc14, "Bdemus"))
 
         # or_b(c:pk(key),sc:pk(key))
         pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
         desc15 = "or_b(c:pk({}),sc:pk({}))".format(*pk_hex_list)
-        self.test_miniscript_expr(desc15, "Bdemus")
+        miniscript_list.append(self.test_miniscript_expr(desc15, "Bdemus"))
 
         # or_d(c:pk_h(key),c:pk_h(key))
         pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
         desc16 = "or_d(c:pk({}),c:pk({}))".format(*pk_hex_list)
-        self.test_miniscript_expr(desc16, "Bdemus")
+        miniscript_list.append(self.test_miniscript_expr(desc16, "Bdemus"))
 
         # t:or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:hash160(h))))
         # and_v(or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:hash160(h)))),1)
@@ -169,7 +317,8 @@ class MiniscriptTest(BitcoinTestFramework):
         desc17_alt = ("and_v(or_c(c:pk({}),and_v(vc:pk({}),or_c(c:pk({})," +
                      "v:hash160({})))),1)").format(*pk_hex_list,
                                                    h160_digest.hex())
-        self.test_miniscript_expr(desc17, "Bufsm", desc17_alt)
+        miniscript_list.append(self.test_miniscript_expr(desc17, "Bufsm",
+                                                         desc17_alt))
 
         # t:or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:sha256(h))))
         # and_v(or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:sha256(h)))),1)
@@ -180,7 +329,8 @@ class MiniscriptTest(BitcoinTestFramework):
         desc18_alt = ("and_v(or_c(c:pk({}),and_v(vc:pk({})," +
                      "or_c(c:pk({}),v:sha256({})))),1)").format(
                          *pk_hex_list, sha256_digest.hex())
-        self.test_miniscript_expr(desc18, "Bufsm", desc18_alt)
+        miniscript_list.append(self.test_miniscript_expr(desc18, "Bufsm",
+                                                         desc18_alt))
 
         # or_i(and_v(vc:pk_h(key_local),hash256(h)),older(20))
         h256_digest = list(hash256_dict)[0]
@@ -188,16 +338,16 @@ class MiniscriptTest(BitcoinTestFramework):
         delay = 20
         desc19 = "or_i(and_v(vc:pk_h({}),hash256({})),older({}))".format(
             pkh0.hex(), h256_digest.hex(), delay)
-        self.test_miniscript_expr(desc19, "Bfm")
+        miniscript_list.append(self.test_miniscript_expr(desc19, "Bfm"))
 
         # andor(c:pk(key),older(25),c:pk(key))
         delay = 25
         pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
         desc20 = "andor(c:pk({}),older({}),c:pk({}))".format(
             pk_hex_list[0], delay, pk_hex_list[1])
-        self.test_miniscript_expr(desc20, "Bdems")
+        miniscript_list.append(self.test_miniscript_expr(desc20, "Bdems"))
 
-        # andor(c:pk(key),or_i(and_v(vc:pk_h(key),hash160(h)),older(35)),c:pk(key))
+        # andor(c:pk(key),or_i(and_v(vc:pk_h(key),ripemd160(h)),older(35)),c:pk(key))
         older = 35
         pkh0 = list(keyhash_dict)[0]
         pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
@@ -206,7 +356,7 @@ class MiniscriptTest(BitcoinTestFramework):
                   "older({})),c:pk({}))").format(
             pk_hex_list[0], pkh0.hex(), ripemd160_digest.hex(), older,
             pk_hex_list[1])
-        self.test_miniscript_expr(desc21, "Bdems")
+        miniscript_list.append(self.test_miniscript_expr(desc21, "Bdems"))
 
         # thresh(k,c:pk(key),sc:pk(key),sc:pk(key),sdv:after(30))
         n = 4
@@ -215,7 +365,8 @@ class MiniscriptTest(BitcoinTestFramework):
             pk_hex_list = self.get_pubkey_hex_list(n-1, keyhash_dict)
             desc22 = ("thresh({},c:pk({}),sc:pk({}),sc:pk({})," +
                            "sdv:after({}))").format(k, *pk_hex_list, after)
-            self.test_miniscript_expr(desc22, "Bdmus")
+            miniscript_list.append(self.test_miniscript_expr(
+                desc22, "Bdmus"))
 
         # thresh(k,c:pk(key),sc:pk(key),sc:pk(key),sc:pk(key),sc:pk(key))
         n = 5
@@ -223,7 +374,8 @@ class MiniscriptTest(BitcoinTestFramework):
             pk_hex_list = self.get_pubkey_hex_list(n, keyhash_dict)
             desc23 = ("thresh({},c:pk({}),sc:pk({}),sc:pk({}),sc:pk({})" +
                            ",sc:pk({}))").format(k, *pk_hex_list)
-            self.test_miniscript_expr(desc23, "Bdemus")
+            miniscript_list.append(self.test_miniscript_expr(
+                desc23, "Bdemus"))
 
         # or_d(thresh_m(1,key),or_b(thresh_m(3,key,key,key),su:after(50)))
         # or_d(thresh_m(1,key),or_b(thresh_m(3,key,key,key),s:or_i(after(50),0)))
@@ -241,7 +393,8 @@ class MiniscriptTest(BitcoinTestFramework):
                                                       pk_hex_list[1],
                                                       pk_hex_list[2],
                                                       pk_hex_list[3], after)
-        self.test_miniscript_expr(desc24, "Bdemu", desc24_alt)
+        miniscript_list.append(self.test_miniscript_expr(
+            desc24, "Bdemu", desc24_alt))
 
         # uuj:and_v(v:thresh_m(2,key,key),after(10))
         # or_i(or_i(j:and_v(v:thresh_m(2,key,key),after(time)),0),0)
@@ -252,7 +405,8 @@ class MiniscriptTest(BitcoinTestFramework):
             k, pk_hex_list[0], pk_hex_list[1], delay)
         desc25_alt = ("or_i(or_i(j:and_v(v:thresh_m({},{},{}),after({})),0)," +
                       "0)").format(k, pk_hex_list[0], pk_hex_list[1], delay)
-        self.test_miniscript_expr(desc25, "Bdsm", desc25_alt)
+        miniscript_list.append(self.test_miniscript_expr(
+            desc25, "Bdsm", desc25_alt))
 
         # or_b(un:thresh_m(k,key,key),al:older(delay))
         # or_b(or_i(n:thresh_m(k,key,key),0),a:or_i(0,older(delay)))
@@ -265,7 +419,14 @@ class MiniscriptTest(BitcoinTestFramework):
                       "a:or_i(0,older({})))").format(k, pk_hex_list[0],
                                                      pk_hex_list[1],
                                                      older)
-        self.test_miniscript_expr(desc26, "Bdu", desc26_alt)
+        miniscript_list.append(self.test_miniscript_expr(desc26, "Bdu",
+                                                         desc26_alt))
+
+        # Test Miniscript satisfaction of all test expressions.
+        for ms in miniscript_list:
+            self.test_miniscript_satisfaction(ms, keyhash_dict, sha256_dict,
+                                              hash256_dict, ripemd160_dict,
+                                              hash160_dict)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_miniscript.py
+++ b/test/functional/feature_miniscript.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test miniscript implementation."""
+
+from test_framework.key import ECKey
+from test_framework.miniscript import Node
+from test_framework.messages import hash256, sha256
+from test_framework.script import hash160
+from test_framework.test_framework import BitcoinTestFramework
+
+import hashlib
+
+
+class MiniscriptTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def test_miniscript_expr(self, desc_str, property_str):
+        node = Node.from_desc(desc_str)
+        node_from_script = Node.from_script(node.script)
+        assert(''.join(sorted(property_str)) ==
+               ''.join(sorted(node.p.to_string()))
+               )
+        assert(node.desc == desc_str)
+        assert(node_from_script.desc == node.desc)
+        assert(node_from_script.script == node.script)
+        return node
+
+    def generate_key_pair(self, keyhash_dict):
+        privkey = ECKey()
+        privkey.generate()
+        pubkeyhash = hash160(privkey.get_pubkey().get_bytes())
+        keyhash_dict[pubkeyhash] = privkey
+
+    def get_pubkey_hex_list(self, n, keyhash_dict):
+        key_hex_list = []
+        for pkh in list(keyhash_dict)[0:n]:
+            pk_hex = keyhash_dict[pkh].get_pubkey().get_bytes().hex()
+            key_hex_list.append(pk_hex)
+        return key_hex_list
+
+    def run_test(self):
+        # Generate key pairs.
+        keyhash_dict = {}
+        for i in range(5):
+            self.generate_key_pair(keyhash_dict)
+
+        # Generate hashlocks.
+        sha256_dict = {}
+        hash256_dict = {}
+        ripemd160_dict = {}
+        hash160_dict = {}
+        for i in range(5):
+            secret = ECKey()
+            secret.generate()
+            sha256_dict[sha256(secret.get_bytes())] = secret.get_bytes()
+            hash256_dict[hash256(secret.get_bytes())] = secret.get_bytes()
+            ripemd160_dict[hashlib.new(
+                'ripemd160', secret.get_bytes()).digest()] = secret.get_bytes()
+            hash160_dict[hash160(secret.get_bytes())] = secret.get_bytes()
+
+        # Test (de)serialization of terminal expressions.
+
+        # pk(key)
+        pk_hex = self.get_pubkey_hex_list(1, keyhash_dict)[0]
+        desc0 = "pk({})".format(pk_hex)
+        self.test_miniscript_expr(desc0, "Konduesm")
+
+        # pk_h(key)
+        pkh = list(keyhash_dict)[0]
+        desc1 = "pk_h({})".format(pkh.hex())
+        self.test_miniscript_expr(desc1, "Knduesm")
+
+        # older(delay)
+        delay = 20
+        desc2 = "older({})".format(delay)
+        self.test_miniscript_expr(desc2, "Bzfm")
+
+        # after(time)
+        time = 21
+        desc3 = "after({})".format(time)
+        self.test_miniscript_expr(desc3, "Bzfm")
+
+        # sha256(h)
+        sha256_digest = list(sha256_dict)[0]
+        desc5 = "sha256({})".format(sha256_digest.hex())
+        self.test_miniscript_expr(desc5, "Bondum")
+
+        # hash256(h)
+        h256_digest = list(hash256_dict)[0]
+        desc6 = "hash256({})".format(h256_digest.hex())
+        self.test_miniscript_expr(desc6, "Bondum")
+
+        # ripemd160(h)
+        ripemd160_digest = list(ripemd160_dict)[0]
+        desc7 = "ripemd160({})".format(ripemd160_digest.hex())
+        self.test_miniscript_expr(desc7, "Bondum")
+
+        # hash160(h)
+        h160_digest = list(hash160_dict)[0]
+        desc8 = "hash160({})".format(h160_digest.hex())
+        self.test_miniscript_expr(desc8, "Bondum")
+
+        # thresh_m(k, pk, pk, ...)
+        k = 2
+        pk_hex_list = self.get_pubkey_hex_list(3, keyhash_dict)
+        desc9 = ("thresh_m({},{},{},{})").format(k, pk_hex_list[0],
+                                                 pk_hex_list[1],
+                                                 pk_hex_list[2])
+        self.test_miniscript_expr(desc9, "Bnduesm")
+
+
+if __name__ == '__main__':
+    MiniscriptTest().main()

--- a/test/functional/feature_miniscript.py
+++ b/test/functional/feature_miniscript.py
@@ -18,15 +18,19 @@ class MiniscriptTest(BitcoinTestFramework):
         self.num_nodes = 1
         self.setup_clean_chain = True
 
-    def test_miniscript_expr(self, desc_str, property_str):
+    def test_miniscript_expr(self, desc_str, property_str,
+                             alt_desc_str=None):
         node = Node.from_desc(desc_str)
         node_from_script = Node.from_script(node.script)
         assert(''.join(sorted(property_str)) ==
                ''.join(sorted(node.p.to_string()))
                )
         assert(node.desc == desc_str)
-        assert(node_from_script.desc == node.desc)
         assert(node_from_script.script == node.script)
+        if alt_desc_str is None:
+            assert(node_from_script.desc == node.desc)
+        else:
+            assert(node_from_script.desc == alt_desc_str)
         return node
 
     def generate_key_pair(self, keyhash_dict):
@@ -111,6 +115,157 @@ class MiniscriptTest(BitcoinTestFramework):
                                                  pk_hex_list[1],
                                                  pk_hex_list[2])
         self.test_miniscript_expr(desc9, "Bnduesm")
+
+        # Test (de)serialization of composable expressions.
+
+        # c:pkh(key)
+        pkh = list(keyhash_dict)[0]
+        desc10 = "c:pk_h({})".format(pkh.hex())
+        self.test_miniscript_expr(desc10, "Bndemus")
+
+        # and_v(vc:pk_h(key), c:pk_h(key)) expression.
+        pkh0 = list(keyhash_dict)[0]
+        pkh1 = list(keyhash_dict)[1]
+        desc11 = "and_v(vc:pk_h({}),c:pk_h({}))".format(pkh0.hex(), pkh1.hex())
+        self.test_miniscript_expr(desc11, "Bnfmus")
+
+        # and_v(vc:pk_h(key),older(delay))) expression.
+        pkh0 = list(keyhash_dict)[0]
+        delay = 10
+        desc12 = "and_v(vc:pk_h({}),older({}))".format(
+            pkh0.hex(), delay)
+        self.test_miniscript_expr(desc12, "Bnfms")
+
+        # or_b(c:pk(key),a:and_b(c:pk_h(key),sc:pk(key)))
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        pkh0 = list(keyhash_dict)[0]
+        desc13 = "or_b(c:pk({}),a:and_b(c:pk_h({}),sc:pk({})))".format(
+            pk_hex_list[0], pkh0.hex(), pk_hex_list[1])
+        self.test_miniscript_expr(desc13, "Bdemus")
+
+        # or_b(c:pk(key),a:and_n(c:pk(key),c:pk_h(key)))
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        pkh0 = list(keyhash_dict)[0]
+        desc14 = "or_b(c:pk({}),a:and_n(c:pk({}),c:pk_h({})))".format(
+            *pk_hex_list, pkh0.hex())
+        self.test_miniscript_expr(desc14, "Bdemus")
+
+        # or_b(c:pk(key),sc:pk(key))
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        desc15 = "or_b(c:pk({}),sc:pk({}))".format(*pk_hex_list)
+        self.test_miniscript_expr(desc15, "Bdemus")
+
+        # or_d(c:pk_h(key),c:pk_h(key))
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        desc16 = "or_d(c:pk({}),c:pk({}))".format(*pk_hex_list)
+        self.test_miniscript_expr(desc16, "Bdemus")
+
+        # t:or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:hash160(h))))
+        # and_v(or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:hash160(h)))),1)
+        h160_digest = list(hash160_dict)[0]
+        pk_hex_list = self.get_pubkey_hex_list(3, keyhash_dict)
+        desc17 = ("t:or_c(c:pk({}),and_v(vc:pk({}),or_c(c:pk({})," +
+                 "v:hash160({}))))").format(*pk_hex_list, h160_digest.hex())
+        desc17_alt = ("and_v(or_c(c:pk({}),and_v(vc:pk({}),or_c(c:pk({})," +
+                     "v:hash160({})))),1)").format(*pk_hex_list,
+                                                   h160_digest.hex())
+        self.test_miniscript_expr(desc17, "Bufsm", desc17_alt)
+
+        # t:or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:sha256(h))))
+        # and_v(or_c(c:pk(key),and_v(vc:pk(key),or_c(c:pk(key),v:sha256(h)))),1)
+        sha256_digest = list(sha256_dict)[0]
+        pk_hex_list = self.get_pubkey_hex_list(3, keyhash_dict)
+        desc18 = ("t:or_c(c:pk({}),and_v(vc:pk({}),or_c(c:pk({})," +
+                 "v:sha256({}))))").format(*pk_hex_list, sha256_digest.hex())
+        desc18_alt = ("and_v(or_c(c:pk({}),and_v(vc:pk({})," +
+                     "or_c(c:pk({}),v:sha256({})))),1)").format(
+                         *pk_hex_list, sha256_digest.hex())
+        self.test_miniscript_expr(desc18, "Bufsm", desc18_alt)
+
+        # or_i(and_v(vc:pk_h(key_local),hash256(h)),older(20))
+        h256_digest = list(hash256_dict)[0]
+        pkh0 = list(keyhash_dict)[0]
+        delay = 20
+        desc19 = "or_i(and_v(vc:pk_h({}),hash256({})),older({}))".format(
+            pkh0.hex(), h256_digest.hex(), delay)
+        self.test_miniscript_expr(desc19, "Bfm")
+
+        # andor(c:pk(key),older(25),c:pk(key))
+        delay = 25
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        desc20 = "andor(c:pk({}),older({}),c:pk({}))".format(
+            pk_hex_list[0], delay, pk_hex_list[1])
+        self.test_miniscript_expr(desc20, "Bdems")
+
+        # andor(c:pk(key),or_i(and_v(vc:pk_h(key),hash160(h)),older(35)),c:pk(key))
+        older = 35
+        pkh0 = list(keyhash_dict)[0]
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        ripemd160_digest = list(ripemd160_dict)[0]
+        desc21 = ("andor(c:pk({}),or_i(and_v(vc:pk_h({}),ripemd160({}))," +
+                  "older({})),c:pk({}))").format(
+            pk_hex_list[0], pkh0.hex(), ripemd160_digest.hex(), older,
+            pk_hex_list[1])
+        self.test_miniscript_expr(desc21, "Bdems")
+
+        # thresh(k,c:pk(key),sc:pk(key),sc:pk(key),sdv:after(30))
+        n = 4
+        after = 30
+        for k in range(2, n):
+            pk_hex_list = self.get_pubkey_hex_list(n-1, keyhash_dict)
+            desc22 = ("thresh({},c:pk({}),sc:pk({}),sc:pk({})," +
+                           "sdv:after({}))").format(k, *pk_hex_list, after)
+            self.test_miniscript_expr(desc22, "Bdmus")
+
+        # thresh(k,c:pk(key),sc:pk(key),sc:pk(key),sc:pk(key),sc:pk(key))
+        n = 5
+        for k in range(2, n):
+            pk_hex_list = self.get_pubkey_hex_list(n, keyhash_dict)
+            desc23 = ("thresh({},c:pk({}),sc:pk({}),sc:pk({}),sc:pk({})" +
+                           ",sc:pk({}))").format(k, *pk_hex_list)
+            self.test_miniscript_expr(desc23, "Bdemus")
+
+        # or_d(thresh_m(1,key),or_b(thresh_m(3,key,key,key),su:after(50)))
+        # or_d(thresh_m(1,key),or_b(thresh_m(3,key,key,key),s:or_i(after(50),0)))
+        k1 = 1
+        k2 = 2
+        after = 30
+        pk_hex_list = self.get_pubkey_hex_list(4, keyhash_dict)
+        desc24 = ("or_d(thresh_m({},{}),or_b(thresh_m({},{},{},{})," +
+                         "su:after({})))").format(k1, pk_hex_list[0], k2,
+                                                  pk_hex_list[1],
+                                                  pk_hex_list[2],
+                                                  pk_hex_list[3], after)
+        desc24_alt = ("or_d(thresh_m({},{}),or_b(thresh_m({},{},{},{})," +
+                      "s:or_i(after({}),0)))").format(k1, pk_hex_list[0], k2,
+                                                      pk_hex_list[1],
+                                                      pk_hex_list[2],
+                                                      pk_hex_list[3], after)
+        self.test_miniscript_expr(desc24, "Bdemu", desc24_alt)
+
+        # uuj:and_v(v:thresh_m(2,key,key),after(10))
+        # or_i(or_i(j:and_v(v:thresh_m(2,key,key),after(time)),0),0)
+        k = 2
+        delay = 40
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        desc25 = "uuj:and_v(v:thresh_m({},{},{}),after({}))".format(
+            k, pk_hex_list[0], pk_hex_list[1], delay)
+        desc25_alt = ("or_i(or_i(j:and_v(v:thresh_m({},{},{}),after({})),0)," +
+                      "0)").format(k, pk_hex_list[0], pk_hex_list[1], delay)
+        self.test_miniscript_expr(desc25, "Bdsm", desc25_alt)
+
+        # or_b(un:thresh_m(k,key,key),al:older(delay))
+        # or_b(or_i(n:thresh_m(k,key,key),0),a:or_i(0,older(delay)))
+        k = 2
+        older = 45
+        pk_hex_list = self.get_pubkey_hex_list(2, keyhash_dict)
+        desc26 = "or_b(un:thresh_m({},{},{}),al:older({}))".format(
+            k, pk_hex_list[0], pk_hex_list[1], older)
+        desc26_alt = ("or_b(or_i(n:thresh_m({},{},{}),0)," +
+                      "a:or_i(0,older({})))").format(k, pk_hex_list[0],
+                                                     pk_hex_list[1],
+                                                     older)
+        self.test_miniscript_expr(desc26, "Bdu", desc26_alt)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_miniscript.py
+++ b/test/functional/feature_miniscript.py
@@ -56,7 +56,7 @@ class MiniscriptTest(BitcoinTestFramework):
                                                tx.vout[0].nValue)
         # Test each canonical AND non-canonical
         # satisfying witness for spending transaction.
-        for wit_sat in node.sat:
+        for wit_sat in node.sat+node.sat_ncan:
             witness_arr = []
             for sat_element in wit_sat:
                 # Set sequence for input at index 0.

--- a/test/functional/test_framework/miniscript.py
+++ b/test/functional/test_framework/miniscript.py
@@ -6,6 +6,13 @@
 
 from enum import Enum
 
+from .key import ECPubKey
+from .script import CScript, OP_ADD, OP_CHECKLOCKTIMEVERIFY, \
+    OP_CHECKSEQUENCEVERIFY, OP_CHECKMULTISIG, OP_CHECKSIG, \
+    OP_CHECKMULTISIGVERIFY, OP_CHECKSIGVERIFY, OP_DUP, OP_EQUAL, \
+    OP_EQUALVERIFY, OP_HASH160, OP_HASH256, OP_RIPEMD160, OP_SHA256, \
+    OP_SIZE, OP_VERIFY
+
 
 class Property:
     """Miniscript expression property"""
@@ -101,3 +108,467 @@ class NodeType(Enum):
     ANDOR = 27
     THRESH = 28
     THRESH_M = 29
+
+
+class Node:
+    """Miniscript expression class
+
+    Provides methods to instantiate a miniscript node from a string descriptor
+    or script. Node.sat, Node.dsat, Node.sat_ncan and Node.dsat_ncan return a
+    list of tuples which encode the (dis)satisfying witness stack.
+    """
+
+    def __init__(self):
+        self.desc = ''
+        self.children = None
+        self.t = None
+        self._sat = None
+        self._k = None
+        self._pk = []
+        self._pk_h = None
+
+    @staticmethod
+    def from_desc(string):
+        """Construct miniscript node from string descriptor"""
+        tag, child_exprs = Node._parse_string(string)
+        k = None
+
+        if tag == '0':
+            return Node().construct_just_0()
+
+        if tag == '1':
+            return Node().construct_just_1()
+
+        if tag == 'pk':
+            key_b = bytes.fromhex(child_exprs[0])
+            key_obj = ECPubKey()
+            key_obj.set(key_b)
+            return Node().construct_pk(key_obj)
+
+        if tag == 'pk_h':
+            keyhash_b = bytes.fromhex(child_exprs[0])
+            return Node().construct_pk_h(keyhash_b)
+
+        if tag == "older":
+            n = int(child_exprs[0])
+            return Node().construct_older(n)
+
+        if tag == "after":
+            time = int(child_exprs[0])
+            return Node().construct_after(time)
+
+        if tag in ["sha256", "hash256", "ripemd160", "hash160"]:
+            hash_b = bytes.fromhex(child_exprs[0])
+            return getattr(Node(), "construct_"+tag)(hash_b)
+
+        if tag == 'thresh_m':
+            k = int(child_exprs.pop(0))
+            key_n = []
+            for child_expr in child_exprs:
+                key_obj = ECPubKey()
+                key_obj.set(bytes.fromhex(child_expr))
+                key_n.append(key_obj)
+            return Node().construct_thresh_m(k, key_n)
+
+        if tag == 'thresh':
+            k = int(child_exprs.pop(0))
+            return Node().construct_thresh(
+                k, Node._parse_child_strings(child_exprs))
+
+        # Standard node constructor forms:
+        # construct_tag(node_x, node_y, ...):
+        return getattr(Node(), "construct_"+tag)(
+                *Node._parse_child_strings(child_exprs))
+
+    @property
+    def script(self):
+        return CScript(Node._collapse_script(self._script))
+
+    @staticmethod
+    def from_script(c_script):
+        """Construct miniscript node from script"""
+        expr_list = []
+        for op in c_script:
+            # Encode 0, 20, 32 as int.
+            # Other values are coerced to int types with Node._coerce_to_int()
+            if op in [b'', b'\x14', b'\x20']:
+                op_int = int.from_bytes(op, byteorder='big')
+                expr_list.append(op_int)
+            else:
+                expr_list.append(op)
+
+        # Decompose script:
+        # OP_CHECKSIGVERIFY > OP_CHECKSIG + OP_VERIFY
+        # OP_CHECKMULTISIGVERIFY > OP_CHECKMULTISIG + OP_VERIFY
+        # OP_EQUALVERIFY > OP_EQUAL + OP_VERIFY
+        expr_list = Node._decompose_script(expr_list)
+        expr_list_len = len(expr_list)
+
+        # Parse for terminal expressions.
+        idx = 0
+        while idx < expr_list_len:
+
+            # Match against pk(key).
+            if isinstance(expr_list[idx], bytes) and \
+                    len(expr_list[idx]) == 33 and \
+                    expr_list[idx][0] in [2, 3]:
+                key = ECPubKey()
+                key.set(expr_list[idx])
+                expr_list[idx] = Node().construct_pk(key)
+
+            # Match against just1.
+            if expr_list[idx] == 1:
+                expr_list[idx] = Node().construct_just_1()
+
+            # Match against just0.
+            if expr_list[idx] == 0:
+                expr_list[idx] = Node().construct_just_0()
+
+            # 2 element terminal expressions.
+            if expr_list_len-idx >= 2:
+                try:
+                    # Timelock encoding n.
+                    n_int = Node._coerce_to_int(expr_list[idx])
+                    # Match against older.
+                    if n_int >= 1 and \
+                            expr_list[idx+1] == OP_CHECKSEQUENCEVERIFY:
+                        node = Node().construct_older(n_int)
+                        expr_list = expr_list[:idx]+[node]+expr_list[idx+2:]
+                        expr_list_len -= 1
+                    # Match against after.
+                    elif n_int >= 1 and n_int <= 2**32 and \
+                            expr_list[idx+1] == OP_CHECKLOCKTIMEVERIFY:
+                        node = Node().construct_after(n_int)
+                        expr_list = expr_list[:idx]+[node]+expr_list[idx+2:]
+                        expr_list_len -= 1
+                except Exception:
+                    pass
+
+            # 4 element terminal expressions.
+            if expr_list_len-idx >= 5:
+
+                # Match against pk_h(pkhash).
+                if expr_list[idx:idx+2] == [OP_DUP, OP_HASH160] and \
+                        isinstance(expr_list[idx+2], bytes) and \
+                        len(expr_list[idx+2]) == 20 and \
+                        expr_list[idx+3:idx+5] == [OP_EQUAL, OP_VERIFY]:
+                    node = Node().construct_pk_h(expr_list[idx+2])
+                    expr_list = expr_list[:idx]+[node]+expr_list[idx+5:]
+                    # Reduce length of list after node construction.
+                    expr_list_len -= 4
+
+            # 6 element terminal expressions.
+            if expr_list_len-idx >= 7:
+
+                # Match against sha256.
+                if expr_list[idx:idx+5] == [OP_SIZE, 32, OP_EQUAL,
+                                            OP_VERIFY, OP_SHA256] and \
+                        isinstance(expr_list[idx+5], bytes) and \
+                        len(expr_list[idx+5]) == 32 and \
+                        expr_list[idx+6] == OP_EQUAL:
+                    node = Node().construct_sha256(expr_list[idx+5])
+                    expr_list = expr_list[:idx]+[node]+expr_list[idx+7:]
+                    expr_list_len -= 6
+
+                # Match against hash256.
+                if expr_list[idx:idx+5] == [OP_SIZE, 32, OP_EQUAL,
+                                            OP_VERIFY, OP_HASH256] and \
+                        isinstance(expr_list[idx+5], bytes) and \
+                        len(expr_list[idx+5]) == 32 and \
+                        expr_list[idx+6] == OP_EQUAL:
+                    node = Node().construct_hash256(expr_list[idx+5])
+                    expr_list = expr_list[:idx]+[node]+expr_list[idx+7:]
+                    expr_list_len -= 6
+
+                # Match against ripemd160.
+                if expr_list[idx:idx+5] == [OP_SIZE, 32, OP_EQUAL,
+                                            OP_VERIFY, OP_RIPEMD160] and \
+                        isinstance(expr_list[idx+5], bytes) and \
+                        len(expr_list[idx+5]) == 20 and \
+                        expr_list[idx+6] == OP_EQUAL:
+                    node = Node().construct_ripemd160(expr_list[idx+5])
+                    expr_list = expr_list[:idx]+[node]+expr_list[idx+7:]
+                    expr_list_len -= 6
+
+                # Match against hash160.
+                if expr_list[idx:idx+5] == [OP_SIZE, 32, OP_EQUAL,
+                                            OP_VERIFY, OP_HASH160] and \
+                        isinstance(expr_list[idx+5], bytes) and \
+                        len(expr_list[idx+5]) == 20 and \
+                        expr_list[idx+6] == OP_EQUAL:
+                    node = Node().construct_hash160(expr_list[idx+5])
+                    expr_list = expr_list[:idx]+[node]+expr_list[idx+7:]
+                    expr_list_len -= 6
+
+            # Increment index.
+            idx += 1
+
+        # Construct AST recursively.
+        return Node._parse_expr_list(expr_list)
+
+    @staticmethod
+    def _parse_expr_list(expr_list):
+        # Every recursive call must progress the AST construction,
+        # until it is complete (single root node remains).
+        expr_list_len = len(expr_list)
+
+        # Root node reached.
+        if expr_list_len == 1 and isinstance(expr_list[0], Node):
+            return expr_list[0]
+
+        # Step through each list index and match against templates.
+        idx = expr_list_len - 1
+        while idx >= 0:
+
+            # Match against thresh_m.
+            # Termainal expression, but k and n values can be Nodes (JUST_0/1)
+            if expr_list_len-idx >= 5 and \
+                    ((
+                    isinstance(expr_list[idx], int) and
+                    expr_list_len-idx-3 >= expr_list[idx] >= 1
+                    ) or (
+                    isinstance(expr_list[idx], Node) and
+                    expr_list[idx].t == NodeType.JUST_1
+                    )):
+                k = Node._coerce_to_int(expr_list[idx])
+                # Permissible values for n:
+                # len(expr)-3 >= n >= 1
+                for n in range(k, expr_list_len-2):
+                    # Match ... <PK>*n ...
+                    match, pk_m = True, []
+                    for i in range(n):
+                        if not (isinstance(expr_list[idx+1+i], Node) and
+                                expr_list[idx+1+i].t == NodeType.PK):
+                            match = False
+                            break
+                        else:
+                            key = ECPubKey()
+                            key.set(expr_list[idx+1+i]._pk[0])
+                            pk_m.append(key)
+                    # Match ... <m> <OP_CHECKMULTISIG>
+                    if match is True:
+                        m = Node._coerce_to_int(expr_list[idx+n+1])
+                        if isinstance(m, int) and m == len(pk_m) and \
+                                expr_list[idx+n+2] == OP_CHECKMULTISIG:
+                            try:
+                                node = Node().construct_thresh_m(k, pk_m)
+                                expr_list = expr_list[:idx] + [node] + \
+                                    expr_list[idx+n+3:]
+                                return Node._parse_expr_list(expr_list)
+                            except Exception:
+                                pass
+
+            # Right-to-left parsing.
+            # Step one position left.
+            idx -= 1
+
+        # No match found.
+        raise Exception("Malformed miniscript")
+
+    def construct_just_1(self):
+        self._construct(NodeType.JUST_1, Property().from_string("Bzufm"),
+                        [],
+                        [1], '1')
+        return self
+
+    def construct_just_0(self):
+        self._construct(NodeType.JUST_0, Property().from_string("Bzudems"),
+                        [],
+                        [0], '0')
+        return self
+
+    def construct_pk(self, pubkey):
+        assert isinstance(pubkey, ECPubKey) and pubkey.is_valid
+        self._pk = [pubkey.get_bytes()]
+        self._construct(NodeType.PK, Property().from_string("Konudems"),
+                        [],
+                        [pubkey.get_bytes()], 'pk('+self._pk[0].hex()+')'
+                        )
+        return self
+
+    def construct_pk_h(self, pk_hash_digest):
+        assert isinstance(pk_hash_digest, bytes) and len(pk_hash_digest) == 20
+        self._pk_h = pk_hash_digest
+        self._construct(NodeType.PK_H, Property().from_string("Knudems"),
+                        [],
+                        [OP_DUP, OP_HASH160, pk_hash_digest, OP_EQUALVERIFY],
+                        'pk_h('+pk_hash_digest.hex()+')'
+                        )
+        return self
+
+    def construct_older(self, delay):
+        assert delay >= 1
+        self._delay = delay
+        self._construct(NodeType.OLDER, Property().from_string("Bzfm"),
+                        [],
+                        [delay, OP_CHECKSEQUENCEVERIFY],
+                        'older('+str(delay)+')'
+                        )
+        return self
+
+    def construct_after(self, time):
+        assert time >= 1 and time < 2**31
+        self._time = time
+        self._construct(NodeType.AFTER, Property().from_string("Bzfm"),
+                        [],
+                        [time, OP_CHECKLOCKTIMEVERIFY],
+                        'after('+str(time)+')'
+                        )
+        return self
+
+    def construct_sha256(self, hash_digest):
+        assert isinstance(hash_digest, bytes) and len(hash_digest) == 32
+        self._sha256 = hash_digest
+        self._construct(NodeType.SHA256, Property().from_string("Bonudm"),
+                        [],
+                        [OP_SIZE, 32, OP_EQUALVERIFY,
+                         OP_SHA256, hash_digest, OP_EQUAL],
+                        'sha256('+hash_digest.hex()+')'
+                        )
+        return self
+
+    def construct_hash256(self, hash_digest):
+        assert isinstance(hash_digest, bytes) and len(hash_digest) == 32
+        self._hash256 = hash_digest
+        self._construct(NodeType.HASH256, Property().from_string("Bonudm"),
+                        [],
+                        [OP_SIZE, 32, OP_EQUALVERIFY,
+                         OP_HASH256, hash_digest, OP_EQUAL],
+                        'hash256('+hash_digest.hex()+')'
+                        )
+        return self
+
+    def construct_ripemd160(self, hash_digest):
+        assert isinstance(hash_digest, bytes) and len(hash_digest) == 20
+        self._ripemd160 = hash_digest
+        self._construct(NodeType.RIPEMD160, Property().from_string("Bonudm"),
+                        [],
+                        [OP_SIZE, 32, OP_EQUALVERIFY,
+                         OP_RIPEMD160, hash_digest, OP_EQUAL],
+                        'ripemd160('+hash_digest.hex()+')'
+                        )
+        return self
+
+    def construct_hash160(self, hash_digest):
+        assert isinstance(hash_digest, bytes) and len(hash_digest) == 20
+        self._hash160 = hash_digest
+        self._construct(NodeType.HASH160, Property().from_string("Bonudm"),
+                        [],
+                        [OP_SIZE, 32, OP_EQUALVERIFY,
+                         OP_HASH160, hash_digest, OP_EQUAL],
+                        'hash160('+hash_digest.hex()+')'
+                        )
+        return self
+
+    def construct_thresh_m(self, k, keys_n):
+        self._k = k
+        n = len(keys_n)
+        assert n >= k >= 1
+        prop_str = "Bnudems"
+        self._pk_n = [key.get_bytes() for key in keys_n]
+        desc = "thresh_m("+str(k)+","
+        for idx, key_b in enumerate(self._pk_n):
+            desc += key_b.hex()
+            desc += "," if idx != (n-1) else ")"
+        self._construct(NodeType.THRESH_M, Property().from_string(prop_str),
+                        [],
+                        [k, *self._pk_n, n, OP_CHECKMULTISIG], desc
+                        )
+        return self
+
+    def _construct(self,
+                   node_type, node_prop,
+                   children,
+                   script, desc):
+        self.t = node_type
+        self.p = node_prop
+        self.children = children
+        self._script = script
+        self.desc = desc
+
+    # Utility methods.
+    @staticmethod
+    def _coerce_to_int(expr):
+        # Coerce expression to int when iterating through CScript expressions
+        # after terminal expressions have been parsed.
+        if isinstance(expr, bytes):
+            op_int = int.from_bytes(expr, byteorder="big")
+        elif isinstance(expr, Node) and expr.t == NodeType.JUST_0:
+            op_int = 0
+        elif isinstance(expr, Node) and expr.t == NodeType.JUST_1:
+            op_int = 1
+        else:
+            op_int = expr
+        return op_int
+
+    @staticmethod
+    def _parse_child_strings(child_exprs):
+        child_nodes = []
+        for string in child_exprs:
+            child_nodes.append(Node.from_desc(string))
+        return child_nodes
+
+    @staticmethod
+    def _parse_string(string):
+        string = ''.join(string.split())
+        tag = ''
+        child_exprs = []
+        depth = 0
+
+        for idx, ch in enumerate(string):
+            if (ch == '0' or ch == '1') and len(string) == 1:
+                return ch, child_exprs
+            if ch == ':' and depth == 0:
+                # Discern between 1 or two wrappers.
+                if idx == 1:
+                    return string[0], [string[2:]]
+                else:
+                    return string[0], [string[1:]]
+            if ch == '(':
+                depth += 1
+                if depth == 1:
+                    tag = string[:idx]
+                    prev_idx = idx
+            if ch == ')':
+                depth -= 1
+                if depth == 0:
+                    child_exprs.append(string[prev_idx+1:idx])
+            if ch == ',' and depth == 1:
+                child_exprs.append(string[prev_idx+1:idx])
+                prev_idx = idx
+        if depth == 0 and bool(tag) and bool(child_exprs):
+            return tag, child_exprs
+        else:
+            raise Exception('Malformed miniscript string.')
+
+    @staticmethod
+    def _decompose_script(expr_list):
+        idx = 0
+        while idx < len(expr_list):
+            if expr_list[idx] == OP_CHECKSIGVERIFY:
+                expr_list = expr_list[:idx]+[OP_CHECKSIG, OP_VERIFY]+expr_list[
+                    idx+1:]
+            elif expr_list[idx] == OP_CHECKMULTISIGVERIFY:
+                expr_list = expr_list[:idx]+[OP_CHECKMULTISIG, OP_VERIFY] + \
+                    expr_list[idx+1:]
+            elif expr_list[idx] == OP_EQUALVERIFY:
+                expr_list = expr_list[:idx]+[OP_EQUAL, OP_VERIFY]+expr_list[
+                    idx+1:]
+            idx += 1
+        return expr_list
+
+    @staticmethod
+    def _collapse_script(expr_list):
+        idx = 0
+        while idx < len(expr_list):
+            if expr_list[idx:idx+1] == [OP_CHECKSIG, OP_VERIFY]:
+                expr_list = expr_list[:idx]+[OP_CHECKSIGVERIFY]+expr_list[
+                    idx+2:]
+            elif expr_list[idx:idx+1] == [OP_CHECKMULTISIG, OP_VERIFY]:
+                expr_list = expr_list[:idx]+[OP_CHECKMULTISIGVERIFY] + \
+                    expr_list[idx+2:]
+            elif expr_list[idx:idx+1] == [OP_EQUAL, OP_VERIFY]:
+                expr_list = expr_list[:idx]+[OP_EQUALVERIFY]+expr_list[
+                    idx+2:]
+            idx += 1
+        return expr_list

--- a/test/functional/test_framework/miniscript.py
+++ b/test/functional/test_framework/miniscript.py
@@ -4,6 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Classes and methods to encode and decode miniscripts"""
 
+from enum import Enum
+
 
 class Property:
     """Miniscript expression property"""
@@ -66,3 +68,36 @@ class Property:
             (not self.V or self.f) and \
             (not self.K or self.s) and \
             (not self.z or self.m)
+
+
+class NodeType(Enum):
+    JUST_0 = 0
+    JUST_1 = 1
+    PK = 2
+    PK_H = 3
+    OLDER = 4
+    AFTER = 5
+    SHA256 = 6
+    HASH256 = 7
+    RIPEMD160 = 8
+    HASH160 = 9
+    WRAP_A = 10
+    WRAP_S = 11
+    WRAP_C = 12
+    WRAP_T = 13
+    WRAP_D = 14
+    WRAP_V = 15
+    WRAP_J = 16
+    WRAP_N = 17
+    WRAP_U = 18
+    WRAP_L = 19
+    AND_V = 20
+    AND_B = 21
+    AND_N = 22
+    OR_B = 23
+    OR_C = 24
+    OR_D = 25
+    OR_I = 26
+    ANDOR = 27
+    THRESH = 28
+    THRESH_M = 29

--- a/test/functional/test_framework/miniscript.py
+++ b/test/functional/test_framework/miniscript.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Classes and methods to encode and decode miniscripts"""
+
+
+class Property:
+    """Miniscript expression property"""
+    # "B": Base type
+    # "V": Verify type
+    # "K": Key type
+    # "W": Wrapped type
+    # "z": Zero-arg property
+    # "o": One-arg property
+    # "n": Nonzero arg property
+    # "d": Dissatisfiable property
+    # "u": Unit property
+    # "e": Expression property
+    # "f": Forced property
+    # "s": Safe property
+    # "m": Nonmalleable property
+    # "x": Expensive verify
+    types = "BVKW"
+    props = "zonduefsmx"
+
+    def __init__(self):
+        for literal in self.types+self.props:
+            setattr(self, literal, False)
+
+    def from_string(self, property_str):
+        """Construct property from string of valid property and types"""
+        for char in property_str:
+            assert(hasattr(self, char))
+            setattr(self, char, True)
+        assert self.is_valid()
+        return self
+
+    def to_string(self):
+        """Generate string representation of property"""
+        property_str = ""
+        for char in self.types+self.props:
+            if getattr(self, char):
+                property_str += char
+        return property_str
+
+    def is_valid(self):
+        # Can only be of a single type.
+        num_types = 0
+        for typ in self.types:
+            if getattr(self, typ):
+                num_types += 1
+        assert num_types == 1
+
+        # Check for conflicts in type & properties.
+        return \
+            (not self.z or not self.o) and \
+            (not self.n or not self.z) and \
+            (not self.V or not self.d) and \
+            (not self.K or self.u) and \
+            (not self.V or not self.u) and \
+            (not self.e or not self.f) and \
+            (not self.e or self.d) and \
+            (not self.V or not self.e) and \
+            (not self.d or not self.f) and \
+            (not self.V or self.f) and \
+            (not self.K or self.s) and \
+            (not self.z or self.m)

--- a/test/functional/test_framework/miniscript.py
+++ b/test/functional/test_framework/miniscript.py
@@ -111,6 +111,22 @@ class NodeType(Enum):
     THRESH_M = 29
 
 
+class SatType(Enum):
+    # SatType Class provides information on how to construct satisfying or
+    # non-satisfying witnesses. sat/dsat methods return list of tuples:
+    # [(SatType, Value), (SatType, Value), ...]
+    # The value provides a hint how to construct the resp. witness element.
+    OLDER = 0                       # Value: Delay
+    AFTER = 1                       # Value: Time
+    SIGNATURE = 2                   # Value: 33B Key/20B HASH160 Digest
+    KEY_AND_HASH160_PREIMAGE = 3    # Value: 20B HASH160 Digest
+    SHA256_PREIMAGE = 4             # Value: 32B SHA256 Digest
+    HASH256_PREIMAGE = 5            # Value: 32B HASH256 Digest
+    RIPEMD160_PREIMAGE = 6          # Value: 20B RIPEMD160 Digest
+    HASH160_PREIMAGE = 7            # Value: 20B HASH160 Digest
+    DATA = 8                        # Value: Bytes
+
+
 class Node:
     """Miniscript expression class
 


### PR DESCRIPTION
This PR introduces basic Miniscript support to the TestFramework. 

I believe this would be useful for:

- Functional tests with more complex script satisfaction(s)
- Functional tests for future wallet RPC calls which handle Miniscript
- Entry point for developers looking to integrate Miniscript into external wallet projects (ecdsa, SomberNight, dgpv).

**Usage:**

Miniscript string constructor.
```
# key, delay in descriptor below must be represented as hex/int.

example_desc = “or_b(or_i(n:thresh_m(k,key,key),0),a:or_i(0,older(delay)))”

miniscript_node = Node.from_desc(example_desc)
```

Miniscript CScript constructor.
```
miniscript_node = Node.from_script(cscript)
```

Miniscript type and properties.
```
miniscript_node.p.to_string()
```

(Dis)satisfaction methods, returns list of tuple-lists.
```
# Canonical (dis)satisfying witnesses
miniscript_node.sat
miniscript_node.dsat

# Non-canonical (dis)satisfying witnesses
miniscript_node.sat_ncan
miniscript_node.dsat_ncan
```

Each tuple-list encodes a single, unique satisfying witness:
```
[
	(SatType, Value),
	(SatType, Value),
	(SatType, Value),
	…
]
```
The SatType, Value tuples encode the following witness information in correct order. Exception: Time/Delay tuples are not witness elements and will always be positioned at the beginning of the list.

|  SatType | Value | 
|---|---|
| OLDER | Delay int | 
| AFTER | Time int |
| SIGNATURE | 33B Key/20B HASH160 Digest  |
| KEY_AND_HASH160_PREIMAGE | 20B HASH160 Digest |
| SHA256_PREIMAGE | 32B SHA256 Digest |
| HASH256_PREIMAGE | 32B HASH256 Digest |
| RIPEMD160_PREIMAGE |  20B RIPEMD160 Digest |
| HASH160_PREIMAGE | 20B HASH160 Digest |
| DATA | Bytes |

Our example `miniscript_node.sat` above returns the following 2 satisfying witnesses:
```
[
	[
		(<SatType.DATA: 8>, b'\x01'), 
		(<SatType.DATA: 8>, b''), 
		(<SatType.SIGNATURE: 2>,  key_bytes), 
		(<SatType.SIGNATURE: 2>,  key_bytes), 
		(<SatType.DATA: 8>, b'\x01')
	], 
	[
		(<SatType.OLDER: 0>, 45), 
		(<SatType.DATA: 8>, b''), 
		(<SatType.DATA: 8>, b'')
	]
]
```

**Tests:**

I have included tests in feature_miniscript.py to facilitate potential reviews, but would suggest to omit these if the maintainers decide to merge this PR.
