### PR TITLE
[WIP] Index for UTXO Set Statistics

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -694,6 +694,9 @@ if test x$use_lcov_branch != xno; then
   AC_SUBST(LCOV_OPTS, "$LCOV_OPTS --rc lcov_branch_coverage=1")
 fi
 
+dnl Check for __int128
+AC_CHECK_TYPES([__int128])
+
 dnl Check for endianness
 AC_C_BIGENDIAN
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -135,6 +135,7 @@ BITCOIN_CORE_H = \
   httpserver.h \
   index/base.h \
   index/blockfilterindex.h \
+  index/coinstatsindex.h \
   index/txindex.h \
   indirectmap.h \
   init.h \
@@ -282,6 +283,7 @@ libbitcoin_server_a_SOURCES = \
   httpserver.cpp \
   index/base.cpp \
   index/blockfilterindex.cpp \
+  index/coinstatsindex.cpp \
   index/txindex.cpp \
   interfaces/chain.cpp \
   interfaces/node.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -383,6 +383,8 @@ crypto_libbitcoin_crypto_base_a_SOURCES = \
   crypto/hmac_sha512.h \
   crypto/poly1305.h \
   crypto/poly1305.cpp \
+  crypto/muhash.cpp \
+  crypto/muhash.h \
   crypto/ripemd160.cpp \
   crypto/ripemd160.h \
   crypto/sha1.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -199,6 +199,7 @@ BITCOIN_TESTS =\
   test/bswap_tests.cpp \
   test/checkqueue_tests.cpp \
   test/coins_tests.cpp \
+  test/coinstatsindex_tests.cpp \
   test/compilerbug_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -4,6 +4,7 @@
 
 
 #include <bench/bench.h>
+#include <crypto/muhash.h>
 #include <crypto/ripemd160.h>
 #include <crypto/sha1.h>
 #include <crypto/sha256.h>
@@ -91,6 +92,18 @@ static void FastRandom_1bit(benchmark::State& state)
     }
 }
 
+static void MuHash(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    MuHash3072 acc;
+    unsigned char key[32] = {0};
+    int i = 0;
+    while (state.KeepRunning()) {
+        key[0] = ++i;
+        acc *= MuHash3072(key);
+    }
+}
+
 BENCHMARK(RIPEMD160, 440);
 BENCHMARK(SHA1, 570);
 BENCHMARK(SHA256, 340);
@@ -101,3 +114,5 @@ BENCHMARK(SipHash_32b, 40 * 1000 * 1000);
 BENCHMARK(SHA256D64_1024, 7400);
 BENCHMARK(FastRandom_32bit, 110 * 1000 * 1000);
 BENCHMARK(FastRandom_1bit, 440 * 1000 * 1000);
+
+BENCHMARK(MuHash, 5000);

--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -104,6 +104,58 @@ static void MuHash(benchmark::State& state)
     }
 }
 
+static void MuHashPrecompute(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    MuHash3072 acc;
+    unsigned char key[32];
+    std::vector<unsigned char> randkey = rng.randbytes(32);
+    for (size_t i = 0; i < randkey.size(); i++) {
+        key[i] = randkey[i];
+    }
+
+    while (state.KeepRunning()) {
+        MuHash3072{key};
+    }
+}
+
+static void MuHashAdd(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    MuHash3072 acc;
+    unsigned char key[32];
+    std::vector<unsigned char> randkey = rng.randbytes(32);
+    for (size_t i = 0; i < randkey.size(); i++) {
+        key[i] = randkey[i];
+    }
+
+    MuHash3072 muhash = MuHash3072(key);
+    while (state.KeepRunning()) {
+        acc *= muhash;
+    }
+}
+
+static void MuHashDiv(benchmark::State& state)
+{
+    FastRandomContext rng(true);
+    MuHash3072 acc;
+    unsigned char key[32];
+    std::vector<unsigned char> randkey = rng.randbytes(32);
+    for (size_t i = 0; i < randkey.size(); i++) {
+        key[i] = randkey[i];
+    }
+
+    MuHash3072 muhash = MuHash3072(key);
+
+    for (size_t i = 0; i < state.m_num_iters; i++) {
+        acc *= muhash;
+    }
+
+    while (state.KeepRunning()) {
+        acc /= muhash;
+    }
+}
+
 BENCHMARK(RIPEMD160, 440);
 BENCHMARK(SHA1, 570);
 BENCHMARK(SHA256, 340);
@@ -116,3 +168,6 @@ BENCHMARK(FastRandom_32bit, 110 * 1000 * 1000);
 BENCHMARK(FastRandom_1bit, 440 * 1000 * 1000);
 
 BENCHMARK(MuHash, 5000);
+BENCHMARK(MuHashPrecompute, 5000);
+BENCHMARK(MuHashAdd, 5000);
+BENCHMARK(MuHashDiv, 100);

