### PR TITLE
util: Use locale independent ToString(…) instead of locale dependent strprintf(…) for low-level string formatting

### DIFF
--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -12,8 +12,9 @@
 #include <serialize.h>
 #include <streams.h>
 #include <univalue.h>
-#include <util/system.h>
 #include <util/strencodings.h>
+#include <util/string.h>
+#include <util/system.h>
 
 UniValue ValueFromAmount(const CAmount& amount)
 {
@@ -99,7 +100,7 @@ std::string ScriptToAsmStr(const CScript& script, const bool fAttemptSighashDeco
         }
         if (0 <= opcode && opcode <= OP_PUSHDATA4) {
             if (vch.size() <= static_cast<std::vector<unsigned char>::size_type>(4)) {
-                str += strprintf("%d", CScriptNum(vch, false).getint());
+                str += ToString(CScriptNum(vch, false).getint());
             } else {
                 // the IsUnspendable check makes sure not to try to decode OP_RETURN data that may match the format of a signature
                 if (fAttemptSighashDecode && !script.IsUnspendable()) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -14,13 +14,14 @@
 #include <clientversion.h>
 #include <consensus/consensus.h>
 #include <crypto/sha256.h>
-#include <netbase.h>
 #include <net_permissions.h>
+#include <netbase.h>
 #include <protocol.h>
 #include <random.h>
 #include <scheduler.h>
 #include <ui_interface.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/translation.h>
 
 #ifdef WIN32
@@ -1471,7 +1472,7 @@ static CThreadInterrupt g_upnp_interrupt;
 static std::thread g_upnp_thread;
 static void ThreadMapPort()
 {
-    std::string port = strprintf("%u", GetListenPort());
+    std::string port = ToString(GetListenPort());
     const char * multicastif = nullptr;
     const char * minissdpdpath = nullptr;
     struct UPNPDev * devlist = nullptr;

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -4,10 +4,12 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <netaddress.h>
+
 #include <hash.h>
-#include <util/strencodings.h>
-#include <util/asmap.h>
 #include <tinyformat.h>
+#include <util/asmap.h>
+#include <util/strencodings.h>
+#include <util/string.h>
 
 static const unsigned char pchIPv4[12] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff };
 static const unsigned char pchOnionCat[] = {0xFD,0x87,0xD8,0x7E,0xEB,0x43};
@@ -735,7 +737,7 @@ std::vector<unsigned char> CService::GetKey() const
 
 std::string CService::ToStringPort() const
 {
-    return strprintf("%u", port);
+    return ::ToString(port);
 }
 
 std::string CService::ToStringIPPort() const
@@ -865,7 +867,7 @@ std::string CSubNet::ToString() const
     /* Format output */
     std::string strNetmask;
     if (valid_cidr) {
-        strNetmask = strprintf("%u", cidr);
+        strNetmask = ::ToString(cidr);
     } else {
         if (network.IsIPv4())
             strNetmask = strprintf("%u.%u.%u.%u", netmask[12], netmask[13], netmask[14], netmask[15]);

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -797,7 +797,7 @@ bool ConnectThroughProxy(const proxyType &proxy, const std::string& strDest, int
     if (proxy.randomize_credentials) {
         ProxyCredentials random_auth;
         static std::atomic_int counter(0);
-        random_auth.username = random_auth.password = strprintf("%i", counter++);
+        random_auth.username = random_auth.password = ToString(counter++);
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket)) {
             return false;
         }

--- a/src/script/descriptor.cpp
+++ b/src/script/descriptor.cpp
@@ -8,12 +8,12 @@
 #include <pubkey.h>
 #include <script/script.h>
 #include <script/standard.h>
-
 #include <span.h>
 #include <util/bip32.h>
 #include <util/spanparsing.h>
-#include <util/system.h>
 #include <util/strencodings.h>
+#include <util/string.h>
+#include <util/system.h>
 #include <util/vector.h>
 
 #include <memory>
@@ -678,7 +678,7 @@ class MultisigDescriptor final : public DescriptorImpl
     const int m_threshold;
     const bool m_sorted;
 protected:
-    std::string ToStringExtra() const override { return strprintf("%i", m_threshold); }
+    std::string ToStringExtra() const override { return ::ToString(m_threshold); }
     std::vector<CScript> MakeScripts(const std::vector<CPubKey>& keys, const CScript*, FlatSigningProvider&) const override {
         if (m_sorted) {
             std::vector<CPubKey> sorted_keys(keys);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -42,6 +42,7 @@
 #include <util/moneystr.h>
 #include <util/rbf.h>
 #include <util/strencodings.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <util/translation.h>
 #include <validationinterface.h>
@@ -714,7 +715,7 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
 
     if (nSigOpsCost > MAX_STANDARD_TX_SIGOPS_COST)
         return state.Invalid(TxValidationResult::TX_NOT_STANDARD, "bad-txns-too-many-sigops",
-                strprintf("%d", nSigOpsCost));
+                             ToString(nSigOpsCost));
 
     // No transactions are allowed below minRelayTxFee except from disconnected
     // blocks

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -4222,7 +4222,7 @@ static UniValue upgradewallet(const JSONRPCRequest& request)
         "\nUpgrade the wallet. Upgrades to the latest version if no version number is specified\n"
         "New keys may be generated and a new wallet backup will need to be made.",
         {
-            {"version", RPCArg::Type::NUM, /* default */ strprintf("%d", FEATURE_LATEST), "The version number to upgrade to. Default is the latest wallet version"}
+            {"version", RPCArg::Type::NUM, /* default */ ToString(FEATURE_LATEST), "The version number to upgrade to. Default is the latest wallet version"}
         },
         RPCResults{},
         RPCExamples{

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -402,7 +402,7 @@ public:
         mapValueCopy["fromaccount"] = "";
         WriteOrderPos(nOrderPos, mapValueCopy);
         if (nTimeSmart) {
-            mapValueCopy["timesmart"] = strprintf("%u", nTimeSmart);
+            mapValueCopy["timesmart"] = ToString(nTimeSmart);
         }
 
         std::vector<char> dummy_vector1; //!< Used to be vMerkleBranch


### PR DESCRIPTION
Use locale independent `ToString(…)` instead of locale dependent `strprintf(…)` for low-level string formatting.

Context: See sipas comment in https://github.com/bitcoin/bitcoin/pull/18147#issuecomment-604727148.

Example taken from #18281:

> Low level functions `ScriptToAsmStr` (`core_io`), `i64tostr` (`strencodings`) and `itostr` (`strencodings`) are locale dependent:
> 
> ```c++
> const std::vector<uint8_t> b{0x6a, 0x4, 0xff, 0xff, 0xff, 0xff};
> const CScript script{b.begin(), b.end()};
> for (const std::string& locale_string : {"C", "de_DE"}) {
>     std::locale::global(std::locale(locale_string));
>     std::cout << "[" << locale_string << "] ScriptToAsmStr(script, false) == " 
>         << ScriptToAsmStr(script, false) << "\n";
> }
> ```
> 
> ```
> [C] ScriptToAsmStr(script, false) == OP_RETURN -2147483647
> [de_DE] ScriptToAsmStr(script, false) == OP_RETURN -2.147.483.647
> ```

Fixes #18281.