### PR TITLE
tests: Add fuzzing harnesses for functions in script/

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -117,6 +117,7 @@ FUZZ_TARGETS = \
   test/fuzz/script_interpreter \
   test/fuzz/script_ops \
   test/fuzz/script_sigcache \
+  test/fuzz/script_sign \
   test/fuzz/scriptnum_ops \
   test/fuzz/service_deserialize \
   test/fuzz/signature_checker \
@@ -986,6 +987,12 @@ test_fuzz_script_sigcache_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_sigcache_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_sigcache_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_sigcache_SOURCES = test/fuzz/script_sigcache.cpp
+
+test_fuzz_script_sign_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_sign_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_sign_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_script_sign_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_sign_SOURCES = test/fuzz/script_sign.cpp
 
 test_fuzz_scriptnum_ops_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_scriptnum_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -114,6 +114,7 @@ FUZZ_TARGETS = \
   test/fuzz/script_descriptor_cache \
   test/fuzz/script_deserialize \
   test/fuzz/script_flags \
+  test/fuzz/script_interpreter \
   test/fuzz/script_ops \
   test/fuzz/scriptnum_ops \
   test/fuzz/service_deserialize \
@@ -966,6 +967,12 @@ test_fuzz_script_flags_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_flags_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_flags_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_flags_SOURCES = test/fuzz/script_flags.cpp
+
+test_fuzz_script_interpreter_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_interpreter_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_interpreter_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_script_interpreter_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_interpreter_SOURCES = test/fuzz/script_interpreter.cpp
 
 test_fuzz_script_ops_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_script_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -110,6 +110,7 @@ FUZZ_TARGETS = \
   test/fuzz/rbf \
   test/fuzz/rolling_bloom_filter \
   test/fuzz/script \
+  test/fuzz/script_bitcoin_consensus \
   test/fuzz/script_deserialize \
   test/fuzz/script_flags \
   test/fuzz/script_ops \
@@ -940,6 +941,12 @@ test_fuzz_script_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_SOURCES = test/fuzz/script.cpp
+
+test_fuzz_script_bitcoin_consensus_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_bitcoin_consensus_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_bitcoin_consensus_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_script_bitcoin_consensus_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_bitcoin_consensus_SOURCES = test/fuzz/script_bitcoin_consensus.cpp
 
 test_fuzz_script_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSCRIPT_DESERIALIZE=1
 test_fuzz_script_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -111,6 +111,7 @@ FUZZ_TARGETS = \
   test/fuzz/rolling_bloom_filter \
   test/fuzz/script \
   test/fuzz/script_bitcoin_consensus \
+  test/fuzz/script_descriptor_cache \
   test/fuzz/script_deserialize \
   test/fuzz/script_flags \
   test/fuzz/script_ops \
@@ -947,6 +948,12 @@ test_fuzz_script_bitcoin_consensus_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_bitcoin_consensus_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_bitcoin_consensus_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_bitcoin_consensus_SOURCES = test/fuzz/script_bitcoin_consensus.cpp
+
+test_fuzz_script_descriptor_cache_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_descriptor_cache_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_descriptor_cache_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_script_descriptor_cache_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_descriptor_cache_SOURCES = test/fuzz/script_descriptor_cache.cpp
 
 test_fuzz_script_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DSCRIPT_DESERIALIZE=1
 test_fuzz_script_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -116,6 +116,7 @@ FUZZ_TARGETS = \
   test/fuzz/script_flags \
   test/fuzz/script_interpreter \
   test/fuzz/script_ops \
+  test/fuzz/script_sigcache \
   test/fuzz/scriptnum_ops \
   test/fuzz/service_deserialize \
   test/fuzz/signature_checker \
@@ -979,6 +980,12 @@ test_fuzz_script_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_script_ops_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_script_ops_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_script_ops_SOURCES = test/fuzz/script_ops.cpp
+
+test_fuzz_script_sigcache_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_script_sigcache_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_script_sigcache_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_script_sigcache_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_script_sigcache_SOURCES = test/fuzz/script_sigcache.cpp
 
 test_fuzz_scriptnum_ops_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_scriptnum_ops_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -11,6 +11,7 @@
 #include <script/descriptor.h>
 #include <script/interpreter.h>
 #include <script/script.h>
