### PR TITLE
fuzz: Add missing ECC_Start to key_io test

### DIFF
--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -16,7 +16,9 @@
 
 void initialize()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    static const ECCVerifyHandle verify_handle;
+    ECC_Start();
+    SelectParams(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)


### PR DESCRIPTION
Fixes

```
$ ./src/test/fuzz/key_io ../btc_qa_assets/fuzz_seed_corpus/key_io
INFO: Seed: 2023332714
INFO: Loaded 1 modules   (470791 inline 8-bit counters): 470791 [0x55d4f15d46e0, 0x55d4f16475e7), 
INFO: Loaded 1 PC tables (470791 PCs): 470791 [0x55d4f16475e8,0x55d4f1d76658), 
INFO:      203 files found in ../btc_qa_assets/fuzz_seed_corpus/key_io
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
INFO: seed corpus: files: 203 min: 1b max: 465b total: 16482b rss: 99Mb
key.cpp:154:39: runtime error: null pointer passed as argument 1, which is declared to never be null
secp256k1/include/secp256k1.h:521:3: note: nonnull attribute specified here
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior key.cpp:154:39 in 
