### PR TITLE
bench: Fix benchmarks filters

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -126,6 +126,7 @@ void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double
         }
 
         if (!std::regex_match(p.first, baseMatch, reFilter)) {
+             g_testing_setup = nullptr;
             continue;
         }
 


### PR DESCRIPTION
The bug was introduced in https://github.com/bitcoin/bitcoin/pull/17781
before this fix `./src/bench/bench_bitcoin -filter=*` will fail with:

```
# Benchmark, evals, iterations, total, min, max, median
bench_bitcoin: bench/bench.cpp:119: static void benchmark::BenchRunner::RunAll(benchmark::Printer&, uint64_t, double, const string&, bool): Assertion `g_testing_setup == nullptr' failed.
Aborted (core dumped)
```