### PR TITLE
[WIP] rebase: Call ProcessNewBlock() asynchronously

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1764,6 +1764,8 @@ bool AppInitMain(NodeContext& node)
         return false;
     }
 
+    threadGroup.create_thread(std::bind(&TraceThread<std::function<void()>>, "blockconn", std::function<void()>(std::bind(&CChainState::ProcessBlockValidationQueue, &ChainstateActive()))));
+
     fs::path est_path = GetDataDir() / FEE_ESTIMATES_FILENAME;
     CAutoFile est_filein(fsbridge::fopen(est_path, "rb"), SER_DISK, CLIENT_VERSION);
     // Allowed to fail as this file IS missing on first startup.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -157,6 +157,20 @@ namespace {
      * happens afterwards.
      * Set mapBlockSource[hash].second to false if the node should not be
      * punished if the block is invalid.
+     *
+     * If a block is in this map by the time you read it, this means there
+     * is no reason to re-download the block (as it passed the
+     * ProcessNewBlock state.IsValid()). See the ProcessNewBlock docs for
+     * more info.
+     *
+     * TODO: There is currently a race on the above - we add to this map
+     * before calling PNB and then remove it if the block was malleated. We
+     * should be able to just not add it to the map if the block is malleated.
+     * (This is fixed later in this patch set, so should never hit master!)
+     *
+     * However, things which are not on our best chain but were written to
+     * disk anyway may sit around in here forever, so be careful relying on
+     * its size for any decisions.
      */
     std::map<uint256, std::pair<NodeId, bool>> mapBlockSource GUARDED_BY(cs_main);
 
@@ -244,6 +258,13 @@ namespace {
  * move most (non-validation-specific) state here.
  */
 struct CPeerState {
+    //! If this peer generated some headers for us to add, we store the resulting
+    //! future here and wait for it to complete before we process more data from this
+    //! peer.
+    std::future<bool> pending_block_processing;
+    //! The hash of the block which is pending download.
+    uint256 pending_block_hash;
+
     CPeerState() {}
 };
 
@@ -721,7 +742,7 @@ static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vec
                 // We wouldn't download this block or its descendants from this peer.
                 return;
             }
-            if (pindex->nStatus & BLOCK_HAVE_DATA || ::ChainActive().Contains(pindex)) {
+            if (pindex->nStatus & BLOCK_HAVE_DATA || ::ChainActive().Contains(pindex) || mapBlockSource.count(pindex->GetBlockHash()) != 0) {
                 if (pindex->HaveTxsDownloaded())
                     state->pindexLastCommonBlock = pindex;
             } else if (mapBlocksInFlight.count(pindex->GetBlockHash()) == 0) {
@@ -1878,6 +1899,7 @@ bool static ProcessHeadersMessage(CNode* pfrom, CConnman* connman, CTxMemPool& m
             while (pindexWalk && !::ChainActive().Contains(pindexWalk) && vToFetch.size() <= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
                 if (!(pindexWalk->nStatus & BLOCK_HAVE_DATA) &&
                         !mapBlocksInFlight.count(pindexWalk->GetBlockHash()) &&
+                        !mapBlockSource.count(pindexWalk->GetBlockHash()) &&
                         (!IsWitnessEnabled(pindexWalk->pprev, chainparams.GetConsensus()) || State(pfrom->GetId())->fHaveWitness)) {
                     // We don't have this block, and it's not yet in flight.
                     vToFetch.push_back(pindexWalk);
@@ -2019,19 +2041,18 @@ void static ProcessOrphanTx(CConnman* connman, CTxMemPool& mempool, std::set<uin
 /**
  *  A block has been processed. Handle potential peer punishment and housekeeping.
  */
-void static BlockProcessed(CNode* pfrom, CConnman* connman, std::shared_ptr<CBlock> pblock, BlockValidationState& state, bool new_block)
+void static BlockProcessed(CNode* pfrom, CConnman* connman, CPeerState* peerstate, std::shared_ptr<CBlock> pblock, BlockValidationState& state, std::future<bool>& block_future)
 {
     if (!state.IsValid()) {
         // The block failed anti-dos / mutation checks. Call BlockChecked() callback here.
         // This clears the block from mapBlockSource.
         BlockChecked(*pblock, state, connman);
-    } else if (!new_block) {
         // Block was valid but we've seen it before. Clear it from mapBlockSource.
         LOCK(cs_main);
         ::mapBlockSource.erase(pblock->GetHash());
     } else {
-        // Block is valid and we haven't seen it before. set nLastBlockTime for this peer.
-        pfrom->nLastBlockTime = GetTime();
+        peerstate->pending_block_hash = pblock->GetHash();
+        peerstate->pending_block_processing = std::move(block_future);
     }
 }
 
@@ -2939,8 +2960,9 @@ bool ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::string& msg_
         std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator blockInFlightIt = mapBlocksInFlight.find(pindex->GetBlockHash());
         bool fAlreadyInFlight = blockInFlightIt != mapBlocksInFlight.end();
 
-        if (pindex->nStatus & BLOCK_HAVE_DATA) // Nothing to do here
+        if ((pindex->nStatus & BLOCK_HAVE_DATA) || mapBlockSource.count(pindex->GetBlockHash())) {// Nothing to do here
             return true;
+        }
 
         if (pindex->nChainWork <= ::ChainActive().Tip()->nChainWork || // We know something better
                 pindex->nTx != 0) { // We had this block at some point, but pruned it
@@ -3071,8 +3093,8 @@ bool ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::string& msg_
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
             BlockValidationState dos_state;
-            bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true).get();
-            BlockProcessed(pfrom, connman, pblock, dos_state, fNewBlock);
+            std::future<bool> block_future = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true);
+            BlockProcessed(pfrom, connman, peerstate, pblock, dos_state, block_future);
 
             LOCK(cs_main); // hold cs_main for CBlockIndex::IsValid()
             if (pindex->IsValid(BLOCK_VALID_TRANSACTIONS)) {
@@ -3157,8 +3179,8 @@ bool ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::string& msg_
             // protections in the compact block handler -- see related comment
             // in compact block optimistic reconstruction handling.
             BlockValidationState dos_state;
-            bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true).get();
-            BlockProcessed(pfrom, connman, pblock, dos_state, fNewBlock);
+            std::future<bool> block_future = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true);
+            BlockProcessed(pfrom, connman, peerstate, pblock, dos_state, block_future);
         }
         return true;
     }
@@ -3215,8 +3237,8 @@ bool ProcessMessage(CNode* pfrom, CPeerState* peerstate, const std::string& msg_
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         BlockValidationState dos_state;
-        bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, forceProcessing).get();
-        BlockProcessed(pfrom, connman, pblock, dos_state, fNewBlock);
+        std::future<bool> block_future = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/forceProcessing);
+        BlockProcessed(pfrom, connman, peerstate, pblock, dos_state, block_future);
         return true;
     }
 
