### PR TITLE
wip: gui: Drop connectSlotsByName usage

### DIFF
--- a/src/qt/intro.cpp
+++ b/src/qt/intro.cpp
@@ -151,6 +151,24 @@ Intro::Intro(QWidget *parent, int64_t blockchain_size_gb, int64_t chain_state_si
     });
 
     startThread();
+
+    connect(ui->dataDirectory, &QLineEdit::textChanged, [this](const QString& dataDirStr) {
+        /* Disable OK button until check result comes in */
+        ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+        checkPath(dataDirStr);
+    });
+    connect(ui->dataDirDefault, &QPushButton::clicked, [this] {
+        setDataDirectory(GUIUtil::getDefaultDataDirectory());
+    });
+    connect(ui->ellipsisButton, &QPushButton::clicked, [this] {
+        QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(nullptr, "Choose data directory", ui->dataDirectory->text()));
+        if(!dir.isEmpty())
+            ui->dataDirectory->setText(dir);
+    });
+    connect(ui->dataDirCustom, &QPushButton::clicked, [this] {
+        ui->dataDirectory->setEnabled(true);
+        ui->ellipsisButton->setEnabled(true);
+    });
 }
 
 Intro::~Intro()
@@ -288,31 +306,6 @@ void Intro::UpdateFreeSpaceLabel()
         ui->freeSpace->setStyleSheet("");
     }
     ui->freeSpace->setText(freeString + ".");
-}
-
-void Intro::on_dataDirectory_textChanged(const QString &dataDirStr)
-{
-    /* Disable OK button until check result comes in */
-    ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
-    checkPath(dataDirStr);
-}
-
-void Intro::on_ellipsisButton_clicked()
-{
-    QString dir = QDir::toNativeSeparators(QFileDialog::getExistingDirectory(nullptr, "Choose data directory", ui->dataDirectory->text()));
-    if(!dir.isEmpty())
-        ui->dataDirectory->setText(dir);
-}
-
-void Intro::on_dataDirDefault_clicked()
-{
-    setDataDirectory(GUIUtil::getDefaultDataDirectory());
-}
-
-void Intro::on_dataDirCustom_clicked()
-{
-    ui->dataDirectory->setEnabled(true);
-    ui->ellipsisButton->setEnabled(true);
 }
 
 void Intro::startThread()

--- a/src/qt/intro.h
+++ b/src/qt/intro.h
@@ -56,9 +56,7 @@ public Q_SLOTS:
     void setStatus(int status, const QString &message, quint64 bytesAvailable);
 
 private Q_SLOTS:
-    void on_dataDirectory_textChanged(const QString &arg1);
     void on_ellipsisButton_clicked();
-    void on_dataDirDefault_clicked();
     void on_dataDirCustom_clicked();
 
 private:

--- a/src/qt/receiverequestdialog.cpp
+++ b/src/qt/receiverequestdialog.cpp
@@ -30,6 +30,12 @@ ReceiveRequestDialog::ReceiveRequestDialog(QWidget *parent) :
 #endif
 
     connect(ui->btnSaveAs, &QPushButton::clicked, ui->lblQRCode, &QRImageWidget::saveImage);
+    connect(ui->btnCopyURI, &QPushButton::clicked, [this] {
+        GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(info));
+    });
+    connect(ui->btnCopyAddress, &QPushButton::clicked, [this] {
+        GUIUtil::setClipboard(info.address);
+    });
 }
 
 ReceiveRequestDialog::~ReceiveRequestDialog()
@@ -85,14 +91,4 @@ void ReceiveRequestDialog::update()
     if (ui->lblQRCode->setQR(uri, info.address)) {
         ui->btnSaveAs->setEnabled(true);
     }
-}
-
-void ReceiveRequestDialog::on_btnCopyURI_clicked()
-{
-    GUIUtil::setClipboard(GUIUtil::formatBitcoinURI(info));
-}
-
-void ReceiveRequestDialog::on_btnCopyAddress_clicked()
-{
-    GUIUtil::setClipboard(info.address);
 }

