### PR TITLE
walletdb: Don't remove database transaction logs and instead error

### DIFF
--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -69,7 +69,7 @@ public:
 
     bool Verify(const std::string& strFile);
 
-    bool Open(bool retry);
+    bool Open(bilingual_str& error);
     void Close();
     void Flush(bool fShutdown);
     void CheckpointLSN(const std::string& strFile);

--- a/src/wallet/salvage.cpp
+++ b/src/wallet/salvage.cpp
@@ -5,6 +5,7 @@
 
 #include <fs.h>
 #include <streams.h>
+#include <util/translation.h>
 #include <wallet/salvage.h>
 #include <wallet/wallet.h>
 #include <wallet/walletdb.h>
@@ -20,8 +21,9 @@ bool RecoverDatabaseFile(const fs::path& file_path)
     std::string filename;
     std::shared_ptr<BerkeleyEnvironment> env = GetWalletEnv(file_path, filename);
 
-    if (!env->Open(true /* retry */)) {
-        tfm::format(std::cerr, "Error initializing wallet database environment %s!", env->Directory());
+    bilingual_str open_err;
+    if (!env->Open(open_err)) {
+        tfm::format(std::cerr, "%s\n", open_err.original);
         return false;
     }
 


### PR DESCRIPTION
Instead of removing the database transaction logs and retrying the
wallet loading, just return an error message to the user. Additionally,
speciically for DB_RUNRECOVERY, notify the user that this could be due
to different BDB versions.

Kind of implements the suggestion from https://github.com/bitcoin/bitcoin/pull/18870#discussion_r421647964