### PR TITLE
WIP contrib: Add keys.openpgp.org as backup server

### DIFF
--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -21,6 +21,7 @@ test/lint/lint-all.sh
 
 if [ "$TRAVIS_REPO_SLUG" = "bitcoin/bitcoin" ] && [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then
     git log --merges --before="2 days ago" -1 --format='%H' > ./contrib/verify-commits/trusted-sha512-root-commit
-    travis_retry gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys $(<contrib/verify-commits/trusted-keys) &&
+    ${CI_RETRY_EXE} gpg --keyserver hkps://keys.openpgp.org    --recv-keys $(<contrib/verify-commits/trusted-keys) &&
+    ${CI_RETRY_EXE} gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $(<contrib/verify-commits/trusted-keys) &&
     ./contrib/verify-commits/verify-commits.py --clean-merge=2;
 fi

--- a/contrib/gitian-keys/README.md
+++ b/contrib/gitian-keys/README.md
@@ -17,10 +17,13 @@ gpg --refresh-keys
 ```
 
 To fetch keys of Gitian builders and active developers, feed the list of
-fingerprints of the primary keys into gpg:
+fingerprints of the primary keys into gpg.
+
+Two different keyservers are used to make sure the latest version of the key is fetched.
 
 ```sh
-while read fingerprint keyholder_name; do gpg --keyserver hkp://subset.pool.sks-keyservers.net --recv-keys ${fingerprint}; done < ./keys.txt
+while read fingerprint keyholder_name; do gpg --keyserver hkps://keys.openpgp.org    --recv-keys ${fingerprint}; done < ./keys.txt
+while read fingerprint keyholder_name; do gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys ${fingerprint}; done < ./keys.txt
 ```
 
 Add your key to the list if you provided Gitian signatures for two major or

--- a/contrib/verify-commits/README.md
+++ b/contrib/verify-commits/README.md
@@ -37,9 +37,12 @@ Configuration files
 
 Import trusted keys
 -------------------
-In order to check the commit signatures, you must add the trusted PGP keys to your machine. [GnuPG](https://gnupg.org/) may be used to import the trusted keys by running the following command:
+In order to check the commit signatures, you must add the trusted PGP keys to your machine. [GnuPG](https://gnupg.org/)
+may be used to import the trusted keys by downloading them from a keyserver. To ensure that the latest version of the
+key is fetched, two different keyservers are used:
 
 ```sh
+gpg --keyserver hkps://keys.openpgp.org    --recv-keys $(<contrib/verify-commits/trusted-keys)
 gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys $(<contrib/verify-commits/trusted-keys)
 ```
 


### PR DESCRIPTION
Due to DOS attacks, most keyservers are read-only or have strict upload limits. I can no longer upload my key to SKS keyservers. See also https://gist.github.com/rjhansen/67ab921ffb4084c865b3618d6955275f#executive-summary

The keyservers only have an outdated key of mine, so all gpg --verify checks will fail. For example, in the travis sanity check: https://travis-ci.org/github/bitcoin/bitcoin/builds/664176384

Fix this by switching to keys.openpgp.org as backup.