### PR TITLE
doc: Better explain GNU ld's dislike of ld64's options

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -757,7 +757,9 @@ if test x$use_hardening != xno; then
   esac
 fi
 
-dnl this flag screws up non-darwin gcc even when the check fails. special-case it.
+dnl These flags are specific to ld64, and may cause issues with other linkers.
+dnl For example: GNU ld will intepret -dead_strip as -de and then try and use
+dnl "ad_strip" as the symbol for the entry point.
 if test x$TARGET_OS = xdarwin; then
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip"])
   AX_CHECK_LINK_FLAG([[-Wl,-dead_strip_dylibs]], [LDFLAGS="$LDFLAGS -Wl,-dead_strip_dylibs"])


### PR DESCRIPTION
There's also now more than a single option being special cased for
darwin. If we didn't special case these options they would still end 
up on the link line and the binaries produced would just segfault.

I'm going to plug #17874 here as well, because adding
`-fatal-warnings` to our `AX_CHECK_LINK_FLAG` calls would
mostly prevent this sort of option mangling from happening.

An example of the warning behaviour:
```bash
echo "int main() {}" | g++ -x c++ -std=c++11 -Wl,-dead_strip -
/usr/bin/ld: warning: cannot find entry symbol ad_strip; defaulting to 0000000000001040

nm -C a.out
0000000000001000 t _init
0000000000001040 T _start
                 U ad_strip
``` 