### PR TITLE
miner: fix off-by-ones in BlockAssembler::TestPackage

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -202,9 +202,9 @@ void BlockAssembler::onlyUnconfirmed(CTxMemPool::setEntries& testSet)
 bool BlockAssembler::TestPackage(uint64_t packageSize, int64_t packageSigOpsCost) const
 {
     // TODO: switch to weight-based accounting for packages instead of vsize-based accounting.
-    if (nBlockWeight + WITNESS_SCALE_FACTOR * packageSize >= nBlockMaxWeight)
+    if (nBlockWeight + WITNESS_SCALE_FACTOR * packageSize > nBlockMaxWeight)
         return false;
-    if (nBlockSigOpsCost + packageSigOpsCost >= MAX_BLOCK_SIGOPS_COST)
+    if (nBlockSigOpsCost + packageSigOpsCost > MAX_BLOCK_SIGOPS_COST)
         return false;
     return true;
 }


### PR DESCRIPTION
For both the block weight and the block sigops the test function considered
reaching the exact maximum values already to be too high, i.e. the test was too
conservative by one unit each.

