### PR TITLE
fuzz: fix vector size problem in system fuzzer

### DIFF
--- a/src/test/fuzz/system.cpp
+++ b/src/test/fuzz/system.cpp
@@ -85,7 +85,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         case 7: {
             const std::vector<std::string> random_arguments = ConsumeRandomLengthStringVector(fuzzed_data_provider);
             std::vector<const char*> argv;
-            argv.resize(random_arguments.size());
+            argv.reserve(random_arguments.size());
             for (const std::string& random_argument : random_arguments) {
                 argv.push_back(random_argument.c_str());
             }


### PR DESCRIPTION
This PR fixes a problem with vector resizing in system fuzzer (*case 7* there). Originally, this problem was discussed in PR https://github.com/bitcoin/bitcoin/pull/18908