### PR TITLE
test: Add CreateWalletFromFile test

### DIFF
--- a/src/test/util/logging.cpp
+++ b/src/test/util/logging.cpp
@@ -11,13 +11,13 @@
 
 #include <stdexcept>
 
-DebugLogHelper::DebugLogHelper(std::string message)
-    : m_message{std::move(message)}
+DebugLogHelper::DebugLogHelper(std::string message, MatchFn match)
+    : m_message{std::move(message)}, m_match(std::move(match))
 {
     m_print_connection = LogInstance().PushBackCallback(
         [this](const std::string& s) {
             if (m_found) return;
-            m_found = s.find(m_message) != std::string::npos;
+            m_found = s.find(m_message) != std::string::npos && m_match(&s);
         });
     noui_test_redirect();
 }
@@ -26,7 +26,7 @@ void DebugLogHelper::check_found()
 {
     noui_reconnect();
     LogInstance().DeleteCallback(m_print_connection);
-    if (!m_found) {
+    if (!m_found && m_match(nullptr)) {
         throw std::runtime_error(strprintf("'%s' not found in debug log\n", m_message));
     }
 }

--- a/src/test/util/logging.h
+++ b/src/test/util/logging.h
@@ -17,10 +17,22 @@ class DebugLogHelper
     bool m_found{false};
     std::list<std::function<void(const std::string&)>>::iterator m_print_connection;
 
+    //! Custom match checking function.
+    //!
+    //! Invoked with pointers to lines containing matching strings, and with
+    //! null if check_found() is called without any successful match.
+    //!
+    //! Can return true to enable default DebugLogHelper behavior of:
+    //! (1) ending search after first successful match, and
+    //! (2) raising an error in check_found if no match was found
+    //! Can return false to do the opposite in either case.
+    using MatchFn = std::function<bool(const std::string* line)>;
+    MatchFn m_match;
+
     void check_found();
 
 public:
-    DebugLogHelper(std::string message);
+    DebugLogHelper(std::string message, MatchFn match = [](const std::string*){ return true; });
     ~DebugLogHelper() { check_found(); }
 };
 


### PR DESCRIPTION
Add unit test calling CreateWalletFromFile, which isn't currently called from other unit tests, with some basic checks to make sure it rescans and registers for notifications correctly.

Motivation for this change was to try to write a test that would fail without the early `handleNotifications` call in ef8c6ca60767cac589d98ca57ee33179608ccda8 from https://github.com/bitcoin/bitcoin/pull/16426, but succeed with it:

https://github.com/bitcoin/bitcoin/blob/ef8c6ca60767cac589d98ca57ee33179608ccda8/src/wallet/wallet.cpp#L3978-L3986

However, writing a full test for the race condition that call prevents isn't possible without the locking changes from #16426. So this PR just adds as much test coverage as is possible now.

This new test is also useful for https://github.com/bitcoin/bitcoin/pull/15719, since it detects the stale notifications.transactionAddedToMempool notifications that PR eliminates.