### PR TITLE
test, build: Enable -Werror=sign-compare

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -367,6 +367,7 @@ if test "x$enable_werror" = "xyes"; then
   AX_CHECK_COMPILE_FLAG([-Werror=date-time],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=date-time"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=return-type],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=return-type"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Werror=conditional-uninitialized],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=conditional-uninitialized"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Werror=sign-compare],[ERROR_CXXFLAGS="$ERROR_CXXFLAGS -Werror=sign-compare"],,[[$CXXFLAG_WERROR]])
 fi
 
 if test "x$CXXFLAGS_overridden" = "xno"; then
@@ -383,6 +384,7 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wunused-variable],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wunused-variable"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wdate-time],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wdate-time"],,[[$CXXFLAG_WERROR]])
   AX_CHECK_COMPILE_FLAG([-Wconditional-uninitialized],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wconditional-uninitialized"],,[[$CXXFLAG_WERROR]])
+  AX_CHECK_COMPILE_FLAG([-Wsign-compare],[WARN_CXXFLAGS="$WARN_CXXFLAGS -Wsign-compare"],,[[$CXXFLAG_WERROR]])
 
   dnl Some compilers (gcc) ignore unknown -Wno-* options, but warn about all
   dnl unknown options if any other warning is produced. Test the -Wfoo case, and

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -43,8 +43,8 @@ static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex
     BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
                                                    filter_hashes));
 
-    BOOST_CHECK_EQUAL(filters.size(), 1);
-    BOOST_CHECK_EQUAL(filter_hashes.size(), 1);
+    BOOST_CHECK_EQUAL(filters.size(), 1U);
+    BOOST_CHECK_EQUAL(filter_hashes.size(), 1U);
 
     BOOST_CHECK_EQUAL(filter.GetHash(), expected_filter.GetHash());
     BOOST_CHECK_EQUAL(filter_header, expected_filter.ComputeHeader(last_header));
@@ -255,8 +255,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     BOOST_CHECK(filter_index.LookupFilterRange(0, tip, filters));
     BOOST_CHECK(filter_index.LookupFilterHashRange(0, tip, filter_hashes));
 
-    BOOST_CHECK_EQUAL(filters.size(), tip->nHeight + 1);
-    BOOST_CHECK_EQUAL(filter_hashes.size(), tip->nHeight + 1);
+    assert(tip->nHeight >= 0);
+    BOOST_CHECK_EQUAL(filters.size(), tip->nHeight + 1U);
+    BOOST_CHECK_EQUAL(filter_hashes.size(), tip->nHeight + 1U);
 
     filters.clear();
     filter_hashes.clear();

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -42,14 +42,14 @@ BOOST_AUTO_TEST_CASE(gcsfilter_test)
 BOOST_AUTO_TEST_CASE(gcsfilter_default_constructor)
 {
     GCSFilter filter;
-    BOOST_CHECK_EQUAL(filter.GetN(), 0);
-    BOOST_CHECK_EQUAL(filter.GetEncoded().size(), 1);
+    BOOST_CHECK_EQUAL(filter.GetN(), 0U);
+    BOOST_CHECK_EQUAL(filter.GetEncoded().size(), 1U);
 
     const GCSFilter::Params& params = filter.GetParams();
-    BOOST_CHECK_EQUAL(params.m_siphash_k0, 0);
-    BOOST_CHECK_EQUAL(params.m_siphash_k1, 0);
+    BOOST_CHECK_EQUAL(params.m_siphash_k0, 0U);
+    BOOST_CHECK_EQUAL(params.m_siphash_k1, 0U);
     BOOST_CHECK_EQUAL(params.m_P, 0);
-    BOOST_CHECK_EQUAL(params.m_M, 1);
+    BOOST_CHECK_EQUAL(params.m_M, 1U);
 }
 
 BOOST_AUTO_TEST_CASE(blockfilter_basic_test)

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -488,7 +488,7 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
             ++nHits;
     }
     // Expect about 100 hits
-    BOOST_CHECK_EQUAL(nHits, 75);
+    BOOST_CHECK_EQUAL(nHits, 75U);
 
     BOOST_CHECK(rb1.contains(data[DATASIZE-1]));
     rb1.reset();
