### PR TITLE
Remove outdated comment about DER encoding

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -44,8 +44,7 @@ extern unsigned nMaxDatacarrierBytes;
 /**
  * Mandatory script verification flags that all new blocks must comply with for
  * them to be valid. (but old blocks may not comply with) Currently just P2SH,
- * but in the future other flags may be added, such as a soft-fork to enforce
- * strict DER encoding.
+ * but in the future other flags may be added.
  *
  * Failing one of these tests may trigger a DoS ban - see CheckInputScripts() for
  * details.


### PR DESCRIPTION
This comment got me confused about the status of BIP66 (Thanks jnewbery for explaining)
The comment was added in: https://github.com/bitcoin/bitcoin/pull/3843 
But in https://github.com/bitcoin/bitcoin/pull/5713 strict DER encoding was enforced in consensus, 
and is now it's buried and enforced by the height of the block here: https://github.com/bitcoin/bitcoin/blob/4af01b37d40246cd1fdb54719855927e36a36b46/src/validation.cpp#L1889



P.S. This is also quite confusing: https://github.com/bitcoin/bitcoin/blob/4af01b37d40246cd1fdb54719855927e36a36b46/src/validation.cpp#L1560-L1563 But seems to be intentional: https://github.com/bitcoin/bitcoin/blob/4af01b37d40246cd1fdb54719855927e36a36b46/src/validation.cpp#L1510-L1511