### PR TITLE
rpc, cli, test: add bitcoin-cli -generate command

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -184,6 +184,7 @@ BITCOIN_CORE_H = \
   reverse_iterator.h \
   rpc/blockchain.h \
   rpc/client.h \
+  rpc/mining.h \
   rpc/protocol.h \
   rpc/rawtransaction_util.h \
   rpc/register.h \

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -286,6 +286,28 @@ public:
     }
 };
 
+/** Process RPC generatetoaddress request. */
+class GenerateToAddressRequestHandler : public BaseRequestHandler
+{
+public:
+    UniValue PrepareRequest(const std::string& method, const std::vector<std::string>& args) override
+    {
+        address_str = args.at(1);
+        UniValue params{RPCConvertValues("generatetoaddress", args)};
+        return JSONRPCRequestObj("generatetoaddress", params, 1);
+    }
+
+    UniValue ProcessReply(const UniValue &reply) override
+    {
+        UniValue result(UniValue::VOBJ);
+        result.pushKV("address", address_str);
+        result.pushKV("blocks", reply.get_obj()["result"]);
+        return JSONRPCReplyObj(result, NullUniValue, 1);
+    }
+protected:
+    std::string address_str;
+};
+
 /** Process default single requests */
 class DefaultRequestHandler: public BaseRequestHandler {
 public:

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -477,6 +477,16 @@ static void GetWalletBalances(UniValue& result)
     result.pushKV("balances", balances);
 }
 
+/**
+ * Call RPC getnewaddress.
+ * @returns getnewaddress response as a UniValue object.
+ */
+static UniValue GetNewAddress()
+{
+    std::unique_ptr<BaseRequestHandler> rh{MakeUnique<DefaultRequestHandler>()};
+    return ConnectAndCallRPC(rh.get(), "getnewaddress", /* args=*/{});
+}
+
 static int CommandLineRPC(int argc, char *argv[])
 {
     std::string strPrint;

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -538,8 +538,10 @@ static void GetWalletBalances(UniValue& result)
  */
 static UniValue GetNewAddress()
 {
+    Optional<std::string> wallet_name{};
+    if (gArgs.IsArgSet("-rpcwallet")) wallet_name = gArgs.GetArg("-rpcwallet", "");
     std::unique_ptr<BaseRequestHandler> rh{MakeUnique<DefaultRequestHandler>()};
-    return ConnectAndCallRPC(rh.get(), "getnewaddress", /* args=*/{});
+    return ConnectAndCallRPC(rh.get(), "getnewaddress", /* args=*/{}, wallet_name);
 }
 
 /**

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -217,7 +217,7 @@ UniValue ParseNonRFCJSONValue(const std::string& strVal)
     UniValue jVal;
     if (!jVal.read(std::string("[")+strVal+std::string("]")) ||
         !jVal.isArray() || jVal.size()!=1)
-        throw std::runtime_error(std::string("Error parsing JSON:")+strVal);
+        throw std::runtime_error(std::string("Error parsing JSON: ") + strVal);
     return jVal[0];
 }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -17,6 +17,7 @@
 #include <policy/fees.h>
 #include <pow.h>
 #include <rpc/blockchain.h>
+#include <rpc/mining.h>
 #include <rpc/server.h>
 #include <rpc/util.h>
 #include <script/descriptor.h>
@@ -206,7 +207,7 @@ static UniValue generatetodescriptor(const JSONRPCRequest& request)
         {
             {"num_blocks", RPCArg::Type::NUM, RPCArg::Optional::NO, "How many blocks are generated immediately."},
             {"descriptor", RPCArg::Type::STR, RPCArg::Optional::NO, "The descriptor to send the newly generated bitcoin to."},
-            {"maxtries", RPCArg::Type::NUM, /* default */ "1000000", "How many iterations to try."},
+            {"maxtries", RPCArg::Type::NUM, /* default */ ToString(DEFAULT_MAX_TRIES), "How many iterations to try."},
         },
         RPCResult{
             RPCResult::Type::ARR, "", "hashes of blocks generated",
@@ -220,7 +221,7 @@ static UniValue generatetodescriptor(const JSONRPCRequest& request)
         .Check(request);
 
     const int num_blocks{request.params[0].get_int()};
-    const int64_t max_tries{request.params[2].isNull() ? 1000000 : request.params[2].get_int()};
+    const uint64_t max_tries{request.params[2].isNull() ? DEFAULT_MAX_TRIES : request.params[2].get_int()};
 
     CScript coinbase_script;
     std::string error;
@@ -241,7 +242,7 @@ static UniValue generatetoaddress(const JSONRPCRequest& request)
                 {
                     {"nblocks", RPCArg::Type::NUM, RPCArg::Optional::NO, "How many blocks are generated immediately."},
                     {"address", RPCArg::Type::STR, RPCArg::Optional::NO, "The address to send the newly generated bitcoin to."},
-                    {"maxtries", RPCArg::Type::NUM, /* default */ "1000000", "How many iterations to try."},
+                    {"maxtries", RPCArg::Type::NUM, /* default */ ToString(DEFAULT_MAX_TRIES), "How many iterations to try."},
                 },
                 RPCResult{
                     RPCResult::Type::ARR, "", "hashes of blocks generated",
@@ -257,7 +258,7 @@ static UniValue generatetoaddress(const JSONRPCRequest& request)
             }.Check(request);
 
     int nGenerate = request.params[0].get_int();
-    uint64_t nMaxTries = 1000000;
+    uint64_t nMaxTries{DEFAULT_MAX_TRIES};
     if (!request.params[2].isNull()) {
         nMaxTries = request.params[2].get_int();
     }
@@ -370,7 +371,7 @@ static UniValue generateblock(const JSONRPCRequest& request)
     }
 
     uint256 block_hash;
