### PR TITLE
gui: Improve thread naming

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -163,8 +163,8 @@ void BitcoinCore::initialize()
 {
     try
     {
-        qDebug() << __func__ << ": Running initialization in thread";
         util::ThreadRename("qt-init");
+        qDebug() << __func__ << ": Running initialization in thread";
         interfaces::BlockAndHeaderTipInfo tip_info;
         bool rv = m_node.appInitMain(&tip_info);
         Q_EMIT initializeResult(rv, tip_info);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -15,6 +15,7 @@
 #include <net.h>
 #include <netbase.h>
 #include <util/system.h>
+#include <util/threadnames.h>
 #include <validation.h>
 
 #include <stdint.h>
@@ -52,6 +53,9 @@ ClientModel::ClientModel(interfaces::Node& node, OptionsModel *_optionsModel, QO
     // move timer to thread so that polling doesn't disturb main event loop
     timer->moveToThread(m_thread);
     m_thread->start();
+    QTimer::singleShot(0, timer, []() {
+        util::ThreadRename("qt-clientmodl");
+    });
 
     subscribeToCoreSignals();
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -20,6 +20,7 @@
 #include <rpc/client.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/threadnames.h>
 
 #include <univalue.h>
 
@@ -978,6 +979,9 @@ void RPCConsole::startExecutor()
     // Default implementation of QThread::run() simply spins up an event loop in the thread,
     // which is what we want.
     thread.start();
+    QTimer::singleShot(0, executor, []() {
+        util::ThreadRename("qt-rpcconsole");
+    });
 }
 
 void RPCConsole::on_tabWidget_currentChanged(int index)

--- a/src/qt/walletcontroller.cpp
+++ b/src/qt/walletcontroller.cpp
@@ -14,6 +14,7 @@
 #include <interfaces/handler.h>
 #include <interfaces/node.h>
 #include <util/string.h>
+#include <util/threadnames.h>
 #include <util/translation.h>
 #include <wallet/wallet.h>
 
@@ -45,6 +46,9 @@ WalletController::WalletController(ClientModel& client_model, const PlatformStyl
 
     m_activity_worker->moveToThread(m_activity_thread);
     m_activity_thread->start();
+    QTimer::singleShot(0, m_activity_worker, []() {
+        util::ThreadRename("qt-walletctrl");
+    });
 }
 
 // Not using the default destructor because not all member types definitions are


### PR DESCRIPTION
On **master** (eef90c14ed0f559e3f6e187341009270b84f45cb):
- thread list from OS:
![Screenshot from 2020-04-28 00-25-41](https://user-images.githubusercontent.com/32963518/80425413-3de07100-88ec-11ea-8d7a-79bd9e152395.png)
- log excerpt:
```
2020-04-27T21:25:26Z [] GUI: initialize : Running initialization in thread
...
2020-04-27T21:26:04Z [] Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2020-04-27T21:26:04Z [] Using wallet /home/hebasto/.bitcoin/testnet3/wallets/test2
2020-04-27T21:26:04Z [] BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/test2/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/test2/db.log
2020-04-27T21:26:04Z [] init message: Loading wallet...
2020-04-27T21:26:04Z [] BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/test2/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/test2/db.log
2020-04-27T21:26:04Z [] [test2] Wallet File Version = 169900
2020-04-27T21:26:04Z [] [test2] Keys: 2001 plaintext, 0 encrypted, 2001 w/ metadata, 2001 total. Unknown wallet records: 0
2020-04-27T21:26:04Z [] [test2] Wallet completed loading in              26ms
2020-04-27T21:26:04Z [] GUI: TransactionTablePriv::refreshWallet
2020-04-27T21:26:04Z [] [test2] setKeyPool.size() = 2000
2020-04-27T21:26:04Z [] [test2] mapWallet.size() = 0
2020-04-27T21:26:04Z [] [test2] m_address_book.size() = 0
```

With **this PR**:
- thread list from OS:
![Screenshot from 2020-04-28 00-21-40](https://user-images.githubusercontent.com/32963518/80425527-7a13d180-88ec-11ea-8a34-dfc774bb1c75.png)
- log excerpt:
```
2020-04-27T21:21:25Z [qt-init] GUI: initialize : Running initialization in thread
...
2020-04-27T21:23:08Z [qt-walletctrl] Using BerkeleyDB version Berkeley DB 4.8.30: (April  9, 2010)
2020-04-27T21:23:08Z [qt-walletctrl] Using wallet /home/hebasto/.bitcoin/testnet3/wallets/test2
2020-04-27T21:23:08Z [qt-walletctrl] BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/test2/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/test2/db.log
2020-04-27T21:23:08Z [qt-walletctrl] init message: Loading wallet...
2020-04-27T21:23:08Z [qt-walletctrl] BerkeleyEnvironment::Open: LogDir=/home/hebasto/.bitcoin/testnet3/wallets/test2/database ErrorFile=/home/hebasto/.bitcoin/testnet3/wallets/test2/db.log
2020-04-27T21:23:08Z [qt-walletctrl] [test2] Wallet File Version = 169900
2020-04-27T21:23:08Z [qt-walletctrl] [test2] Keys: 2001 plaintext, 0 encrypted, 2001 w/ metadata, 2001 total. Unknown wallet records: 0
2020-04-27T21:23:08Z [qt-walletctrl] [test2] Wallet completed loading in              37ms
2020-04-27T21:23:08Z [qt-walletctrl] init message: Rescanning...
2020-04-27T21:23:08Z [qt-walletctrl] [test2] Rescanning last 112924 blocks (from block 1609206)...
2020-04-27T21:23:08Z [qt-walletctrl] [test2] Rescan started from block 000000000000003761c81f7efbd8cebf217f39d353ec1ac59c624ac2dddfc2a8...
2020-04-27T21:23:22Z [qt-walletctrl] [test2] Rescan completed in           14157ms
2020-04-27T21:23:22Z [qt-walletctrl] GUI: TransactionTablePriv::refreshWallet
2020-04-27T21:23:22Z [qt-walletctrl] [test2] setKeyPool.size() = 2000
2020-04-27T21:23:22Z [qt-walletctrl] [test2] mapWallet.size() = 0
2020-04-27T21:23:22Z [qt-walletctrl] [test2] m_address_book.size() = 0
```