### PR TITLE
Make SetMiscWarning() accept bilingual_str argument

### DIFF
--- a/src/index/base.cpp
+++ b/src/index/base.cpp
@@ -21,7 +21,7 @@ template<typename... Args>
 static void FatalError(const char* fmt, const Args&... args)
 {
     std::string strMessage = tfm::format(fmt, args...);
-    SetMiscWarning(strMessage);
+    SetMiscWarning(Untranslated(strMessage));
     LogPrintf("*** %s\n", strMessage);
     uiInterface.ThreadSafeMessageBox(
         Untranslated("Error: A fatal internal error occurred, see debug.log for details"),

--- a/src/interfaces/node.cpp
+++ b/src/interfaces/node.cpp
@@ -71,7 +71,7 @@ public:
     std::string getNetwork() override { return Params().NetworkIDString(); }
     void initLogging() override { InitLogging(); }
     void initParameterInteraction() override { InitParameterInteraction(); }
-    std::string getWarnings() override { return GetWarnings(true); }
+    bilingual_str getWarnings() override { return GetWarnings(true); }
     uint32_t getLogCategories() override { return LogInstance().GetCategoryMask(); }
     bool baseInitialize() override
     {

--- a/src/interfaces/node.h
+++ b/src/interfaces/node.h
@@ -10,6 +10,7 @@
 #include <net_types.h>  // For banmap_t
 #include <netaddress.h> // For Network
 #include <support/allocators/secure.h> // For SecureString
+#include <util/translation.h>
 
 #include <functional>
 #include <memory>
@@ -81,7 +82,7 @@ public:
     virtual void initParameterInteraction() = 0;
 
     //! Get warnings.
-    virtual std::string getWarnings() = 0;
+    virtual bilingual_str getWarnings() = 0;
 
     // Get log flags.
     virtual uint32_t getLogCategories() = 0;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -155,7 +155,7 @@ BitcoinCore::BitcoinCore(interfaces::Node& node) :
 void BitcoinCore::handleRunawayException(const std::exception *e)
 {
     PrintExceptionContinue(e, "Runaway exception");
-    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings()));
+    Q_EMIT runawayException(QString::fromStdString(m_node.getWarnings().translated));
 }
 
 void BitcoinCore::initialize()
@@ -599,10 +599,10 @@ int GuiMain(int argc, char* argv[])
         }
     } catch (const std::exception& e) {
         PrintExceptionContinue(&e, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(node->getWarnings()));
+        app.handleRunawayException(QString::fromStdString(node->getWarnings().translated));
     } catch (...) {
         PrintExceptionContinue(nullptr, "Runaway exception");
-        app.handleRunawayException(QString::fromStdString(node->getWarnings()));
+        app.handleRunawayException(QString::fromStdString(node->getWarnings().translated));
     }
     return rv;
 }

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -166,7 +166,7 @@ enum BlockSource ClientModel::getBlockSource() const
 
 QString ClientModel::getStatusBarWarnings() const
 {
-    return QString::fromStdString(m_node.getWarnings());
+    return QString::fromStdString(m_node.getWarnings().translated);
 }
 
 OptionsModel *ClientModel::getOptionsModel()

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -32,6 +32,7 @@
 #include <util/ref.h>
 #include <util/strencodings.h>
 #include <util/system.h>
+#include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
 #include <warnings.h>
@@ -1278,7 +1279,7 @@ UniValue getblockchaininfo(const JSONRPCRequest& request)
     BIP9SoftForkDescPushBack(softforks, "testdummy", consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     obj.pushKV("softforks",             softforks);
 
-    obj.pushKV("warnings", GetWarnings(false));
+    obj.pushKV("warnings", GetWarnings(false).original);
     return obj;
 }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -29,6 +29,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
+#include <util/translation.h>
 #include <validation.h>
 #include <validationinterface.h>
 #include <versionbitsinfo.h>
@@ -416,7 +417,7 @@ static UniValue getmininginfo(const JSONRPCRequest& request)
     obj.pushKV("networkhashps",    getnetworkhashps(request));
     obj.pushKV("pooledtx",         (uint64_t)mempool.size());
     obj.pushKV("chain",            Params().NetworkIDString());
-    obj.pushKV("warnings",         GetWarnings(false));
+    obj.pushKV("warnings",         GetWarnings(false).original);
     return obj;
 }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -22,6 +22,7 @@
 #include <util/strencodings.h>
 #include <util/string.h>
 #include <util/system.h>
+#include <util/translation.h>
 #include <validation.h>
 #include <version.h>
 #include <warnings.h>
@@ -548,7 +549,7 @@ static UniValue getnetworkinfo(const JSONRPCRequest& request)
         }
     }
     obj.pushKV("localaddresses", localAddresses);
