### PR TITLE
test: Add locale fuzzer to FUZZERS_MISSING_CORPORA

### DIFF
--- a/test/fuzz/test_runner.py
+++ b/test/fuzz/test_runner.py
@@ -30,6 +30,7 @@ FUZZERS_MISSING_CORPORA = [
     "integer",
     "key",
     "key_origin_info_deserialize",
+    "locale",
     "merkle_block_deserialize",
     "out_point_deserialize",
     "p2p_transport_deserializer",


### PR DESCRIPTION
Add `locale` fuzzer to `FUZZERS_MISSING_CORPORA`.

This is a follow-up to #18126 which broke Travis. Sorry about that :)
