### PR TITLE
build: Fix Qt link issue for macOS target with DEBUG=1

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -22,6 +22,7 @@ $(package)_extra_sources += $($(package)_qttools_file_name)
 define $(package)_set_vars
 $(package)_config_opts_release = -release
 $(package)_config_opts_debug = -debug
+$(package)_config_opts_darwin_debug = -debug-and-release
 $(package)_config_opts += -bindir $(build_prefix)/bin
 $(package)_config_opts += -c++std c++11
 $(package)_config_opts += -confirm-license


### PR DESCRIPTION
Fix #16391 

With this PR for macOS target, building `depends` with `DEBUG=1` does not cause a linker error for Qt static plugins on the following `configure` script run.

Qt docs refs:
- https://doc.qt.io/qt-5/debug.html#debugging-in-macos-and-xcode
- https://doc.qt.io/qt-5/deployment-plugins.html#debugging-plugins
- https://doc.qt.io/qt-5/qmake-variable-reference.html#config

The obvious downside is the increased compilation time for macOS targets with `DEBUG=1`.