### PR TITLE
test: add further BIP37 size limit checks to p2p_filter.py

### DIFF
--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -8,6 +8,8 @@ Test BIP 37
 
 from test_framework.messages import (
     CInv,
+    MAX_BLOOM_FILTER_SIZE,
+    MAX_BLOOM_HASH_FUNCS,
     MSG_BLOCK,
     MSG_FILTERED_BLOCK,
     msg_filteradd,
@@ -16,6 +18,7 @@ from test_framework.messages import (
     msg_getdata,
 )
 from test_framework.mininode import P2PInterface
+from test_framework.script import MAX_SCRIPT_ELEMENT_SIZE
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
 
@@ -67,7 +70,13 @@ class FilterTest(BitcoinTestFramework):
 
         self.log.info('Check that too large filter is rejected')
         with self.nodes[0].assert_debug_log(['Misbehaving']):
-            filter_node.send_and_ping(msg_filterload(data=b'\xaa', nHashFuncs=51, nTweak=0, nFlags=1))
+            filter_node.send_and_ping(msg_filterload(data=b'\xaa', nHashFuncs=MAX_BLOOM_HASH_FUNCS+1))
+        with self.nodes[0].assert_debug_log(['Misbehaving']):
+            filter_node.send_and_ping(msg_filterload(data=b'\xbb'*(MAX_BLOOM_FILTER_SIZE+1)))
+
+        self.log.info('Check that too large data element to add to the filter is rejected')
+        with self.nodes[0].assert_debug_log(['Misbehaving']):
+            filter_node.send_and_ping(msg_filteradd(data=b'\xcc'*(MAX_SCRIPT_ELEMENT_SIZE+1)))
 
         self.log.info('Add filtered P2P connection to the node')
         filter_node.send_and_ping(filter_node.watch_filter_init)
@@ -116,10 +125,9 @@ class FilterTest(BitcoinTestFramework):
             assert not filter_node.merkleblock_received
             assert not filter_node.tx_received
 
-        self.log.info('Check that sending "filteradd" if no filter is set is treated as misbehavior (+100)')
-        assert_equal(self.nodes[0].getpeerinfo()[0]['banscore'], 0)
-        filter_node.send_and_ping(msg_filteradd(data=b'letsmisbehave'))
-        assert_equal(self.nodes[0].getpeerinfo()[0]['banscore'], 100)
+        self.log.info('Check that sending "filteradd" if no filter is set is treated as misbehavior')
+        with self.nodes[0].assert_debug_log(['Misbehaving']):
+            filter_node.send_and_ping(msg_filteradd(data=b'letsmisbehave'))
 
         self.log.info("Check that division-by-zero remote crash bug [CVE-2013-5700] is fixed")
         filter_node.send_and_ping(msg_filterload(data=b'', nHashFuncs=1))

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -37,6 +37,8 @@ MY_RELAY = 1 # from version 70001 onwards, fRelay should be appended to version 
 
 MAX_LOCATOR_SZ = 101
 MAX_BLOCK_BASE_SIZE = 1000000
+MAX_BLOOM_FILTER_SIZE = 36000
+MAX_BLOOM_HASH_FUNCS = 50
 
 COIN = 100000000  # 1 btc in satoshis
 MAX_MONEY = 21000000 * COIN


### PR DESCRIPTION
This is a follow-up PR to #18628. In addition to the hash-functions limit test introduced with commit https://github.com/bitcoin/bitcoin/pull/18628/commits/fa4c29bc1d2425f861845bae4f3816d9817e622a, it adds checks for the following size limits as defined in [BIP37](https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki):

ad message type `filterload`:
> The filter itself is simply a bit field of arbitrary byte-aligned size. The maximum size is **36,000 bytes**. 

ad message type `filteradd`:
> The data field must be smaller than or equal to **520 bytes** in size (the maximum size of any potentially matched object).

Also introduces new constants for the limits (or reuses the max script size constant in case for the `filteradd` limit).

Also fixes #18711 by changing the misbehaviour check on "filteradd without filterset" (introduced with #18544) below to also use the more commonly used `assert_debug_log` method.