### PR TITLE
gui: Fix unintialized WalletView::progressDialog

### DIFF
--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -66,7 +66,7 @@ private:
 
     TransactionView *transactionView;
 
-    QProgressDialog *progressDialog;
+    QProgressDialog* progressDialog{nullptr};
     const PlatformStyle *platformStyle;
 
 public Q_SLOTS:


### PR DESCRIPTION
#17911 shows that it's possible to read the unintialized `progressDialog` in https://github.com/bitcoin/bitcoin/blob/f32564f0a73c5ad1a107dd112e40516f39d1a51e/src/qt/walletview.cpp#L296-L297. 

And the debugger shows
```
(gdb) bt
#0  0x0000555556687c60 in QProgressDialog::wasCanceled() const ()
#1  0x000055555572989f in WalletView::showProgress (this=0x5555577d7a70, 
    title=..., nProgress=1) at qt/walletview.cpp:322
```

Closes #17911.