### PR TITLE
Bugfix? Restore linking to libmingwthrd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -638,7 +638,12 @@ AC_ARG_WITH([daemon],
 case $host in
   *mingw*)
      TARGET_OS=windows
+
+     dnl Some versions of MinGW may require libmingwthrd linked for a thread-safe stdlib implementation
+     dnl Normally, this is automatically linked by GCC's -mthreads flag, but for some reason (lost in the dust of time), that doesn't work when static linking
+     dnl See also: https://en.bitcoin.it/wiki/Common_Vulnerabilities_and_Exposures#CVE-2012-1910
      AC_CHECK_LIB([mingwthrd],[main],                    [], [AC_MSG_ERROR([libmingwthrd missing])])
+
      AC_CHECK_LIB([kernel32], [GetModuleFileNameA],      [], [AC_MSG_ERROR([libkernel32 missing])])
      AC_CHECK_LIB([user32],   [main],                    [], [AC_MSG_ERROR([libuser32 missing])])
      AC_CHECK_LIB([gdi32],    [main],                    [], [AC_MSG_ERROR([libgdi32 missing])])
@@ -668,6 +673,7 @@ case $host in
        AC_MSG_ERROR([windres not found])
      fi
 
+     dnl As with above, _MT is required and normally defined by -mthreads
      CPPFLAGS="$CPPFLAGS -D_MT -DWIN32 -D_WINDOWS -D_WIN32_WINNT=0x0601 -D_WIN32_IE=0x0501 -DWIN32_LEAN_AND_MEAN"
 
      dnl libtool insists upon adding -nostdlib and a list of objects/libs to link against.

--- a/configure.ac
+++ b/configure.ac
@@ -638,6 +638,7 @@ AC_ARG_WITH([daemon],
 case $host in
   *mingw*)
      TARGET_OS=windows
+     AC_CHECK_LIB([mingwthrd],[main],                    [], [AC_MSG_ERROR([libmingwthrd missing])])
      AC_CHECK_LIB([kernel32], [GetModuleFileNameA],      [], [AC_MSG_ERROR([libkernel32 missing])])
      AC_CHECK_LIB([user32],   [main],                    [], [AC_MSG_ERROR([libuser32 missing])])
      AC_CHECK_LIB([gdi32],    [main],                    [], [AC_MSG_ERROR([libgdi32 missing])])


### PR DESCRIPTION
Possibly necessary to get threadsafe stdlib behaviours

#17740 removed this, under the (accidental) false pretence that `AC_CHECK_LIB` didn't actually cause linkage ([it does](https://www.gnu.org/software/autoconf/manual/autoconf-2.66/html_node/Libraries.html)).

It *appears* this hasn't been necessary since mingw 2.0 released in 2011 turned it into a dummy library, but [CVE-2012-1910](https://en.bitcoin.it/wiki/Common_Vulnerabilities_and_Exposures#CVE-2012-1910) occurred in 2012. Furthermore, we don't have a minimum required version of mingw, and it's possible future releases might use it again (GCC `-mthreads` still links to it).

Seems safest to just add it back in...