### PR TITLE
tests: Fill fuzzing coverage gaps for functions in consensus/validation.h, primitives/block.h and util/translation.h

### DIFF
--- a/src/test/fuzz/addrdb.cpp
+++ b/src/test/fuzz/addrdb.cpp
@@ -3,13 +3,13 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <addrdb.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -30,7 +30,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                                                                               })};
             break;
         case 2: {
-            const Optional<CBanEntry> ban_entry = ConsumeDeserializable<CBanEntry>(fuzzed_data_provider);
+            const std::optional<CBanEntry> ban_entry = ConsumeDeserializable<CBanEntry>(fuzzed_data_provider);
             if (ban_entry) {
                 return *ban_entry;
             }

--- a/src/test/fuzz/asmap.cpp
+++ b/src/test/fuzz/asmap.cpp
@@ -23,8 +23,8 @@ static const std::vector<bool> IPV4_PREFIX_ASMAP = {
     true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
     true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
     true, true, false, true, true, true, true, true, true, true, false, false, false, false, false, false, false, false, // Match 0x00
-    true, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, // Match 0xFF
-    true, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true // Match 0xFF
+    true, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true,         // Match 0xFF
+    true, true, false, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true          // Match 0xFF
 };
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/asmap_direct.cpp
+++ b/src/test/fuzz/asmap_direct.cpp
@@ -2,8 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <util/asmap.h>
 #include <test/fuzz/fuzz.h>
+#include <util/asmap.h>
 
 #include <cstdint>
 #include <optional>
@@ -34,7 +34,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     if (SanityCheckASMap(asmap, buffer.size() - 1 - sep_pos)) {
         // Verify that for valid asmaps, no prefix (except up to 7 zero padding bits) is valid.
         std::vector<bool> asmap_prefix = asmap;
-        while (!asmap_prefix.empty() && asmap_prefix.size() + 7 > asmap.size() && asmap_prefix.back() == false) asmap_prefix.pop_back();
+        while (!asmap_prefix.empty() && asmap_prefix.size() + 7 > asmap.size() && asmap_prefix.back() == false) {
+            asmap_prefix.pop_back();
+        }
         while (!asmap_prefix.empty()) {
             asmap_prefix.pop_back();
             assert(!SanityCheckASMap(asmap_prefix, buffer.size() - 1 - sep_pos));

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -38,12 +38,17 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const Consensus::Params& consensus_params = Params().GetConsensus();
     BlockValidationState validation_state_pow_and_merkle;
     const bool valid_incl_pow_and_merkle = CheckBlock(block, validation_state_pow_and_merkle, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ true);
+    assert(validation_state_pow_and_merkle.IsValid() || validation_state_pow_and_merkle.IsInvalid() || validation_state_pow_and_merkle.IsError());
+    (void)validation_state_pow_and_merkle.Error("");
     BlockValidationState validation_state_pow;
     const bool valid_incl_pow = CheckBlock(block, validation_state_pow, consensus_params, /* fCheckPOW= */ true, /* fCheckMerkleRoot= */ false);
+    assert(validation_state_pow.IsValid() || validation_state_pow.IsInvalid() || validation_state_pow.IsError());
     BlockValidationState validation_state_merkle;
     const bool valid_incl_merkle = CheckBlock(block, validation_state_merkle, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ true);
+    assert(validation_state_merkle.IsValid() || validation_state_merkle.IsInvalid() || validation_state_merkle.IsError());
     BlockValidationState validation_state_none;
     const bool valid_incl_none = CheckBlock(block, validation_state_none, consensus_params, /* fCheckPOW= */ false, /* fCheckMerkleRoot= */ false);
+    assert(validation_state_none.IsValid() || validation_state_none.IsInvalid() || validation_state_none.IsError());
     if (valid_incl_pow_and_merkle) {
         assert(valid_incl_pow && valid_incl_merkle && valid_incl_none);
     } else if (valid_incl_merkle || valid_incl_pow) {

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -38,4 +38,12 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         block.SetNull();
         assert(block.GetBlockHeader().GetHash() == mut_block_header.GetHash());
     }
+    {
+        std::optional<CBlockLocator> block_locator = ConsumeDeserializable<CBlockLocator>(fuzzed_data_provider);
+        if (block_locator) {
+            (void)block_locator->IsNull();
+            block_locator->SetNull();
+            assert(block_locator->IsNull());
+        }
+    }
 }

--- a/src/test/fuzz/block_header.cpp
+++ b/src/test/fuzz/block_header.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <optional.h>
 #include <primitives/block.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -11,13 +10,14 @@
 
 #include <cassert>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const Optional<CBlockHeader> block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
+    const std::optional<CBlockHeader> block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
     if (!block_header) {
         return;
     }

--- a/src/test/fuzz/blockfilter.cpp
+++ b/src/test/fuzz/blockfilter.cpp
@@ -3,19 +3,19 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <blockfilter.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const Optional<BlockFilter> block_filter = ConsumeDeserializable<BlockFilter>(fuzzed_data_provider);
+    const std::optional<BlockFilter> block_filter = ConsumeDeserializable<BlockFilter>(fuzzed_data_provider);
     if (!block_filter) {
         return;
     }

--- a/src/test/fuzz/bloom_filter.cpp
+++ b/src/test/fuzz/bloom_filter.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bloom.h>
-#include <optional.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
@@ -12,6 +11,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -35,7 +35,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 1: {
-            const Optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
+            const std::optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
             if (!out_point) {
                 break;
             }
@@ -46,7 +46,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 2: {
-            const Optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
+            const std::optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
             if (!u256) {
                 break;
             }
@@ -57,7 +57,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 3: {
-            const Optional<CMutableTransaction> mut_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+            const std::optional<CMutableTransaction> mut_tx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
             if (!mut_tx) {
                 break;
             }

--- a/src/test/fuzz/chain.cpp
+++ b/src/test/fuzz/chain.cpp
@@ -3,18 +3,18 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <chain.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    Optional<CDiskBlockIndex> disk_block_index = ConsumeDeserializable<CDiskBlockIndex>(fuzzed_data_provider);
+    std::optional<CDiskBlockIndex> disk_block_index = ConsumeDeserializable<CDiskBlockIndex>(fuzzed_data_provider);
     if (!disk_block_index) {
         return;
     }

--- a/src/test/fuzz/checkqueue.cpp
+++ b/src/test/fuzz/checkqueue.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <checkqueue.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/cuckoocache.cpp
+++ b/src/test/fuzz/cuckoocache.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <cuckoocache.h>
-#include <optional.h>
 #include <script/sigcache.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/fees.cpp
+++ b/src/test/fuzz/fees.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <amount.h>
-#include <optional.h>
 #include <policy/fees.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>

--- a/src/test/fuzz/flatfile.cpp
+++ b/src/test/fuzz/flatfile.cpp
@@ -3,24 +3,24 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <flatfile.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cassert>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    Optional<FlatFilePos> flat_file_pos = ConsumeDeserializable<FlatFilePos>(fuzzed_data_provider);
+    std::optional<FlatFilePos> flat_file_pos = ConsumeDeserializable<FlatFilePos>(fuzzed_data_provider);
     if (!flat_file_pos) {
         return;
     }
-    Optional<FlatFilePos> another_flat_file_pos = ConsumeDeserializable<FlatFilePos>(fuzzed_data_provider);
+    std::optional<FlatFilePos> another_flat_file_pos = ConsumeDeserializable<FlatFilePos>(fuzzed_data_provider);
     if (another_flat_file_pos) {
         assert((*flat_file_pos == *another_flat_file_pos) != (*flat_file_pos != *another_flat_file_pos));
     }

--- a/src/test/fuzz/golomb_rice.cpp
+++ b/src/test/fuzz/golomb_rice.cpp
@@ -5,8 +5,8 @@
 #include <blockfilter.h>
 #include <serialize.h>
 #include <streams.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <util/bytevectorhash.h>
 #include <util/golombrice.h>

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -16,7 +16,8 @@
 #include <string>
 #include <vector>
 
-void initialize() {
+void initialize()
+{
     static const ECCVerifyHandle verify_handle;
 }
 

--- a/src/test/fuzz/merkleblock.cpp
+++ b/src/test/fuzz/merkleblock.cpp
@@ -3,20 +3,20 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <merkleblock.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 #include <uint256.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    Optional<CPartialMerkleTree> partial_merkle_tree = ConsumeDeserializable<CPartialMerkleTree>(fuzzed_data_provider);
+    std::optional<CPartialMerkleTree> partial_merkle_tree = ConsumeDeserializable<CPartialMerkleTree>(fuzzed_data_provider);
     if (!partial_merkle_tree) {
         return;
     }

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -4,7 +4,6 @@
 
 #include <chainparams.h>
 #include <key_io.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/net_permissions.cpp
+++ b/src/test/fuzz/net_permissions.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <net_permissions.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <optional.h>
 #include <policy/fees.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -11,6 +10,7 @@
 #include <txmempool.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -21,7 +21,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     while (fuzzed_data_provider.ConsumeBool()) {
         switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 3)) {
         case 0: {
-            const Optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+            const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
             if (!mtx) {
                 break;
             }
@@ -35,7 +35,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         case 1: {
             std::vector<CTxMemPoolEntry> mempool_entries;
             while (fuzzed_data_provider.ConsumeBool()) {
-                const Optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+                const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
                 if (!mtx) {
                     break;
                 }

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -4,7 +4,6 @@
 
 #include <chain.h>
 #include <chainparams.h>
-#include <optional.h>
 #include <pow.h>
 #include <primitives/block.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -12,6 +11,7 @@
 #include <test/fuzz/util.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -28,7 +28,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const uint32_t fixed_time = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
     const uint32_t fixed_bits = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
     while (fuzzed_data_provider.remaining_bytes() > 0) {
-        const Optional<CBlockHeader> block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
+        const std::optional<CBlockHeader> block_header = ConsumeDeserializable<CBlockHeader>(fuzzed_data_provider);
         if (!block_header) {
             continue;
         }
@@ -72,7 +72,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             }
         }
         {
-            const Optional<uint256> hash = ConsumeDeserializable<uint256>(fuzzed_data_provider);
+            const std::optional<uint256> hash = ConsumeDeserializable<uint256>(fuzzed_data_provider);
             if (hash) {
                 (void)CheckProofOfWork(*hash, fuzzed_data_provider.ConsumeIntegral<unsigned int>(), consensus_params);
             }

--- a/src/test/fuzz/prevector.cpp
+++ b/src/test/fuzz/prevector.cpp
@@ -14,8 +14,9 @@
 
 namespace {
 
-template<unsigned int N, typename T>
-class prevector_tester {
+template <unsigned int N, typename T>
+class prevector_tester
+{
     typedef std::vector<T> realtype;
     realtype real_vector;
     realtype real_vector_alt;
@@ -27,35 +28,36 @@ class prevector_tester {
     typedef typename pretype::size_type Size;
 
 public:
-    void test() const {
+    void test() const
+    {
         const pretype& const_pre_vector = pre_vector;
         assert(real_vector.size() == pre_vector.size());
         assert(real_vector.empty() == pre_vector.empty());
         for (Size s = 0; s < real_vector.size(); s++) {
-             assert(real_vector[s] == pre_vector[s]);
-             assert(&(pre_vector[s]) == &(pre_vector.begin()[s]));
-             assert(&(pre_vector[s]) == &*(pre_vector.begin() + s));
-             assert(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
+            assert(real_vector[s] == pre_vector[s]);
+            assert(&(pre_vector[s]) == &(pre_vector.begin()[s]));
+            assert(&(pre_vector[s]) == &*(pre_vector.begin() + s));
+            assert(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
         }
         // assert(realtype(pre_vector) == real_vector);
         assert(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
         assert(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
         size_t pos = 0;
         for (const T& v : pre_vector) {
-             assert(v == real_vector[pos]);
-             ++pos;
+            assert(v == real_vector[pos]);
+            ++pos;
         }
         for (const T& v : reverse_iterate(pre_vector)) {
-             --pos;
-             assert(v == real_vector[pos]);
+            --pos;
+            assert(v == real_vector[pos]);
         }
         for (const T& v : const_pre_vector) {
-             assert(v == real_vector[pos]);
-             ++pos;
+            assert(v == real_vector[pos]);
+            ++pos;
         }
         for (const T& v : reverse_iterate(const_pre_vector)) {
-             --pos;
-             assert(v == real_vector[pos]);
+            --pos;
+            assert(v == real_vector[pos]);
         }
         CDataStream ss1(SER_DISK, 0);
         CDataStream ss2(SER_DISK, 0);
@@ -67,101 +69,120 @@ public:
         }
     }
 
-    void resize(Size s) {
+    void resize(Size s)
+    {
         real_vector.resize(s);
         assert(real_vector.size() == s);
         pre_vector.resize(s);
         assert(pre_vector.size() == s);
     }
 
-    void reserve(Size s) {
+    void reserve(Size s)
+    {
         real_vector.reserve(s);
         assert(real_vector.capacity() >= s);
         pre_vector.reserve(s);
         assert(pre_vector.capacity() >= s);
     }
 
-    void insert(Size position, const T& value) {
+    void insert(Size position, const T& value)
+    {
         real_vector.insert(real_vector.begin() + position, value);
         pre_vector.insert(pre_vector.begin() + position, value);
     }
 
-    void insert(Size position, Size count, const T& value) {
+    void insert(Size position, Size count, const T& value)
+    {
         real_vector.insert(real_vector.begin() + position, count, value);
         pre_vector.insert(pre_vector.begin() + position, count, value);
     }
 
-    template<typename I>
-    void insert_range(Size position, I first, I last) {
+    template <typename I>
+    void insert_range(Size position, I first, I last)
+    {
         real_vector.insert(real_vector.begin() + position, first, last);
         pre_vector.insert(pre_vector.begin() + position, first, last);
     }
 
-    void erase(Size position) {
+    void erase(Size position)
+    {
         real_vector.erase(real_vector.begin() + position);
         pre_vector.erase(pre_vector.begin() + position);
     }
 
-    void erase(Size first, Size last) {
+    void erase(Size first, Size last)
+    {
         real_vector.erase(real_vector.begin() + first, real_vector.begin() + last);
         pre_vector.erase(pre_vector.begin() + first, pre_vector.begin() + last);
     }
 
-    void update(Size pos, const T& value) {
+    void update(Size pos, const T& value)
+    {
         real_vector[pos] = value;
         pre_vector[pos] = value;
     }
 
-    void push_back(const T& value) {
+    void push_back(const T& value)
+    {
         real_vector.push_back(value);
         pre_vector.push_back(value);
     }
 
-    void pop_back() {
+    void pop_back()
+    {
         real_vector.pop_back();
         pre_vector.pop_back();
     }
 
-    void clear() {
+    void clear()
+    {
         real_vector.clear();
         pre_vector.clear();
     }
 
-    void assign(Size n, const T& value) {
+    void assign(Size n, const T& value)
+    {
         real_vector.assign(n, value);
         pre_vector.assign(n, value);
     }
 
-    Size size() const {
+    Size size() const
+    {
         return real_vector.size();
     }
 
-    Size capacity() const {
+    Size capacity() const
+    {
         return pre_vector.capacity();
     }
 
-    void shrink_to_fit() {
+    void shrink_to_fit()
+    {
         pre_vector.shrink_to_fit();
     }
 
-    void swap() {
+    void swap()
+    {
         real_vector.swap(real_vector_alt);
         pre_vector.swap(pre_vector_alt);
     }
 
-    void move() {
+    void move()
+    {
         real_vector = std::move(real_vector_alt);
         real_vector_alt.clear();
         pre_vector = std::move(pre_vector_alt);
         pre_vector_alt.clear();
     }
 
-    void copy() {
+    void copy()
+    {
         real_vector = real_vector_alt;
         pre_vector = pre_vector_alt;
     }
 
-    void resize_uninitialized(realtype values) {
+    void resize_uninitialized(realtype values)
+    {
         size_t r = values.size();
         size_t s = real_vector.size() / 2;
         if (real_vector.capacity() < s + r) {
@@ -181,7 +202,7 @@ public:
     }
 };
 
-}
+} // namespace
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {

--- a/src/test/fuzz/primitives_transaction.cpp
+++ b/src/test/fuzz/primitives_transaction.cpp
@@ -2,13 +2,13 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <optional.h>
 #include <primitives/transaction.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -16,7 +16,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const CScript script = ConsumeScript(fuzzed_data_provider);
-    const Optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
+    const std::optional<COutPoint> out_point = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
     if (out_point) {
         const CTxIn tx_in{*out_point, script, fuzzed_data_provider.ConsumeIntegral<uint32_t>()};
         (void)tx_in;
@@ -24,8 +24,8 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     const CTxOut tx_out_1{ConsumeMoney(fuzzed_data_provider), script};
     const CTxOut tx_out_2{ConsumeMoney(fuzzed_data_provider), ConsumeScript(fuzzed_data_provider)};
     assert((tx_out_1 == tx_out_2) != (tx_out_1 != tx_out_2));
-    const Optional<CMutableTransaction> mutable_tx_1 = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
-    const Optional<CMutableTransaction> mutable_tx_2 = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    const std::optional<CMutableTransaction> mutable_tx_1 = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    const std::optional<CMutableTransaction> mutable_tx_2 = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
     if (mutable_tx_1 && mutable_tx_2) {
         const CTransaction tx_1{*mutable_tx_1};
         const CTransaction tx_2{*mutable_tx_2};

--- a/src/test/fuzz/protocol.cpp
+++ b/src/test/fuzz/protocol.cpp
@@ -2,20 +2,20 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <optional.h>
 #include <protocol.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
 
 #include <cstdint>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const Optional<CInv> inv = ConsumeDeserializable<CInv>(fuzzed_data_provider);
+    const std::optional<CInv> inv = ConsumeDeserializable<CInv>(fuzzed_data_provider);
     if (!inv) {
         return;
     }
@@ -24,7 +24,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     } catch (const std::out_of_range&) {
     }
     (void)inv->ToString();
-    const Optional<CInv> another_inv = ConsumeDeserializable<CInv>(fuzzed_data_provider);
+    const std::optional<CInv> another_inv = ConsumeDeserializable<CInv>(fuzzed_data_provider);
     if (!another_inv) {
         return;
     }

--- a/src/test/fuzz/rbf.cpp
+++ b/src/test/fuzz/rbf.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <optional.h>
 #include <policy/rbf.h>
 #include <primitives/transaction.h>
 #include <sync.h>
@@ -12,19 +11,20 @@
 #include <txmempool.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    Optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
     if (!mtx) {
         return;
     }
     CTxMemPool pool;
     while (fuzzed_data_provider.ConsumeBool()) {
-        const Optional<CMutableTransaction> another_mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+        const std::optional<CMutableTransaction> another_mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
         if (!another_mtx) {
             break;
         }

--- a/src/test/fuzz/rolling_bloom_filter.cpp
+++ b/src/test/fuzz/rolling_bloom_filter.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <bloom.h>
-#include <optional.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
@@ -11,6 +10,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -32,7 +32,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             break;
         }
         case 1: {
-            const Optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
+            const std::optional<uint256> u256 = ConsumeDeserializable<uint256>(fuzzed_data_provider);
             if (!u256) {
                 break;
             }

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -21,6 +21,11 @@
 #include <univalue.h>
 #include <util/memory.h>
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
 void initialize()
 {
     // Fuzzers using pubkey must hold an ECCVerifyHandle.
@@ -32,7 +37,7 @@ void initialize()
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
-    const Optional<CScript> script_opt = ConsumeDeserializable<CScript>(fuzzed_data_provider);
+    const std::optional<CScript> script_opt = ConsumeDeserializable<CScript>(fuzzed_data_provider);
     if (!script_opt) return;
     const CScript script{*script_opt};
 
@@ -101,7 +106,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         }
     }
 
-    const Optional<CScript> other_script = ConsumeDeserializable<CScript>(fuzzed_data_provider);
+    const std::optional<CScript> other_script = ConsumeDeserializable<CScript>(fuzzed_data_provider);
     if (other_script) {
         {
             CScript script_mut{script};

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -119,4 +119,10 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         int64_t amount_out;
         (void)ParseFixedPoint(random_string_1, fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 1024), &amount_out);
     }
+    {
+        (void)Untranslated(random_string_1);
+        const bilingual_str bs1{random_string_1, random_string_2};
+        const bilingual_str bs2{random_string_2, random_string_1};
+        (void)(bs1 + bs2);
+    }
 }

--- a/src/test/fuzz/strprintf.cpp
+++ b/src/test/fuzz/strprintf.cpp
@@ -6,6 +6,7 @@
 #include <test/fuzz/fuzz.h>
 #include <tinyformat.h>
 #include <util/strencodings.h>
+#include <util/translation.h>
 
 #include <algorithm>
 #include <cstdint>
@@ -16,6 +17,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
     const std::string format_string = fuzzed_data_provider.ConsumeRandomLengthString(64);
+    const bilingual_str bilingual_string{format_string, format_string};
 
     const int digits_in_format_specifier = std::count_if(format_string.begin(), format_string.end(), IsDigit);
 
@@ -47,50 +49,62 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
     try {
         (void)strprintf(format_string, (signed char*)nullptr);
+        (void)tinyformat::format(bilingual_string, (signed char*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (unsigned char*)nullptr);
+        (void)tinyformat::format(bilingual_string, (unsigned char*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (void*)nullptr);
+        (void)tinyformat::format(bilingual_string, (void*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (bool*)nullptr);
+        (void)tinyformat::format(bilingual_string, (bool*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (float*)nullptr);
+        (void)tinyformat::format(bilingual_string, (float*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (double*)nullptr);
+        (void)tinyformat::format(bilingual_string, (double*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (int16_t*)nullptr);
+        (void)tinyformat::format(bilingual_string, (int16_t*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (uint16_t*)nullptr);
+        (void)tinyformat::format(bilingual_string, (uint16_t*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (int32_t*)nullptr);
+        (void)tinyformat::format(bilingual_string, (int32_t*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (uint32_t*)nullptr);
+        (void)tinyformat::format(bilingual_string, (uint32_t*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (int64_t*)nullptr);
+        (void)tinyformat::format(bilingual_string, (int64_t*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
     try {
         (void)strprintf(format_string, (uint64_t*)nullptr);
+        (void)tinyformat::format(bilingual_string, (uint64_t*)nullptr);
     } catch (const tinyformat::format_error&) {
     }
 
@@ -98,21 +112,27 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 5)) {
         case 0:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32));
             break;
         case 1:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeRandomLengthString(32).c_str());
             break;
         case 2:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<signed char>());
             break;
         case 3:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<unsigned char>());
             break;
         case 4:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<char>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<char>());
             break;
         case 5:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeBool());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeBool());
             break;
         }
     } catch (const tinyformat::format_error&) {
@@ -138,27 +158,35 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         switch (fuzzed_data_provider.ConsumeIntegralInRange(0, 7)) {
         case 0:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<float>());
             break;
         case 1:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeFloatingPoint<double>());
             break;
         case 2:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int16_t>());
             break;
         case 3:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint16_t>());
             break;
         case 4:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int32_t>());
             break;
         case 5:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint32_t>());
             break;
         case 6:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<int64_t>());
             break;
         case 7:
             (void)strprintf(format_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
+            (void)tinyformat::format(bilingual_string, fuzzed_data_provider.ConsumeIntegral<uint64_t>());
             break;
         }
     } catch (const tinyformat::format_error&) {

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -9,7 +9,6 @@
 #include <arith_uint256.h>
 #include <attributes.h>
 #include <consensus/consensus.h>
-#include <optional.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <serialize.h>
@@ -21,6 +20,7 @@
 #include <version.h>
 
 #include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -52,7 +52,7 @@ NODISCARD inline std::vector<T> ConsumeRandomLengthIntegralVector(FuzzedDataProv
 }
 
 template <typename T>
-NODISCARD inline Optional<T> ConsumeDeserializable(FuzzedDataProvider& fuzzed_data_provider, const size_t max_length = 4096) noexcept
+NODISCARD inline std::optional<T> ConsumeDeserializable(FuzzedDataProvider& fuzzed_data_provider, const size_t max_length = 4096) noexcept
 {
     const std::vector<uint8_t> buffer = ConsumeRandomLengthByteVector(fuzzed_data_provider, max_length);
     CDataStream ds{buffer, SER_NETWORK, INIT_PROTO_VERSION};
@@ -60,7 +60,7 @@ NODISCARD inline Optional<T> ConsumeDeserializable(FuzzedDataProvider& fuzzed_da
     try {
         ds >> obj;
     } catch (const std::ios_base::failure&) {
-        return nullopt;
+        return std::nullopt;
     }
     return obj;
 }


### PR DESCRIPTION
* Fill fuzzing coverage gaps for functions in `consensus/validation.h`
* Fill fuzzing coverage gaps for functions in `primitives/block.h`
* Fill fuzzing coverage gaps for functions in `util/translation.h`
* Switch from `Optional<T>` to `std::optional<T>` (C++17). Run `clang-format`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)