### PR TITLE
wip: gui: Refactor to drop client and wallet models setters

### DIFF
--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -18,11 +18,16 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-AskPassphraseDialog::AskPassphraseDialog(Mode _mode, QWidget *parent, SecureString* passphrase_out) :
+AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget *parent, SecureString* passphrase_out)
+    : AskPassphraseDialog(mode, nullptr, parent, passphrase_out)
+{
+}
+
+AskPassphraseDialog::AskPassphraseDialog(Mode _mode, WalletModel* wallet_model, QWidget *parent, SecureString* passphrase_out) :
     QDialog(parent),
     ui(new Ui::AskPassphraseDialog),
     mode(_mode),
-    model(nullptr),
+    model(wallet_model),
     fCapsLock(false),
     m_passphrase_out(passphrase_out)
 {
@@ -81,11 +86,6 @@ AskPassphraseDialog::~AskPassphraseDialog()
 {
     secureClearPassFields();
     delete ui;
-}
-
-void AskPassphraseDialog::setModel(WalletModel *_model)
-{
-    this->model = _model;
 }
 
 void AskPassphraseDialog::accept()

--- a/src/qt/askpassphrasedialog.h
+++ b/src/qt/askpassphrasedialog.h
@@ -29,17 +29,16 @@ public:
         Decrypt     /**< Ask passphrase and decrypt wallet */
     };
 
-    explicit AskPassphraseDialog(Mode mode, QWidget *parent, SecureString* passphrase_out = nullptr);
+    explicit AskPassphraseDialog(Mode mode, QWidget *parent, SecureString* passphrase_out);
+    explicit AskPassphraseDialog(Mode mode, WalletModel* wallet_model, QWidget *parent, SecureString* passphrase_out = nullptr);
     ~AskPassphraseDialog();
 
     void accept();
 
-    void setModel(WalletModel *model);
-
 private:
     Ui::AskPassphraseDialog *ui;
     Mode mode;
-    WalletModel *model;
+    WalletModel* const model;
     bool fCapsLock;
     SecureString* m_passphrase_out;
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -110,7 +110,7 @@ public:
 };
 #include <qt/overviewpage.moc>
 
-OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) :
+OverviewPage::OverviewPage(ClientModel* client_model, const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::OverviewPage),
     clientModel(nullptr),
@@ -139,6 +139,8 @@ OverviewPage::OverviewPage(const PlatformStyle *platformStyle, QWidget *parent) 
     showOutOfSyncWarning(true);
     connect(ui->labelWalletStatus, &QPushButton::clicked, this, &OverviewPage::handleOutOfSyncWarningClicks);
     connect(ui->labelTransactionsStatus, &QPushButton::clicked, this, &OverviewPage::handleOutOfSyncWarningClicks);
+
+    setClientModel(client_model);
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -113,7 +113,7 @@ public:
 OverviewPage::OverviewPage(ClientModel* client_model, const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent),
     ui(new Ui::OverviewPage),
-    clientModel(nullptr),
+    clientModel(client_model),
     walletModel(nullptr),
     txdelegate(new TxViewDelegate(platformStyle, this))
 {
@@ -140,7 +140,9 @@ OverviewPage::OverviewPage(ClientModel* client_model, const PlatformStyle *platf
     connect(ui->labelWalletStatus, &QPushButton::clicked, this, &OverviewPage::handleOutOfSyncWarningClicks);
     connect(ui->labelTransactionsStatus, &QPushButton::clicked, this, &OverviewPage::handleOutOfSyncWarningClicks);
 
-    setClientModel(client_model);
+    // Show warning, for example if this is a prerelease version
+    connect(clientModel, &ClientModel::alertsChanged, this, &OverviewPage::updateAlerts);
+    updateAlerts(clientModel->getStatusBarWarnings());
 }
 
 void OverviewPage::handleTransactionClicked(const QModelIndex &index)
@@ -201,16 +203,6 @@ void OverviewPage::updateWatchOnlyLabels(bool showWatchOnly)
 
     if (!showWatchOnly)
         ui->labelWatchImmature->hide();
-}
-
-void OverviewPage::setClientModel(ClientModel *model)
-{
-    this->clientModel = model;
-    if (model) {
-        // Show warning, for example if this is a prerelease version
-        connect(model, &ClientModel::alertsChanged, this, &OverviewPage::updateAlerts);
-        updateAlerts(model->getStatusBarWarnings());
-    }
 }
 
 void OverviewPage::setWalletModel(WalletModel *model)

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -36,9 +36,6 @@ public:
     void setWalletModel(WalletModel *walletModel);
     void showOutOfSyncWarning(bool fShow);
 
