### PR TITLE
Add macOS notarization (including stapling)

### DIFF
--- a/contrib/gitian-descriptors/gitian-osx-signer.yml
+++ b/contrib/gitian-descriptors/gitian-osx-signer.yml
@@ -12,6 +12,7 @@ remotes:
   "dir": "signature"
 files:
 - "bitcoin-osx-unsigned.tar.gz"
+- "signature-osx.tar.gz"
 script: |
   set -e -o pipefail
 
@@ -32,6 +33,13 @@ script: |
 
   UNSIGNED=bitcoin-osx-unsigned.tar.gz
   SIGNED=bitcoin-osx-signed.dmg
+
+  # use local signatures if present
+  if [ -f signature-osx.tar.gz ]
+  then
+    mkdir -p signature
+    tar -xzf signature-osx.tar.gz -C signature
+  fi
 
   tar -xf ${UNSIGNED}
   OSX_VOLNAME="$(cat osx_volname)"

--- a/contrib/macdeploy/detached-sig-create.sh
+++ b/contrib/macdeploy/detached-sig-create.sh
@@ -23,7 +23,7 @@ fi
 rm -rf ${TEMPDIR} ${TEMPLIST}
 mkdir -p ${TEMPDIR}
 
-${CODESIGN} -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
+${CODESIGN} --options runtime --timestamp -f --file-list ${TEMPLIST} "$@" "${BUNDLE}"
 
 grep -v CodeResources < "${TEMPLIST}" | while read i; do
   TARGETFILE="${BUNDLE}/$(echo "${i}" | sed "s|.*${BUNDLE}/||")"

--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -203,7 +203,20 @@ Codesigner only: Sign the macOS binary:
     tar xf bitcoin-osx-unsigned.tar.gz
     ./detached-sig-create.sh -s "Key ID"
     Enter the keychain password and authorize the signature
-    Move signature-osx.tar.gz back to the gitian host
+
+Now a manual deterministic disk image (dmg) creation is required (gbuilt with `gitian-osx-signer.yml` while having the signatures.tar.gz file in the inputs)
+
+notarize the disk image:
+
+    xcrun altool --notarize-app --primary-bundle-id "org.bitcoinfoundation.Bitcoin-Qt" -u "<code-signer-apple-developer-account-username>" -p "<password>" --file bitcoin-${VERSION}-osx.dmg
+
+The notarization takes a few minutes. Check the status:
+
+    xcrun altool --notarization-info <RequestUUID-from-notarize-app-step> -u "<code-signer-apple-developer-account-username>" -p "<password>"
+
+Staple the notarization ticket onto the application
+
+    xcrun stapler staple dist/Bitcoin-Qt.app
 
 Codesigner only: Sign the windows binaries:
 
@@ -215,10 +228,12 @@ Codesigner only: Sign the windows binaries:
 Codesigner only: Commit the detached codesign payloads:
 
     cd ~/bitcoin-detached-sigs
-    checkout the appropriate branch for this release series
+    #checkout the appropriate branch for this release series
     rm -rf *
     tar xf signature-osx.tar.gz
     tar xf signature-win.tar.gz
+    #copy the notarization ticket
+    cp dist/Bitcoin-Qt.app/Contents/CodeResources osx/dist/Bitcoin-Qt.app/Contents/
     git add -a
     git commit -m "point to ${VERSION}"
     git tag -s v${VERSION} HEAD


### PR DESCRIPTION
fixes #15774.

Adds runtime hardening (which is necessary for macOS app notarization)
https://developer.apple.com/documentation/security/hardened_runtime

Notarization doc:
https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution

Hardened Runtime doc:
https://developer.apple.com/documentation/security/hardened_runtime

App Notarization has been tested [here](https://github.com/bitcoin/bitcoin/pull/18171#issuecomment-587488838) and [here](https://github.com/bitcoin/bitcoin/issues/15774#issuecomment-585331276)

Additional release process notes are included.

Needs backport.