### PR TITLE
WIP: Make CScript addition concatenative

### DIFF
--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -428,7 +428,7 @@ class CScript(bytes):
     __slots__ = ()
 
     @classmethod
-    def __coerce_instance(cls, other):
+    def __coerce_instance(cls, other, nested):
         # Coerce other into bytes
         if isinstance(other, CScriptOp):
             other = bytes([other])
@@ -444,6 +444,8 @@ class CScript(bytes):
                 other = bytes([OP_1NEGATE])
             else:
                 other = CScriptOp.encode_op_pushdata(bn2vch(other))
+        elif isinstance(other, CScript) and not nested:
+            pass
         elif isinstance(other, (bytes, bytearray)):
             other = CScriptOp.encode_op_pushdata(other)
         return other
@@ -451,7 +453,7 @@ class CScript(bytes):
     def __add__(self, other):
         # Do the coercion outside of the try block so that errors in it are
         # noticed.
-        other = self.__coerce_instance(other)
+        other = self.__coerce_instance(other, False)
 
         try:
             # bytes.__add__ always returns bytes instances unfortunately
@@ -469,7 +471,7 @@ class CScript(bytes):
         else:
             def coerce_iterable(iterable):
                 for instance in iterable:
-                    yield cls.__coerce_instance(instance)
+                    yield cls.__coerce_instance(instance, True)
             # Annoyingly on both python2 and python3 bytes.join() always
             # returns a bytes instance even when subclassed.
             return super(CScript, cls).__new__(cls, b''.join(coerce_iterable(value)))


### PR DESCRIPTION
This has come up in some testing related stuff I've been working on... Opening as a WIP because a lot of stuff fails as a result and trying to decide if it's worth fixing or if I should ignore it...

Currently:
```python
CScript(["hello", "world"]) != CScript(["hello"]) + CScript(["world"])

CScript(["hello"]) + CScript(["world"]) == CScript(["hello", "\x06\x05world") == CScript(["hello", CScript(["world"]))
```

It doesn't seem like there's a way to reach `CScript(["hello", "world"])` other than by chaining the iterators together, which is clunky.

This patch redefines addition of scripts such that:

```python
CScript(["hello", "world"]) == CScript(["hello"]) + CScript(["world"])

CScript(["hello"]) + CScript(["world"]) != (CScript(["hello", "\x06\x05world") == CScript(["hello", CScript(["world"])))
```

Note that adding a raw bytes to a CScript preserves the old behavior, e.g., `CScript(["hello"]) + "world" == CScript(["hello", "world"])`.

An alternative to this is to get rid of the `nested` parameter to `__coerce_instance` and always leave CScript as concatenative -- e.g., `CScript([a,CScript([b])]) == CScript([a,b]) == CScript([a]) + CScript([a,b])` and you have to coerce to bytes first to get a push. This breaks fewer tests, but seems a bit more subtle?