### PR TITLE
test: add missing #include to fix compiler errors

### DIFF
--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -7,6 +7,7 @@
 #include <test/util/setup_common.h>
 #include <random.h>
 #include <thread>
+#include <deque>
 
 /** Test Suite for CuckooCache
  *


### PR DESCRIPTION
I believe this fixes AppVeyor errors in master. Will close if that is not the case.

Closes #17976