@@ -3489,6 +3511,24 @@ bool PeerLogicValidation::CheckIfBanned(CNode* pnode)
     return false;
 }
 
+bool static IsPendingBlockValidation(CNode* pfrom, CPeerState* peerstate) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
+{
+    if (peerstate->pending_block_processing.valid()) {
+        if (peerstate->pending_block_processing.wait_for(std::chrono::duration<int>::zero()) == std::future_status::ready) {
+            bool fNewBlock = peerstate->pending_block_processing.get();
+            if (fNewBlock) {
+                pfrom->nLastBlockTime = GetTime();
+            } else {
+                LOCK(cs_main);
+                mapBlockSource.erase(peerstate->pending_block_hash);
+            }
+            peerstate->pending_block_processing = std::future<bool>();
+            peerstate->pending_block_hash = uint256();
+            return false;
+        } else { return true; }
+    } else { return false; }
+}
+
 bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
 {
     const CChainParams& chainparams = Params();
@@ -3514,6 +3554,17 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
         for (const CTransactionRef& removedTx : removed_txn) {
             AddToCompactExtraTransactions(removedTx);
         }
+    }
+
+    if (IsPendingBlockValidation(pfrom, peerstate)) {
+        return false;
+    }
+    {
+        // Somewhat annoyingly, tests currently rely on any pending bans/disconnects
+        // being processed prior to any pong responses, thus if we were waiting on a
+        // block validation to complete, we need to recheck bans.
+        LOCK(cs_main);
+        CheckIfBanned(pfrom);
     }
 
     if (pfrom->fDisconnect)
@@ -3761,6 +3812,10 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
 
         LOCK(cs_peerstate);
         CPeerState* peerstate = PeerState(pto->GetId());
+
+        if (IsPendingBlockValidation(pto, peerstate)) {
+            return true;
+        }
 
         //
         // Message: ping

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3035,7 +3035,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
             BlockValidationState dos_state;
-            bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true);
+            bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true).get();
             BlockProcessed(pfrom, connman, pblock, dos_state, fNewBlock);
 
             LOCK(cs_main); // hold cs_main for CBlockIndex::IsValid()
@@ -3121,7 +3121,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             // protections in the compact block handler -- see related comment
             // in compact block optimistic reconstruction handling.
             BlockValidationState dos_state;
-            bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true);
+            bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true).get();
             BlockProcessed(pfrom, connman, pblock, dos_state, fNewBlock);
         }
         return true;
@@ -3179,7 +3179,7 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         BlockValidationState dos_state;
-        bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, forceProcessing);
+        bool fNewBlock = ProcessNewBlock(chainparams, pblock, dos_state, forceProcessing).get();
         BlockProcessed(pfrom, connman, pblock, dos_state, fNewBlock);
         return true;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -264,8 +264,14 @@ struct CPeerState {
     std::future<bool> pending_block_processing;
     //! The hash of the block which is pending download.
     uint256 pending_block_hash;
+    //! Once we've finished processing a block from this peer, we must still wait for
+    //! any related callbacks to fire (to ensure, specifically, that rejects go out
+    //! in order, though this may grow to include more such events in the future).
+    bool pending_event_wait;
 
-    CPeerState() {}
+    CPeerState() {
+        pending_event_wait = false;
+    }
 };
 
 
@@ -3519,7 +3525,7 @@ bool PeerLogicValidation::CheckIfBanned(CNode* pnode)
     return false;
 }
 
-bool static IsPendingBlockValidation(CNode* pfrom, CPeerState* peerstate) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
+bool static IsPendingBlockValidation(CConnman* connman, CNode* pfrom, CPeerState* peerstate) EXCLUSIVE_LOCKS_REQUIRED(cs_peerstate)
 {
     if (peerstate->pending_block_processing.valid()) {
         if (peerstate->pending_block_processing.wait_for(std::chrono::duration<int>::zero()) == std::future_status::ready) {
@@ -3532,9 +3538,26 @@ bool static IsPendingBlockValidation(CNode* pfrom, CPeerState* peerstate) EXCLUS
             }
             peerstate->pending_block_processing = std::future<bool>();
             peerstate->pending_block_hash = uint256();
-            return false;
+
+            // We need to wait for BlockChecked to fire, so we don't re-enable
+            // this peer until the current pending validationinterface callbacks
+            // drain. This ensures bans and reject messages happen in order, as
+            // expected by some of our functional tests.
+            peerstate->pending_event_wait = true;
+            NodeId node_id = pfrom->GetId();
+            CallFunctionInValidationInterfaceQueue([node_id, connman] {
+                LOCK(cs_peerstate);
+                CPeerState* peerstate = PeerState(node_id);
+                if (peerstate != nullptr) {
+                    peerstate->pending_event_wait = false;
+                    connman->WakeMessageHandler();
+                }
+            });
+            return true;
         } else { return true; }
-    } else { return false; }
+    } else {
+        return peerstate->pending_event_wait;
+    }
 }
 
 bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& interruptMsgProc)
@@ -3564,7 +3587,7 @@ bool PeerLogicValidation::ProcessMessages(CNode* pfrom, std::atomic<bool>& inter
         }
     }
 