-    uint64_t max_tries{1000000};
+    uint64_t max_tries{DEFAULT_MAX_TRIES};
     unsigned int extra_nonce{0};
 
     if (!GenerateBlock(EnsureChainman(request.context), block, max_tries, extra_nonce, block_hash) || block_hash.IsNull()) {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -257,11 +257,8 @@ static UniValue generatetoaddress(const JSONRPCRequest& request)
                 },
             }.Check(request);
 
-    int nGenerate = request.params[0].get_int();
-    uint64_t nMaxTries{DEFAULT_MAX_TRIES};
-    if (!request.params[2].isNull()) {
-        nMaxTries = request.params[2].get_int();
-    }
+    const int num_blocks{request.params[0].get_int()};
+    const uint64_t max_tries{request.params[2].isNull() ? DEFAULT_MAX_TRIES : request.params[2].get_int()};
 
     CTxDestination destination = DecodeDestination(request.params[1].get_str());
     if (!IsValidDestination(destination)) {
@@ -273,7 +270,7 @@ static UniValue generatetoaddress(const JSONRPCRequest& request)
 
     CScript coinbase_script = GetScriptForDestination(destination);
 
-    return generateBlocks(chainman, mempool, coinbase_script, nGenerate, nMaxTries);
+    return generateBlocks(chainman, mempool, coinbase_script, num_blocks, max_tries);
 }
 
 static UniValue generateblock(const JSONRPCRequest& request)

--- a/src/rpc/mining.h
+++ b/src/rpc/mining.h
@@ -1,0 +1,11 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_RPC_MINING_H
+#define BITCOIN_RPC_MINING_H
+
+/** Default max iterations to try in RPC generatetodescriptor, generatetoaddress, and generateblock. */
+static const uint64_t DEFAULT_MAX_TRIES{1000000};
+
+#endif // BITCOIN_RPC_MINING_H

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -6,7 +6,12 @@
 
 from decimal import Decimal
 from test_framework.test_framework import BitcoinTestFramework
-from test_framework.util import assert_equal, assert_raises_process_error, get_auth_cookie
+from test_framework.util import (
+    assert_equal,
+    assert_raises_process_error,
+    assert_raises_rpc_error,
+    get_auth_cookie,
+)
 
 # The block reward of coinbaseoutput.nValue (50) BTC/block matures after
 # COINBASE_MATURITY (100) blocks. Therefore, after mining 101 blocks we expect
@@ -17,6 +22,8 @@ BALANCE = (BLOCKS - 100) * 50
 JSON_PARSING_ERROR = 'error: Error parsing JSON:foo'
 BLOCKS_VALUE_OF_ZERO = 'error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero'
 TOO_MANY_ARGS = 'error: too many arguments (maximum 2 for nblocks and maxtries)'