--- a/src/qt/receiverequestdialog.h
+++ b/src/qt/receiverequestdialog.h
@@ -27,9 +27,6 @@ public:
     void setInfo(const SendCoinsRecipient &info);
 
 private Q_SLOTS:
-    void on_btnCopyURI_clicked();
-    void on_btnCopyAddress_clicked();
-
     void update();
 
 private:

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -127,6 +127,15 @@ SendCoinsDialog::SendCoinsDialog(const PlatformStyle *_platformStyle, QWidget *p
     ui->customFee->SetAllowEmpty(false);
     ui->customFee->setValue(settings.value("nTransactionFee").toLongLong());
     minimizeFeeSection(settings.value("fFeeSectionMinimized").toBool());
+
+    connect(ui->sendButton, &QPushButton::clicked, this, &SendCoinsDialog::send);
+    connect(ui->buttonChooseFee, &QPushButton::clicked, [this] {
+        minimizeFeeSection(false);
+    });
+    connect(ui->buttonMinimizeFee, &QPushButton::clicked, [this] {
+        updateFeeMinimizedLabel();
+        minimizeFeeSection(true);
+    });
 }
 
 void SendCoinsDialog::setClientModel(ClientModel *_clientModel)
@@ -220,7 +229,7 @@ SendCoinsDialog::~SendCoinsDialog()
     delete ui;
 }
 
-void SendCoinsDialog::on_sendButton_clicked()
+void SendCoinsDialog::send()
 {
     if(!model || !model->getOptionsModel())
         return;
@@ -631,17 +640,6 @@ void SendCoinsDialog::minimizeFeeSection(bool fMinimize)
     ui->frameFeeSelection->setVisible(!fMinimize);
     ui->horizontalLayoutSmartFee->setContentsMargins(0, (fMinimize ? 0 : 6), 0, 0);
     fFeeMinimized = fMinimize;
-}
-
-void SendCoinsDialog::on_buttonChooseFee_clicked()
-{
-    minimizeFeeSection(false);
-}
-
-void SendCoinsDialog::on_buttonMinimizeFee_clicked()
-{
-    updateFeeMinimizedLabel();
-    minimizeFeeSection(true);
 }
 
 void SendCoinsDialog::useAvailableBalance(SendCoinsEntry* entry)

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -74,9 +74,7 @@ private:
     void updateCoinControlState(CCoinControl& ctrl);
 
 private Q_SLOTS:
-    void on_sendButton_clicked();
-    void on_buttonChooseFee_clicked();
-    void on_buttonMinimizeFee_clicked();
+    void send();
     void removeEntry(SendCoinsEntry* entry);
     void useAvailableBalance(SendCoinsEntry* entry);
     void updateDisplayUnit();

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -50,35 +50,25 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
     connect(ui->deleteButton_is, &QPushButton::clicked, this, &SendCoinsEntry::deleteClicked);
     connect(ui->deleteButton_s, &QPushButton::clicked, this, &SendCoinsEntry::deleteClicked);
     connect(ui->useAvailableBalanceButton, &QPushButton::clicked, this, &SendCoinsEntry::useAvailableBalanceClicked);
