### PR TITLE
doc: Document ALLOW_HOST_PACKAGES dependency option

### DIFF
--- a/depends/README.md
+++ b/depends/README.md
@@ -101,6 +101,10 @@ The following can be set when running make: `make FOO=bar`
 <dd>Don't download/build/cache libs needed to enable the wallet</dd>
 <dt>NO_UPNP</dt>
 <dd>Don't download/build/cache packages needed for enabling upnp</dd>
+<dt>ALLOW_HOST_PACKAGES</dt>
+<dd>Packages that are missed in dependencies (due to `NO_*` option or
+build script logic) are searched for among the host system packages using
+`pkg-config`. It allows building with packages of other (newer) versions</dd>
 <dt>MULTIPROCESS</dt>
 <dd>build libmultiprocess (experimental, requires cmake)</dd>
 <dt>DEBUG</dt>


### PR DESCRIPTION
Provided entry in depends, README.md to ensure that ALLOW_HOST_PACKAGES dependency option is documented, #19113 