### PR TITLE
Print "verifychain" progress every 1 step if user verifies whole blockchain.

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4262,10 +4262,10 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     for (pindex = ::ChainActive().Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
-        if (reportDone < percentageDone/10) {
+        if (reportDone < percentageDone/1) {
             // report every 10% step
             LogPrintf("[%d%%]...", percentageDone); /* Continued */
-            reportDone = percentageDone/10;
+            reportDone = percentageDone/1;
         }
         uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
         if (pindex->nHeight <= ::ChainActive().Height()-nCheckDepth)
@@ -4320,10 +4320,10 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         while (pindex != ::ChainActive().Tip()) {
             boost::this_thread::interruption_point();
             const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
-            if (reportDone < percentageDone/10) {
-                // report every 10% step
+            if (reportDone < percentageDone/1) {
+                // report every 1% step
                 LogPrintf("[%d%%]...", percentageDone); /* Continued */
-                reportDone = percentageDone/10;
+                reportDone = percentageDone/1;
             }
             uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
             pindex = ::ChainActive().Next(pindex);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4321,7 +4321,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         while (pindex != ::ChainActive().Tip()) {
             boost::this_thread::interruption_point();
             const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
-            if (reportDone < percentageDone/log_step) {
+            if (reportDone < percentageDone / log_step) {
                 // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
                 LogPrintf("[%d%%]...", percentageDone); /* Continued */
                 reportDone = percentageDone / log_step;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4324,7 +4324,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
             if (reportDone < percentageDone/log_step) {
                 // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
                 LogPrintf("[%d%%]...", percentageDone); /* Continued */
-                reportDone = percentageDone/log_step;
+                reportDone = percentageDone / log_step;
             }
             uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
             pindex = ::ChainActive().Next(pindex);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4259,7 +4259,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     BlockValidationState state;
     int reportDone = 0;
     int logStep;
-    logStep = nCheckDepth > 1000 ? 1 : 10;
+    const int log_step{nCheckDepth > 1000 ? 1 : 10};
     LogPrintf("[0%%]..."); /* Continued */
     for (pindex = ::ChainActive().Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4266,7 +4266,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         if (reportDone < percentageDone/log_step) {
             // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
             LogPrintf("[%d%%]...", percentageDone); /* Continued */
-            reportDone = percentageDone/log_step;
+            reportDone = percentageDone / log_step;
         }
         uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
         if (pindex->nHeight <= ::ChainActive().Height()-nCheckDepth)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4258,14 +4258,16 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     int nGoodTransactions = 0;
     BlockValidationState state;
     int reportDone = 0;
+    int logStep;
+    logStep = nCheckDepth > 1000 ? 1 : 10;
     LogPrintf("[0%%]..."); /* Continued */
     for (pindex = ::ChainActive().Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
-        if (reportDone < percentageDone/1) {
-            // report every 10% step
+        if (reportDone < percentageDone/logStep) {
+            // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
             LogPrintf("[%d%%]...", percentageDone); /* Continued */
-            reportDone = percentageDone/1;
+            reportDone = percentageDone/logStep;
         }
         uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
         if (pindex->nHeight <= ::ChainActive().Height()-nCheckDepth)
@@ -4320,10 +4322,10 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         while (pindex != ::ChainActive().Tip()) {
             boost::this_thread::interruption_point();
             const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
-            if (reportDone < percentageDone/1) {
-                // report every 1% step
+            if (reportDone < percentageDone/logStep) {
+                // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
                 LogPrintf("[%d%%]...", percentageDone); /* Continued */
-                reportDone = percentageDone/1;
+                reportDone = percentageDone/logStep;
             }
             uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
             pindex = ::ChainActive().Next(pindex);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4258,16 +4258,15 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     int nGoodTransactions = 0;
     BlockValidationState state;
     int reportDone = 0;
-    int logStep;
     const int log_step{nCheckDepth > 1000 ? 1 : 10};
     LogPrintf("[0%%]..."); /* Continued */
     for (pindex = ::ChainActive().Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
-        if (reportDone < percentageDone/logStep) {
+        if (reportDone < percentageDone/log_step) {
             // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
             LogPrintf("[%d%%]...", percentageDone); /* Continued */
-            reportDone = percentageDone/logStep;
+            reportDone = percentageDone/log_step;
         }
         uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
         if (pindex->nHeight <= ::ChainActive().Height()-nCheckDepth)
@@ -4322,10 +4321,10 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
         while (pindex != ::ChainActive().Tip()) {
             boost::this_thread::interruption_point();
             const int percentageDone = std::max(1, std::min(99, 100 - (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * 50)));
-            if (reportDone < percentageDone/logStep) {
+            if (reportDone < percentageDone/log_step) {
                 // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
                 LogPrintf("[%d%%]...", percentageDone); /* Continued */
-                reportDone = percentageDone/logStep;
+                reportDone = percentageDone/log_step;
             }
             uiInterface.ShowProgress(_("Verifying blocks...").translated, percentageDone, false);
             pindex = ::ChainActive().Next(pindex);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4263,7 +4263,7 @@ bool CVerifyDB::VerifyDB(const CChainParams& chainparams, CCoinsView *coinsview,
     for (pindex = ::ChainActive().Tip(); pindex && pindex->pprev; pindex = pindex->pprev) {
         boost::this_thread::interruption_point();
         const int percentageDone = std::max(1, std::min(99, (int)(((double)(::ChainActive().Height() - pindex->nHeight)) / (double)nCheckDepth * (nCheckLevel >= 4 ? 50 : 100))));
-        if (reportDone < percentageDone/log_step) {
+        if (reportDone < percentageDone / log_step) {
             // report every 10% step if nCheckDepth is <= 1000 blocks else report every 1% step.
             LogPrintf("[%d%%]...", percentageDone); /* Continued */
             reportDone = percentageDone / log_step;


### PR DESCRIPTION
Currently "verifychain" prints progress every 10 steps. If a user tries to verify the whole blockchain (verifychain 4 0) it will take a lot of time and printing progress every 1 step is very useful.

<!--
*** Please remove the following help text before submitting: ***

Pull requests without a rationale and clear improvement may be closed
immediately.
-->

<!--
Please provide clear motivation for your patch and explain how it improves
Bitcoin Core user experience or Bitcoin Core developer experience
significantly:

* Any test improvements or new tests that improve coverage are always welcome.
* All other changes should have accompanying unit tests (see `src/test/`) or
  functional tests (see `test/`). Contributors should note which tests cover
  modified code. If no tests exist for a region of modified code, new tests
  should accompany the change.
* Bug fixes are most welcome when they come with steps to reproduce or an
  explanation of the potential issue as well as reasoning for the way the bug
  was fixed.
* Features are welcome, but might be rejected due to design or scope issues.
  If a feature is based on a lot of dependencies, contributors should first
  consider building the system outside of Bitcoin Core, if possible.
* Refactoring changes are only accepted if they are required for a feature or
  bug fix or otherwise improve developer experience significantly. For example,
  most "code style" refactoring changes require a thorough explanation why they
  are useful, what downsides they have and why they *significantly* improve
  developer experience or avoid serious programming bugs. Note that code style
  is often a subjective matter. Unless they are explicitly mentioned to be
  preferred in the [developer notes](/doc/developer-notes.md), stylistic code
  changes are usually rejected.
-->

<!--
Bitcoin Core has a thorough review process and even the most trivial change
needs to pass a lot of eyes and requires non-zero or even substantial time
effort to review. There is a huge lack of active reviewers on the project, so
patches often sit for a long time.
-->
