### PR TITLE
Refactor: Improve setup_clean_chain semantics

### DIFF
--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -63,10 +63,11 @@ don't have test cases for.
 - Avoid stop-starting the nodes multiple times during the test if possible. A
   stop-start takes several seconds, so doing it several times blows up the
   runtime of the test.
-- Set the `self.setup_clean_chain` variable in `set_test_params()` to control whether
-  or not to use the cached data directories. The cached data directories
-  contain a 200-block pre-mined blockchain and wallets for four nodes. Each node
-  has 25 mature blocks (25x50=1250 BTC) in its wallet.
+- Set the `self.use_cached_chain` variable in `set_test_params()` to `False` if
+  you don't want to use the cached data directories (defaults to `True`). The
+  cached data directories contain a 200-block pre-mined blockchain and wallets
+  for four nodes. Each node has 25 mature blocks (25x50=1250 BTC) in its wallet.
+  Using them is much more efficient than mining blocks in your test.
 - When calling RPCs with lots of arguments, consider using named keyword
   arguments instead of positional arguments to make the intent of the call
   clear to readers.

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -76,7 +76,7 @@ class ExampleTest(BitcoinTestFramework):
         """Override test parameters for your individual test.
 
         This method must be overridden and num_nodes must be explicitly set."""
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         # Use self.extra_args to change command-line arguments for the nodes
         self.extra_args = [[], ["-logips"], []]

--- a/test/functional/example_test.py
+++ b/test/functional/example_test.py
@@ -76,6 +76,9 @@ class ExampleTest(BitcoinTestFramework):
         """Override test parameters for your individual test.
 
         This method must be overridden and num_nodes must be explicitly set."""
+        # By default every test loads a pre-mined chain of 200 blocks from cache.
+        # Set use_cached_chain to False to skip this and start from the Genesis
+        # block.
         self.use_cached_chain = False
         self.num_nodes = 3
         # Use self.extra_args to change command-line arguments for the nodes

--- a/test/functional/feature_abortnode.py
+++ b/test/functional/feature_abortnode.py
@@ -17,7 +17,7 @@ import os
 
 class AbortNodeTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.rpc_timeout = 240
 

--- a/test/functional/feature_asmap.py
+++ b/test/functional/feature_asmap.py
@@ -36,7 +36,6 @@ def expected_messages(filename):
 
 class AsmapTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def test_without_asmap_arg(self):

--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -57,7 +57,7 @@ class BaseNode(P2PInterface):
 
 class AssumeValidTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         self.rpc_timeout = 120
 

--- a/test/functional/feature_backwards_compatibility.py
+++ b/test/functional/feature_backwards_compatibility.py
@@ -33,7 +33,7 @@ from test_framework.util import (
 
 class BackwardsCompatibilityTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 6
         # Add new version after each release:
         self.extra_args = [

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -81,7 +81,7 @@ DUPLICATE_COINBASE_SCRIPT_SIG = b'\x01\x78'  # Valid for block at height 120
 class FullBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [['-acceptnonstdtxn=1']]  # This is a consensus block test, we don't care about tx policy
 
     def run_test(self):

--- a/test/functional/feature_blocksdir.py
+++ b/test/functional/feature_blocksdir.py
@@ -13,7 +13,7 @@ from test_framework.test_framework import BitcoinTestFramework, initialize_datad
 
 class BlocksdirTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/feature_cltv.py
+++ b/test/functional/feature_cltv.py
@@ -59,7 +59,7 @@ class BIP65Test(BitcoinTestFramework):
             '-par=1',  # Use only one script thread to get the exact reject reason for testing
             '-acceptnonstdtxn=1',  # cltv_invalidate is nonstandard
         ]]
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.rpc_timeout = 480
 
     def skip_test_if_missing_module(self):

--- a/test/functional/feature_config_args.py
+++ b/test/functional/feature_config_args.py
@@ -11,7 +11,7 @@ from test_framework.test_framework import BitcoinTestFramework
 
 class ConfArgsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.supports_cli = False
         self.wallet_names = []

