### PR TITLE
gui: Add bumpFeePSBT action instead of changing normal bumpfee behavior

### DIFF
--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -77,6 +77,7 @@ private:
     QDateTimeEdit *dateTo;
     QAction *abandonAction;
     QAction *bumpFeeAction;
+    QAction *bumpFeePSBTAction;
 
     QWidget *createDateRangeWidget();
 
@@ -100,7 +101,8 @@ private Q_SLOTS:
     void openThirdPartyTxUrl(QString url);
     void updateWatchOnlyColumn(bool fHaveWatchOnly);
     void abandonTx();
-    void bumpFee();
+    void bumpFee(bool make_psbt = false);
+    void bumpFeePSBT();
 
 Q_SIGNALS:
     void doubleClicked(const QModelIndex&);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -478,7 +478,7 @@ bool WalletModel::saveReceiveRequest(const std::string &sAddress, const int64_t 
         return m_wallet->addDestData(dest, key, sRequest);
 }
 
-bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
+bool WalletModel::bumpFee(uint256 hash, uint256& new_hash, bool create_psbt)
 {
     CCoinControl coin_control;
     coin_control.m_signal_bip125_rbf = true;
@@ -491,8 +491,6 @@ bool WalletModel::bumpFee(uint256 hash, uint256& new_hash)
             (errors.size() ? QString::fromStdString(errors[0]) : "") +")");
          return false;
     }
-
-    const bool create_psbt = m_wallet->privateKeysDisabled();
 
     // allow a user based fee verification
     QString questionString = create_psbt ? tr("Do you want to draft a transaction with fee increase?") : tr("Do you want to increase the fee?");

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -138,7 +138,7 @@ public:
     void loadReceiveRequests(std::vector<std::string>& vReceiveRequests);
     bool saveReceiveRequest(const std::string &sAddress, const int64_t nId, const std::string &sRequest);
 
-    bool bumpFee(uint256 hash, uint256& new_hash);
+    bool bumpFee(uint256 hash, uint256& new_hash, bool make_psbt);
 
     static bool isWalletEnabled();
 


### PR DESCRIPTION
Similar to #18654, instead of a single fee bumping action that changes its behavior based on `IsWalletFlagSet(WALLET_FLAG_DISABLE_PRIVATE_KEYS)`, separate it to have one that always tries to sign and send, and another that copies a psbt to the clipboard. So a new menu action is added and the original action will be disabled if private keys are disabled.

Split from #18627