### PR TITLE
qt: Kill the locale dependency bug class by not allowing Qt to mess with LC_NUMERIC

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -35,6 +35,7 @@
 #include <util/system.h>
 #include <util/threadnames.h>
 
+#include <clocale>
 #include <memory>
 
 #include <QApplication>
@@ -182,6 +183,36 @@ BitcoinApplication::BitcoinApplication(interfaces::Node& node):
     returnValue(0),
     platformStyle(nullptr)
 {
+    // Force the classic locale ("C") for the numeric locale category (LC_NUMERIC).
+    //
+    // Rationale:
+    //
+    // Perhaps surprisingly Qt runs setlocale(LC_ALL, "") on initialization. This
+    // installs the locale specified by the user's LC_ALL (or LC_*) environment
+    // variable as the new C locale.
+    //
+    // In contrast bitcoind does not opt-in to localization -- no call to
+    // setlocale(LC_ALL, "") is made and the environment variables LC_* are
+    // thus ignored.
+    //
+    // This results in an unfortunate situation where the bitcoind is guaranteed
+    // to be running with the classic locale ("C") whereas the locale of
+    // bitcoin-qt will vary depending on the user's environment variables.
+    //
+    // An example: Assuming the environment variable LC_ALL=de_DE then the
+    // call std::to_string(1.23) will return "1.230000" in bitcoind but
+    // "1,230000" in bitcoin-qt.
+    //
+    // From the Qt documentation:
+    // "On Unix/Linux Qt is configured to use the system locale settings by default.
+    //  This can cause a conflict when using POSIX functions, for instance, when
+    //  converting between data types such as floats and strings, since the notation
+    //  may differ between locales. To get around this problem, call the POSIX function
+    //  setlocale(LC_NUMERIC,"C") right after initializing QApplication, QGuiApplication
+    //  or QCoreApplication to reset the locale that is used for number formatting to
+    //  "C"-locale."
+    setlocale(LC_NUMERIC, "C");
+
     setQuitOnLastWindowClosed(false);
 }
 

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -11,6 +11,7 @@ KNOWN_VIOLATIONS=(
     "src/dbwrapper.cpp:.*vsnprintf"
     "src/httprpc.cpp.*trim"
     "src/init.cpp:.*atoi"
+    "src/qt/bitcoin.cpp:.*setlocale"
     "src/qt/rpcconsole.cpp:.*atoi"
     "src/rest.cpp:.*strtol"
     "src/test/dbwrapper_tests.cpp:.*snprintf"


### PR DESCRIPTION
Kill the locale dependency bug class by not allowing Qt to mess with `LC_NUMERIC`.

Context: #18124 (Recommended reading if you are unsure about how C and C++ locales work in C++)

**Guaranteed locale settings before this PR:**

| Program        | C locale category `LC_NUMERIC` | Global C++ locale (`std::locale`) |
| ------------- | ------------- | ----- |
| `bitcoind`      | `C` (classic) | `C` (classic) |
| `bitcoin-qt`      | No guarantee - user-specified  | `C` (classic) |

**Guaranteed locale settings after this PR:**

| Program        | C locale category `LC_NUMERIC` | Global C++ locale (`std::locale`) |
| ------------- | ------------- | ----- |
| `bitcoind`      | `C` (classic) | `C` (classic) |
| `bitcoin-qt`      | `C` (classic)  | `C` (classic) |

**Background:**

Perhaps surprisingly Qt runs `setlocale(LC_ALL, "")` on initialization. This installs the locale specified by the user's `LC_ALL` (or `LC_*`) environment variable as the new C locale.

In contrast `bitcoind` does not opt-in to localization -- no call to `setlocale(LC_ALL, "")` (or `std::locale::global(std::locale(""))`) is made and the environment variables `LC_*` are thus ignored.

This results in an unfortunate situation where the `bitcoind` is guaranteed to be running with the classic locale (`"C"`) whereas the locale of `bitcoin-qt` will vary depending on the user's environment variables.

An example: Assuming the environment variable `LC_ALL=de_DE` then the call `std::to_string(1.23)` will return `"1.230000"` in `bitcoind` but `"1,230000"` in `bitcoin-qt`.

From the [Qt documentation](https://doc.qt.io/qt-5/qcoreapplication.html):

> "On Unix/Linux Qt is configured to use the system locale settings by default. This can cause a conflict when using POSIX functions, for instance, when converting between data types such as floats and strings, since the notation may differ between locales. To get around this problem, call the POSIX function `setlocale(LC_NUMERIC,"C")` right after initializing `QApplication`, `QGuiApplication` or `QCoreApplication` to reset the locale that is used for number formatting to "C"-locale."

---

C and C++ locales 101:

```c++
#include <clocale>
#include <cstdlib>
#include <iostream>
#include <locale>
#include <sstream>
#include <string>

int main(void)
{
    std::cout << "C locale at beginning of main: " << std::string{setlocale(LC_ALL, nullptr)} << "\n";
    std::cout << "C++ locale at beginning of main: " << std::locale{}.name() << "\n\n";
#if OPT_IN_TO_LOCALIZATION_USING_SET_LOCALE
    setlocale(LC_ALL, "");
#endif
#if OPT_IN_TO_LOCALIZATION_USING_STD_LOCALE_GLOBAL
    std::locale::global(std::locale(""));
#endif
    std::ostringstream oss;
    oss << 1000000;
    std::cout << "std::ostringstream oss; oss << 1000000; oss.str() equals " << oss.str() << "\n";
    std::cout << "std::to_string(1.23) equals " << std::to_string(1.23) << "\n\n";
    std::cout << "C locale at end of main: " << std::string{setlocale(LC_ALL, nullptr)} << "\n";
    std::cout << "C++ locale at end of main: " << std::locale{}.name() << "\n\n";
    std::cout << "setlocale(LC_COLLATE,  nullptr) (read-only operation) = " << std::string{setlocale(LC_COLLATE, nullptr)} << "\n";
    std::cout << "setlocale(LC_CTYPE,    nullptr) (read-only operation) = " << std::string{setlocale(LC_CTYPE, nullptr)} << "\n";
    std::cout << "setlocale(LC_MESSAGES, nullptr) (read-only operation) = " << std::string{setlocale(LC_MESSAGES, nullptr)} << "\n";
    std::cout << "setlocale(LC_MONETARY, nullptr) (read-only operation) = " << std::string{setlocale(LC_MONETARY, nullptr)} << "\n";
    std::cout << "setlocale(LC_NUMERIC,  nullptr) (read-only operation) = " << std::string{setlocale(LC_NUMERIC, nullptr)} << "\n";
    std::cout << "setlocale(LC_TIME,     nullptr) (read-only operation) = " << std::string{setlocale(LC_TIME, nullptr)} << "\n";
}
```

Let's try with `LC_ALL=de_DE ./l8n` without any opt-in to locale dependence:

```
$ clang++ -o l8n l8n.cpp
$ LC_ALL=de_DE ./l8n
C locale at beginning of main: C
C++ locale at beginning of main: C

std::ostringstream oss; oss << 1000000; oss.str() equals 1000000
std::to_string(1.23) equals 1.230000

C locale at end of main: C
C++ locale at end of main: C

setlocale(LC_COLLATE,  nullptr) (read-only operation) = C
setlocale(LC_CTYPE,    nullptr) (read-only operation) = C
setlocale(LC_MESSAGES, nullptr) (read-only operation) = C
setlocale(LC_MONETARY, nullptr) (read-only operation) = C
setlocale(LC_NUMERIC,  nullptr) (read-only operation) = C
setlocale(LC_TIME,     nullptr) (read-only operation) = C
```

Let's try with `LC_NUMERIC=de_DE ./l8n` without any opt-in to locale dependence:

```
$ clang++ -o l8n l8n.cpp
$ LC_NUMERIC=de_DE ./l8n
C locale at beginning of main: C
C++ locale at beginning of main: C

std::ostringstream oss; oss << 1000000; oss.str() equals 1000000
std::to_string(1.23) equals 1.230000

C locale at end of main: C
C++ locale at end of main: C

setlocale(LC_COLLATE,  nullptr) (read-only operation) = C
setlocale(LC_CTYPE,    nullptr) (read-only operation) = C
setlocale(LC_MESSAGES, nullptr) (read-only operation) = C
setlocale(LC_MONETARY, nullptr) (read-only operation) = C
setlocale(LC_NUMERIC,  nullptr) (read-only operation) = C
setlocale(LC_TIME,     nullptr) (read-only operation) = C
```

Let's try `LC_ALL=de_DE ./l8n` with opt-in to locale dependence using `set_locale`:

```
$ clang++ -DOPT_IN_TO_LOCALIZATION_USING_SET_LOCALE -o l8n l8n.cpp
$ LC_ALL=de_DE ./l8n
C locale at beginning of main: C
C++ locale at beginning of main: C

std::ostringstream oss; oss << 1000000; oss.str() equals 1000000
std::to_string(1.23) equals 1,230000

C locale at end of main: de_DE
C++ locale at end of main: C

setlocale(LC_COLLATE,  nullptr) (read-only operation) = de_DE
setlocale(LC_CTYPE,    nullptr) (read-only operation) = de_DE
setlocale(LC_MESSAGES, nullptr) (read-only operation) = de_DE
setlocale(LC_MONETARY, nullptr) (read-only operation) = de_DE
setlocale(LC_NUMERIC,  nullptr) (read-only operation) = de_DE
setlocale(LC_TIME,     nullptr) (read-only operation) = de_DE
```

Let's try `LC_ALL=de_DE ./l8n` with opt-in to locale dependence using `std::locale::global`:

```
$ clang++ -DOPT_IN_TO_LOCALIZATION_USING_STD_LOCALE_GLOBAL -o l8n l8n.cpp
$ LC_ALL=de_DE ./l8n
C locale at beginning of main: C
C++ locale at beginning of main: C

std::ostringstream oss; oss << 1000000; oss.str() equals 1.000.000
std::to_string(1.23) equals 1,230000

C locale at end of main: de_DE
C++ locale at end of main: de_DE

setlocale(LC_COLLATE,  nullptr) (read-only operation) = de_DE
setlocale(LC_CTYPE,    nullptr) (read-only operation) = de_DE
setlocale(LC_MESSAGES, nullptr) (read-only operation) = de_DE
setlocale(LC_MONETARY, nullptr) (read-only operation) = de_DE
setlocale(LC_NUMERIC,  nullptr) (read-only operation) = de_DE
setlocale(LC_TIME,     nullptr) (read-only operation) = de_DE
```