--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -1,0 +1,274 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <crypto/muhash.h>
+
+#include <crypto/chacha20.h>
+#include <crypto/common.h>
+
+#include <assert.h>
+#include <stdio.h>
+
+#include <limits>
+
+namespace {
+
+/** Extract the lowest limb of [c0,c1,c2] into n, and left shift the number by 1 limb. */
+#define extract3(c0,c1,c2,n) { \
+    (n) = c0; \
+    c0 = c1; \
+    c1 = c2; \
+    c2 = 0; \
+}
+
+/** Extract the lowest limb of [c0,c1] into n, and left shift the number by 1 limb. */
+#define extract2(c0,c1,n) { \
+    (n) = c0; \
+    c0 = c1; \
+    c1 = 0; \
+}
+
+/** [c0,c1] = a * b */
+#define mul(c0,c1,a,b) { \
+    Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
+    c2 = 0; \
+    c1 = t >> Num3072::LIMB_SIZE; \
+    c0 = t; \
+}
+
+/* [c0,c1,c2] += n * [d0,d1,d2]. c2 is 0 initially */
+#define mulnadd3(c0,c1,c2,d0,d1,d2,n) { \
+    Num3072::double_limb_type t = (Num3072::double_limb_type)d0 * n + c0; \
+    c0 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+    t += (Num3072::double_limb_type)d1 * n + c1; \
+    c1 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+    c2 = t + d2 * n; \
+}
+
+/* [c0,c1] *= n */
+#define muln2(c0,c1,n) { \
+    Num3072::double_limb_type t = (Num3072::double_limb_type)c0 * n; \
+    c0 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+    t += (Num3072::double_limb_type)c1 * n; \
+    c1 = t; \
+    t >>= Num3072::LIMB_SIZE; \
+}
+
+/** [c0,c1,c2] += a * b */
+#define muladd3(c0,c1,c2,a,b) { \
+    Num3072::limb_type tl, th; \
+    { \
+        Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
+        th = t >> Num3072::LIMB_SIZE; \
+        tl = t; \
+    } \
+    c0 += tl; \
+    th += (c0 < tl) ? 1 : 0; \
+    c1 += th; \
+    c2 += (c1 < th) ? 1 : 0; \
+}
+
+/** [c0,c1,c2] += 2 * a * b */
+#define muldbladd3(c0,c1,c2,a,b) { \
+    Num3072::limb_type tl, th; \
+    { \
+        Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
+        th = t >> Num3072::LIMB_SIZE; \
+        tl = t; \
+    } \
+    c0 += tl; \
+    Num3072::limb_type tt = th + ((c0 < tl) ? 1 : 0); \
+    c1 += tt; \
+    c2 += (c1 < tt) ? 1 : 0; \
+    c0 += tl; \
+    th += (c0 < tl) ? 1 : 0; \
+    c1 += th; \
+    c2 += (c1 < th) ? 1 : 0; \
+}
+
+/** [c0,c1] += a */
+#define add2(c0,c1,a) { \
+    c0 += (a); \
+    c1 += (c0 < (a)) ? 1 : 0; \
+}
+
+bool IsOverflow(const Num3072* d)
+{
+    for (int i = 1; i < Num3072::LIMBS - 1; ++i) {
+        if (d->limbs[i] != std::numeric_limits<Num3072::limb_type>::max()) return false;
+    }
+    if (d->limbs[0] <= std::numeric_limits<Num3072::limb_type>::max() - 1103717) return false;
+    return true;
+}
+
+void FullReduce(Num3072* d)
+{
+    Num3072::limb_type c0 = 1103717;
+    for (int i = 0; i < Num3072::LIMBS; ++i) {
+        Num3072::limb_type c1 = 0;
+        add2(c0, c1, d->limbs[i]);
+        extract2(c0, c1, d->limbs[i]);
+    }
+}
+
+void Multiply(Num3072* out, const Num3072* a, const Num3072* b)
+{
+    Num3072::limb_type c0 = 0, c1 = 0;
+    Num3072 tmp;
+
+    /* Compute limbs 0..N-2 of a*b into tmp, including one reduction. */
+    for (int j = 0; j < Num3072::LIMBS - 1; ++j) {
+        Num3072::limb_type d0 = 0, d1 = 0, d2 = 0, c2 = 0;
+        mul(d0, d1, a->limbs[1 + j], b->limbs[Num3072::LIMBS + j - (1 + j)]);
+        for (int i = 2 + j; i < Num3072::LIMBS; ++i) muladd3(d0, d1, d2, a->limbs[i], b->limbs[Num3072::LIMBS + j - i]);
+        mulnadd3(c0, c1, c2, d0, d1, d2, 1103717);
+        for (int i = 0; i < j + 1; ++i) muladd3(c0, c1, c2, a->limbs[i], b->limbs[j - i]);
+        extract3(c0, c1, c2, tmp.limbs[j]);
+    }
+    /* Compute limb N-1 of a*b into tmp. */
+    {
+        Num3072::limb_type c2 = 0;
+        for (int i = 0; i < Num3072::LIMBS; ++i) muladd3(c0, c1, c2, a->limbs[i], b->limbs[Num3072::LIMBS - 1 - i]);
+        extract3(c0, c1, c2, tmp.limbs[Num3072::LIMBS - 1]);
+    }
+    /* Perform a second reduction. */
+    muln2(c0, c1, 1103717);
+    for (int j = 0; j < Num3072::LIMBS; ++j) {
+        add2(c0, c1, tmp.limbs[j]);
+        extract2(c0, c1, out->limbs[j]);
+    }
+    assert(c1 == 0);
+    assert(c0 == 0 || c0 == 1);
+    /* Perform a potential third reduction. */
+    if (c0) FullReduce(out);
+}
+
+void Square(Num3072* out, const Num3072* a)
+{
+    Num3072::limb_type c0 = 0, c1 = 0;
+    Num3072 tmp;
+
+    /* Compute limbs 0..N-2 of a*a into tmp, including one reduction. */
+    for (int j = 0; j < Num3072::LIMBS - 1; ++j) {
+        Num3072::limb_type d0 = 0, d1 = 0, d2 = 0, c2 = 0;
+        for (int i = 0; i < (Num3072::LIMBS - 1 - j) / 2; ++i) muldbladd3(d0, d1, d2, a->limbs[i + j + 1], a->limbs[Num3072::LIMBS - 1 - i]);
+        if ((j + 1) & 1) muladd3(d0, d1, d2, a->limbs[(Num3072::LIMBS - 1 - j) / 2 + j + 1], a->limbs[Num3072::LIMBS - 1 - (Num3072::LIMBS - 1 - j) / 2]);
+        mulnadd3(c0, c1, c2, d0, d1, d2, 1103717);
+        for (int i = 0; i < (j + 1) / 2; ++i) muldbladd3(c0, c1, c2, a->limbs[i], a->limbs[j - i]);
+        if ((j + 1) & 1) muladd3(c0, c1, c2, a->limbs[(j + 1) / 2], a->limbs[j - (j + 1) / 2]);
+        extract3(c0, c1, c2, tmp.limbs[j]);
+    }
+    {
+        Num3072::limb_type c2 = 0;
+        for (int i = 0; i < Num3072::LIMBS / 2; ++i) muldbladd3(c0, c1, c2, a->limbs[i], a->limbs[Num3072::LIMBS - 1 - i]);
+        extract3(c0, c1, c2, tmp.limbs[Num3072::LIMBS - 1]);
+    }
+    /* Perform a second reduction. */
+    muln2(c0, c1, 1103717);
+    for (int j = 0; j < Num3072::LIMBS; ++j) {
+        add2(c0, c1, tmp.limbs[j]);
+        extract2(c0, c1, out->limbs[j]);
+    }
+    assert(c1 == 0);
+    assert(c0 == 0 || c0 == 1);
+    /* Perform a potential third reduction. */
+    if (c0) FullReduce(out);
+}
+
+void Inverse(Num3072* out, const Num3072* a)
+{
+    Num3072 p[12]; // p[i] = a^(2^(2^i)-1)
+    Num3072 x;
+
+    p[0] = *a;
+
+    for (int i = 0; i < 11; ++i) {
+        p[i + 1] = p[i];
+        for (int j = 0; j < (1 << i); ++j) Square(&p[i + 1], &p[i + 1]);
+        Multiply(&p[i + 1], &p[i + 1], &p[i]);
+    }
+
+    x = p[11];
+
+    for (int j = 0; j < 512; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[9]);
+    for (int j = 0; j < 256; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[8]);
+    for (int j = 0; j < 128; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[7]);
+    for (int j = 0; j < 64; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[6]);
+    for (int j = 0; j < 32; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[5]);
+    for (int j = 0; j < 8; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[3]);
+    for (int j = 0; j < 2; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[1]);
+    for (int j = 0; j < 1; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 5; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[2]);
+    for (int j = 0; j < 3; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 2; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 4; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+    for (int j = 0; j < 4; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[1]);
+    for (int j = 0; j < 3; ++j) Square(&x, &x);
+    Multiply(&x, &x, &p[0]);
+
+    *out = x;
+}
+
+}
+
+MuHash3072::MuHash3072() noexcept
+{
+    data.limbs[0] = 1;
+    for (int i = 1; i < Num3072::LIMBS; ++i) data.limbs[i] = 0;
+}
+
+MuHash3072::MuHash3072(const unsigned char* key32) noexcept
+{
+    unsigned char tmp[384];
+    ChaCha20(key32, 32).Keystream(tmp, 384);
+    for (int i = 0; i < Num3072::LIMBS; ++i) {
+        if (sizeof(Num3072::limb_type) == 4) {
+            data.limbs[i] = ReadLE32(tmp + 4 * i);
+        } else if (sizeof(Num3072::limb_type) == 8) {
+            data.limbs[i] = ReadLE64(tmp + 8 * i);
+        }
+    }
+}
+
+void MuHash3072::Finalize(unsigned char* hash384) noexcept
+{
+    if (IsOverflow(&data)) FullReduce(&data);
+    for (int i = 0; i < Num3072::LIMBS; ++i) {
+        if (sizeof(Num3072::limb_type) == 4) {
+            WriteLE32(hash384 + i * 4, data.limbs[i]);
+        } else if (sizeof(Num3072::limb_type) == 8) {
+            WriteLE64(hash384 + i * 8, data.limbs[i]);
+        }
+    }
+}
+
+MuHash3072& MuHash3072::operator*=(const MuHash3072& x) noexcept
+{
+    Multiply(&this->data, &this->data, &x.data);
+    return *this;
+}
+
+MuHash3072& MuHash3072::operator/=(const MuHash3072& x) noexcept
+{
+    Num3072 tmp;
+    Inverse(&tmp, &x.data);
+    Multiply(&this->data, &this->data, &tmp);
+    return *this;
+}

