### PR TITLE
tests: Add fuzzing harnesses for functions in addrdb.h, net_permissions.h and timedata.h

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -4,6 +4,7 @@
 
 FUZZ_TARGETS = \
   test/fuzz/addr_info_deserialize \
+  test/fuzz/addrdb \
   test/fuzz/address_deserialize \
   test/fuzz/addrman_deserialize \
   test/fuzz/asmap \
@@ -287,6 +288,12 @@ test_fuzz_addr_info_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_addr_info_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_addr_info_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_addr_info_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_addrdb_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_addrdb_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_addrdb_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_addrdb_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_addrdb_SOURCES = $(FUZZ_SUITE) test/fuzz/addrdb.cpp
 
 test_fuzz_address_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DADDRESS_DESERIALIZE=1
 test_fuzz_address_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -44,6 +44,7 @@ FUZZ_TARGETS = \
   test/fuzz/merkle_block_deserialize \
   test/fuzz/messageheader_deserialize \
   test/fuzz/multiplication_overflow \
+  test/fuzz/net_permissions \
   test/fuzz/netaddr_deserialize \
   test/fuzz/netaddress \
   test/fuzz/out_point_deserialize \
@@ -529,6 +530,12 @@ test_fuzz_multiplication_overflow_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_multiplication_overflow_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_multiplication_overflow_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_multiplication_overflow_SOURCES = $(FUZZ_SUITE) test/fuzz/multiplication_overflow.cpp
+
+test_fuzz_net_permissions_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_net_permissions_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_net_permissions_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_net_permissions_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_net_permissions_SOURCES = $(FUZZ_SUITE) test/fuzz/net_permissions.cpp
 
 test_fuzz_netaddr_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DNETADDR_DESERIALIZE=1
 test_fuzz_netaddr_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -98,6 +98,7 @@ FUZZ_TARGETS = \
   test/fuzz/string \
   test/fuzz/strprintf \
   test/fuzz/sub_net_deserialize \
+  test/fuzz/timedata \
   test/fuzz/transaction \
   test/fuzz/tx_in \
   test/fuzz/tx_in_deserialize \
@@ -852,6 +853,12 @@ test_fuzz_sub_net_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_sub_net_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_sub_net_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_sub_net_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_timedata_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_timedata_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_timedata_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_timedata_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_timedata_SOURCES = $(FUZZ_SUITE) test/fuzz/timedata.cpp
 
 test_fuzz_transaction_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_transaction_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/addrdb.cpp
+++ b/src/test/fuzz/addrdb.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <addrdb.h>
+#include <optional.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const CBanEntry ban_entry = [&] {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 3)) {
+        case 0:
+            return CBanEntry{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
+            break;
+        case 1:
+            return CBanEntry{fuzzed_data_provider.ConsumeIntegral<int64_t>(), fuzzed_data_provider.PickValueInArray<BanReason>({
+                                                                                  BanReason::BanReasonUnknown,
+                                                                                  BanReason::BanReasonNodeMisbehaving,
+                                                                                  BanReason::BanReasonManuallyAdded,
+                                                                              })};
+            break;
+        case 2: {
+            const Optional<CBanEntry> ban_entry = ConsumeDeserializable<CBanEntry>(fuzzed_data_provider);
+            if (ban_entry) {
+                return *ban_entry;
+            }
+            break;
+        }
+        }
+        return CBanEntry{};
+    }();
+    assert(!ban_entry.banReasonToString().empty());
+}

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <net_permissions.h>
+#include <optional.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::string s = fuzzed_data_provider.ConsumeRandomLengthString(32);
+    const NetPermissionFlags net_permission_flags = fuzzed_data_provider.ConsumeBool() ? fuzzed_data_provider.PickValueInArray<NetPermissionFlags>({
+                                                                                             NetPermissionFlags::PF_NONE,
+                                                                                             NetPermissionFlags::PF_BLOOMFILTER,
+                                                                                             NetPermissionFlags::PF_RELAY,
+                                                                                             NetPermissionFlags::PF_FORCERELAY,
+                                                                                             NetPermissionFlags::PF_NOBAN,
+                                                                                             NetPermissionFlags::PF_MEMPOOL,
+                                                                                             NetPermissionFlags::PF_ISIMPLICIT,
+                                                                                             NetPermissionFlags::PF_ALL,
+                                                                                         }) :
+                                                                                         static_cast<NetPermissionFlags>(fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+
+    NetWhitebindPermissions net_whitebind_permissions;
+    std::string error_net_whitebind_permissions;
+    if (NetWhitebindPermissions::TryParse(s, net_whitebind_permissions, error_net_whitebind_permissions)) {
+        (void)NetPermissions::ToStrings(net_whitebind_permissions.m_flags);
+        (void)NetPermissions::AddFlag(net_whitebind_permissions.m_flags, net_permission_flags);
+        assert(NetPermissions::HasFlag(net_whitebind_permissions.m_flags, net_permission_flags));
+        (void)NetPermissions::ClearFlag(net_whitebind_permissions.m_flags, net_permission_flags);
+        (void)NetPermissions::ToStrings(net_whitebind_permissions.m_flags);
+    }
+
+    NetWhitelistPermissions net_whitelist_permissions;
+    std::string error_net_whitelist_permissions;
+    if (NetWhitelistPermissions::TryParse(s, net_whitelist_permissions, error_net_whitelist_permissions)) {
+        (void)NetPermissions::ToStrings(net_whitelist_permissions.m_flags);
+        (void)NetPermissions::AddFlag(net_whitelist_permissions.m_flags, net_permission_flags);
+        assert(NetPermissions::HasFlag(net_whitelist_permissions.m_flags, net_permission_flags));
+        (void)NetPermissions::ClearFlag(net_whitelist_permissions.m_flags, net_permission_flags);
+        (void)NetPermissions::ToStrings(net_whitelist_permissions.m_flags);
+    }
+}

--- a/src/test/fuzz/timedata.cpp
+++ b/src/test/fuzz/timedata.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <timedata.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const unsigned int max_size = fuzzed_data_provider.ConsumeIntegralInRange<unsigned int>(0, 1000);
+    // Divide by 2 to avoid signed integer overflow in .median()
+    const int64_t initial_value = fuzzed_data_provider.ConsumeIntegral<int64_t>() / 2;
+    CMedianFilter<int64_t> median_filter{max_size, initial_value};
+    while (fuzzed_data_provider.remaining_bytes() > 0) {
+        (void)median_filter.median();
+        assert(median_filter.size() > 0);
+        assert(static_cast<size_t>(median_filter.size()) == median_filter.sorted().size());
+        assert(static_cast<unsigned int>(median_filter.size()) <= max_size || max_size == 0);
+        // Divide by 2 to avoid signed integer overflow in .median()
+        median_filter.input(fuzzed_data_provider.ConsumeIntegral<int64_t>() / 2);
+    }
+}


### PR DESCRIPTION
Add fuzzing harnesses for functions in `addrdb.h`, `net_permissions.h` and `timedata.h`.