### PR TITLE
refactor: Replace RecursiveMutex with Mutex in warnings.cpp

### DIFF
--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -9,32 +9,32 @@
 #include <util/system.h>
 #include <util/translation.h>
 
-static RecursiveMutex cs_warnings;
-static std::string strMiscWarning GUARDED_BY(cs_warnings);
-static bool fLargeWorkForkFound GUARDED_BY(cs_warnings) = false;
-static bool fLargeWorkInvalidChainFound GUARDED_BY(cs_warnings) = false;
+static Mutex g_warnings_mutex;
+static std::string strMiscWarning GUARDED_BY(g_warnings_mutex);
+static bool fLargeWorkForkFound GUARDED_BY(g_warnings_mutex) = false;
+static bool fLargeWorkInvalidChainFound GUARDED_BY(g_warnings_mutex) = false;
 
 void SetMiscWarning(const std::string& strWarning)
 {
-    LOCK(cs_warnings);
+    LOCK(g_warnings_mutex);
     strMiscWarning = strWarning;
 }
 
 void SetfLargeWorkForkFound(bool flag)
 {
-    LOCK(cs_warnings);
+    LOCK(g_warnings_mutex);
     fLargeWorkForkFound = flag;
 }
 
 bool GetfLargeWorkForkFound()
 {
-    LOCK(cs_warnings);
+    LOCK(g_warnings_mutex);
     return fLargeWorkForkFound;
 }
 
 void SetfLargeWorkInvalidChainFound(bool flag)
 {
-    LOCK(cs_warnings);
+    LOCK(g_warnings_mutex);
     fLargeWorkInvalidChainFound = flag;
 }
 
@@ -44,7 +44,7 @@ std::string GetWarnings(bool verbose)
     std::string warnings_verbose;
     const std::string warning_separator = "<hr />";
 
-    LOCK(cs_warnings);
+    LOCK(g_warnings_mutex);
 
     // Pre-release build warning
     if (!CLIENT_VERSION_IS_RELEASE) {


### PR DESCRIPTION
The functions that could lock this mutex, i.e., `SetMiscWarning()`, `{S,G}etfLargeWorkForkFound()`, `SetfLargeWorkInvalidChainFound()`, `GetWarnings()`, do not call itself recursively, and do not call each other either directly or indirectly. Therefore, the `g_warnings_mutex` could be a non-recursive mutex.

Related to #19180.