### PR TITLE
gitian: Add missing automake package to gitian-win-signer.yml

### DIFF
--- a/contrib/gitian-descriptors/gitian-win-signer.yml
+++ b/contrib/gitian-descriptors/gitian-win-signer.yml
@@ -8,6 +8,7 @@ architectures:
 packages:
 - "libssl-dev"
 - "autoconf"
+- "automake"
 - "libtool"
 - "pkg-config"
 remotes:


### PR DESCRIPTION
automake is needed to build osslsigncode otherwise autogen.sh fails with the docker virtualization method.