### PR TITLE
doc: Clarify developer notes about constant naming

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -83,7 +83,7 @@ code.
     separate words (snake_case).
     - Class member variables have a `m_` prefix.
     - Global variables have a `g_` prefix.
-  - Compile-time constant names are all uppercase, and use `_` to separate words.
+  - Constant names are all uppercase, and use `_` to separate words.
   - Class names, function names, and method names are UpperCamelCase
     (PascalCase). Do not prefix class names with `C`.
   - Test suite naming convention: The Boost test suite in file


### PR DESCRIPTION
I'm pretty sure developer notes were intended to say constants should be upper case and variables should be lower case, but right now they are ambiguous about whether to write:

```c++
extern const int SYMBOL;
```

or:

```c++
extern const int g_symbol;
```

First convention above is better than the second convention because it tells you without having to look anything up that the value of `SYMBOL` won't change at runtime. Also I haven't seen other c++ projects using the second convention.