### PR TITLE
Add extra thread for scheduler, move TorControl and OpenAddedConnections to scheduler

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -444,8 +444,8 @@ Threads
 
 - [SchedulerThread (`b-scheduler`)](https://doxygen.bitcoincore.org/class_c_scheduler.html#a14d2800815da93577858ea078aed1fba)
   : Does asynchronous background tasks like dumping wallet contents, dumping
-  addrman, running asynchronous validationinterface callbacks and maintaining
-  tor connections.
+  addrman, running asynchronous validationinterface callbacks, maintaining
+  tor connections and opening added connections.
 
 - Net threads:
 
@@ -461,9 +461,6 @@ Threads
 
   - [ThreadSocketHandler (`b-net`)](https://doxygen.bitcoincore.org/class_c_connman.html#a765597cbfe99c083d8fa3d61bb464e34)
     : Sends/Receives data from peers on port 8333.
-
-  - [ThreadOpenAddedConnections (`b-addcon`)](https://doxygen.bitcoincore.org/class_c_connman.html#a0b787caf95e52a346a2b31a580d60a62)
-    : Opens network connections to added nodes.
 
   - [ThreadOpenConnections (`b-opencon`)](https://doxygen.bitcoincore.org/class_c_connman.html#a55e9feafc3bab78e5c9d408c207faa45)
     : Initiates new connections to peers.

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -444,10 +444,8 @@ Threads
 
 - [SchedulerThread (`b-scheduler`)](https://doxygen.bitcoincore.org/class_c_scheduler.html#a14d2800815da93577858ea078aed1fba)
   : Does asynchronous background tasks like dumping wallet contents, dumping
-  addrman and running asynchronous validationinterface callbacks.
-
-- [TorControlThread (`b-torcontrol`)](https://doxygen.bitcoincore.org/torcontrol_8cpp.html#a4faed3692d57a0d7bdbecf3b37f72de0)
-  : Libevent thread for tor connections.
+  addrman, running asynchronous validationinterface callbacks and maintaining
+  tor connections.
 
 - Net threads:
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1307,9 +1307,10 @@ bool AppInitMain(NodeContext& node)
     assert(!node.scheduler);
     node.scheduler = MakeUnique<CScheduler>();
 
-    // Start the lightweight task scheduler thread
+    // Start two lightweight task scheduler threads
     CScheduler::Function serviceLoop = [&node]{ node.scheduler->serviceQueue(); };
-    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
+    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler1", serviceLoop));
+    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler2", serviceLoop));
 
     // Gather some entropy once per minute.
     node.scheduler->scheduleEvery([]{

--- a/src/net.h
+++ b/src/net.h
@@ -338,7 +338,7 @@ private:
     bool BindListenPort(const CService& bindAddr, bilingual_str& strError, NetPermissionFlags permissions);
     bool Bind(const CService& addr, unsigned int flags, NetPermissionFlags permissions);
     bool InitBinds(const std::vector<CService>& binds, const std::vector<NetWhitebindPermissions>& whiteBinds);
-    void ThreadOpenAddedConnections();
+    void OpenAddedConnections(CScheduler& scheduler);
     void AddOneShot(const std::string& strDest);
     void ProcessOneShot();
     void ThreadOpenConnections(std::vector<std::string> connect);
@@ -414,6 +414,11 @@ private:
     std::atomic<NodeId> nLastNodeId{0};
     unsigned int nPrevNodeCount{0};
 
+    // Keep track of the current round of opening connections
+    // to added nodes.
+    std::vector<AddedNodeInfo> added_connection_queue;
+    bool connection_was_attempted{false};
+
     /**
      * Services this instance offers.
      *
@@ -462,7 +467,6 @@ private:
 
     std::thread threadDNSAddressSeed;
     std::thread threadSocketHandler;
-    std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;
 


### PR DESCRIPTION
I’m exploring the opportunity to “save” threads by moving some of the stuff to the scheduler.
I need this so that we can make some room for blocking execution of #18421 and other similar features in future. Later I want to add #18421 to the scheduler too.

@laanwj initially suggested to use libevent for #18421, but @thebluematt pointed out that it’s undesirable to add that extra dependency on somewhat limited non-standard libevent functions.
Matt also suggested an idea of this PR as an alternative. 

I suggest to compare the safety of this approach to status-quo (which seems to be working well).
If we’ll have 2 threads for scheduler, the requirement is *at most one long blocking task is allowed*.

Right now, everything in scheduling is pretty fast. Tor stuff and OpenAddedConnections both seem to be fast too (that’s where I’d use some extra eyes and experience!), so we’re safe, and there’s even room for an extra task. (#18421).

If there are any concerns, note that we can drop either Tor or OpenAddedConnections from the scheduler, and still be fine. Or we can add third thread to the scheduler, and be even with status quo.