### PR TITLE
util: Remove unused itostr

### DIFF
--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -27,6 +27,7 @@
 #include <univalue.h>
 #include <util/fees.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <validation.h>
 #include <validationinterface.h>
@@ -694,7 +695,7 @@ static UniValue getblocktemplate(const JSONRPCRequest& request)
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
     result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
-    result.pushKV("longpollid", ::ChainActive().Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
+    result.pushKV("longpollid", ::ChainActive().Tip()->GetBlockHash().GetHex() + ToString(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1);
     result.pushKV("mutable", aMutable);

--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -13,9 +13,9 @@
 #include <util/strencodings.h>
 #include <util/threadnames.h>
 
-#include <system_error>
 #include <map>
 #include <set>
+#include <system_error>
 
 #ifdef DEBUG_LOCKCONTENTION
 #if !defined(HAVE_THREAD_LOCAL)
@@ -57,7 +57,7 @@ struct CLockLocation {
     {
         return strprintf(
             "%s %s:%s%s (in thread %s)",
-            mutexName, sourceFile, itostr(sourceLine), (fTry ? " (TRY)" : ""), m_thread_name);
+            mutexName, sourceFile, sourceLine, (fTry ? " (TRY)" : ""), m_thread_name);
     }
 
     std::string Name() const

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -27,6 +27,7 @@
 #include <uint256.h>
 #include <util/moneystr.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <util/time.h>
 #include <version.h>
@@ -93,7 +94,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     // (void)GetVirtualTransactionSize(i64, i64, u32); // function defined only for a subset of int64_t/uint32_t inputs
     (void)HexDigit(ch);
     (void)MoneyRange(i64);
-    (void)i64tostr(i64);
+    (void)ToString(i64);
     (void)IsDigit(ch);
     (void)IsSpace(ch);
     (void)IsSwitchChar(ch);

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -97,7 +97,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     (void)IsDigit(ch);
     (void)IsSpace(ch);
     (void)IsSwitchChar(ch);
-    (void)itostr(i32);
     (void)memusage::DynamicUsage(ch);
     (void)memusage::DynamicUsage(i16);
     (void)memusage::DynamicUsage(i32);

--- a/src/test/fuzz/locale.cpp
+++ b/src/test/fuzz/locale.cpp
@@ -6,6 +6,7 @@
 #include <test/fuzz/fuzz.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 
 #include <cassert>
 #include <clocale>
@@ -54,7 +55,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const int atoi_without_locale = atoi(random_string);
     const int64_t atoi64c_without_locale = atoi64(random_string.c_str());
     const int64_t random_int64 = fuzzed_data_provider.ConsumeIntegral<int64_t>();
-    const std::string i64tostr_without_locale = i64tostr(random_int64);
+    const std::string tostring_without_locale = ToString(random_int64);
     const int32_t random_int32 = fuzzed_data_provider.ConsumeIntegral<int32_t>();
     const std::string strprintf_int_without_locale = strprintf("%d", random_int64);
     const double random_double = fuzzed_data_provider.ConsumeFloatingPoint<double>();
@@ -81,8 +82,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     assert(atoi64c_without_locale == atoi64c_with_locale);
     const int atoi_with_locale = atoi(random_string);
     assert(atoi_without_locale == atoi_with_locale);
-    const std::string i64tostr_with_locale = i64tostr(random_int64);
-    assert(i64tostr_without_locale == i64tostr_with_locale);
+    const std::string tostring_with_locale = ToString(random_int64);
+    assert(tostring_without_locale == tostring_with_locale);
     const std::string strprintf_int_with_locale = strprintf("%d", random_int64);
     assert(strprintf_int_without_locale == strprintf_int_with_locale);
     const std::string strprintf_double_with_locale = strprintf("%f", random_double);

--- a/src/test/fuzz/locale.cpp
+++ b/src/test/fuzz/locale.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
 
@@ -56,7 +56,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const int64_t random_int64 = fuzzed_data_provider.ConsumeIntegral<int64_t>();
     const std::string i64tostr_without_locale = i64tostr(random_int64);
     const int32_t random_int32 = fuzzed_data_provider.ConsumeIntegral<int32_t>();
-    const std::string itostr_without_locale = itostr(random_int32);
     const std::string strprintf_int_without_locale = strprintf("%d", random_int64);
     const double random_double = fuzzed_data_provider.ConsumeFloatingPoint<double>();
     const std::string strprintf_double_without_locale = strprintf("%f", random_double);
@@ -84,8 +83,6 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     assert(atoi_without_locale == atoi_with_locale);
     const std::string i64tostr_with_locale = i64tostr(random_int64);
     assert(i64tostr_without_locale == i64tostr_with_locale);
-    const std::string itostr_with_locale = itostr(random_int32);
-    assert(itostr_without_locale == itostr_with_locale);
     const std::string strprintf_int_with_locale = strprintf("%d", random_int64);
     assert(strprintf_int_without_locale == strprintf_int_with_locale);
     const std::string strprintf_double_with_locale = strprintf("%f", random_double);

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -412,11 +412,6 @@ std::string i64tostr(int64_t n)
     return strprintf("%d", n);
 }
 
-std::string itostr(int n)
-{
-    return strprintf("%d", n);
-}
-
 int64_t atoi64(const char* psz)
 {
 #ifdef _MSC_VER

--- a/src/util/strencodings.cpp
+++ b/src/util/strencodings.cpp
@@ -407,11 +407,6 @@ std::string FormatParagraph(const std::string& in, size_t width, size_t indent)
     return out.str();
 }
 
-std::string i64tostr(int64_t n)
-{
-    return strprintf("%d", n);
-}
-
 int64_t atoi64(const char* psz)
 {
 #ifdef _MSC_VER

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -55,7 +55,6 @@ std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
 void SplitHostPort(std::string in, int& portOut, std::string& hostOut);
-std::string i64tostr(int64_t n);
 int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);

--- a/src/util/strencodings.h
+++ b/src/util/strencodings.h
@@ -54,9 +54,8 @@ std::string DecodeBase32(const std::string& str, bool* pf_invalid = nullptr);
 std::string EncodeBase32(const unsigned char* pch, size_t len);
 std::string EncodeBase32(const std::string& str);
 
-void SplitHostPort(std::string in, int &portOut, std::string &hostOut);
+void SplitHostPort(std::string in, int& portOut, std::string& hostOut);
 std::string i64tostr(int64_t n);
-std::string itostr(int n);
 int64_t atoi64(const char* psz);
 int64_t atoi64(const std::string& str);
 int atoi(const std::string& str);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -16,6 +16,7 @@
 #include <ui_interface.h>
 #include <util/message.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <validationinterface.h>
 #include <wallet/coinselection.h>
@@ -215,7 +216,7 @@ static inline void WriteOrderPos(const int64_t& nOrderPos, mapValue_t& mapValue)
 {
     if (nOrderPos == -1)
         return;
-    mapValue["n"] = i64tostr(nOrderPos);
+    mapValue["n"] = ToString(nOrderPos);
 }
 
 struct COutputEntry


### PR DESCRIPTION
Currently unused, but if someone really needed to use a helper with this functionality in the future, they could use `ToString`.