### PR TITLE
wallet: ensure wallet files are not reused across chains

### DIFF
--- a/src/dummywallet.cpp
+++ b/src/dummywallet.cpp
@@ -50,6 +50,7 @@ void DummyWalletInit::AddWalletOptions(ArgsManager& argsman) const
         "-flushwallet",
         "-privdb",
         "-walletrejectlongchains",
+        "-walletcrosschain",
         "-unsafesqlitesync",
     });
 }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -94,6 +94,7 @@ void WalletInit::AddWalletOptions(ArgsManager& argsman) const
 #endif
 
     argsman.AddArg("-walletrejectlongchains", strprintf("Wallet will not create transactions that violate mempool chain limits (default: %u)", DEFAULT_WALLET_REJECT_LONG_CHAINS), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
+    argsman.AddArg("-walletcrosschain", strprintf("Allow reusing wallet files across chains (default: %u)", DEFAULT_WALLETCROSSCHAIN), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::WALLET_DEBUG_TEST);
 
     argsman.AddHiddenArgs({"-zapwallettxes"});
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2918,6 +2918,20 @@ bool CWallet::AttachChain(const std::shared_ptr<CWallet>& walletInstance, interf
     assert(!walletInstance->m_chain || walletInstance->m_chain == &chain);
     walletInstance->m_chain = &chain;
 
+    // Unless allowed, ensure wallet files are not reused across chains:
+    if (!gArgs.GetBoolArg("-walletcrosschain", DEFAULT_WALLETCROSSCHAIN)) {
+        WalletBatch batch(walletInstance->GetDatabase());
+        CBlockLocator locator;
+        if (batch.ReadBestBlock(locator) && locator.vHave.size() > 0 && chain.getHeight()) {
+            // Wallet is assumed to be from another chain, if genesis block in the active
+            // chain differs from the genesis block known to the wallet.
+            if (chain.getBlockHash(0) != locator.vHave.back()) {
+                error = Untranslated("Wallet files should not be reused across chains. Restart bitcoind with -walletcrosschain to override.");
+                return false;
+            }
+        }
+    }
+
     // Register wallet with validationinterface. It's done before rescan to avoid
     // missing block connections between end of rescan and validation subscribing.
     // Because of wallet lock being hold, block connection notifications are going to

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -102,6 +102,7 @@ static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 static const bool DEFAULT_WALLET_RBF = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
+static const bool DEFAULT_WALLETCROSSCHAIN = false;
 //! -maxtxfee default
 constexpr CAmount DEFAULT_TRANSACTION_MAXFEE{COIN / 10};
 //! Discourage users to set fees higher than this amount (in satoshis) per kB

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -252,6 +252,7 @@ BASE_SCRIPTS = [
     'rpc_bind.py --ipv4',
     'rpc_bind.py --ipv6',
     'rpc_bind.py --nonloopback',
+    'wallet_crosschain.py',
     'mining_basic.py',
     'feature_signet.py',
     'wallet_bumpfee.py --legacy-wallet',

--- a/test/functional/wallet_crosschain.py
+++ b/test/functional/wallet_crosschain.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import os
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import assert_raises_rpc_error
+
+class WalletCrossChain(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def setup_network(self):
+        self.add_nodes(self.num_nodes)
+
+        # Switch node 1 to testnet before starting it.
+        self.nodes[1].chain = 'testnet3'
+        self.nodes[1].extra_args = ['-maxconnections=0'] # disable testnet sync
+        with open(self.nodes[1].bitcoinconf, 'r', encoding='utf8') as conf:
+            conf_data = conf.read()
+        with open (self.nodes[1].bitcoinconf, 'w', encoding='utf8') as conf:
+            conf.write(conf_data.replace('regtest=', 'testnet=').replace('[regtest]', '[test]'))
+
+        self.start_nodes()
+
+    def run_test(self):
+        self.log.info("Creating wallets")
+
+        node0_wallet = os.path.join(self.nodes[0].datadir, 'node0_wallet')
+        self.nodes[0].createwallet(node0_wallet)
+        self.nodes[0].unloadwallet(node0_wallet)
+        node1_wallet = os.path.join(self.nodes[1].datadir, 'node1_wallet')
+        self.nodes[1].createwallet(node1_wallet)
+        self.nodes[1].unloadwallet(node1_wallet)
+
+        self.log.info("Loading wallets into nodes with a different genesis blocks")
+
+        if self.options.descriptors:
+            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[0].loadwallet, node1_wallet)
+            assert_raises_rpc_error(-18, 'Wallet file verification failed.', self.nodes[1].loadwallet, node0_wallet)
+        else:
+            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[0].loadwallet, node1_wallet)
+            assert_raises_rpc_error(-4, 'Wallet files should not be reused across chains.', self.nodes[1].loadwallet, node0_wallet)
+
+        if not self.options.descriptors:
+            self.log.info("Override cross-chain wallet load protection")
+            self.stop_nodes()
+            self.start_nodes([['-walletcrosschain']] * self.num_nodes)
+            self.nodes[0].loadwallet(node1_wallet)
+            self.nodes[1].loadwallet(node0_wallet)
+
+
+if __name__ == '__main__':
+    WalletCrossChain().main()


### PR DESCRIPTION
This implements a proposal in #12805 and is a rebase of #14533.

This seems to be a working approach, but I'm not sure why the `p2p_segwit.py` functional test needed a change, so I'll look into it more.