### PR TITLE
qt: Use parent-child relation to manage lifetime of OptionsModel object

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -210,8 +210,6 @@ BitcoinApplication::~BitcoinApplication()
 
     delete window;
     window = nullptr;
-    delete optionsModel;
-    optionsModel = nullptr;
     delete platformStyle;
     platformStyle = nullptr;
 }
@@ -225,7 +223,7 @@ void BitcoinApplication::createPaymentServer()
 
 void BitcoinApplication::createOptionsModel(bool resetSettings)
 {
-    optionsModel = new OptionsModel(m_node, nullptr, resetSettings);
+    optionsModel = new OptionsModel(m_node, this, resetSettings);
 }
 
 void BitcoinApplication::createWindow(const NetworkStyle *networkStyle)


### PR DESCRIPTION
Both `BitcoinApplication` and `OptionsModel` classes are derived from the `QObject` class, therefore a parent-child relation could be established to manage the lifetime of an `OptionsModel` object:
https://github.com/bitcoin/bitcoin/blob/5236b2e267a58870239673c7ec85e5df0cb8fc8e/src/qt/optionsmodel.cpp#L29-L30

This PR does not change behavior.