### PR TITLE
gui: Import only required Objective-C headers

### DIFF
--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -2,10 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "macdockiconhandler.h"
+#include <qt/macdockiconhandler.h>
 
-#include <AppKit/AppKit.h>
-#include <objc/runtime.h>
+#import <AppKit/NSApplication.h>
+#import <objc/runtime.h>
 
 static MacDockIconHandler *s_instance = nullptr;
 

--- a/src/qt/macnotificationhandler.mm
+++ b/src/qt/macnotificationhandler.mm
@@ -2,11 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "macnotificationhandler.h"
+#include <qt/macnotificationhandler.h>
 
-#undef slots
+#import <Foundation/NSBundle.h>
+#import <Foundation/NSObjCRuntime.h>
+#import <Foundation/NSString.h>
+#import <Foundation/NSUserNotification.h>
 #import <objc/runtime.h>
-#include <Cocoa/Cocoa.h>
 
 // Add an obj-c category (extension) to return the expected bundle identifier
 @implementation NSBundle(returnCorrectIdentifier)

--- a/src/qt/macos_appnap.mm
+++ b/src/qt/macos_appnap.mm
@@ -2,11 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "macos_appnap.h"
+#include <qt/macos_appnap.h>
 
-#include <AvailabilityMacros.h>
-#include <Foundation/NSProcessInfo.h>
-#include <Foundation/Foundation.h>
+#import <Foundation/NSObject.h>
+#import <Foundation/NSProcessInfo.h>
 
 class CAppNapInhibitor::CAppNapImpl
 {


### PR DESCRIPTION
`AppKit/AppKit.h`, `Cocoa/Cocoa.h` and `Foundation/Foundation.h` are just bundles of other headers.

With this PR only required headers are imported.