### PR TITLE
Remove unnecessary input blockfile SetPos

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4685,7 +4685,6 @@ void LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, FlatFi
                 if (dbp)
                     dbp->nPos = nBlockPos;
                 blkdat.SetLimit(nBlockPos + nSize);
-                blkdat.SetPos(nBlockPos);
                 std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
                 CBlock& block = *pblock;
                 blkdat >> block;


### PR DESCRIPTION
Nothing could have changed the position since we retrieved it a few statements earlier. This dates from commit 16d5194165c8c83492b95f431a664d98c40ff254.