### PR TITLE
[0.20] wallet: Add BlockUntilSyncedToCurrentChain to dumpwallet

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -752,6 +752,10 @@ UniValue dumpwallet(const JSONRPCRequest& request)
 
     LegacyScriptPubKeyMan& spk_man = EnsureLegacyScriptPubKeyMan(*wallet);
 
+    // Make sure the results are valid at least up to the most recent block
+    // the user could have gotten from another RPC command prior to now
+    wallet->BlockUntilSyncedToCurrentChain();
+
     auto locked_chain = pwallet->chain().lock();
     LOCK2(pwallet->cs_wallet, spk_man.cs_KeyStore);
 


### PR DESCRIPTION
Just the actual fix

Github-Pull: #18671
Rebased-From: fa60afc4fb957875bab1c8982d9d9e4999a3814c (partial)
