### PR TITLE
net: Make addr relay mockable, add test

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -797,8 +797,8 @@ public:
     std::vector<CAddress> vAddrToSend;
     const std::unique_ptr<CRollingBloomFilter> m_addr_known;
     bool fGetAddr{false};
-    int64_t nNextAddrSend GUARDED_BY(cs_sendProcessing){0};
-    int64_t nNextLocalAddrSend GUARDED_BY(cs_sendProcessing){0};
+    std::chrono::microseconds m_next_addr_send GUARDED_BY(cs_sendProcessing){0};
+    std::chrono::microseconds m_next_local_addr_send GUARDED_BY(cs_sendProcessing){0};
 
     bool IsAddrRelayPeer() const { return m_addr_known != nullptr; }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1365,7 +1365,7 @@ void RelayTransaction(const uint256& txid, const CConnman& connman)
     });
 }
 
-static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connman)
+static void RelayAddress(const CAddress& addr, bool fReachable, const CConnman& connman)
 {
     unsigned int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
 
@@ -1373,7 +1373,7 @@ static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connma
     // Use deterministic randomness to send to the same nodes for 24 hours
     // at a time so the m_addr_knowns of the chosen nodes prevent repeats
     uint64_t hashAddr = addr.GetHash();
-    const CSipHasher hasher = connman->GetDeterministicRandomizer(RANDOMIZER_ID_ADDRESS_RELAY).Write(hashAddr << 32).Write((GetTime() + hashAddr) / (24*60*60));
+    const CSipHasher hasher = connman.GetDeterministicRandomizer(RANDOMIZER_ID_ADDRESS_RELAY).Write(hashAddr << 32).Write((GetTime() + hashAddr) / (24 * 60 * 60));
     FastRandomContext insecure_rand;
 
     std::array<std::pair<uint64_t, CNode*>,2> best{{{0, nullptr}, {0, nullptr}}};
@@ -1398,7 +1398,7 @@ static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connma
         }
     };
 
-    connman->ForEachNodeThen(std::move(sortfunc), std::move(pushfunc));
+    connman.ForEachNodeThen(std::move(sortfunc), std::move(pushfunc));
 }
 
 void static ProcessGetBlockData(CNode* pfrom, const CChainParams& chainparams, const CInv& inv, CConnman* connman)
@@ -2192,7 +2192,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStream& vR
             if (addr.nTime > nSince && !pfrom->fGetAddr && vAddr.size() <= 10 && addr.IsRoutable())
             {
                 // Relay to a limited number of other nodes
-                RelayAddress(addr, fReachable, connman);
+                RelayAddress(addr, fReachable, *connman);
             }
             // Do not store addresses outside our network
             if (fReachable)

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test addr relay
+"""
+
+from test_framework.messages import (
+    CAddress,
+    NODE_NETWORK,
+    NODE_WITNESS,
+    msg_addr,
+)
+from test_framework.mininode import (
+    P2PInterface,
+)
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+)
+import time
+
+ADDRS = []
+for i in range(10):
+    addr = CAddress()
+    addr.time = int(time.time()) + i
+    addr.nServices = NODE_NETWORK | NODE_WITNESS
+    addr.ip = "123.123.123.{}".format(i % 256)
+    addr.port = 8333 + i
+    ADDRS.append(addr)
+
+
+class AddrReceiver(P2PInterface):
+    def on_addr(self, message):
+        for addr in message.addrs:
+            assert_equal(addr.nServices, 9)
+            assert addr.ip.startswith('123.123.123.')
+            assert (8333 <= addr.port < 8343)
+
+
+class AddrTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = False
+        self.num_nodes = 1
+
+    def run_test(self):
+        self.log.info('Create connection that sends addr messages')
+        addr_source = self.nodes[0].add_p2p_connection(P2PInterface())
+        msg = msg_addr()
+
+        self.log.info('Send too large addr message')
+        msg.addrs = ADDRS * 101
+        with self.nodes[0].assert_debug_log(['message addr size() = 1010']):
+            addr_source.send_and_ping(msg)
+
+        self.log.info('Check that addr message content is relayed and added to addrman')
+        addr_receiver = self.nodes[0].add_p2p_connection(AddrReceiver())
+        msg.addrs = ADDRS
+        with self.nodes[0].assert_debug_log([
+                'Added 10 addresses from 127.0.0.1: 0 tried',
+                'received: addr (301 bytes) peer=0',
+                'sending addr (301 bytes) peer=1',
+        ]):
+            addr_source.send_and_ping(msg)
+            self.nodes[0].setmocktime(int(time.time()) + 30 * 60)
+            addr_receiver.sync_with_ping()
+
+
+if __name__ == '__main__':
+    AddrTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -144,6 +144,7 @@ BASE_SCRIPTS = [
     'rpc_blockchain.py',
     'rpc_deprecated.py',
     'wallet_disable.py',
+    'p2p_addr_relay.py',
     'rpc_net.py',
     'wallet_keypool.py',
     'p2p_mempool.py',


### PR DESCRIPTION
As usual:

* Switch to std::chrono time to be type-safe and mockable
* Add basic test that relies on mocktime to add code coverage