### PR TITLE
build: add macOS signing entitlements to macdeploy

### DIFF
--- a/contrib/macdeploy/entitlements.xml
+++ b/contrib/macdeploy/entitlements.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<false/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<false/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<false/>
+	<key>com.apple.security.cs.disable-executable-page-protection</key>
+	<false/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<false/>
+	<key>com.apple.security.get-task-allow</key>
+	<false/>
+  </dict>
+</plist>


### PR DESCRIPTION
This is the entitlements file that could be passed to the `codesign` tool during macOS notarization. We don't have to be explicit with all of these permissions, as most of them are disabled by default.

Also related to #18131.

#### TODO:

- [ ] Add `--options runtime` to `codesign` step.