--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -29,6 +29,54 @@ namespace {
     c1 = 0; \
 }
 
+#if defined(__amd64__) || defined(__x86_64__)
+
+/** [c0,c1] = a * b */
+#define mul(c0,c1,a,b) { \
+    __asm__ ("mulq %3" : "=d"(c1), "=a"(c0) : "a"(a), "g"(b) : "cc"); \
+}
+
+/** [c0,c1,c2] += a * b */
+#define muladd3(c0,c1,c2,a,b) { \
+    uint64_t tl, th; \
+    __asm__ ("mulq %3" : "=a"(tl), "=d"(th) : "a"(a), "g"(b) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "a"(tl), "d"(th) : "cc"); \
+}
+
+/** [c0,c1,c2] += 2 * a * b */
+#define muldbladd3(c0,c1,c2,a,b) { \
+    uint64_t tl, th; \
+    __asm__ ("mulq %3" : "=a"(tl), "=d"(th) : "a"(a), "g"(b) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "a"(tl), "d"(th) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "a"(tl), "d"(th) : "cc"); \
+}
+
+/* [c0,c1,c2] += n * [d0,d1,d2]. c0 is initially 0 */
+#define mulnadd3(c0,c1,c2,d0,d1,d2,n) { \
+    uint64_t tl1, th1, tl2, th2, tl3; \
+    __asm__ ("mulq %3" : "=a"(tl1), "=d"(th1) : "a"(d0), "r"((Num3072::limb_type)n) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "g"(tl1), "g"(th1) : "cc"); \
+    __asm__ ("mulq %3" : "=a"(tl2), "=d"(th2) : "a"(d1), "r"((Num3072::limb_type)n) : "cc"); \
+    __asm__ ("addq %2,%0; adcq %3,%1" : "+r"(c1), "+r"(c2) : "g"(tl2), "g"(th2) : "cc"); \
+    __asm__ ("imulq %2,%1,%0" : "=r"(tl3) : "g"(d2), "i"(n) : "cc"); \
+    __asm__ ("addq %1,%0" : "+r"(c2) : "g"(tl3) : "cc"); \
+}
+
+/* [c0,c1] *= n */
+#define muln2(c0,c1,n) { \
+    uint64_t th; \
+    __asm__ ("mulq %2" : "+a"(c0), "=d"(th) : "r"((Num3072::limb_type)n) : "cc"); \
+    __asm__ ("imul %1,%0,%0" : "+r"(c1) : "i"(n) : "cc"); \
+    __asm__ ("addq %1,%0" : "+r"(c1) : "g"(th) : "cc"); \
+}
+
+/** [c0,c1] += a */
+#define add2(c0,c1,a) { \
+    __asm__ ("add %2,%0; adc $0,%1" : "+r"(c0), "+r"(c1) : "r"(a) : "cc"); \
+}
+
+#else
+
 /** [c0,c1] = a * b */
 #define mul(c0,c1,a,b) { \
     Num3072::double_limb_type t = (Num3072::double_limb_type)a * b; \
@@ -95,6 +143,8 @@ namespace {
     c0 += (a); \
     c1 += (c0 < (a)) ? 1 : 0; \
 }
+
+#endif
 
 bool IsOverflow(const Num3072* d)
 {

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -9,6 +9,7 @@
 #include <config/bitcoin-config.h>
 #endif
 
+#include <serialize.h>
 #include <stdint.h>
 
 struct Num3072 {
@@ -64,6 +65,15 @@ public:
 
     /* Finalize into a 384-byte hash. Does not change this object's value. */
     void Finalize(unsigned char* hash384) noexcept;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        for(int i = 0; i<data.LIMBS; i++) {
+            READWRITE(data.limbs[i]);
+        }
+    }
 };
 
 #endif // BITCOIN_CRYPTO_MUHASH_H

--- a/src/crypto/muhash.h
+++ b/src/crypto/muhash.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2017 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_CRYPTO_MUHASH_H
+#define BITCOIN_CRYPTO_MUHASH_H
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <stdint.h>
+
+struct Num3072 {
+#ifdef HAVE___INT128
+    typedef unsigned __int128 double_limb_type;
+    typedef uint64_t limb_type;
+    static constexpr int LIMBS = 48;
+    static constexpr int LIMB_SIZE = 64;
+#else
+    typedef uint64_t double_limb_type;
+    typedef uint32_t limb_type;
+    static constexpr int LIMBS = 96;
+    static constexpr int LIMB_SIZE = 32;
+#endif
+    limb_type limbs[LIMBS];
+};
+
+/** A class representing MuHash sets
+ *
+ * MuHash is a hashing algorithm that supports adding set elements in any
+ * order but also deleting in any order. As a result, it can maintain a
+ * running sum for a set of data as a whole, and add/subtract when data
+ * is added to or removed from it. A downside of MuHash is that computing
+ * an inverse is relatively expensive. This can be solved by representing
+ * the running value as a fraction, and multiplying added elements into
+ * the numerator and removed elements into the denominator. Only when the
+ * final hash is desired, a single modular inverse and multiplication is
+ * needed to combine the two.
+ *
+ * As the update operations are also associative, H(a)+H(b)+H(c)+H(d) can
+ * in fact be computed as (H(a)+H(b)) + (H(c)+H(d)). This implies that
+ * all of this is perfectly parallellizable: each thread can process an
+ * arbitrary subset of the update operations, allowing them to be
+ * efficiently combined later.
+ */
+class MuHash3072
+{
+private:
+    Num3072 data;
+
+public:
+    /* The empty set. */
+    MuHash3072() noexcept;
+
+    /* A singleton with a single 32-byte key in it. */
+    explicit MuHash3072(const unsigned char* key32) noexcept;
+
+    /* Multiply (resulting in a hash for the union of the sets) */
+    MuHash3072& operator*=(const MuHash3072& add) noexcept;
+
+    /* Divide (resulting in a hash for the difference of the sets) */
+    MuHash3072& operator/=(const MuHash3072& sub) noexcept;
+
+    /* Finalize into a 384-byte hash. Does not change this object's value. */
+    void Finalize(unsigned char* hash384) noexcept;
+};
+
+#endif // BITCOIN_CRYPTO_MUHASH_H

