### PR TITLE
[RFC] bitcoin-asmap utility

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,6 +19,7 @@ BITCOIN_GUI_NAME=bitcoin-qt
 BITCOIN_CLI_NAME=bitcoin-cli
 BITCOIN_TX_NAME=bitcoin-tx
 BITCOIN_WALLET_TOOL_NAME=bitcoin-wallet
+BITCOIN_ASMAP_NAME=bitcoin-asmap
 
 dnl Unless the user specified ARFLAGS, force it to be cr
 AC_ARG_VAR(ARFLAGS, [Flags for the archiver, defaults to <cr> if not set])
@@ -467,7 +468,7 @@ CPPFLAGS="$CPPFLAGS -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS"
 
 AC_ARG_WITH([utils],
   [AS_HELP_STRING([--with-utils],
-  [build bitcoin-cli bitcoin-tx bitcoin-wallet (default=yes)])],
+  [build bitcoin-cli bitcoin-tx bitcoin-wallet bitcoin-asmap (default=yes)])],
   [build_bitcoin_utils=$withval],
   [build_bitcoin_utils=yes])
 
@@ -488,6 +489,12 @@ AC_ARG_ENABLE([util-wallet],
   [build bitcoin-wallet])],
   [build_bitcoin_wallet=$enableval],
   [build_bitcoin_wallet=$build_bitcoin_utils])
+
+AC_ARG_ENABLE([util-asmap],
+  [AS_HELP_STRING([--enable-util-asmap],
+  [build bitcoin-asmap])],
+  [build_bitcoin_asmap=$enableval],
+  [build_bitcoin_asmap=$build_bitcoin_utils])
 
 AC_ARG_WITH([libs],
   [AS_HELP_STRING([--with-libs],
@@ -1081,6 +1088,7 @@ if test "x$enable_fuzz" = "xyes"; then
   build_bitcoin_cli=no
   build_bitcoin_tx=no
   build_bitcoin_wallet=no
+  build_bitcoin_asmap=no
   build_bitcoind=no
   build_bitcoin_libs=no
   bitcoin_enable_qt=no
@@ -1385,6 +1393,10 @@ AC_MSG_CHECKING([whether to build bitcoin-wallet])
 AM_CONDITIONAL([BUILD_BITCOIN_WALLET], [test x$build_bitcoin_wallet = xyes])
 AC_MSG_RESULT($build_bitcoin_wallet)
 
+AC_MSG_CHECKING([whether to build bitcoin-asmap])
+AM_CONDITIONAL([BUILD_BITCOIN_ASMAP], [test x$build_bitcoin_asmap = xyes])
+AC_MSG_RESULT($build_bitcoin_asmap)
+
 AC_MSG_CHECKING([whether to build libraries])
 AM_CONDITIONAL([BUILD_BITCOIN_LIBS], [test x$build_bitcoin_libs = xyes])
 if test x$build_bitcoin_libs = xyes; then
@@ -1508,7 +1520,7 @@ else
   AC_MSG_RESULT([no])
 fi
 
-if test x$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests = xnononononononono; then
+if test x$build_bitcoin_wallet$build_bitcoin_cli$build_bitcoin_tx$build_bitcoin_asmap$build_bitcoin_libs$build_bitcoind$bitcoin_enable_qt$use_bench$use_tests = xnononononononnoono; then
   AC_MSG_ERROR([No targets! Please specify at least one of: --with-utils --with-libs --with-daemon --with-gui --enable-bench or --enable-tests])
 fi
 
@@ -1557,6 +1569,7 @@ AC_SUBST(BITCOIN_DAEMON_NAME)
 AC_SUBST(BITCOIN_GUI_NAME)
 AC_SUBST(BITCOIN_CLI_NAME)
 AC_SUBST(BITCOIN_TX_NAME)
+AC_SUBST(BITCOIN_ASMAP_NAME)
 AC_SUBST(BITCOIN_WALLET_TOOL_NAME)
 
 AC_SUBST(RELDFLAGS)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,6 +91,9 @@ endif
 if BUILD_BITCOIN_TX
   bin_PROGRAMS += bitcoin-tx
 endif
+if BUILD_BITCOIN_ASMAP
+  bin_PROGRAMS += bitcoin-asmap
+endif
 if ENABLE_WALLET
 if BUILD_BITCOIN_WALLET
   bin_PROGRAMS += bitcoin-wallet
@@ -610,6 +613,19 @@ bitcoin_tx_LDADD = \
   $(LIBSECP256K1)
 
 bitcoin_tx_LDADD += $(BOOST_LIBS)
+#
+
+# bitcoin-asmap binary #
+bitcoin_asmap_SOURCES = bitcoin-asmap.cpp
+bitcoin_asmap_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+bitcoin_asmap_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+bitcoin_asmap_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+
+if TARGET_WINDOWS
+bitcoin_asmap_SOURCES += bitcoin-asmap-res.rc
+endif
+
+bitcoin_asmap_LDADD = $(LIBBITCOIN_COMMON) $(LIBBITCOIN_UTIL) $(LIBBITCOIN_CRYPTO) $(BOOST_LIBS)
 #
 
 # bitcoin-wallet binary #

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -9,6 +9,7 @@ FUZZ_TARGETS = \
   test/fuzz/address_deserialize \
   test/fuzz/addrman_deserialize \
   test/fuzz/asmap \
+  test/fuzz/asmap_direct \
   test/fuzz/banentry_deserialize \
   test/fuzz/base_encode_decode \
   test/fuzz/bech32 \
@@ -323,6 +324,12 @@ test_fuzz_asmap_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_asmap_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_asmap_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_asmap_SOURCES = test/fuzz/asmap.cpp
+
+test_fuzz_asmap_direct_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_asmap_direct_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_asmap_direct_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_asmap_direct_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_asmap_direct_SOURCES = test/fuzz/asmap_direct.cpp
 
 test_fuzz_banentry_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBANENTRY_DESERIALIZE=1
 test_fuzz_banentry_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -10,6 +10,7 @@ FUZZ_TARGETS = \
   test/fuzz/addrman_deserialize \
   test/fuzz/asmap \
   test/fuzz/asmap_direct \
+  test/fuzz/asmap_encoder \
   test/fuzz/banentry_deserialize \
   test/fuzz/base_encode_decode \
   test/fuzz/bech32 \
@@ -330,6 +331,12 @@ test_fuzz_asmap_direct_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_asmap_direct_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_asmap_direct_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_asmap_direct_SOURCES = test/fuzz/asmap_direct.cpp
+
+test_fuzz_asmap_encoder_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_asmap_encoder_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_asmap_encoder_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_asmap_encoder_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_asmap_encoder_SOURCES = test/fuzz/asmap_encoder.cpp
 
 test_fuzz_banentry_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBANENTRY_DESERIALIZE=1
 test_fuzz_banentry_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -644,5 +644,9 @@ std::vector<bool> CAddrMan::DecodeAsmap(fs::path path)
             bits.push_back((cur_byte >> bit) & 1);
         }
     }
+    if (!SanityCheckASMap(bits)) {
+        LogPrintf("Sanity check of asmap file %s failed\n", path);
+        return {};
+    }
     return bits;
 }

