### PR TITLE
rpc: generalize address in decoderawtransaction RPCResult

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -463,7 +463,7 @@ static UniValue decoderawtransaction(const JSONRPCRequest& request)
             "         \"reqSigs\" : n,            (numeric) The required sigs\n"
             "         \"type\" : \"pubkeyhash\",  (string) The type, eg 'pubkeyhash'\n"
             "         \"addresses\" : [           (json array of string)\n"
-            "           \"12tvKAXCxZjSmdNbao16dKXC8tRWfcF5oc\"   (string) bitcoin address\n"
+            "           \"address\"               (string) bitcoin address\n"
             "           ,...\n"
             "         ]\n"
             "       }\n"


### PR DESCRIPTION
Another small step to get rid of legacy addresses in the RPC help texts -- for a RPCResult in fact we don't want to see any concrete address at all. All other RPCs containing the `"addresses"` array in the RPCResults (e.g. getrawtransaction, decodescript) show a generic "address" string instead of a concrete address, so we adapt this here as well.
