### PR TITLE
Fix missing header in sync.h

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -10,9 +10,9 @@
 #include <util/macros.h>
 
 #include <condition_variable>
-#include <thread>
 #include <mutex>
-
+#include <string>
+#include <thread>
 
 ////////////////////////////////////////////////
 //                                            //


### PR DESCRIPTION
`std::string` is referenced in `sync.h` but the relevant header is not explicitly included as required by current guideline. Furthermore on osx 10.14.6 with clang-900.0.31 the following error occurs:
```
In file included from threadinterrupt.cpp:6:
In file included from ./threadinterrupt.h:8:
./sync.h:206:21: error: implicit instantiation of undefined template 'std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
        std::string lockname;
```