### PR TITLE
test: Check that wait_until returns if time point is in the past

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -98,6 +98,24 @@ BOOST_AUTO_TEST_CASE(manythreads)
     BOOST_CHECK_EQUAL(counterSum, 200);
 }
 
+BOOST_AUTO_TEST_CASE(wait_until_past)
+{
+    std::condition_variable condvar;
+    Mutex mtx;
+    WAIT_LOCK(mtx, lock);
+
+    const auto no_wait= [&](const std::chrono::seconds& d) {
+        return condvar.wait_until(lock, std::chrono::system_clock::now() - d);
+    };
+
+    BOOST_CHECK(std::cv_status::timeout == no_wait(std::chrono::seconds{1}));
+    BOOST_CHECK(std::cv_status::timeout == no_wait(std::chrono::minutes{1}));
+    BOOST_CHECK(std::cv_status::timeout == no_wait(std::chrono::hours{1}));
+    BOOST_CHECK(std::cv_status::timeout == no_wait(std::chrono::hours{10}));
+    BOOST_CHECK(std::cv_status::timeout == no_wait(std::chrono::hours{100}));
+    BOOST_CHECK(std::cv_status::timeout == no_wait(std::chrono::hours{1000}));
+}
+
 BOOST_AUTO_TEST_CASE(singlethreadedscheduler_ordered)
 {
     CScheduler scheduler;


### PR DESCRIPTION
Add an explicit regression test for the condvar bug (#18227), so that this doesn't happen again