### PR TITLE
random: remove getentropy() fallback for macOS < 10.12

### DIFF
--- a/src/random.cpp
+++ b/src/random.cpp
@@ -15,7 +15,7 @@
 #endif
 #include <logging.h>  // for LogPrintf()
 #include <sync.h>     // for Mutex
-#include <util/time.h> // for GetTime()
+#include <util/time.h> // for GetTimeMicros()
 
 #include <stdlib.h>
 #include <thread>

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -315,13 +315,10 @@ void GetOSRand(unsigned char *ent32)
         RandFailure();
     }
 #elif defined(HAVE_GETENTROPY_RAND) && defined(MAC_OSX)
-    // We need a fallback for OSX < 10.12
-    if (&getentropy != nullptr) {
-        if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
-            RandFailure();
-        }
-    } else {
-        GetDevURandom(ent32);
+    /* getentropy() is available on macOS 10.12 and later.
+     */
+    if (getentropy(ent32, NUM_OS_RANDOM_BYTES) != 0) {
+        RandFailure();
     }
 #elif defined(HAVE_SYSCTL_ARND)
     /* FreeBSD and similar. It is possible for the call to return less


### PR DESCRIPTION
We [no longer support macOS < 10.12](https://github.com/bitcoin/bitcoin/pull/17550) (our binaries will not run), so remove the fallback for when `getentropy()` wasn't available. From the manpage:

```bash
HISTORY
     The getentropy() function appeared in OSX 10.12
```

Note that compiling on macOS you'll see a new unused function warning:
```bash
random.cpp:256:13: warning: unused function 'GetDevURandom' [-Wunused-function]
static void GetDevURandom(unsigned char *ent32)
            ^
1 warning generated.
```

This will likely be addressed as part of #17563.