### PR TITLE
util: fix compilation with mingw-w64 7.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -906,6 +906,22 @@ if test "x$use_thread_local" = xyes || { test "x$use_thread_local" = xauto && te
   LDFLAGS="$TEMP_LDFLAGS"
 fi
 
+dnl check for gmtime_r(), fallback to gmtime_s() if that is unavailable
+dnl fail if neither are available.
+AC_MSG_CHECKING(for gmtime_r)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+  [[ gmtime_r((const time_t *) nullptr, (struct tm *) nullptr); ]])],
+  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_GMTIME_R, 1, [Define this symbol if gmtime_r is available]) ],
+  [ AC_MSG_RESULT(no);
+    AC_MSG_CHECKING(for gmtime_s);
+    AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <ctime>]],
+       [[ gmtime_s((struct tm *) nullptr, (const time_t *) nullptr); ]])],
+       [ AC_MSG_RESULT(yes)],
+       [ AC_MSG_RESULT(no); AC_MSG_ERROR(Both gmtime_r and gmtime_s are unavailable) ]
+    )
+  ]
+)
+
 dnl Check for different ways of gathering OS randomness
 AC_MSG_CHECKING(for Linux getrandom syscall)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
@@ -1596,6 +1612,7 @@ AC_SUBST(EVENT_LIBS)
 AC_SUBST(EVENT_PTHREADS_LIBS)
 AC_SUBST(ZMQ_LIBS)
 AC_SUBST(QR_LIBS)
+AC_SUBST(HAVE_GMTIME_R)
 AC_SUBST(HAVE_FDATASYNC)
 AC_SUBST(HAVE_FULLFSYNC)
 AC_SUBST(HAVE_O_CLOEXEC)

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -78,10 +78,10 @@ int64_t GetSystemTimeInSeconds()
 std::string FormatISO8601DateTime(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    if (gmtime_s(&ts, &time_val) != 0) {
-#else
+#ifdef HAVE_GMTIME_R
     if (gmtime_r(&time_val, &ts) == nullptr) {
+#else
+    if (gmtime_s(&ts, &time_val) != 0) {
 #endif
         return {};
     }
@@ -91,10 +91,10 @@ std::string FormatISO8601DateTime(int64_t nTime) {
 std::string FormatISO8601Date(int64_t nTime) {
     struct tm ts;
     time_t time_val = nTime;
-#ifdef _MSC_VER
-    if (gmtime_s(&ts, &time_val) != 0) {
-#else
+#ifdef HAVE_GMTIME_R
     if (gmtime_r(&time_val, &ts) == nullptr) {
+#else
+    if (gmtime_s(&ts, &time_val) != 0) {
 #endif
         return {};
     }


### PR DESCRIPTION
Something has changed in the mingw-w64 headers such that we
no-longer compile when using 7.0.0.

```bash
util/time.cpp: In function 'std::__cxx11::string FormatISO8601DateTime(int64_t)':
util/time.cpp:84:9: error: 'gmtime_r' was not declared in this scope
     if (gmtime_r(&time_val, &ts) == nullptr) {
         ^~~~~~~~
util/time.cpp: In function 'std::__cxx11::string FormatISO8601Date(int64_t)':
util/time.cpp:97:9: error: 'gmtime_r' was not declared in this scope
     if (gmtime_r(&time_val, &ts) == nullptr) {
```

Looking at time.h, it seems that `gmtime_r()` is only available when
`_POSIX_C_SOURCE` is defined. This must have been the case for 6.0.0 
(which we compile fine using), but no-longer seems to be for 7.0.0?

I've checked that adding `-D_POSIX_C_SOURCE=200112L` to our compile
flags does fix the issue above.

However, an alternative solution seems to be to just use `gmtime_s()`
instead, when compiling with `mingw-w64`, as `gmtime_r()` [just wraps
`gmtime_s()` anyways](https://github.com/mirror/mingw-w64/blob/7c03b11bf173944679102bbe0ac061842e2f594b/mingw-w64-headers/crt/time.h#L284).

I've tested this change crosss-compiling on Debian Bullseye ([mingw-w64 7.0.0](https://packages.debian.org/source/bullseye/mingw-w64)) 
and Buster ([mingw-w64 6.0.0](https://packages.debian.org/source/buster/mingw-w64)).