### PR TITLE
Add error handling to all boost filesystem functions

### DIFF
--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -133,7 +133,7 @@ CDBWrapper::CDBWrapper(const fs::path& path, size_t nCacheSize, bool fMemory, bo
             leveldb::Status result = leveldb::DestroyDB(path.string(), options);
             dbwrapper_private::HandleError(result);
         }
-        TryCreateDirectories(path);
+        assert(TryCreateDirectories(path));
         LogPrintf("Opening LevelDB in %s\n", path.string());
     }
     leveldb::Status status = leveldb::DB::Open(options, path.string(), &pdb);

--- a/src/flatfile.cpp
+++ b/src/flatfile.cpp
@@ -36,7 +36,12 @@ FILE* FlatFileSeq::Open(const FlatFilePos& pos, bool read_only)
         return nullptr;
     }
     fs::path path = FileName(pos);
-    fs::create_directories(path.parent_path());
+    boost::system::error_code ec;
+    fs::create_directories(path.parent_path(), ec);
+    if (ec) {
+        LogPrintf("%s: fs::create_directories: %s %s\n", __func__, ec.message(), path.parent_path().string());
+        return nullptr;
+    }
     FILE* file = fsbridge::fopen(path, read_only ? "rb": "rb+");
     if (!file && !read_only)
         file = fsbridge::fopen(path, "wb+");

