### PR TITLE
init: Clarify C and C++ locale assumptions. Add locale sanity checks to verify assumptions at run-time.

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -34,6 +34,13 @@ static void WaitForShutdown(NodeContext& node)
     Interrupt(node);
 }
 
+static bool LocaleSanityCheck() noexcept
+{
+    const std::locale current_cpp_locale;
+    const std::string current_c_locale{setlocale(LC_ALL, nullptr)};
+    return current_cpp_locale == std::locale::classic() && current_c_locale == "C";
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Start
@@ -115,6 +122,11 @@ static bool AppInit(int argc, char* argv[])
         if (!AppInitSanityChecks())
         {
             // InitError will have been called with detailed error, which ends up on console
+            return false;
+        }
+        if (!LocaleSanityCheck())
+        {
+            InitError("Locale sanity check failure. Aborting.");
             return false;
         }
         if (gArgs.GetBoolArg("-daemon", false))

--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -59,7 +59,13 @@ static_assert(sizeof(size_t) == sizeof(void*), "Sizes of size_t and void* assume
 
 // Some important things we are NOT assuming (non-exhaustive list):
 // * We are NOT assuming a specific value for std::endian::native.
-// * We are NOT assuming a specific value for std::locale("").name().
+// * In bitcoin-qt we are NOT assuming a specific C locale (setlocale), but we
+//   do assume that the global C++ locale (std::locale) is set to the classic
+//   locale. This is verified at run-time by GUILocaleSanityCheck().
+//
+//   In bitcoind we assume that BOTH the C locale and C++ locale are set to the
+//   classic locale. This is verified at run-time by LocaleSanityCheck().
 // * We are NOT assuming a specific value for std::numeric_limits<char>::is_signed.
+
 
 #endif // BITCOIN_COMPAT_ASSUMPTIONS_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -246,9 +246,22 @@ void BitcoinApplication::createSplashScreen(const NetworkStyle *networkStyle)
     connect(this, &BitcoinApplication::requestedShutdown, splash, &QWidget::close);
 }
 
+static void GUILocaleSanityCheck() noexcept
+{
+    // In bitcoin-qt we assume that the global C++ locale (std::locale) is the
+    // classic locale, but we do not make any assumptions about the C locale
+    // (setlocale).
+    const std::locale current_cpp_locale;
+    if (current_cpp_locale != std::locale::classic()) {
+        std::abort();
+    }
+}
+
 bool BitcoinApplication::baseInitialize()
 {
-    return m_node.baseInitialize();
+    const bool initialized = m_node.baseInitialize();
+    GUILocaleSanityCheck();
+    return initialized;
 }
 
 void BitcoinApplication::startThread()

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -8,6 +8,7 @@ KNOWN_VIOLATIONS=(
     "src/bitcoin-tx.cpp.*stoul"
     "src/bitcoin-tx.cpp.*std::to_string"
     "src/bitcoin-tx.cpp.*trim_right"
+    "src/bitcoind.cpp.*setlocale"
     "src/dbwrapper.cpp.*stoul"
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"


### PR DESCRIPTION
Clarify locale assumptions.

Add locale sanity check making sure the global `bitcoind` C and C++ locales are set to the classic `"C"` locale (the minimal locale).

Add locale sanity check making sure the global `bitcoin-qt` C++ locale is set to the classic `"C"` locale (the minimal locale). (We do not assume any specific C locale in `bitcoin-qt`.)

To summarize - assumed locales:

| Program        | C locale (`setlocale`) | Global C++ locale (`std::locale`) |
| ------------- | ------------- | ----- |
| `bitcoind`      | `C` (classic) | `C` (classic) |
| `bitcoin-qt`      | No assumed locale  | `C` (classic) |

