### PR TITLE
net: Add blockfilters white{bind,list} permission flag

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1135,6 +1135,9 @@ void CConnman::AcceptConnection(const ListenSocket& hListenSocket) {
     if (NetPermissions::HasFlag(permissionFlags, PF_BLOOMFILTER)) {
         nodeServices = static_cast<ServiceFlags>(nodeServices | NODE_BLOOM);
     }
+    if (NetPermissions::HasFlag(permissionFlags, PF_BLOCKFILTERS)) {
+        nodeServices = static_cast<ServiceFlags>(nodeServices | NODE_COMPACT_FILTERS);
+    }
 
     const bool inbound_onion = std::find(m_onion_binds.begin(), m_onion_binds.end(), addr_bind) != m_onion_binds.end();
     CNode* pnode = new CNode(id, nodeServices, GetBestHeight(), hSocket, addr, CalculateKeyedNetGroup(addr), nonce, addr_bind, "", ConnectionType::INBOUND, inbound_onion);

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -73,6 +73,7 @@ bool TryParsePermissionFlags(const std::string str, NetPermissionFlags& output, 
 std::vector<std::string> NetPermissions::ToStrings(NetPermissionFlags flags)
 {
     std::vector<std::string> strings;
+    if (NetPermissions::HasFlag(flags, PF_BLOCKFILTERS)) strings.push_back("blockfilters");
     if (NetPermissions::HasFlag(flags, PF_BLOOMFILTER)) strings.push_back("bloomfilter");
     if (NetPermissions::HasFlag(flags, PF_NOBAN)) strings.push_back("noban");
     if (NetPermissions::HasFlag(flags, PF_FORCERELAY)) strings.push_back("forcerelay");

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -10,6 +10,7 @@
 
 const std::vector<std::string> NET_PERMISSIONS_DOC{
     "bloomfilter (allow requesting BIP37 filtered blocks and transactions)",
+    "blockfilters (serve compact block filters to peers per BIP157)"
     "noban (do not ban for misbehavior; implies download)",
     "forcerelay (relay transactions that are already in the mempool; implies relay)",
     "relay (relay even in -blocksonly mode, and unlimited transaction announcements)",
@@ -45,6 +46,7 @@ bool TryParsePermissionFlags(const std::string str, NetPermissionFlags& output, 
             if (commaSeparator != std::string::npos) readen++; // We read ","
 
             if (permission == "bloomfilter" || permission == "bloom") NetPermissions::AddFlag(flags, PF_BLOOMFILTER);
+            else if (permission == "blockfilters" || permission == "compactfilters" || permission == "cfilters") NetPermissions::AddFlag(flags, PF_BLOCKFILTERS_EXPLICIT);
             else if (permission == "noban") NetPermissions::AddFlag(flags, PF_NOBAN);
             else if (permission == "forcerelay") NetPermissions::AddFlag(flags, PF_FORCERELAY);
             else if (permission == "mempool") NetPermissions::AddFlag(flags, PF_MEMPOOL);

--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -33,9 +33,14 @@ enum NetPermissionFlags {
     // Can request addrs without hitting a privacy-preserving cache
     PF_ADDR = (1U << 7),
 
+    // Can query compact filters even if -peerblockfilters is false
+    PF_BLOCKFILTERS = (1U << 8),
+    // Used to avoid an error when PF_ALL is used to set PF_CFILTERS
+    PF_BLOCKFILTERS_EXPLICIT = PF_BLOCKFILTERS | (1U << 9),
+
     // True if the user did not specifically set fine grained permissions
     PF_ISIMPLICIT = (1U << 31),
-    PF_ALL = PF_BLOOMFILTER | PF_FORCERELAY | PF_RELAY | PF_NOBAN | PF_MEMPOOL | PF_DOWNLOAD | PF_ADDR,
+    PF_ALL = PF_BLOOMFILTER | PF_FORCERELAY | PF_RELAY | PF_NOBAN | PF_MEMPOOL | PF_DOWNLOAD | PF_ADDR | PF_BLOCKFILTERS,
 };
 
 class NetPermissions

--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -15,6 +15,7 @@ struct bilingual_str;
 extern const std::vector<std::string> NET_PERMISSIONS_DOC;
 
 enum NetPermissionFlags {
+    // NOTE: When adding here, be sure to update net_permissions.cpp's NetPermissions::ToStrings too
     PF_NONE = 0,
     // Can query bloomfilter even if -peerbloomfilters is false
     PF_BLOOMFILTER = (1U << 1),

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -418,7 +418,8 @@ BOOST_AUTO_TEST_CASE(netpermissions_test)
     BOOST_CHECK(NetWhitelistPermissions::TryParse("bloom,forcerelay,noban,relay,mempool@1.2.3.4/32", whitelistPermissions, error));
 
     const auto strings = NetPermissions::ToStrings(PF_ALL);
-    BOOST_CHECK_EQUAL(strings.size(), 7U);
+    BOOST_CHECK_EQUAL(strings.size(), 8U);
+    BOOST_CHECK(std::find(strings.begin(), strings.end(), "blockfilters") != strings.end());
     BOOST_CHECK(std::find(strings.begin(), strings.end(), "bloomfilter") != strings.end());
     BOOST_CHECK(std::find(strings.begin(), strings.end(), "forcerelay") != strings.end());
     BOOST_CHECK(std::find(strings.begin(), strings.end(), "relay") != strings.end());

--- a/src/test/netbase_tests.cpp
+++ b/src/test/netbase_tests.cpp
@@ -418,15 +418,20 @@ BOOST_AUTO_TEST_CASE(netpermissions_test)
     BOOST_CHECK(NetWhitelistPermissions::TryParse("bloom,forcerelay,noban,relay,mempool@1.2.3.4/32", whitelistPermissions, error));
 
     const auto strings = NetPermissions::ToStrings(PF_ALL);
-    BOOST_CHECK_EQUAL(strings.size(), 8U);
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "blockfilters") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "bloomfilter") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "forcerelay") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "relay") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "noban") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "mempool") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "download") != strings.end());
-    BOOST_CHECK(std::find(strings.begin(), strings.end(), "addr") != strings.end());
+    const std::vector<std::string> expected_strings{
+        "blockfilters",
+        "bloomfilter",
+        "forcerelay",
+        "relay",
+        "noban",
+        "mempool",
+        "download",
+        "addr",
+    };
+    BOOST_CHECK_EQUAL(strings.size(), expected_strings.size());
+    for (const auto& expected : expected_strings) {
+        BOOST_CHECK(std::find(strings.begin(), strings.end(), expected) != strings.end());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(netbase_dont_resolve_strings_with_embedded_nul_characters)

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -107,7 +107,7 @@ class P2PPermissionsTests(BitcoinTestFramework):
         self.checkpermission(
             # all permission added
             ["-whitelist=all@127.0.0.1"],
-            ["forcerelay", "noban", "mempool", "bloomfilter", "relay", "download", "addr"],
+            ["blockfilters", "forcerelay", "noban", "mempool", "bloomfilter", "relay", "download", "addr"],
             False)
 
         self.stop_node(1)

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -107,7 +107,16 @@ class P2PPermissionsTests(BitcoinTestFramework):
         self.checkpermission(
             # all permission added
             ["-whitelist=all@127.0.0.1"],
-            ["blockfilters", "forcerelay", "noban", "mempool", "bloomfilter", "relay", "download", "addr"],
+            [
+                "blockfilters",
+                "forcerelay",
+                "noban",
+                "mempool",
+                "bloomfilter",
+                "relay",
+                "download",
+                "addr",
+            ],
             False)
 
         self.stop_node(1)


### PR DESCRIPTION
Allows enabling compact block filters on a whitelist basis.

~~Note: Won't compile/merge until service bits stuff is merged, so marking WIP although I think this code is itself complete.~~