### PR TITLE
rpc: Validate provided keys for query_options parameter in listunspent

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2898,6 +2898,15 @@ static UniValue listunspent(const JSONRPCRequest& request)
     if (!request.params[4].isNull()) {
         const UniValue& options = request.params[4].get_obj();
 
+        RPCTypeCheckObj(options,
+            {
+                {"minimumAmount", UniValueType()},
+                {"maximumAmount", UniValueType()},
+                {"minimumSumAmount", UniValueType()},
+                {"maximumCount", UniValueType(UniValue::VNUM)},
+            },
+            true, true);
+
         if (options.exists("minimumAmount"))
             nMinimumAmount = AmountFromValue(options["minimumAmount"]);
 


### PR DESCRIPTION
At Dash, one of our developers was working with the `listunspent` RPC command, but instead of saying "minimumAmount" he said "minimmumAmount" as such the RPC wasn't working as expected. 

In https://github.com/dashpay/dash/pull/3507 we implemented a check so that `listunspent` returns an error if an unrecognized option is given. I figured I might as well adapt the code and throw up a PR here.

Cheers!