--- a/src/index/coinstatsindex.cpp
+++ b/src/index/coinstatsindex.cpp
@@ -1,0 +1,391 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <coins.h>
+#include <crypto/muhash.h>
+#include <hash.h>
+#include <index/coinstatsindex.h>
+#include <node/coinstats.h>
+#include <serialize.h>
+#include <txdb.h>
+#include <undo.h>
+#include <validation.h>
+
+constexpr char DB_BLOCK_HASH = 's';
+constexpr char DB_BLOCK_HEIGHT = 't';
+constexpr char DB_MUHASH = 'M';
+
+namespace {
+
+struct DBVal {
+    uint256 muhash;
+    uint64_t transaction_output_count;
+    uint64_t bogo_size;
+    CAmount total_amount;
+    uint64_t disk_size;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(muhash);
+        READWRITE(transaction_output_count);
+        READWRITE(bogo_size);
+        READWRITE(total_amount);
+        READWRITE(disk_size);
+    }
+};
+
+struct DBHeightKey {
+    int height;
+
+    DBHeightKey() : height(0) {}
+    explicit DBHeightKey(int height_in) : height(height_in) {}
+
+    template<typename Stream>
+    void Serialize(Stream& s) const
+    {
+        ser_writedata8(s, DB_BLOCK_HEIGHT);
+        ser_writedata32be(s, height);
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& s)
+    {
+        char prefix = ser_readdata8(s);
+        if (prefix != DB_BLOCK_HEIGHT) {
+            throw std::ios_base::failure("Invalid format for coin stats index DB height key");
+        }
+        height = ser_readdata32be(s);
+    }
+};
+
+struct DBHashKey {
+    uint256 block_hash;
+
+    explicit DBHashKey(const uint256& hash_in) : block_hash(hash_in) {}
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        char prefix = DB_BLOCK_HASH;
+        READWRITE(prefix);
+        if (prefix != DB_BLOCK_HASH) {
+            throw std::ios_base::failure("Invalid format for coin stats index DB hash key");
+        }
+
+        READWRITE(block_hash);
+    }
+};
+
+struct DBMuhash {
+    MuHash3072 hash;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(hash);
+    }
+};
+
+}; // namespace
+
+std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
+
+CoinStatsIndex::CoinStatsIndex(size_t n_cache_size, bool f_memory, bool f_wipe)
+{
+    fs::path path = GetDataDir() / "indexes" / "coinstats";
+    fs::create_directories(path);
+
+    m_db = MakeUnique<CoinStatsIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);
+}
+
+bool CoinStatsIndex::Init()
+{
+    if (!m_db->Read(DB_MUHASH, m_muhash)) {
+        // Check that the cause of the read failure is that the key does not exist. Any other errors
+        // indicate database corruption or a disk failure, and starting the index would cause
+        // further corruption.
+        if (m_db->Exists(DB_MUHASH)) {
+            return error("%s: Cannot read current %s state; index may be corrupted",
+                         __func__, GetName());
+        }
+
+        // If the DB_MUHASH is not set, initialize empty values
+        m_muhash = MuHash3072();
+        m_transaction_output_count = 0;
+        m_bogo_size = 0;
+        m_total_amount = 0;
+        m_disk_size = 0;
+    }
+
+    return BaseIndex::Init();
+}
+
+bool CoinStatsIndex::WriteBlock(const CBlock& block, const CBlockIndex* pindex)
+{
+    CBlockUndo block_undo;
+
+    // Ignore genesis block
+    if (pindex->nHeight > 0) {
+        if (!UndoReadFromDisk(block_undo, pindex)) {
+            return false;
+        }
+
+        std::pair<uint256, DBVal> read_out;
+        if (!m_db->Read(DBHeightKey(pindex->nHeight - 1), read_out)) {
+            return false;
+        }
+
+        uint256 expected_block_hash = pindex->pprev->GetBlockHash();
+        if (read_out.first != expected_block_hash) {
+            return error("%s: previous block header belongs to unexpected block %s; expected %s",
+                         __func__, read_out.first.ToString(), expected_block_hash.ToString());
+        }
+
+        bool is_bip30_block = (pindex->nHeight==91722 && pindex->GetBlockHash() == uint256S("0x00000000000271a2dc26e7667f8419f2e15416dc6955e5a6c6cdf3f2574dd08e")) ||
+                              (pindex->nHeight==91812 && pindex->GetBlockHash() == uint256S("0x00000000000af0aed4792b1acee3d966af36cf5def14935db8de83d6f9306f2f"));
+        MuHash3072 undo_muhash;
+
+        // Add the new utxos created from the block
+        for (size_t i = 0; i < block.vtx.size(); ++i) {
+            const auto& tx = block.vtx.at(i);
+
+            // Skip duplicate txid coinbase transactions (BIP30).
+            if (is_bip30_block && tx->IsCoinBase()) {
+                continue;
+            }
+
+            for (size_t j = 0; j < tx->vout.size(); ++j) {
+                const CTxOut& out = tx->vout[j];
+                COutPoint outpoint = COutPoint(tx->GetHash(), j);
+                Coin coin = Coin(out, pindex->nHeight, tx->IsCoinBase());
+
+                // Skip unspendable coins
+                if (coin.out.scriptPubKey.IsUnspendable()) continue;
+
+                m_muhash *= MuHash3072(GetTruncatedSHA512Hash(outpoint, coin).begin());
+
+                m_transaction_output_count++;
+                m_total_amount += coin.out.nValue;
+                m_bogo_size += 32 /* txid */ + 4 /* vout index */ + 4 /* height + coinbase */ + 8 /* amount */ +
+                               2 /* scriptPubKey len */ + coin.out.scriptPubKey.size() /* scriptPubKey */;
+            }
+
+            // The coinbase tx has no undo data since no former output is spent
+            if (i > 0) {
+                const auto& tx_undo = block_undo.vtxundo.at(i-1);
+
+                for (size_t j = 0; j < tx_undo.vprevout.size(); ++j) {
+                    Coin coin = tx_undo.vprevout[j];
+                    COutPoint outpoint = COutPoint(tx->vin[j].prevout.hash, tx->vin[j].prevout.n);
+
+                    undo_muhash *= MuHash3072(GetTruncatedSHA512Hash(outpoint, coin).begin());
+
+                    m_transaction_output_count--;
+                    m_total_amount -= coin.out.nValue;
+                    m_bogo_size -= 32 /* txid */ + 4 /* vout index */ + 4 /* height + coinbase */ + 8 /* amount */ +
+                                   2 /* scriptPubKey len */ + coin.out.scriptPubKey.size() /* scriptPubKey */;
+                }
+            }
+        }
+
+        m_muhash /= undo_muhash;
+    }
+
+    CCoinsView* coins_view = WITH_LOCK(cs_main, return &ChainstateActive().CoinsDB());
+    m_disk_size = coins_view->EstimateSize();
+
+    std::pair<uint256, DBVal> value;
+    value.first = pindex->GetBlockHash();
+    value.second.muhash = currentHashInternal();
+    value.second.disk_size = m_disk_size;
+    value.second.transaction_output_count = m_transaction_output_count;
+    value.second.bogo_size = m_bogo_size;
+    value.second.total_amount = m_total_amount;
+
+    if (!m_db->Write(DBHeightKey(pindex->nHeight), value)) {
+        return false;
+    }
+
+    if (!m_db->Write(DB_MUHASH, m_muhash)) {
+        return false;
+    }
+
+    return true;
+}
+
+static bool CopyHeightIndexToHashIndex(CDBIterator& db_it, CDBBatch& batch,
+                                       const std::string& index_name,
+                                       int start_height, int stop_height)
+{
+    DBHeightKey key(start_height);
+    db_it.Seek(key);
+
+    for (int height = start_height; height <= stop_height; ++height) {
+        if (!db_it.GetKey(key) || key.height != height) {
+            return error("%s: unexpected key in %s: expected (%c, %d)",
+                         __func__, index_name, DB_BLOCK_HEIGHT, height);
+        }
+
+        std::pair<uint256, DBVal> value;
+        if (!db_it.GetValue(value)) {
+            return error("%s: unable to read value in %s at key (%c, %d)",
+                         __func__, index_name, DB_BLOCK_HEIGHT, height);
+        }
+
+        batch.Write(DBHashKey(value.first), std::move(value.second));
+
+        db_it.Next();
+    }
+    return true;
+}
+
+bool CoinStatsIndex::Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip)
+{
+    assert(current_tip->GetAncestor(new_tip->nHeight) == new_tip);
+
+    CDBBatch batch(*m_db);
+    std::unique_ptr<CDBIterator> db_it(m_db->NewIterator());
+
+    {
+        LOCK(cs_main);
+        CBlockIndex* iter_tip = LookupBlockIndex(current_tip->GetBlockHash());
+        auto& consensus_params = Params().GetConsensus();
+
+        do {
+            CBlock block;
+
+            if (!ReadBlockFromDisk(block, iter_tip, consensus_params)) {
+                return error("%s: Failed to read block %s from disk",
+                               __func__, iter_tip->GetBlockHash().ToString());
+            }
+
+            ReverseBlock(block, iter_tip);
+
+            iter_tip = iter_tip->GetAncestor(iter_tip->nHeight - 1);
+        } while (new_tip != iter_tip);
+    }
+
+    // During a reorg, we need to copy all hash digests for blocks that are getting disconnected from the
+    // height index to the hash index so we can still find them when the height index entries are
+    // overwritten.
+    if (!CopyHeightIndexToHashIndex(*db_it, batch, m_name, new_tip->nHeight, current_tip->nHeight)) {
+        return false;
+    }
+
+    if (!m_db->WriteBatch(batch)) return false;
+
+    return BaseIndex::Rewind(current_tip, new_tip);
+}
+
+static bool LookupOne(const CDBWrapper& db, const CBlockIndex* block_index, DBVal& result)
+{
+    // First check if the result is stored under the height index and the value there matches the
+    // block hash. This should be the case if the block is on the active chain.
+    std::pair<uint256, DBVal> read_out;
+    if (!db.Read(DBHeightKey(block_index->nHeight), read_out)) {
+        return false;
+    }
+    if (read_out.first == block_index->GetBlockHash()) {
+        result = std::move(read_out.second);
+        return true;
+    }
+
+    // If value at the height index corresponds to an different block, the result will be stored in
+    // the hash index.
+    return db.Read(DBHashKey(block_index->GetBlockHash()), result);
+}
+
+bool CoinStatsIndex::LookupStats(const CBlockIndex* block_index, CCoinsStats& coins_stats) const
+{
+    DBVal entry;
+    if (!LookupOne(*m_db, block_index, entry)) {
+        return false;
+    }
+
+    coins_stats.hashSerialized = entry.muhash;
+    coins_stats.nTransactionOutputs = entry.transaction_output_count;
+    coins_stats.nBogoSize = entry.bogo_size;
+    coins_stats.nTotalAmount = entry.total_amount;
+    coins_stats.nDiskSize = entry.disk_size;
+
+    return true;
+}
+
+uint256 CoinStatsIndex::currentHashInternal()
+{
+    unsigned char out[384];
+    m_muhash.Finalize(out);
+    return (TruncatedSHA512Writer(SER_DISK, 0) << out).GetHash();
+}
+
+// Reverse Block in case of reorg
+bool CoinStatsIndex::ReverseBlock(const CBlock& block, const CBlockIndex* pindex)
+{
+    CBlockUndo block_undo;
+    std::pair<uint256, DBVal> read_out;
+
+    if (pindex->nHeight > 0) {
+        if (!UndoReadFromDisk(block_undo, pindex)) {
+            return false;
+        }
+
+        if (!m_db->Read(DBHeightKey(pindex->nHeight - 1), read_out)) {
+            return false;
+        }
+
+        uint256 expected_block_hash = pindex->pprev->GetBlockHash();
+        if (read_out.first != expected_block_hash) {
+            return error("%s: previous block header belongs to unexpected block %s; expected %s",
+                         __func__, read_out.first.ToString(), expected_block_hash.ToString());
+        }
+    }
+
+    MuHash3072 do_muhash;
+
+    // Remove the new utxos that were created from the block
+    for (size_t i = 0; i < block.vtx.size(); ++i) {
+        const auto& tx = block.vtx.at(i);
+
+        for (size_t j = 0; j < tx->vout.size(); ++j) {
+            const CTxOut& out = tx->vout[j];
+            COutPoint outpoint = COutPoint(tx->GetHash(), j);
+            Coin coin = Coin(out, pindex->nHeight, tx->IsCoinBase());
+
+            // Skip unspendable coins
+            if (coin.out.scriptPubKey.IsUnspendable()) continue;
+
+            do_muhash *= MuHash3072(GetTruncatedSHA512Hash(outpoint, coin).begin());
+        }
+
+        // The coinbase tx has no undo data since no former output is spent
+        if (i > 0) {
+            const auto& tx_undo = block_undo.vtxundo.at(i-1);
+
+            for (size_t j = 0; j < tx_undo.vprevout.size(); ++j) {
+                Coin coin = tx_undo.vprevout[j];
+                COutPoint outpoint = COutPoint(tx->vin[j].prevout.hash, tx->vin[j].prevout.n);
+
+                m_muhash *= MuHash3072(GetTruncatedSHA512Hash(outpoint, coin).begin());
+            }
+        }
+    }
+
+    m_muhash /= do_muhash;
+
+    m_transaction_output_count = read_out.second.transaction_output_count;
+    m_total_amount = read_out.second.total_amount;
+    m_bogo_size = read_out.second.bogo_size;
+    m_disk_size = read_out.second.disk_size;
+
+    if (!m_db->Write(DB_MUHASH, m_muhash)) {
+        return false;
+    }
+
+    return true;
+}

