### PR TITLE
util: Pass size to ParseHex to assist preallocation

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -34,6 +34,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/rpc_blockchain.cpp \
   bench/rpc_mempool.cpp \
   bench/util_time.cpp \
+  bench/util_bases16_64.cpp \
   bench/verify_script.cpp \
   bench/base58.cpp \
   bench/bech32.cpp \

--- a/src/bench/util_bases16_64.cpp
+++ b/src/bench/util_bases16_64.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+
+#include <random.h>
+#include <util/strencodings.h>
+
+#include <array>
+#include <vector>
+
+
+static void Base64Encode(benchmark::State& state)
+{
+    static const std::array<unsigned char, 32> buff = {
+        {17, 79, 8, 99, 150, 189, 208, 162, 22, 23, 203, 163, 36, 58, 147,
+            227, 139, 2, 215, 100, 91, 38, 11, 141, 253, 40, 117, 21, 16, 90,
+            200, 24}};
+    while (state.KeepRunning()) {
+        (void)EncodeBase64(buff.data(), buff.size());
+    }
+}
+
+
+static void Base64Decode(benchmark::State& state)
+{
+    std::string str = "X19jb29raWVfXzpkMzE5MjE2NTU2MmY3ZDZiYjZmY2Q0NzQ5YzhhZGIyMjlkMzYxNGRjMjQ0OTBjMTUwOTcwNjI3NWZjMDMyNzUy==";
+    while (state.KeepRunning()) {
+        DecodeBase64(str, nullptr);
+    }
+}
+
+static void Base64DecodeBig(benchmark::State& state)
+{
+    FastRandomContext insecure_rand(true);
+    auto bytes = insecure_rand.randbytes(1024);
+    std::string str = EncodeBase64(bytes.data(), bytes.size());
+    while (state.KeepRunning()) {
+        DecodeBase64(str, nullptr);
+    }
+}
+
+static void Base64DecodeVec(benchmark::State& state)
+{
+    std::string str = "X19jb29raWVfXzpkMzE5MjE2NTU2MmY3ZDZiYjZmY2Q0NzQ5YzhhZGIyMjlkMzYxNGRjMjQ0OTBjMTUwOTcwNjI3NWZjMDMyNzUy==";
+    while (state.KeepRunning()) {
+        DecodeBase64(str.c_str(), nullptr);
+    }
+}
+
+static void HexParse(benchmark::State& state)
+{
+    std::string str = "fc7aba077ad5f4c3a0988d8daa4810d0d4a0e3bcb53af662998898f33df0556a";
+    while (state.KeepRunning()) {
+        ParseHex(str);
+    }
+}
+
+
+BENCHMARK(Base64Encode, 1000 * 1000);
+BENCHMARK(Base64Decode, 1000 * 1000);
+BENCHMARK(Base64DecodeBig, 400 * 1000);
+BENCHMARK(Base64DecodeVec, 1000 * 1000);
+BENCHMARK(HexParse, 1000 * 1000);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -27,6 +27,7 @@ static const std::string SAFE_CHARS[] =
 std::string SanitizeString(const std::string& str, int rule)
 {
     std::string strResult;
+    strResult.reserve(str.size());
     for (std::string::size_type i = 0; i < str.size(); i++)
     {
         if (SAFE_CHARS[rule].find(str[i]) != std::string::npos)
@@ -81,10 +82,12 @@ bool IsHexNumber(const std::string& str)
     return (str.size() > starting_location);
 }
 
-std::vector<unsigned char> ParseHex(const char* psz)
+std::vector<unsigned char> ParseHex(const std::string& str)
 {
     // convert hex dump to vector
     std::vector<unsigned char> vch;
+    vch.reserve(str.size() / 2);
+    auto psz = str.cbegin();
     while (true)
     {
         while (IsSpace(*psz))
@@ -100,11 +103,6 @@ std::vector<unsigned char> ParseHex(const char* psz)
         vch.push_back(n);
     }
     return vch;
-}
-
-std::vector<unsigned char> ParseHex(const std::string& str)
-{
-    return ParseHex(str.c_str());
 }
 
 void SplitHostPort(std::string in, int &portOut, std::string &hostOut) {

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -35,7 +35,6 @@ enum SafeChars
 * @return           A new string without unsafe chars
 */
 std::string SanitizeString(const std::string& str, int rule = SAFE_CHARS_DEFAULT);
-std::vector<unsigned char> ParseHex(const char* psz);
 std::vector<unsigned char> ParseHex(const std::string& str);
 signed char HexDigit(char c);
 /* Returns true if each character in str is a hex character, and has an even


### PR DESCRIPTION
Hi,
~This is kinda chasing Concept ACK if it's worth the review effort.* (noticed it while reviewing a PR)~

~Right now both DecodeBase32 and DecodeBase64 are only ever being called with `std::string` but still process via `char*` and so they run `strlen`(O(n)) twice, once to validate it doesn't contain random zeros(`ValidAsCString`) another to get the length.~

~Instead we can iterate it as a std::string and then if we see `0` in the middle of the string we can fail the process.~

~\* if it is, there's also DecodeBase58 .~

And as a by-product saw 2 other places where we can pre-allocate memory.

EDIT: So the by-product turned out to be the only interesting part of this PR :) (see https://github.com/bitcoin/bitcoin/pull/18061#issuecomment-581968054)
According to the benchmarks this can cut the time it takes to parse a hex by half.