### PR TITLE
[0.19] Final backports for 0.19.1

### DIFF
--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -7,6 +7,7 @@
 #include <test/setup_common.h>
 #include <random.h>
 #include <thread>
+#include <deque>
 
 /** Test Suite for CuckooCache
  *

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1088,17 +1088,19 @@ void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length) {
     SetEndOfFile(hFile);
 #elif defined(MAC_OSX)
     // OSX specific version
+    // NOTE: Contrary to other OS versions, the OSX version assumes that
+    // NOTE: offset is the size of the file.
     fstore_t fst;
     fst.fst_flags = F_ALLOCATECONTIG;
     fst.fst_posmode = F_PEOFPOSMODE;
     fst.fst_offset = 0;
-    fst.fst_length = (off_t)offset + length;
+    fst.fst_length = length; // mac os fst_length takes the # of free bytes to allocate, not desired file size
     fst.fst_bytesalloc = 0;
     if (fcntl(fileno(file), F_PREALLOCATE, &fst) == -1) {
         fst.fst_flags = F_ALLOCATEALL;
         fcntl(fileno(file), F_PREALLOCATE, &fst);
     }
-    ftruncate(fileno(file), fst.fst_length);
+    ftruncate(fileno(file), static_cast<off_t>(offset) + length);
 #else
     #if defined(__linux__)
     // Version using posix_fallocate


### PR DESCRIPTION
We're about ready to do a [0.19.1 release](https://github.com/bitcoin/bitcoin/milestone/44); so I've opened this to collect the last remaining backports. 

If there's something that's been missed / or isn't tagged ["Needs backport (0.19)"](https://github.com/bitcoin/bitcoin/issues?q=is%3Aopen+label%3A%22Needs+backport+%280.19%29%22) that you think should be, please comment.

Currently backports:
* #17887 - bug-fix macos: give free bytes to F_PREALLOCATE
* #17980 - test: add missing #include to fix compiler errors 