### PR TITLE
Store destdata for change in separate key for backward compatibility

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3195,6 +3195,7 @@ DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx>& vWtx)
 bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& address, const std::string& strName, const std::string& strPurpose)
 {
     bool fUpdated = false;
+    const std::string strAddress = EncodeDestination(address);
     {
         LOCK(cs_wallet);
         std::map<CTxDestination, CAddressBookData>::iterator mi = m_address_book.find(address);
@@ -3214,9 +3215,9 @@ bool CWallet::SetAddressBookWithDB(WalletBatch& batch, const CTxDestination& add
     }
     NotifyAddressBookChanged(this, address, strName, IsMine(address) != ISMINE_NO,
                              strPurpose, (fUpdated ? CT_UPDATED : CT_NEW) );
-    if (!strPurpose.empty() && !batch.WritePurpose(EncodeDestination(address), strPurpose))
+    if (!strPurpose.empty() && !batch.WritePurpose(strAddress, strPurpose))
         return false;
-    return batch.WriteName(EncodeDestination(address), strName);
+    return batch.WriteName(strAddress, strName);
 }
 
 bool CWallet::SetAddressBook(const CTxDestination& address, const std::string& strName, const std::string& strPurpose)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -847,6 +847,8 @@ public:
     int64_t ScanningDuration() const { return fScanningWallet ? GetTimeMillis() - m_scanning_start : 0; }
     double ScanningProgress() const { return fScanningWallet ? (double) m_scanning_progress : 0; }
 
+    //! Check for change with non-change destdata and move it to changedata
+    void FixAddressBook(WalletBatch&) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Upgrade stored CKeyMetadata objects to store key origin info as KeyOriginInfo
     void UpgradeKeyMetadata() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
@@ -860,7 +862,7 @@ public:
     //! Erases a destination data tuple in the store and on disk
     bool EraseDestData(WalletBatch& batch, const CTxDestination& dest, const std::string& key) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Adds a destination data tuple to the store, without saving it to disk
-    void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
+    void LoadDestData(const CTxDestination& dest, const std::string& key, const std::string& value, bool is_change) EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Look up a destination data tuple in the store, return true if found false otherwise
     bool GetDestData(const CTxDestination& dest, const std::string& key, std::string* value) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     //! Get all destination values matching a prefix.

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -390,7 +390,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             ssKey >> strAddress;
             ssKey >> strKey;
             ssValue >> strValue;
-            pwallet->LoadDestData(DecodeDestination(strAddress), strKey, strValue);
+            pwallet->LoadDestData(DecodeDestination(strAddress), strKey, strValue, (strType == DBKeys::CHANGEDATA));
         } else if (strType == DBKeys::HDCHAIN) {
             CHDChain chain;
             ssValue >> chain;
@@ -537,6 +537,8 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
     if (wss.fAnyUnordered)
         result = pwallet->ReorderTransactions();
+
+    pwallet->FixAddressBook(*this);
 
     // Upgrade all of the wallet keymetadata to have the hd master key id
     // This operation is not atomic, but if it fails, updated entries are still backwards compatible with older software

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -23,6 +23,7 @@ namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
+const std::string CHANGEDATA{"changedata"};
 const std::string CRYPTED_KEY{"ckey"};
 const std::string CSCRIPT{"cscript"};
 const std::string DEFAULTKEY{"defaultkey"};
@@ -384,7 +385,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
         } else if (strType == DBKeys::ORDERPOSNEXT) {
             ssValue >> pwallet->nOrderPosNext;
-        } else if (strType == DBKeys::DESTDATA) {
+        } else if (strType == DBKeys::DESTDATA || strType == DBKeys::CHANGEDATA) {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;
             ssKey >> strKey;
@@ -740,14 +741,15 @@ bool WalletBatch::VerifyDatabaseFile(const fs::path& wallet_path, std::vector<st
     return BerkeleyBatch::VerifyDatabaseFile(wallet_path, warnings, errorStr, WalletBatch::Recover);
 }
 
-bool WalletBatch::WriteDestData(const std::string &address, const std::string &key, const std::string &value)
+bool WalletBatch::WriteDestData(const std::string &address, const std::string &key, const std::string &value, const bool is_change)
 {
-    return WriteIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(address, key)), value);
+    return WriteIC(std::make_pair(is_change ? DBKeys::CHANGEDATA : DBKeys::DESTDATA, std::make_pair(address, key)), value);
 }
 
 bool WalletBatch::EraseDestData(const std::string &address, const std::string &key)
 {
-    return EraseIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(address, key)));
+    return EraseIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(address, key)))
+        && EraseIC(std::make_pair(DBKeys::CHANGEDATA, std::make_pair(address, key)));
 }
 
 

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -241,7 +241,7 @@ public:
     bool WriteMinVersion(int nVersion);
 
     /// Write destination data key,value tuple to database
-    bool WriteDestData(const std::string &address, const std::string &key, const std::string &value);
+    bool WriteDestData(const std::string &address, const std::string &key, const std::string &value, bool is_change);
     /// Erase destination data tuple from wallet database
     bool EraseDestData(const std::string &address, const std::string &key);
 


### PR DESCRIPTION
#18192 enabled `CAddressBookData` to track change, but old versions will still load entries with destdata as non-change.

To make it backward compatible, this PR changes the database key, for change only, from "destdata" to "changedata" (which should be ignored by older versions).

If we don't merge this in 0.20, we may need to [make an exception for the "used" key](https://github.com/bitcoin/bitcoin/commit/bcbe672733d82b15bdbaf4dc2631749f40133b71), to remain compatible with 0.20 (and lose compatibility with 0.19, but that's less problematic since avoid-reuse wallets have always been broken with that version).