### PR TITLE
build: add data.h dependency to raw files

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -88,7 +88,7 @@ bench: $(BENCH_BINARY) FORCE
 bitcoin_bench_clean : FORCE
 	rm -f $(CLEAN_BITCOIN_BENCH) $(bench_bench_bitcoin_OBJECTS) $(BENCH_BINARY)
 
-%.raw.h: %.raw
+%.raw.h: %.raw bench/data.h
 	@$(MKDIR_P) $(@D)
 	@{ \
 	 echo "static unsigned const char $(*F)_raw[] = {" && \


### PR DESCRIPTION
In the (admittedly rare) cases where the bench data files (.raw) are generated differently e.g. through modifying the bench/data.h file, automake will fail to pick up on the fact the raw.h file(s) need to be regenerated, and the build will error, with something like this:

```
In file included from bench/data.cpp:10:0:
./bench/data/block413567.raw.h:1:40: error: conflicting declaration ‘const unsigned char benchmark::data::block413567 []’
 static unsigned const char block413567[] = {
                                        ^
In file included from bench/data.cpp:5:0:
./bench/data.h:14:35: note: previous declaration as ‘const std::vector<unsigned char> benchmark::data::block413567’
 extern const std::vector<uint8_t> block413567;
                                   ^~~~~~~~~~~
```