### PR TITLE
Fix crashes and infinite loop in ListWalletDir()

### DIFF
--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -270,7 +270,9 @@ bool BerkeleyDatabase::Verify(bilingual_str& errorStr)
         return false;
     }
 
-    if (fs::exists(file_path))
+    boost::system::error_code ec;
+
+    if (fs::exists(file_path, ec))
     {
         assert(m_refcount == 0);
 
@@ -842,11 +844,12 @@ std::unique_ptr<BerkeleyDatabase> MakeBerkeleyDatabase(const fs::path& path, con
 
 bool IsBDBFile(const fs::path& path)
 {
-    if (!fs::exists(path)) return false;
-
     // A Berkeley DB Btree file has at least 4K.
     // This check also prevents opening lock files.
     boost::system::error_code ec;
+
+    if (!fs::exists(path, ec)) return false;
+
     auto size = fs::file_size(path, ec);
     if (ec) LogPrintf("%s: %s %s\n", __func__, ec.message(), path.string());
     if (size < 4096) return false;

--- a/src/wallet/sqlite.cpp
+++ b/src/wallet/sqlite.cpp
@@ -569,7 +569,8 @@ bool SQLiteBatch::TxnAbort()
 bool ExistsSQLiteDatabase(const fs::path& path)
 {
     const fs::path file = path / DATABASE_FILENAME;
-    return fs::symlink_status(file).type() == fs::regular_file && IsSQLiteFile(file);
+    boost::system::error_code ec;
+    return fs::symlink_status(file, ec).type() == fs::regular_file && IsSQLiteFile(file);
 }
 
 std::unique_ptr<SQLiteDatabase> MakeSQLiteDatabase(const fs::path& path, const DatabaseOptions& options, DatabaseStatus& status, bilingual_str& error)
@@ -596,10 +597,11 @@ std::string SQLiteDatabaseVersion()
 
 bool IsSQLiteFile(const fs::path& path)
 {
-    if (!fs::exists(path)) return false;
-
     // A SQLite Database file is at least 512 bytes.
     boost::system::error_code ec;
+
+    if (!fs::exists(path, ec)) return false;
+
     auto size = fs::file_size(path, ec);
     if (ec) LogPrintf("%s: %s %s\n", __func__, ec.message(), path.string());
     if (size < 512) return false;

--- a/src/wallet/walletutil.cpp
+++ b/src/wallet/walletutil.cpp
@@ -39,9 +39,16 @@ std::vector<fs::path> ListWalletDir()
     std::vector<fs::path> paths;
     boost::system::error_code ec;
 
-    for (auto it = fs::recursive_directory_iterator(wallet_dir, ec); it != fs::recursive_directory_iterator(); it.increment(ec)) {
+    auto it = fs::recursive_directory_iterator(wallet_dir, ec);
+    if (ec) {
+        LogPrintf("%s: iterator: %s %s\n", __func__, ec.message(), it->path().string());
+        return paths;
+    }
+
+    for (; it != fs::recursive_directory_iterator(); it.increment(ec)) {
         if (ec) {
-            LogPrintf("%s: %s %s\n", __func__, ec.message(), it->path().string());
+            LogPrintf("%s: increment: %s %s\n", __func__, ec.message(), it->path().string());
+            it.no_push();
             continue;
         }
 


### PR DESCRIPTION
**Crashes:**
If wallet is checking existence of wallet.dat in directory where access is denied then _fs::exists()_ without _ec_ parameter will cause wallet crash.

Reproduction steps on Linux platform:
1. Type: _mkdir ~/.bitcoin/crash_
2. Type:  _sudo chown root:root ~/.bitcoin/crash_
3. Run _bitcoin-qt_
4. Go to menu _"File"_ -> _"Open Wallet"_, wallet will crash immediately

It's fixed by adding "ec" parameter into fs::exists() function to handle any error correctly.

**Infinite loop:**
If iterator is not able to increment because of access denied to next level of recursive scan it will stay on the same position indefinitely causing wallet to stop responding.

Reproduction steps on Windows platform:
1. Create new folder into bitcoin data folder (for example: _%Appdata%\Roaming\Bitcoin\Loop_)
2. Deny access to newly created folder for current user
3. Run _bitcoin-qt.exe_
4. Go to menu "File" -> "Open Wallet", wallet will hang indefinitely

It's fixed by disabling recursion if iterator increment failed. This way iterator will continue to next record in current recursion level not trying to dive into inaccessible directory structure.
