### PR TITLE
[wallet] Track conflicted transactions removed from mempool and fix UI notifications

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -147,7 +147,7 @@ public:
     }
     void TransactionRemovedFromMempool(const CTransactionRef& tx, bool is_conflicted) override
     {
-        m_notifications->transactionRemovedFromMempool(tx);
+        m_notifications->transactionRemovedFromMempool(tx, is_conflicted);
     }
     void BlockConnected(const std::shared_ptr<const CBlock>& block, const CBlockIndex* index) override
     {

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -145,7 +145,7 @@ public:
     {
         m_notifications->transactionAddedToMempool(tx);
     }
-    void TransactionRemovedFromMempool(const CTransactionRef& tx) override
+    void TransactionRemovedFromMempool(const CTransactionRef& tx, bool is_conflicted) override
     {
         m_notifications->transactionRemovedFromMempool(tx);
     }

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -258,7 +258,7 @@ public:
     public:
         virtual ~Notifications() {}
         virtual void transactionAddedToMempool(const CTransactionRef& tx) {}
-        virtual void transactionRemovedFromMempool(const CTransactionRef& ptx) {}
+        virtual void transactionRemovedFromMempool(const CTransactionRef& ptx, bool is_conflicted) {}
         virtual void blockConnected(const CBlock& block, int height) {}
         virtual void blockDisconnected(const CBlock& block, int height) {}
         virtual void updatedBlockTip() {}

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -410,7 +410,7 @@ void CTxMemPool::removeUnchecked(txiter it, MemPoolRemovalReason reason)
         // for any reason except being included in a block. Clients interested
         // in transactions included in blocks can subscribe to the BlockConnected
         // notification.
-        GetMainSignals().TransactionRemovedFromMempool(it->GetSharedTx());
+        GetMainSignals().TransactionRemovedFromMempool(it->GetSharedTx(), reason == MemPoolRemovalReason::CONFLICT);
     }
 
     const uint256 hash = it->GetTx().GetHash();

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -199,13 +199,14 @@ void CMainSignals::TransactionAddedToMempool(const CTransactionRef &ptx) {
                           ptx->GetWitnessHash().ToString());
 }
 
-void CMainSignals::TransactionRemovedFromMempool(const CTransactionRef &ptx) {
-    auto event = [ptx, this] {
-        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.TransactionRemovedFromMempool(ptx); });
+void CMainSignals::TransactionRemovedFromMempool(const CTransactionRef &ptx, bool fIsConflicted) {
+    auto event = [ptx, fIsConflicted, this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.TransactionRemovedFromMempool(ptx, fIsConflicted); });
     };
-    ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s wtxid=%s", __func__,
+    ENQUEUE_AND_LOG_EVENT(event, "%s: txid=%s wtxid=%s conflicted %s", __func__,
                           ptx->GetHash().ToString(),
-                          ptx->GetWitnessHash().ToString());
+                          ptx->GetWitnessHash().ToString(),
+                          fIsConflicted);
 }
 
 void CMainSignals::BlockConnected(const std::shared_ptr<const CBlock> &pblock, const CBlockIndex *pindex) {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -127,9 +127,12 @@ protected:
      * - BlockConnected(A)
      * - BlockConnected(B)
      *
+     * If removal is due to a conflict, provided boolean will be true to inform
+     * any client interested in changing tracking state of notified transaction.
+     *
      * Called on a background thread.
      */
-    virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx) {}
+    virtual void TransactionRemovedFromMempool(const CTransactionRef &ptx, bool fIsConflicted) {}
     /**
      * Notifies listeners of a block being connected.
      * Provides a vector of transactions evicted from the mempool as a result.
@@ -197,7 +200,7 @@ public:
 
     void UpdatedBlockTip(const CBlockIndex *, const CBlockIndex *, bool fInitialDownload);
     void TransactionAddedToMempool(const CTransactionRef &);
-    void TransactionRemovedFromMempool(const CTransactionRef &);
+    void TransactionRemovedFromMempool(const CTransactionRef &, bool fIsConflicted);
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex);
     void ChainStateFlushed(const CBlockLocator &);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -152,6 +152,8 @@ static void WalletTxToJSON(interfaces::Chain& chain, interfaces::Chain::Lock& lo
     }
     uint256 hash = wtx.GetHash();
     entry.pushKV("txid", hash.GetHex());
+    if (wtx.isConflicted())
+        entry.pushKV("conflicted", true);
     UniValue conflicts(UniValue::VARR);
     for (const uint256& conflict : wtx.GetConflicts())
         conflicts.push_back(conflict.GetHex());
@@ -1366,6 +1368,7 @@ static const std::vector<RPCResult> TransactionDescriptionString()
            {RPCResult::Type::NUM, "blockindex", "The index of the transaction in the block that includes it."},
            {RPCResult::Type::NUM_TIME, "blocktime", "The block time expressed in " + UNIX_EPOCH_TIME + "."},
            {RPCResult::Type::STR_HEX, "txid", "The transaction id."},
+           {RPCResult::Type::BOOL, "conflicted", "Only present if transaction is conflicted"},
            {RPCResult::Type::ARR, "walletconflicts", "Conflicting transaction ids.",
            {
                {RPCResult::Type::STR_HEX, "txid", "The transaction id."},

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -928,7 +928,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef& ptx, CWalletTx::Co
                     range.first++;
                 }
             }
-        }
+        } //TODO: if transaction is already signaled as conflicted
 
         bool fExisted = mapWallet.count(tx.GetHash()) != 0;
         if (fExisted && !fUpdate) return false;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -907,8 +907,8 @@ public:
         //! USER_ABORT.
         uint256 last_failed_block;
     };
-    ScanResult ScanForWalletTransactions(const uint256& start_block, int start_height, Optional<int> max_height, const WalletRescanReserver& reserver, bool fUpdate);
-    void transactionRemovedFromMempool(const CTransactionRef &ptx) override;
+    ScanResult ScanForWalletTransactions(const uint256& start_block, int start_height, Optional<int>max_height, const WalletRescanReserver& reserver, bool fUpdate);
+    void transactionRemovedFromMempool(const CTransactionRef &ptxi, bool is_conflicted) override;
     void ReacceptWalletTransactions() EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
     void ResendWalletTransactions();
     struct Balance {


### PR DESCRIPTION
UI notifications and the -walletnotify process should be triggered for wallet transactions that are conflicted out of the mempool by a newly connected block.

Unfortunately, it has been broken by 7e89994 by removing the call to `SyncTransaction()` for block-conflicted transactions in `CWallet::BlockConnected`. This PR restores conflict tracking but instead relies on `TransactionRemovedFromMempool`. 

Doing so allows for wider conflict detection, i.e non-connected wallet transactions. Transaction A may not involves wallet but may be spent by a transaction B paying back to a wallet address. Double-spend of transaction A won't trigger a conflict for transaction B as A isn't tracked by wallet (`mapTxSpends`).

This PR also extends conflicts detection to mempool replacement (`MemPoolRemovalReason::REPLACED`), as for an end-user, consequences are likely to be interpreted the same, conflicted funds aren't available. Distinction of reasons (block-connected or mempool-replacement) should stay clear for us.

Conflicts detection stays a best-effort, as a mempool replacement may happen while wallet is shutdown, and mempool isn't replayed at wallet rescan, conflict can't be see.

Fixes #18325 