### PR TITLE
tests: add CScriptNum::serialize to integer fuzz harness

### DIFF
--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -267,4 +267,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         catch (const std::ios_base::failure&) {
         }
     }
+
+    {
+        CScriptNum::serialize(i64);
+    }
 }


### PR DESCRIPTION
Add a fuzzing harness for `CScriptNum::serialize`, `core_write.cpp:ValueFromAmount` and `util/moneystr.cpp:FormatMoney`.

Those functions manually compute absolute values of `int64_t` numbers which can lead to undefined behavior, see : #18413 #18046 

You can trigger this new harness with the following input : 

```
$ echo -n "-9223372036854775808" > crash-abs-value
$ ./src/test/fuzz/abs_ub crash-abs-value
```

Note that `BitcoinUnits::format`  also does the same (but requires QT headers to compile so I'm not sure we can add it to the fuzzer).