### PR TITLE
Bugfix: devtools/symbol-check: Check PE libraries case-insensitively

### DIFF
--- a/contrib/devtools/symbol-check.py
+++ b/contrib/devtools/symbol-check.py
@@ -101,7 +101,7 @@ MACHO_ALLOWED_LIBRARIES = {
 'libobjc.A.dylib', # Objective-C runtime library
 }
 
-PE_ALLOWED_LIBRARIES = {
+PE_ALLOWED_LIBRARIES = {libname.lower() for libname in (
 'ADVAPI32.dll', # security & registry
 'IPHLPAPI.DLL', # IP helper API
 'KERNEL32.dll', # win32 base APIs
@@ -119,7 +119,7 @@ PE_ALLOWED_LIBRARIES = {
 'UxTheme.dll',
 'VERSION.dll', # version checking
 'WINMM.dll', # WinMM audio API
-}
+)}
 
 class CPPFilt(object):
     '''
@@ -253,7 +253,7 @@ def pe_read_libraries(filename) -> List[str]:
 def check_PE_libraries(filename) -> bool:
     ok = True
     for dylib in pe_read_libraries(filename):
-        if dylib not in PE_ALLOWED_LIBRARIES:
+        if dylib.lower() not in PE_ALLOWED_LIBRARIES:
             print('{} is not in ALLOWED_LIBRARIES!'.format(dylib))
             ok = False
     return ok


### PR DESCRIPTION
For some reason, one of my gitian builds failed because "DLL" was uppercase where `symbol-check.py` expected it lowercase.

Since the PE platform is case insensitive, check it case-insensitively here too.