### PR TITLE
consensus: Don't add spent coins to the cache

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -97,7 +97,6 @@ public:
  * - unspent, FRESH, DIRTY (e.g. a new coin created in the cache)
  * - unspent, not FRESH, DIRTY (e.g. a coin changed in the cache during a reorg)
  * - unspent, not FRESH, not DIRTY (e.g. an unspent coin fetched from the parent cache)
- * - spent, FRESH, not DIRTY (e.g. a spent coin fetched from the parent cache)
  * - spent, not FRESH, DIRTY (e.g. a coin is spent and spentness needs to be flushed to the parent)
  */
 struct CCoinsCacheEntry

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -818,7 +818,7 @@ BOOST_AUTO_TEST_CASE(ccoins_write)
      */
     CheckWriteCoins(ABSENT, ABSENT, ABSENT, NO_ENTRY   , NO_ENTRY   , NO_ENTRY   );
     CheckWriteCoins(ABSENT, SPENT , SPENT , NO_ENTRY   , DIRTY      , DIRTY      );
-    CheckWriteCoins(ABSENT, SPENT , ABSENT, NO_ENTRY   , DIRTY|FRESH, NO_ENTRY   );
+    CheckWriteCoins(ABSENT, SPENT , FAIL  , NO_ENTRY   , DIRTY|FRESH, NO_ENTRY   );
     CheckWriteCoins(ABSENT, VALUE2, VALUE2, NO_ENTRY   , DIRTY      , DIRTY      );
     CheckWriteCoins(ABSENT, VALUE2, VALUE2, NO_ENTRY   , DIRTY|FRESH, DIRTY|FRESH);
     CheckWriteCoins(SPENT , ABSENT, SPENT , 0          , NO_ENTRY   , 0          );

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -40,16 +40,11 @@ class CCoinsViewTest : public CCoinsView
 public:
     [[nodiscard]] bool GetCoin(const COutPoint& outpoint, Coin& coin) const override
     {
-        std::map<COutPoint, Coin>::const_iterator it = map_.find(outpoint);
-        if (it == map_.end()) {
-            return false;
-        }
+        auto it = map_.find(outpoint);
+        if (it == map_.end()) return false;
+
         coin = it->second;
-        if (coin.IsSpent() && InsecureRandBool() == 0) {
-            // Randomly return false in case of an empty entry.
-            return false;
-        }
-        return true;
+        return !(coin.IsSpent());
     }
 
     uint256 GetBestBlock() const override { return hashBestBlock_; }


### PR DESCRIPTION
When fetching a coin from a parent cache, don't add it to the child
cache if it's already spent, since there's no benefit to adding it.

This adds some invariant properties to the coins cache:
- a spent coin cannot be FRESH
- a spent coin must be DIRTY