### PR TITLE
doc: introduce 'make distclean' to macOS build

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -61,6 +61,14 @@ from the root of the repository.
     ./configure
     make
     ```
+    
+    If you receive an error after running **make** about [clang](https://github.com/bitcoin/bitcoin/issues/18776#issuecomment-620081162), please run the following:
+    ```shell
+    make distclean
+    ./autogen.sh
+    ./configure
+    make
+    ```
 
 3.  It is recommended to build and run the unit tests:
     ```shell


### PR DESCRIPTION
I was receiving the following problem with building on macOS outlined here: https://github.com/bitcoin/bitcoin/issues/18776#issuecomment-620081162

@MarcoFalke told me to use the 'make distclean' command to solve the clang issue I was receiving and I thought it'd be useful to mention it in the docs.