--- a/test/functional/feature_csv_activation.py
+++ b/test/functional/feature_csv_activation.py
@@ -147,7 +147,7 @@ def create_bip112txs(node, bip112inputs, varyOP_CSV, txversion, address, locktim
 class BIP68_112_113Test(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [[
             '-whitelist=noban@127.0.0.1',
             '-addresstype=legacy',

--- a/test/functional/feature_dbcrash.py
+++ b/test/functional/feature_dbcrash.py
@@ -49,7 +49,6 @@ from test_framework.util import (
 class ChainstateWriteCrashTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.setup_clean_chain = False
         self.rpc_timeout = 480
         self.supports_cli = False
 

--- a/test/functional/feature_dersig.py
+++ b/test/functional/feature_dersig.py
@@ -43,7 +43,7 @@ class BIP66Test(BitcoinTestFramework):
             '-whitelist=noban@127.0.0.1',
             '-par=1',  # Use only one script thread to get the exact log msg for testing
         ]]
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.rpc_timeout = 240
 
     def skip_test_if_missing_module(self):

--- a/test/functional/feature_filelock.py
+++ b/test/functional/feature_filelock.py
@@ -10,7 +10,7 @@ from test_framework.test_node import ErrorMatch
 
 class FilelockTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
 
     def setup_network(self):

--- a/test/functional/feature_help.py
+++ b/test/functional/feature_help.py
@@ -9,7 +9,7 @@ from test_framework.util import assert_equal
 
 class HelpTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def setup_network(self):

--- a/test/functional/feature_includeconf.py
+++ b/test/functional/feature_includeconf.py
@@ -20,7 +20,6 @@ from test_framework.test_framework import BitcoinTestFramework
 
 class IncludeConfTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def setup_chain(self):

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -22,7 +22,7 @@ from test_framework.util import assert_equal
 
 class LoadblockTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.supports_cli = False
 

--- a/test/functional/feature_logging.py
+++ b/test/functional/feature_logging.py
@@ -13,7 +13,7 @@ from test_framework.test_node import ErrorMatch
 class LoggingTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def relative_log_path(self, name):
         return os.path.join(self.nodes[0].datadir, self.chain, name)

--- a/test/functional/feature_maxuploadtarget.py
+++ b/test/functional/feature_maxuploadtarget.py
@@ -33,7 +33,7 @@ class TestP2PConn(P2PInterface):
 class MaxUploadTest(BitcoinTestFramework):
 
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [[
             "-maxuploadtarget=800",

--- a/test/functional/feature_minchainwork.py
+++ b/test/functional/feature_minchainwork.py
@@ -25,7 +25,7 @@ REGTEST_WORK_PER_BLOCK = 2
 
 class MinimumChainWorkTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
 
         self.extra_args = [[], ["-minimumchainwork=0x65"], ["-minimumchainwork=0x65"]]

--- a/test/functional/feature_notifications.py
+++ b/test/functional/feature_notifications.py
@@ -26,7 +26,7 @@ def notify_outputname(walletname, txid):
 class NotificationsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def setup_network(self):
         self.wallet = ''.join(chr(i) for i in range(FILE_CHAR_START, FILE_CHAR_END) if chr(i) not in FILE_CHARS_DISALLOWED)

--- a/test/functional/feature_nulldummy.py
+++ b/test/functional/feature_nulldummy.py
@@ -39,7 +39,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
     def set_test_params(self):
         # Need two nodes only so GBT doesn't complain that it's not connected
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         # This script tests NULLDUMMY activation, which is part of the 'segwit' deployment, so we go through
         # normal segwit activation here (and don't use the default always-on behaviour).
         self.extra_args = [[

--- a/test/functional/feature_proxy.py
+++ b/test/functional/feature_proxy.py
@@ -57,7 +57,7 @@ NETWORKS = frozenset({NET_IPV4, NET_IPV6, NET_ONION})
 class ProxyTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def setup_nodes(self):
         self.have_ipv6 = test_ipv6_local()

--- a/test/functional/feature_pruning.py
+++ b/test/functional/feature_pruning.py
@@ -73,7 +73,7 @@ def calc_usage(blockdir):
 
 class PruneTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 6
         self.supports_cli = False
 

--- a/test/functional/feature_reindex.py
+++ b/test/functional/feature_reindex.py
@@ -15,7 +15,7 @@ from test_framework.util import assert_equal
 
 class ReindexTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def reindex(self, justchainstate=False):

--- a/test/functional/feature_segwit.py
+++ b/test/functional/feature_segwit.py
@@ -48,7 +48,7 @@ txs_mined = {} # txindex from txid to blockhash
 
 class SegWitTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         # This test tests SegWit both pre and post-activation, so use the normal BIP9 activation.
         self.extra_args = [

--- a/test/functional/feature_settings.py
+++ b/test/functional/feature_settings.py
@@ -15,7 +15,7 @@ from test_framework.util import assert_equal
 
 class SettingsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.wallet_names = []
 

--- a/test/functional/feature_shutdown.py
+++ b/test/functional/feature_shutdown.py
@@ -15,7 +15,7 @@ def test_long_call(node):
 class ShutdownTest(BitcoinTestFramework):
 
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.supports_cli = False
 

--- a/test/functional/feature_signet.py
+++ b/test/functional/feature_signet.py
@@ -27,7 +27,7 @@ class SignetBasicTest(BitcoinTestFramework):
     def set_test_params(self):
         self.chain = "signet"
         self.num_nodes = 6
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         shared_args1 = ["-signetchallenge=51"]  # OP_TRUE
         shared_args2 = []  # default challenge
         # we use the exact same challenge except we do it as a 2-of-2, which means it should fail

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -1198,7 +1198,7 @@ class TaprootTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         # Node 0 has Taproot inactive, Node 1 active.
         self.extra_args = [["-par=1", "-vbparams=taproot:1:1"], ["-par=1"]]
 

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -14,7 +14,7 @@ from test_framework.util import assert_equal
 class UacommentTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def run_test(self):
         self.log.info("test multiple -uacomment")

--- a/test/functional/feature_versionbits_warning.py
+++ b/test/functional/feature_versionbits_warning.py
@@ -26,7 +26,7 @@ VB_PATTERN = re.compile("Warning: unknown new rules activated.*versionbit")
 
 class VersionBitsWarningTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def setup_network(self):

--- a/test/functional/interface_bitcoin_cli.py
+++ b/test/functional/interface_bitcoin_cli.py
@@ -27,7 +27,7 @@ WALLET_NOT_SPECIFIED = 'Wallet file not specified'
 
 class TestBitcoinCli(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):

--- a/test/functional/interface_rest.py
+++ b/test/functional/interface_rest.py
@@ -41,7 +41,7 @@ def filter_output_indices_by_value(vouts, value):
 
 class RESTTest (BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [["-rest"], []]
         self.supports_cli = False

--- a/test/functional/interface_rpc.py
+++ b/test/functional/interface_rpc.py
@@ -21,7 +21,7 @@ def expect_http_status(expected_http_status, expected_rpc_code,
 class RPCInterfaceTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.supports_cli = False
 
     def test_getrpcinfo(self):

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -11,7 +11,7 @@ from test_framework.util import assert_equal, assert_greater_than, assert_raises
 
 class MempoolLimitTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [[
             "-acceptnonstdtxn=1",

--- a/test/functional/mempool_spend_coinbase.py
+++ b/test/functional/mempool_spend_coinbase.py
@@ -20,7 +20,7 @@ from test_framework.wallet import MiniWallet
 class MempoolSpendCoinbaseTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def run_test(self):
         wallet = MiniWallet(self.nodes[0])

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -46,7 +46,7 @@ def assert_template(node, block, expect, rehash=True):
 class MiningTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.supports_cli = False
 
     def mine_chain(self):

--- a/test/functional/mining_prioritisetransaction.py
+++ b/test/functional/mining_prioritisetransaction.py
@@ -12,7 +12,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, create_co
 
 class PrioritiseTransactionTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [[
             "-printpriority=1",

--- a/test/functional/p2p_addr_relay.py
+++ b/test/functional/p2p_addr_relay.py
@@ -39,7 +39,6 @@ class AddrReceiver(P2PInterface):
 
 class AddrTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/p2p_addrv2_relay.py
+++ b/test/functional/p2p_addrv2_relay.py
@@ -47,7 +47,7 @@ class AddrReceiver(P2PInterface):
 
 class AddrTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/p2p_blockfilters.py
+++ b/test/functional/p2p_blockfilters.py
@@ -41,7 +41,7 @@ class CFiltersClient(P2PInterface):
 
 class CompactFiltersTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.rpc_timeout = 480
         self.num_nodes = 2
         self.extra_args = [

--- a/test/functional/p2p_blocksonly.py
+++ b/test/functional/p2p_blocksonly.py
@@ -12,7 +12,6 @@ from test_framework.util import assert_equal
 
 class P2PBlocksOnly(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
         self.extra_args = [["-blocksonly"]]
 

--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -93,7 +93,7 @@ class TestP2PConn(P2PInterface):
 
 class CompactBlocksTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [[
             "-acceptnonstdtxn=1",

--- a/test/functional/p2p_dos_header_tree.py
+++ b/test/functional/p2p_dos_header_tree.py
@@ -19,7 +19,7 @@ import os
 
 class RejectLowDifficultyHeadersTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.chain = 'testnet3'  # Use testnet chain because it has an early checkpoint
         self.num_nodes = 2
 

--- a/test/functional/p2p_eviction.py
+++ b/test/functional/p2p_eviction.py
@@ -34,7 +34,7 @@ class SlowP2PInterface(P2PInterface):
 
 class P2PEvict(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         # The choice of maxconnections=32 results in a maximum of 21 inbound connections
         # (32 - 10 outbound - 1 feeler). 20 inbound peers are protected from eviction:

--- a/test/functional/p2p_filter.py
+++ b/test/functional/p2p_filter.py
@@ -81,7 +81,6 @@ class P2PBloomFilter(P2PInterface):
 
 class FilterTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
         self.extra_args = [[
             '-peerbloomfilters',

--- a/test/functional/p2p_fingerprint.py
+++ b/test/functional/p2p_fingerprint.py
@@ -28,7 +28,7 @@ from test_framework.util import (
 
 class P2PFingerprintTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     # Build a chain of blocks on top of given one

--- a/test/functional/p2p_getaddr_caching.py
+++ b/test/functional/p2p_getaddr_caching.py
@@ -41,7 +41,6 @@ class AddrReceiver(P2PInterface):
 
 class AddrTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/p2p_ibd_txrelay.py
+++ b/test/functional/p2p_ibd_txrelay.py
@@ -15,7 +15,7 @@ NORMAL_FEE_FILTER = Decimal(100) / COIN
 
 class P2PIBDTxRelayTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [
             ["-minrelaytxfee={}".format(NORMAL_FEE_FILTER)],

--- a/test/functional/p2p_invalid_block.py
+++ b/test/functional/p2p_invalid_block.py
@@ -21,7 +21,7 @@ from test_framework.util import assert_equal
 class InvalidBlockRequestTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [["-whitelist=noban@127.0.0.1"]]
 
     def run_test(self):

--- a/test/functional/p2p_invalid_locator.py
+++ b/test/functional/p2p_invalid_locator.py
@@ -13,7 +13,6 @@ from test_framework.test_framework import BitcoinTestFramework
 class InvalidLocatorTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = False
 
     def run_test(self):
         node = self.nodes[0]  # convenience reference to the node

--- a/test/functional/p2p_invalid_messages.py
+++ b/test/functional/p2p_invalid_messages.py
@@ -56,7 +56,7 @@ class SenderOfAddrV2(P2PInterface):
 class InvalidMessagesTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def run_test(self):
         self.test_buffer()

--- a/test/functional/p2p_invalid_tx.py
+++ b/test/functional/p2p_invalid_tx.py
@@ -27,7 +27,7 @@ class InvalidTxRequestTest(BitcoinTestFramework):
         self.extra_args = [[
             "-acceptnonstdtxn=1",
         ]]
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def bootstrap_p2p(self, *, num_connections=1):
         """Add a P2P connection to the node.

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -19,7 +19,7 @@ from test_framework.util import assert_equal
 
 class P2PNoBloomFilterMessages(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [["-peerbloomfilters=0"]]
 

--- a/test/functional/p2p_node_network_limited.py
+++ b/test/functional/p2p_node_network_limited.py
@@ -33,7 +33,7 @@ class P2PIgnoreInv(P2PInterface):
 
 class NodeNetworkLimitedTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         self.extra_args = [['-prune=550', '-addrmantest'], [], []]
 

--- a/test/functional/p2p_permissions.py
+++ b/test/functional/p2p_permissions.py
@@ -29,7 +29,7 @@ from test_framework.util import (
 class P2PPermissionsTests(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def run_test(self):
         self.check_tx_relay()

--- a/test/functional/p2p_ping.py
+++ b/test/functional/p2p_ping.py
@@ -32,7 +32,7 @@ class NodeNoPong(P2PInterface):
 
 class PingPongTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [['-peertimeout=3']]
 

--- a/test/functional/p2p_segwit.py
+++ b/test/functional/p2p_segwit.py
@@ -216,7 +216,7 @@ class TestP2PConn(P2PInterface):
 
 class SegWitTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         # This test tests SegWit both pre and post-activation, so use the normal BIP9 activation.
         self.extra_args = [

--- a/test/functional/p2p_sendheaders.py
+++ b/test/functional/p2p_sendheaders.py
@@ -197,7 +197,7 @@ class BaseNode(P2PInterface):
 
 class SendHeadersTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
 
     def mine_blocks(self, count):

--- a/test/functional/p2p_timeouts.py
+++ b/test/functional/p2p_timeouts.py
@@ -36,7 +36,7 @@ class TestP2PConn(P2PInterface):
 
 class TimeoutsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         # set timeout to receive version/verack to 3 seconds
         self.extra_args = [["-peertimeout=3"]]

--- a/test/functional/p2p_tx_download.py
+++ b/test/functional/p2p_tx_download.py
@@ -55,7 +55,6 @@ MAX_GETDATA_INBOUND_WAIT = GETDATA_TX_INTERVAL + INBOUND_PEER_TX_DELAY + TXID_RE
 
 class TxDownloadTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 2
 
     def test_tx_requests(self):

--- a/test/functional/p2p_unrequested_blocks.py
+++ b/test/functional/p2p_unrequested_blocks.py
@@ -65,7 +65,7 @@ from test_framework.util import (
 
 class AcceptBlockTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [[], ["-minimumchainwork=0x10"]]
 

--- a/test/functional/rpc_bind.py
+++ b/test/functional/rpc_bind.py
@@ -12,7 +12,7 @@ from test_framework.util import assert_equal, assert_raises_rpc_error, get_rpc_p
 
 class RPCBindTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.bind_to_localhost_only = False
         self.num_nodes = 1
         self.supports_cli = False

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -47,7 +47,7 @@ from test_framework.util import (
 
 class BlockchainTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.supports_cli = False
 

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -21,7 +21,7 @@ from test_framework.wallet_util import bytes_to_wif
 
 class RpcCreateMultiSigTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         self.supports_cli = False
 

--- a/test/functional/rpc_decodescript.py
+++ b/test/functional/rpc_decodescript.py
@@ -12,7 +12,7 @@ from io import BytesIO
 
 class DecodeScriptTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def decodescript_script_sig(self):

--- a/test/functional/rpc_deprecated.py
+++ b/test/functional/rpc_deprecated.py
@@ -9,7 +9,7 @@ from test_framework.util import assert_raises_rpc_error, find_vout_for_address
 class DeprecatedRpcTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [[], ['-deprecatedrpc=bumpfee']]
 
     def run_test(self):

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 class DumptxoutsetTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/rpc_estimatefee.py
+++ b/test/functional/rpc_estimatefee.py
@@ -14,7 +14,6 @@ from test_framework.util import assert_raises_rpc_error
 
 class EstimateFeeTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def run_test(self):

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -28,7 +28,7 @@ def get_unspent(listunspent, amount):
 class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         # This test isn't testing tx relay. Set whitelist on the peers for
         # instant tx relay.
         self.extra_args = [['-whitelist=noban@127.0.0.1']] * self.num_nodes

--- a/test/functional/rpc_getblockfilter.py
+++ b/test/functional/rpc_getblockfilter.py
@@ -13,7 +13,7 @@ FILTER_TYPES = ["basic"]
 
 class GetBlockFilterTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [["-blockfilterindex"], []]
 

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -32,7 +32,7 @@ class GetblockstatsTest(BitcoinTestFramework):
 
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.supports_cli = False
 
     def get_stats(self):

--- a/test/functional/rpc_invalidateblock.py
+++ b/test/functional/rpc_invalidateblock.py
@@ -13,7 +13,7 @@ from test_framework.util import (
 
 class InvalidateTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
 
     def setup_network(self):

--- a/test/functional/rpc_net.py
+++ b/test/functional/rpc_net.py
@@ -42,7 +42,7 @@ def assert_net_servicesnames(servicesflag, servicenames):
 
 class NetTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [["-minrelaytxfee=0.00001000"], ["-minrelaytxfee=0.00000500"]]
         self.supports_cli = False

--- a/test/functional/rpc_preciousblock.py
+++ b/test/functional/rpc_preciousblock.py
@@ -33,7 +33,7 @@ def node_sync_via_rpc(nodes):
 
 class PreciousTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         self.supports_cli = False
 

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -24,7 +24,6 @@ MAX_BIP125_RBF_SEQUENCE = 0xfffffffd
 class PSBTTest(BitcoinTestFramework):
 
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 3
         self.extra_args = [
             ["-walletrbf=1"],

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -46,7 +46,7 @@ class multidict(dict):
 # Create one-input, one-output, no-fee transaction:
 class RawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         self.extra_args = [
             ["-txindex"],

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -16,7 +16,7 @@ def descriptors(out):
 class ScantxoutsetTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/rpc_setban.py
+++ b/test/functional/rpc_setban.py
@@ -12,7 +12,7 @@ from test_framework.util import (
 class SetBanTests(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [[],[]]
 
     def run_test(self):

--- a/test/functional/rpc_signmessage.py
+++ b/test/functional/rpc_signmessage.py
@@ -9,7 +9,7 @@ from test_framework.util import assert_equal
 
 class SignMessagesTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [["-addresstype=legacy"]]
 

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -17,7 +17,7 @@ from decimal import Decimal
 
 class SignRawTransactionsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
 
     def skip_test_if_missing_module(self):

--- a/test/functional/rpc_txoutproof.py
+++ b/test/functional/rpc_txoutproof.py
@@ -13,7 +13,7 @@ from test_framework.wallet import MiniWallet
 class MerkleBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [
             [],
             ["-txindex"],

--- a/test/functional/rpc_uptime.py
+++ b/test/functional/rpc_uptime.py
@@ -15,7 +15,7 @@ from test_framework.test_framework import BitcoinTestFramework
 class UptimeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def run_test(self):
         self._test_uptime()

--- a/test/functional/test-shell.md
+++ b/test/functional/test-shell.md
@@ -51,7 +51,7 @@ The following sections demonstrate how to initialize, run, and shut down a
 ## 3. Initializing a `TestShell` object
 
 ```
->>> test = TestShell().setup(num_nodes=2, setup_clean_chain=True)
+>>> test = TestShell().setup(num_nodes=2, use_cached_chain=False)
 20XX-XX-XXTXX:XX:XX.XXXXXXX TestFramework (INFO): Initializing test directory /path/to/bitcoin_func_test_XXXXXXX
 ```
 The `TestShell` forwards all functional test parameters of the parent
@@ -178,7 +178,7 @@ can be called after the TestShell is shut down.
 | `num_nodes` | `1` | Sets the number of initialized bitcoind processes. |
 | `perf` | False | Profiles running nodes with `perf` for the duration of the test if set to `True`. |
 | `rpc_timeout` | `60` | Sets the RPC server timeout for the underlying bitcoind processes. |
-| `setup_clean_chain` | `False` | Initializes an empty blockchain by default. A 199-block-long chain is initialized if set to `True`. |
+| `use_cached_chain` | `True` | A 200-block-long chain is initialized from cache by default. Initializes an empty blockchain if set to `False`. |
 | `randomseed` | Random Integer | `TestShell.options.randomseed` is a member of `TestShell` which can be accessed during a test to seed a random generator. User can override default with a constant value for reproducible test runs. |
 | `supports_cli` | `False` | Whether the bitcoin-cli utility is compiled and available for the test. |
 | `tmpdir` | `"/var/folders/.../"` | Sets directory for test logs. Will be deleted upon a successful test run unless `nocleanup` is set to `True` |

--- a/test/functional/test_framework/test_framework.py
+++ b/test/functional/test_framework/test_framework.py
@@ -90,12 +90,12 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     This class also contains various public and private helper methods."""
 
     chain = None  # type: str
-    setup_clean_chain = None  # type: bool
+    use_cached_chain = None  # type: bool
 
     def __init__(self):
         """Sets test framework defaults. Do not override this method. Instead, override the set_test_params() method"""
         self.chain = 'regtest'
-        self.setup_clean_chain = False
+        self.use_cached_chain = True
         self.nodes = []
         self.network_thread = None
         self.rpc_timeout = 60  # Wait for up to 60 seconds for the RPC server to respond
@@ -346,7 +346,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
     def setup_chain(self):
         """Override this method to customize blockchain setup"""
         self.log.info("Initializing test directory " + self.options.tmpdir)
-        if self.setup_clean_chain:
+        if not self.use_cached_chain:
             self._initialize_chain_clean()
         else:
             self._initialize_chain()
@@ -381,7 +381,7 @@ class BitcoinTestFramework(metaclass=BitcoinTestMetaClass):
         self.start_nodes()
         if self.is_wallet_compiled():
             self.import_deterministic_coinbase_privkeys()
-        if not self.setup_clean_chain:
+        if self.use_cached_chain:
             for n in self.nodes:
                 assert_equal(n.getblockchaininfo()["blocks"], 199)
             # To ensure that all nodes are out of IBD, the most recent block

--- a/test/functional/tool_wallet.py
+++ b/test/functional/tool_wallet.py
@@ -19,7 +19,7 @@ BUFFER_SIZE = 16 * 1024
 class ToolWalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.rpc_timeout = 120
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -65,7 +65,6 @@ def assert_balances(node, mine):
 class AvoidReuseTest(BitcoinTestFramework):
 
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 2
         # This test isn't testing txn relay/timing, so set whitelist on the
         # peers for instant txn relay. This speeds up the test run time 2-3x.

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -45,7 +45,7 @@ from test_framework.util import (
 class WalletBackupTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         # nodes 1, 2,3 are spenders, let's give them a keypool=100
         # whitelist all peers to speed up tx relay / mempool sync
         self.extra_args = [

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -47,7 +47,7 @@ def create_transactions(node, address, amt, fees):
 class WalletTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [
             ['-limitdescendantcount=3'],  # Limit mempool descendants as a hack to have wallet txs rejected from the mempool
             [],

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -24,7 +24,7 @@ class WalletTest(BitcoinTestFramework):
         self.extra_args = [[
             "-acceptnonstdtxn=1",
         ]] * self.num_nodes
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.supports_cli = False
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -40,7 +40,7 @@ TOO_HIGH     = 100000
 class BumpFeeTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.extra_args = [[
             "-walletrbf={}".format(i),
             "-mintxfee=0.00002",

--- a/test/functional/wallet_create_tx.py
+++ b/test/functional/wallet_create_tx.py
@@ -15,7 +15,7 @@ from test_framework.blocktools import (
 
 class CreateTxWalletTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_createwallet.py
+++ b/test/functional/wallet_createwallet.py
@@ -17,7 +17,6 @@ from test_framework.wallet_util import bytes_to_wif, generate_wif_key
 
 class CreateWalletTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_descriptor.py
+++ b/test/functional/wallet_descriptor.py
@@ -13,7 +13,7 @@ from test_framework.util import (
 
 class WalletDescriptorTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [['-keypool=100']]
         self.wallet_names = []

--- a/test/functional/wallet_disable.py
+++ b/test/functional/wallet_disable.py
@@ -13,7 +13,7 @@ from test_framework.util import assert_raises_rpc_error
 
 class DisableWalletTest (BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.extra_args = [["-disablewallet"]]
         self.wallet_names = []

--- a/test/functional/wallet_encryption.py
+++ b/test/functional/wallet_encryption.py
@@ -16,7 +16,7 @@ from test_framework.util import (
 
 class WalletEncryptionTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_fallbackfee.py
+++ b/test/functional/wallet_fallbackfee.py
@@ -9,7 +9,7 @@ from test_framework.util import assert_raises_rpc_error
 class WalletRBFTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -14,7 +14,7 @@ from test_framework.util import (
 
 class WalletGroupTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 5
         self.extra_args = [
             [],

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -16,7 +16,7 @@ from test_framework.util import (
 
 class WalletHDTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.extra_args = [[], ['-keypool=0']]
         self.supports_cli = False

--- a/test/functional/wallet_import_with_label.py
+++ b/test/functional/wallet_import_with_label.py
@@ -17,7 +17,7 @@ from test_framework.wallet_util import test_address
 class ImportWithLabel(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_importdescriptors.py
+++ b/test/functional/wallet_importdescriptors.py
@@ -34,7 +34,7 @@ class ImportDescriptorsTest(BitcoinTestFramework):
         self.extra_args = [["-addresstype=legacy"],
                            ["-addresstype=bech32", "-keypool=5"]
                           ]
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.wallet_names = []
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -37,7 +37,7 @@ class ImportMultiTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 2
         self.extra_args = [["-addresstype=legacy"], ["-addresstype=legacy"]]
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -16,7 +16,7 @@ from test_framework.wallet_util import bytes_to_wif
 
 class ImportPrunedFundsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -21,7 +21,7 @@ from test_framework.util import (
 
 class KeypoolRestoreTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 4
         self.extra_args = [[], ['-keypool=100'], ['-keypool=100'], ['-keypool=100']]
 

--- a/test/functional/wallet_labels.py
+++ b/test/functional/wallet_labels.py
@@ -18,7 +18,7 @@ from test_framework.wallet_util import test_address
 
 class WalletLabelsTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -20,7 +20,7 @@ from decimal import Decimal
 class ListSinceBlockTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 4
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -39,7 +39,7 @@ def test_load_unload(node, name):
 
 class MultiWalletTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 2
         self.rpc_timeout = 120
         self.extra_args = [["-nowallet"], []]

--- a/test/functional/wallet_startup.py
+++ b/test/functional/wallet_startup.py
@@ -14,7 +14,7 @@ from test_framework.util import (
 
 class WalletStartupTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 1
         self.supports_cli = True
 

--- a/test/functional/wallet_upgradewallet.py
+++ b/test/functional/wallet_upgradewallet.py
@@ -46,7 +46,7 @@ def deser_keymeta(f):
 
 class UpgradeWalletTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = True
+        self.use_cached_chain = False
         self.num_nodes = 3
         self.extra_args = [
             ["-addresstype=bech32", "-keypool=2"], # current wallet version

--- a/test/functional/wallet_watchonly.py
+++ b/test/functional/wallet_watchonly.py
@@ -14,7 +14,6 @@ from test_framework.util import (
 
 class CreateWalletWatchonlyTest(BitcoinTestFramework):
     def set_test_params(self):
-        self.setup_clean_chain = False
         self.num_nodes = 1
 
     def skip_test_if_missing_module(self):


### PR DESCRIPTION
The semantics of `setup_clean_chain` are off in my opinion. If it is set to true, there is actually no real chain setup, we only start with the Genesis block. That is not what I would expect 'clean' to mean. The 200 blocks chain that we set up if it is set to false could also be called 'clean' since there are no transactions or reorgs.

I think this is also the reason that other people have been confused. The documentation for `test_shell` is not correct and the default has been re-declared in several tests. This PR fixes the documentation and removes settings that don't change the default. Additionally I suggest renaming `setup_clean_chain` to `skip_chain_setup`.