### PR TITLE
net: Use C++11 member initialization in protocol

### DIFF
--- a/src/compat/assumptions.h
+++ b/src/compat/assumptions.h
@@ -50,6 +50,7 @@ static_assert(sizeof(double) == 8, "64-bit double assumed");
 //             code.
 static_assert(sizeof(short) == 2, "16-bit short assumed");
 static_assert(sizeof(int) == 4, "32-bit int assumed");
+static_assert(sizeof(unsigned) == 4, "32-bit unsigned assumed");
 
 // Assumption: We assume size_t to be 32-bit or 64-bit.
 // Example(s): size_t assumed to be at least 32-bit in ecdsa_signature_parse_der_lax(...).

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -147,24 +147,6 @@ void SetServiceFlagsIBDCache(bool state) {
     g_initial_block_download_completed = state;
 }
 
-
-CAddress::CAddress() : CService()
-{
-    Init();
-}
-
-CAddress::CAddress(CService ipIn, ServiceFlags nServicesIn) : CService(ipIn)
-{
-    Init();
-    nServices = nServicesIn;
-}
-
-void CAddress::Init()
-{
-    nServices = NODE_NONE;
-    nTime = 100000000;
-}
-
 CInv::CInv()
 {
     type = 0;

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -328,15 +328,15 @@ static inline bool MayHaveUsefulAddressDB(ServiceFlags services)
 /** A CService with information about it as peer */
 class CAddress : public CService
 {
-public:
-    CAddress();
-    explicit CAddress(CService ipIn, ServiceFlags nServicesIn);
+    static constexpr uint32_t TIME_INIT{100000000};
 
-    void Init();
+public:
+    CAddress() : CService{} {};
+    explicit CAddress(CService ipIn, ServiceFlags nServicesIn) : CService{ipIn}, nServices{nServicesIn} {};
 
     SERIALIZE_METHODS(CAddress, obj)
     {
-        SER_READ(obj, obj.Init());
+        SER_READ(obj, obj.nTime = TIME_INIT);
         int nVersion = s.GetVersion();
         if (s.GetType() & SER_DISK) {
             READWRITE(nVersion);
@@ -349,10 +349,9 @@ public:
         READWRITEAS(CService, obj);
     }
 
-    ServiceFlags nServices;
-
+    ServiceFlags nServices{NODE_NONE};
     // disk and network only
-    unsigned int nTime;
+    uint32_t nTime{TIME_INIT};
 };
 
 /** getdata message type flags */


### PR DESCRIPTION
This change removes `Init` from the constructors and instead uses C++11 member initialization. This removes a bunch of boilerplate, makes the code easier to read. Also, C++11 member initialization avoids accidental uninitialized members.