### PR TITLE
tests: Add fuzzing harness for CScript and CScriptNum operations

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -61,6 +61,7 @@ FUZZ_TARGETS = \
   test/fuzz/script \
   test/fuzz/script_deserialize \
   test/fuzz/script_flags \
+  test/fuzz/script_ops \
   test/fuzz/service_deserialize \
   test/fuzz/spanparsing \
   test/fuzz/strprintf \
@@ -589,6 +590,12 @@ test_fuzz_script_flags_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_flags_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_flags_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_flags_SOURCES = $(FUZZ_SUITE) test/fuzz/script_flags.cpp
+
+test_fuzz_script_ops_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_ops_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_script_ops_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_ops_SOURCES = $(FUZZ_SUITE) test/fuzz/script_ops.cpp
 
 test_fuzz_service_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSERVICE_DESERIALIZE=1
 test_fuzz_service_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -62,6 +62,7 @@ FUZZ_TARGETS = \
   test/fuzz/script_deserialize \
   test/fuzz/script_flags \
   test/fuzz/script_ops \
+  test/fuzz/scriptnum_ops \
   test/fuzz/service_deserialize \
   test/fuzz/spanparsing \
   test/fuzz/strprintf \
@@ -596,6 +597,12 @@ test_fuzz_script_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_ops_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_ops_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_ops_SOURCES = $(FUZZ_SUITE) test/fuzz/script_ops.cpp
+
+test_fuzz_scriptnum_ops_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_scriptnum_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_scriptnum_ops_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_scriptnum_ops_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_scriptnum_ops_SOURCES = $(FUZZ_SUITE) test/fuzz/scriptnum_ops.cpp
 
 test_fuzz_service_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSERVICE_DESERIALIZE=1
 test_fuzz_service_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -27,7 +27,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     while (fuzzed_data_provider.remaining_bytes() > 0) {
         switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 6)) {
         case 0: {
-            const std::vector<unsigned char>& b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+            const std::vector<unsigned char> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
             (void)bloom_filter.contains(b);
             bloom_filter.insert(b);
             const bool present = bloom_filter.contains(b);

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -24,7 +24,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     while (fuzzed_data_provider.remaining_bytes() > 0) {
         switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 2)) {
         case 0: {
-            const std::vector<unsigned char>& b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+            const std::vector<unsigned char> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
             (void)rolling_bloom_filter.contains(b);
             rolling_bloom_filter.insert(b);
             const bool present = rolling_bloom_filter.contains(b);

--- a/src/test/fuzz/script_ops.cpp
+++ b/src/test/fuzz/script_ops.cpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/script.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    CScript script = ConsumeScript(fuzzed_data_provider);
+    while (fuzzed_data_provider.remaining_bytes() > 0) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 7)) {
+        case 0:
+            script += ConsumeScript(fuzzed_data_provider);
+            break;
+        case 1:
+            script = script + ConsumeScript(fuzzed_data_provider);
+            break;
+        case 2:
+            script << fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            break;
+        case 3:
+            script << ConsumeOpcodeType(fuzzed_data_provider);
+            break;
+        case 4:
+            script << ConsumeScriptNum(fuzzed_data_provider);
+            break;
+        case 5:
+            script << ConsumeRandomLengthByteVector(fuzzed_data_provider);
+            break;
+        case 6:
+            script.clear();
+            break;
+        case 7: {
+            (void)script.GetSigOpCount(false);
+            (void)script.GetSigOpCount(true);
+            (void)script.GetSigOpCount(script);
+            (void)script.HasValidOps();
+            (void)script.IsPayToScriptHash();
+            (void)script.IsPayToWitnessScriptHash();
+            (void)script.IsPushOnly();
+            (void)script.IsUnspendable();
+            {
+                CScript::const_iterator pc = script.begin();
+                opcodetype opcode;
+                (void)script.GetOp(pc, opcode);
+                std::vector<uint8_t> data;
+                (void)script.GetOp(pc, opcode, data);
+                (void)script.IsPushOnly(pc);
+            }
+            {
+                int version;
+                std::vector<uint8_t> program;
+                (void)script.IsWitnessProgram(version, program);
+            }
+            break;
+        }
+        }
+    }
+}