--- a/src/index/coinstatsindex.h
+++ b/src/index/coinstatsindex.h
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INDEX_COINSTATSINDEX_H
+#define BITCOIN_INDEX_COINSTATSINDEX_H
+
+#include <chain.h>
+#include <crypto/muhash.h>
+#include <flatfile.h>
+#include <index/base.h>
+#include <node/coinstats.h>
+
+/**
+ * CoinStatsIndex maintains a rolling hash of the utxo set and
+ * other updated coin statistics.
+ */
+class CoinStatsIndex final : public BaseIndex
+{
+private:
+    std::string m_name;
+    std::unique_ptr<BaseIndex::DB> m_db;
+
+    MuHash3072 m_muhash;
+    uint64_t m_transaction_output_count;
+    uint64_t m_bogo_size;
+    CAmount m_total_amount;
+    uint64_t m_disk_size;
+
+    // Digest of the current Muhash object
+    uint256 currentHashInternal();
+
+    // Roll back the Muhash of a particular block
+    bool ReverseBlock(const CBlock& block, const CBlockIndex* pindex);
+protected:
+    bool Init() override;
+
+    bool WriteBlock(const CBlock& block, const CBlockIndex* pindex) override;
+
+    bool Rewind(const CBlockIndex* current_tip, const CBlockIndex* new_tip) override;
+
+    BaseIndex::DB& GetDB() const override { return *m_db; }
+
+    const char* GetName() const override { return "coinstatsindex"; }
+
+public:
+    // Constructs the index, which becomes available to be queried.
+    explicit CoinStatsIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
+
+    // Look up hash digest for a specific block using CBlockIndex
+    bool LookupStats(const CBlockIndex* block_index, CCoinsStats& coins_stats) const;
+};
+
+/// The global UTXO set hash object.
+extern std::unique_ptr<CoinStatsIndex> g_coin_stats_index;
+
+#endif // BITCOIN_INDEX_COINSTATSINDEX_H

