### PR TITLE
Fix -Wsign-compare warning on ARM 32-bit

### DIFF
--- a/src/util/asmap.cpp
+++ b/src/util/asmap.cpp
@@ -2,9 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <vector>
-#include <assert.h>
+#include <util/asmap.h>
+
 #include <crypto/common.h>
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
 
 namespace {
 
@@ -79,7 +83,8 @@ uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip)
             jump = DecodeJump(pos, endpos);
             if (bits == 0) break;
             if (ip[ip.size() - bits]) {
-                if (jump >= endpos - pos) break;
+                assert(endpos - pos >= 0);
+                if (jump >= static_cast<uint32_t>(endpos - pos)) break;
                 pos += jump;
             }
             bits--;

--- a/src/util/asmap.h
+++ b/src/util/asmap.h
@@ -5,6 +5,9 @@
 #ifndef BITCOIN_UTIL_ASMAP_H
 #define BITCOIN_UTIL_ASMAP_H
 
+#include <cstdint>
+#include <vector>
+
 uint32_t Interpret(const std::vector<bool> &asmap, const std::vector<bool> &ip);
 
 #endif // BITCOIN_UTIL_ASMAP_H


### PR DESCRIPTION
This PR fixes `-Wsign-compare` warning on ARM 32-bit platform which is emitted on master (54f812d9d29893c690ae06b84aaeab128186aa36) by different compilers:

- GCC:
```
  CXX      util/libbitcoin_util_a-asmap.o
util/asmap.cpp: In function ‘uint32_t Interpret(const std::vector<bool>&, const std::vector<bool>&)’:
util/asmap.cpp:82:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
                 if (jump >= endpos - pos) break;
                     ~~~~~^~~~~~~~~~~~~~~
  CXX      util/libbitcoin_util_a-bytevectorhash.o
```

- Clang:
```
  CXX      util/libbitcoin_util_a-asmap.o
util/asmap.cpp:82:26: warning: comparison of integers of different signs: 'uint32_t' (aka 'unsigned int') and 'std::ptrdiff_t' (aka 'int') [-Wsign-compare]
                if (jump >= endpos - pos) break;
                    ~~~~ ^  ~~~~~~~~~~~~
  CXX      util/libbitcoin_util_a-bytevectorhash.o
1 warning generated.
```