### PR TITLE
RPC: Show fee in results for signrawtransaction* for segwit inputs

### DIFF
--- a/doc/release-notes-pr12911.md
+++ b/doc/release-notes-pr12911.md
@@ -1,0 +1,7 @@
+RPC changes
+------------
+
+### Low-level changes
+
+- `signrawtransactionwithkey` and `signrawtransactionwithwallet` will now include a `fee` entry in the results,
+  for cases where the fee is known.

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -744,6 +744,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
                     {
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
+                        {RPCResult::Type::STR_AMOUNT, "fee", /* optional */ true, "The fee (input amounts minus output amounts), if known"},
                         {RPCResult::Type::ARR, "errors", /* optional */ true, "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -745,6 +745,7 @@ static UniValue signrawtransactionwithkey(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
                         {RPCResult::Type::STR_AMOUNT, "fee", /* optional */ true, "The fee (input amounts minus output amounts), if known"},
+                        {RPCResult::Type::STR_AMOUNT, "feerate", /* optional */ true, "The fee rate (in " + CURRENCY_UNIT + "/kB), if fee is known"},
                         {RPCResult::Type::ARR, "errors", /* optional */ true, "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",

--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -292,7 +292,8 @@ void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const 
         TxInErrorToJSON(mtx.vin.at(err_pair.first), vErrors, err_pair.second);
     }
 
-    result.pushKV("hex", EncodeHexTx(CTransaction(mtx)));
+    CTransaction tx(mtx);
+    result.pushKV("hex", EncodeHexTx(tx));
     result.pushKV("complete", complete);
     if (inputs_amount_sum) {
         CAmount inout_amount = *inputs_amount_sum;
@@ -300,6 +301,11 @@ void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const 
             inout_amount -= txout.nValue;
         }
         result.pushKV("fee", ValueFromAmount(inout_amount));
+        result.pushKV("feerate",
+            ValueFromAmount(
+                CFeeRate(inout_amount, GetVirtualTransactionSize(tx)).GetFeePerK()
+            )
+        );
     }
     if (!vErrors.empty()) {
         if (result.exists("errors")) {

--- a/src/rpc/rawtransaction_util.h
+++ b/src/rpc/rawtransaction_util.h
@@ -5,6 +5,9 @@
 #ifndef BITCOIN_RPC_RAWTRANSACTION_UTIL_H
 #define BITCOIN_RPC_RAWTRANSACTION_UTIL_H
 
+#include <amount.h>
+#include <optional.h>
+
 #include <map>
 #include <string>
 
@@ -25,7 +28,7 @@ class SigningProvider;
  * @param result         JSON object where signed transaction results accumulate
  */
 void SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, const UniValue& hashType, UniValue& result);
-void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, std::map<int, std::string>& input_errors, UniValue& result);
+void SignTransactionResultToJSON(CMutableTransaction& mtx, bool complete, const std::map<COutPoint, Coin>& coins, std::map<int, std::string>& input_errors, UniValue& result, const Optional<CAmount>& inputs_amount_sum);
 
 /**
   * Parse a prevtxs UniValue array and get the map of coins from it

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -468,7 +468,7 @@ bool IsSegWitOutput(const SigningProvider& provider, const CScript& script)
     return false;
 }
 
-bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, int nHashType, std::map<int, std::string>& input_errors)
+bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, const std::map<COutPoint, Coin>& coins, int nHashType, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum)
 {
     bool fHashSingle = ((nHashType & ~SIGHASH_ANYONECANPAY) == SIGHASH_SINGLE);
 
@@ -476,20 +476,37 @@ bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* keystore, 
     // transaction to avoid rehashing.
     const CTransaction txConst(mtx);
     // Sign what we can:
+    if (inputs_amount_sum) *inputs_amount_sum = 0;
     for (unsigned int i = 0; i < mtx.vin.size(); i++) {
         CTxIn& txin = mtx.vin[i];
         auto coin = coins.find(txin.prevout);
         if (coin == coins.end() || coin->second.IsSpent()) {
+            if (inputs_amount_sum) {
+                inputs_amount_sum->reset();
+                inputs_amount_sum = nullptr;
+            }
             input_errors[i] = "Input not found or already spent";
             continue;
         }
         const CScript& prevPubKey = coin->second.out.scriptPubKey;
         const CAmount& amount = coin->second.out.nValue;
+        if (inputs_amount_sum && *inputs_amount_sum) {
+            if (amount > 0) {
+                **inputs_amount_sum += amount;
+            } else {
+                inputs_amount_sum->reset();
+                inputs_amount_sum = nullptr;
+            }
+        }
 
         SignatureData sigdata = DataFromTransaction(mtx, i, coin->second.out);
         // Only sign SIGHASH_SINGLE if there's a corresponding output:
         if (!fHashSingle || (i < mtx.vout.size())) {
             ProduceSignature(*keystore, MutableTransactionSignatureCreator(&mtx, i, amount, nHashType), prevPubKey, sigdata);
+            if ((!sigdata.witness) && inputs_amount_sum && *inputs_amount_sum) {
+                inputs_amount_sum->reset();
+                inputs_amount_sum = nullptr;
+            }
         }
 
         UpdateInput(txin, sigdata);

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -8,6 +8,7 @@
 
 #include <coins.h>
 #include <hash.h>
+#include <optional.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <script/keyorigin.h>
@@ -170,6 +171,6 @@ bool IsSolvable(const SigningProvider& provider, const CScript& script);
 bool IsSegWitOutput(const SigningProvider& provider, const CScript& script);
 
 /** Sign the CMutableTransaction */
-bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* provider, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors);
+bool SignTransaction(CMutableTransaction& mtx, const SigningProvider* provider, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum = nullptr);
 
 #endif // BITCOIN_SCRIPT_SIGN_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3194,6 +3194,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
                     {
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
+                        {RPCResult::Type::STR_AMOUNT, "fee", /* optional */ true, "The fee (input amounts minus output amounts), if known"},
                         {RPCResult::Type::ARR, "errors", /* optional */ true, "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",
@@ -3242,10 +3243,11 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
 
     // Script verification errors
     std::map<int, std::string> input_errors;
+    Optional<CAmount> inputs_amount_sum;
 
-    bool complete = pwallet->SignTransaction(mtx, coins, nHashType, input_errors);
+    bool complete = pwallet->SignTransaction(mtx, coins, nHashType, input_errors, &inputs_amount_sum);
     UniValue result(UniValue::VOBJ);
-    SignTransactionResultToJSON(mtx, complete, coins, input_errors, result);
+    SignTransactionResultToJSON(mtx, complete, coins, input_errors, result, inputs_amount_sum);
     return result;
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3195,6 +3195,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
                         {RPCResult::Type::STR_HEX, "hex", "The hex-encoded raw transaction with signature(s)"},
                         {RPCResult::Type::BOOL, "complete", "If the transaction has a complete set of signatures"},
                         {RPCResult::Type::STR_AMOUNT, "fee", /* optional */ true, "The fee (input amounts minus output amounts), if known"},
+                        {RPCResult::Type::STR_AMOUNT, "feerate", /* optional */ true, "The fee rate (in " + CURRENCY_UNIT + "/kB), if fee is known"},
                         {RPCResult::Type::ARR, "errors", /* optional */ true, "Script verification errors (if there are any)",
                         {
                             {RPCResult::Type::OBJ, "", "",

--- a/src/wallet/scriptpubkeyman.cpp
+++ b/src/wallet/scriptpubkeyman.cpp
@@ -566,9 +566,9 @@ bool LegacyScriptPubKeyMan::CanProvide(const CScript& script, SignatureData& sig
     }
 }
 
-bool LegacyScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const
+bool LegacyScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum) const
 {
-    return ::SignTransaction(tx, this, coins, sighash, input_errors);
+    return ::SignTransaction(tx, this, coins, sighash, input_errors, inputs_amount_sum);
 }
 
 SigningResult LegacyScriptPubKeyMan::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const
@@ -2038,7 +2038,7 @@ bool DescriptorScriptPubKeyMan::CanProvide(const CScript& script, SignatureData&
     return IsMine(script);
 }
 
-bool DescriptorScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const
+bool DescriptorScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum) const
 {
     std::unique_ptr<FlatSigningProvider> keys = MakeUnique<FlatSigningProvider>();
     for (const auto& coin_pair : coins) {
@@ -2049,7 +2049,7 @@ bool DescriptorScriptPubKeyMan::SignTransaction(CMutableTransaction& tx, const s
         *keys = Merge(*keys, *coin_keys);
     }
 
-    return ::SignTransaction(tx, keys.get(), coins, sighash, input_errors);
+    return ::SignTransaction(tx, keys.get(), coins, sighash, input_errors, inputs_amount_sum);
 }
 
 SigningResult DescriptorScriptPubKeyMan::SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const

--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -230,7 +230,7 @@ public:
     virtual bool CanProvide(const CScript& script, SignatureData& sigdata) { return false; }
 
     /** Creates new signatures and adds them to the transaction. Returns whether all inputs were signed */
-    virtual bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const { return false; }
+    virtual bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum = nullptr) const { return false; }
     /** Sign a message with the given script */
     virtual SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const { return SigningResult::SIGNING_FAILED; };
     /** Adds script and derivation path information to a PSBT, and optionally signs it. */
@@ -391,7 +391,7 @@ public:
 
     bool CanProvide(const CScript& script, SignatureData& sigdata) override;
 
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const override;
+    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum = nullptr) const override;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr) const override;
 
