### PR TITLE
rpc, cli: add multiwallet balances rpc and use it in -getinfo

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -230,7 +230,7 @@ public:
     const int ID_NETWORKINFO = 0;
     const int ID_BLOCKCHAININFO = 1;
     const int ID_WALLETINFO = 2;
-    const int ID_BALANCES = 3;
+    const int ID_WALLETBALANCES = 3;
 
     /** Create a simulated `getinfo` request. */
     UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) override
@@ -242,7 +242,7 @@ public:
         result.push_back(JSONRPCRequestObj("getnetworkinfo", NullUniValue, ID_NETWORKINFO));
         result.push_back(JSONRPCRequestObj("getblockchaininfo", NullUniValue, ID_BLOCKCHAININFO));
         result.push_back(JSONRPCRequestObj("getwalletinfo", NullUniValue, ID_WALLETINFO));
-        result.push_back(JSONRPCRequestObj("getbalances", NullUniValue, ID_BALANCES));
+        result.push_back(JSONRPCRequestObj("getwalletbalances", NullUniValue, ID_WALLETBALANCES));
         return result;
     }
 
@@ -252,7 +252,7 @@ public:
         UniValue result(UniValue::VOBJ);
         std::vector<UniValue> batch = JSONRPCProcessBatchReply(batch_in, batch_in.size());
         // Errors in getnetworkinfo() and getblockchaininfo() are fatal, pass them on;
-        // getwalletinfo() and getbalances() are allowed to fail if there is no wallet.
+        // getwalletinfo() and getwalletbalances() are allowed to fail if there is no wallet.
         if (!batch[ID_NETWORKINFO]["error"].isNull()) {
             return batch[ID_NETWORKINFO];
         }
@@ -275,10 +275,10 @@ public:
             }
             result.pushKV("paytxfee", batch[ID_WALLETINFO]["result"]["paytxfee"]);
         }
-        if (!batch[ID_BALANCES]["result"].isNull()) {
-            result.pushKV("balance", batch[ID_BALANCES]["result"]["mine"]["trusted"]);
-        }
         result.pushKV("relayfee", batch[ID_NETWORKINFO]["result"]["relayfee"]);
+        if (!batch[ID_WALLETBALANCES]["result"].isNull()) {
+            result.pushKV("balances", batch[ID_WALLETBALANCES]["result"]);
+        }
         result.pushKV("warnings", batch[ID_NETWORKINFO]["result"]["warnings"]);
         return JSONRPCReplyObj(result, NullUniValue, 1);
     }

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -65,7 +65,7 @@ class TestBitcoinCli(BitcoinTestFramework):
 
         if self.is_wallet_compiled():
             self.log.info("Test -getinfo and bitcoin-cli getwalletinfo return expected wallet info")
-            assert_equal(cli_get_info['balance'], BALANCE)
+            assert_equal(cli_get_info['balances'], {'': BALANCE})
             wallet_info = self.nodes[0].getwalletinfo()
             assert_equal(cli_get_info['keypoolsize'], wallet_info['keypoolsize'])
             assert_equal(cli_get_info['unlocked_until'], wallet_info['unlocked_until'])


### PR DESCRIPTION
This PR implements point 2 from #17314 (show balance per wallet):

- create an RPC that returns the ismine.trusted balance for all loaded wallets
- update `bitcoin-cli -getinfo` to use the RPC

before
```json
$ bitcoin-cli -getinfo -regtest
{
  "version": 199900,
  "blocks": 15599,
  "headers": 15599,
  "verificationprogress": 1,
  "timeoffset": 0,
  "connections": 0,
  "proxy": "",
  "difficulty": 4.656542373906925e-10,
  "chain": "regtest",
  "keypoolsize": 1000,
  "paytxfee": 0.00000000,
  "balance": 0.00001000,
  "relayfee": 0.00001000
}

```
after
```json
$ bitcoin-cli -getinfo -regtest
{
  "version": 199900,
  "blocks": 15599,
  "headers": 15599,
  "verificationprogress": 1,
  "timeoffset": 0,
  "connections": 0,
  "proxy": "",
  "difficulty": 4.656542373906925e-10,
  "chain": "regtest",
  "balances": {
    "": 0.00001000,
    "Encrypted": 0.00003500,
    "day-to-day": 0.00000120,
    "side project": 0.00000094
  },
  "relayfee": 0.00001000
}
```
-----
`Review club` discussion about this PR is here: https://bitcoincore.reviews/18453.

This approach is simpler, adds no additional rpc calls in -getinfo and runs faster than doing it on the client side inside bitcoin-cli.cpp, but it also adds the first multiwallet RPC and would need to be well-considered in terms of the API.