### PR TITLE
doc: Fix typo in Coin doxygen comment

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -6,11 +6,11 @@
 #ifndef BITCOIN_COINS_H
 #define BITCOIN_COINS_H
 
-#include <primitives/transaction.h>
 #include <compressor.h>
 #include <core_memusage.h>
 #include <crypto/siphash.h>
 #include <memusage.h>
+#include <primitives/transaction.h>
 #include <serialize.h>
 #include <uint256.h>
 
@@ -25,7 +25,7 @@
  *
  * Serialized format:
  * - VARINT((coinbase ? 1 : 0) | (height << 1))
- * - the non-spent CTxOut (via CTxOutCompressor)
+ * - the non-spent CTxOut (via TxOutCompression)
  */
 class Coin
 {


### PR DESCRIPTION
`CTxOutCompressor` has been renamed in commit 4de934b9b5b4be1bac8fe205f4ee9a79e772dc34, so rename it in the docs as well.