-    obj.pushKV("warnings",       GetWarnings(false));
+    obj.pushKV("warnings",       GetWarnings(false).original);
     return obj;
 }
 

--- a/src/test/timedata_tests.cpp
+++ b/src/test/timedata_tests.cpp
@@ -9,6 +9,7 @@
 #include <test/util/setup_common.h>
 #include <timedata.h>
 #include <util/string.h>
+#include <util/translation.h>
 #include <warnings.h>
 
 #include <string>
@@ -66,7 +67,7 @@ BOOST_AUTO_TEST_CASE(addtimedata)
         MultiAddTimeData(1, DEFAULT_MAX_TIME_ADJUSTMENT + 1); //filter size 5
     }
 
-    BOOST_CHECK(GetWarnings(true).find("clock is wrong") != std::string::npos);
+    BOOST_CHECK(GetWarnings(true).original.find("clock is wrong") != std::string::npos);
 
     // nTimeOffset is not changed if the median of offsets exceeds DEFAULT_MAX_TIME_ADJUSTMENT
     BOOST_CHECK_EQUAL(GetTimeOffset(), 0);

--- a/src/timedata.cpp
+++ b/src/timedata.cpp
@@ -95,7 +95,7 @@ void AddTimeData(const CNetAddr& ip, int64_t nOffsetSample)
                 if (!fMatch) {
                     fDone = true;
                     bilingual_str strMessage = strprintf(_("Please check that your computer's date and time are correct! If your clock is wrong, %s will not work properly."), PACKAGE_NAME);
-                    SetMiscWarning(strMessage.translated);
+                    SetMiscWarning(strMessage);
                     uiInterface.ThreadSafeMessageBox(strMessage, "", CClientUIInterface::MSG_WARNING);
                 }
             }

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -13,14 +13,14 @@
 #include <vector>
 
 static Mutex g_warnings_mutex;
-static std::string strMiscWarning GUARDED_BY(g_warnings_mutex);
+static bilingual_str g_misc_warnings GUARDED_BY(g_warnings_mutex);
 static bool fLargeWorkForkFound GUARDED_BY(g_warnings_mutex) = false;
 static bool fLargeWorkInvalidChainFound GUARDED_BY(g_warnings_mutex) = false;
 
-void SetMiscWarning(const std::string& strWarning)
+void SetMiscWarning(const bilingual_str& warning)
 {
     LOCK(g_warnings_mutex);
-    strMiscWarning = strWarning;
+    g_misc_warnings = warning;
 }
 
 void SetfLargeWorkForkFound(bool flag)
@@ -55,8 +55,8 @@ bilingual_str GetWarnings(bool verbose)
     }
 
     // Misc warnings like out of disk space and clock is wrong
-    if (!strMiscWarning.empty()) {
-        warnings_concise = Untranslated(strMiscWarning);
+    if (!g_misc_warnings.empty()) {
+        warnings_concise = g_misc_warnings;
         warnings_verbose.emplace_back(warnings_concise);
     }
 

--- a/src/warnings.cpp
+++ b/src/warnings.cpp
@@ -41,7 +41,7 @@ void SetfLargeWorkInvalidChainFound(bool flag)
     fLargeWorkInvalidChainFound = flag;
 }
 
-std::string GetWarnings(bool verbose)
+bilingual_str GetWarnings(bool verbose)
 {
     bilingual_str warnings_concise;
     std::vector<bilingual_str> warnings_verbose;
@@ -69,8 +69,8 @@ std::string GetWarnings(bool verbose)
     }
 
     if (verbose) {
-        return Join(warnings_verbose, Untranslated("<hr />")).translated;
+        return Join(warnings_verbose, Untranslated("<hr />"));
     }
 
-    return warnings_concise.original;
+    return warnings_concise;
 }

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -10,7 +10,7 @@
 
 struct bilingual_str;
 
-void SetMiscWarning(const std::string& strWarning);
+void SetMiscWarning(const bilingual_str& warning);
 void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);

--- a/src/warnings.h
+++ b/src/warnings.h
@@ -8,16 +8,18 @@
 
 #include <string>
 
+struct bilingual_str;
+
 void SetMiscWarning(const std::string& strWarning);
 void SetfLargeWorkForkFound(bool flag);
 bool GetfLargeWorkForkFound();
 void SetfLargeWorkInvalidChainFound(bool flag);
 /** Format a string that describes several potential problems detected by the core.
  * @param[in] verbose bool
- * - if true, get all warnings, translated (where possible), separated by <hr />
+ * - if true, get all warnings separated by <hr />
  * - if false, get the most important warning
  * @returns the warning string
  */
-std::string GetWarnings(bool verbose);
+bilingual_str GetWarnings(bool verbose);
 
 #endif //  BITCOIN_WARNINGS_H


### PR DESCRIPTION
This is one more step for consistent usage of `bilingual_str`.

No new translation messages are defined.