--- a/src/bitcoin-asmap-res.rc
+++ b/src/bitcoin-asmap-res.rc
@@ -1,0 +1,35 @@
+#include <windows.h>             // needed for VERSIONINFO
+#include "clientversion.h"       // holds the needed client version information
+
+#define VER_PRODUCTVERSION     CLIENT_VERSION_MAJOR,CLIENT_VERSION_MINOR,CLIENT_VERSION_REVISION,CLIENT_VERSION_BUILD
+#define VER_PRODUCTVERSION_STR STRINGIZE(CLIENT_VERSION_MAJOR) "." STRINGIZE(CLIENT_VERSION_MINOR) "." STRINGIZE(CLIENT_VERSION_REVISION) "." STRINGIZE(CLIENT_VERSION_BUILD)
+#define VER_FILEVERSION        VER_PRODUCTVERSION
+#define VER_FILEVERSION_STR    VER_PRODUCTVERSION_STR
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_FILEVERSION
+PRODUCTVERSION  VER_PRODUCTVERSION
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904E4" // U.S. English - multilingual (hex)
+        BEGIN
+            VALUE "CompanyName",        "Bitcoin"
+            VALUE "FileDescription",    "bitcoin-asmap (CLI Bitcoin asmap file manipulation tool)"
+            VALUE "FileVersion",        VER_FILEVERSION_STR
+            VALUE "InternalName",       "bitcoin-asmap"
+            VALUE "LegalCopyright",     COPYRIGHT_STR
+            VALUE "LegalTrademarks1",   "Distributed under the MIT software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php."
+            VALUE "OriginalFilename",   "bitcoin-asmap.exe"
+            VALUE "ProductName",        "bitcoin-asmap"
+            VALUE "ProductVersion",     VER_PRODUCTVERSION_STR
+        END
+    END
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0, 1252 // language neutral - multilingual (decimal)
+    END
+END

--- a/src/bitcoin-asmap.cpp
+++ b/src/bitcoin-asmap.cpp
@@ -1,0 +1,171 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#if defined(HAVE_CONFIG_H)
+#include <config/bitcoin-config.h>
+#endif
+
+#include <fs.h>
+#include <util/asmap.h>
+#include <util/strencodings.h>
+#include <netaddress.h>
+#include <netbase.h>
+#include <streams.h>
+#include <serialize.h>
+#include <tinyformat.h>
+
+#include <iostream>
+#include <memory>
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool LoadFile(const std::string& arg, std::vector<bool>& bits) {
+    FILE *filestr = fsbridge::fopen(arg, "rb");
+    CAutoFile file(filestr, SER_DISK, 0);
+    if (file.IsNull()) {
+        tfm::format(std::cerr, "Failed to open asmap file '%s'\n", arg);
+        return false;
+    }
+    fseek(filestr, 0, SEEK_END);
+    int length = ftell(filestr);
+    fseek(filestr, 0, SEEK_SET);
+
+    bits.clear();
+    bits.reserve(8 * length);
+    char cur_byte;
+    for (int i = 0; i < length; ++i) {
+        file >> cur_byte;
+        for (int bit = 0; bit < 8; ++bit) {
+            bits.push_back((cur_byte >> bit) & 1);
+        }
+    }
+
+    if (!SanityCheckASMap(bits)) {
+        tfm::format(std::cerr, "Provided asmap file '%s' is invalid\n", arg);
+        return false;
+    }
+
+    return true;
+}
+
+bool SaveFile(const std::string& arg, const std::vector<bool>& bits) {
+    FILE *filestr = fsbridge::fopen(arg, "wb");
+    CAutoFile file(filestr, SER_DISK, 0);
+    if (file.IsNull()) {
+        tfm::format(std::cerr, "Failed to open asmap file '%s'\n", arg);
+        return false;
+    }
+    uint8_t cur_byte = 0;
+    for (size_t i = 0; i < bits.size(); ++i) {
+        cur_byte |= (bits[i] << (i & 7));
+        if ((i & 7) == 7) {
+            file << cur_byte;
+            cur_byte = 0;
+        }
+    }
+    if (bits.size() & 7) file << cur_byte;
+
+    return true;
+}
+
+bool ExecuteDecode(const std::vector<std::string>& args) {
+    if (args.size() != 1) {
+        tfm::format(std::cerr, "Incorrect number of arguments provided to decode (needs exactly 1)\n");
+        return false;
+    }
+
+    std::vector<bool> bits;
+    if (!LoadFile(args[0], bits)) return false;
+
+    for (const auto& item : DecodeASMap(bits)) {
+        tfm::format(std::cout, "%s AS%lu\n", item.first.ToString(), item.second);
+    }
+    return true;
+}
+
+bool ExecuteLookup(const std::vector<std::string>& args) {
+    if (args.size() < 2) {
+        tfm::format(std::cerr, "Incorrect number of arguments provide to lookup (needs at least 2)\n");
+        return false;
+    }
+
+    std::vector<bool> bits;
+    if (!LoadFile(args[0], bits)) return false;
+
+    std::vector<std::pair<CNetAddr, uint32_t>> results;
+    for (size_t i = 1; i < args.size(); ++i) {
+        CNetAddr addr;
+        if (!LookupHost(args[i], addr, false)) {
+            tfm::format(std::cerr, "Cannot parse IP address '%s'\n", args[i]);
+            return false;
+        }
+        uint32_t asn = addr.GetMappedAS(bits);
+        if (asn != 0) results.emplace_back(addr, asn);
+    }
+
+    for (const auto& item : results) {
+        tfm::format(std::cout, "%s AS%lu\n", item.first.ToString(), item.second);
+    }
+
+    return true;
+}
+
+bool ExecuteEncode(const std::vector<std::string>& args) {
+    if (args.size() != 1) {
+        tfm::format(std::cerr, "Incorrect number of arguments provided to encode (needs exactly 1)\n");
+        return false;
+    }
+
+    std::vector<std::pair<CSubNet, uint32_t>> mapping;
+    for (std::string line; std::getline(std::cin, line);) {
+        size_t pos = line.find(" AS");
+        if (pos == std::string::npos) {
+            tfm::format(std::cerr, "Cannot parse '%s'\n", line.c_str());
+            return false;
+        }
+        CSubNet subnet;
+        std::string subnetstr(line.begin(), line.begin() + pos);
+        if (!LookupSubNet(subnetstr, subnet) || subnet.GetCIDR().second < 0) {
+            tfm::format(std::cerr, "Invalid subnet '%s'\n", subnetstr);
+            return false;
+        }
+        uint32_t asn;
+        std::string asnstr(line.begin() + pos +3, line.end());
+        if (!ParseUInt32(asnstr, &asn) || asn == 0 || asn == 0xFFFFFFFF) {
+            tfm::format(std::cerr, "Invalid ASN 'AS%s'\n", asnstr);
+            return false;
+        }
+        mapping.emplace_back(subnet, asn);
+    }
+
+    auto asmap = EncodeASMap(mapping);
+    return SaveFile(args[0], asmap);
+}
+
+}
+
+int main(int argc, char** argv)
+{
+    std::vector<std::string> args;
+    while (*argv != nullptr) args.emplace_back(*(argv++));
+
+    if (args.size() >= 2 && args[1] == "decode") {
+        return !ExecuteDecode(std::vector<std::string>(args.begin() + 2, args.end()));
+    } else if (args.size() >= 2 && args[1] == "encode") {
+        return !ExecuteEncode(std::vector<std::string>(args.begin() + 2, args.end()));
+    } else if (args.size() >= 2 && args[1] == "lookup") {
+        return !ExecuteLookup(std::vector<std::string>(args.begin() + 2, args.end()));
+    } else {
+        tfm::format(std::cerr, "Usage: %s decode <file>          Decode provided asmap file to stdout\n", args[0]);
+        tfm::format(std::cerr, "       %s encode <file>          Encode stdin into provided file\n", args[0]);
+        tfm::format(std::cerr, "       %s lookup <file> <IP>...  Look up ASN for provided IPs in file\n", args[0]);
+        tfm::format(std::cerr, "       %s help                   Print this message\n", args[0]);
+        return (args.size() != 2 || args[1] == "help");
+    }
+
+    return 0;
+}

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -894,3 +894,8 @@ bool operator<(const CSubNet& a, const CSubNet& b)
 {
     return (a.network < b.network || (a.network == b.network && memcmp(a.netmask, b.netmask, 16) < 0));
 }
