### PR TITLE
script: fix SCRIPT_ERR_SIG_PUSHONLY error string

### DIFF
--- a/src/script/script_error.cpp
+++ b/src/script/script_error.cpp
@@ -58,7 +58,7 @@ const char* ScriptErrorString(const ScriptError serror)
         case SCRIPT_ERR_MINIMALDATA:
             return "Data push larger than necessary";
         case SCRIPT_ERR_SIG_PUSHONLY:
-            return "Only non-push operators allowed in signatures";
+            return "Only push operators allowed in signatures";
         case SCRIPT_ERR_SIG_HIGH_S:
             return "Non-canonical signature: S value is unnecessarily high";
         case SCRIPT_ERR_SIG_NULLDUMMY:


### PR DESCRIPTION
Fixes #18411, changing the error message from `"Only non-push operators allowed in signatures"` to `"Only push operators allowed in signatures"`.