+#include <script/script_error.h>
 #include <script/sign.h>
 #include <script/signingprovider.h>
 #include <script/standard.h>
@@ -21,6 +22,8 @@
 #include <univalue.h>
 #include <util/memory.h>
 
+#include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -123,5 +126,41 @@ void test_one_input(const std::vector<uint8_t>& buffer)
             (void)CountWitnessSigOps(script, *other_script, &wit, flags);
             wit.SetNull();
         }
+    }
+
+    (void)GetOpName(ConsumeOpcodeType(fuzzed_data_provider));
+    (void)ScriptErrorString(static_cast<ScriptError>(fuzzed_data_provider.ConsumeIntegralInRange<int>(0, SCRIPT_ERR_ERROR_COUNT)));
+
+    {
+        const std::vector<uint8_t> bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+        CScript append_script{bytes.begin(), bytes.end()};
+        append_script << fuzzed_data_provider.ConsumeIntegral<int64_t>();
+        append_script << ConsumeOpcodeType(fuzzed_data_provider);
+        append_script << CScriptNum{fuzzed_data_provider.ConsumeIntegral<int64_t>()};
+        append_script << ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    }
+
+    {
+        WitnessUnknown witness_unknown_1{};
+        witness_unknown_1.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        const std::vector<uint8_t> witness_unknown_program_1 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
+        witness_unknown_1.length = witness_unknown_program_1.size();
+        std::copy(witness_unknown_program_1.begin(), witness_unknown_program_1.end(), witness_unknown_1.program);
+
+        WitnessUnknown witness_unknown_2{};
+        witness_unknown_2.version = fuzzed_data_provider.ConsumeIntegral<int>();
+        const std::vector<uint8_t> witness_unknown_program_2 = fuzzed_data_provider.ConsumeBytes<uint8_t>(40);
+        witness_unknown_2.length = witness_unknown_program_2.size();
+        std::copy(witness_unknown_program_2.begin(), witness_unknown_program_2.end(), witness_unknown_2.program);
+
+        (void)(witness_unknown_1 == witness_unknown_2);
+        (void)(witness_unknown_1 < witness_unknown_2);
+    }
+
+    {
+        const CTxDestination tx_destination_1 = ConsumeTxDestination(fuzzed_data_provider);
+        const CTxDestination tx_destination_2 = ConsumeTxDestination(fuzzed_data_provider);
+        (void)(tx_destination_1 == tx_destination_2);
+        (void)(tx_destination_1 < tx_destination_2);
     }
 }

--- a/src/test/fuzz/script_bitcoin_consensus.cpp
+++ b/src/test/fuzz/script_bitcoin_consensus.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <script/bitcoinconsensus.h>
+#include <script/interpreter.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::vector<uint8_t> random_bytes_1 = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    const std::vector<uint8_t> random_bytes_2 = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    const CAmount money = ConsumeMoney(fuzzed_data_provider);
+    bitcoinconsensus_error err;
+    bitcoinconsensus_error* err_p = fuzzed_data_provider.ConsumeBool() ? &err : nullptr;
+    const unsigned int n_in = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const unsigned int flags = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    assert(bitcoinconsensus_version() == BITCOINCONSENSUS_API_VER);
+    if ((flags & SCRIPT_VERIFY_WITNESS) != 0 && (flags & SCRIPT_VERIFY_P2SH) == 0) {
+        return;
+    }
+    (void)bitcoinconsensus_verify_script(random_bytes_1.data(), random_bytes_1.size(), random_bytes_2.data(), random_bytes_2.size(), n_in, flags, err_p);
+    (void)bitcoinconsensus_verify_script_with_amount(random_bytes_1.data(), random_bytes_1.size(), money, random_bytes_2.data(), random_bytes_2.size(), n_in, flags, err_p);
+}

