### PR TITLE
test: Properly raise FailedToStartError when rpc shutdown before warmup finished (take 2)

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -225,9 +225,6 @@ class TestNode():
                 self.rpc_connected = True
                 self.url = self.rpc.url
                 return
-            except IOError as e:
-                if e.errno != errno.ECONNREFUSED:  # Port not yet open?
-                    raise  # unknown IO error
             except JSONRPCException as e:  # Initialization phase
                 # -28 RPC in warmup
                 # -342 Service unavailable, RPC server started but is shutting down due to error
@@ -237,6 +234,9 @@ class TestNode():
                 # This might happen when the RPC server is in warmup, but shut down before the call to getblockcount
                 # succeeds. Try again to properly raise the FailedToStartError
                 pass
+            except OSError as e:
+                if e.errno != errno.ECONNREFUSED:  # Port not yet open?
+                    raise  # unknown OS error
             except ValueError as e:  # cookie file not found and no rpcuser or rpcassword. bitcoind still starting
                 if "No RPC credentials" not in str(e):
                     raise


### PR DESCRIPTION
actually (?) fix #18561 

See most recent traceback https://travis-ci.org/github/bitcoin/bitcoin/jobs/674668692#L7062

I believe the reason the error is still there is that ConnectionResetError is derived from OSError:

ConnectionResetError(ConnectionError(OSError))

And IOError is an alias for OSError since python 3.3, see https://docs.python.org/3/library/exceptions.html#IOError

So fix that by renaming IOError to the alias OSError and move the less specific catch clause down a few lines.