### PR TITLE
refactor: Add params to node context

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -85,9 +85,9 @@ static bool AppInit(int argc, char* argv[])
         if (!gArgs.ReadConfigFiles(error, true)) {
             return InitError(strprintf("Error reading configuration file: %s\n", error));
         }
-        // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
+        // Check for chain parameter; Params() calls are only valid after this clause
         try {
-            SelectParams(gArgs.GetChainName());
+            SelectParams(gArgs.GetChainName(), node.base_params, node.params);
         } catch (const std::exception& e) {
             return InitError(strprintf("%s\n", e.what()));
         }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -8,8 +8,8 @@
 #include <chainparamsseeds.h>
 #include <consensus/merkle.h>
 #include <tinyformat.h>
-#include <util/system.h>
 #include <util/strencodings.h>
+#include <util/system.h>
 #include <versionbitsinfo.h>
 
 #include <assert.h>
@@ -399,8 +399,9 @@ std::unique_ptr<const CChainParams> CreateChainParams(const std::string& chain)
     throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 
-void SelectParams(const std::string& network)
+void SelectParams(const std::string& network, const CBaseChainParams* out_base, const CChainParams* out)
 {
-    SelectBaseParams(network);
+    SelectBaseParams(network, out_base);
     globalChainParams = CreateChainParams(network);
+    if (out) out = globalChainParams.get();
 }

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -126,6 +126,6 @@ const CChainParams &Params();
  * Sets the params returned by Params() to those for the given chain name.
  * @throws std::runtime_error when the chain is not supported.
  */
-void SelectParams(const std::string& chain);
+void SelectParams(const std::string& chain, const CBaseChainParams* out_base = nullptr, const CChainParams* out = nullptr);
 
 #endif // BITCOIN_CHAINPARAMS_H

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -6,8 +6,8 @@
 #include <chainparamsbase.h>
 
 #include <tinyformat.h>
-#include <util/system.h>
 #include <util/memory.h>
+#include <util/system.h>
 
 #include <assert.h>
 
@@ -25,7 +25,7 @@ void SetupChainParamsBaseOptions()
     gArgs.AddArg("-vbparams=deployment:start:end", "Use given start/end times for specified version bits deployment (regtest-only)", ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CHAINPARAMS);
 }
 
-static std::unique_ptr<CBaseChainParams> globalChainBaseParams;
+static std::unique_ptr<const CBaseChainParams> globalChainBaseParams;
 
 const CBaseChainParams& BaseParams()
 {
@@ -45,8 +45,9 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }
 
-void SelectBaseParams(const std::string& chain)
+void SelectBaseParams(const std::string& chain, const CBaseChainParams* out)
 {
     globalChainBaseParams = CreateBaseChainParams(chain);
+    if (out) out = globalChainBaseParams.get();
     gArgs.SelectConfigNetwork(chain);
 }

--- a/src/chainparamsbase.h
+++ b/src/chainparamsbase.h
@@ -52,6 +52,6 @@ void SetupChainParamsBaseOptions();
 const CBaseChainParams& BaseParams();
 
 /** Sets the params returned by Params() to those for the given network. */
-void SelectBaseParams(const std::string& chain);
+void SelectBaseParams(const std::string& chain, const CBaseChainParams* out = nullptr);
 
 #endif // BITCOIN_CHAINPARAMSBASE_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -299,6 +299,8 @@ void Shutdown(NodeContext& node)
     ECC_Stop();
     if (node.mempool) node.mempool = nullptr;
     node.scheduler.reset();
