### PR TITLE
[0.20] Add missing QPainterPath include

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -6,6 +6,7 @@
 #include "clientmodel.h"
 
 #include <QPainter>
+#include <QPainterPath>
 #include <QColor>
 #include <QTimer>
 


### PR DESCRIPTION
This is needed to compile with Qt 5.15.

Github-Pull: #19097
Rebased-From: 79b0a69e09c1a912122e6431ea3c530cc292c690
