### PR TITLE
tests: Add fuzzing harnesses for classes CBlockHeader, CFeeRate and various functions

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -93,6 +93,7 @@ FUZZ_TARGETS = \
   test/fuzz/service_deserialize \
   test/fuzz/snapshotmetadata_deserialize \
   test/fuzz/spanparsing \
+  test/fuzz/string \
   test/fuzz/strprintf \
   test/fuzz/sub_net_deserialize \
   test/fuzz/transaction \
@@ -808,11 +809,23 @@ test_fuzz_service_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_service_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_service_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 
+test_fuzz_snapshotmetadata_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSNAPSHOTMETADATA_DESERIALIZE=1
+test_fuzz_snapshotmetadata_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_snapshotmetadata_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_snapshotmetadata_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_snapshotmetadata_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
 test_fuzz_spanparsing_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_spanparsing_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_spanparsing_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_spanparsing_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_spanparsing_SOURCES = $(FUZZ_SUITE) test/fuzz/spanparsing.cpp
+
+test_fuzz_string_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_string_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_string_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_string_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_string_SOURCES = $(FUZZ_SUITE) test/fuzz/string.cpp
 
 test_fuzz_strprintf_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_strprintf_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
@@ -825,12 +838,6 @@ test_fuzz_sub_net_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_sub_net_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_sub_net_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_sub_net_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
-
-test_fuzz_snapshotmetadata_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSNAPSHOTMETADATA_DESERIALIZE=1
-test_fuzz_snapshotmetadata_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
-test_fuzz_snapshotmetadata_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
-test_fuzz_snapshotmetadata_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
-test_fuzz_snapshotmetadata_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
 
 test_fuzz_transaction_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_transaction_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -42,6 +42,7 @@ FUZZ_TARGETS = \
   test/fuzz/locale \
   test/fuzz/merkle_block_deserialize \
   test/fuzz/messageheader_deserialize \
+  test/fuzz/multiplication_overflow \
   test/fuzz/netaddr_deserialize \
   test/fuzz/netaddress \
   test/fuzz/out_point_deserialize \
@@ -512,6 +513,12 @@ test_fuzz_messageheader_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_messageheader_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_messageheader_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_messageheader_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_multiplication_overflow_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_multiplication_overflow_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_multiplication_overflow_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_multiplication_overflow_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_multiplication_overflow_SOURCES = $(FUZZ_SUITE) test/fuzz/multiplication_overflow.cpp
 
 test_fuzz_netaddr_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DNETADDR_DESERIALIZE=1
 test_fuzz_netaddr_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -29,6 +29,7 @@ FUZZ_TARGETS = \
   test/fuzz/descriptor_parse \
   test/fuzz/diskblockindex_deserialize \
   test/fuzz/eval_script \
+  test/fuzz/fee_rate \
   test/fuzz/fee_rate_deserialize \
   test/fuzz/flat_file_pos_deserialize \
   test/fuzz/float \
@@ -433,6 +434,12 @@ test_fuzz_eval_script_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_eval_script_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_eval_script_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_eval_script_SOURCES = $(FUZZ_SUITE) test/fuzz/eval_script.cpp
+
+test_fuzz_fee_rate_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_fee_rate_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_fee_rate_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_fee_rate_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_fee_rate_SOURCES = $(FUZZ_SUITE) test/fuzz/fee_rate.cpp
 
 test_fuzz_fee_rate_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DFEE_RATE_DESERIALIZE=1
 test_fuzz_fee_rate_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -14,6 +14,7 @@ FUZZ_TARGETS = \
   test/fuzz/block_deserialize \
   test/fuzz/block_file_info_deserialize \
   test/fuzz/block_filter_deserialize \
+  test/fuzz/block_header \
   test/fuzz/block_header_and_short_txids_deserialize \
   test/fuzz/blockheader_deserialize \
   test/fuzz/blocklocator_deserialize \
