### PR TITLE
fuzz: http_request workaround for libevent < 2.1.1

### DIFF
--- a/src/test/fuzz/http_request.cpp
+++ b/src/test/fuzz/http_request.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/util.h>
 
 #include <event2/buffer.h>
+#include <event2/event.h>
 #include <event2/http.h>
 #include <event2/http_struct.h>
 
@@ -17,8 +18,24 @@
 #include <string>
 #include <vector>
 
+// workaround for libevent versions before 2.1.1,
+// when internal functions didn't have underscores at the end
+#if LIBEVENT_VERSION_NUMBER < 0x02010100
+extern "C" int evhttp_parse_firstline(struct evhttp_request*, struct evbuffer*);
+extern "C" int evhttp_parse_headers(struct evhttp_request*, struct evbuffer*);
+inline int evhttp_parse_firstline_(struct evhttp_request* r, struct evbuffer* b)
+{
+    return evhttp_parse_firstline(r, b);
+}
+inline int evhttp_parse_headers_(struct evhttp_request* r, struct evbuffer* b)
+{
+    return evhttp_parse_headers(r, b);
+}
+#else
 extern "C" int evhttp_parse_firstline_(struct evhttp_request*, struct evbuffer*);
 extern "C" int evhttp_parse_headers_(struct evhttp_request*, struct evbuffer*);
+#endif
+
 std::string RequestMethodString(HTTPRequest::RequestMethod m);
 
 void test_one_input(const std::vector<uint8_t>& buffer)


### PR DESCRIPTION
The fuzz test `http_request` calls the following two internal libevent functions:
* `evhttp_parse_firstline_`
* `evhttp_parse_headers_`

Before libevent 2.1.1 however, internal functions names didn't end with an underscore (see libevent commit https://github.com/libevent/libevent/commit/8ac3c4c25bea4b9948ab91cd00605bf34fc0bd72 and [Changelog for 2.1.1.-alpha](https://github.com/libevent/libevent/blob/master/ChangeLog#L1830) when the change was first mentioned) hence the build fails with a linking error.
This PR adds a preprocessor workaround to the test that checks for the libevent version (via ~`_EVENT_NUMERIC_VERSION`~ `LIBEVENT_VERSION_NUMBER`) and creates wrapper functions mapping to naming scheme without underscore in case the version is older than 2.1.1.

Tested with Ubuntu Xenial 16.04.6 LTS and clang-8.