### PR TITLE
Serve cfcheckpt requests

### DIFF
--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -21,6 +21,7 @@ static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 100;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 static const bool DEFAULT_PEERBLOOMFILTERS = false;
+static const bool DEFAULT_PEERBLOCKFILTERS = false;
 
 class PeerLogicValidation final : public CValidationInterface, public NetEventsInterface {
 private:

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -40,6 +40,8 @@ const char *SENDCMPCT="sendcmpct";
 const char *CMPCTBLOCK="cmpctblock";
 const char *GETBLOCKTXN="getblocktxn";
 const char *BLOCKTXN="blocktxn";
+const char *GETCFCHECKPT="getcfcheckpt";
+const char *CFCHECKPT="cfcheckpt";
 } // namespace NetMsgType
 
 /** All known message types. Keep this in the same order as the list of
@@ -71,6 +73,8 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::CMPCTBLOCK,
     NetMsgType::GETBLOCKTXN,
     NetMsgType::BLOCKTXN,
+    NetMsgType::GETCFCHECKPT,
+    NetMsgType::CFCHECKPT,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes, allNetMessageTypes+ARRAYLEN(allNetMessageTypes));
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -234,6 +234,20 @@ extern const char *GETBLOCKTXN;
  * @since protocol version 70014 as described by BIP 152
  */
 extern const char *BLOCKTXN;
