### PR TITLE
Accurately account for mempool index memory

### DIFF
--- a/src/indirectmap.h
+++ b/src/indirectmap.h
@@ -6,6 +6,7 @@
 #define BITCOIN_INDIRECTMAP_H
 
 #include <map>
+#include <memory>
 
 template <class T>
 struct DereferencingComparator { bool operator()(const T a, const T b) const { return *a < *b; } };
@@ -20,16 +21,19 @@ struct DereferencingComparator { bool operator()(const T a, const T b) const { r
  * Objects pointed to by keys must not be modified in any way that changes the
  * result of DereferencingComparator.
  */
-template <class K, class T>
+template <class K, class T, class A = std::allocator<std::pair<const K* const, T>>>
 class indirectmap {
 private:
-    typedef std::map<const K*, T, DereferencingComparator<const K*> > base;
+    typedef std::map<const K*, T, DereferencingComparator<const K*>, A> base;
     base m;
 public:
     typedef typename base::iterator iterator;
     typedef typename base::const_iterator const_iterator;
     typedef typename base::size_type size_type;
     typedef typename base::value_type value_type;
+
+    indirectmap() = default;
+    explicit indirectmap(const A& alloc) : m({}, DereferencingComparator<const K*>(), alloc) {}
 
     // passthrough (pointer interface)
     std::pair<iterator, bool> insert(const value_type& value) { return m.insert(value); }

--- a/src/memusage.h
+++ b/src/memusage.h
@@ -33,15 +33,27 @@ static size_t MallocUsage(size_t alloc);
  * allocating/deallocating memory.
  */
 template<typename T>
-class AccountingAllocator : public std::allocator<T>
+class AccountingAllocator
 {
+    using base = std::allocator<T>;
+
+    //! Base allocator
+    base m_base;
+
     //! Pointer to accounting variable, if any.
     size_t* m_allocated;
 
     template<typename U> friend class AccountingAllocator;
-    typedef std::allocator<T> base;
 
 public:
+    using value_type = typename base::value_type;
+    using pointer = typename base::pointer;
+    using const_pointer = typename base::const_pointer;
+    using reference = typename base::reference;
+    using const_reference = typename base::const_reference;
+    using size_type = typename base::size_type;
+    using difference_type = typename base::size_type;
+
     //! Default constructor constructs a non-accounting allocator.
     AccountingAllocator() noexcept : m_allocated(nullptr) {}
 
@@ -54,28 +66,34 @@ public:
     //! A copy-constructed container will be non-accounting.
     static AccountingAllocator select_on_container_copy_construction() { return AccountingAllocator(); }
     //! A copy-assigned container will be non-accounting.
-    typedef std::false_type propagate_on_container_copy_assignment;
+    using propagate_on_container_copy_assignment = std::false_type;
     //! The accounting will follow a container as it's moved.
-    typedef std::true_type propagate_on_container_move_assignment;
+    using propagate_on_container_move_assignment = std::true_type;
     //! The accounting will follow a container as it's swapped.
-    typedef std::true_type propagate_on_container_swap;
+    using propagate_on_container_swap = std::true_type;
 
     // Construct an allocator for a different data type, inheriting the accounting.
-    template <typename U> AccountingAllocator(AccountingAllocator<U>&& a) noexcept : base(std::move(a)), m_allocated(a.m_allocated) {}
-    template <typename U> AccountingAllocator(const AccountingAllocator<U>& a) noexcept : base(a), m_allocated(a.m_allocated) {}
+    template <typename U> AccountingAllocator(AccountingAllocator<U>&& a) noexcept : m_base(std::move(a.m_base)), m_allocated(a.m_allocated) {}
+    template <typename U> AccountingAllocator(const AccountingAllocator<U>& a) noexcept : m_base(a.m_base), m_allocated(a.m_allocated) {}
 
     typename base::value_type* allocate(std::size_t n, const void* hint = nullptr)
     {
-        typename base::value_type* allocation = base::allocate(n, hint);
-        if (m_allocated) *m_allocated += MallocUsage(sizeof(typename base::value_type) * n);
+        value_type* allocation = m_base.allocate(n, hint);
+        if (m_allocated) *m_allocated += MallocUsage(sizeof(value_type) * n);
         return allocation;
     }
 
     void deallocate(typename base::value_type* p, std::size_t n)
     {
-        base::deallocate(p, n);
-        if (m_allocated) *m_allocated -= MallocUsage(sizeof(typename base::value_type) * n);
+        m_base.deallocate(p, n);
+        if (m_allocated) *m_allocated -= MallocUsage(sizeof(value_type) * n);
     }
+
+    template<typename P> void destroy(P* ptr) { m_base.destroy(ptr); }
+    template<typename P, typename... Args> void construct(P* ptr, Args&&... args) { m_base.construct(ptr, std::forward<Args>(args)...); }
+    pointer address(reference x) { return m_base.address(x); }
+    const_pointer address(const_reference x) { return m_base.address(x); }
+    size_type max_size() const noexcept { return m_base.max_size(); }
 
     template<typename U> struct rebind { typedef AccountingAllocator<U> other; };
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -425,6 +425,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
 {
     CTxMemPool pool;
     LOCK2(cs_main, pool.cs);
+    const size_t empty_pool_memory_usage = pool.DynamicMemoryUsage();
     TestMemPoolEntryHelper entry;
 
     CMutableTransaction tx1 = CMutableTransaction();
@@ -447,7 +448,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     BOOST_CHECK(pool.exists(tx1.GetHash()));
     BOOST_CHECK(pool.exists(tx2.GetHash()));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // should remove the lower-feerate transaction
+    pool.TrimToSize((pool.DynamicMemoryUsage() - empty_pool_memory_usage) * 3 / 4 + empty_pool_memory_usage); // should remove the lower-feerate transaction
     BOOST_CHECK(pool.exists(tx1.GetHash()));
     BOOST_CHECK(!pool.exists(tx2.GetHash()));
 
@@ -461,7 +462,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     tx3.vout[0].nValue = 10 * COIN;
     pool.addUnchecked(entry.Fee(20000LL).FromTx(tx3));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() * 3 / 4); // tx3 should pay for tx2 (CPFP)
+    pool.TrimToSize((pool.DynamicMemoryUsage() - empty_pool_memory_usage) * 3 / 4 + empty_pool_memory_usage); // tx3 should pay for tx2 (CPFP)
     BOOST_CHECK(!pool.exists(tx1.GetHash()));
     BOOST_CHECK(pool.exists(tx2.GetHash()));
     BOOST_CHECK(pool.exists(tx3.GetHash()));
@@ -537,7 +538,7 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
         pool.addUnchecked(entry.Fee(1000LL).FromTx(tx5));
     pool.addUnchecked(entry.Fee(9000LL).FromTx(tx7));
 
-    pool.TrimToSize(pool.DynamicMemoryUsage() / 2); // should maximize mempool size by only removing 5/7
+    pool.TrimToSize((pool.DynamicMemoryUsage() - empty_pool_memory_usage) / 2 + empty_pool_memory_usage); // should maximize mempool size by only removing 5/7
     BOOST_CHECK(pool.exists(tx4.GetHash()));
     BOOST_CHECK(!pool.exists(tx5.GetHash()));
     BOOST_CHECK(pool.exists(tx6.GetHash()));

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -115,11 +115,12 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10),
         CoinsCacheSizeState::OK);
 
+    const size_t empty_pool_memory_usage = tx_pool.DynamicMemoryUsage();
     for (int i{0}; i < 3; ++i) {
         add_coin(view);
         print_view_mem_usage(view);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ 1 << 10),
+            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, /*max_mempool_size_bytes*/ (1 << 10) + empty_pool_memory_usage),
             CoinsCacheSizeState::OK);
     }
 
