### PR TITLE
build: Only allow ASCII identifiers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -422,6 +422,9 @@ if test "x$CXXFLAGS_overridden" = "xno"; then
   AX_CHECK_COMPILE_FLAG([-Wdeprecated-copy],[NOWARN_CXXFLAGS="$NOWARN_CXXFLAGS -Wno-deprecated-copy"],,[[$CXXFLAG_WERROR]])
 fi
 
+dnl Don't allow extended (non-ASCII) symbols in identifiers. This is easier for code review.
+AX_CHECK_COMPILE_FLAG([-fno-extended-identifiers],[[CXXFLAGS="$CXXFLAGS -fno-extended-identifiers"]],,[[$CXXFLAG_WERROR]])
+
 enable_sse42=no
 enable_sse41=no
 enable_avx2=no


### PR DESCRIPTION
While emoji and other symbols in C++ identifers (as accepted by newer compilers) are fun, they might create confusion during code review, for example because some symbols look very similar. Forbid such extended identifiers for now.

This is done by providing `-fno-extended-identifiers`. Thanks to sipa for suggesting this compiler flag.