### PR TITLE
net processing: requeue transaction GETDATA requests more frequently

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1741,7 +1741,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
     int64_t nStart = GetTime();
 
     // Minimum time before next feeler connection (in microseconds).
-    int64_t nNextFeeler = PoissonNextSend(nStart*1000*1000, FEELER_INTERVAL);
+    int64_t nNextFeeler = GetPoissonRand(nStart*1000*1000, FEELER_INTERVAL);
     while (!interruptNet)
     {
         ProcessOneShot();
@@ -1810,7 +1810,7 @@ void CConnman::ThreadOpenConnections(const std::vector<std::string> connect)
         if (nOutboundFullRelay >= m_max_outbound_full_relay && nOutboundBlockRelay >= m_max_outbound_block_relay && !GetTryNewOutboundPeer()) {
             int64_t nTime = GetTimeMicros(); // The current time right now (in microseconds).
             if (nTime > nNextFeeler) {
-                nNextFeeler = PoissonNextSend(nTime, FEELER_INTERVAL);
+                nNextFeeler = GetPoissonRand(nTime, FEELER_INTERVAL);
                 fFeeler = true;
             } else {
                 continue;
@@ -2786,7 +2786,7 @@ int64_t CConnman::PoissonNextSendInbound(int64_t now, int average_interval_secon
         // If this function were called from multiple threads simultaneously
         // it would possible that both update the next send variable, and return a different result to their caller.
         // This is not possible in practice as only the net processing thread invokes this function.
-        m_next_send_inv_to_incoming = PoissonNextSend(now, average_interval_seconds);
+        m_next_send_inv_to_incoming = GetPoissonRand(now, average_interval_seconds);
     }
     return m_next_send_inv_to_incoming;
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2791,11 +2791,6 @@ int64_t CConnman::PoissonNextSendInbound(int64_t now, int average_interval_secon
     return m_next_send_inv_to_incoming;
 }
 
-int64_t PoissonNextSend(int64_t now, int average_interval_seconds)
-{
-    return now + (int64_t)(log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
-}
-
 CSipHasher CConnman::GetDeterministicRandomizer(uint64_t id) const
 {
     return CSipHasher(nSeed0, nSeed1).Write(id);

--- a/src/net.h
+++ b/src/net.h
@@ -1003,13 +1003,4 @@ public:
     void MaybeSetAddrName(const std::string& addrNameIn);
 };
 
-/** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
-int64_t PoissonNextSend(int64_t now, int average_interval_seconds);
-
-/** Wrapper to return mockable type */
-inline std::chrono::microseconds PoissonNextSend(std::chrono::microseconds now, std::chrono::seconds average_interval)
-{
-    return std::chrono::microseconds{PoissonNextSend(now.count(), average_interval.count())};
-}
-
 #endif // BITCOIN_NET_H

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3638,14 +3638,14 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
         if (pto->IsAddrRelayPeer() && !::ChainstateActive().IsInitialBlockDownload() && pto->m_next_local_addr_send < current_time) {
             AdvertiseLocal(pto);
-            pto->m_next_local_addr_send = PoissonNextSend(current_time, AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL);
+            pto->m_next_local_addr_send = GetPoissonRand(current_time, AVG_LOCAL_ADDRESS_BROADCAST_INTERVAL);
         }
 
         //
         // Message: addr
         //
         if (pto->IsAddrRelayPeer() && pto->m_next_addr_send < current_time) {
-            pto->m_next_addr_send = PoissonNextSend(current_time, AVG_ADDRESS_BROADCAST_INTERVAL);
+            pto->m_next_addr_send = GetPoissonRand(current_time, AVG_ADDRESS_BROADCAST_INTERVAL);
             std::vector<CAddress> vAddr;
             vAddr.reserve(pto->vAddrToSend.size());
             assert(pto->m_addr_known);
@@ -3863,7 +3863,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                         pto->m_tx_relay->nNextInvSend = std::chrono::microseconds{connman->PoissonNextSendInbound(nNow, INVENTORY_BROADCAST_INTERVAL)};
                     } else {
                         // Use half the delay for outbound peers, as there is less privacy concern for them.
-                        pto->m_tx_relay->nNextInvSend = PoissonNextSend(current_time, std::chrono::seconds{INVENTORY_BROADCAST_INTERVAL >> 1});
+                        pto->m_tx_relay->nNextInvSend = GetPoissonRand(current_time, std::chrono::seconds{INVENTORY_BROADCAST_INTERVAL >> 1});
                     }
                 }
 
@@ -4145,7 +4145,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     connman->PushMessage(pto, msgMaker.Make(NetMsgType::FEEFILTER, filterToSend));
                     pto->m_tx_relay->lastSentFeeFilter = filterToSend;
                 }
-                pto->m_tx_relay->nextSendTimeFeeFilter = PoissonNextSend(timeNow, AVG_FEEFILTER_BROADCAST_INTERVAL);
+                pto->m_tx_relay->nextSendTimeFeeFilter = GetPoissonRand(timeNow, AVG_FEEFILTER_BROADCAST_INTERVAL);
             }
             // If the fee filter has changed substantially and it's still more than MAX_FEEFILTER_CHANGE_DELAY
             // until scheduled broadcast, then move the broadcast to within MAX_FEEFILTER_CHANGE_DELAY.

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -17,6 +17,7 @@
 #include <sync.h>     // for Mutex
 #include <util/time.h> // for GetTimeMicros()
 
+#include <cmath>
 #include <stdlib.h>
 #include <thread>
 
@@ -721,3 +722,9 @@ void RandomInit()
 
     ReportHardwareRand();
 }
