### PR TITLE
test: Remove leftover comment in mining_basic

### DIFF
--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -18,11 +18,9 @@ from test_framework.blocktools import (
 from test_framework.messages import (
     CBlock,
     CBlockHeader,
-    BLOCK_HEADER_SIZE
+    BLOCK_HEADER_SIZE,
 )
-from test_framework.mininode import (
-    P2PDataStore,
-)
+from test_framework.mininode import P2PDataStore
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import (
     assert_equal,
@@ -30,10 +28,15 @@ from test_framework.util import (
     connect_nodes,
 )
 
+
 def assert_template(node, block, expect, rehash=True):
     if rehash:
         block.hashMerkleRoot = block.calc_merkle_root()
-    rsp = node.getblocktemplate(template_request={'data': block.serialize().hex(), 'mode': 'proposal', 'rules': ['segwit']})
+    rsp = node.getblocktemplate(template_request={
+        'data': block.serialize().hex(),
+        'mode': 'proposal',
+        'rules': ['segwit'],
+    })
     assert_equal(rsp, expect)
 
 
@@ -85,7 +88,7 @@ class MiningTest(BitcoinTestFramework):
         next_height = int(tmpl["height"])
         coinbase_tx = create_coinbase(height=next_height)
         # sequence numbers must not be max for nLockTime to have effect
-        coinbase_tx.vin[0].nSequence = 2 ** 32 - 2
+        coinbase_tx.vin[0].nSequence = 2**32 - 2
         coinbase_tx.rehash()
 
         # round-trip the encoded bip34 block height commitment
@@ -116,7 +119,11 @@ class MiningTest(BitcoinTestFramework):
         assert_raises_rpc_error(-22, "Block does not start with a coinbase", node.submitblock, bad_block.serialize().hex())
 
         self.log.info("getblocktemplate: Test truncated final transaction")
-        assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {'data': block.serialize()[:-1].hex(), 'mode': 'proposal', 'rules': ['segwit']})
+        assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {
+            'data': block.serialize()[:-1].hex(),
+            'mode': 'proposal',
+            'rules': ['segwit'],
+        })
 
         self.log.info("getblocktemplate: Test duplicate transaction")
         bad_block = copy.deepcopy(block)
@@ -135,7 +142,7 @@ class MiningTest(BitcoinTestFramework):
 
         self.log.info("getblocktemplate: Test nonfinal transaction")
         bad_block = copy.deepcopy(block)
-        bad_block.vtx[0].nLockTime = 2 ** 32 - 1
+        bad_block.vtx[0].nLockTime = 2**32 - 1
         bad_block.vtx[0].rehash()
         assert_template(node, bad_block, 'bad-txns-nonfinal')
         assert_submitblock(bad_block, 'bad-txns-nonfinal')
@@ -145,7 +152,11 @@ class MiningTest(BitcoinTestFramework):
         bad_block_sn = bytearray(block.serialize())
         assert_equal(bad_block_sn[BLOCK_HEADER_SIZE], 1)
         bad_block_sn[BLOCK_HEADER_SIZE] += 1
-        assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {'data': bad_block_sn.hex(), 'mode': 'proposal', 'rules': ['segwit']})
+        assert_raises_rpc_error(-22, "Block decode failed", node.getblocktemplate, {
+            'data': bad_block_sn.hex(),
+            'mode': 'proposal',
+            'rules': ['segwit'],
+        })
 
         self.log.info("getblocktemplate: Test bad bits")
         bad_block = copy.deepcopy(block)
@@ -160,7 +171,7 @@ class MiningTest(BitcoinTestFramework):
 
         self.log.info("getblocktemplate: Test bad timestamps")
         bad_block = copy.deepcopy(block)
-        bad_block.nTime = 2 ** 31 - 1
+        bad_block.nTime = 2**31 - 1
         assert_template(node, bad_block, 'time-too-new')
         assert_submitblock(bad_block, 'time-too-new', 'time-too-new')
         bad_block.nTime = 0

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -91,7 +91,6 @@ class MiningTest(BitcoinTestFramework):
         coinbase_tx.vin[0].nSequence = 2**32 - 2
         coinbase_tx.rehash()
 
-        # round-trip the encoded bip34 block height commitment
         block = CBlock()
         block.nVersion = tmpl["version"]
         block.hashPrevBlock = int(tmpl["previousblockhash"], 16)


### PR DESCRIPTION
Remove an accidental leftover comment from #19082, which no longer applies and thus might be confusing