@@ -516,7 +516,7 @@ BOOST_AUTO_TEST_CASE(rolling_bloom)
             ++nHits;
     }
     // Expect about 5 false positives
-    BOOST_CHECK_EQUAL(nHits, 6);
+    BOOST_CHECK_EQUAL(nHits, 6U);
 
     // last-1000-entry, 0.01% false positive:
     CRollingBloomFilter rb2(1000, 0.001);

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -70,14 +70,14 @@ BOOST_AUTO_TEST_CASE(compress_script_to_ckey_id)
     CPubKey pubkey = key.GetPubKey();
 
     CScript script = CScript() << OP_DUP << OP_HASH160 << ToByteVector(pubkey.GetID()) << OP_EQUALVERIFY << OP_CHECKSIG;
-    BOOST_CHECK_EQUAL(script.size(), 25);
+    BOOST_CHECK_EQUAL(script.size(), 25U);
 
     std::vector<unsigned char> out;
     bool done = CompressScript(script, out);
     BOOST_CHECK_EQUAL(done, true);
 
     // Check compressed script
-    BOOST_CHECK_EQUAL(out.size(), 21);
+    BOOST_CHECK_EQUAL(out.size(), 21U);
     BOOST_CHECK_EQUAL(out[0], 0x00);
     BOOST_CHECK_EQUAL(memcmp(&out[1], &script[3], 20), 0); // compare the 20 relevant chars of the CKeyId in the script
 }
@@ -87,14 +87,14 @@ BOOST_AUTO_TEST_CASE(compress_script_to_cscript_id)
     // case CScriptID
     CScript script, redeemScript;
     script << OP_HASH160 << ToByteVector(CScriptID(redeemScript)) << OP_EQUAL;
-    BOOST_CHECK_EQUAL(script.size(), 23);
+    BOOST_CHECK_EQUAL(script.size(), 23U);
 
     std::vector<unsigned char> out;
     bool done = CompressScript(script, out);
     BOOST_CHECK_EQUAL(done, true);
 
     // Check compressed script
-    BOOST_CHECK_EQUAL(out.size(), 21);
+    BOOST_CHECK_EQUAL(out.size(), 21U);
     BOOST_CHECK_EQUAL(out[0], 0x01);
     BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 20), 0); // compare the 20 relevant chars of the CScriptId in the script
 }
@@ -105,14 +105,14 @@ BOOST_AUTO_TEST_CASE(compress_script_to_compressed_pubkey_id)
     key.MakeNewKey(true); // case compressed PubKeyID
 
     CScript script = CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG; // COMPRESSED_PUBLIC_KEY_SIZE (33)
-    BOOST_CHECK_EQUAL(script.size(), 35);
+    BOOST_CHECK_EQUAL(script.size(), 35U);
 
     std::vector<unsigned char> out;
     bool done = CompressScript(script, out);
     BOOST_CHECK_EQUAL(done, true);
 
     // Check compressed script
-    BOOST_CHECK_EQUAL(out.size(), 33);
+    BOOST_CHECK_EQUAL(out.size(), 33U);
     BOOST_CHECK_EQUAL(memcmp(&out[0], &script[1], 1), 0);
     BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 32), 0); // compare the 32 chars of the compressed CPubKey
 }
@@ -122,14 +122,14 @@ BOOST_AUTO_TEST_CASE(compress_script_to_uncompressed_pubkey_id)
     CKey key;
     key.MakeNewKey(false); // case uncompressed PubKeyID
     CScript script =  CScript() << ToByteVector(key.GetPubKey()) << OP_CHECKSIG; // PUBLIC_KEY_SIZE (65)
-    BOOST_CHECK_EQUAL(script.size(), 67);                   // 1 char code + 65 char pubkey + OP_CHECKSIG
+    BOOST_CHECK_EQUAL(script.size(), 67U);                   // 1 char code + 65 char pubkey + OP_CHECKSIG
 
     std::vector<unsigned char> out;
     bool done = CompressScript(script, out);
     BOOST_CHECK_EQUAL(done, true);
 
     // Check compressed script
