### PR TITLE
test: Use one node to avoid a race due to missing sync in rpc_signrawtransaction

### DIFF
--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -169,7 +169,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         assert 'complete' in spending_tx_signed
         assert_equal(spending_tx_signed['complete'], True)
 
-        # Now try with a P2PKH script as the witnessScript
+        self.log.info('Try with a P2PKH script as the witnessScript')
         embedded_addr_info = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress('', 'legacy'))
         embedded_privkey = self.nodes[1].dumpprivkey(embedded_addr_info['address'])
         witness_script = embedded_addr_info['scriptPubKey']
@@ -186,9 +186,9 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         # Check the signing completed successfully
         assert 'complete' in spending_tx_signed
         assert_equal(spending_tx_signed['complete'], True)
-        self.nodes[1].sendrawtransaction(spending_tx_signed['hex'])
+        self.nodes[0].sendrawtransaction(spending_tx_signed['hex'])
 
-        # Now try with a P2PK script as the witnessScript
+        self.log.info('Try with a P2PK script as the witnessScript')
         embedded_addr_info = self.nodes[1].getaddressinfo(self.nodes[1].getnewaddress('', 'legacy'))
         embedded_privkey = self.nodes[1].dumpprivkey(embedded_addr_info['address'])
         witness_script = CScript([hex_str_to_bytes(embedded_addr_info['pubkey']), OP_CHECKSIG]).hex()
@@ -205,7 +205,7 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         # Check the signing completed successfully
         assert 'complete' in spending_tx_signed
         assert_equal(spending_tx_signed['complete'], True)
-        self.nodes[1].sendrawtransaction(spending_tx_signed['hex'])
+        self.nodes[0].sendrawtransaction(spending_tx_signed['hex'])
 
     def run_test(self):
         self.successful_signing_test()


### PR DESCRIPTION
Node 0 creates a transaction in a block, and node 1 sends a spending transaction without properly syncing the utxo set.

Fixes intermittent test failure in rpc_signrawtransaction

```
test  2020-04-01T00:14:03.400000Z TestFramework (ERROR): JSONRPC error 
                                   Traceback (most recent call last):
                                     File "C:\projects\bitcoin\test\functional\test_framework\test_framework.py", line 112, in main
                                       self.run_test()
                                     File "C:\projects\bitcoin/test/functional/rpc_signrawtransaction.py", line 213, in run_test
                                       self.witness_script_test()
                                     File "C:\projects\bitcoin/test/functional/rpc_signrawtransaction.py", line 208, in witness_script_test
                                       self.nodes[1].sendrawtransaction(spending_tx_signed['hex'])
                                     File "C:\projects\bitcoin\test\functional\test_framework\coverage.py", line 47, in __call__
                                       return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
                                     File "C:\projects\bitcoin\test\functional\test_framework\authproxy.py", line 141, in __call__
                                       raise JSONRPCException(response['error'], status)
                                   test_framework.authproxy.JSONRPCException: bad-txns-inputs-missingorspent (-25)
```

Full log: https://ci.appveyor.com/project/DrahtBot/bitcoin/builds/31864368