### PR TITLE
log: remove deprecated `db` log category

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -94,6 +94,9 @@ Build System
 Updated settings
 ----------------
 
+- The `-debug=db` logging category, which was deprecated in 0.20 and replaced by
+  `-debug=walletdb` to distinguish it from `coindb`, has been removed. (#19202)
+
 Changes to Wallet or GUI related settings can be found in the GUI or Wallet  section below.
 
 New settings

--- a/src/logging.cpp
+++ b/src/logging.cpp
@@ -95,15 +95,7 @@ void BCLog::Logger::EnableCategory(BCLog::LogFlags flag)
 bool BCLog::Logger::EnableCategory(const std::string& str)
 {
     BCLog::LogFlags flag;
-    if (!GetLogCategory(flag, str)) {
-        if (str == "db") {
-            // DEPRECATION: Added in 0.20, should start returning an error in 0.21
-            LogPrintf("Warning: logging category 'db' is deprecated, use 'walletdb' instead\n");
-            EnableCategory(BCLog::WALLETDB);
-            return true;
-        }
-        return false;
-    }
+    if (!GetLogCategory(flag, str)) return false;
     EnableCategory(flag);
     return true;
 }


### PR DESCRIPTION
The `db` log category was renamed to `walletdb` (like `coindb`) in #17410 and its upcoming removal announced in the 0.20 release notes.

```
- The `-debug=db` logging category has been renamed to
  `-debug=walletdb` to distinguish it from `coindb`.  The `-debug=db`
  option has been deprecated and will be removed in the next major
  release.  (#17410)
```

This PR removes the warning and reverts to the usual behavior for an unrecognised log category.
```
$ bitcoin-cli logging '["db"]'
error code: -8
error message:
unknown logging category db
```
```
$ ./src/bitcoind -debug=db
Warning: Unsupported logging category -debug=db.
2020-06-07T15:30:45Z Bitcoin Core version v0.20.99.0-4c0c89307d (debug build)
2020-06-07T15:30:45Z Warning: Unsupported logging category -debug=db.
2020-06-07T15:30:45Z Assuming ancestors of block 0000000000000000000f2adce67e49b0b6bdeb9de8b7c3d7e93b21e7fc1e819d have valid signatures.
2020-06-07T15:30:45Z Setting nMinimumChainWork=00000000000000000000000000000000000000000e1ab5ec9348e9f4b8eb8154
2020-06-07T15:30:45Z Using the 'sse4(1way),sse41(4way),avx2(8way)' SHA256 implementation
2020-06-07T15:30:45Z Using RdSeed as additional entropy source
```
