### PR TITLE
ci: Run fuzz testing test cases (bitcoin-core/qa-assets) under valgrind to catch memory errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,11 @@ jobs:
         FILE_ENV="./ci/test/00_setup_env_native_multiprocess.sh"
 
     - stage: test
+      name: 'x86_64 Linux  [GOAL: install]  [focal]  [no depends, only system libs, fuzzers under valgrind]'
+      env: >-
+        FILE_ENV="./ci/test/00_setup_env_native_fuzz_with_valgrind.sh"
+
+    - stage: test
       name: 'x86_64 Linux  [GOAL: install]  [xenial]  [no wallet]'
       env: >-
         FILE_ENV="./ci/test/00_setup_env_native_nowallet.sh"


### PR DESCRIPTION
Re-introduce the Travis valgrind fuzzing job which was removed by PR #18899. The removal seems to have been made by accident since the removed job does not appear to be the source of the problem the PR set out to fix.

---

Run fuzz testing [test cases (bitcoin-core/qa-assets)](https://github.com/bitcoin-core/qa-assets) under `valgrind`.

This would have caught `util: Avoid potential uninitialized read in FormatISO8601DateTime(int64_t) by checking gmtime_s/gmtime_r return value` (#18162) and similar cases.

This fuzzing job was introduced in #18166.