### PR TITLE
rpc: gui: Don't change behavior based on private keys disabled, instead add new buttons/rpcs/menu items

### DIFF
--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -6,10 +6,18 @@
 #define BITCOIN_NODE_TRANSACTION_H
 
 #include <attributes.h>
+#include <policy/feerate.h>
 #include <primitives/transaction.h>
 #include <util/error.h>
 
 struct NodeContext;
+
+/** Maximum fee rate for sendrawtransaction and testmempoolaccept RPC calls.
+ * Also used by the GUI when broadcasting a completed PSBT.
+ * By default, a transaction with a fee rate higher than this will be rejected
+ * by these RPCs and the GUI. This can be overridden with the maxfeerate argument.
+ */
+static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
 
 /**
  * Submit a transaction to the mempool and (optionally) relay it to all P2P peers.

--- a/src/psbt.h
+++ b/src/psbt.h
@@ -40,6 +40,10 @@ static constexpr uint8_t PSBT_OUT_BIP32_DERIVATION = 0x02;
 // as a 0 length key which indicates that this is the separator. The separator has no value.
 static constexpr uint8_t PSBT_SEPARATOR = 0x00;
 
+// BIP 174 does not specify a maximum file size, but we set a limit anyway
+// to prevent reading a stream indefinately and running out of memory.
+const std::streamsize MAX_FILE_SIZE_PSBT = 100000000; // 100 MiB
+
 /** A structure for PSBTs which contain per-input information */
 struct PSBTInput
 {

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -317,6 +317,8 @@ void BitcoinGUI::createActions()
     signMessageAction->setStatusTip(tr("Sign messages with your Bitcoin addresses to prove you own them"));
     verifyMessageAction = new QAction(tr("&Verify message..."), this);
     verifyMessageAction->setStatusTip(tr("Verify messages to ensure they were signed with specified Bitcoin addresses"));
+    m_load_psbt_action = new QAction(tr("Load PSBT..."), this);
+    m_load_psbt_action->setStatusTip(tr("Load Partially Signed Bitcoin Transaction"));
 
     openRPCConsoleAction = new QAction(tr("Node window"), this);
     openRPCConsoleAction->setStatusTip(tr("Open node debugging and diagnostic console"));
@@ -366,6 +368,7 @@ void BitcoinGUI::createActions()
         connect(changePassphraseAction, &QAction::triggered, walletFrame, &WalletFrame::changePassphrase);
         connect(signMessageAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
         connect(signMessageAction, &QAction::triggered, [this]{ gotoSignMessageTab(); });
+        connect(m_load_psbt_action, &QAction::triggered, [this]{ gotoLoadPSBT(); });
         connect(verifyMessageAction, &QAction::triggered, [this]{ showNormalIfMinimized(); });
         connect(verifyMessageAction, &QAction::triggered, [this]{ gotoVerifyMessageTab(); });
         connect(usedSendingAddressesAction, &QAction::triggered, walletFrame, &WalletFrame::usedSendingAddresses);
@@ -438,6 +441,7 @@ void BitcoinGUI::createMenuBar()
         file->addAction(backupWalletAction);
         file->addAction(signMessageAction);
         file->addAction(verifyMessageAction);
+        file->addAction(m_load_psbt_action);
         file->addSeparator();
     }
     file->addAction(quitAction);
@@ -853,6 +857,10 @@ void BitcoinGUI::gotoSignMessageTab(QString addr)
 void BitcoinGUI::gotoVerifyMessageTab(QString addr)
 {
     if (walletFrame) walletFrame->gotoVerifyMessageTab(addr);
+}
+void BitcoinGUI::gotoLoadPSBT()
+{
+    if (walletFrame) walletFrame->gotoLoadPSBT();
 }
 #endif // ENABLE_WALLET
 

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -135,6 +135,7 @@ private:
     QAction* usedReceivingAddressesAction = nullptr;
     QAction* signMessageAction = nullptr;
     QAction* verifyMessageAction = nullptr;
+    QAction* m_load_psbt_action = nullptr;
     QAction* aboutAction = nullptr;
     QAction* receiveCoinsAction = nullptr;
     QAction* receiveCoinsMenuAction = nullptr;
@@ -270,6 +271,8 @@ public Q_SLOTS:
     void gotoSignMessageTab(QString addr = "");
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
+    /** Show load Partially Signed Bitcoin Transaction dialog */
+    void gotoLoadPSBT();
 
     /** Show open dialog */
     void openClicked();

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>850</width>
-    <height>526</height>
+    <height>572</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -587,8 +587,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>830</width>
-        <height>104</height>
+        <width>834</width>
+        <height>83</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1">
@@ -761,14 +761,14 @@
           </item>
           <item>
            <widget class="QLabel" name="fallbackFeeWarningLabel">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
             <property name="toolTip">
              <string>Using the fallbackfee can result in sending a transaction that will take several hours or days (or never) to confirm. Consider choosing your fee manually or wait until you have validated the complete chain.</string>
-            </property>
-            <property name="font">
-            <font>
-                <weight>75</weight>
-                <bold>true</bold>
-            </font>
             </property>
             <property name="text">
              <string>Warning: Fee estimation is currently not possible.</string>
@@ -850,7 +850,7 @@
                    <property name="toolTip">
                     <string>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</string>
+Note:  Since the fee is calculated on a per-byte basis, a fee of &quot;100 satoshis per kB&quot; for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</string>
                    </property>
                    <property name="text">
                     <string>per kilobyte</string>
@@ -1074,11 +1074,11 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
            </item>
            <item>
             <widget class="QCheckBox" name="optInRBF">
-             <property name="text">
-              <string>Enable Replace-By-Fee</string>
-             </property>
              <property name="toolTip">
               <string>With Replace-By-Fee (BIP-125) you can increase a transaction's fee after it is sent. Without this, a higher fee may be recommended to compensate for increased transaction delay risk.</string>
+             </property>
+             <property name="text">
+              <string>Enable Replace-By-Fee</string>
              </property>
             </widget>
            </item>
@@ -1118,6 +1118,32 @@ Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis p
        </property>
        <property name="text">
         <string>S&amp;end</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../bitcoin.qrc">
+         <normaloff>:/icons/send</normaloff>:/icons/send</iconset>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+       <property name="default">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="makeUnsignedButton">
+       <property name="minimumSize">
+        <size>
+         <width>150</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Creates a Partially Signed Bitcoin Transaction (PSBT) for use with e.g. an offline wallet, or a PSBT-compatible hardware wallet.</string>
+       </property>
+       <property name="text">
+        <string>Cr&amp;eate Unsigned</string>
        </property>
        <property name="icon">
         <iconset resource="../bitcoin.qrc">

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -60,6 +60,7 @@ private:
     Ui::SendCoinsDialog *ui;
     ClientModel *clientModel;
     WalletModel *model;
+    std::unique_ptr<WalletModelTransaction> m_current_transaction;
     bool fNewRecipientAllowed;
     bool fFeeMinimized;
     const PlatformStyle *platformStyle;
@@ -69,6 +70,8 @@ private:
     // Additional parameter msgArg can be used via .arg(msgArg).
     void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());
     void minimizeFeeSection(bool fMinimize);
