### PR TITLE
GBT segwit rule in RPC error msg missing single quotes

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -532,7 +532,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
 
     // GBT must be called with 'segwit' set in the rules
     if (setClientRules.count("segwit") != 1) {
-        throw JSONRPCError(RPC_INVALID_PARAMETER, "getblocktemplate must be called with the segwit rule set (call with {\"rules\": [\"segwit\"]})");
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "getblocktemplate must be called with the segwit rule set (call with '{\"rules\": [\"segwit\"]}')");
     }
 
     // Update block


### PR DESCRIPTION
The PR https://github.com/bitcoin/bitcoin/pull/16596 to fix issue https://github.com/bitcoin/bitcoin/issues/16594 did not update the error text when getblocktemplate is called without specifying the segwit rule, only the GBT example text. It's possible that this error message is where the user reporting the issue got the incorrect information from. Calling getblocktemplate without rules generates the following.

```getblocktemplate must be called with the segwit rule set (call with {"rules": ["segwit"]}) (code -8)```

Using that example.

```getblocktemplate {"rules": ["segwit"]}```

Generates the following error.

```Error: Error parsing JSON:{rules:```

This commit updates the error text produced when calling getblocktemplate without the segwit rule to.

```getblocktemplate must be called with the segwit rule set (call with '{"rules": ["segwit"]}') (code -8)```

Using that example the following call will work.

```getblocktemplate '{"rules": ["segwit"]}'```
