### PR TITLE
doc: improve subtree check instructions

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -874,7 +874,7 @@ Others are external projects without a tight relationship with our project. Chan
 be sent upstream, but bugfixes may also be prudent to PR against Bitcoin Core so that they can be integrated
 quickly. Cosmetic changes should be purely taken upstream.
 
-There is a tool in `test/lint/git-subtree-check.sh` to check a subtree directory for consistency with
+There is a tool in `test/lint/git-subtree-check.sh` ([instructions](../test/lint#git-subtree-checksh)) to check a subtree directory for consistency with
 its upstream repository.
 
 Current subtrees include:

--- a/test/lint/README.md
+++ b/test/lint/README.md
@@ -23,6 +23,12 @@ maintained:
 * for `src/crypto/ctaes`: https://github.com/bitcoin-core/ctaes.git (branch master)
 * for `src/crc32c`: https://github.com/google/crc32c.git (branch master)
 
+To do so, add the upstream repository as remote:
+
+```
+git remote add --fetch secp256k1 https://github.com/bitcoin-core/secp256k1.git
+```
+
 Usage: `git-subtree-check.sh DIR (COMMIT)`
 
 `COMMIT` may be omitted, in which case `HEAD` is used.

--- a/test/lint/git-subtree-check.sh
+++ b/test/lint/git-subtree-check.sh
@@ -81,7 +81,7 @@ fi
 
 # get the tree in the subtree commit referred to
 if [ "d$(git cat-file -t $rev 2>/dev/null)" != dcommit ]; then
-    echo "subtree commit $rev unavailable: cannot compare" >&2
+    echo "subtree commit $rev unavailable: cannot compare. Did you add and fetch the remote?" >&2
     exit
 fi
 tree_subtree=$(git show -s --format="%T" $rev)


### PR DESCRIPTION
Running `git-subtree-check.sh` requires adding the subtree repository as a remote. I learned that several years ago and then forgot again. 

This PR also improves the error message if the subtree commit can't be found.