### PR TITLE
tests: Don't limit fuzzing inputs to 1 MB for afl-fuzz (now: ∞ ∀ fuzzers)

### DIFF
--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -19,8 +19,6 @@ static bool read_stdin(std::vector<uint8_t>& data)
     ssize_t length = 0;
     while ((length = read(STDIN_FILENO, buffer, 1024)) > 0) {
         data.insert(data.end(), buffer, buffer + length);
-
-        if (data.size() > (1 << 20)) return false;
     }
     return length == 0;
 }


### PR DESCRIPTION
Don't limit fuzzing inputs to 1 MB for `afl-fuzz`.

This change provides a level playing field for all fuzzers which allows for fair benchmarking using projects such as the excellent [FuzzBench](https://github.com/google/fuzzbench) project.

Prior to this commit we limited `afl-fuzz` to ≤1 MB inputs but allowed unlimited length inputs for all other fuzzers.