### PR TITLE
gui: Drop WalletModel dependency to RecentRequestsTableModel

### DIFF
--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -16,6 +16,7 @@
 #include <QVariant>
 
 class PlatformStyle;
+class RecentRequestsTableModel;
 class WalletModel;
 
 namespace Ui {
@@ -44,6 +45,8 @@ public:
 
     void setModel(WalletModel *model);
 
+    RecentRequestsTableModel* recentRequestsTableModel() const { return m_recent_requests_table_model; }
+
 public Q_SLOTS:
     void clear();
     void reject();
@@ -56,6 +59,7 @@ private:
     Ui::ReceiveCoinsDialog *ui;
     GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
     WalletModel *model;
+    RecentRequestsTableModel* m_recent_requests_table_model{nullptr};
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -212,7 +212,8 @@ void TestGUI(interfaces::Node& node)
     // Check Request Payment button
     ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
     receiveCoinsDialog.setModel(&walletModel);
-    RecentRequestsTableModel* requestTableModel = walletModel.getRecentRequestsTableModel();
+    RecentRequestsTableModel* requestTableModel = receiveCoinsDialog.recentRequestsTableModel();
+    assert(requestTableModel);
 
     // Label input
     QLineEdit* labelInput = receiveCoinsDialog.findChild<QLineEdit*>("reqLabel");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -13,7 +13,6 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/paymentserver.h>
-#include <qt/recentrequeststablemodel.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/transactiontablemodel.h>
 
@@ -36,14 +35,12 @@
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces::Node& node, const PlatformStyle *platformStyle, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), m_wallet(std::move(wallet)), m_node(node), optionsModel(_optionsModel), addressTableModel(nullptr),
     transactionTableModel(nullptr),
-    recentRequestsTableModel(nullptr),
     cachedEncryptionStatus(Unencrypted),
     cachedNumBlocks(0)
 {
     fHaveWatchOnly = m_wallet->haveWatchOnly();
     addressTableModel = new AddressTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);
-    recentRequestsTableModel = new RecentRequestsTableModel(this);
 
     subscribeToCoreSignals();
 }
@@ -274,11 +271,6 @@ AddressTableModel *WalletModel::getAddressTableModel()
 TransactionTableModel *WalletModel::getTransactionTableModel()
 {
     return transactionTableModel;
-}
-
-RecentRequestsTableModel *WalletModel::getRecentRequestsTableModel()
-{
-    return recentRequestsTableModel;
 }
 
 WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -26,7 +26,6 @@ enum class OutputType;
 class AddressTableModel;
 class OptionsModel;
 class PlatformStyle;
-class RecentRequestsTableModel;
 class SendCoinsRecipient;
 class TransactionTableModel;
 class WalletModelTransaction;
@@ -78,7 +77,6 @@ public:
     OptionsModel *getOptionsModel();
     AddressTableModel *getAddressTableModel();
     TransactionTableModel *getTransactionTableModel();
-    RecentRequestsTableModel *getRecentRequestsTableModel();
 
     EncryptionStatus getEncryptionStatus() const;
 
@@ -172,7 +170,6 @@ private:
 
     AddressTableModel *addressTableModel;
     TransactionTableModel *transactionTableModel;
-    RecentRequestsTableModel *recentRequestsTableModel;
 
     // Cache some values to be able to detect changes
     interfaces::WalletBalances m_cached_balances;

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -14,7 +14,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "policy/fees -> txmempool -> policy/fees"
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"
     "qt/bitcoingui -> qt/walletframe -> qt/bitcoingui"
-    "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel"
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog"
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel"
     "txmempool -> validation -> txmempool"


### PR DESCRIPTION
This PR moves the `RecentRequestsTableModel` instancing to where it's needed which in turn breaks the circular dependency between `WalletModel` and `RecentRequestsTableModel`.