-    if (IsPendingBlockValidation(pfrom, peerstate)) {
+    if (IsPendingBlockValidation(connman, pfrom, peerstate)) {
         return false;
     }
     {
@@ -3821,7 +3844,7 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
         LOCK(cs_peerstate);
         CPeerState* peerstate = PeerState(pto->GetId());
 
-        if (IsPendingBlockValidation(pto, peerstate)) {
+        if (IsPendingBlockValidation(connman, pto, peerstate)) {
             return true;
         }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1332,8 +1332,11 @@ void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew, const CB
 /**
  * Handle invalid block rejection and consequent peer banning, maintain which
  * peers announce compact blocks.
+ * Called both in case of cursory DoS checks failing (implying the peer is likely
+ * sending us bogus data) and after full validation of the block fails (which may
+ * be OK if it was sent over compact blocks).
  */
-void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidationState& state) {
+static void BlockChecked(const CBlock& block, const BlockValidationState& state, CConnman* connman) {
     LOCK(cs_main);
 
     const uint256 hash(block.GetHash());
@@ -1361,6 +1364,10 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidatio
     }
     if (it != mapBlockSource.end())
         mapBlockSource.erase(it);
+}
+
+void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidationState& state) {
+    ::BlockChecked(block, state, connman);
 }
 
 //////////////////////////////////////////////////////////////////////////////

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3022,7 +3022,8 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             // we have a chain with at least nMinimumChainWork), and we ignore
             // compact blocks with less work than our tip, it is safe to treat
             // reconstructed compact blocks as having been requested.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            BlockValidationState dos_state;
+            ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true, &fNewBlock);
             BlockProcessed(pfrom, pblock, fNewBlock);
 
             LOCK(cs_main); // hold cs_main for CBlockIndex::IsValid()
@@ -3108,7 +3109,8 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             // disk-space attacks), but this should be safe due to the
             // protections in the compact block handler -- see related comment
             // in compact block optimistic reconstruction handling.
-            ProcessNewBlock(chainparams, pblock, /*fForceProcessing=*/true, &fNewBlock);
+            BlockValidationState dos_state;
+            ProcessNewBlock(chainparams, pblock, dos_state, /*fForceProcessing=*/true, &fNewBlock);
             BlockProcessed(pfrom, pblock, fNewBlock);
         }
         return true;
@@ -3166,7 +3168,8 @@ bool ProcessMessage(CNode* pfrom, const std::string& msg_type, CDataStream& vRec
             mapBlockSource.emplace(hash, std::make_pair(pfrom->GetId(), true));
         }
         bool fNewBlock = false;
-        ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
+        BlockValidationState dos_state;
+        ProcessNewBlock(chainparams, pblock, dos_state, forceProcessing, &fNewBlock);
         BlockProcessed(pfrom, pblock, fNewBlock);
         return true;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1427,6 +1427,14 @@ void PeerLogicValidation::BlockChecked(const CBlock& block, const BlockValidatio
     ::BlockChecked(block, state, connman);
 }
 
+/**
+ * Wake up message handler once a block has been processed to process the
+ * next message from the peer that sent us that block.
+ */
+void PeerLogicValidation::BlockProcessed() {
+    connman->WakeMessageHandler();
+}
+
 //////////////////////////////////////////////////////////////////////////////
 //
 // Messages

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -51,6 +51,10 @@ public:
      * Overridden from CValidationInterface.
      */
     void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& pblock) override;
+    /**
+     * Overridden from CValidationInterface.
+     */
+    void BlockProcessed() override;
 
     /** Initialize a peer by adding it to mapNodeState and pushing a message requesting its version */
     void InitializeNode(CNode* pnode) override;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -951,6 +951,9 @@ static UniValue submitblock(const JSONRPCRequest& request)
     if (!new_block && accepted) {
         return "duplicate";
     }
+    if (!dos_state.IsValid()) {
+        return BIP22ValidationResult(dos_state);
+    }
     if (!sc->found) {
         return "inconclusive";
     }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -126,7 +126,7 @@ static bool GenerateBlock(CBlock& block, uint64_t& max_tries, unsigned int& extr
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     BlockValidationState state;
     ProcessNewBlock(Params(), shared_pblock, state, true).wait();
-    if (!state.IsValid())
+    if (ChainActive().Tip()->GetBlockHash() != block.GetHash())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
 
     block_hash = block.GetHash();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -124,7 +124,8 @@ static bool GenerateBlock(CBlock& block, uint64_t& max_tries, unsigned int& extr
     }
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    if (!ProcessNewBlock(chainparams, shared_pblock, true, nullptr))
+    BlockValidationState state;
+    if (!ProcessNewBlock(chainparams, shared_pblock, state, true, nullptr))
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
 
     block_hash = block.GetHash();
@@ -944,7 +945,8 @@ static UniValue submitblock(const JSONRPCRequest& request)
     bool new_block;
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
     RegisterSharedValidationInterface(sc);
-    bool accepted = ProcessNewBlock(Params(), blockptr, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
+    BlockValidationState dos_state;
+    bool accepted = ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &new_block);
     UnregisterSharedValidationInterface(sc);
     if (!new_block && accepted) {
         return "duplicate";

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -125,7 +125,7 @@ static bool GenerateBlock(CBlock& block, uint64_t& max_tries, unsigned int& extr
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     BlockValidationState state;
-    ProcessNewBlock(Params(), shared_pblock, state, true);
+    ProcessNewBlock(Params(), shared_pblock, state, true).wait();
     if (!state.IsValid())
         throw JSONRPCError(RPC_INTERNAL_ERROR, "ProcessNewBlock, block not accepted");
 
@@ -946,7 +946,7 @@ static UniValue submitblock(const JSONRPCRequest& request)
     auto sc = std::make_shared<submitblock_StateCatcher>(block.GetHash());
     RegisterSharedValidationInterface(sc);
     BlockValidationState dos_state;
-    bool new_block = ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true);
+    bool new_block = ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true).get();
     UnregisterSharedValidationInterface(sc);
     if (!new_block && dos_state.IsValid()) {
         return "duplicate";

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -947,6 +947,7 @@ static UniValue submitblock(const JSONRPCRequest& request)
     RegisterSharedValidationInterface(sc);
     BlockValidationState dos_state;
     bool new_block = ProcessNewBlock(Params(), blockptr, dos_state, /* fForceProcessing */ true).get();
+    SyncWithValidationInterfaceQueue();
     UnregisterSharedValidationInterface(sc);
     if (!new_block && dos_state.IsValid()) {
         return "duplicate";

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -173,6 +173,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const auto& block = chainA[i];
         BlockValidationState dos_state;
         BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -192,6 +193,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const auto& block = chainB[i];
         BlockValidationState dos_state;
         BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -224,6 +226,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
         const auto& block = chainA[i];
         BlockValidationState dos_state;
         BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        BOOST_REQUIRE(dos_state.IsValid());
     }
 
      // Check that chain A and B blocks can be retrieved.

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -172,7 +172,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
         BlockValidationState dos_state;
-        ProcessNewBlock(Params(), block, dos_state, true);
+        ProcessNewBlock(Params(), block, dos_state, true).wait();
         BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 2; i++) {
@@ -192,7 +192,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
         BlockValidationState dos_state;
-        ProcessNewBlock(Params(), block, dos_state, true);
+        ProcessNewBlock(Params(), block, dos_state, true).wait();
         BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 3; i++) {
@@ -225,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     for (size_t i = 2; i < 4; i++) {
         const auto& block = chainA[i];
         BlockValidationState dos_state;
-        ProcessNewBlock(Params(), block, dos_state, true);
+        ProcessNewBlock(Params(), block, dos_state, true).wait();
         BOOST_REQUIRE(dos_state.IsValid());
     }
 

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -171,7 +171,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainA_last_header = last_header;
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+        BlockValidationState dos_state;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
     }
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
@@ -189,7 +190,8 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     uint256 chainB_last_header = last_header;
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
+        BlockValidationState dos_state;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
     }
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
@@ -218,10 +220,11 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     }
 
     // Reorg back to chain A.
