### PR TITLE
[WIP] Expand CPFP "carve-out" rule from N=1 to N=100

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -66,6 +66,11 @@ static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
  * configurable as it doesn't materially change DoS parameters.
  */
 static const unsigned int EXTRA_DESCENDANT_TX_SIZE_LIMIT = 10000;
+/**
+ * Each package is allowed this many EXTRA_DESCENDANT_TX_SIZE_LIMIT sized
+ * or less additional transactions.
+ */
+static const unsigned int EXTRA_DESCENDANT_TX_COUNT_LIMIT = 100;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 336;
 /** Maximum kilobytes for transactions to store for processing during reorg */


### PR DESCRIPTION
Chasing concept Acks and discussion. Probably broken. Need p2p wisdom which I lack.

The motivating use-case here is this would allow batched payouts to be safely done for custodial services without them being pinned. Specifically this would allow up to N+1 payments outputs, one of which can be a self-send to the service, which is then spent and RBF'd as needed, similar to the motivating LN use-case given in the code. This could greatly simplify payout logic for services, and allow them to save in fees more aggressively.

Built on https://github.com/bitcoin/bitcoin/pull/18723