### PR TITLE
tests: Add harness which fuzzes EvalScript and VerifyScript using a fuzzed signature checker

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -91,6 +91,7 @@ FUZZ_TARGETS = \
   test/fuzz/script_ops \
   test/fuzz/scriptnum_ops \
   test/fuzz/service_deserialize \
+  test/fuzz/signature_checker \
   test/fuzz/snapshotmetadata_deserialize \
   test/fuzz/spanparsing \
   test/fuzz/string \
@@ -808,6 +809,12 @@ test_fuzz_service_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_service_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_service_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_service_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_signature_checker_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_signature_checker_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_signature_checker_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_signature_checker_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_signature_checker_SOURCES = $(FUZZ_SUITE) test/fuzz/signature_checker.cpp
 
 test_fuzz_snapshotmetadata_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSNAPSHOTMETADATA_DESERIALIZE=1
 test_fuzz_snapshotmetadata_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2009-2019 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <pubkey.h>
+#include <script/interpreter.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <util/memory.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+}
+
+namespace {
+class FuzzedSignatureChecker : public BaseSignatureChecker
+{
+    FuzzedDataProvider& m_fuzzed_data_provider;
+
+public:
+    FuzzedSignatureChecker(FuzzedDataProvider& fuzzed_data_provider) : m_fuzzed_data_provider(fuzzed_data_provider)
+    {
+    }
+
+    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+
+    virtual bool CheckLockTime(const CScriptNum& nLockTime) const
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+
+    virtual bool CheckSequence(const CScriptNum& nSequence) const
+    {
+        return m_fuzzed_data_provider.ConsumeBool();
+    }
+
+    virtual ~FuzzedSignatureChecker() {}
+};
+} // namespace
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const unsigned int flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const SigVersion sig_version = fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0});
+    const std::string script_string_1 = fuzzed_data_provider.ConsumeRandomLengthString(65536);
+    const std::vector<uint8_t> script_bytes_1{script_string_1.begin(), script_string_1.end()};
+    const std::string script_string_2 = fuzzed_data_provider.ConsumeRandomLengthString(65536);
+    const std::vector<uint8_t> script_bytes_2{script_string_2.begin(), script_string_2.end()};
+    std::vector<std::vector<unsigned char>> stack;
+    (void)EvalScript(stack, {script_bytes_1.begin(), script_bytes_1.end()}, flags, FuzzedSignatureChecker(fuzzed_data_provider), sig_version, nullptr);
+    if ((flags & SCRIPT_VERIFY_CLEANSTACK) != 0 && ((flags & SCRIPT_VERIFY_P2SH) == 0 || (flags & SCRIPT_VERIFY_WITNESS) == 0)) {
+        return;
+    }
+    if ((flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
+        return;
+    }
+    (void)VerifyScript({script_bytes_1.begin(), script_bytes_1.end()}, {script_bytes_2.begin(), script_bytes_2.end()}, nullptr, flags, FuzzedSignatureChecker(fuzzed_data_provider), nullptr);
+}


### PR DESCRIPTION
Add harness which fuzzes `EvalScript` and `VerifyScript` using a fuzzed signature checker.

Test this PR using:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/signature_checker
…
```

Closes #17986.