### PR TITLE
Fix release tarball generated by gitian

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -110,8 +110,10 @@ script: |
 
   GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 
-  # Create the source tarball
+  # Create the release tarball using (arbitrarily) the first host
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
+  CONFIG_SITE="${BASEPREFIX}/${HOSTS/ */}/share/config.site" \
+  REFERENCE_DATETIME="${REFERENCE_DATETIME}" \
   contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
@@ -131,7 +133,6 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -112,7 +112,7 @@ script: |
 
   # Create the source tarball
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
-  git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+  contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -109,8 +109,10 @@ script: |
 
   GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 
-  # Create the source tarball
+  # Create the release tarball using (arbitrarily) the first host
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
+  CONFIG_SITE="${BASEPREFIX}/${HOSTS/ */}/share/config.site" \
+  REFERENCE_DATETIME="${REFERENCE_DATETIME}" \
   contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
@@ -123,7 +125,6 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -111,7 +111,7 @@ script: |
 
   # Create the source tarball
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
-  git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+  contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -116,7 +116,7 @@ script: |
 
   # Create the source tarball
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
-  git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+  contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -114,8 +114,10 @@ script: |
 
   GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 
-  # Create the source tarball
+  # Create the release tarball using (arbitrarily) the first host
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
+  CONFIG_SITE="${BASEPREFIX}/${HOSTS/ */}/share/config.site" \
+  REFERENCE_DATETIME="${REFERENCE_DATETIME}" \
   contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
@@ -128,7 +130,6 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security

--- a/contrib/gitian-descriptors/make_release_tarball
+++ b/contrib/gitian-descriptors/make_release_tarball
@@ -5,6 +5,29 @@
 #
 # A helper script to generate source release tarball
 
+set -e
+
 GIT_ARCHIVE="$1"
 . "`dirname "$0"`/assign_DISTNAME"
-git archive --prefix="${DISTNAME}/" --output="${GIT_ARCHIVE}" HEAD
+
+git archive --prefix="${DISTNAME}/" HEAD | tar -xp
+cd "${DISTNAME}"
+
+./autogen.sh
+./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking
+make distclean
+
+cd ..
+tar \
+  --format=ustar \
+  --exclude autom4te.cache \
+  --exclude .deps \
+  --exclude .git \
+  --sort=name \
+  --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 \
+  --mtime="${REFERENCE_DATETIME}" \
+  -c "${DISTNAME}" | \
+  gzip -9n \
+  >"${GIT_ARCHIVE}"
+
+rm -r "${DISTNAME}"

--- a/contrib/gitian-descriptors/make_release_tarball
+++ b/contrib/gitian-descriptors/make_release_tarball
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# A helper script to generate source release tarball
+
+GIT_ARCHIVE="$1"
+. "`dirname "$0"`/assign_DISTNAME"
+git archive --prefix="${DISTNAME}/" --output="${GIT_ARCHIVE}" HEAD

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -158,6 +158,7 @@ GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 # Create the source tarball if not already there
 if [ ! -e "$GIT_ARCHIVE" ]; then
     mkdir -p "$(dirname "$GIT_ARCHIVE")"
+    CONFIG_SITE="${BASEPREFIX}/${HOST}/share/config.site" \
     contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 fi
 
@@ -194,8 +195,6 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 
     # Extract the source tarball
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
-
-    ./autogen.sh
 
     # Configure this DISTSRC for $HOST
     # shellcheck disable=SC2086

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -158,7 +158,7 @@ GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 # Create the source tarball if not already there
 if [ ! -e "$GIT_ARCHIVE" ]; then
     mkdir -p "$(dirname "$GIT_ARCHIVE")"
-    git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+    contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 fi
 
 ###########################


### PR DESCRIPTION
Without losing the new and improved `git-archive` method of ensuring we get the entire source included, this fixes ~~two~~ one remaining regression~~s~~ to standard source code distribution expectations:

1. ~~The tarball should be entirely within a single directory (not extract directly to the working directory).~~ (merged via #20318)
2. The tarball should be pre-autogen'd, so the user can begin with `./configure` and not need maintainer tools.