+
+bool SanityCheckASMap(const std::vector<bool>& asmap)
+{
+    return SanityCheckASMap(asmap, 128); // For IP address lookups, the input is 128 bits
+}

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -926,3 +926,20 @@ std::vector<std::pair<CSubNet, uint32_t>> DecodeASMap(const std::vector<bool>& a
 
     return ret;
 }
+
+std::vector<bool> EncodeASMap(const std::vector<std::pair<CSubNet, uint32_t>>& mappings)
+{
+    std::vector<std::pair<std::vector<bool>, uint32_t>> bitmap;
+
+    std::vector<bool> bits(128);
+    for (const auto& item : mappings) {
+        auto cidr = item.first.GetCIDR();
+        if (cidr.second < 0) return {};
+        for (int bit = 0; bit < cidr.second; ++bit) {
+            bits[bit] = (cidr.first.GetByte((127 - bit) >> 3) >> ((127 - bit) & 7)) & 1;
+        }
+        bitmap.emplace_back(std::vector<bool>(bits.begin(), bits.begin() + cidr.second), item.second);
+    }
+
+    return EncodeASMap(std::move(bitmap), true);
+}

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -180,4 +180,6 @@ class CService : public CNetAddr
         }
 };
 
+bool SanityCheckASMap(const std::vector<bool>& asmap);
+
 #endif // BITCOIN_NETADDRESS_H

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -188,4 +188,6 @@ class CService : public CNetAddr
 
 bool SanityCheckASMap(const std::vector<bool>& asmap);
 
+std::vector<std::pair<CSubNet, uint32_t>> DecodeASMap(const std::vector<bool>& asmap);
+
 #endif // BITCOIN_NETADDRESS_H

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -136,6 +136,12 @@ class CSubNet
         friend bool operator!=(const CSubNet& a, const CSubNet& b) { return !(a == b); }
         friend bool operator<(const CSubNet& a, const CSubNet& b);
 
+        /** Return the (prefix as CNetAddr, mask length) for a CIDR-compatible mask.
+         * This treats IPv4 as embedded in IPv6 (so subtract 96 from length for IPv4).
+         * The length will be negative for non-CIDR masks.
+         */
+        std::pair<CNetAddr, int> GetCIDR() const;
+
         ADD_SERIALIZE_METHODS;
 
         template <typename Stream, typename Operation>

--- a/src/netaddress.h
+++ b/src/netaddress.h
@@ -190,4 +190,6 @@ bool SanityCheckASMap(const std::vector<bool>& asmap);
 
 std::vector<std::pair<CSubNet, uint32_t>> DecodeASMap(const std::vector<bool>& asmap);
 
+std::vector<bool> EncodeASMap(const std::vector<std::pair<CSubNet, uint32_t>>& mappings);
+
 #endif // BITCOIN_NETADDRESS_H

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -3,26 +3,47 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <netaddress.h>
-#include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 
 #include <cstdint>
 #include <vector>
 
+//! asmap code that consumes nothing
+static const std::vector<bool> IPV6_PREFIX_ASMAP = {};
+
+//! asmap code that consumes the 96 prefix bits of ::ffff:0/96 (IPv4-in-IPv6 map)
+static const std::vector<bool> IPV4_PREFIX_ASMAP = {
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
+    true, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, // Match 0xFF
+    true, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true // Match 0xFF
+};
+
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
-    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const Network network = fuzzed_data_provider.PickValueInArray({NET_IPV4, NET_IPV6});
-    if (fuzzed_data_provider.remaining_bytes() < 16) {
-        return;
-    }
-    CNetAddr net_addr;
-    net_addr.SetRaw(network, fuzzed_data_provider.ConsumeBytes<uint8_t>(16).data());
-    std::vector<bool> asmap;
-    for (const char cur_byte : fuzzed_data_provider.ConsumeRemainingBytes<char>()) {
-        for (int bit = 0; bit < 8; ++bit) {
-            asmap.push_back((cur_byte >> bit) & 1);
+    // Encoding: [7 bits: asmap size] [1 bit: ipv6?] [3-130 bytes: asmap] [4 or 16 bytes: addr]
+    if (buffer.size() < 1 + 3 + 4) return;
+    int asmap_size = 3 + (buffer[0] & 127);
+    bool ipv6 = buffer[0] & 128;
+    int addr_size = ipv6 ? 16 : 4;
+    if (buffer.size() < size_t(1 + asmap_size + addr_size)) return;
+    std::vector<bool> asmap = ipv6 ? IPV6_PREFIX_ASMAP : IPV4_PREFIX_ASMAP;
+    asmap.reserve(asmap.size() + 8 * asmap_size);
+    for (int i = 0; i < asmap_size; ++i) {
+        for (int j = 0; j < 8; ++j) {
+            asmap.push_back((buffer[1 + i] >> j) & 1);
         }
     }
+    if (!SanityCheckASMap(asmap)) return;
+    CNetAddr net_addr;
+    net_addr.SetRaw(ipv6 ? NET_IPV6 : NET_IPV4, buffer.data() + 1 + asmap_size);
     (void)net_addr.GetMappedAS(asmap);
 }

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -1,0 +1,46 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/asmap.h>
+#include <test/fuzz/fuzz.h>
+
+#include <cstdint>
+#include <vector>
+
+#include <assert.h>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    // Encoding: [asmap using 1 bit / byte] 0xFF [addr using 1 bit / byte]
+    bool have_sep = false;
+    size_t sep_pos;
+    for (size_t pos = 0; pos < buffer.size(); ++pos) {
+        uint8_t x = buffer[pos];
+        if ((x & 0xFE) == 0) continue;
+        if (x == 0xFF) {
+            if (have_sep) return;
+            have_sep = true;
+            sep_pos = pos;
+        } else {
+            return;
+        }
+    }
+    if (!have_sep) return; // Needs exactly 1 separator
+    if (buffer.size() - sep_pos - 1 > 128) return; // At most 128 bits in IP address
+
+    // Checks on asmap
+    std::vector<bool> asmap(buffer.begin(), buffer.begin() + sep_pos);
+    if (SanityCheckASMap(asmap, buffer.size() - 1 - sep_pos)) {
+        // Verify that for valid asmaps, no prefix (except up to 7 zero padding bits) is valid.
+        std::vector<bool> asmap_prefix = asmap;
+        while (!asmap_prefix.empty() && asmap_prefix.size() + 7 > asmap.size() && asmap_prefix.back() == false) asmap_prefix.pop_back();
+        while (!asmap_prefix.empty()) {
+            asmap_prefix.pop_back();
+            assert(!SanityCheckASMap(asmap_prefix, buffer.size() - 1 - sep_pos));
+        }
+        // No address input should trigger assertions in interpreter
+        std::vector<bool> addr(buffer.begin() + sep_pos + 1, buffer.end());
+        (void)Interpret(asmap, addr);
+    }
+}