-     for (size_t i = 2; i < 4; i++) {
-         const auto& block = chainA[i];
-         BOOST_REQUIRE(ProcessNewBlock(Params(), block, true, nullptr));
-     }
+    for (size_t i = 2; i < 4; i++) {
+        const auto& block = chainA[i];
+        BlockValidationState dos_state;
+        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+    }
 
      // Check that chain A and B blocks can be retrieved.
      chainA_last_header = last_header;

--- a/src/test/blockfilter_index_tests.cpp
+++ b/src/test/blockfilter_index_tests.cpp
@@ -172,7 +172,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     for (size_t i = 0; i < 2; i++) {
         const auto& block = chainA[i];
         BlockValidationState dos_state;
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        ProcessNewBlock(Params(), block, dos_state, true);
         BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 2; i++) {
@@ -192,7 +192,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     for (size_t i = 0; i < 3; i++) {
         const auto& block = chainB[i];
         BlockValidationState dos_state;
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        ProcessNewBlock(Params(), block, dos_state, true);
         BOOST_REQUIRE(dos_state.IsValid());
     }
     for (size_t i = 0; i < 3; i++) {
@@ -225,7 +225,7 @@ BOOST_FIXTURE_TEST_CASE(blockfilter_index_initial_sync, BuildChainTestingSetup)
     for (size_t i = 2; i < 4; i++) {
         const auto& block = chainA[i];
         BlockValidationState dos_state;
-        BOOST_REQUIRE(ProcessNewBlock(Params(), block, dos_state, true, nullptr));
+        ProcessNewBlock(Params(), block, dos_state, true);
         BOOST_REQUIRE(dos_state.IsValid());
     }
 

--- a/src/test/denialofservice_tests.cpp
+++ b/src/test/denialofservice_tests.cpp
@@ -98,11 +98,11 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
 
     // Test starts here
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
         dummyNode1.vSendMsg.clear();
     }
@@ -111,17 +111,17 @@ BOOST_AUTO_TEST_CASE(outbound_slow_chain_eviction)
     // Wait 21 minutes
     SetMockTime(nStartTime+21*60);
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in getheaders
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_vSend);
+        LOCK(dummyNode1.cs_vSend);
         BOOST_CHECK(dummyNode1.vSendMsg.size() > 0);
     }
     // Wait 3 more minutes
     SetMockTime(nStartTime+24*60);
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1)); // should result in disconnect
     }
     BOOST_CHECK(dummyNode1.fDisconnect == true);
@@ -235,7 +235,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
@@ -252,7 +252,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
-        LOCK2(cs_main, dummyNode2.cs_sendProcessing);
+        LOCK(dummyNode2.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(!banman->IsBanned(addr2)); // 2 not banned yet...
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
         Misbehaving(dummyNode2.GetId(), 50);
     }
     {
-        LOCK2(cs_main, dummyNode2.cs_sendProcessing);
+        LOCK(dummyNode2.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode2));
     }
     BOOST_CHECK(banman->IsBanned(addr2));
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 100);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 10);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(!banman->IsBanned(addr1));
@@ -309,7 +309,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
         Misbehaving(dummyNode1.GetId(), 1);
     }
     {
-        LOCK2(cs_main, dummyNode1.cs_sendProcessing);
+        LOCK(dummyNode1.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode1));
     }
     BOOST_CHECK(banman->IsBanned(addr1));
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
         Misbehaving(dummyNode.GetId(), 100);
     }
     {
-        LOCK2(cs_main, dummyNode.cs_sendProcessing);
+        LOCK(dummyNode.cs_sendProcessing);
         BOOST_CHECK(peerLogic->SendMessages(&dummyNode));
     }
     BOOST_CHECK(banman->IsBanned(addr));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BlockValidationState dos_state;
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
+        ProcessNewBlock(chainparams, shared_pblock, dos_state, true);
         BOOST_CHECK(dos_state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BlockValidationState dos_state;
-        ProcessNewBlock(chainparams, shared_pblock, dos_state, true);
+        ProcessNewBlock(chainparams, shared_pblock, dos_state, true).wait();
         BOOST_CHECK(dos_state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -256,6 +256,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
         BlockValidationState dos_state;
         BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
+        BOOST_CHECK(dos_state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -7,6 +7,7 @@
 #include <consensus/consensus.h>
 #include <consensus/merkle.h>
 #include <consensus/tx_verify.h>
+#include <consensus/validation.h>
 #include <miner.h>
 #include <policy/policy.h>
 #include <script/standard.h>
@@ -253,7 +254,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
             pblock->nNonce = blockinfo[i].nonce;
         }
         std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
-        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        BlockValidationState dos_state;
+        BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr));
         pblock->hashPrevBlock = pblock->GetHash();
     }
 

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -33,8 +33,7 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
     }
 
     BlockValidationState dos_state;
-    bool processed{ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
-    assert(processed);
+    ProcessNewBlock(Params(), block, dos_state, true);
     assert(dos_state.IsValid());
 
     return CTxIn{block->vtx[0]->GetHash(), 0};

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -6,6 +6,7 @@
 
 #include <chainparams.h>
 #include <consensus/merkle.h>
+#include <consensus/validation.h>
 #include <key_io.h>
 #include <miner.h>
 #include <node/context.h>
@@ -31,7 +32,8 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
         assert(block->nNonce);
     }
 