+    // Format confirmation message
+    bool PrepareSendText(QString& question_string, QString& informative_text, QString& detailed_text);
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -71,13 +71,14 @@ private:
     void processSendCoinsReturn(const WalletModel::SendCoinsReturn &sendCoinsReturn, const QString &msgArg = QString());
     void minimizeFeeSection(bool fMinimize);
     // Format confirmation message
-    bool PrepareSendText(QString& question_string, QString& informative_text, QString& detailed_text);
+    bool PrepareSendText(QString& question_string, QString& informative_text, QString& detailed_text, bool make_psbt);
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
 
 private Q_SLOTS:
     void on_sendButton_clicked();
+    void on_makeUnsignedButton_clicked();
     void on_buttonChooseFee_clicked();
     void on_buttonMinimizeFee_clicked();
     void removeEntry(SendCoinsEntry* entry);

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -77,6 +77,7 @@ private:
     QDateTimeEdit *dateTo;
     QAction *abandonAction;
     QAction *bumpFeeAction;
+    QAction *bumpFeePSBTAction;
 
     QWidget *createDateRangeWidget();
 
@@ -100,7 +101,8 @@ private Q_SLOTS:
     void openThirdPartyTxUrl(QString url);
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
     void abandonTx();
-    void bumpFee();
+    void bumpFee(bool make_psbt = false);
+    void bumpFeePSBT();
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -163,6 +163,14 @@ void WalletFrame::gotoVerifyMessageTab(QString addr)
         walletView->gotoVerifyMessageTab(addr);
 }
 
