### PR TITLE
test: Add cost_of_change parameter assertions to bnb_search_test

### DIFF
--- a/src/wallet/test/coinselector_tests.cpp
+++ b/src/wallet/test/coinselector_tests.cpp
@@ -189,6 +189,19 @@ BOOST_AUTO_TEST_CASE(bnb_search_test)
     actual_selection.clear();
     selection.clear();
 
+    // Cost of change is greater than the difference between target value and utxo sum
+    add_coin(1 * CENT, 1, actual_selection);
+    BOOST_CHECK(SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0.5 * CENT, selection, value_ret, not_input_fees));
+    BOOST_CHECK_EQUAL(value_ret, 1 * CENT);
+    BOOST_CHECK(equal_sets(selection, actual_selection));
+    actual_selection.clear();
+    selection.clear();
+
+    // Cost of change is less than the difference between target value and utxo sum
+    BOOST_CHECK(!SelectCoinsBnB(GroupCoins(utxo_pool), 0.9 * CENT, 0, selection, value_ret, not_input_fees));
+    actual_selection.clear();
+    selection.clear();
+
     // Select 10 Cent
     add_coin(5 * CENT, 5, utxo_pool);
     add_coin(4 * CENT, 4, actual_selection);


### PR DESCRIPTION
If the `cost_of_change` variable is removed from the method body `SelectCoinsBnB`, there are currently no failing unit tests.  This PR adds assertions about the behavior of the `cost_of_change`:  If the cost of creating a change output is greater than what's leftover, then consume the output and create no change, otherwise, don't consume the output (no match found).
