### PR TITLE
Export standard Script flags in bitcoinconsensus

### DIFF
--- a/doc/shared-libraries.md
+++ b/doc/shared-libraries.md
@@ -5,6 +5,12 @@ Shared Libraries
 
 The purpose of this library is to make the verification functionality that is critical to Bitcoin's consensus available to other applications, e.g. to language bindings.
 
+Policy standardness as enforced by latest software version is also made available. To dissociate between invalidity reasons, either consensus or standardness, an
+application needs to call first `verify_script_standard_with_amount` followed `verify_script`. A failure on first function but success on following means spent is non-standard
+but consensus valid. Policy checks may be used at testing to assert scripts standardness or in production to sanitize counterparty inputs in the case of cooperative witness
+construction. This check only reflects policy in the current release and it may vary between software versions. Therefore if an application rely on pre-signed transactions
+their standardness should be reasserted at every release.
+
 ### API
 
 The interface is defined in the C header `bitcoinconsensus.h` located in `src/script/bitcoinconsensus.h`.
@@ -47,3 +53,4 @@ The interface is defined in the C header `bitcoinconsensus.h` located in `src/sc
 - [node-libbitcoinconsensus](https://github.com/bitpay/node-libbitcoinconsensus) (Node.js Bindings)
 - [java-libbitcoinconsensus](https://github.com/dexX7/java-libbitcoinconsensus) (Java Bindings)
 - [bitcoinconsensus-php](https://github.com/Bit-Wasp/bitcoinconsensus-php) (PHP Bindings)
+- [rust-bitcoinconsensus](https://github.com/rust-bitcoin/rust-bitcoinconsensus) (Rust Bindings)

--- a/src/script/bitcoinconsensus.cpp
+++ b/src/script/bitcoinconsensus.cpp
@@ -5,6 +5,7 @@
 
 #include <script/bitcoinconsensus.h>
 
+#include <policy/policy.h>
 #include <primitives/transaction.h>
 #include <pubkey.h>
 #include <script/interpreter.h>
@@ -119,6 +120,15 @@ int bitcoinconsensus_verify_script(const unsigned char *scriptPubKey, unsigned i
     }
 
     CAmount am(0);
+    return ::verify_script(scriptPubKey, scriptPubKeyLen, am, txTo, txToLen, nIn, flags, err);
+}
+
+int bitcoinconsensus_verify_script_standard_with_amount(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen, int64_t amount,
+                                    const unsigned char *txTo        , unsigned int txToLen,
+                                    unsigned int nIn, bitcoinconsensus_error* err)
+{
+    CAmount am(amount);
+    constexpr unsigned int flags = STANDARD_SCRIPT_VERIFY_FLAGS;
     return ::verify_script(scriptPubKey, scriptPubKeyLen, am, txTo, txToLen, nIn, flags, err);
 }
 

--- a/src/script/bitcoinconsensus.h
+++ b/src/script/bitcoinconsensus.h
@@ -72,6 +72,14 @@ EXPORT_SYMBOL int bitcoinconsensus_verify_script_with_amount(const unsigned char
                                     const unsigned char *txTo        , unsigned int txToLen,
                                     unsigned int nIn, unsigned int flags, bitcoinconsensus_error* err);
 
+/// Returns 1 if the input nIn of the serialized transaction pointed to by
+/// txTo correctly spends the scriptPubKey pointed to by scriptPubKey under
+/// the current standardness constraints.
+/// If not nullptr, err will contain an error/success code for the operation
+EXPORT_SYMBOL int bitcoinconsensus_verify_script_standard_with_amount(const unsigned char *scriptPubKey, unsigned int scriptPubKeyLen, int64_t amount,
+                                    const unsigned char *txTo        , unsigned int txToLen,
+                                    unsigned int nIn, bitcoinconsensus_error* err);
+
 EXPORT_SYMBOL unsigned int bitcoinconsensus_version();
 
 #ifdef __cplusplus


### PR DESCRIPTION
Bitcoinconsensus library makes available consensus script verification flags to other applications. Currently this doesn't enable to verify transaction scripts correctness with regards to deployed standard rules. A defect of adherance to this set of rules hinders severely transaction propagation on the network, and therefore may be a concern if application has a time-sensitive requirement (LN, Atomic Swaps, ...).

* Should API version be bumped ?
* Should documentation/flags name clearly sort between standard/consensus rules ? (while minding that standard/consensus enforcement may vary between witness versions, cf MINIMALIF)
* Should some obscure standard flags (CONST_SCRIPTCODE) gets a real specification ?

See https://github.com/lightningnetwork/lightning-rfc/pull/764 as example of protocol specification directly requiring adherence to standard rules.