### PR TITLE
random: drop unused MACH time headers

### DIFF
--- a/src/randomenv.cpp
+++ b/src/randomenv.cpp
@@ -38,11 +38,6 @@
 #include <sys/utsname.h>
 #include <unistd.h>
 #endif
-#ifdef __MACH__
-#include <mach/clock.h>
-#include <mach/mach.h>
-#include <mach/mach_time.h>
-#endif
 #if HAVE_DECL_GETIFADDRS
 #include <ifaddrs.h>
 #endif


### PR DESCRIPTION
Now that we're no longer special-casing clock usage for MacOS (see #17800), we're
not referencing anything defined in these headers.

Incidentally, this removes our last reference to the `__MACH__` system def. 🎉 