### PR TITLE
refactor: s/command/msg_type/ in CNetMsgMaker and CSerializedNetMsg

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -723,7 +723,7 @@ void V1TransportSerializer::prepareForTransport(CSerializedNetMsg& msg, std::vec
     uint256 hash = Hash(msg.data.begin(), msg.data.end());
 
     // create header
-    CMessageHeader hdr(Params().MessageStart(), msg.command.c_str(), msg.data.size());
+    CMessageHeader hdr(Params().MessageStart(), msg.m_type.c_str(), msg.data.size());
     memcpy(hdr.pchChecksum, hash.begin(), CMessageHeader::CHECKSUM_SIZE);
 
     // serialize header
@@ -2736,7 +2736,7 @@ bool CConnman::NodeFullyConnected(const CNode* pnode)
 void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
 {
     size_t nMessageSize = msg.data.size();
-    LogPrint(BCLog::NET, "sending %s (%d bytes) peer=%d\n",  SanitizeString(msg.command), nMessageSize, pnode->GetId());
+    LogPrint(BCLog::NET, "sending %s (%d bytes) peer=%d\n",  SanitizeString(msg.m_type), nMessageSize, pnode->GetId());
 
     // make sure we use the appropriate network transport format
     std::vector<unsigned char> serializedHeader;
@@ -2748,8 +2748,8 @@ void CConnman::PushMessage(CNode* pnode, CSerializedNetMsg&& msg)
         LOCK(pnode->cs_vSend);
         bool optimisticSend(pnode->vSendMsg.empty());
 
-        //log total amount of bytes per command
-        pnode->mapSendBytesPerMsgCmd[msg.command] += nTotalSize;
+        //log total amount of bytes per message type
+        pnode->mapSendBytesPerMsgCmd[msg.m_type] += nTotalSize;
         pnode->nSendSize += nTotalSize;
 
         if (pnode->nSendSize > nSendBufferMaxSize)

--- a/src/net.h
+++ b/src/net.h
@@ -108,7 +108,7 @@ struct CSerializedNetMsg
     CSerializedNetMsg& operator=(const CSerializedNetMsg&) = delete;
 
     std::vector<unsigned char> data;
-    std::string command;
+    std::string m_type;
 };
 
 

--- a/src/netmessagemaker.h
+++ b/src/netmessagemaker.h
@@ -15,18 +15,18 @@ public:
     explicit CNetMsgMaker(int nVersionIn) : nVersion(nVersionIn){}
 
     template <typename... Args>
-    CSerializedNetMsg Make(int nFlags, std::string sCommand, Args&&... args) const
+    CSerializedNetMsg Make(int nFlags, std::string msg_type, Args&&... args) const
     {
         CSerializedNetMsg msg;
-        msg.command = std::move(sCommand);
+        msg.m_type = std::move(msg_type);
         CVectorWriter{ SER_NETWORK, nFlags | nVersion, msg.data, 0, std::forward<Args>(args)... };
         return msg;
     }
 
     template <typename... Args>
-    CSerializedNetMsg Make(std::string sCommand, Args&&... args) const
+    CSerializedNetMsg Make(std::string msg_type, Args&&... args) const
     {
-        return Make(0, std::move(sCommand), std::forward<Args>(args)...);
+        return Make(0, std::move(msg_type), std::forward<Args>(args)...);
     }
 
 private:

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -62,7 +62,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         const std::string random_message_type{fuzzed_data_provider.ConsumeBytesAsString(CMessageHeader::COMMAND_SIZE).c_str()};
 
         CSerializedNetMsg net_msg;
-        net_msg.command = random_message_type;
+        net_msg.m_type = random_message_type;
         net_msg.data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
 
         CNode& random_node = *peers.at(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, peers.size() - 1));


### PR DESCRIPTION
Follow-up PR for #18533 -- another small step towards getting rid of the confusing "command" terminology. Also see PR #18610 which tackled the functional tests.