-    bool processed{ProcessNewBlock(Params(), block, true, nullptr)};
+    BlockValidationState dos_state;
+    bool processed{ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
     assert(processed);
 
     return CTxIn{block->vtx[0]->GetHash(), 0};

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -35,6 +35,7 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
     BlockValidationState dos_state;
     bool processed{ProcessNewBlock(Params(), block, dos_state, true, nullptr)};
     assert(processed);
+    assert(dos_state.IsValid());
 
     return CTxIn{block->vtx[0]->GetHash(), 0};
 }

--- a/src/test/util/mining.cpp
+++ b/src/test/util/mining.cpp
@@ -33,7 +33,7 @@ CTxIn MineBlock(const NodeContext& node, const CScript& coinbase_scriptPubKey)
     }
 
     BlockValidationState dos_state;
-    ProcessNewBlock(Params(), block, dos_state, true);
+    ProcessNewBlock(Params(), block, dos_state, true).wait();
     assert(dos_state.IsValid());
 
     return CTxIn{block->vtx[0]->GetHash(), 0};

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -229,7 +229,7 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     BlockValidationState dos_state;
-    ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr);
+    ProcessNewBlock(chainparams, shared_pblock, dos_state, true);
 
     CBlock result = block;
     return result;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -229,7 +229,7 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
     BlockValidationState dos_state;
-    ProcessNewBlock(chainparams, shared_pblock, dos_state, true);
+    ProcessNewBlock(chainparams, shared_pblock, dos_state, true).wait();
 
     CBlock result = block;
     return result;

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -228,7 +228,8 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    BlockValidationState dos_state;
+    ProcessNewBlock(chainparams, shared_pblock, dos_state, true, nullptr);
 
     CBlock result = block;
     return result;

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -199,6 +199,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
                     BlockValidationState dos_state;
                     bool processed = ProcessNewBlock(Params(), block, dos_state, true, &ignored);
                     assert(processed);
+                    assert(dos_state.IsValid());
                 }
             }
         });
@@ -237,7 +238,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
     bool ignored;
     auto ProcessBlock = [&ignored](std::shared_ptr<const CBlock> block) -> bool {
         BlockValidationState dos_state;
-        return ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
+        return ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &ignored) && dos_state.IsValid();
     };
 
     // Process all mined blocks

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
 
     // Connect the genesis block and drain any outstanding events
     BlockValidationState dos_state;
-    ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), dos_state, true);
+    ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), dos_state, true).wait();
     BOOST_CHECK(dos_state.IsValid());
     SyncWithValidationInterfaceQueue();
 
@@ -189,14 +189,14 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
             for (int i = 0; i < 1000; i++) {
                 auto block = blocks[insecure.randrange(blocks.size() - 1)];
                 BlockValidationState dos_state;
-                ProcessNewBlock(Params(), block, dos_state, true);
+                ProcessNewBlock(Params(), block, dos_state, true).wait();
             }
 
             // to make sure that eventually we process the full chain - do it here
             for (auto block : blocks) {
                 if (block->vtx.size() == 1) {
                     BlockValidationState dos_state;
-                    ProcessNewBlock(Params(), block, dos_state, true);
+                    ProcessNewBlock(Params(), block, dos_state, true).wait();
                     assert(dos_state.IsValid());
                 }
             }
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
     bool ignored;
     auto ProcessBlock = [&ignored](std::shared_ptr<const CBlock> block) -> bool {
         BlockValidationState dos_state;
-        ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true);
+        ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true).wait();
         return dos_state.IsValid();
     };
 

--- a/src/test/validation_block_tests.cpp
+++ b/src/test/validation_block_tests.cpp
@@ -166,7 +166,8 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
     BOOST_CHECK(ProcessNewBlockHeaders(headers, state, Params()));
 
     // Connect the genesis block and drain any outstanding events
-    BOOST_CHECK(ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), true, &ignored));
+    BlockValidationState dos_state;
+    BOOST_CHECK(ProcessNewBlock(Params(), std::make_shared<CBlock>(Params().GenesisBlock()), dos_state, true, &ignored));
     SyncWithValidationInterfaceQueue();
 
     // subscribe to events (this subscriber will validate event ordering)
@@ -188,13 +189,15 @@ BOOST_AUTO_TEST_CASE(processnewblock_signals_ordering)
             FastRandomContext insecure;
             for (int i = 0; i < 1000; i++) {
                 auto block = blocks[insecure.randrange(blocks.size() - 1)];
-                ProcessNewBlock(Params(), block, true, &ignored);
+                BlockValidationState dos_state;
+                ProcessNewBlock(Params(), block, dos_state, true, &ignored);
             }
 
             // to make sure that eventually we process the full chain - do it here
             for (auto block : blocks) {
                 if (block->vtx.size() == 1) {
-                    bool processed = ProcessNewBlock(Params(), block, true, &ignored);
+                    BlockValidationState dos_state;
+                    bool processed = ProcessNewBlock(Params(), block, dos_state, true, &ignored);
                     assert(processed);
                 }
             }
