### PR TITLE
test: Remove const to work around compiler error on xenial

### DIFF
--- a/src/test/validationinterface_tests.cpp
+++ b/src/test/validationinterface_tests.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(unregister_validation_interface_race)
     // Start thread to generate notifications
     std::thread gen{[&] {
         const CBlock block_dummy;
-        const BlockValidationState state_dummy;
+        BlockValidationState state_dummy;
         while (generate) {
             GetMainSignals().BlockChecked(block_dummy, state_dummy);
         }


### PR DESCRIPTION
Fix the following error in travis:

    test/validationinterface_tests.cpp:26:36: error: default initialization of an object of const type 'const BlockValidationState' without a user-provided default constructor

    const BlockValidationState state_dummy;