### PR TITLE
ci: Switch to bitcoincore.org download

### DIFF
--- a/contrib/devtools/previous_release.sh
+++ b/contrib/devtools/previous_release.sh
@@ -137,7 +137,7 @@ pushd "$TARGET" || exit 1
         else
             BIN_PATH="bin/bitcoin-core-${tag:1}"
         fi
-        URL="https://bitcoin.org/$BIN_PATH/bitcoin-${tag:1}-$PLATFORM.tar.gz"
+        URL="https://bitcoincore.org/$BIN_PATH/bitcoin-${tag:1}-$PLATFORM.tar.gz"
         echo "Fetching: $URL"
         if ! curl -O -f $URL; then
             echo "Download failed."


### PR DESCRIPTION
bitcoin.org is down and not in our control, so it seems odd to rely on it for our ci infrastructure