### PR TITLE
wallet: Refactor the classes in wallet/db.{cpp/h}

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -24,7 +24,6 @@
 #include <univalue.h>
 
 #ifdef ENABLE_WALLET
-#include <wallet/bdb.h>
 #include <wallet/db.h>
 #include <wallet/wallet.h>
 #endif

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -893,7 +893,7 @@ void BerkeleyDatabase::RemoveRef()
     env->m_db_in_use.notify_all();
 }
 
-std::unique_ptr<BerkeleyBatch> BerkeleyDatabase::MakeBatch(const char* mode, bool flush_on_close)
+std::unique_ptr<DatabaseBatch> BerkeleyDatabase::MakeBatch(const char* mode, bool flush_on_close)
 {
     return MakeUnique<BerkeleyBatch>(*this, mode, flush_on_close);
 }

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -424,6 +424,11 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
     }
 }
 
+void BerkeleyDatabase::Open(const char* mode)
+{
+    throw std::logic_error("BerkeleyDatabase does not implement Open. This function should not be called.");
+}
+
 void BerkeleyBatch::Flush()
 {
     if (activeTxn)

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -497,13 +497,11 @@ void BerkeleyEnvironment::ReloadDbEnv()
     Open(true);
 }
 
-bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
+bool BerkeleyDatabase::Rewrite(const char* pszSkip)
 {
-    if (database.IsDummy()) {
+    if (IsDummy()) {
         return true;
     }
-    BerkeleyEnvironment *env = database.env.get();
-    const std::string& strFile = database.strFile;
     while (true) {
         {
             LOCK(cs_db);
@@ -517,7 +515,7 @@ bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
                 LogPrintf("BerkeleyBatch::Rewrite: Rewriting %s...\n", strFile);
                 std::string strFileRes = strFile + ".rewrite";
                 { // surround usage of db with extra {}
-                    BerkeleyBatch db(database, "r");
+                    BerkeleyBatch db(*this, "r");
                     std::unique_ptr<Db> pdbCopy = MakeUnique<Db>(env->dbenv.get(), 0);
 
                     int ret = pdbCopy->open(nullptr,               // Txn pointer
@@ -665,11 +663,6 @@ bool BerkeleyDatabase::PeriodicFlush()
     }
 
     return ret;
-}
-
-bool BerkeleyDatabase::Rewrite(const char* pszSkip)
-{
-    return BerkeleyBatch::Rewrite(*this, pszSkip);
 }
 
 bool BerkeleyDatabase::Backup(const std::string& strDest) const

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -335,7 +335,7 @@ void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
 }
 
 
-BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr)
+BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr), m_cursor(nullptr)
 {
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
@@ -442,6 +442,7 @@ void BerkeleyBatch::Close()
         activeTxn->abort();
     activeTxn = nullptr;
     pdb = nullptr;
+    CloseCursor();
 
     if (fFlushOnClose)
         Flush();
@@ -528,17 +529,17 @@ bool BerkeleyBatch::Rewrite(BerkeleyDatabase& database, const char* pszSkip)
                         fSuccess = false;
                     }
 
-                    Dbc* pcursor = db.GetCursor();
-                    if (pcursor)
+                    if (db.CreateCursor())
                         while (fSuccess) {
                             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
                             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-                            int ret1 = db.ReadAtCursor(pcursor, ssKey, ssValue);
-                            if (ret1 == DB_NOTFOUND) {
-                                pcursor->close();
+                            bool complete;
+                            bool ret1 = db.ReadAtCursor(ssKey, ssValue, complete);
+                            if (complete) {
+                                db.CloseCursor();
                                 break;
-                            } else if (ret1 != 0) {
-                                pcursor->close();
+                            } else if (!ret1) {
+                                db.CloseCursor();
                                 fSuccess = false;
                                 break;
                             }
@@ -738,27 +739,32 @@ void BerkeleyDatabase::ReloadDbEnv()
     }
 }
 
-Dbc* BerkeleyBatch::GetCursor()
+bool BerkeleyBatch::CreateCursor()
 {
+    assert(!m_cursor);
     if (!pdb)
-        return nullptr;
-    Dbc* pcursor = nullptr;
-    int ret = pdb->cursor(nullptr, &pcursor, 0);
+        return false;
+    int ret = pdb->cursor(nullptr, &m_cursor, 0);
     if (ret != 0)
-        return nullptr;
-    return pcursor;
+        return false;
+    return true;
 }
 
-int BerkeleyBatch::ReadAtCursor(Dbc* pcursor, CDataStream& ssKey, CDataStream& ssValue)
+bool BerkeleyBatch::ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete)
 {
+    complete = false;
+    if (m_cursor == nullptr) return false;
     // Read at cursor
     SafeDbt datKey;
     SafeDbt datValue;
-    int ret = pcursor->get(datKey, datValue, DB_NEXT);
+    int ret = m_cursor->get(datKey, datValue, DB_NEXT);
+    if (ret == DB_NOTFOUND) {
+        complete = true;
+    }
     if (ret != 0)
-        return ret;
+        return false;
     else if (datKey.get_data() == nullptr || datValue.get_data() == nullptr)
-        return 99999;
+        return false;
 
     // Convert to streams
     ssKey.SetType(SER_DISK);
@@ -767,7 +773,14 @@ int BerkeleyBatch::ReadAtCursor(Dbc* pcursor, CDataStream& ssKey, CDataStream& s
     ssValue.SetType(SER_DISK);
     ssValue.clear();
     ssValue.write((char*)datValue.get_data(), datValue.get_size());
-    return 0;
+    return true;
+}
+
+void BerkeleyBatch::CloseCursor()
+{
+    if (!m_cursor) return;
+    m_cursor->close();
+    m_cursor = nullptr;
 }
 
 bool BerkeleyBatch::TxnBegin()

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -873,3 +873,8 @@ bool BerkeleyBatch::HasKey(CDataStream& key)
     int ret = pdb->exists(activeTxn, datKey, 0);
     return ret == 0;
 }
+
+std::unique_ptr<BerkeleyBatch> BerkeleyDatabase::MakeBatch(const char* mode, bool flush_on_close)
+{
+    return MakeUnique<BerkeleyBatch>(*this, mode, flush_on_close);
+}

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -336,6 +336,14 @@ void BerkeleyEnvironment::CheckpointLSN(const std::string& strFile)
     dbenv->lsn_reset(strFile.c_str(), 0);
 }
 
+BerkeleyDatabase::~BerkeleyDatabase()
+{
+    if (env) {
+        size_t erased = env->m_databases.erase(strFile);
+        assert(erased == 1);
+        env->m_fileids.erase(strFile);
+    }
+}
 
 BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr), m_cursor(nullptr)
 {
@@ -706,22 +714,17 @@ bool BerkeleyDatabase::Backup(const std::string& strDest) const
     }
 }
 
