### PR TITLE
doc: Increase minimum required GCC to 5.1

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -11,7 +11,7 @@ These are the dependencies currently used by Bitcoin Core. You can find instruct
 | Expat | [2.2.7](https://libexpat.github.io/) |  | No | Yes |  |
 | fontconfig | [2.12.1](https://www.freedesktop.org/software/fontconfig/release/) |  | No | Yes |  |
 | FreeType | [2.7.1](https://download.savannah.gnu.org/releases/freetype) |  | No |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) (Android only) |
-| GCC |  | [4.8+](https://gcc.gnu.org/) (C++11 support) |  |  |  |
+| GCC |  | [5.1+](https://gcc.gnu.org/) (C++11 support) |  |  |  |
 | HarfBuzz-NG |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) |
 | libevent | [2.1.11-stable](https://github.com/libevent/libevent/releases) | [2.0.21](https://github.com/bitcoin/bitcoin/pull/18676) | No |  |  |
 | libpng |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk) |


### PR DESCRIPTION
Since the merge of #13862, and the inclusion of the `<codecvt>` header,
it hasn't been possible to compile bitcoind targeting Windows (as that is 
the only platform on which we use `<codecvt>`) using GCC 4.8.x.

The libstdc++ packaged with GCC didn't include the <codecvt> header until 
GCC 5.1. See the GCC 5 [release notes](https://gcc.gnu.org/gcc-5/changes.html):

> Runtime Library (libstdc++)
> Full support for C++11, including the following new features: 
>	locale facets for Unicode conversion;

Given that we'll be requiring a c++17 capable compiler at some point in
the near future, and, assuming no-one else has noticed this, I think we
can just adjust the docs to indicate that it's actually GCC 5.1+ that is
required (I don't think we need to break it down per target).

```bash
# gcc --version
gcc (Ubuntu 4.8.4-2ubuntu1~14.04.4) 4.8.4

# make V=1
x86_64-w64-mingw32-g++ -std=c++11 -DHAVE_CONFIG_H -I. -I../src/config   -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -I.  -DBOOST_SP_USE_STD_ATOMIC -DBOOST_AC_USE_STD_ATOMIC -mthreads -I/bitcoin/depends/x86_64-w64-mingw32/share/../include -I./leveldb/include -I./leveldb/helpers/memenv -I./secp256k1/include -I./univalue/include -I/bitcoin/depends/x86_64-w64-mingw32/share/../include/  -DHAVE_BUILD_INFO -D__STDC_FORMAT_MACROS -D_MT -DWIN32 -D_WINDOWS -DBOOST_THREAD_USE_LIB -D_WIN32_WINNT=0x0601 -D_FILE_OFFSET_BITS=64  -fstack-reuse=none -Wstack-protector -fstack-protector-all       -pipe -O2  -MT libbitcoin_common_a-netbase.o -MD -MP -MF .deps/libbitcoin_common_a-netbase.Tpo -c -o libbitcoin_common_a-netbase.o `test -f 'netbase.cpp' || echo './'`netbase.cpp
netbase.cpp:19:19: fatal error: codecvt: No such file or directory
 #include <codecvt>
                   ^
compilation terminated.
make[2]: *** [libbitcoin_common_a-netbase.o] Error 1
```