### PR TITLE
doc: Correct spelling errors in comments

### DIFF
--- a/ci/test/05_before_script.sh
+++ b/ci/test/05_before_script.sh
@@ -26,7 +26,7 @@ if [[ $HOST = *-mingw32 ]]; then
 fi
 if [ -z "$NO_DEPENDS" ]; then
   if [[ $DOCKER_NAME_TAG == centos* ]]; then
-    # CentOS has problems building the depends if the config shell is not explicitely set
+    # CentOS has problems building the depends if the config shell is not explicitly set
     # (i.e. for libevent a Makefile with an empty SHELL variable is generated, leading to
     #  an error as the first command is executed)
     SHELL_OPTS="CONFIG_SHELL=/bin/bash"

--- a/src/logging/timer.h
+++ b/src/logging/timer.h
@@ -85,7 +85,7 @@ private:
     const std::string m_title{};
 
     //! Forwarded on to LogPrint if specified - has the effect of only
-    //! outputing the timing log when a particular debug= category is specified.
+    //! outputting the timing log when a particular debug= category is specified.
     const BCLog::LogFlags m_log_category{};
 
 };

--- a/src/node/psbt.cpp
+++ b/src/node/psbt.cpp
@@ -84,7 +84,7 @@ PSBTAnalysis AnalyzePSBT(PartiallySignedTransaction psbtx)
         }
     }
 
-    // Calculate next role for PSBT by grabbing "minumum" PSBTInput next role
+    // Calculate next role for PSBT by grabbing "minimum" PSBTInput next role
     result.next = PSBTRole::EXTRACTOR;
     for (unsigned int i = 0; i < psbtx.tx->vin.size(); ++i) {
         PSBTInputAnalysis& input_analysis = result.inputs[i];

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -753,7 +753,7 @@ public:
      * determine if that transaction has not yet been visited during the current
      * traversal's epoch.
      *     Algorithms using std::set can be replaced on a one by one basis.
-     * Both techniques are not fundamentally incomaptible across the codebase.
+     * Both techniques are not fundamentally incompatible across the codebase.
      * Generally speaking, however, the remaining use of std::set for mempool
      * traversal should be viewed as a TODO for replacement with an epoch based
      * traversal, rather than a preference for std::set over epochs in that

--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -113,7 +113,7 @@ class BackwardsCompatibilityTest(BitcoinTestFramework):
         # Create another conflicting transaction using RBF
         tx3_id = self.nodes[1].sendtoaddress(return_address, 1)
         tx4_id = self.nodes[1].bumpfee(tx3_id)["txid"]
-        # Abondon transaction, but don't confirm
+        # Abandon transaction, but don't confirm
         self.nodes[1].abandontransaction(tx3_id)
 
         # w1_v19: regular wallet, created with v0.19

--- a/test/lint/lint-shell.sh
+++ b/test/lint/lint-shell.sh
@@ -41,7 +41,7 @@ if ! shellcheck "$EXCLUDE" $(git ls-files -- '*.sh' | grep -vE 'src/(leveldb|sec
 fi
 
 if ! command -v yq > /dev/null; then
-    echo "Skipping Gitian desriptor scripts checking since yq is not installed."
+    echo "Skipping Gitian descriptor scripts checking since yq is not installed."
     exit $EXIT_CODE
 fi
 

--- a/test/lint/lint-spelling.ignore-words.txt
+++ b/test/lint/lint-spelling.ignore-words.txt
@@ -12,3 +12,5 @@ keyserver
 homogenous
 setban
 hist
+ser
+unselect


### PR DESCRIPTION
And ci script output.

Identified via test/lint/lint-spelling

Before:
```
$ test/lint/lint-spelling.sh 
ci/test/05_before_script.sh:29: explicitely  ==> explicitly
src/compressor.h:43: Ser  ==> Set
src/compressor.h:78: Ser  ==> Set
src/logging/timer.h:88: outputing  ==> outputting
src/node/psbt.cpp:87: minumum  ==> minimum
src/qt/coincontroldialog.cpp:372: UnSelect  ==> deselect
src/qt/coincontroldialog.cpp:443: unselect  ==> deselect
src/qt/coincontroldialog.cpp:448: UnSelect  ==> deselect
src/qt/coincontroldialog.cpp:699: UnSelect  ==> deselect
src/serialize.h:211: Ser  ==> Set
src/serialize.h:213: Ser  ==> Set
src/serialize.h:228: Ser  ==> Set
src/serialize.h:246: Ser  ==> Set
src/serialize.h:484: Ser  ==> Set
src/serialize.h:490: Ser  ==> Set
src/serialize.h:510: Ser  ==> Set
src/serialize.h:622: Ser  ==> Set
src/serialize.h:740: Ser  ==> Set
src/test/base32_tests.cpp:14: fo  ==> of, for
src/test/base64_tests.cpp:14: fo  ==> of, for
src/txmempool.h:756: incomaptible  ==> incompatible
src/undo.h:26: Ser  ==> Set
src/wallet/coincontrol.h:74: UnSelect  ==> deselect
test/functional/feature_backwards_compatibility.py:116: Abondon  ==> Abandon
test/functional/rpc_getaddressinfo_label_deprecation.py:7: superceded  ==> superseded
test/lint/lint-shell.sh:44: desriptor  ==> descriptor
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/lint-spelling.ignore-words.txt
```

After:
```
$ test/lint/lint-spelling.sh 
src/test/base32_tests.cpp:14: fo  ==> of, for
src/test/base64_tests.cpp:14: fo  ==> of, for
test/functional/rpc_getaddressinfo_label_deprecation.py:7: superceded  ==> superseded
^ Warning: codespell identified likely spelling errors. Any false positives? Add them to the list of ignored words in test/lint/lint-spelling.ignore-words.txt
```