### PR TITLE
wallet: build: Don't write BDB logs and bump BDB to 5.3

### DIFF
--- a/build-aux/m4/bitcoin_find_bdb.m4
+++ b/build-aux/m4/bitcoin_find_bdb.m4
@@ -2,7 +2,7 @@ dnl Copyright (c) 2013-2015 The Bitcoin Core developers
 dnl Distributed under the MIT software license, see the accompanying
 dnl file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-AC_DEFUN([BITCOIN_FIND_BDB48],[
+AC_DEFUN([BITCOIN_FIND_BDB],[
   AC_ARG_VAR(BDB_CFLAGS, [C compiler flags for BerkeleyDB, bypasses autodetection])
   AC_ARG_VAR(BDB_LIBS, [Linker flags for BerkeleyDB, bypasses autodetection])
 
@@ -10,7 +10,6 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
     AC_MSG_CHECKING([for Berkeley DB C++ headers])
     BDB_CPPFLAGS=
     bdbpath=X
-    bdb48path=X
     bdbdirlist=
     for _vn in 4.8 48 4 5 5.3 ''; do
       for _pfx in b lib ''; do
@@ -32,30 +31,12 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
       ],[
         continue
       ])
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-        #include <${searchpath}db_cxx.h>
-      ]],[[
-        #if !(DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 8)
-          #error "failed to find bdb 4.8"
-        #endif
-      ]])],[
-        bdb48path="${searchpath}"
-        break
-      ],[])
     done
     if test "x$bdbpath" = "xX"; then
       AC_MSG_RESULT([no])
       AC_MSG_ERROR([libdb_cxx headers missing, ]AC_PACKAGE_NAME[ requires this library for wallet functionality (--disable-wallet to disable wallet functionality)])
-    elif test "x$bdb48path" = "xX"; then
-      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
-      AC_ARG_WITH([incompatible-bdb],[AS_HELP_STRING([--with-incompatible-bdb], [allow using a bdb version other than 4.8])],[
-        AC_MSG_WARN([Found Berkeley DB other than 4.8; wallets opened by this build will not be portable!])
-      ],[
-        AC_MSG_ERROR([Found Berkeley DB other than 4.8, required for portable wallets (--with-incompatible-bdb to ignore or --disable-wallet to disable wallet functionality)])
-      ])
     else
-      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdb48path}],db_cxx)
-      bdbpath="${bdb48path}"
+      BITCOIN_SUBDIR_TO_INCLUDE(BDB_CPPFLAGS,[${bdbpath}],db_cxx)
     fi
   else
     BDB_CPPFLAGS=${BDB_CFLAGS}