-void BerkeleyDatabase::Flush(bool shutdown)
+void BerkeleyDatabase::Flush()
 {
     if (!IsDummy()) {
-        env->Flush(shutdown);
-        if (shutdown) {
-            LOCK(cs_db);
-            g_dbenvs.erase(env->Directory().string());
-            env = nullptr;
-        } else {
-            // TODO: To avoid g_dbenvs.erase erasing the environment prematurely after the
-            // first database shutdown when multiple databases are open in the same
-            // environment, should replace raw database `env` pointers with shared or weak
-            // pointers, or else separate the database and environment shutdowns so
-            // environments can be shut down after databases.
-            env->m_fileids.erase(strFile);
-        }
+        env->Flush(false);
+    }
+}
+
+void BerkeleyDatabase::Close()
+{
+    if (!IsDummy()) {
+        env->Flush(true);
     }
 }
 

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -345,13 +345,27 @@ BerkeleyDatabase::~BerkeleyDatabase()
 
 BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr), m_cursor(nullptr), m_database(database)
 {
+    database.AddRef();
+    database.Open(pszMode);
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
     env = database.env.get();
-    if (database.IsDummy()) {
+    pdb = database.m_db.get();
+    strFile = database.strFile;
+    bool fCreate = strchr(pszMode, 'c') != nullptr;
+    if (fCreate && !Exists(std::string("version"))) {
+        bool fTmp = fReadOnly;
+        fReadOnly = false;
+        Write(std::string("version"), CLIENT_VERSION);
+        fReadOnly = fTmp;
+    }
+}
+
+void BerkeleyDatabase::Open(const char* pszMode)
+{
+    if (IsDummy()){
         return;
     }
-    const std::string &strFilename = database.strFile;
 
     bool fCreate = strchr(pszMode, 'c') != nullptr;
     unsigned int nFlags = DB_THREAD;
@@ -361,10 +375,9 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
     {
         LOCK(cs_db);
         if (!env->Open(false /* retry */))
-            throw std::runtime_error("BerkeleyBatch: Failed to open database environment.");
+            throw std::runtime_error("BerkeleyDatabase: Failed to open database environment.");
 
-        pdb = database.m_db.get();
-        if (pdb == nullptr) {
+        if (m_db == nullptr) {
             int ret;
             std::unique_ptr<Db> pdb_temp = MakeUnique<Db>(env->dbenv.get(), 0);
 
@@ -373,19 +386,19 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
                 DbMpoolFile* mpf = pdb_temp->get_mpf();
                 ret = mpf->set_flags(DB_MPOOL_NOFILE, 1);
                 if (ret != 0) {
-                    throw std::runtime_error(strprintf("BerkeleyBatch: Failed to configure for no temp file backing for database %s", strFilename));
+                    throw std::runtime_error(strprintf("BerkeleyDatabase: Failed to configure for no temp file backing for database %s", strFile));
                 }
             }
 
             ret = pdb_temp->open(nullptr,                             // Txn pointer
-                            fMockDb ? nullptr : strFilename.c_str(),  // Filename
-                            fMockDb ? strFilename.c_str() : "main",   // Logical db name
+                            fMockDb ? nullptr : strFile.c_str(),      // Filename
+                            fMockDb ? strFile.c_str() : "main",       // Logical db name
                             DB_BTREE,                                 // Database type
                             nFlags,                                   // Flags
                             0);
 
             if (ret != 0) {
-                throw std::runtime_error(strprintf("BerkeleyBatch: Error %d, can't open database %s", ret, strFilename));
+                throw std::runtime_error(strprintf("BerkeleyDatabase: Error %d, can't open database %s", ret, strFile));
             }
 
             // Call CheckUniqueFileid on the containing BDB environment to
@@ -404,27 +417,13 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
             // versions of BDB have an set_lk_exclusive method for this
             // purpose, but the older version we use does not.)
             for (const auto& env : g_dbenvs) {
-                CheckUniqueFileid(*env.second.lock().get(), strFilename, *pdb_temp, this->env->m_fileids[strFilename]);
+                CheckUniqueFileid(*env.second.lock().get(), strFile, *pdb_temp, this->env->m_fileids[strFile]);
             }
 
-            pdb = pdb_temp.release();
-            database.m_db.reset(pdb);
+            m_db.reset(pdb_temp.release());
 
-            if (fCreate && !Exists(std::string("version"))) {
-                bool fTmp = fReadOnly;
-                fReadOnly = false;
-                Write(std::string("version"), CLIENT_VERSION);
-                fReadOnly = fTmp;
-            }
         }
-        database.AddRef();
-        strFile = strFilename;
     }
-}
-
-void BerkeleyDatabase::Open(const char* mode)
-{
-    throw std::logic_error("BerkeleyDatabase does not implement Open. This function should not be called.");
 }
 
 void BerkeleyBatch::Flush()

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -345,7 +345,7 @@ BerkeleyDatabase::~BerkeleyDatabase()
     }
 }
 
-BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr), m_cursor(nullptr)
+BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr), m_cursor(nullptr), m_database(database)
 {
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
     fFlushOnClose = fFlushOnCloseIn;
@@ -419,7 +419,7 @@ BerkeleyBatch::BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode, bo
                 fReadOnly = fTmp;
             }
         }
-        ++env->mapFileUseCount[strFilename];
+        database.AddRef();
         strFile = strFilename;
     }
 }
@@ -457,11 +457,7 @@ void BerkeleyBatch::Close()
     if (fFlushOnClose)
         Flush();
 
-    {
-        LOCK(cs_db);
-        --env->mapFileUseCount[strFile];
-    }
-    env->m_db_in_use.notify_all();
+    m_database.RemoveRef();
 }
 
 void BerkeleyEnvironment::CloseDb(const std::string& strFile)
@@ -875,6 +871,21 @@ bool BerkeleyBatch::HasKey(CDataStream& key)
     // Exists
     int ret = pdb->exists(activeTxn, datKey, 0);
     return ret == 0;
+}
+
+void BerkeleyDatabase::AddRef()
+{
+    LOCK(cs_db);
+    ++env->mapFileUseCount[strFile];
+}
+
+void BerkeleyDatabase::RemoveRef()
+{
+    {
+        LOCK(cs_db);
+        --env->mapFileUseCount[strFile];
+    }
+    env->m_db_in_use.notify_all();
 }
 
 std::unique_ptr<BerkeleyBatch> BerkeleyDatabase::MakeBatch(const char* mode, bool flush_on_close)

--- a/src/wallet/bdb.cpp
+++ b/src/wallet/bdb.cpp
@@ -627,14 +627,12 @@ void BerkeleyEnvironment::Flush(bool fShutdown)
     }
 }
 