--- a/src/test/fuzz/asmap_encoder.cpp
+++ b/src/test/fuzz/asmap_encoder.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <util/asmap.h>
+#include <test/fuzz/fuzz.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <vector>
+#include <stdio.h>
+#include <unordered_map>
+#include <set>
+
+#include <assert.h>
+
+namespace {
+
+/** Extend every prefix with a number of patterns for testing. */
+const std::vector<uint32_t> TEST_PATTERNS = {0, 0xffffffff, 0x55555555, 0xaaaaaaa, 0x2461611a, 0x66eac6e1, 0x943eeccb, 0xc2889f4d};
+
+/** Bytes 0x02..0xFF at the end of a 0x00/0x01 sequence determines the ASN for
+ *  that prefix. Those bytes are mapped to an geometric progressing of valid
+ *  ASN values to give a wide range.
+ */
+const uint32_t TEST_ASNS[254] = {
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 22,
+    23, 25, 26, 28, 29, 31, 33, 35, 38, 40, 43, 45, 48, 51, 54, 58, 61, 65, 69,
+    74, 78, 83, 89, 94, 100, 107, 113, 120, 128, 136, 145, 154, 163, 174, 185,
+    196, 209, 222, 236, 251, 267, 283, 301, 320, 340, 362, 385, 409, 435, 462,
+    491, 522, 555, 590, 628, 667, 709, 754, 802, 852, 906, 963, 1024, 1088,
+    1157, 1230, 1307, 1390, 1478, 1571, 1670, 1775, 1887, 2006, 2133, 2267,
+    2410, 2562, 2724, 2895, 3078, 3272, 3478, 3698, 3931, 4179, 4442, 4722,
+    5020, 5337, 5673, 6031, 6412, 6816, 7246, 7703, 8189, 8705, 9254, 9838,
+    10458, 11117, 11819, 12564, 13356, 14199, 15094, 16046, 17058, 18134,
+    19277, 20493, 21785, 23159, 24620, 26172, 27823, 29578, 31443, 33426,
+    35534, 37775, 40157, 42689, 45382, 48244, 51286, 54520, 57959, 61614,
+    65499, 69630, 74021, 78689, 83652, 88927, 94536, 100498, 106835, 113573,
+    120735, 128349, 136444, 145049, 154196, 163920, 174258, 185247, 196930,
+    209349, 222552, 236587, 251507, 267369, 284230, 302155, 321210, 341467,
+    363002, 385894, 410231, 436102, 463604, 492841, 523922, 556963, 592088,
+    629428, 669122, 711320, 756180, 803868, 854563, 908456, 965748, 1026652,
+    1091398, 1160226, 1233396, 1311179, 1393869, 1481772, 1575220, 1674561,
+    1780166, 1892432, 2011778, 2138650, 2273523, 2416902, 2569323, 2731356,
+    2903609, 3086724, 3281387, 3488327, 3708317, 3942181, 4190793, 4455084,
+    4736042, 5034719, 5352232, 5689769, 6048592, 6430045, 6835554, 7266636,
+    7724904, 8212072, 8729964, 9280516, 9865789, 10487972, 11149392, 11852525,
+    12600001, 13394616, 14239343, 15137342, 16091974, 17106809, 18185644,
+    19332516, 20551715, 21847802, 23225627, 24690343, 26247432, 27902718,
+    29662394, 31533043, 33521664
+};
+
+using elem = std::pair<std::vector<bool>, uint32_t>;
+using elem_ref = std::reference_wrapper<const elem>;
+
+void UpdateExpect(std::unordered_map<std::vector<bool>, uint32_t>& expect, const std::vector<bool>& key, uint32_t asn)
+{
+    std::vector<bool> expanded_key;
+    for (uint32_t pattern : TEST_PATTERNS) {
+        expanded_key = key;
+        expanded_key.resize(32);
+        for (size_t pos = key.size(); pos < 32; ++pos) expanded_key[pos] = (pattern >> pos) & 1;
+        expect[std::move(expanded_key)] = asn;
+    }
+}
+
+void TestASMap(std::vector<elem> input, const std::vector<elem_ref>& input_sorted, bool approx)
+{
+    // Iterate over the input in order from short to long, and build up
+    // a map of expected inputs to outputs. By going from short to long,
+    // the later inputs will correctly overwrite the mappings created by
+    // their prefixes.
+    std::unordered_map<std::vector<bool>, uint32_t> expect;
+    if (!approx) UpdateExpect(expect, {}, 0); // When !approx, everything not explicitly overridden must map to 0
+    for (elem_ref item : input_sorted) {
+        UpdateExpect(expect, item.get().first, item.get().second);
+    }
+
+    // Construct an asmap.
+    auto asmap = EncodeASMap(std::move(input), approx);
+    // It must sanity check.
+    assert(SanityCheckASMap(asmap, 32));
+    // All expected lookups must work.
+    for (const auto& item : expect) {
+        assert(Interpret(asmap, item.first) == item.second);
+    }
+
+    // Check that decoding and re-encoding yields an identical results.
+    // This guarantees that DecodeASMap does not lose any information.
+    auto decoded_asmap = DecodeASMap(asmap, 32);
+    auto recoded_asmap = EncodeASMap(std::move(decoded_asmap), approx);
+    // All expected lookups must work.
+    for (const auto& item : expect) {
+        assert(Interpret(recoded_asmap, item.first) == item.second);
+    }
+}
+
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    // Input format: ([0-32 0/1 bytes for prefix bits of netmask] [1 byte 2-255 for ASN])*
+
+    // First do a sanity check on the input (so we quickly let the fuzzer know this is uninteresting)
+    if (buffer.size() == 0) return;
+    auto it = buffer.begin();
+    while (it != buffer.end()) {
+        auto mask_begin = it;
+        while (it != buffer.end() && (*it & 0xfe) == 0) ++it;
+        if (it - mask_begin > 32) return; // Netmask too short or too long
+        if (it == buffer.end()) return; // Missing ASN
+        ++it;
+    }
+
+    // Parse the input into a format that EncodeASMap understands
+    std::vector<elem> input;
+    std::set<std::vector<bool>> already;
+    it = buffer.begin();
+    while (it != buffer.end()) {
+        auto mask_begin = it;
+        while ((*it & 0xfe) == 0) ++it;
+        auto mask = std::vector<bool>(mask_begin, it);
+        if (!already.emplace(mask).second) return; // Duplicate netmask in input
+        input.emplace_back(std::move(mask), TEST_ASNS[(*it) - 2]);
+        ++it;
+    }
+
+    // Testing requires a sorted version of the inputs as well.
+    // Use a vector of reference_wrapper to avoid copying the inputs.
+    std::vector<elem_ref> input_sorted(input.begin(), input.end());
+    std::sort(input_sorted.begin(), input_sorted.end(), [](elem_ref a, elem_ref b) { return a.get().first.size() < b.get().first.size(); });
+
+    // Test with approx = true
+    TestASMap(input, input_sorted, true);
+
+    // Test with approx = false
+    TestASMap(std::move(input), input_sorted, false);
+}

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -116,7 +116,7 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip)
             break; // Instruction straddles EOF
         }
     }
