### PR TITLE
ci: Add fuzzbuzz integration configuration file

### DIFF
--- a/.fuzzbuzz.yml
+++ b/.fuzzbuzz.yml
@@ -1,0 +1,16 @@
+base: ubuntu:16.04
+language: c++
+engine: libFuzzer
+environment:
+  - CXXFLAGS=-fcoverage-mapping -fno-omit-frame-pointer -fprofile-instr-generate -gline-tables-only -O1
+setup:
+  - sudo apt-get update
+  - sudo apt-get install -y autoconf bsdmainutils clang git libboost-all-dev libboost-program-options-dev libc++1 libc++abi1 libc++abi-dev libc++-dev libclang1 libclang-dev libdb5.3++ libevent-dev libllvm-ocaml-dev libomp5 libomp-dev libprotobuf-dev libqt5core5a libqt5dbus5 libqt5gui5 libssl-dev libtool llvm llvm-dev llvm-runtime pkg-config protobuf-compiler qttools5-dev qttools5-dev-tools software-properties-common
+  - ./autogen.sh
+  - CC=clang CXX=clang++ ./configure --enable-fuzz --with-sanitizers=address,fuzzer,undefined
+  - make
+  - git clone https://github.com/bitcoin-core/qa-assets
+auto_targets:
+  find_targets_command: find src/test/fuzz/ -executable -type f ! -name "*.cpp" ! -name "*.h"
+  base_corpus_dir: qa-assets/fuzz_seed_corpus/
+  memory_limit: none


### PR DESCRIPTION
Add fuzzbuzz integration.

Just like #15338 enabled optional FreeBSD building via Cirrus CI (`.cirrus.yml`) this PR adds optional fuzzing via fuzzbuzz (`.fuzzbuzz.yml`).

Having this merged makes is easier for people to fuzz Bitcoin Core (via their forked repos) using their fuzzbuzz account and then hopefully submit coverage increasing corpus additions upstreams to to https://github.com/bitcoin-core/qa-assets.

Historically it has been mostly been me and MarcoFalke who submit test cases to `qa-assets`, but with this change hopefully more people will join the hunt for coverage increasing fuzzing inputs :)