### PR TITLE
torcontrol: add -tortarget config

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -461,6 +461,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-timeout=<n>", strprintf("Specify connection timeout in milliseconds (minimum: 1, default: %d)", DEFAULT_CONNECT_TIMEOUT), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-peertimeout=<n>", strprintf("Specify p2p connection timeout in seconds. This option determines the amount of time a peer may be inactive before the connection to it is dropped. (minimum: 1, default: %d)", DEFAULT_PEER_CONNECT_TIMEOUT), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::CONNECTION);
     argsman.AddArg("-torcontrol=<ip>:<port>", strprintf("Tor control port to use if onion listening enabled (default: %s)", DEFAULT_TOR_CONTROL), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    argsman.AddArg("-tortarget=<ip:port>", strprintf("Target for Tor HiddenService (default: 127.0.0.1:%i)", defaultChainParams->GetDefaultPort()), ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-torpassword=<pass>", "Tor control port password (default: empty)", ArgsManager::ALLOW_ANY | ArgsManager::SENSITIVE, OptionsCategory::CONNECTION);
 #ifdef USE_UPNP
 #if USE_UPNP


### PR DESCRIPTION
This PR allows torcontrol to auto configure the HiddenService even
when Tor is running on a different host or within a containerized
environment. 

In such an environment, the previously assumed static target of 
`127.0.0.1` was insufficient.

fixes #16693 