### PR TITLE
donotmerge: build: Enable thread-local with glibc compat

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -194,7 +194,7 @@ AC_ARG_ENABLE([glibc-back-compat],
 
 AC_ARG_ENABLE([threadlocal],
   [AS_HELP_STRING([--enable-threadlocal],
-  [enable features that depend on the c++ thread_local keyword (currently just thread names in debug logs). (default is to enabled if there is platform support and glibc-back-compat is not enabled)])],
+  [enable features that depend on the c++ thread_local keyword (currently just thread names in debug logs). (default is to enabled if there is platform support)])],
   [use_thread_local=$enableval],
   [use_thread_local=auto])
 
@@ -861,7 +861,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
   ]
 )
 
-if test "x$use_thread_local" = xyes || { test "x$use_thread_local" = xauto && test "x$use_glibc_compat" = xno; }; then
+if test "x$use_thread_local" = xyes || test "x$use_thread_local" = xauto; then
   TEMP_LDFLAGS="$LDFLAGS"
   LDFLAGS="$TEMP_LDFLAGS $PTHREAD_CFLAGS"
   AC_MSG_CHECKING([for thread_local support])


### PR DESCRIPTION
I don't know when thread-local support was added. or whether disabling it is still necessary after the minimum glibc bump to 2.17 (see #18652).

This is a test for doing gitian builds with thread-local support enabled.
