### PR TITLE
gui: Display warnings as rich text

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -381,7 +381,7 @@ void BitcoinApplication::shutdownResult()
 
 void BitcoinApplication::handleRunawayException(const QString &message)
 {
-    QMessageBox::critical(nullptr, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. %1 can no longer continue safely and will quit.").arg(PACKAGE_NAME) + QString("\n\n") + message);
+    QMessageBox::critical(nullptr, "Runaway exception", BitcoinGUI::tr("A fatal error occurred. %1 can no longer continue safely and will quit.").arg(PACKAGE_NAME) + QString("<br><br>") + message);
     ::exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
On master (6621be53517d69ab855cee4a5978a44d6a133ba3), warnings that contain `<hr />` HTML tag are not displayed correctly:

![Screenshot from 2020-05-06 11-30-10](https://user-images.githubusercontent.com/32963518/81177281-0e49fc80-8faf-11ea-8cac-8847aa517e86.png)

Fixed:

![Screenshot from 2020-05-07 07-30-48](https://user-images.githubusercontent.com/32963518/81255618-ca9ad580-9036-11ea-90ad-7f4d89c1880d.png)