-bool BerkeleyBatch::PeriodicFlush(BerkeleyDatabase& database)
+bool BerkeleyDatabase::PeriodicFlush()
 {
-    if (database.IsDummy()) {
+    if (IsDummy()) {
         return true;
     }
     bool ret = false;
-    BerkeleyEnvironment *env = database.env.get();
-    const std::string& strFile = database.strFile;
     TRY_LOCK(cs_db, lockDb);
     if (lockDb)
     {

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -117,6 +117,10 @@ public:
 
     ~BerkeleyDatabase();
 
+    /** Open the database if it is not already opened.
+     *  Dummy function, doesn't do anything right now, but is needed for class abstraction */
+    void Open(const char* mode);
+
     /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
      */
     bool Rewrite(const char* pszSkip=nullptr);

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -52,7 +52,6 @@ private:
 
 public:
     std::unique_ptr<DbEnv> dbenv;
-    std::map<std::string, int> mapFileUseCount;
     std::map<std::string, std::reference_wrapper<BerkeleyDatabase>> m_databases;
     std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -115,12 +115,7 @@ public:
         assert(inserted.second);
     }
 
-    ~BerkeleyDatabase() {
-        if (env) {
-            size_t erased = env->m_databases.erase(strFile);
-            assert(erased == 1);
-        }
-    }
+    ~BerkeleyDatabase();
 
     /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
      */
@@ -130,9 +125,13 @@ public:
      */
     bool Backup(const std::string& strDest) const;
 
-    /** Make sure all changes are flushed to disk.
+    /** Make sure all changes are flushed to database file.
      */
-    void Flush(bool shutdown);
+    void Flush();
+    /** Flush to the database file and close the database.
+     *  Also close the environment if no other databases are open in it.
+     */
+    void Close();
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
     bool PeriodicFlush();

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -131,6 +131,9 @@ public:
     /** Make sure all changes are flushed to disk.
      */
     void Flush(bool shutdown);
+    /* flush the wallet passively (TRY_LOCK)
+       ideal to be called periodically */
+    bool PeriodicFlush();
 
     void IncrementUpdateCounter();
 
@@ -217,10 +220,6 @@ public:
 
     void Flush();
     void Close();
-
-    /* flush the wallet passively (TRY_LOCK)
-       ideal to be called periodically */
-    static bool PeriodicFlush(BerkeleyDatabase& database);
 
     template <typename K, typename T>
     bool Read(const K& key, T& value)

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -141,6 +141,11 @@ public:
     unsigned int nLastFlushed;
     int64_t nLastWalletUpdate;
 
+    /** Verifies that the database file is not in use */
+    bool VerifyNotInUse(bilingual_str& error);
+    /** Verifies the environment and database file */
+    bool Verify(bilingual_str& error);
+
     /**
      * Pointer to shared database environment.
      *
@@ -216,10 +221,6 @@ public:
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
     static bool PeriodicFlush(BerkeleyDatabase& database);
-    /* verifies the database environment */
-    static bool VerifyEnvironment(const fs::path& file_path, bilingual_str& errorStr);
-    /* verifies the database file */
-    static bool VerifyDatabaseFile(const fs::path& file_path, bilingual_str& errorStr);
 
     template <typename K, typename T>
     bool Read(const K& key, T& value)

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -98,66 +98,61 @@ class BerkeleyBatch;
 /** An instance of this class represents one database.
  * For BerkeleyDB this is just a (env, strFile) tuple.
  **/
-class BerkeleyDatabase
+class BerkeleyDatabase : public WalletDatabase
 {
     friend class BerkeleyBatch;
 public:
     /** Create dummy DB handle */
-    BerkeleyDatabase() : nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(nullptr)
+    BerkeleyDatabase() : WalletDatabase(), env(nullptr)
     {
     }
 
     /** Create DB handle to real database */
     BerkeleyDatabase(std::shared_ptr<BerkeleyEnvironment> env, std::string filename) :
-        nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0), env(std::move(env)), strFile(std::move(filename))
+        WalletDatabase(), env(std::move(env)), strFile(std::move(filename))
     {
         auto inserted = this->env->m_databases.emplace(strFile, std::ref(*this));
         assert(inserted.second);
     }
 
-    ~BerkeleyDatabase();
+    ~BerkeleyDatabase() override;
 
     /** Open the database if it is not already opened.
      *  Dummy function, doesn't do anything right now, but is needed for class abstraction */
-    void Open(const char* mode);
+    void Open(const char* mode) override;
 
     /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
      */
-    bool Rewrite(const char* pszSkip=nullptr);
+    bool Rewrite(const char* pszSkip=nullptr) override;
 
     /** Indicate the a new database user has began using the database. */
-    void AddRef();
+    void AddRef() override;
     /** Indicate that database user has stopped using the database and that it could be flushed or closed. */
-    void RemoveRef();
+    void RemoveRef() override;
 
     /** Back up the entire database to a file.
      */
-    bool Backup(const std::string& strDest) const;
+    bool Backup(const std::string& strDest) const override;
 
     /** Make sure all changes are flushed to database file.
      */
-    void Flush();
+    void Flush() override;
     /** Flush to the database file and close the database.
      *  Also close the environment if no other databases are open in it.
      */
-    void Close();
+    void Close() override;
     /* flush the wallet passively (TRY_LOCK)
        ideal to be called periodically */
-    bool PeriodicFlush();
+    bool PeriodicFlush() override;
 
-    void IncrementUpdateCounter();
+    void IncrementUpdateCounter() override;
 
-    void ReloadDbEnv();
-
-    std::atomic<unsigned int> nUpdateCounter;
-    unsigned int nLastSeen;
-    unsigned int nLastFlushed;
-    int64_t nLastWalletUpdate;
+    void ReloadDbEnv() override;
 
     /** Verifies that the database file is not in use */
-    bool VerifyNotInUse(bilingual_str& error);
+    bool VerifyNotInUse(bilingual_str& error) override;
     /** Verifies the environment and database file */
-    bool Verify(bilingual_str& error);
+    bool Verify(bilingual_str& error) override;
 
     /**
      * Pointer to shared database environment.
@@ -174,7 +169,7 @@ public:
     std::unique_ptr<Db> m_db;
 
     /** Make a BerkeleyBatch connected to this database */
-    std::unique_ptr<BerkeleyBatch> MakeBatch(const char* mode, bool flush_on_close);
+    std::unique_ptr<DatabaseBatch> MakeBatch(const char* mode = "r+", bool flush_on_close = true) override;
 
 private:
     std::string strFile;

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -93,6 +93,8 @@ std::shared_ptr<BerkeleyEnvironment> GetWalletEnv(const fs::path& wallet_path, s
 /** Return wheter a BDB wallet database is currently loaded. */
 bool IsBDBWalletLoaded(const fs::path& wallet_path);
 
+class BerkeleyBatch;
+
 /** An instance of this class represents one database.
  * For BerkeleyDB this is just a (env, strFile) tuple.
  **/
@@ -162,6 +164,9 @@ public:
 
     /** Database pointer. This is initialized lazily and reset during flushes, so it can be null. */
     std::unique_ptr<Db> m_db;
+
+    /** Make a BerkeleyBatch connected to this database */
+    std::unique_ptr<BerkeleyBatch> MakeBatch(const char* mode, bool flush_on_close);
 
 private:
     std::string strFile;

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -53,7 +53,6 @@ private:
 public:
     std::unique_ptr<DbEnv> dbenv;
     std::map<std::string, std::reference_wrapper<BerkeleyDatabase>> m_databases;
-    std::unordered_map<std::string, WalletDatabaseFileId> m_fileids;
     std::condition_variable_any m_db_in_use;
 
     BerkeleyEnvironment(const fs::path& env_directory);

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -98,7 +98,6 @@ class BerkeleyBatch;
  **/
 class BerkeleyDatabase : public WalletDatabase
 {
-    friend class BerkeleyBatch;
 public:
     /** Create dummy DB handle */
     BerkeleyDatabase() : WalletDatabase(), env(nullptr)
@@ -166,11 +165,12 @@ public:
     /** Database pointer. This is initialized lazily and reset during flushes, so it can be null. */
     std::unique_ptr<Db> m_db;
 
+    std::string strFile;
+
     /** Make a BerkeleyBatch connected to this database */
     std::unique_ptr<DatabaseBatch> MakeBatch(const char* mode = "r+", bool flush_on_close = true) override;
 
 private:
-    std::string strFile;
 
     /** Return whether this database handle is a dummy for testing.
      * Only to be used at a low level, application should ideally not care

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -174,7 +174,7 @@ private:
 };
 
 /** RAII class that provides access to a Berkeley database */
-class BerkeleyBatch
+class BerkeleyBatch : public DatabaseBatch
 {
     /** RAII class that automatically cleanses its data on destruction */
     class SafeDbt final
@@ -197,10 +197,10 @@ class BerkeleyBatch
     };
 
 private:
-    bool ReadKey(CDataStream& key, CDataStream& value);
-    bool WriteKey(CDataStream& key, CDataStream& value, bool overwrite=true);
-    bool EraseKey(CDataStream& key);
-    bool HasKey(CDataStream& key);
+    bool ReadKey(CDataStream& key, CDataStream& value) override;
+    bool WriteKey(CDataStream& key, CDataStream& value, bool overwrite=true) override;
+    bool EraseKey(CDataStream& key) override;
+    bool HasKey(CDataStream& key) override;
 
 protected:
     Db* pdb;
@@ -213,84 +213,20 @@ protected:
 
 public:
     explicit BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode = "r+", bool fFlushOnCloseIn=true);
-    ~BerkeleyBatch() { Close(); }
+    ~BerkeleyBatch() override { Close(); }
 
     BerkeleyBatch(const BerkeleyBatch&) = delete;
     BerkeleyBatch& operator=(const BerkeleyBatch&) = delete;
 
-    void Flush();
-    void Close();
+    void Flush() override;
+    void Close() override;
 
-    template <typename K, typename T>
-    bool Read(const K& key, T& value)
-    {
-        // Key
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        ssKey.reserve(1000);
-        ssKey << key;
-
-        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-        bool success = false;
-        bool ret = ReadKey(ssKey, ssValue);
-        if (ret) {
-            // Unserialize value
-            try {
-                ssValue >> value;
-                success = true;
-            } catch (const std::exception&) {
-                // In this case success remains 'false'
-            }
-        }
-        return ret && success;
-    }
-
-    template <typename K, typename T>
-    bool Write(const K& key, const T& value, bool fOverwrite = true)
-    {
-        // Key
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        ssKey.reserve(1000);
-        ssKey << key;
-
-        // Value
-        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-        ssValue.reserve(10000);
-        ssValue << value;
-
-        // Write
-        return WriteKey(ssKey, ssValue, fOverwrite);
-    }
-
-    template <typename K>
-    bool Erase(const K& key)
-    {
-        // Key
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        ssKey.reserve(1000);
-        ssKey << key;
-
-        // Erase
-        return EraseKey(ssKey);
-    }
-
-    template <typename K>
-    bool Exists(const K& key)
-    {
-        // Key
-        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
-        ssKey.reserve(1000);
-        ssKey << key;
-
-        // Exists
-        return HasKey(ssKey);
-    }
-
-    bool CreateCursor();
-    bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete);
-    void CloseCursor();
-    bool TxnBegin();
-    bool TxnCommit();
-    bool TxnAbort();
+    bool CreateCursor() override;
+    bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete) override;
+    void CloseCursor() override;
+    bool TxnBegin() override;
+    bool TxnCommit() override;
+    bool TxnAbort() override;
 };
 
 std::string BerkeleyDatabaseVersion();

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -121,6 +121,11 @@ public:
      */
     bool Rewrite(const char* pszSkip=nullptr);
 