+    connect(ui->payTo, &QLineEdit::textChanged, this, &SendCoinsEntry::updateLabel);
+    connect(ui->pasteButton, &QPushButton::clicked, [this] {
+        // Paste text from clipboard into recipient field
+        ui->payTo->setText(QApplication::clipboard()->text());
+    });
+    connect(ui->addressBookButton, &QPushButton::clicked, [this] {
+        if (!model) return;
+        AddressBookPage dlg(platformStyle, AddressBookPage::ForSelection, AddressBookPage::SendingTab, this);
+        dlg.setModel(model->getAddressTableModel());
+        if (dlg.exec()) {
+            ui->payTo->setText(dlg.getReturnValue());
+            ui->payAmount->setFocus();
+        }
+    });
 }
 
 SendCoinsEntry::~SendCoinsEntry()
 {
     delete ui;
-}
-
-void SendCoinsEntry::on_pasteButton_clicked()
-{
-    // Paste text from clipboard into recipient field
-    ui->payTo->setText(QApplication::clipboard()->text());
-}
-
-void SendCoinsEntry::on_addressBookButton_clicked()
-{
-    if(!model)
-        return;
-    AddressBookPage dlg(platformStyle, AddressBookPage::ForSelection, AddressBookPage::SendingTab, this);
-    dlg.setModel(model->getAddressTableModel());
-    if(dlg.exec())
-    {
-        ui->payTo->setText(dlg.getReturnValue());
-        ui->payAmount->setFocus();
-    }
-}
-
-void SendCoinsEntry::on_payTo_textChanged(const QString &address)
-{
-    updateLabel(address);
 }
 
 void SendCoinsEntry::setModel(WalletModel *_model)

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -64,18 +64,14 @@ Q_SIGNALS:
 private Q_SLOTS:
     void deleteClicked();
     void useAvailableBalanceClicked();
-    void on_payTo_textChanged(const QString &address);
-    void on_addressBookButton_clicked();
-    void on_pasteButton_clicked();
     void updateDisplayUnit();
+    bool updateLabel(const QString& address);
 
 private:
     SendCoinsRecipient recipient;
     Ui::SendCoinsEntry *ui;
     WalletModel *model;
     const PlatformStyle *platformStyle;
-
-    bool updateLabel(const QString &address);
 };
 
 #endif // BITCOIN_QT_SENDCOINSENTRY_H

--- a/src/qt/utilitydialog.cpp
+++ b/src/qt/utilitydialog.cpp
@@ -102,6 +102,8 @@ HelpMessageDialog::HelpMessageDialog(interfaces::Node& node, QWidget *parent, bo
         ui->scrollArea->setVisible(false);
         ui->aboutLogo->setVisible(false);
     }
+
+    connect(ui->okButton, &QDialogButtonBox::accepted, this, &QDialog::accept);
 }
 
 HelpMessageDialog::~HelpMessageDialog()
@@ -125,12 +127,6 @@ void HelpMessageDialog::showOrPrint()
     printToConsole();
 #endif
 }
-
-void HelpMessageDialog::on_okButton_accepted()
-{
-    close();
-}
-
 
 /** "Shutdown" window */
 ShutdownWindow::ShutdownWindow(QWidget *parent, Qt::WindowFlags f):

--- a/src/qt/utilitydialog.h
+++ b/src/qt/utilitydialog.h
@@ -35,9 +35,6 @@ public:
 private:
     Ui::HelpMessageDialog *ui;
     QString text;
-
-private Q_SLOTS:
-    void on_okButton_accepted();
 };
 
 


### PR DESCRIPTION
The code generated by `uic` tool adds `QObject::connectSlotsByName()`, see https://doc.qt.io/qt-5/qmetaobject.html#connectSlotsByName for more information. This can be confirmed with `grep connectSlotsByName src/qt/forms/ui*`

After #13529 it makes sense to also drop `connectSlotsByName` usage following the same reasoning - these connections are now in compile time checked.

Also, starting from https://github.com/qt/qtbase/commit/6301d5e51b0c56d09b0bd1cb63f4908c3f8e2c70#diff-d720bd2a996f09262e267c4917e4cc86it is possible to pass `--no-autoconnection` or `-a`, but this will take longer since it's only available in recent Qt.

For reference:
```diff
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -355,7 +355,7 @@ bitcoin_qt : qt/bitcoin-qt$(EXEEXT)
 ui_%.h: %.ui
        @test -f $(UIC)
        @$(MKDIR_P) $(@D)
-       $(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(UIC) -o $@ $< || (echo "Error creating $@"; false)
+       $(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(UIC) -a -o $@ $< || (echo "Error creating $@"; false)

 %.moc: %.cpp
        $(AM_V_GEN) QT_SELECT=$(QT_SELECT) $(MOC) $(DEFAULT_INCLUDES) $(QT_INCLUDES) $(MOC_DEFS) $< | \
```

Review with `QT_FATAL_WARNINGS=1`.