### PR TITLE
wallet: UnregisterValidationInterface before SyncWithValidationInterfaceQueue

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -354,6 +354,10 @@ public:
         }
         SyncWithValidationInterfaceQueue();
     }
+    void waitForNotifications() override
+    {
+        SyncWithValidationInterfaceQueue();
+    }
     std::unique_ptr<Handler> handleRpc(const CRPCCommand& command) override
     {
         return MakeUnique<RpcHandlerImpl>(command);

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -232,6 +232,9 @@ public:
     //! chain tip.
     virtual void waitForNotificationsIfTipChanged(const uint256& old_tip) = 0;
 
+    //! Wait for pending notifications to be processed.
+    virtual void waitForNotifications() = 0;
+
     //! Register handler for RPC. Command is not copied, so reference
     //! needs to remain valid until Handler is disconnected.
     virtual std::unique_ptr<Handler> handleRpc(const CRPCCommand& command) = 0;

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -195,7 +195,11 @@ void SingleThreadedSchedulerClient::AddToProcessQueue(std::function<void ()> fun
         LOCK(m_cs_callbacks_pending);
         m_callbacks_pending.emplace_back(std::move(func));
     }
-    MaybeScheduleProcessQueue();
+    if (m_pscheduler->AreThreadsServicingQueue()) {
+        MaybeScheduleProcessQueue();
+    } else {
+        EmptyQueue();
+    }
 }
 
 void SingleThreadedSchedulerClient::EmptyQueue() {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -109,9 +109,9 @@ static void ReleaseWallet(CWallet* wallet)
     // so that it's in sync with the current chainstate.
     const std::string name = wallet->GetName();
     wallet->WalletLogPrintf("Releasing wallet\n");
-    wallet->BlockUntilSyncedToCurrentChain();
-    wallet->Flush();
     wallet->m_chain_notifications_handler.reset();
+    wallet->chain().waitForNotifications();
+    wallet->Flush();
     delete wallet;
     // Wallet is now released, notify UnloadWallet, if any.
     {


### PR DESCRIPTION
From boost signal documentation at https://www.boost.org/doc/libs/1_72_0/doc/html/signals2/thread-safety.html:

> When a signal is invoked by calling signal::operator(), the invocation first acquires a lock on the signal's mutex. Then it obtains a handle to the signal's slot list and combiner. Next it releases the signal's mutex, before invoking the combiner to iterate through the slot list.

This means that `UnregisterValidationInterface` doesn't prevent more calls to that interface.

This PR fixes the assumption that no validation calls happen after `UnregisterValidationInterface` in the following code https://github.com/bitcoin/bitcoin/blob/5d92ac26ed8984c29eabc4b78bcddd2423e68dac/src/wallet/wallet.cpp#L114-L115
The actual bug is that `delete wallet` races with the validation notifications.

The fix consists in synchronizing with the validation queue (which happens in `BlockUntilSyncedToCurrentChain`) *after* `UnregisterValidationInterface`.

Alternative to #18279. Fixes #16307.