+    /** Indicate the a new database user has began using the database. */
+    void AddRef();
+    /** Indicate that database user has stopped using the database and that it could be flushed or closed. */
+    void RemoveRef();
+
     /** Back up the entire database to a file.
      */
     bool Backup(const std::string& strDest) const;
@@ -214,6 +219,7 @@ protected:
     bool fReadOnly;
     bool fFlushOnClose;
     BerkeleyEnvironment *env;
+    BerkeleyDatabase& m_database;
 
 public:
     explicit BerkeleyBatch(BerkeleyDatabase& database, const char* pszMode = "r+", bool fFlushOnCloseIn=true);

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -291,8 +291,6 @@ public:
     bool TxnBegin();
     bool TxnCommit();
     bool TxnAbort();
-
-    bool static Rewrite(BerkeleyDatabase& database, const char* pszSkip = nullptr);
 };
 
 std::string BerkeleyDatabaseVersion();

--- a/src/wallet/bdb.h
+++ b/src/wallet/bdb.h
@@ -198,6 +198,7 @@ protected:
     Db* pdb;
     std::string strFile;
     DbTxn* activeTxn;
+    Dbc* m_cursor;
     bool fReadOnly;
     bool fFlushOnClose;
     BerkeleyEnvironment *env;
@@ -284,8 +285,9 @@ public:
         return HasKey(ssKey);
     }
 
-    Dbc* GetCursor();
-    int ReadAtCursor(Dbc* pcursor, CDataStream& ssKey, CDataStream& ssValue);
+    bool CreateCursor();
+    bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete);
+    void CloseCursor();
     bool TxnBegin();
     bool TxnCommit();
     bool TxnAbort();

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -6,12 +6,105 @@
 #ifndef BITCOIN_WALLET_DB_H
 #define BITCOIN_WALLET_DB_H
 
+#include <clientversion.h>
 #include <fs.h>