-    // Reached EOF without RETURN, or aborted (see any of the breaks above).
+    assert(false); // Reached EOF without RETURN, or aborted (see any of the breaks above) - should have been caught by SanityCheckASMap below
     return 0; // 0 is not a valid ASN
 }
 

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -126,11 +126,14 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
     std::vector<bool>::const_iterator pos = begin;
     std::vector<std::pair<uint32_t, int>> jumps; // All future positions we may jump to (bit offset in asmap -> bits to consume left)
     jumps.reserve(bits);
+    Instruction prevopcode = Instruction::JUMP;
+    bool had_incomplete_match = false;
     while (pos != endpos) {
         uint32_t offset = pos - begin;
         if (!jumps.empty() && offset >= jumps.back().first) return false; // There was a jump into the middle of the previous instruction
         Instruction opcode = DecodeType(pos, endpos);
         if (opcode == Instruction::RETURN) {
+            if (prevopcode == Instruction::DEFAULT) return false; // There should not be any RETURN immediately after a DEFAULT (could be combined into just RETURN)
             uint32_t asn = DecodeASN(pos, endpos);
             if (asn == INVALID) return false; // ASN straddles EOF
             if (jumps.empty()) {
@@ -147,6 +150,7 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
                 if (offset != jumps.back().first) return false; // Unreachable code
                 bits = jumps.back().second; // Restore the number of bits we would have had left after this jump
                 jumps.pop_back();
+                prevopcode = Instruction::JUMP;
             }
         } else if (opcode == Instruction::JUMP) {
             uint32_t jump = DecodeJump(pos, endpos);
@@ -157,15 +161,22 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits)
             uint32_t jump_offset = pos - begin + jump;
             if (!jumps.empty() && jump_offset >= jumps.back().first) return false; // Intersecting jumps
             jumps.emplace_back(jump_offset, bits);
+            prevopcode = Instruction::JUMP;
         } else if (opcode == Instruction::MATCH) {
             uint32_t match = DecodeMatch(pos, endpos);
             if (match == INVALID) return false; // Match bits straddle EOF
             int matchlen = CountBits(match) - 1;
+            if (prevopcode != Instruction::MATCH) had_incomplete_match = false;
+            if (matchlen < 8 && had_incomplete_match) return false; // Within a sequence of matches only at most one should be incomplete
+            had_incomplete_match = (matchlen < 8);
             if (bits < matchlen) return false; // Consuming bits past the end of the input
             bits -= matchlen;
+            prevopcode = Instruction::MATCH;
         } else if (opcode == Instruction::DEFAULT) {
+            if (prevopcode == Instruction::DEFAULT) return false; // There should not be two successive DEFAULTs (they could be combined into one)
             uint32_t asn = DecodeASN(pos, endpos);
             if (asn == INVALID) return false; // ASN straddles EOF
+            prevopcode = Instruction::DEFAULT;
         } else {
             return false; // Instruction straddles EOF
         }

--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -2,10 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <algorithm>
 #include <map>
+#include <memory>
 #include <vector>
 #include <assert.h>
 #include <crypto/common.h>
