### PR TITLE
rpc/wallet: initialize nFeeRequired to avoid using garbage value on failure

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -343,7 +343,7 @@ static CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet 
     CScript scriptPubKey = GetScriptForDestination(address);
 
     // Create and send the transaction
-    CAmount nFeeRequired;
+    CAmount nFeeRequired = 0;
     std::string strError;
     std::vector<CRecipient> vecSend;
     int nChangePosRet = -1;


### PR DESCRIPTION
Initialize the `nFeeRequired` variable to avoid using an uninitialized value for errors happening before it is set to 0.

Note: this originally fixed `nFeeRet` in `wallet.cpp`.
