### PR TITLE
refactor: Fix implicit value conversion in  formatPingTime

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -556,7 +556,7 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
 
     // Raw ping time is in microseconds, but show it to user as whole seconds (Bitcoin users should be well used to small numbers with many decimal places by now :)
     stats.m_ping_usec = nPingUsecTime;
-    stats.dMinPing  = (((double)nMinPingUsecTime) / 1e6);
+    stats.m_min_ping_usec  = nMinPingUsecTime;
     stats.dPingWait = (((double)nPingUsecWait) / 1e6);
 
     // Leave string empty if addrLocal invalid (not filled in yet)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -557,7 +557,7 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     // Raw ping time is in microseconds, but show it to user as whole seconds (Bitcoin users should be well used to small numbers with many decimal places by now :)
     stats.m_ping_usec = nPingUsecTime;
     stats.m_min_ping_usec  = nMinPingUsecTime;
-    stats.dPingWait = (((double)nPingUsecWait) / 1e6);
+    stats.m_ping_wait_usec = nPingUsecWait;
 
     // Leave string empty if addrLocal invalid (not filled in yet)
     CService addrLocalUnlocked = GetAddrLocal();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -555,7 +555,7 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
     }
 
     // Raw ping time is in microseconds, but show it to user as whole seconds (Bitcoin users should be well used to small numbers with many decimal places by now :)
-    stats.dPingTime = (((double)nPingUsecTime) / 1e6);
+    stats.m_ping_usec = nPingUsecTime;
     stats.dMinPing  = (((double)nMinPingUsecTime) / 1e6);
     stats.dPingWait = (((double)nPingUsecWait) / 1e6);
 

--- a/src/net.h
+++ b/src/net.h
@@ -596,7 +596,7 @@ public:
     mapMsgCmdSize mapRecvBytesPerMsgCmd;
     NetPermissionFlags m_permissionFlags;
     bool m_legacyWhitelisted;
-    double dPingTime;
+    int64_t m_ping_usec;
     double dPingWait;
     double dMinPing;
     CAmount minFeeFilter;

--- a/src/net.h
+++ b/src/net.h
@@ -597,7 +597,7 @@ public:
     NetPermissionFlags m_permissionFlags;
     bool m_legacyWhitelisted;
     int64_t m_ping_usec;
-    double dPingWait;
+    int64_t m_ping_wait_usec;
     int64_t m_min_ping_usec;
     CAmount minFeeFilter;
     // Our address, as reported by the peer

--- a/src/net.h
+++ b/src/net.h
@@ -598,7 +598,7 @@ public:
     bool m_legacyWhitelisted;
     int64_t m_ping_usec;
     double dPingWait;
-    double dMinPing;
+    int64_t m_min_ping_usec;
     CAmount minFeeFilter;
     // Our address, as reported by the peer
     std::string addrLocal;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -778,6 +778,11 @@ QString formatPingTime(double dPingTime)
     return (dPingTime == std::numeric_limits<int64_t>::max()/1e6 || dPingTime == 0) ? QObject::tr("N/A") : QString(QObject::tr("%1 ms")).arg(QString::number((int)(dPingTime * 1000), 10));
 }
 
+QString formatPingTime(int64_t ping_usec)
+{
+    return (ping_usec == std::numeric_limits<int64_t>::max() || ping_usec == 0) ? QObject::tr("N/A") : QString(QObject::tr("%1 ms")).arg(QString::number((int)(ping_usec / 1000), 10));
+}
+
 QString formatTimeOffset(int64_t nTimeOffset)
 {
   return QString(QObject::tr("%1 s")).arg(QString::number((int)nTimeOffset, 10));

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -773,11 +773,6 @@ QString formatServicesStr(quint64 mask)
         return QObject::tr("None");
 }
 
-QString formatPingTime(double dPingTime)
-{
-    return (dPingTime == std::numeric_limits<int64_t>::max()/1e6 || dPingTime == 0) ? QObject::tr("N/A") : QString(QObject::tr("%1 ms")).arg(QString::number((int)(dPingTime * 1000), 10));
-}
-
 QString formatPingTime(int64_t ping_usec)
 {
     return (ping_usec == std::numeric_limits<int64_t>::max() || ping_usec == 0) ? QObject::tr("N/A") : QString(QObject::tr("%1 ms")).arg(QString::number((int)(ping_usec / 1000), 10));

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -202,9 +202,6 @@ namespace GUIUtil
     /* Format CNodeStats.nServices bitmask into a user-readable string */
     QString formatServicesStr(quint64 mask);
 
-    /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
-    QString formatPingTime(double dPingTime);
-
     /* Format a CNodeStats.m_ping_usec into a user-readable string or display N/A, if 0*/
     QString formatPingTime(int64_t ping_usec);
 

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -205,6 +205,9 @@ namespace GUIUtil
     /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
     QString formatPingTime(double dPingTime);
 
+    /* Format a CNodeStats.m_ping_usec into a user-readable string or display N/A, if 0*/
+    QString formatPingTime(int64_t ping_usec);
+
     /* Format a CNodeCombinedStats.nTimeOffset into a user-readable string. */
     QString formatTimeOffset(int64_t nTimeOffset);
 

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -32,7 +32,7 @@ bool NodeLessThan::operator()(const CNodeCombinedStats &left, const CNodeCombine
     case PeerTableModel::Subversion:
         return pLeft->cleanSubVer.compare(pRight->cleanSubVer) < 0;
     case PeerTableModel::Ping:
-        return pLeft->dMinPing < pRight->dMinPing;
+        return pLeft->m_min_ping_usec < pRight->m_min_ping_usec;
     case PeerTableModel::Sent:
         return pLeft->nSendBytes < pRight->nSendBytes;
     case PeerTableModel::Received:
@@ -161,7 +161,7 @@ QVariant PeerTableModel::data(const QModelIndex &index, int role) const
         case Subversion:
             return QString::fromStdString(rec->nodeStats.cleanSubVer);
         case Ping:
-            return GUIUtil::formatPingTime(rec->nodeStats.dMinPing);
+            return GUIUtil::formatPingTime(rec->nodeStats.m_min_ping_usec);
         case Sent:
             return GUIUtil::formatBytes(rec->nodeStats.nSendBytes);
         case Received:

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1110,7 +1110,7 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerBytesRecv->setText(GUIUtil::formatBytes(stats->nodeStats.nRecvBytes));
     ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetSystemTimeInSeconds() - stats->nodeStats.nTimeConnected));
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.m_ping_usec));
-    ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingWait));
+    ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStats.m_ping_wait_usec));
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.m_min_ping_usec));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1109,7 +1109,7 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerBytesSent->setText(GUIUtil::formatBytes(stats->nodeStats.nSendBytes));
     ui->peerBytesRecv->setText(GUIUtil::formatBytes(stats->nodeStats.nRecvBytes));
     ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetSystemTimeInSeconds() - stats->nodeStats.nTimeConnected));
