### PR TITLE
gui: walletcontroller showProgressDialogue functional progressBar

### DIFF
--- a/src/qt/walletcontroller.h
+++ b/src/qt/walletcontroller.h
@@ -95,7 +95,8 @@ protected:
     interfaces::Node& node() const { return m_wallet_controller->m_node; }
     QObject* worker() const { return m_wallet_controller->m_activity_worker; }
 
-    void showProgressDialog(const QString& label_text);
+    void showProgressDialog(const QString& title_text, const QString& label_text);
+    void updateProgress();
 
     WalletController* const m_wallet_controller;
     QWidget* const m_parent_widget;


### PR DESCRIPTION
 This change takes better advantage of the default "Expanding" policy of the form.

New behavior: 
![Screen Shot 2020-01-21 at 6 04 01 PM](https://user-images.githubusercontent.com/152159/72851191-f73e0380-3c78-11ea-9212-9a34e78c73e5.png)
![Screen Shot 2020-01-21 at 6 06 14 PM](https://user-images.githubusercontent.com/152159/72851200-fad18a80-3c78-11ea-9144-633cf95ecf30.png)


Old behavior:
![Screen Shot 2020-01-21 at 4 54 09 PM](https://user-images.githubusercontent.com/152159/72851574-03769080-3c7a-11ea-861e-783748c1ffce.png)