### PR TITLE
build: Fix boost detection on Ubuntu ARM 18.04

### DIFF
--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -33,7 +33,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 47
+#serial 49
 
 # example boost program (need to pass version)
 m4_define([_AX_BOOST_BASE_PROGRAM],
@@ -126,8 +126,14 @@ AC_DEFUN([_AX_BOOST_BASE_RUNDETECT],[
       [multiarch_libsubdir="lib/${host_cpu}-${host_os}"]
     )
 
+    dnl some arches may advertise a cpu type that doesn't line up with their
+    dnl prefix's cpu type. For example, uname may report armv7l while libs are
+    dnl installed to /usr/lib/arm-linux-gnueabihf. Try getting the compiler's
+    dnl value for an extra chance of finding the correct path.
+    libsubdirs="lib/`$CXX -dumpmachine 2>/dev/null` $libsubdirs"
+
     dnl first we check the system location for boost libraries
-    dnl this location ist chosen if boost libraries are installed with the --layout=system option
+    dnl this location is chosen if boost libraries are installed with the --layout=system option
     dnl or if you install boost with RPM
     AS_IF([test "x$_AX_BOOST_BASE_boost_path" != "x"],[
         AC_MSG_CHECKING([for boostlib >= $1 ($WANT_BOOST_VERSION) includes in "$_AX_BOOST_BASE_boost_path/include"])


### PR DESCRIPTION
Picked from 0.19 branch: https://github.com/bitcoin/bitcoin/commit/cd1e7bb064315ce909dfa1a0a14a5660d985f266

Update `ax_boost_base.m4` to version in progress: autoconf-archive/autoconf-archive#198

Related: #17010.