### PR TITLE
guix: Make V=1 more powerful for debugging

### DIFF
--- a/contrib/guix/README.md
+++ b/contrib/guix/README.md
@@ -142,6 +142,11 @@ find output/ -type f -print0 | sort -z | xargs -r0 sha256sum
   If non-empty, will pass `V=1` to all `make` invocations, making `make` output
   verbose.
 
+  Note that any given value is ignored. The variable is only checked for
+  emptiness. More concretely, this means that `V=` (setting `V` to the empty
+  string) is interpreted the same way as not setting `V` at all, and that `V=0`
+  has the same effect as `V=1`.
+
 * _**ADDITIONAL_GUIX_ENVIRONMENT_FLAGS**_
 
   Additional flags to be passed to `guix environment`. For a fully-bootstrapped

--- a/contrib/guix/libexec/build.sh
+++ b/contrib/guix/libexec/build.sh
@@ -3,6 +3,14 @@ export LC_ALL=C
 set -e -o pipefail
 export TZ=UTC
 
+if [ -n "$V" ]; then
+    # Print both unexpanded (-v) and expanded (-x) forms of commands as they are
+    # read from this file.
+    set -vx
+    # Set VERBOSE for CMake-based builds
+    export VERBOSE="$V"
+fi
+
 # Check that environment variables assumed to be set by the environment are set
 echo "Building for platform triple ${HOST:?not set} with reference timestamp ${SOURCE_DATE_EPOCH:?not set}..."
 echo "At most ${MAX_JOBS:?not set} jobs will run at once..."


### PR DESCRIPTION
```
- Print commands in both unexpanded and expanded forms
- Set VERBOSE=1 for CMake
```

Ping MarcoFalke hopefully you use `V=1` already for the Guix builds on DrahtBot?