### PR TITLE
tests: Add fuzzing harness for serialization/deserialization of floating-points and integrals

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -29,6 +29,7 @@ FUZZ_TARGETS = \
   test/fuzz/eval_script \
   test/fuzz/fee_rate_deserialize \
   test/fuzz/flat_file_pos_deserialize \
+  test/fuzz/float \
   test/fuzz/hex \
   test/fuzz/integer \
   test/fuzz/inv_deserialize \
@@ -386,6 +387,12 @@ test_fuzz_flat_file_pos_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_flat_file_pos_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_flat_file_pos_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_flat_file_pos_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_float_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_float_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_float_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_float_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_float_SOURCES = $(FUZZ_SUITE) test/fuzz/float.cpp
 
 test_fuzz_hex_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_hex_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_INDIRECTMAP_H
 #define BITCOIN_INDIRECTMAP_H
 
+#include <map>
+
 template <class T>
 struct DereferencingComparator { bool operator()(const T a, const T b) const { return *a < *b; } };
 

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -6,9 +6,11 @@
 #define BITCOIN_MEMUSAGE_H
 
 #include <indirectmap.h>
+#include <prevector.h>
 
 #include <stdlib.h>
 
+#include <cassert>
 #include <map>
 #include <memory>
 #include <set>

--- a/src/test/fuzz/float.cpp
+++ b/src/test/fuzz/float.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <memusage.h>
+#include <serialize.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <version.h>
+
+#include <cassert>
+#include <cstdint>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    {
+        const double d = fuzzed_data_provider.ConsumeFloatingPoint<double>();
+        (void)memusage::DynamicUsage(d);
+        assert(ser_uint64_to_double(ser_double_to_uint64(d)) == d);
+
+        CDataStream stream(SER_NETWORK, INIT_PROTO_VERSION);
+        stream << d;
+        double d_deserialized;
+        stream >> d_deserialized;
+        assert(d == d_deserialized);
+    }
+
+    {
+        const float f = fuzzed_data_provider.ConsumeFloatingPoint<float>();
+        (void)memusage::DynamicUsage(f);
+        assert(ser_uint32_to_float(ser_float_to_uint32(f)) == f);
+
+        CDataStream stream(SER_NETWORK, INIT_PROTO_VERSION);
+        stream << f;
+        float f_deserialized;
+        stream >> f_deserialized;
+        assert(f == f_deserialized);
+    }
+}

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -18,12 +18,14 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <serialize.h>
+#include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <uint256.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 #include <util/time.h>
+#include <version.h>
 
 #include <cassert>
 #include <limits>
@@ -53,6 +55,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     // We cannot assume a specific value of std::is_signed<char>::value:
     // ConsumeIntegral<char>() instead of casting from {u,}int8_t.
     const char ch = fuzzed_data_provider.ConsumeIntegral<char>();
+    const bool b = fuzzed_data_provider.ConsumeBool();
 
     const Consensus::Params& consensus_params = Params().GetConsensus();
     (void)CheckProofOfWork(u256, u32, consensus_params);
@@ -123,5 +126,69 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         (void)GetKeyForDestination(store, destination);
         (void)GetScriptForDestination(destination);
         (void)IsValidDestination(destination);
+    }
+
+    {
+        CDataStream stream(SER_NETWORK, INIT_PROTO_VERSION);
+
+        uint256 deserialized_u256;
+        stream << u256;
+        stream >> deserialized_u256;
+        assert(u256 == deserialized_u256 && stream.empty());
+
+        uint160 deserialized_u160;
+        stream << u160;
+        stream >> deserialized_u160;
+        assert(u160 == deserialized_u160 && stream.empty());
+
+        uint64_t deserialized_u64;
+        stream << u64;
+        stream >> deserialized_u64;
+        assert(u64 == deserialized_u64 && stream.empty());
+
+        int64_t deserialized_i64;
+        stream << i64;
+        stream >> deserialized_i64;
+        assert(i64 == deserialized_i64 && stream.empty());
+
+        uint32_t deserialized_u32;
+        stream << u32;
+        stream >> deserialized_u32;
+        assert(u32 == deserialized_u32 && stream.empty());
+
+        int32_t deserialized_i32;
+        stream << i32;
+        stream >> deserialized_i32;
+        assert(i32 == deserialized_i32 && stream.empty());
+
+        uint16_t deserialized_u16;
+        stream << u16;
+        stream >> deserialized_u16;
+        assert(u16 == deserialized_u16 && stream.empty());
+
+        int16_t deserialized_i16;
+        stream << i16;
+        stream >> deserialized_i16;
+        assert(i16 == deserialized_i16 && stream.empty());
+
+        uint8_t deserialized_u8;
+        stream << u8;
+        stream >> deserialized_u8;
+        assert(u8 == deserialized_u8 && stream.empty());
+
+        int8_t deserialized_i8;
+        stream << i8;
+        stream >> deserialized_i8;
+        assert(i8 == deserialized_i8 && stream.empty());
+
+        char deserialized_ch;
+        stream << ch;
+        stream >> deserialized_ch;
+        assert(ch == deserialized_ch && stream.empty());
+
+        bool deserialized_b;
+        stream << b;
+        stream >> deserialized_b;
+        assert(b == deserialized_b && stream.empty());
     }
 }

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -23,6 +23,7 @@ FUZZERS_MISSING_CORPORA = [
     "decode_tx",
     "fee_rate_deserialize",
     "flat_file_pos_deserialize",
+    "float",
     "hex",
     "integer",
     "key_origin_info_deserialize",


### PR DESCRIPTION
Add simple fuzzing harness for functions with floating-point parameters (such as `ser_double_to_uint64(double)`, etc.).

Add serialization/deserialization fuzzing for integral types.

Add missing includes.

To test this PR:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/float
…
```