### PR TITLE
Prevent consecutive ::cs_main locks

### DIFF
--- a/src/qt/test/apptests.cpp
+++ b/src/qt/test/apptests.cpp
@@ -81,8 +81,9 @@ void AppTests::appTests()
 
     // Reset global state to avoid interfering with later tests.
     AbortShutdown();
+    LOCK(::cs_main);
     UnloadBlockIndex();
-    WITH_LOCK(::cs_main, g_chainman.Reset());
+    g_chainman.Reset();
 }
 
 //! Entry point for BitcoinGUI tests.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -976,7 +976,7 @@ static UniValue gettxoutsetinfo(const JSONRPCRequest& request)
     UniValue ret(UniValue::VOBJ);
 
     CCoinsStats stats;
-    ::ChainstateActive().ForceFlushStateToDisk();
+    WITH_LOCK(::cs_main, ::ChainstateActive().ForceFlushStateToDisk());
 
     CCoinsView* coins_view = WITH_LOCK(cs_main, return &ChainstateActive().CoinsDB());
     if (GetUTXOStats(coins_view, stats)) {

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -161,7 +161,7 @@ TestingSetup::~TestingSetup()
     m_node.banman.reset();
     m_node.mempool = nullptr;
     m_node.scheduler.reset();
-    UnloadBlockIndex();
+    WITH_LOCK(::cs_main, UnloadBlockIndex());
     g_chainman.Reset();
     pblocktree.reset();
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2234,7 +2234,7 @@ bool CChainState::FlushStateToDisk(
     FlushStateMode mode,
     int nManualPruneHeight)
 {
-    LOCK(cs_main);
+    AssertLockHeld(::cs_main);
     assert(this->CanFlushToDisk());
     static int64_t nLastWrite = 0;
     static int64_t nLastFlush = 0;
@@ -2895,6 +2895,7 @@ bool CChainState::ActivateBestChain(BlockValidationState &state, const CChainPar
     CheckBlockIndex(chainparams.GetConsensus());
 
     // Write changes periodically to disk, after relay.
+    LOCK(::cs_main);
     if (!FlushStateToDisk(chainparams, state, FlushStateMode::PERIODIC)) {
         return false;
     }
@@ -4503,6 +4504,7 @@ bool CChainState::RewindBlockIndex(const CChainParams& params)
         LimitValidationInterfaceQueue();
 
         // Occasionally flush state to disk.
+        LOCK(::cs_main);
         if (!FlushStateToDisk(params, state, FlushStateMode::PERIODIC)) {
             LogPrintf("RewindBlockIndex: unable to flush state to disk (%s)\n", state.ToString());
             return false;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4544,7 +4544,7 @@ void CChainState::UnloadBlockIndex() {
 // block index state
 void UnloadBlockIndex()
 {
-    LOCK(cs_main);
+    AssertLockHeld(::cs_main);
     g_chainman.Unload();
     pindexBestInvalid = nullptr;
     pindexBestHeader = nullptr;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4330,7 +4330,7 @@ bool CChainState::RollforwardBlock(const CBlockIndex* pindex, CCoinsViewCache& i
 
 bool CChainState::ReplayBlocks(const CChainParams& params)
 {
-    LOCK(cs_main);
+    AssertLockHeld(::cs_main);
 
     CCoinsView& db = this->CoinsDB();
     CCoinsViewCache cache(&db);

--- a/src/validation.h
+++ b/src/validation.h
@@ -271,7 +271,7 @@ void PruneOneBlockFile(const int fileNumber) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 void UnlinkPrunedFiles(const std::set<int>& setFilesToPrune);
 
 /** Prune block files up to a given height */
-void PruneBlockFilesManual(int nManualPruneHeight);
+void PruneBlockFilesManual(int nManualPruneHeight) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
 /** (try to) add transaction to memory pool
  * plTxnReplaced will be appended to with all transactions replaced from mempool **/
@@ -672,14 +672,14 @@ public:
         const CChainParams& chainparams,
         BlockValidationState &state,
         FlushStateMode mode,
-        int nManualPruneHeight = 0);
+        int nManualPruneHeight = 0) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Unconditionally flush all changes to disk.
-    void ForceFlushStateToDisk();
+    void ForceFlushStateToDisk() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     //! Prune blockfiles from the disk if necessary and then flush chainstate changes
     //! if we pruned.
-    void PruneAndFlush();
+    void PruneAndFlush() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 
     /**
      * Make the best chain active, in multiple steps. The result is either failure

--- a/src/validation.h
+++ b/src/validation.h
@@ -240,7 +240,7 @@ bool LoadGenesisBlock(const CChainParams& chainparams);
  * initializing state if we're running with -reindex. */
 bool LoadBlockIndex(const CChainParams& chainparams) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 /** Unload database information */
-void UnloadBlockIndex();
+void UnloadBlockIndex() EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck(int worker_num);
 /** Retrieve a transaction (from memory pool, or from disk, if possible) */

--- a/src/validation.h
+++ b/src/validation.h
@@ -716,7 +716,7 @@ public:
     void ResetBlockFailureFlags(CBlockIndex* pindex) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
 
     /** Replay blocks that aren't fully applied to the database. */
-    bool ReplayBlocks(const CChainParams& params);
+    bool ReplayBlocks(const CChainParams& params) EXCLUSIVE_LOCKS_REQUIRED(::cs_main);
     bool RewindBlockIndex(const CChainParams& params) LOCKS_EXCLUDED(cs_main);
     bool LoadGenesisBlock(const CChainParams& chainparams);
 


### PR DESCRIPTION
This PR prevents consecutive `::cs_main` locks in the following functions:
- `FlushStateToDisk()` that could happen when it is called from:
  - `AcceptToMemoryPoolWithTime()`
  - `CChainState::DisconnectTip()`
  - `CChainState::ConnectTip()`
  - `CChainState::AcceptBlock()`
  - `CChainState::RewindBlockIndex()`
- UnloadBlockIndex()
- CChainState::ReplayBlocks()