### PR TITLE
ci: Remove misplaced comments from folded block scalar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@
 # [1] https://docs.travis-ci.com/user/caching/#build-phases
 # [2] https://docs.travis-ci.com/user/customizing-the-build#build-timeouts
 
+version: ~> 1.0
+
 dist: xenial
 os: linux
 language: minimal
@@ -84,19 +86,19 @@ jobs:
 
     - stage: test
       name: 'ARM  [GOAL: install]  [buster]  [unit tests, functional tests]'
-      arch: arm64
+      arch: arm64  # Can disable QEMU_USER_CMD and run the tests natively without qemu
       env: >-
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
-        QEMU_USER_CMD=""  # Can run the tests natively without qemu
+        QEMU_USER_CMD=""
 
 # s390 build was disabled temporarily because of disk space issues on the Travis VM
 #
 #    - stage: test
 #      name: 'S390x  [GOAL: install]  [buster]  [unit tests, functional tests]'
-#      arch: s390x
+#      arch: s390x  # Can disable QEMU_USER_CMD and run the tests natively without qemu
 #      env: >-
 #        FILE_ENV="./ci/test/00_setup_env_s390x.sh"
-#        QEMU_USER_CMD=""  # Can run the tests natively without qemu
+#        QEMU_USER_CMD=""
 
     - stage: test
       name: 'Win64  [GOAL: deploy]  [unit tests, no gui, no functional tests]'


### PR DESCRIPTION
On master (f3a91ab0edc70e1bcb7e770f0878f03459c399e1) the [build log for ARM](https://travis-ci.org/github/bitcoin/bitcoin/jobs/667247758) contains:
```
$ export FILE_ENV="./ci/test/00_setup_env_arm.sh"
$ export QEMU_USER_CMD=""
$ export Can=
$ export run=
$ export the=
$ export tests=
$ export natively=
$ export without=
$ export qemu=

Setting up build cache
...
```
and
![Screenshot from 2020-03-26 18-58-50](https://user-images.githubusercontent.com/32963518/77674223-e28d2d00-6f93-11ea-82a1-7f805ccb678d.png)

With this PR:
```
$ export FILE_ENV="./ci/test/00_setup_env_arm.sh"
$ export QEMU_USER_CMD=""

Setting up build cache
...
```

and
![Screenshot from 2020-03-26 19-01-56](https://user-images.githubusercontent.com/32963518/77674456-4d3e6880-6f94-11ea-9c83-546c81f1cdf7.png)

---

Also Travis [build config validation](https://docs.travis-ci.com/user/build-config-validation) added:
![Screenshot from 2020-03-26 19-04-19](https://user-images.githubusercontent.com/32963518/77674686-9ee6f300-6f94-11ea-900f-fdef8a673113.png)