-    BOOST_CHECK_EQUAL(out.size(), 33);
+    BOOST_CHECK_EQUAL(out.size(), 33U);
     BOOST_CHECK_EQUAL(memcmp(&out[1], &script[2], 32), 0); // first 32 chars of CPubKey are copied into out[1:]
     BOOST_CHECK_EQUAL(out[0], 0x04 | (script[65] & 0x01)); // least significant bit (lsb) of last char of pubkey is mapped into out[0]
 }

--- a/src/test/descriptor_tests.cpp
+++ b/src/test/descriptor_tests.cpp
@@ -232,7 +232,7 @@ void DoCheck(const std::string& prv, const std::string& pub, int flags, const st
                 std::vector<CScript> spks_inferred;
                 FlatSigningProvider provider_inferred;
                 BOOST_CHECK(inferred->Expand(0, provider_inferred, spks_inferred, provider_inferred));
-                BOOST_CHECK_EQUAL(spks_inferred.size(), 1);
+                BOOST_CHECK_EQUAL(spks_inferred.size(), 1U);
                 BOOST_CHECK(spks_inferred[0] == spks[n]);
                 BOOST_CHECK_EQUAL(IsSolvable(provider_inferred, spks_inferred[0]), !(flags & UNSOLVABLE));
                 BOOST_CHECK(provider_inferred.origins == script_provider.origins);

--- a/src/test/flatfile_tests.cpp
+++ b/src/test/flatfile_tests.cpp
@@ -93,16 +93,16 @@ BOOST_AUTO_TEST_CASE(flatfile_allocate)
 
     bool out_of_space;
 
-    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), 100);
-    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 0))), 100);
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 0), 1, out_of_space), 100U);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 0))), 100U);
     BOOST_CHECK(!out_of_space);
 
-    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 1, out_of_space), 0);
-    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 100);
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 1, out_of_space), 0U);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 100U);
     BOOST_CHECK(!out_of_space);
 
-    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 2, out_of_space), 101);
-    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 200);
+    BOOST_CHECK_EQUAL(seq.Allocate(FlatFilePos(0, 99), 2, out_of_space), 101U);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 99))), 200U);
     BOOST_CHECK(!out_of_space);
 }
 
@@ -116,11 +116,11 @@ BOOST_AUTO_TEST_CASE(flatfile_flush)
 
     // Flush without finalize should not truncate file.
     seq.Flush(FlatFilePos(0, 1));
-    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 100);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 100U);
 
     // Flush with finalize should truncate file.
     seq.Flush(FlatFilePos(0, 1), true);
-    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 1);
+    BOOST_CHECK_EQUAL(fs::file_size(seq.FileName(FlatFilePos(0, 1))), 1U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -393,7 +393,7 @@ BOOST_AUTO_TEST_CASE(netpermissions_test)
     BOOST_CHECK(NetWhitelistPermissions::TryParse("bloom,forcerelay,noban,relay,mempool@1.2.3.4/32", whitelistPermissions, error));
 
     const auto strings = NetPermissions::ToStrings(PF_ALL);
-    BOOST_CHECK_EQUAL(strings.size(), 5);
+    BOOST_CHECK_EQUAL(strings.size(), 5U);
     BOOST_CHECK(std::find(strings.begin(), strings.end(), "bloomfilter") != strings.end());
     BOOST_CHECK(std::find(strings.begin(), strings.end(), "forcerelay") != strings.end());
     BOOST_CHECK(std::find(strings.begin(), strings.end(), "relay") != strings.end());

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(shuffle_stat_test)
     }
     BOOST_CHECK(chi_score > 58.1411); // 99.9999% confidence interval
     BOOST_CHECK(chi_score < 210.275);
-    BOOST_CHECK_EQUAL(sum, 12000);
+    BOOST_CHECK_EQUAL(sum, 12000U);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/streams_tests.cpp
+++ b/src/test/streams_tests.cpp
@@ -72,28 +72,28 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     std::vector<unsigned char> vch = {1, 255, 3, 4, 5, 6};
 
     VectorReader reader(SER_NETWORK, INIT_PROTO_VERSION, vch, 0);
