### PR TITLE
rpc: remove g_rpc_node & g_rpc_chain

### DIFF
--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -7,6 +7,7 @@
 #include <chainparams.h>
 #include <crypto/hmac_sha256.h>
 #include <httpserver.h>
+#include <node/context.h>
 #include <rpc/protocol.h>
 #include <rpc/server.h>
 #include <ui_interface.h>
@@ -151,7 +152,7 @@ static bool RPCAuthorized(const std::string& strAuth, std::string& strAuthUserna
     return multiUserAuthorized(strUserPass);
 }
 
-static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string &)
+static bool HTTPReq_JSONRPC(HTTPRequest* req, const std::string&, NodeContext* pnode)
 {
     // JSONRPC handles only POST
     if (req->GetRequestMethod() != HTTPRequest::POST) {
@@ -288,15 +289,15 @@ static bool InitRPCAuthentication()
     return true;
 }
 
-bool StartHTTPRPC()
+bool StartHTTPRPC(NodeContext* pnode)
 {
     LogPrint(BCLog::RPC, "Starting HTTP RPC server\n");
     if (!InitRPCAuthentication())
         return false;
 
-    RegisterHTTPHandler("/", true, HTTPReq_JSONRPC);
+    RegisterHTTPHandler("/", true, HTTPReq_JSONRPC, pnode);
     if (g_wallet_init_interface.HasWalletSupport()) {
-        RegisterHTTPHandler("/wallet/", false, HTTPReq_JSONRPC);
+        RegisterHTTPHandler("/wallet/", false, HTTPReq_JSONRPC, pnode);
     }
     struct event_base* eventBase = EventBase();
     assert(eventBase);

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -5,11 +5,12 @@
 #ifndef BITCOIN_HTTPRPC_H
 #define BITCOIN_HTTPRPC_H
 
+#include <node/context.h>
 
 /** Start HTTP RPC subsystem.
  * Precondition; HTTP and RPC has been started.
  */
-bool StartHTTPRPC();
+bool StartHTTPRPC(NodeContext* pnode);
 /** Interrupt HTTP RPC subsystem.
  */
 void InterruptHTTPRPC();
@@ -21,7 +22,7 @@ void StopHTTPRPC();
 /** Start HTTP REST subsystem.
  * Precondition; HTTP and RPC has been started.
  */
-void StartREST();
+void StartREST(NodeContext* pnode);
 /** Interrupt RPC REST subsystem.
  */
 void InterruptREST();

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_HTTPSERVER_H
 #define BITCOIN_HTTPSERVER_H
 
+#include <node/context.h>
+
 #include <string>
 #include <functional>
 
@@ -20,7 +22,7 @@ class HTTPRequest;
 /** Initialize HTTP server.
  * Call this before RegisterHTTPHandler or EventBase().
  */
-bool InitHTTPServer();
+bool InitHTTPServer(NodeContext* pnode);
 /** Start HTTP server.
  * This is separate from InitHTTPServer to give users race-condition-free time
  * to register their handlers between InitHTTPServer and StartHTTPServer.
@@ -36,12 +38,12 @@ void StopHTTPServer();
 bool UpdateHTTPServerLogging(bool enable);
 
 /** Handler for requests to a certain HTTP path */
-typedef std::function<bool(HTTPRequest* req, const std::string &)> HTTPRequestHandler;
+typedef std::function<bool(HTTPRequest* req, const std::string&, NodeContext* pnode)> HTTPRequestHandler;
 /** Register handler for prefix.
  * If multiple handlers match a prefix, the first-registered one will
  * be invoked.
  */
-void RegisterHTTPHandler(const std::string &prefix, bool exactMatch, const HTTPRequestHandler &handler);
+void RegisterHTTPHandler(const std::string& prefix, bool exactMatch, const HTTPRequestHandler& handler, NodeContext* pnode);
 /** Unregister handler for prefix */
 void UnregisterHTTPHandler(const std::string &prefix, bool exactMatch);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -771,16 +771,16 @@ static bool InitSanityCheck()
     return true;
 }
 
-static bool AppInitServers()
+static bool AppInitServers(NodeContext* pnode)
 {
     RPCServer::OnStarted(&OnRPCStarted);
     RPCServer::OnStopped(&OnRPCStopped);
-    if (!InitHTTPServer())
+    if (!InitHTTPServer(pnode))
         return false;
     StartRPC();
-    if (!StartHTTPRPC())
+    if (!StartHTTPRPC(pnode))
         return false;
-    if (gArgs.GetBoolArg("-rest", DEFAULT_REST_ENABLE)) StartREST();
+    if (gArgs.GetBoolArg("-rest", DEFAULT_REST_ENABLE)) StartREST(pnode);
     StartHTTPServer();
     return true;
 }
@@ -1317,7 +1317,7 @@ bool AppInitMain(NodeContext& node)
     for (const auto& client : node.chain_clients) {
         client->registerRpcs();
     }
-    g_rpc_node = &node;
+    tableRPC.addNodeContext(&node);
 #if ENABLE_ZMQ
     RegisterZMQRPCCommands(tableRPC);
 #endif
@@ -1330,7 +1330,7 @@ bool AppInitMain(NodeContext& node)
     if (gArgs.GetBoolArg("-server", false))
     {
         uiInterface.InitMessage_connect(SetRPCWarmupStatus);
-        if (!AppInitServers())
+        if (!AppInitServers(&node))
             return InitError(_("Unable to start HTTP server. See debug log for details.").translated);
     }
 

--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -189,10 +189,10 @@ class RpcHandlerImpl : public Handler
 public:
     explicit RpcHandlerImpl(const CRPCCommand& command) : m_command(command), m_wrapped_command(&command)
     {
-        m_command.actor = [this](const JSONRPCRequest& request, UniValue& result, bool last_handler) {
+        m_command.actor = [this](const JSONRPCRequest& request, UniValue& result, bool last_handler, const NodeContext& node) {
             if (!m_wrapped_command) return false;
             try {
-                return m_wrapped_command->actor(request, result, last_handler);
+                return m_wrapped_command->actor(request, result, last_handler, node);
             } catch (const UniValue& e) {
                 // If this is not the last handler and a wallet not found
                 // exception was thrown, return false so the next handler can

--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -508,7 +508,6 @@ public:
     }
     void registerRpcs() override
     {
-        g_rpc_chain = &m_chain;
         return RegisterWalletRPCCommands(m_chain, m_rpc_handlers);
     }
     bool verify() override { return VerifyWallets(m_chain, m_wallet_filenames); }

--- a/src/node/transaction.cpp
+++ b/src/node/transaction.cpp
@@ -13,7 +13,7 @@
 
 #include <future>
 
-TransactionError BroadcastTransaction(NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
+TransactionError BroadcastTransaction(const NodeContext& node, const CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback)
 {
     // BroadcastTransaction can be called by either sendrawtransaction RPC or wallet RPCs.
     // node.connman is assigned both before chain clients and before RPC server is accepting calls,

--- a/src/node/transaction.h
+++ b/src/node/transaction.h
@@ -28,6 +28,6 @@ struct NodeContext;
  * @param[in]  wait_callback wait until callbacks have been processed to avoid stale result due to a sequentially RPC.
  * return error
  */
-NODISCARD TransactionError BroadcastTransaction(NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
+NODISCARD TransactionError BroadcastTransaction(const NodeContext& node, CTransactionRef tx, std::string& err_string, const CAmount& max_tx_fee, bool relay, bool wait_callback);
 
 #endif // BITCOIN_NODE_TRANSACTION_H

--- a/src/qt/test/rpcnestedtests.cpp
+++ b/src/qt/test/rpcnestedtests.cpp
@@ -14,7 +14,7 @@
 #include <QDir>
 #include <QtGlobal>
 
-static UniValue rpcNestedTest_rpc(const JSONRPCRequest& request)
+static UniValue rpcNestedTest_rpc(const JSONRPCRequest& request, const NodeContext& node)
 {
     if (request.fHelp) {
         return "help message";

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -47,11 +47,6 @@ UniValue blockheaderToJSON(const CBlockIndex* tip, const CBlockIndex* blockindex
 /** Used by getblockstats to get feerates at different percentiles by weight  */
 void CalculatePercentilesByWeight(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES], std::vector<std::pair<CAmount, int64_t>>& scores, int64_t total_weight);
 
-//! Pointer to node state that needs to be declared as a global to be accessible
-//! RPC methods. Due to limitations of the RPC framework, there's currently no
-//! direct way to pass in state to RPC methods without globals.
-extern NodeContext* g_rpc_node;
-
-CTxMemPool& EnsureMemPool();
+CTxMemPool& EnsureMemPool(const NodeContext&);
 
 #endif

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -26,7 +26,7 @@
 
 #include <univalue.h>
 
-static UniValue validateaddress(const JSONRPCRequest& request)
+static UniValue validateaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"validateaddress",
                 "\nReturn information about the given bitcoin address.\n",
@@ -70,7 +70,7 @@ static UniValue validateaddress(const JSONRPCRequest& request)
     return ret;
 }
 
-static UniValue createmultisig(const JSONRPCRequest& request)
+static UniValue createmultisig(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"createmultisig",
                 "\nCreates a multi-signature address with n signature of m keys required.\n"
@@ -136,7 +136,7 @@ static UniValue createmultisig(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue getdescriptorinfo(const JSONRPCRequest& request)
+UniValue getdescriptorinfo(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"getdescriptorinfo",
             {"\nAnalyses a descriptor.\n"},
@@ -176,7 +176,7 @@ UniValue getdescriptorinfo(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue deriveaddresses(const JSONRPCRequest& request)
+UniValue deriveaddresses(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"deriveaddresses",
             {"\nDerives one or more addresses corresponding to an output descriptor.\n"
@@ -255,7 +255,7 @@ UniValue deriveaddresses(const JSONRPCRequest& request)
     return addresses;
 }
 
-static UniValue verifymessage(const JSONRPCRequest& request)
+static UniValue verifymessage(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"verifymessage",
                 "\nVerify a signed message\n",
@@ -302,7 +302,7 @@ static UniValue verifymessage(const JSONRPCRequest& request)
     return false;
 }
 
-static UniValue signmessagewithprivkey(const JSONRPCRequest& request)
+static UniValue signmessagewithprivkey(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"signmessagewithprivkey",
                 "\nSign a message with the private key of an address\n",
@@ -340,7 +340,7 @@ static UniValue signmessagewithprivkey(const JSONRPCRequest& request)
     return signature;
 }
 
-static UniValue setmocktime(const JSONRPCRequest& request)
+static UniValue setmocktime(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"setmocktime",
                 "\nSet the local time to given timestamp (-regtest only)\n",
@@ -366,16 +366,14 @@ static UniValue setmocktime(const JSONRPCRequest& request)
     RPCTypeCheck(request.params, {UniValue::VNUM});
     int64_t time = request.params[0].get_int64();
     SetMockTime(time);
-    if (g_rpc_node) {
-        for (const auto& chain_client : g_rpc_node->chain_clients) {
-            chain_client->setMockTime(time);
-        }
+    for (const auto& chain_client : node.chain_clients) {
+        chain_client->setMockTime(time);
     }
 
     return NullUniValue;
 }
 
-static UniValue mockscheduler(const JSONRPCRequest& request)
+static UniValue mockscheduler(const JSONRPCRequest& request, const NodeContext& node)
 {
     RPCHelpMan{"mockscheduler",
         "\nBump the scheduler into the future (-regtest only)\n",
@@ -398,9 +396,8 @@ static UniValue mockscheduler(const JSONRPCRequest& request)
     }
 
     // protect against null pointer dereference
-    CHECK_NONFATAL(g_rpc_node);
-    CHECK_NONFATAL(g_rpc_node->scheduler);
-    g_rpc_node->scheduler->MockForward(std::chrono::seconds(delta_seconds));
+    CHECK_NONFATAL(node.scheduler);
+    node.scheduler->MockForward(std::chrono::seconds(delta_seconds));
 
     return NullUniValue;
 }
@@ -437,7 +434,7 @@ static std::string RPCMallocInfo()
 }
 #endif
 
-static UniValue getmemoryinfo(const JSONRPCRequest& request)
+static UniValue getmemoryinfo(const JSONRPCRequest& request, const NodeContext& node)
 {
     /* Please, avoid using the word "pool" here in the RPC interface or help,
      * as users will undoubtedly confuse it with the other "memory pool"
@@ -508,7 +505,7 @@ static void EnableOrDisableLogCategories(UniValue cats, bool enable) {
     }
 }
 
-UniValue logging(const JSONRPCRequest& request)
+UniValue logging(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"logging",
             "Gets and sets the logging configuration.\n"
@@ -576,7 +573,7 @@ UniValue logging(const JSONRPCRequest& request)
     return result;
 }
 
-static UniValue echo(const JSONRPCRequest& request)
+static UniValue echo(const JSONRPCRequest& request, const NodeContext& node)
 {
     if (request.fHelp)
         throw std::runtime_error(

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -123,15 +123,15 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
     const CChainParams& chainparams = Params();
     // Ideally we'd move all the RPC tests to the functional testing framework
     // instead of unit tests, but for now we need these here.
-    g_rpc_node = &m_node;
     RegisterAllCoreRPCCommands(tableRPC);
+    tableRPC.addNodeContext(&m_node);
 
     m_node.scheduler = MakeUnique<CScheduler>();
 
     // We have to run a scheduler thread to prevent ActivateBestChain
     // from blocking due to queue overrun.
     threadGroup.create_thread([&]{ m_node.scheduler->serviceQueue(); });
-    GetMainSignals().RegisterBackgroundSignalScheduler(*g_rpc_node->scheduler);
+    GetMainSignals().RegisterBackgroundSignalScheduler(*m_node.scheduler);
 
     pblocktree.reset(new CBlockTreeDB(1 << 20, true));
 
@@ -176,7 +176,6 @@ TestingSetup::~TestingSetup()
     threadGroup.join_all();
     GetMainSignals().FlushBackgroundCallbacks();
     GetMainSignals().UnregisterBackgroundSignalScheduler();
-    g_rpc_node = nullptr;
     m_node.connman.reset();
     m_node.banman.reset();
     m_node.args = nullptr;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -90,7 +90,7 @@ static void RescanWallet(CWallet& wallet, const WalletRescanReserver& reserver, 
     }
 }
 
-UniValue importprivkey(const JSONRPCRequest& request)
+UniValue importprivkey(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -194,7 +194,7 @@ UniValue importprivkey(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-UniValue abortrescan(const JSONRPCRequest& request)
+UniValue abortrescan(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -222,7 +222,7 @@ UniValue abortrescan(const JSONRPCRequest& request)
     return true;
 }
 
-UniValue importaddress(const JSONRPCRequest& request)
+UniValue importaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -326,7 +326,7 @@ UniValue importaddress(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-UniValue importprunedfunds(const JSONRPCRequest& request)
+UniValue importprunedfunds(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -386,7 +386,7 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "No addresses in wallet correspond to included transaction");
 }
 
-UniValue removeprunedfunds(const JSONRPCRequest& request)
+UniValue removeprunedfunds(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -426,7 +426,7 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-UniValue importpubkey(const JSONRPCRequest& request)
+UniValue importpubkey(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -515,7 +515,7 @@ UniValue importpubkey(const JSONRPCRequest& request)
 }
 
 
-UniValue importwallet(const JSONRPCRequest& request)
+UniValue importwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -674,7 +674,7 @@ UniValue importwallet(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-UniValue dumpprivkey(const JSONRPCRequest& request)
+UniValue dumpprivkey(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -722,7 +722,7 @@ UniValue dumpprivkey(const JSONRPCRequest& request)
 }
 
 
-UniValue dumpwallet(const JSONRPCRequest& request)
+UniValue dumpwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1264,7 +1264,7 @@ static int64_t GetImportTimestamp(const UniValue& data, int64_t now)
     throw JSONRPCError(RPC_TYPE_ERROR, "Missing required timestamp field for key");
 }
 
-UniValue importmulti(const JSONRPCRequest& mainRequest)
+UniValue importmulti(const JSONRPCRequest& mainRequest, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(mainRequest);
     CWallet* const pwallet = wallet.get();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -182,7 +182,7 @@ static std::string LabelFromValue(const UniValue& value)
     return label;
 }
 
-static UniValue getnewaddress(const JSONRPCRequest& request)
+static UniValue getnewaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -235,7 +235,7 @@ static UniValue getnewaddress(const JSONRPCRequest& request)
     return EncodeDestination(dest);
 }
 
-static UniValue getrawchangeaddress(const JSONRPCRequest& request)
+static UniValue getrawchangeaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -281,7 +281,7 @@ static UniValue getrawchangeaddress(const JSONRPCRequest& request)
 }
 
 
-static UniValue setlabel(const JSONRPCRequest& request)
+static UniValue setlabel(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -353,7 +353,7 @@ static CTransactionRef SendMoney(interfaces::Chain::Lock& locked_chain, CWallet 
     return tx;
 }
 
-static UniValue sendtoaddress(const JSONRPCRequest& request)
+static UniValue sendtoaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -449,7 +449,7 @@ static UniValue sendtoaddress(const JSONRPCRequest& request)
     return tx->GetHash().GetHex();
 }
 
-static UniValue listaddressgroupings(const JSONRPCRequest& request)
+static UniValue listaddressgroupings(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -512,7 +512,7 @@ static UniValue listaddressgroupings(const JSONRPCRequest& request)
     return jsonGroupings;
 }
 
-static UniValue signmessage(const JSONRPCRequest& request)
+static UniValue signmessage(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -618,7 +618,7 @@ static CAmount GetReceived(interfaces::Chain::Lock& locked_chain, const CWallet&
 }
 
 
-static UniValue getreceivedbyaddress(const JSONRPCRequest& request)
+static UniValue getreceivedbyaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -659,7 +659,7 @@ static UniValue getreceivedbyaddress(const JSONRPCRequest& request)
 }
 
 
-static UniValue getreceivedbylabel(const JSONRPCRequest& request)
+static UniValue getreceivedbylabel(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -700,7 +700,7 @@ static UniValue getreceivedbylabel(const JSONRPCRequest& request)
 }
 
 
-static UniValue getbalance(const JSONRPCRequest& request)
+static UniValue getbalance(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -758,7 +758,7 @@ static UniValue getbalance(const JSONRPCRequest& request)
     return ValueFromAmount(bal.m_mine_trusted + (include_watchonly ? bal.m_watchonly_trusted : 0));
 }
 
-static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
+static UniValue getunconfirmedbalance(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -785,7 +785,7 @@ static UniValue getunconfirmedbalance(const JSONRPCRequest &request)
 }
 
 
-static UniValue sendmany(const JSONRPCRequest& request)
+static UniValue sendmany(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -920,7 +920,7 @@ static UniValue sendmany(const JSONRPCRequest& request)
     return tx->GetHash().GetHex();
 }
 
-static UniValue addmultisigaddress(const JSONRPCRequest& request)
+static UniValue addmultisigaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -1163,7 +1163,7 @@ static UniValue ListReceived(interfaces::Chain::Lock& locked_chain, const CWalle
     return ret;
 }
 
-static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
+static UniValue listreceivedbyaddress(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1215,7 +1215,7 @@ static UniValue listreceivedbyaddress(const JSONRPCRequest& request)
     return ListReceived(*locked_chain, pwallet, request.params, false);
 }
 
-static UniValue listreceivedbylabel(const JSONRPCRequest& request)
+static UniValue listreceivedbylabel(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1377,7 +1377,7 @@ static const std::vector<RPCResult> TransactionDescriptionString()
                "may be unknown for unconfirmed transactions not in the mempool"}};
 }
 
-UniValue listtransactions(const JSONRPCRequest& request)
+UniValue listtransactions(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1491,7 +1491,7 @@ UniValue listtransactions(const JSONRPCRequest& request)
     return result;
 }
 
-static UniValue listsinceblock(const JSONRPCRequest& request)
+static UniValue listsinceblock(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1633,7 +1633,7 @@ static UniValue listsinceblock(const JSONRPCRequest& request)
     return ret;
 }
 
-static UniValue gettransaction(const JSONRPCRequest& request)
+static UniValue gettransaction(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1747,7 +1747,7 @@ static UniValue gettransaction(const JSONRPCRequest& request)
     return entry;
 }
 
-static UniValue abandontransaction(const JSONRPCRequest& request)
+static UniValue abandontransaction(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -1792,7 +1792,7 @@ static UniValue abandontransaction(const JSONRPCRequest& request)
 }
 
 
-static UniValue backupwallet(const JSONRPCRequest& request)
+static UniValue backupwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -1829,7 +1829,7 @@ static UniValue backupwallet(const JSONRPCRequest& request)
 }
 
 
-static UniValue keypoolrefill(const JSONRPCRequest& request)
+static UniValue keypoolrefill(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -1877,7 +1877,7 @@ static UniValue keypoolrefill(const JSONRPCRequest& request)
 }
 
 
-static UniValue walletpassphrase(const JSONRPCRequest& request)
+static UniValue walletpassphrase(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -1969,7 +1969,7 @@ static UniValue walletpassphrase(const JSONRPCRequest& request)
 }
 
 
-static UniValue walletpassphrasechange(const JSONRPCRequest& request)
+static UniValue walletpassphrasechange(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -2020,7 +2020,7 @@ static UniValue walletpassphrasechange(const JSONRPCRequest& request)
 }
 
 
-static UniValue walletlock(const JSONRPCRequest& request)
+static UniValue walletlock(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -2061,7 +2061,7 @@ static UniValue walletlock(const JSONRPCRequest& request)
 }
 
 
-static UniValue encryptwallet(const JSONRPCRequest& request)
+static UniValue encryptwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -2122,7 +2122,7 @@ static UniValue encryptwallet(const JSONRPCRequest& request)
     return "wallet encrypted; The keypool has been flushed and a new HD seed was generated (if you are using HD). You need to make a new backup.";
 }
 
-static UniValue lockunspent(const JSONRPCRequest& request)
+static UniValue lockunspent(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -2249,7 +2249,7 @@ static UniValue lockunspent(const JSONRPCRequest& request)
     return true;
 }
 
-static UniValue listlockunspent(const JSONRPCRequest& request)
+static UniValue listlockunspent(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -2305,7 +2305,7 @@ static UniValue listlockunspent(const JSONRPCRequest& request)
     return ret;
 }
 
-static UniValue settxfee(const JSONRPCRequest& request)
+static UniValue settxfee(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -2349,7 +2349,7 @@ static UniValue settxfee(const JSONRPCRequest& request)
     return true;
 }
 
-static UniValue getbalances(const JSONRPCRequest& request)
+static UniValue getbalances(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const rpc_wallet = GetWalletForJSONRPCRequest(request);
     if (!EnsureWalletIsAvailable(rpc_wallet.get(), request.fHelp)) {
@@ -2417,7 +2417,7 @@ static UniValue getbalances(const JSONRPCRequest& request)
     return balances;
 }
 
-static UniValue getwalletinfo(const JSONRPCRequest& request)
+static UniValue getwalletinfo(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -2508,7 +2508,7 @@ static UniValue getwalletinfo(const JSONRPCRequest& request)
     return obj;
 }
 
-static UniValue listwalletdir(const JSONRPCRequest& request)
+static UniValue listwalletdir(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"listwalletdir",
                 "Returns a list of wallets in the wallet directory.\n",
@@ -2543,7 +2543,7 @@ static UniValue listwalletdir(const JSONRPCRequest& request)
     return result;
 }
 
-static UniValue listwallets(const JSONRPCRequest& request)
+static UniValue listwallets(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"listwallets",
                 "Returns a list of currently loaded wallets.\n"
@@ -2576,7 +2576,7 @@ static UniValue listwallets(const JSONRPCRequest& request)
     return obj;
 }
 
-static UniValue loadwallet(const JSONRPCRequest& request)
+static UniValue loadwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"loadwallet",
                 "\nLoads a wallet from a wallet file or directory."
@@ -2612,7 +2612,7 @@ static UniValue loadwallet(const JSONRPCRequest& request)
 
     std::string error;
     std::vector<std::string> warning;
-    std::shared_ptr<CWallet> const wallet = LoadWallet(*g_rpc_chain, location, error, warning);
+    std::shared_ptr<CWallet> const wallet = LoadWallet(*node.chain, location, error, warning);
     if (!wallet) throw JSONRPCError(RPC_WALLET_ERROR, error);
 
     UniValue obj(UniValue::VOBJ);
@@ -2622,7 +2622,7 @@ static UniValue loadwallet(const JSONRPCRequest& request)
     return obj;
 }
 
-static UniValue setwalletflag(const JSONRPCRequest& request)
+static UniValue setwalletflag(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -2690,7 +2690,7 @@ static UniValue setwalletflag(const JSONRPCRequest& request)
     return res;
 }
 
-static UniValue createwallet(const JSONRPCRequest& request)
+static UniValue createwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     RPCHelpMan{
         "createwallet",
@@ -2740,7 +2740,7 @@ static UniValue createwallet(const JSONRPCRequest& request)
 
     std::string error;
     std::shared_ptr<CWallet> wallet;
-    WalletCreationStatus status = CreateWallet(*g_rpc_chain, passphrase, flags, request.params[0].get_str(), error, warnings, wallet);
+    WalletCreationStatus status = CreateWallet(*node.chain, passphrase, flags, request.params[0].get_str(), error, warnings, wallet);
     switch (status) {
         case WalletCreationStatus::CREATION_FAILED:
             throw JSONRPCError(RPC_WALLET_ERROR, error);
@@ -2758,7 +2758,7 @@ static UniValue createwallet(const JSONRPCRequest& request)
     return obj;
 }
 
-static UniValue unloadwallet(const JSONRPCRequest& request)
+static UniValue unloadwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"unloadwallet",
                 "Unloads the wallet referenced by the request endpoint otherwise unloads the wallet specified in the argument.\n"
@@ -2799,7 +2799,7 @@ static UniValue unloadwallet(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-static UniValue listunspent(const JSONRPCRequest& request)
+static UniValue listunspent(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -3133,7 +3133,7 @@ void FundTransaction(CWallet* const pwallet, CMutableTransaction& tx, CAmount& f
     }
 }
 
-static UniValue fundrawtransaction(const JSONRPCRequest& request)
+static UniValue fundrawtransaction(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -3233,7 +3233,7 @@ static UniValue fundrawtransaction(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
+UniValue signrawtransactionwithwallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -3328,7 +3328,7 @@ UniValue signrawtransactionwithwallet(const JSONRPCRequest& request)
     return result;
 }
 
-static UniValue bumpfee(const JSONRPCRequest& request)
+static UniValue bumpfee(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -3501,7 +3501,7 @@ static UniValue bumpfee(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue rescanblockchain(const JSONRPCRequest& request)
+UniValue rescanblockchain(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -3702,7 +3702,7 @@ static UniValue AddressBookDataToJSON(const CAddressBookData& data, const bool v
     return ret;
 }
 
-UniValue getaddressinfo(const JSONRPCRequest& request)
+UniValue getaddressinfo(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -3845,7 +3845,7 @@ UniValue getaddressinfo(const JSONRPCRequest& request)
     return ret;
 }
 
-static UniValue getaddressesbylabel(const JSONRPCRequest& request)
+static UniValue getaddressesbylabel(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -3905,7 +3905,7 @@ static UniValue getaddressesbylabel(const JSONRPCRequest& request)
     return ret;
 }
 
-static UniValue listlabels(const JSONRPCRequest& request)
+static UniValue listlabels(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -3961,7 +3961,7 @@ static UniValue listlabels(const JSONRPCRequest& request)
     return ret;
 }
 
-UniValue sethdseed(const JSONRPCRequest& request)
+UniValue sethdseed(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -4039,7 +4039,7 @@ UniValue sethdseed(const JSONRPCRequest& request)
     return NullUniValue;
 }
 
-UniValue walletprocesspsbt(const JSONRPCRequest& request)
+UniValue walletprocesspsbt(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
@@ -4106,7 +4106,7 @@ UniValue walletprocesspsbt(const JSONRPCRequest& request)
     return result;
 }
 
-UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
+UniValue walletcreatefundedpsbt(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -4231,7 +4231,7 @@ UniValue walletcreatefundedpsbt(const JSONRPCRequest& request)
     return result;
 }
 
-static UniValue upgradewallet(const JSONRPCRequest& request)
+static UniValue upgradewallet(const JSONRPCRequest& request, const NodeContext& node)
 {
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
@@ -4270,16 +4270,16 @@ static UniValue upgradewallet(const JSONRPCRequest& request)
     return error;
 }
 
-UniValue abortrescan(const JSONRPCRequest& request); // in rpcdump.cpp
-UniValue dumpprivkey(const JSONRPCRequest& request); // in rpcdump.cpp
-UniValue importprivkey(const JSONRPCRequest& request);
-UniValue importaddress(const JSONRPCRequest& request);
-UniValue importpubkey(const JSONRPCRequest& request);
-UniValue dumpwallet(const JSONRPCRequest& request);
-UniValue importwallet(const JSONRPCRequest& request);
-UniValue importprunedfunds(const JSONRPCRequest& request);
-UniValue removeprunedfunds(const JSONRPCRequest& request);
-UniValue importmulti(const JSONRPCRequest& request);
+UniValue abortrescan(const JSONRPCRequest& request, const NodeContext& node); // in rpcdump.cpp
+UniValue dumpprivkey(const JSONRPCRequest& request, const NodeContext& node); // in rpcdump.cpp
+UniValue importprivkey(const JSONRPCRequest& request, const NodeContext& node);
+UniValue importaddress(const JSONRPCRequest& request, const NodeContext& node);
+UniValue importpubkey(const JSONRPCRequest& request, const NodeContext& node);
+UniValue dumpwallet(const JSONRPCRequest& request, const NodeContext& node);
+UniValue importwallet(const JSONRPCRequest& request, const NodeContext& node);
+UniValue importprunedfunds(const JSONRPCRequest& request, const NodeContext& node);
+UniValue removeprunedfunds(const JSONRPCRequest& request, const NodeContext& node);
+UniValue importmulti(const JSONRPCRequest& request, const NodeContext& node);
 
 void RegisterWalletRPCCommands(interfaces::Chain& chain, std::vector<std::unique_ptr<interfaces::Handler>>& handlers)
 {
@@ -4351,4 +4351,3 @@ static const CRPCCommand commands[] =
         handlers.emplace_back(chain.handleRpc(commands[vcidx]));
 }
 
-interfaces::Chain* g_rpc_chain = nullptr;

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -6,6 +6,7 @@
 #define BITCOIN_WALLET_RPCWALLET_H
 
 #include <memory>
+#include <node/context.h>
 #include <string>
 #include <vector>
 
@@ -22,12 +23,6 @@ class Chain;
 class Handler;
 }
 
-//! Pointer to chain interface that needs to be declared as a global to be
-//! accessible loadwallet and createwallet methods. Due to limitations of the
-//! RPC framework, there's currently no direct way to pass in state to RPC
-//! methods without globals.
-extern interfaces::Chain* g_rpc_chain;
-
 void RegisterWalletRPCCommands(interfaces::Chain& chain, std::vector<std::unique_ptr<interfaces::Handler>>& handlers);
 
 /**
@@ -42,6 +37,6 @@ void EnsureWalletIsUnlocked(const CWallet*);
 bool EnsureWalletIsAvailable(const CWallet*, bool avoidException);
 LegacyScriptPubKeyMan& EnsureLegacyScriptPubKeyMan(CWallet& wallet, bool also_create = false);
 
-UniValue getaddressinfo(const JSONRPCRequest& request);
-UniValue signrawtransactionwithwallet(const JSONRPCRequest& request);
+UniValue getaddressinfo(const JSONRPCRequest& request, const NodeContext* prpc_node);
+UniValue signrawtransactionwithwallet(const JSONRPCRequest& request, const NodeContext* prpc_node);
 #endif //BITCOIN_WALLET_RPCWALLET_H

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -20,9 +20,9 @@
 #include <boost/test/unit_test.hpp>
 #include <univalue.h>
 
-extern UniValue importmulti(const JSONRPCRequest& request);
-extern UniValue dumpwallet(const JSONRPCRequest& request);
-extern UniValue importwallet(const JSONRPCRequest& request);
+extern UniValue importmulti(const JSONRPCRequest& request, const NodeContext& node);
+extern UniValue dumpwallet(const JSONRPCRequest& request, const NodeContext& node);
+extern UniValue importwallet(const JSONRPCRequest& request, const NodeContext& node);
 
 BOOST_FIXTURE_TEST_SUITE(wallet_tests, WalletTestingSetup)
 
@@ -174,7 +174,7 @@ BOOST_FIXTURE_TEST_CASE(importmulti_rescan, TestChain100Setup)
         request.params.setArray();
         request.params.push_back(keys);
 
-        UniValue response = importmulti(request);
+        UniValue response = importmulti(request, node);
         BOOST_CHECK_EQUAL(response.write(),
             strprintf("[{\"success\":false,\"error\":{\"code\":-1,\"message\":\"Rescan failed for key with creation "
                       "timestamp %d. There was an error reading a block from time %d, which is after or within %d "
@@ -227,7 +227,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back(backup_file);
         AddWallet(wallet);
         wallet->SetLastBlockProcessed(::ChainActive().Height(), ::ChainActive().Tip()->GetBlockHash());
-        ::dumpwallet(request);
+        ::dumpwallet(request, node);
         RemoveWallet(wallet);
     }
 
@@ -243,7 +243,7 @@ BOOST_FIXTURE_TEST_CASE(importwallet_rescan, TestChain100Setup)
         request.params.push_back(backup_file);
         AddWallet(wallet);
         wallet->SetLastBlockProcessed(::ChainActive().Height(), ::ChainActive().Tip()->GetBlockHash());
-        ::importwallet(request);
+        ::importwallet(request, node);
         RemoveWallet(wallet);
 
         BOOST_CHECK_EQUAL(wallet->mapWallet.size(), 3U);

--- a/src/zmq/zmqrpc.cpp
+++ b/src/zmq/zmqrpc.cpp
@@ -13,7 +13,7 @@
 
 namespace {
 
-UniValue getzmqnotifications(const JSONRPCRequest& request)
+UniValue getzmqnotifications(const JSONRPCRequest& request, const NodeContext& node)
 {
             RPCHelpMan{"getzmqnotifications",
                 "\nReturns information about the active ZeroMQ notifications.\n",


### PR DESCRIPTION
This PR removes the global **g_rpc_node** and **g_rpc_chain** pointers from RPC functions and other sources & headers. Instead, a NodeContext const reference, and in some cases a NodeContext pointer, is being forwarded to respective actor callbacks.

Also, this way we avoid changing the **JSONRPCRequest** that, imo, should remain a plain *message transfer object* without any knowledge about its environment. I consider the idea of having a **void pointer** member of **JSONRPCRequest** problematic because it defeats the compiler type checking. In a way, a globally available, but at least *typed*, pointer would still be better than a *void* pointer, in my opinion.

Previously, an RPC function signature looked like this:

```cpp
static UniValue getpeerinfo(const JSONRPCRequest& request)
```

This PR changes it to this:

```cpp
static UniValue getpeerinfo(const JSONRPCRequest& request, const NodeContext& node)
```

For example, a function that previously used **g_rpc_node** like this: 

```cpp
if(!g_rpc_node->connman)
   throw JSONRPCError(RPC_CLIENT_P2P_DISABLED...[snip]...
```

would get the same object this way:

```cpp
if (!node.connman)
                throw JSONRPCError(RPC_CLIENT_P2P_DISABLED,...[snip]...
```

The same applies to former **g_rpc_chain** where functions like *loadwallet* don't need it anymore:

```cpp
LoadWallet(*node.chain, location, error, warning);
```

This all is made possible by taking the NodeContext into the tableRPC object at init:

```cpp
/* Register RPC commands regardless of -server setting so they will be
     * available in the GUI RPC console even if external calls are disabled.
     */
    RegisterAllCoreRPCCommands(tableRPC);
    for (const auto& client : node.chain_clients) {
        client->registerRpcs();
    }
    tableRPC.addNodeContext(&node);    <=== RPC's are available, now take NodeContext to forward it later to them.
```

Each time an RPC is being called, *tableRPC* will forward the *NodeContext* argument:

```cpp
static bool ExecuteCommand(const CRPCCommand& command, const JSONRPCRequest& request, UniValue& result, bool last_handler, const NodeContext& node)
{
    try
    {
        RPCCommandExecution execution(request.strMethod);
        // Execute, convert arguments to array if necessary
        if (request.params.isObject()) {
            return command.actor(transformNamedArguments(request, command.argNames), result, last_handler, node);
        } else {
            return command.actor(request, result, last_handler, node);
```

Fixes https://github.com/bitcoin/bitcoin/issues/17548  