### PR TITLE
refactor: Consolidate unnecessary base58 interfaces

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -84,8 +84,10 @@ bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_
     return true;
 }
 
-std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
+std::string EncodeBase58(const std::vector<unsigned char>& vch)
 {
+    const unsigned char* pbegin = vch.data();
+    const unsigned char* pend = pbegin + vch.size();
     // Skip & count leading zeroes.
     int zeroes = 0;
     int length = 0;
@@ -124,19 +126,6 @@ std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend)
     return str;
 }
 
-std::string EncodeBase58(const std::vector<unsigned char>& vch)
-{
-    return EncodeBase58(vch.data(), vch.data() + vch.size());
-}
-
-bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
-{
-    if (!ValidAsCString(str)) {
-        return false;
-    }
-    return DecodeBase58(str.c_str(), vchRet, max_ret_len);
-}
-
 std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
 {
     // add 4-byte hash check to the end
@@ -146,9 +135,12 @@ std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn)
     return EncodeBase58(vch);
 }
 
-bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len)
+bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len)
 {
-    if (!DecodeBase58(psz, vchRet, max_ret_len > std::numeric_limits<int>::max() - 4 ? std::numeric_limits<int>::max() : max_ret_len + 4) ||
+    if (!ValidAsCString(str)) {
+        return false;
+    }
+    if (!DecodeBase58(str.c_str(), vchRet, max_ret_len > std::numeric_limits<int>::max() - 4 ? std::numeric_limits<int>::max() : max_ret_len + 4) ||
         (vchRet.size() < 4)) {
         vchRet.clear();
         return false;
@@ -161,12 +153,4 @@ bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet, int 
     }
     vchRet.resize(vchRet.size() - 4);
     return true;
-}
-
-bool DecodeBase58Check(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret)
-{
-    if (!ValidAsCString(str)) {
-        return false;
-    }
-    return DecodeBase58Check(str.c_str(), vchRet, max_ret);
 }

--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -37,6 +37,8 @@ static const int8_t mapBase58[256] = {
 
 bool DecodeBase58(const char* psz, std::vector<unsigned char>& vch, int max_ret_len)
 {
+    assert(psz != nullptr);
+    assert(max_ret_len > 0);
     // Skip leading spaces.
     while (*psz && IsSpace(*psz))
         psz++;

--- a/src/base58.h
+++ b/src/base58.h
@@ -20,39 +20,21 @@
 #include <vector>
 
 /**
- * Encode a byte sequence as a base58-encoded string.
- * pbegin and pend cannot be nullptr, unless both are.
- */
-std::string EncodeBase58(const unsigned char* pbegin, const unsigned char* pend);
-
-/**
  * Encode a byte vector as a base58-encoded string
  */
-std::string EncodeBase58(const std::vector<unsigned char>& vch);
-
-/**
- * Decode a base58-encoded string (psz) into a byte vector (vchRet).
- * return true if decoding is successful.
- * psz cannot be nullptr.
- */
-NODISCARD bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len);
-
-/**
- * Decode a base58-encoded string (str) into a byte vector (vchRet).
- * return true if decoding is successful.
- */
-NODISCARD bool DecodeBase58(const std::string& str, std::vector<unsigned char>& vchRet, int max_ret_len);
+NODISCARD std::string EncodeBase58(const std::vector<unsigned char>& vch);
 
 /**
  * Encode a byte vector into a base58-encoded string, including checksum
  */
-std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn);
+NODISCARD std::string EncodeBase58Check(const std::vector<unsigned char>& vchIn);
 
 /**
- * Decode a base58-encoded string (psz) that includes a checksum into a byte
- * vector (vchRet), return true if decoding is successful
+ * Decode a base58-encoded string (psz) into a byte vector (vchRet).
+ * psz cannot be nullptr.
+ * @returns true if decoding is successful.
  */
-NODISCARD bool DecodeBase58Check(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len);
+NODISCARD bool DecodeBase58(const char* psz, std::vector<unsigned char>& vchRet, int max_ret_len);
 
 /**
  * Decode a base58-encoded string (str) that includes a checksum into a byte

--- a/src/bench/base58.cpp
+++ b/src/bench/base58.cpp
@@ -9,7 +9,6 @@
 #include <array>
 #include <vector>
 
-
 static void Base58Encode(benchmark::State& state)
 {
     static const std::array<unsigned char, 32> buff = {
@@ -19,8 +18,10 @@ static void Base58Encode(benchmark::State& state)
             200, 24
         }
     };
+    std::vector<unsigned char> vch;
+    vch.assign(buff.begin(), buff.end());
     while (state.KeepRunning()) {
-        EncodeBase58(buff.data(), buff.data() + buff.size());
+        (void) EncodeBase58(vch);
     }
 }
 
@@ -37,7 +38,7 @@ static void Base58CheckEncode(benchmark::State& state)
     std::vector<unsigned char> vch;
     vch.assign(buff.begin(), buff.end());
     while (state.KeepRunning()) {
-        EncodeBase58Check(vch);
+        (void) EncodeBase58Check(vch);
     }
 }
 

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -92,7 +92,7 @@ static std::string DummyAddress(const CChainParams &params)
     std::vector<unsigned char> sourcedata = params.Base58Prefix(CChainParams::PUBKEY_ADDRESS);
     sourcedata.insert(sourcedata.end(), dummydata, dummydata + sizeof(dummydata));
     for(int i=0; i<256; ++i) { // Try every trailing byte
-        std::string s = EncodeBase58(sourcedata.data(), sourcedata.data() + sourcedata.size());
+        std::string s = EncodeBase58(sourcedata);
         if (!IsValidDestinationString(s)) {
             return s;
         }

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_CASE(base58_EncodeBase58)
         std::vector<unsigned char> sourcedata = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
         BOOST_CHECK_MESSAGE(
-                    EncodeBase58(sourcedata.data(), sourcedata.data() + sourcedata.size()) == base58string,
+                    EncodeBase58(sourcedata) == base58string,
                     strTest);
     }
 }
@@ -54,18 +54,15 @@ BOOST_AUTO_TEST_CASE(base58_DecodeBase58)
         }
         std::vector<unsigned char> expected = ParseHex(test[0].get_str());
         std::string base58string = test[1].get_str();
-        BOOST_CHECK_MESSAGE(DecodeBase58(base58string, result, 256), strTest);
+        BOOST_CHECK_MESSAGE(DecodeBase58(base58string.c_str(), result, 256), strTest);
         BOOST_CHECK_MESSAGE(result.size() == expected.size() && std::equal(result.begin(), result.end(), expected.begin()), strTest);
     }
 
     BOOST_CHECK(!DecodeBase58("invalid", result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("invalid"), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("\0invalid", 8), result, 100));
 
-    BOOST_CHECK(DecodeBase58(std::string("good", 4), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("bad0IOl", 7), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("goodbad0IOl", 11), result, 100));
-    BOOST_CHECK(!DecodeBase58(std::string("good\0bad0IOl", 12), result, 100));
+    BOOST_CHECK(DecodeBase58("good", result, 100));
+    BOOST_CHECK(!DecodeBase58("bad0IOl", result, 100));
+    BOOST_CHECK(!DecodeBase58("goodbad0IOl", result, 100));
 
     // check that DecodeBase58 skips whitespace, but still fails with unexpected non-whitespace at the end.
     BOOST_CHECK(!DecodeBase58(" \t\n\v\f\r skip \r\f\v\n\t a", result, 3));


### PR DESCRIPTION
Four of the seven base58 declarations are strictly unnecessary.

Note there are randomly generated test calls to `DecodeBase58Check` that would violate the unenforced `max_ret_len > 0` expectation of that function, but not the effective `max_ret_len + 4  > 0` assertion enforced here.