### PR TITLE
validation: Persist coins cache to disk and load on startup

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -318,6 +318,9 @@ public:
     //! Check whether all prevouts of the transaction are present in the UTXO set represented by this view
     bool HaveInputs(const CTransaction& tx) const;
 
+    //! The in memory cache of the coins view
+    const CCoinsMap& GetCacheMap() const { return cacheCoins; };
+
 private:
     /**
      * @note this is marked const, but may actually append to `cacheCoins`, increasing

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -242,6 +242,10 @@ void Shutdown(NodeContext& node)
         fFeeEstimatesInitialized = false;
     }
 
+    if (gArgs.GetArg("-persistcoinscache", DEFAULT_PERSIST_COINS_CACHE)) {
+        DumpCoinsCache();
+    }
+
     // FlushStateToDisk generates a ChainStateFlushed callback, which we should avoid missing
     {
         LOCK(cs_main);
@@ -397,6 +401,7 @@ void SetupServerArgs(NodeContext& node)
     gArgs.AddArg("-datadir=<dir>", "Specify data directory", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-dbbatchsize", strprintf("Maximum database write batch size in bytes (default: %u)", nDefaultDbBatchSize), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-dbcache=<n>", strprintf("Maximum database cache size <n> MiB (%d to %d, default: %d). In addition, unused mempool memory is shared for this cache (see -maxmempool).", nMinDbCache, nMaxDbCache, nDefaultDbCache), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
+    gArgs.AddArg("-persistcoinscache", strprintf("Whether to save the coins cache on shutdown and load on restart (default: %u)", DEFAULT_PERSIST_COINS_CACHE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-debuglogfile=<file>", strprintf("Specify location of debug log file. Relative paths will be prefixed by a net-specific datadir location. (-nodebuglogfile to disable; default: %s)", DEFAULT_DEBUGLOGFILE), ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-feefilter", strprintf("Tell other nodes to filter invs to us by our mempool min fee (default: %u)", DEFAULT_FEEFILTER), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::OPTIONS);
     gArgs.AddArg("-includeconf=<file>", "Specify additional configuration file, relative to the -datadir path (only useable from configuration file, not command line)", ArgsManager::ALLOW_ANY, OptionsCategory::OPTIONS);
@@ -755,6 +760,13 @@ static void ThreadImport(std::vector<fs::path> vImportFiles)
         StartShutdown();
         return;
     }
+
+    // -persistcoinscache
+    // Start a thread to warm the coins cache if we're not reindexing
+    if (!fReindex && gArgs.GetArg("-persistcoinscache", DEFAULT_PERSIST_COINS_CACHE)) {
+        threadGroup.create_thread(std::bind(&ThreadWarmCoinsCache));
+    }
+
     } // End scope of CImportingNow
     if (gArgs.GetArg("-persistmempool", DEFAULT_PERSIST_MEMPOOL)) {
         LoadMempool(::mempool);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -5135,6 +5135,112 @@ bool DumpMempool(const CTxMemPool& pool)
     return true;
 }
 
+static const uint64_t COINSCACHE_DUMP_VERSION = 1;
+
+void ThreadWarmCoinsCache()
+{
+    util::ThreadRename("warmcoinscache");
+    ScheduleBatchPriority();
+
+    int64_t start = GetTimeMicros();
+
+    FILE* filestr = fsbridge::fopen(GetDataDir() / "coinscache.dat", "rb");
+    CAutoFile file(filestr, SER_DISK, CLIENT_VERSION);
+    if (file.IsNull()) {
+        LogPrintf("Failed to open coins cache file from disk. Continuing anyway.\n");
+        return;
+    }
+
+    try {
+        uint64_t version;
+        file >> version;
+        if (version != COINSCACHE_DUMP_VERSION) {
+            return;
+        }
+
+        uint64_t persisted_size;
+        file >> persisted_size;
+        uint64_t dbcache = gArgs.GetArg("-dbcache", nDefaultDbCache);
+        // If cache was persisted with larger dbcache don't use it
+        if (persisted_size > dbcache) {
+            return;
+        }
+
+        uint64_t num;
+        file >> num;
+        uint64_t total = num;
+        int64_t last = GetTimeMillis();
+        while (num--) {
+            if (ShutdownRequested()) return;
+            COutPoint outpoint;
+            file >> outpoint;
+            {
+                LOCK(::cs_main);
+                CoinsCacheSizeState cache_state = ::ChainstateActive().GetCoinsCacheSizeState(::mempool);
+                if (cache_state >= CoinsCacheSizeState::LARGE) return;
+                ::ChainstateActive().CoinsTip().AccessCoin(outpoint);
+            }
+            int64_t now = GetTimeMillis();
+            if ((now-last)*MILLI > 5) {
+                LogPrintf("Warming coins cache: %i%% complete. Run with -persistcoinscache=0 to disable.\n", (int)((total-num)/(double)total * 100));
+                last = now;
+            }
+        }
+        int64_t end = GetTimeMicros();
+        LogPrintf("Imported coins cache from disk: %i utxos added to in-memory cache in %gs\n", total, (end-start)*MICRO);
+    } catch (const std::exception& e) {
+        LogPrintf("Failed to deserialize coins cache data on disk: %s. Continuing anyway.\n", e.what());
+    }
+}
+
+bool DumpCoinsCache()
+{
+    int64_t start = GetTimeMicros();
+
+    static Mutex dump_mutex;
+    LOCK(dump_mutex);
+
+    try {
+        FILE* filestr = fsbridge::fopen(GetDataDir() / "coinscache.dat.new", "wb");
+        if (!filestr) {
+            return false;
+        }
+
+        CAutoFile file(filestr, SER_DISK, CLIENT_VERSION);
+
+        uint64_t version = COINSCACHE_DUMP_VERSION;
+        file << version;
+
+        uint64_t dbcache = gArgs.GetArg("-dbcache", nDefaultDbCache);
+        file << dbcache;
+
+        uint64_t count = 0;
+        {
+            LOCK(cs_main);
+            if (!g_chainman.HasValidatedChainstate()) return false;
+            const auto& cacheMap = g_chainman.ValidatedChainstate().CoinsTip().GetCacheMap();
+            for(const auto& imap: cacheMap)
+                if (!imap.second.coin.IsSpent())
+                    count++;
+            file << (uint64_t)count;
+
+            for (const auto& imap : cacheMap)
+                if (!imap.second.coin.IsSpent())
+                    file << imap.first;
+        }
+        if (!FileCommit(file.Get()))
+            throw std::runtime_error("FileCommit failed");
+        file.fclose();
+        RenameOver(GetDataDir() / "coinscache.dat.new", GetDataDir() / "coinscache.dat");
+        int64_t end = GetTimeMicros();
+        LogPrintf("Dumped coins cache in %gs\n", (end-start)*MICRO);
+    } catch (const std::exception& e) {
+        LogPrintf("Failed to dump coins cache: %s. Continuing anyway.\n", e.what());
+        return false;
+    }
+    return true;
+}
+
 //! Guess how far we are in the verification process at the given block index
 //! require cs_main if pindex has not been validated yet (because nChainTx might be unset)
 double GuessVerificationProgress(const ChainTxData& data, const CBlockIndex *pindex) {
@@ -5232,6 +5338,11 @@ CChainState& ChainstateManager::ValidatedChainstate() const
     }
     assert(m_ibd_chainstate);
     return *m_ibd_chainstate.get();
+}
+
+bool ChainstateManager::HasValidatedChainstate() const
+{
+    return (m_snapshot_chainstate && IsSnapshotValidated()) || m_ibd_chainstate;
 }
 
 bool ChainstateManager::IsBackgroundIBD(CChainState* chainstate) const

--- a/src/validation.h
+++ b/src/validation.h
@@ -75,6 +75,8 @@ static const char* const DEFAULT_BLOCKFILTERINDEX = "0";
 static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 /** Default for -persistmempool */
 static const bool DEFAULT_PERSIST_MEMPOOL = true;
