### PR TITLE
build: remove redundant compiler warning suppression

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,9 +349,6 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   dnl unknown options if any other warning is produced. Test the -Wfoo case, and
   dnl set the -Wno-foo case if it works.
   AX_CHECK_COMPILE_FLAG([-Wunused-parameter],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-parameter"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wself-assign],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-self-assign"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wunused-local-typedef],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-unused-local-typedef"],,[[$CXXFLAG_WERROR]])
-  AX_CHECK_COMPILE_FLAG([-Wdeprecated-register],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-register"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wimplicit-fallthrough],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-implicit-fallthrough"],,[[$CXXFLAG_WERROR]])
 fi
 


### PR DESCRIPTION
Compiling with GCC 9.2.1 I'm not able to generate a compile time warning with the following compiler flags removed. I wanted to see whether CI has any issues with the following removed. If any problems arise I'll take a look and possibly close this PR, otherwise perhaps we want to remove these flags to prevent the reintroduction of register, self assign or unused local typedef.

```
no-self-assign
no-unused-local-typedef
no-deprecated-register
```