### PR TITLE
ci: Only clone bitcoin-core/qa-assets when fuzzing

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -102,7 +102,9 @@ else
 fi
 
 if [ ! -d ${DIR_QA_ASSETS} ]; then
+ if [ "$RUN_FUZZ_TESTS" = "true" ]; then
   DOCKER_EXEC git clone https://github.com/bitcoin-core/qa-assets ${DIR_QA_ASSETS}
+ fi
 fi
 export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
 


### PR DESCRIPTION
Currently the only content of that repo are some seeds, so we can speed up some ci builds