### PR TITLE
Wallet: Accept "changedata" db key as an alias to "destdata"

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -23,6 +23,7 @@ namespace DBKeys {
 const std::string ACENTRY{"acentry"};
 const std::string BESTBLOCK_NOMERKLE{"bestblock_nomerkle"};
 const std::string BESTBLOCK{"bestblock"};
+const std::string CHANGEDATA{"changedata"};
 const std::string CRYPTED_KEY{"ckey"};
 const std::string CSCRIPT{"cscript"};
 const std::string DEFAULTKEY{"defaultkey"};
@@ -384,7 +385,7 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             }
         } else if (strType == DBKeys::ORDERPOSNEXT) {
             ssValue >> pwallet->nOrderPosNext;
-        } else if (strType == DBKeys::DESTDATA) {
+        } else if (strType == DBKeys::DESTDATA || strType == DBKeys::CHANGEDATA) {
             std::string strAddress, strKey, strValue;
             ssKey >> strAddress;
             ssKey >> strKey;


### PR DESCRIPTION
This can make 0.20 forward compatible with the changes proposed in #18550 so we don't need an ugly hack for "used" later.

If we end up not doing #18550 as-is, this is ambiguous enough to likely be compatible with any comparable alternative - and worst case we just use another key name (or do nothing at all), and it's no different than if we made no efforts on forward-compatibility.

If we don't end up doing #18550 for whatever reason, this becomes harmless to revert since it only affects reading as-of-yet undefined keys.