### PR TITLE
util: Don't reference errno when pthread fails.

### DIFF
--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1163,8 +1163,9 @@ void ScheduleBatchPriority()
 {
 #ifdef SCHED_BATCH
     const static sched_param param{};
-    if (pthread_setschedparam(pthread_self(), SCHED_BATCH, &param) != 0) {
-        LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(errno));
+    const int rc = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param);
+    if (rc != 0) {
+        LogPrintf("Failed to pthread_setschedparam: %s\n", strerror(rc));
     }
 #endif
 }


### PR DESCRIPTION
Pthread library does not set errno.
Pthread library's errno is returned by return value.