### PR TITLE
test: Replace boost::mutex with std::mutex

### DIFF
--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -9,12 +9,14 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/thread.hpp>
 
+#include <mutex>
+
 BOOST_AUTO_TEST_SUITE(scheduler_tests)
 
-static void microTask(CScheduler& s, boost::mutex& mutex, int& counter, int delta, std::chrono::system_clock::time_point rescheduleTime)
+static void microTask(CScheduler& s, std::mutex& mutex, int& counter, int delta, std::chrono::system_clock::time_point rescheduleTime)
 {
     {
-        boost::unique_lock<boost::mutex> lock(mutex);
+        std::lock_guard<std::mutex> lock(mutex);
         counter += delta;
     }
     std::chrono::system_clock::time_point noTime = std::chrono::system_clock::time_point::min();
@@ -38,7 +40,7 @@ BOOST_AUTO_TEST_CASE(manythreads)
     // counters should sum to the number of initial tasks performed.
     CScheduler microTasks;
 
-    boost::mutex counterMutex[10];
+    std::mutex counterMutex[10];
     int counter[10] = { 0 };
     FastRandomContext rng{/* fDeterministic */ true};
     auto zeroToNine = [](FastRandomContext& rc) -> int { return rc.randrange(10); }; // [0, 9]


### PR DESCRIPTION
This PR replaces `boost::mutex` with `std::mutex` in the `scheduler_tests` test suite.