### PR TITLE
cli: show default values in config args log

### DIFF
--- a/src/util/system.h
+++ b/src/util/system.h
@@ -166,6 +166,7 @@ protected:
     std::set<std::string> m_network_only_args GUARDED_BY(cs_args);
     std::map<OptionsCategory, std::map<std::string, Arg>> m_available_args GUARDED_BY(cs_args);
     std::list<SectionInfo> m_config_sections GUARDED_BY(cs_args);
+    std::map<std::string, std::string> settings_defaults GUARDED_BY(cs_args);
 
     NODISCARD bool ReadConfigStream(std::istream& stream, const std::string& filepath, std::string& error, bool ignore_invalid_keys = false);
 
@@ -329,6 +330,11 @@ public:
      * useful for troubleshooting.
      */
     void LogArgs() const;
+
+    /**
+     * Map of default setting values
+     */
+    const std::map<std::string, std::string> GetSettingsDefaults() const;
 
 private:
     // Helper function for LogArgs().


### PR DESCRIPTION
This PR expands the config args listing that shows up at boot. The motivation for this PR is based on this old issue from 2016: https://github.com/bitcoin/bitcoin/issues/8165

However, this PR isn't changing anything in the UI and only changes the output of the config args list in debug.log.

The proposed config arg list would like this:

```shell
2020-04-12T20:35:30Z Config file arg: [main] daemon="1"
2020-04-12T20:35:30Z Config file arg: [main] deprecatedrpc="signrawtransaction"
2020-04-12T20:35:30Z Config file arg: [main] listen="1", default=1
2020-04-12T20:35:30Z Config file arg: [main] port="8444", default=8333
2020-04-12T20:35:30Z Config file arg: [main] prune="550", default=0
2020-04-12T20:35:30Z Config file arg: [main] rest="1", default=0
2020-04-12T20:35:30Z Config file arg: [main] rpcallowip="127.0.0.1"
2020-04-12T20:35:30Z Config file arg: [main] rpcbind=****, default=127
2020-04-12T20:35:30Z Config file arg: [main] rpcpassword=****
2020-04-12T20:35:30Z Config file arg: [main] rpcport="8445", default=8332
2020-04-12T20:35:30Z Config file arg: [main] rpcuser=****
2020-04-12T20:35:30Z Config file arg: [main] server="1"
2020-04-12T20:35:30Z Config file arg: [regtest] blockfilterindex="basic", default=0
2020-04-12T20:35:30Z Config file arg: [regtest] daemon="0"
2020-04-12T20:35:30Z Config file arg: [regtest] listen="1", default=1
2020-04-12T20:35:30Z Config file arg: [regtest] rest="1", default=0
2020-04-12T20:35:30Z Config file arg: [regtest] rpcallowip="127.0.0.1"
2020-04-12T20:35:30Z Config file arg: [regtest] rpcbind=****, default=127
2020-04-12T20:35:30Z Config file arg: [regtest] server="1"
2020-04-12T20:35:30Z Config file arg: [regtest] upnp="0", default=0
2020-04-12T20:35:30Z Config file arg: [test] daemon="1"
2020-04-12T20:35:30Z Config file arg: [test] deprecatedrpc="signrawtransaction"
2020-04-12T20:35:30Z Config file arg: [test] listen="1", default=1
2020-04-12T20:35:30Z Config file arg: [test] prune="550", default=0
2020-04-12T20:35:30Z Config file arg: [test] rest="1", default=0
2020-04-12T20:35:30Z Config file arg: [test] rpcallowip="127.0.0.1"
2020-04-12T20:35:30Z Config file arg: [test] rpcbind=****, default=127
2020-04-12T20:35:30Z Config file arg: [test] server="1"
```

Only those args that have default values set will be extended with a `default=` entry.

The current implementation is using a simple regex to extract default values from available argument descriptions.