### PR TITLE
ci: Fix brew in Travis

### DIFF
--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -19,7 +19,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   git reset --hard origin/master
   popd || exit 1
   set -o errexit
-  ${CI_RETRY_EXE} brew unlink python@2
   ${CI_RETRY_EXE} brew update
   # brew upgrade returns an error if any of the packages is already up to date
   # Failure is safe to ignore, unless we really need an update.


### PR DESCRIPTION
Since the latest macOS image [update](https://changelog.travis-ci.com/xcode-11-3-1-xcode-11-2-1-xcode-11-1-and-xcode11-images-updated-142286) from 10.14.4 (18E226) to 10.14.6 (18G3020), Travis fails with an error:
```
Error: No such keg: /usr/local/Cellar/python@2
```

~This PR is to test a fix.~