### PR TITLE
p2p: disconnect peers that send filterclear + update existing filter msg disconnect logic

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -3490,13 +3490,15 @@ bool ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRec
     }
 
     if (msg_type == NetMsgType::FILTERCLEAR) {
+        if (!(pfrom.GetLocalServices() & NODE_BLOOM)) {
+            pfrom.fDisconnect = true;
+            return true;
+        }
         if (pfrom.m_tx_relay == nullptr) {
             return true;
         }
         LOCK(pfrom.m_tx_relay->cs_filter);
-        if (pfrom.GetLocalServices() & NODE_BLOOM) {
-            pfrom.m_tx_relay->pfilter = nullptr;
-        }
+        pfrom.m_tx_relay->pfilter = nullptr;
         pfrom.m_tx_relay->fRelayTxes = true;
         return true;
     }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2215,20 +2215,6 @@ bool ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRec
     }
 
 
-    if (!(pfrom.GetLocalServices() & NODE_BLOOM) &&
-              (msg_type == NetMsgType::FILTERLOAD ||
-               msg_type == NetMsgType::FILTERADD))
-    {
-        if (pfrom.nVersion >= NO_BLOOM_VERSION) {
-            LOCK(cs_main);
-            Misbehaving(pfrom.GetId(), 100);
-            return false;
-        } else {
-            pfrom.fDisconnect = true;
-            return false;
-        }
-    }
-
     if (msg_type == NetMsgType::VERSION) {
         // Each connection can only send one version message
         if (pfrom.nVersion != 0)
@@ -3447,6 +3433,10 @@ bool ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRec
     }
 
     if (msg_type == NetMsgType::FILTERLOAD) {
+        if (!(pfrom.GetLocalServices() & NODE_BLOOM)) {
+            pfrom.fDisconnect = true;
+            return true;
+        }
         CBloomFilter filter;
         vRecv >> filter;
 
@@ -3466,6 +3456,10 @@ bool ProcessMessage(CNode& pfrom, const std::string& msg_type, CDataStream& vRec
     }
 
     if (msg_type == NetMsgType::FILTERADD) {
+        if (!(pfrom.GetLocalServices() & NODE_BLOOM)) {
+            pfrom.fDisconnect = true;
+            return true;
+        }
         std::vector<unsigned char> vData;
         vRecv >> vData;
 

--- a/test/functional/p2p_nobloomfilter_messages.py
+++ b/test/functional/p2p_nobloomfilter_messages.py
@@ -8,9 +8,10 @@ Test that, when bloom filters are not enabled, nodes are disconnected if:
 1. They send a p2p mempool message
 2. They send a p2p filterload message
 3. They send a p2p filteradd message
+4. They send a p2p filterclear message
 """
 
-from test_framework.messages import msg_mempool, msg_filteradd, msg_filterload
+from test_framework.messages import msg_mempool, msg_filteradd, msg_filterload, msg_filterclear
 from test_framework.mininode import P2PInterface
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import assert_equal
@@ -38,6 +39,9 @@ class P2PNobloomfilterMessages(BitcoinTestFramework):
 
         self.log.info("Test that node is disconnected if it sends filteradd message")
         self.test_message_causes_disconnect(msg_filteradd(data=b'\xcc'))
+
+        self.log.info("Test that peer is disconnected if it sends a filterclear message")
+        self.test_message_causes_disconnect(msg_filterclear())
 
 if __name__ == '__main__':
     P2PNobloomfilterMessages().main()


### PR DESCRIPTION
Nodes that don't have bloomfilters turned on (i.e. no `NODE_BLOOM` service) should disconnect peers that send them `filterclear` P2P messages.

Non-bloomfilter nodes already disconnect peers for [`filteradd` and `filterload`](https://github.com/bitcoin/bitcoin/blob/19e919217e6d62e3640525e4149de1a4ae04e74f/src/net_processing.cpp#L2218), but #8709 removed `filterclear` so it could be used to reset tx relay. This isn't needed now because using `feefilter` message is much better for this purpose (See #19204).

Also refactors existing disconnect logic for `filteradd` and `filterload` into respective message handlers and removes banning for them.