### PR TITLE
lint: PR description linter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ env:
     - CI_RETRY_EXE="travis_retry"
     - CI_WAIT="while sleep 500; do echo .; done"
     - CACHE_ERR_MSG="Error! Initial build successful, but not enough time remains to run later build stages and tests. See https://docs.travis-ci.com/user/customizing-the-build#build-timeouts . Please manually re-run this job by using the travis restart button. The next run should not time out because the build cache has been saved."
+    - secure: "Fv6ESl8xY2X4FZunKKEBgCTx/06dLs7D+CyMNUgMuUmEuS/oSCw6ydk1tTouITfXnkhMtQtJZdc7oSEmwQxKPMg3b8SSQmBDUjh5SU16rJWbBgsOlrZzE7mHtx56G+UkCNDVteA6JCYsWYeM8aBujwsfTTel+YgPBtSohHOI+Rk="
 before_install:
   - set -o errexit; source ./ci/test/00_setup_env.sh
   - set -o errexit; source ./ci/test/03_before_install.sh

--- a/ci/lint/06_script.sh
+++ b/ci/lint/06_script.sh
@@ -16,6 +16,7 @@ test/lint/git-subtree-check.sh src/univalue
 test/lint/git-subtree-check.sh src/leveldb
 test/lint/git-subtree-check.sh src/crc32c
 test/lint/check-doc.py
+test/lint/check-pr-description.py
 test/lint/check-rpc-mappings.py .
 test/lint/lint-all.sh
 

--- a/test/lint/check-pr-description.py
+++ b/test/lint/check-pr-description.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import os
+import re
+import json
+import codecs
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+
+def get_response(req_url, ghtoken):
+    req = Request(req_url)
+    if ghtoken is not None:
+        req.add_header('Authorization', 'token ' + ghtoken)
+    return urlopen(req)
+
+def retrieve_json(req_url, ghtoken):
+    '''
+    Retrieve json from github.
+    Return None if an error happens.
+    '''
+    try:
+        reader = codecs.getreader('utf-8')
+        return json.load(reader(get_response(req_url, ghtoken)))
+    except HTTPError as e:
+        error_message = e.read()
+        print('Warning: unable to retrieve pull information from github: %s' % e)
+        print('Detailed error: %s' % error_message)
+        return None
+    except Exception as e:
+        print('Warning: unable to retrieve pull information from github: %s' % e)
+        return None
+
+def retrieve_pr_info(pull, ghtoken):
+    req_url = "https://api.github.com/repos/bitcoin/bitcoin/pulls/"+pull
+    return retrieve_json(req_url, ghtoken)
+
+def main():
+    # Get pull request number from Travis environment
+    if 'TRAVIS_PULL_REQUEST' in os.environ:
+        pull = os.environ['TRAVIS_PULL_REQUEST']
+    else:
+        assert False, "Error: No pull request number found, PR description could not be checked"
+
+    # This Github token is in the .travis.yml as a secure (encrypted)
+    # variable. See Travis CI documentation on how it is created:
+    # https://docs.travis-ci.com/user/environment-variables/#encrypting-environment-variables
+    if 'GITHUB_TOKEN' in os.environ:
+        ghtoken = os.environ['GITHUB_TOKEN']
+    else:
+        assert False, "Error: No Github token found, PR description could not be checked"
+
+    # Receive pull information from github
+    info = retrieve_pr_info(pull, ghtoken)
+    if info is None:
+        assert False, "Error: Did not receive a valid response from Github API"
+
+    body = info['body'].strip()
+
+    # Simple, good enough Github username regex that tries to replicate
+    # the logic by which Github tags users in messages and notifies them:
+    # - Newline/start of string or any special character except hyphen
+    # - Followed by @
+    # - Followed by one alphanumeric character
+    # - Followed by up to 37 alphanumeric characters or hyphens
+    # - End with end of line/string or any special character except hyphen
+    # - Ignore case
+    gh_username = "(^|[^a-z0-9-])@([a-z0-9])([a-z0-9-]){0,37}($|[^a-z0-9-])"
+    assert not bool(re.search(gh_username, body, re.IGNORECASE)), "Please remove any GitHub @-prefixed usernames from your PR description"
+
+    # Match a start or an end tag because there may just be a fraction
+    # of the pull request template left over.
+    html_comment_start = "<!--"
+    assert not bool(re.search(html_comment_start, body)), "Please remove the pull request template from your PR description"
+    html_comment_end = "-->"
+    assert not bool(re.search(html_comment_end, body)), "Please remove the pull request template from your PR description"
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is a proof of concept of my idea briefly outlined here https://github.com/bitcoin/bitcoin/pull/18380#issuecomment-601287320. The code is partially based on the merge script.

The new linter uses the pull request number available in the Travis env and the Github API to retrieve the PR description and checks it for common errors, currently @-prefixed GH usernames and fractional left-overs of the pull request template (identified by HTML comments). Currently, users mostly have to be reminded here manually to fix these things or they are caught in the merge process. Obviously this linter can be expanded to check for more similar issues, those are just the ones I am familiar with. For example, usernames in ACK messages could be added as well, as mentioned here: https://github.com/bitcoin-core/bitcoin-maintainer-tools/pull/51

If #18380 gets merged, the HTML comments part is useless but we could put a unique string in the bottom of the pull request template and then match against that. Alternatively, this PR could be a replacement for #18358 

Open question: I was not sure if the script should be more forgiving. It expects to be run in Travis and otherwise fails. I think this makes sense because the user would have to provide the PR number manually if they want to run it locally. It also fails if there is an issue with the Github API which seems to have problems quite frequently. On the other hand, if Github is down, the CI checks should probably not be running anyway. 