### PR TITLE
doc: Remove html comment in PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,8 @@
-<!--
 *** Please remove the following help text before submitting: ***
 
 Pull requests without a rationale and clear improvement may be closed
 immediately.
--->
 
-<!--
 Please provide clear motivation for your patch and explain how it improves
 Bitcoin Core user experience or Bitcoin Core developer experience
 significantly:
@@ -29,11 +26,8 @@ significantly:
   is often a subjective matter. Unless they are explicitly mentioned to be
   preferred in the [developer notes](/doc/developer-notes.md), stylistic code
   changes are usually rejected.
--->
 
-<!--
 Bitcoin Core has a thorough review process and even the most trivial change
 needs to pass a lot of eyes and requires non-zero or even substantial time
 effort to review. There is a huge lack of active reviewers on the project, so
 patches often sit for a long time.
--->


### PR DESCRIPTION
This makes the dummy text visible so that it hopefully doesn't end up in merge commits, like here:

```
$ git log  --oneline --grep='<!--'
a421e0a22f Merge #18376: net: fix use-after-free in tests
dbb067da38 Merge #18379: doc: Comment fix merkle.cpp
712b7d9b47 Merge #17804: doc: Misc RPC help fixes
8625446b4d Merge #17336: scripts: search for first block file for linearize-data with some block files pruned
80fdb6fad1 Merge #17442: fix Typo: "merkelRoot" -> "merkleRoot"
224c19645f Merge #17388: Add missing newline in util_ChainMerge test
53f26cd11d Merge #14421: Fix path to doc/descriptors.md in 0.17 release notes
ea263e1eb0 Merge #13243: Make reusable base class for auxiliary indices
d3908e2cee Merge #12759: [Docs] Improve formatting of developer notes
```

Making it visible gives the pull request author a chance to see it and remove it. If it still ends up in the comment, it gives maintainers and editors a chance to see it and remove it.