### PR TITLE
util: raise a deadly signal in system.cpp fuzzer

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -285,6 +285,7 @@ bool ArgsManager::ParseParameters(int argc, const char* const argv[], std::strin
     m_settings.command_line_options.clear();
 
     for (int i = 1; i < argc; i++) {
+        assert(argv[i]); // system.cpp fuzzer throws UB errors, see PR #18908
         std::string key(argv[i]);
 
 #ifdef MAC_OSX


### PR DESCRIPTION
This PR deliberately raises a *deadly signal* in system.cpp fuzzer while testing ArgsManager::ParseParameters. The motivation for this change is based on experiences from this PR https://github.com/bitcoin/bitcoin/pull/18901

As the fuzzer provoked UB, I implemented a way to catch this error. However, after consultation with **elichai** and **sipa** I came to the conclusion that there was no proper solution in user-related code. The problem was to be fixed in the fuzzer itself. So, a simple `assert` got introduced to provoke a deadly signal when fuzzer walks over it.

For more information, please, check the discussion below.
