### PR TITLE
tests: Add std::locale::global to list of locale dependent functions

### DIFF
--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -97,6 +97,7 @@ LOCALE_DEPENDENT_FUNCTIONS=(
     snprintf
     sprintf
     sscanf
+    std::locale::global
     std::to_string
     stod
     stof


### PR DESCRIPTION
Add `std::locale::global` to list of locale dependent functions in `lint-locale-dependence.sh`.

We currently flag `setlocale(...)` as locale dependent, but prior to this commit we didn't flag
`std::locale::global(...)` as such.

In addition to setting the global C++ locale `std::locale::global(...)` also does the equivalent of `std::setlocale(LC_ALL, ...);`.

Thus the functionality of `std::locale::global(...)` is a superset of `setlocale(...)` :)