### PR TITLE
build: Link time garbage collection

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -42,9 +42,9 @@ script: |
   CONFIGFLAGS="--enable-glibc-back-compat --enable-reduce-exports --disable-bench --disable-gui-tests"
   FAKETIME_HOST_PROGS="gcc g++"
   FAKETIME_PROGS="date ar ranlib nm"
-  HOST_CFLAGS="-O2 -g"
-  HOST_CXXFLAGS="-O2 -g"
-  HOST_LDFLAGS_BASE="-static-libstdc++ -Wl,-O2"
+  HOST_CFLAGS="-O2 -g -ffunction-sections -fdata-sections"
+  HOST_CXXFLAGS="-O2 -g -ffunction-sections -fdata-sections"
+  HOST_LDFLAGS_BASE="-static-libstdc++ -Wl,-O2 -Wl,--gc-sections"
 
   export QT_RCC_TEST=1
   export QT_RCC_SOURCE_DATE_OVERRIDE=1

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -174,7 +174,7 @@ esac
 # CFLAGS
 HOST_CFLAGS="-O2 -g"
 case "$HOST" in
-    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=." ;;
+    *linux*)  HOST_CFLAGS+=" -ffile-prefix-map=${PWD}=. -ffunction-sections -fdata-sections" ;;
     *mingw*)  HOST_CFLAGS+=" -fno-ident" ;;
 esac
 
@@ -183,7 +183,7 @@ HOST_CXXFLAGS="$HOST_CFLAGS"
 
 # LDFLAGS
 case "$HOST" in
-    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++ -Wl,-O2" ;;
+    *linux*)  HOST_LDFLAGS="-Wl,--as-needed -Wl,--dynamic-linker=$glibc_dynamic_linker -static-libstdc++ -Wl,-O2 -Wl,--gc-sections" ;;
     *mingw*)  HOST_LDFLAGS="-Wl,--no-insert-timestamp" ;;
 esac
 


### PR DESCRIPTION
Closes #18579.

Adds the linker flags required to turn on link time garbage collection
to the Linux gitian descriptors and Guix build. After some experimentation
I'm not convinced this is something that we should do for Windows builds
at this stage.

Size comparison for a gitian build of master (df303ceb650521dc7b1ba91e0eea383c387a5860) vs this PR (8c31ef9ec68549c4105e8115f74f435c71b3901c):

| binary | master (df303ceb650521dc7b1ba91e0eea383c387a5860) | PR (8c31ef9ec68549c4105e8115f74f435c71b3901c) | saving | 
| - | - | - | - |
| bitcoind | 10525336 | 9775672 | 7% |
| bitcoin-cli | 2055800 | 1113624 | 45% |
| bitcoin-qt | 31896456 | 31114024 | 2.5%
| bitcoin-tx | 2376152 | 1372536 | 42% |
| bitcoin-wallet | 5899168 | 3199808 | 45% |
| test_bitcoin | 17063328 | 15354784 | 10% |