### PR TITLE
Add -uaappend option to append a literal string to user agent

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -534,6 +534,7 @@ void SetupServerArgs(NodeContext& node)
     argsman.AddArg("-printpriority", strprintf("Log transaction fee per kB when mining blocks (default: %u)", DEFAULT_PRINTPRIORITY), ArgsManager::ALLOW_ANY | ArgsManager::DEBUG_ONLY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-printtoconsole", "Send trace/debug info to console (default: 1 when no -daemon. To disable logging to file, set -nodebuglogfile)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
     argsman.AddArg("-shrinkdebugfile", "Shrink debug.log file on client startup (default: 1 when no -debug)", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
+    argsman.AddArg("-uaappend=<cmt>", "Append literal to the user agent string (should only be used for software embedding)", ArgsManager::ALLOW_ANY, OptionsCategory::CONNECTION);
     argsman.AddArg("-uacomment=<cmt>", "Append comment to the user agent string", ArgsManager::ALLOW_ANY, OptionsCategory::DEBUG_TEST);
 
     SetupChainParamsBaseOptions(argsman);
@@ -1398,6 +1399,10 @@ bool AppInitMain(const util::Ref& context, NodeContext& node, interfaces::BlockA
         uacomments.push_back(cmt);
     }
     strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
+    for (auto append : gArgs.GetArgs("-uaappend")) {
+        if (append.back() != '/') append += '/';
+        strSubVersion += append;
+    }
     if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
             strSubVersion.size(), MAX_SUBVERSION_LENGTH));

--- a/test/functional/feature_uacomment.py
+++ b/test/functional/feature_uacomment.py
@@ -35,6 +35,13 @@ class UacommentTest(BitcoinTestFramework):
             expected = r"Error: User Agent comment \(" + re.escape(unsafe_char) + r"\) contains unsafe characters."
             self.nodes[0].assert_start_raises_init_error(["-uacomment=" + unsafe_char], expected, match=ErrorMatch.FULL_REGEX)
 
+        self.log.info("test -uaappend")
+        self.restart_node(0, ["-uaappend=foo:0"])
+        assert_equal(self.nodes[0].getnetworkinfo()["subversion"][-7:], '/foo:0/')
+
+        self.restart_node(0, ["-uaappend=foo:9/"])
+        assert_equal(self.nodes[0].getnetworkinfo()["subversion"][-7:], '/foo:9/')
+
 
 if __name__ == '__main__':
     UacommentTest().main()


### PR DESCRIPTION
This can be used by other software that controls the node instance (eg, ABCore)
