### PR TITLE
Use `libc++` headers from macOS SDK instead of from clang

### DIFF
--- a/contrib/macdeploy/README.md
+++ b/contrib/macdeploy/README.md
@@ -14,9 +14,11 @@ When complete, it will have produced `Bitcoin-Qt.dmg`.
 
 ## SDK Extraction
 
-`Xcode.app` is packaged in a `.xip` archive.
-This makes the SDK less-trivial to extract on non-macOS machines.
-One approach (tested on Debian Buster) is outlined below:
+### Step 1: Obtaining `Xcode.app`
+
+After Xcode version 7.x, Apple started shipping the `Xcode.app` in a `.xip`
+archive. This makes the SDK less-trivial to extract on non-macOS machines. One
+approach (tested on Debian Buster) is outlined below:
 
 ```bash
 
@@ -37,16 +39,26 @@ popd
 xar -xf Xcode_10.2.1.xip -C .
 
 ./pbzx/pbzx -n Content | cpio -i
-
-find Xcode.app -type d -name MacOSX.sdk -execdir sh -c 'tar -c MacOSX.sdk/ | gzip -9n > /MacOSX10.14.sdk.tar.gz' \;
 ```
 
-on macOS the process is more straightforward:
+On macOS the process is more straightforward:
 
 ```bash
 xip -x Xcode_10.2.1.xip
-tar -C Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.14.sdk.tar.gz MacOSX.sdk
 ```
+
+### Step 2: Generating `MacOSX10.14.sdk.tar.gz` from `Xcode.app`
+
+To generate `MacOSX10.14.sdk.tar.gz`, run the script
+[`gen_sdk_package.sh`](./gen_sdk_package.sh) with the XCODEDIR environment
+variable pointing to the `Xcode.app` extracted in the previous stage.
+
+```bash
+env SDK_COMPRESSOR=gz XCODEDIR="<path_to_Xcode.app>" \
+    contrib/macdeploy/gen_sdk_package.sh
+```
+
+### Historial macOS SDK Extraction Notes
 
 Our previously used macOS SDK (`MacOSX10.11.sdk`) can be extracted from
 [Xcode 7.3.1 dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg).

