### PR TITLE
doc: block-relay-only vs blocksonly

### DIFF
--- a/doc/reduce-memory.md
+++ b/doc/reduce-memory.md
@@ -24,7 +24,9 @@ The size of some in-memory caches can be reduced. As caches trade off memory usa
 
 ## Number of peers
 
-- `-maxconnections=<n>` - the maximum number of connections, this defaults to `125`. Each active connection takes up some memory. Only significant if incoming connections are enabled, otherwise the number of connections will never be more than `10`. Of the 10 outbound peers, there can be 8 full outgoing connections and 2 -blocksonly peers, in which case they are block/addr peers, but not tx peers.
+- `-maxconnections=<n>` - the maximum number of connections, this defaults to 125. Each active connection takes up some
+  memory. This option applies only if incoming connections are enabled, otherwise the number of connections will never
+  be more than 10. Of the 10 outbound peers, there can be 8 full-relay connections and 2 block-relay-only ones.
 
 ## Thread configuration
 

--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -5,8 +5,8 @@ Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
 By default, Bitcoin Core allows up to 125 connections to different peers, 10 of
 which are outbound. You can therefore, have at most 115 inbound connections.
-Of the 10 outbound peers, there can be 8 full outgoing connections and 2 with
-the -blocksonly mode turned on. You can therefore, have at most 115 inbound connections.
+Of the 10 outbound peers, there can be 8 full-relay connections and 2
+block-relay-only ones.
 
 The default settings can result in relatively significant traffic consumption.
 


### PR DESCRIPTION
Those are different concepts, see https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.19.0.1.md#p2p-changes for the block-relay-only nodes.