### PR TITLE
test: Remove RPCOverloadWrapper boilerplate

### DIFF
--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -538,6 +538,8 @@ class TestNodeCLIAttr:
 def arg_to_cli(arg):
     if isinstance(arg, bool):
         return str(arg).lower()
+    elif arg is None:
+        return 'null'
     elif isinstance(arg, dict) or isinstance(arg, list):
         return json.dumps(arg, default=EncodeDecimal)
     else:
@@ -608,27 +610,13 @@ class RPCOverloadWrapper():
     def __getattr__(self, name):
         return getattr(self.rpc, name)
 
-    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase=None, avoid_reuse=None, descriptors=None):
-        if self.is_cli:
-            if disable_private_keys is None:
-                disable_private_keys = 'null'
-            if blank is None:
-                blank = 'null'
-            if passphrase is None:
-                passphrase = ''
-            if avoid_reuse is None:
-                avoid_reuse = 'null'
+    def createwallet(self, wallet_name, disable_private_keys=None, blank=None, passphrase='', avoid_reuse=None, descriptors=None):
         if descriptors is None:
             descriptors = self.descriptors
         return self.__getattr__('createwallet')(wallet_name, disable_private_keys, blank, passphrase, avoid_reuse, descriptors)
 
     def importprivkey(self, privkey, label=None, rescan=None):
         wallet_info = self.getwalletinfo()
-        if self.is_cli:
-            if label is None:
-                label = 'null'
-            if rescan is None:
-                rescan = 'null'
         if 'descriptors' not in wallet_info or ('descriptors' in wallet_info and not wallet_info['descriptors']):
             return self.__getattr__('importprivkey')(privkey, label, rescan)
         desc = descsum_create('combo(' + privkey + ')')
@@ -643,11 +631,6 @@ class RPCOverloadWrapper():
 
     def addmultisigaddress(self, nrequired, keys, label=None, address_type=None):
         wallet_info = self.getwalletinfo()
-        if self.is_cli:
-            if label is None:
-                label = 'null'
-            if address_type is None:
-                address_type = 'null'
         if 'descriptors' not in wallet_info or ('descriptors' in wallet_info and not wallet_info['descriptors']):
             return self.__getattr__('addmultisigaddress')(nrequired, keys, label, address_type)
         cms = self.createmultisig(nrequired, keys, address_type)
@@ -663,11 +646,6 @@ class RPCOverloadWrapper():
 
     def importpubkey(self, pubkey, label=None, rescan=None):
         wallet_info = self.getwalletinfo()
-        if self.is_cli:
-            if label is None:
-                label = 'null'
-            if rescan is None:
-                rescan = 'null'
         if 'descriptors' not in wallet_info or ('descriptors' in wallet_info and not wallet_info['descriptors']):
             return self.__getattr__('importpubkey')(pubkey, label, rescan)
         desc = descsum_create('combo(' + pubkey + ')')
@@ -682,13 +660,6 @@ class RPCOverloadWrapper():
 
     def importaddress(self, address, label=None, rescan=None, p2sh=None):
         wallet_info = self.getwalletinfo()
-        if self.is_cli:
-            if label is None:
-                label = 'null'
-            if rescan is None:
-                rescan = 'null'
-            if p2sh is None:
-                p2sh = 'null'
         if 'descriptors' not in wallet_info or ('descriptors' in wallet_info and not wallet_info['descriptors']):
             return self.__getattr__('importaddress')(address, label, rescan, p2sh)
         is_hex = False


### PR DESCRIPTION
There are too many wrappers in test_node already, so at least the code that implements the wrappers should be as minimal as possible.