### PR TITLE
build: Fix behavior when ALLOW_HOST_PACKAGES unset

### DIFF
--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -59,7 +59,7 @@ PKG_CONFIG="`which pkg-config` --static"
 # avoid ruining the cache. Sigh.
 export PKG_CONFIG_PATH=$depends_prefix/share/pkgconfig:$depends_prefix/lib/pkgconfig
 if test -z "@allow_host_packages@"; then
-  export PKGCONFIG_LIBDIR=
+  export PKG_CONFIG_LIBDIR=$depends_prefix/lib/pkgconfig
 fi
 
 CPPFLAGS="-I$depends_prefix/include/ $CPPFLAGS"


### PR DESCRIPTION
On master (f05c1ac444e0c893516535bfdf07c5c8cd9bce16) during building with depends host packages are always considered by `pkg-config` regardless of `ALLOW_HOST_PACKAGES` environment variable. This causes issues like #18042.

This is an alternative to #18042 and #18045.

On master:
```
$ make HOST=x86_64-apple-darwin16 -C depends
$ CONFIG_SITE=$PWD/depends/x86_64-apple-darwin16/share/config.site ./configure
...
checking for QT_DBUS... yes
...
checking whether to build GUI with support for D-Bus... yes
...
```

---

With this PR:
1) `ALLOW_HOST_PACKAGES` unset
```
$ make HOST=x86_64-apple-darwin16 -C depends
$ CONFIG_SITE=$PWD/depends/x86_64-apple-darwin16/share/config.site ./configure
...
checking for QT_DBUS... no
...
checking whether to build GUI with support for D-Bus... no
...
```
2) `ALLOW_HOST_PACKAGES=1`
```
$ make HOST=x86_64-apple-darwin16 ALLOW_HOST_PACKAGES=1 -C depends
$ CONFIG_SITE=$PWD/depends/x86_64-apple-darwin16/share/config.site ./configure
...
checking for QT_DBUS... yes
...
checking whether to build GUI with support for D-Bus... yes
...
```