### PR TITLE
Add ASM optimizations for MuHash3072

### DIFF
--- a/src/crypto/muhash.cpp
+++ b/src/crypto/muhash.cpp
@@ -16,7 +16,6 @@ namespace {
 
 using limb_t = Num3072::limb_t;
 using double_limb_t = Num3072::double_limb_t;
-constexpr int LIMB_SIZE = Num3072::LIMB_SIZE;
 /** 2^3072 - 1103717, the largest 3072-bit safe prime number, is used as the modulus. */
 constexpr limb_t MAX_PRIME_DIFF = 1103717;
 
@@ -28,6 +27,51 @@ inline void extract3(limb_t& c0, limb_t& c1, limb_t& c2, limb_t& n)
     c1 = c2;
     c2 = 0;
 }
+
+#if defined(__amd64__) || defined(__x86_64__)
+
+/** [c0,c1] = a * b */
+#define mul(c0,c1,a,b) { \
+    __asm__ ("mulq %3" : "=d"(c1), "=a"(c0) : "a"(a), "g"(b) : "cc"); \
+}
+
+/** [c0,c1,c2] += a * b */
+#define muladd3(c0,c1,c2,a,b) { \
+    uint64_t tl, th; \
+    __asm__ ("mulq %3" : "=a"(tl), "=d"(th) : "a"(a), "g"(b) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "a"(tl), "d"(th) : "cc"); \
+}
+
+/** [c0,c1,c2] += 2 * a * b */
+#define muldbladd3(c0,c1,c2,a,b) { \
+    uint64_t tl, th; \
+    __asm__ ("mulq %3" : "=a"(tl), "=d"(th) : "a"(a), "g"(b) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "a"(tl), "d"(th) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "a"(tl), "d"(th) : "cc"); \
+}
+
+/* [c0,c1,c2] += n * [d0,d1,d2]. c2 is initially 0 */
+#define mulnadd3(c0,c1,c2,d0,d1,d2,n) { \
+    uint64_t tl1, th1, tl2, th2, tl3; \
+    __asm__ ("mulq %3" : "=a"(tl1), "=d"(th1) : "a"(d0), "r"((limb_t)n) : "cc"); \
+    __asm__ ("addq %3,%0; adcq %4,%1; adcq $0,%2" : "+r"(c0), "+r"(c1), "+r"(c2) : "g"(tl1), "g"(th1) : "cc"); \
+    __asm__ ("mulq %3" : "=a"(tl2), "=d"(th2) : "a"(d1), "r"((limb_t)n) : "cc"); \
+    __asm__ ("addq %2,%0; adcq %3,%1" : "+r"(c1), "+r"(c2) : "g"(tl2), "g"(th2) : "cc"); \
+    __asm__ ("imulq %2,%1,%0" : "=r"(tl3) : "g"(d2), "i"(n) : "cc"); \
+    __asm__ ("addq %1,%0" : "+r"(c2) : "g"(tl3) : "cc"); \
+}
+
+/* [c0,c1] *= n */
+#define muln2(c0,c1,n) { \
+    uint64_t th; \
+    __asm__ ("mulq %2" : "+a"(c0), "=d"(th) : "r"((limb_t)n) : "cc"); \
+    __asm__ ("imul %1,%0,%0" : "+r"(c1) : "i"(n) : "cc"); \
+    __asm__ ("addq %1,%0" : "+r"(c1) : "g"(th) : "cc"); \
+}
+
+#else
+
+constexpr int LIMB_SIZE = Num3072::LIMB_SIZE;
 
 /** [c0,c1] = a * b */
 inline void mul(limb_t& c0, limb_t& c1, const limb_t& a, const limb_t& b)
@@ -88,6 +132,8 @@ inline void muldbladd3(limb_t& c0, limb_t& c1, limb_t& c2, const limb_t& a, cons
     c1 += th;
     c2 += (c1 < th) ? 1 : 0;
 }
+
+#endif
 
 /**
  * Add limb a to [c0,c1]: [c0,c1] += a. Then extract the lowest


### PR DESCRIPTION
Adds assembly optimizations for `MuHash3072` which is used for the `muhash` calculation of the UTXO set hash. 