### PR TITLE
tests: Use BasicTestingSetup to initialise fuzzing environment

### DIFF
--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -11,6 +11,7 @@
 #include <pubkey.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <validation.h>
 #include <version.h>
 
@@ -19,8 +20,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/block.cpp
+++ b/src/test/fuzz/block.cpp
@@ -11,7 +11,7 @@
 #include <pubkey.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <validation.h>
 #include <version.h>
 
@@ -20,7 +20,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/cuckoocache.cpp
+++ b/src/test/fuzz/cuckoocache.cpp
@@ -7,7 +7,6 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/setup_common.h>
 
 #include <cstdint>
 #include <string>

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -6,12 +6,12 @@
 #include <pubkey.h>
 #include <script/descriptor.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/descriptor_parse.cpp
+++ b/src/test/fuzz/descriptor_parse.cpp
@@ -2,16 +2,15 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
 #include <pubkey.h>
 #include <script/descriptor.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <util/memory.h>
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -20,7 +20,7 @@
 #include <pubkey.h>
 #include <script/keyorigin.h>
 #include <streams.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <undo.h>
 #include <version.h>
 
@@ -35,7 +35,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 namespace {

--- a/src/test/fuzz/deserialize.cpp
+++ b/src/test/fuzz/deserialize.cpp
@@ -20,6 +20,7 @@
 #include <pubkey.h>
 #include <script/keyorigin.h>
 #include <streams.h>
+#include <test/util/setup_common.h>
 #include <undo.h>
 #include <version.h>
 
@@ -34,8 +35,7 @@
 
 void initialize()
 {
-    // Fuzzers using pubkey must hold an ECCVerifyHandle.
-    static const ECCVerifyHandle verify_handle;
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 namespace {

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -6,13 +6,14 @@
 #include <script/interpreter.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 
 #include <limits>
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/eval_script.cpp
+++ b/src/test/fuzz/eval_script.cpp
@@ -6,14 +6,14 @@
 #include <script/interpreter.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <util/memory.h>
 
 #include <limits>
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/fuzz.cpp
+++ b/src/test/fuzz/fuzz.cpp
@@ -7,6 +7,8 @@
 #include <test/util/setup_common.h>
 
 #include <cstdint>
+#include <functional>
+#include <string>
 #include <unistd.h>
 #include <vector>
 

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -7,7 +7,7 @@
 #include <pubkey.h>
 #include <rpc/util.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <uint256.h>
 #include <univalue.h>
 #include <util/strencodings.h>
@@ -19,7 +19,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/hex.cpp
+++ b/src/test/fuzz/hex.cpp
@@ -7,6 +7,7 @@
 #include <pubkey.h>
 #include <rpc/util.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <uint256.h>
 #include <univalue.h>
 #include <util/strencodings.h>
@@ -18,7 +19,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -24,6 +24,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/moneystr.h>
@@ -42,7 +43,7 @@
 
 void initialize()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/integer.cpp
+++ b/src/test/fuzz/integer.cpp
@@ -24,7 +24,6 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/setup_common.h>
 #include <uint256.h>
 #include <util/check.h>
 #include <util/moneystr.h>
@@ -43,7 +42,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -2,8 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
-#include <chainparamsbase.h>
 #include <key.h>
 #include <key_io.h>
 #include <outputtype.h>
@@ -17,7 +15,7 @@
 #include <script/standard.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <util/memory.h>
 #include <util/strencodings.h>
 
@@ -29,7 +27,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/key.cpp
+++ b/src/test/fuzz/key.cpp
@@ -17,6 +17,7 @@
 #include <script/standard.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 #include <util/strencodings.h>
 
@@ -28,9 +29,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle ecc_verify_handle;
-    ECC_Start();
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -8,6 +8,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 
 #include <cassert>
 #include <cstdint>
@@ -16,9 +17,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
-    ECC_Start();
-    SelectParams(CBaseChainParams::MAIN);
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/key_io.cpp
+++ b/src/test/fuzz/key_io.cpp
@@ -8,7 +8,7 @@
 #include <script/signingprovider.h>
 #include <script/standard.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 
 #include <cassert>
 #include <cstdint>
@@ -17,7 +17,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -2,12 +2,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
 #include <key_io.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/setup_common.h>
 #include <util/message.h>
 #include <util/strencodings.h>
 
@@ -19,7 +17,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/message.cpp
+++ b/src/test/fuzz/message.cpp
@@ -7,6 +7,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
 #include <util/message.h>
 #include <util/strencodings.h>
 
@@ -18,9 +19,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle ecc_verify_handle;
-    ECC_Start();
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/p2p_transport_deserializer.cpp
+++ b/src/test/fuzz/p2p_transport_deserializer.cpp
@@ -6,7 +6,7 @@
 #include <net.h>
 #include <protocol.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 
 #include <cassert>
 #include <cstdint>
@@ -15,7 +15,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/p2p_transport_deserializer.cpp
+++ b/src/test/fuzz/p2p_transport_deserializer.cpp
@@ -6,6 +6,7 @@
 #include <net.h>
 #include <protocol.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 
 #include <cassert>
 #include <cstdint>
@@ -14,7 +15,7 @@
 
 void initialize()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -7,6 +7,7 @@
 #include <rpc/client.h>
 #include <rpc/util.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 
 #include <limits>
@@ -14,8 +15,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/parse_univalue.cpp
+++ b/src/test/fuzz/parse_univalue.cpp
@@ -2,14 +2,12 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
 #include <core_io.h>
 #include <rpc/client.h>
 #include <rpc/util.h>
-#include <test/fuzz/fuzz.h>
 #include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/setup_common.h>
 #include <util/memory.h>
 
 #include <limits>
@@ -17,7 +15,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -59,7 +59,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         {
             (void)GetBlockProof(current_block);
             (void)CalculateNextWorkRequired(&current_block, fuzzed_data_provider.ConsumeIntegralInRange<int64_t>(0, std::numeric_limits<int64_t>::max()), consensus_params);
-            if (current_block.nHeight != std::numeric_limits<int>::max() && current_block.nHeight - (consensus_params.DifficultyAdjustmentInterval() - 1) >= 0) {
+            if (current_block.nHeight != std::numeric_limits<int>::max()) {
                 (void)GetNextWorkRequired(&current_block, &(*block_header), consensus_params);
             }
         }

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -9,6 +9,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
 
 #include <cstdint>
 #include <optional>
@@ -17,7 +18,7 @@
 
 void initialize()
 {
-    SelectParams(CBaseChainParams::MAIN);
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/pow.cpp
+++ b/src/test/fuzz/pow.cpp
@@ -9,7 +9,6 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/setup_common.h>
 
 #include <cstdint>
 #include <optional>
@@ -18,7 +17,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/process_messages.cpp
+++ b/src/test/fuzz/process_messages.cpp
@@ -69,11 +69,7 @@ void test_one_input(const std::vector<uint8_t>& buffer)
 
         (void)connman.ReceiveMsgFrom(random_node, net_msg);
         random_node.fPauseSend = false;
-
-        try {
-            connman.ProcessMessagesOnce(random_node);
-        } catch (const std::ios_base::failure&) {
-        }
+        connman.ProcessMessagesOnce(random_node);
     }
     SyncWithValidationInterfaceQueue();
     LOCK2(::cs_main, g_cs_orphans); // See init.cpp for rationale for implicit locking order requirement

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -10,7 +10,7 @@
 #include <pubkey.h>
 #include <script/script.h>
 #include <streams.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <util/memory.h>
 #include <version.h>
 
@@ -20,7 +20,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/psbt.cpp
+++ b/src/test/fuzz/psbt.cpp
@@ -10,6 +10,7 @@
 #include <pubkey.h>
 #include <script/script.h>
 #include <streams.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 #include <version.h>
 
@@ -19,7 +20,7 @@
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
 #include <compressor.h>
 #include <core_io.h>
 #include <core_memusage.h>
@@ -19,7 +18,6 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
-#include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/memory.h>
 
@@ -32,7 +30,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/script.cpp
+++ b/src/test/fuzz/script.cpp
@@ -19,6 +19,7 @@
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
 #include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/memory.h>
 
@@ -31,10 +32,7 @@
 
 void initialize()
 {
-    // Fuzzers using pubkey must hold an ECCVerifyHandle.
-    static const ECCVerifyHandle verify_handle;
-
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -5,7 +5,7 @@
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <streams.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <util/memory.h>
 #include <version.h>
 
@@ -16,7 +16,7 @@ static bool IsValidFlagCombination(unsigned flags);
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/script_flags.cpp
+++ b/src/test/fuzz/script_flags.cpp
@@ -5,6 +5,7 @@
 #include <pubkey.h>
 #include <script/interpreter.h>
 #include <streams.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 #include <version.h>
 
@@ -15,7 +16,7 @@ static bool IsValidFlagCombination(unsigned flags);
 
 void initialize()
 {
-    static const ECCVerifyHandle verify_handle;
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -6,6 +6,7 @@
 #include <script/interpreter.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <util/memory.h>
 
 #include <cstdint>
@@ -15,7 +16,7 @@
 
 void initialize()
 {
-    static const auto verify_handle = MakeUnique<ECCVerifyHandle>();
+    static const BasicTestingSetup basic_testing_setup;
 }
 
 namespace {

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -6,7 +6,7 @@
 #include <script/interpreter.h>
 #include <test/fuzz/FuzzedDataProvider.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <util/memory.h>
 
 #include <cstdint>
@@ -16,7 +16,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup;
+    InitializeFuzzingContext(CBaseChainParams::MAIN);
 }
 
 namespace {

--- a/src/test/fuzz/signature_checker.cpp
+++ b/src/test/fuzz/signature_checker.cpp
@@ -43,8 +43,6 @@ public:
     {
         return m_fuzzed_data_provider.ConsumeBool();
     }
-
-    virtual ~FuzzedSignatureChecker() {}
 };
 } // namespace
 

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include <chainparams.h>
 #include <coins.h>
 #include <consensus/tx_check.h>
 #include <consensus/tx_verify.h>
@@ -14,7 +13,7 @@
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
-#include <test/util/setup_common.h>
+#include <test/fuzz/util.h>
 #include <univalue.h>
 #include <util/rbf.h>
 #include <validation.h>
@@ -24,7 +23,7 @@
 
 void initialize()
 {
-    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
+    InitializeFuzzingContext();
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)

--- a/src/test/fuzz/transaction.cpp
+++ b/src/test/fuzz/transaction.cpp
@@ -14,6 +14,7 @@
 #include <primitives/transaction.h>
 #include <streams.h>
 #include <test/fuzz/fuzz.h>
+#include <test/util/setup_common.h>
 #include <univalue.h>
 #include <util/rbf.h>
 #include <validation.h>
@@ -23,7 +24,7 @@
 
 void initialize()
 {
-    SelectParams(CBaseChainParams::REGTEST);
+    static const BasicTestingSetup basic_testing_setup{CBaseChainParams::REGTEST};
 }
 
 void test_one_input(const std::vector<uint8_t>& buffer)


### PR DESCRIPTION
Use `BasicTestingSetup` to initialise fuzzing environment (as suggested by MarcoFalke).

Also: Remove unreachable fuzzing code. Various small coverage improvements.

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)