@@ -233,7 +236,8 @@ BOOST_AUTO_TEST_CASE(mempool_locks_reorg)
 {
     bool ignored;
     auto ProcessBlock = [&ignored](std::shared_ptr<const CBlock> block) -> bool {
-        return ProcessNewBlock(Params(), block, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
+        BlockValidationState dos_state;
+        return ProcessNewBlock(Params(), block, dos_state, /* fForceProcessing */ true, /* fNewBlock */ &ignored);
     };
 
     // Process all mined blocks

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -57,7 +57,7 @@ public:
     {
         if (m_on_destroy) m_on_destroy();
     }
-    void BlockChecked(const CBlock& block, const BlockValidationState& state) override
+    void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) override
     {
         if (m_on_call) m_on_call();
     }
@@ -65,7 +65,7 @@ public:
     {
         std::shared_ptr<const CBlock> block = std::make_shared<CBlock>();
         BlockValidationState state;
-        GetMainSignals().BlockChecked(block, state);
+        GetMainSignals().NewPoWValidBlock(nullptr, std::make_shared<CBlock>());
     }
     std::function<void()> m_on_call;
     std::function<void()> m_on_destroy;

--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -22,7 +22,7 @@ BOOST_AUTO_TEST_CASE(unregister_validation_interface_race)
 
     // Start thread to generate notifications
     std::thread gen{[&] {
-        const CBlock block_dummy;
+        const std::shared_ptr<const CBlock> block_dummy = std::make_shared<const CBlock>();
         const BlockValidationState state_dummy;
         while (generate) {
             GetMainSignals().BlockChecked(block_dummy, state_dummy);
@@ -63,7 +63,7 @@ public:
     }
     static void Call()
     {
-        CBlock block;
+        std::shared_ptr<const CBlock> block = std::make_shared<CBlock>();
         BlockValidationState state;
         GetMainSignals().BlockChecked(block, state);
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3832,7 +3832,6 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
             ret = ::ChainstateActive().AcceptBlock(pblock, dos_state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
         }
         if (!ret) {
-            GetMainSignals().BlockChecked(*pblock, dos_state);
             return error("%s: AcceptBlock FAILED (%s)", __func__, dos_state.ToString());
         }
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3855,6 +3855,7 @@ void CChainState::ProcessBlockValidationQueue()
             error("%s: ActivateBestChain failed (%s)", __func__, state.ToString());
 
         result_promise.set_value(true);
+        GetMainSignals().BlockProcessed();
         LimitValidationInterfaceQueue();
     }
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3838,9 +3838,9 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 
     NotifyHeaderTip();
 
-    BlockValidationState state; // Only used to report errors, not invalidity - ignore it
-    if (!::ChainstateActive().ActivateBestChain(state, chainparams, pblock))
-        return error("%s: ActivateBestChain failed (%s)", __func__, state.ToString());
+    BlockValidationState dummy_state; // Only used to report errors, not invalidity - ignore it
+    if (!::ChainstateActive().ActivateBestChain(dummy_state, chainparams, pblock))
+        return error("%s: ActivateBestChain failed (%s)", __func__, dummy_state.ToString());
 
     return true;
 }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3729,22 +3729,9 @@ static FlatFilePos SaveBlockToDisk(const CBlock& block, int nHeight, const CChai
     return blockPos;
 }
 
-/** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
-bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock)
+bool CChainState::ShouldMaybeWrite(CBlockIndex* pindex, bool fRequested)
 {
-    const CBlock& block = *pblock;
-
-    if (fNewBlock) *fNewBlock = false;
     AssertLockHeld(cs_main);
-
-    CBlockIndex *pindexDummy = nullptr;
-    CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
-
-    bool accepted_header = m_blockman.AcceptBlockHeader(block, state, chainparams, &pindex);
-    CheckBlockIndex(chainparams.GetConsensus());
-
-    if (!accepted_header)
-        return false;
 
     // Try to process all requested blocks that we don't have, but only
     // process an unrequested block if it's new and has enough work to
@@ -3765,18 +3752,40 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
 
     // TODO: deal better with return value and error conditions for duplicate
     // and unrequested blocks.
-    if (fAlreadyHave) return true;
+    if (fAlreadyHave) return false;
     if (!fRequested) {  // If we didn't ask for it:
-        if (pindex->nTx != 0) return true;    // This is a previously-processed block that was pruned
-        if (!fHasMoreOrSameWork) return true; // Don't process less-work chains
-        if (fTooFarAhead) return true;        // Block height is too high
+        if (pindex->nTx != 0) return false;    // This is a previously-processed block that was pruned
+        if (!fHasMoreOrSameWork) return false; // Don't process less-work chains
+        if (fTooFarAhead) return false;        // Block height is too high
 
         // Protect against DoS attacks from low-work chains.
         // If our tip is behind, a peer could try to send us
         // low-work blocks on a fake chain that we would never
         // request; don't process these.
-        if (pindex->nChainWork < nMinimumChainWork) return true;
+        if (pindex->nChainWork < nMinimumChainWork) return false;
     }
+
+    return true;
+}
+
+/** Check block before we go to write it to disk */
+bool CChainState::PreWriteCheckBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, bool* fShouldWrite)
+{
+    AssertLockHeld(cs_main);
+
+    const CBlock& block = *pblock;
+    if (fShouldWrite) *fShouldWrite = false;
+
+    CBlockIndex *pindexDummy = nullptr;
+    CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
+
+    bool accepted_header = m_blockman.AcceptBlockHeader(block, state, chainparams, &pindex);
+    CheckBlockIndex(chainparams.GetConsensus());
+
+    if (!accepted_header)
+        return false;
+
+    if (!ShouldMaybeWrite(pindex, fRequested)) return true;
 
     if (!CheckBlock(block, state, chainparams.GetConsensus()) ||
         !ContextualCheckBlock(block, state, chainparams.GetConsensus(), pindex->pprev)) {
@@ -3785,6 +3794,29 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
             setDirtyBlockIndex.insert(pindex);
         }
         return error("%s: %s", __func__, state.ToString());
+    }
+
+    if (fShouldWrite) *fShouldWrite = true;
+    return true;
+}
+
+/** Store block on disk. If dbp is non-nullptr, the file is known to already reside on disk */
+bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, const FlatFilePos* dbp, bool* fNewBlock)
+{
+    AssertLockHeld(cs_main);
+
+    const CBlock& block = *pblock;
+    if (fNewBlock) *fNewBlock = false;
+
+    CBlockIndex *pindexDummy = nullptr;
+    CBlockIndex *&pindex = ppindex ? *ppindex : pindexDummy;
+
+    bool fShouldWrite = false;
+    if (!PreWriteCheckBlock(pblock, state, chainparams, &pindex, fRequested, &fShouldWrite)) {
+        return false;
+    }
+    if (!fShouldWrite) {
+        return true;
     }
 
     // Header is valid/has work, merkle tree and segwit merkle tree are good...RELAY NOW
@@ -3847,6 +3879,47 @@ void CChainState::ProcessBlockValidationQueue()
         }
 
         CChainParams chainparams = Params();
