### PR TITLE
util: Fail to parse empty string in ParseMoney

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -1199,6 +1199,12 @@ BOOST_AUTO_TEST_CASE(util_ParseMoney)
     BOOST_CHECK(ParseMoney("0.00000001", ret));
     BOOST_CHECK_EQUAL(ret, COIN/100000000);
 
+    // Parsing amount that can not be represented in ret should fail
+    BOOST_CHECK(!ParseMoney("0.000000001", ret));
+
+    // Parsing empty string should fail
+    BOOST_CHECK(!ParseMoney("", ret));
+
     // Attempted 63 bit overflow should fail
     BOOST_CHECK(!ParseMoney("92233720368.54775808", ret));
 

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -36,14 +36,10 @@ bool ParseMoney(const std::string& str, CAmount& nRet)
     if (!ValidAsCString(str)) {
         return false;
     }
-    return ParseMoney(str.c_str(), nRet);
-}
 
-bool ParseMoney(const char* pszIn, CAmount& nRet)
-{
     std::string strWhole;
     int64_t nUnits = 0;
-    const char* p = pszIn;
+    const char* p = str.c_str();
     while (IsSpace(*p))
         p++;
     for (; *p; p++)

--- a/src/util/moneystr.cpp
+++ b/src/util/moneystr.cpp
@@ -37,6 +37,10 @@ bool ParseMoney(const std::string& str, CAmount& nRet)
         return false;
     }
 
+    if (str.empty()) {
+        return false;
+    }
+
     std::string strWhole;
     int64_t nUnits = 0;
     const char* p = str.c_str();

--- a/src/util/moneystr.h
+++ b/src/util/moneystr.h
@@ -18,7 +18,7 @@
  * JSON but use AmountFromValue and ValueFromAmount for that.
  */
 std::string FormatMoney(const CAmount& n);
+/** Parse an amount denoted in full coins. E.g. "0.0034" supplied on the command line. **/
 NODISCARD bool ParseMoney(const std::string& str, CAmount& nRet);
-NODISCARD bool ParseMoney(const char* pszIn, CAmount& nRet);
 
 #endif // BITCOIN_UTIL_MONEYSTR_H


### PR DESCRIPTION
Supplying a fee rate or an amount on the command line as an empty string, which currently parses as `0` seems fragile and confusing. See for example the confusion in #18214. 

Fixes #18214