### PR TITLE
lib: Optimizing siphash implementation

### DIFF
--- a/src/bench/crypto_hash.cpp
+++ b/src/bench/crypto_hash.cpp
@@ -85,8 +85,29 @@ static void SipHash_32b(benchmark::Bench& bench)
 {
     uint256 x;
     uint64_t k1 = 0;
-    bench.run([&] {
+    bench.batch(x.size()).unit("byte").run([&] {
         *((uint64_t*)x.begin()) = SipHashUint256(0, ++k1, x);
+    });
+}
+
+static void SipHash_3b(benchmark::Bench& bench)
+{
+    uint64_t hash = 0;
+    uint64_t k2 = 0;
+    std::vector<uint8_t> in(3, 0xee);
+    bench.batch(in.size()).unit("byte").run([&] {
+        hash = CSipHasher(hash, ++k2).Write(in.data(), in.size()).Finalize();
+    });
+}
+
+
+static void SipHash(benchmark::Bench& bench)
+{
+    uint64_t hash = 0;
+    uint64_t k2 = 0;
+    std::vector<uint8_t> in(BUFFER_SIZE, 0);
+    bench.batch(in.size()).unit("byte").run([&] {
+        hash = CSipHasher(hash, ++k2).Write(in.data(), in.size()).Finalize();
     });
 }
 
@@ -155,9 +176,11 @@ BENCHMARK(SHA1);
 BENCHMARK(SHA256);
 BENCHMARK(SHA512);
 BENCHMARK(SHA3_256_1M);
+BENCHMARK(SipHash);
 
 BENCHMARK(SHA256_32b);
 BENCHMARK(SipHash_32b);
+BENCHMARK(SipHash_3b);
 BENCHMARK(SHA256D64_1024);
 BENCHMARK(FastRandom_32bit);
 BENCHMARK(FastRandom_1bit);

--- a/src/crypto/siphash.cpp
+++ b/src/crypto/siphash.cpp
@@ -2,7 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <crypto/common.h>
 #include <crypto/siphash.h>
+
+#include <algorithm>
 
 #define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
 
@@ -22,14 +25,14 @@ CSipHasher::CSipHasher(uint64_t k0, uint64_t k1)
     v[2] = 0x6c7967656e657261ULL ^ k0;
     v[3] = 0x7465646279746573ULL ^ k1;
     count = 0;
-    tmp = 0;
+    tail = 0;
 }
 
 CSipHasher& CSipHasher::Write(uint64_t data)
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
 
-    assert(count % 8 == 0);
+    assert((count & 0x07) == 0);
 
     v3 ^= data;
     SIPROUND;
@@ -45,30 +48,57 @@ CSipHasher& CSipHasher::Write(uint64_t data)
     return *this;
 }
 
+
+/// Load a uint64_t from 0 to 7 bytes.
+inline uint64_t ReadU64ByLenLE(const unsigned char* data, size_t len)
+{
+    assert(len < 8);
+    uint64_t out = 0;
+    for (size_t i = 0; i < len; ++i) {
+        out |= (uint64_t)data[i] << (i * 8);
+    }
+    return out;
+}
+
 CSipHasher& CSipHasher::Write(const unsigned char* data, size_t size)
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
-    uint64_t t = tmp;
-    uint8_t c = count;
+    auto ntail = count & 0x07;
+    count += size;
 
