### PR TITLE
rpc: fix broken RPCExamples for waitforblock(height)

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -270,7 +270,7 @@ static UniValue waitforblock(const JSONRPCRequest& request)
                         {RPCResult::Type::NUM, "height", "Block height"},
                     }},
                 RPCExamples{
-                    HelpExampleCli("waitforblock", "\"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\", 1000")
+                    HelpExampleCli("waitforblock", "\"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\" 1000")
             + HelpExampleRpc("waitforblock", "\"0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862\", 1000")
                 },
             }.Check(request);
@@ -314,8 +314,8 @@ static UniValue waitforblockheight(const JSONRPCRequest& request)
                         {RPCResult::Type::NUM, "height", "Block height"},
                     }},
                 RPCExamples{
-                    HelpExampleCli("waitforblockheight", "\"100\", 1000")
-            + HelpExampleRpc("waitforblockheight", "\"100\", 1000")
+                    HelpExampleCli("waitforblockheight", "100 1000")
+            + HelpExampleRpc("waitforblockheight", "100, 1000")
                 },
             }.Check(request);
     int timeout = 0;


### PR DESCRIPTION
This PR fixes several broken RPCExamples from the "blockchain" category:
- `HelpExampleCli` for `waitforblock` (disturbing comma between arguments)
- `HelpExampleCli` for `waitforblockheight` (disturbing comma between arguments)
- `HelpExampleRpc` for `waitforblockheight` (disturbing quotation marks around integer argument)

Note that the CLI example for `waitforblockheight` would also work with the first argument in quotation marks (in contrast to the RPC example), but I removed them as well as they are not needed.

Outputs for the non-working examples in the master branch:
```
$ ./bitcoin-cli waitforblock "0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862", 1000
error code: -8
error message:
blockhash must be of length 64 (not 65, for '0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862,')
```

```
$ ./bitcoin-cli waitforblockheight "100", 1000
error: Error parsing JSON:100,
```

```
$ curl --user __cookie__ --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "waitforblockheight", "params": ["100", 1000]}' -H 'content-type: text/plain;' http://127.0.0.1:8332/
Enter host password for user '__cookie__':
{"result":null,"error":{"code":-1,"message":"JSON value is not an integer as expected"},"id":"curltest"}
```

Outputs for the fixed examples in the PR branch:
```
$ ./bitcoin-cli waitforblock "0000000000079f8ef3d2c688c244eb7a4570b24c9ed7b4a8c619eb02596f8862" 1000
{
  "hash": "0000000000000000000910ae4d56120e0ddd55c0552e80ed12dba147abc68080",
  "height": 622416
}
```

```
$ ./bitcoin-cli waitforblockheight 100 1000
{
  "hash": "0000000000000000000910ae4d56120e0ddd55c0552e80ed12dba147abc68080",
  "height": 622416
}
```

```
$ curl --user __cookie__ --data-binary '{"jsonrpc": "1.0", "id": "curltest", "method": "waitforblockheight", "params": [100, 1000]}' -H 'content-type: text/plain;' http://127.0.0.1:8332/
Enter host password for user '__cookie__':
{"result":{"hash":"0000000000000000000910ae4d56120e0ddd55c0552e80ed12dba147abc68080","height":622416},"error":null,"id":"curltest"}
```