### PR TITLE
test: Check header hash in wait_for_getheaders

### DIFF
--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -1393,7 +1393,7 @@ class FullBlockTest(BitcoinTestFramework):
         # an INV for the next block and receive two getheaders - one for the
         # IBD and one for the INV. We'd respond to both and could get
         # unexpectedly disconnected if the DoS score for that error is 50.
-        self.nodes[0].p2p.wait_for_getheaders(timeout=timeout)
+        self.nodes[0].p2p.wait_for_getheaders(header_hash=0, timeout=timeout)
 
     def reconnect_p2p(self, timeout=60):
         """Tear down and bootstrap the P2P connection to the node.

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -233,7 +233,7 @@ class MiningTest(BitcoinTestFramework):
 
         # Should ask for the block from a p2p node, if they announce the header as well:
         node.add_p2p_connection(P2PDataStore())
-        node.p2p.wait_for_getheaders(timeout=5)  # Drop the first getheaders
+        node.p2p.wait_for_getheaders(header_hash=0, timeout=5)  # Drop the first getheaders
         node.p2p.send_blocks_and_test(blocks=[block], node=node)
         # Must be active now:
         assert chain_tip(block.hash, status='active', branchlen=0) in node.getchaintips()

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -176,7 +176,7 @@ class TestP2PConn(P2PInterface):
             self.send_message(msg)
         else:
             self.send_message(msg_inv(inv=[CInv(MSG_BLOCK, block.sha256)]))
-            self.wait_for_getheaders()
+            self.wait_for_getheaders(block.sha256)
             self.send_message(msg)
         self.wait_for_getdata([block.sha256])
 

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -337,7 +337,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 if j == 0:
                     # Announce via inv
                     test_node.send_block_inv(tip)
-                    test_node.wait_for_getheaders()
+                    test_node.wait_for_getheaders(tip)
                     # Should have received a getheaders now
                     test_node.send_header_for_blocks(blocks)
                     # Test that duplicate inv's won't result in duplicate
@@ -539,7 +539,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[1]])
-            test_node.wait_for_getheaders()
+            test_node.wait_for_getheaders(header_hash=0)
             test_node.send_header_for_blocks(blocks)
             test_node.wait_for_getdata([x.sha256 for x in blocks])
             [test_node.send_message(msg_block(x)) for x in blocks]
@@ -562,7 +562,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[i]])
-            test_node.wait_for_getheaders()
+            test_node.wait_for_getheaders(header_hash=0)
 
         # Next header will connect, should re-set our count:
         test_node.send_header_for_blocks([blocks[0]])
@@ -577,7 +577,7 @@ class SendHeadersTest(BitcoinTestFramework):
             with mininode_lock:
                 test_node.last_message.pop("getheaders", None)
             test_node.send_header_for_blocks([blocks[i % len(blocks)]])
-            test_node.wait_for_getheaders()
+            test_node.wait_for_getheaders(header_hash=0)
 
         # Eventually this stops working.
         test_node.send_header_for_blocks([blocks[-1]])

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -430,17 +430,17 @@ class P2PInterface(P2PConnection):
 
         self.wait_until(test_function, timeout=timeout)
 
-    def wait_for_getheaders(self, timeout=60):
+    def wait_for_getheaders(self, header_hash, timeout=60):
         """Waits for a getheaders message.
 
-        Receiving any getheaders message will satisfy the predicate. the last_message["getheaders"]
-        value must be explicitly cleared before calling this method, or this will return
-        immediately with success. TODO: change this method to take a hash value and only
-        return true if the correct block header has been requested."""
+        The object hashes in the hashstop  must match the provided header_hash."""
 
         def test_function():
             assert self.is_connected
-            return self.last_message.get("getheaders")
+            last_headers = self.last_message.get("getheaders")
+            if not last_headers:
+                return False
+            return last_headers.hashstop == header_hash
 
         self.wait_until(test_function, timeout=timeout)
 


### PR DESCRIPTION
Previously, `wait_for_getheaders` only looked for the presence of a recent `"getheaders"` message. Additionally checking the  `hashstop` inside the message should make tests involving `wait_for_getheaders` more robust.

Issue: #18614 