### PR TITLE
bench: Remove requirement that all benches use same testing setup

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -15,7 +15,6 @@
 #include <numeric>
 #include <regex>
 
-const RegTestingSetup* g_testing_setup = nullptr;
 const std::function<void(const std::string&)> G_TEST_LOG_FUN{};
 
 void benchmark::ConsolePrinter::header()
@@ -115,18 +114,7 @@ void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double
     printer.header();
 
     for (const auto& p : benchmarks()) {
-        RegTestingSetup test{};
-        assert(g_testing_setup == nullptr);
-        g_testing_setup = &test;
-        {
-            LOCK(cs_main);
-            assert(::ChainActive().Height() == 0);
-            const bool witness_enabled{IsWitnessEnabled(::ChainActive().Tip(), Params().GetConsensus())};
-            assert(witness_enabled);
-        }
-
         if (!std::regex_match(p.first, baseMatch, reFilter)) {
-             g_testing_setup = nullptr;
             continue;
         }
 
@@ -139,7 +127,6 @@ void benchmark::BenchRunner::RunAll(Printer& printer, uint64_t num_evals, double
             p.second.func(state);
         }
         printer.result(state);
-        g_testing_setup = nullptr;
     }
 
     printer.footer();

--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -14,9 +14,6 @@
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>
 
-struct RegTestingSetup;
-extern const RegTestingSetup* g_testing_setup; //!< A pointer to the current testing setup
-
 // Simple micro-benchmarking framework; API mostly matches a subset of the Google Benchmark
 // framework (see https://github.com/google/benchmark)
 // Why not use the Google Benchmark framework? Because adding Yet Another Dependency

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -16,6 +16,7 @@
 
 static void AssembleBlock(benchmark::State& state)
 {
+    RegTestingSetup test_setup;
     const std::vector<unsigned char> op_true{OP_TRUE};
     CScriptWitness witness;
     witness.stack.push_back(op_true);
@@ -30,7 +31,7 @@ static void AssembleBlock(benchmark::State& state)
     std::array<CTransactionRef, NUM_BLOCKS - COINBASE_MATURITY + 1> txs;
     for (size_t b{0}; b < NUM_BLOCKS; ++b) {
         CMutableTransaction tx;
-        tx.vin.push_back(MineBlock(g_testing_setup->m_node, SCRIPT_PUB));
+        tx.vin.push_back(MineBlock(test_setup.m_node, SCRIPT_PUB));
         tx.vin.back().scriptWitness = witness;
         tx.vout.emplace_back(1337, SCRIPT_PUB);
         if (NUM_BLOCKS - b >= COINBASE_MATURITY)
@@ -47,7 +48,7 @@ static void AssembleBlock(benchmark::State& state)
     }
 
     while (state.KeepRunning()) {
-        PrepareBlock(g_testing_setup->m_node, SCRIPT_PUB);
+        PrepareBlock(test_setup.m_node, SCRIPT_PUB);
     }
 }
 

--- a/src/bench/block_assemble.cpp
+++ b/src/bench/block_assemble.cpp
@@ -42,7 +42,7 @@ static void AssembleBlock(benchmark::State& state)
 
         for (const auto& txr : txs) {
             TxValidationState state;
-            bool ret{::AcceptToMemoryPool(::mempool, state, txr, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
+            bool ret{::AcceptToMemoryPool(*test_setup.m_node.mempool, state, txr, nullptr /* plTxnReplaced */, false /* bypass_limits */, /* nAbsurdFee */ 0)};
             assert(ret);
         }
     }

--- a/src/bench/ccoins_caching.cpp
+++ b/src/bench/ccoins_caching.cpp
@@ -18,6 +18,9 @@
 // (https://github.com/bitcoin/bitcoin/issues/7883#issuecomment-224807484)
 static void CCoinsCaching(benchmark::State& state)
 {
+    const ECCVerifyHandle verify_handle;
+    ECC_Start();
+
     FillableSigningProvider keystore;
     CCoinsView coinsDummy;
     CCoinsViewCache coins(&coinsDummy);
@@ -47,6 +50,7 @@ static void CCoinsCaching(benchmark::State& state)
         CAmount value = coins.GetValueIn(tx_1);
         assert(value == (50 + 21 + 22) * COIN);
     }
+    ECC_Stop();
 }
 
 BENCHMARK(CCoinsCaching, 170 * 1000);

--- a/src/bench/checkqueue.cpp
+++ b/src/bench/checkqueue.cpp
@@ -4,7 +4,9 @@
 
 #include <bench/bench.h>
 #include <checkqueue.h>
+#include <key.h>
 #include <prevector.h>
+#include <pubkey.h>
 #include <random.h>
 #include <util/system.h>
 
