### PR TITLE
test: add coverage for -rpcwallet cli option

### DIFF
--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -3,6 +3,7 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Test bitcoin-cli"""
+from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal, assert_raises_process_error, get_auth_cookie
 
@@ -72,8 +73,48 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_equal(cli_get_info['paytxfee'], wallet_info['paytxfee'])
             assert_equal(cli_get_info['relayfee'], network_info['relayfee'])
             assert_equal(self.nodes[0].cli.getwalletinfo(), wallet_info)
+
+            # Setup to test -getinfo and -rpcwallet= with multiple wallets.
+            wallets = ['', 'Encrypted', 'secret']
+            amounts = [Decimal('59.999928'), Decimal(9), Decimal(31)]
+            self.nodes[0].createwallet(wallet_name=wallets[1])
+            self.nodes[0].createwallet(wallet_name=wallets[2])
+            w1 = self.nodes[0].get_wallet_rpc(wallets[0])
+            w2 = self.nodes[0].get_wallet_rpc(wallets[1])
+            w3 = self.nodes[0].get_wallet_rpc(wallets[2])
+            w1.walletpassphrase(password, self.rpc_timeout)
+            w1.sendtoaddress(w2.getnewaddress(), amounts[1])
+            w1.sendtoaddress(w3.getnewaddress(), amounts[2])
+
+            # Mine a block to confirm; adds a block reward (50 BTC) to the default wallet.
+            self.nodes[0].generate(1)
+
+            self.log.info("Test -getinfo with multiple wallets loaded returns no balance")
+            assert_equal(set(self.nodes[0].listwallets()), set(wallets))
+            assert 'balance' not in self.nodes[0].cli('-getinfo').send_cli().keys()
+
+            self.log.info("Test -getinfo with multiple wallets and -rpcwallet returns specified wallet balance")
+            for i in range(len(wallets)):
+                cli_get_info = self.nodes[0].cli('-getinfo').send_cli('-rpcwallet={}'.format(wallets[i]))
+                assert_equal(cli_get_info['balance'], amounts[i])
+
+            self.log.info("Test -getinfo with multiple wallets and -rpcwallet=non-existing-wallet returns no balance")
+            assert 'balance' not in self.nodes[0].cli('-getinfo').send_cli('-rpcwallet=does-not-exist').keys()
+
+            self.log.info("Test -getinfo after unloading all wallets except a non-default one returns its balance")
+            self.nodes[0].unloadwallet(wallets[0])
+            self.nodes[0].unloadwallet(wallets[2])
+            assert_equal(self.nodes[0].listwallets(), [wallets[1]])
+            assert_equal(self.nodes[0].cli('-getinfo').send_cli()['balance'], amounts[1])
+
+            self.log.info("Test -getinfo -rpcwallet=remaining-non-default-wallet returns its balance")
+            assert_equal(self.nodes[0].cli('-getinfo').send_cli('-rpcwallet={}'.format(wallets[1]))['balance'], amounts[1])
+
+            self.log.info("Test -getinfo with -rpcwallet=unloaded wallet returns no balance")
+            assert 'balance' not in self.nodes[0].cli('-getinfo').send_cli('-rpcwallet={}'.format(wallets[2])).keys()
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
+            self.nodes[0].generate(1)  # maintain block parity with the wallet_compiled conditional branch
 
         self.log.info("Test -version with node stopped")
         self.stop_node(0)
@@ -85,7 +126,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.nodes[0].wait_for_cookie_credentials()  # ensure cookie file is available to avoid race condition
         blocks = self.nodes[0].cli('-rpcwait').send_cli('getblockcount')
         self.nodes[0].wait_for_rpc_connection()
-        assert_equal(blocks, BLOCKS)
+        assert_equal(blocks, BLOCKS + 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The bitcoin-cli `-rpcwallet=` option is an essential RPC/CLI option when more than one wallet is loaded (see `bitcoin-cli -help | grep -A5 rpcwallet` or `src/bitcoin-cli.cpp::L61`) and it currently has no test coverage.

It is not only used by users, but also by the test framework and ~10 test files via `get_wallet_rpc()`.

This PR adds coverage, while simultaneously improving the `-getinfo` coverage when multiple wallets are loaded. This is similar to the test coverage that would be added in #18594.