### PR TITLE
Add BIP324 encrypted p2p transport de-/serializer (only used in tests)

### DIFF
--- a/src/crypto/chacha_poly_aead.cpp
+++ b/src/crypto/chacha_poly_aead.cpp
@@ -4,6 +4,7 @@
 
 #include <crypto/chacha_poly_aead.h>
 
+#include <crypto/common.h>
 #include <crypto/poly1305.h>
 #include <support/cleanse.h>
 
@@ -27,19 +28,52 @@ int timingsafe_bcmp(const unsigned char* b1, const unsigned char* b2, size_t n)
 
 #endif // TIMINGSAFE_BCMP
 
+void ChaCha20ReKey4096::SetKey(const unsigned char* key, size_t keylen) {
+    assert(keylen == 32);
+    m_ctx.SetKey(key, keylen);
+
+    // set initial sequence number
+    m_seqnr = 0;
+    m_ctx.SetIV(m_seqnr);
+
+    // precompute first chunk of keystream
+    m_ctx.Keystream(m_keystream, KEYSTREAM_SIZE);
+    m_keystream_pos = 0;
+}
+
+void ChaCha20ReKey4096::Crypt(const unsigned char* input, unsigned char* output, size_t bytes) {
+    size_t message_pos = 0;
+
+    // TODO: speedup with a block approach (rather then looping over every byte)
+    while (bytes > message_pos) {
+        output[message_pos] = input[message_pos] ^ ReadLE32(&m_keystream[m_keystream_pos]);
+        m_keystream_pos++;
+        message_pos++;
+        if (m_keystream_pos == KEYSTREAM_SIZE-CHACHA20_POLY1305_AEAD_KEY_LEN) {
+            // we reached the end of the keystream
+            // rekey with the remaining and last 32 bytes and precompute the next 4096 bytes
+            m_ctx.SetKey(&m_keystream[m_keystream_pos], CHACHA20_POLY1305_AEAD_KEY_LEN);
+            m_ctx.SetIV(++m_seqnr);
+            m_ctx.Keystream(m_keystream, KEYSTREAM_SIZE);
+            // reset keystream position
+            m_keystream_pos = 0;
+        }
+    }
+}
+
+ChaCha20ReKey4096::~ChaCha20ReKey4096() {
+    memory_cleanse(m_keystream, KEYSTREAM_SIZE);
+}
+
 ChaCha20Poly1305AEAD::ChaCha20Poly1305AEAD(const unsigned char* K_1, size_t K_1_len, const unsigned char* K_2, size_t K_2_len)
 {
     assert(K_1_len == CHACHA20_POLY1305_AEAD_KEY_LEN);
     assert(K_2_len == CHACHA20_POLY1305_AEAD_KEY_LEN);
     m_chacha_main.SetKey(K_1, CHACHA20_POLY1305_AEAD_KEY_LEN);
     m_chacha_header.SetKey(K_2, CHACHA20_POLY1305_AEAD_KEY_LEN);
-
-    // set the cached sequence number to uint64 max which hints for an unset cache.
-    // we can't hit uint64 max since the rekey rule (which resets the sequence number) is 1GB
-    m_cached_aad_seqnr = std::numeric_limits<uint64_t>::max();
 }
 
