### PR TITLE
ci: Add big endian native s390x build

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,7 +37,7 @@ task:
   timeout_in: 60m
   env:
     MAKEJOBS: "-j9"
-    RUN_CI_ON_HOST: "1"
+    DANGER_RUN_CI_ON_HOST: "1"
     TEST_RUNNER_PORT_MIN: "14000"  # Must be larger than 12321, which is used for the http cache. See https://cirrus-ci.org/guide/writing-tasks/#http-cache
     CCACHE_SIZE: "200M"
     CCACHE_DIR: "/tmp/ccache_dir"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ cache:
     - $TRAVIS_BUILD_DIR/depends/sdk-sources
     - $TRAVIS_BUILD_DIR/ci/scratch/.ccache
     - $TRAVIS_BUILD_DIR/releases/$HOST
-    # macOS
-    - $HOME/Library/Caches/Homebrew
-    - /usr/local/Homebrew
 before_cache:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then brew cleanup; fi
 stages:
@@ -90,6 +87,26 @@ jobs:
       env: >-
         FILE_ENV="./ci/test/00_setup_env_arm.sh"
         QEMU_USER_CMD=""
+
+    - stage: test
+      name: 's390x native BE [GOAL: install] [bionic] [no depends, no GUI]'
+      arch: s390x
+      dist: bionic
+      addons:
+        apt:
+          packages:
+            - bsdmainutils
+            - libboost-filesystem-dev
+            - libboost-system-dev
+            - libboost-test-dev
+            - libboost-thread-dev
+            - libdb++-dev
+            - libdb-dev
+            - libevent-dev
+      env: >-
+        RUN_CI_ON_HOST=true
+        CI_USE_APT_INSTALL=no
+        FILE_ENV="./ci/test/00_setup_env_s390x_host.sh"
 
 # s390 build was disabled temporarily because of disk space issues on the Travis VM
 #
@@ -158,6 +175,12 @@ jobs:
       # Xcode 11.3.1, macOS 10.14, SDK 10.15
       # https://docs.travis-ci.com/user/reference/osx/#macos-version
       osx_image: xcode11.3
+      cache:
+        directories:
+          - $TRAVIS_BUILD_DIR/ci/scratch/.ccache
+          - $TRAVIS_BUILD_DIR/releases/$HOST
+          - $HOME/Library/Caches/Homebrew
+          - /usr/local/Homebrew
       addons:
         homebrew:
           packages:
@@ -171,4 +194,6 @@ jobs:
           - ccache
           - zeromq
       env: >-
+        RUN_CI_ON_HOST=true
+        CI_USE_APT_INSTALL=no
         FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ jobs:
             - libdb-dev
             - libevent-dev
       env: >-
-        RUN_CI_ON_HOST=true
+        DANGER_RUN_CI_ON_HOST=true
         CI_USE_APT_INSTALL=no
         FILE_ENV="./ci/test/00_setup_env_s390x_host.sh"
 
@@ -194,6 +194,6 @@ jobs:
           - ccache
           - zeromq
       env: >-
-        RUN_CI_ON_HOST=true
+        DANGER_RUN_CI_ON_HOST=true
         CI_USE_APT_INSTALL=no
         FILE_ENV="./ci/test/00_setup_env_mac_host.sh"

--- a/ci/test/00_setup_env_s390x_host.sh
+++ b/ci/test/00_setup_env_s390x_host.sh
@@ -6,12 +6,9 @@
 
 export LC_ALL=C.UTF-8
 
-export HOST=x86_64-apple-darwin16
-export PIP_PACKAGES="zmq"
-export RUN_UNIT_TESTS=true
-export RUN_FUNCTIONAL_TESTS=false
-export GOAL="install"
-export BITCOIN_CONFIG="--enable-gui --enable-reduce-exports --enable-werror"
-# Run without depends
+export HOST=s390x-linux-gnu
 export NO_DEPENDS=1
-export OSX_SDK=""
+export BITCOIN_CONFIG="--with-incompatible-bdb --enable-reduce-exports"
+export RUN_UNIT_TESTS=true
+export RUN_FUNCTIONAL_TESTS=true
+export GOAL="install"

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -35,7 +35,7 @@ fi
 
 export P_CI_DIR="$PWD"
 
-if [ -z "$RUN_CI_ON_HOST" ]; then
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Creating $DOCKER_NAME_TAG container to run in"
   ${CI_RETRY_EXE} docker pull "$DOCKER_NAME_TAG"
 
@@ -91,7 +91,7 @@ export DIR_FUZZ_IN=${DIR_QA_ASSETS}/fuzz_seed_corpus/
 
 DOCKER_EXEC mkdir -p "${BASE_SCRATCH_DIR}/sanitizer-output/"
 
-if [ -z "$RUN_CI_ON_HOST" ]; then
+if [ -z "$DANGER_RUN_CI_ON_HOST" ]; then
   echo "Create $BASE_ROOT_DIR"
   DOCKER_EXEC rsync -a /ro_base/ $BASE_ROOT_DIR
 fi

--- a/ci/test/04_install.sh
+++ b/ci/test/04_install.sh
@@ -66,7 +66,7 @@ fi
 if [[ $DOCKER_NAME_TAG == centos* ]]; then
   ${CI_RETRY_EXE} DOCKER_EXEC yum -y install epel-release
   ${CI_RETRY_EXE} DOCKER_EXEC yum -y install $DOCKER_PACKAGES $PACKAGES
-elif [ "$TRAVIS_OS_NAME" != "osx" ]; then
+elif [ "$CI_USE_APT_INSTALL" != "no" ]; then
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get update
   ${CI_RETRY_EXE} DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -y $PACKAGES $DOCKER_PACKAGES
 fi
@@ -77,6 +77,7 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
 else
   DOCKER_EXEC free -m -h
   DOCKER_EXEC echo "Number of CPUs \(nproc\):" \$\(nproc\)
+  DOCKER_EXEC echo $(lscpu | grep Endian)
   DOCKER_EXEC echo "Free disk space:"
   DOCKER_EXEC df -h
 fi


### PR DESCRIPTION
Unlike the Docker wrapped solution (#17591) this PR suggests running on host system directly.

This approach makes builds quick and stable (see: #18106).

The excerpt from the Travis log:
```
...
Running on host system without docker wrapper
...
Byte Order: Big Endian
...
```