### PR TITLE
include QPainterPath to fix compile error with Qt 5.15

### DIFF
--- a/src/qt/trafficgraphwidget.h
+++ b/src/qt/trafficgraphwidget.h
@@ -7,6 +7,7 @@
 
 #include <QWidget>
 #include <QQueue>
+#include <QPainterPath>
 
 class ClientModel;
 


### PR DESCRIPTION
include QPainterPath to fix compile error with Qt 5.15