--- a/src/node/coinstats.cpp
+++ b/src/node/coinstats.cpp
@@ -19,7 +19,6 @@ static void ApplyStats(CCoinsStats &stats, CHashWriter& ss, const uint256& hash,
     assert(!outputs.empty());
     ss << hash;
     ss << VARINT(outputs.begin()->second.nHeight * 2 + outputs.begin()->second.fCoinBase ? 1u : 0u);
-    stats.nTransactions++;
     for (const auto& output : outputs) {
         ss << VARINT(output.first + 1);
         ss << output.second.out.scriptPubKey;

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -8,6 +8,7 @@
 
 #include <amount.h>
 #include <coins.h>
+#include <chain.h>
 #include <uint256.h>
 
 #include <cstdint>
@@ -29,6 +30,7 @@ struct CCoinsStats
 };
 
 //! Calculate statistics about the unspent transaction output set
+bool GetUTXOStats(CCoinsView* view, CCoinsStats& stats, const CBlockIndex* pindex);
 bool GetUTXOStats(CCoinsView* view, CCoinsStats& stats);
 
 //! Calculate a TruncatedSHA512 hash for a specific UTXO

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -17,7 +17,6 @@ struct CCoinsStats
 {
     int nHeight{0};
     uint256 hashBlock{};
-    uint64_t nTransactions{0};
     uint64_t nTransactionOutputs{0};
     uint64_t nBogoSize{0};
     uint256 hashSerialized{};

--- a/src/node/coinstats.h
+++ b/src/node/coinstats.h
@@ -7,6 +7,7 @@
 #define BITCOIN_NODE_COINSTATS_H
 
 #include <amount.h>
+#include <coins.h>
 #include <uint256.h>
 
 #include <cstdint>
@@ -29,5 +30,8 @@ struct CCoinsStats
 
 //! Calculate statistics about the unspent transaction output set
 bool GetUTXOStats(CCoinsView* view, CCoinsStats& stats);
+
+//! Calculate a TruncatedSHA512 hash for a specific UTXO
+uint256 GetTruncatedSHA512Hash(const COutPoint&, const Coin&);
 
 #endif // BITCOIN_NODE_COINSTATS_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -960,7 +960,6 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
                     {
                         {RPCResult::Type::NUM, "height", "The current block height (index)"},
                         {RPCResult::Type::STR_HEX, "bestblock", "The hash of the block at the tip of the chain"},
-                        {RPCResult::Type::NUM, "transactions", "The number of transactions with unspent outputs"},
                         {RPCResult::Type::NUM, "txouts", "The number of unspent transaction outputs"},
                         {RPCResult::Type::NUM, "bogosize", "A meaningless metric for UTXO set size"},
                         {RPCResult::Type::STR_HEX, "hash_serialized_2", "The serialized hash"},
@@ -982,7 +981,6 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
     if (GetUTXOStats(coins_view, stats)) {
         ret.pushKV("height", (int64_t)stats.nHeight);
         ret.pushKV("bestblock", stats.hashBlock.GetHex());
-        ret.pushKV("transactions", (int64_t)stats.nTransactions);
         ret.pushKV("txouts", (int64_t)stats.nTransactionOutputs);
         ret.pushKV("bogosize", (int64_t)stats.nBogoSize);
         ret.pushKV("hash_serialized_2", stats.hashSerialized.GetHex());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -962,7 +962,7 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "bestblock", "The hash of the block at the tip of the chain"},
                         {RPCResult::Type::NUM, "txouts", "The number of unspent transaction outputs"},
                         {RPCResult::Type::NUM, "bogosize", "A meaningless metric for UTXO set size"},
-                        {RPCResult::Type::STR_HEX, "hash_serialized_2", "The serialized hash"},
+                        {RPCResult::Type::STR_HEX, "utxo_set_hash", "The serialized hash"},
                         {RPCResult::Type::NUM, "disk_size", "The estimated size of the chainstate on disk"},
                         {RPCResult::Type::STR_AMOUNT, "total_amount", "The total amount"},
                     }},
@@ -983,7 +983,7 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
         ret.pushKV("bestblock", stats.hashBlock.GetHex());
         ret.pushKV("txouts", (int64_t)stats.nTransactionOutputs);
         ret.pushKV("bogosize", (int64_t)stats.nBogoSize);
-        ret.pushKV("hash_serialized_2", stats.hashSerialized.GetHex());
+        ret.pushKV("utxo_set_hash", stats.hashSerialized.GetHex());
         ret.pushKV("disk_size", stats.nDiskSize);
         ret.pushKV("total_amount", ValueFromAmount(stats.nTotalAmount));
     } else {

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -135,6 +135,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "verifychain", 0, "checklevel" },
     { "verifychain", 1, "nblocks" },
     { "getblockstats", 0, "hash_or_height" },
