### PR TITLE
test: enable opening partial p2p connections where useful

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -165,7 +165,7 @@ class AssumeValidTest(BitcoinTestFramework):
         self.start_node(2, extra_args=["-assumevalid=" + hex(block102.sha256)])
 
         p2p0 = self.nodes[0].add_p2p_connection(BaseNode())
-        p2p1 = self.nodes[1].add_p2p_connection(BaseNode())
+        p2p1 = self.nodes[1].add_p2p_connection(BaseNode(), sync_with_ping=False)
         p2p2 = self.nodes[2].add_p2p_connection(BaseNode())
 
         # send header lists to all three nodes

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1386,7 +1386,7 @@ class FullBlockTest(BitcoinTestFramework):
         """Add a P2P connection to the node.
 
         Helper to connect and wait for version handshake."""
-        self.nodes[0].add_p2p_connection(P2PDataStore())
+        self.nodes[0].add_p2p_connection(P2PDataStore(), sync_with_ping=False)
         # We need to wait for the initial getheaders from the peer before we
         # start populating our blockstore. If we don't, then we may run ahead
         # to the next subtest before we receive the getheaders. We'd then send

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -142,7 +142,7 @@ class MaxUploadTest(BitcoinTestFramework):
         self.start_node(0, ["-whitelist=noban@127.0.0.1", "-maxuploadtarget=1"])
 
         # Reconnect to self.nodes[0]
-        self.nodes[0].add_p2p_connection(TestP2PConn())
+        self.nodes[0].add_p2p_connection(TestP2PConn(), sync_with_ping=False)
 
         #retrieve 20 blocks which should be enough to break the 1MB limit
         getdata_request.inv = [CInv(2, big_new_block)]

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -796,9 +796,9 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def run_test(self):
         # Setup the p2p connections
-        self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=2))
-        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=1), services=NODE_NETWORK)
-        self.additional_segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=2))
+        self.segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=2), sync_with_ping=False)
+        self.old_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=1), services=NODE_NETWORK, sync_with_ping=False)
+        self.additional_segwit_node = self.nodes[0].add_p2p_connection(TestP2PConn(cmpct_version=2), sync_with_ping=False)
 
         # We will need UTXOs to construct transactions in later tests.
         self.make_utxos()

--- a/test/functional/p2p_dos_header_tree.py
+++ b/test/functional/p2p_dos_header_tree.py
@@ -46,7 +46,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         self.headers_fork = [FromHex(CBlockHeader(), h) for h in self.headers_fork]
 
         self.log.info("Feed all non-fork headers, including and up to the first checkpoint")
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(), sync_with_ping=False)
         self.nodes[0].p2p.send_and_ping(msg_headers(self.headers))
         assert {
             'height': 546,
@@ -63,7 +63,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         self.log.info("Feed all fork headers (succeeds without checkpoint)")
         # On node 0 it succeeds because checkpoints are disabled
         self.restart_node(0, extra_args=['-nocheckpoints'])
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(), sync_with_ping=False)
         self.nodes[0].p2p.send_and_ping(msg_headers(self.headers_fork))
         assert {
             "height": 2,
@@ -73,7 +73,7 @@ class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
         } in self.nodes[0].getchaintips()
 
         # On node 1 it succeeds because no checkpoint has been reached yet by a chain tip
