### PR TITLE
build: Do not use QtDBus for macOS builds

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -87,6 +87,10 @@ dnl Outputs: See _BITCOIN_QT_FIND_LIBS_*
 dnl Outputs: Sets variables for all qt-related tools.
 dnl Outputs: bitcoin_enable_qt, bitcoin_enable_qt_dbus, bitcoin_enable_qt_test
 AC_DEFUN([BITCOIN_QT_CONFIGURE],[
+  if test x$TARGET_OS = xdarwin; then
+    use_dbus=no
+  fi
+
   use_pkgconfig=$1
 
   if test "x$use_pkgconfig" = x; then


### PR DESCRIPTION
This is an alternative to #18042:

> When cross compiling for macOS with depends, we do not compile with dbus.
> ...
> This fixes the error by always avoiding DBUS notification on macOS.
> 
> Another (eventually better) way to fix this would be to avoid detection of host qt pkg-config packages when cross compiling.