### PR TITLE
validation: Persist coins cache to disk and load on startup

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -318,6 +318,9 @@ public:
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
 
+    //! The in memory cache of the coins view
+    const CCoinsMap& GetCacheMap() const { return cacheCoins; };
+
 private:
     /**
      * @note this is marked const, but may actually append to `cacheCoins`, increasing

--- a/src/validation.h
+++ b/src/validation.h
@@ -75,6 +75,8 @@ static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
+/** Default for -persistcoinscache */
+static const bool DEFAULT_PERSIST_COINS_CACHE = true;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 /** Default for -stopatheight */
@@ -906,6 +908,12 @@ bool DumpMempool(const CTxMemPool& pool);
 
 /** Load the mempool from disk. */
 bool LoadMempool(CTxMemPool& pool);
+
+/** Dump the coins cache to disk. */
+bool DumpCoinsCache(const CCoinsViewCache& coinsCache);
+
+/** Load the coins cache from disk. */
+bool LoadCoinsCache(CCoinsViewCache& coinsCache);
 
 //! Check whether the block associated with this index entry is pruned or not.
 inline bool IsBlockPruned(const CBlockIndex* pblockindex)


### PR DESCRIPTION
This PR adds a way to persist the coins cache on shutdown to a file named `coinscache.dat`, similar to what is done for the mempool. On startup this file is used to warm the cache so it doesn't get cold between restarts.

This introduces a new config arg, `-persistcoinscache`, that is defaulted to true unless `-dbcache` is set to a higher value than default.

With a higher cache value the amount of disk space used for the file could be very large and the warm up could take an excessively long time, so it defaults to off to prevent any footguns. With a max dbcache after a reindex or IBD it will dump the entire utxo set and load it into memory on startup. Testing this today I had a file size of 2.4GB and it took ~22 minutes to warm the cache with an SSD.

After #17487 we can add a change to not wipe the cache on periodic flushes. We could then run the node continuously with the entire utxo set in memory. This could be useful for users who want to connect blocks quickly.

I'm not sure how I should write tests for this.