+#include <util/vector.h>
+
+#include <stdio.h>
 
 namespace {
 
@@ -39,6 +44,42 @@ uint32_t DecodeBits(std::vector<bool>::const_iterator& bitpos, const std::vector
     return INVALID; // Reached EOF in exponent
 }
 
+/** Append an encoding of value (with specified minval/bit_sizes parameters) to out. */
+void EncodeBits(std::vector<bool>& out, uint32_t val, uint32_t minval, const std::vector<uint8_t>& bit_sizes)
+{
+    val -= minval;
+    for (size_t pos = 0; pos < bit_sizes.size(); ++pos) {
+        uint8_t bit_size = bit_sizes[pos];
+        if (val >> bit_size) {
+            val -= (1 << bit_size);
+            out.push_back(true);
+        } else {
+            if (pos + 1 < bit_sizes.size()) out.push_back(false);
+            for (int b = 0; b < bit_size; ++b) out.push_back((val >> (bit_size - 1 - b)) & 1);
+            return;
+        }
+    }
+    assert(false);
+}
+
+/** Predict how big an encoding of value (with specified minval/bit_sizes parameters) will be. */
+size_t SizeBits(uint32_t val, uint32_t minval, const std::vector<uint8_t>& bit_sizes)
+{
+    size_t ret = 0;
+    val -= minval;
+    for (size_t pos = 0; pos < bit_sizes.size(); ++pos) {
+        uint8_t bit_size = bit_sizes[pos];
+        if (val >> bit_size) {
+            val -= (1 << bit_size);
+            ++ret;
+        } else {
+            if (pos + 1 < bit_sizes.size()) ++ret;
+            return ret + bit_size;
+        }
+    }
+    assert(false);
+}
+
 enum class Instruction : uint32_t
 {
     RETURN = 0,
@@ -53,12 +94,17 @@ Instruction DecodeType(std::vector<bool>::const_iterator& bitpos, const std::vec
     return Instruction(DecodeBits(bitpos, endpos, 0, TYPE_BIT_SIZES));
 }
 
+void EncodeType(std::vector<bool>& out, Instruction opcode) { EncodeBits(out, uint32_t(opcode), 0, TYPE_BIT_SIZES); }
+size_t SizeType(Instruction opcode) { return SizeBits(uint32_t(opcode), 0, TYPE_BIT_SIZES); }
+
 const std::vector<uint8_t> ASN_BIT_SIZES{15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
 uint32_t DecodeASN(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
 {
     return DecodeBits(bitpos, endpos, 1, ASN_BIT_SIZES);
 }
 
+void EncodeASN(std::vector<bool>& out, uint32_t asn) { EncodeBits(out, asn, 1, ASN_BIT_SIZES); }
+size_t SizeASN(uint32_t asn) { return SizeBits(asn, 1, ASN_BIT_SIZES); }
 
 const std::vector<uint8_t> MATCH_BIT_SIZES{1, 2, 3, 4, 5, 6, 7, 8};
 uint32_t DecodeMatch(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
@@ -66,11 +112,364 @@ uint32_t DecodeMatch(std::vector<bool>::const_iterator& bitpos, const std::vecto
     return DecodeBits(bitpos, endpos, 2, MATCH_BIT_SIZES);
 }
 
+void EncodeMatch(std::vector<bool>& out, uint32_t match) { EncodeBits(out, match, 2, MATCH_BIT_SIZES); }
+size_t SizeMatch(uint32_t match) { return SizeBits(match, 2, MATCH_BIT_SIZES); }
+constexpr uint32_t MATCH_MAX = 0x1FF;
 
 const std::vector<uint8_t> JUMP_BIT_SIZES{5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30};
 uint32_t DecodeJump(std::vector<bool>::const_iterator& bitpos, const std::vector<bool>::const_iterator& endpos)
 {
     return DecodeBits(bitpos, endpos, 17, JUMP_BIT_SIZES);
+}
+
+void EncodeJump(std::vector<bool>& out, uint32_t offset) { EncodeBits(out, offset, 17, JUMP_BIT_SIZES); }
+size_t SizeJump(uint32_t offset) { return SizeBits(offset, 17, JUMP_BIT_SIZES); }
+
+/** A (node of) a binary prefix tree that represents a mapping.
+ *
+ * This data structure is used as an intermediate representation when encoding.
+ *
+ * Each node is either:
+ * - A leaf (with sub[0,1] set to nullptr, and asn set)
+ * - An inner node (with sub[0,1] pointing to child nodes, and asn ignored)
+ */
+struct ASMapTrie {
+    /** The asn this node maps to if it is a leaf.
+     *
+     * - 0 means unmatched (no mapping exists for this prefix)
+     * - INVALID means dontcare (the encoding is allowed to map this to anything)
+     * - Any other value is the ASN itself.
+     *
+     * This is always 0 for inner nodes in the tree.
+     */
+    uint32_t asn = 0; /* 0=unmatched; INVALID=dontcare; others=asn */
+
+    /** The child nodes of this tree. They're nullptr for leaf nodes. */
+    std::unique_ptr<ASMapTrie> sub[2];
+
+    /** Check whether this node is a leaf. */
+    bool IsLeaf() const { return !sub[0]; }
+
+    /** Convert this node into a leaf with ASN v, regardless of what it was. */
+    void MakeLeaf(uint32_t v)
+    {
+        asn = v;
+        sub[0].reset(nullptr);
+        sub[1].reset(nullptr);
+    }
+
+    /** Make the prefix identified by begin..end map to ASN v. */
+    void MapTo(std::vector<bool>::const_iterator begin, std::vector<bool>::const_iterator end, uint32_t v)
+    {
+        if (begin == end) {
+            MakeLeaf(v);
+        } else {
+            if (IsLeaf()) {
+                // We need to descend into this node, but it's a leaf. Convert to inner node.
+                sub[0].reset(new ASMapTrie());
+                sub[1].reset(new ASMapTrie());
+                sub[0]->asn = sub[1]->asn = asn;
+                asn = 0;
+            }
+            sub[*begin]->MapTo(std::next(begin), end, v);
+        }
+    }
+
+    /** Remove unnecessary branches. */
+    void Compact()
+    {
+        if (IsLeaf()) return; // If a node is already a leaf we can't compact it further.
+        // Compact the child nodes, if possible.
+        sub[0]->Compact();
+        sub[1]->Compact();
+        // If both are (now) leaf nodes, maybe then can be merged into one.
+        if (sub[0]->IsLeaf() && sub[1]->IsLeaf()) {
+            if (sub[0]->asn == sub[1]->asn || sub[1]->asn == INVALID) {
+                // If they map to the same thing, or the second one does not matter, turn this
+                // node into a leaf equal to the first one.
+                MakeLeaf(sub[0]->asn);
+            } else if (sub[0]->asn == INVALID) {
+                // If the first one does not matter, turn this node into a leaf equal to the
+                // second one.
+                MakeLeaf(sub[1]->asn);
+            }
+        }
+    }
+};
+
+/** This class represents a potential encoding for an ASMapTrie node (=subtree). */
+struct ASMapEncoding {
+    /** Encodings for the subtrees.
+     *  - For RETURN: both are nullptr
+     *  - For DEFAULT and MATCH: left is set but right is nullptr
+     *  - For JUMP: both are set (left represents the 0 path, right the 1 path)
+     *
+     * std::shared_ptr is used because these subtrees are built in a generic
+     * programming fashion. We first construct the optimal encodings for every
+     * ASMapTrie node's children, and from those, compute the optimal encodings
+     * for the node itself. Since there may be multiple parent-encodings that
+     * are built on the same child-encodings, we need to allow them to be
+     * shared, or we'd end up with an exponential memory growth.
+     */
+    std::shared_ptr<const ASMapEncoding> left, right;
+
+    /** The number of bits this encoding will encode to (including all children).
+     *
+     * This value can be INVALID for RETURN instructions with ASN 0. These do not
+     * actually have a valid encoding, but they're used as temporaries that can
+     * get absorbed into MATCH instructions at parent levels.
+     */
+    uint32_t bits;
+
+    /** What opcode to encode. */
+    Instruction opcode;
+
+    /** What value to encode.
+     *  - For RETURN: the value to return (0=no match, INVALID=dontcare, anything else: ASN)
+     *  - For DEFAULT: the ASN to set default_asn to (only valid ASNs>0 allowed)
+     *  - For MATCH: the matchval (encoding the bits to match with; see PushMatchVal documentation)
+     *  - For JUMP: 0
+     */
+    uint32_t value;
+
+    /** Encodings can be generic or contextual. They're contextual if they are only
+     * valid when interpreted in an environment where default_asn has a specific
+     * pre-set value. This is stored in the context member. It is:
+     * - 0 if it has be interpreted with default_asn=0 (the initial value).
+     * - INVALID if it is a generic encoding (which is valid in any context).
+     * - Any other value if the last executed DEFAULT instruction before this
+     *   encoding has to be that exact value.
+    */
+    uint32_t context;
+
+    /** Whether this encoding will be valid in any context. */
+    bool IsGeneric() const { return context == INVALID; }
+
+    /** Whether an encoding actually exists for this node. */
+    bool IsValid() const { return bits != INVALID; }
+
+    /** Compute number of bits of a prospective encoding. 0 = cannot be encoded.
+     *
+     * This is a separate static function, so that we can avoid constructing a
+     * new object if it wouldn't actually be an improvement.
+     */
+    static size_t ComputeBits(Instruction opcode, uint32_t value, const std::shared_ptr<const ASMapEncoding>& left, const std::shared_ptr<const ASMapEncoding>& right)
+    {
+        if (opcode == Instruction::RETURN) {
+            // Return 0 is invalid, so output INVALID. Return dontcare (INVALID) is encoded as RETURN 1.
+            return value == 0 ? INVALID : SizeType(opcode) + SizeASN(value == INVALID ? 1 : value);
+        } else if (opcode == Instruction::JUMP) {
+            return SizeType(opcode) + SizeJump(left->bits) + left->bits + right->bits;
+        } else if (opcode == Instruction::MATCH) {
+            return SizeType(opcode) + SizeMatch(value) + left->bits;
+        } else {
+            return SizeType(opcode) + SizeASN(value) + left->bits;
+        }
+    }
+
+    /** Construct a new potential encoding object.
+     * - o: the instruction opcode
+     * - c: the context (incl. 0 or INVALID to represent default_asn=0 or dontcare)
+     * - v: the value (ASN for RETURN/DEFAULT, matchval for MATCH, 0 for JUMP)
+     * - l, r: the child encodings
+     */
+    ASMapEncoding(Instruction o, uint32_t c, uint32_t v, const std::shared_ptr<const ASMapEncoding>& l, const std::shared_ptr<const ASMapEncoding>& r)
+    {
+        opcode = o;
+        value = v;
+        context = c;
+        bits = ComputeBits(o, v, l, r);
+        left = l;
+        right = r;
+        if (o == Instruction::RETURN) {
+            assert(IsGeneric()); // RETURN instructions are always generic,
+            assert(!left && !right); // .. and never have child encodings
+        } else if (o == Instruction::JUMP) {
+            assert(left && right && left->IsValid() && right->IsValid()); // JUMP instructions have 2 valid child encodings,
+            assert(value == 0); // ... and don't have any value.
+            assert(l->IsGeneric() || r->IsGeneric() || l->context == r->context); // If both children are contextual, they must have the same context.
+            assert(context == (l->IsGeneric() ? r->context : l->context)); // The JUMP's context is the more specific one of its children's contexts.
+        } else if (o == Instruction::MATCH) {
+            assert(left && !right && left->IsValid()); // MATCH instructions have 1 valid child encoding
+            assert(value >= 2 && value <= MATCH_MAX); // Their value must be in range
+            // If the child is contextual, the MATCH must inherit it. However,
+            // if the child is generic, the MATCH may be more specific, as it
+            // will return the default_asn in case of failure).
+            assert(left->IsGeneric() || left->context == context);
+        } else if (o == Instruction::DEFAULT) {
+            assert(left && !right && left->IsValid()); // DEFAULT instructions have 1 valid child encoding,
+            assert(value != 0 && value != INVALID); // ... they cannot be 0 or dontcare,
+            assert(IsGeneric()); // ...and they're valid in every context.
+        } else {
+            assert(false);
+        }
+    }
+
+    /** Append the encoding to out. */
+    void Encode(std::vector<bool>& out) const
+    {
+        assert(IsValid()); // Only valid nodes can be encoded.
+        size_t old_size = out.size(); // Keep track of the old size.
+        EncodeType(out, opcode);
+        if (opcode == Instruction::RETURN) {
+            EncodeASN(out, value == INVALID ? 1 : value);
+        } else if (opcode == Instruction::JUMP) {
+            EncodeJump(out, left->bits);
+            left->Encode(out);
+            right->Encode(out);
+        } else if (opcode == Instruction::MATCH) {
+            EncodeMatch(out, value);
+            left->Encode(out);
+        } else if (opcode == Instruction::DEFAULT) {
+            EncodeASN(out, value);
+            left->Encode(out);
+        }
+        assert(out.size() == old_size + bits); // Verify that exactly bits bits were added.
+    }
+};
+
+/** A data structure to hold all best encodings for a subtree. */
+struct ASMapEncodings {
+    // We only keep the single best generic encoding (if one exists), and at
+    // most one contextual encoding per context value (including 0).
+    //
+    // If it were possible to have a MATCH encoding and a non-MATCH encoding
+    // for the same node and the same context, where the non-MATCH encoding was
+    // smaller, we would have needed to keep both. This is because MATCH nodes
+    // may be extended more cheaply than others, so an extension of a MATCH
+    // in that case could be smaller than the extension of the non-MATCH one.
+    //
+    // It turns out this is unnecessary, because when a MATCH encoding exists
+    // for a certain node and context, it is always the smallest encoding.
+
+    /** The best generic encoding for the subtree (nullptr if none). */
+    std::shared_ptr<const ASMapEncoding> generic;
+    /** The best contextual encodings for the subtree (for every context value). */
+    std::map<uint32_t, std::shared_ptr<const ASMapEncoding>> contextual;
+
+    /** Update this data structure with a new prospective encoding. */
+    void Consider(Instruction opcode, uint32_t context, uint32_t value = 0, const std::shared_ptr<const ASMapEncoding>& left = {}, const std::shared_ptr<const ASMapEncoding>& right = {})
+    {
+        // Compute its validity/size without constructing a new object first.
+        size_t bits = ASMapEncoding::ComputeBits(opcode, value, left, right);
+        if (context == INVALID) {
+            // Update best generic encoding if it's generic, and better than what we had.
+            if (!generic || bits < generic->bits) {
+                generic = std::make_shared<const ASMapEncoding>(opcode, context, value, left, right);
+            }
+        } else {
+            // Contextual encodings are never invalid (only RETURN can be invalid, and those are always generic).
+            assert(bits != INVALID);
+            auto it = contextual.emplace(context, std::shared_ptr<const ASMapEncoding>());
+            if (it.second || bits < it.first->second->bits) {
+                // Update best contextual encoding for the provided context, if it's new, or better than what we had.
+                it.first->second = std::make_shared<const ASMapEncoding>(opcode, context, value, left, right);
+            }
+        }
+    }
+};
+
+/** This function computes an extension to a matchval.
+ *
+ * Matchings are encoded as integers whose bits are the bits to be matched with,
+ * prefixed by a 1.
+ *
+ * So for example:
+ * - 2 = 0b10: match 0
+ * - 3 = 0b11: match 1
+ * - 9 = 0b1001: match 0,0,1
+ * - 25 = 0b11001: match 1,0,0,1
+ *
+ * This function computes a matchval that represents first matching with bit,
+ * and then matching with whatever is represented by matchval val.
+ */
+uint32_t PushMatchVal(uint32_t val, bool bit)
+{
+    int bits = CountBits(val) - 1;
+    return val + ((1 + bit) << bits);
+}
+
+/** Given an inner AsMapTrie node, with encodings l and r for its two children,
+ *  update encs with all potential encodings for the node based on this child
+ *  encodings.
+ */
+void ConsiderBranch(ASMapEncodings& encs, const std::shared_ptr<const ASMapEncoding>& l, const std::shared_ptr<const ASMapEncoding>& r) {
+    // If the right side is a RETURN with a value that compatible with the left side's context,
+    // consider a MATCH node that elides the RETURN.
+    if (r->opcode == Instruction::RETURN && (l->context == r->value || l->IsGeneric() || r->value == INVALID)) {
+        uint32_t context = l->IsGeneric() ? r->value : l->context;
+        if (l->opcode == Instruction::MATCH && PushMatchVal(l->value, false) <= MATCH_MAX) {
+            // The left side is a MATCH we can extend with a 0 bit.
+            encs.Consider(Instruction::MATCH, context, PushMatchVal(l->value, false), l->left);
+        } else if (l->IsValid()) {
+            // The left side is a valid node we can choose (2 means "match 0").
+            encs.Consider(Instruction::MATCH, context, 2, l);
+        }
+    }
+    // If the left side is a RETURN with a value that compatible with the right side's context,
+    // consider a MATCH node that elides the RETURN.
+    if (l->opcode == Instruction::RETURN && (r->context == l->value || r->IsGeneric() || l->value == INVALID)) {
+        uint32_t context = r->IsGeneric() ? l->value : r->context;
+        if (r->opcode == Instruction::MATCH && PushMatchVal(r->value, true) <= MATCH_MAX) {
+            // The right side is a MATCH we can extend with a 1 bit.
+            encs.Consider(Instruction::MATCH, context, PushMatchVal(r->value, true), r->left);
+        } else if (r->IsValid()) {
+            // The right side is a valid node we can choose (3 means "match 1").
+            encs.Consider(Instruction::MATCH, context, 3, r);
+        }
+    }
+
+    // If left and right are both valid, and they have compatible contexts, consider a JUMP node.
+    if (l->IsValid() && r->IsValid() && (l->context == r->context || l->IsGeneric() || r->IsGeneric())) {
+        encs.Consider(Instruction::JUMP, l->IsGeneric() ? r->context : l->context, 0, l, r);
+    }
+}
+
+/** Compute the best encodings (generic and contextual for any relevant context) for trie. */
+ASMapEncodings Encode(const std::unique_ptr<ASMapTrie>& trie)
+{
+    ASMapEncodings ret;
+
+    if (trie->IsLeaf()) {
+        // Leaf nodes are just directly turned into RETURN encodings (which may be invalid if asn=0).
+        ret.Consider(Instruction::RETURN, INVALID, trie->asn);
+    } else {
+        // Otherwise, compute the best encodings for the child nodes.
+        auto left = Encode(trie->sub[0]);
+        auto right = Encode(trie->sub[1]);
+
+        // Consider a branch between the two best generic encodings.
+        if (left.generic && right.generic) ConsiderBranch(ret, left.generic, right.generic);
+        // If there is a generic encoding on the left, combine it with all contextual encodings on the right.
+        if (left.generic) {
+            for (const auto& entry : right.contextual) ConsiderBranch(ret, left.generic, entry.second);
+        }
+        // If there is a generic encoding on the right, combine it with all contextual encodings on the left
+        if (right.generic) {
+            for (const auto& entry : left.contextual) ConsiderBranch(ret, entry.second, right.generic);
+        }
+        // Combine all contextual encodings where the context matches left and right.
+        for (const auto& left_entry : left.contextual) {
+            auto it = right.contextual.find(left_entry.first);
+            if (it != right.contextual.end()) ConsiderBranch(ret, left_entry.second, it->second);
+        }
+        // Any resulting contextual encoding with context!=0 can be converted into a generic one using a DEFAULT instruction.
+        for (const auto& entry : ret.contextual) {
+            if (entry.first != 0) ret.Consider(Instruction::DEFAULT, INVALID, entry.first, entry.second);
+        }
+        // If we have a valid generic encoding, any contextual ones that are not better can be removed.
+        if (ret.generic && ret.generic->IsValid()) {
+            for (auto it = ret.contextual.begin(); it != ret.contextual.end(); ) {
+                if (it->second->bits >= ret.generic->bits) {
+                    it = ret.contextual.erase(it);
+                } else {
+                    it = std::next(it);
+                }
+            }
+        }
+    }
+
+    return ret;
 }
 
 }
@@ -242,4 +641,34 @@ std::vector<std::pair<std::vector<bool>, uint32_t>> DecodeASMap(const std::vecto
         }
     }
     return {}; // Unexpected EOF
+}
+
+std::vector<bool> EncodeASMap(std::vector<std::pair<std::vector<bool>, uint32_t>> input, bool approx)
+{
+    // Sort the list from short to long prefixes.
+    using item = std::pair<std::vector<bool>, uint32_t>;
+    std::sort(input.begin(), input.end(), [](const item& a, const item& b) { return a.first.size() < b.first.size(); });
+
+    std::unique_ptr<ASMapTrie> elem(new ASMapTrie());
+    // If approx is set, we first assign the entire range to dontcare.
+    if (approx) elem->MakeLeaf(INVALID);
+    // Then overwrite the mapping for the provided prefixes to the provided ASNs.
+    // This is done in order from short to long, so that a mapping for a shorter
+    // prefix doesn't overwrite their children.
+    for (const item& entry : input) {
+        elem->MapTo(entry.first.begin(), entry.first.end(), entry.second);
+    }
+    // Remove unnecessary branches from the tree.
+    elem->Compact();
+
+    auto data = Encode(elem);
+    std::vector<bool> ret;
+    if (data.contextual.count(0) && data.contextual[0]->IsValid()) {
+        // Return the best encoding for context 0 (which is valid at the top level), if it exists.
+        data.contextual[0]->Encode(ret);
+    } else {
+        // Or the best generic one otherwise.
+        data.generic->Encode(ret);
+    }
+    return ret;
 }

--- a/src/util/asmap.h
+++ b/src/util/asmap.h
@@ -5,6 +5,11 @@
 #ifndef BITCOIN_UTIL_ASMAP_H
 #define BITCOIN_UTIL_ASMAP_H
 
+#include <stdint.h>
+#include <vector>
+
 uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip);
+
+bool SanityCheckASMap(const std::vector<bool>& asmap, int bits);
 
 #endif // BITCOIN_UTIL_ASMAP_H

--- a/src/util/asmap.h
+++ b/src/util/asmap.h
@@ -14,4 +14,10 @@ bool SanityCheckASMap(const std::vector<bool>& asmap, int bits);
 
 std::vector<std::pair<std::vector<bool>, uint32_t>> DecodeASMap(const std::vector<bool>& asmap, int bits);
 
+/** Encode a mapping to an asmap.
+ *
+ * If approx is true, unmapped prefixes will be reassigned to minimize output size.
+ */
+std::vector<bool> EncodeASMap(std::vector<std::pair<std::vector<bool>, uint32_t>> input, bool approx);
+
 #endif // BITCOIN_UTIL_ASMAP_H

--- a/src/util/asmap.h
+++ b/src/util/asmap.h
@@ -12,4 +12,6 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip);
 
 bool SanityCheckASMap(const std::vector<bool>& asmap, int bits);
 