+void WalletFrame::gotoLoadPSBT()
+{
+    WalletView *walletView = currentWalletView();
+    if (walletView) {
+        walletView->gotoLoadPSBT();
+    }
+}
+
 void WalletFrame::encryptWallet(bool status)
 {
     WalletView *walletView = currentWalletView();

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -78,6 +78,9 @@ public Q_SLOTS:
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
 
+    /** Load Partially Signed Bitcoin Transaction */
+    void gotoLoadPSBT();
+
     /** Encrypt the wallet */
     void encryptWallet(bool status);
     /** Backup the wallet */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -478,7 +478,7 @@ bool WalletModel::saveReceiveRequest(const std::string &sAddress, const int64_t 
         return m_wallet->addDestData(dest, key, sRequest);
 }
 
-bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
+bool WalletModel::bumpFee(uint256 hash, uint256& new_hash, bool create_psbt)
 {
     CCoinControl coin_control;
     coin_control.m_signal_bip125_rbf = true;
@@ -491,8 +491,6 @@ bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
             (errors.size() ? QString::fromStdString(errors[0]) : "") +")");
          return false;
     }
-
-    const bool create_psbt = m_wallet->privateKeysDisabled();
 
     // allow a user based fee verification
     QString questionString = create_psbt ? tr("Do you want to draft a transaction with fee increase?") : tr("Do you want to increase the fee?");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -131,7 +131,7 @@ bool WalletModel::validateAddress(const QString &address)
     return IsValidDestinationString(address.toStdString());
 }
 
-WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl)
+WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl, bool sign)
 {
     CAmount total = 0;
     bool fSubtractFeeFromAmount = false;
@@ -188,7 +188,7 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
         std::string strFailReason;
 
         auto& newTx = transaction.getWtx();
-        newTx = m_wallet->createTransaction(vecSend, coinControl, !wallet().privateKeysDisabled() /* sign */, nChangePosRet, nFeeRequired, strFailReason);
+        newTx = m_wallet->createTransaction(vecSend, coinControl, sign, nChangePosRet, nFeeRequired, strFailReason);
         transaction.setTransactionFee(nFeeRequired);
         if (fSubtractFeeFromAmount && newTx)
             transaction.reassignAmounts(nChangePosRet);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -138,7 +138,7 @@ public:
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string &sAddress, const int64_t nId, const std::string &sRequest);
 
-    bool bumpFee(uint256 hash, uint256& new_hash);
+    bool bumpFee(uint256 hash, uint256& new_hash, bool make_psbt);
 
     static bool isWalletEnabled();
 

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -99,7 +99,7 @@ public:
     };
 
     // prepare transaction for getting txfee before sending coins
-    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl);
+    SendCoinsReturn prepareTransaction(WalletModelTransaction &transaction, const CCoinControl& coinControl, bool sign);
 
     // Send coins to a list of recipients
     SendCoinsReturn sendCoins(WalletModelTransaction &transaction);

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -4,6 +4,9 @@
 
 #include <qt/walletview.h>
 
+#include <node/psbt.h>
+#include <node/transaction.h>
+#include <policy/policy.h>
 #include <qt/addressbookpage.h>
 #include <qt/askpassphrasedialog.h>
 #include <qt/clientmodel.h>
@@ -20,6 +23,7 @@
 
 #include <interfaces/node.h>
 #include <ui_interface.h>
+#include <util/strencodings.h>
 
 #include <QAction>
 #include <QActionGroup>
@@ -195,6 +199,80 @@ void WalletView::gotoVerifyMessageTab(QString addr)
 
     if (!addr.isEmpty())
         signVerifyMessageDialog->setAddress_VM(addr);
