### PR TITLE
Add a link from ZMQ doc to ZMQ example in contrib/

### DIFF
--- a/doc/zmq.md
+++ b/doc/zmq.md
@@ -96,7 +96,7 @@ ZeroMQ endpoint specifiers for TCP (and others) are documented in the
 Client side, then, the ZeroMQ subscriber socket must have the
 ZMQ_SUBSCRIBE option set to one or either of these prefixes (for
 instance, just `hash`); without doing so will result in no messages
-arriving. Please see `contrib/zmq/zmq_sub.py` for a working example.
+arriving. Please see [`contrib/zmq/zmq_sub.py`](/contrib/zmq/zmq_sub.py) for a working example.
 
 ## Remarks
 


### PR DESCRIPTION
No code changes :).  Only a small convenience improvement in zmq doc.