### PR TITLE
Add new filter type v0 for segwit only Scripts to blockfilterindex

### DIFF
--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -282,7 +282,7 @@ static GCSFilter::ElementSet BuildFilterElements(const CBlock& block,
     for (const CTxUndo& tx_undo : block_undo.vtxundo) {
         for (const Coin& prevout : tx_undo.vprevout) {
             const CScript& script = prevout.out.scriptPubKey;
-            if (script.empty() || script[0] == OP_RETURN) continue;
+            if (script.empty()) continue;
             if (only_segwit) {
                 int witnessversion;
                 std::vector<unsigned char> witnessprogram;
@@ -323,15 +323,16 @@ BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const
     case BlockFilterType::V0:
         m_filter = GCSFilter(params, BuildFilterElements(block, block_undo, true));
         break;
-    default: assert(false);
+    case BlockFilterType::INVALID:
+        assert(false);
     }
 }
 
 bool BlockFilter::BuildParams(GCSFilter::Params& params) const
 {
     switch (m_filter_type) {
-    case BlockFilterType::V0:
     case BlockFilterType::BASIC:
+    case BlockFilterType::V0:
         params.m_siphash_k0 = m_block_hash.GetUint64(0);
         params.m_siphash_k1 = m_block_hash.GetUint64(1);
         params.m_P = BASIC_FILTER_P;

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -337,22 +337,17 @@ BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const
     case BlockFilterType::V0:
         m_filter = GCSFilter(params, V0FilterElements(block, block_undo));
         break;
+    default: assert(false);
     }
 }
 
 bool BlockFilter::BuildParams(GCSFilter::Params& params) const
 {
     switch (m_filter_type) {
+    case BlockFilterType::V0:
     case BlockFilterType::BASIC:
         params.m_siphash_k0 = m_block_hash.GetUint64(0);
         params.m_siphash_k1 = m_block_hash.GetUint64(1);
-        params.m_P = BASIC_FILTER_P;
-        params.m_M = BASIC_FILTER_M;
-        return true;
-    case BlockFilterType::V0:
-        params.m_siphash_k0 = m_block_hash.GetUint64(0);
-        params.m_siphash_k1 = m_block_hash.GetUint64(1);
-        // Using the same filter params as basic type.
         params.m_P = BASIC_FILTER_P;
         params.m_M = BASIC_FILTER_M;
         return true;

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -350,7 +350,7 @@ bool BlockFilter::BuildParams(GCSFilter::Params& params) const
     case BlockFilterType::P2WPKH:
         params.m_siphash_k0 = m_block_hash.GetUint64(0);
         params.m_siphash_k1 = m_block_hash.GetUint64(1);
-        // using the same filter params as basic type
+        // Using the same filter params as basic type.
         params.m_P = BASIC_FILTER_P;
         params.m_M = BASIC_FILTER_M;
         return true;

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -259,7 +259,7 @@ const std::string& ListBlockFilterTypes()
 
 static GCSFilter::ElementSet BuildFilterElements(const CBlock& block,
                                                  const CBlockUndo& block_undo,
-                                                 bool only_segwit = true,
+                                                 bool only_segwit = false,
                                                  int witness_version = 0)
 {
     GCSFilter::ElementSet elements;
@@ -318,10 +318,10 @@ BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const
 
     switch (m_filter_type) {
     case BlockFilterType::BASIC:
-        m_filter = GCSFilter(params, BuildFilterElements(block, block_undo, false));
+        m_filter = GCSFilter(params, BuildFilterElements(block, block_undo));
         break;
     case BlockFilterType::V0:
-        m_filter = GCSFilter(params, BuildFilterElements(block, block_undo));
+        m_filter = GCSFilter(params, BuildFilterElements(block, block_undo, true));
         break;
     default: assert(false);
     }

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -11,6 +11,7 @@
 #include <hash.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
+#include <script/standard.h>
 #include <streams.h>
 
 /// SerType used to serialize parameters in GCS filter encoding.
@@ -21,6 +22,7 @@ static constexpr int GCS_SER_VERSION = 0;
 
 static const std::map<BlockFilterType, std::string> g_filter_types = {
     {BlockFilterType::BASIC, "basic"},
+    {BlockFilterType::P2WPKH, "p2wpkh"},
 };
 
 template <typename OStream>
@@ -279,6 +281,34 @@ static GCSFilter::ElementSet BasicFilterElements(const CBlock& block,
     return elements;
 }
 
+static GCSFilter::ElementSet P2WPKHFilterElements(const CBlock& block,
+    const CBlockUndo& block_undo)
+{
+    GCSFilter::ElementSet elements;
+
+    for (const CTransactionRef& tx : block.vtx) {
+        for (const CTxOut& txout : tx->vout) {
+            const CScript& scriptPubKey = txout.scriptPubKey;
+            std::vector<std::vector<unsigned char>> solutions;
+            txnouttype script_type = Solver(txout.scriptPubKey, solutions);
+            if (scriptPubKey.empty() || script_type != TX_WITNESS_V0_KEYHASH) continue;
+            elements.emplace(scriptPubKey.begin(), scriptPubKey.end());
+        }
+    }
+
+    for (const CTxUndo& tx_undo : block_undo.vtxundo) {
+        for (const Coin& prevout : tx_undo.vprevout) {
+            const CScript& scriptPubKey = prevout.out.scriptPubKey;
+            std::vector<std::vector<unsigned char>> solutions;
+            txnouttype script_type = Solver(scriptPubKey, solutions);
+            if (scriptPubKey.empty() || script_type != TX_WITNESS_V0_KEYHASH) continue;
+            elements.emplace(scriptPubKey.begin(), scriptPubKey.end());
+        }
+    }
+
+    return elements;
+}
+
 BlockFilter::BlockFilter(BlockFilterType filter_type, const uint256& block_hash,
                          std::vector<unsigned char> filter)
     : m_filter_type(filter_type), m_block_hash(block_hash)
@@ -297,7 +327,15 @@ BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const
     if (!BuildParams(params)) {
         throw std::invalid_argument("unknown filter_type");
     }
-    m_filter = GCSFilter(params, BasicFilterElements(block, block_undo));
+
+    switch (m_filter_type) {
+    case BlockFilterType::BASIC:
+        m_filter = GCSFilter(params, BasicFilterElements(block, block_undo));
+        break;
+    case BlockFilterType::P2WPKH:
+        m_filter = GCSFilter(params, P2WPKHFilterElements(block, block_undo));
+        break;
+    }
 }
 
 bool BlockFilter::BuildParams(GCSFilter::Params& params) const
@@ -306,6 +344,13 @@ bool BlockFilter::BuildParams(GCSFilter::Params& params) const
     case BlockFilterType::BASIC:
         params.m_siphash_k0 = m_block_hash.GetUint64(0);
         params.m_siphash_k1 = m_block_hash.GetUint64(1);
+        params.m_P = BASIC_FILTER_P;
+        params.m_M = BASIC_FILTER_M;
+        return true;
+    case BlockFilterType::P2WPKH:
+        params.m_siphash_k0 = m_block_hash.GetUint64(0);
+        params.m_siphash_k1 = m_block_hash.GetUint64(1);
+        // using the same filter params as basic type
         params.m_P = BASIC_FILTER_P;
         params.m_M = BASIC_FILTER_M;
         return true;

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -22,7 +22,7 @@ static constexpr int GCS_SER_VERSION = 0;
 
 static const std::map<BlockFilterType, std::string> g_filter_types = {
     {BlockFilterType::BASIC, "basic"},
-    {BlockFilterType::P2WPKH, "p2wpkh"},
+    {BlockFilterType::V0, "v0"},
 };
 
 template <typename OStream>
@@ -281,7 +281,7 @@ static GCSFilter::ElementSet BasicFilterElements(const CBlock& block,
     return elements;
 }
 
-static GCSFilter::ElementSet P2WPKHFilterElements(const CBlock& block,
+static GCSFilter::ElementSet V0FilterElements(const CBlock& block,
     const CBlockUndo& block_undo)
 {
     GCSFilter::ElementSet elements;
@@ -289,9 +289,10 @@ static GCSFilter::ElementSet P2WPKHFilterElements(const CBlock& block,
     for (const CTransactionRef& tx : block.vtx) {
         for (const CTxOut& txout : tx->vout) {
             const CScript& scriptPubKey = txout.scriptPubKey;
-            std::vector<std::vector<unsigned char>> solutions;
-            txnouttype script_type = Solver(txout.scriptPubKey, solutions);
-            if (scriptPubKey.empty() || script_type != TX_WITNESS_V0_KEYHASH) continue;
+            int witnessversion;
+            std::vector<unsigned char> witnessprogram;
+            if (scriptPubKey.empty() || !scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) continue;
+            if (!(witnessversion == 0 && (witnessprogram.size() == WITNESS_V0_KEYHASH_SIZE || witnessprogram.size() == WITNESS_V0_SCRIPTHASH_SIZE)))  continue;
             elements.emplace(scriptPubKey.begin(), scriptPubKey.end());
         }
     }
@@ -299,9 +300,10 @@ static GCSFilter::ElementSet P2WPKHFilterElements(const CBlock& block,
     for (const CTxUndo& tx_undo : block_undo.vtxundo) {
         for (const Coin& prevout : tx_undo.vprevout) {
             const CScript& scriptPubKey = prevout.out.scriptPubKey;
-            std::vector<std::vector<unsigned char>> solutions;
-            txnouttype script_type = Solver(scriptPubKey, solutions);
-            if (scriptPubKey.empty() || script_type != TX_WITNESS_V0_KEYHASH) continue;
+            int witnessversion;
+            std::vector<unsigned char> witnessprogram;
+            if (scriptPubKey.empty() || !scriptPubKey.IsWitnessProgram(witnessversion, witnessprogram)) continue;
+            if (!(witnessversion == 0 && (witnessprogram.size() == WITNESS_V0_KEYHASH_SIZE || witnessprogram.size() == WITNESS_V0_SCRIPTHASH_SIZE))) continue;
             elements.emplace(scriptPubKey.begin(), scriptPubKey.end());
         }
     }
@@ -332,8 +334,8 @@ BlockFilter::BlockFilter(BlockFilterType filter_type, const CBlock& block, const
     case BlockFilterType::BASIC:
         m_filter = GCSFilter(params, BasicFilterElements(block, block_undo));
         break;
-    case BlockFilterType::P2WPKH:
-        m_filter = GCSFilter(params, P2WPKHFilterElements(block, block_undo));
+    case BlockFilterType::V0:
+        m_filter = GCSFilter(params, V0FilterElements(block, block_undo));
         break;
     }
 }
@@ -347,7 +349,7 @@ bool BlockFilter::BuildParams(GCSFilter::Params& params) const
         params.m_P = BASIC_FILTER_P;
         params.m_M = BASIC_FILTER_M;
         return true;
-    case BlockFilterType::P2WPKH:
+    case BlockFilterType::V0:
         params.m_siphash_k0 = m_block_hash.GetUint64(0);
         params.m_siphash_k1 = m_block_hash.GetUint64(1);
         // Using the same filter params as basic type.

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -89,7 +89,7 @@ enum class BlockFilterType : uint8_t
 {
     BASIC = 0,
     // Filter 1 is reserved as an option to include all filters.
-    P2WPKH = 2,
+    V0 = 2,
     INVALID = 255,
 };
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -88,6 +88,8 @@ constexpr uint32_t BASIC_FILTER_M = 784931;
 enum class BlockFilterType : uint8_t
 {
     BASIC = 0,
+    // Floter 1 is reserved as option to include all filters
+    P2WPKH = 2,
     INVALID = 255,
 };
 

--- a/src/blockfilter.h
+++ b/src/blockfilter.h
@@ -88,7 +88,7 @@ constexpr uint32_t BASIC_FILTER_M = 784931;
 enum class BlockFilterType : uint8_t
 {
     BASIC = 0,
-    // Floter 1 is reserved as option to include all filters
+    // Filter 1 is reserved as an option to include all filters.
     P2WPKH = 2,
     INVALID = 255,
 };

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2195,7 +2195,7 @@ static UniValue getblockfilter(const JSONRPCRequest& request)
                 "\nRetrieve a BIP 157 content filter for a particular block.\n",
                 {
                     {"blockhash", RPCArg::Type::STR_HEX, RPCArg::Optional::NO, "The hash of the block"},
-                    {"filtertype", RPCArg::Type::STR, /*default*/ "basic", "The type name of the filter"},
+                    {"filtertype", RPCArg::Type::STR, /*default*/ "basic", "The type name of the filter, values: " + ListBlockFilterTypes()},
                 },
                 RPCResult{
                     "{\n"

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <script/standard.h>
+
 BOOST_AUTO_TEST_SUITE(blockfilter_tests)
 
 BOOST_AUTO_TEST_CASE(gcsfilter_test)
@@ -125,6 +127,72 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
     BOOST_CHECK(default_ctor_block_filter_1.GetEncodedFilter() == default_ctor_block_filter_2.GetEncodedFilter());
 }
 
+BOOST_AUTO_TEST_CASE(blockfilter_p2wpkh_test)
+{
+    CScript included_scripts[2], excluded_scripts[9];
+
+    included_scripts[0] = GetScriptForDestination(WitnessV0KeyHash());  // p2wpkh 
+    included_scripts[1] = GetScriptForDestination(WitnessV0KeyHash()); // p2wpkh 
+
+    excluded_scripts[0] << std::vector<unsigned char>(0, 65) << OP_CHECKSIG; // p2pk 
+    excluded_scripts[1] << OP_0 << OP_HASH160 << std::vector<unsigned char>(1, 20) << OP_EQUALVERIFY << OP_CHECKSIG; // p2pkh 
+    excluded_scripts[2] << OP_1 << std::vector<unsigned char>(2, 33) << OP_1 << OP_CHECKMULTISIG; // multisig 
+    excluded_scripts[3] << OP_0 << std::vector<unsigned char>(3, 32); // push data 
+    excluded_scripts[4] << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // random script 
+    excluded_scripts[5] << OP_RETURN << std::vector<unsigned char>(4, 40); // opreturn 
+    excluded_scripts[6] = GetScriptForDestination(WitnessV0ScriptHash()); // p2wsh
+    excluded_scripts[7] << OP_RETURN << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // none standard opreturn
+
+    CMutableTransaction tx_1;
+    tx_1.vout.emplace_back(100, included_scripts[0]);
+    tx_1.vout.emplace_back(200, excluded_scripts[0]);
+    tx_1.vout.emplace_back(300, excluded_scripts[1]);
+    tx_1.vout.emplace_back(400, excluded_scripts[2]);
+
+    CMutableTransaction tx_2;
+    tx_2.vout.emplace_back(100, excluded_scripts[3]);
+    tx_2.vout.emplace_back(0, excluded_scripts[4]);
+    tx_2.vout.emplace_back(400, excluded_scripts[5]);
+    tx_2.vout.emplace_back(400, excluded_scripts[8]); // Script is empty
+
+    CBlock block;
+    block.vtx.push_back(MakeTransactionRef(tx_1));
+    block.vtx.push_back(MakeTransactionRef(tx_2));
+
+    CBlockUndo block_undo;
+    block_undo.vtxundo.emplace_back();
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(500, included_scripts[1]), 1000, true);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(600, excluded_scripts[6]), 10000, false);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(700, excluded_scripts[7]), 100000, false);
+
+    BlockFilter block_filter(BlockFilterType::P2WPKH, block, block_undo);
+    const GCSFilter& filter = block_filter.GetFilter();
+
+    for (const CScript& script : included_scripts) {
+        BOOST_CHECK(filter.Match(GCSFilter::Element(script.begin(), script.end())));
+    }
+    for (const CScript& script : excluded_scripts) {
+        BOOST_CHECK(!filter.Match(GCSFilter::Element(script.begin(), script.end())));
+    }
+
+    // Test serialization/unserialization.
+    BlockFilter block_filter2;
+
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << block_filter;
+    stream >> block_filter2;
+
+    BOOST_CHECK_EQUAL(block_filter.GetFilterType(), block_filter2.GetFilterType());
+    BOOST_CHECK_EQUAL(block_filter.GetBlockHash(), block_filter2.GetBlockHash());
+    BOOST_CHECK(block_filter.GetEncodedFilter() == block_filter2.GetEncodedFilter());
+
+    BlockFilter default_ctor_block_filter_1;
+    BlockFilter default_ctor_block_filter_2;
+    BOOST_CHECK_EQUAL(default_ctor_block_filter_1.GetFilterType(), default_ctor_block_filter_2.GetFilterType());
+    BOOST_CHECK_EQUAL(default_ctor_block_filter_1.GetBlockHash(), default_ctor_block_filter_2.GetBlockHash());
+    BOOST_CHECK(default_ctor_block_filter_1.GetEncodedFilter() == default_ctor_block_filter_2.GetEncodedFilter());
+}
+
 BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 {
     UniValue json;
@@ -182,13 +250,19 @@ BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 BOOST_AUTO_TEST_CASE(blockfilter_type_names)
 {
     BOOST_CHECK_EQUAL(BlockFilterTypeName(BlockFilterType::BASIC), "basic");
+    BOOST_CHECK_EQUAL(BlockFilterTypeName(BlockFilterType::P2WPKH), "p2wpkh");
     BOOST_CHECK_EQUAL(BlockFilterTypeName(static_cast<BlockFilterType>(255)), "");
 
-    BlockFilterType filter_type;
-    BOOST_CHECK(BlockFilterTypeByName("basic", filter_type));
-    BOOST_CHECK_EQUAL(filter_type, BlockFilterType::BASIC);
+    BlockFilterType filter_type_basic;
+    BOOST_CHECK(BlockFilterTypeByName("basic", filter_type_basic));
+    BOOST_CHECK_EQUAL(filter_type_basic, BlockFilterType::BASIC);
 
-    BOOST_CHECK(!BlockFilterTypeByName("unknown", filter_type));
+    BlockFilterType filter_type_p2wpkh;
+    BOOST_CHECK(BlockFilterTypeByName("p2wpkh", filter_type_p2wpkh));
+    BOOST_CHECK_EQUAL(filter_type_p2wpkh, BlockFilterType::P2WPKH);
+
+    BlockFilterType filter_type_unknown;
+    BOOST_CHECK(!BlockFilterTypeByName("unknown", filter_type_unknown));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -127,12 +127,15 @@ BOOST_AUTO_TEST_CASE(blockfilter_basic_test)
     BOOST_CHECK(default_ctor_block_filter_1.GetEncodedFilter() == default_ctor_block_filter_2.GetEncodedFilter());
 }
 
-BOOST_AUTO_TEST_CASE(blockfilter_p2wpkh_test)
+BOOST_AUTO_TEST_CASE(blockfilter_v0_test)
 {
-    CScript included_scripts[2], excluded_scripts[9];
+    CScript included_scripts[4], excluded_scripts[8];
 
     included_scripts[0] = GetScriptForDestination(WitnessV0KeyHash());  // p2wpkh 
     included_scripts[1] = GetScriptForDestination(WitnessV0KeyHash()); // p2wpkh 
+    included_scripts[2] = GetScriptForDestination(WitnessV0ScriptHash()); // p2wsh
+    included_scripts[3] = GetScriptForDestination(WitnessV0ScriptHash()); // p2wsh
+
 
     excluded_scripts[0] << std::vector<unsigned char>(0, 65) << OP_CHECKSIG; // p2pk 
     excluded_scripts[1] << OP_0 << OP_HASH160 << std::vector<unsigned char>(1, 20) << OP_EQUALVERIFY << OP_CHECKSIG; // p2pkh 
@@ -140,20 +143,20 @@ BOOST_AUTO_TEST_CASE(blockfilter_p2wpkh_test)
     excluded_scripts[3] << OP_0 << std::vector<unsigned char>(3, 32); // push data 
     excluded_scripts[4] << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // random script 
     excluded_scripts[5] << OP_RETURN << std::vector<unsigned char>(4, 40); // opreturn 
-    excluded_scripts[6] = GetScriptForDestination(WitnessV0ScriptHash()); // p2wsh
-    excluded_scripts[7] << OP_RETURN << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // none standard opreturn
+    excluded_scripts[6] << OP_RETURN << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // none standard opreturn
 
     CMutableTransaction tx_1;
     tx_1.vout.emplace_back(100, included_scripts[0]);
+    tx_1.vout.emplace_back(100, included_scripts[2]);
     tx_1.vout.emplace_back(200, excluded_scripts[0]);
     tx_1.vout.emplace_back(300, excluded_scripts[1]);
     tx_1.vout.emplace_back(400, excluded_scripts[2]);
 
     CMutableTransaction tx_2;
+    tx_2.vout.emplace_back(100, included_scripts[3]);
     tx_2.vout.emplace_back(100, excluded_scripts[3]);
     tx_2.vout.emplace_back(0, excluded_scripts[4]);
-    tx_2.vout.emplace_back(400, excluded_scripts[5]);
-    tx_2.vout.emplace_back(400, excluded_scripts[8]); // Script is empty
+    tx_2.vout.emplace_back(400, excluded_scripts[7]); // Script is empty
 
     CBlock block;
     block.vtx.push_back(MakeTransactionRef(tx_1));
@@ -162,10 +165,10 @@ BOOST_AUTO_TEST_CASE(blockfilter_p2wpkh_test)
     CBlockUndo block_undo;
     block_undo.vtxundo.emplace_back();
     block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(500, included_scripts[1]), 1000, true);
-    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(600, excluded_scripts[6]), 10000, false);
-    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(700, excluded_scripts[7]), 100000, false);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(600, excluded_scripts[5]), 10000, false);
+    block_undo.vtxundo.back().vprevout.emplace_back(CTxOut(700, excluded_scripts[6]), 100000, false);
 
-    BlockFilter block_filter(BlockFilterType::P2WPKH, block, block_undo);
+    BlockFilter block_filter(BlockFilterType::V0, block, block_undo);
     const GCSFilter& filter = block_filter.GetFilter();
 
     for (const CScript& script : included_scripts) {
@@ -250,16 +253,16 @@ BOOST_AUTO_TEST_CASE(blockfilters_json_test)
 BOOST_AUTO_TEST_CASE(blockfilter_type_names)
 {
     BOOST_CHECK_EQUAL(BlockFilterTypeName(BlockFilterType::BASIC), "basic");
-    BOOST_CHECK_EQUAL(BlockFilterTypeName(BlockFilterType::P2WPKH), "p2wpkh");
+    BOOST_CHECK_EQUAL(BlockFilterTypeName(BlockFilterType::V0), "v0");
     BOOST_CHECK_EQUAL(BlockFilterTypeName(static_cast<BlockFilterType>(255)), "");
 
     BlockFilterType filter_type_basic;
     BOOST_CHECK(BlockFilterTypeByName("basic", filter_type_basic));
     BOOST_CHECK_EQUAL(filter_type_basic, BlockFilterType::BASIC);
 
-    BlockFilterType filter_type_p2wpkh;
-    BOOST_CHECK(BlockFilterTypeByName("p2wpkh", filter_type_p2wpkh));
-    BOOST_CHECK_EQUAL(filter_type_p2wpkh, BlockFilterType::P2WPKH);
+    BlockFilterType filter_type_v0;
+    BOOST_CHECK(BlockFilterTypeByName("v0", filter_type_v0));
+    BOOST_CHECK_EQUAL(filter_type_v0, BlockFilterType::V0);
 
     BlockFilterType filter_type_unknown;
     BOOST_CHECK(!BlockFilterTypeByName("unknown", filter_type_unknown));

--- a/src/test/blockfilter_tests.cpp
+++ b/src/test/blockfilter_tests.cpp
@@ -131,18 +131,17 @@ BOOST_AUTO_TEST_CASE(blockfilter_v0_test)
 {
     CScript included_scripts[4], excluded_scripts[8];
 
-    included_scripts[0] = GetScriptForDestination(WitnessV0KeyHash());  // p2wpkh 
-    included_scripts[1] = GetScriptForDestination(WitnessV0KeyHash()); // p2wpkh 
+    included_scripts[0] = GetScriptForDestination(WitnessV0KeyHash());  // p2wpkh
+    included_scripts[1] = GetScriptForDestination(WitnessV0KeyHash()); // p2wpkh
     included_scripts[2] = GetScriptForDestination(WitnessV0ScriptHash()); // p2wsh
     included_scripts[3] = GetScriptForDestination(WitnessV0ScriptHash()); // p2wsh
 
-
-    excluded_scripts[0] << std::vector<unsigned char>(0, 65) << OP_CHECKSIG; // p2pk 
-    excluded_scripts[1] << OP_0 << OP_HASH160 << std::vector<unsigned char>(1, 20) << OP_EQUALVERIFY << OP_CHECKSIG; // p2pkh 
-    excluded_scripts[2] << OP_1 << std::vector<unsigned char>(2, 33) << OP_1 << OP_CHECKMULTISIG; // multisig 
-    excluded_scripts[3] << OP_0 << std::vector<unsigned char>(3, 32); // push data 
-    excluded_scripts[4] << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // random script 
-    excluded_scripts[5] << OP_RETURN << std::vector<unsigned char>(4, 40); // opreturn 
+    excluded_scripts[0] << std::vector<unsigned char>(0, 65) << OP_CHECKSIG; // p2pk
+    excluded_scripts[1] << OP_0 << OP_HASH160 << std::vector<unsigned char>(1, 20) << OP_EQUALVERIFY << OP_CHECKSIG; // p2pkh
+    excluded_scripts[2] << OP_1 << std::vector<unsigned char>(2, 33) << OP_1 << OP_CHECKMULTISIG; // multisig
+    excluded_scripts[3] << OP_0 << std::vector<unsigned char>(3, 32); // push data
+    excluded_scripts[4] << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // random script
+    excluded_scripts[5] << OP_RETURN << std::vector<unsigned char>(4, 40); // opreturn
     excluded_scripts[6] << OP_RETURN << OP_4 << OP_ADD << OP_8 << OP_EQUAL; // none standard opreturn
 
     CMutableTransaction tx_1;


### PR DESCRIPTION
**Introduce a new BlockFilter type [v0] next to the existing basic filter type, which is described in BIP 158.**
https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki#block-filter

Resolves #18222 

The BlockFilterIndex implementation allows for the addition of other filter types, this PR will add a new filter type for segwit script programs v0  types only.
Light clients (especially new clients that deal with segwit addresses only) do not need any legacy script types in the filters, and with this PR can choose to only index a much smaller portion of the chain.
That will greatly reduce the amount of data on disk and that is fetch over the network.

The same GCS parameters where used as basic type.

Total size of serialized filers as of block 619 361:
- Basic = 4.76 GB
- v0 = 252 MB 

Building the Index time
- Basic = 3.5 hours
- v0  = 3.5 hours 

Enabled in the config by:
```
blockfilterindex=p2wpkh
```
Enabling more then one filter:
```
blockfilterindex=v0
blockfilterindex=basic
```
