### PR TITLE
build: Drop deprecated ACLOCAL_AMFLAGS variable

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,6 @@
 print-%:
 	@echo $* = $($*)
 
-ACLOCAL_AMFLAGS = -I build-aux/m4
 SUBDIRS = src
 if ENABLE_MAN
 SUBDIRS += doc/man


### PR DESCRIPTION
This PR is a followup of #18290.

The special make variable `ACLOCAL_AMFLAGS` is deprecated since Automake 1.13 release.
`AC_CONFIG_MACRO_DIR` macro is traced by `aclocal`, and is used to declare the local m4 include directories.

For the reference:
- [GNU Automake 1.13 released](https://lists.gnu.org/archive/html/automake/2012-12/msg00038.html)
- [GNU Automake 1.14 released](https://lists.gnu.org/archive/html/automake/2013-06/msg00040.html)