### PR TITLE
build: enforce minimum required Windows version (7)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -595,6 +595,8 @@ case $host in
      archive_cmds_CXX="\$CC -shared \$libobjs \$deplibs \$compiler_flags -static -o \$output_objdir/\$soname \${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker \$lib"
      postdeps_CXX=
 
+     dnl We require Windows 7 (NT 6.1) or later
+     AX_CHECK_LINK_FLAG([[-Wl,--major-subsystem-version -Wl,6 -Wl,--minor-subsystem-version -Wl,1]],[LDFLAGS="$LDFLAGS -Wl,--major-subsystem-version -Wl,6 -Wl,--minor-subsystem-version -Wl,1"],,[[$LDFLAG_WERROR]])
      ;;
   *darwin*)
      TARGET_OS=darwin


### PR DESCRIPTION
Instruct the linker to set the major & minor subsystem versions in the PE
header to 6 & 1 (NT 6.1 which corresponds to Windows 7). Similar to
the behaviour on macOS, the binary will now refuse to run on 
unsupported versions of Windows, which, for us, is XP & Vista.

![windows_no_run](https://user-images.githubusercontent.com/863730/81654555-38e0fd00-9468-11ea-9cc8-caf37dec5713.png)