+    { "gettxoutsetinfo", 0, "hash_or_height" },
     { "getblockstats", 1, "stats" },
     { "pruneblockchain", 0, "height" },
     { "keypoolrefill", 0, "newsize" },

--- a/src/test/coinstatsindex_tests.cpp
+++ b/src/test/coinstatsindex_tests.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <index/coinstatsindex.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(coinstatsindex_tests)
+
+BOOST_FIXTURE_TEST_CASE(coinstatsindex_initial_sync, TestChain100Setup)
+{
+    CoinStatsIndex coin_stats_index(1 << 20, true);
+
+    CCoinsStats coin_stats;
+    const CBlockIndex* block_index;
+    {
+        LOCK(cs_main);
+        block_index = ::ChainActive().Tip();
+    }
+
+    // CoinStatsIndex should not be found before it is started.
+    BOOST_CHECK(!coin_stats_index.LookupStats(block_index, coin_stats));
+
+    // BlockUntilSyncedToCurrentChain should return false before CoinStatsIndex
+    // is started.
+    BOOST_CHECK(!coin_stats_index.BlockUntilSyncedToCurrentChain());
+
+    coin_stats_index.Start();
+
+    // Allow the CoinStatsIndex to catch up with the block index that is syncing
+    // in a background thread.
+    constexpr int64_t timeout_ms = 120 * 1000;
+    int64_t time_start = GetTimeMillis();
+    while (!coin_stats_index.BlockUntilSyncedToCurrentChain()) {
+        BOOST_REQUIRE(time_start + timeout_ms > GetTimeMillis());
+        UninterruptibleSleep(std::chrono::milliseconds{100});
+    }
+
+    // Check that CoinStatsIndex works for genesis block.
+    const CBlockIndex* genesis_block_index;
+    {
+        LOCK(cs_main);
+        genesis_block_index = ::ChainActive().Genesis();
+    }
+    BOOST_CHECK(coin_stats_index.LookupStats(genesis_block_index, coin_stats));
+
+    // Check that CoinStatsIndex updates with new blocks.
+    coin_stats_index.LookupStats(block_index, coin_stats);
+
+    CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+    std::vector<CMutableTransaction> noTxns;
+    CreateAndProcessBlock(noTxns, scriptPubKey);
+
+    // Let the CoinStatsIndex to catch up again.
+    BOOST_CHECK(coin_stats_index.BlockUntilSyncedToCurrentChain());
+
+    CCoinsStats new_coin_stats;
+    const CBlockIndex* new_block_index;
+    {
+        LOCK(cs_main);
+        new_block_index = ::ChainActive().Tip();
+    }
+    coin_stats_index.LookupStats(new_block_index, new_coin_stats);
+
+    BOOST_CHECK(block_index != new_block_index);
+    BOOST_CHECK(coin_stats.hashSerialized != new_coin_stats.hashSerialized);
+
+    // Shutdown sequence (c.f. Shutdown() in init.cpp)
+    coin_stats_index.Stop();
+
+    // Rest of shutdown sequence and destructors happen in ~TestingSetup()
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.h
+++ b/src/validation.h
@@ -71,6 +71,7 @@ static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
+static const bool DEFAULT_UTXOSTATSINDEX = false;
 static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -763,7 +763,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.send_blocks([b56p2], success=False, reject_reason='bad-txns-duplicate', reconnect=True)
 
         self.move_tip("57p2")
-        self.send_blocks([b57p2], True)
+        self.send_blocks([b57p2], True, timeout=180)
 
         self.move_tip(57)
         self.send_blocks([b57], False)  # The tip is not updated because 57p2 seen first

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test CoinStatsIndex across nodes.
+
+Test that the values returned by gettxoutsetinfo are consistent
+between a node running the coinstatsindex and a node without
+the index.
+"""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    try_rpc,
+    wait_until,
+)
+
+class CoinStatsIndexTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+        self.supports_cli = False
+        self.extra_args = [
+            [],
+            ["-coinstatsindex"]
+        ]
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        self._test_coin_stats_index()
+
+    def _test_coin_stats_index(self):
+        node = self.nodes[0]
+        index_node = self.nodes[1]
+
+        # Generate a normal transaction and mine it
+        node.generate(101)
+        address = self.nodes[0].get_deterministic_priv_key().address
+        node.sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
+        node.generate(1)
+
+        self.sync_blocks(timeout=120)
+
+        self.log.info("Test that gettxoutsetinfo() output is consistent with or without coinstatsindex option")
+        wait_until(lambda: not try_rpc(-32603, "Unable to read UTXO set", node.gettxoutsetinfo))
+        res0 = node.gettxoutsetinfo()
+        wait_until(lambda: not try_rpc(-32603, "Unable to read UTXO set", index_node.gettxoutsetinfo))
+        res1 = index_node.gettxoutsetinfo()
+
+        # The field 'disk_size' is non-deterministic and can thus not be
+        # compared across different nodes.
+        del res1['disk_size'], res0['disk_size']
+
+        # Everything left should be the same
+        assert_equal(res1, res0)
+
+
+if __name__ == '__main__':
+    CoinStatsIndexTest().main()

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -12,6 +12,7 @@ the index.
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_raises_rpc_error,
     try_rpc,
     wait_until,
 )
@@ -57,6 +58,23 @@ class CoinStatsIndexTest(BitcoinTestFramework):
         # Everything left should be the same
         assert_equal(res1, res0)
 
+        self.log.info("Test that gettxoutsetinfo() can get fetch data on specific heights with index")
+
+        # Generate a new tip
+        node.generate(5)
+
+        # Fetch old stats by height
+        res2 = index_node.gettxoutsetinfo(102)
+        del res2['disk_size']
+        assert_equal(res0, res2)
+
+        # Fetch old stats by hash
+        res3 = index_node.gettxoutsetinfo(res0['bestblock'])
+        del res3['disk_size']
+        assert_equal(res0, res3)
+
+        # It does not work without coinstatsindex
+        assert_raises_rpc_error(-8, "Querying specific block heights requires CoinStatsIndex", node.gettxoutsetinfo, 102)
 
 if __name__ == '__main__':
     CoinStatsIndexTest().main()

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -90,7 +90,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
                 # Any of these RPC calls could throw due to node crash
                 self.start_node(node_index)
                 self.nodes[node_index].waitforblock(expected_tip)
-                utxo_hash = self.nodes[node_index].gettxoutsetinfo()['hash_serialized_2']
+                utxo_hash = self.nodes[node_index].gettxoutsetinfo()['utxo_set_hash']
                 return utxo_hash
             except:
                 # An exception here should mean the node is about to crash.
@@ -135,7 +135,7 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         If any nodes crash while updating, we'll compare utxo hashes to
         ensure recovery was successful."""
 
-        node3_utxo_hash = self.nodes[3].gettxoutsetinfo()['hash_serialized_2']
+        node3_utxo_hash = self.nodes[3].gettxoutsetinfo()['utxo_set_hash']
 
         # Retrieve all the blocks from node3
         blocks = []
@@ -177,12 +177,12 @@ class ChainstateWriteCrashTest(BitcoinTestFramework):
         """Verify that the utxo hash of each node matches node3.
 
         Restart any nodes that crash while querying."""
-        node3_utxo_hash = self.nodes[3].gettxoutsetinfo()['hash_serialized_2']
+        node3_utxo_hash = self.nodes[3].gettxoutsetinfo()['utxo_set_hash']
         self.log.info("Verifying utxo hash matches for all nodes")
 
         for i in range(3):
             try:
-                nodei_utxo_hash = self.nodes[i].gettxoutsetinfo()['hash_serialized_2']
+                nodei_utxo_hash = self.nodes[i].gettxoutsetinfo()['utxo_set_hash']
             except OSError:
                 # probably a crash on db flushing
                 nodei_utxo_hash = self.restart_node(i, self.nodes[3].getbestblockhash())

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -208,7 +208,6 @@ class BlockchainTest(BitcoinTestFramework):
         res = node.gettxoutsetinfo()
 
         assert_equal(res['total_amount'], Decimal('8725.00000000'))
-        assert_equal(res['transactions'], 200)
         assert_equal(res['height'], 200)
         assert_equal(res['txouts'], 200)
         assert_equal(res['bogosize'], 15000),
@@ -224,7 +223,6 @@ class BlockchainTest(BitcoinTestFramework):
         node.invalidateblock(b1hash)
 
         res2 = node.gettxoutsetinfo()
-        assert_equal(res2['transactions'], 0)
         assert_equal(res2['total_amount'], Decimal('0'))
         assert_equal(res2['height'], 0)
         assert_equal(res2['txouts'], 0)

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -216,7 +216,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert size > 6400
         assert size < 64000
         assert_equal(len(res['bestblock']), 64)
-        assert_equal(len(res['hash_serialized_2']), 64)
+        assert_equal(len(res['utxo_set_hash']), 64)
 
         self.log.info("Test that gettxoutsetinfo() works for blockchain with just the genesis block")
         b1hash = node.getblockhash(1)
@@ -228,7 +228,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res2['txouts'], 0)
         assert_equal(res2['bogosize'], 0),
         assert_equal(res2['bestblock'], node.getblockhash(0))
