### PR TITLE
net: reference instead of copy in BlockConnected range loop

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1182,7 +1182,7 @@ void PeerLogicValidation::BlockConnected(const std::shared_ptr<const CBlock>& pb
     }
     {
         LOCK(g_cs_recent_confirmed_transactions);
-        for (const auto ptx : pblock->vtx) {
+        for (const auto& ptx : pblock->vtx) {
             g_recent_confirmed_transactions->insert(ptx->GetHash());
         }
     }


### PR DESCRIPTION
Reference elements in range for loop instead of copying them and
fix Clang `-Wrange-loop-analysis` warning introduced in a029e18

```
net_processing.cpp:1185:25: warning: loop variable 'ptx' of
type 'const std::shared_ptr<const CTransaction>' creates a copy from
type 'const std::shared_ptr<const CTransaction>' [-Wrange-loop-analysis]
        for (const auto ptx : pblock->vtx) {
                        ^
net_processing.cpp:1185:14: note: use reference type
'const std::shared_ptr<const CTransaction> &' to prevent copying
        for (const auto ptx : pblock->vtx) {
             ^~~~~~~~~~~~~~~~
1 warning generated.
```
