### PR TITLE
rpc: added getrpcwhitelist method

### DIFF
--- a/doc/release-notes-18827.md
+++ b/doc/release-notes-18827.md
@@ -1,0 +1,1 @@
+- New rpc: `getrpcwhitelist` that returns a list of allowed RPCs for the calling user.

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -322,3 +322,8 @@ void StopHTTPRPC()
         httpRPCTimerInterface.reset();
     }
 }
+
+const std::set<std::string>& GetWhitelistedRpcs(const std::string& user_name)
+{
+    return g_rpc_whitelist.at(user_name);
+}

--- a/src/httprpc.h
+++ b/src/httprpc.h
@@ -4,7 +4,8 @@
 
 #ifndef BITCOIN_HTTPRPC_H
 #define BITCOIN_HTTPRPC_H
-
+#include <string>
+#include <set>
 
 /** Start HTTP RPC subsystem.
  * Precondition; HTTP and RPC has been started.
@@ -29,5 +30,8 @@ void InterruptREST();
  * Precondition; HTTP and RPC has been stopped.
  */
 void StopREST();
+/** Returns a collection of whitelisted RPCs for the given user
+ */
+const std::set<std::string>& GetWhitelistedRpcs(const std::string& user_name);
 
 #endif

--- a/test/functional/rpc_getrpcwhitelist.py
+++ b/test/functional/rpc_getrpcwhitelist.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017-2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+Test getrpcwhitelist RPC call.
+"""
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    get_datadir_path,
+    str_to_b64str
+)
+import http.client
+import json
+import os
+import urllib.parse
+
+def call_rpc(node, settings, rpc):
+    url = urllib.parse.urlparse(node.url)
+    headers = {"Authorization": "Basic " + str_to_b64str('{}:{}'.format(settings[0], settings[2]))}
+    conn = http.client.HTTPConnection(url.hostname, url.port)
+    conn.connect()
+    conn.request('POST', '/', '{"method": "' + rpc + '"}', headers)
+    resp = conn.getresponse()
+    code = resp.status
+    if code == 200:
+        json_ret = json.loads(resp.read().decode())
+    else:
+        json_ret = {"result": None}
+    conn.close()
+    return {"status": code, "json": json_ret['result']}
+
+class RPCWhitelistTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+
+    def setup_chain(self):
+        super().setup_chain()
+        self.settings = ["dummy",
+                         "4e799db4b65924f4468b1c9ff3a68109$5fcd282dcaf4ae74599934a543626c0a11e7e83ead30f07b182058ead8e85da9",
+                         "dummypwd",
+                         "getbalance,getrpcwhitelist,getwalletinfo"]
+        self.settings_forbidden = ["dummy2",
+                        "f3d319f64b076012f75626c9d895fced$7f55381a24fda02c5de7c18fc377f56fc573149b4d6f83daa9fd584210b51f99",
+                        "dummy2pwd",
+                        "getbalance,getwalletinfo"]
+
+        # declare rpc-whitelisting entries
+        with open(os.path.join(get_datadir_path(self.options.tmpdir, 0), "bitcoin.conf"), 'a', encoding='utf8') as f:
+            f.write("\nrpcwhitelistdefault=0\n")
+            f.write("rpcauth={}:{}\n".format(self.settings[0], self.settings[1]))
+            f.write("rpcwhitelist={}:{}\n".format(self.settings[0], self.settings[3]))
+            f.write("rpcauth={}:{}\n".format(self.settings_forbidden[0], self.settings_forbidden[1]))
+            f.write("rpcwhitelist={}:{}\n".format(self.settings_forbidden[0], self.settings_forbidden[3]))
+
+    def run_test(self):
+        self.log.info("Test getrpcwhitelist")
+        whitelisted = self.settings[3].split(',')
+
+        # should return allowed rpcs
+        result = call_rpc(self.nodes[0], self.settings, 'getrpcwhitelist')
+        assert_equal(200, result['status'])
+        assert_equal(result['json']['methods'], whitelisted)
+        # should fail because user has no rpcwhitelist-rpc entry in bitcoin.conf
+        result = call_rpc(self.nodes[0], self.settings_forbidden, 'getrpcwhitelist')
+        assert_equal(result['status'], 403)
+
+if __name__ == "__main__":
+    RPCWhitelistTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -148,6 +148,7 @@ BASE_SCRIPTS = [
     'rpc_psbt.py --descriptors',
     'rpc_users.py',
     'rpc_whitelist.py',
+    'rpc_getrpcwhitelist.py',
     'feature_proxy.py',
     'rpc_signrawtransaction.py',
     'wallet_groups.py',


### PR DESCRIPTION
This PR implements a new RPC, `getrpcwhitelist`, that returns whitelisted methods for the calling user.

Example:

```shell
./src/bitcoin-cli -regtest getrpcwhitelist
{
  "methods": [
    "getbalance",
    "getrpcwhitelist",
    "getwalletinfo"
  ]
}
```

A new functional test, `rpc_getrpcwhitelist`, and a `release-notes` entry are included.

Fixes https://github.com/bitcoin/bitcoin/issues/18822