### PR TITLE
gui: fix compiler warning in formatPingTime()

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -775,7 +775,10 @@ QString formatServicesStr(quint64 mask)
 
 QString formatPingTime(double dPingTime)
 {
-    return (dPingTime == std::numeric_limits<int64_t>::max()/1e6 || dPingTime == 0) ? QObject::tr("N/A") : QString(QObject::tr("%1 ms")).arg(QString::number((int)(dPingTime * 1000), 10));
+    return (dPingTime == (double)std::numeric_limits<int64_t>::max() / 1e6 ||
+            dPingTime == 0)
+        ? QObject::tr("N/A")
+        : QString(QObject::tr("%1 ms")).arg(QString::number((int)(dPingTime * 1000), 10));
 }
 
 QString formatTimeOffset(int64_t nTimeOffset)


### PR DESCRIPTION
With Clang 10.0.0:

```
qt/guiutil.cpp:778:26: warning: implicit conversion from 'std::__1::numeric_limits<long>::type'
      (aka 'long') to 'double' changes value from 9223372036854775807 to 9223372036854775808
      [-Wimplicit-int-float-conversion]
    return (dPingTime == std::numeric_limits<int64_t>::max()/1e6 || dPingTime == 0) ? QObject::...
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

When assigning to `dPingTime` a similar typecast is used:

```
src/net.cpp:558:    stats.dPingTime = (((double)nPingUsecTime) / 1e6);
```

so it should be ok to change 9223372036854775807 to 9223372036854775808.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
