### PR TITLE
Bugfix: Only use git for build info if the repository is actually the right one

### DIFF
--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -110,8 +110,10 @@ script: |
 
   GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 
-  # Create the source tarball
+  # Create the release tarball using (arbitrarily) the first host
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
+  CONFIG_SITE="${BASEPREFIX}/${HOSTS/ */}/share/config.site" \
+  REFERENCE_DATETIME="${REFERENCE_DATETIME}" \
   contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
@@ -131,7 +133,6 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -112,7 +112,7 @@ script: |
 
   # Create the source tarball
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
-  git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+  contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -109,8 +109,10 @@ script: |
 
   GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 
-  # Create the source tarball
+  # Create the release tarball using (arbitrarily) the first host
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
+  CONFIG_SITE="${BASEPREFIX}/${HOSTS/ */}/share/config.site" \
+  REFERENCE_DATETIME="${REFERENCE_DATETIME}" \
   contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
@@ -123,7 +125,6 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS}
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -111,7 +111,7 @@ script: |
 
   # Create the source tarball
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
-  git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+  contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -116,7 +116,7 @@ script: |
 
   # Create the source tarball
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
-  git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+  contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
   # Extract the git archive into a dir for each host and build

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -114,8 +114,10 @@ script: |
 
   GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 
-  # Create the source tarball
+  # Create the release tarball using (arbitrarily) the first host
   mkdir -p "$(dirname "$GIT_ARCHIVE")"
+  CONFIG_SITE="${BASEPREFIX}/${HOSTS/ */}/share/config.site" \
+  REFERENCE_DATETIME="${REFERENCE_DATETIME}" \
   contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 
   ORIGPATH="$PATH"
@@ -128,7 +130,6 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
 
-    ./autogen.sh
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}"
     make ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security

--- a/contrib/gitian-descriptors/make_release_tarball
+++ b/contrib/gitian-descriptors/make_release_tarball
@@ -5,6 +5,29 @@
 #
 # A helper script to generate source release tarball
 
+set -e
+
 GIT_ARCHIVE="$1"
 . "`dirname "$0"`/assign_DISTNAME"
-git archive --prefix="${DISTNAME}/" --output="${GIT_ARCHIVE}" HEAD
+
+git archive --prefix="${DISTNAME}/" HEAD | tar -xp
+cd "${DISTNAME}"
+
+./autogen.sh
+./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking
+make distclean
+
+cd ..
+tar \
+  --format=ustar \
+  --exclude autom4te.cache \
+  --exclude .deps \
+  --exclude .git \
+  --sort=name \
+  --mode='u+rw,go+r-w,a+X' --owner=0 --group=0 \
+  --mtime="${REFERENCE_DATETIME}" \
+  -c "${DISTNAME}" | \
+  gzip -9n \
+  >"${GIT_ARCHIVE}"
+
+rm -r "${DISTNAME}"

--- a/contrib/gitian-descriptors/make_release_tarball
+++ b/contrib/gitian-descriptors/make_release_tarball
@@ -11,6 +11,11 @@ GIT_ARCHIVE="$1"
 . "`dirname "$0"`/assign_DISTNAME"
 
 git archive --prefix="${DISTNAME}/" HEAD | tar -xp
+
+# Generate correct build info file from git, before we lose git
+GIT_BUILD_INFO="$(share/genbuild.sh /dev/stdout)"
+sed 's/\/\/ No build information available/'"${GIT_BUILD_INFO}"'/' -i "${DISTNAME}/share/genbuild.sh"
+
 cd "${DISTNAME}"
 
 ./autogen.sh

--- a/contrib/gitian-descriptors/make_release_tarball
+++ b/contrib/gitian-descriptors/make_release_tarball
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Copyright (c) 2020 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# A helper script to generate source release tarball
+
+GIT_ARCHIVE="$1"
+. "`dirname "$0"`/assign_DISTNAME"
+git archive --prefix="${DISTNAME}/" --output="${GIT_ARCHIVE}" HEAD

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -158,6 +158,7 @@ GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 # Create the source tarball if not already there
 if [ ! -e "$GIT_ARCHIVE" ]; then
     mkdir -p "$(dirname "$GIT_ARCHIVE")"
+    CONFIG_SITE="${BASEPREFIX}/${HOST}/share/config.site" \
     contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 fi
 
@@ -194,8 +195,6 @@ export PATH="${BASEPREFIX}/${HOST}/native/bin:${PATH}"
 
     # Extract the source tarball
     tar --strip-components=1 -xf "${GIT_ARCHIVE}"
-
-    ./autogen.sh
 
     # Configure this DISTSRC for $HOST
     # shellcheck disable=SC2086

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -158,7 +158,7 @@ GIT_ARCHIVE="${OUTDIR}/src/${DISTNAME}.tar.gz"
 # Create the source tarball if not already there
 if [ ! -e "$GIT_ARCHIVE" ]; then
     mkdir -p "$(dirname "$GIT_ARCHIVE")"
-    git archive --prefix="${DISTNAME}/" --output="$GIT_ARCHIVE" HEAD
+    contrib/gitian-descriptors/make_release_tarball "${GIT_ARCHIVE}"
 fi
 
 ###########################

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -45,7 +45,9 @@ if [ -n "$GIT_TAG" ]; then
 elif [ -n "$GIT_COMMIT" ]; then
     NEWINFO="#define BUILD_GIT_COMMIT \"$GIT_COMMIT\""
 else
-    NEWINFO="// No build information available"
+    # NOTE: The NEWINFO line below this comment gets replaced by a string-match in contrib/gitian-descriptors/make_release_tarball
+    # If changing it, update the script too!
+    NEWINFO='// No build information available'
 fi
 
 # only update build.h if necessary

--- a/share/genbuild.sh
+++ b/share/genbuild.sh
@@ -18,9 +18,14 @@ else
     exit 1
 fi
 
+# This checks that we are actually part of the intended git repository, and not just getting info about some unrelated git repository that the code happens to be in a directory under
+git_check_in_repo() {
+    ! { git status --porcelain -uall --ignored "$@" 2>/dev/null || echo '??'; } | grep -q '?'
+}
+
 GIT_TAG=""
 GIT_COMMIT=""
-if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ]; then
+if [ "${BITCOIN_GENBUILD_NO_GIT}" != "1" ] && [ -e "$(command -v git)" ] && [ "$(git rev-parse --is-inside-work-tree 2>/dev/null)" = "true" ] && git_check_in_repo share/genbuild.sh; then
     # clean 'dirty' status of touched files that haven't been modified
     git diff >/dev/null 2>/dev/null
 


### PR DESCRIPTION
Fixes using unrelated git repos again, after the fix in #7522 was unexplicably removed by #18556

Also (really) fixes the "build version hack" (#18349) by embedding the correct tag in the release `genbuild.sh`

Based on top of #18818 to avoid unnecessary conflicts/rebasing once that's merged