### PR TITLE
Bugfix in bn2vch: avoid excessive padding

### DIFF
--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -31,8 +31,8 @@ def bn2vch(v):
     # isn't a spare bit in the bit length, add an extension byte.
     have_ext = False
     ext = bytearray()
-    if v.bit_length() > 0:
-        have_ext = (v.bit_length() & 0x07) == 0
+    if v.bit_length() > 0 && (v.bit_length() & 0x07) == 0:
+        have_ext = True
         ext.append(0)
 
     # Is the number negative?


### PR DESCRIPTION
It seems #17319 introduced an (unobserved) bug in the test framework in `bn2vch`: a zero padding byte was added for every nonzero number, even when the top byte was <= 0x7F. Fix this.
