### PR TITLE
script: Fix gitian-build.py --pull option

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -234,17 +234,19 @@ def main():
     if args.commit and args.pull:
         raise Exception('Cannot have both commit and pull')
     args.commit = ('' if args.commit else 'v') + args.version
+    print(args.commit)
 
     os.chdir('bitcoin')
     if args.pull:
         subprocess.check_call(['git', 'fetch', args.url, 'refs/pull/'+args.version+'/merge'])
         os.chdir('../gitian-builder/inputs/bitcoin')
         subprocess.check_call(['git', 'fetch', args.url, 'refs/pull/'+args.version+'/merge'])
-        args.commit = subprocess.check_output(['git', 'show', '-s', '--format=%H', 'FETCH_HEAD'], universal_newlines=True, encoding='utf8').strip()
         args.version = 'pull-' + args.version
-    print(args.commit)
-    subprocess.check_call(['git', 'fetch'])
-    subprocess.check_call(['git', 'checkout', args.commit])
+    else:
+        subprocess.check_call(['git', 'fetch', args.url, args.commit])
+
+    subprocess.check_call(['git', 'checkout', 'FETCH_HEAD'])
+    args.commit = subprocess.check_output(['git', 'log', '-1', '--format=%H'], universal_newlines=True, encoding='utf8').strip()
     os.chdir(workdir)
 
     os.chdir('gitian-builder')

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -31,6 +31,11 @@ def setup():
         subprocess.check_call(['git', 'clone', 'https://github.com/bitcoin-core/bitcoin-detached-sigs.git'])
     if not os.path.isdir('gitian-builder'):
         subprocess.check_call(['git', 'clone', 'https://github.com/devrandom/gitian-builder.git'])
+        os.chdir('gitian-builder')
+        os.makedirs('inputs')
+        os.chdir('inputs')
+        subprocess.check_call(['git', 'clone', 'https://github.com/bitcoin/bitcoin.git'])
+        os.chdir(workdir)
     if not os.path.isdir('bitcoin'):
         subprocess.check_call(['git', 'clone', 'https://github.com/bitcoin/bitcoin.git'])
     os.chdir('gitian-builder')


### PR DESCRIPTION
During testing #18331 I've encountered with three bugs of the `gitian-build.py` script.

The **first** one:
```
$ git clone https://github.com/bitcoin/bitcoin.git
$ cp ./bitcoin/contrib/gitian-build.py .
$ ./gitian-build.py --setup
$ ./gitian-build.py --pull --build --os w --detach-sign hebasto 18331
remote: Enumerating objects: 19, done.
remote: Counting objects: 100% (19/19), done.
remote: Total 27 (delta 19), reused 19 (delta 19), pack-reused 8
Unpacking objects: 100% (27/27), 6.77 KiB | 315.00 KiB/s, done.
From https://github.com/bitcoin/bitcoin
 * branch                refs/pull/18331/merge -> FETCH_HEAD
Traceback (most recent call last):
  File "./gitian-build.py", line 262, in <module>
    main()
  File "./gitian-build.py", line 236, in main
    os.chdir('../gitian-builder/inputs/bitcoin')
FileNotFoundError: [Errno 2] No such file or directory: '../gitian-builder/inputs/bitcoin'
```
i.e., `gitian-builder/inputs/bitcoin` repository is not initialized at all if the first `--build` command comes with `--pull` option.

---

The **second** bug:
```
...
$ ./gitian-build.py --pull --build --os w --detach-sign hebasto 18331
$ cd bitcoin
$ git log -1 --oneline 
e2d36639c (HEAD -> master, origin/master, origin/HEAD) Merge #18228: test: Add missing syncwithvalidationinterfacequeue
$ cd ../gitian-builder/inputs/bitcoin/
$ git log -1 --oneline 
57da42921 (HEAD) Merge f05f8a49e02b49b6bcbdb82681b4c67509e8db73 into e2d36639ca87b980b147047e4e47cf160b2c9406
```
i.e., gitian descriptors, which were passed to `gbuild`, are from the wrong commit.

---

The **third** bug:
https://github.com/bitcoin/bitcoin/blob/d402c1e4d3e812341176e0948d64ff126f9ec3c1/contrib/gitian-build.py#L241
i.e., `--url` option is ignored here.

---

This PR fixes all described bugs.

UPDATE. This PR was also used during #21036 testing.