### PR TITLE
gui: use PACKAGE_NAME in exception message

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -381,7 +381,7 @@ void BitcoinApplication::shutdownResult()
 
 void BitcoinApplication::handleRunawayException(const QString &message)
 {
-    QMessageBox::critical(nullptr, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. Bitcoin can no longer continue safely and will quit.") + QString("\n\n") + message);
+    QMessageBox::critical(nullptr, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. %1 can no longer continue safely and will quit.").arg(PACKAGE_NAME) + QString("\n\n") + message);
     ::exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
Should address [this comment](https://github.com/bitcoin/bitcoin/issues/18643#issuecomment-613761345).

![qt_exception](https://user-images.githubusercontent.com/863730/79310875-348bf780-7f2f-11ea-9970-ba1ac28c7849.png)

Can be triggered with a diff like:
```diff
diff --git a/src/qt/modaloverlay.cpp b/src/qt/modaloverlay.cpp
index 6243a71c7..e5d499012 100644
--- a/src/qt/modaloverlay.cpp
+++ b/src/qt/modaloverlay.cpp
@@ -6,6 +6,7 @@
 #include <qt/forms/ui_modaloverlay.h>
 
 #include <qt/guiutil.h>
+#include <util/check.h>
 
 #include <chainparams.h>
 
@@ -179,6 +180,7 @@ void ModalOverlay::showHide(bool hide, bool userRequested)
 
 void ModalOverlay::closeClicked()
 {
+    CHECK_NONFATAL(false);
     showHide(true);
     userClosed = true;
 }
```
and clicking close in the modal.
```bash
EXCEPTION: 18NonFatalCheckError       
qt/modaloverlay.cpp:183 (closeClicked)
Internal bug detected: 'false'
You may report this issue here: https://github.com/bitcoin/bitcoin/issues
```