### PR TITLE
Silence "redundant move in return statement" warning on GCC9

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -240,7 +240,15 @@ public:
         if (try_lock && result && !*result) return {};
         // std::move necessary on some compilers due to conversion from
         // LockImpl to Lock pointer
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wredundant-move"
+#endif
         return std::move(result);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     }
     bool findBlock(const uint256& hash, CBlock* block, int64_t* time, int64_t* time_max) override
     {


### PR DESCRIPTION
SIlence this warning on GCC9:
```
  CXX      interfaces/libbitcoin_server_a-chain.o
interfaces/chain.cpp: In member function ‘virtual std::unique_ptr<interfaces::Chain::Lock> interfaces::{anonymous}::ChainImpl::lock(bool)’:
interfaces/chain.cpp:243:25: warning: redundant move in return statement [-Wredundant-move]
  243 |         return std::move(result);
      |                ~~~~~~~~~^~~~~~~~
interfaces/chain.cpp:243:25: note: remove ‘std::move’ call
```
According to comment above this code, `std::move()` cannot be removed here, as is needed for some compilers, so silencing using GCC diagnostic pragmas is the only way.

`"-Wpragmas"` part is needed because on older compilers, like GCC7, you will have the following warning otherwise:
```
interfaces/chain.cpp: In member function 'virtual std::unique_ptr<interfaces::Chain::Lock> interfaces::{anonymous}::ChainImpl::lock(bool)':
interfaces/chain.cpp:244:32: warning: unknown option after '#pragma GCC diagnostic' kind [-Wpragmas]
 #pragma GCC diagnostic ignored "-Wredundant-move"
                                ^~~~~~~~~~~~~~~~~~
```