### PR TITLE
ci: Use Homebrew addon on native macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,8 +153,20 @@ jobs:
       name: 'macOS 10.14 native [GOAL: install] [GUI] [no depends]'
       os: osx
       # Use the most recent version:
-      # Xcode 11.2.1, macOS 10.14, JDK 13.0.1, SDK 10.15
+      # Xcode 11.3.1, macOS 10.14, SDK 10.15
       # https://docs.travis-ci.com/user/reference/osx/#macos-version
-      osx_image: xcode11.2
+      osx_image: xcode11.3
+      addons:
+        homebrew:
+          packages:
+          - libtool
+          - berkeley-db4
+          - boost
+          - miniupnpc
+          - qt
+          - qrencode
+          - python3
+          - ccache
+          - zeromq
       env: >-
         FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/ci/test/00_setup_env_mac_host.sh
+++ b/ci/test/00_setup_env_mac_host.sh
@@ -7,7 +7,6 @@
 export LC_ALL=C.UTF-8
 
 export HOST=x86_64-apple-darwin16
-export BREW_PACKAGES="automake berkeley-db4 libtool boost miniupnpc pkg-config qt qrencode python3 ccache zeromq"
 export PIP_PACKAGES="zmq"
 export RUN_CI_ON_HOST=true
 export RUN_UNIT_TESTS=true

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -14,27 +14,8 @@ if [[ $QEMU_USER_CMD == qemu-s390* ]]; then
 fi
 
 if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-  set +o errexit
-  pushd /usr/local/Homebrew || exit 1
-  git reset --hard origin/master
-  popd || exit 1
-  set -o errexit
-  ${CI_RETRY_EXE} brew update
-  # brew upgrade returns an error if any of the packages is already up to date
-  # Failure is safe to ignore, unless we really need an update.
-  brew upgrade $BREW_PACKAGES || true
-
-  # install new packages (brew install returns an error if already installed)
-  for i in $BREW_PACKAGES; do
-    if ! brew list | grep -q $i; then
-      ${CI_RETRY_EXE} brew install $i
-    fi
-  done
-
   export PATH="/usr/local/opt/ccache/libexec:$PATH"
-
   ${CI_RETRY_EXE} pip3 install $PIP_PACKAGES
-
 fi
 
 mkdir -p "${BASE_SCRATCH_DIR}"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -19,7 +19,6 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
   git reset --hard origin/master
   popd || exit 1
   set -o errexit
-  ${CI_RETRY_EXE} brew unlink python@2
   ${CI_RETRY_EXE} brew update
   # brew upgrade returns an error if any of the packages is already up to date
   # Failure is safe to ignore, unless we really need an update.


### PR DESCRIPTION
Recently almost every macOS image update on Travis breaks our builds:
- #17848
- #18436 

This PR:
- fixes the error caused by the recent [update](https://changelog.travis-ci.com/xcode-11-3-1-xcode-11-2-1-xcode-11-1-and-xcode11-images-updated-142286) from 10.14.4 (18E226) to 10.14.6 (18G3020) on March 25
- leverages [Homebrew addon](https://config.travis-ci.com/ref/job/addons/homebrew) to install packages

Homebrew is not told to install `automake` and `pkg-config` packages, as the [docs](https://docs.travis-ci.com/user/reference/osx/#compilers-and-build-toolchain) states that they are pre-installed:
>    - automake 1.16.1
>    - pkg-config 0.29.2