### PR TITLE
psbt_wallet_tests: use unique_ptr for GetSigningProvider

### DIFF
--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
     // Try to sign the mutated input
     SignatureData sigdata;
     psbtx.inputs[0].FillSignatureData(sigdata);
-    const SigningProvider* provider = m_wallet.GetSigningProvider(ws1, sigdata);
+    const std::unique_ptr<SigningProvider> provider = m_wallet.GetSigningProvider(ws1, sigdata);
     BOOST_CHECK(!SignPSBTInput(*provider, psbtx, 0, SIGHASH_ALL));
 }
 


### PR DESCRIPTION
#17261 changed GetSigningProvider to return a unique_ptr, but #17156 made psbt_wallet_tests use it as well, and wasn't correspondingly updated.