### PR TITLE
test: add BIP37 'filterclear' test to p2p_filter.py

### DIFF
--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -11,6 +11,7 @@ from test_framework.messages import (
     MSG_FILTERED_BLOCK,
     msg_getdata,
     msg_filterload,
+    msg_filterclear,
 )
 from test_framework.mininode import (
     P2PInterface,
@@ -96,6 +97,13 @@ class FilterTest(BitcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(filter_address, 90)
         filter_node.wait_for_tx(txid)
         assert not filter_node.merkleblock_received
+
+        self.log.info('Check that after deleting filter all txs get relayed again')
+        filter_node.send_message(msg_filterclear())
+        filter_node.sync_with_ping()
+        for _ in range(5):
+            txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 7)
+            filter_node.wait_for_tx(txid)
 
 
 if __name__ == '__main__':

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -1356,6 +1356,23 @@ class msg_filterload:
             self.data, self.nHashFuncs, self.nTweak, self.nFlags)
 
 
+class msg_filterclear:
+    __slots__ = ()
+    command = b"filterclear"
+
+    def __init__(self):
+        pass
+
+    def deserialize(self, f):
+        pass
+
+    def serialize(self):
+        return b""
+
+    def __repr__(self):
+        return "msg_filterclear()"
+
+
 class msg_feefilter:
     __slots__ = ("feerate",)
     command = b"feefilter"

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -30,6 +30,7 @@ from test_framework.messages import (
     msg_blocktxn,
     msg_cmpctblock,
     msg_feefilter,
+    msg_filterclear,
     msg_filterload,
     msg_getaddr,
     msg_getblocks,
@@ -64,6 +65,7 @@ MESSAGEMAP = {
     b"blocktxn": msg_blocktxn,
     b"cmpctblock": msg_cmpctblock,
     b"feefilter": msg_feefilter,
+    b"filterclear": msg_filterclear,
     b"filterload": msg_filterload,
     b"getaddr": msg_getaddr,
     b"getblocks": msg_getblocks,
@@ -322,6 +324,7 @@ class P2PInterface(P2PConnection):
     def on_blocktxn(self, message): pass
     def on_cmpctblock(self, message): pass
     def on_feefilter(self, message): pass
+    def on_filterclear(self, message): pass
     def on_filterload(self, message): pass
     def on_getaddr(self, message): pass
     def on_getblocks(self, message): pass


### PR DESCRIPTION
Integrates the message type `filterclear` to the test framework and adds a simple test to `p2p_filter.py`, checking that arbitrary txs get relayed again after deleting the filter.