### PR TITLE
RPC: Remove final comma for last entry of fixed-size arrays/objects in RPCResult

### DIFF
--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -293,7 +293,7 @@ UniValue JSONRPCTransactionError(TransactionError terr, const std::string& err_s
 struct Section {
     Section(const std::string& left, const std::string& right)
         : m_left{left}, m_right{right} {}
-    const std::string m_left;
+    std::string m_left;
     const std::string m_right;
 };
 
@@ -645,6 +645,10 @@ void RPCResult::ToSections(Sections& sections, const OuterType outer_type, const
         }
         if (m_type == Type::ARR) {
             sections.PushSection({indent_next + "...", ""});
+        } else {
+            CHECK_NONFATAL(!m_inner.empty());
+            // Remove final comma, which would be invalid JSON
+            sections.m_sections.back().m_left.pop_back();
         }
         sections.PushSection({indent + "]" + maybe_separator, ""});
         return;
@@ -658,6 +662,10 @@ void RPCResult::ToSections(Sections& sections, const OuterType outer_type, const
         if (m_type == Type::OBJ_DYN) {
             // If the dictionary keys are dynamic, use three dots for continuation
             sections.PushSection({indent_next + "...", ""});
+        } else {
+            CHECK_NONFATAL(!m_inner.empty());
+            // Remove final comma, which would be invalid JSON
+            sections.m_sections.back().m_left.pop_back();
         }
         sections.PushSection({indent + "}" + maybe_separator, ""});
         return;


### PR DESCRIPTION
JSON doesn't allow a trailing comma in arrays
