### PR TITLE
build: remove -Qunused-arguments workaround for clang + ccache

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1410,9 +1410,6 @@ if test "x$use_ccache" != "xno"; then
   fi
   AC_MSG_RESULT($use_ccache)
 fi
-if test "x$use_ccache" = "xyes"; then
-    AX_CHECK_PREPROC_FLAG([-Qunused-arguments],[CPPFLAGS="-Qunused-arguments $CPPFLAGS"])
-fi
 
 dnl enable wallet
 AC_MSG_CHECKING([if wallet should be enabled])


### PR DESCRIPTION
This was added in 386efb7695debaf5f0f328a2e4c9abc342161665 to address spammy Clang warnings when building with ccache.

The issue was addressed in [ccache 3.2](https://bugzilla.samba.org/show_bug.cgi?id=8118), and from a look at most major distros, it's only Debian Jessie that has a version of ccache older than that ([3.1](https://packages.debian.org/jessie/ccache)).

Therefore I think it's acceptable to drop this workaround, and re-enable warnings for unused driver arguments (when compiling using Clang and ccache).