### PR TITLE
wallet: Make sure no DescriptorScriptPubKeyMan or WalletDescriptor members are left uninitialized after construction

### DIFF
--- a/src/wallet/scriptpubkeyman.h
+++ b/src/wallet/scriptpubkeyman.h
@@ -497,7 +497,7 @@ private:
     int32_t m_max_cached_index = -1;
 
     OutputType m_address_type;
-    bool m_internal;
+    bool m_internal = false;
 
     KeyMap m_map_keys GUARDED_BY(cs_desc_man);
     CryptedKeyMap m_map_crypted_keys GUARDED_BY(cs_desc_man);

--- a/src/wallet/walletutil.h
+++ b/src/wallet/walletutil.h
@@ -92,10 +92,10 @@ class WalletDescriptor
 {
 public:
     std::shared_ptr<Descriptor> descriptor;
-    uint64_t creation_time;
-    int32_t range_start; // First item in range; start of range, inclusive, i.e. [range_start, range_end). This never changes.
-    int32_t range_end; // Item after the last; end of range, exclusive, i.e. [range_start, range_end). This will increment with each TopUp()
-    int32_t next_index; // Position of the next item to generate
+    uint64_t creation_time = 0;
+    int32_t range_start = 0; // First item in range; start of range, inclusive, i.e. [range_start, range_end). This never changes.
+    int32_t range_end = 0; // Item after the last; end of range, exclusive, i.e. [range_start, range_end). This will increment with each TopUp()
+    int32_t next_index = 0; // Position of the next item to generate
     DescriptorCache cache;
 
     ADD_SERIALIZE_METHODS;


### PR DESCRIPTION
This is a small folllow-up to #16528 ("Native Descriptor Wallets using DescriptorScriptPubKeyMan") which was merged in to `master` a couple of hours ago.

Make sure no `DescriptorScriptPubKeyMan` or `WalletDescriptor` members are left uninitialized after construction.

Before this change `bool m_internal` was left uninitialized when using the `DescriptorScriptPubKeyMan(WalletStorage&, WalletDescriptor&)` ctor.

The same goes for the now initialized integers which were left uninitialized when using the `WalletDescriptor()` ctor.