### PR TITLE
doc: remove PPA note from release-process.md

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -121,7 +121,7 @@ Ensure gitian-builder is up-to-date:
     echo '5a60e0a4b3e0b4d655317b2f12a810211c50242138322b16e7e01c6fbb89d92f inputs/osslsigncode-2.0.tar.gz' | sha256sum -c
     popd
 
-Create the macOS SDK tarball, see the [macOS build instructions](build-osx.md#deterministic-macos-dmg-notes) for details, and copy it into the inputs directory.
+Create the macOS SDK tarball, see the [macdeploy instructions](/contrib/macdeploy/README.md#deterministic-macos-dmg-notes) for details, and copy it into the inputs directory.
 
 ### Optional: Seed the Gitian sources cache and offline git repositories
 
@@ -327,8 +327,6 @@ bitcoin.org (see below for bitcoin.org update instructions).
   - bitcoincore.org RPC documentation update
 
   - Update packaging repo
-
-      - Notify BlueMatt so that he can start building [the PPAs](https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin)
 
       - Push the flatpak to flathub, e.g. https://github.com/flathub/org.bitcoincore.bitcoin-qt/pull/2
 


### PR DESCRIPTION
The PPA is [no longer maintained](https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin) (in favour of the [snap](https://github.com/bitcoin-core/packaging/tree/master/snap)), so no need to bug the bluematt.

Also fixes a link to the macdeploy instructions.