### PR TITLE
depends: Patch libevent build to fix IPv6 -rpcbind on Windows

### DIFF
--- a/depends/packages/libevent.mk
+++ b/depends/packages/libevent.mk
@@ -3,8 +3,10 @@ $(package)_version=2.1.11-stable
 $(package)_download_path=https://github.com/libevent/libevent/archive/
 $(package)_file_name=release-$($(package)_version).tar.gz
 $(package)_sha256_hash=229393ab2bf0dc94694f21836846b424f3532585bac3468738b7bf752c03901e
+$(package)_patches=0001-fix-windows-getaddrinfo.patch
 
 define $(package)_preprocess_cmds
+   patch -p1 < $($(package)_patch_dir)/0001-fix-windows-getaddrinfo.patch && \
   ./autogen.sh
 endef
 

--- a/depends/patches/libevent/0001-fix-windows-getaddrinfo.patch
+++ b/depends/patches/libevent/0001-fix-windows-getaddrinfo.patch
@@ -1,0 +1,15 @@
+diff -ur libevent-2.1.8-stable.orig/configure.ac libevent-2.1.8-stable/configure.ac
+--- libevent-2.1.8-stable.orig/configure.ac	2017-01-29 17:51:00.000000000 +0000
++++ libevent-2.1.8-stable/configure.ac	2020-03-07 01:11:16.311335005 +0000
+@@ -389,6 +389,10 @@
+ 		#ifdef HAVE_NETDB_H
+ 		#include <netdb.h>
+ 		#endif
++#ifdef _WIN32
++#include <winsock2.h>
++#include <ws2tcpip.h>
++#endif
+ 	    ]],
+ 	    [[
+ 		getaddrinfo;
+Only in libevent-2.1.8-stable: configure.ac~


### PR DESCRIPTION
libevent uses getaddrinfo when available, and falls back to gethostbyname
Windows has both, but gethostbyname only supports IPv4
libevent fails to detect Windows's getaddrinfo due to not including the right headers
This patches libevent's configure script to check it correctly

Upstream issue: https://github.com/libevent/libevent/issues/966