### PR TITLE
util: Handle HTTP_SERVICE_UNAVAILABLE in bitcoin-cli

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -396,6 +396,8 @@ static UniValue CallRPC(BaseRequestHandler *rh, const std::string& strMethod, co
         } else {
             throw std::runtime_error("Authorization failed: Incorrect rpcuser or rpcpassword");
         }
+    } else if (response.status == HTTP_SERVICE_UNAVAILABLE) {
+        throw std::runtime_error(strprintf("Server response: %s", response.body));
     } else if (response.status >= 400 && response.status != HTTP_BAD_REQUEST && response.status != HTTP_NOT_FOUND && response.status != HTTP_INTERNAL_SERVER_ERROR)
         throw std::runtime_error(strprintf("server returned HTTP error %d", response.status));
     else if (response.body.empty())

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -268,7 +268,7 @@ static void http_request_cb(struct evhttp_request* req, void* arg)
             item.release(); /* if true, queue took ownership */
         else {
             LogPrintf("WARNING: request rejected because http work queue depth exceeded, it can be increased with the -rpcworkqueue= setting\n");
-            item->req->WriteReply(HTTP_INTERNAL_SERVER_ERROR, "Work queue depth exceeded");
+            item->req->WriteReply(HTTP_SERVICE_UNAVAILABLE, "Work queue depth exceeded");
         }
     } else {
         hreq->WriteReply(HTTP_NOT_FOUND);


### PR DESCRIPTION
On master (c8971547d9c9460fcbec6f54888df83f002c3dfd) the `bitcoin-cli` does not handle the "work queue depth exceeded" event properly.

Steps to reproduce:
```
# terminal 0
./src/bitcoind -debug=rpc -rpcthreads=1 -rpcworkqueue=1

# terminal 1
./src/bitcoin-cli gettxoutsetinfo

# terminal 2
./src/bitcoin-cli gettxoutsetinfo

# terminal 3
./src/bitcoin-cli gettxoutsetinfo
error: couldn't parse reply from server
```

**Expected behavior**

Get a message from a server that work queue depth exceeded.

**Actual behavior**

Got the misleading message "_couldn't parse reply from server_".

---

With this PR:
```
# terminal 0
./src/bitcoind -debug=rpc -rpcthreads=1 -rpcworkqueue=1

# terminal 1
./src/bitcoin-cli gettxoutsetinfo

# terminal 2
./src/bitcoin-cli gettxoutsetinfo

# terminal 3
./src/bitcoin-cli gettxoutsetinfo
error: Server response: Work queue depth exceeded
```

---

UPDATE: apparently, it is an alternative to #18335