### PR TITLE
gui: fix font inconsistency on send coins form

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -105,7 +105,6 @@ void setupAddressWidget(QValidatedLineEdit *widget, QWidget *parent)
 {
     parent->setFocusProxy(widget);
 
-    widget->setFont(fixedPitchFont());
     // We don't want translators to use own addresses in translations
     // and this is the only place, where this address is supplied.
     widget->setPlaceholderText(QObject::tr("Enter a Bitcoin address (e.g. %1)").arg(


### PR DESCRIPTION
Small change to the QT font when displaying the address input on the 'Send' tab of the GUI to make it consistent with the rest of the form

This change involved removing the `setFont` function from being called in `setupAddressWidget` meaning it should use the default font instead

`setupAddressWidget` is also called on the following files:

- `editaddressdialog.cpp`
- `sendcoinsdialog.cpp`
- `sendcoinsentry.cpp`
- `signverifymessagedialog.cpp`

This change works on all the above QT pages and helps neaten up the font consistency.

**Linux Screenshots**

master
![before](https://user-images.githubusercontent.com/31032215/76364111-5258b200-631c-11ea-8e58-7037e047515e.png)

pr
![after](https://user-images.githubusercontent.com/31032215/76364120-571d6600-631c-11ea-98df-b8f1c66f969c.png)


**Mac Screenshots**

master
<img width="640" alt="before_mac" src="https://user-images.githubusercontent.com/31032215/76364136-613f6480-631c-11ea-98ec-57d3fe9c887b.png">

pr
<img width="640" alt="after_mac" src="https://user-images.githubusercontent.com/31032215/76364148-69979f80-631c-11ea-9b5f-b29141f920e6.png">