-    BOOST_CHECK_EQUAL(reader.size(), 6);
+    BOOST_CHECK_EQUAL(reader.size(), 6U);
     BOOST_CHECK(!reader.empty());
 
     // Read a single byte as an unsigned char.
     unsigned char a;
     reader >> a;
     BOOST_CHECK_EQUAL(a, 1);
-    BOOST_CHECK_EQUAL(reader.size(), 5);
+    BOOST_CHECK_EQUAL(reader.size(), 5U);
     BOOST_CHECK(!reader.empty());
 
     // Read a single byte as a signed char.
     signed char b;
     reader >> b;
     BOOST_CHECK_EQUAL(b, -1);
-    BOOST_CHECK_EQUAL(reader.size(), 4);
+    BOOST_CHECK_EQUAL(reader.size(), 4U);
     BOOST_CHECK(!reader.empty());
 
     // Read a 4 bytes as an unsigned int.
     unsigned int c;
     reader >> c;
-    BOOST_CHECK_EQUAL(c, 100992003); // 3,4,5,6 in little-endian base-256
-    BOOST_CHECK_EQUAL(reader.size(), 0);
+    BOOST_CHECK_EQUAL(c, 100992003U); // 3,4,5,6 in little-endian base-256
+    BOOST_CHECK_EQUAL(reader.size(), 0U);
     BOOST_CHECK(reader.empty());
 
     // Reading after end of byte vector throws an error.
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(streams_vector_reader)
     VectorReader new_reader(SER_NETWORK, INIT_PROTO_VERSION, vch, 0);
     new_reader >> d;
     BOOST_CHECK_EQUAL(d, 67370753); // 1,255,3,4 in little-endian base-256
-    BOOST_CHECK_EQUAL(new_reader.size(), 2);
+    BOOST_CHECK_EQUAL(new_reader.size(), 2U);
     BOOST_CHECK(!new_reader.empty());
 
     // Reading after end of byte vector throws an error even if the reader is
@@ -136,14 +136,14 @@ BOOST_AUTO_TEST_CASE(bitstream_reader_writer)
     BOOST_CHECK_EQUAL(serialized_int2, (uint16_t)0x1072); // NOTE: Serialized as LE
 
     BitStreamReader<CDataStream> bit_reader(data_copy);
-    BOOST_CHECK_EQUAL(bit_reader.Read(1), 0);
-    BOOST_CHECK_EQUAL(bit_reader.Read(2), 2);
-    BOOST_CHECK_EQUAL(bit_reader.Read(3), 6);
-    BOOST_CHECK_EQUAL(bit_reader.Read(4), 11);
-    BOOST_CHECK_EQUAL(bit_reader.Read(5), 1);
-    BOOST_CHECK_EQUAL(bit_reader.Read(6), 32);
-    BOOST_CHECK_EQUAL(bit_reader.Read(7), 7);
-    BOOST_CHECK_EQUAL(bit_reader.Read(16), 30497);
+    BOOST_CHECK_EQUAL(bit_reader.Read(1), 0U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(2), 2U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(3), 6U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(4), 11U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(5), 1U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(6), 32U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(7), 7U);
+    BOOST_CHECK_EQUAL(bit_reader.Read(16), 30497U);
     BOOST_CHECK_THROW(bit_reader.Read(8), std::ios_base::failure);
 }
 
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     BOOST_CHECK_EQUAL(i, 1);
 
     // After reading bytes 0 and 1, we're positioned at 2.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 2);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 2U);
 
     // Rewind to offset 0, ok (within the 10 byte window).
     BOOST_CHECK(bf.SetPos(0));
@@ -263,18 +263,18 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     // The default argument removes the limit completely.
     BOOST_CHECK(bf.SetLimit());
     // The read position should still be at 3 (no change).
-    BOOST_CHECK_EQUAL(bf.GetPos(), 3);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 3U);
 
     // Read from current offset, 3, forward until position 10.
     for (uint8_t j = 3; j < 10; ++j) {
         bf >> i;
         BOOST_CHECK_EQUAL(i, j);
     }
