### PR TITLE
doc: Update init and reduce-traffic docs for -blocksonly

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -24,8 +24,7 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 
 ## Number of peers
 
-- `-maxconnections=<n>` - the maximum number of connections, this defaults to `125`. Each active connection takes up some memory. Only significant if incoming
-   connections are enabled, otherwise the number of connections will never be more than `8`.
+- `-maxconnections=<n>` - the maximum number of connections, this defaults to `125`. Each active connection takes up some memory. Only significant if incoming connections are enabled, otherwise the number of connections will never be more than `10`. Of the 10 outbound peers, there can be 8 full outgoing connections and 2 -blocksonly peers, in which case they are block/addr peers, but not tx peers.
 
 ## Thread configuration
 

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -3,8 +3,10 @@ Reduce Traffic
 
 Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
-By default, Bitcoin Core allows up to 125 connections to different peers, 8 of
-which are outbound. You can therefore, have at most 117 inbound connections.
+By default, Bitcoin Core allows up to 125 connections to different peers, 10 of
+which are outbound. You can therefore, have at most 115 inbound connections.
+Of the 10 outbound peers, there can be 8 full outgoing connections and 2 with
+the -blocksonly mode turned on. You can therefore, have at most 115 inbound connections.
 
 The default settings can result in relatively significant traffic consumption.
 
@@ -26,7 +28,7 @@ calculating the target.
 
 ## 2. Disable "listening" (`-listen=0`)
 
-Disabling listening will result in fewer nodes connected (remember the maximum of 8
+Disabling listening will result in fewer nodes connected (remember the maximum of 10
 outbound peers). Fewer nodes will result in less traffic usage as you are relaying
 blocks and transactions to fewer nodes.
 
@@ -44,7 +46,11 @@ with other peers, you can disable transaction relay.
 Be reminded of the effects of this setting.
 
 - Fee estimation will no longer work.
-- Not relaying other's transactions could hurt your privacy if used while a
-  wallet is loaded or if you use the node to broadcast transactions.
+- It sets the flag "-walletbroadcast" to be "0", only if it is currently unset.
+  Doing so disables the automatic broadcasting of transactions from wallet. Not
+  relaying other's transactions could hurt your privacy if used while a wallet
+  is loaded or if you use the node to broadcast transactions.
+- If a peer is whitelisted and "-whitelistforcerelay" is set to "1" (which will
+  also set "whitelistrelay" to "1"), we will still receive and relay their transactions.
 - It makes block propagation slower because compact block relay can only be
   used when transaction relay is enabled.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -371,7 +371,7 @@ void SetupServerArgs()
     gArgs.AddArg("-blocknotify=<cmd>", "Execute command when the best block changes (%s in cmd is replaced by block hash)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
 #endif
     gArgs.AddArg("-blockreconstructionextratxn=<n>", strprintf("Extra transactions to keep in memory for compact block reconstructions (default: %u)", DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
-    gArgs.AddArg("-blocksonly", strprintf("Whether to reject transactions from network peers. Transactions from the wallet, RPC and relay whitelisted inbound peers are not affected. (default: %u)", DEFAULT_BLOCKSONLY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-blocksonly", strprintf("Whether to reject transactions from network peers. Automatic broadcast and rebroadcast of any transactions from inbound peers is disabled, unless '-whitelistforcerelay' is '1', in which case whitelisted peers' transactions will be relayed. RPC transactions are not affected. (default: %u)", DEFAULT_BLOCKSONLY), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-conf=<file>", strprintf("Specify configuration file. Relative paths will be prefixed by datadir location. (default: %s)", BITCOIN_CONF_FILENAME), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-dbbatchsize", strprintf("Maximum database write batch size in bytes (default: %u)", nDefaultDbBatchSize), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);


### PR DESCRIPTION
When -blocksonly is set to 1, it interacts with the -walletbroadcast
parameter and sets it to 0. 

This behavior is not captured by the current documentation, which
claims that -blocksonly does not impact any wallet transactions at
all.

Fixes #17294