### PR TITLE
tests: Add fuzzing harnesses for CAutoFile, CBufferedFile, LoadExternalBlockFile and other FILE* consumers

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -10,6 +10,7 @@ FUZZ_TARGETS = \
   test/fuzz/addrman_deserialize \
   test/fuzz/asmap \
   test/fuzz/asmap_direct \
+  test/fuzz/autofile \
   test/fuzz/banentry_deserialize \
   test/fuzz/banman \
   test/fuzz/base_encode_decode \
@@ -349,6 +350,12 @@ test_fuzz_asmap_direct_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_asmap_direct_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_asmap_direct_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_asmap_direct_SOURCES = test/fuzz/asmap_direct.cpp
+
+test_fuzz_autofile_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_autofile_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_autofile_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_autofile_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_autofile_SOURCES = test/fuzz/autofile.cpp
 
 test_fuzz_banentry_deserialize_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) -DBANENTRY_DESERIALIZE=1
 test_fuzz_banentry_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -30,6 +30,7 @@ FUZZ_TARGETS = \
   test/fuzz/blockundo_deserialize \
   test/fuzz/bloom_filter \
   test/fuzz/bloomfilter_deserialize \
+  test/fuzz/buffered_file \
   test/fuzz/chain \
   test/fuzz/checkqueue \
   test/fuzz/coins_deserialize \
@@ -470,6 +471,12 @@ test_fuzz_bloomfilter_deserialize_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_bloomfilter_deserialize_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_bloomfilter_deserialize_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_bloomfilter_deserialize_SOURCES = test/fuzz/deserialize.cpp
+
+test_fuzz_buffered_file_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_buffered_file_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_buffered_file_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_buffered_file_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_buffered_file_SOURCES = test/fuzz/buffered_file.cpp
 
 test_fuzz_chain_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_chain_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -57,6 +57,7 @@ FUZZ_TARGETS = \
   test/fuzz/key_io \
   test/fuzz/key_origin_info_deserialize \
   test/fuzz/kitchen_sink \
+  test/fuzz/load_external_block_file \
   test/fuzz/locale \
   test/fuzz/merkle_block_deserialize \
   test/fuzz/merkleblock \
@@ -633,6 +634,12 @@ test_fuzz_kitchen_sink_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_kitchen_sink_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_kitchen_sink_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_kitchen_sink_SOURCES = test/fuzz/kitchen_sink.cpp
+
+test_fuzz_load_external_block_file_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_load_external_block_file_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_load_external_block_file_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_load_external_block_file_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_load_external_block_file_SOURCES = test/fuzz/load_external_block_file.cpp
 
 test_fuzz_locale_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_locale_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -77,6 +77,7 @@ FUZZ_TARGETS = \
   test/fuzz/partial_merkle_tree_deserialize \
   test/fuzz/partially_signed_transaction_deserialize \
   test/fuzz/policy_estimator \
+  test/fuzz/policy_estimator_io \
   test/fuzz/pow \
   test/fuzz/prefilled_transaction_deserialize \
   test/fuzz/prevector \
@@ -760,6 +761,12 @@ test_fuzz_policy_estimator_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 test_fuzz_policy_estimator_LDADD = $(FUZZ_SUITE_LD_COMMON)
 test_fuzz_policy_estimator_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
 test_fuzz_policy_estimator_SOURCES = test/fuzz/policy_estimator.cpp
+
+test_fuzz_policy_estimator_io_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+test_fuzz_policy_estimator_io_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
+test_fuzz_policy_estimator_io_LDADD = $(FUZZ_SUITE_LD_COMMON)
+test_fuzz_policy_estimator_io_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
+test_fuzz_policy_estimator_io_SOURCES = test/fuzz/policy_estimator_io.cpp
 
 test_fuzz_pow_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 test_fuzz_pow_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/test/fuzz/autofile.cpp
