### PR TITLE
Bugfix & simplify bn2vch using int.to_bytes

### DIFF
--- a/test/functional/framework_test_script.py
+++ b/test/functional/framework_test_script.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests for test_framework.script."""
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.script import bn2vch
+from test_framework.util import assert_equal
+
+def test_bn2vch():
+    assert_equal(bn2vch(0), bytes([]))
+    assert_equal(bn2vch(1), bytes([0x01]))
+    assert_equal(bn2vch(-1), bytes([0x81]))
+    assert_equal(bn2vch(0x7F), bytes([0x7F]))
+    assert_equal(bn2vch(-0x7F), bytes([0xFF]))
+    assert_equal(bn2vch(0x80), bytes([0x80, 0x00]))
+    assert_equal(bn2vch(-0x80), bytes([0x80, 0x80]))
+    assert_equal(bn2vch(0xFF), bytes([0xFF, 0x00]))
+    assert_equal(bn2vch(-0xFF), bytes([0xFF, 0x80]))
+    assert_equal(bn2vch(0x100), bytes([0x00, 0x01]))
+    assert_equal(bn2vch(-0x100), bytes([0x00, 0x81]))
+    assert_equal(bn2vch(0x7FFF), bytes([0xFF, 0x7F]))
+    assert_equal(bn2vch(-0x8000), bytes([0x00, 0x80, 0x80]))
+    assert_equal(bn2vch(-0x7FFFFF), bytes([0xFF, 0xFF, 0xFF]))
+    assert_equal(bn2vch(0x80000000), bytes([0x00, 0x00, 0x00, 0x80, 0x00]))
+    assert_equal(bn2vch(-0x80000000), bytes([0x00, 0x00, 0x00, 0x80, 0x80]))
+    assert_equal(bn2vch(0xFFFFFFFF), bytes([0xFF, 0xFF, 0xFF, 0xFF, 0x00]))
+
+    assert_equal(bn2vch(123456789), bytes([0x15, 0xCD, 0x5B, 0x07]))
+    assert_equal(bn2vch(-54321), bytes([0x31, 0xD4, 0x80]))
+
+class FrameworkTestScript(BitcoinTestFramework):
+    def setup_network(self):
+        pass
+
+    def set_test_params(self):
+        self.num_nodes = 0
+
+    def run_test(self):
+        test_bn2vch()
+
+if __name__ == '__main__':
+    FrameworkTestScript().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -222,6 +222,7 @@ BASE_SCRIPTS = [
     'rpc_help.py',
     'feature_help.py',
     'feature_shutdown.py',
+    'framework_test_script.py',
     # Don't append tests at the end to avoid merge conflicts
     # Put them in a random line within the section that fits their approximate run-time
 ]
@@ -614,7 +615,7 @@ class TestResult():
 def check_script_prefixes():
     """Check that test scripts start with one of the allowed name prefixes."""
 
-    good_prefixes_re = re.compile("(example|feature|interface|mempool|mining|p2p|rpc|wallet|tool)_")
+    good_prefixes_re = re.compile("^(example|feature|interface|mempool|mining|p2p|rpc|wallet|tool|framework_test)_")
     bad_script_names = [script for script in ALL_SCRIPTS if good_prefixes_re.match(script) is None]
 
     if bad_script_names:


### PR DESCRIPTION
Alternative to #18374, fixing the incorrect padding added sometimes in `bn2vch`.

Since we're using Python 3.2+, a much simpler implementation of `bn2vch` is possible using `int.to_bytes`.

This also adds a "functional" test for bn2vch, in a new "framework_test_script.py", where the "framework_test_" prefix is intended for tests of the framework itself.