### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/src/leveldb/CONTRIBUTING.md
+++ b/src/leveldb/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 We'd love to accept your code patches! However, before we can take them, we
-have to jump a couple of legal hurdles.
+have to jump through a couple of legal hurdles.
 
 ## Contributor License Agreements
 


### PR DESCRIPTION
Missing a key word in the second sentence. Without "through", there is no direction of where the "jump" is going. Though it's implied, it's better if it's in the sentence. 
