### PR TITLE
test: Remove incorrect assumptions in validation_flush_tests

### DIFF
--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -11,16 +11,16 @@ BOOST_FIXTURE_TEST_SUITE(bswap_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(bswap_tests)
 {
-	// Sibling in bitcoin/src/qt/test/compattests.cpp
-	uint16_t u1 = 0x1234;
-	uint32_t u2 = 0x56789abc;
-	uint64_t u3 = 0xdef0123456789abc;
-	uint16_t e1 = 0x3412;
-	uint32_t e2 = 0xbc9a7856;
-	uint64_t e3 = 0xbc9a78563412f0de;
-	BOOST_CHECK(bswap_16(u1) == e1);
-	BOOST_CHECK(bswap_32(u2) == e2);
-	BOOST_CHECK(bswap_64(u3) == e3);
+    // Sibling in bitcoin/src/qt/test/compattests.cpp
+    uint16_t u1 = 0x1234;
+    uint32_t u2 = 0x56789abc;
+    uint64_t u3 = 0xdef0123456789abc;
+    uint16_t e1 = 0x3412;
+    uint32_t e2 = 0xbc9a7856;
+    uint64_t e3 = 0xbc9a78563412f0de;
+    BOOST_CHECK(bswap_16(u1) == e1);
+    BOOST_CHECK(bswap_32(u2) == e2);
+    BOOST_CHECK(bswap_64(u3) == e3);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -122,10 +122,9 @@ BOOST_AUTO_TEST_CASE(tx_valid)
             std::map<COutPoint, int64_t> mapprevOutValues;
             UniValue inputs = test[0].get_array();
             bool fValid = true;
-	    for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
-	        const UniValue& input = inputs[inpIdx];
-                if (!input.isArray())
-                {
+            for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
+                const UniValue& input = inputs[inpIdx];
+                if (!input.isArray()) {
                     fValid = false;
                     break;
                 }
@@ -209,10 +208,9 @@ BOOST_AUTO_TEST_CASE(tx_invalid)
             std::map<COutPoint, int64_t> mapprevOutValues;
             UniValue inputs = test[0].get_array();
             bool fValid = true;
-	    for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
-	        const UniValue& input = inputs[inpIdx];
-                if (!input.isArray())
-                {
+            for (unsigned int inpIdx = 0; inpIdx < inputs.size(); inpIdx++) {
+                const UniValue& input = inputs[inpIdx];
+                if (!input.isArray()) {
                     fValid = false;
                     break;
                 }


### PR DESCRIPTION
The tests assume standard library internals that may not hold on all supported archs or when the code is instrumented for sanitizer or debug use cases

Fixes #18111 