+}
+
+void WalletView::gotoLoadPSBT()
+{
+    QString filename = GUIUtil::getOpenFileName(this,
+        tr("Load Transaction Data"), QString(),
+        tr("Partially Signed Transaction (*.psbt)"), nullptr);
+    if (filename.isEmpty()) return;
+    if (GetFileSize(filename.toLocal8Bit().data(), MAX_FILE_SIZE_PSBT) == MAX_FILE_SIZE_PSBT) {
+        Q_EMIT message(tr("Error"), tr("PSBT file must be smaller than 100 MiB"), CClientUIInterface::MSG_ERROR);
+        return;
+    }
+    std::ifstream in(filename.toLocal8Bit().data(), std::ios::binary);
+    std::string data(std::istreambuf_iterator<char>{in}, {});
+
+    std::string error;
+    PartiallySignedTransaction psbtx;
+    if (!DecodeRawPSBT(psbtx, data, error)) {
+        Q_EMIT message(tr("Error"), tr("Unable to decode PSBT file") + "\n" + QString::fromStdString(error), CClientUIInterface::MSG_ERROR);
+        return;
+    }
+
+    CMutableTransaction mtx;
+    bool complete = false;
+    PSBTAnalysis analysis = AnalyzePSBT(psbtx);
+    QMessageBox msgBox;
+    msgBox.setText("PSBT");
+    switch (analysis.next) {
+    case PSBTRole::CREATOR:
+    case PSBTRole::UPDATER:
+        msgBox.setInformativeText("PSBT is incomplete. Copy to clipboard for manual inspection?");
+        break;
+    case PSBTRole::SIGNER:
+        msgBox.setInformativeText("Transaction needs more signatures. Copy to clipboard?");
+        break;
+    case PSBTRole::FINALIZER:
+    case PSBTRole::EXTRACTOR:
+        complete = FinalizeAndExtractPSBT(psbtx, mtx);
+        if (complete) {
+            msgBox.setInformativeText(tr("Would you like to send this transaction?"));
+        } else {
+            // The analyzer missed something, e.g. if there are final_scriptSig/final_scriptWitness
+            // but with invalid signatures.
+            msgBox.setInformativeText(tr("There was an unexpected problem processing the PSBT. Copy to clipboard for manual inspection?"));
+        }
+    }
+
+    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::Cancel);
+    switch (msgBox.exec()) {
+    case QMessageBox::Yes: {
+        if (complete) {
+            std::string err_string;
+            CTransactionRef tx = MakeTransactionRef(mtx);
+
+            TransactionError result = BroadcastTransaction(*clientModel->node().context(), tx, err_string, DEFAULT_MAX_RAW_TX_FEE_RATE.GetFeePerK(), /* relay */ true, /* wait_callback */ false);
+            if (result == TransactionError::OK) {
+                Q_EMIT message(tr("Success"), tr("Broadcasted transaction sucessfully."), CClientUIInterface::MSG_INFORMATION | CClientUIInterface::MODAL);
+            } else {
+                Q_EMIT message(tr("Error"), QString::fromStdString(err_string), CClientUIInterface::MSG_ERROR);
+            }
+        } else {
+            // Serialize the PSBT
+            CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+            ssTx << psbtx;
+            GUIUtil::setClipboard(EncodeBase64(ssTx.str()).c_str());
+            Q_EMIT message(tr("PSBT copied"), "Copied to clipboard", CClientUIInterface::MSG_INFORMATION);
+            return;
+        }
+    }
+    case QMessageBox::Cancel:
+        break;
+    default:
+        assert(false);
+    }
 }
 
 bool WalletView::handlePaymentRequest(const SendCoinsRecipient& recipient)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -83,6 +83,8 @@ public Q_SLOTS:
     void gotoSignMessageTab(QString addr = "");
     /** Show Sign/Verify Message dialog and switch to verify message tab */
     void gotoVerifyMessageTab(QString addr = "");
