### PR TITLE
rpc, wallet: Scan mempool after import*

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -185,6 +185,8 @@ UniValue importprivkey(const JSONRPCRequest& request)
                 pwallet->ImportScripts({GetScriptForDestination(WitnessV0KeyHash(vchAddress))}, 0 /* timestamp */);
             }
         }
+        // Scan mempool for transactions
+        pwallet->chain().requestMempoolTransactions(*pwallet);
     }
     if (fRescan) {
         RescanWallet(*pwallet, reserver);

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -310,6 +310,8 @@ UniValue importaddress(const JSONRPCRequest& request)
         } else {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
         }
+        // Scan mempool for transactions
+        pwallet->chain().requestMempoolTransactions(*pwallet);
     }
     if (fRescan)
     {

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -270,6 +270,19 @@ class WalletTest(BitcoinTestFramework):
         self.sync_all()
         assert_equal(self.nodes[0].getbalance(minconf=0), total_amount + 1)  # The reorg recovered our fee of 1 coin
 
+        self.log.info('Check if mempool is taken into account after import*')
+        address = self.nodes[0].getnewaddress()
+        self.nodes[0].sendtoaddress(address, 0.1)
+        self.nodes[0].unloadwallet('')
+        # check importaddress on fresh wallet
+        self.nodes[0].createwallet('w1', False, True)
+        self.nodes[0].importaddress(address)
+        assert_equal(self.nodes[0].getbalances()['mine']['untrusted_pending'], 0)
+        assert_equal(self.nodes[0].getbalances()['watchonly']['untrusted_pending'], Decimal('0.1'))
+        self.nodes[0].importprivkey(privkey)
+        assert_equal(self.nodes[0].getbalances()['mine']['untrusted_pending'], Decimal('0.1'))
+        assert_equal(self.nodes[0].getbalances()['watchonly']['untrusted_pending'], 0)
+        self.nodes[0].unloadwallet('w1')
 
 if __name__ == '__main__':
     WalletTest().main()

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -272,6 +272,7 @@ class WalletTest(BitcoinTestFramework):
 
         self.log.info('Check if mempool is taken into account after import*')
         address = self.nodes[0].getnewaddress()
+        privkey = self.nodes[0].dumpprivkey(address)
         self.nodes[0].sendtoaddress(address, 0.1)
         self.nodes[0].unloadwallet('')
         # check importaddress on fresh wallet
@@ -283,6 +284,10 @@ class WalletTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbalances()['mine']['untrusted_pending'], Decimal('0.1'))
         assert_equal(self.nodes[0].getbalances()['watchonly']['untrusted_pending'], 0)
         self.nodes[0].unloadwallet('w1')
+        # check importprivkey on fresh wallet
+        self.nodes[0].createwallet('w2', False, True)
+        self.nodes[0].importprivkey(privkey)
+        assert_equal(self.nodes[0].getbalances()['mine']['untrusted_pending'], Decimal('0.1'))
 
 if __name__ == '__main__':
     WalletTest().main()


### PR DESCRIPTION
Mempool transactions are ignored on `import*` RPC. This results in unexpected results if the mempool contains transactions relevant for the imported material.

Fixes #18954.