### PR TITLE
rpc: return block hash & height in getbalances, gettransaction & getwalletinfo JSONs

### DIFF
--- a/doc/release-notes-18570.md
+++ b/doc/release-notes-18570.md
@@ -1,0 +1,6 @@
+- The `getbalances` RPC now returns a `lastprocessedblock` JSON object which contains the wallet's last processed block
+  hash and height at the time the balances were calculated. This result shouldn't be cached because importing new keys could invalidate it.
+- The `gettransaction` RPC now returns a `lastprocessedblock` JSON object which contains the wallet's last processed block
+  hash and height at the time the transaction information was generated.
+- The `getwalletinfo` RPC now returns a `lastprocessedblock` JSON object which contains the wallet's last processed block
+  hash and height at the time the wallet information was generated.

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -10,6 +10,8 @@ from test_framework.address import ADDRESS_BCRT1_UNSPENDABLE as ADDRESS_WATCHONL
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_greater_than,
+    assert_is_hash_string,
     assert_raises_rpc_error,
     connect_nodes,
     sync_blocks,
@@ -158,8 +160,13 @@ class WalletTest(BitcoinTestFramework):
             expected_balances_1 = {'mine':      {'immature':          Decimal('0E-8'),
                                                  'trusted':           Decimal('0E-8'),  # node 1's send had an unsafe input
                                                  'untrusted_pending': Decimal('30.0') - fee_node_1}}  # Doesn't include output of node 0's send since it was spent
-            assert_equal(self.nodes[0].getbalances(), expected_balances_0)
-            assert_equal(self.nodes[1].getbalances(), expected_balances_1)
+            balances_0 = self.nodes[0].getbalances()
+            balances_1 = self.nodes[1].getbalances()
+            # remove lastprocessedblock keys (they will be tested later)
+            del balances_0['lastprocessedblock']
+            del balances_1['lastprocessedblock']
+            assert_equal(balances_0, expected_balances_0)
+            assert_equal(balances_1, expected_balances_1)
             # getbalance without any arguments includes unconfirmed transactions, but not untrusted transactions
             assert_equal(self.nodes[0].getbalance(), Decimal('9.99'))  # change from node 0's send
             assert_equal(self.nodes[1].getbalance(), Decimal('0'))  # node 1's send had an unsafe input
@@ -270,6 +277,33 @@ class WalletTest(BitcoinTestFramework):
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(minconf=0), total_amount + 1)  # The reorg recovered our fee of 1 coin
 
+
+        #Tests the lastprocessedblock JSON object in getbalances, getwalletinfo
+        #and gettransaction by checking for valid hex strings and by comparing
+        #the hashes & heights between generated blocks.
+        self.log.info("Test getbalances returns expected lastprocessedblock json object")
+        self.nodes[0].generatetoaddress(2, self.nodes[0].get_deterministic_priv_key().address)
+        balances = self.nodes[0].getbalances()
+        assert_greater_than(balances['mine']['immature'], 0)
+
+        prev_hash = self.nodes[0].getbestblockhash()
+        prev_height = self.nodes[0].getblock(prev_hash)['height']
+        self.nodes[0].generatetoaddress(5, self.nodes[0].get_deterministic_priv_key().address)
+        lastblock = self.nodes[0].getbalances()['lastprocessedblock']
+        assert_is_hash_string(lastblock['hash'])
+        assert_equal((prev_hash == lastblock['hash']), False)
+        assert_greater_than(lastblock['height'], prev_height)
+
+        self.log.info("Test getwalletinfo returns expected lastprocessedblock json object")
+        walletinfo = self.nodes[0].getwalletinfo()
+        assert_greater_than(walletinfo['lastprocessedblock']['height'], 0)
+        assert_is_hash_string(walletinfo['lastprocessedblock']['hash'])
+
+        self.log.info("Test gettransaction returns expected lastprocessedblock json object")
+        txid = self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
+        self.nodes[0].generatetoaddress(6, self.nodes[0].get_deterministic_priv_key().address)
+        tx_info = self.nodes[0].gettransaction(txid)
+        assert_is_hash_string(tx_info['lastprocessedblock']['hash'])
 
 if __name__ == '__main__':
     WalletTest().main()

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -510,7 +510,7 @@ class WalletTest(BitcoinTestFramework):
                                  "category": baz["category"],
                                  "vout":     baz["vout"]}
         expected_fields = frozenset({'amount', 'bip125-replaceable', 'confirmations', 'details', 'fee',
-                                     'hex', 'time', 'timereceived', 'trusted', 'txid', 'walletconflicts'})
+                                     'hex', 'lastprocessedblock', 'time', 'timereceived', 'trusted', 'txid', 'walletconflicts'})
         verbose_field = "decoded"
         expected_verbose_fields = expected_fields | {verbose_field}
 


### PR DESCRIPTION
This PR expands the JSONs returned from **getbalances**, **gettransaction** and **getwalletinfo** RPCs by adding a new property: **lastprocessedblock** that contains the **hash** and **height** of the block.

* getbalances
```shell
./src/bitcoin-cli -regtest getbalances
{
  "mine": {
    "trusted": 14284.37500000,
    "untrusted_pending": 0.00000000,
    "immature": 254.68750000
  },
  "lastprocessedblock": {
   "hash": "5ba7e8b9a9e6aed88b4641257ef13ecaace1211688f5b5fec99cad36e1650e5d",
   "height": 786
  }
}
```
* gettransaction
```shell
./src/bitcoin-cli -regtest gettransaction fa3fd022eaccd003d93a02f31848fc34d81e4e07a9a2e7690e49f92c8c1004cb
 [...snip...]
  "lastprocessedblock": {
    "hash": "592d87f3f7ff48ddf1ae07dcd0003de9e484c0df00be3b78a9681c84d607e030",
    "height": 796
  }
}
```
* getwalletinfo
```shell
./src/bitcoin-cli -regtest getwalletinfo
{
  "walletname": "",
  "walletversion": 169900,
  "balance": 14315.62500000,
  [...snip...]
  "lastprocessedblock": {
       "hash": "592d87f3f7ff48ddf1ae07dcd0003de9e484c0df00be3b78a9681c84d607e030",
       "height": 796
    }
}
```

Changes:

* Introduced a new wallet function `GetLastBlockHash` to return `m_last_block_processed `
* Introduced helper function `AppendLastProcessedBlock` to insert JSON objects
* Introduced static RPCResult variable `RESULT_LAST_PROCESSED_BLOCK` for JSON reuse
* Added tests in `tests/functional/wallet_balance.py`
* Added release-notes-18570.md

The motivation for this PR can be found here https://github.com/bitcoin/bitcoin/issues/18567

The idea to make `lastprocessedblock` an object that contains both hash and height is from **vasild**. Originally, only the hash was shown.

Fixes https://github.com/bitcoin/bitcoin/issues/18567