@@ -342,6 +343,12 @@ test_fuzz_block_filter_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_block_filter_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_block_filter_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_block_filter_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_block_header_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_block_header_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_block_header_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_block_header_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_block_header_SOURCES = $(FUZZ_SUITE) test/fuzz/block_header.cpp
 
 test_fuzz_block_header_and_short_txids_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCK_HEADER_AND_SHORT_TXIDS_DESERIALIZE=1
 test_fuzz_block_header_and_short_txids_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <primitives/block.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <uint256.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const Optional<CBlockHeader> block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
+    if (!block_header) {
+        return;
+    }
+    {
+        const uint256 hash = block_header->GetHash();
+        static const uint256 u256_max(uint256S("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"));
+        assert(hash != u256_max);
+        assert(block_header->GetBlockTime() == block_header->nTime);
+        assert(block_header->IsNull() == (block_header->nBits == 0));
+    }
+    {
+        CBlockHeader mut_block_header = *block_header;
+        mut_block_header.SetNull();
+        assert(mut_block_header.IsNull());
+        CBlock block{*block_header};
+        assert(block.GetBlockHeader().GetHash() == block_header->GetHash());
+        (void)block.ToString();
+        block.SetNull();
+        assert(block.GetBlockHeader().GetHash() == mut_block_header.GetHash());
+    }
+}

--- a/src/test/fuzz/fee_rate.cpp
+++ b/src/test/fuzz/fee_rate.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <amount.h>
+#include <policy/feerate.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const CAmount satoshis_per_k = ConsumeMoney(fuzzed_data_provider);
+    const CFeeRate fee_rate{satoshis_per_k};
+
+    (void)fee_rate.GetFeePerK();
+    const size_t bytes = fuzzed_data_provider.ConsumeIntegral<size_t>();
+    if (!MultiplicationOverflow(static_cast<int64_t>(bytes), satoshis_per_k) && bytes <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+        (void)fee_rate.GetFee(bytes);
+    }
+    (void)fee_rate.ToString();
+
+    const CAmount another_satoshis_per_k = ConsumeMoney(fuzzed_data_provider);
+    CFeeRate larger_fee_rate{another_satoshis_per_k};
+    larger_fee_rate += fee_rate;
+    if (satoshis_per_k != 0 && another_satoshis_per_k != 0) {
+        assert(fee_rate < larger_fee_rate);
+        assert(!(fee_rate > larger_fee_rate));
+        assert(!(fee_rate == larger_fee_rate));
+        assert(fee_rate <= larger_fee_rate);
+        assert(!(fee_rate >= larger_fee_rate));
+        assert(fee_rate != larger_fee_rate);
+    }
+}

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -23,6 +23,7 @@
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <time.h>
 #include <uint256.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
@@ -31,6 +32,7 @@
 #include <version.h>
 
 #include <cassert>
+#include <chrono>
 #include <limits>
 #include <vector>
 
@@ -124,6 +126,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             assert(parsed_money == i64);
         }
     }
+    const std::chrono::seconds seconds{i64};
+    assert(count_seconds(seconds) == i64);
 
     const arith_uint256 au256 = UintToArith256(u256);
     assert(ArithToUint256(au256) == u256);

