### PR TITLE
net: Reduce `TransportDeserializer` interface to 2 methods

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -565,6 +565,18 @@ void CNode::copyStats(CNodeStats &stats, const std::vector<bool> &m_asmap)
 }
 #undef X
 
+/**
+ * Try to decode all CNetMessage%s from the first \p nBytes bytes of the \p pch
+ * buffer and send them off for further processing.
+ *
+ * @param[out] complete Whether or not at least one CNetMessage was successfully
+ *                      decoded.
+ *
+ * @returns Whether or not an unhandleable error has occured (e.g. failure to
+ *          deserialize the header or ludicrous message sizes).
+ *
+ * @see ReadMessages(const char *, unsigned int, const CMessageHeader::MessageStartChars&, int64_t)
+ */
 bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes, bool& complete)
 {
     complete = false;

--- a/src/net.h
+++ b/src/net.h
@@ -638,14 +638,8 @@ public:
  */
 class TransportDeserializer {
 public:
-    // returns true if the current deserialization is complete
-    virtual bool Complete() const = 0;
     // set the serialization context version
     virtual void SetVersion(int version) = 0;
-    // read and deserialize data
-    virtual int Read(const char *data, unsigned int bytes) = 0;
-    // decomposes a message from the context
-    virtual CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) = 0;
     /**
      * Try to decode all CNetMessage%s from the first \p num_bytes bytes of the
      * \p receive_buffer buffer.
@@ -702,7 +696,7 @@ public:
         Reset();
     }
 
-    bool Complete() const override
+    bool Complete() const
     {
         if (!in_data)
             return false;
@@ -713,12 +707,11 @@ public:
         hdrbuf.SetVersion(nVersionIn);
         vRecv.SetVersion(nVersionIn);
     }
-    int Read(const char *pch, unsigned int nBytes) override {
+    int Read(const char *pch, unsigned int nBytes) {
         int ret = in_data ? readData(pch, nBytes) : readHeader(pch, nBytes);
         if (ret < 0) Reset();
         return ret;
     }
-    CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time) override;
     std::tuple<bool, std::vector<CNetMessage>> ReadMessages(const char *receive_buffer, unsigned int num_bytes, const CMessageHeader::MessageStartChars& message_start, int64_t time) override {
         std::vector<CNetMessage> out_msgs;
         while (num_bytes > 0) {
@@ -737,6 +730,7 @@ public:
         }
         return std::make_tuple(true, out_msgs);
     }
+    CNetMessage GetMessage(const CMessageHeader::MessageStartChars& message_start, int64_t time);
 };
 
 /** The TransportSerializer prepares messages for the network transport


### PR DESCRIPTION
Mostly inspired by https://github.com/bitcoin/bitcoin/pull/16202#issuecomment-535152710, I believe this will also allow some simplifications in #18242.

If you're concerned about the net added line count, don't be: this PR also adds some documentation to `net.{h,cpp}`.

I'm happy for this to go in after #18242 and I'll rebase.