### PR TITLE
init: Remove boost::thread_group

### DIFF
--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -36,9 +36,9 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
         void swap(PrevectorJob& x){p.swap(x.p);};
     };
     CCheckQueue<PrevectorJob> queue {QUEUE_BATCH_SIZE};
-    boost::thread_group tg;
+    std::vector<boost::thread> tg;
     for (auto x = 0; x < std::max(MIN_CORES, GetNumCores()); ++x) {
-       tg.create_thread([&]{queue.Thread();});
+        tg.emplace_back([&] { queue.Thread(); });
     }
     while (state.KeepRunning()) {
         // Make insecure_rand here so that each iteration is identical.
@@ -55,7 +55,11 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
         // it is done explicitly here for clarity
         control.Wait();
     }
-    tg.interrupt_all();
-    tg.join_all();
+    for (auto& thread : tg) {
+        thread.interrupt();
+    }
+    for (auto& thread : tg) {
+        thread.join();
+    }
 }
 BENCHMARK(CCheckQueueSpeedPrevectorJob, 1400);

--- a/src/node/context.cpp
+++ b/src/node/context.cpp
@@ -10,5 +10,7 @@
 #include <net_processing.h>
 #include <scheduler.h>
 
+#include <boost/thread.hpp>
+
 NodeContext::NodeContext() {}
 NodeContext::~NodeContext() {}

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -17,6 +17,9 @@ namespace interfaces {
 class Chain;
 class ChainClient;
 } // namespace interfaces
+namespace boost {
+class thread;
+}
 
 //! NodeContext struct containing references to chain state and connection
 //! state.
@@ -36,6 +39,8 @@ struct NodeContext {
     std::unique_ptr<interfaces::Chain> chain;
     std::vector<std::unique_ptr<interfaces::ChainClient>> chain_clients;
     std::unique_ptr<CScheduler> scheduler;
+    /** The thread group used by the scheduler and checkqueue. */
+    std::unique_ptr<std::vector<boost::thread>> thread_group;
 
     //! Declare default constructor and destructor that are not inline, so code
     //! instantiating the NodeContext struct doesn't need to #include class

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -5,11 +5,6 @@
 #ifndef BITCOIN_SCHEDULER_H
 #define BITCOIN_SCHEDULER_H
 
-//
-// NOTE:
-// boost::thread should be ported to std::thread
-// when we support C++11.
-//
 #include <condition_variable>
 #include <functional>
 #include <list>
@@ -26,7 +21,7 @@
 // CScheduler* s = new CScheduler();
 // s->scheduleFromNow(doSomething, 11); // Assuming a: void doSomething() { }
 // s->scheduleFromNow(std::bind(Class::func, this, argument), 3);
-// boost::thread* t = new boost::thread(std::bind(CScheduler::serviceQueue, s));
+// std::thread* t = new std::thread([&] { s->serviceQueue(); });
 //
 // ... then at program shutdown, make sure to call stop() to clean up the thread(s) running serviceQueue:
 // s->stop();

--- a/src/test/cuckoocache_tests.cpp
+++ b/src/test/cuckoocache_tests.cpp
@@ -9,6 +9,9 @@
 #include <thread>
 #include <deque>
 
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
+
 /** Test Suite for CuckooCache
  *
  *  1. All tests should have a deterministic result (using insecure rand

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -72,8 +72,6 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 
     // txindex job may be scheduled, so stop scheduler before destructing
     m_node.scheduler->stop();
-    threadGroup.interrupt_all();
-    threadGroup.join_all();
 
     // Rest of shutdown sequence and destructors happen in ~TestingSetup()
 }

--- a/src/test/util/setup_common.h
+++ b/src/test/util/setup_common.h
@@ -16,8 +16,6 @@
 
 #include <type_traits>
 
-#include <boost/thread.hpp>
-
 /** This is connected to the logger. Can be used to redirect logs to any other log */
 extern const std::function<void(const std::string&)> G_TEST_LOG_FUN;
 
@@ -84,7 +82,6 @@ private:
  */
 struct TestingSetup : public BasicTestingSetup {
     NodeContext m_node;
-    boost::thread_group threadGroup;
 
     explicit TestingSetup(const std::string& chainName = CBaseChainParams::MAIN);
     ~TestingSetup();

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -17,8 +17,6 @@
 #include <atomic>
 #include <string>
 
-#include <boost/thread.hpp>
-
 namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
@@ -487,11 +485,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
                 pwallet->WalletLogPrintf("%s\n", strErr);
         }
         pcursor->close();
-    }
-    catch (const boost::thread_interrupted&) {
-        throw;
-    }
-    catch (...) {
+    } catch (...) {
         result = DBErrors::CORRUPT;
     }
 
@@ -593,11 +587,7 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::vector<CW
             }
         }
         pcursor->close();
-    }
-    catch (const boost::thread_interrupted&) {
-        throw;
-    }
-    catch (...) {
+    } catch (...) {
         result = DBErrors::CORRUPT;
     }
 

--- a/test/lint/lint-includes.sh
+++ b/test/lint/lint-includes.sh
@@ -69,7 +69,9 @@ EXPECTED_BOOST_INCLUDES=(
     boost/test/unit_test.hpp
     boost/thread.hpp
     boost/thread/condition_variable.hpp
+    boost/thread/locks.hpp
     boost/thread/mutex.hpp
+    boost/thread/shared_mutex.hpp
     boost/thread/thread.hpp
     boost/variant.hpp
     boost/variant/apply_visitor.hpp


### PR DESCRIPTION
This removes `boost::thread*` where possible. We still need `boost::thread` for the checkqueue, but ripping it out there should now be a smaller diff.