### PR TITLE
test: set a name for CI Docker containers

### DIFF
--- a/ci/test/00_setup_env.sh
+++ b/ci/test/00_setup_env.sh
@@ -34,6 +34,7 @@ export USE_BUSY_BOX=${USE_BUSY_BOX:-false}
 export RUN_UNIT_TESTS=${RUN_UNIT_TESTS:-true}
 export RUN_FUNCTIONAL_TESTS=${RUN_FUNCTIONAL_TESTS:-true}
 export RUN_FUZZ_TESTS=${RUN_FUZZ_TESTS:-false}
+export CONTAINER_NAME=${CONTAINER_NAME:-ci_unnamed}
 export DOCKER_NAME_TAG=${DOCKER_NAME_TAG:-ubuntu:18.04}
 # Randomize test order.
 # See https://www.boost.org/doc/libs/1_71_0/libs/test/doc/html/boost_test/utf_reference/rt_param_reference/random.html

--- a/ci/test/00_setup_env_arm.sh
+++ b/ci/test/00_setup_env_arm.sh
@@ -16,6 +16,7 @@ if [ -n "$QEMU_USER_CMD" ]; then
   # Likely cross-compiling, so install the needed gcc and qemu-user
   export PACKAGES="$PACKAGES qemu-user"
 fi
+export CONTAINER_NAME=ci_arm_linux
 # Use debian to avoid 404 apt errors when cross compiling
 export DOCKER_NAME_TAG="debian:buster"
 export USE_BUSY_BOX=true

--- a/ci/test/00_setup_env_i686_centos.sh
+++ b/ci/test/00_setup_env_i686_centos.sh
@@ -7,6 +7,7 @@
 export LC_ALL=C.UTF-8
 
 export HOST=i686-pc-linux-gnu
+export CONTAINER_NAME=ci_i686_centos_7
 export DOCKER_NAME_TAG=centos:7
 export DOCKER_PACKAGES="gcc-c++ glibc-devel.x86_64 libstdc++-devel.x86_64 glibc-devel.i686 libstdc++-devel.i686 ccache libtool make git python3 python36-zmq which patch lbzip2 dash"
 export GOAL="install"

--- a/ci/test/00_setup_env_mac.sh
+++ b/ci/test/00_setup_env_mac.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_macos_cross
 export HOST=x86_64-apple-darwin16
 export PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python3-dev python3-setuptools"
 export OSX_SDK=10.14

--- a/ci/test/00_setup_env_native_asan.sh
+++ b/ci/test/00_setup_env_native_asan.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_native_asan
 export PACKAGES="clang-8 llvm-8 python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 # Use clang-8 instead of default clang (which is clang-6 on Bionic) to avoid spurious segfaults when running on ppc64le
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_native_fuzz.sh
+++ b/ci/test/00_setup_env_native_fuzz.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_native_fuzz
 export PACKAGES="clang-8 llvm-8 python3 libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev"
 export NO_DEPENDS=1
 export RUN_UNIT_TESTS=false

--- a/ci/test/00_setup_env_native_nowallet.sh
+++ b/ci/test/00_setup_env_native_nowallet.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_native_nowallet
 export PACKAGES="python3-zmq"
 export DEP_OPTS="NO_WALLET=1"
 export GOAL="install"

--- a/ci/test/00_setup_env_native_qt5.sh
+++ b/ci/test/00_setup_env_native_qt5.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_native_qt5
 export PACKAGES="python3-zmq qtbase5-dev qttools5-dev-tools libdbus-1-dev libharfbuzz-dev"
 export DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1 ALLOW_HOST_PACKAGES=1"
 export TEST_RUNNER_EXTRA="--coverage --extended --exclude feature_dbcrash"  # Run extended tests so that coverage does not fail, but exclude the very slow dbcrash

--- a/ci/test/00_setup_env_native_tsan.sh
+++ b/ci/test/00_setup_env_native_tsan.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_native_tsan
 export DOCKER_NAME_TAG=ubuntu:16.04
 export PACKAGES="clang llvm python3-zmq qtbase5-dev qttools5-dev-tools libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libqrencode-dev"
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_native_valgrind.sh
+++ b/ci/test/00_setup_env_native_valgrind.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_native_valgrind
 export PACKAGES="valgrind clang llvm python3-zmq libevent-dev bsdmainutils libboost-system-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev"
 export USE_VALGRIND=1
 export NO_DEPENDS=1

--- a/ci/test/00_setup_env_s390x.sh
+++ b/ci/test/00_setup_env_s390x.sh
@@ -17,6 +17,7 @@ if [ -n "$QEMU_USER_CMD" ]; then
   export PACKAGES="$PACKAGES g++-s390x-linux-gnu qemu-user libc6:s390x libstdc++6:s390x libfontconfig1:s390x libxcb1:s390x"
 fi
 # Use debian to avoid 404 apt errors
+export CONTAINER_NAME=ci_s390x
 export DOCKER_NAME_TAG="debian:buster"
 export RUN_UNIT_TESTS=true
 export RUN_FUNCTIONAL_TESTS=true

--- a/ci/test/00_setup_env_win64.sh
+++ b/ci/test/00_setup_env_win64.sh
@@ -6,6 +6,7 @@
 
 export LC_ALL=C.UTF-8
 
+export CONTAINER_NAME=ci_win64
 export HOST=x86_64-w64-mingw32
 export PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine-binfmt wine64"
 export RUN_FUNCTIONAL_TESTS=false

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -64,6 +64,7 @@ if [ -z "$RUN_CI_ON_HOST" ]; then
                   --mount type=bind,src=$DEPENDS_DIR,dst=$DEPENDS_DIR \
                   -w $BASE_ROOT_DIR \
                   --env-file /tmp/env \
+                  --name $CONTAINER_NAME \
                   $DOCKER_NAME_TAG)
 
   DOCKER_EXEC () {


### PR DESCRIPTION
Addresses one part of #16664, by making it easier to identify CI containers that are running locally. By default Docker will generate random names, like `peaceful_rubin`, with this change, we explicitly set names for all containers.