### PR TITLE
test: add more assert_* methods

### DIFF
--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -25,6 +25,11 @@ from test_framework.mininode import (
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
+    assert_not_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+    assert_less_than,
+    assert_less_than_or_equal,
     connect_nodes,
     wait_until,
 )
@@ -133,6 +138,30 @@ class ExampleTest(BitcoinTestFramework):
 
         self.log.info("Running custom_method")
 
+    def test_asserts(self):
+        """Test assert methods
+
+        This method should be used to try out various assert_* methods."""
+
+        besthash = self.nodes[0].getbestblockhash()
+        besthash_copy = besthash
+
+        assert_equal(besthash, besthash_copy)
+
+        block1 = self.nodes[0].getblock(self.nodes[0].getbestblockhash())
+        self.nodes[0].generate(nblocks=1)
+        block2 = self.nodes[0].getblock(self.nodes[0].getbestblockhash())
+
+        assert_not_equal(block1, block2)
+
+        height1 = block1['height']
+        height2 = block2['height']
+
+        assert_greater_than(height2, height1)
+        assert_greater_than_or_equal(height2, height1)
+        assert_less_than(height1, height2)
+        assert_less_than_or_equal(height1, height2)
+
     def run_test(self):
         """Main test logic"""
 
@@ -153,6 +182,9 @@ class ExampleTest(BitcoinTestFramework):
         # Logs are nice. Do plenty of them. They can be used in place of comments for
         # breaking the test into sub-sections.
         self.log.info("Starting test!")
+
+        self.log.info("Testing assert methods")
+        self.test_asserts()
 
         self.log.info("Calling a custom function")
         custom_function()

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -45,6 +45,10 @@ def assert_equal(thing1, thing2, *args):
     if thing1 != thing2 or any(thing1 != arg for arg in args):
         raise AssertionError("not(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
 
+def assert_not_equal(thing1, thing2, *args):
+   if thing1 == thing2 and all(thing1 == arg for arg in args):
+        raise AssertionError("(%s)" % " == ".join(str(arg) for arg in (thing1, thing2) + args))
+
 def assert_greater_than(thing1, thing2):
     if thing1 <= thing2:
         raise AssertionError("%s <= %s" % (str(thing1), str(thing2)))
@@ -52,6 +56,14 @@ def assert_greater_than(thing1, thing2):
 def assert_greater_than_or_equal(thing1, thing2):
     if thing1 < thing2:
         raise AssertionError("%s < %s" % (str(thing1), str(thing2)))
+
+def assert_less_than(thing1, thing2):
+    if thing1 >= thing2:
+        raise AssertionError("%s >= %s" % (str(thing1), str(thing2)))
+
+def assert_less_than_or_equal(thing1, thing2):
+    if thing1 > thing2:
+        raise AssertionError("%s > %s" % (str(thing1), str(thing2)))
 
 def assert_raises(exc, fun, *args, **kwds):
     assert_raises_message(exc, None, fun, *args, **kwds)


### PR DESCRIPTION
This PR adds new **assert_** methods to `functional/test_framework/util.py`:

* *assert_not_equal*
* *assert_less_than*
* *assert_less_than_or_equal*

Additionally, the `example_test.py` got a new method `test_asserts` to showcase them. I have searched for **test-the-test**-showcases but couldn't find any, hence the expansion of `example_test.py`

The motivation for this PR is based on my own experience with writing functional tests. From time to time I ran into situations where I wanted to test for something that **is not equal X** or **less than X**, but as only *assert_equal* respective *assert_greater_than* were available, I had to *negate expressions* first, before testing them with available asserts:

```python
assert_equal(negated_expression, False)
assert_equal(greater_than_expression, False)
```
