### PR TITLE
build: fix sysctl() detection on macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -935,11 +935,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>
 AC_MSG_CHECKING(for sysctl)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
   #include <sys/sysctl.h>]],
- [[ static const int name[2] = {CTL_KERN, KERN_VERSION};
-    #ifdef __linux__
+ [[ #ifdef __linux__
     #error "Don't use sysctl on Linux, it's deprecated even when it works"
     #endif
-    sysctl(name, 2, nullptr, nullptr, nullptr, 0); ]])],
+    sysctl(nullptr, 2, nullptr, nullptr, nullptr, 0); ]])],
  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCTL, 1,[Define this symbol if the BSD sysctl() is available]) ],
  [ AC_MSG_RESULT(no)]
 )
@@ -947,7 +946,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
 AC_MSG_CHECKING(for sysctl KERN_ARND)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
   #include <sys/sysctl.h>]],
- [[ static const int name[2] = {CTL_KERN, KERN_ARND};
+ [[ #ifdef __linux__
+    #error "Don't use sysctl on Linux, it's deprecated even when it works"
+    #endif
+    static int name[2] = {CTL_KERN, KERN_ARND};
     sysctl(name, 2, nullptr, nullptr, nullptr, 0); ]])],
  [ AC_MSG_RESULT(yes); AC_DEFINE(HAVE_SYSCTL_ARND, 1,[Define this symbol if the BSD sysctl(KERN_ARND) is available]) ],
  [ AC_MSG_RESULT(no)]

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -321,10 +321,10 @@ void GetOSRand(unsigned char *ent32)
         RandFailure();
     }
 #elif defined(HAVE_SYSCTL_ARND)
-    /* FreeBSD and similar. It is possible for the call to return less
+    /* FreeBSD, NetBSD and similar. It is possible for the call to return less
      * bytes than requested, so need to read in a loop.
      */
-    static const int name[2] = {CTL_KERN, KERN_ARND};
+    static int name[2] = {CTL_KERN, KERN_ARND};
     int have = 0;
     do {
         size_t len = NUM_OS_RANDOM_BYTES - have;


### PR DESCRIPTION
[`sysctl()` on *BSD](https://www.unix.com/man-page/FreeBSD/3/sysctl/) takes a "const int *name", whereas [`sysctl()` on macOS](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/sysctl.3.html)
it takes an "int *name". So our configure check and `sysctl()` detection on
macOS currently fails:

```bash
/usr/include/sys/sysctl.h:759:9: note: candidate function not viable:
	no known conversion from 'const int [2]' to 'int *' for 1st argument
int     sysctl(int *, u_int, void *, size_t *, void *, size_t);
```

The simplest change seems to be to change the param to a "int *name", which
will work during configure on macOS and *BSD systems.

For consistency I've changed both calls, but note that macOS doesn't
have `KERN_ARND`, so that check will always fail regardless. We can revert/add
documentation if preferred.