--- a/src/test/fuzz/scriptnum_ops.cpp
+++ b/src/test/fuzz/scriptnum_ops.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/script.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <vector>
+
+namespace {
+bool IsValidAddition(const CScriptNum& lhs, const CScriptNum& rhs)
+{
+    return rhs == 0 || (rhs > 0 && lhs <= CScriptNum{std::numeric_limits<int64_t>::max()} - rhs) || (rhs < 0 && lhs >= CScriptNum{std::numeric_limits<int64_t>::min()} - rhs);
+}
+
+bool IsValidSubtraction(const CScriptNum& lhs, const CScriptNum& rhs)
+{
+    return rhs == 0 || (rhs > 0 && lhs >= CScriptNum{std::numeric_limits<int64_t>::min()} + rhs) || (rhs < 0 && lhs <= CScriptNum{std::numeric_limits<int64_t>::max()} + rhs);
+}
+} // namespace
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    CScriptNum script_num = ConsumeScriptNum(fuzzed_data_provider);
+    while (fuzzed_data_provider.remaining_bytes() > 0) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 11)) {
+        case 0: {
+            const int64_t i = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            assert((script_num == i) != (script_num != i));
+            assert((script_num <= i) != script_num > i);
+            assert((script_num >= i) != (script_num < i));
+            // Avoid signed integer overflow:
+            // script/script.h:264:93: runtime error: signed integer overflow: -2261405121394637306 + -9223372036854775802 cannot be represented in type 'long'
+            if (IsValidAddition(script_num, CScriptNum{i})) {
+                assert((script_num + i) - i == script_num);
+            }
+            // Avoid signed integer overflow:
+            // script/script.h:265:93: runtime error: signed integer overflow: 9223371895120855039 - -9223372036854710486 cannot be represented in type 'long'
+            if (IsValidSubtraction(script_num, CScriptNum{i})) {
+                assert((script_num - i) + i == script_num);
+            }
+            break;
+        }
+        case 1: {
+            const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
+            assert((script_num == random_script_num) != (script_num != random_script_num));
+            assert((script_num <= random_script_num) != (script_num > random_script_num));
+            assert((script_num >= random_script_num) != (script_num < random_script_num));
+            // Avoid signed integer overflow:
+            // script/script.h:264:93: runtime error: signed integer overflow: -9223126527765971126 + -9223372036854756825 cannot be represented in type 'long'
+            if (IsValidAddition(script_num, random_script_num)) {
+                assert((script_num + random_script_num) - random_script_num == script_num);
+            }
+            // Avoid signed integer overflow:
+            // script/script.h:265:93: runtime error: signed integer overflow: 6052837899185946624 - -9223372036854775808 cannot be represented in type 'long'
+            if (IsValidSubtraction(script_num, random_script_num)) {
+                assert((script_num - random_script_num) + random_script_num == script_num);
+            }
+            break;
+        }
+        case 2: {
+            const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
+            if (!IsValidAddition(script_num, random_script_num)) {
+                // Avoid assertion failure:
+                // ./script/script.h:292: CScriptNum &CScriptNum::operator+=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) || (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs)' failed.
+                break;
+            }
+            script_num += random_script_num;
+            break;
+        }
+        case 3: {
+            const CScriptNum random_script_num = ConsumeScriptNum(fuzzed_data_provider);
+            if (!IsValidSubtraction(script_num, random_script_num)) {
+                // Avoid assertion failure:
+                // ./script/script.h:300: CScriptNum &CScriptNum::operator-=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) || (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs)' failed.
+                break;
+            }
+            script_num -= random_script_num;
+            break;
+        }
+        case 4:
+            script_num = script_num & fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            break;
+        case 5:
+            script_num = script_num & ConsumeScriptNum(fuzzed_data_provider);
+            break;
+        case 6:
+            script_num &= ConsumeScriptNum(fuzzed_data_provider);
+            break;
+        case 7:
+            if (script_num == CScriptNum{std::numeric_limits<int64_t>::min()}) {
+                // Avoid assertion failure:
+                // ./script/script.h:279: CScriptNum CScriptNum::operator-() const: Assertion `m_value != std::numeric_limits<int64_t>::min()' failed.
+                break;
+            }
+            script_num = -script_num;
+            break;
+        case 8:
+            script_num = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            break;
+        case 9: {
+            const int64_t random_integer = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            if (!IsValidAddition(script_num, CScriptNum{random_integer})) {
+                // Avoid assertion failure:
+                // ./script/script.h:292: CScriptNum &CScriptNum::operator+=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value <= std::numeric_limits<int64_t>::max() - rhs) || (rhs < 0 && m_value >= std::numeric_limits<int64_t>::min() - rhs)' failed.
+                break;
+            }
+            script_num += random_integer;
+            break;
+        }
+        case 10: {
+            const int64_t random_integer = fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            if (!IsValidSubtraction(script_num, CScriptNum{random_integer})) {
+                // Avoid assertion failure:
+                // ./script/script.h:300: CScriptNum &CScriptNum::operator-=(const int64_t &): Assertion `rhs == 0 || (rhs > 0 && m_value >= std::numeric_limits<int64_t>::min() + rhs) || (rhs < 0 && m_value <= std::numeric_limits<int64_t>::max() + rhs)' failed.
+                break;
+            }
+            script_num -= random_integer;
+            break;
+        }
+        case 11:
+            script_num &= fuzzed_data_provider.ConsumeIntegral<int64_t>();
+            break;
+        }
+        // Avoid negation failure:
+        // script/script.h:332:35: runtime error: negation of -9223372036854775808 cannot be represented in type 'int64_t' (aka 'long'); cast to an unsigned type to negate this value to itself
+        if (script_num != CScriptNum{std::numeric_limits<int64_t>::min()}) {
+            (void)script_num.getvch();
+        }
+    }
+}

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -7,9 +7,11 @@
 
 #include <attributes.h>
 #include <optional.h>
