### PR TITLE
qt: remove bug fix for Qt < 5.5

### DIFF
--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -379,14 +379,6 @@ void CoinControlDialog::viewItemChanged(QTreeWidgetItem* item, int column)
         if (ui->treeWidget->isEnabled()) // do not update on every click for (un)select all
             CoinControlDialog::updateLabels(model, this);
     }
-
-    // TODO: Remove this temporary qt5 fix after Qt5.3 and Qt5.4 are no longer used.
-    //       Fixed in Qt5.5 and above: https://bugreports.qt.io/browse/QTBUG-43473
-    else if (column == COLUMN_CHECKBOX && item->childCount() > 0)
-    {
-        if (item->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked && item->child(0)->checkState(COLUMN_CHECKBOX) == Qt::PartiallyChecked)
-            item->setCheckState(COLUMN_CHECKBOX, Qt::Checked);
-    }
 }
 
 // shows count of locked unspent outputs


### PR DESCRIPTION
Remove the code used to fix a Qt bug in versions before Qt 5.5.0 as described in this link https://bugreports.qt.io/browse/QTBUG-43473

Now the minimum requirement is Qt 5.5.1 as described in https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md

This code is not necessary anymore