+        {
+            LOCK(cs_main);
+
+            CBlockIndex* pindex = LookupBlockIndex(pblock->GetHash());
+            assert(pindex);
+
+            // Check that we still want this block
+            if (!ShouldMaybeWrite(pindex, fForceProcessing)) {
+                result_promise.set_value(false);
+                continue;
+            }
+
+            // We already verified the block in ProcessNewBlock, so no need to check merkle roots here again
+
+            // Header is valid/has work, merkle tree and segwit merkle tree are good...RELAY NOW
+            // (but if it does not build on our best tip, let the SendMessages loop relay it)
+            if (!IsInitialBlockDownload() && m_chain.Tip() == pindex->pprev)
+                GetMainSignals().NewPoWValidBlock(pindex, pblock);
+
+            BlockValidationState state;
+            try {
+                FlatFilePos blockPos = SaveBlockToDisk(*pblock, pindex->nHeight, chainparams, nullptr);
+                if (blockPos.IsNull()) {
+                    error(strprintf("%s: Failed to find position to write new block to disk", __func__).c_str());
+                    result_promise.set_value(false);
+                    continue;
+                }
+                ReceivedBlockTransactions(*pblock, pindex, blockPos, chainparams.GetConsensus());
+            } catch (const std::runtime_error& e) {
+                AbortNode(state, std::string("System error: ") + e.what());
+            }
+
+            FlushStateToDisk(chainparams, state, FlushStateMode::NONE);
+
+            CheckBlockIndex(chainparams.GetConsensus());
+
+            if (state.IsError()) {
+                result_promise.set_value(false);
+                continue;
+            }
+        }
 
         NotifyHeaderTip();
 
@@ -3869,8 +3942,6 @@ std::future<bool> CChainState::ProcessNewBlock(const CChainParams& chainparams, 
     bool fNewBlock = false;
 
     {
-        CBlockIndex *pindex = nullptr;
-
         // CheckBlock() does not support multi-threaded block validation because CBlock::fChecked can cause data race.
         // Therefore, the following critical section must include the CheckBlock() call as well.
         LOCK(cs_main);
@@ -3880,7 +3951,7 @@ std::future<bool> CChainState::ProcessNewBlock(const CChainParams& chainparams, 
         bool ret = CheckBlock(*pblock, dos_state, chainparams.GetConsensus());
         if (ret) {
             // Store to disk
-            ret = ::ChainstateActive().AcceptBlock(pblock, dos_state, chainparams, &pindex, fForceProcessing, nullptr, &fNewBlock);
+            ret = PreWriteCheckBlock(pblock, dos_state, chainparams, nullptr, fForceProcessing, &fNewBlock);
         }
         if (!ret || !fNewBlock) {
             if (!ret) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2601,7 +2601,7 @@ bool CChainState::ConnectTip(BlockValidationState& state, const CChainParams& ch
     {
         CCoinsViewCache view(&CoinsTip());
         bool rv = ConnectBlock(blockConnecting, state, pindexNew, view, chainparams);
-        GetMainSignals().BlockChecked(blockConnecting, state);
+        GetMainSignals().BlockChecked(pthisBlock, state);
         if (!rv) {
             if (state.IsInvalid())
                 InvalidBlockFound(pindexNew, state);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3812,14 +3812,13 @@ bool CChainState::AcceptBlock(const std::shared_ptr<const CBlock>& pblock, Block
     return true;
 }
 
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool *fNewBlock)
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, BlockValidationState& dos_state, bool fForceProcessing, bool *fNewBlock)
 {
     AssertLockNotHeld(cs_main);
 
     {
         CBlockIndex *pindex = nullptr;
         if (fNewBlock) *fNewBlock = false;
-        BlockValidationState state;
 
         // CheckBlock() does not support multi-threaded block validation because CBlock::fChecked can cause data race.
         // Therefore, the following critical section must include the CheckBlock() call as well.
@@ -3827,14 +3826,14 @@ bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<cons
 
         // Ensure that CheckBlock() passes before calling AcceptBlock, as
         // belt-and-suspenders.
-        bool ret = CheckBlock(*pblock, state, chainparams.GetConsensus());
+        bool ret = CheckBlock(*pblock, dos_state, chainparams.GetConsensus());
         if (ret) {
             // Store to disk
-            ret = ::ChainstateActive().AcceptBlock(pblock, state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
+            ret = ::ChainstateActive().AcceptBlock(pblock, dos_state, chainparams, &pindex, fForceProcessing, nullptr, fNewBlock);
         }
         if (!ret) {
-            GetMainSignals().BlockChecked(*pblock, state);
-            return error("%s: AcceptBlock FAILED (%s)", __func__, state.ToString());
+            GetMainSignals().BlockChecked(*pblock, dos_state);
+            return error("%s: AcceptBlock FAILED (%s)", __func__, dos_state.ToString());
         }
     }
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -161,9 +161,10 @@ extern uint64_t nPruneTarget;
  * best chain soon, or fForceProcessing is set), but pblock has been mutated,
  * state is guaranteed to be some non-IsValid() state.
  *
- * If fForceProcessing is set (or fNewBlock returns true), and state.IsValid(),
- * barring pruning and a desire to re-download a pruned block, there should
- * never be any reason to re-ProcessNewBlock any block with the same hash.
+ * If fForceProcessing is set (or the function returns true), and
+ * state.IsValid(), barring pruning and a desire to re-download a pruned block,
+ * there should never be any reason to re-ProcessNewBlock any block with the
+ * same hash.
  *
  * May not be called in a validationinterface callback.
  *
@@ -171,10 +172,9 @@ extern uint64_t nPruneTarget;
  * @param[out]  state             Only used for failures in CheckBlock/AcceptBlock. For failure in block connection,
  *                                a CValidationInterface BlockChecked callback is used to notify clients of validity.
  * @param[in]   fForceProcessing  Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  fNewBlock         A boolean which is set to indicate if the block was first received via this call
- * @returns     bool              If the block was processed, independently of block validity
+ * @returns     If the block was first received via this call
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, BlockValidationState& state, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, BlockValidationState& state, bool fForceProcessing) LOCKS_EXCLUDED(cs_main);
 
 /**
  * Process incoming block headers.

--- a/src/validation.h
+++ b/src/validation.h
@@ -157,12 +157,13 @@ extern uint64_t nPruneTarget;
  * May not be called in a
  * validationinterface callback.
  *
- * @param[in]   pblock  The block we want to process.
- * @param[in]   fForceProcessing Process this block even if unrequested; used for non-network block sources and whitelisted peers.
- * @param[out]  fNewBlock A boolean which is set to indicate if the block was first received via this call
- * @returns     If the block was processed, independently of block validity
+ * @param[in]   pblock            The block we want to process.
+ * @param[out]  state             Currently unused.
+ * @param[in]   fForceProcessing  Process this block even if unrequested; used for non-network block sources and whitelisted peers.
+ * @param[out]  fNewBlock         A boolean which is set to indicate if the block was first received via this call
+ * @returns     bool              If the block was processed, independently of block validity
  */
-bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
+bool ProcessNewBlock(const CChainParams& chainparams, const std::shared_ptr<const CBlock> pblock, BlockValidationState& state, bool fForceProcessing, bool* fNewBlock) LOCKS_EXCLUDED(cs_main);
 
 /**
  * Process incoming block headers.

--- a/src/validation.h
+++ b/src/validation.h
@@ -571,6 +571,22 @@ private:
     /** Indicates the block validation thread is parked */
     bool m_block_validation_parked;
 
+    /**
+     * Utility function to check if it makes sense to write the given block to
+     * disk right now.
+     * Checks whether we already had/have the block and whether it meets DoS
+     * criteria.
+     */
+    bool ShouldMaybeWrite(CBlockIndex* pindex, bool fRequested) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
+    /**
+     * Performs initial DoS checks for the given block (assuming ShouldMaybeWrite
+     * passes).
+     * Will detect any cases of malleability, ie if this passes, pblock is a
+     * "good" copy of the block.
+     */
+    bool PreWriteCheckBlock(const std::shared_ptr<const CBlock>& pblock, BlockValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex, bool fRequested, bool* fShouldWrite) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
+
 public:
     explicit CChainState(BlockManager& blockman, uint256 from_snapshot_blockhash = uint256());
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -147,18 +147,29 @@ extern uint64_t nPruneTarget;
  * block is made active. Note that it does not, however, guarantee that the
  * specific block passed to it has been checked for validity!
  *
- * If you want to *possibly* get feedback on whether pblock is valid, you must
- * install a CValidationInterface (see validationinterface.h) - this will have
- * its BlockChecked method called whenever *any* block completes validation.
+ * Performs initial sanity checks using the provided BlockValidationState before
+ * connecting any block(s). If you want to *possibly* get feedback on whether
+ * pblock is valid beyond just cursory mutation/DoS checks, you must install
+ * a CValidationInterface (see validationinterface.h) - this will have its
+ * BlockChecked method called whenever *any* block completes validation (note
+ * that any invalidity returned via state will *not* also be provided via
+ * BlockChecked). There is, of course, no guarantee that any given block which
+ * is not a part of the eventual best chain will ever be checked.
  *
- * Note that we guarantee that either the proof-of-work is valid on pblock, or
- * (and possibly also) BlockChecked will have been called.
+ * If the block pblock is built on is in our header tree, and pblock is a
+ * candidate for accepting to disk (either because it is a candidate for the
+ * best chain soon, or fForceProcessing is set), but pblock has been mutated,
+ * state is guaranteed to be some non-IsValid() state.
  *
- * May not be called in a
- * validationinterface callback.
+ * If fForceProcessing is set (or fNewBlock returns true), and state.IsValid(),
+ * barring pruning and a desire to re-download a pruned block, there should
+ * never be any reason to re-ProcessNewBlock any block with the same hash.
+ *
+ * May not be called in a validationinterface callback.
  *
  * @param[in]   pblock            The block we want to process.
- * @param[out]  state             Currently unused.
+ * @param[out]  state             Only used for failures in CheckBlock/AcceptBlock. For failure in block connection,
+ *                                a CValidationInterface BlockChecked callback is used to notify clients of validity.
  * @param[in]   fForceProcessing  Process this block even if unrequested; used for non-network block sources and whitelisted peers.
  * @param[out]  fNewBlock         A boolean which is set to indicate if the block was first received via this call
  * @returns     bool              If the block was processed, independently of block validity

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -254,3 +254,9 @@ void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared
     LOG_EVENT("%s: block hash=%s", __func__, block->GetHash().ToString());
     m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.NewPoWValidBlock(pindex, block); });
 }
+
+void CMainSignals::BlockProcessed() {
+    m_internals->m_schedulerClient.AddToProcessQueue([this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BlockProcessed(); });
+    });
+}

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -244,10 +244,12 @@ void CMainSignals::ChainStateFlushed(const CBlockLocator &locator) {
                           locator.IsNull() ? "null" : locator.vHave.front().ToString());
 }
 
