### PR TITLE
build: fix libevent linking errors for bench-only builds

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -5,6 +5,7 @@
 bin_PROGRAMS += bench/bench_bitcoin
 BENCH_SRCDIR = bench
 BENCH_BINARY = bench/bench_bitcoin$(EXEEXT)
+EVENT_LIBS   += -levent
 
 RAW_BENCH_FILES = \
   bench/data/block413567.raw
@@ -43,12 +44,11 @@ bench_bench_bitcoin_SOURCES = \
 
 nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_BENCH_FILES)
 
-bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
+bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 bench_bench_bitcoin_LDADD = \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_WALLET) \
-  $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_COMMON) \
   $(LIBBITCOIN_UTIL) \
   $(LIBBITCOIN_CONSENSUS) \


### PR DESCRIPTION
This PR fixes the linking errors for bench-only builds by adding a **-levent** flag to EVENT_LIBS.

Additionally, it fixes a typo in **$(EVENT_CFLAGS)** and removes the double **$(LIBBITCOIN_SERVER)** linking entry, because a similar one was also fixed in the Makefile.am: https://github.com/bitcoin/bitcoin/pull/17910 

Fixes https://github.com/bitcoin/bitcoin/issues/18373