### PR TITLE
qa: Test shared validation interface

### DIFF
--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -67,8 +67,8 @@ public:
     void Clear()
     {
         LOCK(m_mutex);
-        for (auto it = m_list.begin(); it != m_list.end();) {
-            it = --it->count ? std::next(it) : m_list.erase(it);
+        for (const auto& entry : m_map) {
+            if (!--entry.second->count) m_list.erase(entry.second);
         }
         m_map.clear();
     }


### PR DESCRIPTION
Based on #18338, only last commit matters. Quoting the test description:

```
// Test UnregisterSharedValidationInterface ensuring that if interface is
// unregistered during the middle of a callback, interface is destroyed as soon
// as callback returns.
```

All credits to ryanofsky.