### PR TITLE
qt: Fix deprecated QCharRef usage

### DIFF
--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -137,7 +137,7 @@ SplashScreen::~SplashScreen()
 bool SplashScreen::eventFilter(QObject * obj, QEvent * ev) {
     if (ev->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(ev);
-        if(keyEvent->text()[0] == 'q') {
+        if (keyEvent->key() == Qt::Key_Q) {
             m_node.startShutdown();
         }
     }


### PR DESCRIPTION
From Qt docs:
- [`QKeyEvent::text()`](https://doc.qt.io/qt-5/qkeyevent.html#text):
> Return values when modifier keys such as Shift, Control, Alt, and Meta are pressed differ among platforms and could return an empty string.

- [`QString::operator[]()`](https://doc.qt.io/qt-5/qstring.html#operator-5b-5d):

> **Note:** Before Qt 5.14 it was possible to use this operator to access a character at an out-of-bounds position in the string, and then assign to such a position, causing the string to be automatically resized. Furthermore, assigning a value to the returned `QCharRef` would cause a detach of the string, even if the string has been copied in the meanwhile (and the `QCharRef` kept alive while the copy was taken). These behaviors are deprecated, and will be changed in a future version of Qt.

Since Qt 5.14 this causes a `QCharRef` warning if any modifier key is pressed while the splashscreen is still displayed.

Fix #18080.

Note: Ctrl+Q will also close the spashscreen now.