### PR TITLE
test: changing signature of wait_until().

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -226,7 +226,7 @@ Note: gdb attach step may require ptrace_scope to be modified, or `sudo` precedi
 See this link for considerations: https://www.kernel.org/doc/Documentation/security/Yama.txt
 
 Often while debugging rpc calls from functional tests, the test might reach timeout before
-process can return a response. Use `--timeout-factor 0` to disable all rpc timeouts for that partcular
+process can return a response. Use `--timeout-factor 0` to disable all rpc timeouts for that particular
 functional test. Ex: `test/functional/wallet_hd.py --timeout-factor 0`.
 
 ##### Profiling

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -207,7 +207,7 @@ class P2PConnection(asyncio.Protocol):
                 self._log_message("receive", t)
                 self.on_message(t)
         except Exception as e:
-            logger.exception('Error reading message:', repr(e))
+            logger.exception('Error reading message: {}'.format(repr(e)))
             raise
 
     def on_message(self, message):
@@ -375,7 +375,7 @@ class P2PInterface(P2PConnection):
     # Connection helper methods
 
     def wait_until(self, test_function, timeout=60):
-        wait_until(test_function, timeout=timeout, lock=mininode_lock, timeout_factor=self.timeout_factor)
+        wait_until(test_function, timeout=timeout * self.timeout_factor, lock=mininode_lock)
 
     def wait_for_disconnect(self, timeout=60):
         test_function = lambda: not self.is_connected

--- a/test/functional/test_framework/test_node.py
+++ b/test/functional/test_framework/test_node.py
@@ -358,7 +358,7 @@ class TestNode():
         return True
 
     def wait_until_stopped(self, timeout=BITCOIND_PROC_WAIT_TIMEOUT):
-        wait_until(self.is_node_stopped, timeout=timeout, timeout_factor=self.timeout_factor)
+        wait_until(self.is_node_stopped, timeout=timeout * self.timeout_factor)
 
     @contextlib.contextmanager
     def assert_debug_log(self, expected_msgs, unexpected_msgs=None, timeout=2):

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -208,10 +208,9 @@ def str_to_b64str(string):
 def satoshi_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
-def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None, timeout_factor=1.0):
+def wait_until(predicate, *, attempts=float('inf'), timeout=float('inf'), lock=None):
     if attempts == float('inf') and timeout == float('inf'):
         timeout = 60
-    timeout = timeout * timeout_factor
     attempt = 0
     time_end = time.time() + timeout
 


### PR DESCRIPTION
As a follow up on [#18986(comment)](https://github.com/bitcoin/bitcoin/pull/18986#discussion_r426768706), jnewbery suggested that wait_until() is unnecessarily taking `timeout_factor` as a parameter, whereas the client should have this knowledge and can directly provide `wait_until()` the required timeout.

As it turned out almost nowhere the client is passing `timeout_factor` to `wait_until()` and changing the signature is enough to enforce the intended behavior.

Verified all the existing tests are passing. 
Verified all the existing tests are passing with `timeout-factor 0`.    