+std::vector<std::pair<std::vector<bool>, uint32_t>> DecodeASMap(const std::vector<bool>& asmap, int bits);
+
 #endif // BITCOIN_UTIL_ASMAP_H


### PR DESCRIPTION
This adds a new binary, `bitcoin-asmap` that can be used to construct, inspect, and query asmap files. It replaces the Python scripts I had at https://github.com/sipa/asmap with something more performant, efficient, and auditable.

There are some rough edges still (in particular documenting the code and a number of edge cases), but I'd like to offer it for comments here. I'm not sure we want this code to be part of the Bitcoin Core codebase, but it certainly has advantages (in terms of code reuse and having consistent encoder/decoder). I think it may also be beneficial that users have a way to audit these files using code that's subject to our review and testing process.

This PR includes a fuzz test that verifies (for small, reduced inputs) that encoding produces asmap files consistent with their input, that invoking the interpreter on them works as expected, and that decoding and re-encoding does not change their behavior.

Given a text file `asmap.txt` with lines like these:

```
193.189.95.0/24 AS34906
193.189.96.0/24 AS20850
193.189.98.0/23 AS33925
193.190.0.0/15 AS2611
193.19.102.0/23 AS20485
193.19.103.0/24 AS8342
193.19.106.0/23 AS3257
```

You can run `bitcoin-asmap encode asmap.dat <asmap.txt` to construct an asmap file in a few seconds. `bitcoin-asmap decode asmap.dat` will decode it back to the original format (note however that the result may look very different, as unassigned IP ranges get remapped for efficiency). `bitcoin-asmap lookup asmap.dat 193.190.253.208` will look up one entry in it.

There is code at https://github.com/rrybarczyk/asmap-rs (by @rrybarczyk and @naumenkogs) to build input for this tool using RIPE's dumps of Internet routing tables.