### PR TITLE
ci: Check for submodules

### DIFF
--- a/test/lint/lint-submodule.sh
+++ b/test/lint/lint-submodule.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# This script checks for git modules
+export LC_ALL=C
+EXIT_CODE=0
+
+CMD=$(git submodule status --recursive)
+if test -n "$CMD";
+then
+    echo These submodules were found, delete them:
+    echo "$CMD"
+    EXIT_CODE=1
+fi
+
+exit $EXIT_CODE
+


### PR DESCRIPTION
See #18019.
The current solution looks like this (I also tested with multiple submodules):
```
These submodules were found, delete them:
 355a5a310019659d9bf6818d2fd66fbb214dfed7 curl (curl-7_68_0-108-g355a5a310)
```
The submodule example command was `git submodule add https://github.com/curl/curl.git curl`