### PR TITLE
build: Automatically include both `git`-tracked and bootstrapped files.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,22 +43,6 @@ OSX_INSTALLER_ICONS=$(top_srcdir)/src/qt/res/icons/bitcoin.icns
 OSX_PLIST=$(top_builddir)/share/qt/Info.plist #not installed
 OSX_QT_TRANSLATIONS = da,de,es,hu,ru,uk,zh_CN,zh_TW
 
-DIST_CONTRIB = \
-	       $(top_srcdir)/contrib/linearize/linearize-data.py \
-	       $(top_srcdir)/contrib/linearize/linearize-hashes.py
-
-DIST_SHARE = \
-  $(top_srcdir)/share/genbuild.sh \
-  $(top_srcdir)/share/rpcauth
-
-BIN_CHECKS=$(top_srcdir)/contrib/devtools/symbol-check.py \
-           $(top_srcdir)/contrib/devtools/security-check.py
-
-WINDOWS_PACKAGING = $(top_srcdir)/share/pixmaps/bitcoin.ico \
-  $(top_srcdir)/share/pixmaps/nsis-header.bmp \
-  $(top_srcdir)/share/pixmaps/nsis-wizard.bmp \
-  $(top_srcdir)/doc/README_windows.txt
-
 OSX_PACKAGING = $(OSX_DEPLOY_SCRIPT) $(OSX_FANCY_PLIST) $(OSX_INSTALLER_ICONS) \
   $(top_srcdir)/contrib/macdeploy/$(OSX_BACKGROUND_SVG) \
   $(OSX_DSSTORE_GEN) \
@@ -255,67 +239,7 @@ endif
 
 dist_noinst_SCRIPTS = autogen.sh
 
-EXTRA_DIST = $(DIST_SHARE) $(DIST_CONTRIB) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
-
-EXTRA_DIST += \
-    test/functional \
-    test/fuzz
-
-EXTRA_DIST += \
-    test/util/bitcoin-util-test.py \
-    test/util/data/bitcoin-util-test.json \
-    test/util/data/blanktxv1.hex \
-    test/util/data/blanktxv1.json \
-    test/util/data/blanktxv2.hex \
-    test/util/data/blanktxv2.json \
-    test/util/data/tt-delin1-out.hex \
-    test/util/data/tt-delin1-out.json \
-    test/util/data/tt-delout1-out.hex \
-    test/util/data/tt-delout1-out.json \
-    test/util/data/tt-locktime317000-out.hex \
-    test/util/data/tt-locktime317000-out.json \
-    test/util/data/tx394b54bb.hex \
-    test/util/data/txcreate1.hex \
-    test/util/data/txcreate1.json \
-    test/util/data/txcreate2.hex \
-    test/util/data/txcreate2.json \
-    test/util/data/txcreatedata1.hex \
-    test/util/data/txcreatedata1.json \
-    test/util/data/txcreatedata2.hex \
-    test/util/data/txcreatedata2.json \
-    test/util/data/txcreatedata_seq0.hex \
-    test/util/data/txcreatedata_seq0.json \
-    test/util/data/txcreatedata_seq1.hex \
-    test/util/data/txcreatedata_seq1.json \
-    test/util/data/txcreatemultisig1.hex \
-    test/util/data/txcreatemultisig1.json \
-    test/util/data/txcreatemultisig2.hex \
-    test/util/data/txcreatemultisig2.json \
-    test/util/data/txcreatemultisig3.hex \
-    test/util/data/txcreatemultisig3.json \
-    test/util/data/txcreatemultisig4.hex \
-    test/util/data/txcreatemultisig4.json \
-    test/util/data/txcreatemultisig5.json \
-    test/util/data/txcreateoutpubkey1.hex \
-    test/util/data/txcreateoutpubkey1.json \
-    test/util/data/txcreateoutpubkey2.hex \
-    test/util/data/txcreateoutpubkey2.json \
-    test/util/data/txcreateoutpubkey3.hex \
-    test/util/data/txcreateoutpubkey3.json \
-    test/util/data/txcreatescript1.hex \
-    test/util/data/txcreatescript1.json \
-    test/util/data/txcreatescript2.hex \
-    test/util/data/txcreatescript2.json \
-    test/util/data/txcreatescript3.hex \
-    test/util/data/txcreatescript3.json \
-    test/util/data/txcreatescript4.hex \
-    test/util/data/txcreatescript4.json \
-    test/util/data/txcreatescript5.hex \
-    test/util/data/txcreatescript6.hex \
-    test/util/data/txcreatesignv1.hex \
-    test/util/data/txcreatesignv1.json \
-    test/util/data/txcreatesignv2.hex \
-    test/util/rpcauth-test.py
+EXTRA_DIST = $(shell $(GIT) ls-files | sort)
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
 

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -147,9 +147,6 @@ script: |
   SOURCEDIST=$(echo bitcoin-*.tar.gz)
   DISTNAME=${SOURCEDIST/%.tar.gz}
 