-        self.nodes[1].add_p2p_connection(P2PInterface())
+        self.nodes[1].add_p2p_connection(P2PInterface(), sync_with_ping=False)
         self.nodes[1].p2p.send_and_ping(msg_headers(self.headers_fork))
         assert {
             "height": 2,

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -65,15 +65,15 @@ class FilterTest(BitcoinTestFramework):
         self.skip_if_no_wallet()
 
     def run_test(self):
-        filter_node = self.nodes[0].add_p2p_connection(FilterNode())
+        filter_node = self.nodes[0].add_p2p_connection(FilterNode(), sync_with_ping=False)
 
-        self.log.info('Check that too large filter is rejected')
+        self.log.info('Check that too-large filter is rejected')
         with self.nodes[0].assert_debug_log(['Misbehaving']):
             filter_node.send_and_ping(msg_filterload(data=b'\xaa', nHashFuncs=MAX_BLOOM_HASH_FUNCS+1))
         with self.nodes[0].assert_debug_log(['Misbehaving']):
             filter_node.send_and_ping(msg_filterload(data=b'\xbb'*(MAX_BLOOM_FILTER_SIZE+1)))
 
-        self.log.info('Check that too large data element to add to the filter is rejected')
+        self.log.info('Check that too-large data element to add to the filter is rejected')
         with self.nodes[0].assert_debug_log(['Misbehaving']):
             filter_node.send_and_ping(msg_filteradd(data=b'\xcc'*(MAX_SCRIPT_ELEMENT_SIZE+1)))
 

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -55,8 +55,8 @@ class InvalidMessagesTest(BitcoinTestFramework):
 
         node = self.nodes[0]
         self.node = node
-        node.add_p2p_connection(P2PDataStore())
-        conn2 = node.add_p2p_connection(P2PDataStore())
+        node.add_p2p_connection(P2PDataStore(), sync_with_ping=False)
+        conn2 = node.add_p2p_connection(P2PDataStore(), sync_with_ping=False)
 
         msg_limit = 4 * 1000 * 1000  # 4MB, per MAX_PROTOCOL_MESSAGE_LENGTH
         valid_data_limit = msg_limit - 5  # Account for the 4-byte length prefix
@@ -163,7 +163,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
             self.nodes[0].disconnect_p2ps()
 
     def test_checksum(self):
-        conn = self.nodes[0].add_p2p_connection(P2PDataStore())
+        conn = self.nodes[0].add_p2p_connection(P2PDataStore(), sync_with_ping=False)
         with self.nodes[0].assert_debug_log(['CHECKSUM ERROR (badmsg, 2 bytes), expected 78df0a04 was ffffffff']):
             msg = conn.build_message(msg_unrecognized(str_data="d"))
             cut_len = (
@@ -192,7 +192,7 @@ class InvalidMessagesTest(BitcoinTestFramework):
             self.nodes[0].disconnect_p2ps()
 
     def test_msgtype(self):
-        conn = self.nodes[0].add_p2p_connection(P2PDataStore())
+        conn = self.nodes[0].add_p2p_connection(P2PDataStore(), sync_with_ping=False)
         with self.nodes[0].assert_debug_log(['PROCESSMESSAGE: ERRORS IN HEADER']):
             msg = msg_unrecognized(str_data="d")
             msg.msgtype = b'\xff' * 12

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -81,9 +81,9 @@ class AcceptBlockTest(BitcoinTestFramework):
     def run_test(self):
         # Setup the p2p connections
         # test_node connects to node0 (not whitelisted)
-        test_node = self.nodes[0].add_p2p_connection(P2PInterface())
+        test_node = self.nodes[0].add_p2p_connection(P2PInterface(), sync_with_ping=False)
         # min_work_node connects to node1 (whitelisted)
-        min_work_node = self.nodes[1].add_p2p_connection(P2PInterface())
+        min_work_node = self.nodes[1].add_p2p_connection(P2PInterface(), sync_with_ping=False)
 
         # 1. Have nodes mine a block (leave IBD)
         [n.generatetoaddress(1, n.get_deterministic_priv_key().address) for n in self.nodes]
@@ -198,7 +198,7 @@ class AcceptBlockTest(BitcoinTestFramework):
         self.nodes[0].disconnect_p2ps()
         self.nodes[1].disconnect_p2ps()
 
-        test_node = self.nodes[0].add_p2p_connection(P2PInterface())
+        test_node = self.nodes[0].add_p2p_connection(P2PInterface(), sync_with_ping=False)
 
         test_node.send_and_ping(msg_block(block_h1f))
         assert_equal(self.nodes[0].getblockcount(), 2)

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -140,7 +140,7 @@ class NetTest(BitcoinTestFramework):
             assert_net_servicesnames(int(info[0]["services"], 0x10), info[0]["servicesnames"])
 
     def _test_getnodeaddresses(self):
-        self.nodes[0].add_p2p_connection(P2PInterface())
+        self.nodes[0].add_p2p_connection(P2PInterface(), sync_with_ping=False)
 
         # send some addresses to the node via the p2p message addr
         msg = msg_addr()

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -475,7 +475,7 @@ class TestNode():
                     assert_msg = "bitcoind should have exited with expected error " + expected_msg
                 self._raise_assertion_error(assert_msg)
 
-    def add_p2p_connection(self, p2p_conn, *, wait_for_verack=True, **kwargs):
+    def add_p2p_connection(self, p2p_conn, *, wait_for_verack=True, sync_with_ping=True, **kwargs):
         """Add a p2p connection to the node.
 
         This method adds the p2p connection to the self.p2ps list and also
@@ -500,7 +500,11 @@ class TestNode():
             #
             # So syncing here is redundant when we only want to send a message, but the cost is low (a few milliseconds)
             # in comparision to the upside of making tests less fragile and unexpected intermittent errors less likely.
-            p2p_conn.sync_with_ping()
+            #
+            # If a caller needs to open a partial connection for testing purposes or follows this call with send_with_ping
+            # (or send_message + sync_with_ping), it may avoid syncing here by passing sync_with_ping=False.
+            if sync_with_ping:
+                p2p_conn.sync_with_ping()
 
         return p2p_conn
 


### PR DESCRIPTION
As a follow-up to PR #18247, which added `sync_with_ping` by default in `add_p2p_connection()`, this PR allows optionally passing an argument to `add_p2p_connection` to avoid running `sync_with_ping` for partial connections.

The second commit passes that argument in cases where `add_p2p_connection` is followed closely by a call to `sync_with_ping` or `send_with_ping`, or where the test integrity appears better served with the previous behavior of opening a partial connection.

As this PR maintains previous behavior WRT a few tests, there should be no downside here.