### PR TITLE
tests: Add fuzzing harness for MessageSign, MessageVerify and other functions in util/message.h

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -52,6 +52,7 @@ FUZZ_TARGETS = \
   test/fuzz/locale \
   test/fuzz/merkle_block_deserialize \
   test/fuzz/merkleblock \
+  test/fuzz/message \
   test/fuzz/messageheader_deserialize \
   test/fuzz/multiplication_overflow \
   test/fuzz/net_permissions \
@@ -584,6 +585,12 @@ test_fuzz_merkleblock_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_merkleblock_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_merkleblock_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_merkleblock_SOURCES = test/fuzz/merkleblock.cpp
+
+test_fuzz_message_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_message_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_message_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_message_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_message_SOURCES = test/fuzz/message.cpp
 
 test_fuzz_messageheader_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DMESSAGEHEADER_DESERIALIZE=1
 test_fuzz_messageheader_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <key_io.h>
+#include <optional.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <util/message.h>
+#include <util/strencodings.h>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    static const ECCVerifyHandle ecc_verify_handle;
+    ECC_Start();
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::string random_message = fuzzed_data_provider.ConsumeRandomLengthString(1024);
+    {
+        const std::vector<uint8_t> random_bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+        CKey private_key;
+        private_key.Set(random_bytes.begin(), random_bytes.end(), fuzzed_data_provider.ConsumeBool());
+        std::string signature;
+        const bool message_signed = MessageSign(private_key, random_message, signature);
+        if (private_key.IsValid()) {
+            assert(message_signed);
+            const MessageVerificationResult verification_result = MessageVerify(EncodeDestination(PKHash(private_key.GetPubKey().GetID())), signature, random_message);
+            assert(verification_result == MessageVerificationResult::OK);
+        }
+    }
+    {
+        (void)MessageHash(random_message);
+        (void)MessageVerify(fuzzed_data_provider.ConsumeRandomLengthString(1024), fuzzed_data_provider.ConsumeRandomLengthString(1024), random_message);
+        (void)SigningResultString(fuzzed_data_provider.PickValueInArray({SigningResult::OK, SigningResult::PRIVATE_KEY_NOT_AVAILABLE, SigningResult::SIGNING_FAILED}));
+    }
+}


### PR DESCRIPTION
Add fuzzing harness for `MessageSign`, `MessageVerify` and other functions in `util/message.h`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)