@@ -64,7 +45,7 @@ AC_DEFUN([BITCOIN_FIND_BDB48],[
 
   if test "x$BDB_LIBS" = "x"; then
     # TODO: Ideally this could find the library version and make sure it matches the headers being used
-    for searchlib in db_cxx-4.8 db_cxx db4_cxx; do
+    for searchlib in db_cxx-5.3 db_cxx db5_cxx; do
       AC_CHECK_LIB([$searchlib],[main],[
         BDB_LIBS="-l${searchlib}"
         break

--- a/configure.ac
+++ b/configure.ac
@@ -1132,7 +1132,7 @@ fi
 
 if test x$enable_wallet != xno; then
     dnl Check for libdb_cxx only if wallet enabled
-    BITCOIN_FIND_BDB48
+    BITCOIN_FIND_BDB
 fi
 
 dnl Check for libminiupnpc (optional)

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -1,8 +1,8 @@
 package=bdb
-$(package)_version=4.8.30
+$(package)_version=5.3.28
 $(package)_download_path=https://download.oracle.com/berkeley-db
 $(package)_file_name=db-$($(package)_version).NC.tar.gz
-$(package)_sha256_hash=12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef
+$(package)_sha256_hash=76a25560d9e52a198d37a31440fd07632b5f1f8f9f2b6d5438f4bc3e7c9013ef
 $(package)_build_subdir=build_unix
 
 define $(package)_set_vars
@@ -14,8 +14,8 @@ $(package)_cppflags_mingw32=-DUNICODE -D_UNICODE
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' dbinc/atomic.h && \
-  sed -i.old 's/atomic_init/atomic_init_db/' dbinc/atomic.h mp/mp_region.c mp/mp_mvcc.c mp/mp_fget.c mutex/mut_method.c mutex/mut_tas.c && \
+  sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' src/dbinc/atomic.h && \
+  sed -i.old 's/atomic_init/atomic_init_db/' src/dbinc/atomic.h src/mp/mp_region.c src/mp/mp_mvcc.c src/mp/mp_fget.c src/mutex/mut_method.c src/mutex/mut_tas.c && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub dist
 endef
 
@@ -24,7 +24,7 @@ define $(package)_config_cmds
 endef
 
 define $(package)_build_cmds
-  $(MAKE) libdb_cxx-4.8.a libdb-4.8.a
+  $(MAKE) libdb_cxx-5.3.a libdb-5.3.a
 endef
 
 define $(package)_stage_cmds


### PR DESCRIPTION
Berkeley DB uses a database transaction log to ensure Durability (the D of ACID). But we already have a couple of options enabled that remove the guarantee of Durability anyways (we enable DB_TXN_WRITE_NOSYNC). So the log already isn't as useful to us as it could be. Furthermore, we don't really make use of the BDB's transaction feature. Almost every single read and write that we do is itself atomic and a single transaction. We do each read and write of a record as a single transaction. Flushing is always done when a `WalletBatch` is destroyed, and we have many single use `WalletBatch` objects.

We do, in a few places, batch transactions so even after a transaction is committed, it may not be flushed to the database. In those instances, the log is useful as it does recover whatever wasn't written. But whatever didn't get written also doesn't matter. If a new transaction was being written, the blockchain can be rescanned. If new metadata was being written, the user can just re-enter it. For newly generated keys, those keys didn't see any use if their records didn't get flushed to the db (that flushing always happens before the key generation function returns). So it's fine to lose those keys, and for HD wallets, they will be regenerated anyways, so nothing is lost.

The single exception to the single record single transaction that we usually do is with encrypting existing private keys. This encryption is done in a single transaction so that it is atomic, and that is many records being written. But even with that, the transaction log isn't useful. We abort before anything is flushed to disk so the wallet state is not inconsistent and all of the unencrypted private keys are still there. The encryption can then be redone. So the log is not useful there.

Additionally, we are already trying to get rid of the transaction log as much as possible. We turn on the auto remove (DB_LOG_AUTO_REMOVE) and the logs are always cleaned up on a clean shutdown. As mentioned earlier, the transaction log already has a flag that doesn't always flush the log anyways. So I don't think that just completely avoiding transaction logs entirely is unreasonable.

Logs are disabled by using the db flag DB_TXN_NOT_DURABLE to prevent logs being written for a db, and using the db env flag DB_LOG_IN_MEMORY to keep all db environment logs in memory.

Not having the BDB logs additionally allows us to remove the BDB 4.8 requirement. This requirement was because the Oracle keeps changing the log file format. The database file format itself has not changed in a long time. The log file format difference would supposedly make downgrades more difficult because the log files are not downgradable. However in my testing, this was not actually the case as the log files would be moved out of the way if the database could not be opened, so downgrading wasn't that much of a problem, especially with clean shutdowns. Not having the transaction log be written at all makes this not a problem entirely as there aren't any log files to get in the way. So we can now allow for other BDB versions.

Bumping to BDB 5.3 is done only because that's the version that is provided by many (most?) distros. With this change, `--with-incompatible-bdb` is no longer needed and we can simply build and installation instructions to just "install bdb from your package manager".

***

This change might be contentions, so here are some alternatives that we might want to discuss:
* Not having logs at all might make the wallet more unreliable. Maybe instead of getting rid of the logs entirely we can output compatible log files for use in BDB 4.8. But that's clunky and just locks us into BDB 5.3 (or whatever version).
  * We could possibly have our own consistent log file format which is then loaded into BDB somehow
* Instead of no logs at all, when we encounter newer log files, copy them (as we do now) and the wallet.dat file to a backup location in the walletdir so that users can recover them if they see consistency issues with the wallet file. This still lets us change BDB.