### PR TITLE
test: Pass ArgsManager into getarg_tests

### DIFF
--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -39,14 +39,14 @@ void LocalTestingSetup :: ResetArgs(const std::string& strArg)
         vecChar.push_back(s.c_str());
 
     std::string error;
-    BOOST_CHECK(gArgs.ParseParameters(vecChar.size(), vecChar.data(), error));
+    BOOST_CHECK(m_args.ParseParameters(vecChar.size(), vecChar.data(), error));
 }
 
 void LocalTestingSetup :: SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args)
 {
-    gArgs.ClearArgs();
+    m_args.ClearArgs();
     for (const auto& arg : args) {
-        gArgs.AddArg(arg.first, "", arg.second, OptionsCategory::OPTIONS);
+        m_args.AddArg(arg.first, "", arg.second, OptionsCategory::OPTIONS);
     }
 }
 
@@ -55,52 +55,52 @@ BOOST_AUTO_TEST_CASE(boolarg)
     const auto foo = std::make_pair("-foo", ArgsManager::ALLOW_ANY);
     SetupArgs({foo});
     ResetArgs("-foo");
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
 
-    BOOST_CHECK(!gArgs.GetBoolArg("-fo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-fo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-fo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-fo", true));
 
-    BOOST_CHECK(!gArgs.GetBoolArg("-fooo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-fooo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-fooo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-fooo", true));
 
     ResetArgs("-foo=0");
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo=1");
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
 
     // New 0.6 feature: auto-map -nosomething to !-something:
     ResetArgs("-nofoo");
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
 
     ResetArgs("-nofoo=1");
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo -nofoo");  // -nofoo should win
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo=1 -nofoo=1");  // -nofoo should win
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
 
     ResetArgs("-foo=0 -nofoo=0");  // -nofoo=0 should win
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
 
     // New 0.6 feature: treat -- same as -:
     ResetArgs("--foo=1");
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
 
     ResetArgs("--nofoo=1");
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
 
 }
 
@@ -110,24 +110,24 @@ BOOST_AUTO_TEST_CASE(stringarg)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", "eleven"), "eleven");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "eleven");
 
     ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", "eleven"), "");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "");
 
     ResetArgs("-foo=");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", ""), "");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", "eleven"), "");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "");
 
     ResetArgs("-foo=11");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", ""), "11");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", "eleven"), "11");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "11");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "11");
 
     ResetArgs("-foo=eleven");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", ""), "eleven");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", "eleven"), "eleven");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "eleven");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", "eleven"), "eleven");
 
 }
 
@@ -137,20 +137,20 @@ BOOST_AUTO_TEST_CASE(intarg)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", 11), 11);
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", 0), 0);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 11), 11);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 0), 0);
 
     ResetArgs("-foo -bar");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", 11), 0);
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-bar", 11), 0);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 11), 0);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 11), 0);
 
     ResetArgs("-foo=11 -bar=12");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", 0), 11);
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-bar", 11), 12);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 0), 11);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 11), 12);
 
     ResetArgs("-foo=NaN -bar=NotANumber");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", 1), 0);
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-bar", 11), 0);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", 1), 0);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 11), 0);
 }
 
 BOOST_AUTO_TEST_CASE(doubledash)
@@ -159,11 +159,11 @@ BOOST_AUTO_TEST_CASE(doubledash)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("--foo");
-    BOOST_CHECK_EQUAL(gArgs.GetBoolArg("-foo", false), true);
+    BOOST_CHECK_EQUAL(m_args.GetBoolArg("-foo", false), true);
 
     ResetArgs("--foo=verbose --bar=1");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-foo", ""), "verbose");
-    BOOST_CHECK_EQUAL(gArgs.GetArg("-bar", 0), 1);
+    BOOST_CHECK_EQUAL(m_args.GetArg("-foo", ""), "verbose");
+    BOOST_CHECK_EQUAL(m_args.GetArg("-bar", 0), 1);
 }
 
 BOOST_AUTO_TEST_CASE(boolargno)
@@ -172,24 +172,24 @@ BOOST_AUTO_TEST_CASE(boolargno)
     const auto bar = std::make_pair("-bar", ArgsManager::ALLOW_ANY);
     SetupArgs({foo, bar});
     ResetArgs("-nofoo");
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo=1");
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo=0");
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
 
     ResetArgs("-foo --nofoo"); // --nofoo should win
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", true));
-    BOOST_CHECK(!gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(!m_args.GetBoolArg("-foo", false));
 
     ResetArgs("-nofoo -foo"); // foo always wins:
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", true));
-    BOOST_CHECK(gArgs.GetBoolArg("-foo", false));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", true));
+    BOOST_CHECK(m_args.GetBoolArg("-foo", false));
 }
 
 BOOST_AUTO_TEST_CASE(logargs)
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(logargs)
         });
 
     // Log the arguments
-    gArgs.LogArgs();
+    m_args.LogArgs();
 
     LogInstance().DeleteCallback(print_connection);
     // Check that what should appear does, and what shouldn't doesn't.

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -13,9 +13,18 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
+namespace getarg_tests{
+    class LocalTestingSetup : BasicTestingSetup {
+        protected:
+        void SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args);
+        void ResetArgs(const std::string& strArg);
+        ArgsManager m_args;
+    };
+}
 
-static void ResetArgs(const std::string& strArg)
+BOOST_FIXTURE_TEST_SUITE(getarg_tests, LocalTestingSetup)
+
+void LocalTestingSetup :: ResetArgs(const std::string& strArg)
 {
     std::vector<std::string> vecArg;
     if (strArg.size())
@@ -33,7 +42,7 @@ static void ResetArgs(const std::string& strArg)
     BOOST_CHECK(gArgs.ParseParameters(vecChar.size(), vecChar.data(), error));
 }
 
-static void SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args)
+void LocalTestingSetup :: SetupArgs(const std::vector<std::pair<std::string, unsigned int>>& args)
 {
     gArgs.ClearArgs();
     for (const auto& arg : args) {


### PR DESCRIPTION
Replaced the global argsManager gArgs with a locally defined one in getarg_tests. This is to avoid confusion in arg settings between the test's ArgsManager and the   #18804 