--- a/src/test/fuzz/multiplication_overflow.cpp
+++ b/src/test/fuzz/multiplication_overflow.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace {
+template <typename T>
+void TestMultiplicationOverflow(FuzzedDataProvider& fuzzed_data_provider)
+{
+    const T i = fuzzed_data_provider.ConsumeIntegral<T>();
+    const T j = fuzzed_data_provider.ConsumeIntegral<T>();
+    const bool is_multiplication_overflow_custom = MultiplicationOverflow(i, j);
+    T result_builtin;
+    const bool is_multiplication_overflow_builtin = __builtin_mul_overflow(i, j, &result_builtin);
+    assert(is_multiplication_overflow_custom == is_multiplication_overflow_builtin);
+    if (!is_multiplication_overflow_custom) {
+        assert(i * j == result_builtin);
+    }
+}
+} // namespace
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    TestMultiplicationOverflow<int64_t>(fuzzed_data_provider);
+    TestMultiplicationOverflow<uint64_t>(fuzzed_data_provider);
+    TestMultiplicationOverflow<int32_t>(fuzzed_data_provider);
+    TestMultiplicationOverflow<uint32_t>(fuzzed_data_provider);
+    TestMultiplicationOverflow<int16_t>(fuzzed_data_provider);
+    TestMultiplicationOverflow<uint16_t>(fuzzed_data_provider);
+    TestMultiplicationOverflow<char>(fuzzed_data_provider);
+    TestMultiplicationOverflow<unsigned char>(fuzzed_data_provider);
+    TestMultiplicationOverflow<signed char>(fuzzed_data_provider);
+    TestMultiplicationOverflow<bool>(fuzzed_data_provider);
+}

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blockfilter.h>
+#include <clientversion.h>
+#include <logging.h>
+#include <netbase.h>
+#include <outputtype.h>
+#include <rpc/client.h>
+#include <rpc/request.h>
+#include <rpc/server.h>
+#include <rpc/util.h>
+#include <script/descriptor.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <util/error.h>
+#include <util/fees.h>
+#include <util/message.h>
+#include <util/settings.h>
+#include <util/strencodings.h>
+#include <util/string.h>
+#include <util/system.h>
+#include <util/translation.h>
+#include <util/url.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::string random_string_1 = fuzzed_data_provider.ConsumeRandomLengthString(32);
+    const std::string random_string_2 = fuzzed_data_provider.ConsumeRandomLengthString(32);
+    const std::vector<std::string> random_string_vector = ConsumeRandomLengthStringVector(fuzzed_data_provider);
+
+    (void)AmountErrMsg(random_string_1, random_string_2);
+    (void)AmountHighWarn(random_string_1);
+    BlockFilterType block_filter_type;
+    (void)BlockFilterTypeByName(random_string_1, block_filter_type);
+    (void)Capitalize(random_string_1);
+    (void)CopyrightHolders(random_string_1);
+    FeeEstimateMode fee_estimate_mode;
+    (void)FeeModeFromString(random_string_1, fee_estimate_mode);
+    (void)FormatParagraph(random_string_1, fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 1000), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 1000));
+    (void)FormatSubVersion(random_string_1, fuzzed_data_provider.ConsumeIntegral<int>(), random_string_vector);
+    (void)GetDescriptorChecksum(random_string_1);
+    (void)HelpExampleCli(random_string_1, random_string_2);
+    (void)HelpExampleRpc(random_string_1, random_string_2);
+    (void)HelpMessageGroup(random_string_1);
+    (void)HelpMessageOpt(random_string_1, random_string_2);
+    (void)IsDeprecatedRPCEnabled(random_string_1);
+    (void)Join(random_string_vector, random_string_1);
+    (void)JSONRPCError(fuzzed_data_provider.ConsumeIntegral<int>(), random_string_1);
+    const util::Settings settings;
+    (void)OnlyHasDefaultSectionSetting(settings, random_string_1, random_string_2);
+    (void)ParseNetwork(random_string_1);
+    try {
+        (void)ParseNonRFCJSONValue(random_string_1);
+    } catch (const std::runtime_error&) {
+    }
+    OutputType output_type;
+    (void)ParseOutputType(random_string_1, output_type);
+    (void)ResolveErrMsg(random_string_1, random_string_2);
+    try {
+        (void)RPCConvertNamedValues(random_string_1, random_string_vector);
+    } catch (const std::runtime_error&) {
+    }
+    try {
+        (void)RPCConvertValues(random_string_1, random_string_vector);
+    } catch (const std::runtime_error&) {
+    }
+    (void)SanitizeString(random_string_1);
+    (void)SanitizeString(random_string_1, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 3));
+    (void)ShellEscape(random_string_1);
+    int port_out;
+    std::string host_out;
+    SplitHostPort(random_string_1, port_out, host_out);
+    (void)TimingResistantEqual(random_string_1, random_string_2);
+    (void)ToLower(random_string_1);
+    (void)ToUpper(random_string_1);
+    (void)TrimString(random_string_1);
+    (void)TrimString(random_string_1, random_string_2);
+    (void)urlDecode(random_string_1);
+    (void)ValidAsCString(random_string_1);
+    (void)_(random_string_1.c_str());
+}

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -25,6 +25,16 @@ NODISCARD inline std::vector<uint8_t> ConsumeRandomLengthByteVector(FuzzedDataPr
     return {s.begin(), s.end()};
 }
 
