### PR TITLE
tests: Add fuzzing harnesses for various classes/functions in policy/ (CBlockPolicyEstimator, IsRBFOptIn(…), etc.)

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -104,6 +104,7 @@ FUZZ_TARGETS = \
   test/fuzz/psbt_output_deserialize \
   test/fuzz/pub_key_deserialize \
   test/fuzz/random \
+  test/fuzz/rbf \
   test/fuzz/rolling_bloom_filter \
   test/fuzz/script \
   test/fuzz/script_deserialize \
@@ -899,6 +900,12 @@ test_fuzz_random_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_random_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_random_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_random_SOURCES = test/fuzz/random.cpp
+
+test_fuzz_rbf_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_rbf_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_rbf_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_rbf_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_rbf_SOURCES = test/fuzz/rbf.cpp
 
 test_fuzz_rolling_bloom_filter_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_rolling_bloom_filter_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -67,6 +67,7 @@ FUZZ_TARGETS = \
   test/fuzz/parse_univalue \
   test/fuzz/partial_merkle_tree_deserialize \
   test/fuzz/partially_signed_transaction_deserialize \
+  test/fuzz/policy_estimator \
   test/fuzz/pow \
   test/fuzz/prefilled_transaction_deserialize \
   test/fuzz/prevector \
@@ -682,6 +683,12 @@ test_fuzz_partially_signed_transaction_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(P
 test_fuzz_partially_signed_transaction_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_partially_signed_transaction_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_partially_signed_transaction_deserialize_SOURCES = test/fuzz/deserialize.cpp
+
+test_fuzz_policy_estimator_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_policy_estimator_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_policy_estimator_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_policy_estimator_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_policy_estimator_SOURCES = test/fuzz/policy_estimator.cpp
 
 test_fuzz_pow_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_pow_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <policy/fees.h>
+#include <primitives/transaction.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <txmempool.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    CBlockPolicyEstimator block_policy_estimator;
+    while (fuzzed_data_provider.ConsumeBool()) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 3)) {
+        case 0: {
+            const Optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+            if (!mtx) {
+                break;
+            }
+            const CTransaction tx{*mtx};
+            block_policy_estimator.processTransaction(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx), fuzzed_data_provider.ConsumeBool());
+            if (fuzzed_data_provider.ConsumeBool()) {
+                (void)block_policy_estimator.removeTx(tx.GetHash(), /* inBlock */ fuzzed_data_provider.ConsumeBool());
+            }
+            break;
+        }
+        case 1: {
+            std::vector<CTxMemPoolEntry> mempool_entries;
+            while (fuzzed_data_provider.ConsumeBool()) {
+                const Optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+                if (!mtx) {
+                    break;
+                }
+                const CTransaction tx{*mtx};
+                mempool_entries.push_back(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
+            }
+            std::vector<const CTxMemPoolEntry*> ptrs;
+            ptrs.reserve(mempool_entries.size());
+            for (const CTxMemPoolEntry& mempool_entry : mempool_entries) {
+                ptrs.push_back(&mempool_entry);
+            }
+            block_policy_estimator.processBlock(fuzzed_data_provider.ConsumeIntegral<unsigned int>(), ptrs);
+            break;
+        }
+        case 2: {
+            (void)block_policy_estimator.removeTx(ConsumeUInt256(fuzzed_data_provider), /* inBlock */ fuzzed_data_provider.ConsumeBool());
+            break;
+        }
+        case 3: {
+            block_policy_estimator.FlushUnconfirmed();
+            break;
+        }
+        }
+        (void)block_policy_estimator.estimateFee(fuzzed_data_provider.ConsumeIntegral<int>());
+        EstimationResult result;
+        (void)block_policy_estimator.estimateRawFee(fuzzed_data_provider.ConsumeIntegral<int>(), fuzzed_data_provider.ConsumeFloatingPoint<double>(), fuzzed_data_provider.PickValueInArray({FeeEstimateHorizon::SHORT_HALFLIFE, FeeEstimateHorizon::MED_HALFLIFE, FeeEstimateHorizon::LONG_HALFLIFE}), fuzzed_data_provider.ConsumeBool() ? &result : nullptr);
+        FeeCalculation fee_calculation;
+        (void)block_policy_estimator.estimateSmartFee(fuzzed_data_provider.ConsumeIntegral<int>(), fuzzed_data_provider.ConsumeBool() ? &fee_calculation : nullptr, fuzzed_data_provider.ConsumeBool());
+        (void)block_policy_estimator.HighestTargetTracked(fuzzed_data_provider.PickValueInArray({FeeEstimateHorizon::SHORT_HALFLIFE, FeeEstimateHorizon::MED_HALFLIFE, FeeEstimateHorizon::LONG_HALFLIFE}));
+    }
+}

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <policy/rbf.h>
+#include <primitives/transaction.h>
+#include <sync.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <txmempool.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    Optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    if (!mtx) {
+        return;
+    }
+    CTxMemPool pool;
+    while (fuzzed_data_provider.ConsumeBool()) {
+        const Optional<CMutableTransaction> another_mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+        if (!another_mtx) {
+            break;
+        }
+        const CTransaction another_tx{*another_mtx};
+        if (fuzzed_data_provider.ConsumeBool() && !mtx->vin.empty()) {
+            mtx->vin[0].prevout = COutPoint{another_tx.GetHash(), 0};
+        }
+        LOCK2(cs_main, pool.cs);
+        pool.addUnchecked(ConsumeTxMemPoolEntry(fuzzed_data_provider, another_tx));
+    }
+    const CTransaction tx{*mtx};
+    if (fuzzed_data_provider.ConsumeBool()) {
+        LOCK2(cs_main, pool.cs);
+        pool.addUnchecked(ConsumeTxMemPoolEntry(fuzzed_data_provider, tx));
+    }
+    {
+        LOCK(pool.cs);
+        (void)IsRBFOptIn(tx, pool);
+    }
+}

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -104,7 +104,10 @@ NODISCARD inline CTxMemPoolEntry ConsumeTxMemPoolEntry(FuzzedDataProvider& fuzze
 {
     // Avoid:
     // policy/feerate.cpp:28:34: runtime error: signed integer overflow: 34873208148477500 * 1000 cannot be represented in type 'long'
-    const CAmount fee = ConsumeMoney(fuzzed_data_provider) / static_cast<CAmount>(100);
+    //
+    // Reproduce using CFeeRate(348732081484775, 10).GetFeePerK()
+    const CAmount fee = std::min<CAmount>(ConsumeMoney(fuzzed_data_provider), std::numeric_limits<CAmount>::max() / static_cast<CAmount>(100000));
+    assert(MoneyRange(fee));
     const int64_t time = fuzzed_data_provider.ConsumeIntegral<int64_t>();
     const unsigned int entry_height = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
     const bool spends_coinbase = fuzzed_data_provider.ConsumeBool();


### PR DESCRIPTION
Add fuzzing harnesses for various classes/functions in `policy/` (`CBlockPolicyEstimator`, `IsRBFOptIn(…)`, etc.).

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)