### PR TITLE
gui: Throttle GUI update pace when -reindex

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -242,8 +242,9 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, int heig
         clientmodel->cachedBestHeaderHeight = height;
         clientmodel->cachedBestHeaderTime = blockTime;
     }
-    // if we are in-sync or if we notify a header update, update the UI regardless of last update time
-    if (fHeader || !initialSync || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
+
+    // During initial sync, block notifications, and header notifications from reindexing are both throttled.
+    if (!initialSync || (fHeader && !clientmodel->node().getReindex()) || now - nLastUpdateNotification > MODEL_UPDATE_DELAY) {
         //pass an async signal to the UI thread
         bool invoked = QMetaObject::invokeMethod(clientmodel, "numBlocksChanged", Qt::QueuedConnection,
                                   Q_ARG(int, height),


### PR DESCRIPTION
This is grabbed from #17565.

All **laanwj**'s and **ryanofsky**'s suggestions are implemented.

With this PR,  the GUI does not freeze when a user runs:
```
$ ./src/qt/bitcoin-qt -reindex
```
