### PR TITLE
doc: -whitelist/-whitebind documentation improvements

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -465,13 +465,13 @@ void SetupServerArgs(NodeContext& node)
 #else
     hidden_args.emplace_back("-upnp");
 #endif
-    gArgs.AddArg("-whitebind=<[permissions@]addr>", "Bind to given address and whitelist peers connecting to it. "
+    gArgs.AddArg("-whitebind=<[permissions@]addr>", "Bind to the given address and whitelist the peers connecting to it. "
         "Use [host]:port notation for IPv6. Allowed permissions: " + Join(NET_PERMISSIONS_DOC, ", ") + ". "
         "Specify multiple permissions separated by commas (default: noban,mempool,relay). Can be specified multiple times.", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
 
-    gArgs.AddArg("-whitelist=<[permissions@]IP address or network>", "Whitelist peers connecting from the given IP address (e.g. 1.2.3.4) or "
-        "CIDR notated network(e.g. 1.2.3.0/24). Uses same permissions as "
-        "-whitebind. Can be specified multiple times." , ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
+    gArgs.AddArg("-whitelist=<[permissions@]IP address or network>", "Whitelist the peers connecting from the given IP address (e.g. 1.2.3.4) or "
+        "CIDR-notated network (e.g. 1.2.3.0/24). Uses the same permissions as -whitebind. Can be specified multiple times.",
+        ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
 
     g_wallet_init_interface.AddWalletOptions();
 


### PR DESCRIPTION
Result:

```
  -whitebind=<[permissions@]addr>
       Bind to the given address and whitelist the peers connecting to it. Use
       [host]:port notation for IPv6. Allowed permissions: bloomfilter
       (allow requesting BIP37 filtered blocks and transactions), noban
       (do not ban for misbehavior), forcerelay (relay transactions that
       are already in the mempool; implies relay), relay (relay even in
       -blocksonly mode), mempool (allow requesting BIP35 mempool
       contents). Specify multiple permissions separated by commas
       (default: noban,mempool,relay). Can be specified multiple times.

  -whitelist=<[permissions@]IP address or network>
       Whitelist the peers connecting from the given IP address (e.g. 1.2.3.4)
       or CIDR-notated network (e.g. 1.2.3.0/24). Uses the same
       permissions as -whitebind. Can be specified multiple times.
```