### PR TITLE
wallet: Fully process previous RPCs before accepting new ones

### DIFF
--- a/src/interfaces/chain.cpp
+++ b/src/interfaces/chain.cpp
@@ -384,12 +384,8 @@ public:
     {
         return MakeUnique<NotificationsHandlerImpl>(std::move(notifications));
     }
-    void waitForNotificationsIfTipChanged(const uint256& old_tip) override
+    void waitForNotifications() override
     {
-        if (!old_tip.IsNull()) {
-            LOCK(::cs_main);
-            if (old_tip == ::ChainActive().Tip()->GetBlockHash()) return;
-        }
         SyncWithValidationInterfaceQueue();
     }
     std::unique_ptr<Handler> handleRpc(const CRPCCommand& command) override

--- a/src/interfaces/chain.h
+++ b/src/interfaces/chain.h
@@ -268,9 +268,8 @@ public:
     //! Register handler for notifications.
     virtual std::unique_ptr<Handler> handleNotifications(std::shared_ptr<Notifications> notifications) = 0;
 
-    //! Wait for pending notifications to be processed unless block hash points to the current
-    //! chain tip.
-    virtual void waitForNotificationsIfTipChanged(const uint256& old_tip) = 0;
+    //! Wait for pending notifications to be processed
+    virtual void waitForNotifications() = 0;
 
     //! Register handler for RPC. Command is not copied, so reference
     //! needs to remain valid until Handler is disconnected.

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1154,14 +1154,13 @@ void CWallet::updatedBlockTip()
 }
 
 
-void CWallet::BlockUntilSyncedToCurrentChain() const {
+void CWallet::BlockUntilSyncedToCurrentChain() const
+{
     AssertLockNotHeld(cs_wallet);
-    // Skip the queue-draining stuff if we know we're caught up with
-    // ::ChainActive().Tip(), otherwise put a callback in the validation interface queue and wait
-    // for the queue to drain enough to execute it (indicating we are caught up
-    // at least with the time we entered this function).
-    uint256 last_block_hash = WITH_LOCK(cs_wallet, return m_last_block_processed);
-    chain().waitForNotificationsIfTipChanged(last_block_hash);
+    // Wait for all chain and mempool notifications that
+    // * may have been reported in previous RPCs
+    // * or may have been fired by previous RPCs, while not yet being reflected in RPCs because they are still in the queue
+    chain().waitForNotifications();
 }
 
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1144,7 +1144,7 @@ public:
 
     /**
      * Blocks until the wallet state is up-to-date to /at least/ the current
-     * chain at the time this function is entered
+     * chain and mempool at the time this function is entered
      * Obviously holding cs_main/cs_wallet when going into this call may cause
      * deadlock
      */


### PR DESCRIPTION
The wallet may process calls without waiting on the result and effects of previous calls. This causes failures in user scripts, because later RPCs may depend on the state changes from previous RPCs.


For example, the following might fail on current master:

```
txid = sendtoaddress(...)
bumpfee(txid)
abandontransaction(txid)  # fails because tx is still in the mempool
```


Fixes #18831