### PR TITLE
tests: Add fuzzing harness for CNode

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -70,6 +70,7 @@ FUZZ_TARGETS = \
   test/fuzz/message \
   test/fuzz/messageheader_deserialize \
   test/fuzz/multiplication_overflow \
+  test/fuzz/net \
   test/fuzz/net_permissions \
   test/fuzz/netaddr_deserialize \
   test/fuzz/netaddress \
@@ -721,6 +722,12 @@ test_fuzz_multiplication_overflow_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_multiplication_overflow_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_multiplication_overflow_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_multiplication_overflow_SOURCES = test/fuzz/multiplication_overflow.cpp
+
+test_fuzz_net_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_net_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_net_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_net_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_net_SOURCES = test/fuzz/net.cpp
 
 test_fuzz_net_permissions_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_net_permissions_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/net.cpp
+++ b/src/test/fuzz/net.cpp
@@ -1,0 +1,156 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <chainparamsbase.h>
+#include <net.h>
+#include <net_permissions.h>
+#include <netaddress.h>
+#include <optional.h>
+#include <protocol.h>
+#include <random.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+void initialize()
+{
+    static const BasicTestingSetup basic_testing_setup;
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+
+    const std::optional<CAddress> address = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
+    if (!address) {
+        return;
+    }
+    const std::optional<CAddress> address_bind = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
+    if (!address_bind) {
+        return;
+    }
+
+    CNode node{fuzzed_data_provider.ConsumeIntegral<NodeId>(),
+               static_cast<ServiceFlags>(fuzzed_data_provider.ConsumeIntegral<uint64_t>()),
+               fuzzed_data_provider.ConsumeIntegral<int>(),
+               INVALID_SOCKET,
+               *address,
+               fuzzed_data_provider.ConsumeIntegral<uint64_t>(),
+               fuzzed_data_provider.ConsumeIntegral<uint64_t>(),
+               *address_bind,
+               fuzzed_data_provider.ConsumeRandomLengthString(32),
+               fuzzed_data_provider.PickValueInArray({ConnectionType::INBOUND, ConnectionType::OUTBOUND, ConnectionType::MANUAL, ConnectionType::FEELER, ConnectionType::BLOCK_RELAY, ConnectionType::ADDR_FETCH})};
+    while (fuzzed_data_provider.ConsumeBool()) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 12)) {
+        case 0: {
+            node.CloseSocketDisconnect();
+            break;
+        }
+        case 1: {
+            node.MaybeSetAddrName(fuzzed_data_provider.ConsumeRandomLengthString(32));
+            break;
+        }
+        case 2: {
+            node.SetSendVersion(fuzzed_data_provider.ConsumeIntegral<int>());
+            break;
+        }
+        case 3: {
+            const std::vector<bool> asmap = ConsumeRandomLengthIntegralVector<bool>(fuzzed_data_provider, 128);
+            if (!SanityCheckASMap(asmap)) {
+                break;
+            }
+            CNodeStats stats;
+            node.copyStats(stats, asmap);
+            break;
+        }
+        case 4: {
+            node.SetRecvVersion(fuzzed_data_provider.ConsumeIntegral<int>());
+            break;
+        }
+        case 5: {
+            const CNode* add_ref_node = node.AddRef();
+            assert(add_ref_node == &node);
+            break;
+        }
+        case 6: {
+            if (node.GetRefCount() > 0) {
+                node.Release();
+            }
+            break;
+        }
+        case 7: {
+            if (node.m_addr_known == nullptr) {
+                break;
+            }
+            const std::optional<CAddress> addr_opt = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
+            if (!addr_opt) {
+                break;
+            }
+            node.AddAddressKnown(*addr_opt);
+            break;
+        }
+        case 8: {
+            if (node.m_addr_known == nullptr) {
+                break;
+            }
+            const std::optional<CAddress> addr_opt = ConsumeDeserializable<CAddress>(fuzzed_data_provider);
+            if (!addr_opt) {
+                break;
+            }
+            FastRandomContext fast_random_context{ConsumeUInt256(fuzzed_data_provider)};
+            node.PushAddress(*addr_opt, fast_random_context);
+            break;
+        }
+        case 9: {
+            const std::optional<CInv> inv_opt = ConsumeDeserializable<CInv>(fuzzed_data_provider);
+            if (!inv_opt) {
+                break;
+            }
+            node.AddKnownTx(inv_opt->hash);
+            break;
+        }
+        case 10: {
+            node.PushTxInventory(ConsumeUInt256(fuzzed_data_provider));
+            break;
+        }
+        case 11: {
+            const std::optional<CService> service_opt = ConsumeDeserializable<CService>(fuzzed_data_provider);
+            if (!service_opt) {
+                break;
+            }
+            node.SetAddrLocal(*service_opt);
+            break;
+        }
+        case 12: {
+            const std::vector<uint8_t> b = ConsumeRandomLengthByteVector(fuzzed_data_provider);
+            bool complete;
+            node.ReceiveMsgBytes((const char*)b.data(), b.size(), complete);
+            break;
+        }
+        }
+    }
+
+    (void)node.GetAddrLocal();
+    (void)node.GetAddrName();
+    (void)node.GetId();
+    (void)node.GetLocalNonce();
+    (void)node.GetLocalServices();
+    (void)node.GetMyStartingHeight();
+    (void)node.GetRecvVersion();
+    const int ref_count = node.GetRefCount();
+    assert(ref_count >= 0);
+    (void)node.GetSendVersion();
+    (void)node.IsAddrRelayPeer();
+
+    const NetPermissionFlags net_permission_flags = fuzzed_data_provider.ConsumeBool() ?
+                                                        fuzzed_data_provider.PickValueInArray<NetPermissionFlags>({NetPermissionFlags::PF_NONE, NetPermissionFlags::PF_BLOOMFILTER, NetPermissionFlags::PF_RELAY, NetPermissionFlags::PF_FORCERELAY, NetPermissionFlags::PF_NOBAN, NetPermissionFlags::PF_MEMPOOL, NetPermissionFlags::PF_ISIMPLICIT, NetPermissionFlags::PF_ALL}) :
+                                                        static_cast<NetPermissionFlags>(fuzzed_data_provider.ConsumeIntegral<uint32_t>());
+    (void)node.HasPermission(net_permission_flags);
+}


### PR DESCRIPTION
Add fuzzing harness for `CNode`.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)