### PR TITLE
wallet: Fix typo in assert that is compile-time true

### DIFF
--- a/src/test/script_standard_tests.cpp
+++ b/src/test/script_standard_tests.cpp
@@ -13,6 +13,12 @@
 
 BOOST_FIXTURE_TEST_SUITE(script_standard_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(dest_default_is_no_dest)
+{
+    CTxDestination dest;
+    BOOST_CHECK(!IsValidDestination(dest));
+}
+
 BOOST_AUTO_TEST_CASE(script_standard_Solver_success)
 {
     CKey keys[3];

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2777,7 +2777,10 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                     strFailReason = _("Transaction needs a change address, but we can't generate it. Please call keypoolrefill first.").translated;
                 }
                 scriptChange = GetScriptForDestination(dest);
-                assert(!dest.empty() || scriptChange.empty());
+                // A valid destination implies a change script (and
+                // vice-versa). An empty change script will abort later, if the
+                // change keypool ran out, but change is required.
+                CHECK_NONFATAL(IsValidDestination(dest) != scriptChange.empty());
             }
             CTxOut change_prototype_txout(0, scriptChange);
             coin_selection_params.change_output_size = GetSerializeSize(change_prototype_txout);
@@ -2994,7 +2997,7 @@ bool CWallet::CreateTransaction(interfaces::Chain::Lock& locked_chain, const std
                 continue;
             }
 
-            // Give up if change keypool ran out and we failed to find a solution without change:
+            // Give up if change keypool ran out and change is required
             if (scriptChange.empty() && nChangePosInOut != -1) {
                 return false;
             }


### PR DESCRIPTION
Commit 92bcd70808b9cac56b184903aa6d37baf9641b37 presumably added a check that a `dest` of type `CNoDestination` implies an empty `scriptChange`.

However, it accidentally checked for `boost::variant::empty`, which always returns false: https://www.boost.org/doc/libs/1_72_0/doc/html/boost/variant.html#id-1_3_46_5_4_1_1_16_2-bb