### PR TITLE
Test some transaction creation with non-empty fee estimator

### DIFF
--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -13,6 +13,7 @@ from test_framework.util import (
     assert_equal,
     assert_greater_than,
     assert_greater_than_or_equal,
+    assert_raises_rpc_error,
     connect_nodes,
     satoshi_round,
 )
@@ -226,6 +227,10 @@ class EstimateFeeTest(BitcoinTestFramework):
         self.fees_per_kb = []
         self.memutxo = []
         self.confutxo = self.txouts  # Start with the set of confirmed txouts after splitting
+
+        assert_raises_rpc_error(-8, "Invalid conf_target, must be between 1 - 1008", self.nodes[0].estimatesmartfee, 0)
+        assert_raises_rpc_error(-8, "Invalid conf_target, must be between 1 - 1008", self.nodes[0].estimatesmartfee, 1009)
+
         self.log.info("Will output estimates for 1/2/3/6/15/25 blocks")
 
         for i in range(2):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -34,7 +34,7 @@ def assert_approx(v, vexp, vspan=0.00001):
 
 def assert_fee_amount(fee, tx_size, fee_per_kB):
     """Assert the fee was in range"""
-    target_fee = round(tx_size * fee_per_kB / 1000, 8)
+    target_fee = Decimal(tx_size * fee_per_kB / 1000).quantize(Decimal('.00000001'), rounding=ROUND_DOWN)
     if fee < target_fee:
         raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
     # allow the wallet's estimation to be at most 2 bytes off


### PR DESCRIPTION
These tests give additional coverage to RPCs that use `conf_target` in a meaningful way that doesn't just return min rates.

Inspired by https://github.com/bitcoin/bitcoin/issues/18240