### PR TITLE
tests: Add fuzzing harness for classes/functions in blockfilter.h. Add integer {de,}serialization fuzzing.

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -17,6 +17,7 @@ FUZZ_TARGETS = \
   test/fuzz/block_filter_deserialize \
   test/fuzz/block_header \
   test/fuzz/block_header_and_short_txids_deserialize \
+  test/fuzz/blockfilter \
   test/fuzz/blockheader_deserialize \
   test/fuzz/blocklocator_deserialize \
   test/fuzz/blockmerkleroot \
@@ -368,6 +369,12 @@ test_fuzz_block_header_and_short_txids_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(P
 test_fuzz_block_header_and_short_txids_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_block_header_and_short_txids_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_block_header_and_short_txids_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_blockfilter_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_blockfilter_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_blockfilter_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_blockfilter_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_blockfilter_SOURCES = $(FUZZ_SUITE) test/fuzz/blockfilter.cpp
 
 test_fuzz_blockheader_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBLOCKHEADER_DESERIALIZE=1
 test_fuzz_blockheader_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/blockfilter.cpp
+++ b/src/test/fuzz/blockfilter.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <blockfilter.h>
+#include <optional.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const Optional<BlockFilter> block_filter = ConsumeDeserializable<BlockFilter>(fuzzed_data_provider);
+    if (!block_filter) {
+        return;
+    }
+    {
+        (void)block_filter->ComputeHeader(ConsumeUInt256(fuzzed_data_provider));
+        (void)block_filter->GetBlockHash();
+        (void)block_filter->GetEncodedFilter();
+        (void)block_filter->GetHash();
+    }
+    {
+        const BlockFilterType block_filter_type = block_filter->GetFilterType();
+        (void)BlockFilterTypeName(block_filter_type);
+    }
+    {
+        const GCSFilter gcs_filter = block_filter->GetFilter();
+        (void)gcs_filter.GetN();
+        (void)gcs_filter.GetParams();
+        (void)gcs_filter.GetEncoded();
+        (void)gcs_filter.Match(ConsumeRandomLengthByteVector(fuzzed_data_provider));
+        GCSFilter::ElementSet element_set;
+        while (fuzzed_data_provider.ConsumeBool()) {
+            element_set.insert(ConsumeRandomLengthByteVector(fuzzed_data_provider));
+            gcs_filter.MatchAny(element_set);
+        }
+    }
+}

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -227,4 +227,44 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         (void)HasAllDesirableServiceFlags(service_flags);
         (void)MayHaveUsefulAddressDB(service_flags);
     }
+
+    {
+        CDataStream stream(SER_NETWORK, INIT_PROTO_VERSION);
+
+        ser_writedata64(stream, u64);
+        const uint64_t deserialized_u64 = ser_readdata64(stream);
+        assert(u64 == deserialized_u64 && stream.empty());
+
+        ser_writedata32(stream, u32);
+        const uint32_t deserialized_u32 = ser_readdata32(stream);
+        assert(u32 == deserialized_u32 && stream.empty());
+
+        ser_writedata32be(stream, u32);
+        const uint32_t deserialized_u32be = ser_readdata32be(stream);
+        assert(u32 == deserialized_u32be && stream.empty());
+
+        ser_writedata16(stream, u16);
+        const uint16_t deserialized_u16 = ser_readdata16(stream);
+        assert(u16 == deserialized_u16 && stream.empty());
+
+        ser_writedata16be(stream, u16);
+        const uint16_t deserialized_u16be = ser_readdata16be(stream);
+        assert(u16 == deserialized_u16be && stream.empty());
+
+        ser_writedata8(stream, u8);
+        const uint8_t deserialized_u8 = ser_readdata8(stream);
+        assert(u8 == deserialized_u8 && stream.empty());
+    }
+
+    {
+        CDataStream stream(SER_NETWORK, INIT_PROTO_VERSION);
+
+        WriteCompactSize(stream, u64);
+        try {
+            const uint64_t deserialized_u64 = ReadCompactSize(stream);
+            assert(u64 == deserialized_u64 && stream.empty());
+        }
+        catch (const std::ios_base::failure&) {
+        }
+    }
 }

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -13,6 +13,7 @@
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <uint256.h>
 #include <version.h>
 
 #include <cstdint>
@@ -68,6 +69,15 @@ NODISCARD inline CScript ConsumeScript(FuzzedDataProvider& fuzzed_data_provider)
 NODISCARD inline CScriptNum ConsumeScriptNum(FuzzedDataProvider& fuzzed_data_provider) noexcept
 {
     return CScriptNum{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
+}
+
+NODISCARD inline uint256 ConsumeUInt256(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    const std::vector<unsigned char> v256 = fuzzed_data_provider.ConsumeBytes<unsigned char>(sizeof(uint256));
+    if (v256.size() != sizeof(uint256)) {
+        return {};
+    }
+    return uint256{v256};
 }
 
 template <typename T>


### PR DESCRIPTION
Add fuzzing harness for classes/functions in `blockfilter.h`.

Add integer serialization/deserialization fuzzing harness.