--- a/src/index/blockfilterindex.cpp
+++ b/src/index/blockfilterindex.cpp
@@ -104,7 +104,12 @@ BlockFilterIndex::BlockFilterIndex(BlockFilterType filter_type,
     if (filter_name.empty()) throw std::invalid_argument("unknown filter_type");
 
     fs::path path = GetDataDir() / "indexes" / "blockfilter" / filter_name;
-    fs::create_directories(path);
+    boost::system::error_code ec;
+    fs::create_directories(path, ec);
+    if (ec) {
+        LogPrintf("%s: fs::create_directories: %s %s\n", __func__, ec.message(), path.string());
+        return;
+    }
 
     m_name = filter_name + " block filter index";
     m_db = MakeUnique<BaseIndex::DB>(path / "db", n_cache_size, f_memory, f_wipe);

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -315,9 +315,8 @@ void BCLog::Logger::ShrinkDebugFile()
 
     // Special files (e.g. device nodes) may not have a size.
     size_t log_size = 0;
-    try {
-        log_size = fs::file_size(m_file_path);
-    } catch (const fs::filesystem_error&) {}
+    boost::system::error_code ec;
+    log_size = fs::file_size(m_file_path, ec);
 
     // If debug.log file is more than 10% bigger the RECENT_DEBUG_HISTORY_SIZE
     // trim it down by saving only the last RECENT_DEBUG_HISTORY_SIZE bytes

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2300,7 +2300,8 @@ UniValue dumptxoutset(const JSONRPCRequest& request)
     // to avoid confusion due to an interruption.
     fs::path temppath = fs::absolute(request.params[0].get_str() + ".incomplete", GetDataDir());
 
-    if (fs::exists(path)) {
+    boost::system::error_code ec;
+    if (fs::exists(path, ec)) {
         throw JSONRPCError(
             RPC_INVALID_PARAMETER,
             path.string() + " already exists. If you are sure this is what you want, "
@@ -2361,7 +2362,11 @@ UniValue dumptxoutset(const JSONRPCRequest& request)
     }
 
     afile.fclose();
-    fs::rename(temppath, path);
+    fs::rename(temppath, path, ec);
+    if (ec) {
+        LogPrintf("%s: %s %s %s\n", __func__, ec.message(), temppath.string(), path.string());
+        path = temppath;
+    }
 
     UniValue result(UniValue::VOBJ);
     result.pushKV("coins_written", stats.coins_count);

--- a/src/rpc/request.cpp
+++ b/src/rpc/request.cpp
@@ -123,10 +123,10 @@ bool GetAuthCookie(std::string *cookie_out)
 
 void DeleteAuthCookie()
 {
-    try {
-        fs::remove(GetAuthCookieFile());
-    } catch (const fs::filesystem_error& e) {
-        LogPrintf("%s: Unable to remove random auth cookie file: %s\n", __func__, fsbridge::get_filesystem_error_message(e));
+    boost::system::error_code ec;
+    fs::remove(GetAuthCookieFile(), ec);
+    if (ec) {
+        LogPrintf("%s: Unable to remove random auth cookie file: %s %s\n", __func__, ec.message(), GetAuthCookieFile().string());
     }
 }
 

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -68,7 +68,14 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
  */
 void ReleaseDirectoryLocks();
 
-bool TryCreateDirectories(const fs::path& p);
+typedef enum TryCreateDirectoriesStatus_t
+{
+    TRY_CREATE_DIRECTORIES_FAILED = 0, // Failed to create directory
+    TRY_CREATE_DIRECTORIES_OK = 1,     // New directory created
+    TRY_CREATE_DIRECTORIES_EXISTS = 2, // Directory already exists
+} TryCreateDirectoriesStatus;
+
+TryCreateDirectoriesStatus TryCreateDirectories(const fs::path& p);
 fs::path GetDefaultDataDir();
 // The blocks directory is always net specific.
 const fs::path &GetBlocksDir();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3909,9 +3909,18 @@ void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune)
 {
     for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it) {
         FlatFilePos pos(*it, 0);
-        fs::remove(BlockFileSeq().FileName(pos));
-        fs::remove(UndoFileSeq().FileName(pos));
-        LogPrintf("Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
+        boost::system::error_code ec;
+        fs::remove(BlockFileSeq().FileName(pos), ec);
+        if (!ec) {
+            fs::remove(UndoFileSeq().FileName(pos), ec);
+            if (!ec) {
+                LogPrintf("Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
+            } else {
+                LogPrintf("Prune: %s unable to remove undo file: %s %s\n", __func__, ec.message(), UndoFileSeq().FileName(pos).string());
+            }
+        } else {
+            LogPrintf("Prune: %s unable to remove block file: %s %s\n", __func__, ec.message(), BlockFileSeq().FileName(pos).string());
+        }
     }
 }
 

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -19,10 +19,11 @@ bool VerifyWallets(interfaces::Chain& chain, const std::vector<std::string>& wal
         boost::system::error_code error;
         // The canonical path cleans the path, preventing >1 Berkeley environment instances for the same directory
         fs::path canonical_wallet_dir = fs::canonical(wallet_dir, error);
-        if (error || !fs::exists(wallet_dir)) {
+        boost::system::error_code ec;
+        if (error || !fs::exists(wallet_dir, ec)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" does not exist").translated, wallet_dir.string()));
             return false;
-        } else if (!fs::is_directory(wallet_dir)) {
+        } else if (!fs::is_directory(wallet_dir, ec)) {
             chain.initError(strprintf(_("Specified -walletdir \"%s\" is not a directory").translated, wallet_dir.string()));
             return false;
         // The canonical path transforms relative paths into absolute ones, so we check the non-canonical version

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -763,7 +763,8 @@ UniValue dumpwallet(const JSONRPCRequest& request)
      * https://github.com/bitcoin/bitcoin/issues/9934
      * It may also avoid other security issues.
      */
-    if (fs::exists(filepath)) {
+    boost::system::error_code ec;
+    if (fs::exists(filepath, ec)) {
         throw JSONRPCError(RPC_INVALID_PARAMETER, filepath.string() + " already exists. If you are sure this is what you want, move it out of the way first");
     }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2584,12 +2584,13 @@ static UniValue loadwallet(const JSONRPCRequest& request)
 
     WalletLocation location(request.params[0].get_str());
 
+    boost::system::error_code ec;
     if (!location.Exists()) {
         throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Wallet " + location.GetName() + " not found.");
-    } else if (fs::is_directory(location.GetPath())) {
+    } else if (fs::is_directory(location.GetPath(), ec)) {
         // The given filename is a directory. Check that there's a wallet.dat file.
         fs::path wallet_dat_file = location.GetPath() / "wallet.dat";
-        if (fs::symlink_status(wallet_dat_file).type() == fs::file_not_found) {
+        if (fs::symlink_status(wallet_dat_file, ec).type() == fs::file_not_found) {
             throw JSONRPCError(RPC_WALLET_NOT_FOUND, "Directory " + location.GetName() + " does not contain a wallet.dat file.");
         }
     }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3599,9 +3599,10 @@ bool CWallet::Verify(interfaces::Chain& chain, const WalletLocation& location, b
     // 4. For backwards compatibility, the name of a data file in -walletdir.
     LOCK(cs_wallets);
     const fs::path& wallet_path = location.GetPath();
-    fs::file_type path_type = fs::symlink_status(wallet_path).type();
+    boost::system::error_code ec;
+    fs::file_type path_type = fs::symlink_status(wallet_path, ec).type();
     if (!(path_type == fs::file_not_found || path_type == fs::directory_file ||
-          (path_type == fs::symlink_file && fs::is_directory(wallet_path)) ||
+          (path_type == fs::symlink_file && fs::is_directory(wallet_path, ec)) ||
           (path_type == fs::regular_file && fs::path(location.GetName()).filename() == location.GetName()))) {
         error_string = strprintf(
               "Invalid -wallet path '%s'. -wallet path should point to a directory where wallet.dat and "

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -21,7 +21,8 @@ static void WalletToolReleaseWallet(CWallet* wallet)
 
 static std::shared_ptr<CWallet> CreateWallet(const std::string& name, const fs::path& path)
 {
-    if (fs::exists(path)) {
+    boost::system::error_code ec;
+    if (fs::exists(path, ec)) {
         tfm::format(std::cerr, "Error: File exists already\n");
         return nullptr;
     }
@@ -49,7 +50,8 @@ static std::shared_ptr<CWallet> CreateWallet(const std::string& name, const fs::
 
 static std::shared_ptr<CWallet> LoadWallet(const std::string& name, const fs::path& path)
 {
-    if (!fs::exists(path)) {
+    boost::system::error_code ec;
+    if (!fs::exists(path, ec)) {
         tfm::format(std::cerr, "Error: Wallet files does not exist\n");
         return nullptr;
     }
@@ -113,7 +115,8 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
             wallet_instance->Flush(true);
         }
     } else if (command == "info") {
-        if (!fs::exists(path)) {
+        boost::system::error_code ec;
+        if (!fs::exists(path, ec)) {
             tfm::format(std::cerr, "Error: no wallet file at %s\n", name);
             return false;
         }

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -89,7 +89,7 @@ class MultiWalletTest(BitcoinTestFramework):
             assert_equal(os.path.isfile(wallet_file(wallet_name)), True)
 
         # should not initialize if wallet path can't be created
-        exp_stderr = "boost::filesystem::create_directory:"
+        exp_stderr = "Error: Error initializing wallet database environment"
         self.nodes[0].assert_start_raises_init_error(['-wallet=wallet.dat/bad'], exp_stderr, match=ErrorMatch.PARTIAL_REGEX)
 
         self.nodes[0].assert_start_raises_init_error(['-walletdir=wallets'], 'Error: Specified -walletdir "wallets" does not exist')

--- a/test/lint/lint-boost-filesystem-parameters.sh
+++ b/test/lint/lint-boost-filesystem-parameters.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Check that all boost filesystem functions have necessary parameters, tests excluded
+
+export LC_ALL=C
+
+check_params () {
+    RET_VAL=""
+    EXPECTED=$(echo $2 | grep -o "," | tr -d "\n")
+    GREP=$(git grep -n "$1(" -- "*.cpp")
+    IFS=$'\n'
+
+    for LINE in ${GREP}
+    do
+        # tests should not be checked
+        if [[ ${LINE} != *"/test/"* ]]; then
+            PARAMS=$(echo ${LINE} | grep -oP "(?<=$1\()([^|&{]+)(?=[|&{(\n)])")
+            COUNT=$(echo ${PARAMS} | grep -o "," | tr -d "\n")
+            if [[ $2 == *"fs::"* ]] && [[ ${PARAMS} != *"fs::"* ]]; then
+                ${COUNT}=,${COUNT}
+            fi
+            if [[ ${#COUNT} -lt ${#EXPECTED} ]]; then
+                RET_VAL+=${LINE}${IFS};
+            fi
+        fi
+    done
+
+    if [[ ${RET_VAL} != "" ]]; then
+        echo "All calls to $1() should use error_code parameter"
+        echo
+        echo "${RET_VAL}"
+        echo
+        echo "Expected use:"
+        echo "    boost::system::error_code ec;"
+        echo "    retval = $1($2);"
+        echo "    if (ec) {"
+        echo "        ..."
+        echo "    }"
+        exit 1
+    fi
+}
+
+
+check_params "fs::canonical" "path, ec"
+#check_params "fs::canonical" "path, base, ec"
+
+check_params "fs::copy" "from, to, ec"
+check_params "fs::copy_directory" "from, to, ec"
+
+# optional fs:: parameters can be detected
+check_params "fs::copy_file" "pathFrom, pathTo[, fs::copy_option], ec"
+
+check_params "fs::copy_symlink" "existingSymlink, newSymlink, ec"
+check_params "fs::create_directories" "path, ec"
+check_params "fs::create_directory" "path, ec"
+check_params "fs::create_directory_symlink" "pathTo, newSymlink, ec"
+check_params "fs::create_hardlink" "pathTo, newHardLink, ec"
+check_params "fs::create_symlink" "pathTo, newSymlink, ec"
+
+# at least error_code parameter
+check_params "fs::current_path" "ec"
+# path is mandatory if used standalone
+check_params "  fs::current_path" "path, ec"
+
+check_params " = fs::directory_iterator" "path, ec"
+
+check_params "fs::exists" "path, ec"
+check_params "fs::equivalent" "path1, path2, ec"
+check_params "fs::file_size" "path, ec"
+check_params "fs::hard_link_count" "path, ec"
+check_params "fs::initial_path" "ec"
+check_params "fs::is_directory" "path, ec"
+check_params "fs::is_empty" "path, ec"
+check_params "fs::is_other" "path, ec"
+check_params "fs::is_regular_file" "path, ec"
+check_params "fs::is_symlink" "path, ec"
+check_params "fs::last_write_time" "path, new_time, ec"
+check_params "fs::read_symlink" "path, ec"
+
+# variable number of parameters
+#check_params "fs::relative" "path, ec"
+#check_params "fs::relative" "path, base, ec"
+
+check_params "fs::remove" "path, ec"
+check_params "fs::remove_all" "path, ec"
+check_params "fs::rename" "from, to, ec"
+
+check_params " = fs::recursive_directory_iterator" "path, ec"
+
+check_params "fs::resize_file" "path, size, ec"
+check_params "fs::space" "path, ec"
+check_params "fs::status" "path, ec"
+check_params "fs::symlink_status" "path, ec"
+check_params "fs::system_complete" "path, ec"
+check_params "fs::temp_directory_path" "ec"
+
+# error code not necessary for default model
+#check_params "fs::unique_path" "model, ec"
+
+check_params "fs::weakly_canonical" "path, ec"


### PR DESCRIPTION
All boost filesystem functions should be handled using error code to prevent random crashes caused by inaccesible files or directories. Increment in iterator should use separate error code variable because it have to be handled specifically to prevent infinite loop in diving to inaccessible directories.

To prevent coding errors in future the lint test is added to check if error code parameters are present.

Previous conversation about issue in #18095
