### PR TITLE
test: Add missing syncwithvalidationinterfacequeue

### DIFF
--- a/test/functional/wallet_resendwallettransactions.py
+++ b/test/functional/wallet_resendwallettransactions.py
@@ -12,6 +12,7 @@ from test_framework.mininode import P2PInterface, mininode_lock
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, wait_until
 
+
 class P2PStoreTxInvs(P2PInterface):
     def __init__(self):
         super().__init__()
@@ -23,6 +24,7 @@ class P2PStoreTxInvs(P2PInterface):
             if i.type == 1:
                 # save txid
                 self.tx_invs_received[i.hash] += 1
+
 
 class ResendWalletTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
@@ -63,6 +65,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         node.submitblock(ToHex(block))
 
         # Transaction should not be rebroadcast
+        node.syncwithvalidationinterfacequeue()
         node.p2ps[1].sync_with_ping()
         assert_equal(node.p2ps[1].tx_invs_received[txid], 0)
 
@@ -71,6 +74,7 @@ class ResendWalletTransactionsTest(BitcoinTestFramework):
         rebroadcast_time = int(time.time()) + 41 * 60
         node.setmocktime(rebroadcast_time)
         wait_until(lambda: node.p2ps[1].tx_invs_received[txid] >= 1, lock=mininode_lock)
+
 
 if __name__ == '__main__':
     ResendWalletTransactionsTest().main()


### PR DESCRIPTION
The wallet rebroadcast functionality learns about new blocks via the validation interface queue. To avoid test failures such as https://ci.appveyor.com/project/DrahtBot/bitcoin/builds/31119387#L466 , we can sync with the queue before advancing the test.


