### PR TITLE
doc: update rest info on block size and json

### DIFF
--- a/doc/REST-interface.md
+++ b/doc/REST-interface.md
@@ -30,7 +30,7 @@ To query for a confirmed transaction, enable the transaction index via "txindex=
 Given a block hash: returns a block, in binary, hex-encoded binary or JSON formats.
 Responds with 404 if the block doesn't exist.
 
-The HTTP request and response are both handled entirely in-memory, thus making maximum memory usage at least 2.66MB (1 MB max block, plus hex encoding) per request.
+The HTTP request and response are both handled entirely in-memory.
 
 With the /notxdetails/ option JSON response will only contain the transaction hash instead of the complete transaction details. The option only affects the JSON response.
 

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -206,7 +206,7 @@ static bool rest_headers(HTTPRequest* req,
         return true;
     }
     default: {
-        return RESTERR(req, HTTP_NOT_FOUND, "output format not found (available: .bin, .hex)");
+        return RESTERR(req, HTTP_NOT_FOUND, "output format not found (available: .bin, .hex, .json)");
     }
     }
 }


### PR DESCRIPTION
Addressing the ambiguous block size text in rest docs: https://github.com/bitcoin/bitcoin/issues/18703

Also makes sure to let developers know there is `.json` option for the rest output format.