+    node.base_params = nullptr;
+    node.params = nullptr;
 
     try {
         if (!fs::remove(GetPidFile())) {

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -63,7 +63,7 @@ public:
     void forceSetArg(const std::string& arg, const std::string& value) override { gArgs.ForceSetArg(arg, value); }
     bool softSetArg(const std::string& arg, const std::string& value) override { return gArgs.SoftSetArg(arg, value); }
     bool softSetBoolArg(const std::string& arg, bool value) override { return gArgs.SoftSetBoolArg(arg, value); }
-    void selectParams(const std::string& network) override { SelectParams(network); }
+    void selectParams(const std::string& network) override { SelectParams(network, m_context.base_params, m_context.params); }
     uint64_t getAssumedBlockchainSize() override { return Params().AssumedBlockchainSize(); }
     uint64_t getAssumedChainStateSize() override { return Params().AssumedChainStateSize(); }
     std::string getNetwork() override { return Params().NetworkIDString(); }

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -5,10 +5,13 @@
 #ifndef BITCOIN_NODE_CONTEXT_H
 #define BITCOIN_NODE_CONTEXT_H
 
+#include <cassert>
 #include <memory>
 #include <vector>
 
 class BanMan;
+class CBaseChainParams;
+class CChainParams;
 class CConnman;
 class CScheduler;
 class CTxMemPool;
@@ -33,6 +36,8 @@ struct NodeContext {
     CTxMemPool* mempool{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
     std::unique_ptr<PeerLogicValidation> peer_logic;
     std::unique_ptr<BanMan> banman;
+    const CBaseChainParams* base_params{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
+    const CChainParams* params{nullptr};          // Currently a raw pointer because the memory is not managed by this struct
     std::unique_ptr<interfaces::Chain> chain;
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
     std::unique_ptr<CScheduler> scheduler;
@@ -43,5 +48,17 @@ struct NodeContext {
     NodeContext();
     ~NodeContext();
 };
+
+inline const CBaseChainParams& EnsureBaseParams(const NodeContext& node)
+{
+    assert(node.base_params);
+    return *node.base_params;
+};
+
+inline const CChainParams& EnsureParams(const NodeContext& node)
+{
+    assert(node.params);
+    return *node.params;
+}
 
 #endif // BITCOIN_NODE_CONTEXT_H

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -511,7 +511,7 @@ int GuiMain(int argc, char* argv[])
     // - QSettings() will use the new application name after this, resulting in network-specific settings
     // - Needs to be done before createOptionsModel
 
-    // Check for -chain, -testnet or -regtest parameter (Params() calls are only valid after this clause)
+    // Check for chain parameter; Params() calls are only valid after this clause
     try {
         node->selectParams(gArgs.GetChainName());
     } catch(std::exception &e) {

--- a/src/test/fuzz/process_message.cpp
+++ b/src/test/fuzz/process_message.cpp
@@ -85,7 +85,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     p2p_node.SetSendVersion(PROTOCOL_VERSION);
     g_setup->m_node.peer_logic->InitializeNode(&p2p_node);
     try {
-        (void)ProcessMessage(&p2p_node, random_message_type, random_bytes_data_stream, GetTimeMillis(), Params(), *g_setup->m_node.mempool, g_setup->m_node.connman.get(), g_setup->m_node.banman.get(), std::atomic<bool>{false});
+        (void)ProcessMessage(&p2p_node, random_message_type, random_bytes_data_stream, GetTimeMillis(), EnsureParams(g_setup->m_node), *g_setup->m_node.mempool, g_setup->m_node.connman.get(), g_setup->m_node.banman.get(), std::atomic<bool>{false});
     } catch (const std::ios_base::failure& e) {
         const std::string exception_message{e.what()};
         const auto p = EXPECTED_DESERIALIZATION_EXCEPTIONS.find(exception_message);

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -71,7 +71,7 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
     fs::create_directories(m_path_root);
     gArgs.ForceSetArg("-datadir", m_path_root.string());
     ClearDatadirCache();
-    SelectParams(chainName);
+    SelectParams(chainName, m_node.base_params, m_node.params);
     SeedInsecureRand();
     gArgs.ForceSetArg("-printtoconsole", "0");
     if (G_TEST_LOG_FUN) LogInstance().PushBackCallback(G_TEST_LOG_FUN);
@@ -93,6 +93,8 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName)
 
 BasicTestingSetup::~BasicTestingSetup()
 {
+    m_node.base_params = nullptr;
+    m_node.params = nullptr;
     LogInstance().DisconnectTestLogger();
     fs::remove_all(m_path_root);
     ECC_Stop();
@@ -172,7 +174,7 @@ TestChain100Setup::TestChain100Setup()
     // TODO: fix the code to support SegWit blocks.
     gArgs.ForceSetArg("-segwitheight", "432");
     // Need to recreate chainparams
-    SelectParams(CBaseChainParams::REGTEST);
+    SelectParams(CBaseChainParams::REGTEST, m_node.base_params, m_node.params);
 
     // Generate a 100-block chain:
     coinbaseKey.MakeNewKey(true);

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -73,6 +73,7 @@ static constexpr CAmount CENT{1000000};
  */
 struct BasicTestingSetup {
     ECCVerifyHandle globalVerifyHandle;
+    NodeContext m_node;
 
     explicit BasicTestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~BasicTestingSetup();
@@ -84,7 +85,6 @@ private:
  * Included are coins database, script check threads setup.
  */
 struct TestingSetup : public BasicTestingSetup {
-    NodeContext m_node;
     boost::thread_group threadGroup;
 
     explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);


### PR DESCRIPTION
`EnsureParams(node)` and `Params()` are completely identical, but slowly removing the global `Params()` makes the code easier to reason about and easier to test.
Some places do not rely on the global, but pass around the params through deep call stacks. If the params are passed along with a node context, those could be removed, as just passing a node context should be sufficient.

I suggest that existing code stays as is, but whenever code is touched for other reasons, it could be updated to use `EnsureParams()`.