### PR TITLE
test: Add missing sync_blocks to wallet_hd

### DIFF
--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -11,7 +11,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
     connect_nodes,
-    assert_raises_rpc_error
+    assert_raises_rpc_error,
 )
 
 
@@ -32,11 +32,11 @@ class WalletHDTest(BitcoinTestFramework):
 
         # create an internal key
         change_addr = self.nodes[1].getrawchangeaddress()
-        change_addrV= self.nodes[1].getaddressinfo(change_addr)
+        change_addrV = self.nodes[1].getaddressinfo(change_addr)
         if self.options.descriptors:
             assert_equal(change_addrV["hdkeypath"], "m/84'/1'/0'/1/0")
         else:
-            assert_equal(change_addrV["hdkeypath"], "m/0'/1'/0'") #first internal child key
+            assert_equal(change_addrV["hdkeypath"], "m/0'/1'/0'")  #first internal child key
 
         # Import a non-HD private key in the HD wallet
         non_hd_add = 'bcrt1qmevj8zfx0wdvp05cqwkmr6mxkfx60yezwjksmt'
@@ -58,7 +58,7 @@ class WalletHDTest(BitcoinTestFramework):
             if self.options.descriptors:
                 assert_equal(hd_info["hdkeypath"], "m/84'/1'/0'/0/" + str(i))
             else:
-                assert_equal(hd_info["hdkeypath"], "m/0'/0'/"+str(i)+"'")
+                assert_equal(hd_info["hdkeypath"], "m/0'/0'/" + str(i) + "'")
             assert_equal(hd_info["hdmasterfingerprint"], hd_fingerprint)
             self.nodes[0].sendtoaddress(hd_add, 1)
             self.nodes[0].generate(1)
@@ -67,11 +67,11 @@ class WalletHDTest(BitcoinTestFramework):
 
         # create an internal key (again)
         change_addr = self.nodes[1].getrawchangeaddress()
-        change_addrV= self.nodes[1].getaddressinfo(change_addr)
+        change_addrV = self.nodes[1].getaddressinfo(change_addr)
         if self.options.descriptors:
             assert_equal(change_addrV["hdkeypath"], "m/84'/1'/0'/1/1")
         else:
-            assert_equal(change_addrV["hdkeypath"], "m/0'/1'/1'") #second internal child key
+            assert_equal(change_addrV["hdkeypath"], "m/0'/1'/1'")  #second internal child key
 
         self.sync_all()
         assert_equal(self.nodes[1].getbalance(), NUM_HD_ADDS + 1)
@@ -82,7 +82,10 @@ class WalletHDTest(BitcoinTestFramework):
         # otherwise node1 would auto-recover all funds in flag the keypool keys as used
         shutil.rmtree(os.path.join(self.nodes[1].datadir, self.chain, "blocks"))
         shutil.rmtree(os.path.join(self.nodes[1].datadir, self.chain, "chainstate"))
-        shutil.copyfile(os.path.join(self.nodes[1].datadir, "hd.bak"), os.path.join(self.nodes[1].datadir, self.chain, 'wallets', "wallet.dat"))
+        shutil.copyfile(
+            os.path.join(self.nodes[1].datadir, "hd.bak"),
+            os.path.join(self.nodes[1].datadir, self.chain, 'wallets', "wallet.dat"),
+        )
         self.start_node(1)
 
         # Assert that derivation is deterministic
@@ -93,7 +96,7 @@ class WalletHDTest(BitcoinTestFramework):
             if self.options.descriptors:
                 assert_equal(hd_info_2["hdkeypath"], "m/84'/1'/0'/0/" + str(i))
             else:
-                assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/"+str(i)+"'")
+                assert_equal(hd_info_2["hdkeypath"], "m/0'/0'/" + str(i) + "'")
             assert_equal(hd_info_2["hdmasterfingerprint"], hd_fingerprint)
         assert_equal(hd_add, hd_add_2)
         connect_nodes(self.nodes[0], 1)
@@ -108,7 +111,10 @@ class WalletHDTest(BitcoinTestFramework):
         self.stop_node(1)
         shutil.rmtree(os.path.join(self.nodes[1].datadir, self.chain, "blocks"))
         shutil.rmtree(os.path.join(self.nodes[1].datadir, self.chain, "chainstate"))
-        shutil.copyfile(os.path.join(self.nodes[1].datadir, "hd.bak"), os.path.join(self.nodes[1].datadir, self.chain, "wallets", "wallet.dat"))
+        shutil.copyfile(
+            os.path.join(self.nodes[1].datadir, "hd.bak"),
+            os.path.join(self.nodes[1].datadir, self.chain, "wallets", "wallet.dat"),
+        )
         self.start_node(1, extra_args=self.extra_args[1])
         connect_nodes(self.nodes[0], 1)
         self.sync_all()
@@ -142,8 +148,9 @@ class WalletHDTest(BitcoinTestFramework):
             new_masterkeyid = self.nodes[1].getwalletinfo()['hdseedid']
             assert orig_masterkeyid != new_masterkeyid
             addr = self.nodes[1].getnewaddress()
