### PR TITLE
doc: Coin::IsSpent() can also mean never existed

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -73,6 +73,9 @@ public:
         ::Unserialize(s, Using<TxOutCompression>(out));
     }
 
+    /** Either this coin never existed (see e.g. coinEmpty in coins.cpp), or it
+      * did exist and has been spent.
+      */
     bool IsSpent() const {
         return out.IsNull();
     }


### PR DESCRIPTION
This can be especially confusing where `AccessCoin()` is used with logic like this:

```c++
    while (iter.n < MAX_OUTPUTS_PER_BLOCK) {
        const Coin& alternate = view.AccessCoin(iter);
        if (!alternate.IsSpent()) return alternate;
```