### PR TITLE
rpc: Do not advertise dumptxoutset as a way to flush the chainstate

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2242,8 +2242,7 @@ UniValue dumptxoutset(const JSONRPCRequest& request)
 {
     RPCHelpMan{
         "dumptxoutset",
-        "\nWrite the serialized UTXO set to disk.\n"
-        "Incidentally flushes the latest coinsdb (leveldb) to disk.\n",
+        "\nWrite the serialized UTXO set to disk.\n",
         {
             {"path",
                 RPCArg::Type::STR,


### PR DESCRIPTION
The help message leaks several implementation details: leveldb and flush.

Neither of them are relevant to the end user and I don't see why we should make them part of the API contract.