-            assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/0\'/0\'') # Make sure the new address is the first from the keypool
-            self.nodes[1].keypoolrefill(1) # Fill keypool with 1 key
+            # Make sure the new address is the first from the keypool
+            assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/0\'/0\'')
+            self.nodes[1].keypoolrefill(1)  # Fill keypool with 1 key
 
             # Set a new HD seed on node 1 without flushing the keypool
             new_seed = self.nodes[0].dumpprivkey(self.nodes[0].getnewaddress())
@@ -153,13 +160,15 @@ class WalletHDTest(BitcoinTestFramework):
             assert orig_masterkeyid != new_masterkeyid
             addr = self.nodes[1].getnewaddress()
             assert_equal(orig_masterkeyid, self.nodes[1].getaddressinfo(addr)['hdseedid'])
-            assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/0\'/1\'') # Make sure the new address continues previous keypool
+            # Make sure the new address continues previous keypool
+            assert_equal(self.nodes[1].getaddressinfo(addr)['hdkeypath'], 'm/0\'/0\'/1\'')
 
             # Check that the next address is from the new seed
             self.nodes[1].keypoolrefill(1)
             next_addr = self.nodes[1].getnewaddress()
             assert_equal(new_masterkeyid, self.nodes[1].getaddressinfo(next_addr)['hdseedid'])
-            assert_equal(self.nodes[1].getaddressinfo(next_addr)['hdkeypath'], 'm/0\'/0\'/0\'') # Make sure the new address is not from previous keypool
+            # Make sure the new address is not from previous keypool
+            assert_equal(self.nodes[1].getaddressinfo(next_addr)['hdkeypath'], 'm/0\'/0\'/0\'')
             assert next_addr != addr
 
             # Sethdseed parameter validity
@@ -185,13 +194,13 @@ class WalletHDTest(BitcoinTestFramework):
 
             self.nodes[1].createwallet(wallet_name='restore', blank=True)
             restore_rpc = self.nodes[1].get_wallet_rpc('restore')
-            restore_rpc.sethdseed(True, seed) # Set to be the same seed as origin_rpc
-            restore_rpc.sethdseed(True) # Rotate to a new seed, making original `seed` inactive
+            restore_rpc.sethdseed(True, seed)  # Set to be the same seed as origin_rpc
+            restore_rpc.sethdseed(True)  # Rotate to a new seed, making original `seed` inactive
 
             self.nodes[1].createwallet(wallet_name='restore2', blank=True)
             restore2_rpc = self.nodes[1].get_wallet_rpc('restore2')
-            restore2_rpc.sethdseed(True, seed) # Set to be the same seed as origin_rpc
-            restore2_rpc.sethdseed(True) # Rotate to a new seed, making original `seed` inactive
+            restore2_rpc.sethdseed(True, seed)  # Set to be the same seed as origin_rpc
+            restore2_rpc.sethdseed(True)  # Rotate to a new seed, making original `seed` inactive
 
             # Check persistence of inactive seed by reloading restore. restore2 is still loaded to test the case where the wallet is not reloaded
             restore_rpc.unloadwallet()
@@ -201,8 +210,8 @@ class WalletHDTest(BitcoinTestFramework):
             # Empty origin keypool and get an address that is beyond the initial keypool
             origin_rpc.getnewaddress()
             origin_rpc.getnewaddress()
-            last_addr = origin_rpc.getnewaddress() # Last address of initial keypool
-            addr = origin_rpc.getnewaddress() # First address beyond initial keypool
+            last_addr = origin_rpc.getnewaddress()  # Last address of initial keypool
+            addr = origin_rpc.getnewaddress()  # First address beyond initial keypool
 
             # Check that the restored seed has last_addr but does not have addr
             info = restore_rpc.getaddressinfo(last_addr)
@@ -266,5 +275,6 @@ class WalletHDTest(BitcoinTestFramework):
             info = restore2_rpc.getaddressinfo(addr)
             assert_equal(info['ismine'], False)
 
+
 if __name__ == '__main__':
-    WalletHDTest().main ()
+    WalletHDTest().main()

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -231,6 +231,7 @@ class WalletHDTest(BitcoinTestFramework):
             txid = self.nodes[0].sendtoaddress(addr, 1)
             origin_rpc.sendrawtransaction(self.nodes[0].gettransaction(txid)['hex'])
             self.nodes[0].generate(1)
+            self.sync_blocks()
             origin_rpc.gettransaction(txid)
             assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', restore_rpc.gettransaction, txid)
             out_of_kp_txid = txid
@@ -241,6 +242,7 @@ class WalletHDTest(BitcoinTestFramework):
             txid = self.nodes[0].sendtoaddress(last_addr, 1)
             origin_rpc.sendrawtransaction(self.nodes[0].gettransaction(txid)['hex'])
             self.nodes[0].generate(1)
+            self.sync_blocks()
             origin_rpc.gettransaction(txid)
             restore_rpc.gettransaction(txid)
             assert_raises_rpc_error(-5, 'Invalid or non-wallet transaction id', restore_rpc.gettransaction, out_of_kp_txid)


### PR DESCRIPTION
This fixes the `                                   test_framework.authproxy.JSONRPCException: non-final (-26)` error when node 1 is one block behind of node 0. (height 122 vs 123)