-    BOOST_CHECK_EQUAL(bf.GetPos(), 10);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 10U);
 
     // We're guaranteed (just barely) to be able to rewind to zero.
     BOOST_CHECK(bf.SetPos(0));
-    BOOST_CHECK_EQUAL(bf.GetPos(), 0);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 0U);
     bf >> i;
     BOOST_CHECK_EQUAL(i, 0);
 
@@ -284,12 +284,12 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     BOOST_CHECK(bf.SetPos(10));
     bf >> i;
     BOOST_CHECK_EQUAL(i, 10);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 11);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 11U);
 
     // Now it's only guaranteed that we can rewind to offset 1
     // (current read position, 11, minus rewind amount, 10).
     BOOST_CHECK(bf.SetPos(1));
-    BOOST_CHECK_EQUAL(bf.GetPos(), 1);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 1U);
     bf >> i;
     BOOST_CHECK_EQUAL(i, 1);
 
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
             BOOST_CHECK_EQUAL(a[j], 11 + j);
         }
     }
-    BOOST_CHECK_EQUAL(bf.GetPos(), 40);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 40U);
 
     // We've read the entire file, the next read should throw.
     try {
@@ -317,11 +317,11 @@ BOOST_AUTO_TEST_CASE(streams_buffered_file)
     BOOST_CHECK(bf.eof());
 
     // Still at offset 40, we can go back 10, to 30.
-    BOOST_CHECK_EQUAL(bf.GetPos(), 40);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 40U);
     BOOST_CHECK(bf.SetPos(30));
     bf >> i;
     BOOST_CHECK_EQUAL(i, 30);
-    BOOST_CHECK_EQUAL(bf.GetPos(), 31);
+    BOOST_CHECK_EQUAL(bf.GetPos(), 31U);
 
     // We're too far to rewind to position zero.
     BOOST_CHECK(!bf.SetPos(0));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -240,9 +240,9 @@ public:
         BOOST_CHECK_EQUAL(test.GetSetting("-value").write(), expect.setting.write());
         auto settings_list = test.GetSettingsList("-value");
         if (expect.setting.isNull() || expect.setting.isFalse()) {
-            BOOST_CHECK_EQUAL(settings_list.size(), 0);
+            BOOST_CHECK_EQUAL(settings_list.size(), 0U);
         } else {
-            BOOST_CHECK_EQUAL(settings_list.size(), 1);
+            BOOST_CHECK_EQUAL(settings_list.size(), 1U);
             BOOST_CHECK_EQUAL(settings_list[0].write(), expect.setting.write());
         }
 
@@ -1911,7 +1911,7 @@ BOOST_AUTO_TEST_CASE(test_spanparsing)
 
     input = "xxx";
     results = Split(MakeSpan(input), 'x');
-    BOOST_CHECK_EQUAL(results.size(), 4);
+    BOOST_CHECK_EQUAL(results.size(), 4U);
     BOOST_CHECK_EQUAL(SpanToStr(results[0]), "");
     BOOST_CHECK_EQUAL(SpanToStr(results[1]), "");
     BOOST_CHECK_EQUAL(SpanToStr(results[2]), "");
@@ -1919,19 +1919,19 @@ BOOST_AUTO_TEST_CASE(test_spanparsing)
 
     input = "one#two#three";
     results = Split(MakeSpan(input), '-');
-    BOOST_CHECK_EQUAL(results.size(), 1);
+    BOOST_CHECK_EQUAL(results.size(), 1U);
     BOOST_CHECK_EQUAL(SpanToStr(results[0]), "one#two#three");
 
     input = "one#two#three";
     results = Split(MakeSpan(input), '#');
-    BOOST_CHECK_EQUAL(results.size(), 3);
+    BOOST_CHECK_EQUAL(results.size(), 3U);
     BOOST_CHECK_EQUAL(SpanToStr(results[0]), "one");
     BOOST_CHECK_EQUAL(SpanToStr(results[1]), "two");
     BOOST_CHECK_EQUAL(SpanToStr(results[2]), "three");
 
     input = "*foo*bar*";
     results = Split(MakeSpan(input), '*');