+    /** Load Partially Signed Bitcoin Transaction */
+    void gotoLoadPSBT();
 
     /** Show incoming transaction notification for new transactions.
 

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -150,6 +150,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "getmempoolancestors", 1, "verbose" },
     { "getmempooldescendants", 1, "verbose" },
     { "bumpfee", 1, "options" },
+    { "psbtbumpfee", 1, "options" },
     { "logging", 0, "include" },
     { "logging", 1, "exclude" },
     { "disconnectnode", 1, "nodeid" },

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -40,12 +40,6 @@
 
 #include <univalue.h>
 
-/** Maximum fee rate for sendrawtransaction and testmempoolaccept.
- * By default, a transaction with a fee rate higher than this will be rejected
- * by the RPCs. This can be overridden with the maxfeerate argument.
- */
-static const CFeeRate DEFAULT_MAX_RAW_TX_FEE_RATE{COIN / 10};
-
 static void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
 {
     // Call into TxToUniv() in bitcoin-common to decode the transaction hex.

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -141,6 +141,12 @@ bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes)
     return free_bytes_available >= min_disk_space + additional_bytes;
 }
 
+std::streampos GetFileSize(const char* path, std::streamsize max) {
+    std::ifstream file(path, std::ios::binary);
+    file.ignore(max);
+    return file.gcount();
+}
+
 /**
  * Interpret a string argument as a boolean.
  *

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -63,6 +63,14 @@ void UnlockDirectory(const fs::path& directory, const std::string& lockfile_name
 bool DirIsWritable(const fs::path& directory);
 bool CheckDiskSpace(const fs::path& dir, uint64_t additional_bytes = 0);
 
+/** Get the size of a file by scanning it.
+ *
+ * @param[in] path The file path
+ * @param[in] max Stop seeking beyond this limit
+ * @return The file size or max
+ */
+std::streampos GetFileSize(const char* path, std::streamsize max = std::numeric_limits<std::streamsize>::max());
+
 /** Release all directory locks. This is used for unit testing only, at runtime
  * the global destructor will take care of the locks.
  */

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3464,6 +3464,10 @@ static UniValue bumpfee(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
+    if (!pwallet->chain().rpcEnableDeprecated("bumpfee") && pwallet->IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)) {
+        throw JSONRPCError(RPC_METHOD_DEPRECATED, "Using bumpfee with wallets that have private keys disabled is deprecated. Use psbtbumpfee instead or restart bitcoind with -deprecatedrpc=bumpfee. This functionality will be removed in 0.22");
+    }
+
     RPCTypeCheck(request.params, {UniValue::VSTR, UniValue::VOBJ});
     uint256 hash(ParseHashV(request.params[0], "txid"));
     CAmount old_fee;

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -4,13 +4,13 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test deprecation of RPC calls."""
 from test_framework.test_framework import BitcoinTestFramework
-# from test_framework.util import assert_raises_rpc_error
+from test_framework.util import assert_raises_rpc_error, find_vout_for_address
 
 class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.setup_clean_chain = True
-        self.extra_args = [[], []]
+        self.extra_args = [[], ['-deprecatedrpc=bumpfee']]
 
     def run_test(self):
         # This test should be used to verify correct behaviour of deprecated
@@ -23,7 +23,38 @@ class DeprecatedRpcTest(BitcoinTestFramework):
         # self.log.info("Test generate RPC")
         # assert_raises_rpc_error(-32, 'The wallet generate rpc method is deprecated', self.nodes[0].rpc.generate, 1)
         # self.nodes[1].generate(1)
-        self.log.info("No tested deprecated RPC methods")
+
+        if self.is_wallet_compiled():
+            self.log.info("Test bumpfee RPC")
+            self.nodes[0].generate(101)
+            self.nodes[0].createwallet(wallet_name='nopriv', disable_private_keys=True)
+            noprivs0 = self.nodes[0].get_wallet_rpc('nopriv')
+            w0 = self.nodes[0].get_wallet_rpc('')
+            self.nodes[1].createwallet(wallet_name='nopriv', disable_private_keys=True)
+            noprivs1 = self.nodes[1].get_wallet_rpc('nopriv')
+
+            address = w0.getnewaddress()
+            desc = w0.getaddressinfo(address)['desc']
+            change_addr = w0.getrawchangeaddress()
+            change_desc = w0.getaddressinfo(change_addr)['desc']
+            txid = w0.sendtoaddress(address=address, amount=10)
+            vout = find_vout_for_address(w0, txid, address)
+            self.nodes[0].generate(1)
+            rawtx = w0.createrawtransaction([{'txid': txid, 'vout': vout}], {w0.getnewaddress(): 5}, 0, True)
+            rawtx = w0.fundrawtransaction(rawtx, {'changeAddress': change_addr})
+            signed_tx = w0.signrawtransactionwithwallet(rawtx['hex'])['hex']
+
+            noprivs0.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
+            noprivs1.importmulti([{'desc': desc, 'timestamp': 0}, {'desc': change_desc, 'timestamp': 0, 'internal': True}])
+
+            txid = w0.sendrawtransaction(signed_tx)
+            self.sync_all()
+
+            assert_raises_rpc_error(-32, 'Using bumpfee with wallets that have private keys disabled is deprecated. Use psbtbumpfee instead or restart bitcoind with -deprecatedrpc=bumpfee. This functionality will be removed in 0.22', noprivs0.bumpfee, txid)
+            bumped_psbt = noprivs1.bumpfee(txid)
+            assert 'psbt' in bumped_psbt
+        else:
+            self.log.info("No tested deprecated RPC methods")
 
 if __name__ == '__main__':
     DeprecatedRpcTest().main()

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -104,13 +104,19 @@ def test_simple_bumpfee_succeeds(self, mode, rbf_node, peer_node, dest_address):
     self.sync_mempools((rbf_node, peer_node))
     assert rbfid in rbf_node.getrawmempool() and rbfid in peer_node.getrawmempool()
     if mode == "fee_rate":
+        bumped_psbt = rbf_node.psbtbumpfee(rbfid, {"fee_rate": NORMAL})
         bumped_tx = rbf_node.bumpfee(rbfid, {"fee_rate": NORMAL})
     else:
+        bumped_psbt = rbf_node.psbtbumpfee(rbfid)
         bumped_tx = rbf_node.bumpfee(rbfid)
     assert_equal(bumped_tx["errors"], [])
     assert bumped_tx["fee"] > -rbftx["fee"]
     assert_equal(bumped_tx["origfee"], -rbftx["fee"])
     assert "psbt" not in bumped_tx
+    assert_equal(bumped_psbt["errors"], [])
+    assert bumped_psbt["fee"] > -rbftx["fee"]
+    assert_equal(bumped_psbt["origfee"], -rbftx["fee"])
+    assert "psbt" in bumped_psbt
     # check that bumped_tx propagates, original tx was evicted and has a wallet conflict
     self.sync_mempools((rbf_node, peer_node))
     assert bumped_tx["txid"] in rbf_node.getrawmempool()
@@ -362,7 +368,7 @@ def test_watchonly_psbt(self, peer_node, rbf_node, dest_address):
     assert_equal(len(watcher.decodepsbt(psbt)["tx"]["vin"]), 1)
 
     # Bump fee, obnoxiously high to add additional watchonly input
-    bumped_psbt = watcher.bumpfee(original_txid, {"fee_rate": HIGH})
+    bumped_psbt = watcher.psbtbumpfee(original_txid, {"fee_rate": HIGH})
     assert_greater_than(len(watcher.decodepsbt(bumped_psbt['psbt'])["tx"]["vin"]), 1)
     assert "txid" not in bumped_psbt
     assert_equal(bumped_psbt["origfee"], -watcher.gettransaction(original_txid)["fee"])


### PR DESCRIPTION
Instead of changing some actions' behavior based on `IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)`, make separate things that work with no private keys. In particular, instead of having `bumpfee` give out a psbt when there are no private keys, add a `psbtbumpfee` RPC that always gives out a psbt and just have `bumpfee` be disabled when there are no private keys. This is mirrored in the GUI bumpfee menu items. Additionally, instead of changing the `Send` button to `Create Unsigned` when there are no private keys, just always have a `Create Unsigned` button and disable `Send` when there are no private keys. To deal with `bumpfee` already doing the mutated behavior thing, that behavior is hidden behind a `-deprecatedrpc=bumpfee` option.

To make the GUI stuff easier to follow, test, and review, this is being based on #17509