### PR TITLE
script: Disallow silent bool -> CScript conversion

### DIFF
--- a/src/script/script.h
+++ b/src/script/script.h
@@ -433,7 +433,7 @@ public:
         return ret;
     }
 
-    CScript(int64_t b)        { operator<<(b); }
+    explicit CScript(int64_t b) { operator<<(b); }
 
     explicit CScript(opcodetype b)     { operator<<(b); }
     explicit CScript(const CScriptNum& b) { operator<<(b); }


### PR DESCRIPTION
Makes nonsensical stuff like `ScriptToAsmStr(false,false);` a compile failure