### PR TITLE
Document discouragement logic with regards to malicious exploitation

### DIFF
--- a/src/banman.h
+++ b/src/banman.h
@@ -53,6 +53,14 @@ class CSubNet;
 // transaction that fails a policy check and a future version changes the
 // policy check so the transaction is accepted, then that transaction could
 // cause the network to split between old nodes and new nodes.
+//
+// Discouragement logic can be exploited by an on-path attacker: not necessarily
+// the user's hosting ISP, but any "critical" ISP between peers. An attacker may
+// spoof packets with invalid data to trigger honest nodes discouraging outbound
+// connections to each other. This may be used to influence the network topology
+// in a way that is favorable to the attacker to carrying out single-node eclipsing
+// or network partitions. An "impersonation" like this would benefit from mitigation
+// implemented for other infrastructure attack scenario (e.g Erebus).
 
 class BanMan
 {


### PR DESCRIPTION
Beyond cases where an attacker is sending invalid data to a honest
peer and those one relaying it forward therefore provoking its
temporary ban, a direct impersonation is possible. An attacker
can directly sends invalid data spoofing IP address of a honest
reachable peer. Such scenario assumes infrastructure capabilities and
therefore is less concerning with regards to state-of-the-art
infrastructure attacks with same threat model (Erebus).