### PR TITLE
tests: Add fuzzing harness for AS-mapping (asmap)

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -7,6 +7,7 @@ FUZZ_TARGETS = \
   test/fuzz/addr_info_deserialize \
   test/fuzz/address_deserialize \
   test/fuzz/addrman_deserialize \
+  test/fuzz/asmap \
   test/fuzz/banentry_deserialize \
   test/fuzz/base_encode_decode \
   test/fuzz/bech32 \
@@ -254,6 +255,12 @@ test_fuzz_addrman_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_addrman_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_addrman_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_addrman_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_asmap_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_asmap_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_asmap_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_asmap_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_asmap_SOURCES = $(FUZZ_SUITE) test/fuzz/asmap.cpp
 
 test_fuzz_banentry_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBANENTRY_DESERIALIZE=1
 test_fuzz_banentry_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -39,7 +39,6 @@ class CNetAddr
         explicit CNetAddr(const struct in_addr& ipv4Addr);
         void SetIP(const CNetAddr& ip);
 
-    private:
         /**
          * Set raw IPv4 or IPv6 address (in network byte order)
          * @note Only NET_IPV4 and NET_IPV6 are allowed for network.

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <netaddress.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+
+#include <cstdint>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const Network network = fuzzed_data_provider.PickValueInArray({NET_IPV4, NET_IPV6});
+    if (fuzzed_data_provider.remaining_bytes() < 16) {
+        return;
+    }
+    CNetAddr net_addr;
+    net_addr.SetRaw(network, fuzzed_data_provider.ConsumeBytes<uint8_t>(16).data());
+    std::vector<bool> asmap;
+    for (const char cur_byte : fuzzed_data_provider.ConsumeRemainingBytes<char>()) {
+        for (int bit = 0; bit < 8; ++bit) {
+            asmap.push_back((cur_byte >> bit) & 1);
+        }
+    }
+    (void)net_addr.GetMappedAS(asmap);
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -15,6 +15,7 @@ import logging
 # Fuzzers known to lack a seed corpus in https://github.com/bitcoin-core/qa-assets/tree/master/fuzz_seed_corpus
 FUZZERS_MISSING_CORPORA = [
     "addr_info_deserialize",
+    "asmap",
     "base_encode_decode",
     "block",
     "block_file_info_deserialize",


### PR DESCRIPTION
Add fuzzing harness for AS-mapping (`asmap`).

To test this PR:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/asmap
…
```
