### PR TITLE
tests: Add fuzzing harness for strprintf(…)

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -54,6 +54,7 @@ FUZZ_TARGETS = \
   test/fuzz/script_flags \
   test/fuzz/service_deserialize \
   test/fuzz/spanparsing \
+  test/fuzz/strprintf \
   test/fuzz/sub_net_deserialize \
   test/fuzz/transaction \
   test/fuzz/tx_in \
@@ -534,6 +535,12 @@ test_fuzz_spanparsing_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_spanparsing_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_spanparsing_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_spanparsing_SOURCES = $(FUZZ_SUITE) test/fuzz/spanparsing.cpp
+
+test_fuzz_strprintf_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_strprintf_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_strprintf_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_strprintf_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_strprintf_SOURCES = $(FUZZ_SUITE) test/fuzz/strprintf.cpp
 
 test_fuzz_sub_net_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSUB_NET_DESERIALIZE=1
 test_fuzz_sub_net_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <tinyformat.h>
+#include <util/strencodings.h>
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::string format_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
+
+    const int digits_in_format_specifier = std::count_if(format_string.begin(), format_string.end(), IsDigit);
+
+    // Avoid triggering the following crash bug:
+    // * strprintf("%987654321000000:", 1);
+    //
+    // Avoid triggering the following OOM bug:
+    // * strprintf("%.222222200000000$", 1.1);
+    //
+    // Upstream bug report: https://github.com/c42f/tinyformat/issues/70
+    if (format_string.find("%") != std::string::npos && digits_in_format_specifier >= 7) {
+        return;
+    }
+
+    // Avoid triggering the following crash bug:
+    // * strprintf("%1$*1$*", -11111111);
+    //
+    // Upstream bug report: https://github.com/c42f/tinyformat/issues/70
+    if (format_string.find("%") != std::string::npos && format_string.find("$") != std::string::npos && format_string.find("*") != std::string::npos && digits_in_format_specifier > 0) {
+        return;
+    }
+
+    // Avoid triggering the following crash bug:
+    // * strprintf("%.1s", (char*)nullptr);
+    //
+    // (void)strprintf(format_string, (char*)nullptr);
+    //
+    // Upstream bug report: https://github.com/c42f/tinyformat/issues/70
+
+    try {
+        (void)strprintf(format_string, (signed char*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (unsigned char*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (void*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (bool*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (float*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (double*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (int16_t*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (uint16_t*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (int32_t*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (uint32_t*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (int64_t*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+    try {
+        (void)strprintf(format_string, (uint64_t*)nullptr);
+    } catch (const tinyformat::format_error&) {
+    }
+
+    try {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 13)) {
+        case 0:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+            break;
+        case 1:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+            break;
+        case 2:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+            break;
+        case 3:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+            break;
+        case 4:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<char>());
+            break;
+        case 5:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeBool());
+            break;
+        case 6:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+            break;
+        case 7:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+            break;
+        case 8:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+            break;
+        case 9:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+            break;
+        case 10:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+            break;
+        case 11:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+            break;
+        case 12:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+            break;
+        case 13:
+            (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            break;
+        default:
+            assert(false);
+        }
+    } catch (const tinyformat::format_error&) {
+    }
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -39,6 +39,7 @@ FUZZERS_MISSING_CORPORA = [
     "psbt_output_deserialize",
     "pub_key_deserialize",
     "script_deserialize",
+    "strprintf",
     "sub_net_deserialize",
     "tx_in",
     "tx_in_deserialize",

--- a/test/lint/lint-format-strings.sh
+++ b/test/lint/lint-format-strings.sh
@@ -34,7 +34,7 @@ if ! python3 -m doctest test/lint/lint-format-strings.py; then
 fi
 for S in "${FUNCTION_NAMES_AND_NUMBER_OF_LEADING_ARGUMENTS[@]}"; do
     IFS="," read -r FUNCTION_NAME SKIP_ARGUMENTS <<< "${S}"
-    for MATCHING_FILE in $(git grep --full-name -l "${FUNCTION_NAME}" -- "*.c" "*.cpp" "*.h" | sort | grep -vE "^src/(leveldb|secp256k1|tinyformat|univalue)"); do
+    for MATCHING_FILE in $(git grep --full-name -l "${FUNCTION_NAME}" -- "*.c" "*.cpp" "*.h" | sort | grep -vE "^src/(leveldb|secp256k1|tinyformat|univalue|test/fuzz/strprintf.cpp)"); do
         MATCHING_FILES+=("${MATCHING_FILE}")
     done
     if ! test/lint/lint-format-strings.py --skip-arguments "${SKIP_ARGUMENTS}" "${FUNCTION_NAME}" "${MATCHING_FILES[@]}"; then


### PR DESCRIPTION
Add fuzzing harness for `strprintf(…)`.

Update `FuzzedDataProvider.h`.

Avoid hitting some issues in tinyformat (reported upstreams in https://github.com/c42f/tinyformat/issues/70).

---

Found issues in tinyformat:

**Issue 1.** The following causes a signed integer overflow followed by an allocation of 9 GB of RAM (or an OOM in memory constrained environments):

```
strprintf("%.777777700000000$", 1.0);
```

**Issue 2.** The following causes a stack overflow:

```
strprintf("%987654321000000:", 1);
```

**Issue 3.** The following causes a stack overflow:

```
strprintf("%1$*1$*", -11111111);
```

**Issue 4.** The following causes a `NULL` pointer dereference:

```
strprintf("%.1s", (char *)nullptr);
```

**Issue 5.** The following causes a float cast overflow:

```
strprintf("%c", -1000.0);
```

**Issue 6.** The following causes a float cast overflow followed by an invalid integer negation:

```
strprintf("%*", std::numeric_limits<double>::lowest());
```