### PR TITLE
add macOS notarization info to the release process doc

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -258,6 +258,13 @@ Commit your signature for the signed macOS/Windows binaries:
 
 ### After 3 or more people have gitian-built and their results match:
 
+- macOS codesigner only: Create disk image notarization:
+Only one person handles notarization. Everyone else should skip to the next step. Requires an Apple Mac computer.
+
+```bash
+xcrun altool --notarize-app --primary-bundle-id "org.bitcoinfoundation.Bitcoin-Qt" -u "<code-signer-apple-developer-account-username>" -p "<password>" --file bitcoin-${VERSION}-osx.dmg
+```
+
 - Create `SHA256SUMS.asc` for the builds, and GPG-sign it:
 
 ```bash


### PR DESCRIPTION
Should solve #15774.

Adds a note on how to notarize the macOS disk image to the release process documentation. Since macOS 10.14.5, applications must be notarized in order to run (user can disable the strictness though).

The `xcrun altool --notarize-app` call uploads the .dmg-file to the apple gatekeeper server where it will be scanned for malware. Once approved, users opening the Bitcoin-Qt.app will no longer see the missing-notarization error (requires internet connection). Offline users can still disable the notarization-check feature in their macOS settings.

In order to execute the notarization, one needs the Bitcoin Core Code Signing Association Apple Developer Programm credentials (it's a manual per app created password).

We could further expand towards offline-notarization capabilities by "stapling" the Apple approved notarization ticket into the application bundle (non trivial to implement in out gitian process).

General info: 
https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution

Developer instruction using a manual build process (like we do):
https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow