### PR TITLE
util: Make our stringstream usage locale independent

### DIFF
--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <locale>
 #include <mutex>
 #include <sstream>
 #include <set>
@@ -213,6 +214,7 @@ const std::string& ListBlockFilterTypes()
     static std::once_flag flag;
     std::call_once(flag, []() {
             std::stringstream ret;
+            ret.imbue(std::locale::classic());
             bool first = true;
             for (auto entry : g_filter_types) {
                 if (!first) ret << ", ";

--- a/src/blockfilter.cpp
+++ b/src/blockfilter.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <locale>
 #include <mutex>
 #include <sstream>
 #include <set>
@@ -14,6 +13,7 @@
 #include <script/script.h>
 #include <streams.h>
 #include <util/golombrice.h>
+#include <util/string.h>
 
 /// SerType used to serialize parameters in GCS filter encoding.
 static constexpr int GCS_SER_TYPE = SER_NETWORK;
@@ -213,8 +213,7 @@ const std::string& ListBlockFilterTypes()
 
     static std::once_flag flag;
     std::call_once(flag, []() {
-            std::stringstream ret;
-            ret.imbue(std::locale::classic());
+            std::stringstream ret = LocaleIndependentStringStream();
             bool first = true;
             for (auto entry : g_filter_types) {
                 if (!first) ret << ", ";

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -6,6 +6,7 @@
 
 #include <tinyformat.h>
 
+#include <locale>
 
 /**
  * Name of client reported in the 'version' message. Report the same name
@@ -87,6 +88,7 @@ std::string FormatFullVersion()
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
 {
     std::ostringstream ss;
+    ss.imbue(std::locale::classic());
     ss << "/";
     ss << name << ":" << FormatVersion(nClientVersion);
     if (!comments.empty())

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -3,10 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <clientversion.h>
-
 #include <tinyformat.h>
-
-#include <locale>
+#include <util/string.h>
 
 /**
  * Name of client reported in the 'version' message. Report the same name
@@ -87,8 +85,7 @@ std::string FormatFullVersion()
  */
 std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
 {
-    std::ostringstream ss;
-    ss.imbue(std::locale::classic());
+    std::stringstream ss = LocaleIndependentStringStream();
     ss << "/";
     ss << name << ":" << FormatVersion(nClientVersion);
     if (!comments.empty())

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -8,6 +8,8 @@
 #include <hash.h>
 #include <tinyformat.h>
 
+#include <locale>
+
 uint256 CBlockHeader::GetHash() const
 {
     return SerializeHash(*this);
@@ -16,6 +18,7 @@ uint256 CBlockHeader::GetHash() const
 std::string CBlock::ToString() const
 {
     std::stringstream s;
+    s.imbue(std::locale::classic());
     s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -7,8 +7,10 @@
 
 #include <hash.h>
 #include <tinyformat.h>
+#include <util/string.h>
 
-#include <locale>
+#include <sstream>
+#include <string>
 
 uint256 CBlockHeader::GetHash() const
 {
@@ -17,8 +19,7 @@ uint256 CBlockHeader::GetHash() const
 
 std::string CBlock::ToString() const
 {
-    std::stringstream s;
-    s.imbue(std::locale::classic());
+    std::stringstream s = LocaleIndependentStringStream();
     s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -23,12 +23,12 @@
 #include <key_io.h>
 #include <psbt.h>
 #include <ui_interface.h>
+#include <util/string.h>
 #include <util/system.h> // for GetBoolArg
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h> // for CRecipient
 
-#include <locale>
-#include <stdint.h>
+#include <cstdint>
 
 #include <QDebug>
 #include <QMessageBox>
@@ -469,8 +469,7 @@ bool WalletModel::saveReceiveRequest(const std::string &sAddress, const int64_t 
 {
     CTxDestination dest = DecodeDestination(sAddress);
 
-    std::stringstream ss;
-    ss.imbue(std::locale::classic());
+    std::stringstream ss = LocaleIndependentStringStream();
     ss << nId;
     std::string key = "rr" + ss.str(); // "rr" prefix = "receive request" in destdata
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -27,6 +27,7 @@
 #include <wallet/coincontrol.h>
 #include <wallet/wallet.h> // for CRecipient
 
+#include <locale>
 #include <stdint.h>
 
 #include <QDebug>
@@ -469,6 +470,7 @@ bool WalletModel::saveReceiveRequest(const std::string &sAddress, const int64_t 
     CTxDestination dest = DecodeDestination(sAddress);
 
     std::stringstream ss;
+    ss.imbue(std::locale::classic());
     ss << nId;
     std::string key = "rr" + ss.str(); // "rr" prefix = "receive request" in destdata
 

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -9,10 +9,11 @@
 #include <boost/test/unit_test.hpp>
 
 #include <cmath>
+#include <cstdint>
 #include <iomanip>
 #include <limits>
+#include <locale>
 #include <sstream>
-#include <stdint.h>
 #include <string>
 
 BOOST_FIXTURE_TEST_SUITE(arith_uint256_tests, BasicTestingSetup)
@@ -57,6 +58,7 @@ const arith_uint256 HalfL = (OneL << 255);
 static std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
     std::stringstream Stream;
+    Stream.imbue(std::locale::classic());
     Stream << std::hex;
     for (unsigned int i = 0; i < width; ++i)
     {

--- a/src/test/arith_uint256_tests.cpp
+++ b/src/test/arith_uint256_tests.cpp
@@ -5,6 +5,7 @@
 #include <arith_uint256.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/string.h>
 
 #include <boost/test/unit_test.hpp>
 
@@ -57,8 +58,7 @@ const arith_uint256 MaxL = arith_uint256V(std::vector<unsigned char>(MaxArray,Ma
 const arith_uint256 HalfL = (OneL << 255);
 static std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
-    std::stringstream Stream;
-    Stream.imbue(std::locale::classic());
+    std::stringstream Stream = LocaleIndependentStringStream();
     Stream << std::hex;
     for (unsigned int i = 0; i < width; ++i)
     {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -50,6 +50,7 @@ const uint160 MaxS = uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
 static std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
     std::stringstream Stream;
+    Stream.imbue(std::locale::classic());
     Stream << std::hex;
     for (unsigned int i = 0; i < width; ++i)
     {

--- a/src/test/uint256_tests.cpp
+++ b/src/test/uint256_tests.cpp
@@ -6,6 +6,7 @@
 #include <streams.h>
 #include <test/util/setup_common.h>
 #include <uint256.h>
+#include <util/string.h>
 #include <version.h>
 
 #include <boost/test/unit_test.hpp>
@@ -49,8 +50,7 @@ const uint160 MaxS = uint160(std::vector<unsigned char>(MaxArray,MaxArray+20));
 
 static std::string ArrayToString(const unsigned char A[], unsigned int width)
 {
-    std::stringstream Stream;
-    Stream.imbue(std::locale::classic());
+    std::stringstream Stream = LocaleIndependentStringStream();
     Stream << std::hex;
     for (unsigned int i = 0; i < width; ++i)
     {

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -176,6 +176,7 @@ struct TestArgsManager : public ArgsManager
     void ReadConfigString(const std::string str_config)
     {
         std::istringstream streamConfig(str_config);
+        streamConfig.imbue(std::locale::classic());
         {
             LOCK(cs_args);
             m_settings.ro_config.clear();
@@ -952,6 +953,7 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
             conf += "\n";
         }
         std::istringstream conf_stream(conf);
+        conf_stream.imbue(std::locale::classic());
         BOOST_CHECK(parser.ReadConfigStream(conf_stream, "filepath", error));
         BOOST_CHECK_EQUAL(error, "");
 
@@ -1089,6 +1091,7 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
             conf += "\n";
         }
         std::istringstream conf_stream(conf);
+        conf_stream.imbue(std::locale::classic());
         BOOST_CHECK(parser.ReadConfigStream(conf_stream, "filepath", error));
         BOOST_CHECK_EQUAL(error, "");
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -175,8 +175,8 @@ struct TestArgsManager : public ArgsManager
     TestArgsManager() { m_network_only_args.clear(); }
     void ReadConfigString(const std::string str_config)
     {
-        std::istringstream streamConfig(str_config);
-        streamConfig.imbue(std::locale::classic());
+        std::stringstream streamConfig = LocaleIndependentStringStream();
+        streamConfig << str_config;
         {
             LOCK(cs_args);
             m_settings.ro_config.clear();
@@ -952,8 +952,8 @@ BOOST_FIXTURE_TEST_CASE(util_ArgsMerge, ArgsMergeTestingSetup)
             conf += conf_val;
             conf += "\n";
         }
-        std::istringstream conf_stream(conf);
-        conf_stream.imbue(std::locale::classic());
+        std::stringstream conf_stream = LocaleIndependentStringStream();
+        conf_stream << conf;
         BOOST_CHECK(parser.ReadConfigStream(conf_stream, "filepath", error));
         BOOST_CHECK_EQUAL(error, "");
 
@@ -1090,8 +1090,8 @@ BOOST_FIXTURE_TEST_CASE(util_ChainMerge, ChainMergeTestingSetup)
             conf += argstr + 1;
             conf += "\n";
         }
-        std::istringstream conf_stream(conf);
-        conf_stream.imbue(std::locale::classic());
+        std::stringstream conf_stream = LocaleIndependentStringStream();
+        conf_stream << conf;
         BOOST_CHECK(parser.ReadConfigStream(conf_stream, "filepath", error));
         BOOST_CHECK_EQUAL(error, "");
 

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -143,6 +143,7 @@ namespace tfm = tinyformat;
 // Implementation details.
 #include <algorithm>
 #include <iostream>
+#include <locale>    // Added for Bitcoin Core
 #include <sstream>
 #include <stdexcept> // Added for Bitcoin Core
 
@@ -288,6 +289,7 @@ template<typename T>
 inline void formatTruncated(std::ostream& out, const T& value, int ntrunc)
 {
     std::ostringstream tmp;
+    tmp.imbue(std::locale::classic()); // Added for Bitcoin Core
     tmp << value;
     std::string result = tmp.str();
     out.write(result.c_str(), (std::min)(ntrunc, static_cast<int>(result.size())));
@@ -912,6 +914,7 @@ inline void formatImpl(std::ostream& out, const char* fmt,
             // it crudely by formatting into a temporary string stream and
             // munging the resulting string.
             std::ostringstream tmpStream;
+            tmpStream.imbue(std::locale::classic()); // Added for Bitcoin Core
             tmpStream.copyfmt(out);
             tmpStream.setf(std::ios::showpos);
             arg.format(tmpStream, fmt, fmtEnd, ntrunc);
@@ -1070,6 +1073,7 @@ template<typename... Args>
 std::string format(const char* fmt, const Args&... args)
 {
     std::ostringstream oss;
+    oss.imbue(std::locale::classic()); // Added for Bitcoin Core
     format(oss, fmt, args...);
     return oss.str();
 }
@@ -1099,6 +1103,7 @@ inline void format(std::ostream& out, const char* fmt)
 inline std::string format(const char* fmt)
 {
     std::ostringstream oss;
+    oss.imbue(std::locale::classic()); // Added for Bitcoin Core
     format(oss, fmt);
     return oss.str();
 }
@@ -1126,6 +1131,7 @@ template<TINYFORMAT_ARGTYPES(n)>                                          \
 std::string format(const char* fmt, TINYFORMAT_VARARGS(n))                \
 {                                                                         \
     std::ostringstream oss;                                               \
+    oss.imbue(std::locale::classic()); /* Added for Bitcoin Core */       \
     format(oss, fmt, TINYFORMAT_PASSARGS(n));                             \
     return oss.str();                                                     \
 }                                                                         \
@@ -1152,9 +1158,7 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 template<typename... Args>
 std::string format(const std::string &fmt, const Args&... args)
 {
-    std::ostringstream oss;
-    format(oss, fmt.c_str(), args...);
-    return oss.str();
+    return format(fmt.c_str(), args...);
 }
 
 } // namespace tinyformat

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <locale>
 #include <sstream>
 #include <stdio.h>
 #include <tinyformat.h>
@@ -12,6 +13,7 @@
 bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)
 {
     std::stringstream ss(keypath_str);
+    ss.imbue(std::locale::classic());
     std::string item;
     bool first = true;
     while (std::getline(ss, item, '/')) {

--- a/src/util/bip32.cpp
+++ b/src/util/bip32.cpp
@@ -2,18 +2,17 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <locale>
 #include <sstream>
 #include <stdio.h>
 #include <tinyformat.h>
 #include <util/bip32.h>
 #include <util/strencodings.h>
-
+#include <util/string.h>
 
 bool ParseHDKeypath(const std::string& keypath_str, std::vector<uint32_t>& keypath)
 {
-    std::stringstream ss(keypath_str);
-    ss.imbue(std::locale::classic());
+    std::stringstream ss = LocaleIndependentStringStream();
+    ss << keypath_str;
     std::string item;
     bool first = true;
     while (std::getline(ss, item, '/')) {

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -9,11 +9,10 @@
 #include <tinyformat.h>
 
 #include <algorithm>
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
-#include <errno.h>
 #include <limits>
-#include <locale>
 
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -359,8 +358,8 @@ bool ParseDouble(const std::string& str, double *out)
         return false;
     if (str.size() >= 2 && str[0] == '0' && str[1] == 'x') // No hexadecimal floats allowed
         return false;
-    std::istringstream text(str);
-    text.imbue(std::locale::classic());
+    std::stringstream text = LocaleIndependentStringStream();
+    text << str;
     double result;
     text >> result;
     if(out) *out = result;
@@ -369,8 +368,7 @@ bool ParseDouble(const std::string& str, double *out)
 
 std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
 {
-    std::stringstream out;
-    out.imbue(std::locale::classic());
+    std::stringstream out = LocaleIndependentStringStream();
     size_t ptr = 0;
     size_t indented = 0;
     while (ptr < in.size())

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <errno.h>
 #include <limits>
+#include <locale>
 
 static const std::string CHARS_ALPHA_NUM = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
@@ -369,6 +370,7 @@ bool ParseDouble(const std::string& str, double *out)
 std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
 {
     std::stringstream out;
+    out.imbue(std::locale::classic());
     size_t ptr = 0;
     size_t indented = 0;
     while (ptr < in.size())

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -54,6 +54,17 @@ NODISCARD inline bool ValidAsCString(const std::string& str) noexcept
     return str.size() == strlen(str.c_str());
 }
 
+template <typename T>
+NODISCARD inline T LocaleIndependentStream() noexcept {
+    T stream;
+    stream.imbue(std::locale::classic());
+    return stream;
+}
+
+NODISCARD inline std::stringstream LocaleIndependentStringStream() noexcept {
+    return LocaleIndependentStream<std::stringstream>();
+}
+
 /**
  * Locale-independent version of std::to_string
  */

--- a/src/util/string.h
+++ b/src/util/string.h
@@ -54,15 +54,10 @@ NODISCARD inline bool ValidAsCString(const std::string& str) noexcept
     return str.size() == strlen(str.c_str());
 }
 
-template <typename T>
-NODISCARD inline T LocaleIndependentStream() noexcept {
-    T stream;
-    stream.imbue(std::locale::classic());
-    return stream;
-}
-
 NODISCARD inline std::stringstream LocaleIndependentStringStream() noexcept {
-    return LocaleIndependentStream<std::stringstream>();
+    std::stringstream ss;
+    ss.imbue(std::locale::classic());
+    return ss;
 }
 
 /**
@@ -71,8 +66,7 @@ NODISCARD inline std::stringstream LocaleIndependentStringStream() noexcept {
 template <typename T>
 std::string ToString(const T& t)
 {
-    std::ostringstream oss;
-    oss.imbue(std::locale::classic());
+    std::stringstream oss = LocaleIndependentStringStream();
     oss << t;
     return oss.str();
 }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -6,10 +6,10 @@
 #include <wallet/db.h>
 
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/translation.h>
 
-#include <locale>
-#include <stdint.h>
+#include <cstdint>
 
 #ifndef WIN32
 #include <sys/stat.h>
@@ -453,8 +453,7 @@ bool BerkeleyEnvironment::Salvage(const std::string& strFile, bool fAggressive, 
     if (fAggressive)
         flags |= DB_AGGRESSIVE;
 
-    std::stringstream strDump;
-    strDump.imbue(std::locale::classic());
+    std::stringstream strDump = LocaleIndependentStringStream();
 
     Db db(dbenv.get(), 0);
     int result = db.verify(strFile.c_str(), nullptr, &strDump, flags);

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -8,6 +8,7 @@
 #include <util/strencodings.h>
 #include <util/translation.h>
 
+#include <locale>
 #include <stdint.h>
 
 #ifndef WIN32
@@ -453,6 +454,7 @@ bool BerkeleyEnvironment::Salvage(const std::string& strFile, bool fAggressive, 
         flags |= DB_AGGRESSIVE;
 
     std::stringstream strDump;
+    strDump.imbue(std::locale::classic());
 
     Db db(dbenv.get(), 0);
     int result = db.verify(strFile.c_str(), nullptr, &strDump, flags);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -13,13 +13,13 @@
 #include <script/standard.h>
 #include <sync.h>
 #include <util/bip32.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <util/translation.h>
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 
-#include <locale>
 #include <stdint.h>
 #include <tuple>
 
@@ -32,8 +32,7 @@
 using interfaces::FoundBlock;
 
 std::string static EncodeDumpString(const std::string &str) {
-    std::stringstream ret;
-    ret.imbue(std::locale::classic());
+    std::stringstream ret = LocaleIndependentStringStream();
     for (const unsigned char c : str) {
         if (c <= 32 || c >= 128 || c == '%') {
             ret << '%' << HexStr(&c, &c + 1);
@@ -45,8 +44,7 @@ std::string static EncodeDumpString(const std::string &str) {
 }
 
 static std::string DecodeDumpString(const std::string &str) {
-    std::stringstream ret;
-    ret.imbue(std::locale::classic());
+    std::stringstream ret = LocaleIndependentStringStream();
     for (unsigned int pos = 0; pos < str.length(); pos++) {
         unsigned char c = str[pos];
         if (c == '%' && pos+2 < str.length()) {

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -19,6 +19,7 @@
 #include <wallet/rpcwallet.h>
 #include <wallet/wallet.h>
 
+#include <locale>
 #include <stdint.h>
 #include <tuple>
 
@@ -32,6 +33,7 @@ using interfaces::FoundBlock;
 
 std::string static EncodeDumpString(const std::string &str) {
     std::stringstream ret;
+    ret.imbue(std::locale::classic());
     for (const unsigned char c : str) {
         if (c <= 32 || c >= 128 || c == '%') {
             ret << '%' << HexStr(&c, &c + 1);
@@ -44,6 +46,7 @@ std::string static EncodeDumpString(const std::string &str) {
 
 static std::string DecodeDumpString(const std::string &str) {
     std::stringstream ret;
+    ret.imbue(std::locale::classic());
     for (unsigned int pos = 0; pos < str.length(); pos++) {
         unsigned char c = str[pos];
         if (c == '%' && pos+2 < str.length()) {


### PR DESCRIPTION
Make our `stringstream` usage locale independent.

As discussed with laanwj in https://github.com/bitcoin/bitcoin/pull/18134#issuecomment-604031929. Fixes #18281.