### PR TITLE
Load vcpkg port files from a separate repository.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,8 @@ environment:
   QT_DOWNLOAD_HASH: '9a8c6eb20967873785057fdcd329a657c7f922b0af08c5fde105cc597dd37e21'
   QT_LOCAL_PATH: 'C:\Qt5.9.8_x64_static_vs2019'
   VCPKG_INSTALL_PATH: 'C:\tools\vcpkg\installed'
+  VCPKG_PORTS_REPO: 'https://github.com/sipsorcery/bitcoin-vcpkg-ports.git'
+  VCPKG_PORTS_DIR: 'c:\tools\vcpkg-ports'
 cache:
 - C:\tools\vcpkg\installed -> build_msvc\vcpkg-packages.txt
 - C:\Users\appveyor\clcache -> .appveyor.yml, build_msvc\**, **\Makefile.am, **\*.vcxproj.in
@@ -22,27 +24,19 @@ install:
 # Disable zmq test for now since python zmq library on Windows would cause Access violation sometimes.
 # - cmd: pip install zmq
 # Powershell block below is to install the c++ dependencies via vcpkg. The pseudo code is:
-# 1. Check whether the vcpkg install directory exists (note that updating the vcpkg-packages.txt file
-#    will cause the appveyor cache rules to invalidate the directory)
-# 2. If the directory is missing:
-#    a. Update the vcpkg source (including port files) and build the vcpkg binary,
-#    b. Install the missing packages.
+# 1. Get the list fo required packages from the vcpkg-packages.txt file.
+# 2. Clone the vcpkg custom ports repository.
+# 3. Install the vcpkg dependencies using the custom ports.
 - ps: |
       $env:PACKAGES = Get-Content -Path build_msvc\vcpkg-packages.txt
       Write-Host "vcpkg list: $env:PACKAGES"
-      if(!(Test-Path -Path ($env:VCPKG_INSTALL_PATH))) {
-          cd c:\tools\vcpkg
-          $env:GIT_REDIRECT_STDERR = '2>&1' # git is writing non-errors to STDERR when doing git pull. Send to STDOUT instead.
-          git pull origin master
-          .\bootstrap-vcpkg.bat
-          Add-Content "C:\tools\vcpkg\triplets\$env:PLATFORM-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
-          .\vcpkg install --triplet $env:PLATFORM-windows-static $env:PACKAGES.split() > $null
-          cd "$env:APPVEYOR_BUILD_FOLDER"
-      }
-      else {
-        Write-Host "required vcpkg packages already installed."
-      }
-      c:\tools\vcpkg\vcpkg integrate install
+      $env:GIT_REDIRECT_STDERR = '2>&1' # git is writing non-errors to STDERR when doing git clone. Send to STDOUT instead.
+      git clone $env:VCPKG_PORTS_REPO $env:VCPKG_PORTS_DIR
+      Add-Content "C:\tools\vcpkg\triplets\$env:PLATFORM-windows-static.cmake" "set(VCPKG_BUILD_TYPE release)"
+      vcpkg install --triplet $env:PLATFORM-windows-static --overlay-ports=$env:VCPKG_PORTS_DIR $env:PACKAGES.split() > $null
+      # Deliberately running the same command again to print out confirmation that all packages are installed.
+      vcpkg install --triplet $env:PLATFORM-windows-static --overlay-ports=$env:VCPKG_PORTS_DIR $env:PACKAGES.split()
+      vcpkg integrate install
 before_build:
 - ps:  clcache -M 536870912
 # Powershell block below is to download and extract the Qt static libraries. The pseudo code is:


### PR DESCRIPTION
Prior to this change the vcpkg port files were taken directly from the main vcpkg repository. This results in a dependency changing from time-to-time and breaking the Bitcoin Core build.

This change places the port files in a separate repository where they and the dependencies they install will only be updated when necessary.

I've put the port files in a repository under my account. It's a one line change to the appveyor job to switch to a Bitcoin Core repository.

As discussed in #17976 and #17991.