### PR TITLE
test: Add current year to copyright notice

### DIFF
--- a/test/lint/extended-lint-all.sh
+++ b/test/lint/extended-lint-all.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2019-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #

--- a/test/lint/extended-lint-cppcheck.sh
+++ b/test/lint/extended-lint-cppcheck.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2019 The Bitcoin Core developers
+# Copyright (c) 2019-2020 The Bitcoin Core developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #


### PR DESCRIPTION
#### What happened?
In the previous file commit [`e09c701`](https://github.com/bitcoin/bitcoin/commit/e09c701e0110350f78366fb837308c086b6503c0#diff-1555e8d857c2f076fd42da682602ec16) the year was unintentionally removed with the `./contrib/devtools/copyright_header.py update ./` command in both files.

#### What did I changed?
* I manually added the current missing year in the copyright notice.