### PR TITLE
gui: add missing translation.h include to fix build

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -33,6 +33,7 @@
 #include <ui_interface.h>
 #include <uint256.h>
 #include <util/system.h>
+#include <util/translation.h>
 #include <util/threadnames.h>
 #include <validation.h>
 


### PR DESCRIPTION
After #19176, building the gui on Bionic is failing with:

```bash
  CXX      qt/qt_libbitcoinqt_a-guiutil.o
qt/bitcoin.cpp: In function 'int GuiMain(int, char**)':
qt/bitcoin.cpp:460:35: error: 'Untranslated' was not declared in this scope
           node->initError(strprintf(Untranslated("Error parsing command line arguments: %s\n"), error));
```

The merge commit also failed to compile with the same error:
https://travis-ci.org/github/bitcoin/bitcoin/jobs/696627543