+#include <streams.h>
 
 #include <string>
 
 /** Given a wallet directory path or legacy file path, return path to main data file in the wallet database. */
 fs::path WalletDataFilePath(const fs::path& wallet_path);
 void SplitWalletPath(const fs::path& wallet_path, fs::path& env_directory, std::string& database_filename);
+
+/** RAII class that provides access to a WalletDatabase */
+class DatabaseBatch
+{
+private:
+    virtual bool ReadKey(CDataStream& key, CDataStream& value) = 0;
+    virtual bool WriteKey(CDataStream& key, CDataStream& value, bool overwrite=true) = 0;
+    virtual bool EraseKey(CDataStream& key) = 0;
+    virtual bool HasKey(CDataStream& key) = 0;
+
+public:
+    explicit DatabaseBatch() {}
+    virtual ~DatabaseBatch() {}
+
+    DatabaseBatch(const DatabaseBatch&) = delete;
+    DatabaseBatch& operator=(const DatabaseBatch&) = delete;
+
+    virtual void Flush() = 0;
+    virtual void Close() = 0;
+
+    template <typename K, typename T>
+    bool Read(const K& key, T& value)
+    {
+        // Key
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(1000);
+        ssKey << key;
+
+        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
+        bool success = false;
+        bool ret = ReadKey(ssKey, ssValue);
+        if (ret) {
+            // Unserialize value
+            try {
+                ssValue >> value;
+                success = true;
+            } catch (const std::exception&) {
+                // In this case success remains 'false'
+            }
+        }
+        return ret && success;
+    }
+
+    template <typename K, typename T>
+    bool Write(const K& key, const T& value, bool fOverwrite = true)
+    {
+        // Key
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(1000);
+        ssKey << key;
+
+        // Value
+        CDataStream ssValue(SER_DISK, CLIENT_VERSION);
+        ssValue.reserve(10000);
+        ssValue << value;
+
+        // Write
+        return WriteKey(ssKey, ssValue, fOverwrite);
+    }
+
+    template <typename K>
+    bool Erase(const K& key)
+    {
+        // Key
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(1000);
+        ssKey << key;
+
+        // Erase
+        return EraseKey(ssKey);
+    }
+
+    template <typename K>
+    bool Exists(const K& key)
+    {
+        // Key
+        CDataStream ssKey(SER_DISK, CLIENT_VERSION);
+        ssKey.reserve(1000);
+        ssKey << key;
+
+        // Exists
+        return HasKey(ssKey);
+    }
+
+    virtual bool CreateCursor() = 0;
+    virtual bool ReadAtCursor(CDataStream& ssKey, CDataStream& ssValue, bool& complete) = 0;
+    virtual void CloseCursor() = 0;
+    virtual bool TxnBegin() = 0;
+    virtual bool TxnCommit() = 0;
+    virtual bool TxnAbort() = 0;
+};
 
 #endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -10,7 +10,11 @@
 #include <fs.h>
 #include <streams.h>
 
+#include <atomic>
+#include <memory>
 #include <string>
+
+struct bilingual_str;
 
 /** Given a wallet directory path or legacy file path, return path to main data file in the wallet database. */
 fs::path WalletDataFilePath(const fs::path& wallet_path);
@@ -105,6 +109,64 @@ public:
     virtual bool TxnBegin() = 0;
     virtual bool TxnCommit() = 0;
     virtual bool TxnAbort() = 0;
+};
+
+/** An instance of this class represents one database.
+ **/
+class WalletDatabase
+{
+public:
+    /** Create dummy DB handle */
+    WalletDatabase() : nUpdateCounter(0), nLastSeen(0), nLastFlushed(0), nLastWalletUpdate(0) {}
+    virtual ~WalletDatabase() {};
+
+    /** Open the database if it is not already opened. */
+    virtual void Open(const char* mode) = 0;
+
+    //! Counts the number of active database users to be sure that the database is not closed while someone is using it
+    std::atomic<int> m_refcount{0};
+    /** Indicate the a new database user has began using the database. Increments m_refcount */
+    virtual void AddRef() = 0;
+    /** Indicate that database user has stopped using the database and that it could be flushed or closed. Decrement m_refcount */
+    virtual void RemoveRef() = 0;
+
+    /** Rewrite the entire database on disk, with the exception of key pszSkip if non-zero
+     */
+    virtual bool Rewrite(const char* pszSkip=nullptr) = 0;
+
+    /** Back up the entire database to a file.
+     */
+    virtual bool Backup(const std::string& strDest) const = 0;
+
+    /** Make sure all changes are flushed to database file.
+     */
+    virtual void Flush() = 0;
+    /** Flush to the database file and close the database.
+     *  Also close the environment if no other databases are open in it.
+     */
+    virtual void Close() = 0;
+    /* flush the wallet passively (TRY_LOCK)
+       ideal to be called periodically */
+    virtual bool PeriodicFlush() = 0;
+
+    virtual void IncrementUpdateCounter() = 0;
+
+    virtual void ReloadDbEnv() = 0;
+
+    std::atomic<unsigned int> nUpdateCounter;
+    unsigned int nLastSeen;
+    unsigned int nLastFlushed;
+    int64_t nLastWalletUpdate;
+
+    /** Verifies that the database file is not in use */
+    virtual bool VerifyNotInUse(bilingual_str& error) = 0;
+    /** Verifies the environment and database file */
+    virtual bool Verify(bilingual_str& error) = 0;
+
+    std::string m_file_path;
+
+    /** Make a BerkeleyBatch connected to this database */
+    virtual std::unique_ptr<DatabaseBatch> MakeBatch(const char* mode = "r+", bool flush_on_close = true) = 0;
 };
 
 #endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/load.cpp
+++ b/src/wallet/load.cpp
@@ -96,14 +96,14 @@ void StartWallets(CScheduler& scheduler)
 void FlushWallets()
 {
     for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
-        pwallet->Flush(false);
+        pwallet->Flush();
     }
 }
 
 void StopWallets()
 {
     for (const std::shared_ptr<CWallet>& pwallet : GetWallets()) {
-        pwallet->Flush(true);
+        pwallet->Close();
     }
 }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -423,9 +423,14 @@ bool CWallet::HasWalletSpend(const uint256& txid) const
     return (iter != mapTxSpends.end() && iter->first.hash == txid);
 }
 