-void CMainSignals::BlockChecked(const CBlock& block, const BlockValidationState& state) {
-    LOG_EVENT("%s: block hash=%s state=%s", __func__,
-              block.GetHash().ToString(), state.ToString());
-    m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BlockChecked(block, state); });
+void CMainSignals::BlockChecked(const std::shared_ptr<const CBlock> &pblock, const BlockValidationState& state) {
+    auto event = [pblock, state, this] {
+        m_internals->Iterate([&](CValidationInterface& callbacks) { callbacks.BlockChecked(*pblock, state); });
+    };
+    ENQUEUE_AND_LOG_EVENT(event, "%s: block hash=%s state=%s", __func__,
+                          pblock->GetHash().ToString(), state.ToString());
 }
 
 void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -165,6 +165,8 @@ protected:
      * If the provided BlockValidationState IsValid, the provided block
      * is guaranteed to be the current best block at the time the
      * callback was generated (not necessarily now)
+     *
+     * Called on a background thread.
      */
     virtual void BlockChecked(const CBlock&, const BlockValidationState&) {}
     /**
@@ -207,7 +209,7 @@ public:
     void BlockConnected(const std::shared_ptr<const CBlock> &, const CBlockIndex *pindex);
     void BlockDisconnected(const std::shared_ptr<const CBlock> &, const CBlockIndex* pindex);
     void ChainStateFlushed(const CBlockLocator &);
-    void BlockChecked(const CBlock&, const BlockValidationState&);
+    void BlockChecked(const std::shared_ptr<const CBlock> &, const BlockValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
     void BlockProcessed();
 };

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -171,6 +171,12 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    /**
+     * Notifies listeners that a block which was submitted has been fully processed.
+     *
+     * Called on a background thread.
+     */
+    virtual void BlockProcessed() {}
     friend class CMainSignals;
 };
 
@@ -203,6 +209,7 @@ public:
     void ChainStateFlushed(const CBlockLocator &);
     void BlockChecked(const CBlock&, const BlockValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void BlockProcessed();
 };
 
 CMainSignals& GetMainSignals();


### PR DESCRIPTION
This is a (currently naive) rebase of #16323, which is a rework of #16175, which is a rework of #12934.
Built on top of #17479.

Currently `validationinterface_tests/unregister_all_during_call` fails.

-----

Goals:
- [ ] Add as much documentation as possible to aid with review
- [ ] Split up commits as much as possible to aid with review