### PR TITLE
Avoid strncpy for CMessageHeader::pchCommand

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -85,8 +85,12 @@ CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn)
 CMessageHeader::CMessageHeader(const MessageStartChars& pchMessageStartIn, const char* pszCommand, unsigned int nMessageSizeIn)
 {
     memcpy(pchMessageStart, pchMessageStartIn, MESSAGE_START_SIZE);
-    memset(pchCommand, 0, sizeof(pchCommand));
-    strncpy(pchCommand, pszCommand, COMMAND_SIZE);
+    // Copy pszCommand to pchCommand field with zero padding
+    bool in_padding = false;
+    for (size_t pos = 0; pos < COMMAND_SIZE; ++pos) {
+        pchCommand[pos] = in_padding ? 0 : pszCommand[pos];
+        in_padding = (pchCommand[pos] == 0);
+    }
     nMessageSize = nMessageSizeIn;
     memset(pchChecksum, 0, CHECKSUM_SIZE);
 }


### PR DESCRIPTION
In GCC 9.2.1, I get the warning:

```
In file included from /usr/include/string.h:494,
                 from /usr/include/c++/9/cstring:42,
                 from ./serialize.h:12,
                 from ./netaddress.h:13,
                 from ./protocol.h:13,
                 from protocol.cpp:6:
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘CMessageHeader::CMessageHeader(const unsigned char (&)[4], const char*, unsigned int)’ at protocol.cpp:89:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: warning: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ specified bound 12 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The warning is spurious, as we exactly want the truncation behaviour here (no zero padding in `pchCommand` when the input has length exactly 12), but it seems hard to avoid. The reason is that `strncopy` is designed to operate on C strings, and our target isn't exactly a C string.

I'm changing it here to a simple loop that assigns to every byte in the output once, but if desirable, a solution with `strlen` + `memcpy` + `memset` is also possible.