+++ b/src/test/fuzz/autofile.cpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    FuzzedAutoFileProvider fuzzed_auto_file_provider = ConsumeAutoFile(fuzzed_data_provider);
+    CAutoFile auto_file = fuzzed_auto_file_provider.open();
+    while (fuzzed_data_provider.ConsumeBool()) {
+        switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 5)) {
+        case 0: {
+            std::array<uint8_t, 4096> arr{};
+            try {
+                auto_file.read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+            } catch (const std::ios_base::failure&) {
+            }
+            break;
+        }
+        case 1: {
+            const std::array<uint8_t, 4096> arr{};
+            try {
+                auto_file.write((const char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+            } catch (const std::ios_base::failure&) {
+            }
+            break;
+        }
+        case 2: {
+            try {
+                auto_file.ignore(fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+            } catch (const std::ios_base::failure&) {
+            }
+            break;
+        }
+        case 3: {
+            auto_file.fclose();
+            break;
+        }
+        case 4: {
+            ReadFromStream(fuzzed_data_provider, auto_file);
+            break;
+        }
+        case 5: {
+            WriteToStream(fuzzed_data_provider, auto_file);
+            break;
+        }
+        }
+    }
+    (void)auto_file.Get();
+    (void)auto_file.GetType();
+    (void)auto_file.GetVersion();
+    (void)auto_file.IsNull();
+    if (fuzzed_data_provider.ConsumeBool()) {
+        FILE* f = auto_file.release();
+        if (f != nullptr) {
+            fclose(f);
+        }
+    }
+}

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -29,8 +29,9 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         }
     }
     if (opt_buffered_file && fuzzed_file != nullptr) {
+        bool setpos_fail = false;
         while (fuzzed_data_provider.ConsumeBool()) {
-            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 4)) {
+            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 5)) {
             case 0: {
                 std::array<uint8_t, 4096> arr{};
                 try {
@@ -48,17 +49,30 @@ void test_one_input(const std::vector<uint8_t>& buffer)
                 break;
             }
             case 3: {
+                if (!opt_buffered_file->SetPos(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096))) {
+                    setpos_fail = true;
+                }
+                break;
+            }
+            case 4: {
+                if (setpos_fail) {
+                    // Calling FindByte(...) after a failed SetPos(...) call may result in an infinite loop.
+                    break;
+                }
                 try {
                     opt_buffered_file->FindByte(fuzzed_data_provider.ConsumeIntegral<char>());
                 } catch (const std::ios_base::failure&) {
                 }
                 break;
             }
-            case 4: {
+            case 5: {
                 ReadFromStream(fuzzed_data_provider, *opt_buffered_file);
                 break;
             }
             }
         }
+        opt_buffered_file->GetPos();
+        opt_buffered_file->GetType();
+        opt_buffered_file->GetVersion();
     }
 }

--- a/src/test/fuzz/buffered_file.cpp
+++ b/src/test/fuzz/buffered_file.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <optional.h>
+#include <streams.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <array>
+#include <cstdint>
+#include <iostream>
+#include <optional>
+#include <string>
+#include <vector>
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    FuzzedFileProvider fuzzed_file_provider = ConsumeFile(fuzzed_data_provider);
+    std::optional<CBufferedFile> opt_buffered_file;
+    FILE* fuzzed_file = fuzzed_file_provider.open();
+    try {
+        opt_buffered_file.emplace(fuzzed_file, fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096), fuzzed_data_provider.ConsumeIntegral<int>(), fuzzed_data_provider.ConsumeIntegral<int>());
+    } catch (const std::ios_base::failure&) {
+        if (fuzzed_file != nullptr) {
+            fclose(fuzzed_file);
+        }
+    }
+    if (opt_buffered_file && fuzzed_file != nullptr) {
+        while (fuzzed_data_provider.ConsumeBool()) {
+            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 4)) {
+            case 0: {
+                std::array<uint8_t, 4096> arr{};
+                try {
+                    opt_buffered_file->read((char*)arr.data(), fuzzed_data_provider.ConsumeIntegralInRange<size_t>(0, 4096));
+                } catch (const std::ios_base::failure&) {
+                }
+                break;
+            }
+            case 1: {
+                opt_buffered_file->Seek(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096));
+                break;
+            }
+            case 2: {
+                opt_buffered_file->SetLimit(fuzzed_data_provider.ConsumeIntegralInRange<uint64_t>(0, 4096));
+                break;
+            }
+            case 3: {
+                try {
+                    opt_buffered_file->FindByte(fuzzed_data_provider.ConsumeIntegral<char>());
+                } catch (const std::ios_base::failure&) {
+                }
+                break;
+            }
+            case 4: {
+                ReadFromStream(fuzzed_data_provider, *opt_buffered_file);
+                break;
+            }
+            }
+        }
+    }
+}

--- a/src/test/fuzz/load_external_block_file.cpp
+++ b/src/test/fuzz/load_external_block_file.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chainparams.h>
+#include <flatfile.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+#include <test/util/setup_common.h>
+#include <validation.h>
+
+#include <cstdint>
+#include <vector>
+
+void initialize()
+{
+    InitializeFuzzingContext();
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider{buffer.data(), buffer.size()};
+    FuzzedFileProvider fuzzed_file_provider = ConsumeFile(fuzzed_data_provider);
+    FILE* fuzzed_block_file = fuzzed_file_provider.open();
+    if (fuzzed_block_file == nullptr) {
+        return;
+    }
+    FlatFilePos flat_file_pos;
+    LoadExternalBlockFile(Params(), fuzzed_block_file, fuzzed_data_provider.ConsumeBool() ? &flat_file_pos : nullptr);
+}