--- a/src/test/fuzz/script_descriptor_cache.cpp
+++ b/src/test/fuzz/script_descriptor_cache.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <pubkey.h>
+#include <script/descriptor.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    DescriptorCache descriptor_cache;
+    while (fuzzed_data_provider.ConsumeBool()) {
+        const std::vector<uint8_t> code = fuzzed_data_provider.ConsumeBytes<uint8_t>(BIP32_EXTKEY_SIZE);
+        if (code.size() == BIP32_EXTKEY_SIZE) {
+            CExtPubKey xpub;
+            xpub.Decode(code.data());
+            const uint32_t key_exp_pos = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+            CExtPubKey xpub_fetched;
+            if (fuzzed_data_provider.ConsumeBool()) {
+                (void)descriptor_cache.GetCachedParentExtPubKey(key_exp_pos, xpub_fetched);
+                descriptor_cache.CacheParentExtPubKey(key_exp_pos, xpub);
+                assert(descriptor_cache.GetCachedParentExtPubKey(key_exp_pos, xpub_fetched));
+            } else {
+                const uint32_t der_index = fuzzed_data_provider.ConsumeIntegral<uint32_t>();
+                (void)descriptor_cache.GetCachedDerivedExtPubKey(key_exp_pos, der_index, xpub_fetched);
+                descriptor_cache.CacheDerivedExtPubKey(key_exp_pos, der_index, xpub);
+                assert(descriptor_cache.GetCachedDerivedExtPubKey(key_exp_pos, der_index, xpub_fetched));
+            }
+            assert(xpub == xpub_fetched);
+        }
+        (void)descriptor_cache.GetCachedParentExtPubKeys();
+        (void)descriptor_cache.GetCachedDerivedExtPubKeys();
+    }
+}

--- a/src/test/fuzz/script_interpreter.cpp
+++ b/src/test/fuzz/script_interpreter.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <primitives/transaction.h>
+#include <script/interpreter.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+bool CastToBool(const std::vector<unsigned char>& vch);
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    {
+        const CScript script_code = ConsumeScript(fuzzed_data_provider);
+        const std::optional<CMutableTransaction> mtx = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+        if (mtx) {
+            const CTransaction tx_to{*mtx};
+            const unsigned int in = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+            if (in < tx_to.vin.size()) {
+                (void)SignatureHash(script_code, tx_to, in, fuzzed_data_provider.ConsumeIntegral<int>(), ConsumeMoney(fuzzed_data_provider), fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0}), nullptr);
+                const std::optional<CMutableTransaction> mtx_precomputed = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+                if (mtx_precomputed) {
+                    const CTransaction tx_precomputed{*mtx_precomputed};
+                    const PrecomputedTransactionData precomputed_transaction_data{tx_precomputed};
+                    (void)SignatureHash(script_code, tx_to, in, fuzzed_data_provider.ConsumeIntegral<int>(), ConsumeMoney(fuzzed_data_provider), fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0}), &precomputed_transaction_data);
+                }
+            }
+        }
+    }
+    {
+        (void)CastToBool(ConsumeRandomLengthByteVector(fuzzed_data_provider));
+    }
+}

--- a/src/test/fuzz/script_sigcache.cpp
+++ b/src/test/fuzz/script_sigcache.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <chainparamsbase.h>
+#include <key.h>
+#include <pubkey.h>
+#include <script/sigcache.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    static const ECCVerifyHandle ecc_verify_handle;
+    ECC_Start();
+    SelectParams(CBaseChainParams::REGTEST);
+    InitSignatureCache();
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const std::optional<CMutableTransaction> mutable_transaction = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+    const CTransaction tx = mutable_transaction ? CTransaction{*mutable_transaction} : CTransaction{};
+    const unsigned int n_in = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+    const CAmount amount = ConsumeMoney(fuzzed_data_provider);
+    const bool store = fuzzed_data_provider.ConsumeBool();
+    PrecomputedTransactionData tx_data;
+    CachingTransactionSignatureChecker caching_transaction_signature_checker{mutable_transaction ? &tx : nullptr, n_in, amount, store, tx_data};
+    const std::optional<CPubKey> pub_key = ConsumeDeserializable<CPubKey>(fuzzed_data_provider);
+    if (pub_key) {
+        const std::vector<uint8_t> random_bytes = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+        if (!random_bytes.empty()) {
+            (void)caching_transaction_signature_checker.VerifySignature(random_bytes, *pub_key, ConsumeUInt256(fuzzed_data_provider));
+        }
+    }
+}

