### PR TITLE
doc: mention MAKE=gmake workaround when building on a BSD

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -10,7 +10,7 @@ This guide does not contain instructions for building the GUI.
 
 You will need the following dependencies, which can be installed as root via pkg:
 
-```shell
+```bash
 pkg install autoconf automake boost-libs git gmake libevent libtool pkgconf
 
 git clone https://github.com/bitcoin/bitcoin.git
@@ -18,7 +18,7 @@ git clone https://github.com/bitcoin/bitcoin.git
 
 In order to run the test suite (recommended), you will need to have Python 3 installed:
 
-```shell
+```bash
 pkg install python3
 ```
 
@@ -29,32 +29,33 @@ See [dependencies.md](dependencies.md) for a complete overview.
 BerkeleyDB is only necessary for the wallet functionality. To skip this, pass
 `--disable-wallet` to `./configure` and skip to the next section.
 
-```shell
+```bash
 ./contrib/install_db4.sh `pwd`
 export BDB_PREFIX="$PWD/db4"
 ```
 
 ## Building Bitcoin Core
 
-**Important**: Use `gmake` (the non-GNU `make` will exit with an error):
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 With wallet:
-```shell
+```bash
 ./autogen.sh
 ./configure --with-gui=no \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include"
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    MAKE=gmake
 ```
 
 Without wallet:
-```shell
+```bash
 ./autogen.sh
-./configure --with-gui=no --disable-wallet
+./configure --with-gui=no --disable-wallet MAKE=gmake
 ```
 
 followed by:
 
-```shell
+```bash
 gmake # use -jX here for parallelism
 gmake check # Run tests if Python 3 is available
 ```

--- a/doc/build-netbsd.md
+++ b/doc/build-netbsd.md
@@ -37,13 +37,13 @@ from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 If you have to build it yourself, you can use [the installation script included
 in contrib/](/contrib/install_db4.sh) like so:
 
-```shell
+```bash
 ./contrib/install_db4.sh `pwd`
 ```
 
 from the root of the repository. Then set `BDB_PREFIX` for the next section:
 
-```shell
+```bash
 export BDB_PREFIX="$PWD/db4"
 ```
 
@@ -52,24 +52,26 @@ export BDB_PREFIX="$PWD/db4"
 **Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 With wallet:
-```
+```bash
 ./autogen.sh
 ./configure --with-gui=no CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
     BOOST_LDFLAGS="-L/usr/pkg/lib" \
     BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
-    BDB_CFLAGS="-I${BDB_PREFIX}/include"
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    MAKE=gmake
 ```
 
 Without wallet:
-```
+```bash
 ./autogen.sh
 ./configure --with-gui=no --disable-wallet \
     CPPFLAGS="-I/usr/pkg/include" \
     LDFLAGS="-L/usr/pkg/lib" \
     BOOST_CPPFLAGS="-I/usr/pkg/include" \
-    BOOST_LDFLAGS="-L/usr/pkg/lib"
+    BOOST_LDFLAGS="-L/usr/pkg/lib" \
+    MAKE=gmake
 ```
 
 Build and run the tests:

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -38,19 +38,19 @@ from ports, for the same reason as boost above (g++/libstd++ incompatibility).
 If you have to build it yourself, you can use [the installation script included
 in contrib/](/contrib/install_db4.sh) like so:
 
-```shell
+```bash
 ./contrib/install_db4.sh `pwd` CC=cc CXX=c++
 ```
 
 from the root of the repository. Then set `BDB_PREFIX` for the next section:
 
-```shell
+```bash
 export BDB_PREFIX="$PWD/db4"
 ```
 
 ### Building Bitcoin Core
 
-**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
+**Important**: Use `gmake` (the non-GNU `make` will exit with an error).
 
 Preparation:
 ```bash
@@ -70,12 +70,14 @@ Make sure `BDB_PREFIX` is set to the appropriate path from the above steps.
 To configure with wallet:
 ```bash
 ./configure --with-gui=no CC=cc CXX=c++ \
-    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" BDB_CFLAGS="-I${BDB_PREFIX}/include"
+    BDB_LIBS="-L${BDB_PREFIX}/lib -ldb_cxx-4.8" \
+    BDB_CFLAGS="-I${BDB_PREFIX}/include" \
+    MAKE=gmake
 ```
 
 To configure without wallet:
 ```bash
-./configure --disable-wallet --with-gui=no CC=cc CXX=c++
+./configure --disable-wallet --with-gui=no CC=cc CXX=c++ MAKE=gmake
 ```
 
 Build and run the tests:


### PR DESCRIPTION
Fixes: #14404.
Replaces: #18129.