### PR TITLE
qt: Fix Window -> Minimize menu item

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -456,7 +456,7 @@ void BitcoinGUI::createMenuBar()
     QAction* minimize_action = window_menu->addAction(tr("Minimize"));
     minimize_action->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_M));
     connect(minimize_action, &QAction::triggered, [] {
-        qApp->focusWindow()->showMinimized();
+        QApplication::activeWindow()->showMinimized();
     });
     connect(qApp, &QApplication::focusWindowChanged, [minimize_action] (QWindow* window) {
         minimize_action->setEnabled(window != nullptr && (window->flags() & Qt::Dialog) != Qt::Dialog && window->windowState() != Qt::WindowMinimized);


### PR DESCRIPTION
Now Window -> Minimize menu item is broken on Linux.

Steps to reproduce:

1. start `bitcoin-qt`
2. activate Window -> Minimize menu item with a keyboard (not by a shortcut) or a mouse

**Expected behavior**

The main window gets minimized.

**Actual behavior**

The main window still unchanged. Even worse: the menu widget becomes a separate window:

![Screenshot from 2020-04-07 00-32-02](https://user-images.githubusercontent.com/32963518/78608129-ffb1dd80-7868-11ea-8e73-62ecc140ac1f.png)

This PR does not touch the macOS specific code as `qApp->focusWindow()` seems work on macOS flawlessly.