--- a/src/test/fuzz/script_sign.cpp
+++ b/src/test/fuzz/script_sign.cpp
@@ -1,0 +1,149 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <chainparamsbase.h>
+#include <key.h>
+#include <pubkey.h>
+#include <script/keyorigin.h>
+#include <script/sign.h>
+#include <script/signingprovider.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    static const ECCVerifyHandle ecc_verify_handle;
+    ECC_Start();
+    SelectParams(CBaseChainParams::REGTEST);
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    const std::vector<uint8_t> key = ConsumeRandomLengthByteVector(fuzzed_data_provider, 128);
+
+    {
+        CDataStream random_data_stream = ConsumeDataStream(fuzzed_data_provider);
+        std::map<CPubKey, KeyOriginInfo> hd_keypaths;
+        try {
+            DeserializeHDKeypaths(random_data_stream, key, hd_keypaths);
+        } catch (const std::ios_base::failure&) {
+        }
+        CDataStream serialized{SER_NETWORK, PROTOCOL_VERSION};
+        SerializeHDKeypaths(serialized, hd_keypaths, fuzzed_data_provider.ConsumeIntegral<uint8_t>());
+    }
+
+    {
+        std::map<CPubKey, KeyOriginInfo> hd_keypaths;
+        while (fuzzed_data_provider.ConsumeBool()) {
+            const std::optional<CPubKey> pub_key = ConsumeDeserializable<CPubKey>(fuzzed_data_provider);
+            if (!pub_key) {
+                break;
+            }
+            const std::optional<KeyOriginInfo> key_origin_info = ConsumeDeserializable<KeyOriginInfo>(fuzzed_data_provider);
+            if (!key_origin_info) {
+                break;
+            }
+            hd_keypaths[*pub_key] = *key_origin_info;
+        }
+        CDataStream serialized{SER_NETWORK, PROTOCOL_VERSION};
+        try {
+            SerializeHDKeypaths(serialized, hd_keypaths, fuzzed_data_provider.ConsumeIntegral<uint8_t>());
+        } catch (const std::ios_base::failure&) {
+        }
+        std::map<CPubKey, KeyOriginInfo> deserialized_hd_keypaths;
+        try {
+            DeserializeHDKeypaths(serialized, key, hd_keypaths);
+        } catch (const std::ios_base::failure&) {
+        }
+        assert(hd_keypaths.size() >= deserialized_hd_keypaths.size());
+    }
+
+    {
+        SignatureData signature_data_1{ConsumeScript(fuzzed_data_provider)};
+        SignatureData signature_data_2{ConsumeScript(fuzzed_data_provider)};
+        signature_data_1.MergeSignatureData(signature_data_2);
+    }
+
+    FillableSigningProvider provider;
+    CKey k;
+    const std::vector<uint8_t> key_data = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+    k.Set(key_data.begin(), key_data.end(), fuzzed_data_provider.ConsumeBool());
+    if (k.IsValid()) {
+        provider.AddKey(k);
+    }
+
+    {
+        const std::optional<CMutableTransaction> mutable_transaction = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+        const std::optional<CTxOut> tx_out = ConsumeDeserializable<CTxOut>(fuzzed_data_provider);
+        const unsigned int n_in = fuzzed_data_provider.ConsumeIntegral<unsigned int>();
+        if (mutable_transaction && tx_out && mutable_transaction->vin.size() > n_in) {
+            SignatureData signature_data_1 = DataFromTransaction(*mutable_transaction, n_in, *tx_out);
+            CTxIn input;
+            UpdateInput(input, signature_data_1);
+            const CScript script = ConsumeScript(fuzzed_data_provider);
+            SignatureData signature_data_2{script};
+            signature_data_1.MergeSignatureData(signature_data_2);
+        }
+        if (mutable_transaction) {
+            CTransaction tx_from{*mutable_transaction};
+            CMutableTransaction tx_to;
+            const std::optional<CMutableTransaction> opt_tx_to = ConsumeDeserializable<CMutableTransaction>(fuzzed_data_provider);
+            if (opt_tx_to) {
+                tx_to = *opt_tx_to;
+            }
+            CMutableTransaction script_tx_to = tx_to;
+            CMutableTransaction sign_transaction_tx_to = tx_to;
+            if (n_in < tx_to.vin.size() && tx_to.vin[n_in].prevout.n < tx_from.vout.size()) {
+                (void)SignSignature(provider, tx_from, tx_to, n_in, fuzzed_data_provider.ConsumeIntegral<int>());
+            }
+            if (n_in < script_tx_to.vin.size()) {
+                (void)SignSignature(provider, ConsumeScript(fuzzed_data_provider), script_tx_to, n_in, ConsumeMoney(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<int>());
+                MutableTransactionSignatureCreator signature_creator{&tx_to, n_in, ConsumeMoney(fuzzed_data_provider), fuzzed_data_provider.ConsumeIntegral<int>()};
+                std::vector<unsigned char> vch_sig;
+                CKeyID address;
+                if (fuzzed_data_provider.ConsumeBool()) {
+                    if (k.IsValid()) {
+                        address = k.GetPubKey().GetID();
+                    }
+                } else {
+                    address = CKeyID{ConsumeUInt160(fuzzed_data_provider)};
+                }
+                (void)signature_creator.CreateSig(provider, vch_sig, address, ConsumeScript(fuzzed_data_provider), fuzzed_data_provider.PickValueInArray({SigVersion::BASE, SigVersion::WITNESS_V0}));
+            }
+            std::map<COutPoint, Coin> coins;
+            while (fuzzed_data_provider.ConsumeBool()) {
+                const std::optional<COutPoint> outpoint = ConsumeDeserializable<COutPoint>(fuzzed_data_provider);
+                if (!outpoint) {
+                    break;
+                }
+                const std::optional<Coin> coin = ConsumeDeserializable<Coin>(fuzzed_data_provider);
+                if (!coin) {
+                    break;
+                }
+                coins[*outpoint] = *coin;
+            }
+            std::map<int, std::string> input_errors;
+            (void)SignTransaction(sign_transaction_tx_to, &provider, coins, fuzzed_data_provider.ConsumeIntegral<int>(), input_errors);
+        }
+    }
+
+    {
+        SignatureData signature_data_1;
+        (void)ProduceSignature(provider, DUMMY_SIGNATURE_CREATOR, ConsumeScript(fuzzed_data_provider), signature_data_1);
+        SignatureData signature_data_2;
+        (void)ProduceSignature(provider, DUMMY_MAXIMUM_SIGNATURE_CREATOR, ConsumeScript(fuzzed_data_provider), signature_data_2);
+    }
+}

