### PR TITLE
Allow simple multiwallet rpc calls

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -92,6 +92,10 @@ static void RescanWallet(CWallet& wallet, const WalletRescanReserver& reserver, 
 
 UniValue importprivkey(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &importprivkey);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -224,6 +228,10 @@ UniValue abortrescan(const JSONRPCRequest& request)
 
 UniValue importaddress(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &importaddress);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -328,6 +336,10 @@ UniValue importaddress(const JSONRPCRequest& request)
 
 UniValue importprunedfunds(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &importprunedfunds);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -388,6 +400,10 @@ UniValue importprunedfunds(const JSONRPCRequest& request)
 
 UniValue removeprunedfunds(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &removeprunedfunds);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -428,6 +444,10 @@ UniValue removeprunedfunds(const JSONRPCRequest& request)
 
 UniValue importpubkey(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &importpubkey);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -517,6 +537,10 @@ UniValue importpubkey(const JSONRPCRequest& request)
 
 UniValue importwallet(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &importwallet);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -676,6 +700,10 @@ UniValue importwallet(const JSONRPCRequest& request)
 
 UniValue dumpprivkey(const JSONRPCRequest& request)
 {
+    if (IsMultiwalletJSONRPCRequest(request)) {
+        return ExecForeachWalletJSONRPCRequest(request, &dumpprivkey);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(request);
     const CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
@@ -1266,6 +1294,10 @@ static int64_t GetImportTimestamp(const UniValue& data, int64_t now)
 
 UniValue importmulti(const JSONRPCRequest& mainRequest)
 {
+    if (IsMultiwalletJSONRPCRequest(mainRequest)) {
+        return ExecForeachWalletJSONRPCRequest(mainRequest, &importmulti);
+    }
+
     std::shared_ptr<CWallet> const wallet = GetWalletForJSONRPCRequest(mainRequest);
     CWallet* const pwallet = wallet.get();
     if (!EnsureWalletIsAvailable(pwallet, mainRequest.fHelp)) {

--- a/src/wallet/rpcwallet.h
+++ b/src/wallet/rpcwallet.h
@@ -38,6 +38,10 @@ void RegisterWalletRPCCommands(interfaces::Chain& chain, std::vector<std::unique
  */
 std::shared_ptr<CWallet> GetWalletForJSONRPCRequest(const JSONRPCRequest& request);
 
+bool IsMultiwalletJSONRPCRequest(const JSONRPCRequest& request);
+typedef UniValue(*rpcfn_type)(const JSONRPCRequest& jsonRequest);
+UniValue ExecForeachWalletJSONRPCRequest(JSONRPCRequest mutable_request, const rpcfn_type& func);
+
 void EnsureWalletIsUnlocked(const CWallet*);
 bool EnsureWalletIsAvailable(const CWallet*, bool avoidException);
 LegacyScriptPubKeyMan& EnsureLegacyScriptPubKeyMan(CWallet& wallet, bool also_create = false);


### PR DESCRIPTION
Would fix #18715.
See discussion in #18453.

Currently, batching RPC requests across wallets does not work due to the fact that each wallet has its own endpoint.

This PR allows using a simple wildcard approach for the wallet endpoint (`/wallet/*/`).
Using `bitcoin-cli` `-rpcwallet="*"` or `-rpcwallet="pattern*` works with this PR.

This PR is a simple approach that allows detailed control on a per call basis. Some calls probably need special logic (`rescanblockchain`). Some calls make not much sense across wallets (`dumpwallet` or `backupwallet` as example).

The output (or error/s) will be bundles as json array with a dictionary for each wallet:
```
[
  {
    "walletname": "test",
    "result": 0.00000000
  },
  {
    "walletname": "wallet",
    "result": 0.00000000
  },
  {
    "walletname": "test2",
    "result": 0.00000000
  }
]
```

Alternatives:
* implementing a generic approach on our httpserver/rpcserver layer (complicates layering)
* try to add it to the CRPCTable (overhead for non wallet calls)
* a dedicated "foreachwallet" RPC meta call

Todo:
* [ ] tests
* [ ] documentation