### PR TITLE
threadnames: don't allocate memory in ThreadRename

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -338,7 +338,7 @@ static bool HTTPBindAddresses(struct evhttp* http)
 /** Simple wrapper to set thread name and run work queue */
 static void HTTPWorkQueueRun(WorkQueue<HTTPClosure>* queue, int worker_num)
 {
-    util::ThreadRename(strprintf("httpworker.%i", worker_num));
+    util::ThreadRenameWithWorker("httpworker", worker_num);
     queue->Run();
 }
 

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -250,7 +250,7 @@ void BCLog::Logger::LogPrintStr(const std::string& str)
     std::string str_prefixed = LogEscapeMessage(str);
 
     if (m_log_threadnames && m_started_new_line) {
-        str_prefixed.insert(0, "[" + util::ThreadGetInternalName() + "] ");
+        str_prefixed.insert(0, "[" + std::string(util::ThreadGetInternalName()) + "] ");
     }
 
     str_prefixed = LogTimestampStr(str_prefixed);

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -19,7 +19,7 @@
 
 BOOST_FIXTURE_TEST_SUITE(util_threadnames_tests, BasicTestingSetup)
 
-const std::string TEST_THREAD_NAME_BASE = "test_thread.";
+const std::string TEST_THREAD_NAME_BASE = "test_thread";
 
 /**
  * Run a bunch of threads to all call util::ThreadRename.
@@ -33,7 +33,7 @@ std::set<std::string> RenameEnMasse(int num_threads)
     std::mutex lock;
 
     auto RenameThisThread = [&](int i) {
-        util::ThreadRename(TEST_THREAD_NAME_BASE + ToString(i));
+        util::ThreadRenameWithWorker(TEST_THREAD_NAME_BASE.c_str(), i);
         std::lock_guard<std::mutex> guard(lock);
         names.insert(util::ThreadGetInternalName());
     };
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(util_threadnames_test_rename_threaded)
 
     // Names "test_thread.[n]" should exist for n = [0, 99]
     for (int i = 0; i < 100; ++i) {
-        BOOST_CHECK(names.find(TEST_THREAD_NAME_BASE + ToString(i)) != names.end());
+        BOOST_CHECK(names.find(TEST_THREAD_NAME_BASE + "." + ToString(i)) != names.end());
     }
 
 }

--- a/src/util/threadnames.h
+++ b/src/util/threadnames.h
@@ -12,14 +12,16 @@ namespace util {
 //! as its system thread name.
 //! @note Do not call this for the main thread, as this will interfere with
 //! UNIX utilities such as top and killall. Use ThreadSetInternalName instead.
-void ThreadRename(std::string&&);
+void ThreadRename(const char*);
+
+void ThreadRenameWithWorker(const char*, int);
 
 //! Set the internal (in-memory) name of the current thread only.
-void ThreadSetInternalName(std::string&&);
+void ThreadSetInternalName(const char *);
 
 //! Get the thread's internal (in-memory) name; used e.g. for identification in
 //! logging.
-const std::string& ThreadGetInternalName();
+const char* ThreadGetInternalName();
 
 } // namespace util
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1803,7 +1803,7 @@ static bool WriteUndoDataForBlock(const CBlockUndo& blockundo, BlockValidationSt
 static CCheckQueue<CScriptCheck> scriptcheckqueue(128);
 
 void ThreadScriptCheck(int worker_num) {
-    util::ThreadRename(strprintf("scriptch.%i", worker_num));
+    util::ThreadRenameWithWorker("scriptch", worker_num);
     scriptcheckqueue.Thread();
 }
 

--- a/test/lint/lint-locale-dependence.sh
+++ b/test/lint/lint-locale-dependence.sh
@@ -23,6 +23,7 @@ KNOWN_VIOLATIONS=(
     "src/util/strencodings.cpp:.*strtoul"
     "src/util/strencodings.h:.*atoi"
     "src/util/system.cpp:.*atoi"
+    "src/util/threadnames.cpp:.*snprintf"
 )
 
 REGEXP_IGNORE_EXTERNAL_DEPENDENCIES="^src/(crypto/ctaes/|leveldb/|secp256k1/|tinyformat.h|univalue/)"


### PR DESCRIPTION
In my investigations into heap allocations during IBD, I discovered that ThreadRename is called many many times, in some cases it does multiple string allocations as well. This modifies ThreadRename to not allocate memory, opting for a static thread-local buffer instead.

I also create a new ThreadRenameWithWorker helper to avoid strprintf allocations.

before:
![May02-001641](https://user-images.githubusercontent.com/45598/80857905-7e046400-8c0a-11ea-9f03-6adda93b7ff9.png)

after:
![May02-002048](https://user-images.githubusercontent.com/45598/80857987-329e8580-8c0b-11ea-9c64-9c64b5b69a26.png)

