### PR TITLE
test: Add fuzzing harnesses for various classes/functions in primitives/

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -69,6 +69,7 @@ FUZZ_TARGETS = \
   test/fuzz/partially_signed_transaction_deserialize \
   test/fuzz/pow \
   test/fuzz/prefilled_transaction_deserialize \
+  test/fuzz/primitives_transaction \
   test/fuzz/process_messages \
   test/fuzz/process_message \
   test/fuzz/process_message_addr \
@@ -685,6 +686,12 @@ test_fuzz_prefilled_transaction_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAG
 test_fuzz_prefilled_transaction_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_prefilled_transaction_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_prefilled_transaction_deserialize_SOURCES = test/fuzz/deserialize.cpp
+
+test_fuzz_primitives_transaction_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_primitives_transaction_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_primitives_transaction_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_primitives_transaction_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_primitives_transaction_SOURCES = test/fuzz/primitives_transaction.cpp
 
 test_fuzz_process_messages_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_process_messages_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -62,4 +62,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const size_t raw_memory_size = RecursiveDynamicUsage(block);
     const size_t raw_memory_size_as_shared_ptr = RecursiveDynamicUsage(std::make_shared<CBlock>(block));
     assert(raw_memory_size_as_shared_ptr > raw_memory_size);
+    CBlock block_copy = block;
+    block_copy.SetNull();
+    const bool is_null = block_copy.IsNull();
+    assert(is_null);
 }

--- a/src/test/fuzz/primitives_transaction.cpp
+++ b/src/test/fuzz/primitives_transaction.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <primitives/transaction.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const CScript script = ConsumeScript(fuzzed_data_provider);
+    const Optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
+    if (out_point) {
+        const CTxIn tx_in{*out_point, script, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
+        (void)tx_in;
+    }
+    const CTxOut tx_out_1{ConsumeMoney(fuzzed_data_provider), script};
+    const CTxOut tx_out_2{ConsumeMoney(fuzzed_data_provider), ConsumeScript(fuzzed_data_provider)};
+    assert((tx_out_1 == tx_out_2) != (tx_out_1 != tx_out_2));
+    const Optional<CMutableTransaction> mutable_tx_1 = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    const Optional<CMutableTransaction> mutable_tx_2 = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    if (mutable_tx_1 && mutable_tx_2) {
+        const CTransaction tx_1{*mutable_tx_1};
+        const CTransaction tx_2{*mutable_tx_2};
+        assert((tx_1 == tx_2) != (tx_1 != tx_2));
+    }
+}


### PR DESCRIPTION
Add fuzzing harnesses for various classes/functions in `primitives/`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)