+NODISCARD inline std::vector<std::string> ConsumeRandomLengthStringVector(FuzzedDataProvider& fuzzed_data_provider, size_t max_vector_size = 16, size_t max_string_length = 16) noexcept
+{
+    const size_t n_elements = fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, max_vector_size);
+    std::vector<std::string> r;
+    for (size_t i = 0; i < n_elements; ++i) {
+        r.push_back(fuzzed_data_provider.ConsumeRandomLengthString(max_string_length));
+    }
+    return r;
+}
+
 template <typename T>
 NODISCARD inline Optional<T> ConsumeDeserializable(FuzzedDataProvider& fuzzed_data_provider, size_t max_length = 4096) noexcept
 {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_TEST_FUZZ_UTIL_H
 #define BITCOIN_TEST_FUZZ_UTIL_H
 
+#include <amount.h>
 #include <attributes.h>
 #include <optional.h>
 #include <script/script.h>
@@ -43,6 +44,11 @@ NODISCARD inline opcodetype ConsumeOpcodeType(FuzzedDataProvider& fuzzed_data_pr
     return static_cast<opcodetype>(fuzzed_data_provider.ConsumeIntegralInRange<uint32_t>(0, MAX_OPCODE));
 }
 
+NODISCARD inline CAmount ConsumeMoney(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return fuzzed_data_provider.ConsumeIntegralInRange<CAmount>(0, MAX_MONEY);
+}
+
 NODISCARD inline CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
     const std::vector<uint8_t> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
@@ -52,6 +58,29 @@ NODISCARD inline CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider)
 NODISCARD inline CScriptNum ConsumeScriptNum(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
     return CScriptNum{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
+}
+
+template <typename T>
+bool MultiplicationOverflow(T i, T j)
+{
+    static_assert(std::is_integral<T>::value, "Integral required.");
+    if (std::numeric_limits<T>::is_signed) {
+        if (i > 0) {
+            if (j > 0) {
+                return i > (std::numeric_limits<T>::max() / j);
+            } else {
+                return j < (std::numeric_limits<T>::min() / i);
+            }
+        } else {
+            if (j > 0) {
+                return i < (std::numeric_limits<T>::min() / j);
+            } else {
+                return i != 0 && (j < (std::numeric_limits<T>::max() / i));
+            }
+        }
+    } else {
+        return j != 0 && i > std::numeric_limits<T>::max() / j;
+    }
 }
 
 #endif // BITCOIN_TEST_FUZZ_UTIL_H


### PR DESCRIPTION
Add fuzzing harnesses for classes `CBlockHeader`, `CFeeRate` and various functions.

To test this PR:

```
$ make distclean
$ ./autogen.sh
$ CC=clang CXX=clang++ ./configure --enable-fuzz \
      --with-sanitizers=address,fuzzer,undefined
$ make
$ src/test/fuzz/block_header
^c (ctrl-c)
$ src/test/fuzz/fee_rate
^c (ctrl-c)
$ src/test/fuzz/integer
^c (ctrl-c)
$ src/test/fuzz/multiplication_overflow
^c (ctrl-c)
$ src/test/fuzz/string
^c (ctrl-c)
```