-void CWallet::Flush(bool shutdown)
+void CWallet::Flush()
 {
-    database->Flush(shutdown);
+    database->Flush();
+}
+
+void CWallet::Close()
+{
+    database->Close();
 }
 
 void CWallet::SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator> range)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3708,15 +3708,13 @@ bool CWallet::Verify(interfaces::Chain& chain, const WalletLocation& location, b
     std::unique_ptr<WalletDatabase> database = CreateWalletDatabase(wallet_path);
 
     try {
-        if (!WalletBatch::VerifyEnvironment(wallet_path, error_string)) {
-            return false;
-        }
+        return database->Verify(error_string);
     } catch (const fs::filesystem_error& e) {
         error_string = Untranslated(strprintf("Error loading wallet %s. %s", location.GetName(), fsbridge::get_filesystem_error_message(e)));
         return false;
     }
 
-    return WalletBatch::VerifyDatabaseFile(wallet_path, error_string);
+    assert(false);
 }
 
 std::shared_ptr<CWallet> CWallet::CreateWalletFromFile(interfaces::Chain& chain, const WalletLocation& location, bilingual_str& error, std::vector<bilingual_str>& warnings, uint64_t wallet_creation_flags)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -1083,7 +1083,10 @@ public:
     bool HasWalletSpend(const uint256& txid) const EXCLUSIVE_LOCKS_REQUIRED(cs_wallet);
 
     //! Flush wallet (bitdb flush)
