### PR TITLE
test: Set -logthreadnames in unit tests

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1317,8 +1317,7 @@ bool AppInitMain(const util::Ref& context, NodeContext& node)
     node.scheduler = MakeUnique<CScheduler>();
 
     // Start the lightweight task scheduler thread
-    CScheduler::Function serviceLoop = [&node]{ node.scheduler->serviceQueue(); };
-    threadGroup.create_thread(std::bind(&TraceThread<CScheduler::Function>, "scheduler", serviceLoop));
+    threadGroup.create_thread([&] { TraceThread("scheduler", [&] { node.scheduler->serviceQueue(); }); });
 
     // Gather some entropy once per minute.
     node.scheduler->scheduleEvery([]{

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -74,11 +74,13 @@ BasicTestingSetup::BasicTestingSetup(const std::string& chainName, const std::ve
             "dummy",
             "-printtoconsole=0",
             "-logtimemicros",
+            "-logthreadnames",
             "-debug",
             "-debugexclude=libevent",
             "-debugexclude=leveldb",
         },
         extra_args);
+    util::ThreadRename("test");
     fs::create_directories(m_path_root);
     gArgs.ForceSetArg("-datadir", m_path_root.string());
     ClearDatadirCache();

--- a/src/test/util/setup_common.cpp
+++ b/src/test/util/setup_common.cpp
@@ -129,7 +129,7 @@ TestingSetup::TestingSetup(const std::string& chainName, const std::vector<const
 
     // We have to run a scheduler thread to prevent ActivateBestChain
     // from blocking due to queue overrun.
-    threadGroup.create_thread([&]{ m_node.scheduler->serviceQueue(); });
+    threadGroup.create_thread([&] { TraceThread("scheduler", [&] { m_node.scheduler->serviceQueue(); }); });
     GetMainSignals().RegisterBackgroundSignalScheduler(*m_node.scheduler);
 
     pblocktree.reset(new CBlockTreeDB(1 << 20, true));

--- a/src/test/util_threadnames_tests.cpp
+++ b/src/test/util_threadnames_tests.cpp
@@ -53,8 +53,6 @@ std::set<std::string> RenameEnMasse(int num_threads)
  */
 BOOST_AUTO_TEST_CASE(util_threadnames_test_rename_threaded)
 {
-    BOOST_CHECK_EQUAL(util::ThreadGetInternalName(), "");
-
 #if !defined(HAVE_THREAD_LOCAL)
     // This test doesn't apply to platforms where we don't have thread_local.
     return;


### PR DESCRIPTION
Generally the unit tests are single threaded, with the exception of the script check threads, the schedule, and optionally indexer threads.

Like the functional tests, the thread name can serve additional debug information, so set `-logthreadnames` in unit tests.

Can be tested with

```
./src/test/test_bitcoin -l test_suite -t validation_tests/test_combiner_all -- DEBUG_LOG_OUT