### PR TITLE
chain: Do not fill out parameters in findCommonAncestor(...) if ancestor is not found

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -275,7 +275,7 @@ public:
         const CBlockIndex* block1 = LookupBlockIndex(block_hash1);
         const CBlockIndex* block2 = LookupBlockIndex(block_hash2);
         const CBlockIndex* ancestor = block1 && block2 ? LastCommonAncestor(block1, block2) : nullptr;
-        return FillBlock(ancestor, ancestor_out, lock) & FillBlock(block1, block1_out, lock) & FillBlock(block2, block2_out, lock);
+        return FillBlock(ancestor, ancestor_out, lock) && FillBlock(block1, block1_out, lock) && FillBlock(block2, block2_out, lock);
     }
     void findCoins(std::map<COutPoint, Coin>& coins) override { return FindCoins(m_node, coins); }
     double guessVerificationProgress(const uint256& block_hash) override

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -161,7 +161,8 @@ public:
         const FoundBlock& ancestor_out={}) = 0;
 
     //! Find most recent common ancestor between two blocks and optionally
-    //! return block information.
+    //! return block information. block1_out and block2_out are not filled
+    //! if the ancestor is not found.
     virtual bool findCommonAncestor(const uint256& block_hash1,
         const uint256& block_hash2,
         const FoundBlock& ancestor_out={},


### PR DESCRIPTION
This is a follow-up to #17954 which was merged yesterday.

See [post-merge comments](https://github.com/bitcoin/bitcoin/pull/17954#issuecomment-614073173) in #17954 for context:

> Oh, I didn't see this during review. I read the method as nothing is filled when the ancestor is not found. I.e. I read the `&` as `&&`. Is there any caller that depends on this edge case?