### PR TITLE
tests: Add fuzzing harnesses for functions/classes in chain.h and protocol.h

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -83,6 +83,7 @@ FUZZ_TARGETS = \
   test/fuzz/process_message_tx \
   test/fuzz/process_message_verack \
   test/fuzz/process_message_version \
+  test/fuzz/protocol \
   test/fuzz/psbt \
   test/fuzz/psbt_input_deserialize \
   test/fuzz/psbt_output_deserialize \
@@ -765,6 +766,12 @@ test_fuzz_process_message_version_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_process_message_version_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_process_message_version_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_process_message_version_SOURCES = $(FUZZ_SUITE) test/fuzz/process_message.cpp
+
+test_fuzz_protocol_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_protocol_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_protocol_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_protocol_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_protocol_SOURCES = $(FUZZ_SUITE) test/fuzz/protocol.cpp
 
 test_fuzz_psbt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_psbt_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -26,6 +26,7 @@ FUZZ_TARGETS = \
   test/fuzz/blockundo_deserialize \
   test/fuzz/bloom_filter \
   test/fuzz/bloomfilter_deserialize \
+  test/fuzz/chain \
   test/fuzz/coins_deserialize \
   test/fuzz/decode_tx \
   test/fuzz/descriptor_parse \
@@ -424,6 +425,12 @@ test_fuzz_bloomfilter_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_bloomfilter_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_bloomfilter_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_bloomfilter_deserialize_SOURCES = $(FUZZ_SUITE) test/fuzz/deserialize.cpp
+
+test_fuzz_chain_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_chain_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_chain_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_chain_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_chain_SOURCES = $(FUZZ_SUITE) test/fuzz/chain.cpp
 
 test_fuzz_coins_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DCOINS_DESERIALIZE=1
 test_fuzz_coins_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <optional.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    Optional<CDiskBlockIndex> disk_block_index = ConsumeDeserializable<CDiskBlockIndex>(fuzzed_data_provider);
+    if (!disk_block_index) {
+        return;
+    }
+
+    const uint256 zero{};
+    disk_block_index->phashBlock = &zero;
+    (void)disk_block_index->GetBlockHash();
+    (void)disk_block_index->GetBlockPos();
+    (void)disk_block_index->GetBlockTime();
+    (void)disk_block_index->GetBlockTimeMax();
+    (void)disk_block_index->GetMedianTimePast();
+    (void)disk_block_index->GetUndoPos();
+    (void)disk_block_index->HaveTxsDownloaded();
+    (void)disk_block_index->IsValid();
+    (void)disk_block_index->ToString();
+
+    const CBlockHeader block_header = disk_block_index->GetBlockHeader();
+    (void)CDiskBlockIndex{*disk_block_index};
+    (void)disk_block_index->BuildSkip();
+
+    while (fuzzed_data_provider.ConsumeBool()) {
+        const BlockStatus block_status = fuzzed_data_provider.PickValueInArray({
+            BlockStatus::BLOCK_VALID_UNKNOWN,
+            BlockStatus::BLOCK_VALID_RESERVED,
+            BlockStatus::BLOCK_VALID_TREE,
+            BlockStatus::BLOCK_VALID_TRANSACTIONS,
+            BlockStatus::BLOCK_VALID_CHAIN,
+            BlockStatus::BLOCK_VALID_SCRIPTS,
+            BlockStatus::BLOCK_VALID_MASK,
+            BlockStatus::BLOCK_HAVE_DATA,
+            BlockStatus::BLOCK_HAVE_UNDO,
+            BlockStatus::BLOCK_HAVE_MASK,
+            BlockStatus::BLOCK_FAILED_VALID,
+            BlockStatus::BLOCK_FAILED_CHILD,
+            BlockStatus::BLOCK_FAILED_MASK,
+            BlockStatus::BLOCK_OPT_WITNESS,
+        });
+        if (block_status & ~BLOCK_VALID_MASK) {
+            continue;
+        }
+        (void)disk_block_index->RaiseValidity(block_status);
+    }
+
+    CBlockIndex block_index{block_header};
+    block_index.phashBlock = &zero;
+    (void)block_index.GetBlockHash();
+    (void)block_index.ToString();
+}

--- a/src/test/fuzz/protocol.cpp
+++ b/src/test/fuzz/protocol.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <protocol.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const Optional<CInv> inv = ConsumeDeserializable<CInv>(fuzzed_data_provider);
+    if (!inv) {
+        return;
+    }
+    try {
+        (void)inv->GetCommand();
+    } catch (const std::out_of_range&) {
+    }
+    (void)inv->ToString();
+    const Optional<CInv> another_inv = ConsumeDeserializable<CInv>(fuzzed_data_provider);
+    if (!another_inv) {
+        return;
+    }
+    (void)(*inv < *another_inv);
+}


### PR DESCRIPTION
Add fuzzing harnesses for functions/classes in `chain.h` and `protocol.h`.