### PR TITLE
doc: fix git add argument

### DIFF
--- a/doc/release-process.md
+++ b/doc/release-process.md
@@ -219,7 +219,7 @@ Codesigner only: Commit the detached codesign payloads:
     rm -rf *
     tar xf signature-osx.tar.gz
     tar xf signature-win.tar.gz
-    git add -a
+    git add -A
     git commit -m "point to ${VERSION}"
     git tag -s v${VERSION} HEAD
     git push the current branch and new tag


### PR DESCRIPTION
[`A`](https://git-scm.com/docs/git-add#Documentation/git-add.txt--A) is the correct flag.