### PR TITLE
qt: Deduplicate NumConnections enum

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -64,18 +64,9 @@ ClientModel::~ClientModel()
     m_thread->wait();
 }
 
-int ClientModel::getNumConnections(unsigned int flags) const
+int ClientModel::getNumConnections(CConnman::NumConnections flags) const
 {
-    CConnman::NumConnections connections = CConnman::CONNECTIONS_NONE;
-
-    if(flags == CONNECTIONS_IN)
-        connections = CConnman::CONNECTIONS_IN;
-    else if (flags == CONNECTIONS_OUT)
-        connections = CConnman::CONNECTIONS_OUT;
-    else if (flags == CONNECTIONS_ALL)
-        connections = CConnman::CONNECTIONS_ALL;
-
-    return m_node.getNodeCount(connections);
+    return m_node.getNodeCount(flags);
 }
 
 int ClientModel::getHeaderTipHeight() const

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -5,13 +5,15 @@
 #ifndef BITCOIN_QT_CLIENTMODEL_H
 #define BITCOIN_QT_CLIENTMODEL_H
 
-#include <QObject>
-#include <QDateTime>
+#include <net.h>
+#include <sync.h>
+#include <uint256.h>
 
 #include <atomic>
 #include <memory>
-#include <sync.h>
-#include <uint256.h>
+
+#include <QDateTime>
+#include <QObject>
 
 class BanTableModel;
 class CBlockIndex;
@@ -35,13 +37,6 @@ enum class BlockSource {
     NETWORK
 };
 
-enum NumConnections {
-    CONNECTIONS_NONE = 0,
-    CONNECTIONS_IN   = (1U << 0),
-    CONNECTIONS_OUT  = (1U << 1),
-    CONNECTIONS_ALL  = (CONNECTIONS_IN | CONNECTIONS_OUT),
-};
-
 /** Model for Bitcoin network client. */
 class ClientModel : public QObject
 {
@@ -57,7 +52,7 @@ public:
     BanTableModel *getBanTableModel();
 
     //! Return number of connections, default is in- and outbound (total)
-    int getNumConnections(unsigned int flags = CONNECTIONS_ALL) const;
+    int getNumConnections(CConnman::NumConnections flags = CConnman::CONNECTIONS_ALL) const;
     int getNumBlocks() const;
     uint256 getBestBlockHash();
     int getHeaderTipHeight() const;

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -15,9 +15,10 @@
 #include <qt/walletmodel.h>
 #include <chainparams.h>
 #include <interfaces/node.h>
+#include <net.h>
 #include <netbase.h>
-#include <rpc/server.h>
 #include <rpc/client.h>
+#include <rpc/server.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 
@@ -843,8 +844,8 @@ void RPCConsole::message(int category, const QString &message, bool html)
 void RPCConsole::updateNetworkState()
 {
     QString connections = QString::number(clientModel->getNumConnections()) + " (";
-    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_IN)) + " / ";
-    connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CONNECTIONS_OUT)) + ")";
+    connections += tr("In:") + " " + QString::number(clientModel->getNumConnections(CConnman::CONNECTIONS_IN)) + " / ";
+    connections += tr("Out:") + " " + QString::number(clientModel->getNumConnections(CConnman::CONNECTIONS_OUT)) + ")";
 
     if(!clientModel->node().getNetworkActive()) {
         connections += " (" + tr("Network activity disabled") + ")";


### PR DESCRIPTION
There are two identical `NumConnections` enums in the code base:
- `enum NumConnections` in `qt/clientmodel.h` was introduced in #3685
- `enum CConnman::NumConnections` in `net.h` was introduced in #8085

This PR drops the former enum in favor of the latter one.