-    while (size--) {
-        t |= ((uint64_t)(*(data++))) << (8 * (c % 8));
-        c++;
-        if ((c & 7) == 0) {
-            v3 ^= t;
+    size_t needed = 0;
+
+    if (ntail != 0) {
+        needed = 8 - ntail;
+        tail |= ReadU64ByLenLE(data, std::min(size, needed)) << 8 * ntail;
+        if (size < needed) {
+            return *this;
+        } else {
+            v3 ^= tail;
             SIPROUND;
             SIPROUND;
-            v0 ^= t;
-            t = 0;
+            v0 ^= tail;
         }
+    }
+
+    size_t len = size - needed;
+    auto left = len & 0x07;
+
+    auto i = needed;
+    while (i < len - left) {
+        uint64_t mi = ReadLE64(data + i);
+        v3 ^= mi;
+        SIPROUND;
+        SIPROUND;
+        v0 ^= mi;
+        i += 8;
     }
 
     v[0] = v0;
     v[1] = v1;
     v[2] = v2;
     v[3] = v3;
-    count = c;
-    tmp = t;
+    tail = ReadU64ByLenLE(data + i, left);
 
     return *this;
 }
@@ -77,12 +107,14 @@ uint64_t CSipHasher::Finalize() const
 {
     uint64_t v0 = v[0], v1 = v[1], v2 = v[2], v3 = v[3];
 
-    uint64_t t = tmp | (((uint64_t)count) << 56);
+
+    uint64_t t = tail | (((uint64_t)count) << 56);
 
     v3 ^= t;
     SIPROUND;
     SIPROUND;
     v0 ^= t;
+
     v2 ^= 0xFF;
     SIPROUND;
     SIPROUND;

--- a/src/crypto/siphash.h
+++ b/src/crypto/siphash.h
@@ -14,8 +14,8 @@ class CSipHasher
 {
 private:
     uint64_t v[4];
-    uint64_t tmp;
-    uint8_t count; // Only the low 8 bits of the input size matter.
+    uint64_t tail; // bytes that weren't processed yet.
+    uint8_t count;  // total amount of bytes inputted.
 
 public:
     /** Construct a SipHash calculator initialized with 128-bit key (k0, k1) */


### PR DESCRIPTION
Hi,
This builds on #18013

Before anything I want to point out that we have 3 SipHash implementations `CSipHasher`, `SipHashUint256`, `SipHashUint256Extra`. this PR touches only the first one(not used in any hashmap AFAIK).

I re-implemented the `CSipHasher` with performance up to **3X times faster for big strings** (`BUFFER_SIZE = 1000*1000`) and **5%-19% faster for small strings** (3 bytes, because a minute of syncing showed me that 3 bytes siphash is something that happens quite often)

Benchmarks against other siphash implementations can be found here: https://gist.github.com/elichai/abdebeeaee7e581bc74c75cb9487b3af (code: https://github.com/elichai/siphash-bench)

My implementation was inspired by the one in Rust's stdlib (https://github.com/rust-lang/rust/blob/master/src/libcore/hash/sip.rs) which rust-bitcoin use in https://github.com/rust-bitcoin/bitcoin_hashes.

Before:
```
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         4.20809     0.0011912   0.00122256  0.00120163  
SipHash_32b                                     5           40000000    4.1793      2.08632e-08 2.0948e-08  2.08949e-08 
SipHash_3b                                      5           40000000    3.18892     1.56861e-08 1.64617e-08 1.5749e-08  
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         4.24318     0.00120808  0.00121676  0.00121336  
SipHash_32b                                     5           40000000    4.23684     2.06753e-08 2.16015e-08 2.14555e-08 
SipHash_3b                                      5           40000000    3.15998     1.54582e-08 1.61558e-08 1.58555e-08 
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         4.2472      0.0012113   0.00121558  0.00121324  
SipHash_32b                                     5           40000000    4.20925     2.09789e-08 2.11288e-08 2.10327e-08 
SipHash_3b                                      5           40000000    3.10727     1.54352e-08 1.55982e-08 1.55463e-08 
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         4.37224     0.00124528  0.00125769  0.0012473   
SipHash_32b                                     5           40000000    4.26011     2.1214e-08  2.134e-08   2.13171e-08 
SipHash_3b                                      5           40000000    3.18842     1.59033e-08 1.59832e-08 1.59432e-08 
```

After:
```
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         1.36254     0.000386656 0.000392219 0.000388635 
SipHash_32b                                     5           40000000    4.31286     2.13773e-08 2.17857e-08 2.16181e-08 
SipHash_3b                                      5           40000000    2.91375     1.44794e-08 1.46495e-08 1.45848e-08 
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         1.32683     0.000372232 0.000386258 0.000376842 
SipHash_32b                                     5           40000000    4.15533     2.069e-08   2.08661e-08 2.07693e-08 
SipHash_3b                                      5           40000000    2.77612     1.38154e-08 1.3988e-08  1.38665e-08 
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         1.36596     0.00038727  0.000392932 0.000391074 
SipHash_32b                                     5           40000000    4.27694     2.13219e-08 2.14471e-08 2.13672e-08 
SipHash_3b                                      5           40000000    2.75763     1.37529e-08 1.38244e-08 1.37862e-08 
$ ./src/bench/bench_bitcoin -filter="SipHash|SipHash_3b|SipHash_32b"
#Benchmark                                      evals       iterations  total       min         max         median      
SipHash                                         5           700         1.34316     0.000376846 0.000386059 0.000385079 
SipHash_32b                                     5           40000000    4.23368     2.1066e-08  2.14124e-08 2.11283e-08 
SipHash_3b                                      5           40000000    2.81931     1.40299e-08 1.42123e-08 1.40787e-08 
```

~Also made the benchmarks print a more readable output(https://gist.github.com/elichai/812c8866a69959404b480d968e080475), 
this is limited by up to 47 chars of benchmark name, so as long as we don't add more names like `CHACHA20_POLY1305_AEAD_256BYTES_ENCRYPT_DECRYPT` and longer then it will be fine.
(it can probably be adjustable but that will require iterating over all the tests before running them to determine the longest cell and I thought the 47 limit is more than reasonable)~