+#include <script/script.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <version.h>
 
 #include <cstdint>
@@ -34,6 +36,22 @@ NODISCARD inline Optional<T> ConsumeDeserializable(FuzzedDataProvider& fuzzed_da
         return nullopt;
     }
     return obj;
+}
+
+NODISCARD inline opcodetype ConsumeOpcodeType(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return static_cast<opcodetype>(fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, MAX_OPCODE));
+}
+
+NODISCARD inline CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    const std::vector<uint8_t> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    return {b.begin(), b.end()};
+}
+
+NODISCARD inline CScriptNum ConsumeScriptNum(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return CScriptNum{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
 }
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_H

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -27,7 +27,7 @@ NODISCARD inline std::vector<uint8_t> ConsumeRandomLengthByteVector(FuzzedDataPr
 template <typename T>
 NODISCARD inline Optional<T> ConsumeDeserializable(FuzzedDataProvider& fuzzed_data_provider, size_t max_length = 4096) noexcept
 {
-    const std::vector<uint8_t>& buffer = ConsumeRandomLengthByteVector(fuzzed_data_provider, max_length);
+    const std::vector<uint8_t> buffer = ConsumeRandomLengthByteVector(fuzzed_data_provider, max_length);
     CDataStream ds{buffer, SER_NETWORK, INIT_PROTO_VERSION};
     T obj;
     try {


### PR DESCRIPTION
Add fuzzing harness for `CScript` and `CScriptNum` operations.

Test this PR using:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/script_ops
…
$ src/test/fuzz/scriptnum_ops
…
```