### PR TITLE
Use shared pointers only in validation interface

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -299,9 +299,6 @@ void BaseIndex::Interrupt()
 
 void BaseIndex::Start()
 {
-    // Need to register this ValidationInterface before running Init(), so that
-    // callbacks are not missed if Init sets m_synced to true.
-    RegisterValidationInterface(this);
     if (!Init()) {
         FatalError("%s: %s failed to initialize", __func__, GetName());
         return;
@@ -313,8 +310,6 @@ void BaseIndex::Start()
 
 void BaseIndex::Stop()
 {
-    UnregisterValidationInterface(this);
-
     if (m_thread_sync.joinable()) {
         m_thread_sync.join();
     }

--- a/src/index/base.h
+++ b/src/index/base.h
@@ -102,7 +102,7 @@ protected:
 
 public:
     /// Destructor interrupts sync thread if running and blocks until it exits.
-    virtual ~BaseIndex();
+    ~BaseIndex() override;
 
     /// Blocks the current thread until the index is caught up to the current
     /// state of the block chain. This only blocks if the index has gotten in

--- a/src/index/blockfilterindex.h
+++ b/src/index/blockfilterindex.h
@@ -81,10 +81,10 @@ public:
  * Get a block filter index by type. Returns nullptr if index has not been initialized or was
  * already destroyed.
  */
-BlockFilterIndex* GetBlockFilterIndex(BlockFilterType filter_type);
+std::shared_ptr<BlockFilterIndex> GetBlockFilterIndex(BlockFilterType filter_type);
 
 /** Iterate over all running block filter indexes, invoking fn on each. */
-void ForEachBlockFilterIndex(std::function<void (BlockFilterIndex&)> fn);
+void ForEachBlockFilterIndex(std::function<void (std::shared_ptr<BlockFilterIndex>)> fn);
 
 /**
  * Initialize a block filter index for the given type if one does not already exist. Returns true if

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -14,7 +14,7 @@ constexpr char DB_BEST_BLOCK = 'B';
 constexpr char DB_TXINDEX = 't';
 constexpr char DB_TXINDEX_BLOCK = 'T';
 
-std::unique_ptr<TxIndex> g_txindex;
+std::shared_ptr<TxIndex> g_txindex;
 
 
 

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -49,6 +49,6 @@ public:
 };
 
 /// The global transaction index, used in GetTransaction. May be null.
-extern std::unique_ptr<TxIndex> g_txindex;
+extern std::shared_ptr<TxIndex> g_txindex;
 
 #endif // BITCOIN_INDEX_TXINDEX_H

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -37,7 +37,7 @@ public:
     explicit TxIndex(size_t n_cache_size, bool f_memory = false, bool f_wipe = false);
 
     // Destructor is declared because this class contains a unique_ptr to an incomplete type.
-    virtual ~TxIndex() override;
+    ~TxIndex() override;
 
     /// Look up a transaction by hash.
     ///

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -89,13 +89,13 @@ public:
     explicit NotificationsHandlerImpl(std::shared_ptr<Chain::Notifications> notifications)
         : m_proxy(std::make_shared<NotificationsProxy>(std::move(notifications)))
     {
-        RegisterSharedValidationInterface(m_proxy);
+        RegisterValidationInterface(m_proxy);
     }
     ~NotificationsHandlerImpl() override { disconnect(); }
     void disconnect() override
     {
         if (m_proxy) {
-            UnregisterSharedValidationInterface(m_proxy);
+            UnregisterValidationInterface(m_proxy);
             m_proxy.reset();
         }
     }

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -60,7 +60,7 @@ public:
         : m_notifications(std::move(notifications))
     {
     }
-    virtual ~NotificationsProxy() = default;
+    ~NotificationsProxy() override = default;
     void TransactionAddedToMempool(const CTransactionRef& tx, uint64_t mempool_sequence) override
     {
         if (auto notification = m_notifications.lock())

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -251,7 +251,7 @@ public:
     };
 
     //! Register handler for notifications.
-    virtual std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) = 0;
+    virtual std::unique_ptr<Handler> handleNotifications(std::weak_ptr<Notifications> notifications) = 0;
 
     //! Wait for pending notifications to be processed unless block hash points to the current
     //! chain tip.

--- a/src/net.h
+++ b/src/net.h
@@ -626,7 +626,7 @@ protected:
      * Protected destructor so that instances can only be deleted by derived classes.
      * If that restriction is no longer desired, this should be made public and virtual.
      */
-    ~NetEventsInterface() = default;
+    virtual ~NetEventsInterface() = default;
 };
 
 enum

--- a/src/net.h
+++ b/src/net.h
@@ -209,7 +209,7 @@ public:
         int nMaxFeeler = 0;
         int nBestHeight = 0;
         CClientUIInterface* uiInterface = nullptr;
-        NetEventsInterface* m_msgproc = nullptr;
+        std::shared_ptr<NetEventsInterface> m_msgproc;
         BanMan* m_banman = nullptr;
         unsigned int nSendBufferMaxSize = 0;
         unsigned int nReceiveFloodSize = 0;
@@ -557,7 +557,7 @@ private:
     bool m_use_addrman_outgoing;
     std::atomic<int> nBestHeight;
     CClientUIInterface* clientInterface;
-    NetEventsInterface* m_msgproc;
+    std::shared_ptr<NetEventsInterface> m_msgproc;
     /** Pointer to this node's banman. May be nullptr - check existence before dereferencing. */
     BanMan* m_banman;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2153,7 +2153,7 @@ static bool PrepareBlockFilterRequest(CNode& peer, const CChainParams& chain_par
                                       BlockFilterType filter_type, uint32_t start_height,
                                       const uint256& stop_hash, uint32_t max_height_diff,
                                       const CBlockIndex*& stop_index,
-                                      BlockFilterIndex*& filter_index)
+                                      std::shared_ptr<BlockFilterIndex>& filter_index)
 {
     const bool supported_filter_type =
         (filter_type == BlockFilterType::BASIC &&
@@ -2224,7 +2224,7 @@ static void ProcessGetCFilters(CNode& peer, CDataStream& vRecv, const CChainPara
     const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
 
     const CBlockIndex* stop_index;
-    BlockFilterIndex* filter_index;
+    std::shared_ptr<BlockFilterIndex> filter_index;
     if (!PrepareBlockFilterRequest(peer, chain_params, filter_type, start_height, stop_hash,
                                    MAX_GETCFILTERS_SIZE, stop_index, filter_index)) {
         return;
@@ -2266,7 +2266,7 @@ static void ProcessGetCFHeaders(CNode& peer, CDataStream& vRecv, const CChainPar
     const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
 
     const CBlockIndex* stop_index;
-    BlockFilterIndex* filter_index;
+    std::shared_ptr<BlockFilterIndex> filter_index;
     if (!PrepareBlockFilterRequest(peer, chain_params, filter_type, start_height, stop_hash,
                                    MAX_GETCFHEADERS_SIZE, stop_index, filter_index)) {
         return;
@@ -2320,7 +2320,7 @@ static void ProcessGetCFCheckPt(CNode& peer, CDataStream& vRecv, const CChainPar
     const BlockFilterType filter_type = static_cast<BlockFilterType>(filter_type_ser);
 
     const CBlockIndex* stop_index;
-    BlockFilterIndex* filter_index;
+    std::shared_ptr<BlockFilterIndex> filter_index;
     if (!PrepareBlockFilterRequest(peer, chain_params, filter_type, /*start_height=*/0, stop_hash,
                                    /*max_height_diff=*/std::numeric_limits<uint32_t>::max(),
                                    stop_index, filter_index)) {

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -36,7 +36,7 @@ class WalletClient;
 struct NodeContext {
     std::unique_ptr<CConnman> connman;
     std::unique_ptr<CTxMemPool> mempool;
-    std::unique_ptr<PeerManager> peerman;
+    std::shared_ptr<PeerManager> peerman;
     ChainstateManager* chainman{nullptr}; // Currently a raw pointer because the memory is not managed by this struct
     std::unique_ptr<BanMan> banman;
     ArgsManager* args{nullptr}; // Currently a raw pointer because the memory is not managed by this struct

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2304,7 +2304,7 @@ static RPCHelpMan getblockfilter()
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Unknown filtertype");
     }
 
-    BlockFilterIndex* index = GetBlockFilterIndex(filtertype);
+    auto index = GetBlockFilterIndex(filtertype);
     if (!index) {
         throw JSONRPCError(RPC_MISC_ERROR, "Index is not enabled for filtertype " + filtertype_name);
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -972,9 +972,9 @@ static RPCHelpMan submitblock()
 
     bool new_block;
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
-    RegisterSharedValidationInterface(sc);
+    RegisterValidationInterface(sc);
     bool accepted = EnsureChainman(request.context).ProcessNewBlock(Params(), blockptr, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
-    UnregisterSharedValidationInterface(sc);
+    UnregisterValidationInterface(sc);
     if (!new_block && accepted) {
         return "duplicate";
     }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -683,8 +683,8 @@ static RPCHelpMan getindexinfo()
         result.pushKVs(SummaryToJSON(g_txindex->GetSummary(), index_name));
     }
 
-    ForEachBlockFilterIndex([&result, &index_name](const BlockFilterIndex& index) {
-        result.pushKVs(SummaryToJSON(index.GetSummary(), index_name));
+    ForEachBlockFilterIndex([&result, &index_name](std::shared_ptr<BlockFilterIndex> index) {
+        result.pushKVs(SummaryToJSON(index->GetSummary(), index_name));
     });
 
     return result;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -23,11 +23,11 @@ struct BuildChainTestingSetup : public TestChain100Setup {
     bool BuildChain(const CBlockIndex* pindex, const CScript& coinbase_script_pub_key, size_t length, std::vector<std::shared_ptr<CBlock>>& chain);
 };
 
-static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex* block_index,
+static bool CheckFilterLookups(std::shared_ptr<BlockFilterIndex> filter_index, const CBlockIndex* block_index,
                                uint256& last_header)
 {
     BlockFilter expected_filter;
-    if (!ComputeFilter(filter_index.GetFilterType(), block_index, expected_filter)) {
+    if (!ComputeFilter(filter_index->GetFilterType(), block_index, expected_filter)) {
         BOOST_ERROR("ComputeFilter failed on block " << block_index->nHeight);
         return false;
     }
@@ -37,10 +37,10 @@ static bool CheckFilterLookups(BlockFilterIndex& filter_index, const CBlockIndex
     std::vector<BlockFilter> filters;
     std::vector<uint256> filter_hashes;
 
-    BOOST_CHECK(filter_index.LookupFilter(block_index, filter));
-    BOOST_CHECK(filter_index.LookupFilterHeader(block_index, filter_header));
-    BOOST_CHECK(filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+    BOOST_CHECK(filter_index->LookupFilter(block_index, filter));
+    BOOST_CHECK(filter_index->LookupFilterHeader(block_index, filter_header));
+    BOOST_CHECK(filter_index->LookupFilterRange(block_index->nHeight, block_index, filters));
+    BOOST_CHECK(filter_index->LookupFilterHashRange(block_index->nHeight, block_index,
                                                    filter_hashes));
 
     BOOST_CHECK_EQUAL(filters.size(), 1U);
@@ -104,7 +104,7 @@ bool BuildChainTestingSetup::BuildChain(const CBlockIndex* pindex,
 
 BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
 {
-    BlockFilterIndex filter_index(BlockFilterType::BASIC, 1 << 20, true);
+    auto filter_index = std::make_shared<BlockFilterIndex>(BlockFilterType::BASIC, 1 << 20, true);
 
     uint256 last_header;
 
@@ -120,23 +120,24 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         for (const CBlockIndex* block_index = ::ChainActive().Genesis();
              block_index != nullptr;
              block_index = ::ChainActive().Next(block_index)) {
-            BOOST_CHECK(!filter_index.LookupFilter(block_index, filter));
-            BOOST_CHECK(!filter_index.LookupFilterHeader(block_index, filter_header));
-            BOOST_CHECK(!filter_index.LookupFilterRange(block_index->nHeight, block_index, filters));
-            BOOST_CHECK(!filter_index.LookupFilterHashRange(block_index->nHeight, block_index,
+            BOOST_CHECK(!filter_index->LookupFilter(block_index, filter));
+            BOOST_CHECK(!filter_index->LookupFilterHeader(block_index, filter_header));
+            BOOST_CHECK(!filter_index->LookupFilterRange(block_index->nHeight, block_index, filters));
+            BOOST_CHECK(!filter_index->LookupFilterHashRange(block_index->nHeight, block_index,
                                                             filter_hashes));
         }
     }
 
     // BlockUntilSyncedToCurrentChain should return false before index is started.
-    BOOST_CHECK(!filter_index.BlockUntilSyncedToCurrentChain());
+    BOOST_CHECK(!filter_index->BlockUntilSyncedToCurrentChain());
 
-    filter_index.Start();
+    RegisterValidationInterface(filter_index);
+    filter_index->Start();
 
     // Allow filter index to catch up with the block index.
     constexpr int64_t timeout_ms = 10 * 1000;
     int64_t time_start = GetTimeMillis();
-    while (!filter_index.BlockUntilSyncedToCurrentChain()) {
+    while (!filter_index->BlockUntilSyncedToCurrentChain()) {
         BOOST_REQUIRE(time_start + timeout_ms > GetTimeMillis());
         UninterruptibleSleep(std::chrono::milliseconds{100});
     }
@@ -181,7 +182,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
             block_index = LookupBlockIndex(block->GetHash());
         }
 
-        BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
+        BOOST_CHECK(filter_index->BlockUntilSyncedToCurrentChain());
         CheckFilterLookups(filter_index, block_index, chainA_last_header);
     }
 
@@ -199,7 +200,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
             block_index = LookupBlockIndex(block->GetHash());
         }
 
-        BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
+        BOOST_CHECK(filter_index->BlockUntilSyncedToCurrentChain());
         CheckFilterLookups(filter_index, block_index, chainB_last_header);
     }
 
@@ -213,7 +214,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
             block_index = LookupBlockIndex(block->GetHash());
         }
 
-        BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
+        BOOST_CHECK(filter_index->BlockUntilSyncedToCurrentChain());
         CheckFilterLookups(filter_index, block_index, chainA_last_header);
     }
 
@@ -233,14 +234,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
              LOCK(cs_main);
              block_index = LookupBlockIndex(chainA[i]->GetHash());
          }
-         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
+         BOOST_CHECK(filter_index->BlockUntilSyncedToCurrentChain());
          CheckFilterLookups(filter_index, block_index, chainA_last_header);
 
          {
              LOCK(cs_main);
              block_index = LookupBlockIndex(chainB[i]->GetHash());
          }
-         BOOST_CHECK(filter_index.BlockUntilSyncedToCurrentChain());
+         BOOST_CHECK(filter_index->BlockUntilSyncedToCurrentChain());
          CheckFilterLookups(filter_index, block_index, chainB_last_header);
      }
 
@@ -252,8 +253,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         LOCK(cs_main);
         tip = ::ChainActive().Tip();
     }
-    BOOST_CHECK(filter_index.LookupFilterRange(0, tip, filters));
-    BOOST_CHECK(filter_index.LookupFilterHashRange(0, tip, filter_hashes));
+    BOOST_CHECK(filter_index->LookupFilterRange(0, tip, filters));
+    BOOST_CHECK(filter_index->LookupFilterHashRange(0, tip, filter_hashes));
 
     assert(tip->nHeight >= 0);
     BOOST_CHECK_EQUAL(filters.size(), tip->nHeight + 1U);
@@ -262,15 +263,14 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     filters.clear();
     filter_hashes.clear();
 
-    filter_index.Interrupt();
-    filter_index.Stop();
+    filter_index->Interrupt();
+    UnregisterValidationInterface(filter_index);
+    filter_index->Stop();
 }
 
 BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
 {
-    BlockFilterIndex* filter_index;
-
-    filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
+    auto filter_index = GetBlockFilterIndex(BlockFilterType::BASIC);
     BOOST_CHECK(filter_index == nullptr);
 
     BOOST_CHECK(InitBlockFilterIndex(BlockFilterType::BASIC, 1 << 20, true, false));
@@ -283,7 +283,9 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_init_destroy, BasicTestingSetup)
     BOOST_CHECK(!InitBlockFilterIndex(BlockFilterType::BASIC, 1 << 20, true, false));
 
     int iter_count = 0;
-    ForEachBlockFilterIndex([&iter_count](BlockFilterIndex& _index) { iter_count++; });
+    ForEachBlockFilterIndex([&iter_count](std::shared_ptr<BlockFilterIndex>) {
+        iter_count++;
+    });
     BOOST_CHECK_EQUAL(iter_count, 1);
 
     BOOST_CHECK(DestroyBlockFilterIndex(BlockFilterType::BASIC));

--- a/src/test/txindex_tests.cpp
+++ b/src/test/txindex_tests.cpp
@@ -14,25 +14,26 @@ BOOST_AUTO_TEST_SUITE(txindex_tests)
 
 BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
 {
-    TxIndex txindex(1 << 20, true);
+    auto txindex = std::make_shared<TxIndex>(1 << 20, true);
 
     CTransactionRef tx_disk;
     uint256 block_hash;
 
     // Transaction should not be found in the index before it is started.
     for (const auto& txn : m_coinbase_txns) {
-        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
+        BOOST_CHECK(!txindex->FindTx(txn->GetHash(), block_hash, tx_disk));
     }
 
     // BlockUntilSyncedToCurrentChain should return false before txindex is started.
-    BOOST_CHECK(!txindex.BlockUntilSyncedToCurrentChain());
+    BOOST_CHECK(!txindex->BlockUntilSyncedToCurrentChain());
 
-    txindex.Start();
+    RegisterValidationInterface(txindex);
+    txindex->Start();
 
     // Allow tx index to catch up with the block index.
     constexpr int64_t timeout_ms = 10 * 1000;
     int64_t time_start = GetTimeMillis();
-    while (!txindex.BlockUntilSyncedToCurrentChain()) {
+    while (!txindex->BlockUntilSyncedToCurrentChain()) {
         BOOST_REQUIRE(time_start + timeout_ms > GetTimeMillis());
         UninterruptibleSleep(std::chrono::milliseconds{100});
     }
@@ -40,12 +41,12 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     // Check that txindex excludes genesis block transactions.
     const CBlock& genesis_block = Params().GenesisBlock();
     for (const auto& txn : genesis_block.vtx) {
-        BOOST_CHECK(!txindex.FindTx(txn->GetHash(), block_hash, tx_disk));
+        BOOST_CHECK(!txindex->FindTx(txn->GetHash(), block_hash, tx_disk));
     }
 
     // Check that txindex has all txs that were in the chain before it started.
     for (const auto& txn : m_coinbase_txns) {
-        if (!txindex.FindTx(txn->GetHash(), block_hash, tx_disk)) {
+        if (!txindex->FindTx(txn->GetHash(), block_hash, tx_disk)) {
             BOOST_ERROR("FindTx failed");
         } else if (tx_disk->GetHash() != txn->GetHash()) {
             BOOST_ERROR("Read incorrect tx");
@@ -59,8 +60,8 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
         const CBlock& block = CreateAndProcessBlock(no_txns, coinbase_script_pub_key);
         const CTransaction& txn = *block.vtx[0];
 
-        BOOST_CHECK(txindex.BlockUntilSyncedToCurrentChain());
-        if (!txindex.FindTx(txn.GetHash(), block_hash, tx_disk)) {
+        BOOST_CHECK(txindex->BlockUntilSyncedToCurrentChain());
+        if (!txindex->FindTx(txn.GetHash(), block_hash, tx_disk)) {
             BOOST_ERROR("FindTx failed");
         } else if (tx_disk->GetHash() != txn.GetHash()) {
             BOOST_ERROR("Read incorrect tx");
@@ -68,7 +69,8 @@ BOOST_FIXTURE_TEST_CASE(txindex_initial_sync, TestChain100Setup)
     }
 
     // shutdown sequence (c.f. Shutdown() in init.cpp)
-    txindex.Stop();
+    UnregisterValidationInterface(txindex);
+    txindex->Stop();
 
     // Let scheduler events finish running to avoid accessing any memory related to txindex after it is destructed
     SyncWithValidationInterfaceQueue();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -169,10 +169,10 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 
     m_node.banman = MakeUnique<BanMan>(GetDataDir() / "banlist.dat", nullptr, DEFAULT_MISBEHAVING_BANTIME);
     m_node.connman = MakeUnique<CConnman>(0x1337, 0x1337); // Deterministic randomness for tests.
-    m_node.peerman = MakeUnique<PeerManager>(chainparams, *m_node.connman, m_node.banman.get(), *m_node.scheduler, *m_node.chainman, *m_node.mempool);
+    m_node.peerman = std::make_shared<PeerManager>(chainparams, *m_node.connman, m_node.banman.get(), *m_node.scheduler, *m_node.chainman, *m_node.mempool);
     {
         CConnman::Options options;
-        options.m_msgproc = m_node.peerman.get();
+        options.m_msgproc = m_node.peerman;
         m_node.connman->Init(options);
     }
 }

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
         initial_tip = ::ChainActive().Tip();
     }
     auto sub = std::make_shared<TestSubscriber>(initial_tip->GetBlockHash());
-    RegisterSharedValidationInterface(sub);
+    RegisterValidationInterface(sub);
 
     // create a bunch of threads that repeatedly process a block generated above at random
     // this will create parallelism and randomness inside validation - the ValidationInterface
@@ -206,7 +206,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     }
     SyncWithValidationInterfaceQueue();
 
-    UnregisterSharedValidationInterface(sub);
+    UnregisterValidationInterface(sub);
 
     LOCK(cs_main);
     BOOST_CHECK_EQUAL(sub->m_expected_tip, ::ChainActive().Tip()->GetBlockHash());

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE(unregister_validation_interface_race)
         // keep going for about 1 sec, which is 250k iterations
         for (int i = 0; i < 250000; i++) {
             auto sub = std::make_shared<TestSubscriberNoop>();
-            RegisterSharedValidationInterface(sub);
-            UnregisterSharedValidationInterface(sub);
+            RegisterValidationInterface(sub);
+            UnregisterValidationInterface(sub);
         }
         // tell the other thread we are done
         generate = false;
@@ -77,7 +77,7 @@ public:
 BOOST_AUTO_TEST_CASE(unregister_all_during_call)
 {
     bool destroyed = false;
-    RegisterSharedValidationInterface(std::make_shared<TestInterface>(
+    RegisterValidationInterface(std::make_shared<TestInterface>(
         [&] {
             // First call should decrements reference count 2 -> 1
             UnregisterAllValidationInterfaces();

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -53,7 +53,7 @@ public:
         : m_on_call(std::move(on_call)), m_on_destroy(std::move(on_destroy))
     {
     }
-    virtual ~TestInterface()
+    ~TestInterface() override
     {
         if (m_on_destroy) m_on_destroy();
     }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -24,20 +24,11 @@ class CScheduler;
 enum class MemPoolRemovalReason;
 
 /** Register subscriber */
-void RegisterValidationInterface(CValidationInterface* callbacks);
-/** Unregister subscriber. DEPRECATED. This is not safe to use when the RPC server or main message handler thread is running. */
-void UnregisterValidationInterface(CValidationInterface* callbacks);
+void RegisterValidationInterface(std::shared_ptr<CValidationInterface> callbacks);
+/** Unregister subscriber */
+void UnregisterValidationInterface(std::shared_ptr<CValidationInterface> callbacks);
 /** Unregister all subscribers */
 void UnregisterAllValidationInterfaces();
-
-// Alternate registration functions that release a shared_ptr after the last
-// notification is sent. These are useful for race-free cleanup, since
-// unregistration is nonblocking and can return before the last notification is
-// processed.
-/** Register subscriber */
-void RegisterSharedValidationInterface(std::shared_ptr<CValidationInterface> callbacks);
-/** Unregister subscriber */
-void UnregisterSharedValidationInterface(std::shared_ptr<CValidationInterface> callbacks);
 
 /**
  * Pushes a function to callback onto the notification queue, guaranteeing any
@@ -181,8 +172,8 @@ class CMainSignals {
 private:
     std::unique_ptr<MainSignalsInstance> m_internals;
 
-    friend void ::RegisterSharedValidationInterface(std::shared_ptr<CValidationInterface>);
-    friend void ::UnregisterValidationInterface(CValidationInterface*);
+    friend void ::RegisterValidationInterface(std::shared_ptr<CValidationInterface>);
+    friend void ::UnregisterValidationInterface(std::shared_ptr<CValidationInterface>);
     friend void ::UnregisterAllValidationInterfaces();
     friend void ::CallFunctionInValidationInterfaceQueue(std::function<void ()> func);
 

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -72,7 +72,7 @@ protected:
      * Protected destructor so that instances can only be deleted by derived classes.
      * If that restriction is no longer desired, this should be made public and virtual.
      */
-    ~CValidationInterface() = default;
+    virtual ~CValidationInterface() = default;
     /**
      * Notifies listeners when the block chain tip advances.
      *

--- a/src/wallet/test/psbt_wallet_tests.cpp
+++ b/src/wallet/test/psbt_wallet_tests.cpp
@@ -15,19 +15,19 @@ BOOST_FIXTURE_TEST_SUITE(psbt_wallet_tests, WalletTestingSetup)
 
 BOOST_AUTO_TEST_CASE(psbt_updater_test)
 {
-    auto spk_man = m_wallet.GetOrCreateLegacyScriptPubKeyMan();
-    LOCK2(m_wallet.cs_wallet, spk_man->cs_KeyStore);
+    auto spk_man = m_wallet->GetOrCreateLegacyScriptPubKeyMan();
+    LOCK2(m_wallet->cs_wallet, spk_man->cs_KeyStore);
 
     // Create prevtxs and add to wallet
     CDataStream s_prev_tx1(ParseHex("0200000000010158e87a21b56daf0c23be8e7070456c336f7cbaa5c8757924f545887bb2abdd7501000000171600145f275f436b09a8cc9a2eb2a2f528485c68a56323feffffff02d8231f1b0100000017a914aed962d6654f9a2b36608eb9d64d2b260db4f1118700c2eb0b0000000017a914b7f5faf40e3d40a5a459b1db3535f2b72fa921e88702483045022100a22edcc6e5bc511af4cc4ae0de0fcd75c7e04d8c1c3a8aa9d820ed4b967384ec02200642963597b9b1bc22c75e9f3e117284a962188bf5e8a74c895089046a20ad770121035509a48eb623e10aace8bfd0212fdb8a8e5af3c94b0b133b95e114cab89e4f7965000000"), SER_NETWORK, PROTOCOL_VERSION);
     CTransactionRef prev_tx1;
     s_prev_tx1 >> prev_tx1;
-    m_wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(prev_tx1->GetHash()), std::forward_as_tuple(&m_wallet, prev_tx1));
+    m_wallet->mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(prev_tx1->GetHash()), std::forward_as_tuple(m_wallet.get(), prev_tx1));
 
     CDataStream s_prev_tx2(ParseHex("0200000001aad73931018bd25f84ae400b68848be09db706eac2ac18298babee71ab656f8b0000000048473044022058f6fc7c6a33e1b31548d481c826c015bd30135aad42cd67790dab66d2ad243b02204a1ced2604c6735b6393e5b41691dd78b00f0c5942fb9f751856faa938157dba01feffffff0280f0fa020000000017a9140fb9463421696b82c833af241c78c17ddbde493487d0f20a270100000017a91429ca74f8a08f81999428185c97b5d852e4063f618765000000"), SER_NETWORK, PROTOCOL_VERSION);
     CTransactionRef prev_tx2;
     s_prev_tx2 >> prev_tx2;
-    m_wallet.mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(prev_tx2->GetHash()), std::forward_as_tuple(&m_wallet, prev_tx2));
+    m_wallet->mapWallet.emplace(std::piecewise_construct, std::forward_as_tuple(prev_tx2->GetHash()), std::forward_as_tuple(m_wallet.get(), prev_tx2));
 
     // Add scripts
     CScript rs1;
@@ -58,7 +58,7 @@ BOOST_AUTO_TEST_CASE(psbt_updater_test)
 
     // Fill transaction with our data
     bool complete = true;
-    BOOST_REQUIRE_EQUAL(TransactionError::OK, m_wallet.FillPSBT(psbtx, complete, SIGHASH_ALL, false, true));
+    BOOST_REQUIRE_EQUAL(TransactionError::OK, m_wallet->FillPSBT(psbtx, complete, SIGHASH_ALL, false, true));
 
     // Get the final tx
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);

--- a/src/wallet/test/wallet_test_fixture.cpp
+++ b/src/wallet/test/wallet_test_fixture.cpp
@@ -6,10 +6,10 @@
 
 WalletTestingSetup::WalletTestingSetup(const std::string& chainName)
     : TestingSetup(chainName),
-      m_wallet(m_chain.get(), "", CreateMockWalletDatabase())
+      m_wallet(std::make_shared<CWallet>(m_chain.get(), "", CreateMockWalletDatabase()))
 {
     bool fFirstRun;
-    m_wallet.LoadWallet(fFirstRun);
-    m_chain_notifications_handler = m_chain->handleNotifications({ &m_wallet, [](CWallet*) {} });
+    m_wallet->LoadWallet(fFirstRun);
+    m_chain_notifications_handler = m_chain->handleNotifications(m_wallet);
     m_wallet_client->registerRpcs();
 }

--- a/src/wallet/test/wallet_test_fixture.h
+++ b/src/wallet/test/wallet_test_fixture.h
@@ -22,7 +22,7 @@ struct WalletTestingSetup : public TestingSetup {
 
     std::unique_ptr<interfaces::Chain> m_chain = interfaces::MakeChain(m_node);
     std::unique_ptr<interfaces::WalletClient> m_wallet_client = interfaces::MakeWalletClient(*m_chain, *Assert(m_node.args));
-    CWallet m_wallet;
+    std::shared_ptr<CWallet> m_wallet;
     std::unique_ptr<interfaces::Handler> m_chain_notifications_handler;
 };
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -372,24 +372,24 @@ static int64_t AddTx(ChainstateManager& chainman, CWallet& wallet, uint32_t lock
 BOOST_AUTO_TEST_CASE(ComputeTimeSmart)
 {
     // New transaction should use clock time if lower than block time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 1, 100, 120), 100);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, *m_wallet, 1, 100, 120), 100);
 
     // Test that updating existing transaction does not change smart time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 1, 200, 220), 100);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, *m_wallet, 1, 200, 220), 100);
 
     // New transaction should use clock time if there's no block time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 2, 300, 0), 300);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, *m_wallet, 2, 300, 0), 300);
 
     // New transaction should use block time if lower than clock time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 3, 420, 400), 400);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, *m_wallet, 3, 420, 400), 400);
 
     // New transaction should use latest entry time if higher than
     // min(block time, clock time).
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 4, 500, 390), 400);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, *m_wallet, 4, 500, 390), 400);
 
     // If there are future entries, new transaction should use time of the
     // newest entry that is no more than 300 seconds ahead of the clock time.
-    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, m_wallet, 5, 50, 600), 300);
+    BOOST_CHECK_EQUAL(AddTx(*m_node.chainman, *m_wallet, 5, 50, 600), 300);
 
     // Reset mock time for other tests.
     SetMockTime(0);
@@ -398,13 +398,13 @@ BOOST_AUTO_TEST_CASE(ComputeTimeSmart)
 BOOST_AUTO_TEST_CASE(LoadReceiveRequests)
 {
     CTxDestination dest = PKHash();
-    LOCK(m_wallet.cs_wallet);
-    WalletBatch batch{m_wallet.GetDatabase()};
-    m_wallet.AddDestData(batch, dest, "misc", "val_misc");
-    m_wallet.AddDestData(batch, dest, "rr0", "val_rr0");
-    m_wallet.AddDestData(batch, dest, "rr1", "val_rr1");
+    LOCK(m_wallet->cs_wallet);
+    WalletBatch batch{m_wallet->GetDatabase()};
+    m_wallet->AddDestData(batch, dest, "misc", "val_misc");
+    m_wallet->AddDestData(batch, dest, "rr0", "val_rr0");
+    m_wallet->AddDestData(batch, dest, "rr1", "val_rr1");
 
-    auto values = m_wallet.GetDestValues("rr");
+    auto values = m_wallet->GetDestValues("rr");
     BOOST_CHECK_EQUAL(values.size(), 2U);
     BOOST_CHECK_EQUAL(values[0], "val_rr0");
     BOOST_CHECK_EQUAL(values[1], "val_rr1");
@@ -460,7 +460,7 @@ BOOST_AUTO_TEST_CASE(WatchOnlyPubKeys)
 {
     CKey key;
     CPubKey pubkey;
-    LegacyScriptPubKeyMan* spk_man = m_wallet.GetOrCreateLegacyScriptPubKeyMan();
+    LegacyScriptPubKeyMan* spk_man = m_wallet->GetOrCreateLegacyScriptPubKeyMan();
 
     BOOST_CHECK(!spk_man->HaveWatchOnly());
 

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -188,4 +188,4 @@ void CZMQNotificationInterface::BlockDisconnected(const std::shared_ptr<const CB
     });
 }
 
-CZMQNotificationInterface* g_zmq_notification_interface = nullptr;
+std::shared_ptr<CZMQNotificationInterface> g_zmq_notification_interface;

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -39,6 +39,6 @@ private:
     std::list<std::unique_ptr<CZMQAbstractNotifier>> notifiers;
 };
 
-extern CZMQNotificationInterface* g_zmq_notification_interface;
+extern std::shared_ptr<CZMQNotificationInterface> g_zmq_notification_interface;
 
 #endif // BITCOIN_ZMQ_ZMQNOTIFICATIONINTERFACE_H


### PR DESCRIPTION
This pull request fully replace #18279 it fix 3 issues with wallet
1. Crash in wallet destructor while it tries to delete mutex while it's hold by notification thread
2. Crash in notification disconnect due to notification callback is set to nullptr before unregister interface is done
3. Ensure unregister interface has no more background callbacks before returning to notification disconnect