### PR TITLE
doc: Extract net permissions doc

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -51,6 +51,7 @@
 #include <ui_interface.h>
 #include <util/asmap.h>
 #include <util/moneystr.h>
+#include <util/string.h>
 #include <util/system.h>
 #include <util/threadnames.h>
 #include <util/translation.h>
@@ -465,11 +466,7 @@ void SetupServerArgs(NodeContext& node)
     hidden_args.emplace_back("-upnp");
 #endif
     gArgs.AddArg("-whitebind=<[permissions@]addr>", "Bind to given address and whitelist peers connecting to it. "
-        "Use [host]:port notation for IPv6. Allowed permissions are bloomfilter (allow requesting BIP37 filtered blocks and transactions), "
-        "noban (do not ban for misbehavior), "
-        "forcerelay (relay transactions that are already in the mempool; implies relay), "
-        "relay (relay even in -blocksonly mode), "
-        "and mempool (allow requesting BIP35 mempool contents). "
+        "Use [host]:port notation for IPv6. Allowed permissions: " + Join(NET_PERMISSIONS_DOC, ", ") + ". "
         "Specify multiple permissions separated by commas (default: noban,mempool,relay). Can be specified multiple times.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
 
     gArgs.AddArg("-whitelist=<[permissions@]IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or "

--- a/src/net_permissions.cpp
+++ b/src/net_permissions.cpp
@@ -8,6 +8,14 @@
 #include <util/system.h>
 #include <util/translation.h>
 
+const std::vector<std::string> NET_PERMISSIONS_DOC{
+    "bloomfilter (allow requesting BIP37 filtered blocks and transactions)",
+    "noban (do not ban for misbehavior)",
+    "forcerelay (relay transactions that are already in the mempool; implies relay)",
+    "relay (relay even in -blocksonly mode)",
+    "mempool (allow requesting BIP35 mempool contents)",
+};
+
 // The parse the following format "perm1,perm2@xxxxxx"
 bool TryParsePermissionFlags(const std::string str, NetPermissionFlags& output, size_t& readen, std::string& error)
 {

--- a/src/net_permissions.h
+++ b/src/net_permissions.h
@@ -2,12 +2,16 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <netaddress.h>
+
 #include <string>
 #include <vector>
-#include <netaddress.h>
 
 #ifndef BITCOIN_NET_PERMISSIONS_H
 #define BITCOIN_NET_PERMISSIONS_H
+
+extern const std::vector<std::string> NET_PERMISSIONS_DOC;
+
 enum NetPermissionFlags
 {
     PF_NONE = 0,
@@ -27,6 +31,7 @@ enum NetPermissionFlags
     PF_ISIMPLICIT = (1U << 31),
     PF_ALL = PF_BLOOMFILTER | PF_FORCERELAY | PF_RELAY | PF_NOBAN | PF_MEMPOOL,
 };
+
 class NetPermissions
 {
 public:
@@ -45,6 +50,7 @@ public:
         flags = static_cast<NetPermissionFlags>(flags & ~f);
     }
 };
+
 class NetWhitebindPermissions : public NetPermissions
 {
 public:


### PR DESCRIPTION
Moving the documentation of each flag form the already over-large init.cpp into the net permissions module should clean up the code a bit. Moreover, making the documentation available is also required for an (currently imaginary) `setnetpermissions` RPC.