--- a/src/test/fuzz/string.cpp
+++ b/src/test/fuzz/string.cpp
@@ -12,6 +12,7 @@
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
+#include <script/script.h>
 #include <serialize.h>
 #include <streams.h>
 #include <test/fuzz/FuzzedDataProvider.h>
@@ -89,6 +90,10 @@ void test_one_input(const std::vector<uint8_t>& buffer)
     (void)urlDecode(random_string_1);
     (void)ValidAsCString(random_string_1);
     (void)_(random_string_1.c_str());
+    try {
+        throw scriptnum_error{random_string_1};
+    } catch (const std::runtime_error&) {
+    }
 
     {
         CDataStream data_stream{SER_NETWORK, INIT_PROTO_VERSION};


### PR DESCRIPTION
Add fuzzing harnesses for functions in `script/`:
* Add fuzzing helper functions `ConsumeDataStream` and `ConsumeUInt160`
* Fill fuzzing coverage gaps for functions in `script/script.h`, `script/script_error.h` and `script/standard.h`
* Add fuzzing harness for functions in `script/bitcoinconsensus.h`
* Add fuzzing harness for functions in `script/descriptor.h`
* Add fuzzing harness for functions in `script/interpreter.h`
* Add fuzzing harness for functions in `script/sigcache.h`
* Add fuzzing harness for functions in `script/sign.h`

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)