### PR TITLE
refactor: Add ChainClient setMockTime, getWallets methods

### DIFF
--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -280,6 +280,12 @@ public:
 
     //! Shut down client.
     virtual void stop() = 0;
+
+    //! Set mock time.
+    virtual void setMockTime(int64_t time) = 0;
+
+    //! Return interfaces for accessing wallets (if any).
+    virtual std::vector<std::unique_ptr<Wallet>> getWallets() = 0;
 };
 
 //! Return implementation of Chain interface.

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -251,8 +251,9 @@ public:
     std::vector<std::unique_ptr<Wallet>> getWallets() override
     {
         std::vector<std::unique_ptr<Wallet>> wallets;
-        for (const std::shared_ptr<CWallet>& wallet : GetWallets()) {
-            wallets.emplace_back(MakeWallet(wallet));
+        for (auto& client : m_context.chain_clients) {
+            auto client_wallets = client->getWallets();
+            std::move(client_wallets.begin(), client_wallets.end(), std::back_inserter(wallets));
         }
         return wallets;
     }

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -529,6 +529,15 @@ public:
     void start(CScheduler& scheduler) override { return StartWallets(scheduler); }
     void flush() override { return FlushWallets(); }
     void stop() override { return StopWallets(); }
+    void setMockTime(int64_t time) override { return SetMockTime(time); }
+    std::vector<std::unique_ptr<Wallet>> getWallets() override
+    {
+        std::vector<std::unique_ptr<Wallet>> wallets;
+        for (const auto& wallet : GetWallets()) {
+            wallets.emplace_back(MakeWallet(wallet));
+        }
+        return wallets;
+    }
     ~WalletClientImpl() override { UnloadWallets(); }
 
     Chain& m_chain;

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -14,7 +14,6 @@
 #include <functional>
 #include <map>
 #include <memory>
-#include <psbt.h>
 #include <stdint.h>
 #include <string>
 #include <tuple>
@@ -25,12 +24,13 @@ class CCoinControl;
 class CFeeRate;
 class CKey;
 class CWallet;
-enum isminetype : unsigned int;
 enum class FeeReason;
-typedef uint8_t isminefilter;
-
 enum class OutputType;
+enum class TransactionError;
+enum isminetype : unsigned int;
 struct CRecipient;
+struct PartiallySignedTransaction;
+typedef uint8_t isminefilter;
 
 namespace interfaces {
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -20,6 +20,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <key_io.h>
+#include <psbt.h>
 #include <ui_interface.h>
 #include <util/system.h> // for GetBoolArg
 #include <wallet/coincontrol.h>

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <httpserver.h>
+#include <interfaces/chain.h>
 #include <key_io.h>
 #include <node/context.h>
 #include <outputtype.h>
@@ -356,7 +357,13 @@ static UniValue setmocktime(const JSONRPCRequest& request)
     LOCK(cs_main);
 
     RPCTypeCheck(request.params, {UniValue::VNUM});
-    SetMockTime(request.params[0].get_int64());
+    int64_t time = request.params[0].get_int64();
+    SetMockTime(time);
+    if (g_rpc_node) {
+        for (const auto& chain_client : g_rpc_node->chain_clients) {
+            chain_client->setMockTime(time);
+        }
+    }
 
     return NullUniValue;
 }


### PR DESCRIPTION
This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10).

These changes are needed to set mock times, and get wallet interface pointers correctly when
wallet code is running in a different process from node code in #10102