--- a/src/test/fuzz/policy_estimator.cpp
+++ b/src/test/fuzz/policy_estimator.cpp
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+void initialize()
+{
+    InitializeFuzzingContext();
+}
+
 void test_one_input(const std::vector<uint8_t>& buffer)
 {
     FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
@@ -65,5 +70,11 @@ void test_one_input(const std::vector<uint8_t>& buffer)
         FeeCalculation fee_calculation;
         (void)block_policy_estimator.estimateSmartFee(fuzzed_data_provider.ConsumeIntegral<int>(), fuzzed_data_provider.ConsumeBool() ? &fee_calculation : nullptr, fuzzed_data_provider.ConsumeBool());
         (void)block_policy_estimator.HighestTargetTracked(fuzzed_data_provider.PickValueInArray({FeeEstimateHorizon::SHORT_HALFLIFE, FeeEstimateHorizon::MED_HALFLIFE, FeeEstimateHorizon::LONG_HALFLIFE}));
+    }
+    {
+        FuzzedAutoFileProvider fuzzed_auto_file_provider = ConsumeAutoFile(fuzzed_data_provider);
+        CAutoFile fuzzed_auto_file = fuzzed_auto_file_provider.open();
+        block_policy_estimator.Write(fuzzed_auto_file);
+        block_policy_estimator.Read(fuzzed_auto_file);
     }
 }

--- a/src/test/fuzz/policy_estimator_io.cpp
+++ b/src/test/fuzz/policy_estimator_io.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/fees.h>
+#include <test/fuzz/FuzzedDataProvider.h>
+#include <test/fuzz/fuzz.h>
+#include <test/fuzz/util.h>
+
+#include <cstdint>
+#include <vector>
+
+void initialize()
+{
+    InitializeFuzzingContext();
+}
+
+void test_one_input(const std::vector<uint8_t>& buffer)
+{
+    FuzzedDataProvider fuzzed_data_provider(buffer.data(), buffer.size());
+    FuzzedAutoFileProvider fuzzed_auto_file_provider = ConsumeAutoFile(fuzzed_data_provider);
+    CAutoFile fuzzed_auto_file = fuzzed_auto_file_provider.open();
+    // Re-using block_policy_estimator across runs to avoid costly creation of CBlockPolicyEstimator object.
+    static CBlockPolicyEstimator block_policy_estimator;
+    if (block_policy_estimator.Read(fuzzed_auto_file)) {
+        block_policy_estimator.Write(fuzzed_auto_file);
+    }
+}

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -383,4 +383,25 @@ NODISCARD inline FuzzedFileProvider ConsumeFile(FuzzedDataProvider& fuzzed_data_
     return {fuzzed_data_provider};
 }
 
+class FuzzedAutoFileProvider
+{
+    FuzzedDataProvider& m_fuzzed_data_provider;
+    FuzzedFileProvider m_fuzzed_file_provider;
+
+public:
+    FuzzedAutoFileProvider(FuzzedDataProvider& fuzzed_data_provider) : m_fuzzed_data_provider{fuzzed_data_provider}, m_fuzzed_file_provider{fuzzed_data_provider}
+    {
+    }
+
+    CAutoFile open()
+    {
+        return {m_fuzzed_file_provider.open(), m_fuzzed_data_provider.ConsumeIntegral<int>(), m_fuzzed_data_provider.ConsumeIntegral<int>()};
+    }
+};
+
+NODISCARD inline FuzzedAutoFileProvider ConsumeAutoFile(FuzzedDataProvider& fuzzed_data_provider) noexcept
+{
+    return {fuzzed_data_provider};
+}
+
 #endif // BITCOIN_TEST_FUZZ_UTIL_H

--- a/src/test/fuzz/util.h
+++ b/src/test/fuzz/util.h
@@ -404,4 +404,70 @@ NODISCARD inline FuzzedAutoFileProvider ConsumeAutoFile(FuzzedDataProvider& fuzz
     return {fuzzed_data_provider};
 }
 