-bool ChaCha20Poly1305AEAD::Crypt(uint64_t seqnr_payload, uint64_t seqnr_aad, int aad_pos, unsigned char* dest, size_t dest_len /* length of the output buffer for sanity checks */, const unsigned char* src, size_t src_len, bool is_encrypt)
+bool ChaCha20Poly1305AEAD::Crypt(unsigned char* dest, size_t dest_len /* length of the output buffer for sanity checks */, const unsigned char* src, size_t src_len, bool is_encrypt)
 {
     // check buffer boundaries
     if (
@@ -52,18 +86,24 @@ bool ChaCha20Poly1305AEAD::Crypt(uint64_t seqnr_payload, uint64_t seqnr_aad, int
 
     unsigned char expected_tag[POLY1305_TAGLEN], poly_key[POLY1305_KEYLEN];
     memset(poly_key, 0, sizeof(poly_key));
-    m_chacha_main.SetIV(seqnr_payload);
 
-    // block counter 0 for the poly1305 key
-    // use lower 32bytes for the poly1305 key
-    // (throws away 32 unused bytes (upper 32) from this ChaCha20 round)
-    m_chacha_main.Seek(0);
-    m_chacha_main.Crypt(poly_key, poly_key, sizeof(poly_key));
+    // 1. AAD (the encrypted packet length), use the header-keystream
+    if (is_encrypt) {
+        m_chacha_header.Crypt(src, dest, 3);
+    } else {
+        // we must use ChaCha20Poly1305AEAD::DecryptLength before calling ChaCha20Poly1305AEAD::Crypt
+        // thus the length has already been encrypted, avoid doing it again and messing up the keystream position
+        // keep the encrypted version of the AAD to not break verifying the MAC
+        memcpy(dest, src, 3);
+    }
 
-    // if decrypting, verify the tag prior to decryption
+    // 2. derive the poly1305 key from the header-keystream
+    m_chacha_header.Crypt(poly_key, poly_key, sizeof(poly_key));
+
+    // 3. if decrypting, verify the MAC prior to decryption
     if (!is_encrypt) {
-        const unsigned char* tag = src + src_len - POLY1305_TAGLEN;
-        poly1305_auth(expected_tag, src, src_len - POLY1305_TAGLEN, poly_key);
+        const unsigned char* tag = src + src_len - POLY1305_TAGLEN; //the MAC appended in the package
+        poly1305_auth(expected_tag, src, src_len - POLY1305_TAGLEN, poly_key); //the calculated MAC
 
         // constant time compare the calculated MAC with the provided MAC
         if (timingsafe_bcmp(expected_tag, tag, POLY1305_TAGLEN) != 0) {
@@ -72,54 +112,35 @@ bool ChaCha20Poly1305AEAD::Crypt(uint64_t seqnr_payload, uint64_t seqnr_aad, int
             return false;
         }
         memory_cleanse(expected_tag, sizeof(expected_tag));
-        // MAC has been successfully verified, make sure we don't covert it in decryption
+        // MAC has been successfully verified, make sure we don't decrypt it
         src_len -= POLY1305_TAGLEN;
     }
 
-    // calculate and cache the next 64byte keystream block if requested sequence number is not yet the cache
-    if (m_cached_aad_seqnr != seqnr_aad) {
-        m_cached_aad_seqnr = seqnr_aad;
-        m_chacha_header.SetIV(seqnr_aad);
-        m_chacha_header.Seek(0);
-        m_chacha_header.Keystream(m_aad_keystream_buffer, CHACHA20_ROUND_OUTPUT);
-    }
-    // crypt the AAD (3 bytes message length) with given position in AAD cipher instance keystream
-    dest[0] = src[0] ^ m_aad_keystream_buffer[aad_pos];
-    dest[1] = src[1] ^ m_aad_keystream_buffer[aad_pos + 1];
-    dest[2] = src[2] ^ m_aad_keystream_buffer[aad_pos + 2];
-
-    // Set the playload ChaCha instance block counter to 1 and crypt the payload
-    m_chacha_main.Seek(1);
+    // 4. crypt the payload
     m_chacha_main.Crypt(src + CHACHA20_POLY1305_AEAD_AAD_LEN, dest + CHACHA20_POLY1305_AEAD_AAD_LEN, src_len - CHACHA20_POLY1305_AEAD_AAD_LEN);
 
-    // If encrypting, calculate and append tag
+    // 5. If encrypting, calculate and append MAC
     if (is_encrypt) {
-        // the poly1305 tag expands over the AAD (3 bytes length) & encrypted payload
+        // the poly1305 MAC expands over the AAD (3 bytes length) & encrypted payload
         poly1305_auth(dest + src_len, dest, src_len, poly_key);
     }
 
-    // cleanse no longer required MAC and polykey
+    // cleanse no longer required polykey
     memory_cleanse(poly_key, sizeof(poly_key));
     return true;
 }
 
-bool ChaCha20Poly1305AEAD::GetLength(uint32_t* len24_out, uint64_t seqnr_aad, int aad_pos, const uint8_t* ciphertext)
+bool ChaCha20Poly1305AEAD::DecryptLength(uint32_t* len24_out, const uint8_t* ciphertext)
 {
-    // enforce valid aad position to avoid accessing outside of the 64byte keystream cache
-    // (there is space for 21 times 3 bytes)
-    assert(aad_pos >= 0 && aad_pos < CHACHA20_ROUND_OUTPUT - CHACHA20_POLY1305_AEAD_AAD_LEN);
-    if (m_cached_aad_seqnr != seqnr_aad) {
-        // we need to calculate the 64 keystream bytes since we reached a new aad sequence number
-        m_cached_aad_seqnr = seqnr_aad;
-        m_chacha_header.SetIV(seqnr_aad);                                         // use LE for the nonce
-        m_chacha_header.Seek(0);                                                  // block counter 0
-        m_chacha_header.Keystream(m_aad_keystream_buffer, CHACHA20_ROUND_OUTPUT); // write keystream to the cache
-    }
+    // decrypt the length
+    // once we hit the re-key limit in the keystream (byte 4064) we can't go back to decrypt the length again
+    // we need to keep the decrypted and the encrypted version in memory to check the max packet length and
+    // to have the capability to verify the MAC
+    unsigned char length_buffer[CHACHA20_POLY1305_AEAD_AAD_LEN];
+    m_chacha_header.Crypt(ciphertext, length_buffer, sizeof(length_buffer));
 
-    // decrypt the ciphertext length by XORing the right position of the 64byte keystream cache with the ciphertext
-    *len24_out = (ciphertext[0] ^ m_aad_keystream_buffer[aad_pos + 0]) |
-                 (ciphertext[1] ^ m_aad_keystream_buffer[aad_pos + 1]) << 8 |
-                 (ciphertext[2] ^ m_aad_keystream_buffer[aad_pos + 2]) << 16;
-
+    *len24_out = (length_buffer[0]) |
+                 (length_buffer[1]) << 8 |
+                 (length_buffer[2]) << 16;
     return true;
 }

--- a/src/crypto/chacha_poly_aead.h
+++ b/src/crypto/chacha_poly_aead.h
@@ -6,6 +6,7 @@
 #define BITCOIN_CRYPTO_CHACHA_POLY_AEAD_H
 
 #include <crypto/chacha20.h>
+#include <crypto/poly1305.h>
 
 #include <cmath>
 
@@ -36,91 +37,86 @@ static constexpr int AAD_PACKAGES_PER_ROUND = 21;        /* 64 / 3 round down*/
  *
  * ==== Detailed Construction ====
  *
- * The chacha20-poly1305@bitcoin cipher requires two 256 bits of key material as
- * output from the key exchange. Each key (K_1 and K_2) are used by two separate
- * instances of chacha20.
- *
- * The instance keyed by K_1 is a stream cipher that is used only to encrypt the 3
- * byte packet length field and has its own sequence number. The second instance,
- * keyed by K_2, is used in conjunction with poly1305 to build an AEAD
- * (Authenticated Encryption with Associated Data) that is used to encrypt and
- * authenticate the entire packet.
- *
- * Two separate cipher instances are used here so as to keep the packet lengths
- * confidential but not create an oracle for the packet payload cipher by
- * decrypting and using the packet length prior to checking the MAC. By using an
- * independently-keyed cipher instance to encrypt the length, an active attacker
- * seeking to exploit the packet input handling as a decryption oracle can learn
- * nothing about the payload contents or its MAC (assuming key derivation,
- * ChaCha20 and Poly1305 are secure).
- *
- * The AEAD is constructed as follows: for each packet, generate a Poly1305 key by
- * taking the first 256 bits of ChaCha20 stream output generated using K_2, an IV
- * consisting of the packet sequence number encoded as an LE uint64 and a ChaCha20
- * block counter of zero. The K_2 ChaCha20 block counter is then set to the
- * little-endian encoding of 1 (i.e. {1, 0, 0, 0, 0, 0, 0, 0}) and this instance
- * is used for encryption of the packet payload.
- *
- * ==== Packet Handling ====
- *
- * When receiving a packet, the length must be decrypted first. When 3 bytes of
- * ciphertext length have been received, they may be decrypted.
- *
- * A ChaCha20 round always calculates 64bytes which is sufficient to crypt 21
- * times a 3 bytes length field (21*3 = 63). The length field sequence number can
- * thus be used 21 times (keystream caching).
- *
- * The length field must be enc-/decrypted with the ChaCha20 keystream keyed with
- * K_1 defined by block counter 0, the length field sequence number in little
- * endian and a keystream position from 0 to 60.
- *
- * Once the entire packet has been received, the MAC MUST be checked before
- * decryption. A per-packet Poly1305 key is generated as described above and the
- * MAC tag calculated using Poly1305 with this key over the ciphertext of the
- * packet length and the payload together. The calculated MAC is then compared in
- * constant time with the one appended to the packet and the packet decrypted
- * using ChaCha20 as described above (with K_2, the packet sequence number as
- * nonce and a starting block counter of 1).
- *
- * Detection of an invalid MAC MUST lead to immediate connection termination.
- *
- * To send a packet, first encode the 3 byte length and encrypt it using K_1 as
- * described above. Encrypt the packet payload (using K_2) and append it to the
- * encrypted length. Finally, calculate a MAC tag and append it.
- *
- * The initiating peer MUST use <code>K_1_A, K_2_A</code> to encrypt messages on
- * the send channel, <code>K_1_B, K_2_B</code> MUST be used to decrypt messages on
- * the receive channel.
- *
- * The responding peer MUST use <code>K_1_A, K_2_A</code> to decrypt messages on
- * the receive channel, <code>K_1_B, K_2_B</code> MUST be used to encrypt messages
- * on the send channel.
- *
- * Optimized implementations of ChaCha20-Poly1305@bitcoin are relatively fast in
- * general, therefore it is very likely that encrypted messages require not more
- * CPU cycles per bytes then the current unencrypted p2p message format
- * (ChaCha20/Poly1305 versus double SHA256).
- *
- * The initial packet sequence numbers are 0.
- *
- * K_2 ChaCha20 cipher instance (payload) must never reuse a {key, nonce} for
- * encryption nor may it be used to encrypt more than 2^70 bytes under the same
- * {key, nonce}.
- *
- * K_1 ChaCha20 cipher instance (length field/AAD) must never reuse a {key, nonce,
- * position-in-keystream} for encryption nor may it be used to encrypt more than
- * 2^70 bytes under the same {key, nonce}.
- *
- * We use message sequence numbers for both communication directions.
- */
+The chacha20-poly1305@bitcoin cipher requires two 256 bits of key material as
+* output from the key exchange. Each key (K_1 and K_2) are used by two separate
+* instances of chacha20.
+*
+* The instance keyed by K_1 is a stream cipher that is used for the per-message
+* metadata, specifically for the poly1305 authentication key as well as for the
+* length encryption. The second instance, keyed by K_2, is used to encrypt the
+* entire payload.
+*
+* Two separate cipher instances are used here so as to keep the packet lengths
+* confidential (best effort; for passive observing) but not create an oracle for
+* the packet payload cipher by decrypting and using the packet length prior to
+* checking the MAC. By using an independently-keyed cipher instance to encrypt
+* the length, an active attacker seeking to exploit the packet input handling as
+* a decryption oracle can learn nothing about the payload contents or its MAC
+* (assuming key derivation, ChaCha20 and Poly1305 are secure). Active observers
+* can still obtain the message length (ex. active ciphertext bit flipping or
+* traffic shemantics analysis)
+*
+* The AEAD is constructed as follows: generate two ChaCha20 streams, initially
+* keyed with K_1 and K_2 and IV of 0 and a block counter of 0 and a sequence
+* number 0 as IV. After encrypting 4064 bytes, the following 32 bytes are used to
+* re-key the ChaCha20 context.
+*
+* Byte-level forward security is possible by precomputing 4096 bytes of stream
+* output, caching it, resetting the key to the final 32 bytes of the output, and
+* then wiping the remaining 4064 bytes of cached data as it gets used.
+*
+* For each packet, use 3 bytes from the remaining ChaCha20 stream generated using
+* K_1 to encrypt the length. Use additional 32 bytes of the same stream to
+* generate a Poly1305 key.
+*
+* If we reach bytes 4064 on the ChaCha20 stream, use the next 32 bytes (byte
+* 4065-4096) and set is as the new ChaCha20 key, reset the counter to 0 while
+* incrementing the sequence number + 1 and set is as IV (little endian encoding).
+*
+* For the payload, use the ChaCha20 stream keyed with K_1 and apply the same
+* re-key rules.
+*
+*
+* ==== Packet Handling ====
+*
+* When receiving a packet, the length must be decrypted first. When 3 bytes of
+* ciphertext length have been received, they MUST be decrypted.
+*
+* Once the entire packet has been received, the MAC MUST be checked before
+* decryption. A per-packet Poly1305 key is generated as described above and the
+* MAC tag is calculated using Poly1305 with this key over the ciphertext of the
+* packet length and the payload together. The calculated MAC is then compared in
+* constant time with the one appended to the packet and the packet decrypted
+* using ChaCha20 as described above (with K_2, the packet sequence number as
+* nonce and a starting block counter of 1).
+*
+* Detection of an invalid MAC MUST lead to immediate connection termination.
+*
+* To send a packet, first encode the 3 byte length and encrypt it using the
+* ChaCha20 stream keyed with K_1 as described above. Encrypt the packet payload
+* (using the ChaCha20 stream keyed with K_2) and append it to the encrypted
+* length. Finally, calculate a MAC tag and append it.
+*/
+
+const int KEYSTREAM_SIZE = 4096;
+
+class ChaCha20ReKey4096 {
+private:
+    ChaCha20 m_ctx;
+    uint64_t m_seqnr{0};
+    size_t m_keystream_pos{0};
+    unsigned char m_keystream[KEYSTREAM_SIZE] = {0};
+public:
+    ~ChaCha20ReKey4096();
+    void SetKey(const unsigned char* key, size_t keylen);
+    void Crypt(const unsigned char* input, unsigned char* output, size_t bytes);
+};
 
 class ChaCha20Poly1305AEAD
 {
 private:
-    ChaCha20 m_chacha_main;                                      // payload and poly1305 key-derivation cipher instance
-    ChaCha20 m_chacha_header;                                    // AAD cipher instance (encrypted length)
-    unsigned char m_aad_keystream_buffer[CHACHA20_ROUND_OUTPUT]; // aad keystream cache
-    uint64_t m_cached_aad_seqnr;                                 // aad keystream cache hint
+    ChaCha20ReKey4096 m_chacha_main;                                      // payload and poly1305 key-derivation cipher instance
+    ChaCha20ReKey4096 m_chacha_header;                                    // AAD cipher instance (encrypted length)
 
 public:
     ChaCha20Poly1305AEAD(const unsigned char* K_1, size_t K_1_len, const unsigned char* K_2, size_t K_2_len);
@@ -128,19 +124,19 @@ public:
     explicit ChaCha20Poly1305AEAD(const ChaCha20Poly1305AEAD&) = delete;
 
     /** Encrypts/decrypts a packet
-        seqnr_payload, the message sequence number
-        seqnr_aad, the messages AAD sequence number which allows reuse of the AAD keystream
-        aad_pos, position to use in the AAD keystream to encrypt the AAD
         dest, output buffer, must be of a size equal or larger then CHACHA20_POLY1305_AEAD_AAD_LEN + payload (+ POLY1305_TAG_LEN in encryption) bytes
         destlen, length of the destination buffer
         src, the AAD+payload to encrypt or the AAD+payload+MAC to decrypt
         src_len, the length of the source buffer
         is_encrypt, set to true if we encrypt (creates and appends the MAC instead of verifying it)
         */
-    bool Crypt(uint64_t seqnr_payload, uint64_t seqnr_aad, int aad_pos, unsigned char* dest, size_t dest_len, const unsigned char* src, size_t src_len, bool is_encrypt);
+    bool Crypt(unsigned char* dest, size_t dest_len, const unsigned char* src, size_t src_len, bool is_encrypt);
 
-    /** decrypts the 3 bytes AAD data and decodes it into a uint32_t field */
-    bool GetLength(uint32_t* len24_out, uint64_t seqnr_aad, int aad_pos, const uint8_t* ciphertext);
+    /** decrypts the 3 bytes AAD data (the packet length) and decodes it into a uint32_t field
+        the ciphertext will not be manipulated but the AEAD state changes (can't be called multiple times)
+        Ciphertext needs to stay encrypted due to the MAC check that will follow (requires encrypted length)
+        */
+    bool DecryptLength(uint32_t* len24_out, const uint8_t* ciphertext);
 };
 
 #endif // BITCOIN_CRYPTO_CHACHA_POLY_AEAD_H

--- a/src/crypto/chacha_poly_aead.h
+++ b/src/crypto/chacha_poly_aead.h
@@ -12,6 +12,7 @@
 
 static constexpr int CHACHA20_POLY1305_AEAD_KEY_LEN = 32;
 static constexpr int CHACHA20_POLY1305_AEAD_AAD_LEN = 3; /* 3 bytes length */
+static constexpr int CHACHA20_POLY1305_AEAD_TAG_LEN = 16; /* 16 bytes poly1305 tag */
 static constexpr int CHACHA20_ROUND_OUTPUT = 64;         /* 64 bytes per round */
 static constexpr int AAD_PACKAGES_PER_ROUND = 21;        /* 64 / 3 round down*/
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2836,8 +2836,9 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, SOCKET hSocketIn, const
         m_addr_known = MakeUnique<CRollingBloomFilter>(5000, 0.001);
     }
 
-    for (const std::string &msg : getAllNetMessageTypes())
-        mapRecvBytesPerMsgCmd[msg] = 0;
+    for (const auto &msg : getAllNetMessageTypes()) {
+        mapRecvBytesPerMsgCmd[msg.second] = 0;
+    }
     mapRecvBytesPerMsgCmd[NET_MESSAGE_COMMAND_OTHER] = 0;
 
     if (fLogIPs) {

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -47,46 +47,45 @@ const char *CFCHECKPT="cfcheckpt";
 const char *WTXIDRELAY="wtxidrelay";
 } // namespace NetMsgType
 
-/** All known message types. Keep this in the same order as the list of
+/** All known message types including the short-ID. Keep this in the same order as the list of
  * messages above and in protocol.h.
  */
-const static std::string allNetMessageTypes[] = {
-    NetMsgType::VERSION,
-    NetMsgType::VERACK,
-    NetMsgType::ADDR,
-    NetMsgType::ADDRV2,
-    NetMsgType::SENDADDRV2,
-    NetMsgType::INV,
-    NetMsgType::GETDATA,
-    NetMsgType::MERKLEBLOCK,
-    NetMsgType::GETBLOCKS,
-    NetMsgType::GETHEADERS,
-    NetMsgType::TX,
-    NetMsgType::HEADERS,
-    NetMsgType::BLOCK,
-    NetMsgType::GETADDR,
-    NetMsgType::MEMPOOL,
-    NetMsgType::PING,
-    NetMsgType::PONG,
-    NetMsgType::NOTFOUND,
-    NetMsgType::FILTERLOAD,
-    NetMsgType::FILTERADD,
-    NetMsgType::FILTERCLEAR,
-    NetMsgType::SENDHEADERS,
-    NetMsgType::FEEFILTER,
-    NetMsgType::SENDCMPCT,
-    NetMsgType::CMPCTBLOCK,
-    NetMsgType::GETBLOCKTXN,
-    NetMsgType::BLOCKTXN,
-    NetMsgType::GETCFILTERS,
-    NetMsgType::CFILTER,
-    NetMsgType::GETCFHEADERS,
-    NetMsgType::CFHEADERS,
-    NetMsgType::GETCFCHECKPT,
-    NetMsgType::CFCHECKPT,
-    NetMsgType::WTXIDRELAY,
+const static std::map<uint8_t, std::string> allNetMessageTypes = {
+    {38, NetMsgType::VERSION},
+    {37, NetMsgType::VERACK},
+    {13, NetMsgType::ADDR},
+    {46, NetMsgType::ADDRV2},
+    {47, NetMsgType::SENDADDRV2},
+    {27, NetMsgType::INV},
+    {24, NetMsgType::GETDATA},
+    {29, NetMsgType::MERKLEBLOCK},
+    {22, NetMsgType::GETBLOCKS},
+    {25, NetMsgType::GETHEADERS},
+    {36, NetMsgType::TX},
+    {26, NetMsgType::HEADERS},
+    {14, NetMsgType::BLOCK},
+    {21, NetMsgType::GETADDR},
+    {28, NetMsgType::MEMPOOL},
+    {31, NetMsgType::PING},
+    {32, NetMsgType::PONG},
+    {30, NetMsgType::NOTFOUND},
+    {20, NetMsgType::FILTERLOAD},
+    {18, NetMsgType::FILTERADD},
+    {19, NetMsgType::FILTERCLEAR},
+    {35, NetMsgType::SENDHEADERS},
+    {17, NetMsgType::FEEFILTER},
+    {34, NetMsgType::SENDCMPCT},
+    {16, NetMsgType::CMPCTBLOCK},
+    {23, NetMsgType::GETBLOCKTXN},
+    {15, NetMsgType::BLOCKTXN},
+    {39, NetMsgType::GETCFILTERS},
+    {40, NetMsgType::CFILTER},
+    {41, NetMsgType::GETCFHEADERS},
+    {42, NetMsgType::CFHEADERS},
+    {43, NetMsgType::GETCFCHECKPT},
+    {44, NetMsgType::CFCHECKPT},
+    {45, NetMsgType::WTXIDRELAY}
 };
-const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 
 CMessageHeader::CMessageHeader()
 {
@@ -187,9 +186,9 @@ std::string CInv::ToString() const
     }
 }
 
-const std::vector<std::string> &getAllNetMessageTypes()
+const std::map<uint8_t, std::string> &getAllNetMessageTypes()
 {
-    return allNetMessageTypesVec;
+    return allNetMessageTypes;
 }
 
 /**
@@ -235,4 +234,24 @@ GenTxid ToGenTxid(const CInv& inv)
 {
     assert(inv.IsGenTxMsg());
     return {inv.IsMsgWtx(), inv.hash};
+}
+
+Optional<uint8_t> GetShortCommandIDFromCommand(const std::string& cmd)
+{
+    for (const std::pair<uint8_t, std::string> entry : allNetMessageTypes) {
+        if (entry.second == cmd) {
+            return entry.first;
+        }
+    }
+    return {};
+}
+
+bool GetCommandFromShortCommandID(uint8_t shortID, std::string& cmd)
+{
+    auto it = allNetMessageTypes.find(shortID);
+    if (it != allNetMessageTypes.end()) {
+        cmd = it->second;
+        return true;
+    }
+    return false;
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -11,6 +11,7 @@
 #define BITCOIN_PROTOCOL_H
 
 #include <netaddress.h>
+#include <optional.h>
 #include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
@@ -263,7 +264,17 @@ extern const char* WTXIDRELAY;
 }; // namespace NetMsgType
 
 /* Get a vector of all valid message types (see above) */
-const std::vector<std::string>& getAllNetMessageTypes();
+const std::map<uint8_t, std::string>& getAllNetMessageTypes();
+
+/** Short Command IDs are a low bandwidth representations of a message type
+ *   The mapping is a peer to peer agreement
+ *
+ *   returns the short command ID for a command (if command has a short ID) */
+Optional<uint8_t> GetShortCommandIDFromCommand(const std::string& cmd);
+
+/** returns the command (string) from a short command ID
+ * returns an empty string if short command ID has not been found */
+bool GetCommandFromShortCommandID(uint8_t shortID, std::string& cmd);
 
 /** nServices flags */
 enum ServiceFlags : uint64_t {

--- a/src/test/fuzz/p2p_transport_deserializer.cpp
+++ b/src/test/fuzz/p2p_transport_deserializer.cpp
@@ -17,26 +17,36 @@ void initialize_p2p_transport_deserializer()
     SelectParams(CBaseChainParams::REGTEST);
 }
 
-FUZZ_TARGET_INIT(p2p_transport_deserializer, initialize_p2p_transport_deserializer)
-{
-    // Construct deserializer, with a dummy NodeId
-    V1TransportDeserializer deserializer{Params(), (NodeId)0, SER_NETWORK, INIT_PROTO_VERSION};
-    Span<const uint8_t> msg_bytes{buffer};
+void test_deserializer(std::unique_ptr<TransportDeserializer>& deserializer, Span<const uint8_t> msg_bytes, const int header_size) {
+    size_t original_size = msg_bytes.size();
     while (msg_bytes.size() > 0) {
-        const int handled = deserializer.Read(msg_bytes);
+        const int handled = deserializer->Read(msg_bytes);
         if (handled < 0) {
             break;
         }
-        if (deserializer.Complete()) {
+        if (deserializer->Complete()) {
             const std::chrono::microseconds m_time{std::numeric_limits<int64_t>::max()};
             uint32_t out_err_raw_size{0};
-            Optional<CNetMessage> result{deserializer.GetMessage(m_time, out_err_raw_size)};
+            Optional<CNetMessage> result{deserializer->GetMessage(m_time, out_err_raw_size)};
             if (result) {
                 assert(result->m_command.size() <= CMessageHeader::COMMAND_SIZE);
-                assert(result->m_raw_message_size <= buffer.size());
-                assert(result->m_raw_message_size == CMessageHeader::HEADER_SIZE + result->m_message_size);
+                assert(result->m_raw_message_size <= original_size);
+                assert(result->m_raw_message_size == header_size + result->m_message_size);
                 assert(result->m_time == m_time);
             }
         }
     }
+}
+FUZZ_TARGET_INIT(p2p_transport_deserializer, initialize_p2p_transport_deserializer)
+{
+    // Construct deserializer, with a dummy NodeId
+    std::unique_ptr<TransportDeserializer> v1_deserializer = MakeUnique<V1TransportDeserializer>(Params(), (NodeId)0, SER_NETWORK, INIT_PROTO_VERSION);
+    Span<const uint8_t> msg_bytes_v1{buffer};
+    test_deserializer(v1_deserializer, msg_bytes_v1, CMessageHeader::HEADER_SIZE);
+
+    const CPrivKey k1(32, 0);
+    const CPrivKey k2(32, 0);
+    Span<const uint8_t> msg_bytes_v2{buffer};
+    std::unique_ptr<TransportDeserializer> v2_deserializer = MakeUnique<V2TransportDeserializer>(V2TransportDeserializer((NodeId)0, k1, k2));
+    test_deserializer(v2_deserializer, msg_bytes_v2, CHACHA20_POLY1305_AEAD_AAD_LEN + CHACHA20_POLY1305_AEAD_TAG_LEN);
 }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <net.h>
 #include <netbase.h>
+#include <netmessagemaker.h>
 #include <optional.h>
 #include <serialize.h>
 #include <span.h>
@@ -928,5 +929,84 @@ BOOST_AUTO_TEST_CASE(node_eviction_test)
         }
     }
 }
+
+void message_serialize_deserialize_test(bool v2, const std::vector<CSerializedNetMsg>& test_msgs)
+{
+    // use 32 byte keys with all zeros
+    CPrivKey k1(32, 0);
+    CPrivKey k2(32, 0);
+
+    // construct the serializers
+    std::unique_ptr<TransportSerializer> serializer;
+    std::unique_ptr<TransportDeserializer> deserializer;
+
+    if (v2) {
+        serializer = MakeUnique<V2TransportSerializer>(V2TransportSerializer(k1, k2));
+        deserializer = MakeUnique<V2TransportDeserializer>(V2TransportDeserializer((NodeId)0, k1, k2));
+    } else {
+        serializer = MakeUnique<V1TransportSerializer>(V1TransportSerializer());
+        deserializer = MakeUnique<V1TransportDeserializer>(V1TransportDeserializer(Params(), (NodeId)0, SER_NETWORK, INIT_PROTO_VERSION));
+    }
+    // run a couple of times through all messages with the same AEAD instance
+    for (unsigned int i = 0; i < 100; i++) {
+        for (const CSerializedNetMsg& msg_orig : test_msgs) {
+            // bypass the copy protection
+            CSerializedNetMsg msg;
+            msg.data = msg_orig.data;
+            msg.m_type = msg_orig.m_type;
+            size_t raw_msg_size = msg.data.size();
+
+            std::vector<unsigned char> serialized_header;
+            serializer->prepareForTransport(msg, serialized_header);
+
+            // read two times
+            //  first: read header
+            size_t read_bytes = 0;
+            Span<const uint8_t> span_header(serialized_header.data(), serialized_header.size());
+            if (serialized_header.size() > 0) read_bytes += deserializer->Read(span_header);
+            //  second: read the encrypted payload (if required)
+            Span<const uint8_t> span_msg(msg.data.data(), msg.data.size());
+            if (msg.data.size() > 0) read_bytes += deserializer->Read(span_msg);
+            if (msg.data.size() > read_bytes && msg.data.size() - read_bytes > 0) {
+                Span<const uint8_t> span_msg(msg.data.data() + read_bytes, msg.data.size() - read_bytes);
+                read_bytes += deserializer->Read(span_msg);
+            }
+            BOOST_CHECK(deserializer->Complete());
+            BOOST_CHECK_EQUAL(read_bytes, msg.data.size() + serialized_header.size());
+            // message must be complete
+            uint32_t out_err_raw_size{0};
+            Optional<CNetMessage> result{deserializer->GetMessage(GetTime<std::chrono::microseconds>(), out_err_raw_size)};
+            BOOST_CHECK_EQUAL(result->m_command, msg.m_type);
+            BOOST_CHECK_EQUAL(raw_msg_size, result->m_message_size);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(net_v2)
+{
+    // create some messages where we perform serialization and deserialization
+    std::vector<CSerializedNetMsg> test_msgs;
+    test_msgs.push_back(CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERACK));
+    test_msgs.push_back(CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::VERSION, PROTOCOL_VERSION, (int)NODE_NETWORK, 123, CAddress(CService(), NODE_NONE), CAddress(CService(), NODE_NONE), 123, "foobar", 500000, true));
+    test_msgs.push_back(CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::PING, 123456));
+    CDataStream stream(ParseHex("020000000001013107ca31e1950a9b44b75ce3e8f30127e4d823ed8add1263a1cc8adcc8e49164000000001716001487835ecf51ea0351ef266d216a7e7a3e74b84b4efeffffff02082268590000000017a9144a94391b99e672b03f56d3f60800ef28bc304c4f8700ca9a3b0000000017a9146d5df9e79f752e3c53fc468db89cafda4f7d00cb87024730440220677de5b11a5617d541ba06a1fa5921ab6b4509f8028b23f18ab8c01c5eb1fcfb02202fe382e6e87653f60ff157aeb3a18fc888736720f27ced546b0b77431edabdb0012102608c772598e9645933a86bcd662a3b939e02fb3e77966c9713db5648d5ba8a0006010000"), SER_NETWORK, PROTOCOL_VERSION);
+    test_msgs.push_back(CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::TX, CTransaction(deserialize, stream)));
+    std::vector<CInv> vInv;
+    for (unsigned int i = 0; i < 1000; i++) {
+        vInv.push_back(CInv(MSG_BLOCK, Params().GenesisBlock().GetHash()));
+    }
+    test_msgs.push_back(CNetMsgMaker(INIT_PROTO_VERSION).Make(NetMsgType::INV, vInv));
+
+    // add a dummy message
+    std::string dummy;
+    for (unsigned int i = 0; i < 100; i++) {
+        dummy += "020000000001013107ca31e1950a9b44b75ce3e8f30127e4d823ed8add1263a1cc8adcc8e49164000000001716001487835ecf51ea0351ef266d216a7e7a3e74b84b4efeffffff02082268590000000017a9144a94391b99e672b03f56d3f60800ef28bc304c4f8700ca9a3b0000000017a9146d5df9e79f752e3c53fc468db89cafda4f7d00cb87024730440220677de5b11a5617d541ba06a1fa5921ab6b4509f8028b23f18ab8c01c5eb1fcfb02202fe382e6e87653f60ff157aeb3a18fc888736720f27ced546b0b77431edabdb0012102608c772598e9645933a86bcd662a3b939e02fb3e77966c9713db5648d5ba8a0006010000";
+    }
+    test_msgs.push_back(CNetMsgMaker(INIT_PROTO_VERSION).Make("foobar", dummy));
+
+    message_serialize_deserialize_test(true, test_msgs);
+    message_serialize_deserialize_test(false, test_msgs);
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
BIP324 is [here](https://gist.github.com/jonasschnelli/c530ea8421b8d0e80c51486325587c52) (not submitted to the BIP repository since it's still under work).

This PR adds a message transport de-/serializer for encrypted message after BIP324.

**Includes:**
* correct AEAD handling
* short command IDs

**Excludes (to keep it reviewable):**
* The handshake (pubkey exchange [subject to change due to downgrade attack prevention])
* ECDH (enabling libsecp256k1 & `CKey` implementation)
* service flag and a way to globally enable it

**The code is exclusively used in the tests**

**This is based on #20962 (please review first)**