### PR TITLE
bench: Add logging benchmark

### DIFF
--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -30,6 +30,7 @@ bench_bench_bitcoin_SOURCES = \
   bench/ccoins_caching.cpp \
   bench/gcs_filter.cpp \
   bench/hashpadding.cpp \
+  bench/logging.cpp \
   bench/merkle_root.cpp \
   bench/mempool_eviction.cpp \
   bench/mempool_stress.cpp \

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -13,39 +13,39 @@ GENERATED_BENCH_FILES = $(RAW_BENCH_FILES:.raw=.raw.h)
 bench_bench_bitcoin_SOURCES = \
   $(RAW_BENCH_FILES) \
   bench/addrman.cpp \
-  bench/bench_bitcoin.cpp \
+  bench/base58.cpp \
+  bench/bech32.cpp \
   bench/bench.cpp \
   bench/bench.h \
+  bench/bench_bitcoin.cpp \
   bench/block_assemble.cpp \
-  bench/checkblock.cpp \
-  bench/checkqueue.cpp \
-  bench/data.h \
-  bench/data.cpp \
-  bench/duplicate_inputs.cpp \
-  bench/examples.cpp \
-  bench/rollingbloom.cpp \
+  bench/ccoins_caching.cpp \
   bench/chacha20.cpp \
   bench/chacha_poly_aead.cpp \
+  bench/checkblock.cpp \
+  bench/checkqueue.cpp \
   bench/crypto_hash.cpp \
-  bench/ccoins_caching.cpp \
+  bench/data.cpp \
+  bench/data.h \
+  bench/duplicate_inputs.cpp \
+  bench/examples.cpp \
   bench/gcs_filter.cpp \
   bench/hashpadding.cpp \
+  bench/lockedpool.cpp \
   bench/logging.cpp \
-  bench/merkle_root.cpp \
   bench/mempool_eviction.cpp \
   bench/mempool_stress.cpp \
-  bench/nanobench.h \
+  bench/merkle_root.cpp \
   bench/nanobench.cpp \
+  bench/nanobench.h \
   bench/peer_eviction.cpp \
+  bench/poly1305.cpp \
+  bench/prevector.cpp \
+  bench/rollingbloom.cpp \
   bench/rpc_blockchain.cpp \
   bench/rpc_mempool.cpp \
   bench/util_time.cpp \
-  bench/verify_script.cpp \
-  bench/base58.cpp \
-  bench/bech32.cpp \
-  bench/lockedpool.cpp \
-  bench/poly1305.cpp \
-  bench/prevector.cpp
+  bench/verify_script.cpp
 
 nodist_bench_bench_bitcoin_SOURCES = $(GENERATED_BENCH_FILES)
 

--- a/src/bench/logging.cpp
+++ b/src/bench/logging.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <bench/bench.h>
+#include <logging.h>
+#include <test/util/setup_common.h>
+
+
+static void Logging(benchmark::Bench& bench, const std::vector<const char*>& extra_args, const std::function<void()>& log)
+{
+    TestingSetup test_setup{
+        CBaseChainParams::REGTEST,
+        extra_args,
+    };
+
+    bench.run([&] { log(); });
+}
+
+static void LoggingYoThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=1"}, [] { LogPrintf("%s\n", "test"); });
+}
+static void LoggingNoThreadNames(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0"}, [] { LogPrintf("%s\n", "test"); });
+}
+static void LoggingYoCategory(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0", "-debug=net"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
+}
+static void LoggingNoCategory(benchmark::Bench& bench)
+{
+    Logging(bench, {"-logthreadnames=0", "-debug=0"}, [] { LogPrint(BCLog::NET, "%s\n", "test"); });
+}
+static void LoggingNoFile(benchmark::Bench& bench)
+{
+    Logging(bench, {"-nodebuglogfile", "-debug=1"}, [] {
+        LogPrintf("%s\n", "test");
+        LogPrint(BCLog::NET, "%s\n", "test");
+    });
+}
+
+BENCHMARK(LoggingYoThreadNames);
+BENCHMARK(LoggingNoThreadNames);
+BENCHMARK(LoggingYoCategory);
+BENCHMARK(LoggingNoCategory);
+BENCHMARK(LoggingNoFile);


### PR DESCRIPTION
Might make finding performance bottlenecks or regressions (https://github.com/bitcoin/bitcoin/pull/17218) easier.

For example, fuzzing relies on disabled logging to be as fast as possible.