### PR TITLE
logging: enable thread_local usage on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -885,11 +885,6 @@ if test "x$use_thread_local" = xyes || { test "x$use_thread_local" = xauto && te
           dnl https://gist.github.com/jamesob/fe9a872051a88b2025b1aa37bfa98605
           AC_MSG_RESULT(no)
           ;;
-        *darwin*)
-          dnl TODO enable thread_local on later versions of Darwin where it is
-          dnl supported (per https://stackoverflow.com/a/29929949)
-          AC_MSG_RESULT(no)
-          ;;
         *freebsd*)
           dnl FreeBSD's implementation of thread_local is also buggy (per
           dnl https://groups.google.com/d/msg/bsdmailinglist/22ncTZAbDp4/Dii_pII5AwAJ)


### PR DESCRIPTION
Now that we're building against a newer SDK (`10.14`), we should be able to enable `thread_local` usage on macOS. Have tested building and running locally, as well as cross-compiling and running the binaries on a macOS 10.14 system.

#### master 8a56f79d491271120abc3843c46e9dda44edd308
```bash
src/bitcoind -logthreadnames=1
2020-02-06T04:38:33Z [] Bitcoin Core version v0.19.99.0-8a56f79d4 (release build)
2020-02-06T04:38:33Z [] Assuming ancestors of block 00000000000000000005f8920febd3925f8272a6a71237563d78c2edfdd09ddf have valid signatures.
2020-02-06T04:38:33Z [] Setting nMinimumChainWork=000000000000000000000000000000000000000008ea3cf107ae0dec57f03fe8
2020-02-06T04:38:33Z [] Using the 'sse4(1way),sse41(4way),avx2(8way)' SHA256 implementation
2020-02-06T04:38:33Z [] Using RdSeed as additional entropy source
```

#### this PR d76894987d0277e8011932ab7dfd77c537f8ea6e
```bash
checking for thread_local support... yes
...
src/bitcoind -logthreadnames=1
2020-02-06T04:17:49Z [net] net thread start
2020-02-06T04:17:49Z [opencon] opencon thread start
2020-02-06T04:17:49Z [dnsseed] dnsseed thread start
2020-02-06T04:17:49Z [init] init message: Done loading
2020-02-06T04:17:49Z [msghand] msghand thread start
2020-02-06T04:17:49Z [addcon] addcon thread start
...
2020-02-06T04:17:54Z [init] tor: Thread interrupt
2020-02-06T04:17:54Z [init] Shutdown: In progress...
```

From the [Xcode 8 release notes](https://developer.apple.com/library/archive/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW78)
> C++ now supports the thread_local keyword, which declares thread-local storage (TLS) and supports C++ classes with non-trivial constructors and destructors. (9001553)