### PR TITLE
Bugfix: QA: Read response data for non-JSON responses in authproxy

### DIFF
--- a/test/functional/test_framework/authproxy.py
+++ b/test/functional/test_framework/authproxy.py
@@ -179,11 +179,11 @@ class AuthServiceProxy(object):
                 'code': -342, 'message': 'missing HTTP response from server'})
 
         content_type = http_response.getheader('Content-Type')
+        responsedata = http_response.read().decode('utf8')
         if content_type != 'application/json':
             raise JSONRPCException({
                 'code': -342, 'message': 'non-JSON HTTP response with \'%i %s\' from server' % (http_response.status, http_response.reason)})
 
-        responsedata = http_response.read().decode('utf8')
         response = json.loads(responsedata, parse_float=decimal.Decimal)
         elapsed = time.time() - req_start_time
         if "error" in response and response["error"] is None:


### PR DESCRIPTION
This is needed because we reuse connections, which breaks unless responses are entirely read

(Not sure how to reproduce this with current master, but this fix is needed to refactor `call_rpc` out of the test for #19117)