-    ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingTime));
+    ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.m_ping_usec));
     ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingWait));
     ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.dMinPing));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1111,7 +1111,7 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetSystemTimeInSeconds() - stats->nodeStats.nTimeConnected));
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.m_ping_usec));
     ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingWait));
-    ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.dMinPing));
+    ui->peerMinPing->setText(GUIUtil::formatPingTime(stats->nodeStats.m_min_ping_usec));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));
     ui->peerVersion->setText(QString("%1").arg(QString::number(stats->nodeStats.nVersion)));
     ui->peerSubversion->setText(QString::fromStdString(stats->nodeStats.cleanSubVer));

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -165,8 +165,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("bytesrecv", stats.nRecvBytes);
         obj.pushKV("conntime", stats.nTimeConnected);
         obj.pushKV("timeoffset", stats.nTimeOffset);
-        if (stats.dPingTime > 0.0)
-            obj.pushKV("pingtime", stats.dPingTime);
+        if (stats.m_ping_usec > 0)
+            obj.pushKV("pingtime", stats.m_ping_usec / 1e6);
         if (stats.dMinPing < static_cast<double>(std::numeric_limits<int64_t>::max())/1e6)
             obj.pushKV("minping", stats.dMinPing);
         if (stats.dPingWait > 0.0)

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -169,8 +169,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
             obj.pushKV("pingtime", stats.m_ping_usec / 1e6);
         if (stats.m_min_ping_usec < std::numeric_limits<int64_t>::max())
             obj.pushKV("minping", stats.m_min_ping_usec / 1e6);
-        if (stats.dPingWait > 0.0)
-            obj.pushKV("pingwait", stats.dPingWait);
+        if (stats.m_ping_wait_usec > 0)
+            obj.pushKV("pingwait", stats.m_ping_wait_usec / 1e6);
         obj.pushKV("version", stats.nVersion);
         // Use the sanitized form of subver here, to avoid tricksy remote peers from
         // corrupting or modifying the JSON output by putting special characters in

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -167,8 +167,8 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("timeoffset", stats.nTimeOffset);
         if (stats.m_ping_usec > 0)
             obj.pushKV("pingtime", stats.m_ping_usec / 1e6);
-        if (stats.dMinPing < static_cast<double>(std::numeric_limits<int64_t>::max())/1e6)
-            obj.pushKV("minping", stats.dMinPing);
+        if (stats.m_min_ping_usec < std::numeric_limits<int64_t>::max())
+            obj.pushKV("minping", stats.m_min_ping_usec / 1e6);
         if (stats.dPingWait > 0.0)
             obj.pushKV("pingwait", stats.dPingWait);
         obj.pushKV("version", stats.nVersion);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -165,12 +165,15 @@ static UniValue getpeerinfo(const JSONRPCRequest& request)
         obj.pushKV("bytesrecv", stats.nRecvBytes);
         obj.pushKV("conntime", stats.nTimeConnected);
         obj.pushKV("timeoffset", stats.nTimeOffset);
-        if (stats.m_ping_usec > 0)
-            obj.pushKV("pingtime", stats.m_ping_usec / 1e6);
-        if (stats.m_min_ping_usec < std::numeric_limits<int64_t>::max())
-            obj.pushKV("minping", stats.m_min_ping_usec / 1e6);
-        if (stats.m_ping_wait_usec > 0)
-            obj.pushKV("pingwait", stats.m_ping_wait_usec / 1e6);
+        if (stats.m_ping_usec > 0) {
+            obj.pushKV("pingtime", ((double)stats.m_ping_usec) / 1e6);
+        }
+        if (stats.m_min_ping_usec < std::numeric_limits<int64_t>::max()) {
+            obj.pushKV("minping", ((double)stats.m_min_ping_usec) / 1e6);
+        }
+        if (stats.m_ping_wait_usec > 0) {
+            obj.pushKV("pingwait", ((double)stats.m_ping_wait_usec) / 1e6);
+        }
         obj.pushKV("version", stats.nVersion);
         // Use the sanitized form of subver here, to avoid tricksy remote peers from
         // corrupting or modifying the JSON output by putting special characters in


### PR DESCRIPTION
Alternative to #18252, see motivation there.

This changes `CNodeStats` to handle ping timestamps as their original incoming usec `int64_t` values until the time they need to be displayed.