@@ -135,7 +136,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
         BOOST_CHECK(usage_percentage >= 0.9);
         BOOST_CHECK(usage_percentage < 1);
         BOOST_CHECK_EQUAL(
-            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, 1 << 10),
+            chainstate.GetCoinsCacheSizeState(tx_pool, MAX_COINS_CACHE_BYTES, (1 << 10) + empty_pool_memory_usage),
             CoinsCacheSizeState::LARGE);
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -329,6 +329,7 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
 CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
     : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_allocation_counter(0), m_epoch(0),
       m_has_epoch_guard(false), mapTx(memusage::AccountingAllocator<CTxMemPoolEntry>(m_allocation_counter)),
+      mapLinks({}, CompareIteratorByHash(), memusage::AccountingAllocator<std::pair<const txiter, TxLinks>>(m_allocation_counter)),
       mapDeltas({}, std::less<uint256>(), memusage::AccountingAllocator<std::pair<const uint256, CAmount>>(m_allocation_counter))
 {
     _clear(); //lock free clear
@@ -919,7 +920,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage + m_allocation_counter;
+    return memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage + m_allocation_counter;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -327,7 +327,9 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
 }
 
 CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
-    : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_allocation_counter(0), m_epoch(0), m_has_epoch_guard(false), mapTx(memusage::AccountingAllocator<CTxMemPoolEntry>(m_allocation_counter))
+    : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_allocation_counter(0), m_epoch(0),
+      m_has_epoch_guard(false), mapTx(memusage::AccountingAllocator<CTxMemPoolEntry>(m_allocation_counter)),
+      mapDeltas({}, std::less<uint256>(), memusage::AccountingAllocator<std::pair<const uint256, CAmount>>(m_allocation_counter))
 {
     _clear(); //lock free clear
 
@@ -853,7 +855,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256& hash, const CAmount& nFeeD
 void CTxMemPool::ApplyDelta(const uint256 hash, CAmount &nFeeDelta) const
 {
     LOCK(cs);
-    std::map<uint256, CAmount>::const_iterator pos = mapDeltas.find(hash);
+    auto pos = mapDeltas.find(hash);
     if (pos == mapDeltas.end())
         return;
     const CAmount &delta = pos->second;
@@ -917,7 +919,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage + m_allocation_counter;
+    return memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage + m_allocation_counter;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -331,6 +331,7 @@ CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
       m_has_epoch_guard(false), mapTx(memusage::AccountingAllocator<CTxMemPoolEntry>(m_allocation_counter)),
       vTxHashes(memusage::AccountingAllocator<std::pair<uint256, txiter>>(m_allocation_counter)),
       mapLinks({}, CompareIteratorByHash(), memusage::AccountingAllocator<std::pair<const txiter, TxLinks>>(m_allocation_counter)),
+      mapNextTx(memusage::AccountingAllocator<std::pair<const COutPoint* const, const CTransaction*>>(m_allocation_counter)),
       mapDeltas({}, std::less<uint256>(), memusage::AccountingAllocator<std::pair<const uint256, CAmount>>(m_allocation_counter))
 {
     _clear(); //lock free clear
@@ -921,7 +922,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return memusage::DynamicUsage(mapNextTx) + cachedInnerUsage + m_allocation_counter;
+    return cachedInnerUsage + m_allocation_counter;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -327,7 +327,7 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
 }
 
 CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
-    : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_epoch(0), m_has_epoch_guard(false)
+    : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_allocation_counter(0), m_epoch(0), m_has_epoch_guard(false), mapTx(memusage::AccountingAllocator<CTxMemPoolEntry>(m_allocation_counter))
 {
     _clear(); //lock free clear
 
@@ -917,8 +917,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    // Estimate the overhead of mapTx to be 12 pointers + an allocation, as no exact formula for boost::multi_index_contained is implemented.
-    return memusage::MallocUsage(sizeof(CTxMemPoolEntry) + 12 * sizeof(void*)) * mapTx.size() + memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage;
+    return memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(mapDeltas) + memusage::DynamicUsage(mapLinks) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage + m_allocation_counter;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -329,6 +329,7 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
 CTxMemPool::CTxMemPool(CBlockPolicyEstimator* estimator)
     : nTransactionsUpdated(0), minerPolicyEstimator(estimator), m_allocation_counter(0), m_epoch(0),
       m_has_epoch_guard(false), mapTx(memusage::AccountingAllocator<CTxMemPoolEntry>(m_allocation_counter)),
+      vTxHashes(memusage::AccountingAllocator<std::pair<uint256, txiter>>(m_allocation_counter)),
       mapLinks({}, CompareIteratorByHash(), memusage::AccountingAllocator<std::pair<const txiter, TxLinks>>(m_allocation_counter)),
       mapDeltas({}, std::less<uint256>(), memusage::AccountingAllocator<std::pair<const uint256, CAmount>>(m_allocation_counter))
 {
@@ -920,7 +921,7 @@ bool CCoinsViewMemPool::GetCoin(const COutPoint &outpoint, Coin &coin) const {
 
 size_t CTxMemPool::DynamicMemoryUsage() const {
     LOCK(cs);
-    return memusage::DynamicUsage(mapNextTx) + memusage::DynamicUsage(vTxHashes) + cachedInnerUsage + m_allocation_counter;
+    return memusage::DynamicUsage(mapNextTx) + cachedInnerUsage + m_allocation_counter;
 }
 
 void CTxMemPool::RemoveUnbroadcastTx(const uint256& txid, const bool unchecked) {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -449,6 +449,7 @@ private:
 
     uint64_t totalTxSize;      //!< sum of all mempool tx's virtual sizes. Differs from serialized tx size since witness data is discounted. Defined in BIP 141.
     uint64_t cachedInnerUsage; //!< sum of dynamic memory usage of all the map elements (NOT the maps themselves)
+    size_t m_allocation_counter GUARDED_BY(cs); //!< Accounting variable for AccountingAllocator-managed containers
 
     mutable int64_t lastRollingFeeUpdate;
     mutable bool blockSinceLastRollingFeeBump;
@@ -487,7 +488,8 @@ public:
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByAncestorFee
             >
-        >
+        >,
+        memusage::AccountingAllocator<CTxMemPoolEntry>
     > indexed_transaction_set;
 
     /**

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -556,7 +556,7 @@ private:
 
 public:
     indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
-    std::map<uint256, CAmount> mapDeltas;
+    std::map<uint256, CAmount, std::less<uint256>, memusage::AccountingAllocator<std::pair<const uint256, CAmount>>> mapDeltas GUARDED_BY(cs);
 
     /** Create a new CTxMemPool.
      */

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -530,7 +530,7 @@ public:
             return a->GetTx().GetHash() < b->GetTx().GetHash();
         }
     };
-    typedef std::set<txiter, CompareIteratorByHash> setEntries;
+    typedef std::set<txiter, CompareIteratorByHash, memusage::AccountingAllocator<txiter>> setEntries;
 
     const setEntries & GetMemPoolParents(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
     const setEntries & GetMemPoolChildren(txiter entry) const EXCLUSIVE_LOCKS_REQUIRED(cs);
@@ -541,6 +541,10 @@ private:
     struct TxLinks {
         setEntries parents;
         setEntries children;
+
+        TxLinks(size_t& allocation_counter) :
+            parents({}, CompareIteratorByHash(), memusage::AccountingAllocator<txiter>(allocation_counter)),
+            children({}, CompareIteratorByHash(), memusage::AccountingAllocator<txiter>(allocation_counter)) {}
     };
 
     typedef std::map<txiter, TxLinks, CompareIteratorByHash, memusage::AccountingAllocator<std::pair<const txiter, TxLinks>>> txlinksMap;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -555,7 +555,7 @@ private:
     std::set<uint256> m_unbroadcast_txids GUARDED_BY(cs);
 
 public:
-    indirectmap<COutPoint, const CTransaction*> mapNextTx GUARDED_BY(cs);
+    indirectmap<COutPoint, const CTransaction*, memusage::AccountingAllocator<std::pair<const COutPoint* const, const CTransaction*>>> mapNextTx GUARDED_BY(cs);
     std::map<uint256, CAmount, std::less<uint256>, memusage::AccountingAllocator<std::pair<const uint256, CAmount>>> mapDeltas GUARDED_BY(cs);
 
     /** Create a new CTxMemPool.

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -543,11 +543,11 @@ private:
         setEntries children;
     };
 
-    typedef std::map<txiter, TxLinks, CompareIteratorByHash> txlinksMap;
-    txlinksMap mapLinks;
+    typedef std::map<txiter, TxLinks, CompareIteratorByHash, memusage::AccountingAllocator<std::pair<const txiter, TxLinks>>> txlinksMap;
+    txlinksMap mapLinks GUARDED_BY(cs);
 
-    void UpdateParent(txiter entry, txiter parent, bool add);
-    void UpdateChild(txiter entry, txiter child, bool add);
+    void UpdateParent(txiter entry, txiter parent, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
+    void UpdateChild(txiter entry, txiter child, bool add) EXCLUSIVE_LOCKS_REQUIRED(cs);
 
     std::vector<indexed_transaction_set::const_iterator> GetSortedDepthAndScore() const EXCLUSIVE_LOCKS_REQUIRED(cs);
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -523,7 +523,7 @@ public:
     indexed_transaction_set mapTx GUARDED_BY(cs);
 
     using txiter = indexed_transaction_set::nth_index<0>::type::const_iterator;
-    std::vector<std::pair<uint256, txiter>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
+    std::vector<std::pair<uint256, txiter>, memusage::AccountingAllocator<std::pair<uint256, txiter>>> vTxHashes GUARDED_BY(cs); //!< All tx witness hashes/entries in mapTx, in random order
 
     struct CompareIteratorByHash {
         bool operator()(const txiter &a, const txiter &b) const {


### PR DESCRIPTION
This introduces a C++ allocator class (`memusage::AccountingAllocator`) which enables containers that accurately account for all their memory allocations in a tracker variable.

This is then used to replace the heuristics in the mempool to guess memory usage.