### PR TITLE
[WIP] script: prevent OP_NEGATE from generating negative zero.

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -37,12 +37,7 @@ bool CastToBool(const valtype& vch)
     for (unsigned int i = 0; i < vch.size(); i++)
     {
         if (vch[i] != 0)
-        {
-            // Can be negative zero
-            if (i == vch.size()-1 && vch[i] == 0x80)
-                return false;
             return true;
-        }
     }
     return false;
 }
@@ -787,7 +782,7 @@ bool EvalScript(std::vector<std::vector<unsigned char> >& stack, const CScript& 
                     {
                     case OP_1ADD:       bn += bnOne; break;
                     case OP_1SUB:       bn -= bnOne; break;
-                    case OP_NEGATE:     bn = -bn; break;
+                    case OP_NEGATE:     if (bn != bnZero) bn = -bn; break;
                     case OP_ABS:        if (bn < bnZero) bn = -bn; break;
                     case OP_NOT:        bn = (bn == bnZero); break;
                     case OP_0NOTEQUAL:  bn = (bn != bnZero); break;


### PR DESCRIPTION
Prevent OP_NEGATE from generating negative zero since negative zero is implementation defined for C/C++.

Do you agree with negative zero issue?
Does this impact CastToBool since mentions negative zero?
Looking for feedback as I am unsure how to test these changes?
