### PR TITLE
multiprocess: Add basic spawn and IPC support

### DIFF
--- a/build_msvc/bitcoind/bitcoind.vcxproj
+++ b/build_msvc/bitcoind/bitcoind.vcxproj
@@ -10,6 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\bitcoind.cpp" />
+    <ClCompile Include="..\..\src\init\bitcoind.cpp">
+      <ObjectFileName>$(IntDir)init_bitcoind.obj</ObjectFileName>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\libbitcoinconsensus\libbitcoinconsensus.vcxproj">

--- a/depends/packages/native_libmultiprocess.mk
+++ b/depends/packages/native_libmultiprocess.mk
@@ -1,8 +1,8 @@
 package=native_libmultiprocess
-$(package)_version=5741d750a04e644a03336090d8979c6d033e32c0
+$(package)_version=d576d975debdc9090bd2582f83f49c76c0061698
 $(package)_download_path=https://github.com/chaincodelabs/libmultiprocess/archive
 $(package)_file_name=$($(package)_version).tar.gz
-$(package)_sha256_hash=ac848db49a6ed53e423c62d54bd87f1f08cbb0326254a8667e10bbfe5bf032a4
+$(package)_sha256_hash=9f8b055c8bba755dc32fe799b67c20b91e7b13e67cadafbc54c0f1def057a370
 $(package)_dependencies=native_capnp
 
 define $(package)_config_cmds