+
+int64_t PoissonNextSend(int64_t now, int average_interval_seconds)
+{
+    return now + (int64_t)(log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
+}
+

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -723,7 +723,7 @@ void RandomInit()
     ReportHardwareRand();
 }
 
-int64_t PoissonNextSend(int64_t now, int average_interval_seconds)
+int64_t GetPoissonRand(int64_t now, int average_interval_seconds)
 {
     return now + (int64_t)(std::log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
 }

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -725,6 +725,6 @@ void RandomInit()
 
 int64_t PoissonNextSend(int64_t now, int average_interval_seconds)
 {
-    return now + (int64_t)(log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
+    return now + (int64_t)(std::log1p(GetRand(1ULL << 48) * -0.0000000000000035527136788 /* -1/2^48 */) * average_interval_seconds * -1000000.0 + 0.5);
 }
 

--- a/src/random.h
+++ b/src/random.h
@@ -253,4 +253,13 @@ bool Random_SanityCheck();
  */
 void RandomInit();
 
+/** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
+int64_t PoissonNextSend(int64_t now, int average_interval_seconds);
+
+/** Wrapper to return mockable type */
+inline std::chrono::microseconds PoissonNextSend(std::chrono::microseconds now, std::chrono::seconds average_interval)
+{
+    return std::chrono::microseconds{PoissonNextSend(now.count(), average_interval.count())};
+}
+
 #endif // BITCOIN_RANDOM_H

--- a/src/random.h
+++ b/src/random.h
@@ -254,12 +254,12 @@ bool Random_SanityCheck();
 void RandomInit();
 
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
-int64_t PoissonNextSend(int64_t now, int average_interval_seconds);
+int64_t GetPoissonRand(int64_t now, int average_interval_seconds);
 
 /** Wrapper to return mockable type */
-inline std::chrono::microseconds PoissonNextSend(std::chrono::microseconds now, std::chrono::seconds average_interval)
+inline std::chrono::microseconds GetPoissonRand(std::chrono::microseconds now, std::chrono::seconds average_interval)
 {
-    return std::chrono::microseconds{PoissonNextSend(now.count(), average_interval.count())};
+    return std::chrono::microseconds{GetPoissonRand(now.count(), average_interval.count())};
 }
 
 #endif // BITCOIN_RANDOM_H

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -8,6 +8,7 @@
 #include <clientversion.h>
 #include <net.h>
 #include <netbase.h>
+#include <random.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/util/setup_common.h>
@@ -303,21 +304,6 @@ BOOST_AUTO_TEST_CASE(LocalAddress_BasicLifecycle)
 
     RemoveLocal(addr);
     BOOST_CHECK_EQUAL(IsLocal(addr), false);
-}
-
-BOOST_AUTO_TEST_CASE(PoissonNextSend)
-{
-    g_mock_deterministic_tests = true;
-
-    int64_t now = 5000;
-    int average_interval_seconds = 600;
-
-    auto poisson = ::PoissonNextSend(now, average_interval_seconds);
-    std::chrono::microseconds poisson_chrono = ::PoissonNextSend(std::chrono::microseconds{now}, std::chrono::seconds{average_interval_seconds});
-
-    BOOST_CHECK_EQUAL(poisson, poisson_chrono.count());
-
-    g_mock_deterministic_tests = false;
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -130,15 +130,15 @@ BOOST_AUTO_TEST_CASE(shuffle_stat_test)
     BOOST_CHECK_EQUAL(sum, 12000);
 }
 
-BOOST_AUTO_TEST_CASE(PoissonNextSend)
+BOOST_AUTO_TEST_CASE(GetPoissonRand)
 {
     g_mock_deterministic_tests = true;
 
     int64_t now = 5000;
     int average_interval_seconds = 600;
 
-    auto poisson = ::PoissonNextSend(now, average_interval_seconds);
-    std::chrono::microseconds poisson_chrono = ::PoissonNextSend(std::chrono::microseconds{now}, std::chrono::seconds{average_interval_seconds});
+    auto poisson = ::GetPoissonRand(now, average_interval_seconds);
+    std::chrono::microseconds poisson_chrono = ::GetPoissonRand(std::chrono::microseconds{now}, std::chrono::seconds{average_interval_seconds});
 
     BOOST_CHECK_EQUAL(poisson, poisson_chrono.count());
 

--- a/src/test/random_tests.cpp
+++ b/src/test/random_tests.cpp
@@ -130,4 +130,19 @@ BOOST_AUTO_TEST_CASE(shuffle_stat_test)
     BOOST_CHECK_EQUAL(sum, 12000);
 }
 
+BOOST_AUTO_TEST_CASE(PoissonNextSend)
+{
+    g_mock_deterministic_tests = true;
+
+    int64_t now = 5000;
+    int average_interval_seconds = 600;
+
+    auto poisson = ::PoissonNextSend(now, average_interval_seconds);
+    std::chrono::microseconds poisson_chrono = ::PoissonNextSend(std::chrono::microseconds{now}, std::chrono::seconds{average_interval_seconds});
+
+    BOOST_CHECK_EQUAL(poisson, poisson_chrono.count());
+
+    g_mock_deterministic_tests = false;
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Requeuing requests after the previous timeout means that if the transaction has cleared from g_already_asked_for, we'll wait up to a minute until we request it from another peer. Instead, set the process_time more frequently, so we'll rerequest it sooner.