### PR TITLE
rpc: add missing HelpExampleRpc for getblockfilter

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2178,7 +2178,8 @@ static UniValue getblockfilter(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "header", "the hex-encoded filter header"},
                     }},
                 RPCExamples{
-                    HelpExampleCli("getblockfilter", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" \"basic\"")
+                    HelpExampleCli("getblockfilter", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\" \"basic\"") +
+                    HelpExampleRpc("getblockfilter", "\"00000000c937983704a73af28acdec37b049d214adbda81d7e2a3dd146f6ed09\", \"basic\"")
                 }
             }.Check(request);
 


### PR DESCRIPTION
From all RPCs in the "blockchain" category, `getblockfilter` is the only one where there is only a CLI example present but not a curl RPC example (all other RPCs in this category have either both or none). This PR adds the missing `HelpExampleRpc` string.