### PR TITLE
qt: Handle exceptions instead of crash

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -385,6 +385,12 @@ void BitcoinApplication::handleRunawayException(const QString &message)
     ::exit(EXIT_FAILURE);
 }
 
+void BitcoinApplication::handleNonFatalException(const QString& exception_message)
+{
+    assert(QThread::currentThread() == qApp->thread());
+    QMessageBox::warning(nullptr, "Internal error", exception_message);
+}
+
 WId BitcoinApplication::getMainWinId() const
 {
     if (!window)

--- a/src/qt/bitcoin.h
+++ b/src/qt/bitcoin.h
@@ -95,6 +95,7 @@ public Q_SLOTS:
     void shutdownResult();
     /// Handle runaway exceptions. Shows a message box with the problem and quits the program.
     void handleRunawayException(const QString &message);
+    void handleNonFatalException(const QString& exception_message);
 
 Q_SIGNALS:
     void requestedInitialize();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -370,7 +370,7 @@ bool SendCoinsDialog::PrepareSendText(QString& question_string, QString& informa
     return true;
 }
 
-void SendCoinsDialog::on_sendButton_clicked()
+void SendCoinsDialog::sendButtonClickedHelper()
 {
     if(!model || !model->getOptionsModel())
         return;
@@ -459,6 +459,11 @@ void SendCoinsDialog::on_sendButton_clicked()
     }
     fNewRecipientAllowed = true;
     m_current_transaction.reset();
+}
+
+void SendCoinsDialog::on_sendButton_clicked()
+{
+    GUIUtil::shieldException([&] { sendButtonClickedHelper(); });
 }
 
 void SendCoinsDialog::clear()

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -75,6 +75,7 @@ private:
     void updateFeeMinimizedLabel();
     // Update the passed in CCoinControl with state from the GUI
     void updateCoinControlState(CCoinControl& ctrl);
+    void sendButtonClickedHelper();
 
 private Q_SLOTS:
     void on_sendButton_clicked();

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -8,6 +8,7 @@
 #include <qt/bitcoinunits.h>
 #include <qt/csvmodelwriter.h>
 #include <qt/editaddressdialog.h>
+#include <qt/guiutil.h>
 #include <qt/optionsmodel.h>
 #include <qt/platformstyle.h>
 #include <qt/transactiondescdialog.h>
@@ -420,7 +421,7 @@ void TransactionView::abandonTx()
     model->getTransactionTableModel()->updateTransaction(hashQStr, CT_UPDATED, false);
 }
 
-void TransactionView::bumpFee()
+void TransactionView::bumpFeeHelper()
 {
     if(!transactionView || !transactionView->selectionModel())
         return;
@@ -441,6 +442,11 @@ void TransactionView::bumpFee()
         qApp->processEvents();
         Q_EMIT bumpedFee(newHash);
     }
+}
+
+void TransactionView::bumpFee()
+{
+    GUIUtil::shieldException([&] { bumpFeeHelper(); });
 }
 
 void TransactionView::copyAddress()

--- a/src/qt/transactionview.h
+++ b/src/qt/transactionview.h
@@ -85,6 +85,7 @@ private:
     virtual void resizeEvent(QResizeEvent* event) override;
 
     bool eventFilter(QObject *obj, QEvent *event) override;
+    void bumpFeeHelper();
 
 private Q_SLOTS:
     void contextualMenu(const QPoint &);


### PR DESCRIPTION
Related issue #18643.

With this PR the GUI handles the wallet-related exception, displays it to a user:

![Screenshot from 2020-05-06 18-16-51](https://user-images.githubusercontent.com/32963518/81194870-d306f800-8fc5-11ea-860a-b9510bb3bd2b.png)

and, if the exception is a non-fatal error, leaves the main window running.