### PR TITLE
test: Disable s390 build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,12 +88,14 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
         QEMU_USER_CMD=""  # Can run the tests natively without qemu
 
-    - stage: test
-      name: 'S390x  [GOAL: install]  [buster]  [unit tests, functional tests]'
-      arch: s390x
-      env: >-
-        FILE_ENV="./ci/test/00_setup_env_s390x.sh"
-        QEMU_USER_CMD=""  # Can run the tests natively without qemu
+# s390 build was disabled temporarily because of disk space issues on the Travis VM
+#
+#    - stage: test
+#      name: 'S390x  [GOAL: install]  [buster]  [unit tests, functional tests]'
+#      arch: s390x
+#      env: >-
+#        FILE_ENV="./ci/test/00_setup_env_s390x.sh"
+#        QEMU_USER_CMD=""  # Can run the tests natively without qemu
 
     - stage: test
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'


### PR DESCRIPTION
Travis is consistently failing on s390 due to out of disk space issues,
which causes false positives. Disable the s390 build for now until
this is fixed some other way.
