### PR TITLE
test: display command line options passed to send_cli() in debug log

### DIFF
--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -51,7 +51,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.log.info("Test -getinfo returns expected network and blockchain info")
         if self.is_wallet_compiled():
             self.nodes[0].encryptwallet(password)
-        cli_get_info = self.nodes[0].cli().send_cli('-getinfo')
+        cli_get_info = self.nodes[0].cli('-getinfo').send_cli()
         network_info = self.nodes[0].getnetworkinfo()
         blockchain_info = self.nodes[0].getblockchaininfo()
         assert_equal(cli_get_info['version'], network_info['version'])
@@ -77,7 +77,7 @@ class TestBitcoinCli(BitcoinTestFramework):
 
         self.log.info("Test -version with node stopped")
         self.stop_node(0)
-        cli_response = self.nodes[0].cli().send_cli('-version')
+        cli_response = self.nodes[0].cli('-version').send_cli()
         assert "{} RPC client version".format(self.config['environment']['PACKAGE_NAME']) in cli_response
 
         self.log.info("Test -rpcwait option successfully waits for RPC connection")

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -580,7 +580,7 @@ class TestNodeCLI():
         if command is not None:
             p_args += [command]
         p_args += pos_args + named_args
-        self.log.debug("Running bitcoin-cli command: %s" % command)
+        self.log.debug("Running bitcoin-cli {}".format(p_args[2:]))
         process = subprocess.Popen(p_args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
         cli_stdout, cli_stderr = process.communicate(input=self.input)
         returncode = process.poll()


### PR DESCRIPTION
as per https://github.com/bitcoin/bitcoin/pull/18691#discussion_r411382589, and revert two cli calls changed in #18691 from rpc commands back to command line options (these were the only occurrences).