### PR TITLE
doc: fixing init.md documentation to not require rpcpassword

### DIFF
--- a/doc/init.md
+++ b/doc/init.md
@@ -20,9 +20,9 @@ The macOS configuration assumes bitcoind will be set up for the current user.
 Configuration
 ---------------------------------
 
-At a bare minimum, bitcoind requires that the rpcpassword setting be set
-when running as a daemon.  If the configuration file does not exist or this
-setting is not set, bitcoind will shut down promptly after startup.
+Running bitcoind as a daemon does not require any manual configuration. You may
+set the `rpcauth` setting in the `bitcoin.conf` configuration file to override
+the default behaviour of using a special cookie for authentication.
 
 This password does not have to be remembered or typed as it is mostly used
 as a fixed token that bitcoind and client programs read from the configuration


### PR DESCRIPTION
Configuration section in [doc/init.md](https://github.com/bitcoin/bitcoin/blob/master/doc/init.md) says user must set rpcpassword in order to run bitcoind. Since [71cbea](https://github.com/bitcoin/bitcoin/commit/71cbeaad9a929ba6a7b62d9b37a09b214ae00c1a) fixed the code to use a cookie for authentication, it is not mandatory to set rpcpassword in the configuration.

Fixes #16346
