### PR TITLE
gui: Shortcut to close ModalOverlay

### DIFF
--- a/src/qt/forms/modaloverlay.ui
+++ b/src/qt/forms/modaloverlay.ui
@@ -351,6 +351,9 @@ QLabel { color: rgb(40,40,40);  }</string>
              <property name="text">
               <string>Hide</string>
              </property>
+             <property name="shortcut">
+              <string>Esc</string>
+             </property>
              <property name="focusPolicy">
               <enum>Qt::StrongFocus</enum>
              </property>


### PR DESCRIPTION
This adds the shortcut `Esc` to hide the ModalOverlay.
The motivation is that it is annoying to always move the cursor to "Hide" when quickly testing something in the GUI with an outdated chain.