### PR TITLE
test: Fix mining to an invalid target + ensure that a new block has the correct hash internally

### DIFF
--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -632,7 +632,7 @@ class FullBlockTest(BitcoinTestFramework):
         self.move_tip(44)
         b47 = self.next_block(47, solve=False)
         target = uint256_from_compact(b47.nBits)
-        while b47.sha256 < target:
+        while b47.sha256 <= target:
             b47.nNonce += 1
             b47.rehash()
         self.send_blocks([b47], False, force_send=True, reject_reason='high-hash', reconnect=True)
@@ -1345,6 +1345,8 @@ class FullBlockTest(BitcoinTestFramework):
             block.hashMerkleRoot = block.calc_merkle_root()
         if solve:
             block.solve()
+        else:
+            block.rehash()
         self.tip = block
         self.block_heights[block.sha256] = height
         assert number not in self.blocks


### PR DESCRIPTION
Test with block 47 in the `feature_block.py` creates a block with a hash higher than the target, which is supposed to fail. Now two issues exist there, and both have low probability of showing up:

1. The creation is done with `while (hash < target)`, which is wrong, because hash = target is a valid mined value based on the code in the function `CheckProofOfWork()` that validates the mining target:
```
    if (UintToArith256(hash) > bnTarget)
        return false;
```
2. As we know the hash stored in CBlock class in Python is stateful, unlike how it's in C++, where calling `CBlock::GetHash()` will actively calculate the hash and not cache it anywhere. With this, blocks that come out of the method `next_block` can have incorrect hash value when `solve=False`. This is because the `next_block` is mostly used with `solve=True`, and solving does call the function `rehash()` which calculates the hash of the block, but with `solve=False`, nothing calls that method. And since the work to be done in regtests is very low, the probably of this problem showing up is very low, but it practically happens (well, with much higher probability compared to issue No. 1 above).

This PR fixes both these issues.