### PR TITLE
Auto-detect SHA256 implementation in benchmarks

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -4,6 +4,7 @@
 
 #include <bench/bench.h>
 
+#include <crypto/sha256.h>
 #include <util/strencodings.h>
 #include <util/system.h>
 
@@ -35,6 +36,7 @@ int main(int argc, char** argv)
 {
     ArgsManager argsman;
     SetupBenchArgs(argsman);
+    SHA256AutoDetect();
     std::string error;
     if (!argsman.ParseParameters(argc, argv, error)) {
         tfm::format(std::cerr, "Error parsing command line arguments: %s\n", error);


### PR DESCRIPTION
It seems `SHA256AutoDetect()` was not being called in benchmarks, making the numbers only reflect the naive implementation. Fix this by calling it in bench_bitcoin's setup.