### PR TITLE
Make mininode_lock non-reentrant

### DIFF
--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -305,10 +305,9 @@ class CompactBlocksTest(BitcoinTestFramework):
         self.check_compactblock_construction_from_block(version, header_and_shortids, block_hash, block)
 
         # Now fetch the compact block using a normal non-announce getdata
-        with mininode_lock:
-            test_node.clear_block_announcement()
-            inv = CInv(MSG_CMPCT_BLOCK, block_hash)
-            test_node.send_message(msg_getdata([inv]))
+        test_node.clear_block_announcement()
+        inv = CInv(MSG_CMPCT_BLOCK, block_hash)
+        test_node.send_message(msg_getdata([inv]))
 
         wait_until(test_node.received_block_announcement, timeout=30, lock=mininode_lock)
 

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -658,8 +658,6 @@ class P2PTxInvStore(P2PInterface):
                 # save txid
                 self.tx_invs_received[i.hash] += 1
 
-        super().on_inv(message)
-
     def get_invs(self):
         with mininode_lock:
             return list(self.tx_invs_received.keys())

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -669,6 +669,6 @@ class P2PTxInvStore(P2PInterface):
         The mempool should mark unbroadcast=False for these transactions.
         """
         # Wait until invs have been received (and getdatas sent) for each txid.
-        self.wait_until(lambda: set(self.get_invs()) == set([int(tx, 16) for tx in txns]), timeout)
+        self.wait_until(lambda: set(self.tx_invs_received.keys()) == set([int(tx, 16) for tx in txns]), timeout)
         # Flush messages and wait for the getdatas to be processed
         self.sync_with_ping()

--- a/test/functional/test_framework/mininode.py
+++ b/test/functional/test_framework/mininode.py
@@ -492,7 +492,7 @@ class P2PInterface(P2PConnection):
 # P2PConnection acquires this lock whenever delivering a message to a P2PInterface.
 # This lock should be acquired in the thread running the test logic to synchronize
 # access to any data shared with the P2PInterface or P2PConnection.
-mininode_lock = threading.RLock()
+mininode_lock = threading.Lock()
 
 
 class NetworkThread(threading.Thread):


### PR DESCRIPTION
There's no need for mininode_lock to be reentrant.
Use a simpler non-recursive lock.