-    BOOST_CHECK_EQUAL(results.size(), 4);
+    BOOST_CHECK_EQUAL(results.size(), 4U);
     BOOST_CHECK_EQUAL(SpanToStr(results[0]), "");
     BOOST_CHECK_EQUAL(SpanToStr(results[1]), "foo");
     BOOST_CHECK_EQUAL(SpanToStr(results[2]), "bar");
@@ -1990,24 +1990,24 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
     BOOST_CHECK(t3.origin == &t3);
 
     auto v1 = Vector(t1);
-    BOOST_CHECK_EQUAL(v1.size(), 1);
+    BOOST_CHECK_EQUAL(v1.size(), 1U);
     BOOST_CHECK(v1[0].origin == &t1);
     BOOST_CHECK_EQUAL(v1[0].copies, 1);
 
     auto v2 = Vector(std::move(t2));
-    BOOST_CHECK_EQUAL(v2.size(), 1);
+    BOOST_CHECK_EQUAL(v2.size(), 1U);
     BOOST_CHECK(v2[0].origin == &t2);
     BOOST_CHECK_EQUAL(v2[0].copies, 0);
 
     auto v3 = Vector(t1, std::move(t2));
-    BOOST_CHECK_EQUAL(v3.size(), 2);
+    BOOST_CHECK_EQUAL(v3.size(), 2U);
     BOOST_CHECK(v3[0].origin == &t1);
     BOOST_CHECK(v3[1].origin == &t2);
     BOOST_CHECK_EQUAL(v3[0].copies, 1);
     BOOST_CHECK_EQUAL(v3[1].copies, 0);
 
     auto v4 = Vector(std::move(v3[0]), v3[1], std::move(t3));
-    BOOST_CHECK_EQUAL(v4.size(), 3);
+    BOOST_CHECK_EQUAL(v4.size(), 3U);
     BOOST_CHECK(v4[0].origin == &t1);
     BOOST_CHECK(v4[1].origin == &t2);
     BOOST_CHECK(v4[2].origin == &t3);
@@ -2016,7 +2016,7 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
     BOOST_CHECK_EQUAL(v4[2].copies, 0);
 
     auto v5 = Cat(v1, v4);
-    BOOST_CHECK_EQUAL(v5.size(), 4);
+    BOOST_CHECK_EQUAL(v5.size(), 4U);
     BOOST_CHECK(v5[0].origin == &t1);
     BOOST_CHECK(v5[1].origin == &t1);
     BOOST_CHECK(v5[2].origin == &t2);
@@ -2027,7 +2027,7 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
     BOOST_CHECK_EQUAL(v5[3].copies, 1);
 
     auto v6 = Cat(std::move(v1), v3);
-    BOOST_CHECK_EQUAL(v6.size(), 3);
+    BOOST_CHECK_EQUAL(v6.size(), 3U);
     BOOST_CHECK(v6[0].origin == &t1);
     BOOST_CHECK(v6[1].origin == &t1);
     BOOST_CHECK(v6[2].origin == &t2);
@@ -2036,7 +2036,7 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
     BOOST_CHECK_EQUAL(v6[2].copies, 1);
 
     auto v7 = Cat(v2, std::move(v4));
-    BOOST_CHECK_EQUAL(v7.size(), 4);
+    BOOST_CHECK_EQUAL(v7.size(), 4U);
     BOOST_CHECK(v7[0].origin == &t2);
     BOOST_CHECK(v7[1].origin == &t1);
     BOOST_CHECK(v7[2].origin == &t2);
@@ -2047,7 +2047,7 @@ BOOST_AUTO_TEST_CASE(test_tracked_vector)
     BOOST_CHECK_EQUAL(v7[3].copies, 0);
 
     auto v8 = Cat(std::move(v2), std::move(v3));
-    BOOST_CHECK_EQUAL(v8.size(), 3);
+    BOOST_CHECK_EQUAL(v8.size(), 3U);
     BOOST_CHECK(v8[0].origin == &t2);
     BOOST_CHECK(v8[1].origin == &t1);
     BOOST_CHECK(v8[2].origin == &t2);

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(util_threadnames_test_rename_threaded)
 
     std::set<std::string> names = RenameEnMasse(100);
 