-  # Workaround for tarball not building with the bare tag version (prep)
-  make -C src obj/build.h
-
   ORIGPATH="$PATH"
   # Extract the release tarball into a dir for each host and build
   for i in ${HOSTS}; do
@@ -166,11 +163,6 @@ script: |
     INSTALLPATH="${PWD}/installed/${DISTNAME}"
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
-
-    # Workaround for tarball not building with the bare tag version
-    echo '#!/bin/true' >share/genbuild.sh
-    mkdir src/obj
-    cp ../src/obj/build.h src/obj/
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
     make ${MAKEOPTS}

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -147,6 +147,13 @@ script: |
   SOURCEDIST=$(echo bitcoin-*.tar.gz)
   DISTNAME=${SOURCEDIST/%.tar.gz}
 
+  # Correct tar file order
+  mkdir -p temp
+  pushd temp
+  tar -xf ../$SOURCEDIST
+  find bitcoin-* | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
+  popd
+
   ORIGPATH="$PATH"
   # Extract the release tarball into a dir for each host and build
   for i in ${HOSTS}; do
@@ -181,6 +188,5 @@ script: |
     cd ../../
     rm -rf distsrc-${i}
   done
-
-  mkdir -p ${OUTDIR}/src
-  git archive --output=${OUTDIR}/src/${DISTNAME}.tar.gz HEAD
+  mkdir -p $OUTDIR/src
+  mv $SOURCEDIST $OUTDIR/src

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -110,6 +110,13 @@ script: |
   SOURCEDIST=$(echo bitcoin-*.tar.gz)
   DISTNAME=${SOURCEDIST/%.tar.gz}
 
+  # Correct tar file order
+  mkdir -p temp
+  pushd temp
+  tar -xf ../$SOURCEDIST
+  find bitcoin-* | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
+  popd
+
   ORIGPATH="$PATH"
   # Extract the release tarball into a dir for each host and build
   for i in ${HOSTS}; do
@@ -151,8 +158,6 @@ script: |
     find ${DISTNAME} | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ${OUTDIR}/${DISTNAME}-${i}.tar.gz
     cd ../../
   done
-
-  mkdir -p ${OUTDIR}/src
-  git archive --output=${OUTDIR}/src/${DISTNAME}.tar.gz HEAD
-
+  mkdir -p $OUTDIR/src
+  mv $SOURCEDIST $OUTDIR/src
   mv ${OUTDIR}/${DISTNAME}-x86_64-*.tar.gz ${OUTDIR}/${DISTNAME}-osx64.tar.gz

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -110,9 +110,6 @@ script: |
   SOURCEDIST=$(echo bitcoin-*.tar.gz)
   DISTNAME=${SOURCEDIST/%.tar.gz}
 
-  # Workaround for tarball not building with the bare tag version (prep)
-  make -C src obj/build.h
-
   ORIGPATH="$PATH"
   # Extract the release tarball into a dir for each host and build
   for i in ${HOSTS}; do
@@ -122,11 +119,6 @@ script: |
     INSTALLPATH="${PWD}/installed/${DISTNAME}"
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
-
-    # Workaround for tarball not building with the bare tag version
-    echo '#!/bin/true' >share/genbuild.sh
-    mkdir src/obj
-    cp ../src/obj/build.h src/obj/
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
     make ${MAKEOPTS}

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -117,9 +117,6 @@ script: |
   SOURCEDIST=$(echo bitcoin-*.tar.gz)
   DISTNAME=${SOURCEDIST/%.tar.gz}
 
-  # Workaround for tarball not building with the bare tag version (prep)
-  make -C src obj/build.h
-
   ORIGPATH="$PATH"
   # Extract the release tarball into a dir for each host and build
   for i in ${HOSTS}; do
@@ -129,11 +126,6 @@ script: |
     INSTALLPATH="${PWD}/installed/${DISTNAME}"
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
-
-    # Workaround for tarball not building with the bare tag version
-    echo '#!/bin/true' >share/genbuild.sh
-    mkdir src/obj
-    cp ../src/obj/build.h src/obj/
 
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -117,6 +117,13 @@ script: |
   SOURCEDIST=$(echo bitcoin-*.tar.gz)
   DISTNAME=${SOURCEDIST/%.tar.gz}
 
+  # Correct tar file order
+  mkdir -p temp
+  pushd temp
+  tar -xf ../$SOURCEDIST
+  find bitcoin-* | sort | tar --mtime="$REFERENCE_DATETIME" --no-recursion --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 -c -T - | gzip -9n > ../$SOURCEDIST
+  popd
+
   ORIGPATH="$PATH"
   # Extract the release tarball into a dir for each host and build
   for i in ${HOSTS}; do
@@ -147,10 +154,8 @@ script: |
     cd ../../
     rm -rf distsrc-${i}
   done
