### PR TITLE
[WIP] ci: Disable AppVeyor update on 2020-03-20

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 version: '{branch}.{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Previous Visual Studio 2019
 configuration: Release
 platform: x64
 clone_depth: 5


### PR DESCRIPTION
Disable [Visual Studio 2019 image update on March 20, 2020](https://www.appveyor.com/updates/2020/03/20/).

It was intended to fix #18548.