### PR TITLE
build: remove --large-address-aware linker flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -682,8 +682,6 @@ if test x$ac_cv_sys_large_files != x &&
   CPPFLAGS="$CPPFLAGS -D_LARGE_FILES=$ac_cv_sys_large_files"
 fi
 
-AX_CHECK_LINK_FLAG([[-Wl,--large-address-aware]], [LDFLAGS="$LDFLAGS -Wl,--large-address-aware"])
-
 AX_GCC_FUNC_ATTRIBUTE([visibility])
 AX_GCC_FUNC_ATTRIBUTE([dllexport])
 AX_GCC_FUNC_ATTRIBUTE([dllimport])


### PR DESCRIPTION
This flag was used when building 32-bit Windows executables, which we no-longer 
do, and is not accepted by the linker for any of the hosts we currently build 
for. i.e:

```bash
checking whether the linker accepts -Wl,--large-address-aware... no
```

--large-address-aware
    If given, the appropriate bit in the "Characteristics" field of the COFF
    header is set to indicate that this executable supports virtual addresses
    greater than 2 gigabytes. This should be used in conjunction with the /3GB
    or /USERVA=value megabytes switch in the "[operating systems]" section of
    the BOOT .INI. Otherwise, this bit has no effect. [This option is specific
    to PE targeted ports of the linker]

You can check that the appropriate bit in the COFF header of our 64-bit
Windows binaries is still be set using dumpbin. i.e:

```powershell
dumpbin /headers .\bitcoind.exe 

FILE HEADER VALUES
<snip>
26 characteristics
     Executable
     Line numbers stripped
     Application can handle large (>2GB) addresses
```