### PR TITLE
tests: Add basic fuzzing harness for CNetAddr/CService/CSubNet related functions (netaddress.h)

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -42,6 +42,7 @@ FUZZ_TARGETS = \
   test/fuzz/merkle_block_deserialize \
   test/fuzz/messageheader_deserialize \
   test/fuzz/netaddr_deserialize \
+  test/fuzz/netaddress \
   test/fuzz/out_point_deserialize \
   test/fuzz/p2p_transport_deserializer \
   test/fuzz/parse_hd_keypath \
@@ -474,6 +475,12 @@ test_fuzz_netaddr_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_netaddr_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_netaddr_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_netaddr_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_netaddress_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_netaddress_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_netaddress_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_netaddress_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_netaddress_SOURCES = $(FUZZ_SUITE) test/fuzz/netaddress.cpp
 
 test_fuzz_out_point_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DOUT_POINT_DESERIALIZE=1
 test_fuzz_out_point_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/netaddress.cpp
+++ b/src/test/fuzz/netaddress.cpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <netaddress.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+
+#include <cassert>
+#include <cstdint>
+#include <netinet/in.h>
+#include <vector>
+
+namespace {
+CNetAddr ConsumeNetAddr(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    const Network network = fuzzed_data_provider.PickValueInArray({Network::NET_IPV4, Network::NET_IPV6, Network::NET_INTERNAL, Network::NET_ONION});
+    if (network == Network::NET_IPV4) {
+        const in_addr v4_addr = {
+            .s_addr = fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+        return CNetAddr{v4_addr};
+    } else if (network == Network::NET_IPV6) {
+        if (fuzzed_data_provider.remaining_bytes() < 16) {
+            return CNetAddr{};
+        }
+        in6_addr v6_addr = {};
+        memcpy(v6_addr.s6_addr, fuzzed_data_provider.ConsumeBytes<uint8_t>(16).data(), 16);
+        return CNetAddr{v6_addr, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+    } else if (network == Network::NET_INTERNAL) {
+        CNetAddr net_addr;
+        net_addr.SetInternal(fuzzed_data_provider.ConsumeBytesAsString(32));
+        return net_addr;
+    } else if (network == Network::NET_ONION) {
+        CNetAddr net_addr;
+        net_addr.SetSpecial(fuzzed_data_provider.ConsumeBytesAsString(32));
+        return net_addr;
+    } else {
+        assert(false);
+    }
+}
+}; // namespace
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const CNetAddr net_addr = ConsumeNetAddr(fuzzed_data_provider);
+    for (int i = 0; i < 15; ++i) {
+        (void)net_addr.GetByte(i);
+    }
+    (void)net_addr.GetHash();
+    (void)net_addr.GetNetClass();
+    if (net_addr.GetNetwork() == Network::NET_IPV4) {
+        assert(net_addr.IsIPv4());
+    }
+    if (net_addr.GetNetwork() == Network::NET_IPV6) {
+        assert(net_addr.IsIPv6());
+    }
+    if (net_addr.GetNetwork() == Network::NET_ONION) {
+        assert(net_addr.IsTor());
+    }
+    if (net_addr.GetNetwork() == Network::NET_INTERNAL) {
+        assert(net_addr.IsInternal());
+    }
+    if (net_addr.GetNetwork() == Network::NET_UNROUTABLE) {
+        assert(!net_addr.IsRoutable());
+    }
+    (void)net_addr.IsBindAny();
+    if (net_addr.IsInternal()) {
+        assert(net_addr.GetNetwork() == Network::NET_INTERNAL);
+    }
+    if (net_addr.IsIPv4()) {
+        assert(net_addr.GetNetwork() == Network::NET_IPV4 || net_addr.GetNetwork() == Network::NET_UNROUTABLE);
+    }
+    if (net_addr.IsIPv6()) {
+        assert(net_addr.GetNetwork() == Network::NET_IPV6 || net_addr.GetNetwork() == Network::NET_UNROUTABLE);
+    }
+    (void)net_addr.IsLocal();
+    if (net_addr.IsRFC1918() || net_addr.IsRFC2544() || net_addr.IsRFC6598() || net_addr.IsRFC5737() || net_addr.IsRFC3927()) {
+        assert(net_addr.IsIPv4());
+    }
+    (void)net_addr.IsRFC2544();
+    if (net_addr.IsRFC3849() || net_addr.IsRFC3964() || net_addr.IsRFC4380() || net_addr.IsRFC4843() || net_addr.IsRFC7343() || net_addr.IsRFC4862() || net_addr.IsRFC6052() || net_addr.IsRFC6145()) {
+        assert(net_addr.IsIPv6());
+    }
+    (void)net_addr.IsRFC3927();
+    (void)net_addr.IsRFC3964();
+    if (net_addr.IsRFC4193()) {
+        assert(net_addr.GetNetwork() == Network::NET_ONION || net_addr.GetNetwork() == Network::NET_INTERNAL || net_addr.GetNetwork() == Network::NET_UNROUTABLE);
+    }
+    (void)net_addr.IsRFC4380();
+    (void)net_addr.IsRFC4843();
+    (void)net_addr.IsRFC4862();
+    (void)net_addr.IsRFC5737();
+    (void)net_addr.IsRFC6052();
+    (void)net_addr.IsRFC6145();
+    (void)net_addr.IsRFC6598();
+    (void)net_addr.IsRFC7343();
+    if (!net_addr.IsRoutable()) {
+        assert(net_addr.GetNetwork() == Network::NET_UNROUTABLE || net_addr.GetNetwork() == Network::NET_INTERNAL);
+    }
+    if (net_addr.IsTor()) {
+        assert(net_addr.GetNetwork() == Network::NET_ONION);
+    }
+    (void)net_addr.IsValid();
+    (void)net_addr.ToString();
+    (void)net_addr.ToStringIP();
+
+    const CSubNet sub_net{net_addr, fuzzed_data_provider.ConsumeIntegral<int32_t>()};
+    (void)sub_net.IsValid();
+    (void)sub_net.ToString();
+
+    const CService service{net_addr, fuzzed_data_provider.ConsumeIntegral<uint16_t>()};
+    (void)service.GetKey();
+    (void)service.GetPort();
+    (void)service.ToString();
+    (void)service.ToStringIPPort();
+    (void)service.ToStringPort();
+
+    const CNetAddr other_net_addr = ConsumeNetAddr(fuzzed_data_provider);
+    (void)net_addr.GetReachabilityFrom(&other_net_addr);
+    (void)sub_net.Match(other_net_addr);
+}

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -14,6 +14,7 @@ import logging
 
 # Fuzzers known to lack a seed corpus in https://github.com/bitcoin-core/qa-assets/tree/master/fuzz_seed_corpus
 FUZZERS_MISSING_CORPORA = [
+    "netaddress",
 ]
 
 

--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -12,11 +12,6 @@ import sys
 import subprocess
 import logging
 
-# Fuzzers known to lack a seed corpus in https://github.com/bitcoin-core/qa-assets/tree/master/fuzz_seed_corpus
-FUZZERS_MISSING_CORPORA = [
-    "netaddress",
-]
-
 
 def main():
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -95,6 +90,20 @@ def main():
 
     logging.info("{} of {} detected fuzz target(s) selected: {}".format(len(test_list_selection), len(test_list_all), " ".join(test_list_selection)))
 
+    test_list_seedless = []
+    for t in test_list_selection:
+        corpus_path = os.path.join(args.seed_dir, t)
+        if not os.path.exists(corpus_path) or len(os.listdir(corpus_path)) == 0:
+            test_list_seedless.append(t)
+    test_list_seedless.sort()
+    if test_list_seedless:
+        logging.info(
+            "Fuzzing harnesses lacking a seed corpus: {}".format(
+                " ".join(test_list_seedless)
+            )
+        )
+        logging.info("Please consider adding a fuzz seed corpus at https://github.com/bitcoin-core/qa-assets")
+
     try:
         help_output = subprocess.run(
             args=[
@@ -125,8 +134,7 @@ def main():
 def run_once(*, corpus, test_list, build_dir, export_coverage, use_valgrind):
     for t in test_list:
         corpus_path = os.path.join(corpus, t)
-        if t in FUZZERS_MISSING_CORPORA:
-            os.makedirs(corpus_path, exist_ok=True)
+        os.makedirs(corpus_path, exist_ok=True)
         args = [
             os.path.join(build_dir, 'src', 'test', 'fuzz', t),
             '-runs=1',


### PR DESCRIPTION
Add basic fuzzing harness for `CNetAddr`/`CService`/`CSubNet` related functions (`netaddress.h`).

To test this PR:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/netaddress
…
```