### PR TITLE
build: add --enable-determinism configure flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -262,6 +262,13 @@ AC_ARG_ENABLE([gprof],
     [enable_gprof=$enableval],
     [enable_gprof=no])
 
+dnl Pass compiler & liner flags that make builds deterministic
+AC_ARG_ENABLE([determinism],
+    [AS_HELP_STRING([--enable-determinism],
+                    [Enable compilation flags that make builds deterministic (default is no)])],
+    [enable_determinism=$enableval],
+    [enable_determinism=no])
+
 dnl Turn warnings into errors
 AC_ARG_ENABLE([werror],
     [AS_HELP_STRING([--enable-werror],
@@ -762,6 +769,12 @@ if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip_dylibs]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip_dylibs"])
   AX_CHECK_LINK_FLAG([[-Wl,-bind_at_load]], [HARDENED_LDFLAGS="$HARDENED_LDFLAGS -Wl,-bind_at_load"])
+fi
+
+if test x$enable_determinism = xyes; then
+  if test x$TARGET_OS = xwindows; then
+    AX_CHECK_LINK_FLAG([[-Wl,--no-insert-timestamp]], [LDFLAGS="$LDFLAGS -Wl,--no-insert-timestamp"])
+  fi
 fi
 
 AC_CHECK_HEADERS([endian.h sys/endian.h byteswap.h stdio.h stdlib.h unistd.h strings.h sys/types.h sys/stat.h sys/select.h sys/prctl.h sys/sysctl.h vm/vm_param.h sys/vmmeter.h sys/resources.h])


### PR DESCRIPTION
This adds a `--enable-determinsm` configure flag, which if used, will enable additional compile / link time flags to make subsequent builds of bitcoind deterministic.

The first flag enabled is `--no-insert-timestamp`. This prevents the linker from embedding timestamps, and makes consecutive builds of `bitcoind.exe` deterministic. This will likely also be used for [Guix Windows builds](https://github.com/bitcoin/bitcoin/pull/17595#issuecomment-582696467).

[`--no-insert-timestamp`](https://manpages.debian.org/buster/binutils-mingw-w64-x86-64/x86_64-w64-mingw32-ld.bfd.1.en.html):
> The option --no-insert-timestamp can be used to insert a zero value for the timestamp, this ensuring that binaries produced from identical sources will compare identically.

Diff of consecutive builds of [master](https://github.com/bitcoin/bitcoin/commit/2bdc476d4d23256d8396bb9051a511f540d87392):
```diff
--- bitcoind.exe.1
+++ bitcoind.exe.2
@@ -2,20 +2,20 @@
 00000060: 7420 6265 2072 756e 2069 6e20 444f 5320  t be run in DOS 
 00000070: 6d6f 6465 2e0d 0d0a 2400 0000 0000 0000  mode....$.......
-00000080: 5045 0000 6486 1400 57e8 445e 00da 6900  PE..d...W.D^..i.
+00000080: 5045 0000 6486 1400 e3e9 445e 00da 6900  PE..d.....D^..i.
 00000090: e015 0100 f000 2600 0b02 021f 00de 4900  ......&.......I.
 000000a0: 00b0 5b00 008a 0000 e014 0000 0010 0000  ..[.............
 000000b0: 0000 4000 0000 0000 0010 0000 0002 0000  ..@.............
 000000c0: 0400 0000 0000 0000 0500 0200 0000 0000  ................
-000000d0: 00f0 6a00 0006 0000 bd31 af00 0300 6001  ..j......1....`.
+000000d0: 00f0 6a00 0006 0000 d434 af00 0300 6001  ..j......4....`.
 000000e0: 0000 2000 0000 0000 0010 0000 0000 0000  .. .............
@@ -373594,15 +373594,15 @@
 005b35f0: 0000 0000 0000 0000 0000 0000 0000 0000  ................
-005b3600: 0000 0000 57e8 445e 0000 0000 7ce1 5b00  ....W.D^....|.[.
+005b3600: 0000 0000 e2e9 445e 0000 0000 7ce1 5b00  ......D^....|.[.
 005b3610: 0100 0000 2200 0000 2200 0000 28e0 5b00  ...."..."...(.[.
```