### PR TITLE
rpc: update validateaddress RPCExamples to bech32

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -1089,7 +1089,8 @@ A few guidelines for introducing and reviewing new RPC interfaces:
     new RPC is replacing a deprecated RPC, to avoid both RPCs confusingly
     showing up in the command list.
 
-- Use *invalid* bech32 addresses for `RPCExamples` help documentation.
+- Use *invalid* bech32 addresses (e.g. the constant `EXAMPLE_ADDRESS`) for
+  `RPCExamples` help documentation.
 
   - *Rationale*: Prevent accidental transactions by users and encourage the use
     of bech32 addresses by default.

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -42,8 +42,8 @@ static UniValue validateaddress(const JSONRPCRequest& request)
             "}\n"
                 },
                 RPCExamples{
-                    HelpExampleCli("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
-            + HelpExampleRpc("validateaddress", "\"1PSSGeFHDnKNxiEyFrD1wcEaHr9hrQDDWc\"")
+                    HelpExampleCli("validateaddress", EXAMPLE_ADDRESS) +
+                    HelpExampleRpc("validateaddress", EXAMPLE_ADDRESS)
                 },
             }.Check(request);
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -14,6 +14,7 @@
 #include <tuple>
 
 const std::string UNIX_EPOCH_TIME = "UNIX epoch time";
+const std::string EXAMPLE_ADDRESS = "\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"";
 
 void RPCTypeCheck(const UniValue& params,
                   const std::list<UniValueType>& typesExpected,

--- a/src/rpc/util.h
+++ b/src/rpc/util.h
@@ -28,6 +28,12 @@
  */
 extern const std::string UNIX_EPOCH_TIME;
 
+/**
+ * Example bech32 address used in multiple RPCExamples. The address is intentionally
+ * invalid to prevent accidental transactions by users.
+ */
+extern const std::string EXAMPLE_ADDRESS;
+
 class FillableSigningProvider;
 class CPubKey;
 class CScript;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3737,8 +3737,6 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
         return NullUniValue;
     }
 
-    const std::string example_address = "\"bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl\"";
-
             RPCHelpMan{"getaddressinfo",
                 "\nReturn information about the given bitcoin address.\n"
                 "Some of the information will only be present if the address is in the active wallet.\n",
@@ -3791,8 +3789,8 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
             "}\n"
                 },
                 RPCExamples{
-                    HelpExampleCli("getaddressinfo", example_address) +
-                    HelpExampleRpc("getaddressinfo", example_address)
+                    HelpExampleCli("getaddressinfo", EXAMPLE_ADDRESS) +
+                    HelpExampleRpc("getaddressinfo", EXAMPLE_ADDRESS)
                 },
             }.Check(request);
 


### PR DESCRIPTION
Another small step to get rid of legacy addresses in the RPC help texts and by that encourage the use of bech32 addresses by default. The (invalid) address is the same as in the `getaddressinfo` RPC (see 2ee0cb3330ccf70f0540cb42370796e32eff1569, kudos to jonatack!), I don't think it adds any value to have a different example address per RPC.