-private:
-    void setClientModel(ClientModel *clientModel);
-
 public Q_SLOTS:
     void setBalance(const interfaces::WalletBalances& balances);
 
@@ -48,7 +45,7 @@ Q_SIGNALS:
 
 private:
     Ui::OverviewPage *ui;
-    ClientModel *clientModel;
+    ClientModel* const clientModel;
     WalletModel *walletModel;
     interfaces::WalletBalances m_balances;
 

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -30,12 +30,14 @@ class OverviewPage : public QWidget
     Q_OBJECT
 
 public:
-    explicit OverviewPage(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    explicit OverviewPage(ClientModel* client_model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
     ~OverviewPage();
 
-    void setClientModel(ClientModel *clientModel);
     void setWalletModel(WalletModel *walletModel);
     void showOutOfSyncWarning(bool fShow);
+
+private:
+    void setClientModel(ClientModel *clientModel);
 
 public Q_SLOTS:
     void setBalance(const interfaces::WalletBalances& balances);

--- a/src/qt/overviewpage.h
+++ b/src/qt/overviewpage.h
@@ -30,10 +30,9 @@ class OverviewPage : public QWidget
     Q_OBJECT
 
 public:
-    explicit OverviewPage(ClientModel* client_model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    explicit OverviewPage(ClientModel* client_model, WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
     ~OverviewPage();
 
-    void setWalletModel(WalletModel *walletModel);
     void showOutOfSyncWarning(bool fShow);
 
 public Q_SLOTS:
@@ -46,7 +45,7 @@ Q_SIGNALS:
 private:
     Ui::OverviewPage *ui;
     ClientModel* const clientModel;
-    WalletModel *walletModel;
+    WalletModel* const walletModel;
     interfaces::WalletBalances m_balances;
 
     TxViewDelegate *txdelegate;

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -20,7 +20,7 @@
 #include <QScrollBar>
 #include <QTextDocument>
 
-ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
+ReceiveCoinsDialog::ReceiveCoinsDialog(WalletModel* wallet_model, const PlatformStyle *_platformStyle, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ReceiveCoinsDialog),
     columnResizingFixer(nullptr),
@@ -62,6 +62,8 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *_platformStyle, QWid
     connect(copyAmountAction, &QAction::triggered, this, &ReceiveCoinsDialog::copyAmount);
 
     connect(ui->clearButton, &QPushButton::clicked, this, &ReceiveCoinsDialog::clear);
+
+    setModel(wallet_model);
 }
 
 void ReceiveCoinsDialog::setModel(WalletModel *_model)

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -152,9 +152,8 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", address_type);
     SendCoinsRecipient info(address, label,
         ui->reqAmount->value(), ui->reqMessage->text());
-    ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
+    ReceiveRequestDialog *dialog = new ReceiveRequestDialog(model, this);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
-    dialog->setModel(model);
     dialog->setInfo(info);
     dialog->show();
     clear();
@@ -165,8 +164,7 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
 
 void ReceiveCoinsDialog::on_recentRequestsView_doubleClicked(const QModelIndex &index)
 {
-    ReceiveRequestDialog *dialog = new ReceiveRequestDialog(this);
-    dialog->setModel(model);
+    ReceiveRequestDialog *dialog = new ReceiveRequestDialog(model, this);
     dialog->setInfo(m_recent_requests_table_model->entry(index.row()).recipient);
     dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -16,6 +16,7 @@
 #include <QVariant>
 
 class PlatformStyle;
+class RecentRequestsTableModel;
 class WalletModel;
 
 namespace Ui {
@@ -44,6 +45,8 @@ public:
 
     void setModel(WalletModel *model);
 
+    RecentRequestsTableModel* recentRequestsTableModel() const { return m_recent_requests_table_model; }
+
 public Q_SLOTS:
     void clear();
     void reject();
@@ -56,6 +59,7 @@ private:
     Ui::ReceiveCoinsDialog *ui;
     GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
     WalletModel *model;
+    RecentRequestsTableModel* m_recent_requests_table_model{nullptr};
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
 

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -56,12 +56,11 @@ protected:
 private:
     Ui::ReceiveCoinsDialog *ui;
     GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
-    WalletModel *model;
+    WalletModel* const model;
     RecentRequestsTableModel* m_recent_requests_table_model{nullptr};
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
 
-    void setModel(WalletModel *model);
     QModelIndex selectedRow();
     void copyColumnToClipboard(int column);
     virtual void resizeEvent(QResizeEvent *event);

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -40,10 +40,8 @@ public:
         MINIMUM_COLUMN_WIDTH = 130
     };
 
-    explicit ReceiveCoinsDialog(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    explicit ReceiveCoinsDialog(WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
     ~ReceiveCoinsDialog();
-
-    void setModel(WalletModel *model);
 
     RecentRequestsTableModel* recentRequestsTableModel() const { return m_recent_requests_table_model; }
 
@@ -63,6 +61,7 @@ private:
     QMenu *contextMenu;
     const PlatformStyle *platformStyle;
 
+    void setModel(WalletModel *model);
     QModelIndex selectedRow();
     void copyColumnToClipboard(int column);
     virtual void resizeEvent(QResizeEvent *event);

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -17,10 +17,10 @@
 #include <config/bitcoin-config.h> /* for USE_QRCODE */
 #endif
 
-ReceiveRequestDialog::ReceiveRequestDialog(QWidget *parent) :
+ReceiveRequestDialog::ReceiveRequestDialog(WalletModel* wallet_model, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::ReceiveRequestDialog),
-    model(nullptr)
+    model(wallet_model)
 {
     ui->setupUi(this);
 
@@ -30,22 +30,15 @@ ReceiveRequestDialog::ReceiveRequestDialog(QWidget *parent) :
 #endif
 
     connect(ui->btnSaveAs, &QPushButton::clicked, ui->lblQRCode, &QRImageWidget::saveImage);
+    connect(model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &ReceiveRequestDialog::update);
+
+    // update the display unit if necessary
+    update();
 }
 
 ReceiveRequestDialog::~ReceiveRequestDialog()
 {
     delete ui;
-}
-
-void ReceiveRequestDialog::setModel(WalletModel *_model)
-{
-    this->model = _model;
-
-    if (_model)
-        connect(_model->getOptionsModel(), &OptionsModel::displayUnitChanged, this, &ReceiveRequestDialog::update);
-
-    // update the display unit if necessary
-    update();
 }
 
 void ReceiveRequestDialog::setInfo(const SendCoinsRecipient &_info)

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -20,10 +20,9 @@ class ReceiveRequestDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ReceiveRequestDialog(QWidget *parent = nullptr);
+    explicit ReceiveRequestDialog(WalletModel* wallet_model, QWidget *parent = nullptr);
     ~ReceiveRequestDialog();
 
-    void setModel(WalletModel *model);
     void setInfo(const SendCoinsRecipient &info);
 
 private Q_SLOTS:
@@ -34,7 +33,7 @@ private Q_SLOTS:
 
 private:
     Ui::ReceiveRequestDialog *ui;
-    WalletModel *model;
+    WalletModel* const model;
     SendCoinsRecipient info;
 };
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -53,7 +53,7 @@ int getIndexForConfTarget(int target) {
     return confTargets.size() - 1;
 }
 
-SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
+SendCoinsDialog::SendCoinsDialog(ClientModel* client_model, WalletModel* wallet_model, const PlatformStyle *_platformStyle, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SendCoinsDialog),
     clientModel(nullptr),
@@ -127,6 +127,9 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     ui->customFee->SetAllowEmpty(false);
     ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
     minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+
+    setClientModel(client_model);
+    setModel(wallet_model);
 }
 
 void SendCoinsDialog::setClientModel(ClientModel *_clientModel)

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -69,9 +69,6 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
-    void setClientModel(ClientModel *clientModel);
-    void setModel(WalletModel *model);
-
 
 private Q_SLOTS:
     void on_sendButton_clicked();

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -31,11 +31,8 @@ class SendCoinsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SendCoinsDialog(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
+    explicit SendCoinsDialog(ClientModel* client_model, WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
     ~SendCoinsDialog();
-
-    void setClientModel(ClientModel *clientModel);
-    void setModel(WalletModel *model);
 
     /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases (issue https://bugreports.qt-project.org/browse/QTBUG-10907).
      */
@@ -72,6 +69,9 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
+    void setClientModel(ClientModel *clientModel);
+    void setModel(WalletModel *model);
+
 
 private Q_SLOTS:
     void on_sendButton_clicked();

--- a/src/qt/signverifymessagedialog.cpp
+++ b/src/qt/signverifymessagedialog.cpp
@@ -18,10 +18,10 @@
 
 #include <QClipboard>
 
-SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformStyle, QWidget *parent) :
+SignVerifyMessageDialog::SignVerifyMessageDialog(WalletModel* wallet_model, const PlatformStyle *_platformStyle, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SignVerifyMessageDialog),
-    model(nullptr),
+    model(wallet_model),
     platformStyle(_platformStyle)
 {
     ui->setupUi(this);
@@ -52,11 +52,6 @@ SignVerifyMessageDialog::SignVerifyMessageDialog(const PlatformStyle *_platformS
 SignVerifyMessageDialog::~SignVerifyMessageDialog()
 {
     delete ui;
-}
-
-void SignVerifyMessageDialog::setModel(WalletModel *_model)
-{
-    this->model = _model;
 }
 
 void SignVerifyMessageDialog::setAddress_SM(const QString &address)

--- a/src/qt/signverifymessagedialog.h
+++ b/src/qt/signverifymessagedialog.h
@@ -19,10 +19,9 @@ class SignVerifyMessageDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit SignVerifyMessageDialog(const PlatformStyle *platformStyle, QWidget *parent);
+    explicit SignVerifyMessageDialog(WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent);
     ~SignVerifyMessageDialog();
 
-    void setModel(WalletModel *model);
     void setAddress_SM(const QString &address);
     void setAddress_VM(const QString &address);
 
@@ -34,7 +33,7 @@ protected:
 
 private:
     Ui::SignVerifyMessageDialog *ui;
-    WalletModel *model;
+    WalletModel* const model;
     const PlatformStyle *platformStyle;
 
 private Q_SLOTS:

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -212,7 +212,8 @@ void TestGUI(interfaces::Node& node)
     // Check Request Payment button
     ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
     receiveCoinsDialog.setModel(&walletModel);
-    RecentRequestsTableModel* requestTableModel = walletModel.getRecentRequestsTableModel();
+    RecentRequestsTableModel* requestTableModel = receiveCoinsDialog.recentRequestsTableModel();
+    assert(requestTableModel);
 
     // Label input
     QLineEdit* labelInput = receiveCoinsDialog.findChild<QLineEdit*>("reqLabel");

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -8,6 +8,7 @@
 #include <interfaces/chain.h>
 #include <interfaces/node.h>
 #include <qt/bitcoinamountfield.h>
+#include <qt/clientmodel.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/qvalidatedlineedit.h>
@@ -165,13 +166,13 @@ void TestGUI(interfaces::Node& node)
 
     // Create widgets for sending coins and listing transactions.
     std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
-    SendCoinsDialog sendCoinsDialog(platformStyle.get());
     TransactionView transactionView(platformStyle.get());
     OptionsModel optionsModel(node);
+    ClientModel client_model(node, &optionsModel);
     AddWallet(wallet);
     WalletModel walletModel(interfaces::MakeWallet(wallet), node, platformStyle.get(), &optionsModel);
     RemoveWallet(wallet);
-    sendCoinsDialog.setModel(&walletModel);
+    SendCoinsDialog sendCoinsDialog(&client_model, &walletModel, platformStyle.get());
     transactionView.setModel(&walletModel);
 
     {
@@ -200,8 +201,7 @@ void TestGUI(interfaces::Node& node)
     BumpFee(transactionView, txid2, true /* expect disabled */, "already bumped" /* expected error */, false /* cancel */);
 
     // Check current balance on OverviewPage
-    OverviewPage overviewPage(platformStyle.get());
-    overviewPage.setWalletModel(&walletModel);
+    OverviewPage overviewPage(&client_model, &walletModel, platformStyle.get());
     QLabel* balanceLabel = overviewPage.findChild<QLabel*>("labelBalance");
     QString balanceText = balanceLabel->text();
     int unit = walletModel.getOptionsModel()->getDisplayUnit();
@@ -210,8 +210,7 @@ void TestGUI(interfaces::Node& node)
     QCOMPARE(balanceText, balanceComparison);
 
     // Check Request Payment button
-    ReceiveCoinsDialog receiveCoinsDialog(platformStyle.get());
-    receiveCoinsDialog.setModel(&walletModel);
+    ReceiveCoinsDialog receiveCoinsDialog(&walletModel, platformStyle.get());
     RecentRequestsTableModel* requestTableModel = receiveCoinsDialog.recentRequestsTableModel();
     assert(requestTableModel);
 

--- a/src/qt/test/wallettests.cpp
+++ b/src/qt/test/wallettests.cpp
@@ -166,14 +166,13 @@ void TestGUI(interfaces::Node& node)
 
     // Create widgets for sending coins and listing transactions.
     std::unique_ptr<const PlatformStyle> platformStyle(PlatformStyle::instantiate("other"));
-    TransactionView transactionView(platformStyle.get());
     OptionsModel optionsModel(node);
     ClientModel client_model(node, &optionsModel);
     AddWallet(wallet);
     WalletModel walletModel(interfaces::MakeWallet(wallet), node, platformStyle.get(), &optionsModel);
     RemoveWallet(wallet);
     SendCoinsDialog sendCoinsDialog(&client_model, &walletModel, platformStyle.get());
-    transactionView.setModel(&walletModel);
+    TransactionView transactionView(&walletModel, platformStyle.get());
 
     {
         // Check balance in send dialog

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -35,7 +35,7 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
-TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *parent) :
+TransactionView::TransactionView(WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent) :
     QWidget(parent), model(nullptr), transactionProxyModel(nullptr),
     transactionView(nullptr), abandonAction(nullptr), bumpFeeAction(nullptr), columnResizingFixer(nullptr)
 {
@@ -202,6 +202,8 @@ TransactionView::TransactionView(const PlatformStyle *platformStyle, QWidget *pa
     connect(this, &TransactionView::bumpedFee, [this](const uint256& txid) {
       focusTransaction(txid);
     });
+
+    setModel(wallet_model);
 }
 
 void TransactionView::setModel(WalletModel *_model)

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -58,7 +58,7 @@ public:
     };
 
 private:
-    WalletModel *model;
+    WalletModel* const model;
     TransactionFilterProxy *transactionProxyModel;
     QTableView *transactionView;
 
@@ -83,7 +83,6 @@ private:
     virtual void resizeEvent(QResizeEvent* event);
 
     bool eventFilter(QObject *obj, QEvent *event);
-    void setModel(WalletModel *model);
 
 private Q_SLOTS:
     void contextualMenu(const QPoint &);

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -34,9 +34,7 @@ class TransactionView : public QWidget
     Q_OBJECT
 
 public:
-    explicit TransactionView(const PlatformStyle *platformStyle, QWidget *parent = nullptr);
-
-    void setModel(WalletModel *model);
+    explicit TransactionView(WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent = nullptr);
 
     // Date ranges for filter
     enum DateEnum
@@ -85,6 +83,7 @@ private:
     virtual void resizeEvent(QResizeEvent* event);
 
     bool eventFilter(QObject *obj, QEvent *event);
+    void setModel(WalletModel *model);
 
 private Q_SLOTS:
     void contextualMenu(const QPoint &);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -45,9 +45,7 @@ bool WalletFrame::addWallet(WalletModel *walletModel)
 
     if (mapWalletViews.count(walletModel) > 0) return false;
 
-    WalletView *walletView = new WalletView(platformStyle, this);
-    walletView->setClientModel(clientModel);
-    walletView->setWalletModel(walletModel);
+    WalletView *walletView = new WalletView(clientModel, walletModel, platformStyle, this);
     walletView->showOutOfSyncWarning(bOutOfSync);
 
     WalletView* current_wallet_view = currentWalletView();

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -13,7 +13,6 @@
 #include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/paymentserver.h>
-#include <qt/recentrequeststablemodel.h>
 #include <qt/sendcoinsdialog.h>
 #include <qt/transactiontablemodel.h>
 
@@ -36,14 +35,12 @@
 WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces::Node& node, const PlatformStyle *platformStyle, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), m_wallet(std::move(wallet)), m_node(node), optionsModel(_optionsModel), addressTableModel(nullptr),
     transactionTableModel(nullptr),
-    recentRequestsTableModel(nullptr),
     cachedEncryptionStatus(Unencrypted),
     cachedNumBlocks(0)
 {
     fHaveWatchOnly = m_wallet->haveWatchOnly();
     addressTableModel = new AddressTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);
-    recentRequestsTableModel = new RecentRequestsTableModel(this);
 
     subscribeToCoreSignals();
 }
@@ -274,11 +271,6 @@ AddressTableModel *WalletModel::getAddressTableModel()
 TransactionTableModel *WalletModel::getTransactionTableModel()
 {
     return transactionTableModel;
-}
-
-RecentRequestsTableModel *WalletModel::getRecentRequestsTableModel()
-{
-    return recentRequestsTableModel;
 }
 
 WalletModel::EncryptionStatus WalletModel::getEncryptionStatus() const

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -26,7 +26,6 @@ enum class OutputType;
 class AddressTableModel;
 class OptionsModel;
 class PlatformStyle;
-class RecentRequestsTableModel;
 class SendCoinsRecipient;
 class TransactionTableModel;
 class WalletModelTransaction;
@@ -78,7 +77,6 @@ public:
     OptionsModel *getOptionsModel();
     AddressTableModel *getAddressTableModel();
     TransactionTableModel *getTransactionTableModel();
-    RecentRequestsTableModel *getRecentRequestsTableModel();
 
     EncryptionStatus getEncryptionStatus() const;
 
@@ -172,7 +170,6 @@ private:
 
     AddressTableModel *addressTableModel;
     TransactionTableModel *transactionTableModel;
-    RecentRequestsTableModel *recentRequestsTableModel;
 
     // Cache some values to be able to detect changes
     interfaces::WalletBalances m_cached_balances;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -54,7 +54,7 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
     transactionsPage->setLayout(vbox);
 
     receiveCoinsPage = new ReceiveCoinsDialog(wallet_model, platformStyle);
-    sendCoinsPage = new SendCoinsDialog(platformStyle);
+    sendCoinsPage = new SendCoinsDialog(client_model, wallet_model, platformStyle);
 
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
     usedReceivingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::ReceivingTab, this);
@@ -95,7 +95,6 @@ void WalletView::setClientModel(ClientModel *_clientModel)
     this->clientModel = _clientModel;
 
     overviewPage->setClientModel(_clientModel);
-    sendCoinsPage->setClientModel(_clientModel);
 }
 
 void WalletView::setWalletModel(WalletModel *_walletModel)
@@ -105,7 +104,6 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     // Put transaction list in tabs
     transactionView->setModel(_walletModel);
     overviewPage->setWalletModel(_walletModel);
-    sendCoinsPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
     usedSendingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -156,9 +156,8 @@ void WalletView::gotoSendCoinsPage(QString addr)
 void WalletView::gotoSignMessageTab(QString addr)
 {
     // calls show() in showTab_SM()
-    SignVerifyMessageDialog *signVerifyMessageDialog = new SignVerifyMessageDialog(platformStyle, this);
+    SignVerifyMessageDialog *signVerifyMessageDialog = new SignVerifyMessageDialog(walletModel, platformStyle, this);
     signVerifyMessageDialog->setAttribute(Qt::WA_DeleteOnClose);
-    signVerifyMessageDialog->setModel(walletModel);
     signVerifyMessageDialog->showTab_SM(true);
 
     if (!addr.isEmpty())
@@ -168,9 +167,8 @@ void WalletView::gotoSignMessageTab(QString addr)
 void WalletView::gotoVerifyMessageTab(QString addr)
 {
     // calls show() in showTab_VM()
-    SignVerifyMessageDialog *signVerifyMessageDialog = new SignVerifyMessageDialog(platformStyle, this);
+    SignVerifyMessageDialog *signVerifyMessageDialog = new SignVerifyMessageDialog(walletModel, platformStyle, this);
     signVerifyMessageDialog->setAttribute(Qt::WA_DeleteOnClose);
-    signVerifyMessageDialog->setModel(walletModel);
     signVerifyMessageDialog->showTab_VM(true);
 
     if (!addr.isEmpty())

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -31,12 +31,12 @@
 
 WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, const PlatformStyle *_platformStyle, QWidget *parent):
     QStackedWidget(parent),
-    clientModel(nullptr),
+    clientModel(client_model),
     walletModel(nullptr),
     platformStyle(_platformStyle)
 {
     // Create tabs
-    overviewPage = new OverviewPage(platformStyle);
+    overviewPage = new OverviewPage(client_model, platformStyle);
 
     transactionsPage = new QWidget(this);
     QVBoxLayout *vbox = new QVBoxLayout();
@@ -82,19 +82,13 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
     // Pass through messages from transactionView
     connect(transactionView, &TransactionView::message, this, &WalletView::message);
 
-    setClientModel(client_model);
     setWalletModel(wallet_model);
+
+    overviewPage->setClientModel(clientModel);
 }
 
 WalletView::~WalletView()
 {
-}
-
-void WalletView::setClientModel(ClientModel *_clientModel)
-{
-    this->clientModel = _clientModel;
-
-    overviewPage->setClientModel(_clientModel);
 }
 
 void WalletView::setWalletModel(WalletModel *_walletModel)

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -41,7 +41,7 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
     transactionsPage = new QWidget(this);
     QVBoxLayout *vbox = new QVBoxLayout();
     QHBoxLayout *hbox_buttons = new QHBoxLayout();
-    transactionView = new TransactionView(platformStyle, this);
+    transactionView = new TransactionView(wallet_model, platformStyle, this);
     vbox->addWidget(transactionView);
     QPushButton *exportButton = new QPushButton(tr("&Export"), this);
     exportButton->setToolTip(tr("Export the data in the current tab to a file"));
@@ -83,7 +83,6 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
     connect(transactionView, &TransactionView::message, this, &WalletView::message);
 
     // Put transaction list in tabs
-    transactionView->setModel(walletModel);
     usedReceivingAddressesPage->setModel(walletModel->getAddressTableModel());
     usedSendingAddressesPage->setModel(walletModel->getAddressTableModel());
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -106,8 +106,6 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
 
     // Show progress dialog
     connect(walletModel, &WalletModel::showProgress, this, &WalletView::showProgress);
-
-    overviewPage->setClientModel(clientModel);
 }
 
 WalletView::~WalletView()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -29,7 +29,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 
-WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
+WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, const PlatformStyle *_platformStyle, QWidget *parent):
     QStackedWidget(parent),
     clientModel(nullptr),
     walletModel(nullptr),
@@ -81,6 +81,9 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, QWidget *parent):
     connect(sendCoinsPage, &SendCoinsDialog::message, this, &WalletView::message);
     // Pass through messages from transactionView
     connect(transactionView, &TransactionView::message, this, &WalletView::message);
+
+    setClientModel(client_model);
+    setWalletModel(wallet_model);
 }
 
 WalletView::~WalletView()

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -36,7 +36,7 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
     platformStyle(_platformStyle)
 {
     // Create tabs
-    overviewPage = new OverviewPage(client_model, platformStyle);
+    overviewPage = new OverviewPage(client_model, wallet_model, platformStyle);
 
     transactionsPage = new QWidget(this);
     QVBoxLayout *vbox = new QVBoxLayout();
@@ -84,7 +84,6 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
 
     // Put transaction list in tabs
     transactionView->setModel(walletModel);
-    overviewPage->setWalletModel(walletModel);
     usedReceivingAddressesPage->setModel(walletModel->getAddressTableModel());
     usedSendingAddressesPage->setModel(walletModel->getAddressTableModel());
 

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -194,8 +194,7 @@ void WalletView::encryptWallet(bool status)
 {
     if(!walletModel)
         return;
-    AskPassphraseDialog dlg(status ? AskPassphraseDialog::Encrypt : AskPassphraseDialog::Decrypt, this);
-    dlg.setModel(walletModel);
+    AskPassphraseDialog dlg(status ? AskPassphraseDialog::Encrypt : AskPassphraseDialog::Decrypt, walletModel, this);
     dlg.exec();
 
     updateEncryptionStatus();
@@ -222,8 +221,7 @@ void WalletView::backupWallet()
 
 void WalletView::changePassphrase()
 {
-    AskPassphraseDialog dlg(AskPassphraseDialog::ChangePass, this);
-    dlg.setModel(walletModel);
+    AskPassphraseDialog dlg(AskPassphraseDialog::ChangePass, walletModel, this);
     dlg.exec();
 }
 
@@ -234,8 +232,7 @@ void WalletView::unlockWallet()
     // Unlock wallet when requested by wallet model
     if (walletModel->getEncryptionStatus() == WalletModel::Locked)
     {
-        AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, this);
-        dlg.setModel(walletModel);
+        AskPassphraseDialog dlg(AskPassphraseDialog::Unlock, walletModel, this);
         dlg.exec();
     }
 }

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -53,7 +53,7 @@ WalletView::WalletView(ClientModel* client_model, WalletModel* wallet_model, con
     vbox->addLayout(hbox_buttons);
     transactionsPage->setLayout(vbox);
 
-    receiveCoinsPage = new ReceiveCoinsDialog(platformStyle);
+    receiveCoinsPage = new ReceiveCoinsDialog(wallet_model, platformStyle);
     sendCoinsPage = new SendCoinsDialog(platformStyle);
 
     usedSendingAddressesPage = new AddressBookPage(platformStyle, AddressBookPage::ForEditing, AddressBookPage::SendingTab, this);
@@ -105,7 +105,6 @@ void WalletView::setWalletModel(WalletModel *_walletModel)
     // Put transaction list in tabs
     transactionView->setModel(_walletModel);
     overviewPage->setWalletModel(_walletModel);
-    receiveCoinsPage->setModel(_walletModel);
     sendCoinsPage->setModel(_walletModel);
     usedReceivingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);
     usedSendingAddressesPage->setModel(_walletModel ? _walletModel->getAddressTableModel() : nullptr);

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -46,7 +46,7 @@ public:
 
 private:
     ClientModel* const clientModel;
-    WalletModel *walletModel;
+    WalletModel* const walletModel;
 
     OverviewPage *overviewPage;
     QWidget *transactionsPage;
@@ -59,12 +59,6 @@ private:
 
     QProgressDialog *progressDialog;
     const PlatformStyle *platformStyle;
-
-    /** Set the wallet model.
-        The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
-        functionality.
-    */
-    void setWalletModel(WalletModel *walletModel);
 
 public Q_SLOTS:
     /** Switch to overview (home) page */

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -45,7 +45,7 @@ public:
     void showOutOfSyncWarning(bool fShow);
 
 private:
-    ClientModel *clientModel;
+    ClientModel* const clientModel;
     WalletModel *walletModel;
 
     OverviewPage *overviewPage;
@@ -60,10 +60,6 @@ private:
     QProgressDialog *progressDialog;
     const PlatformStyle *platformStyle;
 
-    /** Set the client model.
-        The client model represents the part of the core that communicates with the P2P network, and is wallet-agnostic.
-    */
-    void setClientModel(ClientModel *clientModel);
     /** Set the wallet model.
         The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
         functionality.

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -35,19 +35,10 @@ class WalletView : public QStackedWidget
     Q_OBJECT
 
 public:
-    explicit WalletView(const PlatformStyle *platformStyle, QWidget *parent);
+    explicit WalletView(ClientModel* client_model, WalletModel* wallet_model, const PlatformStyle *platformStyle, QWidget *parent);
     ~WalletView();
 
-    /** Set the client model.
-        The client model represents the part of the core that communicates with the P2P network, and is wallet-agnostic.
-    */
-    void setClientModel(ClientModel *clientModel);
     WalletModel *getWalletModel() { return walletModel; }
-    /** Set the wallet model.
-        The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
-        functionality.
-    */
-    void setWalletModel(WalletModel *walletModel);
 
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 
@@ -68,6 +59,16 @@ private:
 
     QProgressDialog *progressDialog;
     const PlatformStyle *platformStyle;
+
+    /** Set the client model.
+        The client model represents the part of the core that communicates with the P2P network, and is wallet-agnostic.
+    */
+    void setClientModel(ClientModel *clientModel);
+    /** Set the wallet model.
+        The wallet model represents a bitcoin wallet, and offers access to the list of transactions, address book and sending
+        functionality.
+    */
+    void setWalletModel(WalletModel *walletModel);
 
 public Q_SLOTS:
     /** Switch to overview (home) page */

--- a/test/lint/lint-circular-dependencies.sh
+++ b/test/lint/lint-circular-dependencies.sh
@@ -14,7 +14,6 @@ EXPECTED_CIRCULAR_DEPENDENCIES=(
     "policy/fees -> txmempool -> policy/fees"
     "qt/addresstablemodel -> qt/walletmodel -> qt/addresstablemodel"
     "qt/bitcoingui -> qt/walletframe -> qt/bitcoingui"
-    "qt/recentrequeststablemodel -> qt/walletmodel -> qt/recentrequeststablemodel"
     "qt/sendcoinsdialog -> qt/walletmodel -> qt/sendcoinsdialog"
     "qt/transactiontablemodel -> qt/walletmodel -> qt/transactiontablemodel"
     "txmempool -> validation -> txmempool"


### PR DESCRIPTION
This change makes the code simpler as the client and wallet models are set in the constructor and are constant.

Based on #18064, only bbb33d6.

This does't change behavior.