### PR TITLE
test: replace 'regtest' leftovers by self.chain

### DIFF
--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -93,8 +93,8 @@ class ConfArgsTest(BitcoinTestFramework):
                     'Command-line arg: rpcpassword=****',
                     'Command-line arg: rpcuser=****',
                     'Command-line arg: torpassword=****',
-                    'Config file arg: regtest="1"',
-                    'Config file arg: [regtest] server="1"',
+                    'Config file arg: %s="1"' % self.chain,
+                    'Config file arg: [%s] server="1"' % self.chain,
                 ],
                 unexpected_msgs=[
                     'alice:f7efda5c189b999524f151318c0c86$d5b51b3beffbc0',

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -25,7 +25,7 @@ class DumptxoutsetTest(BitcoinTestFramework):
 
         FILENAME = 'txoutset.dat'
         out = node.dumptxoutset(FILENAME)
-        expected_path = Path(node.datadir) / 'regtest' / FILENAME
+        expected_path = Path(node.datadir) / self.chain / FILENAME
 
         assert expected_path.is_file()
 


### PR DESCRIPTION
This is a follow-up PR to #16681 (fixes #18068), replacing all remaining hardcoded `"regtest"` strings in functional tests by `self.chain`.