### PR TITLE
Changed the date format on Block Syncing overlay

### DIFF
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -122,7 +122,7 @@ void ModalOverlay::tipUpdate(int count, const QDateTime& blockDate, double nVeri
     }
 
     // show the last block date
-    ui->newestBlockDate->setText(blockDate.toString());
+    ui->newestBlockDate->setText(blockDate.toString("yyyy-MM-dd hh:mm:ss"));
 
     // show the percentage done according to nVerificationProgress
     ui->percentageProgress->setText(QString::number(nVerificationProgress*100, 'f', 2)+"%");


### PR DESCRIPTION
The default date format used by QDate has a weird format _(Fri Mar 7 11:34:02 2020)_, so I have changed this to a format that is more user-friendly _(2020-03-07 11:34:02)_.

<img width="821" alt="Bitcoin Core New Date" src="https://user-images.githubusercontent.com/9567098/76152382-f8a37e00-60b6-11ea-8569-be6d69b892c6.png">