### PR TITLE
tests: Add --valgrind option to test/fuzz/test_runner.py for running fuzzing test cases under valgrind

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -62,6 +62,11 @@ def main():
         help='If true, export coverage information to files in the seed corpus',
     )
     parser.add_argument(
+        '--valgrind',
+        action='store_true',
+        help='If true, run fuzzing binaries under the valgrind memory error detector. Valgrind 3.14 or later required.',
+    )
+    parser.add_argument(
         'seed_dir',
         help='The seed corpus to run on (must contain subfolders for each fuzz target).',
     )
@@ -129,10 +134,11 @@ def main():
         test_list=test_list_selection,
         build_dir=config["environment"]["BUILDDIR"],
         export_coverage=args.export_coverage,
+        use_valgrind=args.valgrind,
     )
 
 
-def run_once(*, corpus, test_list, build_dir, export_coverage):
+def run_once(*, corpus, test_list, build_dir, export_coverage, use_valgrind):
     for t in test_list:
         corpus_path = os.path.join(corpus, t)
         if t in FUZZERS_MISSING_CORPORA:
@@ -143,6 +149,8 @@ def run_once(*, corpus, test_list, build_dir, export_coverage):
             '-detect_leaks=0',
             corpus_path,
         ]
+        if use_valgrind:
+            args = ['valgrind', '--quiet', '--error-exitcode=1', '--exit-on-first-error=yes'] + args
         logging.debug('Run {} with args {}'.format(t, args))
         result = subprocess.run(args, stderr=subprocess.PIPE, universal_newlines=True)
         output = result.stderr


### PR DESCRIPTION
Add `--valgrind` option to `test/fuzz/test_runner.py` for running fuzzing test cases under `valgrind`.

Test this PR using:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=fuzzer
$ make
$ git clone https://github.com/bitcoin-core/qa-assets
$ test/fuzz/test_runner.py --valgrind -l DEBUG qa-assets/fuzz_seed_corpus/
```