### PR TITLE
gui: Fix segfault for loading and immediately unloading wallet

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -24,6 +24,7 @@
 #include <qt/walletframe.h>
 #include <qt/walletmodel.h>
 #include <qt/walletview.h>
+#include <wallet/wallet.h>
 #endif // ENABLE_WALLET
 
 #ifdef Q_OS_MAC
@@ -643,6 +644,11 @@ void BitcoinGUI::addWallet(WalletModel* walletModel)
         m_wallet_selector_label_action->setVisible(true);
         m_wallet_selector_action->setVisible(true);
     }
+
+    const std::lock_guard<std::mutex> lock(g_loading_wallet_models_mutex);
+    g_loading_wallet_models_set.erase(walletModel);
+    assert(g_loading_wallet_models_set.count(walletModel) == 0);
+    g_loading_wallet_models_cv.notify_all();
 }
 
 void BitcoinGUI::removeWallet(WalletModel* walletModel)

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -40,6 +40,11 @@ WalletModel::WalletModel(std::unique_ptr<interfaces::Wallet> wallet, interfaces:
     cachedEncryptionStatus(Unencrypted),
     cachedNumBlocks(0)
 {
+    {
+        const std::lock_guard<std::mutex> lock(g_loading_wallet_models_mutex);
+        g_loading_wallet_models_set.insert(this);
+    }
+
     fHaveWatchOnly = m_wallet->haveWatchOnly();
     addressTableModel = new AddressTableModel(this);
     transactionTableModel = new TransactionTableModel(platformStyle, this);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -37,6 +37,11 @@
 
 #include <boost/signals2/signal.hpp>
 
+class WalletModel;
+extern std::set<WalletModel*> g_loading_wallet_models_set;
+extern std::condition_variable g_loading_wallet_models_cv;
+extern std::mutex g_loading_wallet_models_mutex;
+
 using LoadWalletFn = std::function<void(std::unique_ptr<interfaces::Wallet> wallet)>;
 
 //! Explicitly unload and delete the wallet.


### PR DESCRIPTION
These changes block a wallet unload until the GUI completes the process of its model loading.

Fix #18362