### PR TITLE
Periodically update DNS caches for better privacy of non-reachable nodes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -937,6 +937,16 @@ bool CConnman::AttemptToEvictConnection()
     return false;
 }
 
+int CConnman::CountInboundConnections() const
+{
+    int inbounds = 0;
+    LOCK(cs_vNodes);
+    for (const CNode* node : vNodes) {
+        if (node->fInbound) inbounds++;
+    }
+    return inbounds;
+}
+
 void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
@@ -964,12 +974,7 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
         legacyWhitelisted = true;
     }
 
-    {
-        LOCK(cs_vNodes);
-        for (const CNode* pnode : vNodes) {
-            if (pnode->fInbound) nInbound++;
-        }
-    }
+    nInbound = CountInboundConnections();
 
     if (hSocket == INVALID_SOCKET)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -351,6 +351,7 @@ private:
     void ProcessOneShot();
     void ThreadOpenConnections(std::vector<std::string> connect);
     void ThreadMessageHandler();
+    int CountInboundConnections() const;
     void AcceptConnection(const ListenSocket& hListenSocket);
     void DisconnectNodes();
     void NotifyNumConnectionsChanged();

--- a/src/net.h
+++ b/src/net.h
@@ -362,6 +362,16 @@ private:
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
 
+    // Reachable nodes should periodically make requests
+    // to DNS servers even if they don't need them.
+    // Then, when new nodes from the same subnets need to query DNS,
+    // they are likely to hit the cache instead.
+    // For non-reachable nodes this means more privacy,
+    // because fewer actors would know about their query.
+    // For reachable nodes there is no privacy loss due to this,
+    // because being reachable already makes them public.
+    void DNSCachesUpdate() const;
+
     uint64_t CalculateKeyedNetGroup(const CAddress& ad) const;
 
     CNode* FindNode(const CNetAddr& ip);


### PR DESCRIPTION
Every time a fresh Bitcoin Core node starts, it makes a DNS query to learn about nodes in the network. This process leaks the privacy of those new nodes: every required DNS server and the corresponding infrastructure would be aware that a new node was spinned up in a particular internet segment.
The goal of this proposal is to reduce the number of those actors learning about a new node.
The way to achieve it is to keep DNS server caches updated, so that new nodes rarely hit anything past the early servers.

To keep them updated, every reachable node would periodically make all widely used DNS queries, thus, triggering DNS cache updates on the resolvers appearing on their path to the end DNS servers.
This, obviously, would leak more information about the existence of these reachable nodes. We think this is no big deal, because those nodes are already easy to find, since they are reachable.

Note that this helps only to those private nodes, which share a subnet with some reachable node running this code.

In future, it would be great to analyze the results of those queries against a local AddrMan to check for anomalies.

The idea was originally proposed by Greg Maxwell.