+/** Default for -persistcoinscache */
+static const bool DEFAULT_PERSIST_COINS_CACHE = true;
 /** Default for using fee filter */
 static const bool DEFAULT_FEEFILTER = true;
 /** Default for -stopatheight */
@@ -860,6 +862,8 @@ public:
     //! background validation has completed, this is the snapshot chain.
     CChainState& ValidatedChainstate() const;
 
+    bool HasValidatedChainstate() const;
+
     CChain& ValidatedChain() const { return ValidatedChainstate().m_chain; }
     CBlockIndex* ValidatedTip() const { return ValidatedChain().Tip(); }
 
@@ -906,6 +910,12 @@ bool DumpMempool(const CTxMemPool& pool);
 
 /** Load the mempool from disk. */
 bool LoadMempool(CTxMemPool& pool);
+
+/** Dump the coins cache to disk. */
+bool DumpCoinsCache();
+
+/** Thread to warm the coins cache from disk. */
+void ThreadWarmCoinsCache();
 
 //! Check whether the block associated with this index entry is pruned or not.
 inline bool IsBlockPruned(const CBlockIndex* pblockindex)


### PR DESCRIPTION
This PR adds a way to persist the coins cache on shutdown to a file named `coinscache.dat`, similar to what is done for the mempool. On startup this file is used to warm the cache so it doesn't get cold between restarts. This can be useful for users who want to connect blocks quickly with a high `-dbcache` value.

This introduces a new config arg, `-persistcoinscache`, that is defaulted to false. With a higher cache value the amount of disk space used for the file could be very large, so it defaults to off to prevent any footguns. With lower cache values this configuration could cause the cache to flush sooner than necessary and would probably not provide any benefit.

With a max dbcache after a reindex or IBD it will dump the entire utxo set and load it into memory on startup. Testing this today I had a file size of 2.4GB and it took ~22 minutes to fully reinsert the utxo set into the cache with an SSD.

After #17487 we can [add a change to not wipe the cache on periodic flushes](https://github.com/bitcoin/bitcoin/pull/17487#issuecomment-629929852). Users could then run the node continuously with the entire utxo set in memory. [Benchmarking](https://github.com/bitcoin/bitcoin/pull/18941#issuecomment-633684774) shows running in this configuration could save several hundred milliseconds when connecting blocks, vs an empty cache that is cleared periodically or during restarts.