-    BOOST_CHECK_EQUAL(names.size(), 100);
+    BOOST_CHECK_EQUAL(names.size(), 100U);
 
     // Names "test_thread.[n]" should exist for n = [0, 99]
     for (int i = 0; i < 100; ++i) {

--- a/src/test/validation_flush_tests.cpp
+++ b/src/test/validation_flush_tests.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     // (prevector<28, unsigned char>) when assigned 56 bytes of data per above.
     //
     // See also: Coin::DynamicMemoryUsage().
-    constexpr int COIN_SIZE = is_64_bit ? 80 : 64;
+    constexpr unsigned int COIN_SIZE = is_64_bit ? 80 : 64;
 
     auto print_view_mem_usage = [](CCoinsViewCache& view) {
         BOOST_TEST_MESSAGE("CCoinsViewCache memory usage: " << view.DynamicMemoryUsage());
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(getcoinscachesizestate)
     }
 
     print_view_mem_usage(view);
-    BOOST_CHECK_EQUAL(view.DynamicMemoryUsage(), is_64_bit ? 32 : 16);
+    BOOST_CHECK_EQUAL(view.DynamicMemoryUsage(), is_64_bit ? 32U : 16U);
 
     // We should be able to add COINS_UNTIL_CRITICAL coins to the cache before going CRITICAL.
     // This is contingent not only on the dynamic memory usage of the Coins

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -93,7 +93,8 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip)
             jump = DecodeJump(pos, endpos);
             if (jump == INVALID) break; // Jump offset straddles EOF
             if (bits == 0) break; // No input bits left
-            if (jump >= endpos - pos) break; // Jumping past EOF
+            if (pos + jump < pos) break; // overflow
+            if (pos + jump >= endpos) break; // Jumping past EOF
             if (ip[ip.size() - bits]) {
                 pos += jump;
             }
@@ -155,7 +156,8 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
         } else if (opcode == Instruction::JUMP) {
             uint32_t jump = DecodeJump(pos, endpos);
             if (jump == INVALID) return false; // Jump offset straddles EOF
-            if (jump > endpos - pos) return false; // Jump out of range
+            if (pos + jump < pos) return false; // overflow
+            if (pos + jump > endpos) return false; // Jump out of range
             if (bits == 0) return false; // Consuming bits past the end of the input
             --bits;
             uint32_t jump_offset = pos - begin + jump;

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -742,8 +742,8 @@ BOOST_FIXTURE_TEST_CASE(CreateWalletFromFile, TestChain100Setup)
     BOOST_CHECK_EQUAL(addtx_count, 2);
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_tx.GetHash()), 1);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(mempool_tx.GetHash()), 1);
+        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_tx.GetHash()), 1U);
+        BOOST_CHECK_EQUAL(wallet->mapWallet.count(mempool_tx.GetHash()), 1U);
     }
 
 
@@ -779,8 +779,8 @@ BOOST_FIXTURE_TEST_CASE(CreateWalletFromFile, TestChain100Setup)
     BOOST_CHECK_EQUAL(addtx_count, 4);
     {
         LOCK(wallet->cs_wallet);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_tx.GetHash()), 1);
-        BOOST_CHECK_EQUAL(wallet->mapWallet.count(mempool_tx.GetHash()), 1);
+        BOOST_CHECK_EQUAL(wallet->mapWallet.count(block_tx.GetHash()), 1U);
+        BOOST_CHECK_EQUAL(wallet->mapWallet.count(mempool_tx.GetHash()), 1U);
     }
 
 


### PR DESCRIPTION
Disallowing sign-comparison mismatches can help to prevent the introduction of overflow and interpretation bugs.

In this case, ~all~ most existing violations are in the tests, and most simply required annotating the literal as unsigned for comparison.

This was previously prevented by violations in leveldb which were fixed upstream and merged in #17398. You can test that by building this branch against: 22d11187ee3c7abfe9d43c9eb68f102498cc2b9a vs 75fb37ce68289eb7e00e2ccdd2ef7f9271332545