### PR TITLE
gui: Drop BanTableModel dependency to ClientModel

### DIFF
--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -6,11 +6,10 @@
 
 #include <interfaces/node.h>
 #include <net_types.h> // For banmap_t
-#include <qt/clientmodel.h>
 
 #include <utility>
 
-#include <QDebug>
+#include <QDateTime>
 #include <QList>
 
 bool BannedNodeLessThan::operator()(const CCombinedBan& left, const CCombinedBan& right) const
@@ -78,10 +77,9 @@ public:
     }
 };
 
-BanTableModel::BanTableModel(interfaces::Node& node, ClientModel *parent) :
+BanTableModel::BanTableModel(interfaces::Node& node, QObject* parent) :
     QAbstractTableModel(parent),
-    m_node(node),
-    clientModel(parent)
+    m_node(node)
 {
     columns << tr("IP/Netmask") << tr("Banned Until");
     priv.reset(new BanTablePriv());

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -12,7 +12,6 @@
 #include <QAbstractTableModel>
 #include <QStringList>
 
-class ClientModel;
 class BanTablePriv;
 
 namespace interfaces {
@@ -45,7 +44,7 @@ class BanTableModel : public QAbstractTableModel
     Q_OBJECT
 
 public:
-    explicit BanTableModel(interfaces::Node& node, ClientModel *parent = nullptr);
+    explicit BanTableModel(interfaces::Node& node, QObject* parent = nullptr);
     ~BanTableModel();
     void startAutoRefresh();
     void stopAutoRefresh();
@@ -72,7 +71,6 @@ public Q_SLOTS:
 
 private:
     interfaces::Node& m_node;
-    ClientModel *clientModel;
     QStringList columns;
     std::unique_ptr<BanTablePriv> priv;
 };

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -13,7 +13,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "index/txindex -> validation -> index/txindex"
     "policy/fees -> txmempool -> policy/fees"
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"
-    "qt/bantablemodel -> qt/clientmodel -> qt/bantablemodel"
     "qt/bitcoingui -> qt/utilitydialog -> qt/bitcoingui"
     "qt/bitcoingui -> qt/walletframe -> qt/bitcoingui"
     "qt/bitcoingui -> qt/walletview -> qt/bitcoingui"


### PR DESCRIPTION
Trivial change since `ClientModel` is not used by `BanTableModel`.  