### PR TITLE
scripts: add MACHO tests to test-security-check.py

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -197,6 +197,15 @@ def check_MACHO_NOUNDEFS(executable) -> bool:
         return True
     return False
 
+def check_MACHO_NX(executable) -> bool:
+    '''
+    Check for no stack execution
+    '''
+    flags = get_MACHO_executable_flags(executable)
+    if 'ALLOW_STACK_EXECUTION' in flags:
+        return False
+    return True
+
 CHECKS = {
 'ELF': [
     ('PIE', check_ELF_PIE),
@@ -212,6 +221,7 @@ CHECKS = {
 'MACHO': [
     ('PIE', check_MACHO_PIE),
     ('NOUNDEFS', check_MACHO_NOUNDEFS),
+    ('NX', check_MACHO_NX)
 ]
 }
 

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -43,16 +43,20 @@ class TestSecurityChecks(unittest.TestCase):
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-znoexecstack','-fstack-protector-all','-Wl,-zrelro','-Wl,-z,now','-pie','-fPIE']),
                 (0, ''))
 
-    def test_64bit_PE(self):
+    def test_PE(self):
         source = 'test1.c'
         executable = 'test1.exe'
         cc = 'x86_64-w64-mingw32-gcc'
         write_testcode(source)
 
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--no-nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va']), (1, executable+': failed DYNAMIC_BASE HIGH_ENTROPY_VA NX'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va']), (1, executable+': failed DYNAMIC_BASE HIGH_ENTROPY_VA'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--no-high-entropy-va']), (1, executable+': failed HIGH_ENTROPY_VA'))
-        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--high-entropy-va']), (0, ''))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--no-nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va']),
+            (1, executable+': failed DYNAMIC_BASE HIGH_ENTROPY_VA NX'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--no-dynamicbase','-Wl,--no-high-entropy-va']),
+            (1, executable+': failed DYNAMIC_BASE HIGH_ENTROPY_VA'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--no-high-entropy-va']),
+            (1, executable+': failed HIGH_ENTROPY_VA'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--high-entropy-va']),
+            (0, ''))
 
     def test_MACHO(self):
         source = 'test1.c'

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -60,6 +60,8 @@ class TestSecurityChecks(unittest.TestCase):
         cc = 'clang'
         write_testcode(source)
 
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace', '-Wl,-allow_stack_execute']),
+            (1, executable+': failed PIE NOUNDEFS NX'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace']),
             (1, executable+': failed PIE NOUNDEFS'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie']),

--- a/contrib/devtools/test-security-check.py
+++ b/contrib/devtools/test-security-check.py
@@ -54,6 +54,19 @@ class TestSecurityChecks(unittest.TestCase):
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--no-high-entropy-va']), (1, executable+': failed HIGH_ENTROPY_VA'))
         self.assertEqual(call_security_check(cc, source, executable, ['-Wl,--nxcompat','-Wl,--dynamicbase','-Wl,--high-entropy-va']), (0, ''))
 
+    def test_MACHO(self):
+        source = 'test1.c'
+        executable = 'test1'
+        cc = 'clang'
+        write_testcode(source)
+
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie','-Wl,-flat_namespace']),
+            (1, executable+': failed PIE NOUNDEFS'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-no_pie']),
+            (1, executable+': failed PIE'))
+        self.assertEqual(call_security_check(cc, source, executable, ['-Wl,-pie']),
+            (0, ''))
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Adds tests for the MACHO checks in security-check.py:
https://github.com/bitcoin/bitcoin/blob/ac579ada7e83a1b8100d611412f9ede885a4e522/contrib/devtools/security-check.py#L212-L214

I'm planning on following up with more checks in security-check.py, and corresponding tests in test-security-check.py.

Note that you'll probably have to be on macOS to run them. You can run just this suite with `python3 test-security-check.py TestSecurityChecks.test_MACHO`. 