--- a/contrib/macdeploy/gen_sdk_package.sh
+++ b/contrib/macdeploy/gen_sdk_package.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+#
+# Package the OS X SDKs into a tar file to be used by `build.sh`.
+#
+
+export LC_ALL=C
+
+
+which gnutar &>/dev/null
+
+if [ $? -eq 0 ]; then
+  TAR=gnutar
+else
+  TAR=tar
+fi
+
+
+if [ -z "$SDK_COMPRESSOR" ]; then
+  which xz &>/dev/null
+
+  if [ $? -eq 0 ]; then
+    SDK_COMPRESSOR=xz
+    SDK_EXT="tar.xz"
+  else
+    SDK_COMPRESSOR=bzip2
+    SDK_EXT="tar.bz2"
+  fi
+fi
+
+case $SDK_COMPRESSOR in
+  "gz")
+    SDK_COMPRESSOR=gzip
+    SDK_EXT=".tar.gz"
+    ;;
+  "bzip2")
+    SDK_EXT=".tar.bz2"
+    ;;
+  "xz")
+    SDK_EXT=".tar.xz"
+    ;;
+  "zip")
+    SDK_EXT=".zip"
+    ;;
+  *)
+    echo "error: unknown compressor \"$SDK_COMPRESSOR\"" >&2
+    exit 1
+esac
+
+function compress()
+{
+  case $SDK_COMPRESSOR in
+    "zip")
+      $SDK_COMPRESSOR -q -5 -r - $1 > $2 ;;
+    *)
+      tar cf - $1 | $SDK_COMPRESSOR -5 - > $2 ;;
+  esac
+}
+
+
+function rreadlink()
+{
+  if [ ! -h "$1" ]; then
+    echo "$1"
+  else
+    local link="$(expr "$(command ls -ld -- "$1")" : '.*-> \(.*\)$')"
+    cd $(dirname $1)
+    rreadlink "$link" | sed "s|^\([^/].*\)\$|$(dirname $1)/\1|"
+  fi
+}
+
+function set_xcode_dir()
+{
+  local tmp=$(ls $1 2>/dev/null | grep "^Xcode.*.app" | grep -v "beta" | head -n1)
+
+  if [ -z "$tmp" ]; then
+    tmp=$(ls $1 2>/dev/null | grep "^Xcode.*.app" | head -n1)
+  fi
+
+  if [ -n "$tmp" ]; then
+    XCODEDIR="$1/$tmp"
+  fi
+}
+
+
+if [ $(uname -s) != "Darwin" ]; then
+  if [ -z "$XCODEDIR" ]; then
+    echo "This script must be run on OS X" 1>&2
+    echo "... Or with XCODEDIR=... on Linux" 1>&2
+    exit 1
+  else
+    case "$XCODEDIR" in
+      /*) ;;
+      *) XCODEDIR="$PWD/$XCODEDIR" ;;
+    esac
+    set_xcode_dir "$XCODEDIR"
+  fi
+else
+  set_xcode_dir $(echo /Volumes/Xcode* | tr ' ' '\n' | grep -v "beta" | head -n1)
+
+  if [ -z "$XCODEDIR" ]; then
+    set_xcode_dir /Applications
+
+    if [ -z "$XCODEDIR" ]; then
+      set_xcode_dir $(echo /Volumes/Xcode* | tr ' ' '\n' | head -n1)
+
+      if [ -z "$XCODEDIR" ]; then
+        echo "please mount Xcode.dmg" 1>&2
+        exit 1
+      fi
+    fi
+  fi
+fi
+
+if [ ! -d "$XCODEDIR" ]; then
+  echo "cannot find Xcode (XCODEDIR=$XCODEDIR)" 1>&2
+  exit 1
+fi
+
+echo -e "found Xcode: $XCODEDIR"
+
+WDIR=$(pwd)
+
+set -e
+
+pushd "$XCODEDIR" &>/dev/null
+
+if [ -d "Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs" ]; then
+  pushd "Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs" &>/dev/null
+else
+  if [ -d "../Packages" ]; then
+    pushd "../Packages" &>/dev/null
+  elif [ -d "Packages" ]; then
+    pushd "Packages" &>/dev/null
+  else
+    if [ $? -ne 0 ]; then
+      echo "Xcode (or this script) is out of date" 1>&2
+      echo "trying some magic to find the SDKs anyway ..." 1>&2
+
+      SDKDIR=$(find . -name SDKs -type d | grep MacOSX | head -n1)
+
+      if [ -z "$SDKDIR" ]; then
+        echo "cannot find SDKs!" 1>&2
+        exit 1
+      fi
+
+      pushd "$SDKDIR" &>/dev/null
+    fi
+  fi
+fi
+
+SDKS=$(ls | grep "^MacOSX10.*" | grep -v "Patch")
+
+if [ -z "$SDKS" ]; then
+    echo "No SDK found" 1>&2
+    exit 1
+fi
+
+# Xcode 5
+LIBCXXDIR1="Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/c++/v1"
+
+# Xcode 6
+LIBCXXDIR2="Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1"
+
+# Manual directory
+MANDIR="Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/share/man"
+
+for SDK in $SDKS; do
+  echo -n "packaging $(echo "$SDK" | sed -E "s/(.sdk|.pkg)//g") SDK "
+  echo "(this may take several minutes) ..."
+
+  if [[ $SDK == *.pkg ]]; then
+    cp $SDK $WDIR
+    continue
+  fi
+
+  TMP=$(mktemp -d /tmp/XXXXXXXXXXX)
+  cp -r $(rreadlink $SDK) $TMP/$SDK &>/dev/null || true
+
+  pushd "$XCODEDIR" &>/dev/null
+
+  mkdir -p $TMP/$SDK/usr/include/c++
+
+  # libc++ headers for C++11/C++14
+  if [ -d $LIBCXXDIR1 ]; then
+    cp -rf $LIBCXXDIR1 "$TMP/$SDK/usr/include/c++"
+  elif [ -d $LIBCXXDIR2 ]; then
+    cp -rf $LIBCXXDIR2 "$TMP/$SDK/usr/include/c++"
+  fi
+
+  if [ -d $MANDIR ]; then
+    mkdir -p $TMP/$SDK/usr/share/man
+    cp -rf $MANDIR/* $TMP/$SDK/usr/share/man
+  fi
+
+  popd &>/dev/null
+
+  pushd $TMP &>/dev/null
+  compress "*" "$WDIR/$SDK$SDK_EXT"
+  popd &>/dev/null
+
+  rm -rf $TMP
+done
+
+popd &>/dev/null
+popd &>/dev/null
+
+echo ""
+ls -lh | grep MacOSX

--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -73,6 +73,5 @@ define $(package)_stage_cmds
   cp lib/libLTO.so $($(package)_staging_prefix_dir)/lib/ && \
   cp -rf lib/clang/$($(package)_clang_version)/include/* $($(package)_staging_prefix_dir)/lib/clang/$($(package)_clang_version)/include/ && \
   cp bin/llvm-dsymutil $($(package)_staging_prefix_dir)/bin/$(host)-dsymutil && \
-  if `test -d include/c++/`; then cp -rf include/c++/ $($(package)_staging_prefix_dir)/include/; fi && \
   if `test -d lib/c++/`; then cp -rf lib/c++/ $($(package)_staging_prefix_dir)/lib/; fi
 endef


### PR DESCRIPTION
~~Based on #16392~~ **Update:** Base PR has been merged.

Why this is useful: Previously, we were using [the `libc++` headers copied from the clang package we downloaded from llvm.org](https://github.com/bitcoin/bitcoin/pull/18072/commits/8e888983b7ced7a53d21272085a74558b20d7821). This is suboptimal as our goal is to have a toolchain that can target macOS, which (in Xcode.app) has its own set of `libc++` headers that can [differ from those of the clang package](https://gist.github.com/fanquake/9315a02416f56d1545dfef7f9c75bc45). It seems to me that given our goal, it is better to use what Apple intends, and not rely on upstream `clang` <-> Apple `clang` compatibility.

-----

This requires a regeneration of the macOS SDK, I apologize that this didn't make it into #16392, please follow the updated instructions here: https://github.com/bitcoin/bitcoin/pull/18072/commits/8e8fadff59c48b33ffbdac14acd52f469954307d?short_path=9de36be#diff-9de36befe13356841c2699ee0eff4a0a (I'm linking to the Markdown diff so that people who need to regenerate the macOS SDK can see the difference in procedure from before)