@@ -596,7 +596,7 @@ public:
 
     bool CanProvide(const CScript& script, SignatureData& sigdata) override;
 
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const override;
+    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum = nullptr) const override;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const override;
     TransactionError FillPSBT(PartiallySignedTransaction& psbt, int sighash_type = 1 /* SIGHASH_ALL */, bool sign = true, bool bip32derivs = false, int* n_signed = nullptr) const override;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2462,13 +2462,13 @@ bool CWallet::SignTransaction(CMutableTransaction& tx) const
     return SignTransaction(tx, coins, SIGHASH_ALL, input_errors);
 }
 
-bool CWallet::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const
+bool CWallet::SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum) const
 {
     // Try to sign with all ScriptPubKeyMans
     for (ScriptPubKeyMan* spk_man : GetAllScriptPubKeyMans()) {
         // spk_man->SignTransaction will return true if the transaction is complete,
         // so we can exit early and return true if that happens
-        if (spk_man->SignTransaction(tx, coins, sighash, input_errors)) {
+        if (spk_man->SignTransaction(tx, coins, sighash, input_errors, inputs_amount_sum)) {
             return true;
         }
     }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -953,7 +953,7 @@ public:
     // Fetch the inputs and sign with SIGHASH_ALL.
     bool SignTransaction(CMutableTransaction& tx) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     // Sign the tx given the input coins and sighash.
-    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors) const;
+    bool SignTransaction(CMutableTransaction& tx, const std::map<COutPoint, Coin>& coins, int sighash, std::map<int, std::string>& input_errors, Optional<CAmount>* inputs_amount_sum = nullptr) const;
     SigningResult SignMessage(const std::string& message, const PKHash& pkhash, std::string& str_sig) const;
 
     /**

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -19,6 +19,7 @@ from test_framework.messages import COIN, COutPoint, CTransaction, CTxIn, CTxOut
 from test_framework.script import CScript, OP_HASH160, OP_CHECKSIG, OP_0, hash160, OP_EQUAL, OP_DUP, OP_EQUALVERIFY, OP_1, OP_2, OP_CHECKMULTISIG, OP_TRUE, OP_DROP
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
+    assert_approx,
     assert_equal,
     assert_is_hex_string,
     assert_raises_rpc_error,
@@ -283,6 +284,32 @@ class SegWitTest(BitcoinTestFramework):
 
         # Mine a block to clear the gbt cache again.
         self.nodes[0].generate(1)
+
+        self.log.info("Signing with all-segwit inputs reveals fee rate")
+        addr = self.nodes[0].getnewaddress(address_type='p2sh-segwit')
+        txid = self.nodes[0].sendtoaddress(addr, 1)
+        tx = self.nodes[0].getrawtransaction(txid, True)
+        n = -1
+        value = -1
+        for o in tx["vout"]:
+            if o["scriptPubKey"]["addresses"][0] == addr:
+                n = o["n"]
+                value = Decimal(o["value"])
+                break
+        assert n > -1 # failure means we could not find the address in the outputs despite sending to it
+        assert_equal(value, 1) # failure means we got an unexpected amount of coins, despite trying to send 1
+        fee = Decimal("0.00010000")
+        value_out = value - fee
+        self.nodes[0].generatetoaddress(1, self.nodes[0].getnewaddress())
+        raw = self.nodes[0].createrawtransaction([{"txid" : txid, "vout" : n}], [{self.nodes[0].getnewaddress() : value_out}])
+        signed = self.nodes[0].signrawtransactionwithwallet(raw)
+        assert_equal(signed["complete"], True)
+        txsize = self.nodes[0].decoderawtransaction(signed['hex'])['vsize']
+        exp_feerate = 1000 * fee / Decimal(txsize)
+        assert_approx(signed["feerate"], exp_feerate, Decimal("0.00000010"))
+        # discrepancy = 100000000 * (exp_feerate - signed["feerate"])
+        # assert -10 < discrepancy < 10
+        assert_equal(Decimal(signed["fee"]), fee)
 
         self.log.info("Verify behaviour of importaddress and listunspent")
 


### PR DESCRIPTION
Rebase of #12911

> This adds a "fee" field to the resulting JSON for `signrawtransaction*` so a user can double check the fee they're paying before sending a transaction. The field is only shown in cases where the input amounts are all known ⇔ are all segwit inputs.
> 
> ```
> $ ./bitcoin-cli -regtest signrawtransactionwithwallet 0200000001901c16d5ac11824ca64c9c9dbe925c83fc1af9872bb23bbc9c6cd25419e2f69c0000000000feffffff0210b2d0df0000000017a914d9214ccd777e5cce540d38c3466c2cb5545339c5874031354a0000000017a914bee793caf793996dc9f617a5ad04ec2b87c6f9538700000000
> {
>   "hex": "0200000001901c16d5ac11824ca64c9c9dbe925c83fc1af9872bb23bbc9c6cd25419e2f69c00000000494830450221008fd0d0cfd16a06f282e720129351f2756f416b916f7a0a3be8d5db0c7db107af022028dafae6ec7d30882efe101c16b5f3893254bf5385664eddadf0d3f6e479381c01feffffff0210b2d0df0000000017a914d9214ccd777e5cce540d38c3466c2cb5545339c5874031354a0000000017a914bee793caf793996dc9f617a5ad04ec2b87c6f9538700000000",
>   "complete": true,
>   "fee": 0.00003760,
>   "feerate": 0.00020000
> }
> ```