### PR TITLE
[0.19] Further 0.19 backports

### DIFF
--- a/depends/packages/native_libdmg-hfsplus.mk
+++ b/depends/packages/native_libdmg-hfsplus.mk
@@ -10,7 +10,7 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin ..
+  cmake -DCMAKE_INSTALL_PREFIX:PATH=$(build_prefix)/bin -DCMAKE_C_FLAGS="-Wl,--build-id=none" ..
 endef
 
 define $(package)_build_cmds

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -81,12 +81,12 @@ void WalletModel::pollBalanceChanged()
         return;
     }
 
-    if(fForceCheckBalanceChanged || m_node.getNumBlocks() != cachedNumBlocks)
+    if(fForceCheckBalanceChanged || numBlocks != cachedNumBlocks)
     {
         fForceCheckBalanceChanged = false;
 
         // Balance and number of transactions might have changed
-        cachedNumBlocks = m_node.getNumBlocks();
+        cachedNumBlocks = numBlocks;
 
         checkBalanceChanged(new_balances);
         if(transactionTableModel)


### PR DESCRIPTION
These are not blockers for the 0.19.1 release, as per [IRC discussion this morning](http://www.erisian.com.au/bitcoin-core-dev/log-2020-02-27.html#l-331), doesn't look like there will be an rc3. This PR can collect further backports for the 0.19 branch.

Currently backports:
* https://github.com/bitcoin/bitcoin/pull/18004 - build: don't embed a build-id when building libdmg-hfsplus
* https://github.com/bitcoin/bitcoin/pull/18123 - gui: Fix race in WalletModel::pollBalanceChanged