### PR TITLE
depends: Make it possible to build Boost dependency using a clang toolset (./b2 toolset=clang)

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -26,6 +26,10 @@ $(package)_config_libraries=filesystem,system,thread,test
 $(package)_cxxflags=-std=c++11 -fvisibility=hidden
 $(package)_cxxflags_linux=-fPIC
 $(package)_cxxflags_android=-fPIC
+ifneq (,$(findstring clang,$(CXX)))
+  $(package)_toolset_$(host_os)=clang
+  $(package)_cxx=$(CXX)
+endif
 endef
 
 define $(package)_preprocess_cmds

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -33,13 +33,13 @@ define $(package)_preprocess_cmds
 endef
 
 define $(package)_config_cmds
-  ./bootstrap.sh --without-icu --with-libraries=$($(package)_config_libraries)
+  ./bootstrap.sh --without-icu --with-libraries=$($(package)_config_libraries) toolset=$($(package)_toolset_$(host_os))
 endef
 
 define $(package)_build_cmds
-  ./b2 -d2 -j2 -d1 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) stage
+  ./b2 -d2 -j2 -d1 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) toolset=$($(package)_toolset_$(host_os)) stage
 endef
 
 define $(package)_stage_cmds
-  ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) install
+  ./b2 -d0 -j4 --prefix=$($(package)_staging_prefix_dir) $($(package)_config_opts) toolset=$($(package)_toolset_$(host_os)) install
 endef


### PR DESCRIPTION
Make it possible to build Boost dependency using a clang toolset (`./b2 toolset=clang`).

Submitted as a separate pull as required by MarcoFalke in https://github.com/bitcoin/bitcoin/pull/18288#discussion_r390368931.

Fixes #15914.