### PR TITLE
valgrind: remove outdated suppressions

### DIFF
--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -184,11 +184,3 @@
    ...
    fun:_ZN5BCLog6Logger12StartLoggingEv
 }
-{
-   Suppress BCLog::Logger::StartLogging() still reachable memory warning
-   Memcheck:Leak
-   match-leak-kinds: reachable
-   fun:malloc
-   ...
-   fun:_ZN5BCLog6Logger12StartLoggingEv
-}

--- a/contrib/valgrind.supp
+++ b/contrib/valgrind.supp
@@ -192,8 +192,3 @@
    ...
    fun:_ZN5BCLog6Logger12StartLoggingEv
 }
-{
-   Suppress rest_blockhash_by_height Conditional jump or move depends on uninitialised value(s)
-   Memcheck:Cond
-   fun:_ZL24rest_blockhash_by_heightP11HTTPRequestRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
-}


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/commit/708e3c7e85a666d5b8da8638a819c0f3973fcca4: `Suppress rest_blockhash_by_height` should no longer be needed after #18785.

https://github.com/bitcoin/bitcoin/commit/d7120f7f78cda5ed1ab91f83e9b546de68dbee47 : Removes a duplicate `Suppress BCLog::Logger::StartLogging()` suppression that was added in #17770.