### PR TITLE
doc: Add non-thread-safe note to FeeFilterRounder::round()

### DIFF
--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -273,7 +273,7 @@ public:
     /** Create new FeeFilterRounder */
     explicit FeeFilterRounder(const CFeeRate& minIncrementalFee);
 
-    /** Quantize a minimum fee for privacy purpose before broadcast **/
+    /** Quantize a minimum fee for privacy purpose before broadcast. Not thread-safe due to use of FastRandomContext */
     CAmount round(CAmount currentMinFee);
 
 private:


### PR DESCRIPTION
The `FastRandomContext` class is documented as not thread-safe.
This PR adds a relevant note to the `FeeFilterRounder::round()` function declaration.

Close #19254