+WALLET_NOT_LOADED = 'Requested wallet does not exist or is not loaded'
+WALLET_NOT_SPECIFIED = 'Wallet file not specified'
 
 class TestBitcoinCli(BitcoinTestFramework):
     def set_test_params(self):
@@ -88,6 +95,8 @@ class TestBitcoinCli(BitcoinTestFramework):
             w1 = self.nodes[0].get_wallet_rpc(wallets[0])
             w2 = self.nodes[0].get_wallet_rpc(wallets[1])
             w3 = self.nodes[0].get_wallet_rpc(wallets[2])
+            rpcwallet2 = '-rpcwallet={}'.format(wallets[1])
+            rpcwallet3 = '-rpcwallet={}'.format(wallets[2])
             w1.walletpassphrase(password, self.rpc_timeout)
             w2.encryptwallet(password)
             w1.sendtoaddress(w2.getnewaddress(), amounts[1])
@@ -128,18 +137,18 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_equal(cli_get_info['balance'], amounts[1])
 
             self.log.info("Test -getinfo with -rpcwallet=remaining-non-default-wallet returns only its balance")
-            cli_get_info = self.nodes[0].cli('-getinfo', '-rpcwallet={}'.format(wallets[1])).send_cli()
+            cli_get_info = self.nodes[0].cli('-getinfo', rpcwallet2).send_cli()
             assert 'balances' not in cli_get_info.keys()
             assert_equal(cli_get_info['balance'], amounts[1])
 
             self.log.info("Test -getinfo with -rpcwallet=unloaded wallet returns no balances")
-            cli_get_info = self.nodes[0].cli('-getinfo', '-rpcwallet={}'.format(wallets[2])).send_cli()
+            cli_get_info = self.nodes[0].cli('-getinfo', rpcwallet3).send_cli()
             assert 'balance' not in cli_get_info_keys
             assert 'balances' not in cli_get_info_keys
 
             # Test bitcoin-cli -generate.
             n1 = 3
-            n2 = 5
+            n2 = 4
             w2.walletpassphrase(password, self.rpc_timeout)
             blocks = self.nodes[0].getblockcount()
 
@@ -165,9 +174,56 @@ class TestBitcoinCli(BitcoinTestFramework):
             assert_equal(set(generate.keys()), {'address', 'blocks'})
             assert_equal(len(generate["blocks"]), n2)
             assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n1 + n2)
+
+            self.log.info('Test -generate -rpcwallet in single-wallet mode')
+            generate = self.nodes[0].cli(rpcwallet2, '-generate').send_cli()
+            assert_equal(set(generate.keys()), {'address', 'blocks'})
+            assert_equal(len(generate["blocks"]), 1)
+            assert_equal(self.nodes[0].getblockcount(), blocks + 2 + n1 + n2)
+
+            self.log.info('Test -generate -rpcwallet=unloaded wallet raises RPC error')
+            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate').echo)
+            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate', 'foo').echo)
+            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate', 0).echo)
+            assert_raises_rpc_error(-18, WALLET_NOT_LOADED, self.nodes[0].cli(rpcwallet3, '-generate', 1, 2, 3).echo)
+
+            # Test bitcoin-cli -generate with -rpcwallet in multiwallet mode.
+            self.nodes[0].loadwallet(wallets[2])
+            n3 = 4
+            n4 = 10
+            blocks = self.nodes[0].getblockcount()
+
+            self.log.info('Test -generate -rpcwallet with no args')
+            generate = self.nodes[0].cli(rpcwallet2, '-generate').send_cli()
+            assert_equal(set(generate.keys()), {'address', 'blocks'})
+            assert_equal(len(generate["blocks"]), 1)
+            assert_equal(self.nodes[0].getblockcount(), blocks + 1)
+
+            self.log.info('Test -generate -rpcwallet with bad args')
+            assert_raises_process_error(1, JSON_PARSING_ERROR, self.nodes[0].cli(rpcwallet2, '-generate', 'foo').echo)
+            assert_raises_process_error(1, BLOCKS_VALUE_OF_ZERO, self.nodes[0].cli(rpcwallet2, '-generate', 0).echo)
+            assert_raises_process_error(1, TOO_MANY_ARGS, self.nodes[0].cli(rpcwallet2, '-generate', 1, 2, 3).echo)
+
+            self.log.info('Test -generate -rpcwallet with nblocks')
+            generate = self.nodes[0].cli(rpcwallet2, '-generate', n3).send_cli()
+            assert_equal(set(generate.keys()), {'address', 'blocks'})
+            assert_equal(len(generate["blocks"]), n3)
+            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n3)
+
+            self.log.info('Test -generate -rpcwallet with nblocks and maxtries')
+            generate = self.nodes[0].cli(rpcwallet2, '-generate', n4, 1000000).send_cli()
+            assert_equal(set(generate.keys()), {'address', 'blocks'})
+            assert_equal(len(generate["blocks"]), n4)
+            assert_equal(self.nodes[0].getblockcount(), blocks + 1 + n3 + n4)
+
+            self.log.info('Test -generate without -rpcwallet in multiwallet mode raises RPC error')
+            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate').echo)
+            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 'foo').echo)
+            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 0).echo)
+            assert_raises_rpc_error(-19, WALLET_NOT_SPECIFIED, self.nodes[0].cli('-generate', 1, 2, 3).echo)
         else:
             self.log.info("*** Wallet not compiled; cli getwalletinfo and -getinfo wallet tests skipped")
