### PR TITLE
Consolidate service flag bit-to-name conversion to a shared serviceFlagToStr function

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -199,3 +199,27 @@ const std::vector<std::string> &getAllNetMessageTypes()
 {
     return allNetMessageTypesVec;
 }
+
+std::string serviceFlagToStr(const uint64_t mask, const int bit)
+{
+    switch (ServiceFlags(mask)) {
+    case NODE_NONE: abort();  // impossible
+    case NODE_NETWORK:         return "NETWORK";
+    case NODE_GETUTXO:         return "GETUTXO";
+    case NODE_BLOOM:           return "BLOOM";
+    case NODE_WITNESS:         return "WITNESS";
+    case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
+    // Not using default, so we get warned when a case is missing
+    }
+
+    std::ostringstream stream;
+    stream.imbue(std::locale::classic());
+    stream << "UNKNOWN[";
+    if (bit < 8) {
+        stream << mask;
+    } else {
+        stream << "2^" << bit;
+    }
+    stream << "]";
+    return stream.str();
+}

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -237,7 +237,7 @@ const std::vector<std::string> &getAllNetMessageTypes();
 
 /** nServices flags */
 enum ServiceFlags : uint64_t {
-    // NOTE: When adding here, be sure to update qt/guiutil.cpp's formatServicesStr too
+    // NOTE: When adding here, be sure to update serviceFlagToStr too
     // Nothing
     NODE_NONE = 0,
     // NODE_NETWORK means that the node is capable of serving the complete block chain. It is currently
@@ -267,6 +267,8 @@ enum ServiceFlags : uint64_t {
     // do not actually support. Other service bits should be allocated via the
     // BIP process.
 };
+
+std::string serviceFlagToStr(uint64_t mask, int bit);
 
 /**
  * Gets the set of service flags which are "desirable" for a given peer.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -737,24 +737,6 @@ QString formatDurationStr(int secs)
     return strList.join(" ");
 }
 
-QString serviceFlagToStr(const quint64 mask, const int bit)
-{
-    switch (ServiceFlags(mask)) {
-    case NODE_NONE: abort();  // impossible
-    case NODE_NETWORK:         return "NETWORK";
-    case NODE_GETUTXO:         return "GETUTXO";
-    case NODE_BLOOM:           return "BLOOM";
-    case NODE_WITNESS:         return "WITNESS";
-    case NODE_NETWORK_LIMITED: return "NETWORK_LIMITED";
-    // Not using default, so we get warned when a case is missing
-    }
-    if (bit < 8) {
-        return QString("%1[%2]").arg("UNKNOWN").arg(mask);
-    } else {
-        return QString("%1[2^%2]").arg("UNKNOWN").arg(bit);
-    }
-}
-
 QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
@@ -763,7 +745,7 @@ QString formatServicesStr(quint64 mask)
         uint64_t check = 1ull << i;
         if (mask & check)
         {
-            strList.append(serviceFlagToStr(check, i));
+            strList.append(QString::fromStdString(serviceFlagToStr(mask, i)));
         }
     }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -760,7 +760,7 @@ QString formatServicesStr(quint64 mask)
     QStringList strList;
 
     for (int i = 0; i < 64; i++) {
-        uint64_t check = 1LL << i;
+        uint64_t check = 1ull << i;
         if (mask & check)
         {
             strList.append(serviceFlagToStr(check, i));

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -736,18 +736,15 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
 
 UniValue GetServicesNames(ServiceFlags services)
 {
+    const uint64_t services_n = services;
     UniValue servicesNames(UniValue::VARR);
 
-    if (services & NODE_NETWORK)
-        servicesNames.push_back("NETWORK");
-    if (services & NODE_GETUTXO)
-        servicesNames.push_back("GETUTXO");
-    if (services & NODE_BLOOM)
-        servicesNames.push_back("BLOOM");
-    if (services & NODE_WITNESS)
-        servicesNames.push_back("WITNESS");
-    if (services & NODE_NETWORK_LIMITED)
-        servicesNames.push_back("NETWORK_LIMITED");
+    for (int i = 0; i < 64; ++i) {
+        const uint64_t mask = 1ull << i;
+        if (services_n & mask) {
+            servicesNames.push_back(serviceFlagToStr(mask, i));
+        }
+    }
 
     return servicesNames;
 }


### PR DESCRIPTION
Side effect: this results in the RPC showing unknown service bits as "UNKNOWN[n]" like the GUI.

Note that there is no common mask-to-`vector<string>` function because both GUI and RPC would need to iterate through it to convert to their desired target formats.
