### PR TITLE
test: Moved the CScriptNum asserts into the unit test in script.py

### DIFF
--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -29,8 +29,6 @@ from test_framework.util import (
     assert_raises_rpc_error,
     connect_nodes,
 )
-from test_framework.script import CScriptNum
-
 
 def assert_template(node, block, expect, rehash=True):
     if rehash:
@@ -91,12 +89,6 @@ class MiningTest(BitcoinTestFramework):
         coinbase_tx.rehash()
 
         # round-trip the encoded bip34 block height commitment
-        assert_equal(CScriptNum.decode(coinbase_tx.vin[0].scriptSig), next_height)
-        # round-trip negative and multi-byte CScriptNums to catch python regression
-        assert_equal(CScriptNum.decode(CScriptNum.encode(CScriptNum(1500))), 1500)
-        assert_equal(CScriptNum.decode(CScriptNum.encode(CScriptNum(-1500))), -1500)
-        assert_equal(CScriptNum.decode(CScriptNum.encode(CScriptNum(-1))), -1)
-
         block = CBlock()
         block.nVersion = tmpl["version"]
         block.hashPrevBlock = int(tmpl["previousblockhash"], 16)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -4,6 +4,8 @@
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 """Utilities for manipulating blocks and transactions."""
 
+import unittest
+
 from .address import (
     key_to_p2sh_p2wpkh,
     key_to_p2wpkh,
@@ -217,3 +219,9 @@ def send_to_witness(use_p2wsh, node, utxo, pubkey, encode_p2sh, amount, sign=Tru
             tx_to_witness = ToHex(tx)
 
     return node.sendrawtransaction(tx_to_witness)
+
+class TestFrameworkBlockTools(unittest.TestCase):
+    def test_create_coinbase(self):
+        height = 20
+        coinbase_tx = create_coinbase(height=height)
+        assert_equal(CScriptNum.decode(coinbase_tx.vin[0].scriptSig), height)

--- a/test/functional/test_framework/script.py
+++ b/test/functional/test_framework/script.py
@@ -731,3 +731,9 @@ class TestFrameworkScript(unittest.TestCase):
         self.assertEqual(bn2vch(0xFFFFFFFF), bytes([0xFF, 0xFF, 0xFF, 0xFF, 0x00]))
         self.assertEqual(bn2vch(123456789), bytes([0x15, 0xCD, 0x5B, 0x07]))
         self.assertEqual(bn2vch(-54321), bytes([0x31, 0xD4, 0x80]))
+
+    def test_cscriptnum_encoding(self):
+        # round-trip negative and multi-byte CScriptNums
+        values = [0, 1, -1, -2, 127, 128, -255, 256, (1 << 15) - 1, -(1 << 16), (1 << 24) - 1, (1 << 31), 1 - (1 << 32), 1 << 40, 1500, -1500]
+        for value in values:
+            self.assertEqual(CScriptNum.decode(CScriptNum.encode(CScriptNum(value))), value)

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -68,6 +68,7 @@ TEST_EXIT_SKIPPED = 77
 
 TEST_FRAMEWORK_MODULES = [
     "address",
+    "blocktools",
     "script",
 ]
 


### PR DESCRIPTION
The CScriptNum test (#14816) is a roundtrip test of the test framework. Thus, it would be better suited as a unit test. This is now possible with the introduction of the unit test module for the functional tests. See #18576. 

This PR:
1. Refactors the CScriptNum tests into 2 unit tests, one in script.py and one in blocktools.py.
2. Extends the script.py CScriptNum test to trial larger numbers.
