### PR TITLE
rpc: remove unused getbalances() code

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2390,8 +2390,6 @@ static UniValue getbalances(const JSONRPCRequest& request)
     auto locked_chain = wallet.chain().lock();
     LOCK(wallet.cs_wallet);
 
-    UniValue obj(UniValue::VOBJ);
-
     const auto bal = wallet.GetBalance();
     UniValue balances{UniValue::VOBJ};
     {


### PR DESCRIPTION
This line from 999931cf8f1 appears to be extraneous and replaced 2 lines after by `UniValue balances{UniValue::VOBJ};`.