+/**
+ * getcfcheckpt requests evenly spaced compact filter headers, enabling
+ * parallelized download and validation of the headers between them.
+ * Only available with service bit NODE_COMPACT_FILTERS as described by
+ * BIP 157 & 158.
+ */
+extern const char *GETCFCHECKPT;
+/**
+ * cfcheckpt is a response to a getcfcheckpt request containing a vector of
+ * evenly spaced filter headers for blocks on the requested chain.
+ * Only available with service bit NODE_COMPACT_FILTERS as described by
+ * BIP 157 & 158.
+ */
+extern const char *CFCHECKPT;
 };
 
 /* Get a vector of all valid message types (see above) */

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Tests NODE_COMPACT_FILTERS (BIP 157/158).
+
+Tests that a node configured with -blockfilterindex and -peerblockfilters can serve
+cfcheckpts.
+"""
+
+from test_framework.messages import (
+    FILTER_TYPE_BASIC,
+    msg_getcfcheckpt,
+)
+from test_framework.mininode import P2PInterface
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    connect_nodes,
+    disconnect_nodes,
+    wait_until,
+)
+
+class CompactFiltersTest(BitcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.rpc_timeout = 480
+        self.num_nodes = 2
+        self.extra_args = [
+            ["-blockfilterindex", "-peerblockfilters"],
+            ["-blockfilterindex"],
+        ]
+
+    def run_test(self):
+        # Node 0 supports COMPACT_FILTERS, node 1 does not.
+        node0 = self.nodes[0].add_p2p_connection(P2PInterface())
+        node1 = self.nodes[1].add_p2p_connection(P2PInterface())
+
+        # Nodes 0 & 1 share the same first 999 blocks in the chain.
+        self.nodes[0].generate(999)
+        self.sync_blocks(timeout=600)
+
+        # Stale blocks by disconnecting nodes 0 & 1, mining, then reconnecting
+        disconnect_nodes(self.nodes[0], 1)
+
+        self.nodes[0].generate(1)
+        wait_until(lambda: self.nodes[0].getblockcount() == 1000)
+        stale_block_hash = self.nodes[0].getblockhash(1000)
+
+        self.nodes[1].generate(1001)
+        wait_until(lambda: self.nodes[1].getblockcount() == 2000)
+
+        self.log.info("get cfcheckpt on chain to be re-orged out.")
+        request = msg_getcfcheckpt(
+            filter_type=FILTER_TYPE_BASIC,
+            stop_hash=int(stale_block_hash, 16)
+        )
+        node0.send_and_ping(message=request)
+        response = node0.last_message['cfcheckpt']
+        assert_equal(response.filter_type, request.filter_type)
+        assert_equal(response.stop_hash, request.stop_hash)
+        assert_equal(len(response.headers), 1)
+
+        self.log.info("Reorg node 0 to a new chain.")
+        connect_nodes(self.nodes[0], 1)
+        self.sync_blocks(timeout=600)
+
+        main_block_hash = self.nodes[0].getblockhash(1000)
+        assert main_block_hash != stale_block_hash, "node 0 chain did not reorganize"
+
+        self.log.info("Check that peers can fetch cfcheckpt on active chain.")
+        tip_hash = self.nodes[0].getbestblockhash()
+        request = msg_getcfcheckpt(
+            filter_type=FILTER_TYPE_BASIC,
+            stop_hash=int(tip_hash, 16)
+        )
+        node0.send_and_ping(request)
+        response = node0.last_message['cfcheckpt']
+        assert_equal(response.filter_type, request.filter_type)
+        assert_equal(response.stop_hash, request.stop_hash)
+
+        main_cfcheckpt = self.nodes[0].getblockfilter(main_block_hash, 'basic')['header']
+        tip_cfcheckpt = self.nodes[0].getblockfilter(tip_hash, 'basic')['header']
+        assert_equal(
+            response.headers,
+            [int(header, 16) for header in (main_cfcheckpt, tip_cfcheckpt)]
+        )
+
+        self.log.info("Check that peers can fetch cfcheckpt on stale chain.")
+        request = msg_getcfcheckpt(
+            filter_type=FILTER_TYPE_BASIC,
+            stop_hash=int(stale_block_hash, 16)
+        )
+        node0.send_and_ping(request)
+        response = node0.last_message['cfcheckpt']
+
+        stale_cfcheckpt = self.nodes[0].getblockfilter(stale_block_hash, 'basic')['header']
+        assert_equal(
+            response.headers,
+            [int(header, 16) for header in (stale_cfcheckpt,)]
+        )
+
+        self.log.info("Requests to node 1 without NODE_COMPACT_FILTERS results in disconnection.")
+        requests = [
+            msg_getcfcheckpt(
+                filter_type=FILTER_TYPE_BASIC,
+                stop_hash=int(main_block_hash, 16)
+            ),
+        ]
+        for request in requests:
+            node1 = self.nodes[1].add_p2p_connection(P2PInterface())
+            node1.send_message(request)
+            node1.wait_for_disconnect()
+
+        self.log.info("Check that invalid requests result in disconnection.")
+        requests = [
+            # Requesting unknown filter type results in disconnection.
+            msg_getcfcheckpt(
+                filter_type=255,
+                stop_hash=int(main_block_hash, 16)
+            ),
+            # Requesting unknown hash results in disconnection.
+            msg_getcfcheckpt(
+                filter_type=FILTER_TYPE_BASIC,
+                stop_hash=123456789,
+            ),
+        ]
+        for request in requests:
+            node0 = self.nodes[0].add_p2p_connection(P2PInterface())
+            node0.send_message(request)
+            node0.wait_for_disconnect()
+
+if __name__ == '__main__':
+    CompactFiltersTest().main()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -31,6 +31,7 @@ from test_framework.messages import (
     msg_block,
     MSG_BLOCK,
     msg_blocktxn,
+    msg_cfcheckpt,
     msg_cmpctblock,
     msg_feefilter,
     msg_filteradd,
@@ -67,6 +68,7 @@ MESSAGEMAP = {
     b"addr": msg_addr,
     b"block": msg_block,
     b"blocktxn": msg_blocktxn,
+    b"cfcheckpt": msg_cfcheckpt,
     b"cmpctblock": msg_cmpctblock,
     b"feefilter": msg_feefilter,
     b"filteradd": msg_filteradd,
@@ -328,6 +330,7 @@ class P2PInterface(P2PConnection):
     def on_addr(self, message): pass
     def on_block(self, message): pass
     def on_blocktxn(self, message): pass
+    def on_cfcheckpt(self, message): pass
     def on_cmpctblock(self, message): pass
     def on_feefilter(self, message): pass
     def on_filteradd(self, message): pass

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -225,6 +225,7 @@ BASE_SCRIPTS = [
     'feature_loadblock.py',
     'p2p_dos_header_tree.py',
     'p2p_unrequested_blocks.py',
+    'p2p_blockfilters.py',
     'feature_includeconf.py',
     'feature_asmap.py',
     'mempool_unbroadcast.py',


### PR DESCRIPTION
Serve cfcheckpt messages if basic block filter index is enabled and `-peercfilters` is set.

`NODE_COMPACT_FILTERS` is not signaled to peers, but functionality can be used for testing and serving pre-configured clients.