-    void Flush(bool shutdown=false);
+    void Flush();
+
+    //! Close wallet database
+    void Close();
 
     /** Wallet is about to be unloaded */
     boost::signals2::signal<void ()> NotifyUnload;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -121,7 +121,7 @@ bool WalletBatch::WriteCryptedKey(const CPubKey& vchPubKey,
     if (!WriteIC(key, std::make_pair(vchCryptedSecret, checksum), false)) {
         // It may already exist, so try writing just the checksum
         std::vector<unsigned char> val;
-        if (!m_batch.Read(key, val)) {
+        if (!m_batch->Read(key, val)) {
             return false;
         }
         if (!WriteIC(key, std::make_pair(val, checksum), true)) {
@@ -166,8 +166,8 @@ bool WalletBatch::WriteBestBlock(const CBlockLocator& locator)
 
 bool WalletBatch::ReadBestBlock(CBlockLocator& locator)
 {
-    if (m_batch.Read(DBKeys::BESTBLOCK, locator) && !locator.vHave.empty()) return true;
-    return m_batch.Read(DBKeys::BESTBLOCK_NOMERKLE, locator);
+    if (m_batch->Read(DBKeys::BESTBLOCK, locator) && !locator.vHave.empty()) return true;
+    return m_batch->Read(DBKeys::BESTBLOCK_NOMERKLE, locator);
 }
 
 bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
@@ -177,7 +177,7 @@ bool WalletBatch::WriteOrderPosNext(int64_t nOrderPosNext)
 
 bool WalletBatch::ReadPool(int64_t nPool, CKeyPool& keypool)
 {
-    return m_batch.Read(std::make_pair(DBKeys::POOL, nPool), keypool);
+    return m_batch->Read(std::make_pair(DBKeys::POOL, nPool), keypool);
 }
 
 bool WalletBatch::WritePool(int64_t nPool, const CKeyPool& keypool)
@@ -692,14 +692,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
     LOCK(pwallet->cs_wallet);
     try {
         int nMinVersion = 0;
-        if (m_batch.Read(DBKeys::MINVERSION, nMinVersion)) {
+        if (m_batch->Read(DBKeys::MINVERSION, nMinVersion)) {
             if (nMinVersion > FEATURE_LATEST)
                 return DBErrors::TOO_NEW;
             pwallet->LoadMinVersion(nMinVersion);
         }
 
         // Get cursor
-        if (!m_batch.CreateCursor())
+        if (!m_batch->CreateCursor())
         {
             pwallet->WalletLogPrintf("Error getting wallet database cursor\n");
             return DBErrors::CORRUPT;
@@ -711,14 +711,14 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
             bool complete;
-            bool ret = m_batch.ReadAtCursor(ssKey, ssValue, complete);
+            bool ret = m_batch->ReadAtCursor(ssKey, ssValue, complete);
             if (complete) {
-                m_batch.CloseCursor();
+                m_batch->CloseCursor();
                 break;
             }
             else if (!ret)
             {
-                m_batch.CloseCursor();
+                m_batch->CloseCursor();
                 pwallet->WalletLogPrintf("Error reading next record from wallet database\n");
                 return DBErrors::CORRUPT;
             }
@@ -746,7 +746,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
                 pwallet->WalletLogPrintf("%s\n", strErr);
         }
     } catch (...) {
-        m_batch.CloseCursor();
+        m_batch->CloseCursor();
         result = DBErrors::CORRUPT;
     }
 
@@ -785,7 +785,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
 
     // Last client version to open this wallet, was previously the file version number
     int last_client = CLIENT_VERSION;
-    m_batch.Read(DBKeys::VERSION, last_client);
+    m_batch->Read(DBKeys::VERSION, last_client);
 
     int wallet_version = pwallet->GetVersion();
     pwallet->WalletLogPrintf("Wallet File Version = %d\n", wallet_version > 0 ? wallet_version : last_client);
@@ -810,7 +810,7 @@ DBErrors WalletBatch::LoadWallet(CWallet* pwallet)
         return DBErrors::NEED_REWRITE;
 
     if (last_client < CLIENT_VERSION) // Update
-        m_batch.Write(DBKeys::VERSION, CLIENT_VERSION);
+        m_batch->Write(DBKeys::VERSION, CLIENT_VERSION);
 
     if (wss.fAnyUnordered)
         result = pwallet->ReorderTransactions();
@@ -846,13 +846,13 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWal
 
     try {
         int nMinVersion = 0;
-        if (m_batch.Read(DBKeys::MINVERSION, nMinVersion)) {
+        if (m_batch->Read(DBKeys::MINVERSION, nMinVersion)) {
             if (nMinVersion > FEATURE_LATEST)
                 return DBErrors::TOO_NEW;
         }
 
         // Get cursor
-        if (!m_batch.CreateCursor())
+        if (!m_batch->CreateCursor())
         {
             LogPrintf("Error getting wallet database cursor\n");
             return DBErrors::CORRUPT;
@@ -864,12 +864,12 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWal
             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
             bool complete;
-            bool ret = m_batch.ReadAtCursor(ssKey, ssValue, complete);
+            bool ret = m_batch->ReadAtCursor(ssKey, ssValue, complete);
             if (complete) {
-                m_batch.CloseCursor();
+                m_batch->CloseCursor();
                 break;
             } else if (!ret) {
-                m_batch.CloseCursor();
+                m_batch->CloseCursor();
                 LogPrintf("Error reading next record from wallet database\n");
                 return DBErrors::CORRUPT;
             }
@@ -885,7 +885,7 @@ DBErrors WalletBatch::FindWalletTx(std::vector<uint256>& vTxHash, std::list<CWal
             }
         }
     } catch (...) {
-        m_batch.CloseCursor();
+        m_batch->CloseCursor();
         result = DBErrors::CORRUPT;
     }
 
@@ -1000,17 +1000,17 @@ bool WalletBatch::WriteWalletFlags(const uint64_t flags)
 
 bool WalletBatch::TxnBegin()
 {
-    return m_batch.TxnBegin();
+    return m_batch->TxnBegin();
 }
 
 bool WalletBatch::TxnCommit()
 {
-    return m_batch.TxnCommit();
+    return m_batch->TxnCommit();
 }
 
 bool WalletBatch::TxnAbort()
 {
-    return m_batch.TxnAbort();
+    return m_batch->TxnAbort();
 }
 
 bool IsWalletLoaded(const fs::path& wallet_path)

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -968,7 +968,7 @@ void MaybeCompactWalletDB()
         }
 
         if (dbh.nLastFlushed != nUpdateCounter && GetTime() - dbh.nLastWalletUpdate >= 2) {
-            if (BerkeleyBatch::PeriodicFlush(dbh)) {
+            if (dbh.PeriodicFlush()) {
                 dbh.nLastFlushed = nUpdateCounter;
             }
         }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -977,16 +977,6 @@ void MaybeCompactWalletDB()
     fOneThread = false;
 }
 
-bool WalletBatch::VerifyEnvironment(const fs::path& wallet_path, bilingual_str& errorStr)
-{
-    return BerkeleyBatch::VerifyEnvironment(wallet_path, errorStr);
-}
-
-bool WalletBatch::VerifyDatabaseFile(const fs::path& wallet_path, bilingual_str& errorStr)
-{
-    return BerkeleyBatch::VerifyDatabaseFile(wallet_path, errorStr);
-}
-
 bool WalletBatch::WriteDestData(const std::string &address, const std::string &key, const std::string &value)
 {
     return WriteIC(std::make_pair(DBKeys::DESTDATA, std::make_pair(address, key)), value);

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1019,20 +1019,20 @@ bool IsWalletLoaded(const fs::path& wallet_path)
 }
 
 /** Return object for accessing database at specified path. */
-std::unique_ptr<BerkeleyDatabase> CreateWalletDatabase(const fs::path& path)
+std::unique_ptr<WalletDatabase> CreateWalletDatabase(const fs::path& path)
 {
     std::string filename;
     return MakeUnique<BerkeleyDatabase>(GetWalletEnv(path, filename), std::move(filename));
 }
 
 /** Return object for accessing dummy database with no read/write capabilities. */
-std::unique_ptr<BerkeleyDatabase> CreateDummyWalletDatabase()
+std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase()
 {
     return MakeUnique<BerkeleyDatabase>();
 }
 
 /** Return object for accessing temporary in-memory database. */
-std::unique_ptr<BerkeleyDatabase> CreateMockWalletDatabase()
+std::unique_ptr<WalletDatabase> CreateMockWalletDatabase()
 {
     return MakeUnique<BerkeleyDatabase>(std::make_shared<BerkeleyEnvironment>(), "");
 }

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -40,9 +40,6 @@ class CWalletTx;
 class uint160;
 class uint256;
 
-/** Backend-agnostic database type. */
-using WalletDatabase = BerkeleyDatabase;
-
 /** Error statuses for the wallet database */
 enum class DBErrors
 {
@@ -280,7 +277,7 @@ public:
     //! Abort current transaction
     bool TxnAbort();
 private:
-    std::unique_ptr<BerkeleyBatch> m_batch;
+    std::unique_ptr<DatabaseBatch> m_batch;
     WalletDatabase& m_database;
 };
 
@@ -294,12 +291,12 @@ bool ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue, st
 bool IsWalletLoaded(const fs::path& wallet_path);
 
 /** Return object for accessing database at specified path. */
-std::unique_ptr<BerkeleyDatabase> CreateWalletDatabase(const fs::path& path);
+std::unique_ptr<WalletDatabase> CreateWalletDatabase(const fs::path& path);
 
 /** Return object for accessing dummy database with no read/write capabilities. */
-std::unique_ptr<BerkeleyDatabase> CreateDummyWalletDatabase();
+std::unique_ptr<WalletDatabase> CreateDummyWalletDatabase();
 
 /** Return object for accessing temporary in-memory database. */
-std::unique_ptr<BerkeleyDatabase> CreateMockWalletDatabase();
+std::unique_ptr<WalletDatabase> CreateMockWalletDatabase();
 
 #endif // BITCOIN_WALLET_WALLETDB_H

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -183,12 +183,12 @@ private:
     template <typename K, typename T>
     bool WriteIC(const K& key, const T& value, bool fOverwrite = true)
     {
-        if (!m_batch.Write(key, value, fOverwrite)) {
+        if (!m_batch->Write(key, value, fOverwrite)) {
             return false;
         }
         m_database.IncrementUpdateCounter();
         if (m_database.nUpdateCounter % 1000 == 0) {
-            m_batch.Flush();
+            m_batch->Flush();
         }
         return true;
     }
@@ -196,19 +196,19 @@ private:
     template <typename K>
     bool EraseIC(const K& key)
     {
-        if (!m_batch.Erase(key)) {
+        if (!m_batch->Erase(key)) {
             return false;
         }
         m_database.IncrementUpdateCounter();
         if (m_database.nUpdateCounter % 1000 == 0) {
-            m_batch.Flush();
+            m_batch->Flush();
         }
         return true;
     }
 
 public:
     explicit WalletBatch(WalletDatabase& database, const char* pszMode = "r+", bool _fFlushOnClose = true) :
-        m_batch(database, pszMode, _fFlushOnClose),
+        m_batch(database.MakeBatch(pszMode, _fFlushOnClose)),
         m_database(database)
     {
     }
@@ -280,7 +280,7 @@ public:
     //! Abort current transaction
     bool TxnAbort();
 private:
-    BerkeleyBatch m_batch;
+    std::unique_ptr<BerkeleyBatch> m_batch;
     WalletDatabase& m_database;
 };
 

--- a/src/wallet/wallettool.cpp
+++ b/src/wallet/wallettool.cpp
@@ -17,7 +17,7 @@ namespace WalletTool {
 static void WalletToolReleaseWallet(CWallet* wallet)
 {
     wallet->WalletLogPrintf("Releasing wallet\n");
-    wallet->Flush(true);
+    wallet->Close();
     delete wallet;
 }
 
@@ -133,7 +133,7 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
         std::shared_ptr<CWallet> wallet_instance = CreateWallet(name, path);
         if (wallet_instance) {
             WalletShowInfo(wallet_instance.get());
-            wallet_instance->Flush(true);
+            wallet_instance->Close();
         }
     } else if (command == "info" || command == "salvage") {
         if (!fs::exists(path)) {
@@ -152,7 +152,7 @@ bool ExecuteWalletToolFunc(const std::string& command, const std::string& name)
             std::shared_ptr<CWallet> wallet_instance = LoadWallet(name, path);
             if (!wallet_instance) return false;
             WalletShowInfo(wallet_instance.get());
-            wallet_instance->Flush(true);
+            wallet_instance->Close();
         } else if (command == "salvage") {
             return SalvageWallet(path);
         }

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -103,7 +103,7 @@ class MultiWalletTest(BitcoinTestFramework):
 
         # should not initialize if one wallet is a copy of another
         shutil.copyfile(wallet_dir('w8'), wallet_dir('w8_copy'))
-        exp_stderr = r"BerkeleyBatch: Can't open database w8_copy \(duplicates fileid \w+ from w8\)"
+        exp_stderr = r"Error: BerkeleyDatabase: Can't open database .+\w8_copy \(duplicates fileid \w+ from .+/w8\)"
         self.nodes[0].assert_start_raises_init_error(['-wallet=w8', '-wallet=w8_copy'], exp_stderr, match=ErrorMatch.PARTIAL_REGEX)
 
         # should not initialize if wallet file is a symlink
@@ -229,10 +229,10 @@ class MultiWalletTest(BitcoinTestFramework):
         assert_raises_rpc_error(-4, "Wallet file verification failed. Error loading wallet wallet.dat. Duplicate -wallet filename specified.", self.nodes[0].loadwallet, 'wallet.dat')
 
         # Fail to load if one wallet is a copy of another
-        assert_raises_rpc_error(-4, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
+        assert_raises_rpc_error(-4, "duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
 
         # Fail to load if one wallet is a copy of another, test this twice to make sure that we don't re-introduce #14304
-        assert_raises_rpc_error(-4, "BerkeleyBatch: Can't open database w8_copy (duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
+        assert_raises_rpc_error(-4, "duplicates fileid", self.nodes[0].loadwallet, 'w8_copy')
 
 
         # Fail to load if wallet file is a symlink


### PR DESCRIPTION
The data storage layer of the wallet is fairly complicated and not well encapsulated or modularized. This makes it difficult for us to introduce new data storage methods. So this PR refactors it such that there is a clear way to introduce other storage options. This is also intended to clean up the logic of the database layer so that it is easier to follow and reason about.

In the database, there are 3 classes: `BerkeleyBatch`, `BerkeleyDatabase`, and `BerkeleyEnvironment`. `BerkeleyDatabase` is typenamed to `WalletDatabase`. The goal is to introduce two abstract classes: `WalletDatabase` and `DatabaseBatch`. These will be implemented by `BerkeleyDatabase` and `BerkeleyBatch`. This abstract classes can be inherited by other storage methods. All of the database specific things should be hidden in those classes.

To achieve this, we move the database handling things in `BerkeleyBatch` and turn it purely into a data accessor for the `BerkeleyDatabase`. Particularly, various static functions that operated on a `BerkeleyDatabase` are changed to be member functions of `BerkeleyDatabase`. `Read`, `Write`, `Erase`, and `Exists` are refactored to have separate functions that can be overridden by other classes. Instead of `GetCursor` returning a BDB specific `Dbc` object, new `CreateCursor` and `CloseCursor` functions are added and the cursor is handled internally within the `BerkeleyBatch`. We are then able to introduce the `DatabaseBatch` abstract class.

Functionality is further moved out of `BerkeleyBatch` into `BerkeleyDatabase`. Notably the `Db` handle creation is moved from `BerkeleyBatch`'s constructor and to a new `Open` function in `BerkeleyDatabase`. `BerkeleyDatabase` will also handle closing with a new `Close` function instead of having this be part of `Flush`.

Additionally, the existence of `BerkeleyEnvironment` is hidden inside of `BerkeleyDatabase`. `mapFileUseCount` is removed. Instead `WalletDatabase` will track it's use count with `m_refcount`. This is incremented by newly introduced `AddRef` and `RemoveRef` functions. `m_refcount` is used to ensure that the database and environment are not closed while the database may still be in use.

Instead of each `BerkeleyEnvironment` tracking the fileids of the databases in that environment, a global map `g_fileids` is used. Since we were already going through every open fileid for the uniqeness check, it doesn't matter what `BerkeleyEnvironment` has a database with a particular fileid. All we care about is that there is a database in any of the environments that has the same fileid of the database that is currently being opened.

Lastly, `BerkeleyBatch, `BerkeleyDatabase`, and `BerkeleyEnvironment` are moved into new files `wallet/bdb.{cpp/h}`. `WalletDatabase` and `DatabaseBatch` are in `wallet/db.{cpp/h}`. This just gives better organization of the code so they aren't all mixed together.

***

I've started breaking this down into separate PRs. Some of the simpler stuff is moved up to the front so they can be merged first.

* [x] Mostly simple moveonly things: #19290
  * walletdb: Make SpliWalletFilePath non-static
  * walletdb: Add IsBDBWalletLoaded to look for BDB wallets specifically
  * walletdb: move IsWalletLoaded to walletdb.cpp
  * walletdb: moveonly: Move BerkeleyBatch Cursor and Txn funcs to cpp
  * walletdb: Move BDB specific things into bdb.{cpp/h}

These PRs are independent of each other and can be merged out of order after #19290 is merged
* [x] Refactor Read, Write, Erase, Exists: #19292
  * walletdb: refactor Read, Write, Erase, and Exists into non-template func
* [x] Handle cursor internally: #19308
  * walletdb: Handle cursor internally
* [x] Make Create, CreateMock, and CreateDummy standalone: #19310
  * Add Create*WalletDatabase functions
  * scripted-diff: Replace WalletDatabase::Create* with CreateWalletDatabase
  * Remove WalletDatabase::Create, CreateMock, and CreateDummy
* [x] Move BerkeleyBatch static functions: #19324
  * walletdb: Combine VerifyDatabaseFile and VerifyEnvironment
  * walletdb: Move PeriodicFlush into WalletDatabase
  * walletdb: Move Rewrite into BerkeleyDatabase

These PRs require the previous listed to be merged first and need to be merged in order
* [x] Introduce `DatabaseBatch`: #19325
  * walletdb: Refactor DatabaseBatch abstract class from BerkeleyBatch
  * walletdb: Add MakeBatch function to BerkeleyDatabase and use it
* [x] Introduce `WalletDatabase`: #19334
  * walletdb: Move BerkeleyDatabase::Flush(true) to Close()
  * walletdb: Introduce AddRef and RemoveRef functions
  * walletdb: Add BerkeleyDatabase::Open dummy function
  * walletdb: Introduce WalletDatabase abstract class
* [ ] Cleanup the separation: #19335
  * walletdb: track database file use as m_refcount within BerkeleyDatabase
  * walletdb: Move Db->open to BerkeleyDatabase::Open
  * walletdb: Use a global g_fileids instead of m_fileids for each env
  * walletdb: Remove BerkeleyBatch friend class from BerkeleyDatabase

I will continue to break this down as things get merged.