### PR TITLE
scripts: add PE dylib checking to symbol-check.py

### DIFF
--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -109,7 +109,7 @@ certain symbols and are only linked against allowed libraries.
 For Linux this means checking for allowed gcc, glibc and libstdc++ version symbols.
 This makes sure they are still compatible with the minimum supported distribution versions.
 
-For macOS we check that the executables are only linked against libraries we allow.
+For macOS and Windows we check that the executables are only linked against libraries we allow.
 
 Example usage after a gitian build:
 

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -145,6 +145,7 @@ script: |
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
+    make ${MAKEOPTS} -C src check-symbols
     make deploy
     make install DESTDIR=${INSTALLPATH}
     cp -f --target-directory="${OUTDIR}" ./bitcoin-*-setup-unsigned.exe

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -703,6 +703,11 @@ if TARGET_DARWIN
 	$(AM_V_at) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
 endif
 
+if TARGET_WINDOWS
+	@echo "Checking Windows dynamic libraries..."
+	$(AM_V_at) OBJDUMP=$(OBJDUMP) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)
+endif
+
 if GLIBC_BACK_COMPAT
 	@echo "Checking glibc back compat..."
 	$(AM_V_at) READELF=$(READELF) CPPFILT=$(CPPFILT) $(PYTHON) $(top_srcdir)/contrib/devtools/symbol-check.py $(bin_PROGRAMS)


### PR DESCRIPTION
Uses `objdump -x` and looks for `DLL Name:` lines. i.e:
```bash
objdump -x src/qt/bitcoin-qt.exe | grep "DLL Name:"
	DLL Name: ADVAPI32.dll
	DLL Name: dwmapi.dll
	DLL Name: GDI32.dll
	DLL Name: IMM32.dll
	DLL Name: IPHLPAPI.DLL
	DLL Name: KERNEL32.dll
	DLL Name: msvcrt.dll
	DLL Name: ole32.dll
	DLL Name: OLEAUT32.dll
	DLL Name: SHELL32.dll
	DLL Name: SHLWAPI.dll
	DLL Name: USER32.dll
	DLL Name: UxTheme.dll
	DLL Name: VERSION.dll
	DLL Name: WINMM.dll
	DLL Name: WS2_32.dll
```