### PR TITLE
gui: Refactor WalletFrame to extend QStackView

### DIFF
--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -14,20 +14,14 @@
 #include <QLabel>
 
 WalletFrame::WalletFrame(const PlatformStyle *_platformStyle, BitcoinGUI *_gui) :
-    QFrame(_gui),
+    QStackedWidget(_gui),
     gui(_gui),
     platformStyle(_platformStyle)
 {
-    // Leave HBox hook for adding a list view later
-    QHBoxLayout *walletFrameLayout = new QHBoxLayout(this);
     setContentsMargins(0,0,0,0);
-    walletStack = new QStackedWidget(this);
-    walletFrameLayout->setContentsMargins(0,0,0,0);
-    walletFrameLayout->addWidget(walletStack);
-
     QLabel *noWallet = new QLabel(tr("No wallet has been loaded."));
     noWallet->setAlignment(Qt::AlignCenter);
-    walletStack->addWidget(noWallet);
+    addWidget(noWallet);
 }
 
 WalletFrame::~WalletFrame()
@@ -61,7 +55,7 @@ bool WalletFrame::addWallet(WalletModel *walletModel)
         walletView->gotoOverviewPage();
     }
 
-    walletStack->addWidget(walletView);
+    addWidget(walletView);
     mapWalletViews[walletModel] = walletView;
 
     connect(walletView, &WalletView::outOfSyncWarningClicked, this, &WalletFrame::outOfSyncWarningClicked);
@@ -82,7 +76,7 @@ void WalletFrame::setCurrentWallet(WalletModel* wallet_model)
     if (mapWalletViews.count(wallet_model) == 0) return;
 
     WalletView *walletView = mapWalletViews.value(wallet_model);
-    walletStack->setCurrentWidget(walletView);
+    setCurrentWidget(walletView);
     assert(walletView);
     walletView->updateEncryptionStatus();
 }
@@ -92,7 +86,7 @@ void WalletFrame::removeWallet(WalletModel* wallet_model)
     if (mapWalletViews.count(wallet_model) == 0) return;
 
     WalletView *walletView = mapWalletViews.take(wallet_model);
-    walletStack->removeWidget(walletView);
+    removeWidget(walletView);
     delete walletView;
 }
 
@@ -100,7 +94,7 @@ void WalletFrame::removeAllWallets()
 {
     QMap<WalletModel*, WalletView*>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
-        walletStack->removeWidget(i.value());
+        removeWidget(i.value());
     mapWalletViews.clear();
 }
 
@@ -215,7 +209,7 @@ void WalletFrame::usedReceivingAddresses()
 
 WalletView* WalletFrame::currentWalletView() const
 {
-    return qobject_cast<WalletView*>(walletStack->currentWidget());
+    return qobject_cast<WalletView*>(currentWidget());
 }
 
 WalletModel* WalletFrame::currentWalletModel() const

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -5,7 +5,7 @@
 #ifndef BITCOIN_QT_WALLETFRAME_H
 #define BITCOIN_QT_WALLETFRAME_H
 
-#include <QFrame>
+#include <QStackedWidget>
 #include <QMap>
 
 class BitcoinGUI;
@@ -15,10 +15,6 @@ class SendCoinsRecipient;
 class WalletModel;
 class WalletView;
 
-QT_BEGIN_NAMESPACE
-class QStackedWidget;
-QT_END_NAMESPACE
-
 /**
  * A container for embedding all wallet-related
  * controls into BitcoinGUI. The purpose of this class is to allow future
@@ -26,7 +22,7 @@ QT_END_NAMESPACE
  * modifications to BitcoinGUI, thus greatly simplifying merges while
  * reducing the risk of breaking top-level stuff.
  */
-class WalletFrame : public QFrame
+class WalletFrame : public QStackedWidget
 {
     Q_OBJECT
 
@@ -50,7 +46,6 @@ Q_SIGNALS:
     void requestedSyncWarningInfo();
 
 private:
-    QStackedWidget *walletStack;
     BitcoinGUI *gui;
     ClientModel *clientModel;
     QMap<WalletModel*, WalletView*> mapWalletViews;


### PR DESCRIPTION
Some code added in #2220 no longer applies as the list of wallets is actually a combo in the toolbar.

Considering #16883, it's very unlikely the current GUI will change and follow the idea of #2220.