--- a/doc/multiprocess.md
+++ b/doc/multiprocess.md
@@ -15,7 +15,7 @@ Specific next steps after [#10102](https://github.com/bitcoin/bitcoin/pull/10102
 
 ## Debugging
 
-After [#10102](https://github.com/bitcoin/bitcoin/pull/10102), the `-debug=ipc` command line option can be used to see requests and responses between processes.
+The `-debug=ipc` command line option can be used to see requests and responses between processes.
 
 ## Installation
 
@@ -33,3 +33,40 @@ BITCOIND=bitcoin-node test/functional/test_runner.py
 The configure script will pick up settings and library locations from the depends directory, so there is no need to pass `--enable-multiprocess` as a separate flag when using the depends system (it's controlled by the `MULTIPROCESS=1` option).
 
 Alternately, you can install [Cap'n Proto](https://capnproto.org/) and [libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) packages on your system, and just run `./configure --enable-multiprocess` without using the depends system. The configure script will be able to locate the installed packages via [pkg-config](https://www.freedesktop.org/wiki/Software/pkg-config/). See [Installation](https://github.com/chaincodelabs/libmultiprocess#installation) section of the libmultiprocess readme for install steps. See [build-unix.md](build-unix.md) and [build-osx.md](build-osx.md) for information about installing dependencies in general.
+
+## IPC implementation details
+
+Cross process Node, Wallet, and Chain interfaces are defined in
+[`src/interfaces/`](../src/interfaces/). These are C++ classes which follow
+[conventions](developer-notes.md#internal-interface-guidelines), like passing
+serializable arguments so they can be called from different processes, and
+making methods pure virtual so they can have proxy implementations that forward
+calls between processes.
+
+When Wallet, Node, and Chain code is running in the same process, calling any
+interface method invokes the implementation directly. When code is running in
+different processes, calling an interface method invokes a proxy interface
+implementation that communicates with a remote process and invokes the real
+implementation in the remote process. The
+[libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) code
+generation tool internally generates proxy client classes and proxy server
+classes for this purpose that are thin wrappers around Cap'n Proto
+[client](https://capnproto.org/cxxrpc.html#clients) and
+[server](https://capnproto.org/cxxrpc.html#servers) classes, which handle the
+actual serialization and socket communication.
+
+As much as possible, calls between processes are meant to work the same as
+calls within a single process without adding limitations or requiring extra
+implementation effort. Processes communicate with each other by calling regular
+[C++ interface methods](../src/interfaces/README.md). Method arguments and
+return values are automatically serialized and sent between processes. Object
+references and `std::function` arguments are automatically tracked and mapped
+to allow invoked code to call back into invoking code at any time, and there is
+a 1:1 threading model where any thread invoking a method in another process has
+a corresponding thread in the invoked process responsible for executing all
+method calls from the source thread, without blocking I/O or holding up another
+call, and using the same thread local variables, locks, and callbacks between
+calls. The forwarding, tracking, and threading is implemented inside the
+[libmultiprocess](https://github.com/chaincodelabs/libmultiprocess) library
+which has the design goal of making calls between processes look like calls in
+the same process to the extent possible.

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -640,13 +640,13 @@ bitcoin_bin_ldadd = \
 
 bitcoin_bin_ldadd += $(BOOST_LIBS) $(BDB_LIBS) $(MINIUPNPC_LIBS) $(NATPMP_LIBS) $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ZMQ_LIBS) $(SQLITE_LIBS)
 
-bitcoind_SOURCES = $(bitcoin_daemon_sources)
+bitcoind_SOURCES = $(bitcoin_daemon_sources) init/bitcoind.cpp
 bitcoind_CPPFLAGS = $(bitcoin_bin_cppflags)
 bitcoind_CXXFLAGS = $(bitcoin_bin_cxxflags)
 bitcoind_LDFLAGS = $(bitcoin_bin_ldflags)
 bitcoind_LDADD = $(LIBBITCOIN_SERVER) $(bitcoin_bin_ldadd)
 
-bitcoin_node_SOURCES = $(bitcoin_daemon_sources)
+bitcoin_node_SOURCES = $(bitcoin_daemon_sources) init/bitcoin-node.cpp
 bitcoin_node_CPPFLAGS = $(bitcoin_bin_cppflags)
 bitcoin_node_CXXFLAGS = $(bitcoin_bin_cxxflags)
 bitcoin_node_LDFLAGS = $(bitcoin_bin_ldflags)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,6 +74,7 @@ EXTRA_LIBRARIES += \
   $(LIBBITCOIN_CONSENSUS) \
   $(LIBBITCOIN_SERVER) \
   $(LIBBITCOIN_CLI) \
+  $(LIBBITCOIN_IPC) \
   $(LIBBITCOIN_WALLET) \
   $(LIBBITCOIN_WALLET_TOOL) \
   $(LIBBITCOIN_ZMQ)
@@ -300,6 +301,8 @@ obj/build.h: FORCE
 	@$(top_srcdir)/share/genbuild.sh "$(abs_top_builddir)/src/obj/build.h" \
 	  "$(abs_top_srcdir)"
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
+
+ipc/capnp/libbitcoin_ipc_a-ipc.$(OBJEXT): $(libbitcoin_ipc_mpgen_input:=.h)
 
 # server: shared between bitcoind and bitcoin-qt
 # Contains code accessing mempool and chain state that is meant to be separated
@@ -647,7 +650,7 @@ bitcoin_node_SOURCES = $(bitcoin_daemon_sources)
 bitcoin_node_CPPFLAGS = $(bitcoin_bin_cppflags)
 bitcoin_node_CXXFLAGS = $(bitcoin_bin_cxxflags)
 bitcoin_node_LDFLAGS = $(bitcoin_bin_ldflags)
-bitcoin_node_LDADD = $(LIBBITCOIN_SERVER) $(bitcoin_bin_ldadd)
+bitcoin_node_LDADD = $(LIBBITCOIN_SERVER) $(bitcoin_bin_ldadd) $(LIBBITCOIN_IPC) $(LIBMULTIPROCESS_LIBS)
 
 # bitcoin-cli binary #
 bitcoin_cli_SOURCES = bitcoin-cli.cpp
@@ -809,6 +812,38 @@ check-security: $(bin_PROGRAMS)
 if HARDEN
 	@echo "Checking binary security..."
 	$(AM_V_at) OBJDUMP=$(OBJDUMP) OTOOL=$(OTOOL) $(PYTHON) $(top_srcdir)/contrib/devtools/security-check.py $(bin_PROGRAMS)
+endif
+
+libbitcoin_ipc_mpgen_input = \
+  ipc/capnp/init.capnp
+EXTRA_DIST += $(libbitcoin_ipc_mpgen_input)
+%.capnp:
+
+if BUILD_MULTIPROCESS
+LIBBITCOIN_IPC=libbitcoin_ipc.a
+libbitcoin_ipc_a_SOURCES = \
+  ipc/capnp/init-types.h \
+  ipc/capnp/protocol.cpp \
+  ipc/capnp/protocol.h \
+  ipc/exception.h \
+  ipc/interfaces.cpp \
+  ipc/process.cpp \
+  ipc/process.h \
+  ipc/protocol.h
+libbitcoin_ipc_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
+libbitcoin_ipc_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS) $(LIBMULTIPROCESS_CFLAGS)
+
+include $(MPGEN_PREFIX)/include/mpgen.mk
+libbitcoin_ipc_mpgen_output = \
+  $(libbitcoin_ipc_mpgen_input:=.c++) \
+  $(libbitcoin_ipc_mpgen_input:=.h) \
+  $(libbitcoin_ipc_mpgen_input:=.proxy-client.c++) \
+  $(libbitcoin_ipc_mpgen_input:=.proxy-server.c++) \
+  $(libbitcoin_ipc_mpgen_input:=.proxy-types.c++) \
+  $(libbitcoin_ipc_mpgen_input:=.proxy-types.h) \
+  $(libbitcoin_ipc_mpgen_input:=.proxy.h)
+nodist_libbitcoin_ipc_a_SOURCES = $(libbitcoin_ipc_mpgen_output)
+CLEANFILES += $(libbitcoin_ipc_mpgen_output)
 endif
 
 if EMBEDDED_LEVELDB

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,6 +159,8 @@ BITCOIN_CORE_H = \
   init/common.h \
   interfaces/chain.h \
   interfaces/handler.h \
+  interfaces/init.h \
+  interfaces/ipc.h \
   interfaces/node.h \
   interfaces/wallet.h \
   key.h \
@@ -559,6 +561,7 @@ libbitcoin_util_a_SOURCES = \
   compat/strnlen.cpp \
   fs.cpp \
   interfaces/handler.cpp \
+  interfaces/init.cpp \
   logging.cpp \
   random.cpp \
   randomenv.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -159,6 +159,7 @@ BITCOIN_CORE_H = \
   init.h \
   init/common.h \
   interfaces/chain.h \
+  interfaces/echo.h \
   interfaces/handler.h \
   interfaces/init.h \
   interfaces/ipc.h \
@@ -563,6 +564,7 @@ libbitcoin_util_a_SOURCES = \
   compat/glibcxx_sanity.cpp \
   compat/strnlen.cpp \
   fs.cpp \
+  interfaces/echo.cpp \
   interfaces/handler.cpp \
   interfaces/init.cpp \
   logging.cpp \
@@ -815,6 +817,7 @@ if HARDEN
 endif
 
 libbitcoin_ipc_mpgen_input = \
+  ipc/capnp/echo.capnp \
   ipc/capnp/init.capnp
 EXTRA_DIST += $(libbitcoin_ipc_mpgen_input)
 %.capnp:

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -12,6 +12,7 @@
 #include <compat.h>
 #include <init.h>
 #include <interfaces/chain.h>
+#include <interfaces/init.h>
 #include <node/context.h>
 #include <node/ui_interface.h>
 #include <noui.h>
@@ -104,10 +105,8 @@ int fork_daemon(bool nochdir, bool noclose, TokenPipeEnd& endpoint)
 
 #endif
 
-static bool AppInit(int argc, char* argv[])
+static bool AppInit(NodeContext& node, int argc, char* argv[])
 {
-    NodeContext node;
-
     bool fRet = false;
 
     util::ThreadSetInternalName("init");
@@ -254,10 +253,18 @@ int main(int argc, char* argv[])
     util::WinCmdLineArgs winArgs;
     std::tie(argc, argv) = winArgs.get();
 #endif
+
+    NodeContext node;
+    int exit_status;
+    std::unique_ptr<interfaces::Init> init = interfaces::MakeNodeInit(node, argc, argv, exit_status);
+    if (!init) {
+        return exit_status;
+    }
+
     SetupEnvironment();
 
     // Connect bitcoind signal handlers
     noui_connect();
 
-    return (AppInit(argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE);
+    return (AppInit(node, argc, argv) ? EXIT_SUCCESS : EXIT_FAILURE);
 }

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <interfaces/echo.h>
 #include <interfaces/init.h>
 #include <interfaces/ipc.h>
 #include <node/context.h>
@@ -21,6 +22,7 @@ public:
     {
         m_node.init = this;
     }
+    std::unique_ptr<interfaces::Echo> makeEcho() override { return interfaces::MakeEcho(); }
     interfaces::Ipc* ipc() override { return m_ipc.get(); }
     NodeContext& m_node;
     std::unique_ptr<interfaces::Ipc> m_ipc;

--- a/src/init/bitcoin-node.cpp
+++ b/src/init/bitcoin-node.cpp
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/init.h>
+#include <interfaces/ipc.h>
+#include <node/context.h>
+
+#include <memory>
+
+namespace init {
+namespace {
+const char* EXE_NAME = "bitcoin-node";
+
+class BitcoinNodeInit : public interfaces::Init
+{
+public:
+    BitcoinNodeInit(NodeContext& node, const char* arg0)
+        : m_node(node),
+          m_ipc(interfaces::MakeIpc(EXE_NAME, arg0, *this))
+    {
+        m_node.init = this;
+    }
+    interfaces::Ipc* ipc() override { return m_ipc.get(); }
+    NodeContext& m_node;
+    std::unique_ptr<interfaces::Ipc> m_ipc;
+};
+} // namespace
+} // namespace init
+
+namespace interfaces {
+std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status)
+{
+    auto init = std::make_unique<init::BitcoinNodeInit>(node, argc > 0 ? argv[0] : "");
+    // Check if bitcoin-node is being invoked as an IPC server. If so, then
+    // bypass normal execution and just respond to requests over the IPC
+    // channel and return null.
+    if (init->m_ipc->startSpawnedProcess(argc, argv, exit_status)) {
+        return nullptr;
+    }
+    return init;
+}
+} // namespace interfaces

--- a/src/init/bitcoind.cpp
+++ b/src/init/bitcoind.cpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/init.h>
+#include <node/context.h>
+
+#include <memory>
+
+namespace init {
+namespace {
+class BitcoindInit : public interfaces::Init
+{
+public:
+    BitcoindInit(NodeContext& node) : m_node(node)
+    {
+        m_node.init = this;
+    }
+    NodeContext& m_node;
+};
+} // namespace
+} // namespace init
+
+namespace interfaces {
+std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status)
+{
+    return std::make_unique<init::BitcoindInit>(node);
+}
+} // namespace interfaces

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -12,6 +12,8 @@ The following interfaces are defined here:
 
 * [`Handler`](handler.h) — returned by `handleEvent` methods on interfaces above and used to manage lifetimes of event handlers.
 
-* [`Init`](init.h) — used by multiprocess code to access interfaces above on startup. Added in [#10102](https://github.com/bitcoin/bitcoin/pull/10102).
+* [`Init`](init.h) — used by multiprocess code to access interfaces above on startup. Added in [#19160](https://github.com/bitcoin/bitcoin/pull/19160).
 
-The interfaces above define boundaries between major components of bitcoin code (node, wallet, and gui), making it possible for them to run in different processes, and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.
+* [`Ipc`](ipc.h) — used by multiprocess code to access `Init` interface across processes. Added in [#19160](https://github.com/bitcoin/bitcoin/pull/19160).
+
+The interfaces above define boundaries between major components of bitcoin code (node, wallet, and gui), making it possible for them to run in [different processes](../../doc/multiprocess.md), and be tested, developed, and understood independently. These interfaces are not currently designed to be stable or to be used externally.

--- a/src/interfaces/echo.cpp
+++ b/src/interfaces/echo.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/echo.h>
+
+#include <memory>
+
+namespace interfaces {
+namespace {
+class EchoImpl : public Echo
+{
+public:
+    std::string echo(const std::string& echo) override { return echo; }
+};
+} // namespace
+std::unique_ptr<Echo> MakeEcho() { return std::make_unique<EchoImpl>(); }
+} // namespace interfaces

--- a/src/interfaces/echo.h
+++ b/src/interfaces/echo.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_ECHO_H
+#define BITCOIN_INTERFACES_ECHO_H
+
+#include <memory>
+#include <string>
+
+namespace interfaces {
+//! Simple string echoing interface for testing.
+class Echo
+{
+public:
+    virtual ~Echo() {}
+
+    //! Echo provided string.
+    virtual std::string echo(const std::string& echo) = 0;
+};
+
+//! Return implementation of Echo interface.
+std::unique_ptr<Echo> MakeEcho();
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_ECHO_H

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include <interfaces/chain.h>
+#include <interfaces/echo.h>
 #include <interfaces/init.h>
 #include <interfaces/node.h>
 #include <interfaces/wallet.h>
@@ -11,5 +12,6 @@ namespace interfaces {
 std::unique_ptr<Node> Init::makeNode() { return {}; }
 std::unique_ptr<Chain> Init::makeChain() { return {}; }
 std::unique_ptr<WalletClient> Init::makeWalletClient(Chain& chain) { return {}; }
+std::unique_ptr<Echo> Init::makeEcho() { return {}; }
 Ipc* Init::ipc() { return nullptr; }
 } // namespace interfaces

--- a/src/interfaces/init.cpp
+++ b/src/interfaces/init.cpp
@@ -1,0 +1,15 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/chain.h>
+#include <interfaces/init.h>
+#include <interfaces/node.h>
+#include <interfaces/wallet.h>
+
+namespace interfaces {
+std::unique_ptr<Node> Init::makeNode() { return {}; }
+std::unique_ptr<Chain> Init::makeChain() { return {}; }
+std::unique_ptr<WalletClient> Init::makeWalletClient(Chain& chain) { return {}; }
+Ipc* Init::ipc() { return nullptr; }
+} // namespace interfaces

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -31,6 +31,20 @@ public:
     virtual std::unique_ptr<WalletClient> makeWalletClient(Chain& chain);
     virtual Ipc* ipc();
 };
+
+//! Return implementation of Init interface for the node process. If the argv
+//! indicates that this is a child process spawned to handle requests from a
+//! parent process, this blocks and handles requests, then returns null and a
+//! status code to exit with. If this returns non-null, the caller can start up
+//! normally and use the Init object to spawn and connect to other processes
+//! while it is running.
+std::unique_ptr<Init> MakeNodeInit(NodeContext& node, int argc, char* argv[], int& exit_status);
+
+//! Return implementation of Init interface for the wallet process.
+std::unique_ptr<Init> MakeWalletInit(int argc, char* argv[], int& exit_status);
+
+//! Return implementation of Init interface for the gui process.
+std::unique_ptr<Init> MakeGuiInit(int argc, char* argv[]);
 } // namespace interfaces
 
 #endif // BITCOIN_INTERFACES_INIT_H

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -11,6 +11,7 @@ struct NodeContext;
 
 namespace interfaces {
 class Chain;
+class Echo;
 class Ipc;
 class Node;
 class WalletClient;
@@ -29,6 +30,7 @@ public:
     virtual std::unique_ptr<Node> makeNode();
     virtual std::unique_ptr<Chain> makeChain();
     virtual std::unique_ptr<WalletClient> makeWalletClient(Chain& chain);
+    virtual std::unique_ptr<Echo> makeEcho();
     virtual Ipc* ipc();
 };
 

--- a/src/interfaces/init.h
+++ b/src/interfaces/init.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_INIT_H
+#define BITCOIN_INTERFACES_INIT_H
+
+#include <memory>
+
+struct NodeContext;
+
+namespace interfaces {
+class Chain;
+class Ipc;
+class Node;
+class WalletClient;
+
+//! Initial interface created when a process is first started, and used to give
+//! and get access to other interfaces (Node, Chain, Wallet, etc).
+//!
+//! There is a different Init interface implementation for each process
+//! (bitcoin-gui, bitcoin-node, bitcoin-wallet, bitcoind, bitcoin-qt) and each
+//! implementation can implement the make methods for interfaces it supports.
+//! The default make methods all return null.
+class Init
+{
+public:
+    virtual ~Init() = default;
+    virtual std::unique_ptr<Node> makeNode();
+    virtual std::unique_ptr<Chain> makeChain();
+    virtual std::unique_ptr<WalletClient> makeWalletClient(Chain& chain);
+    virtual Ipc* ipc();
+};
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_INIT_H

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -13,7 +13,30 @@ namespace interfaces {
 class Init;
 
 //! Interface providing access to interprocess-communication (IPC)
-//! functionality.
+//! functionality. The IPC implementation is responsible for establishing
+//! connections between a controlling process and a process being controlled.
+//! When a connection is established, the process being controlled returns an
+//! interfaces::Init pointer to the controlling process, which the controlling
+//! process can use to get access to other interfaces and functionality.
+//!
+//! When spawning a new process, the steps are:
+//!
+//! 1. The controlling process calls interfaces::Ipc::spawnProcess(), which
+//!    calls ipc::Process::spawn(), which spawns a new process and returns a
+//!    socketpair file descriptor for communicating with it.
+//!    interfaces::Ipc::spawnProcess() then calls ipc::Protocol::connect()
+//!    passing the socketpair descriptor, which returns a local proxy
+//!    interfaces::Init implementation calling remote interfaces::Init methods.
+//! 2. The spawned process calls interfaces::Ipc::startSpawnProcess(), which
+//!    calls ipc::Process::checkSpawned() to read command line arguments and
+//!    determine whether it is a spawned process and what socketpair file
+//!    descriptor it should use. It then calls ipc::Protocol::serve() to handle
+//!    incoming requests from the socketpair and invoke interfaces::Init
+//!    interface methods, and exit when the socket is closed.
+//! 3. The controlling process calls local proxy interfaces::Init object methods
+//!    to make other proxy objects calling other remote interfaces. It can also
+//!    destroy the initial interfaces::Init object to close the connection and
+//!    shut down the spawned process.
 class Ipc
 {
 public:

--- a/src/interfaces/ipc.h
+++ b/src/interfaces/ipc.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_INTERFACES_IPC_H
+#define BITCOIN_INTERFACES_IPC_H
+
+#include <functional>
+#include <memory>
+#include <typeindex>
+
+namespace interfaces {
+class Init;
+
+//! Interface providing access to interprocess-communication (IPC)
+//! functionality.
+class Ipc
+{
+public:
+    virtual ~Ipc() = default;
+
+    //! Spawn a child process returning pointer to its Init interface.
+    virtual std::unique_ptr<Init> spawnProcess(const char* exe_name) = 0;
+
+    //! If this is a spawned process, block and handle requests from the parent
+    //! process by forwarding them to this process's Init interface, then return
+    //! true. If this is not a spawned child process, return false.
+    virtual bool startSpawnedProcess(int argc, char* argv[], int& exit_status) = 0;
+
+    //! Add cleanup callback to remote interface that will run when the
+    //! interface is deleted.
+    template<typename Interface>
+    void addCleanup(Interface& iface, std::function<void()> cleanup)
+    {
+        addCleanup(typeid(Interface), &iface, std::move(cleanup));
+    }
+
+protected:
+    //! Internal implementation of public addCleanup method (above) as a
+    //! type-erased virtual function, since template functions can't be virtual.
+    virtual void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) = 0;
+};
+
+//! Return implementation of Ipc interface.
+std::unique_ptr<Ipc> MakeIpc(const char* exe_name, const char* process_argv0, Init& init);
+} // namespace interfaces
+
+#endif // BITCOIN_INTERFACES_IPC_H

--- a/src/ipc/capnp/.gitignore
+++ b/src/ipc/capnp/.gitignore
@@ -1,0 +1,2 @@
+# capnp generated files
+*.capnp.*

--- a/src/ipc/capnp/echo.capnp
+++ b/src/ipc/capnp/echo.capnp
@@ -2,19 +2,16 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-@0xf2c5cfa319406aa6;
+@0x888b4f7f51e691f7;
 
 using Cxx = import "/capnp/c++.capnp";
 $Cxx.namespace("ipc::capnp::messages");
 
 using Proxy = import "/mp/proxy.capnp";
 $Proxy.include("interfaces/echo.h");
-$Proxy.include("interfaces/init.h");
-$Proxy.includeTypes("ipc/capnp/init-types.h");
+$Proxy.include("ipc/capnp/echo.capnp.h");
 
-using Echo = import "echo.capnp";
-
-interface Init $Proxy.wrap("interfaces::Init") {
-    construct @0 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
-    makeEcho @1 (context :Proxy.Context) -> (result :Echo.Echo);
+interface Echo $Proxy.wrap("interfaces::Echo") {
+    destroy @0 (context :Proxy.Context) -> ();
+    echo @1 (context :Proxy.Context, echo: Text) -> (result :Text);
 }

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -1,0 +1,7 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_CAPNP_INIT_TYPES_H
+#define BITCOIN_IPC_CAPNP_INIT_TYPES_H
+#endif // BITCOIN_IPC_CAPNP_INIT_TYPES_H

--- a/src/ipc/capnp/init-types.h
+++ b/src/ipc/capnp/init-types.h
@@ -4,4 +4,7 @@
 
 #ifndef BITCOIN_IPC_CAPNP_INIT_TYPES_H
 #define BITCOIN_IPC_CAPNP_INIT_TYPES_H
+
+#include <ipc/capnp/echo.capnp.proxy-types.h>
+
 #endif // BITCOIN_IPC_CAPNP_INIT_TYPES_H

--- a/src/ipc/capnp/init.capnp
+++ b/src/ipc/capnp/init.capnp
@@ -1,0 +1,16 @@
+# Copyright (c) 2021 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+@0xf2c5cfa319406aa6;
+
+using Cxx = import "/capnp/c++.capnp";
+$Cxx.namespace("ipc::capnp::messages");
+
+using Proxy = import "/mp/proxy.capnp";
+$Proxy.include("interfaces/init.h");
+$Proxy.includeTypes("ipc/capnp/init-types.h");
+
+interface Init $Proxy.wrap("interfaces::Init") {
+    construct @0 (threadMap: Proxy.ThreadMap) -> (threadMap :Proxy.ThreadMap);
+}

--- a/src/ipc/capnp/protocol.cpp
+++ b/src/ipc/capnp/protocol.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <interfaces/init.h>
+#include <ipc/capnp/init.capnp.h>
+#include <ipc/capnp/init.capnp.proxy.h>
+#include <ipc/capnp/protocol.h>
+#include <ipc/exception.h>
+#include <ipc/protocol.h>
+#include <kj/async.h>
+#include <logging.h>
+#include <mp/proxy-io.h>
+#include <mp/proxy-types.h>
+#include <mp/util.h>
+#include <util/threadnames.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+namespace ipc {
+namespace capnp {
+namespace {
+void IpcLogFn(bool raise, std::string message)
+{
+    LogPrint(BCLog::IPC, "%s\n", message);
+    if (raise) throw Exception(message);
+}
+
+class CapnpProtocol : public Protocol
+{
+public:
+    ~CapnpProtocol() noexcept(true)
+    {
+        if (m_loop) {
+            std::unique_lock<std::mutex> lock(m_loop->m_mutex);
+            m_loop->removeClient(lock);
+        }
+        if (m_loop_thread.joinable()) m_loop_thread.join();
+        assert(!m_loop);
+    };
+    std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name) override
+    {
+        startLoop(exe_name);
+        return mp::ConnectStream<messages::Init>(*m_loop, fd);
+    }
+    void serve(int fd, const char* exe_name, interfaces::Init& init) override
+    {
+        assert(!m_loop);
+        mp::g_thread_context.thread_name = mp::ThreadName(exe_name);
+        m_loop.emplace(exe_name, &IpcLogFn, nullptr);
+        mp::ServeStream<messages::Init>(*m_loop, fd, init);
+        m_loop->loop();
+        m_loop.reset();
+    }
+    void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) override
+    {
+        mp::ProxyTypeRegister::types().at(type)(iface).cleanup.emplace_back(std::move(cleanup));
+    }
+    void startLoop(const char* exe_name)
+    {
+        if (m_loop) return;
+        std::promise<void> promise;
+        m_loop_thread = std::thread([&] {
+            util::ThreadRename("capnp-loop");
+            m_loop.emplace(exe_name, &IpcLogFn, nullptr);
+            {
+                std::unique_lock<std::mutex> lock(m_loop->m_mutex);
+                m_loop->addClient(lock);
+            }
+            promise.set_value();
+            m_loop->loop();
+            m_loop.reset();
+        });
+        promise.get_future().wait();
+    }
+    std::thread m_loop_thread;
+    std::optional<mp::EventLoop> m_loop;
+};
+} // namespace
+
+std::unique_ptr<Protocol> MakeCapnpProtocol() { return std::make_unique<CapnpProtocol>(); }
+} // namespace capnp
+} // namespace ipc

--- a/src/ipc/capnp/protocol.h
+++ b/src/ipc/capnp/protocol.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_CAPNP_PROTOCOL_H
+#define BITCOIN_IPC_CAPNP_PROTOCOL_H
+
+#include <memory>
+
+namespace ipc {
+class Protocol;
+namespace capnp {
+std::unique_ptr<Protocol> MakeCapnpProtocol();
+} // namespace capnp
+} // namespace ipc
+
+#endif // BITCOIN_IPC_CAPNP_PROTOCOL_H

--- a/src/ipc/exception.h
+++ b/src/ipc/exception.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_EXCEPTION_H
+#define BITCOIN_IPC_EXCEPTION_H
+
+#include <stdexcept>
+
+namespace ipc {
+//! Exception class thrown when a call to remote method fails due to an IPC
+//! error, like a socket getting disconnected.
+class Exception : public std::runtime_error
+{
+public:
+    using std::runtime_error::runtime_error;
+};
+} // namespace ipc
+
+#endif // BITCOIN_IPC_EXCEPTION_H

--- a/src/ipc/interfaces.cpp
+++ b/src/ipc/interfaces.cpp
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <fs.h>
+#include <interfaces/init.h>
+#include <interfaces/ipc.h>
+#include <ipc/capnp/protocol.h>
+#include <ipc/process.h>
+#include <ipc/protocol.h>
+#include <logging.h>
+#include <tinyformat.h>
+#include <util/system.h>
+
+#include <functional>
+#include <memory>
+#include <stdexcept>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace ipc {
+namespace {
+class IpcImpl : public interfaces::Ipc
+{
+public:
+    IpcImpl(const char* exe_name, const char* process_argv0, interfaces::Init& init)
+        : m_exe_name(exe_name), m_process_argv0(process_argv0), m_init(init),
+          m_protocol(ipc::capnp::MakeCapnpProtocol()), m_process(ipc::MakeProcess())
+    {
+    }
+    std::unique_ptr<interfaces::Init> spawnProcess(const char* new_exe_name) override
+    {
+        int pid;
+        int fd = m_process->spawn(new_exe_name, m_process_argv0, pid);
+        LogPrint(::BCLog::IPC, "Process %s pid %i launched\n", new_exe_name, pid);
+        auto init = m_protocol->connect(fd, m_exe_name);
+        Ipc::addCleanup(*init, [this, new_exe_name, pid] {
+            int status = m_process->waitSpawned(pid);
+            LogPrint(::BCLog::IPC, "Process %s pid %i exited with status %i\n", new_exe_name, pid, status);
+        });
+        return init;
+    }
+    bool startSpawnedProcess(int argc, char* argv[], int& exit_status) override
+    {
+        exit_status = EXIT_FAILURE;
+        int32_t fd = -1;
+        if (!m_process->checkSpawned(argc, argv, fd)) {
+            return false;
+        }
+        m_protocol->serve(fd, m_exe_name, m_init);
+        exit_status = EXIT_SUCCESS;
+        return true;
+    }
+    void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) override
+    {
+        m_protocol->addCleanup(type, iface, std::move(cleanup));
+    }
+    const char* m_exe_name;
+    const char* m_process_argv0;
+    interfaces::Init& m_init;
+    std::unique_ptr<Protocol> m_protocol;
+    std::unique_ptr<Process> m_process;
+};
+} // namespace
+} // namespace ipc
+
+namespace interfaces {
+std::unique_ptr<Ipc> MakeIpc(const char* exe_name, const char* process_argv0, Init& init)
+{
+    return std::make_unique<ipc::IpcImpl>(exe_name, process_argv0, init);
+}
+} // namespace interfaces

--- a/src/ipc/process.cpp
+++ b/src/ipc/process.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <fs.h>
+#include <ipc/process.h>
+#include <ipc/protocol.h>
+#include <mp/util.h>
+#include <tinyformat.h>
+#include <util/strencodings.h>
+
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <stdlib.h>
+#include <string.h>
+#include <system_error>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace ipc {
+namespace {
+class ProcessImpl : public Process
+{
+public:
+    int spawn(const std::string& new_exe_name, const fs::path& argv0_path, int& pid) override
+    {
+        return mp::SpawnProcess(pid, [&](int fd) {
+            fs::path path = argv0_path;
+            path.remove_filename();
+            path.append(new_exe_name);
+            return std::vector<std::string>{path.string(), "-ipcfd", strprintf("%i", fd)};
+        });
+    }
+    int waitSpawned(int pid) override { return mp::WaitProcess(pid); }
+    bool checkSpawned(int argc, char* argv[], int& fd) override
+    {
+        // If this process was not started with a single -ipcfd argument, it is
+        // not a process spawned by the spawn() call above, so return false and
+        // do not try to serve requests.
+        if (argc != 3 || strcmp(argv[1], "-ipcfd") != 0) {
+            return false;
+        }
+        // If a single -ipcfd argument was provided, return true and get the
+        // file descriptor so Protocol::serve() can be called to handle
+        // requests from the parent process. The -ipcfd argument is not valid
+        // in combination with other arguments because the parent process
+        // should be able to control the child process through the IPC protocol
+        // without passing information out of band.
+        if (!ParseInt32(argv[2], &fd)) {
+            throw std::runtime_error(strprintf("Invalid -ipcfd number '%s'", argv[2]));
+        }
+        return true;
+    }
+};
+} // namespace
+
+std::unique_ptr<Process> MakeProcess() { return std::make_unique<ProcessImpl>(); }
+} // namespace ipc

--- a/src/ipc/process.h
+++ b/src/ipc/process.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_PROCESS_H
+#define BITCOIN_IPC_PROCESS_H
+
+#include <memory>
+#include <string>
+
+namespace ipc {
+class Protocol;
+
+//! IPC process interface for spawning bitcoin processes and serving requests
+//! in processes that have been spawned.
+//!
+//! There will be different implementations of this interface depending on the
+//! platform (e.g. unix, windows).
+class Process
+{
+public:
+    virtual ~Process() = default;
+
+    //! Spawn process and return socket file descriptor for communicating with
+    //! it.
+    virtual int spawn(const std::string& new_exe_name, const fs::path& argv0_path, int& pid) = 0;
+
+    //! Wait for spawned process to exit and return its exit code.
+    virtual int waitSpawned(int pid) = 0;
+
+    //! Parse command line and determine if current process is a spawned child
+    //! process. If so, return true and a file descriptor for communicating
+    //! with the parent process.
+    virtual bool checkSpawned(int argc, char* argv[], int& fd) = 0;
+};
+
+//! Constructor for Process interface. Implementation will vary depending on
+//! the platform (unix or windows).
+std::unique_ptr<Process> MakeProcess();
+} // namespace ipc
+
+#endif // BITCOIN_IPC_PROCESS_H

--- a/src/ipc/protocol.h
+++ b/src/ipc/protocol.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_IPC_PROTOCOL_H
+#define BITCOIN_IPC_PROTOCOL_H
+
+#include <interfaces/init.h>
+
+#include <functional>
+#include <memory>
+#include <typeindex>
+
+namespace ipc {
+//! IPC protocol interface for calling IPC methods over sockets.
+//!
+//! There may be different implementations of this interface for different IPC
+//! protocols (e.g. Cap'n Proto, gRPC, JSON-RPC, or custom protocols).
+class Protocol
+{
+public:
+    virtual ~Protocol() = default;
+
+    //! Return Init interface that forwards requests over given socket descriptor.
+    //! Socket communication is handled on a background thread.
+    virtual std::unique_ptr<interfaces::Init> connect(int fd, const char* exe_name) = 0;
+
+    //! Handle requests on provided socket descriptor, forwarding them to the
+    //! provided Init interface. Socket communication is handled on the
+    //! current thread, and this call blocks until the socket is closed.
+    virtual void serve(int fd, const char* exe_name, interfaces::Init& init) = 0;
+
+    //! Add cleanup callback to interface that will run when the interface is
+    //! deleted.
+    virtual void addCleanup(std::type_index type, void* iface, std::function<void()> cleanup) = 0;
+};
+} // namespace ipc
+
+#endif // BITCOIN_IPC_PROTOCOL_H

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -157,6 +157,7 @@ const CLogCategoryDesc LogCategories[] =
     {BCLog::LEVELDB, "leveldb"},
     {BCLog::VALIDATION, "validation"},
     {BCLog::I2P, "i2p"},
+    {BCLog::IPC, "ipc"},
     {BCLog::ALL, "1"},
     {BCLog::ALL, "all"},
 };

--- a/src/logging.h
+++ b/src/logging.h
@@ -58,6 +58,7 @@ namespace BCLog {
         LEVELDB     = (1 << 20),
         VALIDATION  = (1 << 21),
         I2P         = (1 << 22),
+        IPC         = (1 << 23),
         ALL         = ~(uint32_t)0,
     };
 

--- a/src/node/context.h
+++ b/src/node/context.h
@@ -22,6 +22,7 @@ class PeerManager;
 namespace interfaces {
 class Chain;
 class ChainClient;
+class Init;
 class WalletClient;
 } // namespace interfaces
 
@@ -36,6 +37,8 @@ class WalletClient;
 //! any member functions. It should just be a collection of references that can
 //! be used without pulling in unwanted dependencies or functionality.
 struct NodeContext {
+    //! Init interface for initializing current process and connecting to other processes.
+    interfaces::Init* init{nullptr};
     std::unique_ptr<CAddrMan> addrman;
     std::unique_ptr<CConnman> connman;
     std::unique_ptr<CTxMemPool> mempool;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -7,6 +7,9 @@
 #include <index/blockfilterindex.h>
 #include <index/txindex.h>
 #include <interfaces/chain.h>
+#include <interfaces/echo.h>
+#include <interfaces/init.h>
+#include <interfaces/ipc.h>
 #include <key_io.h>
 #include <node/context.h>
 #include <outputtype.h>
@@ -644,6 +647,43 @@ static RPCHelpMan echo(const std::string& name)
 static RPCHelpMan echo() { return echo("echo"); }
 static RPCHelpMan echojson() { return echo("echojson"); }
 
+static RPCHelpMan echoipc()
+{
+    return RPCHelpMan{
+        "echoipc",
+        "\nEcho back the input argument, passing it through a spawned process in a multiprocess build.\n"
+        "This command is for testing.\n",
+        {{"arg", RPCArg::Type::STR, RPCArg::Optional::NO, "The string to echo",}},
+        RPCResult{RPCResult::Type::STR, "echo", "The echoed string."},
+        RPCExamples{HelpExampleCli("echo", "\"Hello world\"") +
+                    HelpExampleRpc("echo", "\"Hello world\"")},
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue {
+            std::unique_ptr<interfaces::Echo> echo;
+            if (interfaces::Ipc* ipc = Assert(EnsureAnyNodeContext(request.context).init)->ipc()) {
+                // Spawn a new bitcoin-node process and call makeEcho to get a
+                // client pointer to a interfaces::Echo instance running in
+                // that process. This is just for testing. A slightly more
+                // realistic test spawning a different executable instead of
+                // the same executable would add a new bitcoin-echo executable,
+                // and spawn bitcoin-echo below instead of bitcoin-node. But
+                // using bitcoin-node avoids the need to build and install a
+                // new executable just for this one test.
+                auto init = ipc->spawnProcess("bitcoin-node");
+                echo = init->makeEcho();
+                ipc->addCleanup(*echo, [init = init.release()] { delete init; });
+            } else {
+                // IPC support is not available because this is a bitcoind
+                // process not a bitcoind-node process, so just create a local
+                // interfaces::Echo object and return it so the `echoipc` RPC
+                // method will work, and the python test calling `echoipc`
+                // can expect the same result.
+                echo = interfaces::MakeEcho();
+            }
+            return echo->echo(request.params[0].get_str());
+        },
+    };
+}
+
 static UniValue SummaryToJSON(const IndexSummary&& summary, std::string index_name)
 {
     UniValue ret_summary(UniValue::VOBJ);
@@ -719,6 +759,7 @@ static const CRPCCommand commands[] =
     { "hidden",             &mockscheduler,           },
     { "hidden",             &echo,                    },
     { "hidden",             &echojson,                },
+    { "hidden",             &echoipc,                 },
 };
 // clang-format on
     for (const auto& c : commands) {

--- a/test/functional/rpc_misc.py
+++ b/test/functional/rpc_misc.py
@@ -61,6 +61,9 @@ class RpcMiscTest(BitcoinTestFramework):
         node.logging(include=['qt'])
         assert_equal(node.logging()['qt'], True)
 
+        self.log.info("test echoipc (testing spawned process in multiprocess build)")
+        assert_equal(node.echoipc("hello"), "hello")
+
         self.log.info("test getindexinfo")
         # Without any indices running the RPC returns an empty object
         assert_equal(node.getindexinfo(), {})

--- a/test/lint/lint-include-guards.sh
+++ b/test/lint/lint-include-guards.sh
@@ -15,7 +15,7 @@ REGEXP_EXCLUDE_FILES_WITH_PREFIX="src/(crypto/ctaes/|leveldb/|crc32c/|secp256k1/
 EXIT_CODE=0
 for HEADER_FILE in $(git ls-files -- "*.h" | grep -vE "^${REGEXP_EXCLUDE_FILES_WITH_PREFIX}")
 do
-    HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr / _ | tr "[:lower:]" "[:upper:]")
+    HEADER_ID_BASE=$(cut -f2- -d/ <<< "${HEADER_FILE}" | sed "s/\.h$//g" | tr / _ | tr - _ | tr "[:lower:]" "[:upper:]")
     HEADER_ID="${HEADER_ID_PREFIX}${HEADER_ID_BASE}${HEADER_ID_SUFFIX}"
     if [[ $(grep -cE "^#(ifndef|define) ${HEADER_ID}" "${HEADER_FILE}") != 2 ]]; then
         echo "${HEADER_FILE} seems to be missing the expected include guard:"


### PR DESCRIPTION
This PR is part of the [process separation project](https://github.com/bitcoin/bitcoin/projects/10).

---

This PR adds basic process spawning and IPC method call support to `bitcoin-node` executables built with `--enable-multiprocess`[*].

These changes are used in https://github.com/bitcoin/bitcoin/pull/10102 to let node, gui, and wallet functionality run in different processes, and extended in https://github.com/bitcoin/bitcoin/pull/19460 and https://github.com/bitcoin/bitcoin/pull/19461 after that to allow gui and wallet processes to be started and stopped independently and connect to the node over a socket.

These changes can also be used to implement new functionality outside the `bitcoin-node` process like external indexes or pluggable transports (https://github.com/bitcoin/bitcoin/pull/18988). The `Ipc::spawnProcess` and `Ipc::serveProcess` methods added here are entry points for spawning a child process and serving a parent process, and being able to make bidirectional, multithreaded method calls between the processes. A simple example of this is implemented in commit "Add echoipc RPC method and test."

Changes in this PR aside from the echo test were originally part of #10102, but have been split and moved here for easier review, and so they can be used for other applications like external plugins.

Additional notes about this PR can be found at https://bitcoincore.reviews/19160

[*] Note: the `--enable-multiprocess` feature is still experimental, and not enabled by default, and not yet supported on windows. More information can be found in [doc/multiprocess.md](https://github.com/bitcoin/bitcoin/blob/master/doc/multiprocess.md)