-        assert_equal(len(res2['hash_serialized_2']), 64)
+        assert_equal(len(res2['utxo_set_hash']), 64)
 
         self.log.info("Test that gettxoutsetinfo() returns the same result after invalidate/reconsider block")
         node.reconsiderblock(b1hash)

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -621,7 +621,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
 
             os.rmdir(cache_path('wallets'))  # Remove empty wallets dir
             for entry in os.listdir(cache_path()):
-                if entry not in ['chainstate', 'blocks']:  # Only keep chainstate and blocks folder
+                if entry not in ['chainstate', 'blocks', 'indexes']:  # Only indexes, chainstate and blocks folders
                     os.remove(cache_path(entry))
 
         for i in range(self.num_nodes):

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -234,6 +234,7 @@ BASE_SCRIPTS = [
     'rpc_deriveaddresses.py --usecli',
     'rpc_scantxoutset.py',
     'feature_logging.py',
+    'feature_coinstatsindex.py',
     'p2p_node_network_limited.py',
     'p2p_permissions.py',
     'feature_blocksdir.py',

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -11,6 +11,7 @@ export LC_ALL=C
 EXPECTED_CIRCULAR_DEPENDENCIES=(
     "chainparamsbase -> util/system -> chainparamsbase"
     "index/txindex -> validation -> index/txindex"
+    "index/coinstatsindex -> node/coinstats -> index/coinstatsindex"
     "policy/fees -> txmempool -> policy/fees"
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"
     "qt/bitcoingui -> qt/walletframe -> qt/bitcoingui"


### PR DESCRIPTION
**This PR will not be updated anymore because the project is now split up into multiple pull requests. But I will use it to keep track of the projects PRs:**

| Content                                             | PR     | Status   | Review Club |
| --------------------------------------------------- |--------|----------|--------|
| Add Muhash and SHA256Writer (unused)                | #19055 | Merged     | [notes](https://bitcoincore.reviews/19055.html)
| Add Muhash Python implementation (unused)           | #19105 | Merged  | [notes](https://bitcoincore.reviews/19105.html) |
| Add hash_type NONE (Muhash code independent)		  | #19328 | Merged	  | - |
| Add hash_type MUHASH						          | #19145 | Merged     | ?  |
| Add ASM optimizations for MuHash					  | #19181 | Open	  | ?   |
| Add CoinStatsIndex          | #19521       | Merged         | ? |
| Parallelize gettxoutsetinfo        |      |     |   |
| Remove legacy UTXO set hash                         |        | (future) | |

Since it's starting to get confusing I am trying to visualize the dependencies of the open PRs in this depency graph:

```
+--------------+   +-------------+   +----------+
|#19328        |   |#19105       |   |#19055    |
|hash_type NONE|   |Muhash Python|   |Muhash CPP|
+----+-----+---+   +------+------+   +-+----+---+
     ^     ^              ^            ^    ^
     |     |              |            |    |
     |     |    +---------+------+     |    |
     |     +----+#19145          +-----+    |
     |          |hash_type MUHASH|          |
     |          +----------------+          |
     |                               +------+---+
+----+--------+                      |#19181    |
|#19521       |                      |MuHash ASM|
|No hash Index|                      +----------+
+-------------+

```

---

This implements an index of coin statistics with the goal of making the response time of the `gettxoutsetinfo` RPC call dramatically faster. Currently, this RPC is scanning the full UTXO set every time it is called which makes it hard to use for users that [want to continually check the coin supply](https://blog.bitmex.com/forkmonitor-unexpected-inflation-detection-and-warning-system/) or compare UTXO set hashes between different nodes. It is especially challenging in periods of multiple quickly mined blocks, even relatively fast machines.

Implementation overview:
- The current serialization of the UTXO set for the purpose of hashing is changed based on sipa's concept in proposed on the [mailing list in 2017](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-May/014337.html) and #10434
- The hashing algorithm in for the UTXO set is changed to Muhash, which was also implemented by sipa
- CoinStatsIndex is added which keeps an index of all values that would require `gettxoutsetinfo` to scan the UTXO set
- CoinStatsIndex can be activated through the flag `-coinstatsindex`

Todos/Open questions:
- The transactions count is currently not implemented as it seems not knowable ex-post without running a full IBD to build up the index. I am looking for a solution to this. Ideas are:
  - Require `txindex` and the transactions count from it
  - Remove transactions count or mark it as unreliable in a different way if coinstatsindex is enabled
- The transactions count question is also interesting because it seems to be the only obstacle to providing access to historical coin statistics, which may be a nice follow-up feature if transaction counts can be ignored somehow
- More benchmarking to evaluate potential switch from Muhash to [ECMH](https://github.com/bitcoin-core/secp256k1/pull/477) as the hashing algorithm
- IBD benchmarking with the index enabled
- Tests could be improved

This is an extension to my [rolling UTXO set hash proposal](https://gist.github.com/fjahr/fa4892874b090d3a4f4fccc5bafa0210) from last year.

Edit: 3c5c1ca should probably be squashed into the prior commits but I wanted to leave sipa's commits unchanged for the start.