### PR TITLE
util: simplify the interface of serviceFlagToStr()

### DIFF
--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -195,9 +195,10 @@ const std::vector<std::string> &getAllNetMessageTypes()
     return allNetMessageTypesVec;
 }
 
-std::string serviceFlagToStr(const uint64_t mask, const int bit)
+std::string serviceFlagToStr(size_t bit)
 {
-    switch (ServiceFlags(mask)) {
+    const uint64_t service_flag = 1ULL << bit;
+    switch ((ServiceFlags)service_flag) {
     case NODE_NONE: abort();  // impossible
     case NODE_NETWORK:         return "NETWORK";
     case NODE_GETUTXO:         return "GETUTXO";
@@ -211,7 +212,7 @@ std::string serviceFlagToStr(const uint64_t mask, const int bit)
     stream.imbue(std::locale::classic());
     stream << "UNKNOWN[";
     if (bit < 8) {
-        stream << mask;
+        stream << service_flag;
     } else {
         stream << "2^" << bit;
     }

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -195,7 +195,12 @@ const std::vector<std::string> &getAllNetMessageTypes()
     return allNetMessageTypesVec;
 }
 
-std::string serviceFlagToStr(size_t bit)
+/**
+ * Convert a service flag (NODE_*) to a human readable string.
+ * It supports unknown service flags which will be returned as "UNKNOWN[...]".
+ * @param[in] bit the service flag is calculated as (1 << bit)
+ */
+static std::string serviceFlagToStr(size_t bit)
 {
     const uint64_t service_flag = 1ULL << bit;
     switch ((ServiceFlags)service_flag) {
@@ -218,4 +223,17 @@ std::string serviceFlagToStr(size_t bit)
     }
     stream << "]";
     return stream.str();
+}
+
+std::vector<std::string> serviceFlagsToStr(uint64_t flags)
+{
+    std::vector<std::string> str_flags;
+
+    for (size_t i = 0; i < sizeof(flags) * 8; ++i) {
+        if (flags & (1ULL << i)) {
+            str_flags.emplace_back(serviceFlagToStr(i));
+        }
+    }
+
+    return str_flags;
 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -289,11 +289,11 @@ enum ServiceFlags : uint64_t {
 };
 
 /**
- * Convert a service flag (NODE_*) to a human readable string.
+ * Convert service flags (a bitmask of NODE_*) to human readable strings.
  * It supports unknown service flags which will be returned as "UNKNOWN[...]".
- * @param[in] bit the service flag is calculated as (1 << bit)
+ * @param[in] flags multiple NODE_* bitwise-OR-ed together
  */
-std::string serviceFlagToStr(size_t bit);
+std::vector<std::string> serviceFlagsToStr(uint64_t flags);
 
 /**
  * Gets the set of service flags which are "desirable" for a given peer.

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -288,7 +288,12 @@ enum ServiceFlags : uint64_t {
     // BIP process.
 };
 
-std::string serviceFlagToStr(uint64_t mask, int bit);
+/**
+ * Convert a service flag (NODE_*) to a human readable string.
+ * It supports unknown service flags which will be returned as "UNKNOWN[...]".
+ * @param[in] bit the service flag is calculated as (1 << bit)
+ */
+std::string serviceFlagToStr(size_t bit);
 
 /**
  * Gets the set of service flags which are "desirable" for a given peer.

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -755,12 +755,8 @@ QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
 
-    for (int i = 0; i < 64; i++) {
-        uint64_t check = 1ull << i;
-        if (mask & check)
-        {
-            strList.append(QString::fromStdString(serviceFlagToStr(i)));
-        }
+    for (const auto& flag : serviceFlagsToStr(mask)) {
+        strList.append(QString::fromStdString(flag));
     }
 
     if (strList.size())

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -759,7 +759,7 @@ QString formatServicesStr(quint64 mask)
         uint64_t check = 1ull << i;
         if (mask & check)
         {
-            strList.append(QString::fromStdString(serviceFlagToStr(mask, i)));
+            strList.append(QString::fromStdString(serviceFlagToStr(i)));
         }
     }
 

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -841,14 +841,10 @@ std::vector<CScript> EvalDescriptorStringOrObject(const UniValue& scanobject, Fl
 
 UniValue GetServicesNames(ServiceFlags services)
 {
-    const uint64_t services_n = services;
     UniValue servicesNames(UniValue::VARR);
 
-    for (int i = 0; i < 64; ++i) {
-        const uint64_t mask = 1ull << i;
-        if (services_n & mask) {
-            servicesNames.push_back(serviceFlagToStr(i));
-        }
+    for (const auto& flag : serviceFlagsToStr(services)) {
+        servicesNames.push_back(flag);
     }
 
     return servicesNames;

--- a/src/rpc/util.cpp
+++ b/src/rpc/util.cpp
@@ -847,7 +847,7 @@ UniValue GetServicesNames(ServiceFlags services)
     for (int i = 0; i < 64; ++i) {
         const uint64_t mask = 1ull << i;
         if (services_n & mask) {
-            servicesNames.push_back(serviceFlagToStr(mask, i));
+            servicesNames.push_back(serviceFlagToStr(i));
         }
     }
 


### PR DESCRIPTION
Don't take two redundant arguments in `serviceFlagToStr()`.

Introduce `serviceFlagsToStr()` which takes a mask (with more than one
bit set) and returns a vector of strings.

As a side effect this fixes an issue introduced in
https://github.com/bitcoin/bitcoin/pull/18165 due to which the GUI could
print something like `UNKNOWN[1033] & UNKNOWN[1033] & UNKNOWN[2^10]`
instead of `NETWORK & WITNESS`.