### PR TITLE
Bugfix: GUI: Remove broken ability to edit the address field in the sending address book

### DIFF
--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -250,36 +250,6 @@ bool AddressTableModel::setData(const QModelIndex &index, const QVariant &value,
                 return false;
             }
             walletModel->wallet().setAddressBook(curAddress, value.toString().toStdString(), strPurpose);
-        } else if(index.column() == Address) {
-            CTxDestination newAddress = DecodeDestination(value.toString().toStdString());
-            // Refuse to set invalid address, set error status and return false
-            if(boost::get<CNoDestination>(&newAddress))
-            {
-                editStatus = INVALID_ADDRESS;
-                return false;
-            }
-            // Do nothing, if old address == new address
-            else if(newAddress == curAddress)
-            {
-                editStatus = NO_CHANGES;
-                return false;
-            }
-            // Check for duplicate addresses to prevent accidental deletion of addresses, if you try
-            // to paste an existing address over another address (with a different label)
-            if (walletModel->wallet().getAddress(
-                    newAddress, /* name= */ nullptr, /* is_mine= */ nullptr, /* purpose= */ nullptr))
-            {
-                editStatus = DUPLICATE_ADDRESS;
-                return false;
-            }
-            // Double-check that we're not overwriting a receiving address
-            else if(rec->type == AddressTableEntry::Sending)
-            {
-                // Remove old entry
-                walletModel->wallet().delAddressBook(curAddress);
-                // Add new entry with new address
-                walletModel->wallet().setAddressBook(newAddress, value.toString().toStdString(), strPurpose);
-            }
         }
         return true;
     }

--- a/src/qt/addresstablemodel.cpp
+++ b/src/qt/addresstablemodel.cpp
@@ -307,9 +307,7 @@ Qt::ItemFlags AddressTableModel::flags(const QModelIndex &index) const
     Qt::ItemFlags retval = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
     // Can edit address and label for sending addresses,
     // and only label for receiving addresses.
-    if(rec->type == AddressTableEntry::Sending ||
-      (rec->type == AddressTableEntry::Receiving && index.column()==Label))
-    {
+    if ((rec->type == AddressTableEntry::Sending || rec->type == AddressTableEntry::Receiving) && index.column() == Label) {
         retval |= Qt::ItemIsEditable;
     }
     return retval;

--- a/src/qt/editaddressdialog.cpp
+++ b/src/qt/editaddressdialog.cpp
@@ -34,6 +34,7 @@ EditAddressDialog::EditAddressDialog(Mode _mode, QWidget *parent) :
         break;
     case EditSendingAddress:
         setWindowTitle(tr("Edit sending address"));
+        ui->addressEdit->setEnabled(false);
         break;
     }
 

--- a/src/qt/forms/addressbookpage.ui
+++ b/src/qt/forms/addressbookpage.ui
@@ -34,7 +34,7 @@
       <enum>Qt::CustomContextMenu</enum>
      </property>
      <property name="toolTip">
-      <string>Right-click to edit address or label</string>
+      <string>Right-click to edit label</string>
      </property>
      <property name="tabKeyNavigation">
       <bool>false</bool>


### PR DESCRIPTION
Apparently in the sending address book, it is possible to edit the address field of an address/label row.

Doing so, however, has 2 pretty big bugs:

**Bug 1** (since 0.17, #10244): Instead of moving the label, the new address's label was set to the new address itself, and the actual label was lost completely.

**Bug 2** (effectively since 0.19, #13756): All metadata associated with the old address (prior to edit) is deleted, except for label and purpose. Probably some should remain with the old address (eg, whether the associated key was used to spend already), and others should be moved to the new address (no existing cases, just hypothetically). I doubt we should ever just outright delete it.

Edit: **Bug 3** (unconfirmed, debatable): Editing both the label and address in the label-editing dialog would still delete the label for the old address.

**Proposed resolution**: Remove the ability to edit the address field. It doesn't really make sense.