@@ -24,6 +26,9 @@ static const unsigned int QUEUE_BATCH_SIZE = 128;
 // and there is a little bit of work done between calls to Add.
 static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
 {
+    const ECCVerifyHandle verify_handle;
+    ECC_Start();
+
     struct PrevectorJob {
         prevector<PREVECTOR_SIZE, uint8_t> p;
         PrevectorJob(){
@@ -59,5 +64,6 @@ static void CCheckQueueSpeedPrevectorJob(benchmark::State& state)
     }
     tg.interrupt_all();
     tg.join_all();
+    ECC_Stop();
 }
 BENCHMARK(CCheckQueueSpeedPrevectorJob, 1400);

--- a/src/bench/duplicate_inputs.cpp
+++ b/src/bench/duplicate_inputs.cpp
@@ -7,12 +7,15 @@
 #include <consensus/merkle.h>
 #include <consensus/validation.h>
 #include <pow.h>
+#include <test/util/setup_common.h>
 #include <txmempool.h>
 #include <validation.h>
 
 
 static void DuplicateInputs(benchmark::State& state)
 {
+    RegTestingSetup test_setup;
+
     const CScript SCRIPT_PUB{CScript(OP_TRUE)};
 
     const CChainParams& chainparams = Params();

--- a/src/bench/mempool_eviction.cpp
+++ b/src/bench/mempool_eviction.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 #include <policy/policy.h>
+#include <test/util/setup_common.h>
 #include <txmempool.h>
 
 
@@ -24,6 +25,8 @@ static void AddTx(const CTransactionRef& tx, const CAmount& nFee, CTxMemPool& po
 // unique transactions for a more meaningful performance measurement.
 static void MempoolEviction(benchmark::State& state)
 {
+    RegTestingSetup test_setup;
+
     CMutableTransaction tx1 = CMutableTransaction();
     tx1.vin.resize(1);
     tx1.vin[0].scriptSig = CScript() << OP_1;

--- a/src/bench/mempool_stress.cpp
+++ b/src/bench/mempool_stress.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 #include <policy/policy.h>
+#include <test/util/setup_common.h>
 #include <txmempool.h>
 
 #include <vector>
@@ -73,6 +74,7 @@ static void ComplexMemPool(benchmark::State& state)
         ordered_coins.emplace_back(MakeTransactionRef(tx));
         available_coins.emplace_back(ordered_coins.back(), tx_counter++);
     }
+    TestingSetup test_setup;
     CTxMemPool pool;
     LOCK2(cs_main, pool.cs);
     while (state.KeepRunning()) {

--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -18,6 +18,9 @@
 // modified to measure performance of other types of scripts.
 static void VerifyScriptBench(benchmark::State& state)
 {
+    const ECCVerifyHandle verify_handle;
+    ECC_Start();
+
     const int flags = SCRIPT_VERIFY_WITNESS | SCRIPT_VERIFY_P2SH;
     const int witnessversion = 0;
 
@@ -69,6 +72,7 @@ static void VerifyScriptBench(benchmark::State& state)
         assert(csuccess == 1);
 #endif
     }
+    ECC_Stop();
 }
 
 static void VerifyNestedIfScript(benchmark::State& state) {

--- a/src/bench/wallet_balance.cpp
+++ b/src/bench/wallet_balance.cpp
@@ -14,6 +14,7 @@
 
 static void WalletBalance(benchmark::State& state, const bool set_dirty, const bool add_watchonly, const bool add_mine)
 {
+    RegTestingSetup test_setup;
     const auto& ADDRESS_WATCHONLY = ADDRESS_BCRT1_UNSPENDABLE;
 
     NodeContext node;
@@ -30,8 +31,8 @@ static void WalletBalance(benchmark::State& state, const bool set_dirty, const b
     if (add_watchonly) importaddress(wallet, ADDRESS_WATCHONLY);
 
     for (int i = 0; i < 100; ++i) {
-        generatetoaddress(g_testing_setup->m_node, address_mine.get_value_or(ADDRESS_WATCHONLY));
-        generatetoaddress(g_testing_setup->m_node, ADDRESS_WATCHONLY);
+        generatetoaddress(test_setup.m_node, address_mine.get_value_or(ADDRESS_WATCHONLY));
+        generatetoaddress(test_setup.m_node, ADDRESS_WATCHONLY);
     }
     SyncWithValidationInterfaceQueue();
 


### PR DESCRIPTION
The benches have always set up one global testing setup. This makes it hard to pick no testing setup at all or one with different params.

Fix this by removing any global state setup from the main `bench.cpp` and leave the setup to each individual bench.

One reason to have one global testing setup is to set the datadir location to a tempdir to avoid reading or writing in the default datadir location. But #13687 should prevent this already.