-            self.nodes[0].generate(10)  # maintain block parity with the wallet_compiled conditional branch
+            self.nodes[0].generate(25)  # maintain block parity with the wallet_compiled conditional branch
 
         self.log.info("Test -version with node stopped")
         self.stop_node(0)
@@ -179,7 +235,7 @@ class TestBitcoinCli(BitcoinTestFramework):
         self.nodes[0].wait_for_cookie_credentials()  # ensure cookie file is available to avoid race condition
         blocks = self.nodes[0].cli('-rpcwait').send_cli('getblockcount')
         self.nodes[0].wait_for_rpc_connection()
-        assert_equal(blocks, BLOCKS + 10)
+        assert_equal(blocks, BLOCKS + 25)
 
 
 if __name__ == '__main__':

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -19,7 +19,7 @@ from test_framework.util import (
 BLOCKS = 101
 BALANCE = (BLOCKS - 100) * 50
 
-JSON_PARSING_ERROR = 'error: Error parsing JSON:foo'
+JSON_PARSING_ERROR = 'error: Error parsing JSON: foo'
 BLOCKS_VALUE_OF_ZERO = 'error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero'
 TOO_MANY_ARGS = 'error: too many arguments (maximum 2 for nblocks and maxtries)'
 WALLET_NOT_LOADED = 'Requested wallet does not exist or is not loaded'


### PR DESCRIPTION
This PR continues and completes the work begun in #17700 working on issue #16000 to create a client-side version of RPC `generate`.

Basically, `bitcoin-cli -generate` wraps calling `generatenewaddress` followed by `generatetoaddress [nblocks] [maxtries]` and prints the following:

```
$ bitcoin-cli -generate
{
  "address": "bcrt1qn4aszr2y2xvpa70y675a76wsu70wlkwvdyyln6"
  "blocks": [
    "01d2ebcddf663da90b28da7f6805115e2ba7818f16fe747258836646a43a0bb5",
  ]
}

$ bitcoin-cli -rpcwallet=wallet-name -generate 3 100
{
  "address": "bcrt1q4cunfw0gnsj7g7e6mk0v0uuvvau9mwr09dj45l",
  "blocks": [
    "7a6650ca5e0c614992ee64fb148a7e5e022af842e4b6003f81abd8baf1e75136",
    "01d2ebcddf663da90b28da7f6805115e2ba7818f16fe747258836646a43a0bb5",
    "3f8795ec40b1ad812b818c177680841be319a3f6753d4e32dc7dfb5bafe5d00e"
  ]
}
```

Help doc:
```
$ bitcoin-cli -h | grep -A5 "\-generate"
  -generate
       Generate blocks immediately, equivalent to RPC generatenewaddress
       followed by RPC generatetoaddress. Optional positional arguments
       are number of blocks to generate (default: 1) and maximum
       iterations to try (default: 1000000), equivalent to RPC
       generatetoaddress nblocks and maxtries arguments. Example:
       bitcoin-cli -generate 4 1000
```

Quite a bit of test coverage turned out to be needed to cover the change and the different cases (arguments, multiwallet mode) and error-handling.

This PR also improves some things that working on these changes brought to light.

Credit to Harris Brakmić for the initial work in #17700.