-
-  mkdir -p ${OUTDIR}/src
-  git archive --output=${OUTDIR}/src/${DISTNAME}.tar.gz HEAD
-
+  mkdir -p $OUTDIR/src
+  mv $SOURCEDIST $OUTDIR/src
   cp -rf contrib/windeploy $BUILD_DIR
   cd $BUILD_DIR/windeploy
   mkdir unsigned

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -37,6 +37,8 @@ if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$
     # otherwise generate suffix from git, i.e. string like "59887e8-dirty"
     SUFFIX=$(git rev-parse --short HEAD)
     git diff-index --quiet HEAD -- || SUFFIX="$SUFFIX-dirty"
+elif [ -f "$FILE" ]; then
+    exit 0
 fi
 
 if [ -n "$DESC" ]; then

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -540,7 +540,7 @@ libbitcoin_cli_a_SOURCES = \
   rpc/client.cpp \
   $(BITCOIN_CORE_H)
 
-nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
+libbitcoin_util_a_SOURCES += obj/build.h
 #
 
 # bitcoind binary #


### PR DESCRIPTION
```
This allows us to:

1. Retain the automatic inclusion of bootstrapped files inside dist
   source tarballs
2. Also automatically include all git-tracked files in EXTRA_DIST

Notes:

1. We already rely on git for `make dist` anyway (see dist-hook).
2. As of automake:77d39959511295f5a30332d5d03f0a6956bd9460 (this is just
   the latest master I have so there's a point of reference for the
   future), we can observe the behaviour of `make dist` in
   `lib/am/distdir.am`. Search for the `distdir-am` target within that
   file. You will see that if a file was already added to the distdir,
   it won't be added again.
```

-----

I also performed a gitian build, here's a diff of the source tarball and one produced with simply `git archive`, as expected, the difference is only in the bootstrapped files.

```
$ diff -rl gitian git
Only in gitian: aclocal.m4
Only in gitian/build-aux: compile
Only in gitian/build-aux: config.guess
Only in gitian/build-aux: config.sub
Only in gitian/build-aux: depcomp
Only in gitian/build-aux: install-sh
Only in gitian/build-aux: ltmain.sh
Only in gitian/build-aux/m4: libtool.m4
Only in gitian/build-aux/m4: lt~obsolete.m4
Only in gitian/build-aux/m4: ltoptions.m4
Only in gitian/build-aux/m4: ltsugar.m4
Only in gitian/build-aux/m4: ltversion.m4
Only in gitian/build-aux: missing
Only in gitian/build-aux: test-driver
Only in gitian: configure
Only in gitian/doc/man: Makefile.in
Only in gitian: Makefile.in
Only in gitian/src/config: bitcoin-config.h.in
Only in gitian/src: Makefile.in
Only in gitian/src/secp256k1: aclocal.m4
Only in gitian/src/secp256k1/build-aux: compile
Only in gitian/src/secp256k1/build-aux: config.guess
Only in gitian/src/secp256k1/build-aux: config.sub
Only in gitian/src/secp256k1/build-aux: depcomp
Only in gitian/src/secp256k1/build-aux: install-sh
Only in gitian/src/secp256k1/build-aux: ltmain.sh
Only in gitian/src/secp256k1/build-aux/m4: libtool.m4
Only in gitian/src/secp256k1/build-aux/m4: lt~obsolete.m4
Only in gitian/src/secp256k1/build-aux/m4: ltoptions.m4
Only in gitian/src/secp256k1/build-aux/m4: ltsugar.m4
Only in gitian/src/secp256k1/build-aux/m4: ltversion.m4
Only in gitian/src/secp256k1/build-aux: missing
Only in gitian/src/secp256k1/build-aux: test-driver
Only in gitian/src/secp256k1: configure
Only in gitian/src/secp256k1: Makefile.in
Only in gitian/src/secp256k1/src: libsecp256k1-config.h.in
Only in gitian/src/univalue: aclocal.m4
Only in gitian/src/univalue/build-aux: compile
Only in gitian/src/univalue/build-aux: config.guess
Only in gitian/src/univalue/build-aux: config.sub
Only in gitian/src/univalue/build-aux: depcomp
Only in gitian/src/univalue/build-aux: install-sh
Only in gitian/src/univalue/build-aux: ltmain.sh
Only in gitian/src/univalue/build-aux/m4: libtool.m4
Only in gitian/src/univalue/build-aux/m4: lt~obsolete.m4
Only in gitian/src/univalue/build-aux/m4: ltoptions.m4
Only in gitian/src/univalue/build-aux/m4: ltsugar.m4
Only in gitian/src/univalue/build-aux/m4: ltversion.m4
Only in gitian/src/univalue/build-aux: missing
Only in gitian/src/univalue/build-aux: test-driver
Only in gitian/src/univalue: configure
Only in gitian/src/univalue: Makefile.in
Only in gitian/src/univalue: univalue-config.h.in
```