+#define WRITE_TO_STREAM_CASE(id, type, consume) \
+    case id: {                                  \
+        type o = consume;                       \
+        stream << o;                            \
+        break;                                  \
+    }
+template <typename Stream>
+void WriteToStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) noexcept
+{
+    while (fuzzed_data_provider.ConsumeBool()) {
+        try {
+            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 13)) {
+                WRITE_TO_STREAM_CASE(0, bool, fuzzed_data_provider.ConsumeBool())
+                WRITE_TO_STREAM_CASE(1, char, fuzzed_data_provider.ConsumeIntegral<char>())
+                WRITE_TO_STREAM_CASE(2, int8_t, fuzzed_data_provider.ConsumeIntegral<int8_t>())
+                WRITE_TO_STREAM_CASE(3, uint8_t, fuzzed_data_provider.ConsumeIntegral<uint8_t>())
+                WRITE_TO_STREAM_CASE(4, int16_t, fuzzed_data_provider.ConsumeIntegral<int16_t>())
+                WRITE_TO_STREAM_CASE(5, uint16_t, fuzzed_data_provider.ConsumeIntegral<uint16_t>())
+                WRITE_TO_STREAM_CASE(6, int32_t, fuzzed_data_provider.ConsumeIntegral<int32_t>())
+                WRITE_TO_STREAM_CASE(7, uint32_t, fuzzed_data_provider.ConsumeIntegral<uint32_t>())
+                WRITE_TO_STREAM_CASE(8, int64_t, fuzzed_data_provider.ConsumeIntegral<int64_t>())
+                WRITE_TO_STREAM_CASE(9, uint64_t, fuzzed_data_provider.ConsumeIntegral<uint64_t>())
+                WRITE_TO_STREAM_CASE(10, float, fuzzed_data_provider.ConsumeFloatingPoint<float>())
+                WRITE_TO_STREAM_CASE(11, double, fuzzed_data_provider.ConsumeFloatingPoint<double>())
+                WRITE_TO_STREAM_CASE(12, std::string, fuzzed_data_provider.ConsumeRandomLengthString(32))
+                WRITE_TO_STREAM_CASE(13, std::vector<char>, ConsumeRandomLengthIntegralVector<char>(fuzzed_data_provider))
+            }
+        } catch (const std::ios_base::failure&) {
+            break;
+        }
+    }
+}
+
+#define READ_FROM_STREAM_CASE(id, type) \
+    case id: {                          \
+        type o;                         \
+        stream >> o;                    \
+        break;                          \
+    }
+template <typename Stream>
+void ReadFromStream(FuzzedDataProvider& fuzzed_data_provider, Stream& stream) noexcept
+{
+    while (fuzzed_data_provider.ConsumeBool()) {
+        try {
+            switch (fuzzed_data_provider.ConsumeIntegralInRange<int>(0, 13)) {
+                READ_FROM_STREAM_CASE(0, bool)
+                READ_FROM_STREAM_CASE(1, char)
+                READ_FROM_STREAM_CASE(2, int8_t)
+                READ_FROM_STREAM_CASE(3, uint8_t)
+                READ_FROM_STREAM_CASE(4, int16_t)
+                READ_FROM_STREAM_CASE(5, uint16_t)
+                READ_FROM_STREAM_CASE(6, int32_t)
+                READ_FROM_STREAM_CASE(7, uint32_t)
+                READ_FROM_STREAM_CASE(8, int64_t)
+                READ_FROM_STREAM_CASE(9, uint64_t)
+                READ_FROM_STREAM_CASE(10, float)
+                READ_FROM_STREAM_CASE(11, double)
+                READ_FROM_STREAM_CASE(12, std::string)
+                READ_FROM_STREAM_CASE(13, std::vector<char>)
+            }
+        } catch (const std::ios_base::failure&) {
+            break;
+        }
+    }
+}
+
 #endif // BITCOIN_TEST_FUZZ_UTIL_H


### PR DESCRIPTION
Add fuzzing harnesses for `CAutoFile`, `CBufferedFile`, `LoadExternalBlockFile` and other `FILE*` consumers:
* Add `FuzzedFileProvider` which provides a `FILE*` interface to `FuzzedDataProvider` using `fopencookie`
* Add `FuzzedAutoFileProvider` which provides a `CAutoFile` interface to `FuzzedDataProvider`
* Add serialization/deserialization fuzzing helpers `WriteToStream(…)`/`ReadFromStream(…)`
* Add fuzzing harness for `CAutoFile` (`streams.h`)
* Add fuzzing harness for `CBufferedFile` (`streams.h`)
* Add fuzzing harness for `LoadExternalBlockFile(...)` (`validation.h`)
* Add fuzzing harness for `CBlockPolicyEstimator::Read` and `CBlockPolicyEstimator::Write` (`policy/fees.h`)

See [`doc/fuzzing.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/fuzzing.md) for information on how to fuzz Bitcoin Core. Don't forget to contribute any coverage increasing inputs you find to the [Bitcoin Core fuzzing corpus repo](https://github.com/bitcoin-core/qa-assets).

Happy fuzzing :)